### PR TITLE
gc: move write barriers before the store

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -198,8 +198,7 @@ JL_DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc)
     size_t newnrows = n + inc;
     if (!isbitsunion && elsz == 0) {
         jl_genericmemory_t *newmem = jl_alloc_genericmemory(mtype, MAXINTVAL - 2);
-        a->ref.mem = newmem;
-        jl_gc_wb(a, newmem);
+        jl_gc_write(a, a->ref.mem, newmem);
         a->dimsize[0] = newnrows;
         return;
     }
@@ -227,8 +226,7 @@ JL_DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc)
             char *newtypetagdata = (char*)newmem->ptr + newmaxsize * elsz + oldoffset;
             memcpy(newtypetagdata, typetagdata, n);
         }
-        a->ref.mem = newmem;
-        jl_gc_wb(a, newmem);
+        jl_gc_write(a, a->ref.mem, newmem);
         if (isbitsunion)
             a->ref.ptr_or_offset = (void*)oldoffset;
         else

--- a/src/ast.c
+++ b/src/ast.c
@@ -843,18 +843,13 @@ JL_DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr)
                 jl_array_ptr_ref(new_code, i)
             ));
         }
-        new_ci->code = new_code;
-        jl_gc_wb(new_ci, new_code);
-        new_ci->slotnames = jl_array_copy(new_ci->slotnames);
-        jl_gc_wb(new_ci, new_ci->slotnames);
-        new_ci->slotflags = jl_array_copy(new_ci->slotflags);
-        jl_gc_wb(new_ci, new_ci->slotflags);
-        new_ci->ssaflags = jl_array_copy(new_ci->ssaflags);
-        jl_gc_wb(new_ci, new_ci->ssaflags);
+        jl_gc_write(new_ci, new_ci->code, new_code);
+        jl_gc_write(new_ci, new_ci->slotnames, jl_array_copy(new_ci->slotnames));
+        jl_gc_write(new_ci, new_ci->slotflags, jl_array_copy(new_ci->slotflags));
+        jl_gc_write(new_ci, new_ci->ssaflags, jl_array_copy(new_ci->ssaflags));
 
         if (jl_is_array(new_ci->ssavaluetypes)) {
-            new_ci->ssavaluetypes = (jl_value_t*)jl_array_copy((jl_array_t*)new_ci->ssavaluetypes);
-            jl_gc_wb(new_ci, new_ci->ssavaluetypes);
+            jl_gc_write(new_ci, new_ci->ssavaluetypes, (jl_value_t*)jl_array_copy((jl_array_t*)new_ci->ssavaluetypes));
         }
         JL_GC_POP();
         return (jl_value_t*)new_ci;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -897,9 +897,9 @@ JL_CALLABLE(jl_f__apply_iterate)
                 roots[stackalloc] = state;
                 _grow_to(&roots[0], &newargs, &arg_heap, &n_alloc, n + precount + 1, extra);
                 JL_GC_ASSERT_LIVE(value);
-                newargs[n++] = value;
                 if (arg_heap)
                     jl_gc_wb(arg_heap, value);
+                newargs[n++] = value;
                 roots[stackalloc + 1] = NULL;
                 JL_GC_ASSERT_LIVE(state);
                 args[1] = state;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -814,9 +814,12 @@ JL_CALLABLE(jl_f__apply_iterate)
             assert(newargs != NULL); // inform GCChecker that we didn't write a NULL here
             for (j = 0; j < al; j++) {
                 // jl_fieldref may allocate.
-                newargs[n++] = jl_fieldref(ai, j);
+                jl_value_t *val = jl_fieldref(ai, j);
                 if (arg_heap)
-                    jl_gc_wb(arg_heap, newargs[n - 1]);
+                    jl_gc_write(arg_heap, newargs[n], val);
+                else
+                    newargs[n] = val;
+                n++;
             }
         }
         else if (jl_is_genericmemory(ai)) {
@@ -832,16 +835,21 @@ JL_CALLABLE(jl_f__apply_iterate)
                     // apply with array splatting may have embedded NULL value (#11772)
                     if (__unlikely(arg == NULL))
                         jl_throw(jl_undefref_exception);
-                    newargs[n++] = arg;
                     if (arg_heap)
-                        jl_gc_wb(arg_heap, arg);
+                        jl_gc_write(arg_heap, newargs[n], arg);
+                    else
+                        newargs[n] = arg;
+                    n++;
                 }
             }
             else {
                 for (j = 0; j < al; j++) {
-                    newargs[n++] = jl_genericmemoryref(mem, j);
+                    jl_value_t *val = jl_genericmemoryref(mem, j);
                     if (arg_heap)
-                        jl_gc_wb(arg_heap, newargs[n - 1]);
+                        jl_gc_write(arg_heap, newargs[n], val);
+                    else
+                        newargs[n] = val;
+                    n++;
                 }
             }
         }
@@ -858,16 +866,21 @@ JL_CALLABLE(jl_f__apply_iterate)
                     // apply with array splatting may have embedded NULL value (#11772)
                     if (__unlikely(arg == NULL))
                         jl_throw(jl_undefref_exception);
-                    newargs[n++] = arg;
                     if (arg_heap)
-                        jl_gc_wb(arg_heap, arg);
+                        jl_gc_write(arg_heap, newargs[n], arg);
+                    else
+                        newargs[n] = arg;
+                    n++;
                 }
             }
             else {
                 for (j = 0; j < al; j++) {
-                    newargs[n++] = jl_arrayref(aai, j);
+                    jl_value_t *val = jl_arrayref(aai, j);
                     if (arg_heap)
-                        jl_gc_wb(arg_heap, newargs[n - 1]);
+                        jl_gc_write(arg_heap, newargs[n], val);
+                    else
+                        newargs[n] = val;
+                    n++;
                 }
             }
         }
@@ -2196,8 +2209,7 @@ static void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super)
     if (jl_is_datatype(super) && tt->name == ((jl_datatype_t*)super)->name)
         jl_errorf("invalid subtyping in definition of %s: a type cannot subtype itself.", type_name);
     jl_check_valid_supertype(super, type_name);
-    tt->super = (jl_datatype_t*)super;
-    jl_gc_wb(tt, tt->super);
+    jl_gc_write(tt, tt->super, (jl_datatype_t*)super);
 }
 
 JL_CALLABLE(jl_f__setsuper)
@@ -2412,8 +2424,7 @@ JL_CALLABLE(jl_f__typebody)
                 }
             }
         }
-        dt->types = (jl_svec_t*)ft;
-        jl_gc_wb(dt, ft);
+        jl_gc_write(dt, dt->types, (jl_svec_t*)ft);
         // If a supertype can reference the same type, then we may not be
         // able to compute the layout of the object before needing to
         // publish it, so we must assume it cannot be inlined, if that

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2659,6 +2659,33 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
     if (needlock)
         emit_lockstate_value(ctx, needlock, true);
     jl_cgval_t oldval = rhs;
+    // Emit the write barrier *before* the store. The barrier receives the new
+    // value being stored. Roots for the non-boxed case are derived from the
+    // `rhs` cgval (type-accurate) rather than the lowered `r`, since `r` may be
+    // an integer (e.g. for atomic stores) that no longer exposes its pointers.
+    auto emit_store_pre_barrier = [&] {
+        if (parent == NULL || !tracked_pointers)
+            return;
+        if (isboxed) {
+            if (type_is_permalloc(rhs.typ))
+                return;
+            assert(r != nullptr);
+            emit_write_barrier(ctx, parent, r);
+        }
+        else if (!rhs.inline_roots.empty()) {
+            emit_write_multibarrier(ctx, parent, rhs);
+        }
+        else {
+            // The field is stored inline; derive the tracked pointers from the
+            // unboxed aggregate of `rhs` (which may itself still be boxed here).
+            Value *agg = emit_unbox(ctx, julia_type_to_llvm(ctx, rhs.typ), rhs);
+            emit_write_multibarrier(ctx, parent, agg, rhs.typ);
+        }
+    };
+    // For op == StoreKind::Modify the new value isn't known yet; its barrier is
+    // emitted later, once `rhs`/`r` have been computed.
+    if (op != StoreKind::Modify)
+        emit_store_pre_barrier();
     // TODO: we should do Release ordering for anything with CountTrackedPointers(elty).count > 0, instead of just isboxed
     if (op == StoreKind::Set || (Order == AtomicOrdering::NotAtomic && op == StoreKind::Swap)) {
         if (op == StoreKind::Swap) {
@@ -2877,6 +2904,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             }
             if (needlock)
                 emit_lockstate_value(ctx, needlock, true); // relock
+            emit_store_pre_barrier();
             cmpop = oldval;
         }
         Value *Done;
@@ -2990,40 +3018,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         ctx.builder.SetInsertPoint(DoneBB);
     if (needlock)
         emit_lockstate_value(ctx, needlock, false);
-    if (parent != NULL && tracked_pointers && (!isboxed || !type_is_permalloc(rhs.typ))) {
-        if (op == StoreKind::Replace || op == StoreKind::SetOnce) {
-            BasicBlock *BB = BasicBlock::Create(ctx.builder.getContext(), "xchg_wb", ctx.f);
-            DoneBB = BasicBlock::Create(ctx.builder.getContext(), "done_xchg_wb", ctx.f);
-            ctx.builder.CreateCondBr(Success, BB, DoneBB);
-            ctx.builder.SetInsertPoint(BB);
-        }
-        if (r) {
-            if (realelty != elty)
-                r = ctx.builder.Insert(CastInst::Create(Instruction::Trunc, r, realelty));
-            if (intcast) {
-                ctx.builder.CreateStore(r, intcast);
-                r = ctx.builder.CreateLoad(intcast_eltyp, intcast);
-            }
-            else if (!isboxed && intcast_eltyp) {
-                assert(op == StoreKind::Set);
-                // setfield doesn't use intcast, so need to reload rhs with the correct type
-                r = emit_unbox(ctx, intcast_eltyp, rhs);
-            }
-            if (!isboxed)
-                emit_write_multibarrier(ctx, parent, r, rhs.typ);
-            else
-                emit_write_barrier(ctx, parent, r);
-        }
-        else {
-            assert(!isboxed);
-            assert(!rhs.inline_roots.empty());
-            emit_write_multibarrier(ctx, parent, rhs);
-        }
-        if (op == StoreKind::Replace || op == StoreKind::SetOnce) {
-            ctx.builder.CreateBr(DoneBB);
-            ctx.builder.SetInsertPoint(DoneBB);
-        }
-    }
+    // Write barrier is emitted before the store (see emit_store_pre_barrier above).
     switch (op) {
     case StoreKind::Modify: {
         const jl_cgval_t argv[2] = { oldval, rhs };

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2659,10 +2659,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
     if (needlock)
         emit_lockstate_value(ctx, needlock, true);
     jl_cgval_t oldval = rhs;
-    // Emit the write barrier *before* the store. The barrier receives the new
-    // value being stored. Roots for the non-boxed case are derived from the
-    // `rhs` cgval (type-accurate) rather than the lowered `r`, since `r` may be
-    // an integer (e.g. for atomic stores) that no longer exposes its pointers.
+    // Emit the write barrier for the new value *before* the store.
     auto emit_store_pre_barrier = [&] {
         if (parent == NULL || !tracked_pointers)
             return;
@@ -2676,9 +2673,13 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             emit_write_multibarrier(ctx, parent, rhs);
         }
         else {
-            // The field is stored inline; derive the tracked pointers from the
-            // unboxed aggregate of `rhs` (which may itself still be boxed here).
-            Value *agg = emit_unbox(ctx, julia_type_to_llvm(ctx, rhs.typ), rhs);
+            // Unbox to the field's storage type (concrete by construction), not
+            // rhs.typ which may be bottom for an unreachable store (e.g. a modify
+            // of an always-undef field) and would make emit_unbox return null.
+            // intcast_eltyp is the pointer-exposing type when the field was
+            // widened to an integer for atomics.
+            Type *wb_eltyp = intcast_eltyp ? intcast_eltyp : realelty;
+            Value *agg = emit_unbox(ctx, wb_eltyp, rhs);
             emit_write_multibarrier(ctx, parent, agg, rhs.typ);
         }
     };

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -60,13 +60,10 @@ JL_DLLEXPORT void jl_emit_codeinsts_to_jit_fallback(jl_code_instance_t **codeins
         if (jl_is_code_info(inferred))
             continue;
         if (jl_is_svec(src->edges)) {
-            jl_atomic_store_release(&codeinst->inferred, (jl_value_t*)src->edges);
-            jl_gc_wb(codeinst, src->edges);
+            jl_gc_write_atomic(codeinst, codeinst->inferred, (jl_value_t*)src->edges, release);
         }
-        jl_atomic_store_release(&codeinst->debuginfo, src->debuginfo);
-        jl_gc_wb(codeinst, src->debuginfo);
-        jl_atomic_store_release(&codeinst->inferred, (jl_value_t*)src);
-        jl_gc_wb(codeinst, src);
+        jl_gc_write_atomic(codeinst, codeinst->debuginfo, src->debuginfo, release);
+        jl_gc_write_atomic(codeinst, codeinst->inferred, (jl_value_t*)src, release);
     }
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4538,9 +4538,9 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         for (size_t i = 0; i < nargs; i++) {
             Value *elem = boxed(ctx, argv[i + 1]);
             Value *elem_ptr = emit_ptrgep(ctx, svec_derived, ctx.types().sizeof_ptr * (i + 1));
+            emit_write_barrier(ctx, svec, elem);
             auto *store = ctx.builder.CreateAlignedStore(elem, elem_ptr, Align(ctx.types().sizeof_ptr));
             store->setOrdering(AtomicOrdering::Release);
-            emit_write_barrier(ctx, svec, elem);
         }
         *ret = mark_julia_type(ctx, svec, true, jl_simplevector_type);
         return true;

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -1936,6 +1936,8 @@ inline void set_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t
         size_t fsz = jl_datatype_size((jl_datatype_t*)rty); // need to shrink-wrap the final copy
         assert(!isatomic || jl_typeis(rhs, ty));
         int needlock = (isatomic && fsz > MAX_ATOMIC_SIZE);
+        if (hasptr)
+            jl_gc_multi_wb(v, rhs); // rhs is immutable
         if (isatomic && !needlock) {
             jl_atomic_store_bits((char*)v + offs, rhs, fsz);
         }
@@ -1947,8 +1949,6 @@ inline void set_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t
         else {
             memassign_safe(hasptr, (char*)v + offs, rhs, fsz);
         }
-        if (hasptr)
-            jl_gc_multi_wb(v, rhs); // rhs is immutable
     }
 }
 
@@ -1970,6 +1970,8 @@ inline jl_value_t *swap_bits(jl_value_t *ty, char *v, uint8_t *psel, jl_value_t 
     assert(!isatomic || jl_typeis(rhs, ty));
     jl_value_t *r;
     if (isatomic && !needlock) {
+        if (hasptr)
+            jl_gc_multi_wb(parent, rhs); // rhs is immutable
         r = jl_atomic_swap_bits(rty, v, rhs, fsz);
     }
     else {
@@ -1978,6 +1980,8 @@ inline jl_value_t *swap_bits(jl_value_t *ty, char *v, uint8_t *psel, jl_value_t 
             r = jl_gc_alloc(ct->ptls, fsz, ty);
             char *px = lock(v, parent, needlock, isatomic);
             memcpy((char*)r, px, fsz);
+            if (hasptr)
+                jl_gc_multi_wb(parent, rhs); // rhs is immutable
             memcpy(px, (char*)rhs, fsz);
             unlock(v, parent, needlock, isatomic);
         }
@@ -1991,13 +1995,13 @@ inline jl_value_t *swap_bits(jl_value_t *ty, char *v, uint8_t *psel, jl_value_t 
                 if (jl_is_datatype_singleton((jl_datatype_t*)rty))
                     return r;
             }
+            if (hasptr)
+                jl_gc_multi_wb(parent, rhs); // rhs is immutable
             memassign_safe(hasptr, v, rhs, fsz);
         }
     }
     if (!isunion)
         r = undefref_check((jl_datatype_t*)layout_ty, r);
-    if (hasptr)
-        jl_gc_multi_wb(parent, rhs); // rhs is immutable
     if (__unlikely(r == NULL))
         jl_throw(jl_undefref_exception);
     return r;
@@ -2012,11 +2016,11 @@ jl_value_t *swap_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_
     jl_value_t *r;
     char *p = (char*)v + offs;
     if (jl_field_isptr(st, i)) {
+        jl_gc_wb(v, rhs);
         if (isatomic)
             r = jl_atomic_exchange((_Atomic(jl_value_t*)*)p, rhs);
         else
             r = jl_atomic_exchange_release((_Atomic(jl_value_t*)*)p, rhs);
-        jl_gc_wb(v, rhs);
         if (__unlikely(r == NULL))
             jl_throw(jl_undefref_exception);
         return r;
@@ -2046,8 +2050,8 @@ inline jl_value_t *modify_value(jl_value_t *ty, _Atomic(jl_value_t*) *p, jl_valu
             jl_check_binding_assign_value(b, mod, name, y, "modifyglobal!");
         else if (!jl_isa(y, ty))
             jl_type_error(jl_is_genericmemory(parent) ? "memoryrefmodify!" : "modifyfield!", ty, y);
+        jl_gc_wb(parent, y);
         if (isatomic ? jl_atomic_cmpswap(p, &r, y) : jl_atomic_cmpswap_release(p, &r, y)) {
-            jl_gc_wb(parent, y);
             break;
         }
         args[0] = r;
@@ -2107,9 +2111,9 @@ inline jl_value_t *modify_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value_
         jl_value_t *yty = jl_typeof(y);
         if (isatomic && !needlock) {
             assert(yty == rty);
+            if (hasptr)
+                jl_gc_multi_wb(parent, y); // y is immutable
             if (jl_atomic_bool_cmpswap_bits(p, r, y, fsz)) {
-                if (hasptr)
-                    jl_gc_multi_wb(parent, y); // y is immutable
                 break;
             }
         }
@@ -2134,12 +2138,12 @@ inline jl_value_t *modify_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value_
                 else {
                     assert(jl_typeis(y, ty) && rty == layout_ty);
                 }
+                if (hasptr)
+                    jl_gc_multi_wb(parent, y); // y is immutable
                 memassign_safe(hasptr, px, y, fsz);
             }
             unlock(p, parent, needlock, isatomic);
             if (success) {
-                if (hasptr)
-                    jl_gc_multi_wb(parent, y); // y is immutable
                 break;
             }
         }
@@ -2175,9 +2179,8 @@ inline jl_value_t *replace_value(jl_value_t *ty, _Atomic(jl_value_t*) *p, jl_val
     jl_value_t *r = expected;
     int success;
     while (1) {
+        jl_gc_wb(parent, rhs);
         success = isatomic ? jl_atomic_cmpswap(p, &r, rhs) : jl_atomic_cmpswap_release(p, &r, rhs);
-        if (success)
-            jl_gc_wb(parent, rhs);
         if (__unlikely(r == NULL)) {
             if (mod && name)
                 jl_undefined_var_error(name, (jl_value_t*)mod);
@@ -2218,6 +2221,8 @@ inline jl_value_t *replace_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value
     assert(!jl_field_isptr(rettyp, 0));
     jl_value_t *r = jl_gc_alloc(ct->ptls, jl_datatype_size(rettyp), rettyp);
     if (isatomic && !needlock) {
+        if (hasptr)
+            jl_gc_multi_wb(parent, rhs); // rhs is immutable
         size_t rsz = jl_datatype_size((jl_datatype_t*)rty); // need to shrink-wrap the compare
         success = jl_atomic_cmpswap_bits((jl_datatype_t*)rty, r, p, expected, rhs, rsz);
         *((uint8_t*)r + fsz) = success ? 1 : 0;
@@ -2248,12 +2253,12 @@ inline jl_value_t *replace_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value
                 if (jl_is_datatype_singleton((jl_datatype_t*)rty))
                     return r;
             }
+            if (hasptr)
+                jl_gc_multi_wb(parent, rhs); // rhs is immutable
             memassign_safe(hasptr, px, rhs, rsz);
         }
         unlock(p, parent, needlock, isatomic);
     }
-    if (success && hasptr)
-        jl_gc_multi_wb(parent, rhs); // rhs is immutable
     if (!isunion) {
         r = undefref_check((jl_datatype_t*)rty, r);
         if (__unlikely(r == NULL))
@@ -2288,17 +2293,18 @@ inline int setonce_bits(jl_datatype_t *rty, char *p, jl_value_t *parent, jl_valu
     int needlock = (isatomic && fsz > MAX_ATOMIC_SIZE);
     int success;
     if (isatomic && !needlock) {
+        jl_gc_multi_wb(parent, rhs); // rhs is immutable
         success = jl_atomic_storeonce_bits(rty, p, rhs, fsz);
     }
     else {
         char *px = lock(p, parent, needlock, isatomic);
         success = undefref_check(rty, (jl_value_t*)px) == NULL;
-        if (success)
+        if (success) {
+            jl_gc_multi_wb(parent, rhs); // rhs is immutable
             memassign_safe(hasptr, px, rhs, fsz);
+        }
         unlock(p, parent, needlock, isatomic);
     }
-    if (success)
-        jl_gc_multi_wb(parent, rhs); // rhs is immutable
     return success;
 }
 
@@ -2313,9 +2319,8 @@ int set_nth_fieldonce(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t *rh
     if (jl_field_isptr(st, i)) {
         _Atomic(jl_value_t*) *px = (_Atomic(jl_value_t*)*)p;
         jl_value_t *r = NULL;
+        jl_gc_wb(v, rhs);
         success = isatomic ? jl_atomic_cmpswap(px, &r, rhs) : jl_atomic_cmpswap_release(px, &r, rhs);
-        if (success)
-            jl_gc_wb(v, rhs);
     }
     else {
         int isunion = jl_is_uniontype(ty);

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -357,7 +357,7 @@ STATIC_INLINE void jl_maybe_allocate_singleton_instance(jl_datatype_t *st) JL_NO
         return;
     if (jl_is_datatype_make_singleton(st)) {
         jl_task_t *ct = jl_current_task;
-        st->instance = jl_gc_permobj(ct->ptls, 0, st, 0);
+        jl_gc_write(st, st->instance, jl_gc_permobj(ct->ptls, 0, st, 0));
     }
 }
 
@@ -628,7 +628,7 @@ void jl_get_genericmemory_layout(jl_datatype_t *st)
             zeroinst->ptr = (char*)zeroinst + JL_SMALL_BYTE_ALIGNMENT;
             memset(zeroinst->ptr, 0, elsz ? elsz : isunion);
             assert(!st->instance);
-            st->instance = (jl_value_t*)zeroinst;
+            jl_gc_write(st, st->instance, (jl_value_t*)zeroinst);
         }
     }
 }
@@ -929,13 +929,11 @@ static void jl_process_field_attrs(jl_svec_t *fattrs, jl_svec_t *fnames, int mut
 // Caller must handle GC rooting of wrapper across this call
 static void jl_setup_type_wrapper(jl_typename_t *tn, jl_svec_t *parameters, jl_value_t **wrapper)
 {
-    tn->wrapper = *wrapper;
-    jl_gc_wb(tn, *wrapper);
+    jl_gc_write(tn, tn->wrapper, *wrapper);
     int np = jl_svec_len(parameters);
     for (int i = np - 1; i >= 0; i--) {
         *wrapper = jl_new_struct(jl_unionall_type, jl_svecref(parameters, i), *wrapper);
-        tn->wrapper = *wrapper;
-        jl_gc_wb(tn, *wrapper);
+        jl_gc_write(tn, tn->wrapper, *wrapper);
     }
 }
 
@@ -958,12 +956,9 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(
 
     // init enough before possibly calling jl_new_typename_in
     t = jl_new_uninitialized_datatype();
-    t->super = super;
-    if (super != NULL) jl_gc_wb(t, t->super);
-    t->parameters = parameters;
-    jl_gc_wb(t, t->parameters);
-    t->types = ftypes;
-    if (ftypes != NULL) jl_gc_wb(t, t->types);
+    jl_gc_write(t, t->super, super);
+    jl_gc_write(t, t->parameters, parameters);
+    jl_gc_write(t, t->types, ftypes);
 
     t->name = NULL;
     if (jl_is_typename(name)) {
@@ -975,10 +970,8 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(
     else {
         tn = jl_new_typename_in((jl_sym_t*)name, module, abstract, mutabl);
     }
-    t->name = tn;
-    jl_gc_wb(t, t->name);
-    t->name->names = fnames;
-    jl_gc_wb(t->name, t->name->names);
+    jl_gc_write(t, t->name, tn);
+    jl_gc_write(t->name, t->name->names, fnames);
     tn->n_uninitialized = jl_svec_len(fnames) - ninitialized;
 
     uint32_t *atomicfields = NULL;
@@ -1066,7 +1059,7 @@ JL_DLLEXPORT jl_datatype_t * jl_new_foreign_type(jl_sym_t *name,
     desc->markfunc = markfunc;
     desc->sweepfunc = sweepfunc;
     bt->layout = layout;
-    bt->instance = NULL;
+    jl_gc_write(bt, bt->instance, NULL);
     return bt;
 }
 
@@ -1917,8 +1910,7 @@ inline void set_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t
         return;
     }
     if (jl_field_isptr(st, i)) {
-        jl_atomic_store_release((_Atomic(jl_value_t*)*)((char*)v + offs), rhs);
-        jl_gc_wb(v, rhs);
+        jl_gc_write_atomic(v, ((_Atomic(jl_value_t*)*)((char*)v + offs))[0], rhs, release);
     }
     else {
         jl_value_t *ty = jl_field_type_concrete(st, i);
@@ -2700,10 +2692,8 @@ JL_DLLEXPORT jl_value_t *jl_resolve_typegroup(jl_module_t *module, jl_svec_t *ty
 
             // Create typename
             jl_typename_t *tn = jl_new_typename_in(name, module, abstract, mutabl);
-            datatypes[i]->name = tn;
-            jl_gc_wb(datatypes[i], tn);
-            tn->names = fieldnames;
-            jl_gc_wb(tn, fieldnames);
+            jl_gc_write(datatypes[i], datatypes[i]->name, tn);
+            jl_gc_write(tn, tn->names, fieldnames);
             tn->n_uninitialized = (int32_t)(jl_svec_len(fieldnames) - min_initialized);
 
             // Set up initial values
@@ -2722,8 +2712,7 @@ JL_DLLEXPORT jl_value_t *jl_resolve_typegroup(jl_module_t *module, jl_svec_t *ty
             jl_svec_t *info = (jl_svec_t*)jl_svecref(struct_infos, i);
             jl_svec_t *params = (jl_svec_t*)jl_svecref(info, 0);
 
-            datatypes[i]->parameters = params;
-            jl_gc_wb(datatypes[i], params);
+            jl_gc_write(datatypes[i], datatypes[i]->parameters, params);
 
             // Create wrapper UnionAll chain
             if (datatypes[i]->name->wrapper == NULL) {
@@ -2758,8 +2747,7 @@ JL_DLLEXPORT jl_value_t *jl_resolve_typegroup(jl_module_t *module, jl_svec_t *ty
                     datatypes[i]->name == ((jl_datatype_t*)resolved_super)->name)
                     jl_errorf("invalid subtyping in definition of %s: a type cannot subtype itself.", type_name);
                 jl_check_valid_supertype(resolved_super, type_name);
-                datatypes[i]->super = (jl_datatype_t*)resolved_super;
-                jl_gc_wb(datatypes[i], datatypes[i]->super);
+                jl_gc_write(datatypes[i], datatypes[i]->super, (jl_datatype_t*)resolved_super);
                 JL_GC_POP();
             }
         }
@@ -2794,8 +2782,7 @@ JL_DLLEXPORT jl_value_t *jl_resolve_typegroup(jl_module_t *module, jl_svec_t *ty
             jl_tvar_t *tv = (jl_tvar_t*)jl_svecref(typevars, i);
             jl_check_field_types(ftypes, tv->name);
             jl_datatype_t *dt = unwrap_to_datatype(results[i]);
-            dt->types = ftypes;
-            jl_gc_wb(dt, ftypes);
+            jl_gc_write(dt, dt->types, ftypes);
             JL_GC_POP();
         }
     }

--- a/src/gc-wb-stock.h
+++ b/src/gc-wb-stock.h
@@ -13,15 +13,12 @@ extern "C" {
 
 STATIC_INLINE void jl_gc_wb(const void *parent, const void *ptr) JL_NOTSAFEPOINT
 {
-    // parent and ptr isa jl_value_t*
-    // The barrier is emitted before the store and may receive a NULL ptr (e.g.
-    // when a field is being cleared); a NULL child is never young so it cannot
+    // parent isa jl_value_t* and ptr isa jl_value_t* or NULL
+    // ptr is NULL when a field is being cleared and does not
     // require the parent to be remembered.
 #ifndef __clang_gcanalyzer__
-    // Hidden from the GC analyzer: branching on `ptr != NULL` here splits the
-    // analysis state, and on the assumed-NULL path the caller's subsequent
-    // store of `ptr` no longer registers as rooting it, producing false
-    // "may have been GCed" reports at the next safepoint.
+    // Hidden from the GC analyzer because tracking the state of parent and ptr
+    // uses up budget leading to spurious failures and jl_gc_wb doesn't interact with safepoints.
     if (__unlikely(jl_astaggedvalue(parent)->bits.gc == 3 /* GC_OLD_MARKED */ && // parent is old and not in remset
                    (jl_astaggedvalue(parent)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */ || // parent in image and not in remset
                     (ptr != NULL && (jl_astaggedvalue(ptr)->bits.gc & 1 /* GC_MARKED */) == 0)))) // ptr is young

--- a/src/gc-wb-stock.h
+++ b/src/gc-wb-stock.h
@@ -14,10 +14,19 @@ extern "C" {
 STATIC_INLINE void jl_gc_wb(const void *parent, const void *ptr) JL_NOTSAFEPOINT
 {
     // parent and ptr isa jl_value_t*
+    // The barrier is emitted before the store and may receive a NULL ptr (e.g.
+    // when a field is being cleared); a NULL child is never young so it cannot
+    // require the parent to be remembered.
+#ifndef __clang_gcanalyzer__
+    // Hidden from the GC analyzer: branching on `ptr != NULL` here splits the
+    // analysis state, and on the assumed-NULL path the caller's subsequent
+    // store of `ptr` no longer registers as rooting it, producing false
+    // "may have been GCed" reports at the next safepoint.
     if (__unlikely(jl_astaggedvalue(parent)->bits.gc == 3 /* GC_OLD_MARKED */ && // parent is old and not in remset
                    (jl_astaggedvalue(parent)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */ || // parent in image and not in remset
-                    (jl_astaggedvalue(ptr)->bits.gc & 1 /* GC_MARKED */) == 0))) // ptr is young
+                    (ptr != NULL && (jl_astaggedvalue(ptr)->bits.gc & 1 /* GC_MARKED */) == 0)))) // ptr is young
         jl_gc_queue_root((jl_value_t*)parent);
+#endif
 }
 
 STATIC_INLINE void jl_gc_wb_back(const void *ptr) JL_NOTSAFEPOINT // ptr isa jl_value_t*

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -456,11 +456,11 @@ JL_DLLEXPORT void jl_memoryrefset(jl_genericmemoryref_t m, jl_value_t *rhs JL_RO
     }
     if (layout->flags.arrayelem_isboxed) {
         assert((char*)m.ptr_or_offset - (char*)m.mem->ptr < sizeof(jl_value_t*) * m.mem->length);
+        jl_gc_wb(jl_genericmemory_owner(m.mem), rhs);
         if (isatomic)
             jl_atomic_store((_Atomic(jl_value_t*)*)m.ptr_or_offset, rhs);
         else
             jl_atomic_store_release((_Atomic(jl_value_t*)*)m.ptr_or_offset, rhs);
-        jl_gc_wb(jl_genericmemory_owner(m.mem), rhs);
         return;
     }
     int hasptr;
@@ -485,6 +485,8 @@ JL_DLLEXPORT void jl_memoryrefset(jl_genericmemoryref_t m, jl_value_t *rhs JL_RO
         assert(data - (char*)m.mem->ptr < layout->size * m.mem->length);
         int needlock = layout->flags.arrayelem_islocked;
         size_t fsz = jl_datatype_size((jl_datatype_t*)jl_typeof(rhs)); // need to shrink-wrap the final copy
+        if (hasptr)
+            jl_gc_multi_wb(jl_genericmemory_owner(m.mem), rhs); // rhs is immutable
         if (isatomic && !needlock) {
             jl_atomic_store_bits(data, rhs, fsz);
         }
@@ -496,8 +498,6 @@ JL_DLLEXPORT void jl_memoryrefset(jl_genericmemoryref_t m, jl_value_t *rhs JL_RO
         else {
             memassign_safe(hasptr, data, rhs, fsz);
         }
-        if (hasptr)
-            jl_gc_multi_wb(jl_genericmemory_owner(m.mem), rhs); // rhs is immutable
     }
 }
 
@@ -514,11 +514,11 @@ JL_DLLEXPORT jl_value_t *jl_memoryrefswap(jl_genericmemoryref_t m, jl_value_t *r
     if (layout->flags.arrayelem_isboxed) {
         assert(data - (char*)m.mem->ptr < sizeof(jl_value_t*) * m.mem->length);
         jl_value_t *r;
+        jl_gc_wb(owner, rhs);
         if (isatomic)
             r = jl_atomic_exchange((_Atomic(jl_value_t*)*)data, rhs);
         else
             r = jl_atomic_exchange_release((_Atomic(jl_value_t*)*)data, rhs);
-        jl_gc_wb(owner, rhs);
         if (__unlikely(r == NULL))
             jl_throw(jl_undefref_exception);
         return r;
@@ -599,9 +599,8 @@ JL_DLLEXPORT jl_value_t *jl_memoryrefsetonce(jl_genericmemoryref_t m, jl_value_t
         assert(data - (char*)m.mem->ptr < sizeof(jl_value_t*) * m.mem->length);
         jl_value_t *r = NULL;
         _Atomic(jl_value_t*) *px = (_Atomic(jl_value_t*)*)data;
+        jl_gc_wb(owner, rhs);
         success = isatomic ? jl_atomic_cmpswap(px, &r, rhs) : jl_atomic_cmpswap_release(px, &r, rhs);
-        if (success)
-            jl_gc_wb(owner, rhs);
     }
     else {
         if (layout->flags.arrayelem_isunion) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -246,8 +246,7 @@ static jl_method_instance_t *jl_specializations_get_linfo_(jl_method_t *m JL_PRO
     }
     jl_method_instance_t *mi = mi_insert ? mi_insert : jl_get_specialized(m, type, sparams);
     if (specializations == (jl_value_t*)jl_emptysvec) {
-        jl_atomic_store_release(&m->specializations, (jl_value_t*)mi);
-        jl_gc_wb(m, mi);
+        jl_gc_write_atomic(m, m->specializations, (jl_value_t*)mi, release);
     }
     else {
         JL_GC_PUSH1(&mi);
@@ -260,8 +259,7 @@ static jl_method_instance_t *jl_specializations_get_linfo_(jl_method_t *m JL_PRO
             i = cl - 1;
             specializations = (jl_value_t*)jl_svec_fill(cl, jl_nothing);
             jl_svecset(specializations, hv ? 0 : i--, mi);
-            jl_atomic_store_release(&m->specializations, specializations);
-            jl_gc_wb(m, specializations);
+            jl_gc_write_atomic(m, m->specializations, specializations, release);
             if (hv)
                 jl_smallintset_insert(&m->speckeyset, (jl_value_t*)m, speccache_hash, 0, specializations);
         }
@@ -287,8 +285,7 @@ static jl_method_instance_t *jl_specializations_get_linfo_(jl_method_t *m JL_PRO
                        (char*)jl_svec_data(specializations) + sizeof(void*) * i,
                        sizeof(void*) * (cl - i));
             specializations = (jl_value_t*)nc;
-            jl_atomic_store_release(&m->specializations, specializations);
-            jl_gc_wb(m, specializations);
+            jl_gc_write_atomic(m, m->specializations, specializations, release);
             if (!hv)
                 i += ncl - cl;
         }
@@ -361,8 +358,7 @@ jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *sname, jl_fptr_args
     m->nospecialize = ~m->nospecialize;
 
     jl_method_instance_t *mi = jl_get_specialized(m, (jl_value_t*)tuptyp, jl_emptysvec);
-    jl_atomic_store_relaxed(&m->unspecialized, mi);
-    jl_gc_wb(m, mi);
+    jl_gc_write_atomic(m, m->unspecialized, mi, relaxed);
 
     jl_debuginfo_t *di = NULL;
     jl_svec_t *edges = jl_emptysvec;
@@ -696,22 +692,18 @@ JL_DLLEXPORT void jl_update_codeinst(
 {
     assert(min_world <= max_world && "attempting to set invalid world constraints");
     //assert((!jl_is_method(codeinst->def->def.value) || max_world != ~(size_t)0 || min_world <= 1 || jl_svec_len(edges) != 0) && "missing edges");
-    codeinst->analysis_results = analysis_results;
-    jl_gc_wb(codeinst, analysis_results);
+    jl_gc_write(codeinst, codeinst->analysis_results, analysis_results);
     codeinst->time_infer_total = julia_double_to_half(time_infer_total);
     codeinst->time_infer_cache_saved = julia_double_to_half(time_infer_cache_saved);
     codeinst->time_infer_self = julia_double_to_half(time_infer_self);
     jl_atomic_store_relaxed(&codeinst->ipo_purity_bits, effects);
-    jl_atomic_store_relaxed(&codeinst->debuginfo, di);
-    jl_gc_wb(codeinst, di);
-    jl_atomic_store_relaxed(&codeinst->edges, edges);
-    jl_gc_wb(codeinst, edges);
+    jl_gc_write_atomic(codeinst, codeinst->debuginfo, di, relaxed);
+    jl_gc_write_atomic(codeinst, codeinst->edges, edges, relaxed);
     if ((const_flags & 1) != 0) {
         assert(codeinst->rettype_const);
         jl_atomic_store_release(&codeinst->invoke, jl_fptr_const_return);
     }
-    jl_atomic_store_release(&codeinst->inferred, inferred);
-    jl_gc_wb(codeinst, inferred);
+    jl_gc_write_atomic(codeinst, codeinst->inferred, inferred, release);
     jl_atomic_store_relaxed(&codeinst->min_world, min_world); // XXX: these should be unchanged?
     jl_atomic_store_relaxed(&codeinst->max_world, max_world); // since the edges shouldn't change after jl_fill_codeinst
 }
@@ -726,19 +718,14 @@ JL_DLLEXPORT void jl_fill_codeinst(
 {
     assert(min_world <= max_world && "attempting to set invalid world constraints");
     //assert((!jl_is_method(codeinst->def->def.value) || max_world != ~(size_t)0 || min_world <= 1 || jl_svec_len(edges) != 0) && "missing edges");
-    codeinst->rettype = rettype;
-    jl_gc_wb(codeinst, rettype);
-    codeinst->exctype = exctype;
-    jl_gc_wb(codeinst, exctype);
+    jl_gc_write(codeinst, codeinst->rettype, rettype);
+    jl_gc_write(codeinst, codeinst->exctype, exctype);
     if ((const_flags & 2) != 0) {
-        codeinst->rettype_const = inferred_const;
-        jl_gc_wb(codeinst, inferred_const);
+        jl_gc_write(codeinst, codeinst->rettype_const, inferred_const);
     }
-    jl_atomic_store_relaxed(&codeinst->edges, edges);
-    jl_gc_wb(codeinst, edges);
+    jl_gc_write_atomic(codeinst, codeinst->edges, edges, relaxed);
     if ((jl_value_t*)di != jl_nothing) {
-        jl_atomic_store_relaxed(&codeinst->debuginfo, di);
-        jl_gc_wb(codeinst, di);
+        jl_gc_write_atomic(codeinst, codeinst->debuginfo, di, relaxed);
     }
     if ((const_flags & 1) != 0) {
         // TODO: may want to follow ordering restrictions here (see jitlayers.cpp)
@@ -746,10 +733,10 @@ JL_DLLEXPORT void jl_fill_codeinst(
         jl_atomic_store_release(&codeinst->invoke, jl_fptr_const_return);
     }
     jl_atomic_store_relaxed(&codeinst->ipo_purity_bits, effects);
-    codeinst->analysis_results = analysis_results;
+    jl_gc_write(codeinst, codeinst->analysis_results, analysis_results);
     assert(jl_atomic_load_relaxed(&codeinst->min_world) == 1);
     assert(jl_atomic_load_relaxed(&codeinst->max_world) == 0);
-    jl_atomic_store_release(&codeinst->inferred, jl_nothing);
+    jl_gc_write_atomic(codeinst, codeinst->inferred, jl_nothing, release);
     jl_atomic_store_release(&codeinst->min_world, min_world);
     jl_atomic_store_release(&codeinst->max_world, max_world);
 }
@@ -799,11 +786,8 @@ JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi,
         oldci = jl_atomic_load_relaxed(slot);
     }
     if (oldci != ci) {
-        jl_atomic_store_relaxed(&ci->next, oldci);
-        if (oldci)
-            jl_gc_wb(ci, oldci);
-        jl_atomic_store_release(slot, ci);
-        jl_gc_wb(parent, ci);
+        jl_gc_write_atomic(ci, ci->next, oldci, relaxed);
+        jl_gc_write_atomic(parent, *slot, ci, release);
         if (oldci != NULL) {
             // list is now potentially circular, need to go find old pointer to ci starting from oldci and insert next there
             do {
@@ -812,9 +796,7 @@ JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi,
                 oldci = jl_atomic_load_relaxed(slot);
             } while (oldci && oldci != ci);
             if (oldci) {
-                jl_atomic_store_release(slot, next);
-                if (next)
-                    jl_gc_wb(parent, next);
+                jl_gc_write_atomic(parent, *slot, next, release);
             }
         }
     }
@@ -834,11 +816,8 @@ JL_DLLEXPORT int jl_mi_try_insert(jl_method_instance_t *mi,
     jl_code_instance_t *oldci = jl_atomic_load_relaxed(&mi->cache);
     int ret = 0;
     if (oldci == expected_ci) {
-        jl_atomic_store_relaxed(&ci->next, oldci);
-        if (oldci)
-            jl_gc_wb(ci, oldci);
-        jl_atomic_store_release(&mi->cache, ci);
-        jl_gc_wb(mi, ci);
+        jl_gc_write_atomic(ci, ci->next, oldci, relaxed);
+        jl_gc_write_atomic(mi, mi->cache, ci, release);
         ret = 1;
     }
     if (jl_is_method(mi->def.method))
@@ -1763,12 +1742,10 @@ static void cache_insert(
         }
         jl_genericmemory_t *oldcache = jl_atomic_load_relaxed(&mc->leafcache);
         jl_typemap_entry_t *old = (jl_typemap_entry_t*)jl_eqtable_get(oldcache, (jl_value_t*)tt, jl_nothing);
-        jl_atomic_store_relaxed(&newentry->next, old);
-        jl_gc_wb(newentry, old);
+        jl_gc_write_atomic(newentry, newentry->next, old, relaxed);
         jl_genericmemory_t *newcache = jl_eqtable_put(jl_atomic_load_relaxed(&mc->leafcache), (jl_value_t*)tt, (jl_value_t*)newentry, NULL);
         if (newcache != oldcache) {
-            jl_atomic_store_release(&mc->leafcache, newcache);
-            jl_gc_wb(mc, newcache);
+            jl_gc_write_atomic(mc, mc->leafcache, newcache, release);
         }
     }
     else {
@@ -1875,8 +1852,7 @@ static void recache_method(
     if (mc && tt != NULL) {
         jl_typemap_entry_t *entry = lookup_leafcache(jl_atomic_load_relaxed(&mc->leafcache), (jl_value_t*)tt, world);
         if (entry) {
-            entry->func.linfo = newmeth;
-            jl_gc_wb(entry, newmeth);
+            jl_gc_write(entry, entry->func.linfo, newmeth);
             orig_in_cache = 1;
             if (jl_egal((jl_value_t*)tt, (jl_value_t*)newmeth->specTypes)) {
                 if (mc) JL_UNLOCK(&mc->writelock);
@@ -1889,8 +1865,7 @@ static void recache_method(
         assert(cache);
         jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
         if (entry && jl_subtype((jl_value_t*)entry->sig, (jl_value_t*)newmeth->specTypes)) {
-            entry->func.linfo = newmeth;
-            jl_gc_wb(entry, newmeth);
+            jl_gc_write(entry, entry->func.linfo, newmeth);
             if (entry->simplesig == (void*)jl_nothing || jl_egal((jl_value_t*)entry->simplesig, compute_simplett((jl_tupletype_t*)newmeth->specTypes))) {
                 if (mc) JL_UNLOCK(&mc->writelock);
                 return; // cache entry already sufficient
@@ -2543,8 +2518,7 @@ JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, 
         if (!backedges) {
             // lazy-init the backedges array
             backedges = jl_alloc_vec_any(0);
-            callee->backedges = backedges;
-            jl_gc_wb(callee, backedges);
+            jl_gc_write(callee, callee->backedges, backedges);
         }
         push_edge(backedges, invokesig, caller);
     }
@@ -2575,8 +2549,7 @@ static void _typename_add_backedge(jl_typename_t *tn, int explct, void *env0)
         jl_genericmemory_t *newtable = jl_eqtable_put(allbackedges, (jl_value_t*)tn, (jl_value_t*)backedges, NULL);
         JL_GC_POP();
         if (newtable != allbackedges) {
-            jl_method_table->backedges = newtable;
-            jl_gc_wb(jl_method_table, newtable);
+            jl_gc_write(jl_method_table, jl_method_table->backedges, newtable);
         }
     }
     // check if the edge is already present and avoid adding a duplicate
@@ -2868,7 +2841,7 @@ JL_DLLEXPORT void jl_disable_new_worlds(void)
     jl_foreach_reachable_mtable(erase_all_backedges, mod_array, (void*)NULL);
 
     JL_LOCK(&jl_method_table->cache->writelock);
-    jl_method_table->backedges = (jl_genericmemory_t*)jl_an_empty_memory_any;
+    jl_gc_write(jl_method_table, jl_method_table->backedges, (jl_genericmemory_t*)jl_an_empty_memory_any);
     JL_UNLOCK(&jl_method_table->cache->writelock);
     JL_GC_POP();
 }
@@ -3156,16 +3129,14 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             }
             ssize_t idx;
             m_interferences = jl_idset_put_key(m_interferences, (jl_value_t*)method, &idx);
-            jl_atomic_store_release(&m->interferences, m_interferences);
-            jl_gc_wb(m, m_interferences);
+            jl_gc_write_atomic(m, m->interferences, m_interferences, release);
             for (j = 0; j < n; j++) {
                 jl_method_t *m2 = d[j];
                 if (m2 && method_in_interferences(m, m2)) {
                     jl_genericmemory_t *m2_interferences = jl_atomic_load_relaxed(&m2->interferences);
                     ssize_t idx;
                     m2_interferences = jl_idset_put_key(m2_interferences, (jl_value_t*)method, &idx);
-                    jl_atomic_store_release(&m2->interferences, m2_interferences);
-                    jl_gc_wb(m2, m2_interferences);
+                    jl_gc_write_atomic(m2, m2->interferences, m2_interferences, release);
                 }
             }
             loctag = jl_atomic_load_relaxed(&m->specializations); // use loctag for a gcroot
@@ -3217,8 +3188,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                     jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
                     ssize_t idx;
                     m_interferences = jl_idset_put_key(m_interferences, (jl_value_t*)method, &idx);
-                    jl_atomic_store_release(&m->interferences, m_interferences);
-                    jl_gc_wb(m, m_interferences);
+                    jl_gc_write_atomic(m, m->interferences, m_interferences, release);
                 }
                 // Add methods that intersect but are not more specific to interference list
                 jl_atomic_store_relaxed(&m->dispatch_status, m_dispatch);
@@ -3323,7 +3293,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                 }
             }
         }
-        jl_atomic_store_relaxed(&mc->leafcache, (jl_genericmemory_t*)jl_an_empty_memory_any);
+        jl_gc_write_atomic(mc, mc->leafcache, (jl_genericmemory_t*)jl_an_empty_memory_any, relaxed);
     }
     JL_UNLOCK(&mc->writelock);
     if (invalidated && _jl_debug_method_invalidation) {
@@ -3333,8 +3303,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     }
     jl_atomic_store_relaxed(&newentry->max_world, ~(size_t)0);
     jl_atomic_store_relaxed(&method->dispatch_status, dispatch_bits); // TODO: this should be sequenced fully after the world counter store
-    jl_atomic_store_release(&method->interferences, interferences);
-    jl_gc_wb(method, interferences);
+    jl_gc_write_atomic(method, method->interferences, interferences, release);
     JL_GC_POP();
 }
 
@@ -3471,8 +3440,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_get_unspecialized(jl_method_t *def JL_PROP
         unspec = jl_atomic_load_relaxed(&def->unspecialized);
         if (unspec == NULL) {
             unspec = jl_get_specialized(def, def->sig, jl_emptysvec);
-            jl_atomic_store_release(&def->unspecialized, unspec);
-            jl_gc_wb(def, unspec);
+            jl_gc_write_atomic(def, def->unspecialized, unspec, release);
         }
         JL_UNLOCK(&def->writelock);
     }
@@ -3778,9 +3746,7 @@ jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi JL_PROPAGATES_ROOT
             jl_atomic_load_relaxed(&codeinst2->edges));
     if (jl_atomic_load_relaxed(&codeinst->invoke) == NULL) {
         // TODO: add edges and jl_promote_ci_to_current here
-        codeinst->rettype_const = codeinst2->rettype_const;
-        if (codeinst->rettype_const)
-            jl_gc_wb(codeinst, codeinst->rettype_const);
+        jl_gc_write(codeinst, codeinst->rettype_const, codeinst2->rettype_const);
         uint8_t specsigflags;
         jl_callptr_t invoke;
         void *fptr;
@@ -4774,12 +4740,10 @@ jl_value_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_t *
             0, 0, 0);
     assert(jl_is_datatype(ftype));
     JL_GC_PUSH1(&ftype);
-    ftype->name->singletonname = name;
-    jl_gc_wb(ftype->name, name);
+    jl_gc_write(ftype->name, ftype->name->singletonname, name);
     jl_declare_constant_val3(NULL, module, tname, (jl_value_t*)ftype, PARTITION_KIND_CONST, new_world);
     jl_value_t *f = jl_new_struct(ftype);
-    ftype->instance = f;
-    jl_gc_wb(ftype, f);
+    jl_gc_write(ftype, ftype->instance, f);
     JL_GC_POP();
     return (jl_value_t*)f;
 }
@@ -5562,10 +5526,9 @@ JL_DLLEXPORT void jl_extern_c(jl_value_t *name, jl_value_t *declrt, jl_tupletype
         jl_error("@ccallable: could not find requested method");
     JL_GC_PUSH1(&meth);
     if (name == jl_nothing)
-        meth->ccallable = jl_svec2(declrt, (jl_value_t*)sigt);
+        jl_gc_write(meth, meth->ccallable, jl_svec2(declrt, (jl_value_t*)sigt));
     else
-        meth->ccallable = jl_svec3(declrt, (jl_value_t*)sigt, name);
-    jl_gc_wb(meth, meth->ccallable);
+        jl_gc_write(meth, meth->ccallable, jl_svec3(declrt, (jl_value_t*)sigt, name));
     JL_GC_POP();
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -1728,7 +1728,7 @@ static void cache_insert(
     JL_GC_PUSH2(&simplett, &newentry);
     simplett = (jl_datatype_t*)compute_simplett(cachett);
     newentry = jl_typemap_alloc(cachett, simplett, guardsigs, (jl_value_t*)newmeth, min_valid, max_valid);
-    if (mc && cachett == tt && tt->hash && !tt->hasfreetypevars) {
+    if (mc && tt && cachett == tt && tt->hash && !tt->hasfreetypevars) {
         // we check `tt->hash` exists, since otherwise the NamedTuple
         // constructor and `structdiff` method pollutes this lookup with a lot
         // of garbage in the linear table search

--- a/src/gf.c
+++ b/src/gf.c
@@ -586,6 +586,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_uninferred(
                 return codeinst;
             jl_debuginfo_t *debuginfo = jl_atomic_load_relaxed(&codeinst->debuginfo);
             if (di != debuginfo) {
+                jl_gc_wb(codeinst, di);
                 if (!(debuginfo == NULL && jl_atomic_cmpswap_relaxed(&codeinst->debuginfo, &debuginfo, di)))
                     if (!(debuginfo && jl_egal((jl_value_t*)debuginfo, (jl_value_t*)di)))
                         continue;
@@ -2344,6 +2345,7 @@ static void _invalidate_backedges(jl_method_instance_t *replaced_mi, jl_code_ins
     if (!replaced_ci) {
         // We know all backedges are deleted - clear them eagerly
         // Clears both array and flags
+        jl_gc_wb(replaced_mi, NULL);
         replaced_mi->backedges = NULL;
         jl_atomic_fetch_and_relaxed(&replaced_mi->flags, ~MI_FLAG_BACKEDGES_ALL);
     }
@@ -2812,12 +2814,14 @@ static int erase_method_backedges(jl_typemap_entry_t *def, void *closure)
         for (i = 0; i < l; i++) {
             jl_method_instance_t *mi = (jl_method_instance_t*)jl_svecref(specializations, i);
             if ((jl_value_t*)mi != jl_nothing) {
+                jl_gc_wb(mi, NULL);
                 mi->backedges = 0;
             }
         }
     }
     else {
         jl_method_instance_t *mi = (jl_method_instance_t*)specializations;
+        jl_gc_wb(mi, NULL);
         mi->backedges = 0;
     }
     JL_UNLOCK(&method->writelock);

--- a/src/iddict.c
+++ b/src/iddict.c
@@ -61,8 +61,7 @@ static inline int jl_table_assign_bp(jl_genericmemory_t **pa, jl_value_t *key, j
             }
             if (jl_egal(key, k2)) {
                 if (jl_atomic_load_relaxed(&tab[index + 1]) != NULL) {
-                    jl_atomic_store_release(&tab[index + 1], val);
-                    jl_gc_wb(a, val);
+                    jl_gc_write_atomic(a, tab[index + 1], val, release);
                     return 0;
                 }
                 // `nothing` is our sentinel value for deletion, so need to keep searching if it's also our search key
@@ -80,10 +79,8 @@ static inline int jl_table_assign_bp(jl_genericmemory_t **pa, jl_value_t *key, j
         } while (iter <= maxprobe && index != orig);
 
         if (empty_slot != -1) {
-            jl_atomic_store_release(&tab[empty_slot], key);
-            jl_gc_wb(a, key);
-            jl_atomic_store_release(&tab[empty_slot + 1], val);
-            jl_gc_wb(a, val);
+            jl_gc_write_atomic(a, tab[empty_slot], key, release);
+            jl_gc_write_atomic(a, tab[empty_slot + 1], val, release);
             return 1;
         }
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -726,8 +726,7 @@ jl_value_t *jl_code_or_ci_for_interpreter(jl_method_instance_t *mi, size_t world
                 // under the assumption that the interpreter may need to
                 // access it frequently. TODO: Have some sort of usage-based
                 // cache here.
-                m->source = (jl_value_t*)src;
-                jl_gc_wb(m, src);
+                jl_gc_write(m, m->source, src);
             }
             ret = (jl_value_t*)src;
         }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -556,8 +556,9 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
                 // GC preserve the old_scope, since it is not rooted in the `jl_handler_t *`,
                 // the newly entered scope is preserved through the current_task.
                 JL_GC_PUSH1(&old_scope);
-                ct->scope = eval_value(jl_enternode_scope(stmt), s);
-                jl_gc_wb_current_task(ct, ct->scope);
+                jl_value_t *new_scope = eval_value(jl_enternode_scope(stmt), s);
+                jl_gc_wb_current_task(ct, new_scope);
+                ct->scope = new_scope;
                 if (!jl_setjmp(__eh.eh_ctx, 0)) {
                     ct->eh = &__eh;
                     eval_body(stmts, s, next_ip, toplevel);

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -598,8 +598,7 @@ static jl_genericmemory_t *jl_decode_value_memory(jl_ircode_state *s, jl_value_t
         jl_value_t **data = (jl_value_t**)m->ptr;
         size_t i, numel = m->length;
         for (i = 0; i < numel; i++) {
-            data[i] = jl_decode_value(s);
-            jl_gc_wb(m, data[i]);
+            jl_gc_write(m, data[i], jl_decode_value(s));
         }
     }
     else if (layout->first_ptr >= 0) {
@@ -614,8 +613,7 @@ static jl_genericmemory_t *jl_decode_value_memory(jl_ircode_state *s, jl_value_t
                 jl_value_t **fld = &((jl_value_t**)data)[ptr];
                 if ((char*)fld != start)
                     ios_readall(s->s, start, (const char*)fld - start);
-                *fld = jl_decode_value(s);
-                jl_gc_wb(m, fld);
+                jl_gc_write(m, *fld, jl_decode_value(s));
                 start = (char*)&fld[1];
             }
             data += elsz;
@@ -681,8 +679,7 @@ static jl_value_t *jl_decode_value_expr(jl_ircode_state *s, uint8_t tag)
     jl_value_t **data = jl_array_ptr_data(e->args);
     jl_value_t *owner = jl_array_owner(e->args);
     for (i = 0; i < len; i++) {
-        data[i] = jl_decode_value(s);
-        jl_gc_wb(owner, data[i]);
+        jl_gc_write(owner, data[i], jl_decode_value(s));
     }
     JL_GC_POP();
     return (jl_value_t*)e;
@@ -711,8 +708,7 @@ static jl_value_t *jl_decode_value_phi(jl_ircode_state *s, uint8_t tag)
     }
     jl_value_t **data_v = jl_array_ptr_data(v);
     for (i = 0; i < len_v; i++) {
-        data_v[i] = jl_decode_value(s);
-        jl_gc_wb(jl_array_owner(v), data_v[i]);
+        jl_gc_write(jl_array_owner(v), data_v[i], jl_decode_value(s));
     }
     JL_GC_POP();
     return phi;
@@ -731,8 +727,7 @@ static jl_value_t *jl_decode_value_phic(jl_ircode_state *s, uint8_t tag)
     phic = jl_new_struct(jl_phicnode_type, v);
     jl_value_t **data = jl_array_ptr_data(v);
     for (i = 0; i < len; i++) {
-        data[i] = jl_decode_value(s);
-        jl_gc_wb(jl_array_owner(v), data[i]);
+        jl_gc_write(jl_array_owner(v), data[i], jl_decode_value(s));
     }
     JL_GC_POP();
     return phic;
@@ -768,8 +763,7 @@ static jl_value_t *jl_decode_value_any(jl_ircode_state *s)
             jl_value_t **fld = &((jl_value_t**)data)[ptr];
             if ((char*)fld != start)
                 ios_readall(s->s, start, (const char*)fld - start);
-            *fld = jl_decode_value(s);
-            jl_gc_wb(v, *fld);
+            jl_gc_write(v, *fld, jl_decode_value(s));
             start = (char*)&fld[1];
         }
         JL_GC_POP();
@@ -1026,8 +1020,7 @@ JL_DLLEXPORT jl_string_t *jl_compress_ir(jl_method_t *m, jl_code_info_t *code)
     ios_mem(&dest, 0);
 
     if (m->roots == NULL) {
-        m->roots = jl_alloc_vec_any(0);
-        jl_gc_wb(m, m->roots);
+        jl_gc_write(m, m->roots, jl_alloc_vec_any(0));
     }
     jl_value_t *edges = code->edges;
     jl_ircode_state s = {
@@ -1147,8 +1140,7 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ir(jl_method_t *m, jl_code_instance_t
     code->inlining_cost = jl_decode_inlining_cost(read_uint8(s.s));
 
     size_t nslots = read_int32(s.s);
-    code->slotflags = jl_alloc_array_1d(jl_array_uint8_type, nslots);
-    jl_gc_wb(code, code->slotflags);
+    jl_gc_write(code, code->slotflags, jl_alloc_array_1d(jl_array_uint8_type, nslots));
     ios_readall(s.s, jl_array_data(code->slotflags, char), nslots);
 
     if (flags.bits.nargsmatchesmethod) {
@@ -1158,17 +1150,14 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ir(jl_method_t *m, jl_code_instance_t
     }
 
     size_t i, l = read_uint64(s.s);
-    code->code = jl_alloc_array_1d(jl_array_any_type, l);
-    jl_gc_wb(code, code->code);
+    jl_gc_write(code, code->code, jl_alloc_array_1d(jl_array_any_type, l));
     for (i = 0; i < l; i++) {
         s.ssaid = i;
         jl_array_ptr_set(code->code, i, jl_decode_value(&s));
     }
     s.ssaid = 0;
-    code->ssavaluetypes = jl_decode_value(&s);
-    jl_gc_wb(code, code->ssavaluetypes);
-    code->ssaflags = jl_alloc_array_1d(jl_array_uint32_type, l);
-    jl_gc_wb(code, code->ssaflags);
+    jl_gc_write(code, code->ssavaluetypes, jl_decode_value(&s));
+    jl_gc_write(code, code->ssaflags, jl_alloc_array_1d(jl_array_uint32_type, l));
     uint32_t *ssaflags_data = jl_array_data(code->ssaflags, uint32_t);
     if (flags.bits.has_ssaflags)
         ios_readall(s.s, (char*)ssaflags_data, l * sizeof(*ssaflags_data));
@@ -1176,21 +1165,20 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ir(jl_method_t *m, jl_code_instance_t
         memset(ssaflags_data, 0, l * sizeof(*ssaflags_data));
 
     if (m->is_for_opaque_closure) {
-        code->slottypes = jl_decode_value(&s);
-        jl_gc_wb(code, code->slottypes);
+        jl_gc_write(code, code->slottypes, jl_decode_value(&s));
     }
 
     slotnames = jl_decode_value(&s);
     if (!jl_is_string(slotnames))
         slotnames = m->slot_syms;
-    code->slotnames = jl_uncompress_argnames(slotnames);
-    jl_gc_wb(code, code->slotnames);
+    jl_gc_write(code, code->slotnames, jl_uncompress_argnames(slotnames));
 
-    if (metadata)
-        code->debuginfo = jl_atomic_load_relaxed(&metadata->debuginfo);
-    else
-        code->debuginfo = m->debuginfo;
-    jl_gc_wb(code, code->debuginfo);
+    if (metadata) {
+        jl_debuginfo_t *new_debuginfo = jl_atomic_load_relaxed(&metadata->debuginfo);
+        jl_gc_wb(code, new_debuginfo);
+        code->debuginfo = new_debuginfo;
+    } else
+        jl_gc_write(code, code->debuginfo, m->debuginfo);
     assert(code->debuginfo);
     assert(jl_array_nrows(code->code) == codelocs_nstmts(code->debuginfo->codelocs) || jl_string_len(code->debuginfo->codelocs) == 0);
 
@@ -1201,14 +1189,11 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ir(jl_method_t *m, jl_code_instance_t
     ios_close(s.s);
     JL_UNLOCK(&m->writelock); // Might GC
     if (metadata) {
-        code->parent = jl_get_ci_mi(metadata);
-        jl_gc_wb(code, code->parent);
-        code->rettype = metadata->rettype;
-        jl_gc_wb(code, code->rettype);
+        jl_gc_write(code, code->parent, jl_get_ci_mi(metadata));
+        jl_gc_write(code, code->rettype, metadata->rettype);
         code->min_world = jl_atomic_load_relaxed(&metadata->min_world);
         code->max_world = jl_atomic_load_relaxed(&metadata->max_world);
-        code->edges = (jl_value_t*)s.edges;
-        jl_gc_wb(code, s.edges);
+        jl_gc_write(code, code->edges, (jl_value_t*)s.edges);
     }
     JL_GC_POP();
 

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1093,8 +1093,10 @@ JL_DLLEXPORT jl_string_t *jl_compress_ir(jl_method_t *m, jl_code_info_t *code)
     ios_flush(s.s);
     v = jl_pchar_to_string(s.s->buf, s.s->size);
     ios_close(s.s);
-    if (jl_array_nrows(m->roots) == 0)
+    if (jl_array_nrows(m->roots) == 0) {
+        jl_gc_wb(m, NULL);
         m->roots = NULL;
+    }
     JL_UNLOCK(&m->writelock); // Might GC
     JL_GC_POP();
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -551,12 +551,10 @@ void jl_generate_fptr_for_unspecialized_impl(jl_code_instance_t *unspec)
             ++UnspecFPtrCount;
             jl_svec_t *edges = (jl_svec_t*)src->edges;
             if (jl_is_svec(edges)) {
-                jl_atomic_store_release(&unspec->edges, edges); // n.b. this assumes the field was always empty svec(), which is not entirely true
-                jl_gc_wb(unspec, edges);
+                jl_gc_write_atomic(unspec, unspec->edges, edges, release); // n.b. this assumes the field was always empty svec(), which is not entirely true
             }
             jl_debuginfo_t *debuginfo = src->debuginfo;
-            jl_atomic_store_release(&unspec->debuginfo, debuginfo); // n.b. this assumes the field was previously NULL, which is not entirely true
-            jl_gc_wb(unspec, debuginfo);
+            jl_gc_write_atomic(unspec, unspec->debuginfo, debuginfo, release); // n.b. this assumes the field was previously NULL, which is not entirely true
             jl_emit_codeinsts_to_jit(&unspec, &src, 1);
             jl_ExecutionEngine->publishCIs(unspec, true);
         }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1257,8 +1257,7 @@ static void cache_insert_type_set(jl_datatype_t *val, uint_t hv)
         else
             newsz = sz << 2;
         a = cache_rehash_set(a, newsz);
-        jl_atomic_store_release(&val->name->cache, a);
-        jl_gc_wb(val->name, a);
+        jl_gc_write_atomic(val->name, val->name->cache, a, release);
     }
 }
 
@@ -1295,8 +1294,7 @@ static void cache_insert_type_linear(jl_datatype_t *type, ssize_t insert_at)
     if (n == 0 || jl_svecref(cache, n - 1) != jl_nothing) {
         jl_svec_t *nc = jl_svec_fill(n < 4 ? 4 : n * 2, jl_nothing);
         memcpy(jl_svec_data(nc), jl_svec_data(cache), sizeof(void*) * n);
-        jl_atomic_store_release(&type->name->linearcache, nc);
-        jl_gc_wb(type->name, nc);
+        jl_gc_write_atomic(type->name, type->name->linearcache, nc, release);
         cache = nc;
     }
     assert(jl_svecref(cache, insert_at) == jl_nothing);
@@ -1324,8 +1322,7 @@ void jl_cache_type_(jl_datatype_t *type)
         jl_value_t *uw = jl_unwrap_unionall(key[0]);
         if (jl_is_datatype(uw) && key[0] == ((jl_datatype_t*)uw)->name->wrapper) {
             jl_typename_t *tn2 = ((jl_datatype_t*)uw)->name;
-            jl_atomic_store_release(&tn2->Typeofwrapper, (jl_value_t*)type);
-            jl_gc_wb(tn2, type);
+            jl_gc_write_atomic(tn2, tn2->Typeofwrapper, (jl_value_t*)type, release);
             return;
         }
     }
@@ -2334,8 +2331,10 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
             jl_value_t *tw = extract_wrapper(pi);
             if (tw && tw != pi && (tn != jl_type_typename || jl_typeof(pi) == jl_typeof(tw)) &&
                     !jl_has_free_typevars(pi) && jl_types_equal(pi, tw)) {
-                iparams[i] = tw;
-                if (p) jl_gc_wb(p, tw);
+                if (p)
+                    jl_gc_write(p, iparams[i], tw);
+                else
+                    iparams[i] = tw;
             }
         }
         if (tn == jl_type_typename && jl_is_typeeq(iparams[0]) &&
@@ -2414,8 +2413,10 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
             jl_value_t *pi = iparams[i];
             jl_value_t *newp = normalize_unionalls(pi);
             if (newp != pi) {
-                iparams[i] = newp;
-                if (p) jl_gc_wb(p, newp);
+                if (p)
+                    jl_gc_write(p, iparams[i], newp);
+                else
+                    iparams[i] = newp;
                 changed = 1;
             }
             if (istuple && cacheable && !jl_is_concrete_type(newp))
@@ -2450,8 +2451,10 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
             if (cacheable || !jl_has_free_typevars(pi)) {
                 pi = jl_as_global_root(pi, cacheable);
                 if (pi != NULL) {
-                    iparams[i] = pi;
-                    if (p) jl_gc_wb(p, pi);
+                    if (p)
+                        jl_gc_write(p, iparams[i], pi);
+                    else
+                        iparams[i] = pi;
                 }
             }
         }
@@ -2490,11 +2493,9 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
     top.tt = (jl_datatype_t*)ndt;
     top.prev = stack;
     stack = &top;
-    ndt->name = tn;
-    jl_gc_wb(ndt, ndt->name);
+    jl_gc_write(ndt, ndt->name, tn);
     ndt->super = NULL;
-    ndt->parameters = p;
-    jl_gc_wb(ndt, ndt->parameters);
+    jl_gc_write(ndt, ndt->parameters, p);
     ndt->types = NULL; // to be filled in below
     int invalid = 0;
     if (istuple) {
@@ -2527,7 +2528,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                 if (invalid) break;
             }
             if (values_tt == jl_bottom_type && nf > 0) {
-                ndt->types = jl_svec_fill(nf, jl_bottom_type);
+                jl_gc_write(ndt, ndt->types, jl_svec_fill(nf, jl_bottom_type));
             }
             else {
                 if (!jl_is_datatype(values_tt)) {
@@ -2539,9 +2540,8 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                         jl_error("NamedTuple names and field types must have matching lengths");
                     invalid = 1;
                 }
-                ndt->types = ((jl_datatype_t*)values_tt)->parameters;
+                jl_gc_write(ndt, ndt->types, ((jl_datatype_t*)values_tt)->parameters);
             }
-            jl_gc_wb(ndt, ndt->types);
         }
         else {
             ndt->types = jl_emptysvec; // XXX: this is essentially always incorrect
@@ -2584,8 +2584,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
             JL_GC_POP();
             return NULL;
         }
-        ndt->super = (jl_datatype_t *)super;
-        jl_gc_wb(ndt, ndt->super);
+        jl_gc_write(ndt, ndt->super, (jl_datatype_t *)super);
     }
     jl_svec_t *ftypes = dt->types;
     if (ftypes == NULL)
@@ -2594,8 +2593,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
         // in the process of creating this type definition:
         // need to instantiate the super and types fields later
         if (tn->partial == NULL) {
-            tn->partial = jl_alloc_vec_any(0);
-            jl_gc_wb(tn, tn->partial);
+            jl_gc_write(tn, tn->partial, jl_alloc_vec_any(0));
         }
         jl_array_ptr_1d_push(tn->partial, (jl_value_t*)ndt);
     }
@@ -2608,10 +2606,9 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
         else if (cacheable) {
             // recursively instantiate the types of the fields
             if (dt->types == NULL)
-                ndt->types = jl_compute_fieldtypes(ndt, stack, cacheable);
+                jl_gc_write(ndt, ndt->types, jl_compute_fieldtypes(ndt, stack, cacheable));
             else
-                ndt->types = inst_ftypes(ftypes, env, stack, cacheable);
-            jl_gc_wb(ndt, ndt->types);
+                jl_gc_write(ndt, ndt->types, inst_ftypes(ftypes, env, stack, cacheable));
         }
     }
 
@@ -2759,9 +2756,10 @@ static jl_value_t *inst_tuple_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_
                 pi = jl_bottom_type;
             }
         }
-        iparams[i] = pi;
         if (ip_heap)
-            jl_gc_wb(ip_heap, pi);
+            jl_gc_write(ip_heap, iparams[i], pi);
+        else
+            iparams[i] = pi;
         bound |= (pi != elt);
     }
     if (t != NULL && bound)
@@ -3008,8 +3006,7 @@ jl_typeeq_t *jl_wrap_Type(jl_value_t *t)
     jl_set_typetagof(te, jl_typeeq_tag, 0);
     te->T = t;
     if (t == jl_bottom_type && jl_typeofbottom_type && jl_typeofbottom_type->name) {
-        jl_atomic_store_relaxed(&jl_typeofbottom_type->name->Typeofwrapper, (jl_value_t*)te);
-        jl_gc_wb(jl_typeofbottom_type->name, te);
+        jl_gc_write_atomic(jl_typeofbottom_type->name, jl_typeofbottom_type->name->Typeofwrapper, (jl_value_t*)te, relaxed);
     }
     JL_GC_POP();
     return te;
@@ -3091,8 +3088,7 @@ JL_DLLEXPORT jl_svec_t *jl_compute_fieldtypes(jl_datatype_t *st JL_PROPAGATES_RO
     jl_typestack_t top;
     top.tt = st;
     top.prev = (jl_typestack_t*)stack;
-    st->types = inst_ftypes(wt->types, &env[n - 1], &top, cacheable);
-    jl_gc_wb(st, st->types);
+    jl_gc_write(st, st->types, inst_ftypes(wt->types, &env[n - 1], &top, cacheable));
     return st->types;
 }
 
@@ -3127,8 +3123,7 @@ void jl_reinstantiate_inner_types(jl_datatype_t *t) // can throw!
         for (i = 0; i < n; i++)
             env[i].val = jl_svecref(ndt->parameters, i);
 
-        ndt->super = (jl_datatype_t*)inst_type_w_((jl_value_t*)t->super, &env[n - 1], &top, 1, 0);
-        jl_gc_wb(ndt, ndt->super);
+        jl_gc_write(ndt, ndt->super, (jl_datatype_t*)inst_type_w_((jl_value_t*)t->super, &env[n - 1], &top, 1, 0));
     }
 
     if (t->types != jl_emptysvec) {
@@ -3147,14 +3142,13 @@ void jl_reinstantiate_inner_types(jl_datatype_t *t) // can throw!
             jl_typestack_t ndt_top;
             ndt_top.tt = ndt;
             ndt_top.prev = &top;
-            ndt->types = inst_ftypes(t->types, &env[n - 1], &ndt_top, 1);
-            jl_gc_wb(ndt, ndt->types);
+            jl_gc_write(ndt, ndt->types, inst_ftypes(t->types, &env[n - 1], &ndt_top, 1));
             if (ndt->isconcretetype) { // cacheable
                 jl_compute_field_offsets(ndt);
             }
             jl_array_ptr_set(partial, j, NULL);
         }
-        t->name->partial = NULL;
+        jl_gc_write(t->name, t->name->partial, NULL);
     }
     else {
         assert(jl_field_names(t) == jl_emptysvec);
@@ -4202,13 +4196,13 @@ void post_boot_hooks(void)
     jl_datatype_t *jl_unsigned_type = (jl_datatype_t*)core("Unsigned");
     jl_datatype_t *jl_integer_type = (jl_datatype_t*)core("Integer");
 
-    jl_bool_type->super = jl_integer_type;
-    jl_uint8_type->super = jl_unsigned_type;
-    jl_uint16_type->super = jl_unsigned_type;
-    jl_uint32_type->super = jl_unsigned_type;
-    jl_uint64_type->super = jl_unsigned_type;
-    jl_int32_type->super = jl_signed_type;
-    jl_int64_type->super = jl_signed_type;
+    jl_gc_write(jl_bool_type, jl_bool_type->super, jl_integer_type);
+    jl_gc_write(jl_uint8_type, jl_uint8_type->super, jl_unsigned_type);
+    jl_gc_write(jl_uint16_type, jl_uint16_type->super, jl_unsigned_type);
+    jl_gc_write(jl_uint32_type, jl_uint32_type->super, jl_unsigned_type);
+    jl_gc_write(jl_uint64_type, jl_uint64_type->super, jl_unsigned_type);
+    jl_gc_write(jl_int32_type, jl_int32_type->super, jl_signed_type);
+    jl_gc_write(jl_int64_type, jl_int64_type->super, jl_signed_type);
 
     jl_stackovf_exception       = jl_new_struct_uninit((jl_datatype_t*)core("StackOverflowError"));
     jl_diverror_exception       = jl_new_struct_uninit((jl_datatype_t*)core("DivideError"));

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1222,11 +1222,11 @@ static int cache_insert_type_set_(jl_svec_t *a, jl_datatype_t *val, uint_t hv, i
     do {
         jl_value_t *tab_i = jl_atomic_load_relaxed(&tab[index]);
         if (tab_i == jl_nothing) {
+            jl_gc_wb(a, (jl_value_t*)val);
             if (atomic)
                 jl_atomic_store_release(&tab[index], (jl_value_t*)val);
             else
                 jl_atomic_store_relaxed(&tab[index], (jl_value_t*)val);
-            jl_gc_wb(a, val);
             return 1;
         }
         index = (index + 1) & (sz - 1);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1266,8 +1266,8 @@ STATIC_INLINE jl_value_t *jl_svecset(
     // while svec is supposedly immutable, in practice we sometimes publish it
     // first and set the values lazily. Those users occasionally might need to
     // instead use jl_atomic_store_release here.
-    jl_atomic_store_relaxed((_Atomic(jl_value_t*)*)jl_svec_data(t) + i, (jl_value_t*)x);
     jl_gc_wb(t, x);
+    jl_atomic_store_relaxed((_Atomic(jl_value_t*)*)jl_svec_data(t) + i, (jl_value_t*)x);
     return (jl_value_t*)x;
 }
 #endif

--- a/src/julia.h
+++ b/src/julia.h
@@ -1306,6 +1306,23 @@ STATIC_INLINE jl_value_t *jl_genericmemory_owner(jl_genericmemory_t *m JL_PROPAG
 #endif
 #endif
 
+// Utility for doing a basic write with the appropriate write barrier.
+// `parent` is the GC-tracked owner, `field` is an lvalue (e.g. obj->member),
+// and `val` is the new value to store. The barrier is emitted *before* the
+// store and receives the new value being stored.
+#define jl_gc_write(parent, field, val) do { \
+    void *_jl_write_val = (void*)(val); \
+    jl_gc_wb((parent), _jl_write_val); \
+    (field) = (__typeof__(field))_jl_write_val; \
+} while (0)
+
+// Atomic variant: `field` must be an _Atomic lvalue, `order` is relaxed or release.
+#define jl_gc_write_atomic(parent, field, val, order) do { \
+    __typeof__(jl_atomic_load_relaxed(&(field))) _jl_write_val = (__typeof__(jl_atomic_load_relaxed(&(field))))(val); \
+    jl_gc_wb((parent), (const void *)_jl_write_val); \
+    jl_atomic_store_##order(&(field), _jl_write_val); \
+} while (0)
+
 /*
   how - allocation style
   0 = data is inlined
@@ -1359,10 +1376,7 @@ STATIC_INLINE jl_value_t *jl_genericmemory_ptr_set(
     jl_genericmemory_t *m_ = (jl_genericmemory_t*)m;
     assert(((jl_datatype_t*)jl_typetagof(m_))->layout->flags.arrayelem_isboxed);
     assert(i < m_->length);
-    jl_atomic_store_release(((_Atomic(jl_value_t*)*)(m_->ptr)) + i, (jl_value_t*)x);
-    if (x) {
-        jl_gc_wb(m, x);
-    }
+    jl_gc_write_atomic(m, ((_Atomic(jl_value_t*)*)(m_->ptr))[i], (jl_value_t*)x, release);
     return (jl_value_t*)x;
 }
 #endif
@@ -1407,10 +1421,7 @@ STATIC_INLINE jl_value_t *jl_array_ptr_set(
 {
     assert(((jl_datatype_t*)jl_typetagof(((jl_array_t*)a)->ref.mem))->layout->flags.arrayelem_isboxed);
     assert(i < jl_array_len(a));
-    jl_atomic_store_release(jl_array_data(a, _Atomic(jl_value_t*)) + i, (jl_value_t*)x);
-    if (x) {
-        jl_gc_wb(jl_array_owner((jl_array_t*)a), x);
-    }
+    jl_gc_write_atomic(jl_array_owner((jl_array_t*)a), jl_array_data(a, _Atomic(jl_value_t*))[i], (jl_value_t*)x, release);
     return (jl_value_t*)x;
 }
 #endif

--- a/src/method.c
+++ b/src/method.c
@@ -1358,9 +1358,9 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
         jl_errorf("cannot add methods to builtin function `%s`", jl_symbol_name(name));
 
     m = jl_new_method_uninit(module);
-    m->external_mt = (jl_value_t*)external_mt;
     if (external_mt)
-        jl_gc_wb(m, external_mt);
+        jl_gc_wb_fresh(m, external_mt);
+    m->external_mt = (jl_value_t*)external_mt;
     m->sig = argtype;
     m->name = name;
     m->isva = isva;

--- a/src/method.c
+++ b/src/method.c
@@ -39,8 +39,7 @@ void jl_add_scanned_method(jl_module_t *m, jl_method_t *meth)
 {
     JL_LOCK(&m->lock);
     if (m->scanned_methods == jl_nothing) {
-        m->scanned_methods = (jl_value_t*)jl_alloc_vec_any(0);
-        jl_gc_wb(m, m->scanned_methods);
+        jl_gc_write(m, m->scanned_methods, (jl_value_t*)jl_alloc_vec_any(0));
     }
     jl_array_ptr_1d_push((jl_array_t*)m->scanned_methods, (jl_value_t*)meth);
     JL_UNLOCK(&m->lock);
@@ -125,8 +124,7 @@ static jl_value_t *resolve_definition_effects(jl_value_t *expr, jl_module_t *mod
         if (typ == (jl_value_t*)jl_voidpointer_type) {
             jl_value_t *a = jl_exprarg(e, 1);
             JL_TYPECHK(cfunction method definition, quotenode, a);
-            *(jl_value_t**)a = jl_toplevel_eval(module, *(jl_value_t**)a);
-            jl_gc_wb(a, *(jl_value_t**)a);
+            jl_gc_write(a, *(jl_value_t**)a, jl_toplevel_eval(module, *(jl_value_t**)a));
         }
         jl_value_t *rt = jl_exprarg(e, 2);
         jl_value_t *at = jl_exprarg(e, 3);
@@ -462,17 +460,14 @@ jl_code_info_t *jl_new_code_info_from_ir(jl_expr_t *ir)
 
     jl_array_t *codelocs_any = (jl_array_t*)jl_exprarg(ir, 3);
     jl_array_t *linetable = (jl_array_t*)jl_exprarg(ir, 4);
-    li->debuginfo = jl_linetable_to_debuginfo(codelocs_any, linetable);
-    jl_gc_wb(li, li->debuginfo);
+    jl_gc_write(li, li->debuginfo, jl_linetable_to_debuginfo(codelocs_any, linetable));
 
     assert(jl_is_expr(bodyex));
     jl_array_t *body = bodyex->args;
-    li->code = body;
-    jl_gc_wb(li, li->code);
+    jl_gc_write(li, li->code, body);
     size_t n = jl_array_nrows(body);
     jl_value_t **bd = (jl_value_t**)jl_array_ptr_data((jl_array_t*)li->code);
-    li->ssaflags = jl_alloc_array_1d(jl_array_uint32_type, n);
-    jl_gc_wb(li, li->ssaflags);
+    jl_gc_write(li, li->ssaflags, jl_alloc_array_1d(jl_array_uint32_type, n));
     int inbounds_depth = 0; // number of stacked inbounds
     // isempty(inline_flags): no user callsite inline annotation
     // last(inline_flags) == 1: callsite inline region
@@ -631,12 +626,9 @@ jl_code_info_t *jl_new_code_info_from_ir(jl_expr_t *ir)
     jl_value_t *ssavalue_types = jl_array_ptr_ref(vinfo, 2);
     assert(jl_is_long(ssavalue_types));
     size_t nssavalue = jl_unbox_long(ssavalue_types);
-    li->slotnames = jl_alloc_array_1d(jl_array_symbol_type, nslots);
-    jl_gc_wb(li, li->slotnames);
-    li->slotflags = jl_alloc_array_1d(jl_array_uint8_type, nslots);
-    jl_gc_wb(li, li->slotflags);
-    li->ssavaluetypes = jl_box_long(nssavalue);
-    jl_gc_wb(li, li->ssavaluetypes);
+    jl_gc_write(li, li->slotnames, jl_alloc_array_1d(jl_array_symbol_type, nslots));
+    jl_gc_write(li, li->slotflags, jl_alloc_array_1d(jl_array_uint8_type, nslots));
+    jl_gc_write(li, li->ssavaluetypes, jl_box_long(nssavalue));
 
     // Flags that need to be copied to slotflags
     const uint8_t vinfo_mask = 8 | 16 | 32 | 64;
@@ -1008,8 +1000,7 @@ JL_DLLEXPORT void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
                     jl_error("duplicate @generated function body");
                 jl_value_t *gexpr = jl_exprarg(st, 1);
                 // the frontend would put (new (core GeneratedFunctionStub) funcname argnames sp) here, for example
-                m->generator = jl_toplevel_eval(m->module, gexpr);
-                jl_gc_wb(m, m->generator);
+                jl_gc_write(m, m->generator, jl_toplevel_eval(m->module, gexpr));
                 st = jl_nothing;
             }
             else if (nargs == 1 && jl_exprarg(st, 0) == (jl_value_t*)jl_generated_only_sym) {
@@ -1032,20 +1023,15 @@ JL_DLLEXPORT void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
     if (src->nargs == 0)
         src->nargs = m->nargs;
     assert(m->nargs == src->nargs);
-    src->code = copy;
-    jl_gc_wb(src, copy);
-    m->slot_syms = jl_compress_argnames(src->slotnames);
-    jl_gc_wb(m, m->slot_syms);
+    jl_gc_write(src, src->code, copy);
+    jl_gc_write(m, m->slot_syms, jl_compress_argnames(src->slotnames));
     if (gen_only) {
         m->source = NULL;
     }
     else {
-        m->debuginfo = src->debuginfo;
-        jl_gc_wb(m, m->debuginfo);
-        m->source = (jl_value_t*)src;
-        jl_gc_wb(m, m->source);
-        m->source = (jl_value_t*)jl_compress_ir(m, NULL);
-        jl_gc_wb(m, m->source);
+        jl_gc_write(m, m->debuginfo, src->debuginfo);
+        jl_gc_write(m, m->source, (jl_value_t*)src);
+        jl_gc_write(m, m->source, (jl_value_t*)jl_compress_ir(m, NULL));
     }
     JL_GC_POP();
 }
@@ -1166,7 +1152,7 @@ void jl_mi_done_backedges(jl_method_instance_t *mi JL_PROPAGATES_ROOT, uint8_t o
             }
             if (insb == 0) {
                 // All were deleted
-                mi->backedges = NULL;
+                jl_gc_write(mi, mi->backedges, NULL);
             } else {
                 jl_array_del_end(backedges, n - insb);
             }
@@ -1198,8 +1184,7 @@ jl_method_t *jl_make_opaque_closure_method(jl_module_t *module, jl_value_t *name
     m->file = jl_is_symbol(file) ? (jl_sym_t*)file : jl_empty_sym;
     m->line = jl_linenode_line(functionloc);
     if (isinferred) {
-        m->slot_syms = jl_compress_argnames(ci->slotnames);
-        jl_gc_wb(m, m->slot_syms);
+        jl_gc_write(m, m->slot_syms, jl_compress_argnames(ci->slotnames));
     } else {
         jl_method_set_source(m, ci);
     }
@@ -1457,12 +1442,10 @@ static void add_root_block(jl_array_t *root_blocks, uint64_t modid, size_t len)
 static void prepare_method_for_roots(jl_method_t *m, uint64_t modid)
 {
     if (!m->roots) {
-        m->roots = jl_alloc_vec_any(0);
-        jl_gc_wb(m, m->roots);
+        jl_gc_write(m, m->roots, jl_alloc_vec_any(0));
     }
     if (!m->root_blocks && modid != 0) {
-        m->root_blocks = jl_alloc_array_1d(jl_array_uint64_type, 0);
-        jl_gc_wb(m, m->root_blocks);
+        jl_gc_write(m, m->root_blocks, jl_alloc_array_1d(jl_array_uint64_type, 0));
     }
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -392,9 +392,7 @@ JL_DLLEXPORT void jl_update_loaded_bpart(jl_binding_t *b, jl_binding_partition_t
     struct implicit_search_resolution resolution = jl_resolve_implicit_import(b, NULL, jl_atomic_load_acquire(&jl_world_counter), 0);
     jl_atomic_store_relaxed(&bpart->min_world, resolution.min_world);
     jl_atomic_store_relaxed(&bpart->max_world, resolution.max_world);
-    bpart->restriction = resolution.binding_or_const;
-    if (resolution.binding_or_const)
-        jl_gc_wb(bpart, resolution.binding_or_const);
+    jl_gc_write(bpart, bpart->restriction, resolution.binding_or_const);
     bpart->kind = resolution.ultimate_kind;
 }
 
@@ -615,9 +613,7 @@ JL_DLLEXPORT jl_binding_partition_t *jl_declare_constant_val3(
         }
         if (jl_atomic_load_relaxed(&bpart->min_world) == new_world) {
             bpart->kind = constant_kind | (bpart->kind & PARTITION_MASK_FLAG);
-            bpart->restriction = val;
-            if (val)
-                jl_gc_wb(bpart, val);
+            jl_gc_write(bpart, bpart->restriction, val);
             new_bpart = bpart;
         } else {
             new_bpart = jl_replace_binding_locked(b, bpart, val, constant_kind, new_world);
@@ -649,22 +645,21 @@ JL_DLLEXPORT jl_binding_partition_t *jl_declare_constant_val3(
             new_prev_bpart = backdate_bpart;
             while (1) {
                 backdate_bpart->kind = (size_t)PARTITION_KIND_BACKDATED_CONST | (prev_bpart->kind & 0xf0);
+                jl_gc_wb_fresh(backdate_bpart, val);
                 backdate_bpart->restriction = val;
                 jl_atomic_store_relaxed(&backdate_bpart->min_world,
                     jl_atomic_load_relaxed(&prev_bpart->min_world));
-                jl_gc_wb_fresh(backdate_bpart, val);
                 jl_atomic_store_relaxed(&backdate_bpart->max_world,
                     jl_atomic_load_relaxed(&prev_bpart->max_world));
                 prev_bpart = jl_atomic_load_relaxed(&prev_bpart->next);
                 if (!prev_bpart)
                     break;
                 jl_binding_partition_t *next_prev_bpart = new_binding_partition();
-                jl_atomic_store_relaxed(&backdate_bpart->next, next_prev_bpart);
                 jl_gc_wb(backdate_bpart, next_prev_bpart);
+                jl_atomic_store_relaxed(&backdate_bpart->next, next_prev_bpart);
                 backdate_bpart = next_prev_bpart;
             }
-            jl_atomic_store_release(&new_bpart->next, new_prev_bpart);
-            jl_gc_wb(new_bpart, new_prev_bpart);
+            jl_gc_write_atomic(new_bpart, new_bpart->next, new_prev_bpart, release);
         }
     }
     JL_GC_POP();
@@ -800,8 +795,7 @@ static jl_binding_t *new_binding(jl_module_t *mod, jl_sym_t *name)
     b->backedges = NULL;
     jl_atomic_store_relaxed(&b->flags, 0);
     JL_GC_PUSH1(&b);
-    b->globalref = jl_new_globalref(mod, name, b);
-    jl_gc_wb(b, b->globalref);
+    jl_gc_write(b, b->globalref, jl_new_globalref(mod, name, b));
     JL_GC_POP();
     return b;
 }
@@ -1356,8 +1350,7 @@ void jl_add_usings_backedge(jl_module_t *from, jl_module_t *to)
 {
     JL_LOCK(&from->lock);
     if (from->usings_backedges == jl_nothing) {
-        from->usings_backedges = (jl_value_t*)jl_alloc_vec_any(0);
-        jl_gc_wb(from, from->usings_backedges);
+        jl_gc_write(from, from->usings_backedges, (jl_value_t*)jl_alloc_vec_any(0));
     }
     jl_array_ptr_1d_push((jl_array_t*)from->usings_backedges, (jl_value_t*)to);
     JL_UNLOCK(&from->lock);
@@ -1629,8 +1622,7 @@ JL_DLLEXPORT jl_binding_t *jl_get_module_binding(jl_module_t *m, jl_sym_t *var, 
                     memcpy((char*)jl_svec_data(nc), jl_svec_data(bindings), sizeof(void*) * i);
                 for (size_t j = i; j < ncl; j++)
                     jl_svec_data(nc)[j] = jl_nothing;
-                jl_atomic_store_release(&m->bindings, nc);
-                jl_gc_wb(m, nc);
+                jl_gc_write_atomic(m, m->bindings, nc, release);
                 bindings = nc;
             }
             jl_binding_t *b = new_binding(m, var);
@@ -1685,8 +1677,7 @@ void jl_set_initial_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val JL_ROOT
     if (exported)
         jl_atomic_fetch_or_relaxed(&bp->flags, BINDING_FLAG_PUBLICP);
     bpart->kind = kind | (bpart->kind & PARTITION_MASK_FLAG);
-    bpart->restriction = val;
-    jl_gc_wb(bpart, val);
+    jl_gc_write(bpart, bpart->restriction, val);
 }
 
 JL_DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val JL_ROOTED_BY_ARG(0))
@@ -1697,8 +1688,7 @@ JL_DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val JL
     jl_atomic_store_relaxed(&bpart->min_world, 0);
     jl_atomic_store_release(&bpart->max_world, ~(size_t)0);
     bpart->kind = PARTITION_KIND_CONST | (bpart->kind & PARTITION_MASK_FLAG);
-    bpart->restriction = val;
-    jl_gc_wb(bpart, val);
+    jl_gc_write(bpart, bpart->restriction, val);
 }
 
 void jl_invalidate_binding_refs(jl_globalref_t *ref, jl_binding_partition_t *invalidated_bpart, jl_binding_partition_t *new_bpart, size_t new_world)
@@ -1723,8 +1713,7 @@ JL_DLLEXPORT void jl_add_binding_backedge(jl_binding_t *b, jl_value_t *edge)
 {
     JL_LOCK(&b->globalref->mod->lock);
     if (!b->backedges) {
-        b->backedges = jl_alloc_vec_any(0);
-        jl_gc_wb(b, b->backedges);
+        jl_gc_write(b, b->backedges, jl_alloc_vec_any(0));
     } else if (jl_array_len(b->backedges) > 0 &&
                jl_array_ptr_ref(b->backedges, jl_array_len(b->backedges)-1) == edge) {
         // Optimization: Deduplicate repeated insertion of the same edge (e.g. during
@@ -1805,19 +1794,18 @@ JL_DLLEXPORT jl_binding_partition_t *jl_replace_binding_locked2(jl_binding_t *b,
     }
     else {
         new_bpart->kind = kind;
-        new_bpart->restriction = restriction_val;
         jl_gc_wb_fresh(new_bpart, restriction_val);
+        new_bpart->restriction = restriction_val;
     }
     jl_atomic_store_release(&old_bpart->max_world, new_world-1);
-    jl_atomic_store_relaxed(&new_bpart->next, old_bpart);
     jl_gc_wb_fresh(new_bpart, old_bpart);
+    jl_atomic_store_relaxed(&new_bpart->next, old_bpart);
 
     if ((jl_bpart_is_exported(old_bpart->kind) || jl_bpart_is_exported(kind)) && jl_require_world != ~(size_t)0) {
         jl_atomic_store_release(&b->globalref->mod->export_set_changed_since_require_world, 1);
     }
 
-    jl_atomic_store_release(&b->partitions, new_bpart);
-    jl_gc_wb(b, new_bpart);
+    jl_gc_write_atomic(b, b->partitions, new_bpart, release);
     JL_GC_POP();
 
     if (jl_typeinf_world != 1) {
@@ -1985,16 +1973,15 @@ jl_value_t *jl_check_binding_assign_value(jl_binding_t *b JL_PROPAGATES_ROOT, jl
 JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var, jl_value_t *rhs)
 {
     if (jl_check_binding_assign_value(b, mod, var, rhs, "setglobal!") != NULL) {
-        jl_atomic_store_release(&b->value, rhs);
-        jl_gc_wb(b, rhs);
+        jl_gc_write_atomic(b, b->value, rhs, release);
     }
 }
 
 JL_DLLEXPORT jl_value_t *jl_checked_swap(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var, jl_value_t *rhs)
 {
     jl_check_binding_assign_value(b, mod, var, rhs, "swapglobal!");
-    jl_value_t *old = jl_atomic_exchange(&b->value, rhs);
     jl_gc_wb(b, rhs);
+    jl_value_t *old = jl_atomic_exchange(&b->value, rhs);
     if (__unlikely(old == NULL))
         jl_undefined_var_error(var, (jl_value_t*)mod);
     return old;
@@ -2208,7 +2195,7 @@ JL_DLLEXPORT jl_uuid_t jl_module_uuid(jl_module_t* m) { return m->uuid; }
 
 // TODO: make this part of the module constructor and read-only?
 JL_DLLEXPORT void jl_set_module_uuid(jl_module_t *m, jl_uuid_t uuid) { m->uuid = uuid; }
-JL_DLLEXPORT void jl_set_module_parent(jl_module_t *m, jl_module_t *parent) { m->parent = parent; }
+JL_DLLEXPORT void jl_set_module_parent(jl_module_t *m, jl_module_t *parent) { jl_gc_write(m, m->parent, parent); }
 
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent) JL_NOTSAFEPOINT
 {
@@ -2235,7 +2222,7 @@ JL_DLLEXPORT void jl_clear_implicit_imports(jl_module_t *m)
             break;
         jl_binding_partition_t *bpart = jl_get_binding_partition(b, jl_current_task->world_age);
         if (jl_bkind_is_some_implicit(jl_binding_kind(bpart))) {
-            jl_atomic_store_relaxed(&b->partitions, NULL);
+            jl_gc_write_atomic(b, b->partitions, NULL, relaxed);
         }
     }
     JL_UNLOCK(&m->lock);

--- a/src/module.c
+++ b/src/module.c
@@ -162,6 +162,7 @@ retry:
                         if (next_max_world >= expected_prev_min_world-1 && next->kind == new_kind && next->restriction == resolution.binding_or_const) {
                             if (jl_atomic_cmpswap(&prev->min_world, &expected_prev_min_world, next_min_world)) {
                                 jl_binding_partition_t *nextnext = jl_atomic_load_relaxed(&next->next);
+                                jl_gc_wb(prev, nextnext);
                                 if (!jl_atomic_cmpswap(&prev->next, &next, nextnext)) {
                                     // `next` may have been merged into its subsequent partition - we need to retry
                                     assert(next);
@@ -183,8 +184,8 @@ retry:
     jl_binding_partition_t *new_bpart = new_binding_partition();
     jl_atomic_store_relaxed(&new_bpart->max_world, new_max_world);
     new_bpart->kind = new_kind;
+    jl_gc_wb_fresh(new_bpart, resolution.binding_or_const);
     new_bpart->restriction = resolution.binding_or_const;
-    jl_gc_wb_fresh(new_bpart, new_bpart->restriction);
 
     if (next) {
         // See if we can merge the next partition into this one
@@ -198,9 +199,9 @@ retry:
 
     jl_atomic_store_relaxed(&new_bpart->min_world, new_min_world);
     jl_atomic_store_relaxed(&new_bpart->next, next);
+    jl_gc_wb(gap.parent, new_bpart);
     if (!jl_atomic_cmpswap(gap.insert, &gap.replace, new_bpart))
         return NULL;
-    jl_gc_wb(gap.parent, new_bpart);
     return new_bpart;
 }
 
@@ -775,12 +776,12 @@ static jl_globalref_t *jl_new_globalref(jl_module_t *mod, jl_sym_t *name, jl_bin
     jl_task_t *ct = jl_current_task;
     jl_globalref_t *g = (jl_globalref_t*)jl_gc_alloc(ct->ptls, sizeof(jl_globalref_t), jl_globalref_type);
     jl_set_typetagof(g, jl_globalref_tag, 0);
+    jl_gc_wb_fresh(g, mod);
     g->mod = mod;
-    jl_gc_wb_fresh(g, g->mod);
+    jl_gc_wb_fresh(g, name);
     g->name = name;
-    jl_gc_wb_fresh(g, g->name);
+    jl_gc_wb_fresh(g, b);
     g->binding = b;
-    jl_gc_wb_fresh(g, g->binding);
     return g;
 }
 
@@ -1364,9 +1365,9 @@ void jl_module_initial_using(jl_module_t *to, jl_module_t *from)
         .max_world = ~(size_t)0,
         .flags = 0
     };
+    jl_gc_wb(to, from);
     arraylist_grow(&to->usings, sizeof(struct _jl_module_using)/sizeof(void*));
     memcpy(&to->usings.items[to->usings.len-4], &new_item, sizeof(struct _jl_module_using));
-    jl_gc_wb(to, from);
     jl_add_usings_backedge(from, to);
 }
 
@@ -1397,9 +1398,9 @@ JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from, size_t fla
             .max_world = ~(size_t)0,
             .flags = flags
         };
+        jl_gc_wb(to, from);
         arraylist_grow(&to->usings, sizeof(struct _jl_module_using)/sizeof(void*));
         memcpy(&to->usings.items[to->usings.len-4], &new_item, sizeof(struct _jl_module_using));
-        jl_gc_wb(to, from);
     } else {
         // Update existing entry to add new flags
         struct _jl_module_using *existing = module_usings_getidx(to, existing_idx);
@@ -1784,8 +1785,8 @@ JL_DLLEXPORT jl_binding_partition_t *jl_replace_binding_locked2(jl_binding_t *b,
         if (resolution.should_be_reexported) {
             new_bpart->kind |= PARTITION_FLAG_IMPLICITLY_EXPORTED;
         }
-        new_bpart->restriction = resolution.binding_or_const;
         jl_gc_wb_fresh(new_bpart, resolution.binding_or_const);
+        new_bpart->restriction = resolution.binding_or_const;
         assert(resolution.min_world <= new_world && resolution.max_world == ~(size_t)0);
         if (new_bpart->kind == old_bpart->kind && new_bpart->restriction == old_bpart->restriction) {
             JL_GC_POP();
@@ -2010,8 +2011,8 @@ JL_DLLEXPORT jl_value_t *jl_checked_assignonce(jl_binding_t *b, jl_module_t *mod
 {
     jl_check_binding_assign_value(b, mod, var, rhs, "setglobalonce!");
     jl_value_t *old = NULL;
-    if (jl_atomic_cmpswap(&b->value, &old, rhs))
-        jl_gc_wb(b, rhs);
+    jl_gc_wb(b, rhs);
+    jl_atomic_cmpswap(&b->value, &old, rhs);
     return old;
 }
 

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -396,8 +396,7 @@ static void jl_reserve_excstack(jl_task_t *ct, jl_excstack_t **stack JL_REQUIRE_
     new_s->reserved_size = reserved_size;
     if (s)
         jl_copy_excstack(new_s, s);
-    *stack = new_s;
-    jl_gc_wb(ct, new_s);
+    jl_gc_write(ct, *stack, new_s);
 }
 
 void jl_push_excstack(jl_task_t *ct, jl_excstack_t **stack JL_REQUIRE_ROOTED_SLOT,

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -296,8 +296,8 @@ JL_DLLEXPORT void jl_eh_restore_state(jl_task_t *ct, jl_handler_t *eh)
     sig_atomic_t old_defer_signal = ptls->defer_signal;
     ct->eh = eh->prev;
     ct->gcstack = eh->gcstack;
+    jl_gc_wb_current_task(ct, eh->scope);
     ct->scope = eh->scope;
-    jl_gc_wb_current_task(ct, ct->scope);
     small_arraylist_t *locks = &ptls->locks;
     int unlocks = locks->len > eh->locks_len;
     if (unlocks) {
@@ -336,8 +336,8 @@ JL_DLLEXPORT void jl_eh_restore_state(jl_task_t *ct, jl_handler_t *eh)
 JL_DLLEXPORT void jl_eh_restore_state_noexcept(jl_task_t *ct, jl_handler_t *eh)
 {
     assert(ct->gcstack == eh->gcstack && "Incorrect GC usage under try catch");
+    jl_gc_wb_current_task(ct, eh->scope);
     ct->scope = eh->scope;
-    jl_gc_wb_current_task(ct, ct->scope);
     ct->eh = eh->prev;
     ct->ptls->defer_signal = eh->defer_signal; // optional, but certain try-finally (in stream.jl) may be slightly harder to write without this
 }

--- a/src/smallintset.c
+++ b/src/smallintset.c
@@ -174,8 +174,8 @@ void jl_smallintset_insert(_Atomic(jl_genericmemory_t*) *pcache, jl_value_t *par
     jl_genericmemory_t *a = jl_atomic_load_relaxed(pcache);
     if (val + 1 >= jl_max_int(a)) {
         a = smallintset_rehash(a, hash, data, a->length, val + 1);
-        jl_atomic_store_release(pcache, a);
         if (parent) jl_gc_wb(parent, a);
+        jl_atomic_store_release(pcache, a);
     }
     while (1) {
         if (smallintset_insert_(a, hash(val, data), val + 1))
@@ -195,8 +195,8 @@ void jl_smallintset_insert(_Atomic(jl_genericmemory_t*) *pcache, jl_value_t *par
         else
             newsz = sz << 2;
         a = smallintset_rehash(a, hash, data, newsz, 0);
-        jl_atomic_store_release(pcache, a);
         if (parent) jl_gc_wb(parent, a);
+        jl_atomic_store_release(pcache, a);
     }
 }
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2423,10 +2423,8 @@ static void jl_prune_idset(_Atomic(jl_svec_t*) *pkeys, _Atomic(jl_genericmemory_
     assert(serialization_queue.items[(char*)idx - 1 - (char*)HT_NOTFOUND] == keyset);
     ptrhash_put(&serialization_order, jl_atomic_load_relaxed(&keyset2), idx);
     serialization_queue.items[(char*)idx - 1 - (char*)HT_NOTFOUND] = jl_atomic_load_relaxed(&keyset2);
-    jl_atomic_store_relaxed(pkeys, keys2);
-    jl_gc_wb(parent, keys2);
-    jl_atomic_store_relaxed(pkeyset, jl_atomic_load_relaxed(&keyset2));
-    jl_gc_wb(parent, jl_atomic_load_relaxed(&keyset2));
+    jl_gc_write_atomic(parent, *pkeys, keys2, relaxed);
+    jl_gc_write_atomic(parent, *pkeyset, jl_atomic_load_relaxed(&keyset2), relaxed);
 }
 
 static void jl_prune_method_specializations(jl_method_t *m) JL_GC_DISABLED
@@ -2470,8 +2468,7 @@ static jl_value_t *strip_codeinfo_meta(jl_method_t *m, jl_value_t *ci_, jl_code_
         ci = (jl_code_info_t*)ci_;
     }
     strip_slotnames(ci->slotnames, jl_array_len(ci->slotnames));
-    ci->debuginfo = jl_nulldebuginfo;
-    jl_gc_wb(ci, ci->debuginfo);
+    jl_gc_write(ci, ci->debuginfo, jl_nulldebuginfo);
     jl_value_t *ret = (jl_value_t*)ci;
     if (compressed)
         ret = (jl_value_t*)jl_compress_ir(m, ci);
@@ -2538,8 +2535,7 @@ static int strip_all_codeinfos__(jl_typemap_entry_t *def, void *_env)
         }
         if (jl_options.strip_metadata) {
             if (!stripped_ir) {
-                m->source = strip_codeinfo_meta(m, m->source, NULL);
-                jl_gc_wb(m, m->source);
+                jl_gc_write(m, m->source, strip_codeinfo_meta(m, m->source, NULL));
             }
             jl_array_t *slotnames = jl_uncompress_argnames(m->slot_syms);
             JL_GC_PUSH1(&slotnames);
@@ -2548,8 +2544,7 @@ static int strip_all_codeinfos__(jl_typemap_entry_t *def, void *_env)
             if (jl_tparam0(jl_unwrap_unionall(m->sig)) == (jl_value_t*)jl_kwcall_type)
                 tostrip = m->nargs;
             strip_slotnames(slotnames, tostrip);
-            m->slot_syms = jl_compress_argnames(slotnames);
-            jl_gc_wb(m, m->slot_syms);
+            jl_gc_write(m, m->slot_syms, jl_compress_argnames(slotnames));
             JL_GC_POP();
         }
     }
@@ -3012,9 +3007,8 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             }
             else if (jl_is_typename(v)) {
                 jl_typename_t *tn = (jl_typename_t*)v;
-                jl_atomic_store_relaxed(&tn->cache,
-                    jl_prune_type_cache_hash(jl_atomic_load_relaxed(&tn->cache)));
-                jl_gc_wb(tn, jl_atomic_load_relaxed(&tn->cache));
+                jl_gc_write_atomic(tn, tn->cache,
+                    jl_prune_type_cache_hash(jl_atomic_load_relaxed(&tn->cache)), relaxed);
                 jl_prune_type_cache_linear(jl_atomic_load_relaxed(&tn->linearcache));
             }
             else if (jl_is_method_instance(v)) {
@@ -3775,8 +3769,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         export_jl_sysimg_globals();
         jl_global_roots_list = (jl_genericmemory_t*)jl_read_value(&s);
         jl_global_roots_keyset = (jl_genericmemory_t*)jl_read_value(&s);
-        s.ptls->root_task->tls = jl_read_value(&s);
-        jl_gc_wb(s.ptls->root_task, s.ptls->root_task->tls);
+        jl_gc_write(s.ptls->root_task, s.ptls->root_task->tls, jl_read_value(&s));
 
         uint32_t gs_ctr = read_uint32(f);
         jl_require_world = read_uint(f);
@@ -4095,8 +4088,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
             jl_globalref_t *r = (jl_globalref_t*)obj;
             if (r->binding == NULL) {
                 jl_globalref_t *gr = (jl_globalref_t*)jl_module_globalref(r->mod, r->name);
-                r->binding = gr->binding;
-                jl_gc_wb(r, gr->binding);
+                jl_gc_write(r, r->binding, gr->binding);
             }
         }
         else if (jl_is_module(obj)) {

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2488,9 +2488,8 @@ static void strip_specializations_(jl_method_instance_t *mi)
             }
             else if (jl_options.strip_metadata) {
                 jl_value_t *stripped = strip_codeinfo_meta(mi->def.method, inferred, codeinst);
-                if (jl_atomic_cmpswap_relaxed(&codeinst->inferred, &inferred, stripped)) {
-                    jl_gc_wb(codeinst, stripped);
-                }
+                jl_gc_wb(codeinst, stripped);
+                jl_atomic_cmpswap_relaxed(&codeinst->inferred, &inferred, stripped);
             }
         }
         if (jl_options.strip_ir)

--- a/src/task.c
+++ b/src/task.c
@@ -461,6 +461,7 @@ JL_NO_ASAN static void ctx_switch(jl_task_t *lastt)
         jl_stack_context_t copy_ctx;
     } lasttstate;
 
+    jl_gc_wb_back(lastt);
     if (killed) {
         *pt = NULL; // can't fail after here: clear the gc-root for the target task now
         lastt->gcstack = NULL;
@@ -501,7 +502,6 @@ JL_NO_ASAN static void ctx_switch(jl_task_t *lastt)
     // move the barrier back instead of walking the shadow stack again here to check if that is required
     // even if killed (dropping the stack) and just the scope field matters,
     // let the gc figure that out next time it does a quick mark
-    jl_gc_wb_back(lastt);
 
     // set up global state for new task and clear global state for old task
     t->ptls = ptls;
@@ -1133,8 +1133,8 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_fu
     t->donenotify = completion_future;
     jl_atomic_store_relaxed(&t->_isexception, 0);
     // Inherit scope from parent task
+    jl_gc_wb_fresh(t, ct->scope);
     t->scope = ct->scope;
-    jl_gc_wb_fresh(t, t->scope);
     // Fork task-local random state from parent
     jl_rng_split(t->rngState, ct->rngState);
     // there is no active exception handler available on this stack yet
@@ -1583,8 +1583,8 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     ct->result = jl_nothing;
     ct->donenotify = jl_nothing;
     jl_atomic_store_relaxed(&ct->_isexception, 0);
+    jl_gc_wb_fresh(ct, jl_nothing);
     ct->scope = jl_nothing;
-    jl_gc_wb_knownold(ct, ct->scope);
     ct->eh = NULL;
     ct->gcstack = NULL;
     ct->excstack = NULL;

--- a/src/task.c
+++ b/src/task.c
@@ -1282,8 +1282,7 @@ CFI_NORETURN
         }
 skip_pop_exception:;
     }
-    ct->result = res;
-    jl_gc_wb(ct, ct->result);
+    jl_gc_write(ct, ct->result, res);
     jl_finish_task(ct);
     jl_gc_debug_fprint_critical_error(ios_safe_stderr);
     abort();

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -145,8 +145,7 @@ JL_DLLEXPORT jl_module_t *jl_begin_new_module(jl_module_t *parent_module, jl_sym
     JL_UNLOCK(&jl_modules_mutex);
     // copy parent environment info into submodule
     newm->uuid = parent_module->uuid;
-    newm->file = jl_symbol(filename);
-    jl_gc_wb_knownold(newm, newm->file);
+    jl_gc_write(newm, newm->file, jl_symbol(filename));
     newm->line = lineno;
 
     // add standard imports unless baremodule
@@ -325,9 +324,7 @@ void jl_declare_global(jl_module_t *m, jl_value_t *arg, jl_value_t *set_type, in
                 check_safe_newbinding(gm, gs);
                 if (jl_atomic_load_relaxed(&bpart->min_world) == new_world) {
                     bpart->kind = new_kind | (bpart->kind & PARTITION_MASK_FLAG);
-                    bpart->restriction = global_type;
-                    if (global_type)
-                        jl_gc_wb(bpart, global_type);
+                    jl_gc_write(bpart, bpart->restriction, global_type);
                     continue;
                 } else {
                     jl_replace_binding_locked(b, bpart, global_type, new_kind, new_world);
@@ -532,8 +529,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_method_instance_for_thunk(jl_code_info_t *
     JL_GC_PUSH1(&mi);
 
     jl_code_instance_t *ci = jl_new_codeinst_for_uninferred(mi, src);
-    jl_atomic_store_relaxed(&mi->cache, ci);
-    jl_gc_wb(mi, ci);
+    jl_gc_write_atomic(mi, mi->cache, ci, relaxed);
 
     JL_GC_POP();
     return mi;

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -319,16 +319,16 @@ static void mtcache_hash_insert(_Atomic(jl_genericmemory_t*) *pcache, jl_value_t
     jl_genericmemory_t *a = jl_atomic_load_relaxed(pcache);
     if (a == (jl_genericmemory_t*)jl_an_empty_memory_any) {
         a = jl_alloc_memory_any(16);
-        jl_atomic_store_release(pcache, a);
         if (parent)
             jl_gc_wb(parent, a);
+        jl_atomic_store_release(pcache, a);
     }
     a = jl_eqtable_put(a, key, val, &inserted);
     assert(inserted);
     if (a != jl_atomic_load_relaxed(pcache)) {
-        jl_atomic_store_release(pcache, a);
         if (parent)
             jl_gc_wb(parent, a);
+        jl_atomic_store_release(pcache, a);
     }
 }
 
@@ -1395,8 +1395,8 @@ static void jl_typemap_insert_generic(
     if (count > MAX_METHLIST_COUNT) {
         ml = jl_method_convert_list_to_cache(
             map, (jl_typemap_entry_t*)ml, tparam, offs, doublesplit != NULL);
-        jl_atomic_store_release(pml, ml);
         jl_gc_wb(parent, ml);
+        jl_atomic_store_release(pml, ml);
         if (doublesplit)
             jl_typemap_memory_insert_(map, (_Atomic(jl_genericmemory_t*)*)pml, doublesplit, newrec, parent, 0, offs, NULL);
         else

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -1325,7 +1325,7 @@ static jl_value_t *jl_method_convert_list_to_cache(
     JL_GC_PUSH4(&cache, &dblcache, &next, &ml);
     while (ml != (void*)jl_nothing) {
         next = jl_atomic_load_relaxed(&ml->next);
-        jl_atomic_store_relaxed(&ml->next, (jl_typemap_entry_t*)jl_nothing);
+        jl_gc_write_atomic(ml, ml->next, (jl_typemap_entry_t*)jl_nothing, relaxed);
         // n.b. this is being done concurrently with lookups!
         // TODO: is it safe to be doing this concurrently with lookups?
         if (doublesplit) {
@@ -1368,10 +1368,9 @@ static void jl_typemap_list_insert_(
         l = jl_atomic_load_relaxed(&l->next);
     }
 
-    jl_atomic_store_relaxed(&newrec->next, l);
-    jl_gc_wb(newrec, l);
-    jl_atomic_store_release(pml, newrec);
+    jl_gc_write_atomic(newrec, newrec->next, l, relaxed);
     jl_gc_wb(parent, newrec);
+    jl_atomic_store_release(pml, newrec);
 }
 
 // n.b. tparam value only needed if doublesplit is set (for jl_method_convert_list_to_cache)


### PR DESCRIPTION
Relocate the stock GC write barrier so that `jl_gc_wb(parent, newval)` runs before the field store rather than after it. Every write-barrier call site across the runtime and the codegen now emit their barrier ahead of the store

The stock generational barrier reads only the parent and new-value GC tags and never the old field, so moving it ahead of the (non-safepointing) store is behavior-neutral for the stock collector while establishing the pre-write barrier interface that a concurrent collector requires.

Add `jl_gc_write`/`jl_gc_write_atomic` helper macros that perform the barrier before the store, and make stock `jl_gc_wb` treat a `NULL` child as a no-op, since the barrier now also fires when a field is cleared.

This should make https://github.com/JuliaLang/julia/pull/61215 a lot easier to land.

Coauthored by Fable 5