### PR TITLE
llvm-expand-atomic-modify: fix use-before-def when op ignores the loaded value

### DIFF
--- a/src/llvm-expand-atomic-modify.cpp
+++ b/src/llvm-expand-atomic-modify.cpp
@@ -402,6 +402,10 @@ void expandAtomicModifyToCmpXchg(CallInst &Modify,
           RMW->moveBeforePreserving(cast<Instruction>(ValOp->getUser())->getIterator()); // ValOp is a user of RMW, and RMW has no other dependants (per patternMatchAtomicRMWOp)
           Val = ValOp->get();
         } else if (RMWOp == AtomicRMWInst::Xchg) {
+          // The op ignored the loaded value, so NewVal is computed by the
+          // inlined op body which may be after RMW: move RMW down to the
+          // original call site, which NewVal is known to dominate.
+          RMW->moveBeforePreserving(Modify.getIterator());
           Val = NewVal;
         } else {
           // convert to an atomic fence of the form: atomicrmw or %ptr, 0

--- a/test/llvmpasses/atomic-modify.ll
+++ b/test/llvmpasses/atomic-modify.ll
@@ -49,6 +49,11 @@ define i8 @xchg.i8(i8 %x, i8 %y) {
     ret i8 %y
 }
 
+define i8 @xchgshl.i8(i8 %x, i8 %y) {
+    %z = shl i8 %y, 1
+    ret i8 %z
+}
+
 define double @fadd.f64(double %x, double %y) {
     %z = fadd double %y, %x
     ret double %z
@@ -212,6 +217,17 @@ top:
   %oldnew = call {i8, i8} (ptr, ptr, i8, i8, ...) @julia.atomicmodify.i8(ptr align(1) %a, ptr @xchg.i8, i8 5, i8 1, i8 %b)
   %newval = extractvalue {i8, i8} %oldnew, 1
   ret i8 %newval
+}
+
+define i8 @mod_i8_xchg_computed(ptr %a, i8 %b) {
+; CHECK-LABEL: @mod_i8_xchg_computed
+; CHECK: [[newval:%.*]] = shl i8 %b, 1
+; CHECK-NEXT: [[oldval:%.*]] = atomicrmw xchg ptr %a, i8 [[newval]] release, align 1
+; CHECK-NEXT: ret i8 [[oldval]]
+top:
+  %oldnew = call {i8, i8} (ptr, ptr, i8, i8, ...) @julia.atomicmodify.i8(ptr align(1) %a, ptr @xchgshl.i8, i8 5, i8 1, i8 %b)
+  %oldval = extractvalue {i8, i8} %oldnew, 0
+  ret i8 %oldval
 }
 
 define double @mod_i8_fadd(ptr %a, double %b) {


### PR DESCRIPTION
When the modify op does not use the loaded value (e.g. `atomic_pointermodify(p, (o, v) -> 2v, x, order)`), the placeholder atomicrmw has no uses after inlining the op body, so `patternMatchAtomicRMWOp` returns `Xchg` with no `ValOp`. The expansion then installed `NewVal` as the xchg operand, but `NewVal` is computed by the inlined op body which sits after the placeholder atomicrmw, producing use-before-def IR that fails the verifier (and crashes the backend on release builds). Move the atomicrmw down to the original call site, which `NewVal` is known to dominate, before installing it as the operand.

Fixes #62060

This pull request was written with the assistance of generative AI (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)