### PR TITLE
Fix assignment to `where` creating unintentional functions

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1647,19 +1647,12 @@
 
 (define (expand-assignment e (const? #f))
   (define lhs (cadr e))
-  (define (function-lhs? lhs)
-    (and (pair? lhs)
-         (or (eq? (car lhs) 'call)
-             (eq? (car lhs) 'where)
-             (and (eq? (car lhs) '|::|)
-                  (pair? (cadr lhs))
-                  (eq? (car (cadr lhs)) 'call)))))
   (define (assignment-to-function lhs e)  ;; convert '= expr to 'function expr
     (cons 'function (cdr e)))
   (define (maybe-wrap-const x)
     (if const? `(const ,x) x))
   (cond
-   ((function-lhs? lhs)
+   ((eventually-call? lhs)
     ;; `const f() = ...` - The `const` here is inoperative, but the syntax
     ;; happened to work in earlier versions, so simply strip `const`.
     (expand-forms (assignment-to-function lhs e)))
@@ -1670,7 +1663,7 @@
     ;; chain of assignments - convert a=b=c to `b=c; a=c`
     (let loop ((lhss (list lhs))
                (rhs  (caddr e)))
-      (if (and (assignment? rhs) (not (function-lhs? (cadr rhs))))
+      (if (and (assignment? rhs) (not (eventually-call? (cadr rhs))))
           (loop (cons (cadr rhs) lhss) (caddr rhs))
           (let* ((rr (if (symbol-like? rhs) rhs (make-ssavalue)))
                  (lhss (reverse lhss))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -4726,3 +4726,23 @@ module M59755 end
     @test M59755.v6 === 5
     @test Base.binding_kind(M59755, :v6) == Base.PARTITION_KIND_CONST
 end
+
+@testset "assignment to where-expr throws unless LHS is `call`" for ex in [
+    :(x where T = 1)
+    :((x...) where T = 1)
+    Expr(:(=), Expr(:where, Expr(:block, :a, :b)), 1)
+    :((((a,b,c::T)     where T<:U where U<:Any) = (a,b,c))(1,2,3))
+    :((((a,b=0,c::T=0) where T<:U where U<:Any) = (a,b,c))(1))
+    :((((a,b=0,c::T=0) where T<:U where U<:Any) = (a,b,c))(1,2))
+    :((((a,b=0,c::T=0) where T<:U where U<:Any) = (a,b,c))(1,2,3))
+    :((((a::T...)      where T<:U where U<:Any) = (a...,))(1,2,3))
+    :((((a::T;)        where T<:U where U<:Any) = a)(1))
+    :((((a::T;b=2)     where T<:U where U<:Any) = (a,b))(1))
+    :((((a::T;b=2)     where T<:U where U<:Any) = (a,b))(1;b=3))
+    :((((a::T=0;b=2)   where T<:U where U<:Any) = (a,b))())
+    :((((a::T=0;b=2)   where T<:U where U<:Any) = (a,b))(1))
+    :((((a::T=0;b=2)   where T<:U where U<:Any) = (a,b))(;b=3))
+    :((((a::T=0;b=2)   where T<:U where U<:Any) = (a,b))(1;b=3))
+    ]
+    @test_throws "invalid assignment location" Core.eval(@__MODULE__, ex)
+end


### PR DESCRIPTION
Fix #62051.  Assigning to `where` (unless it's a function definition) is
     generally disallowed, and assigning to a tuple in general is used for
     destructuring rather than function definition, so this behaviour doesn't
     make sense.  It's also inconsistent with what lowering generally thinks is
     a function definition (e.g. `global` wrapping this assignment is broken).