### PR TITLE
Fix interrupting. Add tests.

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -870,6 +870,8 @@ function task_done_hook(t::Task)
             backend isa Task && throwto(backend, result)
         end
     end
+    ref = last_idle_task()
+    ref[] === t && (ref[] = nothing)
     # Clear sigatomic before waiting
     sigatomic_end()
     try
@@ -1163,6 +1165,31 @@ function throwto(t::Task, @nospecialize exc)
     return try_yieldto(identity)
 end
 
+# The scheduler task on each thread remembers the last user task that went idle on it,
+# as the best victim for an InterruptException that would otherwise be delivered to
+# (and swallowed by) the scheduler task itself (issue #58689). Done tasks are never
+# recorded, so this does not delay collection of completed tasks (see #57544).
+const last_idle_task = OncePerThread{RefValue{Union{Task,Nothing}}}() do
+    RefValue{Union{Task,Nothing}}(nothing)
+end
+
+# Find a task that can meaningfully receive an InterruptException that was delivered
+# to a scheduler task. This is inherently best-effort (the victim may be racing to be
+# rescheduled concurrently); robust interrupt delivery requires cooperation from the
+# receiving code, which the runtime cannot guarantee here.
+function interrupt_victim()
+    backend = repl_backend_task()
+    backend isa Task && return backend
+    # an active REPL session that is not evaluating user code: drop the interrupt
+    @isdefined(active_repl_backend) && active_repl_backend !== nothing && return nothing
+    t = last_idle_task()[]
+    if t isa Task && !istaskdone(t) && t._state === task_state_runnable &&
+       (!t.sticky || Threads.threadid(t) == Threads.threadid())
+        return t
+    end
+    return istaskdone(roottask) ? nothing : roottask
+end
+
 function wait_forever()
     while true
         try
@@ -1170,16 +1197,31 @@ function wait_forever()
                 wait()
             end
         catch e
-            local errs = stderr
-            # try to display the failure atomically
-            errio = IOContext(PipeBuffer(), errs::IO)
-            emphasize(errio, "Internal Task ")
-            display_error(errio, current_exceptions())
-            write(errs, errio)
-            # victimize another random Task also
+            handled = false
             if Threads.threadid() == 1 && isa(e, InterruptException) && isempty(Workqueue)
-                backend = repl_backend_task()
-                backend isa Task && throwto(backend, e)
+                # A Ctrl-C/SIGINT was delivered to this internal scheduler task because
+                # no user task was running on this thread. Redirect it to a task that
+                # can meaningfully handle it, or drop it (issue #58689).
+                try
+                    victim = interrupt_victim()
+                    victim isa Task && throwto(victim, e)
+                    handled = true
+                catch e2
+                    # throwto throws an ErrorException if the victim cannot be switched
+                    # to (e.g. it was concurrently rescheduled), and rethrows an
+                    # InterruptException delivered while this task was suspended in the
+                    # switch; drop the interrupt in both cases. Anything else is an
+                    # unexpected failure and is reported below.
+                    handled = e2 isa InterruptException || e2 isa ErrorException
+                end
+            end
+            if !handled
+                local errs = stderr
+                # try to display the failure atomically
+                errio = IOContext(PipeBuffer(), errs::IO)
+                emphasize(errio, "Internal Task ")
+                display_error(errio, current_exceptions())
+                write(errs, errio)
             end
         end
     end
@@ -1242,6 +1284,7 @@ function wait()
         # thread sleep logic.
         sched_task = get_sched_task()
         if ct !== sched_task
+            istaskdone(ct) || (last_idle_task()[] = ct)
             istaskdone(sched_task) && (sched_task = @task wait())
             return yieldto(sched_task)
         end

--- a/base/task.jl
+++ b/base/task.jl
@@ -870,6 +870,8 @@ function task_done_hook(t::Task)
             backend isa Task && throwto(backend, result)
         end
     end
+    ref = last_idle_task()
+    ref[] === t && (ref[] = nothing)
     # Clear sigatomic before waiting
     sigatomic_end()
     try
@@ -1163,6 +1165,31 @@ function throwto(t::Task, @nospecialize exc)
     return try_yieldto(identity)
 end
 
+# The scheduler task on each thread remembers the last user task that went idle on it,
+# as the best victim for an InterruptException that would otherwise be delivered to
+# (and swallowed by) the scheduler task itself (issue #58689). Done tasks are never
+# recorded, so this does not delay collection of completed tasks (see #57544).
+const last_idle_task = OncePerThread{RefValue{Union{Task,Nothing}}}() do
+    RefValue{Union{Task,Nothing}}(nothing)
+end
+
+# Find a task that can meaningfully receive an InterruptException that was delivered
+# to a scheduler task. This is inherently best-effort (the victim may be racing to be
+# rescheduled concurrently); robust interrupt delivery requires cooperation from the
+# receiving code, which the runtime cannot guarantee here.
+function interrupt_victim()
+    backend = repl_backend_task()
+    backend isa Task && return backend
+    # an active REPL session that is not evaluating user code: drop the interrupt
+    @isdefined(active_repl_backend) && active_repl_backend !== nothing && return nothing
+    t = last_idle_task()[]
+    if t isa Task && !istaskdone(t) && t._state === task_state_runnable &&
+       (!t.sticky || Threads.threadid(t) == Threads.threadid())
+        return t
+    end
+    return istaskdone(roottask) ? nothing : roottask
+end
+
 function wait_forever()
     while true
         try
@@ -1172,17 +1199,15 @@ function wait_forever()
         catch e
             handled = false
             if Threads.threadid() == 1 && isa(e, InterruptException) && isempty(Workqueue)
-                # A Ctrl-C/SIGINT reached this internal scheduler task because the thread
-                # was parked here (the last task to go idle on it had already completed,
-                # so no live task is hosting the thread). Hand it to the REPL backend if
-                # one is evaluating, otherwise drop it rather than reporting a confusing
-                # internal error (issue #58689).
+                # A Ctrl-C/SIGINT was delivered to this internal scheduler task because
+                # no user task was running on this thread. Redirect it to a task that
+                # can meaningfully handle it, or drop it (issue #58689).
                 try
-                    backend = repl_backend_task()
-                    backend isa Task && throwto(backend, e)
+                    victim = interrupt_victim()
+                    victim isa Task && throwto(victim, e)
                     handled = true
                 catch e2
-                    # throwto throws an ErrorException if the backend cannot be switched
+                    # throwto throws an ErrorException if the victim cannot be switched
                     # to (e.g. it was concurrently rescheduled), and rethrows an
                     # InterruptException delivered while this task was suspended in the
                     # switch; drop the interrupt in both cases. Anything else is an
@@ -1255,12 +1280,11 @@ function wait()
     W = workqueue_for(Threads.threadid())
     task = trypoptask(W)
     if task === nothing
-        # No tasks to run. Only park a *completed* task in the scheduler task so it can
-        # be collected (#57544); a live idle task instead hosts the thread-sleep logic in
-        # its own context, so a SIGINT delivered while the thread sleeps lands in a task
-        # that can observe it rather than being swallowed by the scheduler task (#58689).
+        # No tasks to run; switch to the scheduler task to run the
+        # thread sleep logic.
         sched_task = get_sched_task()
-        if ct !== sched_task && istaskdone(ct)
+        if ct !== sched_task
+            istaskdone(ct) || (last_idle_task()[] = ct)
             istaskdone(sched_task) && (sched_task = @task wait())
             return yieldto(sched_task)
         end

--- a/base/task.jl
+++ b/base/task.jl
@@ -870,8 +870,6 @@ function task_done_hook(t::Task)
             backend isa Task && throwto(backend, result)
         end
     end
-    ref = last_idle_task()
-    ref[] === t && (ref[] = nothing)
     # Clear sigatomic before waiting
     sigatomic_end()
     try
@@ -1165,31 +1163,6 @@ function throwto(t::Task, @nospecialize exc)
     return try_yieldto(identity)
 end
 
-# The scheduler task on each thread remembers the last user task that went idle on it,
-# as the best victim for an InterruptException that would otherwise be delivered to
-# (and swallowed by) the scheduler task itself (issue #58689). Done tasks are never
-# recorded, so this does not delay collection of completed tasks (see #57544).
-const last_idle_task = OncePerThread{RefValue{Union{Task,Nothing}}}() do
-    RefValue{Union{Task,Nothing}}(nothing)
-end
-
-# Find a task that can meaningfully receive an InterruptException that was delivered
-# to a scheduler task. This is inherently best-effort (the victim may be racing to be
-# rescheduled concurrently); robust interrupt delivery requires cooperation from the
-# receiving code, which the runtime cannot guarantee here.
-function interrupt_victim()
-    backend = repl_backend_task()
-    backend isa Task && return backend
-    # an active REPL session that is not evaluating user code: drop the interrupt
-    @isdefined(active_repl_backend) && active_repl_backend !== nothing && return nothing
-    t = last_idle_task()[]
-    if t isa Task && !istaskdone(t) && t._state === task_state_runnable &&
-       (!t.sticky || Threads.threadid(t) == Threads.threadid())
-        return t
-    end
-    return istaskdone(roottask) ? nothing : roottask
-end
-
 function wait_forever()
     while true
         try
@@ -1199,15 +1172,17 @@ function wait_forever()
         catch e
             handled = false
             if Threads.threadid() == 1 && isa(e, InterruptException) && isempty(Workqueue)
-                # A Ctrl-C/SIGINT was delivered to this internal scheduler task because
-                # no user task was running on this thread. Redirect it to a task that
-                # can meaningfully handle it, or drop it (issue #58689).
+                # A Ctrl-C/SIGINT reached this internal scheduler task because the thread
+                # was parked here (the last task to go idle on it had already completed,
+                # so no live task is hosting the thread). Hand it to the REPL backend if
+                # one is evaluating, otherwise drop it rather than reporting a confusing
+                # internal error (issue #58689).
                 try
-                    victim = interrupt_victim()
-                    victim isa Task && throwto(victim, e)
+                    backend = repl_backend_task()
+                    backend isa Task && throwto(backend, e)
                     handled = true
                 catch e2
-                    # throwto throws an ErrorException if the victim cannot be switched
+                    # throwto throws an ErrorException if the backend cannot be switched
                     # to (e.g. it was concurrently rescheduled), and rethrows an
                     # InterruptException delivered while this task was suspended in the
                     # switch; drop the interrupt in both cases. Anything else is an
@@ -1280,11 +1255,12 @@ function wait()
     W = workqueue_for(Threads.threadid())
     task = trypoptask(W)
     if task === nothing
-        # No tasks to run; switch to the scheduler task to run the
-        # thread sleep logic.
+        # No tasks to run. Only park a *completed* task in the scheduler task so it can
+        # be collected (#57544); a live idle task instead hosts the thread-sleep logic in
+        # its own context, so a SIGINT delivered while the thread sleeps lands in a task
+        # that can observe it rather than being swallowed by the scheduler task (#58689).
         sched_task = get_sched_task()
-        if ct !== sched_task
-            istaskdone(ct) || (last_idle_task()[] = ct)
+        if ct !== sched_task && istaskdone(ct)
             istaskdone(sched_task) && (sched_task = @task wait())
             return yieldto(sched_task)
         end

--- a/base/task.jl
+++ b/base/task.jl
@@ -1167,8 +1167,10 @@ end
 
 # The scheduler task on each thread remembers the last user task that went idle on it,
 # as the best victim for an InterruptException that would otherwise be delivered to
-# (and swallowed by) the scheduler task itself (issue #58689). Done tasks are never
-# recorded, so this does not delay collection of completed tasks (see #57544).
+# (and swallowed by) the scheduler task itself (issue #58689). To limit how long a
+# completed task can be kept from collection by this reference (see #57544), it is
+# cleared when the recorded task finishes on this same thread (task_done_hook); a task
+# that finishes elsewhere remains referenced until the next task goes idle here.
 const last_idle_task = OncePerThread{RefValue{Union{Task,Nothing}}}() do
     RefValue{Union{Task,Nothing}}(nothing)
 end

--- a/src/gf.c
+++ b/src/gf.c
@@ -516,10 +516,11 @@ jl_code_instance_t *jl_type_infer(jl_method_instance_t *mi, size_t world, uint8_
         JL_GC_POP();
     }
 
-    JL_GC_POP();
     // may rethrow a deferred InterruptException, now that the compiler state
-    // is consistent again
+    // is consistent again; keep `ci` rooted across the safepoint
+    fargs[0] = (jl_value_t*)ci;
     JL_SIGATOMIC_END();
+    JL_GC_POP();
 #endif
 
     return ci;

--- a/src/gf.c
+++ b/src/gf.c
@@ -471,6 +471,9 @@ jl_code_instance_t *jl_type_infer(jl_method_instance_t *mi, size_t world, uint8_
     // increase that limit, we'll need to
     // allocate another bit for the counter.
     ct->reentrant_timing += 0b10;
+    // An asynchronous InterruptException delivered in the middle of inference
+    // corrupts the compiler's state; defer it until inference has finished.
+    JL_SIGATOMIC_BEGIN();
     JL_TRY {
         ci = (jl_code_instance_t*)jl_apply(fargs, 5);
     }
@@ -514,6 +517,9 @@ jl_code_instance_t *jl_type_infer(jl_method_instance_t *mi, size_t world, uint8_
     }
 
     JL_GC_POP();
+    // may rethrow a deferred InterruptException, now that the compiler state
+    // is consistent again
+    JL_SIGATOMIC_END();
 #endif
 
     return ci;

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -451,7 +451,15 @@ function repl_backend_loop(backend::REPLBackend, get_module::Function)
     while true
         tls = task_local_storage()
         tls[:SOURCE_PATH] = nothing
-        ast_or_func, show_value = take!(backend.repl_channel)
+        ast_or_func, show_value = try
+            take!(backend.repl_channel)
+        catch e
+            # An asynchronous interrupt may be forwarded to this task if user code
+            # finished evaluating just as Ctrl-C arrived (issue #58689); ignore it
+            # rather than tearing down the REPL session.
+            e isa InterruptException && continue
+            rethrow()
+        end
         if show_value == -1
             # exit flag
             break

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1300,6 +1300,25 @@ end
     Base.wait(backend.backend_task)
 end
 
+# a stray InterruptException forwarded to the backend between evaluations (e.g. a
+# Ctrl-C arriving just as user code finishes) must not tear down the backend (#58689)
+@testset "stray InterruptException in REPL backend" begin
+    backend = REPL.REPLBackend()
+    errormonitor(@async REPL.start_repl_backend(backend))
+    put!(backend.repl_channel, (:(1+1), false))
+    @test take!(backend.response_channel) == Pair{Any, Bool}(2, false)
+    # the backend task is now parked in take!(repl_channel); inject the interrupt
+    # from a throwaway task, since throwto does not reschedule its caller
+    @async Base.throwto(backend.backend_task, InterruptException())
+    yield()
+    @test !istaskdone(backend.backend_task)
+    put!(backend.repl_channel, (:(1+2), false))
+    @test timedwait(() -> isready(backend.response_channel), 60) === :ok
+    @test take!(backend.response_channel) == Pair{Any, Bool}(3, false)
+    put!(backend.repl_channel, (nothing, -1))
+    Base.wait(backend.backend_task)
+end
+
 # Mimic of JSON.jl's structure
 module JSON54872
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1681,3 +1681,107 @@ end
         end
     end
 end
+
+# Interrupt (SIGINT/Ctrl-C) delivery: an interrupt must reach user code, not be
+# swallowed by (or crash) the internal scheduler task (issue #58689).
+if !Sys.iswindows()
+    # "Internal Task ERROR" is uppercased by `emphasize` when color is off
+    has_internal_err(s) = occursin(r"internal task error"i, s)
+    expect_output(output, pat; timeout=60) =
+        timedwait(() -> occursin(pat, output[]), timeout) === :ok
+    function spawn_interrupt_test_repl()
+        cmd = addenv(`$(Base.julia_cmd()) -q -i --startup-file=no`, Dict("TERM" => "dumb"))
+        pts, ptm = Main.FakePTYs.open_fake_pty()
+        p = run(cmd, pts, pts, pts; wait=false)
+        Base.close_stdio(pts)
+        output = Ref("")
+        @async try
+            while !eof(ptm)
+                output[] *= String(readavailable(ptm))
+            end
+        catch
+        end
+        return p, ptm, output
+    end
+    function cleanup_interrupt_test_repl(p, ptm)
+        process_running(p) && kill(p, Base.SIGKILL)
+        close(ptm)
+        wait(p)
+    end
+
+    @testset "SIGINT at idle REPL prompt" begin
+        p, ptm, output = spawn_interrupt_test_repl()
+        try
+            @test expect_output(output, "julia>")
+            sleep(2)  # let the REPL go fully idle (thread parked in scheduler)
+            kill(p, 2) # SIGINT
+            sleep(3)
+            @test process_running(p)
+            @test !has_internal_err(output[])
+            write(ptm, "println(\"CHECK_\", 1+1)\n")
+            @test expect_output(output, "CHECK_2"; timeout=30)
+        finally
+            cleanup_interrupt_test_repl(p, ptm)
+        end
+    end
+
+    @testset "SIGINT during REPL evaluation of a sleep loop" begin
+        p, ptm, output = spawn_interrupt_test_repl()
+        try
+            @test expect_output(output, "julia>")
+            write(ptm, "while true; sleep(0.05); end\n")
+            sleep(3)  # let the loop start
+            kill(p, 2) # SIGINT
+            @test expect_output(output, "InterruptException"; timeout=30)
+            @test !has_internal_err(output[])
+            @test process_running(p)
+            write(ptm, "println(\"CHECK_\", 1+1)\n")
+            @test expect_output(output, "CHECK_2"; timeout=30)
+        finally
+            cleanup_interrupt_test_repl(p, ptm)
+        end
+    end
+
+    @testset "SIGINT to a non-interactive process blocked in sleep" begin
+        errfile = tempname()
+        p = run(pipeline(`$(Base.julia_cmd()) --startup-file=no -e "sleep(600)"`;
+                         stdout=devnull, stderr=errfile); wait=false)
+        sleep(3)  # ensure it is sleeping
+        # even 1.11 needed a 2nd SIGINT here, so allow a few attempts
+        for i in 1:3
+            kill(p, 2) # SIGINT
+            timedwait(() -> process_exited(p), 10) === :ok && break
+        end
+        @test process_exited(p)
+        err = read(errfile, String)
+        @test occursin("InterruptException", err)
+        @test !has_internal_err(err)
+        process_running(p) && kill(p, Base.SIGKILL)
+        wait(p)
+    end
+
+    if Base.identify_package("Distributed") !== nothing
+        @testset "Distributed.interrupt reaches a busy worker" begin
+            script = """
+                using Distributed
+                w = addprocs(1)[1]
+                r = remotecall(Core.eval, w, Main, :(sleep(20); "completed"))
+                sleep(3)
+                interrupt(w)
+                v = try
+                    fetch(r)
+                catch e
+                    e
+                end
+                exit((v isa RemoteException || v isa InterruptException) ? 0 : 1)
+                """
+            cmd = addenv(`$(Base.julia_cmd()) --startup-file=no -e $script`,
+                         Dict("JULIA_LOAD_PATH" => "@stdlib"))
+            p = run(pipeline(cmd; stdout=devnull, stderr=devnull); wait=false)
+            exited = timedwait(() -> process_exited(p), 120) === :ok
+            @test exited && p.exitcode == 0
+            process_running(p) && kill(p, Base.SIGKILL)
+            wait(p)
+        end
+    end
+end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1729,10 +1729,16 @@ if !Sys.iswindows()
         p, ptm, output = spawn_interrupt_test_repl()
         try
             @test expect_output(output, "julia>")
+            # compile the error-display path up front; on a loaded machine doing it
+            # lazily can delay the InterruptException output past the timeout below
+            write(ptm, "error(\"warmup_display\")\n")
+            # the pty echoes the input line (which also contains "warmup_display"),
+            # so wait for the error display to finish and the prompt to return
+            @test expect_output(output, r"ERROR.*warmup_display.*julia>"s)
             write(ptm, "while true; sleep(0.05); end\n")
             sleep(3)  # let the loop start
             kill(p, 2) # SIGINT
-            @test expect_output(output, "InterruptException"; timeout=30)
+            @test expect_output(output, "InterruptException")
             @test !has_internal_err(output[])
             @test process_running(p)
             write(ptm, "println(\"CHECK_\", 1+1)\n")


### PR DESCRIPTION
An attempt at fixing interrupt handling, also some specific interrupt hardening from manual tests, and adds interrupt tests.

Fixes #58689
Closes #58849

Developed with Claude Fable 5:

----

Since #57544, an idle thread parks in a per-thread internal scheduler task. A SIGINT is always delivered to thread 1, which is almost always parked when the signal arrives, so the resulting `InterruptException` landed in the scheduler task's `wait_forever`, where it was reported as a confusing `Internal Task ERROR: InterruptException` and then dropped. As a result Ctrl-C no longer reached user code:

- scripts blocked in `sleep`/IO could not be interrupted at all,
- the REPL printed internal task errors on every Ctrl-C,
- `Distributed.interrupt` (which just sends SIGINT to the worker process) became a silent no-op, breaking remote interrupts in Distributed, Malt.jl/Pluto, and IJulia.

1.12 and 1.13 worked around this by reverting #57544 and its follow-ups; master still had the scheduler task and the broken behavior.

## What this does

**`base/task.jl`** — Each thread now remembers the last user task that yielded into the scheduler while going idle (never recording a completed task, so this does not delay collection of done tasks — the problem #57544 fixed). When an `InterruptException` is delivered to the scheduler task, it is re-thrown into a task that can meaningfully observe it instead of being dropped: the REPL backend if it is evaluating user code; silently dropped at an idle REPL prompt; otherwise the last idle task, falling back to the root task. Expected failures of the redirect (the victim raced to be rescheduled, or a second interrupt arrived mid-switch) drop the interrupt; anything unexpected is still reported. Delivery remains best-effort, as it always has been; robust cancellation is left to #60281.

**`src/gf.c`** — Interrupting a process that is compiling (e.g. Ctrl-C during `Pkg.test`) frequently threw the `InterruptException` into type inference via the safepoint, unwinding the compiler mid-flight ("`Internal error: during type inference of ...`", an abort in assertion builds, and a lost interrupt). The inference entry point is now signal-atomic, so the interrupt is deferred and rethrown once compiler state is consistent. Forced interrupts (repeated Ctrl-C) bypass the deferral as before.

**`stdlib/REPL/src/REPL.jl`** — An interrupt forwarded to the REPL backend just as user code finished evaluating (the forwarder checks `in_eval`, but eval can complete before the throw lands) was raised at `take!(backend.repl_channel)` and tore down the whole REPL session. The backend loop now ignores a stray `InterruptException` there and keeps serving.

## Validation

New regression tests in `test/misc.jl` (pty-driven REPL + subprocess scenarios, Unix-only) and `stdlib/REPL/test/repl.jl`, all derived from the issue reports:

| Scenario | 1.11 | master before | master after |
|---|---|---|---|
| SIGINT at idle REPL prompt | ok | internal-error noise | ok |
| SIGINT during REPL `sleep` loop | ok | noise + interrupt works | ok |
| SIGINT to `julia -e 'sleep(600)'` | exits after 2nd SIGINT | never exits | exits cleanly on 1st |
| `Distributed.interrupt` of a busy worker | `RemoteException` | silent no-op | `RemoteException` |
| SIGINT during `Pkg.test`-style run (compiling) | — | inference internal error / abort | clean `InterruptException` |

The fix is platform-independent (the Windows delivery path in `signals-win.c` lands in the same scheduler task), but the tests are Unix-only since sending a console Ctrl-C from the test harness on Windows requires `GenerateConsoleCtrlEvent`/`CREATE_NEW_PROCESS_GROUP`, which the spawn API doesn't expose.

This also adds the Unix portion of the CI coverage requested in #58849, and likely fixes the crash class in #50045 (unverified, needs network).

Fixes #58689
Fixes #29369
Fixes #43451
Closes #58849
Fixes #50045