### PR TITLE
inference: Preserve caller signature constraints in method lookup

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -37,48 +37,49 @@ else
 
 using Core.Intrinsics, Core.IR
 
-using Core: ABIOverride, Builtin, CodeInstance, IntrinsicFunction, AnyType, MethodInstance, MethodMatch,
-    MethodTable, MethodCache, PartialOpaque, SimpleVector, TypeofVararg,
-    TypeEq,
-    _apply_iterate, apply_type, compilerbarrier, donotdelete, memoryref_isassigned,
-    memoryrefget, memoryrefnew, memoryrefoffset, memoryrefset!, memoryrefunset!, print, println, show, svec,
-    typename, unsafe_write, write, stdout, stderr
+using Core: ABIOverride, AnyType, Builtin, CodeInstance, IntrinsicFunction, MethodCache,
+    MethodInstance, MethodMatch, MethodTable, PartialOpaque, SimpleVector, TypeEq,
+    TypeofVararg, _apply_iterate, apply_type, compilerbarrier, donotdelete,
+    memoryref_isassigned, memoryrefget, memoryrefnew, memoryrefoffset, memoryrefset!,
+    memoryrefunset!, print, println, show, stderr, stdout, svec, typename, unsafe_write,
+    write
 
 using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospecializeinfer,
-    PARTITION_KIND_GLOBAL, PARTITION_KIND_UNDEF_CONST, PARTITION_KIND_BACKDATED_CONST, PARTITION_KIND_DECLARED,
-    PARTITION_FLAG_DEPWARN,
-    Base, BitVector, Bottom, Callable, DataTypeFieldDesc,
-    EffectsOverride, Filter, Generator, NUM_EFFECTS_OVERRIDES,
-    OneTo, Ordering, RefValue, _NAMEDTUPLE_NAME,
-    _array_for, _bits_findnext, _defaultctors, _methods_by_ftype, _uniontypes, all, allocatedinline, any,
-    argument_datatypename, binding_kind, cconvert, copy_exprargs, datatype_arrayelem,
-    datatype_fieldcount, datatype_fieldtypes, datatype_layoutsize, datatype_nfields,
-    datatype_pointerfree, decode_effects_override, diff_names, fieldindex, visit,
-    generating_output, get_nospecializeinfer_sig, get_world_counter, has_free_typevars, has_typevar,
-    hasgenerator, hasintersect, indexed_iterate, isType, isTypeEq, isTypeEgal,
-    is_file_tracked, is_function_def,
-    is_meta_expr, is_meta_expr_head, is_nospecialized, is_nospecializeinfer, is_defined_const_binding,
-    is_some_const_binding, is_some_guard, is_some_imported, is_some_explicit_imported, is_some_binding_imported, is_valid_intrinsic_elptr,
-    isbitsunion, isconcretedispatch, isdispatchelem, isexpr, isfieldatomic, isidentityfree,
-    iskindtype, ismutabletypename, ismutationfree, issingletontype, isvarargtype, isvatuple,
-    kwerr, lookup_binding_partition, may_invoke_generator, methods, midpoint, moduleroot,
-    partition_restriction, quoted, rename_unionall, rewrap_unionall, specialize_method,
-    structdiff, tls_world_age, type_parameter, unconstrain_vararg_length, unionlen, uniontype_layout,
-    uniontypes, unsafe_convert, unwrap_unionall, unwrapva, vect, widen_diagonal,
-    _uncompressed_ir, datatype_min_ninitialized,
-    partialstruct_init_undefs, fieldcount_noerror, _eval_import, _eval_using,
-    get_ci_mi, get_methodtable, morespecific, specializations, has_image_globalref,
-    rewrap_free_typevars, find_free_typevars, typeintersect_env,
-    PARTITION_MASK_KIND, PARTITION_KIND_GUARD, PARTITION_FLAG_EXPORTED, PARTITION_FLAG_DEPRECATED,
-    BINDING_FLAG_ANY_IMPLICIT_EDGES, is_some_implicit, IteratorSize, SizeUnknown, get_require_world, JLOptions,
-    devnull, devnull as stdin
+    BINDING_FLAG_ANY_IMPLICIT_EDGES, Base, BitVector, Bottom, Callable,
+    DataTypeFieldDesc, EffectsOverride, Filter, Generator, IteratorSize, JLOptions,
+    NUM_EFFECTS_OVERRIDES, OneTo, Ordering, PARTITION_FLAG_DEPRECATED,
+    PARTITION_FLAG_DEPWARN, PARTITION_FLAG_EXPORTED, PARTITION_KIND_BACKDATED_CONST,
+    PARTITION_KIND_DECLARED, PARTITION_KIND_GLOBAL, PARTITION_KIND_GUARD,
+    PARTITION_KIND_UNDEF_CONST, PARTITION_MASK_KIND, RefValue, SizeUnknown,
+    _NAMEDTUPLE_NAME, _array_for, _bits_findnext, _defaultctors, _eval_import,
+    _eval_using, _methods_by_ftype, _uncompressed_ir, _uniontypes, all, allocatedinline,
+    any, argument_datatypename, binding_kind, cconvert, copy_exprargs,
+    datatype_arrayelem, datatype_fieldcount, datatype_fieldtypes, datatype_layoutsize,
+    datatype_min_ninitialized, datatype_nfields, datatype_pointerfree,
+    decode_effects_override, devnull, devnull as stdin, diff_names, fieldcount_noerror,
+    fieldindex, find_free_typevars, generating_output, get_ci_mi, get_methodtable,
+    get_nospecializeinfer_sig, get_require_world, get_world_counter, has_free_typevars,
+    has_image_globalref, has_typevar, hasgenerator, hasintersect, indexed_iterate,
+    isType, isTypeEq, isTypeEgal, is_defined_const_binding, is_file_tracked,
+    is_function_def, is_meta_expr, is_meta_expr_head, is_nospecialized,
+    is_nospecializeinfer, is_some_binding_imported, is_some_const_binding,
+    is_some_explicit_imported, is_some_guard, is_some_implicit, is_some_imported,
+    is_valid_intrinsic_elptr, isbitsunion, isconcretedispatch, isdispatchelem, isexpr,
+    isfieldatomic, isidentityfree, iskindtype, ismutabletypename, ismutationfree,
+    issingletontype, isvarargtype, isvatuple, kwerr, lookup_binding_partition,
+    may_invoke_generator, methods, midpoint, moduleroot, morespecific,
+    partialstruct_init_undefs, partition_restriction, quoted, rename_unionall,
+    rewrap_free_typevars, rewrap_unionall, specializations, specialize_method, structdiff,
+    tls_world_age, type_parameter, typeintersect_env, unconstrain_vararg_length, unionlen,
+    uniontype_layout, uniontypes, unsafe_convert, unwrap_unionall, unwrapva,
+    var_occurs_covariant_only, vect, visit, widen_diagonal
 
 using Base
 using Base.Order
 
-import Base: ==, _topmod, append!, convert, copy, copy!, findall, first, get, get!,
-    getindex, haskey, in, isempty, isready, iterate, iterate, last, length, max_world,
-    min_world, popfirst!, push!, resize!, setindex!, size, intersect
+import Base: ==, _topmod, append!, convert, copy, copy!, findall, first, get, get!, getindex,
+    haskey, in, intersect, isempty, isready, iterate, iterate, last, length, max_world,
+    min_world, popfirst!, push!, resize!, setindex!, size
 
 # Needs to match UUID defined in Project.toml
 ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), Compiler,

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -132,7 +132,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
         return Future(CallMeta(Any, Any, Effects(), NoCallInfo()))
     end
     current_world = get_world_counter()
-    matches = find_method_matches(interp, argtypes, atype; max_methods, fargs=arginfo.fargs)
+    matches = find_method_matches(interp, arginfo, atype, sv; max_methods)
     if isa(matches, FailedMethodMatch)
         add_remark!(interp, sv, matches.reason)
         return Future(CallMeta(Any, Any, Effects(), NoCallInfo()))
@@ -358,32 +358,265 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
     return gfresult
 end
 
-function find_method_matches(interp::AbstractInterpreter, argtypes::Vector{Any}, @nospecialize(atype);
-                             max_union_splitting::Int = InferenceParams(interp).max_union_splitting,
-                             max_methods::Int = InferenceParams(interp).max_methods,
-                             fargs::Union{Nothing,Vector{Any}}=nothing)
-    if is_union_split_eligible(typeinf_lattice(interp), argtypes, max_union_splitting; fargs)
-        return find_union_split_method_matches(interp, argtypes, max_methods; fargs)
+function find_method_matches(
+        interp::AbstractInterpreter, arginfo::ArgInfo, @nospecialize(atype), sv::AbsIntState;
+        max_union_splitting::Int = InferenceParams(interp).max_union_splitting,
+        max_methods::Int = InferenceParams(interp).max_methods
+    )
+    𝕃 = typeinf_lattice(interp)
+    constraints = caller_sig_constraints(arginfo, sv)
+    if constraints !== nothing
+        projection = project_caller_sig(arginfo.argtypes, constraints)
+        if projection !== nothing
+            projected_atype, enums = projection
+            # Fold the caller-frame constraints into the call signature.
+            # Intersecting with `atype` keeps any flow-sensitive refinement of
+            # the call arguments (e.g. a slot narrowed on one branch), which the
+            # projection from the caller's declared parameter types drops.
+            refined_atype = typeintersect(projected_atype, atype)
+            # Only proceed when this strictly narrows the call signature;
+            # otherwise (`refined_atype == atype`) fall through to ordinary union
+            # splitting, which can still split unconstrained union arguments.
+            if refined_atype !== Bottom && !(atype <: refined_atype)
+                # Looking each distributed arm up on its own keeps the per-arm
+                # method count bounded and lets a single covering method report a
+                # full match. `distribute_caller_arms` caps the arm count by
+                # `max_union_splitting` itself, so this branch needs no
+                # `unionsplitcost` gate like the unconstrained path below. With
+                # nothing to distribute, look up the projected signature directly
+                # (ordinary matching distributes its bound).
+                arm_sigs = distribute_caller_arms(refined_atype, enums,
+                    length(arginfo.argtypes), max_union_splitting)
+                if arm_sigs !== nothing
+                    # the per-arm constants are not refined here, so reuse the
+                    # original call argtypes for every arm
+                    arm_argtypes = Vector{Any}[arginfo.argtypes for _ in arm_sigs]
+                    return find_union_split_method_matches(interp, arm_argtypes,
+                        max_methods; split_sigs=arm_sigs)
+                end
+                return find_simple_method_matches(interp, refined_atype, max_methods)
+            end
+        end
+    end
+    if 1 < unionsplitcost(𝕃, arginfo.argtypes; fargs=arginfo.fargs) <= max_union_splitting
+        split_argtypes = switchtupleunion(𝕃, arginfo.argtypes; fargs=arginfo.fargs)
+        return find_union_split_method_matches(interp, split_argtypes, max_methods)
     end
     return find_simple_method_matches(interp, atype, max_methods)
 end
 
-# NOTE this is valid as far as any "constant" lattice element doesn't represent `Union` type
-is_union_split_eligible(𝕃::AbstractLattice, argtypes::Vector{Any}, max_union_splitting::Int;
-                        fargs::Union{Nothing,Vector{Any}}=nothing) =
-    1 < unionsplitcost(𝕃, argtypes; fargs) <= max_union_splitting
+"""
+    CallerSigConstraints
 
-function find_union_split_method_matches(interp::AbstractInterpreter, argtypes::Vector{Any},
-                                         max_methods::Int;
-                                         fargs::Union{Nothing,Vector{Any}}=nothing)
-    split_argtypes = switchtupleunion(typeinf_lattice(interp), argtypes; fargs)
+Represents the caller-side information needed to project the caller method
+signature onto a callee call signature (see `project_caller_sig`).
+
+This intentionally only records call arguments that originate from caller
+argument slots. In particular, it does not try to model static parameters or a
+general argument-origin abstraction.
+
+Fields:
+- `frame_sig` is the original caller method signature, including constraints
+  such as repeated use of the same type variable.
+- `arg_slots[i]` is the caller argument slot used by call argument `i`, or `0`
+  when argument `i` is not known to originate from a caller argument slot.
+- `frame_nargs` is the number of caller argument slots.
+- `frame_nfixed` is the number of fixed caller argument slots. For vararg
+  frames, this excludes the final rest slot.
+"""
+struct CallerSigConstraints
+    frame_sig::Type
+    arg_slots::Vector{Int}
+    frame_nargs::Int
+    frame_nfixed::Int
+    CallerSigConstraints(
+        @nospecialize(frame_sig::Type), arg_slots::Vector{Int}, frame_nargs::Int, frame_nfixed::Int
+    ) = new(frame_sig, arg_slots, frame_nargs, frame_nfixed)
+end
+
+function caller_sig_constraints(arginfo::ArgInfo, sv::AbsIntState)
+    sv isa InferenceState || return nothing
+    # This refinement projects the caller method signature onto the callee call
+    # signature, which is only useful when that signature constrains its
+    # argument slots beyond their individual declared types, i.e. when it is a
+    # `UnionAll` whose type variables couple multiple arguments (or multiple
+    # parameters of one argument).
+    sv.linfo.specTypes isa UnionAll || return nothing
+    fargs = arginfo.fargs
+    fargs === nothing && return nothing
+    length(fargs) == length(arginfo.argtypes) || return nothing
+    any(isvarargtype, arginfo.argtypes) && return nothing
+    nargs = Int(sv.src.nargs)
+    arg_slots = fill(0, length(fargs))
+    found_slot = false
+    for i = 1:length(fargs)
+        farg = ssa_def_slot(fargs[i], sv)
+        farg isa SlotNumber || continue
+        slot = slot_id(farg)
+        # Only caller argument slots are usable here. Other local slots do not
+        # participate in the caller method signature and therefore cannot safely
+        # recover same-TypeVar constraints from it. N.B. This relies on argument
+        # slots holding the values the frame was entered with: lowering renames
+        # an argument that is reassigned in the method body to a fresh local
+        # slot, keeping argument slots read-only. Hand-crafted `CodeInfo` that
+        # assigns to an argument slot would break this assumption.
+        1 <= slot <= nargs || continue
+        arg_slots[i] = slot
+        found_slot = true
+    end
+    found_slot || return nothing
+    return CallerSigConstraints(sv.linfo.specTypes, arg_slots, nargs, nargs - Int(sv.src.isva))
+end
+
+"""
+    project_caller_sig(argtypes::Vector{Any}, constraints::CallerSigConstraints)
+        -> Union{Nothing,Pair{Any,Vector{Tuple{Vector{Int},Vector{Any}}}}}
+
+Project the caller method signature onto the callee call signature: call
+arguments that originate from caller argument slots take the corresponding
+parameter of the caller signature with the caller's type variables kept intact,
+so that constraints such as repeated use of the same variable carry over to
+method lookup. Other arguments use their widened call-site argument types.
+
+A type variable may be kept in multiple covariant argument positions only when
+it is also diagonal in the caller signature. Otherwise (e.g. when the variable
+also occurs invariantly in a caller parameter that is not part of the call),
+the variable would become diagonal in the projected signature — requiring all
+its arguments to have the same concrete type — even though the caller frame
+imposes no such constraint. Such variables are widened to the call-site
+argument types instead.
+
+Returns the projected signature together with its *enumerable* variables: each
+entry `(positions, components)` records a union-bounded variable that appears
+only as a direct (bare) argument type at `positions`, so the call can be
+union-split by distributing the variable over the arms `components` of its upper
+bound (narrowing the bound rather than substituting a concrete type, which keeps
+the diagonal constraint inside each arm). The projected signature itself can
+also be looked up directly, since ordinary method matching distributes a
+union-bounded `∀` variable over the arms of its bound.
+"""
+function project_caller_sig(argtypes::Vector{Any}, constraints::CallerSigConstraints)
+    frame_sig = constraints.frame_sig
+    frame_tuple = unwrap_unionall(frame_sig)
+    frame_tuple isa DataType || return nothing
+    nargs = length(argtypes)
+    params = Vector{Any}(undef, nargs)
+    for i = 1:nargs
+        slot = constraints.arg_slots[i]
+        if slot == 0
+            params[i] = widenconst(argtypes[i])
+        else
+            1 <= slot <= constraints.frame_nargs || return nothing
+            if slot > constraints.frame_nfixed
+                # the vararg rest slot, passed as a tuple value
+                slot == constraints.frame_nfixed + 1 || return nothing
+                isempty(frame_tuple.parameters) && return nothing
+                vaty = frame_tuple.parameters[end]
+                isvarargtype(vaty) || return nothing
+                params[i] = Tuple{vaty}
+            else
+                slot <= length(frame_tuple.parameters) || return nothing
+                decl = frame_tuple.parameters[slot]
+                isvarargtype(decl) && return nothing
+                params[i] = decl
+            end
+        end
+    end
+    enums = Tuple{Vector{Int},Vector{Any}}[]
+    kept_var = false
+    sig = frame_sig
+    while sig isa UnionAll
+        var = sig.var
+        sig = sig.body
+        touched = Int[]
+        allbare = true               # every occurrence of `var` is a whole (bare) argument
+        proj_covariant_only = true   # `var` occurs covariant-only across the projected arguments
+        for i = 1:nargs
+            has_typevar(params[i], var) || continue
+            push!(touched, i)
+            params[i] === var || (allbare = false)
+            var_occurs_covariant_only(params[i], var) || (proj_covariant_only = false)
+        end
+        isempty(touched) && continue
+        # see the docstring; variables with non-trivial bounds are handled conservatively
+        shareable = var.lb === Bottom && !has_free_typevars(var.ub)
+        if shareable && proj_covariant_only
+            # `var` is covariant in the projection, so keeping it shared would
+            # make it diagonal there. Do so only when the caller signature makes
+            # it diagonal too, i.e. `var` occurs covariant-only in the caller
+            # frame; otherwise the projection manufactures a constraint the
+            # caller frame lacks. A single covariant occurrence is unaffected
+            # either way (a lone free variable equals its bound).
+            shareable = var_occurs_covariant_only(frame_tuple, var)
+        end
+        if !shareable
+            for i in touched
+                params[i] = widenconst(argtypes[i])
+            end
+        else
+            kept_var = true
+            if allbare && isa(var.ub, Union)
+                # `var` occurs only as bare argument types and has a union upper
+                # bound, so the call can be split by distributing it over the bound
+                push!(enums, (touched, uniontypes(var.ub)))
+            end
+        end
+    end
+    # A projection that kept no type variable cannot narrow the call signature:
+    # every variable-free parameter is either the widened call-site argument
+    # type itself or a declared type that covers it.
+    kept_var || return nothing
+    all(@nospecialize(x) -> valid_as_lattice(x, true), params) || return nothing
+    projected_sig = rewrap_unionall(Tuple{params...}, frame_sig)
+    return Pair{Any,Vector{Tuple{Vector{Int},Vector{Any}}}}(projected_sig, enums)
+end
+
+# Distribute the enumerable variables of a projected call signature over the arms
+# of their upper bounds, narrowing each variable's bound to one component at a
+# time (keeping the variable, so the diagonal constraint is preserved within each
+# arm). Returns the resulting arm signatures, or `nothing` when the split is not
+# applicable or would exceed `max_union_splitting`.
+function distribute_caller_arms(
+        @nospecialize(atype), enums::Vector{Tuple{Vector{Int},Vector{Any}}}, nargs::Int,
+        max_union_splitting::Int
+    )
+    isempty(enums) && return nothing
+    arms = Any[atype]
+    for (positions, components) in enums
+        newarms = Any[]
+        for arm in arms, comp in components
+            selector = Vector{Any}(undef, nargs)
+            fill!(selector, Any)
+            for p in positions
+                selector[p] = comp
+            end
+            narrowed = typeintersect(arm, Tuple{selector...})
+            narrowed === Bottom && continue
+            push!(newarms, narrowed)
+        end
+        length(newarms) > max_union_splitting && return nothing
+        arms = newarms
+    end
+    return isempty(arms) ? nothing : arms
+end
+
+# Look up each union-split case independently and merge the results. Each case
+# `i` is looked up using `split_sigs[i]` if given, otherwise the signature
+# derived from the argtypes `split_argtypes[i]`; the latter (including any
+# constants) is recorded for each match for later constant propagation.
+# `split_sigs` lets a case be looked up as a richer signature than its argtypes
+# can express, e.g. a bound-narrowed `Tuple{T,T} where T<:A`.
+function find_union_split_method_matches(
+        interp::AbstractInterpreter, split_argtypes::Vector, max_methods::Int;
+        split_sigs::Union{Nothing,Vector{Any}} = nothing
+    )
     infos = MethodMatchInfo[]
     applicable = MethodMatchTarget[]
     applicable_argtypes = Vector{Any}[] # arrays like `argtypes`, including constants, for each match
     valid_worlds = WorldRange()
     for i in 1:length(split_argtypes)
         arg_n = split_argtypes[i]::Vector{Any}
-        sig_n = argtypes_to_type(arg_n)
+        sig_n = split_sigs === nothing ? argtypes_to_type(arg_n) : split_sigs[i]
         sig_n === Bottom && continue
         thismatches = findall(sig_n, method_table(interp); limit = max_methods)
         if thismatches === nothing

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3495,7 +3495,7 @@ function abstract_applicable(interp::AbstractInterpreter, argtypes::Vector{Any},
     if atype === Union{}
         rt = Union{} # accidentally unreachable code
     else
-        matches = find_method_matches(interp, argtypes, atype; max_methods)
+        matches = find_method_matches(interp, ArgInfo(nothing, argtypes), atype, sv; max_methods)
         info = NoCallInfo()
         if isa(matches, FailedMethodMatch)
             rt = Bool # too many matches to analyze

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -4154,6 +4154,97 @@ end
 
 @test Base.return_types(f_apply_union_split, Tuple{Tuple{typeof(sqrt), typeof(abs)}, Int64}) == Any[Union{Int64, Float64}]
 
+# Filter infeasible union split (aviatesk/JET.jl#713)
+module JET713
+bar(::Int, ::Int) = 1
+bar(::Float64, ::Float64) = 2.0
+bar(::Int, ::Float64) = "infeasible"
+bar(::Float64, ::Int) = :infeasible
+
+bar3(::Int, ::Int, ::Int) = 1
+bar3(::Float64, ::Float64, ::Float64) = 2.0
+bar3(::Int, ::Int, ::Float64) = "infeasible"
+bar3(::Int, ::Float64, ::Int) = "infeasible"
+bar3(::Float64, ::Int, ::Int) = "infeasible"
+bar3(::Int, ::Float64, ::Float64) = :infeasible
+bar3(::Float64, ::Int, ::Float64) = :infeasible
+bar3(::Float64, ::Float64, ::Int) = :infeasible
+
+bar_param(::Vector{Int}, ::Vector{Int}) = 1
+bar_param(::Vector{Float64}, ::Vector{Float64}) = 2.0
+bar_param(::Vector{Int}, ::Vector{Float64}) = "infeasible"
+bar_param(::Vector{Float64}, ::Vector{Int}) = :infeasible
+
+bar_vararg(::Int, ::Tuple{Vararg{Int}}) = 1
+bar_vararg(::Float64, ::Tuple{Vararg{Float64}}) = 2.0
+bar_vararg(::Int, ::Tuple{Float64, Vararg{Float64}}) = "infeasible"
+bar_vararg(::Float64, ::Tuple{Int, Vararg{Int}}) = :infeasible
+
+bar_abs(::Missing, ::Missing, ::Int) = 1
+bar_abs(::Missing, ::Missing, ::Float64) = 2.0
+bar_abs(::AbstractString, ::AbstractString, ::Int) = "feasible"
+bar_abs(::AbstractString, ::AbstractString, ::Float64) = :feasible
+bar_abs(::Missing, ::AbstractString, ::Union{Int,Float64}) = nothing # infeasible
+bar_abs(::AbstractString, ::Missing, ::Union{Int,Float64}) = 0x1     # infeasible
+
+bar_nondiag(::T, ::T) where T = 1
+bar_nondiag(::Integer, ::AbstractFloat) = "cross"
+bar_nondiag(::AbstractFloat, ::Integer) = :cross
+
+bar_dist(::Missing, ::Missing) = 1
+bar_dist(::T, ::T) where {T<:AbstractString} = 2.0
+bar_dist(::String, ::SubString{String}) = "mixed" # unreachable: `x` and `y` share one concrete `T`
+bar_dist_nothrow(::Missing, ::Missing) = 1
+bar_dist_nothrow(::T, ::T) where {T<:AbstractString} = 2.0
+
+foo(x::T, y::T) where {T<:Union{Int,Float64}} = bar(x, y)
+foo3(x::T, y::T, z::T) where {T<:Union{Int,Float64}} = bar3(x, y, z)
+foo_param(x::Vector{T}, y::Vector{T}) where {T<:Union{Int,Float64}} = bar_param(x, y)
+foo_untyped(x::T, y::T) where T = bar(x, y)
+same_slot(x::Union{Int,Float64}) = bar(x, x)
+same_slot_diag(x::T, y::T) where {T<:Union{Int,Float64}} = bar(x, x)
+foo_vararg(x::T, y::T, zs::T...) where {T<:Union{Int,Float64}} = bar(x, y)
+foo_vararg_rest(x::T, ys::T...) where {T<:Union{Int,Float64}} = bar_vararg(x, ys)
+foo_abs(x::T, y::T, z::Union{Int,Float64}) where {T<:Union{Missing,AbstractString}} = bar_abs(x, y, z)
+foo_refined(x::T, y::T) where {T<:Union{Int,Float64}} = y isa Int ? bar(x, y) : zero(y)
+# `T` is not diagonal here: the invariant occurrence in `Vector{T}` allows `T` to be
+# bound to an abstract type (e.g. the whole union), so `x` and `y` may have different
+# concrete types at runtime. The union bound is wide enough that the call site
+# exceeds `max_union_splitting`.
+foo_nondiag(x::T, y::T, z::Vector{T}) where {T<:Union{Int8,Int16,Int32,Int64,Float64}} = bar_nondiag(x, y)
+foo_dist(x::T, y::T) where {T<:Union{Missing,AbstractString}} = bar_dist(x, y)
+foo_dist_nothrow(x::T, y::T) where {T<:Union{Missing,AbstractString}} = bar_dist_nothrow(x, y)
+end
+
+@test Base.infer_return_type(JET713.foo) == Union{Int, Float64}
+@test Base.infer_return_type(JET713.foo3) == Union{Int, Float64}
+@test Base.infer_return_type(JET713.foo_param) == Union{Int, Float64}
+@test Base.infer_return_type(JET713.foo_untyped, (Union{Int, Float64},Union{Int, Float64})) == Union{Int, Float64}
+@test Base.infer_return_type(JET713.same_slot) == Union{Int, Float64}
+# Same caller slot in multiple positions of a constrained (`UnionAll` caller) split.
+@test Base.infer_return_type(JET713.same_slot_diag) == Union{Int, Float64}
+# Vararg frames can use constraints from fixed caller argument slots.
+@test Base.infer_return_type(JET713.foo_vararg) == Union{Int, Float64}
+# Vararg rest slots can be projected as tuple values.
+@test Base.infer_return_type(JET713.foo_vararg_rest) == Union{Int, Float64}
+# Feasible splits must not be pruned even when they are not fully covered by the
+# caller signature: `(AbstractString, AbstractString)` is not fully covered by the
+# diagonal `Tuple{T,T} where T<:Union{Missing,AbstractString}`, but is still
+# reachable, e.g. when both arguments are `String`s.
+@test Base.infer_return_type(JET713.foo_abs) == Union{Int, Float64, String, Symbol}
+# A single feasible combination is still worth splitting on: here the infeasible
+# `bar(::Float64, ::Int)` combination is pruned, leaving only `bar(::Int, ::Int)`.
+@test Base.infer_return_type(JET713.foo_refined) == Union{Int, Float64}
+# Projecting the caller signature must not narrow the lookup: since `T` is not diagonal in
+# the caller signature, `Tuple{typeof(bar_nondiag), T, T} where T` would wrongly claim that
+# both arguments have the same concrete type, excluding the reachable cross methods.
+@test Base.infer_return_type(JET713.foo_nondiag) == Union{Int, String, Symbol}
+# `bar_dist(::String, ::SubString{String})` is unreachable from a shared `T`, so it is
+# excluded from the return type; and since the diagonal method covers the `AbstractString`
+# case, the call is also `:nothrow`.
+@test Base.infer_return_type(JET713.foo_dist) == Union{Int, Float64}
+@test Compiler.is_nothrow(Base.infer_effects(JET713.foo_dist_nothrow))
+
 # Precision of typeassert with PartialStruct
 function f_typ_assert(x::Int)
     y = (x, 1)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1255,6 +1255,7 @@ julia> .![true false true]
 length(a::Array{T,1}) where {T} = getfield(getfield(a, :size), 1)
 const C_NULL = bitcast(Ptr{Cvoid}, 0)
 has_typevar(@nospecialize(t), v::TypeVar) = ccall(:jl_has_typevar, Int32, (Any, Any), t, v) !== Int32(0)
+var_occurs_covariant_only(@nospecialize(t), v::TypeVar) = ccall(:jl_var_occurs_covariant_only, Int32, (Any, Any), t, v) !== Int32(0)
 
 # Default constructor generation for structs without explicit inner constructors.
 # Called by lowered code from struct definitions (both flisp and JuliaLowering).

--- a/src/julia.h
+++ b/src/julia.h
@@ -1925,6 +1925,7 @@ STATIC_INLINE int jl_egal_(const jl_value_t *a JL_MAYBE_UNROOTED, const jl_value
 // type predicates and basic operations
 JL_DLLEXPORT int jl_has_free_typevars(jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_has_typevar(jl_value_t *t, jl_tvar_t *v) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_var_occurs_covariant_only(jl_value_t *t, jl_tvar_t *var) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_has_typevar_from_unionall(jl_value_t *t, jl_unionall_t *ua);
 JL_DLLEXPORT int jl_subtype_env_size(jl_value_t *t) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env, int envsz);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1556,6 +1556,15 @@ static int var_occurs_covariant_only(jl_value_t *t, jl_tvar_t *var, int covarian
     return !jl_has_typevar(t, var);
 }
 
+// Test whether every occurrence of `var` in `t` is covariant, treating the top
+// level of `t` as a covariant position. Exposed for the compiler, which uses the
+// same notion of covariance to reason about when a `∀` variable's union upper
+// bound distributes over its arms (see `subtype_unionall`).
+JL_DLLEXPORT int jl_var_occurs_covariant_only(jl_value_t *t, jl_tvar_t *var) JL_NOTSAFEPOINT
+{
+    return var_occurs_covariant_only(t, var, 1);
+}
+
 // A (closed) type value bound only through equality (`Type{X}`) positions is
 // only known up to `==` (#61323); record it as a pinned (lb == ub) typevar
 // marker. A BOUND_EQ channel still marks it *defined* (constrained) for every


### PR DESCRIPTION
Thread caller signature constraints into method matching. When the caller method signature is a `UnionAll` whose type variables couple multiple arguments (or multiple parameters of one argument), the call arguments that originate from caller argument slots are constrained beyond their individually declared types, and method lookup can exploit that.

For direct union arguments, use those constraints while enumerating top-level union-split combinations so infeasible combinations are pruned before they count against the union-splitting limit.

For example:

```julia
foo(x::T, y::T) where {T<:Union{Int, Float64}} = bar(x, y)
```

Here, `bar(::Int, ::Float64)` and `bar(::Float64, ::Int)` are infeasible because both arguments must come from the same `T` chosen by the caller method signature. Repeated uses of the same caller slot within a constrained split merge their constraints by type intersection.

A combination is pruned only when the projected caller frame provably has no intersection with the caller signature. Requiring full coverage (`<:`) instead would be unsound for combinations involving abstract union elements: e.g. `(AbstractString, AbstractString)` is not fully covered by the diagonal `Tuple{T,T} where T<:Union{Missing,AbstractString}`, yet it is still reachable when both arguments are `String`s. Since pruned combinations do not count against `max_union_splitting`, the enumeration itself is additionally bounded by `max_union_splitting^2`.

When call arguments do not expose a useful top-level union split, project the caller frame signature into the callee call signature before method lookup. This preserves same-`TypeVar` constraints inside parameterized argument types such as:

```julia
bar_param(::Vector{Int}, ::Vector{Int}) = 1
bar_param(::Vector{Float64}, ::Vector{Float64}) = 2.0
bar_param(::Vector{Int}, ::Vector{Float64}) = "infeasible"
bar_param(::Vector{Float64}, ::Vector{Int}) = :infeasible

foo_param(x::Vector{T}, y::Vector{T}) where {T<:Union{Int, Float64}} = bar_param(x, y)
```

The cross `bar_param` methods are likewise infeasible because both caller arguments share the same `T`, even though `Vector{T}` itself is not a top-level union split candidate.

Vararg frames use the constrained signature lookup path as well. Fixed caller argument slots are projected directly, and a vararg rest slot passed as a tuple value is projected as `Tuple{Vararg{T}}`, preserving constraints for calls such as `bar_var(x, ys)` from `foo(x::T, ys::T...)`.

This mechanism is deliberately limited to caller signature constraints: same-value coupling between call argument positions (e.g. `bar(x, x)`) is covered by the alias-group-aware union splitting independently of the caller signature.

This also includes related cleanups and clarifications:

- represent constrained split state explicitly with `CallerSigConstraints` and `SwitchTupleUnionState`
- return `Vector{Vector{Any}}` for argtype tuple-union switches

Addresses aviatesk/JET.jl#713.