### PR TITLE
[Windows] RFC: Work around Smart App Control failures by re-generating pkgimages

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -509,6 +509,11 @@ end
 struct TrimFailure <: Exception
     TrimFailure() = new()
 end
+struct ImageLoadBlockedError <: Exception
+    ocachefile::String
+    errcode::UInt32
+    ImageLoadBlockedError(ocachefile::String, errcode::UInt32) = new(ocachefile, errcode)
+end
 
 String(s::String) = s  # no constructor yet
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2472,6 +2472,8 @@ end
 
 # we throw PrecompilableError when a module doesn't want to be precompiled
 import Core: PrecompilableError
+# the runtime throws ImageLoadBlockedError when the OS refuses to load a pkgimage
+import Core: ImageLoadBlockedError
 function show(io::IO, ex::PrecompilableError)
     print(io, "Error when precompiling module, potentially caused by a __precompile__(false) declaration in the module.")
 end
@@ -2898,7 +2900,18 @@ function __require_prelocked(pkg::PkgId, env)
                                 end
                             end
                         end
-                        return compilecache(pkg, spec; loadable_exts)
+                        return let loadable_exts = loadable_exts # to avoid box
+                            retry_if_image_blocked(pkg;
+                                on_retry = (pkg::PkgId, n, err::ImageLoadBlockedError) -> begin
+                                    warning = image_blocked_summary(err)
+                                    warning = warning * " Rebuilding cache for $(repr("text/plain", pkg))"
+                                    warning = warning * " ($n/$(MAX_BLOCKED_IMAGE_RETRIES[]))"
+                                    @warn warning
+                                end,
+                            ) do
+                                compilecache(pkg, spec; loadable_exts)
+                            end
+                        end
                     finally
                         lock(require_lock)
                     end
@@ -3474,6 +3487,83 @@ end
 
 const MAX_NUM_PRECOMPILE_FILES = Ref(10)
 
+# Windows can intermittently refuse to load a pkgimage due to application
+# policy controls, esp. Smart App Control whose cloud reputation (ISG)
+# queries have been observed to fail when querying many new pkgimages.
+const APPLICATION_CONTROL_POLICY_ERROR = UInt32(0x000011C7)
+const MAX_BLOCKED_IMAGE_RETRIES = Ref(3)
+
+image_blocked_summary(ex::ImageLoadBlockedError) =
+    ex.errcode == APPLICATION_CONTROL_POLICY_ERROR ?
+        "Smart App Control blocked loading the image." :
+        "The operating system blocked loading the image (error $(repr(ex.errcode)))."
+
+function showerror(io::IO, ex::ImageLoadBlockedError)
+    print(io, image_blocked_summary(ex))
+    print(io, " LoadLibrary was prevented from loading ", repr(ex.ocachefile))
+    print(io, " (Windows error ", repr(ex.errcode), ").")
+    if ex.errcode == APPLICATION_CONTROL_POLICY_ERROR
+        print(io, " This is usually an intermittent failure caused by a failed")
+        print(io, " cloud reputation (ISG) query. Try again later or disable Smart App Control.")
+    end
+end
+
+# Map a Win32 `LoadLibrary` error code to an `ImageLoadBlockedError` if it
+# indicates an application control policy failure.
+function image_blocked_error(ocachefile::String, errcode::UInt32)
+    if errcode == APPLICATION_CONTROL_POLICY_ERROR
+        return ImageLoadBlockedError(ocachefile, errcode)
+    end
+    return nothing
+end
+
+"""
+    check_pkgimage_not_blocked(ocachefile) -> Union{Nothing,ImageLoadBlockedError}
+
+Load the provided image in a temporary sub-process. Return an `ImageLoadBlockedError`
+if the operating system refuses to load `ocachefile` because an Application Control
+Policy, such as Smart App Control / WDAC blocked it.
+"""
+function check_pkgimage_not_blocked(ocachefile::Union{String,Nothing})
+    @static if !Sys.iswindows()
+        return nothing
+    else
+        ocachefile === nothing && return nothing
+        exe = joinpath(Sys.BINDIR, julia_exename())
+        probe = pipeline(ignorestatus(`$exe --probe-image-load=$ocachefile`), stdout=devnull, stderr=devnull)
+        errcode = run(probe).exitcode % UInt32
+        errcode == 0 && return nothing
+        @debug "Probe `LoadLibrary` of pkgimage failed" ocachefile errcode
+        return image_blocked_error(ocachefile, errcode)
+    end
+end
+
+"""
+    retry_if_image_blocked(build, pkg; on_retry, should_stop) -> Any
+
+Invoke `build`, retrying it whenever it throws an `ImageLoadBlockedError`.
+
+The error is rethrown after `MAX_BLOCKED_IMAGE_RETRIES[]` failed rebuilds, or as
+soon as `should_stop()` returns `true`. `on_retry(pkg, n, err)` is called before
+each re-invocation.
+"""
+function retry_if_image_blocked(build, pkg::PkgId;
+        on_retry = (pkg::PkgId, n, err::ImageLoadBlockedError)->nothing,
+        should_stop = Returns(false))
+    retries = 0
+    max_retries = MAX_BLOCKED_IMAGE_RETRIES[]
+    while true
+        try
+            return build()
+        catch err
+            err isa ImageLoadBlockedError || rethrow()
+            (retries >= max_retries || should_stop()) && rethrow()
+            retries += 1
+            on_retry(pkg, retries, err)
+        end
+    end
+end
+
 function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stderr, internal_stdout::IO = stdout,
                       keep_loaded_modules::Bool = true; flags::Cmd=``, cacheflags::CacheFlags=CacheFlags(),
                       loadable_exts::Union{Vector{PkgId},Nothing}=nothing, signal_channel::Union{Channel{Int32},Nothing}=nothing,
@@ -3609,6 +3699,16 @@ function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stder
                 end
                 @static if Sys.isapple()
                     run(`$(Linking.dsymutil()) $ocachefile`, Base.DevNull(), Base.DevNull(), Base.DevNull())
+                end
+                # Check that the OS will actually load the image before it is
+                # published via the `.ji` rename below.
+                load_error = check_pkgimage_not_blocked(ocachefile)
+                if load_error isa ImageLoadBlockedError
+                    @debug "Image loading blocked with error code $(load_error.errcode). Deleting the rejected cache file." ocachefile
+                    rm(ocachefile; force=true)
+                    throw(load_error)
+                else
+                    @assert load_error === nothing "Unexpected image load error."
                 end
             end
             # this is atomic according to POSIX (not Win32):

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1459,8 +1459,15 @@ function _include_from_serialized(pkg::PkgId, path::String, ocachepath::Union{No
         sv = try
             if ocachepath !== nothing
                 @debug "Loading object cache file $ocachepath for $(repr("text/plain", pkg))"
-                ccall(:jl_restore_package_image_from_file, Any, (Cstring, Any, Cint, Cstring, Cint),
-                    ocachepath, depmods, #=completeinfo=#false, pkg.name, ignore_native)
+                try
+                    ccall(:jl_restore_package_image_from_file, Any, (Cstring, Any, Cint, Cstring, Cint),
+                        ocachepath, depmods, #=completeinfo=#false, pkg.name, ignore_native)
+                catch err
+                    err isa ImageLoadBlockedError || rethrow()
+                    @debug "Loading an existing image for $(repr("text/plain", pkg)) blocked with error code $(err.errcode)." ocachepath
+                    maybe_purge_blocked_cachefile!(err, path, ocachepath)
+                    err
+                end
             else
                 @debug "Loading cache file $path for $(repr("text/plain", pkg))"
                 ccall(:jl_restore_incremental, Any, (Cstring, Any, Cint, Cstring),
@@ -3517,6 +3524,17 @@ function image_blocked_error(ocachefile::String, errcode::UInt32)
     return nothing
 end
 
+# If `load_error` is an ImageLoadBlockedError, delete the cache files for the
+# image: the OS caches its rejection per-file, so the image may not be able to
+# load for a long time and must be rebuilt. Returns whether the files were purged.
+function maybe_purge_blocked_cachefile!(load_error, cachefile::String, ocachefile::Union{String,Nothing})
+    load_error isa ImageLoadBlockedError || return false
+    @debug "Deleting cache file $cachefile: the OS blocked loading its image." exception=load_error
+    rm(cachefile; force=true)
+    ocachefile === nothing || rm(ocachefile; force=true)
+    return true
+end
+
 """
     check_pkgimage_not_blocked(ocachefile) -> Union{Nothing,ImageLoadBlockedError}
 
@@ -3703,12 +3721,8 @@ function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stder
                 # Check that the OS will actually load the image before it is
                 # published via the `.ji` rename below.
                 load_error = check_pkgimage_not_blocked(ocachefile)
-                if load_error isa ImageLoadBlockedError
-                    @debug "Image loading blocked with error code $(load_error.errcode). Deleting the rejected cache file." ocachefile
-                    rm(ocachefile; force=true)
+                if maybe_purge_blocked_cachefile!(load_error, cachefile, ocachefile)
                     throw(load_error)
-                else
-                    @assert load_error === nothing "Unexpected image load error."
                 end
             end
             # this is atomic according to POSIX (not Win32):

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -29,7 +29,8 @@ mutable struct PrecompileJob
     waiting_for_bg::Bool
     verbose_timing::String  # raw payload from the worker subprocess; surfaced in verbose mode
     peak_rss_bytes::UInt64  # max RSS observed by `poll_process_stats!`; 0 on unsupported platforms
-    PrecompileJob() = new(JOB_PENDING, 0.0, "", IOBuffer(), Int32(0), false, "", false, "", UInt64(0))
+    retries::Int  # rebuilds, usually after the OS (Windows) blocked the freshly-created image
+    PrecompileJob() = new(JOB_PENDING, 0.0, "", IOBuffer(), Int32(0), false, "", false, "", UInt64(0), 0)
 end
 
 is_pending(j::PrecompileJob)    = j.status == JOB_PENDING
@@ -41,6 +42,7 @@ has_pid(j::PrecompileJob)       = j.pid > 0
 had_pid(j::PrecompileJob)       = j.had_pid
 is_locked(j::PrecompileJob)     = !isempty(j.lock_holder)
 is_waiting(j::PrecompileJob)    = j.waiting_for_bg
+is_retrying(j::PrecompileJob)   = j.retries > 0
 
 mark_started!(j::PrecompileJob, t::Float64=time()) = (j.status = JOB_STARTED; j.started_at = t)
 mark_recompiled!(j::PrecompileJob) = (j.status = JOB_RECOMPILED)
@@ -1858,6 +1860,8 @@ function spawn_print_loop!(s::PrecompileSession)
                                     color_string(" Being precompiled by $(job.lock_holder)", Base.info_color(), s.hascolor)
                                 elseif is_waiting(job)
                                     color_string(" Waiting for background task / IO / timer. Interrupt to inspect", Base.warn_color(), s.hascolor)
+                                elseif is_retrying(job)
+                                    color_string(retry_annotation(job.retries), Base.warn_color(), s.hascolor)
                                 else
                                     ""
                                 end
@@ -1988,6 +1992,27 @@ function precompile_pkgs_maybe_cachefile_lock(f, s::PrecompileSession, pkg_confi
     return cachefile
 end
 
+# Build a fresh pkgimage via `produce_pkgimage`, retrying if Windows Smart App
+# Control blocked loading the freshly built image. Any retries are reported as
+# part of the precompile task status via the PrecompileSession.
+function retry_if_image_blocked_interactive(produce_pkgimage, s::PrecompileSession, pkg_config::PkgConfig)
+    pkg, _ = pkg_config
+    Base.retry_if_image_blocked(produce_pkgimage, pkg;
+        should_stop = () -> should_stop(s),
+        on_retry = (pkg, n, err) -> @lock s.print_lock begin
+            s.jobs[pkg_config].retries = n
+            if BG.monitoring
+                # The progress display reports the retry: as an inline annotation on the
+                # job line in fancyprint mode, or as a status line in plain mode.
+                !s.fancyprint && println(s.io, "    ", full_name(s.ext_to_parent, pkg),
+                    color_string(retry_annotation(n), Base.warn_color(), s.hascolor))
+            end
+        end
+    )
+end
+
+retry_annotation(n::Int) = " Smart App Control blocked the image. Rebuilding ($n/$(Base.MAX_BLOCKED_IMAGE_RETRIES[]))"
+
 function spawn_precompile_tasks!(s::PrecompileSession;
         direct_deps, was_processed, configs, circular_deps,
         requested_pkgids, pkg_names, requested_pkgs, from_loading)
@@ -2067,10 +2092,13 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                         pid_ch = Channel{Int32}(1)
                         if from_loading && pkg in requested_pkgids
                             Base.errormonitor(Threads.@spawn :samepool begin
-                                pid = try; take!(pid_ch); catch; Int32(0); end
-                                pid > 0 && @lock s.print_lock set_pid!(s.jobs[pkg_config], pid)
+                                # compilecache reports a new pid for each rebuild attempt
+                                # (the channel is closed once the build is done)
+                                for pid in pid_ch
+                                    pid > 0 && @lock s.print_lock set_pid!(s.jobs[pkg_config], pid)
+                                end
                             end)
-                            t = @elapsed ret = begin
+                            t = @elapsed ret = retry_if_image_blocked_interactive(s, pkg_config) do
                                 Base.compilecache(pkg, sourcespec, std_pipe, std_pipe, !s.ignore_loaded;
                                                   flags=flags_, cacheflags, loadable_exts, signal_channel=make_signal_channel(),
                                                   pid_channel=pid_ch, report_timing=true)
@@ -2078,8 +2106,11 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                         else
                             fullname = full_name(s.ext_to_parent, pkg)
                             Base.errormonitor(Threads.@spawn :samepool begin
-                                pid = try; take!(pid_ch); catch; Int32(0); end
-                                pid > 0 && @lock s.print_lock set_pid!(s.jobs[pkg_config], pid)
+                                # compilecache reports a new pid for each rebuild attempt
+                                # (the channel is closed once the build is done)
+                                for pid in pid_ch
+                                    pid > 0 && @lock s.print_lock set_pid!(s.jobs[pkg_config], pid)
+                                end
                             end)
                             t = @elapsed ret = precompile_pkgs_maybe_cachefile_lock(s, pkg_config, fullname) do
                                 if should_stop(s)
@@ -2096,9 +2127,11 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                                 s.logcalls === CoreLogging.Debug && @lock s.print_lock begin
                                     @debug "Precompiling $(repr("text/plain", pkg))"
                                 end
-                                Base.compilecache(pkg, sourcespec, std_pipe, std_pipe, !s.ignore_loaded;
-                                                  flags=flags_, cacheflags, loadable_exts, signal_channel=make_signal_channel(),
-                                                  pid_channel=pid_ch, report_timing=true)
+                                retry_if_image_blocked_interactive(s, pkg_config) do
+                                    Base.compilecache(pkg, sourcespec, std_pipe, std_pipe, !s.ignore_loaded;
+                                                      flags=flags_, cacheflags, loadable_exts, signal_channel=make_signal_channel(),
+                                                      pid_channel=pid_ch, report_timing=true)
+                                end
                             end
                         end
                         if ret isa Exception

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -2013,6 +2013,23 @@ end
 
 retry_annotation(n::Int) = " Smart App Control blocked the image. Rebuilding ($n/$(Base.MAX_BLOCKED_IMAGE_RETRIES[]))"
 
+# An existing image can become blocked by the OS after it was created, which
+# the freshness checks cannot detect. Spawn a sub-process to verify that has
+# not happened and purge the cache if it has.
+#
+# This costs a sub-process spawn for each non-stale cache image, but we only
+# perform the check during pre-compile sessions (not when loading from a
+# complete + fresh cache) so it's worth it to avoid unexpected SAC blocks
+# during the precompile job itself.
+function verify_pkgimage_loadable!(s::PrecompileSession, freshpath::String)
+    Base.JLOptions().use_pkgimages == 1 || return true
+    ocachepath = Base.ocachefile_from_cachefile(freshpath)
+    load_error = Base.check_pkgimage_not_blocked(ocachepath)
+    Base.maybe_purge_blocked_cachefile!(load_error, freshpath, ocachepath) || return true
+    @lock s.cache_lock filter!(kv -> kv.first[4] != freshpath, s.stale_cache)
+    return false
+end
+
 function spawn_precompile_tasks!(s::PrecompileSession;
         direct_deps, was_processed, configs, circular_deps,
         requested_pkgids, pkg_names, requested_pkgs, from_loading)
@@ -2120,7 +2137,7 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                                 local freshpath = @lock s.cache_lock Base.compilecache_freshest_path(pkg; ignore_loaded=s.ignore_loaded,
                                     stale_cache=s.stale_cache, cachepath_cache=s.cachepath_cache, cachepaths, sourcespec, flags=cacheflags)
                                 local is_stale = freshpath === nothing
-                                if !is_stale
+                                if !is_stale && verify_pkgimage_loadable!(s, freshpath)
                                     push!(freshpaths, freshpath)
                                     return nothing
                                 end

--- a/cli/loader_exe.c
+++ b/cli/loader_exe.c
@@ -27,6 +27,11 @@ JL_DLLEXPORT const char* __asan_default_options(void)
 #ifdef _OS_WINDOWS_
 int mainCRTStartup(void)
 {
+    // Allow Windows APIs such as `LoadLibrary` to return a useful error code
+    // to Julia for "critical" errors instead of creating an error pop-up for
+    // the user, which hangs Julia until it's dismissed.
+    SetErrorMode(SEM_FAILCRITICALERRORS);
+
     int argc;
     LPWSTR * wargv = CommandLineToArgv(GetCommandLine(), &argc);
     char ** argv = (char **)malloc(sizeof(char*) * (argc + 1));

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -56,6 +56,7 @@
     XX(gotoifnot_type, jl_datatype_t*) \
     XX(enternode_type, jl_datatype_t*) \
     XX(gotonode_type, jl_datatype_t*) \
+    XX(imageloadblockederror_type, jl_datatype_t*) \
     XX(initerror_type, jl_datatype_t*) \
     XX(int16_type, jl_datatype_t*) \
     XX(int32_type, jl_datatype_t*) \

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -421,6 +421,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_gc_sweep_always_full,
            opt_gc_threads,
            opt_permalloc_pkgimg,
+           opt_probe_image_load,
            opt_trim,
            opt_trace_eval,
            opt_experimental_features,
@@ -492,6 +493,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "strip-metadata",  no_argument,       0, opt_strip_metadata },
         { "strip-ir",        no_argument,       0, opt_strip_ir },
         { "permalloc-pkgimg",required_argument, 0, opt_permalloc_pkgimg },
+        { "probe-image-load",required_argument, 0, opt_probe_image_load },
         { "heap-size-hint",  required_argument, 0, opt_heap_size_hint },
         { "hard-heap-limit", required_argument, 0, opt_hard_heap_limit },
         { "heap-target-increment", required_argument, 0, opt_heap_target_increment },
@@ -1058,6 +1060,22 @@ restart_switch:
             else
                 jl_errorf("julia: invalid argument to --permalloc-pkgimg={yes|no} (%s)", optarg);
             break;
+        case opt_probe_image_load:
+        {
+#if defined(_OS_WINDOWS_)
+            // This is used as a quick test to check whether `LoadLibrary`
+            // will allow us to load an image file or if Smart App Control,
+            // etc. are conspiring against us.
+            //
+            // Perform the load and exit immediately with the result.
+            SetLastError(0);
+            void *probed = jl_dlopen(optarg, JL_RTLD_LAZY);
+            exit(probed != NULL ? 0 : (int)GetLastError());
+#else
+            jl_errorf("julia: --probe-image-load is only supported on Windows");
+#endif
+            break;
+        }
         case opt_timeout_for_safepoint_straggler:
         {
             errno = 0;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4204,6 +4204,7 @@ void post_boot_hooks(void)
     jl_loaderror_type        = (jl_datatype_t*)core("LoadError");
     jl_initerror_type        = (jl_datatype_t*)core("InitError");
     jl_missingcodeerror_type = (jl_datatype_t*)core("MissingCodeError");
+    jl_imageloadblockederror_type = (jl_datatype_t*)core("ImageLoadBlockedError");
 
     jl_pair_type             = core("Pair");
     jl_value_t *kwcall_func  = core("kwcall");

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -4400,19 +4400,33 @@ JL_DLLEXPORT void jl_restore_system_image(jl_image_t *image, jl_image_buf_t buf)
     JL_SIGATOMIC_END();
 }
 
+#ifdef _OS_WINDOWS_
+#define APPLICATION_CONTROL_POLICY_ERROR 0x11C7
+#endif
+
 JL_DLLEXPORT jl_value_t *jl_restore_package_image_from_file(const char *fname, jl_array_t *depmods, int completeinfo, const char *pkgname, int ignore_native)
 {
     void *pkgimg_handle = jl_dlopen(fname, JL_RTLD_LAZY);
     if (!pkgimg_handle) {
 #ifdef _OS_WINDOWS_
-        int err;
+        unsigned int err;
         char reason[256];
         err = GetLastError();
         win32_formatmessage(err, reason, sizeof(reason));
+        // Application control policies can refuse the load and the OS caches the verdict
+        // per-file, so throw an error to allow code loading to delete and rebuild the image.
+        if (err == APPLICATION_CONTROL_POLICY_ERROR && jl_imageloadblockederror_type != NULL) {
+            jl_value_t *path = NULL, *code = NULL;
+            JL_GC_PUSH2(&path, &code);
+            path = jl_cstr_to_string(fname);
+            code = jl_box_uint32(err);
+            jl_throw(jl_new_struct(jl_imageloadblockederror_type, path, code));
+        }
+        jl_errorf("Error opening package file %s (win32 error %u): %s\n", fname, err, reason);
 #else
         const char *reason = dlerror();
-#endif
         jl_errorf("Error opening package file %s: %s\n", fname, reason);
+#endif
     }
 
     jl_image_buf_t buf = get_image_buf(pkgimg_handle, /* is_pkgimage */ 1);


### PR DESCRIPTION
Smart App Control has been driving us a bit mad on Windows. When encountering unsigned DLL's, such as our pkgimages, it subjects them to a "reputation check" by querying the online ISG (Intelligent Security Graph). Especially when querying many new files at once however, these queries have been observed to sporadically fail, and we cannot prevent these queries from happening in the first place because we cannot codesign pkgimages on user machines.

After a failure happens, Windows caches the result (keyed on your pkgimage hash), so that you are unable to load the failing pkgimage for ~20 minutes to several hours, leaving this confusing error message if you try:

<img width="422" height="122" alt="small Screenshot 2026-06-02 221409" src="https://github.com/user-attachments/assets/1df5911e-b94e-4e82-9f61-22ce6e6760bb" />

--------

As a workaround, make Julia much more proactive about detecting these blocks by Windows, and try to resolve the issue automatically by deleting and re-creating your pkgimage files:

1. When creating new pkgimages, load them in a sub-process (via an `--probe-image-load` undocumented CLI option) to force Smart App Control to accept / reject the image and retry on rejection.
2. For existing pkgimages, add an `ImageLoadBlockedError` that can be reported when an attempt to load a pkgimage is blocked by Smart App Control (based on the return value from `LoadLibrary`). If this happens, purge the blocked cache file from `.compiled` and force re-creation of new pkgimages.
3. Add support to the interactive precompilation menu to display any retries due to (1) above.

TODO:
 - [x] Test "fresh pkgimage blocked" pathways on Windows
 - [x] Test "existing pkgimage(s) blocked" pathways on Windows