### PR TITLE
Suppress clang 21 -Wc++-keyword warning enabled by -Wc++-compat

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -568,6 +568,11 @@ JCFLAGS_COMMON     = -std=gnu11 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSE
 JCFLAGS_CLANG      = $(JCFLAGS_COMMON)
 JCFLAGS_GCC        = $(JCFLAGS_COMMON) -fno-gnu-unique
 
+# Xcode 26 (clang 21) folds the new -Wc++-keyword diagnostic into -Wc++-compat, erroring
+# under -Werror on uses of C++ keywords like `wchar_t` as ordinary identifiers in C code.
+# Suppress it; -Wno-unknown-warning-option keeps older clang from rejecting the flag.
+JCFLAGS_CLANG     += -Wno-unknown-warning-option -Wno-c++-keyword
+
 
 # These flags are needed to generate decent debug info
 JCPPFLAGS_COMMON   = -fasynchronous-unwind-tables


### PR DESCRIPTION
Xcode 26's clang (clang 21) folds the new `-Wc++-keyword` diagnostic into `-Wc++-compat`, which the `src/`, `src/support/`, and `src/flisp/` Makefiles enable for C code. Uses of C++ keywords as ordinary identifiers in C — e.g. the `wchar_t` typedef in `src/support/utf8.c` — then fail to compile under `-Werror` (as used on CI):

```
src/support/utf8.c:515:20: error: identifier 'wchar_t' conflicts with a C++ keyword [-Werror,-Wc++-keyword]
```

This currently breaks the `:macos: build aarch64-apple-darwin` CI job on build agents that have been upgraded to macOS Tahoe / Xcode 26 (first failure: [julia-master#58011](https://buildkite.com/julialang/julia-master/builds/58011#019ebb30-d5b0-48d3-9bc7-72fff3a2b0ce)).

Fix: add `-Wno-c++-keyword` to `JCFLAGS_CLANG` in `Make.inc`. Since `JCFLAGS_CLANG = $(JCFLAGS_COMMON)` is lazily expanded, the suppression reliably ends up after the `-Wc++-compat` appended to `JCFLAGS_COMMON` by the per-directory Makefiles, so it wins regardless of include order. Older clang versions don't know this warning flag, so `-Wno-unknown-warning-option` is passed alongside to keep the suppression itself from erroring under `-Werror` on the not-yet-upgraded (Xcode 14.x) agents.

Verified on an upgraded CI machine (honeycrisp, macOS 26.5.1, Xcode 26.5/clang 21): the minimal reproducer and `src/support/utf8.c` compile cleanly with the flag, and a full `make JL_CFLAGS=-Werror JL_CXXFLAGS=-Werror` build is in progress. Also verified that clang 14 accepts the flag combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)