### PR TITLE
test: fix racy variable capture in irrational-to-rational threads test

### DIFF
--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1504,6 +1504,9 @@ end
             Rational{I}(c)
         end
         function is_racy_rational_from_irrational()
+            # `local` is needed to avoid sharing (and racily clobbering) the
+            # outer function's `task`/`ok` while it is fetching them
+            local task, ok
             worker_count = 10 * Threads.nthreads()
             task = ConcurrencyUtilities.run_concurrently_in_new_task(construct, worker_count)
             schedule(task)


### PR DESCRIPTION
Spotted in https://buildkite.com/julialang/julia-master/builds/58009#019eba17-321a-4cab-907c-4628715e32f5/L1890-L1893.

This "capture of a variable that hasn't been mentioned yet" behavior is an easy footgun.

Found by inspection by Claude Fable 🤖 which points out that we also hit this back in https://github.com/JuliaLang/julia/pull/55045#issuecomment-3607464626