### PR TITLE
docs: fix spelling, grammar, and prose in documentation

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -56,7 +56,7 @@ This is the list of reserved keywords in Julia:
 `return`, `struct`, `true`, `try`, `using`, `while`.
 Those keywords are not allowed to be used as variable names.
 
-Names starting and ending with double underscores, or dunders, are reserved for use by Julia. This includes macros. Examples of dunder names currently in use include [`__init__`](@ref), [`__source__`]@(ref), [`__module__`](@ref), [`__precompile__`](@ref), [`@__dot__`](@ref), [`@__DIR__`](@ref), [`@__FILE__`](@ref), [`@__LINE__`](@ref), and [`@__MODULE__`](@ref). These reservations are not currently enforced by the parser.
+Names starting and ending with double underscores, or dunders, are reserved for use by Julia. This includes macros. Examples of dunder names currently in use include [`__init__`](@ref), [`__source__`](@ref), [`__module__`](@ref), [`__precompile__`](@ref), [`@__dot__`](@ref), [`@__DIR__`](@ref), [`@__FILE__`](@ref), [`@__LINE__`](@ref), and [`@__MODULE__`](@ref). These reservations are not currently enforced by the parser.
 
 
 The following two-word sequences are reserved:

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -117,9 +117,9 @@ PNG images in a window can register this capability with Julia, so that calling 
 types with PNG representations will automatically display the image using the module's window.
 
 In order to define a new display backend, one should first create a subtype `D` of the abstract
-class [`AbstractDisplay`](@ref). Then, for each MIME type (`mime` string) that can be displayed on `D`, one should
+type [`AbstractDisplay`](@ref). Then, for each MIME type (`mime` string) that can be displayed on `D`, one should
 define a function `display(d::D, ::MIME"mime", x) = ...` that displays `x` as that MIME type,
-usually by calling [`show(io, mime, x)`](@ref) or [`repr(io, mime, x)`](@ref).
+usually by calling [`show(io, mime, x)`](@ref) or [`repr(mime, x)`](@ref).
 A [`MethodError`](@ref) should be thrown if `x` cannot be displayed
 as that MIME type; this is automatic if one calls `show` or `repr`. Finally, one should define a function
 `display(d::D, x)` that queries [`showable(mime, x)`](@ref) for the `mime` types supported by `D`

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -299,12 +299,12 @@ Base.FastMath.@fastmath
 
 ## Customizable binary operators
 
-Some unicode characters can be used to define new binary operators
+Some Unicode characters can be used to define new binary operators
 that support infix notation.
 For example
 ```⊗(x,y) = kron(x,y)```
 defines the `⊗` (otimes) function to be the Kronecker product,
-and one can call it as binary operator using infix syntax:
+and one can call it as a binary operator using infix syntax:
 ```C = A ⊗ B```
 as well as with the usual prefix syntax
 ```C = ⊗(A,B)```.

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -153,7 +153,7 @@ notifying...
 done
 ```
 
-`OneWayEvent` lets one task to `wait` for another task's `notify`. It is a limited
+`OneWayEvent` lets one task `wait` for another task's `notify`. It is a limited
 communication interface since `wait` can only be used once from a single task (note the
 non-atomic assignment of `ev.task`)
 

--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -153,5 +153,5 @@ CodeInfo(
 ```
 
 Possible values for `debuginfo` are: `:none`, `:source`, and `:default`.
-By default debug information is not printed, but that can be changed
+By default, debug information is not printed, but that can be changed
 by setting `Base.IRShow.default_debuginfo[] = :source`.

--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -48,7 +48,7 @@ of these fields is the `types` field observed in the example above.
 ## Subtypes
 
 The *direct* subtypes of any `DataType` may be listed using [`subtypes`](@ref). For example,
-the abstract `DataType` [`AbstractFloat`](@ref) has four (concrete) subtypes:
+the abstract `DataType` [`AbstractFloat`](@ref) has five (concrete) subtypes:
 
 ```jldoctest; setup = :(using InteractiveUtils)
 julia> InteractiveUtils.subtypes(AbstractFloat)
@@ -117,8 +117,7 @@ method-specific code-lowering is available using [`code_lowered`](@ref),
 and the type-inferred form is available using [`code_typed`](@ref).
 [`code_warntype`](@ref) adds highlighting to the output of [`code_typed`](@ref).
 
-Closer to the machine, the LLVM intermediate representation of a function may be printed using
-by [`code_llvm`](@ref), and finally the compiled machine code is available
+Closer to the machine, the LLVM intermediate representation of a function may be printed using [`code_llvm`](@ref), and finally the compiled machine code is available
 using [`code_native`](@ref) (this will trigger JIT compilation/code
 generation for any function which has not previously been called).
 
@@ -154,5 +153,5 @@ CodeInfo(
 ```
 
 Possible values for `debuginfo` are: `:none`, `:source`, and `:default`.
-Per default debug information is not printed, but that can be changed
+By default debug information is not printed, but that can be changed
 by setting `Base.IRShow.default_debuginfo[] = :source`.

--- a/doc/src/base/scopedvalues.md
+++ b/doc/src/base/scopedvalues.md
@@ -332,7 +332,7 @@ version of Julia.
 
 ## Design inspiration
 
-This design was heavily inspired by [JEPS-429](https://openjdk.org/jeps/429),
+This design was heavily inspired by [JEP 429](https://openjdk.org/jeps/429),
 which in turn was inspired by dynamically scoped free variables in many Lisp dialects. In particular Interlisp-D and its deep binding strategy.
 
-A prior design discussed was context variables ala [PEPS-567](https://peps.python.org/pep-0567/) and implemented in Julia as [ContextVariablesX.jl](https://github.com/tkf/ContextVariablesX.jl).
+A prior design discussed was context variables à la [PEP 567](https://peps.python.org/pep-0567/) and implemented in Julia as [ContextVariablesX.jl](https://github.com/tkf/ContextVariablesX.jl).

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -105,7 +105,7 @@ The list here is not exhaustive, for example there are also
 - [markdown string literals](@ref stdlib-markdown-literals) of the form `md"..."`,
 - [regular expressions and substitution string literals](@ref base-regex-literals), and
 - large integer literals for 128 bit constants of the form
-  [`int128"..."`](@ref Base.@int128_str) resp. [`uint128"..."`](@ref Base.@uint128_str).
+  [`int128"..."`](@ref Base.@int128_str) and [`uint128"..."`](@ref Base.@uint128_str).
 
 ```@docs
 Base.@lazy_str

--- a/doc/src/devdocs/EscapeAnalysis.md
+++ b/doc/src/devdocs/EscapeAnalysis.md
@@ -52,7 +52,7 @@ end
 
 The symbols on the side of each call argument and SSA statements represent the following meaning:
 - `◌` (plain): this value is not analyzed because escape information of it won't be used anyway (when the object is `isbitstype` for example)
-- `✓` (green or cyan): this value never escapes (`has_no_escape(result.state[x])` holds), colored blue if it has arg escape also (`has_arg_escape(result.state[x])` holds)
+- `✓` (green or cyan): this value never escapes (`has_no_escape(result.state[x])` holds), colored cyan if it has arg escape also (`has_arg_escape(result.state[x])` holds)
 - `↑` (blue or yellow): this value can escape to the caller via return (`has_return_escape(result.state[x])` holds), colored yellow if it has unhandled thrown escape also (`has_thrown_escape(result.state[x])` holds)
 - `X` (red): this value can escape to somewhere the escape analysis can't reason about like escapes to a global memory (`has_all_escape(result.state[x])` holds)
 - `*` (bold): this value's escape state is between the `ReturnEscape` and `AllEscape` in the partial order of [`EscapeInfo`](@ref Base.Compiler.EscapeAnalysis.EscapeInfo), colored yellow if it has unhandled thrown escape also (`has_thrown_escape(result.state[x])` holds)
@@ -72,7 +72,7 @@ result.state[Core.SSAValue(3)] # get EscapeInfo of `r3`
 `EscapeAnalysis` is implemented as a [data-flow analysis](https://en.wikipedia.org/wiki/Data-flow_analysis)
 that works on a lattice of [`x::EscapeInfo`](@ref Base.Compiler.EscapeAnalysis.EscapeInfo),
 which is composed of the following properties:
-- `x.Analyzed::Bool`: not formally part of the lattice, only indicates `x` has not been analyzed or not
+- `x.Analyzed::Bool`: not formally part of the lattice, only indicates whether `x` has been analyzed or not
 - `x.ReturnEscape::BitSet`: records SSA statements where `x` can escape to the caller via return
 - `x.ThrownEscape::BitSet`: records SSA statements where `x` can be thrown as exception
   (used for the [exception handling](@ref EA-Exception-Handling) described below)
@@ -346,7 +346,7 @@ Accordingly, `analyze_escapes` is also able to analyze post-inlining IR and coll
 escape information that is useful for certain memory-related optimizations.
 
 However, since certain optimization passes like inlining can change control flows and eliminate dead code,
-they can break the inter-procedural validity of escape information. In particularity,
+they can break the inter-procedural validity of escape information. In particular,
 in order to collect inter-procedurally valid escape information, we need to analyze a pre-inlining IR.
 
 Because of this reason, `analyze_escapes` can analyze `IRCode` at any Julia-level optimization stage,

--- a/doc/src/devdocs/aot.md
+++ b/doc/src/devdocs/aot.md
@@ -21,7 +21,7 @@ Firstly, the methods that need to be compiled to native code must be identified.
 
     Currently when compiling images, Julia runs the trace generation in a different process than the process performing the AOT compilation. This can have impacts when attempting to use a debugger during precompilation. The best way to debug precompilation with a debugger is to use the rr debugger, record the entire process tree, use `rr ps` to identify the relevant failing process, and then use `rr replay -p PID` to replay just the failing process.
 
-Once the methods to be compiled have been identified, they are passed to the `jl_create_system_image` function. This function sets up a number of data structures that will be used when serializing native code to a file, and then calls `jl_create_native` with the array of methods. `jl_create_native` runs codegen on the methods produces one or more LLVM modules. `jl_create_system_image` then records some useful information about what codegen produced from the module(s).
+Once the methods to be compiled have been identified, they are passed to the `jl_create_system_image` function. This function sets up a number of data structures that will be used when serializing native code to a file, and then calls `jl_create_native` with the array of methods. `jl_create_native` runs codegen on the methods and produces one or more LLVM modules. `jl_create_system_image` then records some useful information about what codegen produced from the module(s).
 
 The module(s) are then passed to `jl_dump_native`, along with the information recorded by `jl_create_system_image`. `jl_dump_native` contains the code necessary to serialize the module(s) to bitcode, object, or assembly files depending on the command-line options passed to Julia. The serialized code and information are then written to a file as an archive.
 
@@ -67,7 +67,7 @@ The first step in loading a code image is to load the shared library produced by
 
 ### Loading Native Code
 
-The loader first needs to identify whether the native code that was compiled is valid for the architecture that the loader is running on. This is necessary to avoid executing instructions that older CPUs do not recognize. This is done by checking the CPU features available on the current machine against the CPU features that the code was compiled for. When multiversioning is enabled, the loader will pick the appropriate version of each function to use based on the CPU features available on the current machine. If none of the feature sets that were multiversioned, the loader will throw an error.
+The loader first needs to identify whether the native code that was compiled is valid for the architecture that the loader is running on. This is necessary to avoid executing instructions that older CPUs do not recognize. This is done by checking the CPU features available on the current machine against the CPU features that the code was compiled for. When multiversioning is enabled, the loader will pick the appropriate version of each function to use based on the CPU features available on the current machine. If none of the multiversioned feature sets match the current CPU, the loader will throw an error.
 
 Part of the multiversioning pass creates a number of global arrays of all of the functions in the module. When this process is multithreaded, an array of arrays is created, which the loader reorganizes into one large array with all of the functions that were compiled for this architecture. A similar process occurs for the global variables in the module.
 

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -619,7 +619,7 @@ for important details on how to modify these fields safely.
 
   * `backedges`
 
-    We store the reverse-list of cache dependencies for efficient tracking of incremental reanalysis/recompilation work that may be needed after a new method definitions.
+    We store the reverse-list of cache dependencies for efficient tracking of incremental reanalysis/recompilation work that may be needed after new method definitions.
     This works by keeping a list of the other `MethodInstance` that have been inferred or optimized to contain a possible call to this `MethodInstance`.
     Those optimization results might be stored somewhere in the `cache`, or it might have been the result of something we didn't want to cache, such as constant propagation.
     Thus we merge all of those backedges to various cache entries here (there's almost always only the one applicable cache entry with a sentinel value for max_world anyways).
@@ -653,7 +653,7 @@ for important details on how to modify these fields safely.
     May contain a cache of the inferred source for this function,
     or it could be set to `nothing` to just indicate `rettype` is inferred.
 
-  * `ftpr`
+  * `fptr`
 
     The generic jlcall entry point.
 

--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -121,7 +121,7 @@ To generate the `rr` trace locally, but not share, you can do:
 julia --bug-report=rr-local
 ```
 
-Note that this is only works on Linux. The blog post on [Time Travelling Bug Reporting](https://julialang.org/blog/2020/05/rr/) has many more details.
+Note that this only works on Linux. The blog post on [Time Travelling Bug Reporting](https://julialang.org/blog/2020/05/rr/) has many more details.
 
 ## Glossary
 

--- a/doc/src/devdocs/build/build.md
+++ b/doc/src/devdocs/build/build.md
@@ -24,7 +24,7 @@ access the network during the build process, add the following in `Make.user`:
 USE_BINARYBUILDER=0
 ```
 
-Building Julia requires 5GiB if building all dependencies and approximately 4GiB of virtual memory.
+Building Julia requires 5GiB of disk space when building all dependencies and approximately 4GiB of virtual memory.
 
 To perform a parallel build, use `make -j N` and supply the maximum
 number of concurrent processes. If the defaults in the build do not work for you, and
@@ -227,7 +227,7 @@ The most complicated dependency is LLVM, for which we require additional patches
 For packaging Julia with LLVM, we recommend either:
  - bundling a Julia-only LLVM library inside the Julia package, or
  - adding the patches to the LLVM package of the distribution.
-   * A complete list of patches is available in on [Github](https://github.com/JuliaLang/llvm-project) see the `julia-release/18.x` branch.
+   * A complete list of patches is available on [Github](https://github.com/JuliaLang/llvm-project) see the `julia-release/18.x` branch.
    * The remaining patches are all upstream bug fixes, and have been contributed into upstream LLVM.
 
 Using an unpatched or different version of LLVM will result in errors and/or poor performance.

--- a/doc/src/devdocs/build/distributing.md
+++ b/doc/src/devdocs/build/distributing.md
@@ -25,7 +25,7 @@ pregenerate the `base/version_git.jl` file with:
 
     make -C base version_git.jl.phony
 
-Julia has lots of build dependencies where we use patched versions that has not
+Julia has lots of build dependencies where we use patched versions that have not
 yet been included by the popular package managers. These dependencies will usually
 be automatically downloaded when you build, but if you want to be able to build
 Julia on a computer without internet access you should create a full-source-dist

--- a/doc/src/devdocs/build/riscv.md
+++ b/doc/src/devdocs/build/riscv.md
@@ -11,7 +11,7 @@ including the output from `cat /proc/cpuinfo`.
 
 ## Compiling Julia
 
-To compilie Julia for RISC-V, you need to manually indicate what architecture, and
+To compile Julia for RISC-V, you need to manually indicate what architecture, and
 optionally which CPU to build for. This can be done by setting the `MARCH` and `MCPU`
 variables in `Make.user`
 
@@ -48,7 +48,7 @@ A native build on a RISC-V device may take a very long time, so it's also
 possible to cross-compile Julia on a faster machine.
 
 First, get a hold of a RISC-V cross-compilation toolchain that provides
-support for C, C++ and Fortran. This can be done by checking-out the
+support for C, C++ and Fortran. This can be done by checking out the
 [riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain)
 repository and building it as follows:
 

--- a/doc/src/devdocs/contributing/aiagents.md
+++ b/doc/src/devdocs/contributing/aiagents.md
@@ -1,6 +1,6 @@
 # Using AI agents to work on Julia
 
-> ![WARNING]
+> [!WARNING]
 > You are responsible for the code you submit in PRs. Do not submit PRs
 > containing AI-generated code that you do not understand or that does not
 > meet the ordinary quality bar for PRs to julia.
@@ -45,5 +45,5 @@ additional information as links - you will need to copy any relevant text into
 the prompt.
 
 Note that Codex rebuilds the environment after every invocation. This can
-add significant latency. Codex work best for well-defined tasks that can
+add significant latency. Codex works best for well-defined tasks that can
 be solved in a single shot.

--- a/doc/src/devdocs/contributing/code-changes.md
+++ b/doc/src/devdocs/contributing/code-changes.md
@@ -6,7 +6,7 @@
 
 The Julia community uses [GitHub issues](https://github.com/JuliaLang/julia/issues) to track and discuss problems, feature requests, and pull requests (PR).
 
-Issues and pull requests should have self explanatory titles such that they can be understood from the list of PRs and Issues.
+Issues and pull requests should have self-explanatory titles such that they can be understood from the list of PRs and Issues.
 i.e. `Add {feature}` and `Fix {bug}` are good, `Fix #12345. Corrects the bug.` is bad.
 
 You can make pull requests for incomplete features to get code review. The convention is to open these as draft PRs and prefix

--- a/doc/src/devdocs/diagnostics.md
+++ b/doc/src/devdocs/diagnostics.md
@@ -33,5 +33,5 @@ different purposes:
   elements arranged as: `[ci₁, bt₁, ci₂, bt₂, ..., ciₙ, btₙ]`.
 
   Note that the backtrace elements `btᵢ` contain raw backtrace data that
-  typically needs to be processed using `stacktrace(Base._reformat_bt(btᵢ...))`.
+  typically needs to be processed using `stacktrace(Base._reformat_bt(btᵢ...))`
   to convert them into a usable stack trace format for analysis.

--- a/doc/src/devdocs/eval.md
+++ b/doc/src/devdocs/eval.md
@@ -82,7 +82,7 @@ instead.
 
 When [`eval()`](@ref) encounters a macro, it expands that AST node before attempting to evaluate
 the expression. Macro expansion involves a handoff from [`eval()`](@ref) (in Julia), to the parser
-function `jl_macroexpand()` (written in `flisp`) to the Julia macro itself (written in - what
+function `jl_macroexpand()` to the Julia macro itself (written in - what
 else - Julia) via `fl_invoke_julia_macro()`, and back.
 
 Typically, macro expansion is invoked as a first step during a call to [`Meta.lower()`](@ref)/`Core._lower()`,
@@ -90,7 +90,7 @@ although it can also be invoked directly by a call to [`macroexpand()`](@ref)/`j
 
 ## [Type Inference](@id dev-type-inference)
 
-Type inference is implemented in Julia by [`typeinf()` in `compiler/typeinfer.jl`](https://github.com/JuliaLang/julia/blob/master/base/compiler/typeinfer.jl).
+Type inference is implemented in Julia by [`typeinf()` in `Compiler/src/typeinfer.jl`](https://github.com/JuliaLang/julia/blob/master/Compiler/src/typeinfer.jl).
 Type inference is the process of examining a Julia function and determining bounds for the types
 of each of its variables, as well as bounds on the type of the return value from the function.
 This enables many future optimizations, such as unboxing of known immutable values, and compile-time

--- a/doc/src/devdocs/external_profilers.md
+++ b/doc/src/devdocs/external_profilers.md
@@ -98,7 +98,7 @@ The `TracyCZoneColor` function can be used to set the color of a certain zone. S
 
 Visit [https://maleadt.github.io/trace-viewer/](https://maleadt.github.io/trace-viewer/) for an (experimental) web viewer for Tracy traces.
 
-You can open a local `.tracy` file or provide a URL from the web (e.g. a file in a Github repo). If you load a trace file from the web, you can also share the page URL directly with others, enabling them to view the same trace.
+You can open a local `.tracy` file or provide a URL from the web (e.g. a file in a GitHub repo). If you load a trace file from the web, you can also share the page URL directly with others, enabling them to view the same trace.
 
 ### Exporting trace data to CSV
 

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -214,7 +214,7 @@ majority of dynamically-dispatched calls involve one or two arguments. In turn, 
 can be resolved by considering only the first argument. (Aside: proponents of single dispatch would
 not be surprised by this at all. However, this argument means "multiple dispatch is easy to optimize
 in practice", and that we should therefore use it, *not* "we should use single dispatch"!). So the
-method table and cache splits up on the structure based on a left-to-right decision tree so allow
+method table and cache splits up on the structure based on a left-to-right decision tree to allow
 efficient nearest-neighbor searches.
 
 The front end generates type declarations for all closures. Initially, this was implemented by

--- a/doc/src/devdocs/gc-sa.md
+++ b/doc/src/devdocs/gc-sa.md
@@ -4,7 +4,7 @@
 
 The analyzer plugin that drives the analysis ships with julia. Its
 source code can be found in `src/clangsa`. Running it requires
-the clang dependency to be build. Set the `BUILD_LLVM_CLANG` variable
+the clang dependency to be built. Set the `BUILD_LLVM_CLANG` variable
 in your Make.user in order to build an appropriate version of clang.
 You may also want to use the prebuilt binaries using the
 `USE_BINARYBUILDER_LLVM` options.
@@ -276,7 +276,7 @@ void example() {
 This annotation implies that a given value is always globally rooted.
 It can be applied to global variable declarations, in which case it
 will apply to the value of those variables (or values if the declaration
-if for an array), or to functions, in which case it will apply to the
+is for an array), or to functions, in which case it will apply to the
 return value of such functions (e.g. for functions that always return
 some private, globally rooted value).
 
@@ -288,8 +288,8 @@ jl_ast_context_t *jl_ast_ctx(fl_context_t *fl) JL_GLOBALLY_ROOTED;
 
 ### `JL_ALWAYS_LEAFTYPE`
 
-This annotations is essentially equivalent to `JL_GLOBALLY_ROOTED`, except that
-is should only be used if those values are globally rooted by virtue of being
+This annotation is essentially equivalent to `JL_GLOBALLY_ROOTED`, except that
+it should only be used if those values are globally rooted by virtue of being
 a leaftype. The rooting of leaftypes is a bit complicated. They are generally
 rooted through `cache` field of the corresponding `TypeName`, which itself is
 rooted by the containing module (so they're rooted as long as the containing

--- a/doc/src/devdocs/gc.md
+++ b/doc/src/devdocs/gc.md
@@ -49,7 +49,7 @@ Although Julia currently uses `libc` `malloc`, it also supports pre-loading othe
 
 Julia’s mark phase is implemented through a parallel depth-first-search that traverses the object graph to determine which objects are alive.
 
-Julia stores age information for its generational GC in the object header: the lowest two bits of an object’s header store a mark bit, set when an object is marked, and an age bit, set when the object is promoted. Because Julia’s GC is non-moving, object age information can’t be only determined through the object's memory address, such as in GC implementations that allocate young objects in certain memory regions and relocate them to other memory regions during object promotion.
+Julia stores age information for its generational GC in the object header: the lowest two bits of an object’s header store a mark bit, set when an object is marked, and an age bit, set when the object is promoted. Because Julia’s GC is non-moving, object age information can’t be determined only through the object’s memory address, such as in GC implementations that allocate young objects in certain memory regions and relocate them to other memory regions during object promotion.
 
 Generational collection is implemented through sticky bits: objects are only pushed to the mark-stack, and therefore traced, if their mark-bits have not been set. When objects reach the oldest generation, their mark-bits aren't reset during a quick sweep, so these objects aren't traced during a subsequent mark phase. A full sweep, however, resets the mark-bits of all objects, so all of them are traced in a subsequent collection.
 

--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -2,7 +2,7 @@
 
 ## How inference works
 
-In Julia compiler, "type inference" refers to the process of deducing the types of later
+In the Julia compiler, "type inference" refers to the process of deducing the types of later
 values from the types of input values. Julia's approach to inference has been described in
 the blog posts below:
 1. [Shows a simplified implementation of the data-flow analysis algorithm, that Julia's type inference routine is based on.](https://aviatesk.github.io/posts/data-flow-problem/)

--- a/doc/src/devdocs/init.md
+++ b/doc/src/devdocs/init.md
@@ -130,7 +130,7 @@ global C pointers to Julia globals defined in `boot.jl`.
 
 From this point on, the code is again uniform, regardless of whether there is a sysimage or not.
 
-Now it runs a loops to call
+Now it runs a loop to call
 [`jl_module_run_initializer()`](https://github.com/JuliaLang/julia/blob/master/src/module.c) for
 each deserialized module to run the `__init__()` function.
 
@@ -188,8 +188,8 @@ Hello World!
 
 | Stack frame                    | Source code     | Notes                                                |
 |:------------------------------ |:--------------- |:---------------------------------------------------- |
-| `jl_uv_write()`                | `jl_uv.c`       | called though [`ccall`](@ref)                        |
-| `julia_write_282942`           | `stream.jl`     | function `write!(s::IO, a::Array{T}) where T`        |
+| `jl_uv_write()`                | `jl_uv.c`       | called through [`ccall`](@ref)                        |
+| `julia_write_282942`           | `stream.jl`     | function `write(s::IO, a::Array{T}) where T`        |
 | `julia_print_284639`           | `ascii.jl`      | `print(io::IO, s::String) = (write(io, s); nothing)` |
 | `jlcall_print_284639`          |                 |                                                      |
 | `jl_apply()`                   | `julia.h`       |                                                      |

--- a/doc/src/devdocs/jit.md
+++ b/doc/src/devdocs/jit.md
@@ -27,7 +27,7 @@ Currently, only one thread at a time is permitted to enter the optimize-compile-
 
 ## Optimization Pipeline
 
-The optimization pipeline is based off LLVM's new pass manager, but the pipeline is customized for Julia's needs. The pipeline is defined in `src/pipeline.cpp`, and broadly proceeds through a number of stages as detailed below.
+The optimization pipeline is based on LLVM's new pass manager, but the pipeline is customized for Julia's needs. The pipeline is defined in `src/pipeline.cpp`, and broadly proceeds through a number of stages as detailed below.
 
 1. Early Simplification
    1. These passes are mainly used to simplify the IR and canonicalize patterns so that later passes can identify those patterns more easily. Additionally, various intrinsic calls such as branch prediction hints and annotations are lowered into other metadata or other IR features. [`SimplifyCFG`](https://llvm.org/docs/Passes.html#simplifycfg-simplify-the-cfg) (simplify control flow graph), [`DCE`](https://llvm.org/docs/Passes.html#dce-dead-code-elimination) (dead code elimination), and [`SROA`](https://llvm.org/docs/Passes.html#sroa-scalar-replacement-of-aggregates) (scalar replacement of aggregates) are some of the key players here.

--- a/doc/src/devdocs/llvm-passes.md
+++ b/doc/src/devdocs/llvm-passes.md
@@ -18,7 +18,7 @@ This pass lowers the `julia.cpu.have_fma.(f32|f64)` intrinsic to either true or 
 
 * Filename: `llvm-demote-float16.cpp`
 * ClassName: `DemoteFloat16Pass`
-* Opt Name `function(DemoteFloat16)`
+* Opt Name: `function(DemoteFloat16)`
 
 This pass replaces [float16](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) operations with float32 operations on architectures that do not natively support float16 operations. This is done by inserting `fpext` and `fptrunc` instructions around any float16 operation. On architectures that do support native float16 operations, this pass is a no-op.
 

--- a/doc/src/devdocs/llvm.md
+++ b/doc/src/devdocs/llvm.md
@@ -71,7 +71,7 @@ system image documentation for the procedure.
 You can also specify to build a debug version of LLVM, by setting either `LLVM_DEBUG = 1` or
 `LLVM_DEBUG = Release` in your `Make.user` file. The former will be a fully unoptimized build
 of LLVM and the latter will produce an optimized build of LLVM. Depending on your needs the
-latter will suffice and it quite a bit faster. If you use `LLVM_DEBUG = Release` you will also
+latter will suffice and it is quite a bit faster. If you use `LLVM_DEBUG = Release` you will also
 want to set `LLVM_ASSERTIONS = 1` to enable diagnostics for different passes. Only `LLVM_DEBUG = 1`
 implies that option by default.
 
@@ -307,7 +307,7 @@ First, only the following address space casts are allowed:
   pointers should generally be storable to a GC slot, even in this address space.
 
 Now let us consider what constitutes a use:
-- Loads whose loaded values is in one of the address spaces
+- Loads whose loaded values are in one of the address spaces
 - Stores of a value in one of the address spaces to a location
 - Stores to a pointer in one of the address spaces
 - Calls for which a value in one of the address spaces is an operand
@@ -395,8 +395,7 @@ void @llvm.julia.gc_preserve_end(token)
 ```
 (The `llvm.` in the name is required in order to be able to use the `token`
 type). The semantics of these intrinsics are as follows:
-At any safepoint that is dominated by a `gc_preserve_begin` call, but that is not
-not dominated by a corresponding `gc_preserve_end` call (i.e. a call whose argument
+At any safepoint that is dominated by a `gc_preserve_begin` call, but that is not dominated by a corresponding `gc_preserve_end` call (i.e. a call whose argument
 is the token returned by a `gc_preserve_begin` call), the values passed as
 arguments to that `gc_preserve_begin` will be kept live. Note that the
 `gc_preserve_begin` still counts as a regular use of those values, so the

--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -242,7 +242,7 @@ Type inference proceeds like so:
 In the above diagram, threads 1 and 2 are doing type inference (the dotted
 line), while thread 3 is activating a new method.  The solid boxes represent
 critical sections where the `world_counter_lock` is held.  `acq`, `rel`, and
-`read`, are acquire loads, release stores, and relaxed loads respectively.
+`read` are acquire loads, release stores, and relaxed loads respectively.
 
 T1 promotes its CI in time, but T2 takes too long, blocking on
 `world_counter_lock` until T3 has finished publishing the new method and

--- a/doc/src/devdocs/object.md
+++ b/doc/src/devdocs/object.md
@@ -143,7 +143,7 @@ typedef struct {
 ```
 
 However, in other cases, the tuple may be converted to an anonymous [`isbits`](@ref) type and
-stored unboxed, or it may not stored at all (if it is not being used in a generic context as a
+stored unboxed, or it may not be stored at all (if it is not being used in a generic context as a
 `jl_value_t*`).
 
 Symbols:

--- a/doc/src/devdocs/offset-arrays.md
+++ b/doc/src/devdocs/offset-arrays.md
@@ -72,7 +72,7 @@ can sometimes simplify such tests.
 ### Linear indexing (`LinearIndices`)
 
 
-Some algorithms are most conveniently (or efficiently) written in terms of a single linear index, `A[i]` even if `A` is multi-dimensional. Regardless of the array's native indices, linear indices always range from `1:length(A)`. However, this raises an ambiguity for one-dimensional arrays (a.k.a., [`AbstractVector`](@ref)): does `v[i]` mean linear indexing , or Cartesian indexing with the array's native indices?
+Some algorithms are most conveniently (or efficiently) written in terms of a single linear index, `A[i]` even if `A` is multi-dimensional. Regardless of the array's native indices, linear indices always range from `1:length(A)`. However, this raises an ambiguity for one-dimensional arrays (a.k.a., [`AbstractVector`](@ref)): does `v[i]` mean linear indexing, or Cartesian indexing with the array's native indices?
 
 For this reason, your best option may be to iterate over the array with `eachindex(A)`, or, if you require the indices to be sequential integers, to get the index range by calling `LinearIndices(A)`. This will return `axes(A, 1)` if A is an AbstractVector, and the equivalent of `1:length(A)` otherwise.
 
@@ -198,7 +198,7 @@ Base.has_offset_axes(obj::MyNon1IndexedArraylikeObject) = true
 ```
 This will allow code that assumes 1-based indexing to detect a problem
 and throw a helpful error, rather than returning incorrect results or
-segfaulting julia.
+segfaulting Julia.
 
 ### Catching errors
 

--- a/doc/src/devdocs/pkgimg.md
+++ b/doc/src/devdocs/pkgimg.md
@@ -2,7 +2,7 @@
 
 Julia package images provide object (native code) caches for Julia packages.
 They are similar to Julia's [system image](@ref dev-sysimg) and support many of the same features.
-In fact the underlying serialization format is the same, and the system image is the base image that the package images are build against.
+In fact the underlying serialization format is the same, and the system image is the base image that the package images are built against.
 
 ## High-level overview
 

--- a/doc/src/devdocs/probes.md
+++ b/doc/src/devdocs/probes.md
@@ -57,7 +57,7 @@ Displaying notes found in: .note.stapsdt
 
 ## Adding probes in libjulia
 
-Probes are declared in dtraces format in the file `src/uprobes.d`. The generated
+Probes are declared in dtrace format in the file `src/uprobes.d`. The generated
 header file is included in `src/julia_internal.h` and if you add probes you should
 provide a noop implementation there.
 

--- a/doc/src/devdocs/sanitizers.md
+++ b/doc/src/devdocs/sanitizers.md
@@ -62,7 +62,7 @@ LLVM makes `testall1` take 8-10 times as long while using 20 times as much memor
 reduced to respectively a factor of 3 and 4 by using the options described below).
 
 By default, Julia sets the `allow_user_segv_handler=1` ASAN flag, which is required for signal
-delivery to work properly. You can define other options using the `ASAN_OPTIONS` environment flag,
+delivery to work properly. You can define other options using the `ASAN_OPTIONS` environment variable,
 in which case you'll need to repeat the default option mentioned before. For example, memory usage
 can be reduced by specifying `fast_unwind_on_malloc=0` and `malloc_context_size=2`, at the cost
 of backtrace accuracy. For now, Julia also sets `detect_leaks=0`, but this should be removed in

--- a/doc/src/devdocs/ssair.md
+++ b/doc/src/devdocs/ssair.md
@@ -28,7 +28,7 @@ using InteractiveUtils
 ```llvm
 CodeInfo(
 1 ─ %1 = invoke Main.sin(x::Float64)::Float64
-│   %2 = Base.lt_float(x, 5.0)::Bool
+│   %2 = Base.lt_float(5.0, x)::Bool
 └──      goto #3 if not %2
 2 ─ %4 = invoke Main.cos(x::Float64)::Float64
 └── %5 = Base.add_float(%1, %4)::Float64
@@ -42,7 +42,7 @@ In this example, we can see all of these changes.
 1. The first basic block is everything in
 ```llvm
 1 ─ %1 = invoke Main.sin(x::Float64)::Float64
-│   %2 = Base.lt_float(x, 5.0)::Bool
+│   %2 = Base.lt_float(5.0, x)::Bool
 └──      goto #3 if not %2
 ```
 2. The `if` statement is translated into `goto #3 if not %2` which goes to the 3rd basic block if `x>5` isn't met and otherwise goes to the second basic block.

--- a/doc/src/devdocs/stdio.md
+++ b/doc/src/devdocs/stdio.md
@@ -32,7 +32,7 @@ void jl_safe_printf(const char *str, ...);
 [`Base.stdin`](@ref), [`Base.stdout`](@ref) and [`Base.stderr`](@ref) are bound to the `JL_STD*` libuv
 streams defined in the runtime.
 
-Julia's `__init__()` function (in `base/sysimg.jl`) calls `reinit_stdio()` (in `base/stream.jl`)
+Julia's `__init__()` function (in `base/Base.jl`) calls `reinit_stdio()` (in `base/libuv.jl`)
 to create Julia objects for [`Base.stdin`](@ref), [`Base.stdout`](@ref) and [`Base.stderr`](@ref).
 
 `reinit_stdio()` uses [`ccall`](@ref) to retrieve pointers to `JL_STD*` and calls `jl_uv_handle_type()`
@@ -91,7 +91,7 @@ However, there is [one place](https://github.com/JuliaLang/julia/blob/master/src
 where femtolisp calls through to `jl_printf()` with a legacy `ios_t` stream.
 
 There is a hack in `ios.h` that makes the `ios_t.bm` field line up with the `uv_stream_t.type`
-and ensures that the values used for `ios_t.bm` to not overlap with valid `UV_HANDLE_TYPE` values.
+and ensures that the values used for `ios_t.bm` do not overlap with valid `UV_HANDLE_TYPE` values.
  This allows `uv_stream_t` pointers to point to `ios_t` streams.
 
 This is needed because `jl_printf()` caller `jl_static_show()` is passed an `ios_t` stream by

--- a/doc/src/devdocs/sysimg.md
+++ b/doc/src/devdocs/sysimg.md
@@ -26,7 +26,7 @@ wrapper functions to automate this process.
 
 The system image can be compiled simultaneously for multiple CPU microarchitectures
 under the same instruction set architecture (ISA). Multiple versions of the same function
-may be created with minimum dispatch point inserted into shared functions
+may be created with minimal dispatch points inserted into shared functions
 in order to take advantage of different ISA extensions or other microarchitecture features.
 The version that offers the best performance will be selected automatically at runtime
 based on available CPU features.

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -525,6 +525,6 @@ than the other.)  Likewise, `Tuple{Int,Vararg{Int}}` is not a subtype of `Tuple{
 considered more specific. However, `morespecific` does get a bonus for length: in particular,
 `Tuple{Int,Int}` is more specific than `Tuple{Int,Vararg{Int}}`.
 
-Additionally, if 2 methods are defined with identical signatures, per type-equal, then they
+Additionally, if 2 methods are defined with identical signatures (i.e., type-equal signatures), then they
 will instead be compared by order of addition, such that the later method is more specific
 than the earlier one.

--- a/doc/src/devdocs/ub.md
+++ b/doc/src/devdocs/ub.md
@@ -5,7 +5,7 @@ In programming language design, it is prudent to separate the concepts of a lang
 To illustrate the distinction, consider a statement like `print(Ref(1).x)`. The language semantics may specify that the observable behavior of this statement is that the value `1` is printed to `stdout`. However, whether or not the object `Ref` is actually allocated may not be semantically observable (even though it may be implicitly observable by looking at memory use, number of allocations, generated code, etc.). Because of this, the implementation is allowed to replace this statement with `print(1)`, which preserves all semantically observable behaviors.
 
 The julia compiler leverages this rule heavily to perform speculative execution. Where the compiler can prove
-that a function has no side effect (e.g. because it is a purely mathmetical computation), the compiler may
+that a function has no side effect (e.g. because it is a purely mathematical computation), the compiler may
 evaluate all or part of a function invocation during the compilation of that function's caller. The validity
 of this optimization is another way of thinking about which behaviors are observable.
 

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -894,8 +894,7 @@ julia> LinearIndices(A)[2, 2]
 
 It's important to note that there's a very large asymmetry in the performance
 of these conversions. Converting a linear index to a set of cartesian indices
-requires dividing and taking the remainder, whereas going the other way is just
-multiplies and adds. In modern processors, integer division can be 10-50 times
+requires dividing and taking the remainder, whereas going the other way is just multiplications and additions. In modern processors, integer division can be 10-50 times
 slower than multiplication. While some arrays — like [`Array`](@ref) itself —
 are implemented using a linear chunk of memory and directly use a linear index
 in their implementations, other arrays — like [`Diagonal`](@ref) — need the
@@ -908,7 +907,7 @@ introspect which is which).
     better to iterate over [`eachindex(A)`](@ref) instead of `1:length(A)`.
     Not only will this be faster in cases where `A` is `IndexCartesian`,
     but it will also support arrays with custom indexing, such as [OffsetArrays](https://github.com/JuliaArrays/OffsetArrays.jl).
-    If only the values are needed, then is better to just iterate the array directly, i.e. `for a in A`.
+    If only the values are needed, then it is better to just iterate the array directly, i.e. `for a in A`.
 
 #### Omitted and extra indices
 

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -32,8 +32,7 @@ The syntax for [`@ccall`](@ref) to generate a call to the library function is:
 @ccall $function_pointer(argvalue1::argtype1, ...)::returntype
 ```
 
-where `library` is a string constant or global variable name (see [Non-constant
-Function -Specifications](@ref) below). The library can be just a name, or it
+where `library` is a string constant or global variable name (see [Non-constant Function Specifications](@ref) below). The library can be just a name, or it
 can specify a full path to the library. The library may be omitted, in which
 case the function name is resolved in the current executable, the current libc,
 or libjulia(-internal). This form can be used to call C library functions,
@@ -42,8 +41,7 @@ Omitting the library *cannot* be used to call a function in any library (like
 specifying `RTLD_DEFAULT` to `dlsym`) as such behavior is slow, complicated,
 and not implemented on all platforms.
 Alternatively, `@ccall` may also be used to call a function pointer
-`$function_pointer`, such as one returned by `Libdl.dlsym`. The `argtype`s
-corresponds to the C-function signature and the `argvalue`s are the actual
+`$function_pointer`, such as one returned by `Libdl.dlsym`. The `argtype`s correspond to the C-function signature and the `argvalue`s are the actual
 argument values to be passed to the function.
 
 !!! note
@@ -199,7 +197,7 @@ julia> function mycompare(a, b)::Cint
        end;
 ```
 
-`qsort` expects a comparison function that return a C `int`, so we annotate the return type
+`qsort` expects a comparison function that returns a C `int`, so we annotate the return type
 to be `Cint`.
 
 In order to pass this function to C, we obtain its address using the macro `@cfunction`:
@@ -976,7 +974,7 @@ The `Libdl.dlopen` function can be overloaded for custom types to provide altern
 However, it is assumed that the library location and handle does not change
 once it is determined, so the result of the call may be cached and reused.
 Therefore, the number of times the `dlopen` expression executes is unspecified,
-and returning different values for multiple calls will results in unspecified
+and returning different values for multiple calls will result in unspecified
 (but valid) behavior.
 
 ### Computed Function Names
@@ -1115,9 +1113,9 @@ The arguments to [`ccall`](@ref) are:
 
 !!! note
     The `(:function, "library")` pair and the input type list must be syntactic tuples
-    (i.e., they can't be variables or values with a type of Tuple.
+    (i.e., they can't be variables or values with a type of Tuple).
 
-    The rettype and argument type values are evaluated at when the containing method is
+    The rettype and argument type values are evaluated when the containing method is
     defined, not runtime.
 
 !!! note "Function Name vs Pointer Syntax"

--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -19,7 +19,7 @@ These questions are answered by searching through the project environments liste
 
 ## Federation of packages
 
-Most of the time, a package is uniquely identifiable simply from its name. However, sometimes a project might encounter a situation where it needs to use two different packages that share the same name. While you might be able fix this by renaming one of the packages, being forced to do so can be highly disruptive in a large, shared code base. Instead, Julia's code loading mechanism allows the same package name to refer to different packages in different components of an application.
+Most of the time, a package is uniquely identifiable simply from its name. However, sometimes a project might encounter a situation where it needs to use two different packages that share the same name. While you might be able to fix this by renaming one of the packages, being forced to do so can be highly disruptive in a large, shared code base. Instead, Julia's code loading mechanism allows the same package name to refer to different packages in different components of an application.
 
 Julia supports federated package management, which means that multiple independent parties can maintain both public and private packages and registries of packages, and that projects can depend on a mix of public and private packages from different registries. Packages from various registries are installed and managed using a common set of tools and workflows. The `Pkg` package manager that ships with Julia lets you install and manage your projects' dependencies. It assists in creating and manipulating project files (which describe what other projects that your project depends on), and manifest files (which snapshot exact versions of your project's complete dependency graph).
 
@@ -179,7 +179,7 @@ If, on the other hand, Julia was loading the *other* `Priv` package—the one wi
 1. `/home/me/.julia/packages/Priv/HDkrT`
 2. `/usr/local/julia/packages/Priv/HDkrT`
 
-Julia uses the first of these that exists to try to load the public `Priv` package from the file `packages/Priv/HDKrT/src/Priv.jl` in the depot where it was found.
+Julia uses the first of these that exists to try to load the public `Priv` package from the file `packages/Priv/HDkrT/src/Priv.jl` in the depot where it was found.
 
 Here is a representation of a possible paths map for our example `App` project environment,
 as provided in the Manifest given above for the dependency graph,
@@ -471,8 +471,7 @@ Scripts and the REPL use the active project's syntax version. This determination
 1. At startup after processing `--project`
 2. Before parsing any REPL input, once for each prompt
 
-In particular, a manual `set_active_project` in a script will not change the syntax versioned used
-for the rest of the script. However, doing so at the REPL (explicitly or implicitly via the Pkg
+In particular, a manual `set_active_project` in a script will not change the syntax version used for the rest of the script. However, doing so at the REPL (explicitly or implicitly via the Pkg
 REPL mode) will affect the syntax version used to parse the *next* REPL input.
 
 ## Conclusion

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -397,7 +397,7 @@ julia> while i <= 3
 3
 ```
 
-The `while` loop evaluates the condition expression (`i <= 3` in this case), and as long it remains
+The `while` loop evaluates the condition expression (`i <= 3` in this case), and as long as it remains
 `true`, keeps also evaluating the body of the `while` loop. If the condition expression is `false`
 when the `while` loop is first reached, the body is never evaluated.
 

--- a/doc/src/manual/conversion-and-promotion.md
+++ b/doc/src/manual/conversion-and-promotion.md
@@ -261,7 +261,7 @@ to a common numeric type for arithmetic operations -- it just happens automatica
 definitions of catch-all promotion methods for a number of other arithmetic and mathematical functions
 in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl), but beyond
 that, there are hardly any calls to `promote` required in Julia Base. The most
-common usages of `promote` occur in outer constructors methods, provided for convenience, to allow
+common usages of `promote` occur in outer constructor methods, provided for convenience, to allow
 constructor calls with mixed types to delegate to an inner type with fields promoted to an appropriate
 common type. For example, recall that [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl)
 provides the following outer constructor method:

--- a/doc/src/manual/distributed-computing.md
+++ b/doc/src/manual/distributed-computing.md
@@ -129,14 +129,14 @@ be computed, then waits for its process to finish, then repeats until we run out
 that the feeder tasks do not begin to execute until the main task reaches the end of the [`@sync`](@ref)
 block, at which point it surrenders control and waits for all the local tasks to complete before
 returning from the function.
-As for v0.7 and beyond, the feeder tasks are able to share state via `nextidx` because
+The feeder tasks are able to share state via `nextidx` because
 they all run on the same process.
 Even if `Tasks` are scheduled cooperatively, locking may still be required in some contexts, as in
 [asynchronous I/O](@ref faq-async-io).
 This means context switches only occur at well-defined points: in this case,
 when [`remotecall_fetch`](@ref) is called. This is the current state of implementation and it may change
 for future Julia versions, as it is intended to make it possible to run up to N `Tasks` on M `Process`, aka
-[M:N Threading](https://en.wikipedia.org/wiki/Thread_(computing)#Models). Then a lock acquiring\releasing
+[M:N Threading](https://en.wikipedia.org/wiki/Thread_(computing)#Models). Then a lock acquiring/releasing
 model for `nextidx` will be needed, as it is not safe to let multiple processes read-write a resource at
 the same time.
 
@@ -529,7 +529,7 @@ The remote object referred to by a [`Future`](@ref Distributed.Future) is stored
 [`RemoteChannel`](@ref), which is rewritable, can point to any type and size of channels, or any
 other implementation of an `AbstractChannel`.
 
-The constructor `RemoteChannel(f::Function, pid)()` allows us to construct references to channels
+The constructor `RemoteChannel(f::Function, pid)` allows us to construct references to channels
 holding more than one value of a specific type. `f` is a function executed on `pid` and it must
 return an `AbstractChannel`.
 
@@ -1291,7 +1291,7 @@ requirements for the inbuilt `LocalManager` and `SSHManager`:
 All processes in a cluster share the same cookie which, by default, is a randomly generated string
 on the master process:
 
-  * [`cluster_cookie()`](@ref) returns the cookie, while `cluster_cookie(cookie)()` sets
+  * [`cluster_cookie()`](@ref) returns the cookie, while `cluster_cookie(cookie)` sets
     it and returns the new cookie.
   * All connections are authenticated on both sides to ensure that only workers started by the master
     are allowed to connect to each other.
@@ -1449,7 +1449,7 @@ To end this short exposure to external packages, we can consider `MPI.jl`, a Jul
 of the MPI protocol. As it would take too long to consider every inner function, it would be better
 to simply appreciate the approach used to implement the protocol.
 
-Consider this toy script which simply calls each subprocess, instantiate its rank and when the master
+Consider this toy script which simply calls each subprocess, instantiates its rank and when the master
 process is reached, performs the ranks' sum
 
 ```julia

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -645,7 +645,7 @@ a
 b
 ```
 
-Any number of expressions many be documented together in this way. This syntax can be useful when
+Any number of expressions may be documented together in this way. This syntax can be useful when
 two functions are related, such as non-mutating and mutating versions `f` and `f!`.
 
 ### Macro-generated code

--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -48,7 +48,7 @@ gcc -o test -fPIC -I$JULIA_DIR/include/julia -L$JULIA_DIR/lib -Wl,-rpath,$JULIA_
 ```
 
 Alternatively, look at the `embedding.c` program in the Julia source tree in the `test/embedding/` folder.
-The file `cli/loader_exe.c` program is another simple example of how to set `jl_options` options while
+The `cli/loader_exe.c` program is another simple example of how to set `jl_options` options while
 linking against `libjulia`.
 
 The first thing that must be done before calling any other Julia C function is to
@@ -113,7 +113,7 @@ Usage: julia-config [--cflags|--ldflags|--ldlibs]
 
 If the above example source is saved in the file `embed_example.c`, then the following
 command will compile it into an executable program on Linux and Windows (MSYS2 environment).
-On macOS, substitute `clang` for `gcc`.:
+On macOS, substitute `clang` for `gcc`:
 
 ```
 /usr/local/julia/share/julia/julia-config.jl --cflags --ldflags --ldlibs | xargs gcc embed_example.c

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -391,8 +391,7 @@ number of logical CPU cores is used in its place.
 
 ### [`JULIA_IMAGE_TIMINGS`](@id JULIA_IMAGE_TIMINGS)
 
-A boolean value that determines if detailed timing information is printed during
-during image compilation. Defaults to 0.
+A boolean value that determines if detailed timing information is printed during image compilation. Defaults to 0.
 
 ### [`JULIA_EXCLUSIVE`](@id JULIA_EXCLUSIVE)
 

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -83,7 +83,7 @@ functionality like command line argument handling. A way to determine that a fil
 this fashion is to check if `abspath(PROGRAM_FILE) == @__FILE__` is `true`.
 
 However, it is recommended to not write files that double as a script and as an importable library.
-If one needs functionality both available as a library and a script, it is better to write is as a library, then import the functionality into a distinct script.
+If one needs functionality both available as a library and a script, it is better to write it as a library, then import the functionality into a distinct script.
 
 ### [How do I catch CTRL-C in a script?](@id catch-ctrl-c)
 
@@ -587,7 +587,7 @@ ans =
 Oops. Adding a `>>>` operator to Matlab wouldn't help, because saturation that occurs when adding
 `n` and `2n` has already destroyed the information necessary to compute the correct midpoint.
 
-Not only is lack of associativity unfortunate for programmers who cannot rely it for techniques
+Not only is lack of associativity unfortunate for programmers who cannot rely on it for techniques
 like this, but it also defeats almost anything compilers might want to do to optimize integer
 arithmetic. For example, since Julia integers use normal machine integer arithmetic, LLVM is free
 to aggressively optimize simple little functions like `f(k) = 5k-1`. The machine code for this
@@ -1053,15 +1053,15 @@ However, upgrading to the next Stable release will always be possible as each re
 
 You may prefer the LTS (Long Term Support) version of Julia if you are looking for a very stable code base.
 The current LTS version of Julia is versioned according to SemVer as v1.6.x;
-this branch will continue to receive bugfixes until a new LTS branch is chosen, at which point the v1.6.x series will no longer received regular bug fixes and all but the most conservative users will be advised to upgrade to the new LTS version series.
+this branch will continue to receive bugfixes until a new LTS branch is chosen, at which point the v1.6.x series will no longer receive regular bug fixes and all but the most conservative users will be advised to upgrade to the new LTS version series.
 As a package developer, you may prefer to develop for the LTS version, to maximize the number of users who can use your package.
 As per SemVer, code written for v1.0 will continue to work for all future LTS and Stable versions.
 In general, even if targeting the LTS, one can develop and run code in the latest Stable version, to take advantage of the improved performance; so long as one avoids using new features (such as added library functions or new methods).
 
 You may prefer the nightly version of Julia if you want to take advantage of the latest updates to the language, and don't mind if the version available today occasionally doesn't actually work.
 As the name implies, releases to the nightly version are made roughly every night (depending on build infrastructure stability).
-In general nightly released are fairly safe to use—your code will not catch on fire.
-However, they may be occasional regressions and or issues that will not be found until more thorough pre-release testing.
+In general nightly releases are fairly safe to use—your code will not catch on fire.
+However, there may be occasional regressions and/or issues that will not be found until more thorough pre-release testing.
 You may wish to test against the nightly version to ensure that such regressions that affect your use case are caught before a release is made.
 
 Finally, you may also consider building Julia from source for yourself. This option is mainly for those individuals who are comfortable at the command line, or interested in learning.

--- a/doc/src/manual/installation.md
+++ b/doc/src/manual/installation.md
@@ -86,7 +86,7 @@ Add-AppxPackage -AppInstallerFile https://install.julialang.org/Julia.appinstall
 
 If neither the Windows Store nor the App Installer version work on your Windows
 system, you can also use a MSI based installer. Note that this installation
-methods comes with serious limitations and is generally not recommended unless
+method comes with serious limitations and is generally not recommended unless
 no other method works. For example, there is no automatic update mechanism for
 Juliaup with this installation method. The 64 bit version of the MSI installer
 can be downloaded from [here](https://install.julialang.org/Julia-x64.msi) and

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -631,7 +631,7 @@ BigInt
 
 The default precision (in number of bits of the significand) and rounding mode of [`BigFloat`](@ref)
 operations can be changed globally by calling [`setprecision`](@ref) and [`setrounding`](@ref),
-and all further calculations will take these changes in account. Alternatively, the precision
+and all further calculations will take these changes into account. Alternatively, the precision
 or the rounding can be changed only within the execution of a particular block of code by using
 the same functions with a `do` block:
 

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -134,7 +134,7 @@ It is also often useful to allow iteration over a collection in *reverse order*
 by iterating over [`Iterators.reverse(iterator)`](@ref). To actually support
 reverse-order iteration, however, an iterator
 type `T` needs to implement `iterate` for `Iterators.Reverse{T}`.
-(Given `r::Iterators.Reverse{T}`, the underling iterator of type `T` is `r.itr`.)
+(Given `r::Iterators.Reverse{T}`, the underlying iterator of type `T` is `r.itr`.)
 In our `Squares` example, we would implement `Iterators.Reverse{Squares}` methods:
 
 ```jldoctest squaretype
@@ -844,7 +844,7 @@ julia> function Base.setproperty!(p::Point, s::Symbol, f)
        end
 ```
 
-It is important that `getfield` and `setfield` are used inside `getproperty` and `setproperty!` instead of the dot syntax,
+It is important that `getfield` and `setfield!` are used inside `getproperty` and `setproperty!` instead of the dot syntax,
 since the dot syntax would make the functions recursive which can lead to type inference issues. We can now
 try out the new functionality:
 
@@ -877,7 +877,7 @@ To support rounding on a new type it is typically sufficient to define the singl
 `round(x::ObjType, r::RoundingMode)`. The passed rounding mode determines in which direction
 the value should be rounded. The most commonly used rounding modes are `RoundNearest`,
 `RoundToZero`, `RoundDown`, and `RoundUp`, as these rounding modes are used in the
-definitions of the one argument `round`, method, and `trunc`, `floor`, and `ceil`,
+definitions of the one argument `round` method, and `trunc`, `floor`, and `ceil`,
 respectively.
 
 In some cases, it is possible to define a three-argument `round` method that is more

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -958,7 +958,7 @@ end
 
 ```
 
-for which we want to add a number of methods to. We can do this programmatically in the
+to which we want to add a number of methods. We can do this programmatically in the
 following loop:
 
 ```jldoctest mynumber-codegen
@@ -1432,7 +1432,7 @@ julia> sub2ind_gen_impl(Tuple{Int,Int}, Int, Int)
 ```
 
 So, the method body that will be used here doesn't include a loop at all - just indexing into
-the two tuples, multiplication and addition/subtraction. All the looping is performed compile-time,
+the two tuples, multiplication and addition/subtraction. All the looping is performed at compile time,
 and we avoid looping during execution entirely. Thus, we only loop *once per type*, in this case
 once per `N` (except in edge cases where the function is generated more than once - see disclaimer
 above).

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -708,7 +708,7 @@ This dispatching branching can be observed, for example, in the logic to sum two
 ### Trait-based dispatch
 
 A natural extension to the iterated dispatch above is to add a layer to
-method selection that allows to dispatch on sets of types which are
+method selection that allows dispatching on sets of types which are
 independent from the sets defined by the type hierarchy.
 We could construct such a set by writing out a `Union` of the types in question,
 but then this set would not be extensible as `Union`-types cannot be
@@ -1005,7 +1005,7 @@ f(x::NTuple{N,Float64}) where {N} = 2
 
 are ambiguous because of the possibility that `N == 0`: there are no
 elements to determine whether the `Int` or `Float64` variant should be
-called. To resolve the ambiguity, one approach is define a method for
+called. To resolve the ambiguity, one approach is to define a method for
 the empty tuple:
 
 ```julia

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -412,8 +412,7 @@ julia> isequal([1, 2, missing], [1, missing, 2])
 false
 ```
 
-Functions [`any`](@ref) and [`all`](@ref) also follow the rules of
-three-valued logic. Thus, returning `missing` when the result cannot be determined:
+Functions [`any`](@ref) and [`all`](@ref) also follow the rules of three-valued logic, thus returning `missing` when the result cannot be determined:
 
 ```jldoctest
 julia> all([true, missing])

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -39,7 +39,7 @@ each threadpool.
     The default number of threads changed in Julia 1.12. Prior versions default to 1 (default thread pool) thread.
     If the number of threads is set to 1 by either doing `-t1` or `JULIA_NUM_THREADS=1` an interactive thread will not be spawned.
 
-Lets start Julia with 4 threads:
+Let's start Julia with 4 threads:
 
 ```bash
 $ julia --threads 4
@@ -85,7 +85,7 @@ julia> Threads.threadid()
 ### Multiple GC Threads
 
 The Garbage Collector (GC) can use multiple threads. The amount used by default matches the compute
-worker threads or can configured by either the `--gcthreads` command line argument or by using the
+worker threads or can be configured by either the `--gcthreads` command line argument or by using the
 [`JULIA_NUM_GC_THREADS`](@ref JULIA_NUM_GC_THREADS) environment variable.
 
 !!! compat "Julia 1.10"
@@ -216,7 +216,7 @@ Note that [`Threads.@threads`](@ref) does not have an optional reduction paramet
 
 The concept of a data-race is elaborated on in ["Communication and data races between threads"](@ref man-communication-and-data-races). For now, just know that a data race can result in incorrect results and dangerous errors.
 
-Lets say we want to make the function `sum_single` below multithreaded.
+Let's say we want to make the function `sum_single` below multithreaded.
 ```julia-repl
 julia> function sum_single(a)
            s = 0
@@ -341,7 +341,7 @@ julia> begin
 100
 ```
 
-All three options are equivalent. Note how the final version requires an explicit `try`-block to ensure that the lock is always unlocked, whereas the first two version do this internally. One should always use the lock pattern above when changing data (such as assigning
+All three options are equivalent. Note how the final version requires an explicit `try`-block to ensure that the lock is always unlocked, whereas the first two versions do this internally. One should always use the lock pattern above when changing data (such as assigning
 to a global or closure variable) accessed by other threads. Failing to do this could have unforeseen and serious consequences.
 
 #### [Using Base.Lockable to associate a lock and a value](@id man-lockable)

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -130,8 +130,7 @@ julia> write("hello.txt", "Hello, World!")
 
 _(`13` is the number of bytes written.)_
 
-You can read the contents of a file with the `read(filename::String)` method, or `read(filename::String, String)`
-to the contents as a string:
+You can read the contents of a file with the `read(filename::String)` method, or `read(filename::String, String)` to read the contents as a string:
 
 ```julia-repl
 julia> read("hello.txt", String)
@@ -405,7 +404,7 @@ UDP can use special multicast addresses to allow simultaneous communication betw
 
 ### Receiving IP Multicast Packets
 
-To transmit data over UDP multicast, simply `recv` on the socket, and the first packet received will be returned. Note that it may not be the first packet that you sent however!
+To receive data over UDP multicast, simply `recv` on the socket, and the first packet received will be returned. Note that it may not be the first packet that you sent however!
 
 ```julia
 using Sockets

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -299,7 +299,7 @@ For users coming to Julia from R, these are some noteworthy differences:
     and unlike decimal literals in Julia, have a type based on the *length* of the literal, including
     leading 0s. For example, `0x0` and `0x00` have type [`UInt8`](@ref), `0x000` and `0x0000` have type
     [`UInt16`](@ref), then literals with 5 to 8 hex digits have type `UInt32`, 9 to 16 hex digits type
-    `UInt64`, 17 to 32 hex digits type `UInt128`, and more that 32 hex digits type `BigInt`.
+    `UInt64`, 17 to 32 hex digits type `UInt128`, and more than 32 hex digits type `BigInt`.
     This needs to be taken into account when defining
     hexadecimal masks, for example `~0xf == 0xf0` is very different from `~0x000f == 0xfff0`. 64 bit `Float64`
     and 32 bit [`Float32`](@ref) bit literals are expressed as `1.0` and `1.0f0` respectively. Floating point
@@ -426,7 +426,7 @@ For users coming to Julia from R, these are some noteworthy differences:
 
 ### Julia ⇔ C/C++: Module interface
   * C++ exposes interfaces using "public" `.h`/`.hpp` files whereas Julia `module`s mark
-    specific symbols that are intended for their users as `public`or `export`ed.
+    specific symbols that are intended for their users as `public` or `export`ed.
     * Often, Julia `module`s simply add functionality by generating new "methods" to existing
       functions (ex: `Base.push!`).
     * Developers of Julia packages therefore cannot rely on header files for interface

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -666,7 +666,7 @@ g(f, x) = f(...)
 g(f) = g(f, 1)
 ```
 
-With this rewrite, the second method that passes along the default argument value does no longer use `f`, calling `g(f)` may therefore not specialize on `f`.
+With this rewrite, the second method that passes along the default argument value no longer uses `f`, calling `g(f)` may therefore not specialize on `f`.
 Writing the original definition as
 
 ```julia
@@ -821,7 +821,7 @@ The numbered boxes are labels and represent targets for jumps (via `goto`) in yo
 Looking at the body, you can see that the first thing that happens is that `pos` is called and the
 return value has been inferred as the `Union` type `Union{Float64, Int64}` shown in uppercase since
 it is a non-concrete type. This means that we cannot know the exact return type of `pos` based on the
-input types. However, the result of `y*x`is a `Float64` no matter if `y` is a `Float64` or `Int64`
+input types. However, the result of `y*x` is a `Float64` no matter if `y` is a `Float64` or `Int64`
 The net result is that `f(x::Float64)` will not be type-unstable
 in its output, even if some of the intermediate computations are type-unstable.
 
@@ -938,7 +938,7 @@ inner function. The second technique recovers full language performance
 in the presence of captured variables. Note that this is a rapidly
 evolving aspect of the compiler, and it is likely that future releases
 will not require this degree of programmer annotation to attain performance.
-In the mean time, some user-contributed packages like
+In the meantime, some user-contributed packages like
 [FastClosures](https://github.com/c42f/FastClosures.jl) automate the
 insertion of `let` statements as in `abmult3`.
 
@@ -1555,14 +1555,14 @@ from the manifest, then revert the change with `pkg> undo`.
 If loading time is dominated by slow `__init__()` methods having compilation, one verbose way to identify what is being
 compiled is to use the julia args `--trace-compile=stderr --trace-compile-timing` which will report a [`precompile`](@ref)
 statement each time a method is compiled, along with how long compilation took. The InteractiveUtils macro
-[`@trace_compile`](@ref) provides a way to enable those args for a specific call. So a call for a complete report report would look like:
+[`@trace_compile`](@ref) provides a way to enable those args for a specific call. So a call for a complete report would look like:
 
 ```julia-repl
 julia> @time @time_imports @trace_compile using CustomPackage
 ...
 ```
 
-Note the `--startup-file=no` which helps isolate the test from packages you may have in your `startup.jl`.
+For a more isolated test at the command line, consider using `--startup-file=no` to avoid interference from packages you may have in your `startup.jl`.
 
 More analysis of the reasons for recompilation can be achieved with the
 [`SnoopCompile`](https://github.com/timholy/SnoopCompile.jl) package.

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -41,7 +41,7 @@ hello
 ```
 
 The `hello` is the output of the `echo` command, sent to [`stdout`](@ref). If the external command fails to run
-successfully, the run method throws an [`ProcessFailedException`](@ref).
+successfully, the run method throws a [`ProcessFailedException`](@ref).
 
 If you want to read the output of the external command, [`read`](@ref) or [`readchomp`](@ref)
 can be used instead:
@@ -388,7 +388,7 @@ saturated throughput.
 We strongly encourage you to try all these examples to see how they work.
 
 ## `Cmd` Objects
-The backtick syntax create an object of type [`Cmd`](@ref). Such object may also be constructed directly from
+The backtick syntax creates an object of type [`Cmd`](@ref). Such an object may also be constructed directly from
 an existing `Cmd` or list of arguments:
 
 ```julia

--- a/doc/src/manual/stacktraces.md
+++ b/doc/src/manual/stacktraces.md
@@ -188,7 +188,7 @@ ERROR: Whoops!
 ## Exception stacks and [`current_exceptions`](@ref)
 
 !!! compat "Julia 1.1"
-    Exception stacks requires at least Julia 1.1.
+    Exception stacks require at least Julia 1.1.
 
 While handling an exception further exceptions may be thrown. It can be useful to inspect all these exceptions to
 identify the root cause of a problem. The julia runtime supports this by pushing each exception onto an internal

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -407,7 +407,7 @@ function, where the index `i` runs consecutively from `1` to [`ncodeunits(s)`](@
 [`codeunits(s)`](@ref) function returns an `AbstractVector{UInt8}` wrapper that lets you
 access these raw codeunits (bytes) as an array.
 
-Strings in Julia can contain invalid UTF-8 code unit sequences. This convention allows to
+Strings in Julia can contain invalid UTF-8 code unit sequences. This convention allows one to
 treat any byte sequence as a `String`. In such situations a rule is that when parsing
 a sequence of code units from left to right characters are formed by the longest sequence of
 8-bit code units that matches the start of one of the following bit patterns
@@ -481,7 +481,7 @@ julia> string(greet, ", ", whom, ".\n")
 
 It is important to be aware of potentially dangerous situations such as concatenation of
 invalid UTF-8 strings. The resulting string may contain different characters than the
-input strings, and its number of characters may be lower than sum of numbers of characters
+input strings, and its number of characters may be lower than the sum of numbers of characters
 of the concatenated strings, e.g.:
 
 ```jldoctest
@@ -1228,7 +1228,7 @@ last backslash escapes a quote, since these backslashes appear before a quote.
     Julia versions.
 
 It is sometimes useful to be able to hold metadata relating to regions of a
-string. A [`AnnotatedString`](@ref Base.AnnotatedString) wraps another string and
+string. An [`AnnotatedString`](@ref Base.AnnotatedString) wraps another string and
 allows for regions of it to be annotated with labelled values (`:label => value`).
 All generic string operations are applied to the underlying string. However,
 when possible, styling information is preserved. This means you can manipulate a

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -163,7 +163,7 @@ defines the `play` method on that particular type, leaving other types to
 have their own implementation.
 
 Similarly, non-exported functions are typically internal and subject to change,
-unless the documentations states otherwise. Names sometimes are given a `_` prefix
+unless the documentation states otherwise. Names sometimes are given a `_` prefix
 (or suffix) to further suggest that something is "internal" or an
 implementation-detail, but it is not a rule.
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -19,7 +19,7 @@ The default behavior in Julia when types are omitted is to allow values to be of
 one can write many useful Julia functions without ever explicitly using types. When additional
 expressiveness is needed, however, it is easy to gradually introduce explicit type annotations
 into previously "untyped" code. Adding annotations serves three primary purposes: to take advantage
-of Julia's powerful multiple-dispatch mechanism,  to improve human readability, and to catch
+of Julia's powerful multiple-dispatch mechanism, to improve human readability, and to catch
 programmer errors.
 
 Describing Julia in the lingo of [type systems](https://en.wikipedia.org/wiki/Type_system), it
@@ -32,7 +32,7 @@ While this might at first seem unduly restrictive, it has many beneficial conseq
 few drawbacks. It turns out that being able to inherit behavior is much more important than being
 able to inherit structure, and inheriting both causes significant difficulties in traditional
 object-oriented languages. While concrete types do have abstract subtypes, there are only two examples of this
-([`Union{}`](@ref man-abstract-types) and [`Type{T}`](@ref man-typet-type))) and additional subtypes
+([`Union{}`](@ref man-abstract-types) and [`Type{T}`](@ref man-typet-type)) and additional subtypes
 of concrete types cannot be declared.
 
 Other high-level aspects of Julia's type system that should be mentioned up front are:
@@ -113,7 +113,7 @@ x::Int8 = 10   # as the left-hand side of an assignment
 
 and applies to the whole current scope, even before the declaration.
 
-As of Julia 1.8, type declarations can now be used in global scope i.e.
+As of Julia 1.8, type declarations can now be used in global scope i.e.,
 type annotations can be added to global variables to make accessing them type stable.
 ```julia
 julia> x::Int = 10
@@ -470,7 +470,7 @@ To recap, two essential properties define immutability in Julia:
   * It is not permitted to modify the value of an immutable type.
     * For bits types this means that the bit pattern of a value once set will never change
       and that value is the identity of a bits type.
-    * For composite  types, this means that the identity of the values of its fields will
+    * For composite types, this means that the identity of the values of its fields will
       never change. When the fields are bits types, that means their bits will never change,
       for fields whose values are mutable types like arrays, that means the fields will
       always refer to the same mutable value even though that mutable value's content may
@@ -510,7 +510,7 @@ ERROR: setfield!: const field .b of type Baz cannot be changed
 
 ## Mutually Recursive Types
 
-Because julia's top level scope is procedural, types defined later in a file are not available for
+Because Julia's top level scope is procedural, types defined later in a file are not available for
 earlier field types. This is generally not a problem if types are written in the order they are
 used, but of course this does not work if there are cycles in the field type definitions:
 

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -382,7 +382,7 @@ s
 
 What does this code do? Hint: it's a trick question. The answer is "it depends." If this code is
 entered interactively, it behaves the same way it does in a function body. But if the code appears
-in a file, it  prints an ambiguity warning and throws an undefined variable error. Let's see it
+in a file, it prints an ambiguity warning and throws an undefined variable error. Let's see it
 working in the REPL first:
 
 ```jldoctest
@@ -753,9 +753,9 @@ to assign a value to a variable that is declared constant the following scenario
   ```
 
 !!! compat "Julia 1.12"
-    Prior to julia 1.12, redefinition of constants was poorly supported. It was restricted to
+    Prior to Julia 1.12, redefinition of constants was poorly supported. It was restricted to
     redefinition of constants of the same type and could lead to observably incorrect behavior
-    or crashes. Constant redefinition is highly discouraged in versions of julia prior to 1.12.
+    or crashes. Constant redefinition is highly discouraged in versions of Julia prior to 1.12.
     See the manual for prior julia versions for further information.
 
 ## [Typed Globals](@id man-typed-globals)

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -150,7 +150,7 @@ try = "No"
 
 Some Unicode characters are considered to be equivalent in identifiers.
 Different ways of entering Unicode combining characters (e.g., accents)
-are treated as equivalent (specifically, Julia identifiers are [NFC](https://en.wikipedia.org/wiki/Unicode_equivalence).
+are treated as equivalent (specifically, Julia identifiers are [NFC-normalized](https://en.wikipedia.org/wiki/Unicode_equivalence)).
 Julia also includes a few non-standard equivalences for characters that are
 visually similar and are easily entered by some input methods. The Unicode
 characters `ɛ` (U+025B: Latin small letter open e) and `µ` (U+00B5: micro sign)

--- a/doc/src/manual/workflow-tips.md
+++ b/doc/src/manual/workflow-tips.md
@@ -59,7 +59,7 @@ your development experience with
 It is common to configure Revise to start whenever julia is started,
 as per the instructions in the [Revise documentation](https://timholy.github.io/Revise.jl/stable/).
 Once configured, Revise will track changes to files in any loaded modules,
-and to any files loaded in to the REPL with `includet` (but not with plain `include`);
+and to any files loaded into the REPL with `includet` (but not with plain `include`);
 you can then edit the files and the changes take effect without restarting your julia session.
 A standard workflow is similar to the REPL-based workflow above, with
 the following modifications:

--- a/doc/src/manual/worldage.md
+++ b/doc/src/manual/worldage.md
@@ -37,7 +37,7 @@ In addition, each [`Task`](@ref) stores a local world age that determines which 
 the global binding and method tables are currently visible to the running task. The world age of
 the running task will never exceed the global world age counter, but may run arbitrarily behind it.
 In general the term "current world age" refers to the local world age of the currently running task.
-The current world age may be retrieved using the (internal) function [`Base.tls_world_age`](@ref)
+The current world age may be retrieved using the (internal) function [`Base.tls_world_age`](@ref).
 
 ```julia-repl
 julia> function f end
@@ -265,7 +265,7 @@ Binding Main.x
 Certain language features capture the current task's world age. Perhaps the most common of
 these is creation of new tasks. Newly created tasks will inherit the creating task's local
 world age at creation time and will retain said world age (unless explicitly raised) even
-if the originating tasks raises its world age:
+if the originating task raises its world age:
 
 ```julia-repl
 julia> const x = 1


### PR DESCRIPTION
This commit improves documentation, including spelling corrections, grammar fixes, broken cross-reference repairs, and prose refinements for clarity. Changes include correcting malformed documentation link syntax (e.g., @(ref) -> (`@ref`)), fixing verb agreement issues, improving sentence structure, and resolving broken or imprecise references in both manual and developer documentation.

This change was written with the assistance of generative AI.