### PR TITLE
gf: fix typeinf timing bit leak silencing cumulative compile time

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3966,6 +3966,7 @@ static jl_code_instance_t *jl_compile_method_very_internal(jl_method_instance_t 
                 mi2 = mi;
             }
             else {
+                jl_typeinf_timing_end(inference_start, is_recompile);
                 return codeinst;
             }
         }

--- a/src/gf.c
+++ b/src/gf.c
@@ -3985,6 +3985,9 @@ static jl_code_instance_t *jl_compile_method_very_internal(jl_method_instance_t 
                     if (ucache_invoke == NULL) {
                         if ((!jl_is_method(def) || def->source == jl_nothing) &&
                             !jl_cached_uninferred(jl_atomic_load_relaxed(&jl_get_ci_mi(codeinst)->cache), world)) {
+                            // end the timing region before escaping, so the task's
+                            // reentrant_timing bit is not left set if this is caught
+                            jl_typeinf_timing_end(inference_start, is_recompile);
                             jl_throw(jl_new_struct(jl_missingcodeerror_type, (jl_value_t*)mi));
                         }
                         jl_generate_fptr_for_unspecialized(codeinst);


### PR DESCRIPTION
Fix the illogically low `(comp)` times reported here https://github.com/JuliaLang/julia/pull/61920#issue-4534142262

Claude:

----

`jl_typeinf_timing_begin` sets a reentrancy bit on the task that only
`jl_typeinf_timing_end` clears; while set, no inference or JIT time is
recorded into `jl_cumulative_compile_time`. Two paths in
`jl_compile_method_very_internal` escape the timing region without clearing
it, permanently silencing measurement on that task:

1. Regression from #61997: the `jl_normalize_to_compilable_mi` fallback's
   early return skips `jl_typeinf_timing_end`. Hit by e.g. macro calls early
   in package precompilation, making the `(comp)` column of
   `precompilepkgs(timing=true)` collapse (Makie: 63.81s → 0.11s with
   unchanged method counts).
2. Pre-existing: the `jl_throw(MissingCodeError)` in the same region leaks
   the bit if the error is caught.

Both now end the timing region before escaping, matching the other exits.