### PR TITLE
analyzegc: don't flag atomic derefs that only take an address

### DIFF
--- a/src/clangsa/ImplicitAtomics.cpp
+++ b/src/clangsa/ImplicitAtomics.cpp
@@ -51,6 +51,29 @@ static bool isStdAtomic(const Expr *E) {
   return E->getType()->isAtomicType();
 }
 
+// `&*p` performs no access, so a deref appearing directly under an
+// address-of (e.g. the `&(field)` of a macro called with `*slot`) is fine.
+static bool isDerefUnderAddrOf(const UnaryOperator *UOp, ASTContext &Ctx) {
+  if (UOp->getOpcode() != UO_Deref)
+    return false;
+  const Stmt *S = UOp;
+  while (true) {
+    DynTypedNodeList Parents = Ctx.getParents(*S);
+    if (Parents.empty())
+      return false;
+    const Stmt *P = Parents[0].get<Stmt>();
+    if (!P)
+      return false;
+    if (isa<ParenExpr>(P) || isa<ImplicitCastExpr>(P)) {
+      S = P;
+      continue;
+    }
+    if (const auto *POp = dyn_cast<UnaryOperator>(P))
+      return POp->getOpcode() == UO_AddrOf;
+    return false;
+  }
+}
+
 void ImplicitAtomicsChecker::reportBug(const Stmt *S, StringRef desc) {
   // try to find the "best" node to attach this to, so we generate fewer duplicate reports
   while (1) {
@@ -100,7 +123,8 @@ void ImplicitAtomicsChecker::registerMatchers(MatchFinder *Finder) {
 void ImplicitAtomicsChecker::check(const MatchFinder::MatchResult &Result) {
   if (const auto *UOp = Result.Nodes.getNodeAs<UnaryOperator>("unary-op")) {
     const Expr *Sub = UOp->getSubExpr();
-    if (isStdAtomic(UOp) || isStdAtomic(Sub))
+    if ((isStdAtomic(UOp) || isStdAtomic(Sub)) &&
+        !isDerefUnderAddrOf(UOp, *Result.Context))
       reportBug(UOp);
   }
   if (const auto *BOp = Result.Nodes.getNodeAs<BinaryOperator>("binary-op")) {

--- a/test/clangsa/ImplicitAtomicsTest.c
+++ b/test/clangsa/ImplicitAtomicsTest.c
@@ -59,6 +59,9 @@ void hiddenAtomics(void) {
     *(int*)&x = 3; // CHECK-NOT: [[@LINE]]
     *(int*)px = 3; // CHECK-NOT: [[@LINE]]
 
+    &*px; // CHECK-NOT: [[@LINE]]
+    *&*px = 3; // CHECK: [[@LINE]]:8: warning: Implicit Atomic seq_cst synchronization
+
     y.y = 2; // CHECK-NOT: [[@LINE]]
     py->y = 2; // CHECK-NOT: [[@LINE]]
 #ifndef __cplusplus // invalid C++ code


### PR DESCRIPTION
Teach the ImplicitAtomics checker that a dereference of an atomic pointer appearing directly under an address-of (`&*p`, possibly through parens/implicit casts) performs no memory access and should not be reported. This pattern arises when macros take a field lvalue argument (e.g. passing `*slot` so the macro can apply `&`).

This was found as part of https://github.com/JuliaLang/julia/pull/62063/.

This commit was written with the assistance of generative AI.