### PR TITLE
Fix egal codegen on large (>512 bytes), split representation isbitsegal types

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3798,12 +3798,10 @@ static Value *emit_bits_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, const
         jl_datatype_t *sty = (jl_datatype_t*)argty;
         size_t sz = jl_datatype_size(sty);
         if (sz > 512 && !sty->layout->flags.haspadding && sty->layout->flags.isbitsegal) {
-            Value *varg1 = arg1.inline_roots.empty() && arg1.ispointer() ? data_pointer(ctx, arg1) :
-                value_to_pointer(ctx, arg1).V;
-            Value *varg2 = arg2.inline_roots.empty() && arg2.ispointer() ? data_pointer(ctx, arg2) :
-                value_to_pointer(ctx, arg2).V;
-            varg1 = emit_pointer_from_objref(ctx, varg1);
-            varg2 = emit_pointer_from_objref(ctx, varg2);
+            jl_cgval_t parg1 = value_to_pointer(ctx, arg1);
+            jl_cgval_t parg2 = value_to_pointer(ctx, arg2);
+            Value *varg1 = emit_pointer_from_objref(ctx, data_pointer(ctx, parg1));
+            Value *varg2 = emit_pointer_from_objref(ctx, data_pointer(ctx, parg2));
             SmallVector<Value*, 0> gc_uses;
             // these roots may seem a bit overkill, but we want to make sure
             // that a!=b implies (a,)!=(b,) even if a and b are unused and
@@ -3817,17 +3815,20 @@ static Value *emit_bits_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, const
                         ConstantInt::get(ctx.types().T_size, sz) },
                     ArrayRef<OperandBundleDef>(&OpBundle, gc_uses.empty() ? 0 : 1));
 
-            if (arg1.tbaa || arg2.tbaa) {
+            // If either argument is in the mixed pointer/data split form,
+            // value_to_pointer will copy it to a fresh alloca in the canonical
+            // layout.  We need to use the copied version's tbaa.
+            if (parg1.tbaa || parg2.tbaa) {
                 jl_aliasinfo_t ai;
-                if (!arg1.tbaa) {
-                    ai = jl_aliasinfo_t::fromTBAA(ctx, arg2.tbaa);
+                if (!parg1.tbaa) {
+                    ai = jl_aliasinfo_t::fromTBAA(ctx, parg2.tbaa);
                 }
-                else if (!arg2.tbaa) {
-                    ai = jl_aliasinfo_t::fromTBAA(ctx, arg1.tbaa);
+                else if (!parg2.tbaa) {
+                    ai = jl_aliasinfo_t::fromTBAA(ctx, parg1.tbaa);
                 }
                 else {
-                    jl_aliasinfo_t arg1_ai = jl_aliasinfo_t::fromTBAA(ctx, arg1.tbaa);
-                    jl_aliasinfo_t arg2_ai = jl_aliasinfo_t::fromTBAA(ctx, arg2.tbaa);
+                    jl_aliasinfo_t arg1_ai = jl_aliasinfo_t::fromTBAA(ctx, parg1.tbaa);
+                    jl_aliasinfo_t arg2_ai = jl_aliasinfo_t::fromTBAA(ctx, parg2.tbaa);
                     ai = arg1_ai.merge(arg2_ai);
                 }
                 ai.decorateInst(answer);

--- a/test/core.jl
+++ b/test/core.jl
@@ -8259,6 +8259,32 @@ let vnull1 = NullableHomogeneousPointerImmutable(),
     @test !opt_jl_egal(vnull2, v2)
 end
 
+# #62095 - egal on large structs (> 512 bytes) with both ptrs and bits has
+# incorrect alias info
+struct MixedGC
+    obj::Base.RefValue{Int}
+    bits::Int
+end
+# 65 elements, so it's large enough to fail on both 32 and 64 bit
+let x = ntuple(i -> MixedGC(Base.RefValue(i), i), Val(65))
+    y = ntuple(i -> MixedGC(x[i].obj, i*2), Val(65))
+    z = ntuple(i -> MixedGC(Base.RefValue(i), i), Val(65))
+
+    @test unopt_jl_egal(x, x)
+    @test unopt_jl_egal(y, y)
+    @test unopt_jl_egal(z, z)
+    @test !unopt_jl_egal(x, y)
+    @test !unopt_jl_egal(x, z)
+    @test !unopt_jl_egal(y, z)
+
+    @test opt_jl_egal(x, x)
+    @test opt_jl_egal(y, y)
+    @test opt_jl_egal(z, z)
+    @test !opt_jl_egal(x, y)
+    @test !opt_jl_egal(x, z)
+    @test !opt_jl_egal(y, z)
+end
+
 # Make sure non-allbits union is handled correctly
 @noinline returns_union37557(r) = r[]
 @noinline compare_union37557(r1, r2) = returns_union37557(r1) === returns_union37557(r2)


### PR DESCRIPTION
Large (> 512 bytes) struct that are isbitsegal emit a memcmp instead of a comparison for each field. However, this requires that both the arguments to the memcmp be in the canonical struct layout, which is a problem for structs in the split layout because of the calling convention.

Here's an example:
```julia
mutable struct Box
    v::Int
end
struct Mixed
    obj::Box                    # Mixed must be bitsegal (Any won't work)
    num::Int
end

const N = 40
const T = NTuple{N, Mixed}

f(a::T, b::T) = a === b

x = ntuple(i -> Mixed(Box(i), i), Val(N))

x === x                         # true
f(x, x)                         # false
```

`N=40` is chosen to make the resulting `NTuple{N, Mixed}` at least 512 bytes.

To make the IR a little more readable, here's an example of the code we'd generate if the threshold for emitting `memcmp` for `===` was 64 bytes:

```llvm
define swiftcc i8 @julia_f_0(ptr nonnull swiftself "gcstack" %0, ptr addrspace(11) noundef nonnull readonly align 8 captures(none) dereferenceable(32) %1, ptr noundef nonnull readonly align 8 captures(none) dereferenceable(16) %2, ptr addrspace(11) noundef nonnull readonly align 8 captures(none) dereferenceable(32) %3, ptr noundef nonnull readonly align 8 captures(none) dereferenceable(16) %4) #0 {
  ; Copy of each argument combined by `recombine_value`.
  %6 = alloca [2 x { ptr addrspace(10), i64 }], align 8
  %7 = alloca [2 x { ptr addrspace(10), i64 }], align 8

  ; Stores generated by `value_to_pointer`
  store ptr addrspace(10) null, ptr %7, align 8
  %8 = getelementptr inbounds i8, ptr %7, i32 16
  store ptr addrspace(10) null, ptr %8, align 8
  store ptr addrspace(10) null, ptr %6, align 8
  %9 = getelementptr inbounds i8, ptr %6, i32 16
  store ptr addrspace(10) null, ptr %9, align 8

  %10 = getelementptr inbounds i8, ptr %0, i32 -152
  %11 = getelementptr inbounds i8, ptr %10, i32 168
  %12 = load ptr, ptr %11, align 8, !tbaa !3
  %13 = getelementptr inbounds i8, ptr %12, i32 16
  %14 = load atomic ptr, ptr %13 monotonic, align 8, !tbaa !7, !invariant.load !9
  fence syncscope("singlethread") seq_cst
  call void @julia.safepoint(ptr %14)
  fence syncscope("singlethread") seq_cst

  ; Copies from `recombine_value`
  %15 = load ptr addrspace(10), ptr %2, align 8, !tbaa !7, !invariant.load !9, !alias.scope !10, !noalias !13
  store ptr addrspace(10) %15, ptr %6, align 8, !tbaa !18, !alias.scope !20, !noalias !21
  %16 = getelementptr inbounds i8, ptr %6, i32 8
  %17 = getelementptr inbounds i8, ptr addrspace(11) %1, i32 8
  call void @llvm.memcpy.p0.p11.i64(ptr align 8 %16, ptr addrspace(11) align 8 %17, i64 8, i1 false), !tbaa !22, !alias.scope !23, !noalias !24
  %18 = getelementptr inbounds i8, ptr %2, i32 8
  %19 = load ptr addrspace(10), ptr %18, align 8, !tbaa !7, !invariant.load !9, !alias.scope !10, !noalias !13
  %20 = getelementptr inbounds i8, ptr %6, i32 16
  store ptr addrspace(10) %19, ptr %20, align 8, !tbaa !18, !alias.scope !20, !noalias !21
  %21 = getelementptr inbounds i8, ptr %6, i32 24
  %22 = getelementptr inbounds i8, ptr addrspace(11) %1, i32 24
  call void @llvm.memcpy.p0.p11.i64(ptr align 8 %21, ptr addrspace(11) align 8 %22, i64 8, i1 false), !tbaa !22, !alias.scope !23, !noalias !24
  %23 = load ptr addrspace(10), ptr %4, align 8, !tbaa !7, !invariant.load !9, !alias.scope !10, !noalias !13
  store ptr addrspace(10) %23, ptr %7, align 8, !tbaa !18, !alias.scope !20, !noalias !21
  %24 = getelementptr inbounds i8, ptr %7, i32 8
  %25 = getelementptr inbounds i8, ptr addrspace(11) %3, i32 8
  call void @llvm.memcpy.p0.p11.i64(ptr align 8 %24, ptr addrspace(11) align 8 %25, i64 8, i1 false), !tbaa !22, !alias.scope !23, !noalias !24
  %26 = getelementptr inbounds i8, ptr %4, i32 8
  %27 = load ptr addrspace(10), ptr %26, align 8, !tbaa !7, !invariant.load !9, !alias.scope !10, !noalias !13
  %28 = getelementptr inbounds i8, ptr %7, i32 16
  store ptr addrspace(10) %27, ptr %28, align 8, !tbaa !18, !alias.scope !20, !noalias !21
  %29 = getelementptr inbounds i8, ptr %7, i32 24
  %30 = getelementptr inbounds i8, ptr addrspace(11) %3, i32 24
  call void @llvm.memcpy.p0.p11.i64(ptr align 8 %29, ptr addrspace(11) align 8 %30, i64 8, i1 false), !tbaa !22, !alias.scope !23, !noalias !24

  %31 = load ptr addrspace(10), ptr %2, align 8, !tbaa !7, !invariant.load !9, !alias.scope !10, !noalias !13
  %32 = getelementptr inbounds i8, ptr %2, i32 8
  %33 = load ptr addrspace(10), ptr %32, align 8, !tbaa !7, !invariant.load !9, !alias.scope !10, !noalias !13
  %34 = load ptr addrspace(10), ptr %4, align 8, !tbaa !7, !invariant.load !9, !alias.scope !10, !noalias !13
  %35 = getelementptr inbounds i8, ptr %4, i32 8
  %36 = load ptr addrspace(10), ptr %35, align 8, !tbaa !7, !invariant.load !9, !alias.scope !10, !noalias !13
  %37 = call i32 @memcmp(ptr %6, ptr %7, i64 32) [ "jl_roots"(ptr addrspace(10) %31, ptr addrspace(10) %33, ptr addrspace(10) %34, ptr addrspace(10) %36) ], !tbaa !7, !alias.scope !10, !noalias !13
  %38 = icmp eq i32 %37, 0
  %39 = zext i1 %38 to i8
  ret i8 %39
}

!0 = !{i32 2, !"Dwarf Version", i32 4}
!1 = !{i32 2, !"Debug Info Version", i32 3}
!2 = !{i32 2, !"julia.optlevel", i32 2}
!3 = !{!4, !4, i64 0}
!4 = !{!"jtbaa_gcframe", !5, i64 0}
!5 = !{!"jtbaa", !6, i64 0}
!6 = !{!"jtbaa"}
!7 = !{!8, !8, i64 0, i64 1}
!8 = !{!"jtbaa_const", !5, i64 0}
!9 = !{}
!10 = !{!11}
!11 = !{!"jnoalias_const", !12}
!12 = !{!"jnoalias"}
!13 = !{!14, !15, !16, !17}
!14 = !{!"jnoalias_gcframe", !12}
!15 = !{!"jnoalias_stack", !12}
!16 = !{!"jnoalias_data", !12}
!17 = !{!"jnoalias_typemd", !12}
!18 = !{!19, !19, i64 0}
!19 = !{!"jtbaa_stack", !5, i64 0}
!20 = !{!15}
!21 = !{!14, !16, !17, !11}
!22 = !{!5, !5, i64 0}
!23 = !{!11, !15}
!24 = !{!14, !16, !17}
!25 = !{!14}
!26 = !{!15, !16, !17, !11}
!27 = !{i64 32}
!28 = !{i64 8}
!29 = !{!30, !30, i64 0}
!30 = !{!"jtbaa_immut", !31, i64 0}
!31 = !{!"jtbaa_value", !32, i64 0}
!32 = !{!"jtbaa_data", !5, i64 0}
!33 = !{!16}
!34 = !{!14, !15, !17, !11}
!35 = !{i64 1}
```

The `memcmp` inherits its alias info from the arguments, meaning it gets `jtbaa_const` as its TBAA, and the `jnoalias_const` alias scope, with every other scope in the noalias set.  LLVM concludes the copies from the arguments to the combined versions on the stack aren't read and deletes them, leaving us with uninitialized stack memory where the non-pointers should be. 
```
Trying to eliminate MemoryDefs at the end of the function
  Check if def 16 = MemoryDef(15) (  store i64 %31, ptr %29, align 8, !tbaa !22, !alias.scope !23, !noalias !24) is at the end the function 
   ... MemoryDef is not accessed until the end of the function
  Check if def 15 = MemoryDef(14) (  store ptr addrspace(10) %28, ptr %8, align 8, !tbaa !18, !alias.scope !20, !noalias !21) is at the end the function 
   ... MemoryDef is not accessed until the end of the function
  Check if def 14 = MemoryDef(13) (  store i64 %26, ptr %24, align 8, !tbaa !22, !alias.scope !23, !noalias !24) is at the end the function 
   ... MemoryDef is not accessed until the end of the function
  Check if def 13 = MemoryDef(12) (  store ptr addrspace(10) %23, ptr %7, align 8, !tbaa !18, !alias.scope !20, !noalias !21) is at the end the function 
   ... MemoryDef is not accessed until the end of the function
  Check if def 12 = MemoryDef(11) (  store i64 %22, ptr %20, align 8, !tbaa !22, !alias.scope !23, !noalias !24) is at the end the function 
   ... MemoryDef is not accessed until the end of the function
  Check if def 11 = MemoryDef(10) (  store ptr addrspace(10) %19, ptr %9, align 8, !tbaa !18, !alias.scope !20, !noalias !21) is at the end the function 
   ... MemoryDef is not accessed until the end of the function
  Check if def 10 = MemoryDef(9) (  store i64 %17, ptr %15, align 8, !tbaa !22, !alias.scope !23, !noalias !24) is at the end the function 
   ... MemoryDef is not accessed until the end of the function
  Check if def 9 = MemoryDef(8) (  store ptr addrspace(10) %14, ptr %6, align 8, !tbaa !18, !alias.scope !20, !noalias !21) is at the end the function 
   ... MemoryDef is not accessed until the end of the function
```


Claude Fable 5 ran into this bug while I was having make a reproducer for a different bug.