### PR TITLE
improve `Char` casing effects

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -6,7 +6,8 @@ module Unicode
 import Base: show, ==, hash, string, Symbol, isless, length, eltype,
              convert, isvalid, ismalformed, isoverlong, iterate,
              AnnotatedString, AnnotatedChar, annotated_chartransform,
-             @assume_effects, annotations, is_overlong_enc, unsafe_codepoint
+             @assume_effects, annotations, is_overlong_enc, throw_invalid_char,
+             unsafe_codepoint
 
 # whether codepoints are valid Unicode scalar values, i.e. 0-0xd7ff, 0xe000-0x10ffff
 
@@ -316,6 +317,14 @@ julia> lowercase('Ö')
 lowercase(c::T) where {T<:AbstractChar} = isascii(c) ? ('A' <= c <= 'Z' ? c + 0x20 : c) :
     T(ccall(:utf8proc_tolower, UInt32, (UInt32,), c))
 
+_ascii_lowercase(c::Char) = reinterpret(Char, (unsafe_codepoint(c) + UInt32(0x20)) << 24)
+
+function lowercase(c::Char)
+    isascii(c) && return 'A' <= c <= 'Z' ? _ascii_lowercase(c) : c
+    ismalformed(c) && throw_invalid_char(c)
+    Char(@assume_effects :foldable :nothrow @ccall utf8proc_tolower(unsafe_codepoint(c)::UInt32)::UInt32)
+end
+
 lowercase(c::AnnotatedChar) = AnnotatedChar(lowercase(c.char), annotations(c))
 
 """
@@ -336,6 +345,14 @@ julia> uppercase('ê')
 """
 uppercase(c::T) where {T<:AbstractChar} = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
     T(ccall(:utf8proc_toupper, UInt32, (UInt32,), c))
+
+_ascii_uppercase(c::Char) = reinterpret(Char, (unsafe_codepoint(c) - UInt32(0x20)) << 24)
+
+function uppercase(c::Char)
+    isascii(c) && return 'a' <= c <= 'z' ? _ascii_uppercase(c) : c
+    ismalformed(c) && throw_invalid_char(c)
+    Char(@assume_effects :foldable :nothrow @ccall utf8proc_toupper(unsafe_codepoint(c)::UInt32)::UInt32)
+end
 
 uppercase(c::AnnotatedChar) = AnnotatedChar(uppercase(c.char), annotations(c))
 
@@ -361,6 +378,12 @@ julia> uppercase('ǆ')
 """
 titlecase(c::T) where {T<:AbstractChar} = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
     T(ccall(:utf8proc_totitle, UInt32, (UInt32,), c))
+
+function titlecase(c::Char)
+    isascii(c) && return 'a' <= c <= 'z' ? _ascii_uppercase(c) : c
+    ismalformed(c) && throw_invalid_char(c)
+    Char(@assume_effects :foldable :nothrow @ccall utf8proc_totitle(unsafe_codepoint(c)::UInt32)::UInt32)
+end
 
 titlecase(c::AnnotatedChar) = AnnotatedChar(titlecase(c.char), annotations(c))
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -6,8 +6,7 @@ module Unicode
 import Base: show, ==, hash, string, Symbol, isless, length, eltype,
              convert, isvalid, ismalformed, isoverlong, iterate,
              AnnotatedString, AnnotatedChar, annotated_chartransform,
-             @assume_effects, annotations, is_overlong_enc, throw_invalid_char,
-             unsafe_codepoint
+             @assume_effects, annotations, is_overlong_enc, unsafe_codepoint
 
 # whether codepoints are valid Unicode scalar values, i.e. 0-0xd7ff, 0xe000-0x10ffff
 
@@ -315,15 +314,7 @@ julia> lowercase('Ö')
 ```
 """
 lowercase(c::T) where {T<:AbstractChar} = isascii(c) ? ('A' <= c <= 'Z' ? c + 0x20 : c) :
-    T(ccall(:utf8proc_tolower, UInt32, (UInt32,), c))
-
-_ascii_lowercase(c::Char) = reinterpret(Char, (unsafe_codepoint(c) + UInt32(0x20)) << 24)
-
-function lowercase(c::Char)
-    isascii(c) && return 'A' <= c <= 'Z' ? _ascii_lowercase(c) : c
-    ismalformed(c) && throw_invalid_char(c)
-    Char(@assume_effects :foldable :nothrow @ccall utf8proc_tolower(unsafe_codepoint(c)::UInt32)::UInt32)
-end
+    T(@assume_effects :foldable :nothrow @ccall utf8proc_tolower(c::UInt32)::UInt32)
 
 lowercase(c::AnnotatedChar) = AnnotatedChar(lowercase(c.char), annotations(c))
 
@@ -344,15 +335,7 @@ julia> uppercase('ê')
 ```
 """
 uppercase(c::T) where {T<:AbstractChar} = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
-    T(ccall(:utf8proc_toupper, UInt32, (UInt32,), c))
-
-_ascii_uppercase(c::Char) = reinterpret(Char, (unsafe_codepoint(c) - UInt32(0x20)) << 24)
-
-function uppercase(c::Char)
-    isascii(c) && return 'a' <= c <= 'z' ? _ascii_uppercase(c) : c
-    ismalformed(c) && throw_invalid_char(c)
-    Char(@assume_effects :foldable :nothrow @ccall utf8proc_toupper(unsafe_codepoint(c)::UInt32)::UInt32)
-end
+    T(@assume_effects :foldable :nothrow @ccall utf8proc_toupper(c::UInt32)::UInt32)
 
 uppercase(c::AnnotatedChar) = AnnotatedChar(uppercase(c.char), annotations(c))
 
@@ -377,13 +360,7 @@ julia> uppercase('ǆ')
 ```
 """
 titlecase(c::T) where {T<:AbstractChar} = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
-    T(ccall(:utf8proc_totitle, UInt32, (UInt32,), c))
-
-function titlecase(c::Char)
-    isascii(c) && return 'a' <= c <= 'z' ? _ascii_uppercase(c) : c
-    ismalformed(c) && throw_invalid_char(c)
-    Char(@assume_effects :foldable :nothrow @ccall utf8proc_totitle(unsafe_codepoint(c)::UInt32)::UInt32)
-end
+    T(@assume_effects :foldable :nothrow @ccall utf8proc_totitle(c::UInt32)::UInt32)
 
 titlecase(c::AnnotatedChar) = AnnotatedChar(titlecase(c.char), annotations(c))
 

--- a/test/char.jl
+++ b/test/char.jl
@@ -369,6 +369,9 @@ end
         @test Base.Unicode.isassigned(c) isa Bool
         @test islowercase(c) isa Bool
         @test isuppercase(c) isa Bool
+        for f in (lowercase, uppercase, titlecase)
+            @test_throws Base.InvalidCharError f(c)
+        end
     end
 end
 
@@ -422,6 +425,11 @@ end
               Base.Unicode.isassigned, Base.Unicode.category_code,
               Base.Unicode.category_abbrev, Base.Unicode.category_string)
         @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (Char,)))
+    end
+    for f in (lowercase, uppercase, titlecase)
+        effects = Base.infer_effects(f, (Char,))
+        @test Core.Compiler.is_foldable(effects)
+        @test !Core.Compiler.is_nothrow(effects)
     end
     for f in (isascii, textwidth, lastindex)
         @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (String,)))


### PR DESCRIPTION
improve effects of `uppercase`, `lowercase`, and `titlecase`.  these were observed to be bad in https://github.com/JuliaLang/LinearAlgebra.jl/issues/1384. the `@assume_effects :foldable :nothrow @ccall utf8proc_` pattern here matches the existing for `islowercase` and `isuppercase`