### PR TITLE
reflection: Fix union field counts

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -51,7 +51,7 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     EffectsOverride, Filter, Generator, NUM_EFFECTS_OVERRIDES,
     OneTo, Ordering, RefValue, _NAMEDTUPLE_NAME,
     _array_for, _bits_findnext, _defaultctors, _methods_by_ftype, _uniontypes, all, allocatedinline, any,
-    argument_datatype, binding_kind, cconvert, copy_exprargs, datatype_arrayelem,
+    argument_datatypename, binding_kind, cconvert, copy_exprargs, datatype_arrayelem,
     datatype_fieldcount, datatype_fieldtypes, datatype_layoutsize, datatype_nfields,
     datatype_pointerfree, decode_effects_override, diff_names, fieldindex, visit,
     generating_output, get_nospecializeinfer_sig, get_world_counter, has_free_typevars, has_typevar,

--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -1478,14 +1478,13 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
             val = stmt.args[2]
         end
         struct_typ = argextype_widened(val, compact)
-        struct_argtyp = argument_datatype(struct_typ)
-        if struct_argtyp === nothing
+        struct_typ_name = argument_datatypename(struct_typ)
+        if struct_typ_name === nothing
             if isa(struct_typ, Union) && is_isdefined
                 lift_comparison!(isdefined, compact, idx, stmt, 𝕃ₒ)
             end
             continue
         end
-        struct_typ_name = struct_argtyp.name
 
         struct_typ_name.atomicfields == C_NULL || continue # TODO: handle more
         if !((field_ordering === :unspecified) ||

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -948,8 +948,8 @@ add_tfunc(<:, 2, 2, subtype_tfunc, 10)
 end
 
 function try_compute_fieldidx(@nospecialize(typ), @nospecialize(field))
-    typ = argument_datatype(typ)
-    typ === nothing && return nothing
+    typ = unwraptv(typ)
+    typ isa Union || typ isa UnionAll || typ isa DataType || return nothing
     if isa(field, Symbol)
         field = fieldindex(typ, field, false)
         field == 0 && return nothing

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -120,7 +120,7 @@ function _limit_type_size(@nospecialize(t), @nospecialize(c), sources::SimpleVec
     elseif isType(t)
         # Type is fairly important, so do not widen it as fast as other types if avoidable
         tt = type_parameter(t)
-        ttu = unwrap_unionall(tt) # TODO: use argument_datatype(tt) after #50692 fixed
+        ttu = unwrap_unionall(tt) # TODO: use a helper that preserves nested Type structure after #50692 is fixed
         # must forbid nesting through this if we detect that potentially occurring
         # we already know !is_derived_type_from_any so refuse to recurse here
         if isType(ttu)
@@ -270,7 +270,7 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
     if isType(t)
         # Type is fairly important, so do not widen it as fast as other types if avoidable
         tt = type_parameter(t)
-        # ttu = unwrap_unionall(tt) # TODO: use argument_datatype(tt) after #50692 fixed
+        # ttu = unwrap_unionall(tt) # TODO: use a helper that preserves nested Type structure after #50692 is fixed
         if isType(c)
             ct = type_parameter(c)
         else

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -623,7 +623,7 @@ function datatype_min_ninitialized(@nospecialize t0)
         if names isa Tuple
             return length(names)
         end
-        t = argument_datatype(types)
+        t = unwrap_unionall(types)
         t isa DataType || return 0
         t.name === Tuple.name || return 0
     end

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -306,13 +306,8 @@ function _modulecolor(method::Method)
     # method table is shared, we now need to distinguish "primary" methods by trying to
     # check if there is a primary `DataType` to identify it with. c.f. how `jl_method_def`
     # would derive this same information (for the name).
-    ft = argument_datatype((unwrap_unionall(method.sig)::DataType).parameters[1])
-    # `ft` should be the type associated with the first argument in the method signature.
-    # If it's `Type`, try to unwrap it again.
-    if isType(ft)
-        ft = argument_datatype(type_parameter(ft))
-    end
-    if ft === nothing || parentmodule(method) === parentmodule(ft) !== Core
+    ft = argument_datatypename((unwrap_unionall(method.sig)::DataType).parameters[1])
+    if ft === nothing || parentmodule(method) === ft.module !== Core
         return nothing
     end
     m = parentmodule_before_main(method)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1248,18 +1248,37 @@ function _fieldindex_nothrow(T::DataType, name::Symbol)
 end
 
 function fieldindex(t::UnionAll, name::Symbol, err::Bool=true)
-    t = argument_datatype(t)
-    if t === nothing
+    return _fieldindex(t, name, err)
+end
+
+function fieldindex(t::Union, name::Symbol, err::Bool=true)
+    return _fieldindex(t, name, err)
+end
+
+function _fieldindex(@nospecialize(t), name::Symbol, err::Bool)
+    idx = _fieldindex_noerror(t, name)
+    if idx === nothing
         err && throw(ArgumentError("type does not have definite fields"))
         return 0
     end
-    return fieldindex(t, name, err)
+    if idx == 0 && err
+        t = _fieldindex_error_type(t)
+        t === nothing && throw(ArgumentError("type does not have definite fields"))
+        return fieldindex(t, name, true)
+    end
+    return idx
 end
 
 function argument_datatype(@nospecialize t)
     @_total_meta
     @noinline
     return ccall(:jl_argument_datatype, Any, (Any,), t)::Union{Nothing,DataType}
+end
+
+function argument_datatypename(@nospecialize t)
+    @_total_meta
+    @noinline
+    return ccall(:jl_argument_datatypename, Any, (Any,), t)::Union{Nothing,Core.TypeName}
 end
 
 function datatype_fieldcount(t::DataType)
@@ -1284,6 +1303,64 @@ function datatype_fieldcount(t::DataType)
     return length(t.name.names)
 end
 
+function _typename_noerror(@nospecialize(t))
+    t = unwrap_unionall(t)
+    if t isa DataType
+        return t.name
+    elseif t isa Union
+        aname = _typename_noerror(t.a)
+        aname === nothing && return nothing
+        bname = _typename_noerror(t.b)
+        return aname === bname ? aname : nothing
+    end
+    return nothing
+end
+
+function _fieldindex_error_type(@nospecialize(t))
+    t = unwrap_unionall(t)
+    if t isa DataType
+        fieldcount_noerror(t) === nothing && return nothing
+        return t
+    elseif t isa Union
+        tn = _typename_noerror(t)
+        tn === nothing && return nothing
+        t = unwrap_unionall(tn.wrapper)
+        t isa DataType || return nothing
+        return t
+    end
+    return nothing
+end
+
+function _fieldindex_noerror(@nospecialize(t), name::Symbol)
+    t = unwrap_unionall(t)
+    if t isa Union
+        _typename_noerror(t) === nothing && return nothing
+        aidx = _fieldindex_noerror(t.a, name)
+        aidx === nothing && return nothing
+        bidx = _fieldindex_noerror(t.b, name)
+        return aidx === bidx ? aidx : nothing
+    elseif t isa DataType
+        return fieldindex(t, name, false)
+    end
+    return nothing
+end
+
+function _fieldcount_noerror(@nospecialize(t))
+    t === Union{} && return 0
+    t = unwrap_unionall(t)
+    if t isa Union
+        _typename_noerror(t) === nothing && return nothing
+        acount = _fieldcount_noerror(t.a)
+        acount === nothing && return nothing
+        bcount = _fieldcount_noerror(t.b)
+        return acount === bcount ? acount : nothing
+    elseif t === Union{}
+        return 0
+    end
+    t isa DataType || return nothing
+    return datatype_fieldcount(t)
+end
+
 """
     fieldcount(t::Type)
 
@@ -1292,13 +1369,14 @@ An error is thrown if the type is too abstract to determine this.
 """
 function fieldcount(@nospecialize t)
     @_foldable_meta
-    if t isa UnionAll || t isa Union
-        t = argument_datatype(t)
-        if t === nothing
-            throw(ArgumentError("type does not have a definite number of fields"))
-        end
-    elseif t === Union{}
+    if t === Union{}
         throw(ArgumentError("The empty type does not have a well-defined number of fields since it does not have instances."))
+    end
+    t = unwrap_unionall(t)
+    if t isa Union
+        fcount = _fieldcount_noerror(t)
+        fcount === nothing && throw(ArgumentError("type does not have a definite number of fields"))
+        return fcount
     end
     if !(t isa DataType)
         throw(TypeError(:fieldcount, DataType, t))
@@ -1311,28 +1389,7 @@ function fieldcount(@nospecialize t)
 end
 
 function fieldcount_noerror(@nospecialize t)
-    if t isa UnionAll || t isa Union
-        t = argument_datatype(t)
-        if t === nothing
-            return nothing
-        end
-    elseif t === Union{}
-        return 0
-    end
-    t isa DataType || return nothing
-    if t.name === _NAMEDTUPLE_NAME
-        names, types = t.parameters
-        if names isa Tuple
-            return length(names)
-        end
-        if types isa DataType && types <: Tuple
-            return fieldcount_noerror(types)
-        end
-        return nothing
-    elseif isabstracttype(t) || (t.name === Tuple.name && isvatuple(t))
-        return nothing
-    end
-    return isdefined(t, :types) ? length(t.types) : length(t.name.names)
+    return _fieldcount_noerror(t)
 end
 
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7994,16 +7994,10 @@ static Function *gen_cfun_wrapper(
 
 static const char *derive_sigt_name(jl_value_t *jargty)
 {
-    jl_datatype_t *dt = (jl_datatype_t*)jl_argument_datatype(jargty);
-    if ((jl_value_t*)dt == jl_nothing)
+    jl_value_t *tn = jl_argument_datatypename(jargty);
+    if (tn == jl_nothing)
         return NULL;
-    jl_sym_t *name = dt->name->singletonname;
-    if (jl_is_typeeq((jl_value_t*)dt)) {
-        dt = (jl_datatype_t*)jl_argument_datatype(jl_typeeq_T((jl_value_t*)dt));
-        if ((jl_value_t*)dt != jl_nothing) {
-            name = dt->name->singletonname;
-        }
-    }
+    jl_sym_t *name = ((jl_typename_t*)tn)->singletonname;
     return jl_symbol_name(name);
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -79,18 +79,18 @@ static size_t get_max_varargs(
         max_varargs = m->max_varargs;
     }
     else {
-        jl_datatype_t *dt1 = jl_nth_argument_datatype(m->sig, 1);
-        jl_datatype_t *dt;
-        if (jl_kwcall_type && dt1 == jl_kwcall_type)
-            dt = jl_nth_argument_datatype(m->sig, 3);
+        jl_typename_t *tn1 = jl_nth_argument_datatypename(m->sig, 1);
+        jl_typename_t *tn;
+        if (jl_kwcall_type && tn1 == jl_kwcall_type->name)
+            tn = jl_nth_argument_datatypename(m->sig, 3);
         else
-            dt = dt1;
-        if (dt != NULL && !jl_is_typeeq((jl_value_t*)dt) && dt != jl_kwcall_type) {
+            tn = tn1;
+        if (tn != NULL && (!jl_kwcall_type || tn != jl_kwcall_type->name)) {
             if (may_increase != NULL)
                 *may_increase = 1; // `max_args` can increase as new methods are inserted
 
-            max_varargs = jl_atomic_load_relaxed(&dt->name->max_args) + 2;
-            if (jl_kwcall_type && dt1 == jl_kwcall_type)
+            max_varargs = jl_atomic_load_relaxed(&tn->max_args) + 2;
+            if (jl_kwcall_type && tn1 == jl_kwcall_type->name)
                 max_varargs += 2;
             if (max_varargs > m->nargs)
                 max_varargs -= m->nargs;
@@ -1758,9 +1758,8 @@ static void cache_insert(
     else {
          jl_typemap_insert(cache, parent, newentry, offs);
          if (mt) {
-             jl_datatype_t *dt = jl_nth_argument_datatype((jl_value_t*)(tt ? tt : cachett), 1);
-             if (dt) {
-                 jl_typename_t *tn = dt->name;
+             jl_typename_t *tn = jl_nth_argument_datatypename((jl_value_t*)(tt ? tt : cachett), 1);
+             if (tn) {
                  int cache_entry_count = jl_atomic_load_relaxed(&tn->cache_entry_count);
                  if (cache_entry_count < 31)
                      jl_atomic_store_relaxed(&tn->cache_entry_count, cache_entry_count + 1);
@@ -2234,10 +2233,10 @@ static void method_overwrite(jl_typemap_entry_t *newentry, jl_method_t *oldvalue
     jl_method_t *method = (jl_method_t*)newentry->func.method;
     jl_module_t *newmod = method->module;
     jl_module_t *oldmod = oldvalue->module;
-    jl_datatype_t *dt = jl_nth_argument_datatype(oldvalue->sig, 1);
-    if (jl_kwcall_type && dt == jl_kwcall_type)
-        dt = jl_nth_argument_datatype(oldvalue->sig, 3);
-    int anon = dt && is_anonfn_typename(jl_symbol_name(dt->name->name));
+    jl_typename_t *tn = jl_nth_argument_datatypename(oldvalue->sig, 1);
+    if (jl_kwcall_type && tn == jl_kwcall_type->name)
+        tn = jl_nth_argument_datatypename(oldvalue->sig, 3);
+    int anon = tn && is_anonfn_typename(jl_symbol_name(tn->name));
     if ((jl_options.warn_overwrite == JL_OPTIONS_WARN_OVERWRITE_ON) ||
         (jl_options.incremental && jl_generating_output()) || anon) {
         JL_STREAM *s = JL_STDERR;
@@ -2264,10 +2263,9 @@ static void method_overwrite(jl_typemap_entry_t *newentry, jl_method_t *oldvalue
 static void update_max_args(jl_value_t *type)
 {
     type = jl_unwrap_unionall(type);
-    jl_datatype_t *dt = jl_nth_argument_datatype(type, 1);
-    if (dt == NULL || dt == jl_kwcall_type || jl_is_typeeq((jl_value_t*)dt))
+    jl_typename_t *tn = jl_nth_argument_datatypename(type, 1);
+    if (tn == NULL || (jl_kwcall_type && tn == jl_kwcall_type->name))
         return;
-    jl_typename_t *tn = dt->name;
     assert(jl_is_datatype(type));
     size_t na = jl_nparams(type);
     if (jl_va_tuple_kind((jl_datatype_t*)type) == JL_VARARG_UNBOUND)

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -21,6 +21,7 @@
     XX(jl_apply_type1) \
     XX(jl_apply_type2) \
     XX(jl_argument_datatype) \
+    XX(jl_argument_datatypename) \
     XX(jl_array_del_end) \
     XX(jl_array_eltype) \
     XX(jl_array_grow_end) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1061,7 +1061,9 @@ JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup_worlds(jl_value_t *types, jl_value_
 
 
 jl_datatype_t *jl_nth_argument_datatype(jl_value_t *argtypes JL_PROPAGATES_ROOT, int n) JL_NOTSAFEPOINT;
+jl_typename_t *jl_nth_argument_datatypename(jl_value_t *argtypes JL_PROPAGATES_ROOT, int n) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_argument_datatype(jl_value_t *argt JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_argument_datatypename(jl_value_t *argt JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_methtable_t *jl_method_table_for(
     jl_value_t *argtypes JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_methcache_t *jl_method_cache_for(

--- a/src/method.c
+++ b/src/method.c
@@ -1302,14 +1302,8 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
 
     // TODO: derive our debug name from the syntax instead of the type
     // if we have a kwcall, try to derive the name from the callee argument method table
-    jl_datatype_t *dtname = (jl_datatype_t*)jl_argument_datatype(jl_kwcall_type && ft == (jl_value_t*)jl_kwcall_type && nargs >= 3 ? jl_svecref(atypes, 2) : ft);
-    name = (jl_value_t*)dtname != jl_nothing ? dtname->name->singletonname : jl_any_type->name->singletonname;
-    if (jl_is_typeeq((jl_value_t*)dtname)) {
-        dtname = (jl_datatype_t*)jl_argument_datatype(jl_typeeq_T((jl_value_t*)dtname));
-        if ((jl_value_t*)dtname != jl_nothing) {
-            name = dtname->name->singletonname;
-        }
-    }
+    jl_value_t *dtname = jl_argument_datatypename(jl_kwcall_type && ft == (jl_value_t*)jl_kwcall_type && nargs >= 3 ? jl_svecref(atypes, 2) : ft);
+    name = dtname != jl_nothing ? ((jl_typename_t*)dtname)->singletonname : jl_any_type->name->singletonname;
 
     if (!jl_is_code_info(f)) {
         // this occurs when there is a closure being added to an out-of-scope function

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -683,19 +683,62 @@ static jl_datatype_t *nth_arg_datatype(jl_value_t *a JL_PROPAGATES_ROOT, int n) 
     return NULL;
 }
 
+static jl_datatype_t *arg_datatype(jl_value_t *a JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    if (jl_is_datatype(a))
+        return (jl_datatype_t*)a;
+    else if (jl_is_typeeq(a)) {
+        jl_value_t *T = jl_typeeq_T(a);
+        if (T == jl_bottom_type)
+            return jl_typeofbottom_type;
+        if (jl_is_datatype(T))
+            return (jl_datatype_t*)T;
+        if (jl_is_typevar(T))
+            return arg_datatype(((jl_tvar_t*)T)->ub);
+        if (jl_is_unionall(T))
+            return arg_datatype(jl_unwrap_unionall(T));
+        return NULL;
+    }
+    else if (jl_is_typevar(a)) {
+        return arg_datatype(((jl_tvar_t*)a)->ub);
+    }
+    else if (jl_is_unionall(a)) {
+        return arg_datatype(((jl_unionall_t*)a)->body);
+    }
+    return NULL;
+}
+
 // get DataType of first tuple element (if present), or NULL if cannot be determined
 jl_datatype_t *jl_nth_argument_datatype(jl_value_t *argtypes JL_PROPAGATES_ROOT, int n) JL_NOTSAFEPOINT
 {
     return nth_arg_datatype(argtypes, n);
 }
 
+// get TypeName of first tuple element (if present), or NULL if cannot be determined
+jl_typename_t *jl_nth_argument_datatypename(jl_value_t *argtypes JL_PROPAGATES_ROOT, int n) JL_NOTSAFEPOINT
+{
+    jl_datatype_t *dt = nth_arg_datatype(argtypes, n);
+    if (dt == NULL)
+        return NULL;
+    return dt->name;
+}
+
 // get DataType implied by a single given type, or `nothing`
 JL_DLLEXPORT jl_value_t *jl_argument_datatype(jl_value_t *argt JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_datatype_t *dt = arg_datatype(argt);
+    if (dt == NULL)
+        return jl_nothing;
+    return (jl_value_t*)dt;
+}
+
+// get TypeName implied by a single given type, or `nothing`
+JL_DLLEXPORT jl_value_t *jl_argument_datatypename(jl_value_t *argt JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
     jl_datatype_t *dt = nth_arg_datatype(argt, 0);
     if (dt == NULL)
         return jl_nothing;
-    return (jl_value_t*)dt;
+    return (jl_value_t*)dt->name;
 }
 
 static int is_globname_binding(jl_value_t *v, jl_datatype_t *dv) JL_NOTSAFEPOINT

--- a/test/core.jl
+++ b/test/core.jl
@@ -405,7 +405,7 @@ end  |> only == Type{typejoin(Int, UInt, Float64)}
 @test typejoin(DataType, Type{Int}) === typejoin(Type{Int}, DataType)
 
 # issue #61915: a method whose function type is `Type{Foo{...} where ...}` must derive its
-# name as `Foo`, not `:Any` (nth_arg_datatype has to unwrap the wrapped UnionAll).
+# name as `Foo`, not `:Any` (argument_datatypename has to unwrap the wrapped UnionAll).
 struct UA61915{T,N,A<:AbstractArray{T,N}}
     a::A
 end
@@ -413,6 +413,9 @@ UA61915{T}(a) where {T} = UA61915{T,ndims(a),typeof(a)}(a)
 @test all(m -> m.name === :UA61915, methods(UA61915))
 @test which(UA61915{Int}, (Vector{Int},)).name === :UA61915
 @test ccall(:jl_argument_datatype, Any, (Any,), Type{Array}) === Base.unwrap_unionall(Array)
+@test ccall(:jl_argument_datatype, Any, (Any,), Union{Tuple{Int},Tuple{Int,Int}}) === nothing
+@test ccall(:jl_argument_datatypename, Any, (Any,), Type{Array}) === Base.unwrap_unionall(Array).name
+@test ccall(:jl_argument_datatypename, Any, (Any,), Union{Tuple{Int},Tuple{Int,Int}}) === Tuple.name
 
 # promote_typejoin returns a Union only with Nothing/Missing combined with concrete types
 for T in (Nothing, Missing)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -516,6 +516,15 @@ tlayout = TLayout(5,7,11)
 @test_throws ArgumentError fieldnames(Real)
 @test_throws ArgumentError fieldnames(AbstractArray)
 
+# Common-field unions keep field-index queries structural without choosing a representative arm.
+@test fieldindex(Union{Base.RefValue{Int},Base.RefValue{Float64}}, :x) == 1
+@test hasfield(Union{Base.RefValue{Int},Base.RefValue{Float64}}, :x)
+@test Core.Compiler.try_compute_fieldidx(Union{Base.RefValue{Int},Base.RefValue{Float64}}, :x) == 1
+@test Core.Compiler.try_compute_fieldidx(Type{Base.RefValue{Int}}, :x) === nothing
+@test fieldindex(Union{Ref{Int},Ref{Float64}}, :x, false) == 0
+@test !hasfield(Union{Ref{Int},Ref{Float64}}, :x)
+@test_throws FieldError fieldindex(Union{Ref{Int},Ref{Float64}}, :x)
+
 @test fieldtype((NamedTuple{T,Tuple{Int,String}} where T), 1) === Int
 @test fieldtype((NamedTuple{T,Tuple{Int,String}} where T), 2) === String
 @test_throws BoundsError fieldtype((NamedTuple{T,Tuple{Int,String}} where T), 3)
@@ -911,6 +920,14 @@ end
 @test_throws ArgumentError fieldcount(Real)
 @test_throws ArgumentError fieldcount(AbstractArray)
 @test_throws ArgumentError fieldcount(Tuple{Any,Vararg{Any}})
+
+# Common-field unions are definite only when all alternatives share the field count.
+@test fieldcount(Union{Tuple{Int,Float64},Tuple{Int,Int}}) == 2
+@test fieldtypes(Union{Tuple{Int,Float64},Tuple{Int,Int}}) == (Int, Union{Float64,Int})
+@test_throws(ArgumentError("type does not have a definite number of fields"),
+             fieldcount(Union{Tuple{Int},Tuple{Int,Int}}))
+@test_throws(ArgumentError("type does not have a definite number of fields"),
+             fieldtypes(Union{Tuple{Int},Tuple{Int,Int}}))
 
 # PR #22979
 


### PR DESCRIPTION
Split argument datatype lookup from common typename lookup and compute reflection field counts structurally, so union types with mismatched field counts are rejected while same-layout unions remain supported.

Fixes #62098