### PR TITLE
inference: Implement `return_type` for opaque closure

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3206,19 +3206,35 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
         isempty(argtypes_vec) && push!(argtypes_vec, Union{})
         aft = argtypes_vec[1]
     end
-    if isa(aft, PartialOpaque)
-        # Match `return_type(::OpaqueClosure, ::DataType)`: infer the OC body with
-        # the runtime type of its captures, not with call-site-only env refinements.
-        aft = PartialOpaque(aft.typ, widenconst(aft.env), aft.parent, aft.source)
-        argtypes_vec[1] = aft
-    elseif !(isa(aft, Const) || (isType(aft) && !has_free_typevars(aft)) ||
-             (isconcretetype(aft) && !(aft <: Builtin) && !iskindtype(aft)))
-        return Future(UNKNOWN)
-    end
-
     # effects are not an issue if we know this statement will get removed, but if it does not get removed,
     # then this could be recursively re-entering inference (via concrete-eval), which will not terminate
     RT_CALL_EFFECTS = Effects(EFFECTS_TOTAL; nortcall=false)
+
+    if isa(aft, PartialOpaque)
+        argtypes_vec[1] = aft = widenconst(aft)
+    end
+    aftw = widenconst(aft)
+    if hasintersect(aftw, Core.OpaqueClosure)
+        # Match `return_type(::OpaqueClosure, ::DataType)`: observe the return type
+        # declared by the OC type without inspecting the opaque closure source.
+        uaft = unwrap_unionall(aftw)
+        if isa(uaft, DataType) && aftw <: Core.OpaqueClosure
+            ocargt = rewrap_unionall(uaft.parameters[1], aftw)
+            if !hasintersect(af_argtype, ocargt)
+                return Future(CallMeta(Const(Union{}), Union{}, RT_CALL_EFFECTS, NoCallInfo()))
+            end
+            rt = rewrap_unionall(uaft.parameters[2], aftw)
+            if aftw isa DataType
+                return Future(CallMeta(Const(rt), Union{}, RT_CALL_EFFECTS, NoCallInfo()))
+            else
+                return Future(CallMeta(Type{<:rt}, Union{}, RT_CALL_EFFECTS, NoCallInfo()))
+            end
+        end
+    end
+    if !(isa(aft, Const) || (isType(aft) && !has_free_typevars(aft)) ||
+         (isconcretetype(aft) && !(aft <: Builtin) && !iskindtype(aft)))
+        return Future(UNKNOWN)
+    end
 
     if contains_is(argtypes_vec, Union{})
         return Future(CallMeta(Const(Union{}), Union{}, RT_CALL_EFFECTS, NoCallInfo()))

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3206,8 +3206,13 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
         isempty(argtypes_vec) && push!(argtypes_vec, Union{})
         aft = argtypes_vec[1]
     end
-    if !(isa(aft, Const) || (isType(aft) && !has_free_typevars(aft)) ||
-            (isconcretetype(aft) && !(aft <: Builtin) && !iskindtype(aft)))
+    if isa(aft, PartialOpaque)
+        # Match `return_type(::OpaqueClosure, ::DataType)`: infer the OC body with
+        # the runtime type of its captures, not with call-site-only env refinements.
+        aft = PartialOpaque(aft.typ, widenconst(aft.env), aft.parent, aft.source)
+        argtypes_vec[1] = aft
+    elseif !(isa(aft, Const) || (isType(aft) && !has_free_typevars(aft)) ||
+             (isconcretetype(aft) && !(aft <: Builtin) && !iskindtype(aft)))
         return Future(UNKNOWN)
     end
 

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1881,11 +1881,19 @@ verify_typeinf_trim(codeinfos::Vector{Any}, onlywarn::Bool) = Core._call_in_worl
 
 function return_type(@nospecialize(f), t::DataType) # this method has a special tfunc
     world = tls_world_age()
-    args = Any[_return_type, NativeInterpreter(world), Tuple{Core.Typeof(f), t.parameters...}]
+    if isa(f, Core.OpaqueClosure)
+        args = Any[_return_type_opaque_closure, NativeInterpreter(world), f, t]
+    else
+        args = Any[_return_type, NativeInterpreter(world), Tuple{Core.Typeof(f), t.parameters...}]
+    end
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
 end
 
 function return_type(@nospecialize(f), t::DataType, world::UInt)
+    if isa(f, Core.OpaqueClosure)
+        args = Any[_return_type_opaque_closure, NativeInterpreter(world), f, t]
+        return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
+    end
     return return_type(Tuple{Core.Typeof(f), t.parameters...}, world)
 end
 
@@ -1897,6 +1905,25 @@ end
 function return_type(t::DataType, world::UInt)
     args = Any[_return_type, NativeInterpreter(world), t]
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
+end
+
+function _return_type_opaque_closure(
+        interp::NativeInterpreter, @nospecialize(oc::Core.OpaqueClosure), t::DataType
+    )
+    m = oc.source
+    isa(m, Method) || return Any
+    if isdefined(m, :source)
+        ocworld = UInt(oc.world)
+        ocinterp = get_inference_world(interp) == ocworld ? interp :
+            NativeInterpreter(ocworld;
+                inf_params = InferenceParams(interp),
+                opt_params = OptimizationParams(interp))
+        rt = typeinf_type(ocinterp, m, Tuple{typeof(oc.captures), t.parameters...}, Core.svec())
+        return rt === nothing ? Any : rt
+    else
+        codeinst = m.specializations.cache
+        return isa(codeinst, CodeInstance) ? codeinst.rettype : Any
+    end
 end
 
 function _return_type(interp::AbstractInterpreter, t::DataType)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1879,21 +1879,21 @@ end
 const _verify_trim_world_age = RefValue{UInt}(typemax(UInt))
 verify_typeinf_trim(codeinfos::Vector{Any}, onlywarn::Bool) = Core._call_in_world(_verify_trim_world_age[], verify_typeinf_trim, Base.stderr, codeinfos, onlywarn)
 
+function _return_type_opaque_closure(@nospecialize(oc::Core.OpaqueClosure), t::DataType)
+    ocargt, ocrt = typeof(oc).parameters
+    hasintersect(t, ocargt) || return Union{}
+    return ocrt
+end
+
 function return_type(@nospecialize(f), t::DataType) # this method has a special tfunc
+    isa(f, Core.OpaqueClosure) && return _return_type_opaque_closure(f, t)
     world = tls_world_age()
-    if isa(f, Core.OpaqueClosure)
-        args = Any[_return_type_opaque_closure, NativeInterpreter(world), f, t]
-    else
-        args = Any[_return_type, NativeInterpreter(world), Tuple{Core.Typeof(f), t.parameters...}]
-    end
+    args = Any[_return_type, NativeInterpreter(world), Tuple{Core.Typeof(f), t.parameters...}]
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
 end
 
 function return_type(@nospecialize(f), t::DataType, world::UInt)
-    if isa(f, Core.OpaqueClosure)
-        args = Any[_return_type_opaque_closure, NativeInterpreter(world), f, t]
-        return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
-    end
+    isa(f, Core.OpaqueClosure) && return _return_type_opaque_closure(f, t)
     return return_type(Tuple{Core.Typeof(f), t.parameters...}, world)
 end
 
@@ -1905,25 +1905,6 @@ end
 function return_type(t::DataType, world::UInt)
     args = Any[_return_type, NativeInterpreter(world), t]
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
-end
-
-function _return_type_opaque_closure(
-        interp::NativeInterpreter, @nospecialize(oc::Core.OpaqueClosure), t::DataType
-    )
-    m = oc.source
-    isa(m, Method) || return Any
-    if isdefined(m, :source)
-        ocworld = UInt(oc.world)
-        ocinterp = get_inference_world(interp) == ocworld ? interp :
-            NativeInterpreter(ocworld;
-                inf_params = InferenceParams(interp),
-                opt_params = OptimizationParams(interp))
-        rt = typeinf_type(ocinterp, m, Tuple{typeof(oc.captures), t.parameters...}, Core.svec())
-        return rt === nothing ? Any : rt
-    else
-        codeinst = m.specializations.cache
-        return isa(codeinst, CodeInstance) ? codeinst.rettype : Any
-    end
 end
 
 function _return_type(interp::AbstractInterpreter, t::DataType)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6892,4 +6892,35 @@ let rt = Base.infer_return_type(NestedTVarSPtype.mk, (Vector, Any))
     @test rt <: (NestedTVarSPtype.ParamStruct{1, 1, Tuple{Colon}, B, Tuple{UnitRange{Int}}} where B<:Tuple{Vector})
 end
 
+# `Core.Compiler.return_type` should infer the body of an `OpaqueClosure` argument that
+# is still a `PartialOpaque` at the call site (rather than bailing to `Type`), since an
+# `OpaqueClosure`'s return type at a given argtype is fully determined by its body.
+function oc_rt_inf()
+    oc = Base.Experimental.@opaque x::Int -> 2x
+    Core.Compiler.return_type(oc, Tuple{Int})
+end
+@test Base.infer_return_type(oc_rt_inf) == Type{Int}
+# An untyped parameter is still probed precisely at the requested argtype.
+function oc_rt_inf_untyped()
+    oc = Base.Experimental.@opaque x -> 2x
+    Core.Compiler.return_type(oc, Tuple{Int})
+end
+@test Base.infer_return_type(oc_rt_inf_untyped) == Type{Int}
+# Captured environment types flow through the `PartialOpaque`, so the probed return
+# type reflects them.
+function oc_rt_inf_env(c::Float64)
+    oc = Base.Experimental.@opaque x::Int -> x + c
+    Core.Compiler.return_type(oc, Tuple{Int})
+end
+@test Base.infer_return_type(oc_rt_inf_env, (Float64,)) == Type{Float64}
+
+# Match runtime `return_type(::OpaqueClosure, ...)` semantics: use the capture tuple's
+# runtime type, not call-site-only constant env refinements.
+function oc_rt_inf_const_env()
+    c = true
+    oc = Base.Experimental.@opaque x::Int -> c ? x : 1.0
+    Core.Compiler.return_type(oc, Tuple{Int})
+end
+@test Base.infer_return_type(oc_rt_inf_const_env) == Type{Union{Float64,Int}}
+
 end # module inference

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6892,35 +6892,26 @@ let rt = Base.infer_return_type(NestedTVarSPtype.mk, (Vector, Any))
     @test rt <: (NestedTVarSPtype.ParamStruct{1, 1, Tuple{Colon}, B, Tuple{UnitRange{Int}}} where B<:Tuple{Vector})
 end
 
-# `Core.Compiler.return_type` should infer the body of an `OpaqueClosure` argument that
-# is still a `PartialOpaque` at the call site (rather than bailing to `Type`), since an
-# `OpaqueClosure`'s return type at a given argtype is fully determined by its body.
-function oc_rt_inf()
+# `Compiler.return_type` on an `OpaqueClosure` should model the declared
+# return type stored in the OC type without inspecting the OC source.
+@test Base.infer_return_type() do
+    oc = Base.Experimental.@opaque Tuple{Int}->Real x -> 2x
+    Compiler.return_type(oc, Tuple{Int})
+end == Type{Real}
+# When the OC is still a `PartialOpaque`, but its declared return type parameter is
+# not exact, do not use the source to recover the runtime-selected OC type.
+@test Base.infer_return_type() do
     oc = Base.Experimental.@opaque x::Int -> 2x
-    Core.Compiler.return_type(oc, Tuple{Int})
-end
-@test Base.infer_return_type(oc_rt_inf) == Type{Int}
-# An untyped parameter is still probed precisely at the requested argtype.
-function oc_rt_inf_untyped()
-    oc = Base.Experimental.@opaque x -> 2x
-    Core.Compiler.return_type(oc, Tuple{Int})
-end
-@test Base.infer_return_type(oc_rt_inf_untyped) == Type{Int}
-# Captured environment types flow through the `PartialOpaque`, so the probed return
-# type reflects them.
-function oc_rt_inf_env(c::Float64)
-    oc = Base.Experimental.@opaque x::Int -> x + c
-    Core.Compiler.return_type(oc, Tuple{Int})
-end
-@test Base.infer_return_type(oc_rt_inf_env, (Float64,)) == Type{Float64}
-
-# Match runtime `return_type(::OpaqueClosure, ...)` semantics: use the capture tuple's
-# runtime type, not call-site-only constant env refinements.
-function oc_rt_inf_const_env()
-    c = true
-    oc = Base.Experimental.@opaque x::Int -> c ? x : 1.0
-    Core.Compiler.return_type(oc, Tuple{Int})
-end
-@test Base.infer_return_type(oc_rt_inf_const_env) == Type{Union{Float64,Int}}
+    Compiler.return_type(oc, Tuple{Int})
+end == Type
+@test Base.infer_return_type((Core.OpaqueClosure{Tuple{Int},Real},)) do oc
+    Compiler.return_type(oc, Tuple{Int})
+end == Type{Real}
+@test Base.infer_return_type((Core.OpaqueClosure{Tuple{Int},<:Real},)) do oc
+    Compiler.return_type(oc, Tuple{Int})
+end == Type{<:Real}
+@test Base.infer_return_type((Core.OpaqueClosure{Tuple{Int},Real},)) do oc
+    Compiler.return_type(oc, Tuple{String})
+end == Type{Union{}}
 
 end # module inference

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -127,22 +127,18 @@ function uses_frontend_opaque(x)
 end
 @test uses_frontend_opaque(10)(8) == 18
 
-# `Core.Compiler.return_type` on OpaqueClosure values
-let oc = @opaque x::Int -> 2x
-    @test Core.Compiler.return_type(oc, Tuple{Int}) == Int
+# `Core.Compiler.return_type` on OpaqueClosure values observes the return type
+# declared by the OC type without inspecting the OC source.
+let oc = @opaque Tuple{Int}->Real x -> 2x
+    @test isa(oc, OpaqueClosure{Tuple{Int}, Real})
+    @test Base.Compiler.return_type(oc, Tuple{Int}) == Real
+    @test Core.Compiler.return_type(oc, Tuple{String}) == Union{}
 end
 let oc = @opaque x -> 2x
-    @test Core.Compiler.return_type(oc, Tuple{Int}) == Int
+    @test Base.Compiler.return_type(oc, Tuple{Int}) === typeof(oc).parameters[2]
 end
-let c = 1.0
-    oc = @opaque x::Int -> x + c
-    @test Core.Compiler.return_type(oc, Tuple{Int}) == Float64
-end
-# `return_type` should model the actual OC value by the runtime type of its
-# captures, not by call-site-only constant refinements of those captures.
-let c = true
-    oc = @opaque x::Int -> c ? x : 1.0
-    @test Core.Compiler.return_type(oc, Tuple{Int}) == Union{Float64,Int}
+let oc = @opaque x::Int -> 2x
+    @test Base.Compiler.return_type(oc, Tuple{Int}) === typeof(oc).parameters[2]
 end
 
 # World age mechanism
@@ -164,14 +160,6 @@ test_oc_world_age() = 1
 g_world_age = @opaque ()->test_oc_world_age()
 @test g_world_age() == 1
 @test isa(mk_oc_world_age(), OpaqueClosure{Tuple{}, Int})
-
-# Compiler.return_type should be aware of the OC world age mechanism
-test_oc_return_type_world_age(x) = 2x
-g_return_type_world_age = @opaque x::Int -> test_oc_return_type_world_age(x)
-test_oc_return_type_world_age(x) = 2.0x
-@test g_return_type_world_age(1) === 2
-@test Core.Compiler.return_type(g_return_type_world_age, Tuple{Int}) == Int
-
 end # module test_world_age
 
 function maybe_vararg(isva::Bool)

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -127,6 +127,24 @@ function uses_frontend_opaque(x)
 end
 @test uses_frontend_opaque(10)(8) == 18
 
+# `Core.Compiler.return_type` on OpaqueClosure values
+let oc = @opaque x::Int -> 2x
+    @test Core.Compiler.return_type(oc, Tuple{Int}) == Int
+end
+let oc = @opaque x -> 2x
+    @test Core.Compiler.return_type(oc, Tuple{Int}) == Int
+end
+let c = 1.0
+    oc = @opaque x::Int -> x + c
+    @test Core.Compiler.return_type(oc, Tuple{Int}) == Float64
+end
+# `return_type` should model the actual OC value by the runtime type of its
+# captures, not by call-site-only constant refinements of those captures.
+let c = true
+    oc = @opaque x::Int -> c ? x : 1.0
+    @test Core.Compiler.return_type(oc, Tuple{Int}) == Union{Float64,Int}
+end
+
 # World age mechanism
 module test_world_age
 
@@ -146,6 +164,13 @@ test_oc_world_age() = 1
 g_world_age = @opaque ()->test_oc_world_age()
 @test g_world_age() == 1
 @test isa(mk_oc_world_age(), OpaqueClosure{Tuple{}, Int})
+
+# Compiler.return_type should be aware of the OC world age mechanism
+test_oc_return_type_world_age(x) = 2x
+g_return_type_world_age = @opaque x::Int -> test_oc_return_type_world_age(x)
+test_oc_return_type_world_age(x) = 2.0x
+@test g_return_type_world_age(1) === 2
+@test Core.Compiler.return_type(g_return_type_world_age, Tuple{Int}) == Int
 
 end # module test_world_age
 


### PR DESCRIPTION
`Compiler.return_type(f, tt)` reduces the query to `_return_type` on `Tuple{Core.Typeof(f), tt.parameters...}`. That is enough for singleton functions, but it does not recover the call signature carried by an `OpaqueClosure` value, so a direct runtime query like `Compiler.return_type(oc, Tuple{Int})` falls back to `Any`.

An `OpaqueClosure` already declares its interface in its type as `OpaqueClosure{ArgType, RT}`. Rather than inferring through the closure source to recover a (possibly tighter) body return type, this PR makes `Compiler.return_type` *respect the opacity* of the closure and observe only the declared return type:

- Runtime (`return_type` in `typeinfer.jl`): special-case `OpaqueClosure` values. Read the declared argument/return type parameters from the OC type; return `Union{}` when the queried argument tuple is incompatible with the declared argument type, otherwise return the declared return type `RT`. The OC source is never inspected.
- Inference (`return_type_tfunc` in `tfuncs.jl`): model the same behavior for `PartialOpaque` and ordinary `OpaqueClosure` callees from their declared type parameters only, so inference-only body information (e.g. constant captures, an inferred-but-not-declared body return type) does not cross the `return_type` boundary. An exact declared return type yields `Type{RT}`, a non-exact one (e.g. `OpaqueClosure{Tuple{Int},<:Real}`) yields `Type{<:RT}`, and an incompatible argument tuple yields `Type{Union{}}`.

This keeps the runtime path and its tfunc model aligned, where both reason from the OC's declared signature instead of arbitrary inference-only refinements of the closure body.