### PR TITLE
loading: record precompile workers in their own rr traces

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3399,7 +3399,11 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
         push!(opts, "--trace-compile-timing")
     end
 
-    cmd = `$(julia_cmd(;cpu_target)::Cmd)
+    # when running under `rr`, forward the wrapper invocation set in the pipeline
+    # to ensure precompile workers record into their own detached traces.
+    rr = get(ENV, "JULIA_RR", "")
+    rr_prefix = isempty(rr) ? String[] : Base.shell_split(rr)
+    cmd = `$(rr_prefix) $(julia_cmd(;cpu_target)::Cmd)
            $(flags)
            $(opts)
            --output-incremental=yes


### PR DESCRIPTION
When precompiling under `rr`, `create_expr_cache` spawned each worker as a plain `julia` process, so every worker was recorded into the parent's single trace and serialized onto effectively one core. This is the dominant cost of precompilation under rr.

The test harness already records Distributed workers in separate traces by launching them through the `rr record --nested=detach` wrapper held in the `JULIA_RR` environment variable (see test/testenv.jl). Do the same for precompile workers: when `JULIA_RR` is set, prefix the worker command with that wrapper so each package is recorded into its own detached trace and the workers run in parallel again.