### PR TITLE
datatype: normalize Type{Union{}} element type in genericmemory layout

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -517,6 +517,8 @@ void jl_get_genericmemory_layout(jl_datatype_t *st)
     jl_value_t *kind = jl_tparam0(st);
     jl_value_t *eltype = jl_tparam1(st);
     jl_value_t *addrspace = jl_tparam2(st);
+
+    eltype = normalize_typeofbottom_layout_alias(eltype);
     if (!st->isconcretetype) {
         // Since parent dt has an opaque layout, we may end up here being asked to copy that layout to subtypes,
         // but we don't actually want to do that unless this object is constructable (or at least has a layout).

--- a/test/core.jl
+++ b/test/core.jl
@@ -8989,3 +8989,16 @@ let T = TypeVar(:T)
     a = UnionAll(T, Union{Vector{T}, Int64})
     @test Union{T, a} == Union{a, T} == Union{T, Int64, Vector}
 end
+
+# `Type{Union{}}` is a `TypeEq` kind, not a `DataType`; its memory layout must be
+# normalized to the singleton `typeof(Union{})` rather than dereferenced as a
+# `DataType`.
+@test isconcretetype(Memory{Type{Union{}}})
+for typ in (Memory{Type{Union{}}}, Vector{Type{Union{}}},
+            Array{Type{Union{}}, 1}, Array{Type{Union{}}, true})
+    @test isconcretetype(typ)
+end
+let m = Memory{Type{Union{}}}(undef, 0)
+    @test length(m) == 0
+    @test eltype(m) === Type{Union{}}
+end


### PR DESCRIPTION
AI description:
> `jl_get_genericmemory_layout` treated an inline element type as a `DataType` and dereferenced its layout. `Type{Union{}}` is a `TypeEq` kind, not a `DataType`, so this read out of bounds and segfaulted. Normalize the element type to the singleton `typeof(Union{})` before inspecting its layout, matching the other layout code paths.


Found by fuzzing the compiler, fix implemented by Claude :robot: Fixes this segfault on master: `Memory{Type{Union{}}}`. Presumably caused by https://github.com/JuliaLang/julia/pull/61915.