### PR TITLE
support: Fix -Wjump-misses-init build error in ios_file (GCC 16 / Win…

### DIFF
--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -959,13 +959,19 @@ ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int tru
     if (create) flags |= O_CREAT;
     if (trunc)  flags |= O_TRUNC;
 #if defined(_OS_WINDOWS_)
-    ssize_t wlen = uv_wtf8_length_as_utf16(fname);
-    if (wlen < 0) goto open_file_err;
-    wchar_t *fname_w = (wchar_t*)alloca(wlen * sizeof(wchar_t));
-    uv_wtf8_to_utf16(fname, (uint16_t*)fname_w, wlen);
-    set_io_wait_begin(1);
-    fd = _wopen(fname_w, flags | O_BINARY | O_NOINHERIT, _S_IREAD | _S_IWRITE);
-    set_io_wait_begin(0);
+    {
+        ssize_t wlen = uv_wtf8_length_as_utf16(fname);
+        if (wlen < 0) {
+            fd = -1;
+        }
+        else {
+            wchar_t *fname_w = (wchar_t*)alloca(wlen * sizeof(wchar_t));
+            uv_wtf8_to_utf16(fname, (uint16_t*)fname_w, wlen);
+            set_io_wait_begin(1);
+            fd = _wopen(fname_w, flags | O_BINARY | O_NOINHERIT, _S_IREAD | _S_IWRITE);
+            set_io_wait_begin(0);
+        }
+    }
 #else
     // The mode of the created file is (mode & ~umask), which resolves with
     // default umask to u=rw,g=r,o=r


### PR DESCRIPTION
…dows)

Under GCC 16 (e.g. mingw GCC 16.1.0), the Windows build of src/support/ios.c failed to compile with:

    error: jump skips variable initialization [-Werror=jump-misses-init]

In ios_file, the Windows (_OS_WINDOWS_) branch declared and initialized locals (wlen and fname_w) after one or more `goto open_file_err` statements. Those gotos could jump past the initialization of these auto variables to the open_file_err label. This is non-conforming in C++ and diagnosed by GCC's -Wjump-misses-init, which Julia promotes to a hard error on Windows via -Wc++-compat -Werror. Older GCC in the previous Windows image did not flag it; GCC 16 does.