### PR TITLE
Markdown: clarify that admonition titles don't support inline markdow…

### DIFF
--- a/stdlib/Markdown/docs/src/index.md
+++ b/stdlib/Markdown/docs/src/index.md
@@ -414,6 +414,7 @@ However, unless the code rendering the Markdown special-cases that particular ad
 
 A custom title for the box can be provided as a string (in double quotes) after the admonition type.
 If no title text is specified after the admonition type, then the type name will be used as the title (e.g. `"Note"` for the `note` admonition).
+Note that admonition titles are parsed as plain strings and do not support inline Markdown or LaTeX formatting (e.g. ``\alpha`` in a title will not be rendered as math).
 
 Admonitions, like most other toplevel elements, can contain other toplevel elements (e.g. lists, images).
 


### PR DESCRIPTION
Clarifies in the Markdown stdlib docs that admonition titles are 
parsed as plain strings and do not support inline Markdown or 
LaTeX formatting (e.g. ``\alpha`` in a title will not be rendered 
as math), as reported in #62106.

Closes #62106