### PR TITLE
win32: drop the illegal ExceptionExecuteHandler disposition (GCC 16)

### DIFF
--- a/src/win32_ucontext.c
+++ b/src/win32_ucontext.c
@@ -26,9 +26,6 @@ JL_DLLEXPORT EXCEPTION_DISPOSITION NTAPI __julia_personality(
 
     EXCEPTION_DISPOSITION rval;
     switch (jl_exception_handler(&ExceptionInfo)) {
-        case EXCEPTION_EXECUTE_HANDLER:
-            rval = ExceptionExecuteHandler;
-            break;
         case EXCEPTION_CONTINUE_EXECUTION:
             rval = ExceptionContinueExecution;
             break;


### PR DESCRIPTION
__julia_personality mapped the EXCEPTION_EXECUTE_HANDLER filter result to the non-standard mingw-w64 `ExceptionExecuteHandler` EXCEPTION_DISPOSITION value. That value was always undefined behavior and newer mingw-w64 has removed it, breaking the build under the GCC 16 Windows toolchain ('ExceptionExecuteHandler' undeclared in src/win32_ucontext.c). Fixes #61733.

The branch was dead anyway: jl_exception_handler (our UnhandledExceptionFilter, src/signals-win.c) only ever returns EXCEPTION_CONTINUE_EXECUTION or EXCEPTION_CONTINUE_SEARCH, never EXCEPTION_EXECUTE_HANDLER. Drop the case; any non-continue-execution result now maps to ExceptionContinueSearch (unchanged behavior).