### PR TITLE
[JuliaSyntax] Make `flags(::SyntaxTree)` type-stable

### DIFF
--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -319,7 +319,7 @@ function kind(ex::SyntaxTree)
 end
 
 function flags(ex::SyntaxTree)
-    get(ex, :syntax_flags, 0x0000)
+    get(ex, :syntax_flags, 0x0000)::UInt16
 end
 
 


### PR DESCRIPTION
`flags(ex::SyntaxTree)` retrieves the syntax flags via Base.get, which reads from a type-erased attribute store and is inferred imprecisely. Annotate the result as `UInt16` (the declared type of the syntax_flags attribute, matching the `0x0000` default) so the function is type-stable, mirroring the adjacent `kind(ex)::Kind`.