### PR TITLE
debuginfo: promote opaque-closure roots in a GC-unsafe region

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -394,22 +394,23 @@ void jl_register_jit_object(const object::ObjectFile &Object,
 {
     // Opaque-closure code instances are not otherwise reachable through their
     // method, so promote them to global roots here, before entering the
-    // JL_NOTSAFEPOINT registerJITObject body. Switch to GC-unsafe, since the
-    // promotion allocates, and the JIT runs materialization in a GC-safe state.
+    // JL_NOTSAFEPOINT registerJITObject body. Scanning the list is safe in the
+    // GC-safe materialization state (registerJITObject reads the same fields),
+    // so only switch to GC-unsafe around the rare allocating promotion.
     // TODO: Tell GCChecker that jl_register_jit_object is entered GC-safe.
 #ifndef __clang_analyzer__
     jl_task_t *ct = jl_current_task;
-    int8_t gc_state = jl_gc_unsafe_enter(ct->ptls);
     for (auto &[ci, funcs] : Info.ci_funcs) {
         jl_method_instance_t *mi = jl_get_ci_mi(ci);
         if (jl_is_method(mi->def.method) && mi->def.method->is_for_opaque_closure) {
             jl_code_instance_t *ci_root = ci;
+            int8_t gc_state = jl_gc_unsafe_enter(ct->ptls);
             JL_GC_PUSH1(&ci_root);
             jl_as_global_root((jl_value_t*)ci_root, 1);
             JL_GC_POP();
+            jl_gc_unsafe_leave(ct->ptls, gc_state);
         }
     }
-    jl_gc_unsafe_leave(ct->ptls, gc_state);
 #endif
     getJITDebugRegistry().registerJITObject(Object, getLoadAddress, Info);
 }

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -394,7 +394,10 @@ void jl_register_jit_object(const object::ObjectFile &Object,
 {
     // Opaque-closure code instances are not otherwise reachable through their
     // method, so promote them to global roots here, before entering the
-    // JL_NOTSAFEPOINT registerJITObject body.
+    // JL_NOTSAFEPOINT registerJITObject body. Switch to GC-unsafe, since the
+    // promotion allocates, and the JIT runs materialization in a GC-safe state.
+    jl_task_t *ct = jl_current_task;
+    int8_t gc_state = jl_gc_unsafe_enter(ct->ptls);
     for (auto &[ci, funcs] : Info.ci_funcs) {
         jl_method_instance_t *mi = jl_get_ci_mi(ci);
         if (jl_is_method(mi->def.method) && mi->def.method->is_for_opaque_closure) {
@@ -404,6 +407,7 @@ void jl_register_jit_object(const object::ObjectFile &Object,
             JL_GC_POP();
         }
     }
+    jl_gc_unsafe_leave(ct->ptls, gc_state);
     getJITDebugRegistry().registerJITObject(Object, getLoadAddress, Info);
 }
 

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -396,6 +396,8 @@ void jl_register_jit_object(const object::ObjectFile &Object,
     // method, so promote them to global roots here, before entering the
     // JL_NOTSAFEPOINT registerJITObject body. Switch to GC-unsafe, since the
     // promotion allocates, and the JIT runs materialization in a GC-safe state.
+    // TODO: Tell GCChecker that jl_register_jit_object is entered GC-safe.
+#ifndef __clang_analyzer__
     jl_task_t *ct = jl_current_task;
     int8_t gc_state = jl_gc_unsafe_enter(ct->ptls);
     for (auto &[ci, funcs] : Info.ci_funcs) {
@@ -408,6 +410,7 @@ void jl_register_jit_object(const object::ObjectFile &Object,
         }
     }
     jl_gc_unsafe_leave(ct->ptls, gc_state);
+#endif
     getJITDebugRegistry().registerJITObject(Object, getLoadAddress, Info);
 }
 


### PR DESCRIPTION
jl_register_jit_object calls jl_as_global_root, which allocates, but the JIT runs materialization in a GC-safe state, tripping the gc_state == 0 assertion. Wrap the promotion in jl_gc_unsafe_enter/leave.

Fixes assertion seen in https://github.com/JuliaLang/julia/pull/62102:

```
julia: /cache/build/builder-amdci5-1/julialang/julia-master/src/gc-stock.c:730: jl_gc_small_alloc_inner: Assertion `__extension__ ({ __auto_type __atomic_load_ptr = (&ptls->gc_state); __typeof__ (*__atomic_load_ptr) __atomic_load_tmp; __atomic_load (__atomic_load_ptr, &__atomic_load_tmp, (memory_order_relaxed)); __atomic_load_tmp; }) == 0' failed.

[421] signal 6 (-6): Aborted
in expression starting at none:1
gsignal at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
abort at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
unknown function (ip: 0x7fa9482db40e) at /lib/x86_64-linux-gnu/libc.so.6
__assert_fail at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
jl_gc_small_alloc_inner at /cache/build/builder-amdci5-1/julialang/julia-master/src/gc-stock.c:730:5
jl_gc_small_alloc_noinline at /cache/build/builder-amdci5-1/julialang/julia-master/src/gc-stock.c:792:12 [inlined]
jl_gc_alloc_ at /cache/build/builder-amdci5-1/julialang/julia-master/src/gc-stock.c:806:13
jl_alloc_genericmemory_unchecked at /cache/build/builder-amdci5-1/julialang/julia-master/src/genericmemory.c:41:30
_new_genericmemory_ at /cache/build/builder-amdci5-1/julialang/julia-master/src/genericmemory.c:69:29 [inlined]
jl_alloc_genericmemory at /cache/build/builder-amdci5-1/julialang/julia-master/src/genericmemory.c:102:12
jl_idset_put_key at /cache/build/builder-amdci5-1/julialang/julia-master/src/idset.c:82:38
jl_as_global_root at /cache/build/builder-amdci5-1/julialang/julia-master/src/staticdata.c:2757:32 [inlined]
jl_as_global_root at /cache/build/builder-amdci5-1/julialang/julia-master/src/staticdata.c:2727:26
jl_register_jit_object at /cache/build/builder-amdci5-1/julialang/julia-master/src/debuginfo.cpp:403:30
notifyEmitted at /cache/build/builder-amdci5-1/julialang/julia-master/src/jitlayers.cpp:704:31
_ZN4llvm3orc21LinkGraphLinkingLayer10JITLinkCtx13notifyEmittedENS_7jitlink20JITLinkMemoryManager14FinalizedAllocE at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZN4llvm3orc21LinkGraphLinkingLayer10JITLinkCtx15notifyFinalizedENS_7jitlink20JITLinkMemoryManager14FinalizedAllocE at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZN4llvm7jitlink13JITLinkerBase10linkPhase4ESt10unique_ptrIS1_St14default_deleteIS1_EENS_8ExpectedINS0_20JITLinkMemoryManager14FinalizedAllocEEE at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZN4llvm6detail18UniqueFunctionBaseIvJNS_8ExpectedINS_7jitlink20JITLinkMemoryManager14FinalizedAllocEEEEE8CallImplIZNS3_13JITLinkerBase10linkPhase3ESt10unique_ptrIS9_St14default_deleteIS9_EENS2_INS_8DenseMapINS_3orc15SymbolStringPtrENSF_17ExecutorSymbolDefENS_12DenseMapInfoISG_vEENS0_12DenseMapPairISG_SH_EEEEEEEUlS6_E_EEvPvRS6_ at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
operator() at /cache/build/builder-amdci5-1/julialang/julia-master/usr/include/llvm/ADT/FunctionExtras.h:389:30 [inlined]
operator()<llvm::Expected<std::vector<llvm::orc::shared::WrapperFunctionCall> > > at /cache/build/builder-amdci5-1/julialang/julia-master/src/cgmemmgr.cpp:1021:28 [inlined]
CallImpl<(anonymous namespace)::JLJITLinkMemoryManager::InFlightAlloc::finalize(llvm::jitlink::JITLinkMemoryManager::InFlightAlloc::OnFinalizedFunction)::<lambda(llvm::Expected<llvm::jitlink::JITLinkMemoryManager::FinalizedAlloc>)> mutable::<lambda(auto:6)> > at /cache/build/builder-amdci5-1/julialang/julia-master/usr/include/llvm/ADT/FunctionExtras.h:222:16
_ZN4llvm3orc6shared18runFinalizeActionsERSt6vectorINS1_19AllocActionCallPairESaIS3_EENS_15unique_functionIFvNS_8ExpectedIS2_INS1_19WrapperFunctionCallESaIS9_EEEEEEE at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
operator() at /cache/build/builder-amdci5-1/julialang/julia-master/src/cgmemmgr.cpp:1018:44 [inlined]
CallImpl<(anonymous namespace)::JLJITLinkMemoryManager::InFlightAlloc::finalize(llvm::jitlink::JITLinkMemoryManager::InFlightAlloc::OnFinalizedFunction)::<lambda(llvm::Expected<llvm::jitlink::JITLinkMemoryManager::FinalizedAlloc>)> > at /cache/build/builder-amdci5-1/julialang/julia-master/usr/include/llvm/ADT/FunctionExtras.h:222:16
operator() at /cache/build/builder-amdci5-1/julialang/julia-master/usr/include/llvm/ADT/FunctionExtras.h:389:30 [inlined]
finalize at /cache/build/builder-amdci5-1/julialang/julia-master/src/cgmemmgr.cpp:992:26 [inlined]
finalize at /cache/build/builder-amdci5-1/julialang/julia-master/src/cgmemmgr.cpp:1011:20
_ZN4llvm7jitlink13JITLinkerBase10linkPhase3ESt10unique_ptrIS1_St14default_deleteIS1_EENS_8ExpectedINS_8DenseMapINS_3orc15SymbolStringPtrENS8_17ExecutorSymbolDefENS_12DenseMapInfoIS9_vEENS_6detail12DenseMapPairIS9_SA_EEEEEE at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZZN4llvm7jitlink24createLookupContinuationIZNS0_13JITLinkerBase10linkPhase2ESt10unique_ptrIS2_St14default_deleteIS2_EENS_8ExpectedIS3_INS0_20JITLinkMemoryManager13InFlightAllocES4_IS9_EEEEEUlNS7_INS_8DenseMapINS_3orc15SymbolStringPtrENSE_17ExecutorSymbolDefENS_12DenseMapInfoISF_vEENS_6detail12DenseMapPairISF_SG_EEEEEEE_EES3_INS0_30JITLinkAsyncLookupContinuationES4_ISP_EET_EN4Impl3runESN_ at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZZN4llvm3orc21LinkGraphLinkingLayer10JITLinkCtx6lookupERKNS_8DenseMapINS0_15SymbolStringPtrENS_7jitlink17SymbolLookupFlagsENS_12DenseMapInfoIS4_vEENS_6detail12DenseMapPairIS4_S6_EEEESt10unique_ptrINS5_30JITLinkAsyncLookupContinuationESt14default_deleteISG_EEENUlNS_8ExpectedINS3_IS4_NS0_17ExecutorSymbolDefES8_NSA_IS4_SL_EEEEEEE0_clESO_ at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZN4llvm6detail18UniqueFunctionBaseIvJNS_8ExpectedINS_8DenseMapINS_3orc15SymbolStringPtrENS4_17ExecutorSymbolDefENS_12DenseMapInfoIS5_vEENS0_12DenseMapPairIS5_S6_EEEEEEEE8CallImplIZNS4_21LinkGraphLinkingLayer10JITLinkCtx6lookupERKNS3_IS5_NS_7jitlink17SymbolLookupFlagsES8_NS9_IS5_SI_EEEESt10unique_ptrINSH_30JITLinkAsyncLookupContinuationESt14default_deleteISO_EEEUlSC_E0_EEvPvRSC_ at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZZN4llvm3orc23AsynchronousSymbolQuery14handleCompleteERNS0_16ExecutionSessionEEN20RunQueryCompleteTask3runEv at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
process_tasks at /cache/build/builder-amdci5-1/julialang/julia-master/src/julia-task-dispatcher.h:396:15
dispatch at /cache/build/builder-amdci5-1/julialang/julia-master/src/julia-task-dispatcher.h:356:20
_ZN4llvm3orc16ExecutionSession22dispatchOutstandingMUsEv at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZN4llvm3orc16ExecutionSession17OL_completeLookupESt10unique_ptrINS0_21InProgressLookupStateESt14default_deleteIS3_EESt10shared_ptrINS0_23AsynchronousSymbolQueryEESt8functionIFvRKNS_8DenseMapIPNS0_8JITDylibENS_8DenseSetINS0_15SymbolStringPtrENS_12DenseMapInfoISF_vEEEENSG_ISD_vEENS_6detail12DenseMapPairISD_SI_EEEEEE at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZN4llvm3orc25InProgressFullLookupState8completeESt10unique_ptrINS0_21InProgressLookupStateESt14default_deleteIS3_EE at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZN4llvm3orc16ExecutionSession19OL_applyQueryPhase1ESt10unique_ptrINS0_21InProgressLookupStateESt14default_deleteIS3_EENS_5ErrorE at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
_ZN4llvm3orc16ExecutionSession6lookupENS0_10LookupKindERKSt6vectorISt4pairIPNS0_8JITDylibENS0_19JITDylibLookupFlagsEESaIS8_EENS0_15SymbolLookupSetENS0_11SymbolStateENS_15unique_functionIFvNS_8ExpectedINS_8DenseMapINS0_15SymbolStringPtrENS0_17ExecutorSymbolDefENS_12DenseMapInfoISI_vEENS_6detail12DenseMapPairISI_SJ_EEEEEEEEESt8functionIFvRKNSH_IS6_NS_8DenseSetISI_SL_EENSK_IS6_vEENSN_IS6_SV_EEEEEE at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/bin/../lib/julia/libLLVM.so.21.1jl (unknown line)
publishCIs at /cache/build/builder-amdci5-1/julialang/julia-master/src/jitlayers.cpp:2085:14
jl_compile_codeinst_impl at /cache/build/builder-amdci5-1/julialang/julia-master/src/jitlayers.cpp:510:39
jl_compile_method_very_internal at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:3946:27
new_opaque_closure at /cache/build/builder-amdci5-1/julialang/julia-master/src/opaque_closure.c:66:14
new_opaque_closure at /cache/build/builder-amdci5-1/julialang/julia-master/src/julia.h:1713:74 [inlined]
jl_new_opaque_closure at /cache/build/builder-amdci5-1/julialang/julia-master/src/opaque_closure.c:143:31 [inlined]
jl_new_opaque_closure_jlcall at /cache/build/builder-amdci5-1/julialang/julia-master/src/opaque_closure.c:189:25
#38 at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/share/julia/test/opaque_closure.jl:335:0 (pc: 1)
unknown function (ip: 0x7fa9287c9dcf) at (unknown file)
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4364:23 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4602:12
jl_apply at /cache/build/builder-amdci5-1/julialang/julia-master/src/julia.h:2388:12 [inlined]
do_call at /cache/build/builder-amdci5-1/julialang/julia-master/src/interpreter.c:123:26
eval_value at /cache/build/builder-amdci5-1/julialang/julia-master/src/interpreter.c:243:16
eval_stmt_value at /cache/build/builder-amdci5-1/julialang/julia-master/src/interpreter.c:194:23 [inlined]
eval_body at /cache/build/builder-amdci5-1/julialang/julia-master/src/interpreter.c:706:13
jl_interpret_toplevel_thunk at /cache/build/builder-amdci5-1/julialang/julia-master/src/interpreter.c:897:21
ijl_eval_thunk at /cache/build/builder-amdci5-1/julialang/julia-master/src/toplevel.c:768:18
jl_toplevel_eval_flex at /cache/build/builder-amdci5-1/julialang/julia-master/src/toplevel.c:712:26
ijl_toplevel_eval at /cache/build/builder-amdci5-1/julialang/julia-master/src/toplevel.c:782:12
ijl_toplevel_eval_in at /cache/build/builder-amdci5-1/julialang/julia-master/src/toplevel.c:827:13
eval at ./boot.jl:522:0 (pc: 1)
EvalInto at ./boot.jl:528:0 (pc: 2)
jfptr_EvalInto_0.1 at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/lib/julia/sys.so (unknown line)
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4364:23 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4602:12
jl_apply at /cache/build/builder-amdci5-1/julialang/julia-master/src/julia.h:2388:12 [inlined]
do_call at /cache/build/builder-amdci5-1/julialang/julia-master/src/interpreter.c:123:26
eval_value at /cache/build/builder-amdci5-1/julialang/julia-master/src/interpreter.c:243:16
eval_body at /cache/build/builder-amdci5-1/julialang/julia-master/src/interpreter.c:594:35
jl_interpret_toplevel_thunk at /cache/build/builder-amdci5-1/julialang/julia-master/src/interpreter.c:897:21
ijl_eval_thunk at /cache/build/builder-amdci5-1/julialang/julia-master/src/toplevel.c:768:18
jl_toplevel_eval_flex at /cache/build/builder-amdci5-1/julialang/julia-master/src/toplevel.c:712:26
jl_eval_toplevel_stmts at /cache/build/builder-amdci5-1/julialang/julia-master/src/toplevel.c:602:15
jl_toplevel_eval_flex at /cache/build/builder-amdci5-1/julialang/julia-master/src/toplevel.c:684:27
ijl_toplevel_eval at /cache/build/builder-amdci5-1/julialang/julia-master/src/toplevel.c:782:12
ijl_toplevel_eval_in at /cache/build/builder-amdci5-1/julialang/julia-master/src/toplevel.c:827:13
eval at ./boot.jl:522:0 (pc: 1)
include_string at ./loading.jl:3132:0 (pc: 207)
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4364:23 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4602:12
_include at ./loading.jl:3192:0 (pc: 122)
include at ./Base.jl:325:0 (pc: 1)
macro expansion at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/share/julia/test/testdefs.jl:35:0 [inlined]
macro expansion at /cache/build/builder-amdci5-1/julialang/julia-master/usr/share/julia/stdlib/v1.14/Test/src/Test.jl:2246:0 [inlined]
macro expansion at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/share/julia/test/testdefs.jl:27:0 [inlined]
macro expansion at ./timing.jl:741:0 [inlined]
#runtests#1 at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/share/julia/test/testdefs.jl:25:0 (pc: 706)
runtests at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/share/julia/test/testdefs.jl:7:0 [inlined]
runtests at /cache/build/tester-amdci4-13/julialang/julia-master/julia-c4ea54845d/share/julia/test/testdefs.jl:7:0 (pc: 2)
unknown function (ip: 0x7fa92a3c64f3) at (unknown file)
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4364:23 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4602:12
jl_apply at /cache/build/builder-amdci5-1/julialang/julia-master/src/julia.h:2388:12 [inlined]
jl_f_invokelatest at /cache/build/builder-amdci5-1/julialang/julia-master/src/builtins.c:918:23
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4364:23 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4602:12
jl_apply at /cache/build/builder-amdci5-1/julialang/julia-master/src/julia.h:2388:12 [inlined]
jl_f__apply_iterate at /cache/build/builder-amdci5-1/julialang/julia-master/src/builtins.c:905:26
invokelatest at ./Base_compiler.jl:270:0 (pc: 2)
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4364:23 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4602:12
jl_apply at /cache/build/builder-amdci5-1/julialang/julia-master/src/julia.h:2388:12 [inlined]
jl_f__apply_iterate at /cache/build/builder-amdci5-1/julialang/julia-master/src/builtins.c:905:26
#handle_msg##4 at /cache/build/builder-amdci5-1/julialang/julia-master/usr/share/julia/stdlib/v1.14/Distributed/src/process_messages.jl:287:0
run_work_thunk at /cache/build/builder-amdci5-1/julialang/julia-master/usr/share/julia/stdlib/v1.14/Distributed/src/process_messages.jl:70:0 (pc: 4)
#handle_msg##2 at /cache/build/builder-amdci5-1/julialang/julia-master/usr/share/julia/stdlib/v1.14/Distributed/src/process_messages.jl:287:0 (pc: 3)
unknown function (ip: 0x7fa92a3c5599) at (unknown file)
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4364:23 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-master/src/gf.c:4602:12
jl_apply at /cache/build/builder-amdci5-1/julialang/julia-master/src/julia.h:2388:12 [inlined]
start_task at /cache/build/builder-amdci5-1/julialang/julia-master/src/task.c:1276:19
Allocations: 110921546 (Pool: 110920550; Big: 996); GC: 85
```