### PR TITLE
[RFC] build: remove `-L$(build_private_libdir)` from sysimage link command

### DIFF
--- a/sysimage.mk
+++ b/sysimage.mk
@@ -19,7 +19,7 @@ sysbase-debug: $(build_private_libdir)/sysbase-debug.$(SHLIB_EXT)
 VERSDIR := v$(shell cut -d. -f1-2 < $(JULIAHOME)/VERSION)
 
 $(build_private_libdir)/%.$(SHLIB_EXT): $(build_private_libdir)/%-o.a
-	@$(call PRINT_LINK, $(CXX) $(LDFLAGS) -shared $(fPIC) -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -o $@ \
+	@$(call PRINT_LINK, $(CXX) $(LDFLAGS) -shared $(fPIC) -L$(build_libdir) -L$(build_shlibdir) -o $@ \
 		$(call whole_archive,$<) \
 		$(if $(findstring -debug,$(notdir $@)),-ljulia-internal-debug -ljulia-debug,-ljulia-internal -ljulia) \
 		$$([ $(OS) = WINNT ] && echo '' $(LIBM) -lssp -Wl,--disable-auto-import -Wl,--disable-runtime-pseudo-reloc))


### PR DESCRIPTION
Fixes #56840

Replace: #57451

> (Note: analysis performed by Claude Code + DeepSeek V4 Pro, for reference.)
> 
> The root cause is a leftover `-L` flag from 2013.
> 
> `sysimage.mk`'s link command included `-L$(build_private_libdir)`, which was introduced to find Julia's own builds of third-party libraries (gmp, pcre, etc.). Later that same month, Julia transitioned to runtime loading of those libraries — all explicit `-l` flags were removed, but the `-L` was forgotten. It's been a dead parameter ever since.
> 
> When CSL later began placing mingw-w64 CRT import libraries into `build_private_libdir` (for the LLD pkgimage link path in `linking.jl`), this leftover `-L` started finding CSL's copies before GCC's own default search paths. GCC's spec file injects the system's `dllcrt2.o` by absolute path, so `libmsvcrt.a` must be version-matched with it. CSL's copy comes from a different mingw-w64 CRT version, causing the `_initterm_e` undefined reference.
> 
> The fix (branch `cyhan/csl-sysimage`) is a one-line deletion: remove `-L$(build_private_libdir)` from `sysimage.mk`. The `build_private_libdir` directory continues to serve `linking.jl`'s `_find_static()` — its original purpose has always been runtime pkgimage linking.
> 
> Full analysis attached:
> https://gist.github.com/inkydragon/40cb95c5cf1077fa900dbcfe25de8b23#file-julia-56840-rca-md

----

Locally test build:

System env:

- Win11, MSYS2 `uname -a`: 
  `MINGW64_NT-10.0-26200 A309-Y9000P 3.6.9-01d6c708.x86_64 2026-05-24 10:45 UTC x86_64 Msys`
- Julia: master (cyhan/csl-sysimage)  
  CSL: 1.5.2+0 
  with mingw-w64-v11.0.1  https://github.com/JuliaPackaging/Yggdrasil/blob/b8e413b58ed0edd71a2f4fe55aed869dc9edbe70/0_RootFS/gcc_sources.jl#L351

build env

- x86_64-w64-mingw32
	- `gcc`: `gcc.exe (Rev5, Built by MSYS2 project) 16.1.0`
	- `ld`: `GNU ld (GNU Binutils) 2.46`
- i686-w64-mingw32
	- `gcc`: `gcc.exe (Rev5, Built by MSYS2 project) 16.1.0`
	- `ld`: `GNU ld (GNU Binutils) 2.46`
- x86_64-w64-mingw32
	- With patch: [cyhan/clang-export-fix](https://github.com/inkydragon/julia/tree/cyhan/clang-export-fix)
	- Without set `USE_SYSTEM_CSL=1`
	- `clang`: clang version 22.1.7
