### PR TITLE
:robot: llvm-expand-atomic-modify: handle non-convertible shape after inlining

### DIFF
--- a/src/llvm-expand-atomic-modify.cpp
+++ b/src/llvm-expand-atomic-modify.cpp
@@ -339,8 +339,7 @@ void expandAtomicModifyToCmpXchg(CallInst &Modify,
 
   ReplacementIRBuilder Builder(&Modify, Modify.getModule()->getDataLayout());
 
-  CallInst *ModifyOp;
-  {
+  auto CreateModifyOp = [&]() {
     SmallVector<Value*> Args(1 + Modify.arg_size() - user_arg_start);
     Args[0] = UndefValue::get(Ty); // Undef used as placeholder for Loaded / RMW;
     for (size_t argi = 0; argi < Modify.arg_size() - user_arg_start; ++argi) {
@@ -348,9 +347,11 @@ void expandAtomicModifyToCmpXchg(CallInst &Modify,
     }
     SmallVector<OperandBundleDef> Defs;
     Modify.getOperandBundlesAsDefs(Defs);
-    ModifyOp = Builder.CreateCall(Op, Args, Defs);
-    ModifyOp->setCallingConv(Op->getCallingConv());
-  }
+    CallInst *C = Builder.CreateCall(Op, Args, Defs);
+    C->setCallingConv(Op->getCallingConv());
+    return C;
+  };
+  CallInst *ModifyOp = CreateModifyOp();
   Use *LoadedOp = &ModifyOp->getOperandUse(0);
 
   Value *OldVal = nullptr;
@@ -394,6 +395,17 @@ void expandAtomicModifyToCmpXchg(CallInst &Modify,
           break;
       } else {
         assert(BinOp != decltype(BinOp)(true));
+        if (BinOp == decltype(BinOp)(false)) {
+          // inlining simplified the op into something unconvertible; recreate
+          // the call so the fallback cmpxchg loop has an op to expand (the
+          // leftover inlined code is dead and write-free, per canReorderWithRMW,
+          // so it is safe to disconnect it from RMW and let DCE remove it)
+          RMW->replaceAllUsesWith(UndefValue::get(Ty));
+          Builder.SetInsertPoint(&Modify);
+          ModifyOp = CreateModifyOp();
+          LoadedOp = &ModifyOp->getOperandUse(0);
+          break;
+        }
         auto RMWOp = std::get<AtomicRMWInst::BinOp>(BinOp);
         assert(RMWOp != AtomicRMWInst::BAD_BINOP);
         assert(isa<UndefValue>(RMW->getOperand(1))); // RMW was previously being used as the placeholder for Val


### PR DESCRIPTION
I was doing some random atomic stuff and the bot got upset about this so opening for consideration:

------------

:robot: 

After InlineFunction, the op shape is re-matched with patternMatchAtomicRMWOp.
The else branch asserted the result was not the `true` token and immediately
did std::get<AtomicRMWInst::BinOp>(BinOp), but the matcher can also return
`false` when InstSimplify folds the body into a shape that is neither an
identity nor convertible to an atomicrmw. That case yielded bad_variant_access
(or UB without exceptions).

Handle `false` explicitly: recreate the op call and fall through to the generic
cmpxchg loop instead of extracting a BinOp. The op-call construction is hoisted
into a CreateModifyOp lambda so it can be reused, and the dead leftover inlined
code is disconnected from the placeholder RMW via replaceAllUsesWith(undef)
(it is write-free per canReorderWithRMW, so DCE can remove it).

-----------------