### PR TITLE
Libdl: Fix `jl_find_dynamic_library_by_addr` on some distros

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -263,30 +263,6 @@ File extension for dynamic libraries (e.g. dll, dylib, so) on the current platfo
 """
 dlext
 
-if (Sys.islinux() || Sys.isbsd()) && !Sys.isapple()
-    struct dl_phdr_info
-        # Base address of object
-        addr::Cuint
-
-        # Null-terminated name of object
-        name::Ptr{UInt8}
-
-        # Pointer to array of ELF program headers for this object
-        phdr::Ptr{Cvoid}
-
-        # Number of program headers for this object
-        phnum::Cshort
-    end
-
-    # This callback function called by dl_iterate_phdr() on Linux and BSD's
-    # DL_ITERATE_PHDR(3) on freebsd
-    function dl_phdr_info_callback(di::dl_phdr_info, size::Csize_t, dynamic_libraries::Vector{String})
-        name = unsafe_string(di.name)
-        push!(dynamic_libraries, name)
-        return Cint(0)
-    end
-end
-
 """
     dllist()
 
@@ -303,13 +279,10 @@ function dllist()
             name = unsafe_string(ccall(:_dyld_get_image_name, Cstring, (UInt32,), i))
             push!(dynamic_libraries, name)
         end
-    elseif Sys.islinux() || Sys.isbsd()
-        callback = @cfunction(dl_phdr_info_callback, Cint,
-                              (Ref{dl_phdr_info}, Csize_t, Ref{Vector{String}}))
-        ccall(:dl_iterate_phdr, Cint, (Ptr{Cvoid}, Ref{Vector{String}}), callback, dynamic_libraries)
-        popfirst!(dynamic_libraries)
-        filter!(!isempty, dynamic_libraries)
-    elseif Sys.iswindows()
+    elseif Sys.iswindows() || Sys.islinux() || Sys.isbsd()
+        # `dl_iterate_phdr` must be handled by C, since otherwise arbitrary Julia
+        # code (in finalizers / ccall symbol resolution) may compete for the dynamic
+        # linker lock held during its callback
         ccall(:jl_dllist, Cint, (Any,), dynamic_libraries)
     else
         # unimplemented

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -304,26 +304,17 @@ void *jl_find_dynamic_library_by_addr(void *symbol, int throw_err, int close) JL
         return NULL;
     }
 #else
-    Dl_info info;
-    if (!dladdr(symbol, &info) || !info.dli_fname) {
+    const char *path = jl_pathname_for_symbol(symbol);
+    if (path == NULL) {
         if (throw_err)
             jl_error("could not load base module");
         return NULL;
     }
-    dlerror();
-    handle = dlopen(info.dli_fname, RTLD_NOW | RTLD_NOLOAD | RTLD_LOCAL);
-#if defined(_OS_FREEBSD_)
-    // FreeBSD will not give you a handle for the executable if you dlopen() it
-    // with RTLD_NOLOAD, so check jl_exe_handle.
-    if (handle == NULL && dlerror() == NULL) {
-        handle = jl_exe_handle;
+    if (path[0] == '\0') { // symbol is in the main executable
+        handle = dlopen(NULL, RTLD_NOW | RTLD_NOLOAD | RTLD_LOCAL);
+    } else {
+        handle = dlopen(path, RTLD_NOW | RTLD_NOLOAD | RTLD_LOCAL);
     }
-#elif !defined(__APPLE__)
-    if (handle == RTLD_DEFAULT && (RTLD_DEFAULT != NULL || dlerror() == NULL)) {
-        // We loaded the executable but got RTLD_DEFAULT back, ask for a real handle instead
-        handle = dlopen("", RTLD_NOW | RTLD_NOLOAD | RTLD_LOCAL);
-    }
-#endif
     if (handle != NULL && close)
         dlclose(handle); // Undo ref count increment from `dlopen`
 #endif

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -355,6 +355,7 @@
     XX(jl_parse_opts) \
     XX(jl_parse_string) \
     XX(jl_pathname_for_handle) \
+    XX(jl_pathname_for_symbol) \
     XX(jl_pchar_to_array) \
     XX(jl_pchar_to_string) \
     XX(jl_pointerref) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -2266,7 +2266,8 @@ JL_DLLEXPORT void jl_task_wait_empty(void);
 JL_DLLEXPORT void jl_postoutput_hook(void);
 JL_DLLEXPORT void JL_NORETURN jl_exit(int status);
 JL_DLLEXPORT void JL_NORETURN jl_raise(int signo);
-JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle);
+JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle) JL_NOTSAFEPOINT;
+JL_DLLEXPORT const char *jl_pathname_for_symbol(void *symbol) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void);
 
 JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s);

--- a/src/sys.c
+++ b/src/sys.c
@@ -688,7 +688,7 @@ static int dlinfo_helper(struct dl_phdr_info *info, size_t size, void *vdata)
 #endif
 
 // Takes a handle (as returned from dlopen()) and returns the absolute path to the image loaded
-JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle)
+JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle) JL_NOTSAFEPOINT
 {
     if (!handle)
         return NULL;
@@ -696,9 +696,9 @@ JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle)
 #ifdef __APPLE__
     // Iterate through all images currently in memory
     for (int32_t i = _dyld_image_count() - 1; i >= 0 ; i--) {
-        // dlopen() each image, check handle
+        // dlopen() each image, check handle.
         const char *image_name = _dyld_get_image_name(i);
-        void *probe_lib = jl_load_dynamic_library(image_name, JL_RTLD_DEFAULT | JL_RTLD_NOLOAD, 0);
+        void *probe_lib = jl_dlopen(image_name, JL_RTLD_DEFAULT | JL_RTLD_NOLOAD);
         jl_dlclose(probe_lib);
 
         // If the handle is the same as what was passed in (modulo mode bits), return this image name
@@ -747,6 +747,82 @@ JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle)
 
 #endif
     return NULL;
+}
+
+#if !defined(_OS_WINDOWS_) && !defined(__APPLE__) && !defined(__GLIBC__)
+struct sym_phdr_query {
+    uintptr_t   addr;
+    const char *name;        // matched dlpi_name
+    int         is_main_exe;
+    int         found;
+    int         index;       // running object index; 0 == main program
+};
+
+static int sym_phdr_helper(struct dl_phdr_info *info, size_t size, void *vdata) JL_NOTSAFEPOINT
+{
+    (void)size;
+    struct sym_phdr_query *q = (struct sym_phdr_query *)vdata;
+    int idx = q->index++;
+    // Find the object whose mapped PT_LOAD segments contain `addr`.
+    for (int i = 0; i < info->dlpi_phnum; i++) {
+        if (info->dlpi_phdr[i].p_type != PT_LOAD)
+            continue;
+        uintptr_t beg = (uintptr_t)info->dlpi_addr + info->dlpi_phdr[i].p_vaddr;
+        uintptr_t end = beg + info->dlpi_phdr[i].p_memsz;
+        if (q->addr >= beg && q->addr < end) {
+            q->name = info->dlpi_name;
+            // Note that `dlpi_name` for the main executable is platform-dependent
+            // and frequently `argv[0]` on non-GLIBC platforms. We do not want to
+            // return that result from this API since it cannot be reliably dlopen'd.
+            //
+            // Return "" instead, which also cannot be dlopen'd either (on non-GLIBC
+            // platforms) but which is at least a consistent value to match on for a
+            // dlopen(NULL) fallback, which does give a handle to the main exe.
+            q->is_main_exe = (idx == 0); // dl_iterate_phdr reports the main program first
+            q->found = 1;
+            return 1; // stop: found the containing object
+        }
+    }
+    return 0; // keep searching
+}
+#endif
+
+// Takes the address of a symbol and returns the path to the image that contains
+// it, or NULL. On ELF, the main executable is reported as the empty string "".
+JL_DLLEXPORT const char *jl_pathname_for_symbol(void *symbol) JL_NOTSAFEPOINT
+{
+    if (!symbol)
+        return NULL;
+#ifdef _OS_WINDOWS_
+    HMODULE handle;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            (LPCWSTR)symbol, &handle))
+        return NULL;
+    return jl_pathname_for_handle(handle);
+#elif defined(__APPLE__)
+    // dyld reports the real image path (including for the main executable).
+    Dl_info info;
+    if (!dladdr(symbol, &info) || !info.dli_fname)
+        return NULL;
+    return info.dli_fname;
+#elif defined(__GLIBC__)
+    // glibc: dladdr1 hands us the containing object's link_map directly.
+    Dl_info info;
+    struct link_map *map = NULL;
+    if (!dladdr1(symbol, &info, (void **)&map, RTLD_DL_LINKMAP) || map == NULL)
+        return NULL;
+    msan_unpoison(&map, sizeof(struct link_map *));
+    msan_unpoison(map, sizeof(struct link_map));
+    msan_unpoison_string(map->l_name);
+    return map->l_name; // the empty string for the main executable
+#else
+    // Other libc: walk the program headers and test PT_LOAD containment.
+    struct sym_phdr_query q = { (uintptr_t)symbol, NULL, 0, 0, 0 };
+    dl_iterate_phdr(&sym_phdr_helper, &q);
+    if (!q.found)
+        return NULL;
+    return q.is_main_exe ? "" : q.name;
+#endif
 }
 
 #ifdef _OS_WINDOWS_

--- a/src/sys.c
+++ b/src/sys.c
@@ -853,6 +853,49 @@ JL_DLLEXPORT int jl_dllist(jl_array_t *list)
     free(hMods);
     return TRUE;
 }
+#elif !defined(__APPLE__)
+struct dllist_data {
+    arraylist_t *names; // strdup'd object names (freed by jl_dllist)
+    int index;
+};
+
+// This runs under the dynamic linker lock (held by `dl_iterate_phdr` across the
+// callback), so it must not allocate Julia objects or otherwise hit a GC safepoint.
+// A stop-the-world here while another thread is blocked in the linker would deadlock
+static int dllist_helper(struct dl_phdr_info *info, size_t size, void *vdata) JL_NOTSAFEPOINT
+{
+    (void)size;
+    struct dllist_data *data = (struct dllist_data *)vdata;
+    int idx = data->index++; // dl_iterate_phdr reports the main program first
+    const char *name = info->dlpi_name;
+    if (idx == 0 || name == NULL || name[0] == '\0')
+        return 0; // skip the main executable and any unnamed objects
+    arraylist_push(data->names, strdup(name));
+    return 0;
+}
+
+// Get a list of all the modules in this process.
+//
+// This is done in C, rather than a Julia `dl_iterate_phdr` callback, so that
+// no Julia code (which can allocate, run finalizers, or re-enter the linker
+// via (lazy) `ccall`) runs under the dynamic loader lock. See `dllist_helper`
+JL_DLLEXPORT int jl_dllist(jl_array_t *list)
+{
+    arraylist_t names;
+    arraylist_new(&names, 0);
+    struct dllist_data data = { &names, 0 };
+    dl_iterate_phdr(&dllist_helper, &data);
+    // The loader lock is now released: safe to allocate Julia objects.
+    for (size_t i = 0; i < names.len; i++) {
+        char *name = (char*)names.items[i];
+        jl_array_grow_end(list, 1);
+        jl_value_t *v = jl_cstr_to_string(name);
+        jl_array_ptr_set(list, jl_array_dim0(list) - 1, v);
+        free(name);
+    }
+    arraylist_free(&names);
+    return 1;
+}
 #endif
 
 JL_DLLEXPORT void jl_raise_debugger(void)


### PR DESCRIPTION
The previous logic here expected `dli_fbase` to be reliable when querying `dladdr` on symbols in the main executable, when in practice its value differs by platform and is frequently `argv[0]`, which of course may not be the executable itself at all. On CentOS in particular, this is often an "absolute" path (e.g. `/build/self_exe`) that does not actually exist.

Fix this by implementing `jl_pathname_for_symbol`, including a guarantee that the returned path is `""` for the executable (rather than `argv[0]`) on ELF platforms. This allows us to `dlopen(NULL, ...)` appropriately when requiring a handle to the main executable.

Claude Opus 4.8 🤖 was used for research and to implement `jl_pathname_for_symbol`

Needed to fix https://github.com/JuliaLang/JuliaC.jl/issues/105.