### PR TITLE
Markdown: parse inline markdown in admonition titles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -101,6 +101,7 @@ Standard library changes
 * Support autolinks for email addresses (#60570)
 * Many improvements and bugfixes for rendering Markdown lists in a terminal ([#55456], [#60519])
 * Strikethrough text via `~strike~` or `~~through~~` is now supported by the Markdown parser. ([#60537])
+* Admonition titles now support inline Markdown formatting (bold, italic, code, LaTeX, links, etc.) ([#62122]).
 * Many, many bug fixes and minor tweaks; overall behavior is now much closer to CommonMark ([#59977], [#60502])
 
 #### Profile

--- a/stdlib/Markdown/docs/src/index.md
+++ b/stdlib/Markdown/docs/src/index.md
@@ -414,7 +414,7 @@ However, unless the code rendering the Markdown special-cases that particular ad
 
 A custom title for the box can be provided as a string (in double quotes) after the admonition type.
 If no title text is specified after the admonition type, then the type name will be used as the title (e.g. `"Note"` for the `note` admonition).
-Note that admonition titles are parsed as plain strings and do not support inline Markdown or LaTeX formatting (e.g. ``\alpha`` in a title will not be rendered as math).
+Admonition titles support inline Markdown formatting, including bold, italic, code, and inline math (e.g. `!!! note "Solution for ``\alpha``"` renders the LaTeX in the title).
 
 Admonitions, like most other toplevel elements, can contain other toplevel elements (e.g. lists, images).
 

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -243,7 +243,7 @@ end
 
 mutable struct Admonition <: MarkdownElement
     category::String
-    title::String
+    title
     content::Vector
 end
 
@@ -266,11 +266,11 @@ function admonition(stream::IO, block::MD)
                 if occursin(untitled, line)
                     m = match(untitled, line)::AbstractMatch
                     # When no title is provided we use CATEGORY_NAME, capitalising it.
-                    m.captures[1], uppercasefirst(m.captures[1])
+                    m.captures[1], parseinline(uppercasefirst(m.captures[1]), block)
                 elseif occursin(titled, line)
                     m = match(titled, line)::AbstractMatch
                     # To have a blank TITLE provide an explicit empty string as TITLE.
-                    m.captures[1], m.captures[2]
+                    m.captures[1], parseinline(m.captures[2], block)
                 else
                     # Admonition header is invalid so we give up parsing here and move
                     # on to the next parser.

--- a/stdlib/Markdown/src/render/html.jl
+++ b/stdlib/Markdown/src/render/html.jl
@@ -120,7 +120,7 @@ end
 function html(io::IO, md::Admonition)
     withtag(io, :div, :class => "admonition $(md.category)") do
         withtag(io, :p, :class => "admonition-title") do
-            print(io, md.title)
+            htmlinline(io, md.title)
         end
         html(io, md.content)
     end

--- a/stdlib/Markdown/src/render/latex.jl
+++ b/stdlib/Markdown/src/render/latex.jl
@@ -75,7 +75,9 @@ function latex(io::IO, md::Admonition)
         wrapinline(io, "textbf") do
             print(io, md.category)
         end
-        println(io, "\n\n", md.title, "\n")
+        print(io, "\n\n")
+        latexinline(io, md.title)
+        println(io, "\n")
         latex(io, md.content)
     end
 end

--- a/stdlib/Markdown/src/render/plain.jl
+++ b/stdlib/Markdown/src/render/plain.jl
@@ -90,7 +90,8 @@ end
 
 function plain(io::IO, md::Admonition)
     s = sprint(plain, md.content)
-    title = md.title == uppercasefirst(md.category) ? "" : " \"$(md.title)\""
+    title_str = sprint(plaininline, md.title)
+    title = title_str == uppercasefirst(md.category) ? "" : " \"$title_str\""
     println(io, "!!! ", md.category, title)
     for line in split(rstrip(s), "\n")
         println(io, isempty(line) ? "" : "    ", line)
@@ -157,6 +158,8 @@ function plaininline(io::IO, md::Code)
         print(io, "`", md.code, "`")
     end
 end
+
+plaininline(io::IO, l::LaTeX) = print(io, "``", l.formula, "``")
 
 plaininline(io::IO, br::LineBreak) = println(io, "\\")
 

--- a/stdlib/Markdown/src/render/rst.jl
+++ b/stdlib/Markdown/src/render/rst.jl
@@ -82,7 +82,8 @@ end
 
 function rst(io::IO, md::Admonition)
     s = sprint(rst, md.content)
-    title = md.title == uppercasefirst(md.category) ? "" : md.title
+    title_str = rstinline(md.title)
+    title = title_str == uppercasefirst(md.category) ? "" : title_str
     println(io, ".. ", md.category, "::", isempty(title) ? "" : " $title")
     for line in split(rstrip(s), "\n")
         println(io, isempty(line) ? "" : "   ", line)

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -54,7 +54,7 @@ function term(io::IO, md::Admonition, columns)
     else
         :default
     end
-    title = if isempty(md.title) md.category else md.title end
+    title = if isempty(md.title) md.category else annotprint(terminline, md.title) end
     print(io, ' '^margin, styled"{$accent,markdown_admonition:│ $title}",
           '\n', ' '^margin, styled"{$accent,markdown_admonition:│}", '\n')
     content = annotprint(term, md.content, columns - 10)

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test, Markdown, StyledStrings
-import Markdown: MD, Paragraph, Header, Italic, Bold, Strikethrough, LineBreak, Table, Code, LaTeX, Footnote
+import Markdown: MD, Paragraph, Header, Admonition, Italic, Bold, Strikethrough, LineBreak, Table, Code, LaTeX, Footnote
 import Base: show
 
 @test isempty(Test.detect_closure_boxes(Markdown))
@@ -841,36 +841,36 @@ end
 
     @test isa(m_1[2], Markdown.Admonition)
     @test m_1[2].category == "note"
-    @test m_1[2].title == "Note"
+    @test sprint(Markdown.plaininline, m_1[2].title) == "Note"
     @test m_1[2].content == []
 
     @test isa(m_1[3], Markdown.Admonition)
     @test m_1[3].category == "warning"
-    @test m_1[3].title == "custom title"
+    @test sprint(Markdown.plaininline, m_1[3].title) == "custom title"
     @test m_1[3].content == []
 
     @test isa(m_1[5], Markdown.Admonition)
     @test m_1[5].category == "danger"
-    @test m_1[5].title == ""
+    @test isempty(m_1[5].title)
     @test m_1[5].content == []
 
     @test isa(m_1[6], Markdown.Paragraph)
 
     @test isa(m_2[1], Markdown.Admonition)
     @test m_2[1].category == "note"
-    @test m_2[1].title == "Note"
+    @test sprint(Markdown.plaininline, m_2[1].title) == "Note"
     @test isa(m_2[1].content[1], Markdown.Paragraph)
     @test isa(m_2[1].content[2], Markdown.Paragraph)
 
     @test isa(m_2[2], Markdown.Admonition)
     @test m_2[2].category == "warning"
-    @test m_2[2].title == "custom title"
+    @test sprint(Markdown.plaininline, m_2[2].title) == "custom title"
     @test isa(m_2[2].content[1], Markdown.List)
     @test isa(m_2[2].content[2], Markdown.Paragraph)
 
     @test isa(m_2[3], Markdown.Admonition)
     @test m_2[3].category == "danger"
-    @test m_2[3].title == ""
+    @test isempty(m_2[3].title)
     @test isa(m_2[3].content[1], Markdown.Code)
     @test isa(m_2[3].content[2], Markdown.Code)
     @test isa(m_2[3].content[3], Markdown.Header{1})
@@ -1012,6 +1012,28 @@ end
 
             """
     @test actual == expected
+
+    # Inline markdown in admonition titles
+    @testset "inline titles" begin
+        # Analogous to the Header inline test: all common inline forms in one shot.
+        @test md"""!!! note "title *foo* `bar` **baz** ~~qux~~"
+            """ == MD(Admonition("note", Any["title ", Italic("foo"), " ", Code("bar"), " ",
+                                             Bold("baz"), " ", Strikethrough("qux")], []))
+
+        # LaTeX specifically, which was the original motivation for this fix.
+        @test md"""!!! note "Title with ``x^2`` math"
+            """ == MD(Admonition("note", Any["Title with ", LaTeX("x^2"), " math"], []))
+
+        # HTML renders inline LaTeX correctly in the title.
+        @test Markdown.html(Markdown.parse("!!! note \"Title with ``x^2`` math\"\n    body\n")) ==
+            "<div class=\"admonition note\"><p class=\"admonition-title\">Title with &#36;x^2&#36; math</p><p>body</p>\n</div>\n"
+
+        # Plain output round-trips correctly for LaTeX and inline formatting.
+        @test Markdown.plain(Markdown.parse("!!! note \"Title with ``x^2`` math\"\n    body\n")) ==
+            "!!! note \"Title with ``x^2`` math\"\n    body\n\n"
+        @test Markdown.plain(Markdown.parse("!!! note \"Title with **bold**\"\n    body\n")) ==
+            "!!! note \"Title with **bold**\"\n    body\n\n"
+    end
 end
 
 @testset "Nested Lists" begin


### PR DESCRIPTION
Admonition titles were stored as raw strings and never run through `parseinline`, unlike header text. This caused all inline formatting (bold, italic, code, LaTeX, links, etc.) to appear as literal source text rather than formatted output.

I looked at `Header.text` for guidance on how to implement this — in `Admonition` itself, in the various renderers, and in the tests:

- Calls `parseinline` on the admonition title in the block parser, exactly mirroring how `Header.text` is handled
- Updates all five renderers to use the appropriate inline rendering function (`htmlinline`, `latexinline`, `terminline`, `plaininline`, `rstinline`)
- Adds `plaininline(::IO, ::LaTeX)` so inline LaTeX round-trips correctly through the plain renderer (` ``formula`` ` syntax rather than `$formula$`)
- Replaces the documentation workaround in #62111 (which claimed the limitation as intentional) with a description of the supported formatting
- Adds tests for the new capabilities
- Updates NEWS.md

Fixes #62106
