### PR TITLE
loading: skip debug-info emission for throwaway precompile codegen

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3289,6 +3289,11 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
     # clears them (and the flag) before staticdata serialization.
     keep_ir = JLOptions().outputo != C_NULL
     keep_ir && ccall(:jl_set_precompile_keep_ir, Cvoid, (Int8,), 1)
+    # Native code generated to run a workload during `include` is thrown away when
+    # this worker exits, so skip its debug-info emission. Restored before the cached
+    # AOT codegen runs at exit, leaving the pkgimage and .ji unchanged.
+    saved_debug_info_level = ccall(:jl_get_default_debug_info_level, Cint, ())
+    ccall(:jl_set_default_debug_info_level, Cvoid, (Cint,), Cint(0))
     # This one changes the parser behavior
     __toplevel__.var"#_internal_julia_parse" = VersionedParse(syntax_version)
     # This one is the compatibility marker for cache loading
@@ -3319,6 +3324,7 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
         end
         ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing)
         keep_ir && ccall(:jl_set_precompile_keep_ir, Cvoid, (Int8,), 0)
+        ccall(:jl_set_default_debug_info_level, Cvoid, (Cint,), saved_debug_info_level)
     end
     # check that the package defined the expected module so we can give a nice error message if not
     m = maybe_root_module(pkg)

--- a/src/gf.c
+++ b/src/gf.c
@@ -1074,6 +1074,16 @@ JL_DLLEXPORT void jl_set_precompile_keep_ir(int8_t v)
     jl_atomic_store_relaxed(&jl_precompile_keep_ir, v);
 }
 
+JL_DLLEXPORT int jl_get_default_debug_info_level(void)
+{
+    return jl_default_cgparams.debug_info_level;
+}
+
+JL_DLLEXPORT void jl_set_default_debug_info_level(int level)
+{
+    jl_default_cgparams.debug_info_level = level;
+}
+
 static int invalidate_all_entries(jl_typemap_entry_t *entry, void *env)
 {
     jl_atomic_store_relaxed(&entry->max_world, 0);


### PR DESCRIPTION
Speeds up precompilation ~4-8%, but needs more repeat tests to be sure.

master 0ea7c16d033e790c568aa042e519d43608d44a98
```
shell> rm -rf ~/.julia/compiled/v1.14/

julia> Base.Precompilation.precompilepkgs(timing=true, verbose=true)
Precompiling project...
   total │ include   (deps)   (comp) │ methods  img-gen     cache  ~pk-rss
...
  25.6 s │  16.90s    3.61s   11.92s │   35974    8.70s    44.2MB   1676MB  ✓ Plots
...
  83.4 s │  54.95s   13.23s   37.10s │  104273   28.45s   146.1MB   2935MB  ✓ Makie
  41.0 s │  26.51s    7.92s   16.74s │   36936   14.52s    49.7MB   2612MB  ✓ GLMakie
  316 dependencies successfully precompiled in 181 seconds. 41 already precompiled.
```

PR
```
   total │ include   (deps)   (comp) │ methods  img-gen     cache  ~pk-rss
...
  24.3 s │  15.85s    3.39s   11.06s │   35980    8.41s    44.2MB   1731MB  ✓ Plots
...
  76.5 s │  50.37s   12.47s   33.27s │  104273   26.14s   146.1MB   3380MB  ✓ Makie
  41.0 s │  26.28s    8.14s   16.27s │   36936   14.71s    49.7MB   2603MB  ✓ GLMakie
  316 dependencies successfully precompiled in 174 seconds. 41 already precompiled.
```

Claude:

----

During package precompilation, the native code generated to run a workload in the `include` phase of a worker is discarded when the worker exits; only the inference results (the .ji) and the AOT-generated pkgimage are cached.

Lower the default codegen debug-info level to 0 around `Base.include` in `include_package_for_output` so that throwaway code skips DWARF emission. The level is restored in the `finally` block, before `jl_write_compiler_output` runs the cached AOT codegen at process exit, so the emitted pkgimage debug info and the .ji are unchanged.