### PR TITLE
mac/app: fix app icon by removing the stale applet asset catalog

### DIFF
--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -37,6 +37,13 @@ dmg/$(APP_NAME): startup.applescript julia.icns
 	-mkdir -p dmg
 	osacompile -o $@ startup.applescript
 	rm $@/Contents/Resources/applet.icns
+	# Newer osacompile ships the applet icon as a compiled asset catalog
+	# (Assets.car, referenced by CFBundleIconName) which modern macOS prefers
+	# over CFBundleIconFile -- so just dropping applet.icns/setting julia.icns
+	# below leaves the generic AppleScript applet icon showing. Remove the stale
+	# catalog and its key so CFBundleIconFile=julia.icns is authoritative.
+	rm -f $@/Contents/Resources/Assets.car
+	-plutil -remove CFBundleIconName $@/Contents/Info.plist
 	cp julia.icns $@/Contents/Resources/
 	plutil -replace CFBundleDevelopmentRegion  -string "en" $@/Contents/Info.plist
 	plutil -insert  CFBundleDisplayName        -string "Julia" $@/Contents/Info.plist


### PR DESCRIPTION
osacompile now ships the applet icon as a compiled asset catalog (Contents/Resources/Assets.car, referenced by CFBundleIconName=applet), which modern macOS prefers over CFBundleIconFile. The recipe replaced applet.icns and set CFBundleIconFile=julia.icns but left the catalog and its key intact, so the bundled .app showed the generic AppleScript applet icon instead of the Julia icon.

Remove Assets.car and the CFBundleIconName key so CFBundleIconFile= julia.icns is authoritative.