### PR TITLE
module: programmatically retract export/public

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,9 @@ New library functions
 ---------------------
 
 * `tap(f)` creates a function that calls `f(x)` for side effects and returns `x`. ([#61340]).
+* `Base.set_binding_visibility!` and `Base.binding_visibility` get and set the declared
+  visibility (`:private`, `:public`, or `:exported`) of a name in a module, allowing an
+  `export` or `public` declaration to be retracted programmatically ([#XXXXX]).
 * `Base.generating_output()` has been made `public` (but not exported) to allow
   checking whether the current process is performing compilation for a
   pkgimage/sysimage ([#61224]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,9 +66,9 @@ New library functions
 ---------------------
 
 * `tap(f)` creates a function that calls `f(x)` for side effects and returns `x`. ([#61340]).
-* `Base.set_binding_visibility!` and `Base.binding_visibility` get and set the declared
-  visibility (`:private`, `:public`, or `:exported`) of a name in a module, allowing an
-  `export` or `public` declaration to be retracted programmatically ([#XXXXX]).
+* `Base.set_binding_visibility!` sets the declared visibility (`:none`, `:public`, or
+  `:export`) of a name in a module, allowing an `export` or `public` declaration to be
+  retracted programmatically ([#62131]).
 * `Base.generating_output()` has been made `public` (but not exported) to allow
   checking whether the current process is performing compilation for a
   pkgimage/sysimage ([#61224]).

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -332,10 +332,14 @@ removes a name's `export` or `public` status.
 Retracting an `export` causes modules that did `using \$mod` to stop resolving
 `sym` implicitly, once their world age advances past this call (see
 [`invokelatest`](@ref) and [`get_world_counter`](@ref)). Because that
-invalidates dependent compiled code, it can be expensive. The `:public` versus
-`:none` distinction is not world-versioned: clearing it takes effect in every
-world age. A name set to `:export` is reported as public by [`ispublic`](@ref)
-regardless.
+invalidates dependent compiled code, it can be expensive.
+
+Unlike the exported flag, the public flag is not world-versioned: setting or
+clearing it takes effect in every world age at once. Retracting to `:none`
+therefore drops public status in all world ages, including ones in which the name
+is declared public. Combined with the world-versioned export flag, this means an
+older world age can still report a name as [`isexported`](@ref) while no longer
+reporting it as [`ispublic`](@ref).
 
 See also [`isexported`](@ref), [`ispublic`](@ref), [`delete_binding`](@ref).
 

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -322,49 +322,31 @@ function delete_binding(mod::Module, sym::Symbol)
 end
 
 """
-    binding_visibility(mod::Module, sym::Symbol) -> Symbol
-
-Return the declared visibility of `mod.sym`: `:exported` (declared with
-`export`), `:public` (declared with `public`), or `:private` (neither).
-
-See also [`set_binding_visibility!`](@ref), [`isexported`](@ref), [`ispublic`](@ref).
-
-!!! compat "Julia 1.14"
-    This function was added in Julia 1.14.
-"""
-function binding_visibility(mod::Module, sym::Symbol)
-    isexported(mod, sym) && return :exported   # checked first: an export is also public
-    ispublic(mod, sym) && return :public
-    return :private
-end
-
-"""
     set_binding_visibility!(mod::Module, sym::Symbol, vis::Symbol)
 
-Select the declared visibility of `mod.sym`, one of `:exported`, `:public`, or
-`:private`. This is the programmatic counterpart to the `export` and `public`
-keywords; unlike them it can also *retract* a declaration, since `:private`
+Select the declared visibility of `mod.sym`, one of `:export`, `:public`, or
+`:none`. This is the programmatic counterpart to the `export` and `public`
+keywords; unlike them it can also *retract* a declaration, since `:none`
 removes a name's `export` or `public` status.
 
 Retracting an `export` causes modules that did `using \$mod` to stop resolving
 `sym` implicitly, once their world age advances past this call (see
 [`invokelatest`](@ref) and [`get_world_counter`](@ref)). Because that
 invalidates dependent compiled code, it can be expensive. The `:public` versus
-`:private` distinction is not world-versioned: clearing it takes effect in every
-world age. A name that is `:exported` is reported as public by [`ispublic`](@ref)
+`:none` distinction is not world-versioned: clearing it takes effect in every
+world age. A name set to `:export` is reported as public by [`ispublic`](@ref)
 regardless.
 
-See also [`binding_visibility`](@ref), [`isexported`](@ref), [`ispublic`](@ref),
-[`delete_binding`](@ref).
+See also [`isexported`](@ref), [`ispublic`](@ref), [`delete_binding`](@ref).
 
 !!! compat "Julia 1.14"
     This function was added in Julia 1.14.
 """
 function set_binding_visibility!(mod::Module, sym::Symbol, vis::Symbol)
-    state = vis === :private  ? Cint(0) :
-            vis === :public   ? Cint(1) :
-            vis === :exported ? Cint(2) :
-            throw(ArgumentError(LazyString("visibility must be :private, :public, or :exported, got ", repr(vis))))
+    state = vis === :none   ? Cint(0) :
+            vis === :public ? Cint(1) :
+            vis === :export ? Cint(2) :
+            throw(ArgumentError(LazyString("visibility must be :none, :public, or :export, got ", repr(vis))))
     ccall(:jl_module_set_visibility, Cvoid, (Any, Any, Cint), mod, sym, state)
     return nothing
 end

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -322,6 +322,54 @@ function delete_binding(mod::Module, sym::Symbol)
 end
 
 """
+    binding_visibility(mod::Module, sym::Symbol) -> Symbol
+
+Return the declared visibility of `mod.sym`: `:exported` (declared with
+`export`), `:public` (declared with `public`), or `:private` (neither).
+
+See also [`set_binding_visibility!`](@ref), [`isexported`](@ref), [`ispublic`](@ref).
+
+!!! compat "Julia 1.14"
+    This function was added in Julia 1.14.
+"""
+function binding_visibility(mod::Module, sym::Symbol)
+    isexported(mod, sym) && return :exported   # checked first: an export is also public
+    ispublic(mod, sym) && return :public
+    return :private
+end
+
+"""
+    set_binding_visibility!(mod::Module, sym::Symbol, vis::Symbol)
+
+Select the declared visibility of `mod.sym`, one of `:exported`, `:public`, or
+`:private`. This is the programmatic counterpart to the `export` and `public`
+keywords; unlike them it can also *retract* a declaration, since `:private`
+removes a name's `export` or `public` status.
+
+Retracting an `export` causes modules that did `using \$mod` to stop resolving
+`sym` implicitly, once their world age advances past this call (see
+[`invokelatest`](@ref) and [`get_world_counter`](@ref)). Because that
+invalidates dependent compiled code, it can be expensive. The `:public` versus
+`:private` distinction is not world-versioned: clearing it takes effect in every
+world age. A name that is `:exported` is reported as public by [`ispublic`](@ref)
+regardless.
+
+See also [`binding_visibility`](@ref), [`isexported`](@ref), [`ispublic`](@ref),
+[`delete_binding`](@ref).
+
+!!! compat "Julia 1.14"
+    This function was added in Julia 1.14.
+"""
+function set_binding_visibility!(mod::Module, sym::Symbol, vis::Symbol)
+    state = vis === :private  ? Cint(0) :
+            vis === :public   ? Cint(1) :
+            vis === :exported ? Cint(2) :
+            throw(ArgumentError(LazyString("visibility must be :private, :public, or :exported, got ", repr(vis))))
+    ccall(:jl_module_set_visibility, Cvoid, (Any, Any, Cint), mod, sym, state)
+    return nothing
+end
+
+"""
     fieldname(x::DataType, i::Integer)
 
 Get the name of field `i` of a `DataType`.

--- a/src/julia.h
+++ b/src/julia.h
@@ -2145,6 +2145,7 @@ JL_DLLEXPORT void jl_module_import(jl_task_t *ct, jl_module_t *to, jl_module_t *
 JL_DLLEXPORT void jl_import_module(jl_task_t *ct, jl_module_t *m, jl_module_t *import, jl_sym_t *asname);
 JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from, size_t flags);
 JL_DLLEXPORT void jl_module_public(jl_module_t *from, jl_value_t **symbols, size_t nsymbols, int exported);
+JL_DLLEXPORT void jl_module_set_visibility(jl_module_t *m, jl_sym_t *var, int state);
 JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s);
 JL_DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var);
 

--- a/src/module.c
+++ b/src/module.c
@@ -1911,6 +1911,36 @@ JL_DLLEXPORT void jl_deprecate_binding(jl_module_t *m, jl_sym_t *var, int flag)
     JL_UNLOCK(&world_counter_lock);
 }
 
+// Select the declared visibility of a binding:
+//   0=private (neither), 1=public, 2=exported
+// The exported flag is world-versioned (it lives in the binding partition and
+// gates implicit resolution through `using`), so clearing it creates a new
+// partition and invalidates dependent code. The public flag is world-agnostic
+// (it lives on the binding). Unlike the `export`/`public` keyword path
+// (jl_module_public_), this both raises and lowers the state, so it does not
+// enforce the public-vs-exported conflict.
+JL_DLLEXPORT void jl_module_set_visibility(jl_module_t *m, jl_sym_t *var, int state)
+{
+    int want_exported = state == 2;
+    int want_public = state >= 1;
+    jl_binding_t *b = jl_get_module_binding(m, var, 1);
+    JL_LOCK(&world_counter_lock);
+    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    jl_binding_partition_t *old_bpart = jl_get_binding_partition(b, jl_current_task->world_age);
+    int was_exported = (old_bpart->kind & PARTITION_FLAG_EXPORTED) != 0;
+    if (was_exported != want_exported) {
+        size_t new_kind = want_exported ? (old_bpart->kind | PARTITION_FLAG_EXPORTED) :
+                                          (old_bpart->kind & ~(size_t)PARTITION_FLAG_EXPORTED);
+        jl_replace_binding_locked2(b, old_bpart, old_bpart->restriction, new_kind, new_world);
+        jl_atomic_store_release(&jl_world_counter, new_world);
+    }
+    JL_UNLOCK(&world_counter_lock);
+    if (want_public)
+        jl_atomic_fetch_or_relaxed(&b->flags, BINDING_FLAG_PUBLICP);
+    else
+        jl_atomic_fetch_and_relaxed(&b->flags, (uint8_t)~BINDING_FLAG_PUBLICP);
+}
+
 static int should_depwarn(jl_binding_t *b, uint8_t flag)
 {
     // We consider bindings deprecated, if:

--- a/src/module.c
+++ b/src/module.c
@@ -1912,7 +1912,7 @@ JL_DLLEXPORT void jl_deprecate_binding(jl_module_t *m, jl_sym_t *var, int flag)
 }
 
 // Select the declared visibility of a binding:
-//   0=private (neither), 1=public, 2=exported
+//   0=none (neither), 1=public, 2=export
 // The exported flag is world-versioned (it lives in the binding partition and
 // gates implicit resolution through `using`), so clearing it creates a new
 // partition and invalidates dependent code. The public flag is world-agnostic

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -106,27 +106,27 @@ module RebindingVisibility
     end
     using .SrcMod
 
-    @test Base.binding_visibility(SrcMod, :visg) == :exported
+    @test Base.isexported(SrcMod, :visg)
     f_use_visg() = visg()
     @test f_use_visg() == 42
 
     # Retract the export: `visg` is still defined in SrcMod but no longer reachable here.
-    Base.set_binding_visibility!(SrcMod, :visg, :private)
-    @test Base.binding_visibility(SrcMod, :visg) == :private
+    Base.set_binding_visibility!(SrcMod, :visg, :none)
     @test !Base.isexported(SrcMod, :visg)
+    @test !Base.ispublic(SrcMod, :visg)
     @test :visg ∉ names(SrcMod)
     @test_throws UndefVarError f_use_visg()
     @test SrcMod.visg() == 42
 
     # Re-export and confirm implicit resolution is restored.
-    Base.set_binding_visibility!(SrcMod, :visg, :exported)
+    Base.set_binding_visibility!(SrcMod, :visg, :export)
     @test Base.isexported(SrcMod, :visg)
     @test :visg ∈ names(SrcMod)
     @test f_use_visg() == 42
 
-    # The public/private flag is independent of export and not world-versioned.
-    @test Base.binding_visibility(SrcMod, :visp) == :public
-    Base.set_binding_visibility!(SrcMod, :visp, :private)
+    # The public flag is independent of export and not world-versioned.
+    @test Base.ispublic(SrcMod, :visp) && !Base.isexported(SrcMod, :visp)
+    Base.set_binding_visibility!(SrcMod, :visp, :none)
     @test !Base.ispublic(SrcMod, :visp)
     Base.set_binding_visibility!(SrcMod, :visp, :public)
     @test Base.ispublic(SrcMod, :visp)
@@ -268,7 +268,7 @@ module RebindingPrecompile
         @eval using RetractExport
         # Retract the export before loading the dependent package
         invokelatest() do
-            Base.set_binding_visibility!(RetractExport, :retract_me, :private)
+            Base.set_binding_visibility!(RetractExport, :retract_me, :none)
         end
         @eval using UseRetractExport
         invokelatest() do
@@ -276,7 +276,7 @@ module RebindingPrecompile
         end
         # Re-export and confirm resolution is restored
         invokelatest() do
-            Base.set_binding_visibility!(RetractExport, :retract_me, :exported)
+            Base.set_binding_visibility!(RetractExport, :retract_me, :export)
         end
         invokelatest() do
             @test UseRetractExport.f_use_retract() == 11

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -93,6 +93,47 @@ module Rebinding
     @test_throws UndefVarError f_return_delete_me_implicit()
 end
 
+# Retracting an `export` with `set_binding_visibility!` makes a name stop
+# resolving through `using`, and re-exporting restores it.
+module RebindingVisibility
+    using Test
+
+    module SrcMod
+        export visg
+        visg() = 42
+        public visp
+        visp() = 7
+    end
+    using .SrcMod
+
+    @test Base.binding_visibility(SrcMod, :visg) == :exported
+    f_use_visg() = visg()
+    @test f_use_visg() == 42
+
+    # Retract the export: `visg` is still defined in SrcMod but no longer reachable here.
+    Base.set_binding_visibility!(SrcMod, :visg, :private)
+    @test Base.binding_visibility(SrcMod, :visg) == :private
+    @test !Base.isexported(SrcMod, :visg)
+    @test :visg ∉ names(SrcMod)
+    @test_throws UndefVarError f_use_visg()
+    @test SrcMod.visg() == 42
+
+    # Re-export and confirm implicit resolution is restored.
+    Base.set_binding_visibility!(SrcMod, :visg, :exported)
+    @test Base.isexported(SrcMod, :visg)
+    @test :visg ∈ names(SrcMod)
+    @test f_use_visg() == 42
+
+    # The public/private flag is independent of export and not world-versioned.
+    @test Base.binding_visibility(SrcMod, :visp) == :public
+    Base.set_binding_visibility!(SrcMod, :visp, :private)
+    @test !Base.ispublic(SrcMod, :visp)
+    Base.set_binding_visibility!(SrcMod, :visp, :public)
+    @test Base.ispublic(SrcMod, :visp)
+
+    @test_throws ArgumentError Base.set_binding_visibility!(SrcMod, :visg, :bogus)
+end
+
 module RebindingPrecompile
     using Test
     include("precompile_utils.jl")
@@ -203,6 +244,42 @@ module RebindingPrecompile
         end
         invokelatest() do
             @test_throws UndefVarError ImportTest.f_use_binding2()
+        end
+    end
+
+    precompile_test_harness("export retraction") do load_path
+        write(joinpath(load_path, "RetractExport.jl"),
+              """
+              module RetractExport
+                export retract_me
+                const retract_me = 11
+              end
+              """)
+        Base.compilecache(Base.PkgId("RetractExport"))
+        write(joinpath(load_path, "UseRetractExport.jl"),
+              """
+              module UseRetractExport
+                using RetractExport
+                f_use_retract() = retract_me
+                @assert f_use_retract() == 11
+              end
+              """)
+        Base.compilecache(Base.PkgId("UseRetractExport"))
+        @eval using RetractExport
+        # Retract the export before loading the dependent package
+        invokelatest() do
+            Base.set_binding_visibility!(RetractExport, :retract_me, :private)
+        end
+        @eval using UseRetractExport
+        invokelatest() do
+            @test_throws UndefVarError UseRetractExport.f_use_retract()
+        end
+        # Re-export and confirm resolution is restored
+        invokelatest() do
+            Base.set_binding_visibility!(RetractExport, :retract_me, :exported)
+        end
+        invokelatest() do
+            @test UseRetractExport.f_use_retract() == 11
         end
     end
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -459,7 +459,7 @@ const a_value = 1
 @test !Base.ispublic(@__MODULE__, :this_is_not_exported)
 end
 
-# binding_visibility / set_binding_visibility!
+# set_binding_visibility!
 module TestBindingVisibility
 using Test
 public a_public_name
@@ -468,13 +468,12 @@ export an_exported_name
 an_exported_name() = 2
 no_decl() = 3
 
-@test Base.binding_visibility(@__MODULE__, :an_exported_name) == :exported
-@test Base.binding_visibility(@__MODULE__, :a_public_name) == :public
-@test Base.binding_visibility(@__MODULE__, :no_decl) == :private
+@test Base.isexported(@__MODULE__, :an_exported_name)
+@test Base.ispublic(@__MODULE__, :a_public_name) && !Base.isexported(@__MODULE__, :a_public_name)
+@test !Base.ispublic(@__MODULE__, :no_decl)
 
-# public <-> private round trip
-Base.set_binding_visibility!(@__MODULE__, :a_public_name, :private)
-@test Base.binding_visibility(@__MODULE__, :a_public_name) == :private
+# public <-> none round trip
+Base.set_binding_visibility!(@__MODULE__, :a_public_name, :none)
 @test !Base.ispublic(@__MODULE__, :a_public_name)
 Base.set_binding_visibility!(@__MODULE__, :a_public_name, :public)
 @test Base.ispublic(@__MODULE__, :a_public_name)
@@ -482,13 +481,12 @@ Base.set_binding_visibility!(@__MODULE__, :a_public_name, :public)
 # an exported name is reported public; lowering it to :public clears only the export
 @test Base.ispublic(@__MODULE__, :an_exported_name)
 Base.set_binding_visibility!(@__MODULE__, :an_exported_name, :public)
-@test Base.binding_visibility(@__MODULE__, :an_exported_name) == :public
 @test !Base.isexported(@__MODULE__, :an_exported_name)
 @test Base.ispublic(@__MODULE__, :an_exported_name)
 
-# promote an undeclared name to exported
-Base.set_binding_visibility!(@__MODULE__, :no_decl, :exported)
-@test Base.binding_visibility(@__MODULE__, :no_decl) == :exported
+# promote an undeclared name to export
+Base.set_binding_visibility!(@__MODULE__, :no_decl, :export)
+@test Base.isexported(@__MODULE__, :no_decl)
 
 @test_throws ArgumentError Base.set_binding_visibility!(@__MODULE__, :no_decl, :bogus)
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -459,6 +459,40 @@ const a_value = 1
 @test !Base.ispublic(@__MODULE__, :this_is_not_exported)
 end
 
+# binding_visibility / set_binding_visibility!
+module TestBindingVisibility
+using Test
+public a_public_name
+a_public_name() = 1
+export an_exported_name
+an_exported_name() = 2
+no_decl() = 3
+
+@test Base.binding_visibility(@__MODULE__, :an_exported_name) == :exported
+@test Base.binding_visibility(@__MODULE__, :a_public_name) == :public
+@test Base.binding_visibility(@__MODULE__, :no_decl) == :private
+
+# public <-> private round trip
+Base.set_binding_visibility!(@__MODULE__, :a_public_name, :private)
+@test Base.binding_visibility(@__MODULE__, :a_public_name) == :private
+@test !Base.ispublic(@__MODULE__, :a_public_name)
+Base.set_binding_visibility!(@__MODULE__, :a_public_name, :public)
+@test Base.ispublic(@__MODULE__, :a_public_name)
+
+# an exported name is reported public; lowering it to :public clears only the export
+@test Base.ispublic(@__MODULE__, :an_exported_name)
+Base.set_binding_visibility!(@__MODULE__, :an_exported_name, :public)
+@test Base.binding_visibility(@__MODULE__, :an_exported_name) == :public
+@test !Base.isexported(@__MODULE__, :an_exported_name)
+@test Base.ispublic(@__MODULE__, :an_exported_name)
+
+# promote an undeclared name to exported
+Base.set_binding_visibility!(@__MODULE__, :no_decl, :exported)
+@test Base.binding_visibility(@__MODULE__, :no_decl) == :exported
+
+@test_throws ArgumentError Base.set_binding_visibility!(@__MODULE__, :no_decl, :bogus)
+end
+
 # PR 13825
 let ex = :(a + b)
     @test string(ex) == "a + b"


### PR DESCRIPTION
Add `jl_module_set_visibility` and the Base wrapper~s~ `set_binding_visibility!` ~/ `binding_visibility`~, which select a name's declared visibility (`:none`, `:public`, or `:export`) in a module. Unlike the `export` and `public` keywords, the selector can lower the state, retracting a declaration. Setting `:none` on an exported name clears the world-versioned `PARTITION_FLAG_EXPORTED`, so modules that did `using M` stop resolving the name once their world age advances past the call; the public flag is cleared on the binding.

This gives tooling a way to honor an `export` removed from source (timholy/Revise.jl#633).

A couple of comments about the larger picture: the design enforces a 3-state model, meaning it's not possible to be both public and exported. It's worth noting that [`jl_module_public_`](https://github.com/JuliaLang/julia/blob/528757702d170f4a6d56192412d7e4a0d042c2b1/src/module.c#L1501-L1507) (still) looks like a "don't change" check, but after discussion with @Keno at https://github.com/timholy/Revise.jl/pull/1089 I now think this should be interpreted as a slightly-confusing mechanism to enforce the 3-state model. (I can add a comment clarifying that if true and desired.) ~~`binding_visibility` isn't strictly needed, but it felt right to add it. I'd argue that Julia's current `isexported` and `ispublic` functions are, in a sense, less honest about this. But I'm happy to delete `binding_visibility` if it's deemed unnecessary.~~ (deleted)