### PR TITLE
export IOError from Base (#62097)

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -177,6 +177,7 @@ export
     DimensionMismatch,
     EOFError,
     InvalidStateException,
+    IOError,
     KeyError,
     MissingException,
     ProcessFailedException,


### PR DESCRIPTION
`IOError` is used throughout Base (e.g. in `file.jl`, `path.jl`, 
`initdefs.jl`) and is thrown when a command execution fails, but 
it was neither exported nor marked as public.

This adds `IOError` to Base's exports so users can catch it 
directly without needing to write `Base.IOError`.


<img width="817" height="560" alt="Screenshot 2026-06-16 at 4 58 22 PM" src="https://github.com/user-attachments/assets/ffc26cfe-6e1c-41aa-80ca-e9b457ca6f71" />


Closes #62097