### PR TITLE
Stop exporting `SMALL_THRESHOLD` from `Base.Sort`

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -40,8 +40,7 @@ export # not exported by Base
     Algorithm,
     DEFAULT_UNSTABLE,
     DEFAULT_STABLE,
-    SMALL_ALGORITHM,
-    SMALL_THRESHOLD
+    SMALL_ALGORITHM
 
 abstract type Algorithm end
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -12,7 +12,7 @@ using .Main.OffsetArrays
 @testset "Base.Sort docstrings" begin
     undoc = Docs.undocumented_names(Base.Sort)
     @test_broken isempty(undoc)
-    @test undoc == [:Algorithm, :SMALL_THRESHOLD, :Sort]
+    @test undoc == [:Algorithm, :Sort]
 end
 
 @testset "Order" begin


### PR DESCRIPTION
It shouldn't be public as it's a quintessential implementation detail but this export makes it public via `Base.Sort.SMALL_THRESHOLD`.

Noticed when attempting to document it in https://github.com/JuliaLang/julia/pull/62026.