### PR TITLE
compiler: forbid inline allocation for Unions containing Tuple types

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -404,6 +404,8 @@ static unsigned union_isinlinable(jl_value_t *ty, int pointerfree, size_t *nbyte
         return na + nb;
     }
     ty = normalize_typeofbottom_layout_alias(ty);
+    if (pointerfree && jl_is_tuple_type(ty))
+        return 0;
     if (jl_is_datatype(ty) && jl_datatype_isinlinealloc((jl_datatype_t*)ty, pointerfree)) {
         size_t sz = jl_datatype_size(ty);
         size_t al = jl_datatype_align(ty);


### PR DESCRIPTION
When precompiled packages load mutually equivalent types that differ in representation (e.g., Tuple{Union{Missing, Int}} vs Union{Tuple{Missing}, Tuple{Int}}), the compiler and subtyping system treat them as equivalent. However, without this fix, they receive different array memory layouts because the Tuple of Unions uses an opaque pointer array, while the Union of Tuples is optimized into an inline isbits array. This layout mismatch causes runtime crashes when method dispatches mix the representations.

By returning 0 from union_isinlinable when encountering a Tuple type while recursing a Union, we forbid inline allocation for these unions. This guarantees that Union{Tuple...} gracefully falls back to the same pointer-array layout as Tuple{Union...}, thereby ensuring layout compatibility for identical types.

Fixes #62126


When precompiled packages load mutually equivalent types that differ in representation (e.g., `Tuple{Union{Missing, Int}}` vs `Union{Tuple{Missing}, Tuple{Int}}`), the compiler and subtyping system treat them as equivalent. However, without this fix, they receive different array memory layouts because the Tuple of Unions uses an opaque pointer array, while the Union of Tuples is optimized into an inline isbits array. This layout mismatch causes runtime crashes when method dispatches mix the representations.

By returning 0 from `union_isinlinable` when encountering a `Tuple` type while recursing a `Union`, we forbid inline allocation for these unions. This guarantees that `Union{Tuple...}` gracefully falls back to the same pointer-array layout as `Tuple{Union...}`, thereby ensuring layout compatibility for identical types.

Fixes #62126

_This pull request was written with the assistance of generative AI._