### PR TITLE
[JuliaLowering] Clean up `import` desugaring

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -3959,27 +3959,9 @@ end
 #-------------------------------------------------------------------------------
 # Expand import / using / export
 
-function expand_importpath(path)
+function expand_importpath(ctx, path)
     @jl_assert kind(path) == K"importpath" path
-    path_spec = Expr(:.)
-    prev_was_dot = true
-    for component in children(path)
-        k = kind(component)
-        if k == K"quote"
-            # Permit quoted path components as in
-            # import A.(:b).:c
-            component = component[1]
-        end
-        @jl_assert kind(component) in (K"Identifier", K".") component
-        name = component.name_val
-        is_dot = kind(component) == K"."
-        if is_dot && !prev_was_dot
-            throw(LoweringError(component, "invalid import path: `.` in identifier path"))
-        end
-        prev_was_dot = is_dot
-        push!(path_spec.args, Symbol(name))
-    end
-    return path_spec
+    setattr(path, :kind, K".")
 end
 
 function expand_import_or_using(ctx, ex)
@@ -3993,7 +3975,7 @@ function expand_import_or_using(ctx, ex)
         #  (call core.svec  2 "x" "y" "z"  1 "w" "w"))
         @jl_assert numchildren(ex[1]) >= 2 ex
         from = ex[1][1]
-        from_path = @ast ctx from QuoteNode(expand_importpath(from))::K"Value"
+        from_path = @ast ctx from [K"inert" expand_importpath(ctx, from)]
         paths = ex[1][2:end]
     else
         # import A.B
@@ -4009,12 +3991,11 @@ function expand_import_or_using(ctx, ex)
         if kind(spec) == K"as"
             @jl_assert numchildren(spec) == 2 spec
             @jl_assert kind(spec[2]) == K"Identifier" spec
-            as_name = Symbol(spec[2].name_val)
-            path = QuoteNode(Expr(:as, expand_importpath(spec[1]), as_name))
+            path = @ast ctx spec [K"as" expand_importpath(ctx, spec[1]) spec[2]]
         else
-            path = QuoteNode(expand_importpath(spec))
+            path = expand_importpath(ctx, spec)
         end
-        push!(path_specs, @ast ctx spec path::K"Value")
+        push!(path_specs, @ast ctx spec [K"inert" path])
     end
     is_using = kind(ex) == K"using"
     stmts = SyntaxList(ctx)

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -393,7 +393,7 @@ function _to_lowered_expr(ex::SyntaxTree)
     elseif k == K"return"
         Core.ReturnNode(_to_lowered_expr(ex[1]))
     elseif k == K"inert"
-        est_to_expr(ex)
+        est_to_expr(remove_scope_layer!(ex))
     elseif k == K"inert_syntaxtree"
         ex[1]
     elseif k == K"code_info"
@@ -404,9 +404,10 @@ function _to_lowered_expr(ex::SyntaxTree)
             ir
         end
     elseif k == K"Value"
-        # TODO: we still do this in ccall, import
+        # TODO: we still do this in some interpolation, genfunc situations
         # @jl_assert !isa_lowering_ast_node(ex.value) (
-        #     ex, "smuggling AST through Value is asking for trouble; find a SyntaxTree representation")
+        #     ex, string("smuggling AST through Value is asking for trouble; ",
+        #                "find a SyntaxTree representation"))
         ex.value isa LineNumberNode ? QuoteNode(ex.value) : ex.value
     elseif k == K"goto"
         Core.GotoNode(ex[1].id)

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -417,20 +417,20 @@ function vst1_importpath(vcx, st; dots_ok)
         [K"as" [K"." xs...] [K"Identifier"]] -> xs
         [K"as" [K"." xs...] x] -> (ok &= @fail(x, "expected identifier"); xs)
         [K"." xs...] -> xs
+        _ -> return @fail(st, "malformed import path")
     end
     seen_first = false
     for c in path_components
-        if kind(c) === K"."
+        if kind(c) === K"Identifier" && c.name_val::String === "."
             if !dots_ok || seen_first
                 ok &= @fail(c, "unexpected `.` in import path")
             end
             continue
         end
-        ok = ok & vst1_ident(vcx, seen_first && kind(c) === K"quote" ? c[1] : c)
+        ok = ok & vst1_ident(vcx, c)
         seen_first = true
     end
-    return !seen_first ?
-        @fail(st, "expected identifier in `importpath`") : ok
+    return !seen_first ? @fail(st, "expected identifier in `importpath`") : ok
 end
 
 vst1_tuple(vcx, st) = @stm st begin

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -1587,6 +1587,13 @@ end
 
         @test JuliaLowering.include_string(test_mod, raw"""
         begin
+            @generated f_gen_quotenodeexpr() = QuoteNode(Expr(:begin, nothing))
+            f_gen_quotenodeexpr()
+        end
+        """; expr_compat_mode) == Expr(:begin, nothing)
+
+        @test JuliaLowering.include_string(test_mod, raw"""
+        begin
             @generated f_gen_gr_nothing() = GlobalRef(Core, :nothing)
             f_gen_gr_nothing()
         end

--- a/JuliaLowering/test/import.jl
+++ b/JuliaLowering/test/import.jl
@@ -74,3 +74,60 @@ import .H.I, .I.J
 @test test_mod.I === H.I
 @test test_mod.J === H.I.J
 @test test_mod.G_global === "exported from G"
+
+@testset "(AI) from macro expansion" for expr_compat_mode in (true, false)
+    macrocall_mod = Module()
+    JuliaLowering.include_string(macrocall_mod, raw"""
+    module Exporter
+        export val
+        val = [123]
+        other = [456]
+    end
+    macro imp_names()
+        :(import .Exporter: val, other as o)
+    end
+    macro use_target()
+        :(using .Exporter)
+    end
+    """; expr_compat_mode)
+    Core.@latestworld
+    JuliaLowering.include_string(macrocall_mod, "@imp_names"; expr_compat_mode)
+    JuliaLowering.include_string(macrocall_mod, "@use_target"; expr_compat_mode)
+    Core.@latestworld
+    @test macrocall_mod.val === macrocall_mod.Exporter.val
+    @test macrocall_mod.o === macrocall_mod.Exporter.other
+    @test !isdefined(macrocall_mod, :other)  # imported only under the name `o`
+end
+
+@testset "Imported macrocalls" for expr_compat_mode in (true, false)
+    # Test importing macros by their @-name
+    macname_mod = Module()
+    JuliaLowering.include_string(macname_mod, raw"""
+    module Macros
+        macro mac1(); "mac1"; end
+        macro mac2(); "mac2"; end
+        module Inner
+            macro mac3(); "mac3"; end
+            macro mac4(); "mac4"; end
+        end
+    end
+    """; expr_compat_mode)
+    JuliaLowering.include_string(macname_mod, raw"""
+    module UseMacros
+        import ..Macros:
+            @mac1,
+            @mac2 as @mac2_renamed,
+            Inner.@mac3,
+            Inner.@mac4 as @mac4_renamed
+    end
+    """; expr_compat_mode)
+    Core.@latestworld
+    @test JuliaLowering.include_string(macname_mod.UseMacros,
+                                       "@mac1()"; expr_compat_mode) == "mac1"
+    @test JuliaLowering.include_string(macname_mod.UseMacros,
+                                       "@mac2_renamed()"; expr_compat_mode) == "mac2"
+    @test JuliaLowering.include_string(macname_mod.UseMacros,
+                                       "@mac3()"; expr_compat_mode) == "mac3"
+    @test JuliaLowering.include_string(macname_mod.UseMacros,
+                                       "@mac4_renamed()"; expr_compat_mode) == "mac4"
+end

--- a/JuliaLowering/test/import_ir.jl
+++ b/JuliaLowering/test/import_ir.jl
@@ -2,7 +2,7 @@
 # Basic import
 import A: b
 #---------------------
-1   (call JuliaLowering.eval_import true TestMod :($(QuoteNode(:($(Expr(:., :A)))))) :($(QuoteNode(:($(Expr(:., :b)))))))
+1   (call JuliaLowering.eval_import true TestMod (inert (. A)) (inert (. b)))
 2   latestworld
 3   (return core.nothing)
 
@@ -10,7 +10,15 @@ import A: b
 # Import with paths and `as`
 import A.B.C: b, c.d as e
 #---------------------
-1   (call JuliaLowering.eval_import true TestMod :($(QuoteNode(:($(Expr(:., :A, :B, :C)))))) :($(QuoteNode(:($(Expr(:., :b)))))) :($(QuoteNode(:(c.d as e)))))
+1   (call JuliaLowering.eval_import true TestMod (inert (. A B C)) (inert (. b)) (inert (as (. c d) e)))
+2   latestworld
+3   (return core.nothing)
+
+########################################
+# Import macrocall
+import A: B.@mac as @mac2
+#---------------------
+1   (call JuliaLowering.eval_import true TestMod (inert (. A)) (inert (as (. B @mac) @mac2)))
 2   latestworld
 3   (return core.nothing)
 
@@ -18,9 +26,9 @@ import A.B.C: b, c.d as e
 # Imports without `from` module need separating with latestworld
 import A, B
 #---------------------
-1   (call JuliaLowering.eval_import true TestMod core.nothing :($(QuoteNode(:($(Expr(:., :A)))))))
+1   (call JuliaLowering.eval_import true TestMod core.nothing (inert (. A)))
 2   latestworld
-3   (call JuliaLowering.eval_import true TestMod core.nothing :($(QuoteNode(:($(Expr(:., :B)))))))
+3   (call JuliaLowering.eval_import true TestMod core.nothing (inert (. B)))
 4   latestworld
 5   (return core.nothing)
 
@@ -28,9 +36,9 @@ import A, B
 # Multiple usings need separating with latestworld
 using A, B
 #---------------------
-1   (call JuliaLowering.eval_using TestMod :($(QuoteNode(:($(Expr(:., :A)))))))
+1   (call JuliaLowering.eval_using TestMod (inert (. A)))
 2   latestworld
-3   (call JuliaLowering.eval_using TestMod :($(QuoteNode(:($(Expr(:., :B)))))))
+3   (call JuliaLowering.eval_using TestMod (inert (. B)))
 4   latestworld
 5   (return core.nothing)
 
@@ -38,7 +46,7 @@ using A, B
 # Using with paths and `as`
 using A.B.C: b, c.d as e
 #---------------------
-1   (call JuliaLowering.eval_import false TestMod :($(QuoteNode(:($(Expr(:., :A, :B, :C)))))) :($(QuoteNode(:($(Expr(:., :b)))))) :($(QuoteNode(:(c.d as e)))))
+1   (call JuliaLowering.eval_import false TestMod (inert (. A B C)) (inert (. b)) (inert (as (. c d) e)))
 2   latestworld
 3   (return core.nothing)
 

--- a/JuliaLowering/test/validation.jl
+++ b/JuliaLowering/test/validation.jl
@@ -166,3 +166,18 @@ end
     ]
     @test vst1_ok(e)
 end
+
+@testset "import/using path" begin
+    # `.` after identifier
+    @test !vst1_ok(Expr(:import, Expr(:., :A, :., :B)))
+    # leading `.` on a name
+    @test !vst1_ok(Expr(:import, Expr(:(:), Expr(:., :M), Expr(:., :., :a))))
+    # non-identifier rename
+    @test !vst1_ok(Expr(:import, Expr(:(:), Expr(:., :M),
+                                      Expr(:as, Expr(:., :a), Expr(:call, :f)))))
+    # empty path
+    @test !vst1_ok(Expr(:import, Expr(:.)))
+    # not an import path
+    @test !vst1_ok(Expr(:import, Expr(:call, :f)))
+    @test !vst1_ok(Expr(:import, 42))
+end


### PR DESCRIPTION
Cleans some dead code after the EST change (we no longer need to handle quoted
     stuff in the importpath).  More importantly, use the `K"inert"`
     representation instead of an Expr in `K"Value"`; I'd like to disallow
     Expr-AST in `K"Value"` entirely (it's best not to allow two representations
     of the same thing), but there are a couple remaining
     generated-function-interpolation cases I haven't touched in this change.

Also expands test coverage (tests partially Clauded)