### PR TITLE
GC: Fix rooting of `iparams` in `inst_datatype_inner`

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2403,6 +2403,17 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
         }
     }
 
+    if (p == NULL) {
+        // slots in iparams are untracked by the GC static analyzer so it won't
+        // complain, but this is used as rooting storage for normalized types
+        // below so it must be rooted properly by the GC
+        p = jl_alloc_svec_uninit(ntp);
+        for (size_t i = 0; i < ntp; i++)
+            jl_svecset(p, i, iparams[i]);
+        iparams = jl_svec_data(p);
+    }
+    assert(jl_is_svec(p) && iparams == jl_svec_data(p));
+
     // try to simplify some type parameters
     if (check && tn != jl_type_typename) {
         int changed = 0;
@@ -2413,10 +2424,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
             jl_value_t *pi = iparams[i];
             jl_value_t *newp = normalize_unionalls(pi);
             if (newp != pi) {
-                if (p)
-                    jl_gc_write(p, iparams[i], newp);
-                else
-                    iparams[i] = newp;
+                jl_gc_write(p, iparams[i], newp);
                 changed = 1;
             }
             if (istuple && cacheable && !jl_is_concrete_type(newp))
@@ -2451,20 +2459,9 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
             if (cacheable || !jl_has_free_typevars(pi)) {
                 pi = jl_as_global_root(pi, cacheable);
                 if (pi != NULL) {
-                    if (p)
-                        jl_gc_write(p, iparams[i], pi);
-                    else
-                        iparams[i] = pi;
+                    jl_gc_write(p, iparams[i], pi);
                 }
             }
-        }
-    }
-
-    // move array of instantiated parameters to heap; we need to keep it
-    if (p == NULL) {
-        p = jl_alloc_svec_uninit(ntp);
-        for (size_t i = 0; i < ntp; i++) {
-            jl_svecset(p, i, iparams[i]);
         }
     }
 


### PR DESCRIPTION
This  `jl_value_t **` array is treated as an untracked region by our static analyzer, so it is possible to copy an unrooted value into it and then extract it later without the analyzer stopping you.

This function has the contract that if `p != NULL`, then `iparams == jl_svec_data(p)` and iparams is rooting storage, but otherwise iparams is not rooting. This causes us to lose track of e.g. newly-allocated normalized types from `normalize_unionall` which are stored only in `iparams`, eventually leading to GC corruption.

Bug introduced in 3c2c5ce2ad5.
(likely exposed somewhat by 26145852c4, which tweaked when type normalization allocates)

Diagnosed with heavy assistance from Claude 🤖. Resolves https://github.com/JuliaLang/julia/issues/62140.