### PR TITLE
NEWS: document @doc return value change in 1.13 (#61877)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,10 @@ New language features
 
 Language changes
 ----------------
+* The return value of `@doc` has changed: it now returns the documented
+  expression (e.g. a function or type) instead of a `Docs.Binding` object
+  as in previous versions. Code that depended on `@doc` returning a
+  `Docs.Binding` will need to be updated ([#59882], [#60681]).
 
 Compiler/Runtime improvements
 -----------------------------


### PR DESCRIPTION
Documents the breaking change to `@doc` return value introduced in 
Julia 1.13 via #59882, as requested in #61877.

In Julia 1.12 and earlier, `@doc` returned a `Docs.Binding` object.
In Julia 1.13, `@doc` now returns the documented expression (e.g. a 
function or type) instead. This change was intentional but was missing 
from the NEWS.md changelog.

<img width="1396" height="761" alt="Screenshot 2026-06-17 at 10 15 59 AM" src="https://github.com/user-attachments/assets/224df079-179d-4f5e-8945-0019f76f0f9b" />


Closes #61877