### PR TITLE
HISTORY: document @doc return value change in 1.13 (#61877)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@ New language features
 Language changes
 ----------------
 
+* The return value of `@doc` has changed: it now returns the documented expression (e.g. a function or type) instead of a `Docs.Binding` object as in previous versions. Code that depended on `@doc` returning a `Docs.Binding` will need to be updated ([#59882], [#60681]).
 * The `hash` algorithm and its values have changed for certain types, most notably `AbstractString`. Any `hash` specializations for equal types to those that changed, such as some third-party string packages, may need to be deleted ([#57509], [#59691]).
 * The `hash(::AbstractString)` function is now a zero-copy / zero-cost function, based upon providing a correct implementation of the `codeunit` and `iterate` functions. Third-party string packages should migrate to the new algorithm by deleting their existing overrides of the `hash` function ([#59691]).
 
@@ -151,7 +152,9 @@ Deprecated or removed
 [#59691]: https://github.com/JuliaLang/julia/issues/59691
 [#59775]: https://github.com/JuliaLang/julia/issues/59775
 [#59825]: https://github.com/JuliaLang/julia/issues/59825
+[#59882]: https://github.com/JuliaLang/julia/issues/59882
 [#60025]: https://github.com/JuliaLang/julia/issues/60025
+[#60681]: https://github.com/JuliaLang/julia/issues/60681
 
 
 Julia v1.12 Release Notes


### PR DESCRIPTION
Documents the breaking change to `@doc`'s return value that was introduced in Julia 1.13 via #59882, as requested in #61877.

In Julia 1.12 and earlier, `@doc` returned a `Docs.Binding` object. In Julia 1.13, `@doc` instead returns the documented expression itself (e.g. a function or type). This change was intentional but was missing from the changelog.

Since 1.13 has already been released, this documents the change in `HISTORY.md` rather than `NEWS.md`. A companion PR (#<PR_NUMBER>) adds the equivalent entry to `NEWS.md` on the `backports-release-1.13` branch.

Closes #61877