### PR TITLE
WIP: syntax evolution: Allow full parser replacement

### DIFF
--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -356,7 +356,7 @@ end
 vst1_toplevel_only(vcx, st) = @stm st begin
     # body will be validated when lowered
     [K"module" [K"Value"] [K"Value"] [K"Identifier"] [K"block" xs...]] ->
-        !(st[1].value isa VersionNumber) ? @fail(st[1], "expected version") :
+        !(st[1].value isa GlobalRef) ? @fail(st[1], "expected parser ref") :
         !(st[2].value isa Bool) ? @fail(st[2], "expected boolean bare flag") :
         pass()
     [K"module" [K"Value"] [K"Identifier"] [K"block" xs...]] ->

--- a/JuliaSyntax/src/integration/expr.jl
+++ b/JuliaSyntax/src/integration/expr.jl
@@ -221,6 +221,38 @@ function version_to_expr(node)
     return VersionNumber(1, nv ÷ 10, nv % 10)
 end
 
+function parser_ref_for_version(ver::VersionNumber)
+    ver <= v"1.13" && return GlobalRef(@__MODULE__, :core_parser_hook_1_13)
+    return GlobalRef(@__MODULE__, Symbol(:core_parser_hook_, ver.major, :_, ver.minor))
+end
+
+parser_ref_for_version(ver::Tuple{Int,Int}) =
+    parser_ref_for_version(VersionNumber(ver[1], ver[2]))
+
+function replace_module_versions!(@nospecialize(ex), parser_ref::GlobalRef)
+    if ex isa Expr
+        if ex.head === :module && !isempty(ex.args) && ex.args[1] isa VersionNumber
+            ex.args[1] = parser_ref
+        end
+        for arg in ex.args
+            replace_module_versions!(arg, parser_ref)
+        end
+    end
+    return ex
+end
+
+function replace_module_versions!(@nospecialize(ex))
+    if ex isa Expr
+        if ex.head === :module && !isempty(ex.args) && ex.args[1] isa VersionNumber
+            ex.args[1] = parser_ref_for_version(ex.args[1])
+        end
+        for arg in ex.args
+            replace_module_versions!(arg)
+        end
+    end
+    return ex
+end
+
 _expr_leaf_val(node::SyntaxNode, _...) = node.val
 _expr_leaf_val(cursor::RedTreeCursor, txtbuf::Vector{UInt8}, txtbuf_offset::UInt32) =
     parse_julia_literal(txtbuf, head(cursor), byte_range(cursor) .+ txtbuf_offset)
@@ -680,13 +712,15 @@ end
 
 function build_tree(::Type{Expr}, stream::ParseStream;
                     filename=nothing, first_line=1,
+                    module_parser=parser_ref_for_version(stream.version),
                     # unused, but required since `_parse` is written generic
                     keep_parens=false)
     source = SourceFile(stream, filename=filename, first_line=first_line)
-    return build_tree(Expr, stream, source)
+    return build_tree(Expr, stream, source; module_parser)
 end
 
-function build_tree(::Type{Expr}, stream::ParseStream, source::SourceFile)
+function build_tree(::Type{Expr}, stream::ParseStream, source::SourceFile;
+                    module_parser=parser_ref_for_version(stream.version))
     txtbuf = unsafe_textbuf(stream)
     cursor = RedTreeCursor(stream)
     wrapper_head = SyntaxHead(K"wrapper",EMPTY_FLAGS)
@@ -704,16 +738,17 @@ function build_tree(::Type{Expr}, stream::ParseStream, source::SourceFile)
             RedTreeCursor, wrapper_head,
             node_to_expr(cursor, source, txtbuf), false)
     end
-    return entry
+    return replace_module_versions!(entry, module_parser)
 end
 
 function to_expr(node)
     source = sourcefile(node)
     txtbuf_offset, txtbuf = _unsafe_wrap_substring(sourcetext(source))
     wrapper_head = SyntaxHead(K"wrapper",EMPTY_FLAGS)
-    return fixup_Expr_child(
+    ex = fixup_Expr_child(
         typeof(node), wrapper_head,
         node_to_expr(node, source, txtbuf, UInt32(txtbuf_offset)), false)
+    return replace_module_versions!(ex)
 end
 
 Base.Expr(node::SyntaxNode) = to_expr(node)

--- a/JuliaSyntax/src/integration/hooks.jl
+++ b/JuliaSyntax/src/integration/hooks.jl
@@ -161,7 +161,9 @@ end
 # Debug log file for dumping parsed code
 const _debug_log = Ref{Union{Nothing,IO}}(nothing)
 
-function core_parser_hook(code, filename::String, lineno::Int, offset::Int, options::Symbol; syntax_version = v"1.13")
+function core_parser_hook(code, filename::String, lineno::Int, offset::Int, options::Symbol;
+                          syntax_version = v"1.13",
+                          module_parser = parser_ref_for_version(syntax_version))
     try
         # TODO: Check that we do all this input wrangling without copying the
         # code buffer
@@ -237,7 +239,7 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
                 # * includes the last line number
                 # * appends the error message
                 source = SourceFile(stream, filename=filename, first_line=lineno)
-                topex = build_tree(Expr, stream, source)
+                topex = build_tree(Expr, stream, source; module_parser)
                 @assert topex.head == :toplevel
                 i = findfirst(_has_nested_error, topex.args)
                 if i > 1 && topex.args[i-1] isa LineNumberNode
@@ -258,7 +260,7 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
             #
             # show_diagnostics(stdout, stream.diagnostics, code)
             #
-            ex = build_tree(Expr, stream; filename=filename, first_line=lineno)
+            ex = build_tree(Expr, stream; filename=filename, first_line=lineno, module_parser)
         end
 
         # Note the next byte in 1-based indexing is `last_byte(stream) + 1` but
@@ -295,6 +297,16 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
 
         _fl_parse_hook(code, filename, lineno, offset, options)
     end
+end
+
+function core_parser_hook_1_13(code, filename::String, lineno::Int, offset::Int, options::Symbol)
+    core_parser_hook(code, filename, lineno, offset, options;
+        syntax_version=v"1.13", module_parser=GlobalRef(@__MODULE__, :core_parser_hook_1_13))
+end
+
+function core_parser_hook_1_14(code, filename::String, lineno::Int, offset::Int, options::Symbol)
+    core_parser_hook(code, filename, lineno, offset, options;
+        syntax_version=v"1.14", module_parser=GlobalRef(@__MODULE__, :core_parser_hook_1_14))
 end
 
 # Core._parse gained a `lineno` argument in

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -1597,8 +1597,12 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
         end
         ret_k = K"="
     elseif k === K"module"
+        has_parser_ref = kind(cs[1]) === K"VERSION"
+        if has_parser_ref
+            cs[1] = valleaf(parser_ref_for_version(version_to_expr(cs[1])))
+        end
         not_bare = valleaf(!has_flags(st, BARE_MODULE_FLAG))
-        insert!(cs, kind(cs[1]) === K"VERSION" ? 2 : 1, not_bare)
+        insert!(cs, has_parser_ref ? 2 : 1, not_bare)
     elseif k === K"quote" && n_cs === 1
         # (quote something_simple) => (inert something_simple)
         ret_c = _green_to_est(st, 1, cs[1])

--- a/JuliaSyntax/test/expr.jl
+++ b/JuliaSyntax/test/expr.jl
@@ -819,7 +819,7 @@
         @test parsestmt("module A end"; version=v"1.13") ==
             Expr(:module, true,  :A, Expr(:block, LineNumberNode(1), LineNumberNode(1)))
         @test parsestmt("module A end"; version=v"1.14") ==
-            Expr(:module, v"1.14", true,  :A, Expr(:block, LineNumberNode(1), LineNumberNode(1)))
+            Expr(:module, GlobalRef(JuliaSyntax, :core_parser_hook_1_14), true,  :A, Expr(:block, LineNumberNode(1), LineNumberNode(1)))
         @test parsestmt("baremodule A end"; version=v"1.13") ==
             Expr(:module, false, :A, Expr(:block, LineNumberNode(1), LineNumberNode(1)))
     end

--- a/JuliaSyntax/test/test_utils.jl
+++ b/JuliaSyntax/test/test_utils.jl
@@ -66,9 +66,9 @@ function remove_macro_linenums!(ex)
 end
 
 function remove_module_versions!(ex)
-    # In v1.14+, JuliaSyntax adds a version as the first argument to module expressions.
+    # In v1.14+, JuliaSyntax adds a parser ref as the first argument to module expressions.
     # Remove it for comparison with flisp output.
-    if Meta.isexpr(ex, :module) && length(ex.args) >= 1 && ex.args[1] isa VersionNumber
+    if Meta.isexpr(ex, :module) && length(ex.args) >= 1 && ex.args[1] isa GlobalRef
         deleteat!(ex.args, 1)
     end
     if ex isa Expr
@@ -187,9 +187,9 @@ function exprs_roughly_equal(fl_ex, ex)
         # The flisp parser adds an extra block around `w` in the following case
         # f(::g(z) = w) = 1
         fl_args[2] = fl_args[2].args[2]
-    elseif h == :module && length(args) == length(fl_args) + 1 && args[1] isa VersionNumber
-        # In v1.14+, JuliaSyntax adds a version as the first argument to module expressions.
-        # Skip the version when comparing.
+    elseif h == :module && length(args) == length(fl_args) + 1 && args[1] isa GlobalRef
+        # In v1.14+, JuliaSyntax adds a parser ref as the first argument to module expressions.
+        # Skip the parser ref when comparing.
         args = args[2:end]
     end
     if length(fl_args) != length(args)

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ New language features
   - It is now possible to control which version of the Julia syntax will be used to parse a package by setting the
     `compat.julia` or `syntax.julia_version` key in Project.toml. This feature is similar to the notion of "editions"
     in other language ecosystems and will allow non-breaking evolution of Julia syntax in future versions.
+    The parser implementation can also be selected with `syntax.version`, naming a parser package from `[deps]`.
     See the "Syntax Versioning" section in the code loading documentation ([#60018]).
   - `ᵅ` (U+U+1D45), `ᵋ` (U+1D4B), `ᶲ` (U+1DB2), `˱` (U+02F1), `˲` (U+02F2), and `ₔ` (U+2094) can now also be used as
     operator suffixes, accessible as `\^alpha`, `\^epsilon`, `\^ltphi`, `\_<`, `\_>`, and `\_schwa` at the REPL

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -1287,7 +1287,7 @@ include(Core, "optimized_generics.jl")
 # Used only by the magic @VERSION macro
 struct MacroSource
     lno::Any # ::LineNumberNode, but needs to be a pointer
-    syntax_ver::Any # ::VersionNumber =#
+    syntax_ver::Any
     MacroSource(@nospecialize(lno), @nospecialize(syntax_ver)) = new(lno, syntax_ver)
 end
 

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -767,9 +767,13 @@ function (vp::VersionedLower)(@nospecialize(code), mod::Module,
 end
 
 function Base.set_syntax_version(m::Module, ver::VersionNumber)
-    parser = Base.VersionedParse(ver)
-    Core.declare_const(m, Symbol("#_internal_julia_parse"), parser)
-    #lowerer = VersionedLower(ver)
+    Base.set_syntax_version(m, Base.syntax_parser_ref(ver))
+    nothing
+end
+
+function Base.set_syntax_version(m::Module, parser_ref::GlobalRef)
+    Core.declare_const(m, Symbol("#_internal_julia_parse"), Base.VersionedParse(parser_ref))
+    #lowerer = ...
     #Core.declare_const(m, :_internal_julia_lower, lowerer)
     nothing
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -262,7 +262,11 @@ and wherefrom to load a julia package.
 struct PkgLoadSpec
     path::String
     julia_syntax_version::VersionNumber
+    syntax_parser::Union{Nothing,PkgId}
 end
+
+PkgLoadSpec(path::String, julia_syntax_version::VersionNumber) =
+    PkgLoadSpec(path, julia_syntax_version, nothing)
 
 struct LoadingCache
     load_path::Vector{String}
@@ -920,7 +924,8 @@ function project_file_ext_load_spec(project_file::String, ext::PkgId)
     if exts !== nothing
         if ext.name in keys(exts) && ext.uuid == uuid5(UUID(d["uuid"]::String), ext.name)
             # Syntax version of the main package applies to its extensions
-            return PkgLoadSpec(find_ext_path(p, ext.name), project_get_syntax_version(d))
+            sv, parser = project_get_syntax_spec(d, project_file)
+            return PkgLoadSpec(find_ext_path(p, ext.name), sv, parser)
         end
     end
     return nothing
@@ -936,13 +941,41 @@ function project_file_name_uuid(project_file::String, name::String)::PkgId
 end
 
 const NON_VERSIONED_SYNTAX = v"1.13"
+const SYNTAX_PARSER_ENTRYPOINT = :core_parser_hook
+
+function syntax_parser_dep_get(deps::Union{Dict{String, Any}, Nothing}, name::String,
+                               where::AbstractString)::PkgId
+    deps === nothing && error("syntax.version = $(repr(name)) in $where requires $(repr(name)) to be listed in [deps]")
+    uuid = get(deps, name, nothing)::Union{String, Nothing}
+    uuid === nothing && error("syntax.version = $(repr(name)) in $where requires $(repr(name)) to be listed in [deps]")
+    return PkgId(UUID(uuid), name)
+end
+
+function manifest_syntax_parser_dep_get(manifest_file::String,
+                                        deps::Union{Vector{String}, Dict{String, Any}, Nothing},
+                                        name::String)::PkgId
+    dep = dep_stanza_get(deps, name)
+    dep === nothing && error("syntax.version = $(repr(name)) in $manifest_file requires $(repr(name)) to be listed in deps")
+    dep.uuid !== nothing && return dep
+
+    all_deps = get_deps(parsed_toml(manifest_file))
+    entries = get(all_deps, name, nothing)::Union{Nothing, Vector{Any}}
+    if entries === nothing || length(entries) != 1
+        error("expected a single entry for syntax.version dependency $(repr(name)) in $(repr(manifest_file))")
+    end
+    entry = first(entries::Vector{Any})::Dict{String, Any}
+    uuid = get(entry, "uuid", nothing)::Union{String, Nothing}
+    uuid === nothing && return dep
+    return PkgId(UUID(uuid), name)
+end
 
 function project_get_syntax_version(d::Dict)
     # Syntax Evolution. First check syntax.julia_version entry
     sv = nothing
     ds = get(d, "syntax", nothing)
     if ds !== nothing
-        sv = VersionNumber(get(ds, "julia_version", nothing))
+        jv = get(ds, "julia_version", nothing)
+        jv !== nothing && (sv = VersionNumber(jv))
     end
     # If not found, default to minimum(compat["julia"])
     if sv === nothing
@@ -967,6 +1000,19 @@ function project_get_syntax_version(d::Dict)
     return sv
 end
 
+function project_get_syntax_parser(d::Dict, where::AbstractString)::Union{Nothing,PkgId}
+    ds = get(d, "syntax", nothing)
+    ds === nothing && return nothing
+    parser_name = get(ds, "version", nothing)::Union{String, Nothing}
+    parser_name === nothing && return nothing
+    return syntax_parser_dep_get(get(d, "deps", nothing)::Union{Dict{String, Any}, Nothing},
+                                 parser_name, where)
+end
+
+function project_get_syntax_spec(d::Dict, where::AbstractString)
+    return (project_get_syntax_version(d), project_get_syntax_parser(d, where))
+end
+
 function project_file_load_spec(project_file::String, name::String)
     d = parsed_toml(project_file)
     entryfile = get(d, "path", nothing)::Union{String, Nothing}
@@ -974,8 +1020,8 @@ function project_file_load_spec(project_file::String, name::String)
     if entryfile === nothing
         entryfile = get(d, "entryfile", nothing)::Union{String, Nothing}
     end
-    sv = project_get_syntax_version(d)
-    return PkgLoadSpec(entry_path(dirname(project_file), name, entryfile), sv)
+    sv, parser = project_get_syntax_spec(d, project_file)
+    return PkgLoadSpec(entry_path(dirname(project_file), name, entryfile), sv, parser)
 end
 
 function workspace_manifest(project_file)
@@ -987,30 +1033,78 @@ function workspace_manifest(project_file)
 end
 
 struct VersionedParse
-    ver::VersionNumber
+    parser_ref::GlobalRef
+end
+
+VersionedParse(ver::VersionNumber) = VersionedParse(syntax_parser_ref(ver))
+
+function syntax_parser_ref(ver::VersionNumber)
+    if !isdefined(Base, :JuliaSyntax)
+        ver === VERSION && return GlobalRef(Core, :_parse)
+        error("JuliaSyntax module is required for syntax version $ver, but it is not loaded.")
+    end
+    return Base.JuliaSyntax.parser_ref_for_version(ver)
+end
+
+function parser_from_ref(parser_ref::GlobalRef)
+    isdefined(parser_ref.mod, parser_ref.name) ||
+        error("syntax parser entry point $(parser_ref.name) is not defined in $(parser_ref.mod)")
+    return getglobal(parser_ref.mod, parser_ref.name)
 end
 
 function (vp::VersionedParse)(code, filename::String, lineno::Int, offset::Int, options::Symbol)
-    if !isdefined(Base, :JuliaSyntax)
-        if vp.ver === VERSION
-            return Core._parse
+    return invokelatest(parser_from_ref(vp.parser_ref), code, filename, lineno, offset, options)
+end
+
+function syntax_parser_ref(syntax_version::VersionNumber, parser_pkg::Nothing,
+                           env::Union{String, Nothing}=nothing)
+    return syntax_parser_ref(syntax_version)
+end
+
+function syntax_parser_ref(syntax_version::VersionNumber, parser_pkg::PkgId,
+                           env::Union{String, Nothing}=nothing)
+    parser_mod = _require_prelocked(parser_pkg, env)
+    parser_ref = GlobalRef(parser_mod, SYNTAX_PARSER_ENTRYPOINT)
+    parser_from_ref(parser_ref)
+    return parser_ref
+end
+
+function syntax_parser_ref(spec::PkgLoadSpec, env::Union{String, Nothing}=nothing)
+    return syntax_parser_ref(spec.julia_syntax_version, spec.syntax_parser, env)
+end
+
+function syntax_parser(syntax_version::VersionNumber, parser_pkg::Union{Nothing,PkgId},
+                       env::Union{String, Nothing}=nothing)
+    return VersionedParse(syntax_parser_ref(syntax_version, parser_pkg, env))
+end
+
+syntax_parser(spec::PkgLoadSpec, env::Union{String, Nothing}=nothing) =
+    syntax_parser(spec.julia_syntax_version, spec.syntax_parser, env)
+
+function active_project_syntax_spec()
+    project = active_project()
+    sv = VERSION
+    parser = nothing
+    if project !== nothing && isfile(project)
+        d = try
+            parsed_toml(project)
+        catch e
+            @warn "Failed to read project $project - defaulting to latest syntax. err=$e"
+            nothing
         end
-        error("JuliaSyntax module is required for syntax version $(vp.ver), but it is not loaded.")
+        if d !== nothing
+            sv, parser = project_get_syntax_spec(d, project)
+        end
     end
-    Base.JuliaSyntax.core_parser_hook(code, filename, lineno, offset, options; syntax_version=vp.ver)
+    return sv, parser
 end
 
 function parser_for_active_project()
-    project = active_project()
-    sv = VERSION
-    if project !== nothing && isfile(project)
-        try
-            sv = project_get_syntax_version(parsed_toml(project))
-        catch e
-            @warn "Failed to read project $project - defaulting to latest syntax. err=$e"
-        end
+    sv, parser_pkg = active_project_syntax_spec()
+    parser_ref = @lock require_lock begin
+        syntax_parser_ref(sv, parser_pkg, nothing)
     end
-    VersionedParse(sv)
+    return VersionedParse(parser_ref)
 end
 
 # find project file's corresponding manifest file
@@ -1263,7 +1357,9 @@ function explicit_manifest_uuid_load_spec(project_file::String, pkg::PkgId)::Uni
                 end
                 parent_path = parent_load_spec.path
                 p = normpath(dirname(parent_path), "..")
-                return PkgLoadSpec(find_ext_path(p, pkg.name), parent_load_spec.julia_syntax_version)
+                return PkgLoadSpec(find_ext_path(p, pkg.name),
+                                   parent_load_spec.julia_syntax_version,
+                                   parent_load_spec.syntax_parser)
             end
         end
     end
@@ -1278,11 +1374,21 @@ function explicit_manifest_entry_load_spec(manifest_file::String, pkg::PkgId, en
     # even if absent from the project file.
     syntax_version = NON_VERSIONED_SYNTAX
     syntax_table = get(entry, "syntax", nothing)
+    syntax_parser = nothing
     if syntax_table !== nothing
-        syntax_version = VersionNumber(get(syntax_table, "julia_version", nothing))
-        # Clamp to minimum supported syntax version
-        if syntax_version <= NON_VERSIONED_SYNTAX
-            syntax_version = NON_VERSIONED_SYNTAX
+        jv = get(syntax_table, "julia_version", nothing)
+        if jv !== nothing
+            syntax_version = VersionNumber(jv)
+            # Clamp to minimum supported syntax version
+            if syntax_version <= NON_VERSIONED_SYNTAX
+                syntax_version = NON_VERSIONED_SYNTAX
+            end
+        end
+        parser_name = get(syntax_table, "version", nothing)::Union{String, Nothing}
+        if parser_name !== nothing
+            syntax_parser = manifest_syntax_parser_dep_get(manifest_file,
+                get(entry, "deps", nothing)::Union{Vector{String}, Dict{String, Any}, Nothing},
+                parser_name)
         end
     end
 
@@ -1291,7 +1397,7 @@ function explicit_manifest_entry_load_spec(manifest_file::String, pkg::PkgId, en
     entryfile = get(entry, "entryfile", nothing)::Union{Nothing, String}
     if path !== nothing
         path = entry_path(normpath(abspath(dirname(manifest_file), path)), pkg.name, entryfile)
-        return PkgLoadSpec(path, syntax_version)
+        return PkgLoadSpec(path, syntax_version, syntax_parser)
     end
     hash = get(entry, "git-tree-sha1", nothing)::Union{Nothing, String}
     if hash === nothing
@@ -1310,7 +1416,8 @@ function explicit_manifest_entry_load_spec(manifest_file::String, pkg::PkgId, en
     for slug in (version_slug(uuid, hash), version_slug(uuid, hash, 4))
         for depot in DEPOT_PATH
             path = joinpath(depot, "packages", pkg.name, slug)
-            ispath(path) && return PkgLoadSpec(entry_path(abspath(path), pkg.name, entryfile), syntax_version)
+            ispath(path) && return PkgLoadSpec(entry_path(abspath(path), pkg.name, entryfile),
+                                               syntax_version, syntax_parser)
         end
     end
     # no depot contains the package, return missing to stop looking
@@ -1351,7 +1458,8 @@ function implicit_manifest_uuid_load_spec(dir::String, pkg::PkgId)::Union{Nothin
     end
     proj = project_file_name_uuid(project_file, pkg.name)
     proj == pkg || return nothing
-    return PkgLoadSpec(path, project_get_syntax_version(parsed_toml(project_file)))
+    sv, parser = project_get_syntax_spec(parsed_toml(project_file), project_file)
+    return PkgLoadSpec(path, sv, parser)
 end
 
 ## other code loading functionality ##
@@ -2938,7 +3046,7 @@ function __require_prelocked(pkg::PkgId, env)
     if uuid !== old_uuid
         ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), __toplevel__, uuid)
     end
-    __toplevel__.var"#_internal_julia_parse" = VersionedParse(spec.julia_syntax_version)
+    __toplevel__.var"#_internal_julia_parse" = syntax_parser(spec, env)
     unlock(require_lock)
     try
         include(__toplevel__, path)
@@ -3258,7 +3366,8 @@ end
 const newly_inferred = []
 
 # this is called in the external process that generates precompiled package files
-function include_package_for_output(pkg::PkgId, input::String, syntax_version::VersionNumber, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String},
+function include_package_for_output(pkg::PkgId, input::String, syntax_version::VersionNumber, syntax_parser_pkg::Union{Nothing,PkgId},
+                                    depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String},
                                     concrete_deps::typeof(_concrete_dependencies), source::Union{Nothing,String})
 
     @lock require_lock begin
@@ -3290,9 +3399,11 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
     keep_ir = JLOptions().outputo != C_NULL
     keep_ir && ccall(:jl_set_precompile_keep_ir, Cvoid, (Int8,), 1)
     # This one changes the parser behavior
-    __toplevel__.var"#_internal_julia_parse" = VersionedParse(syntax_version)
+    __toplevel__.var"#_internal_julia_parse" = @lock require_lock begin
+        syntax_parser(syntax_version, syntax_parser_pkg, nothing)
+    end
     # This one is the compatibility marker for cache loading
-    __toplevel__._internal_syntax_version = cache_syntax_version(syntax_version)
+    __toplevel__._internal_syntax_version = cache_syntax_version(syntax_version, syntax_parser_pkg)
     cumulative_compile_timing(true)
     _precompile_dep_load_ns[] = 0
     _precompile_dep_load_depth[] = 0
@@ -3418,7 +3529,7 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
         Base.track_nested_precomp($(_pkg_str(vcat(Base.precompilation_stack, pkg))))
         Base.loadable_extensions = $(_pkg_str(loadable_exts))
         Base.precompiling_extension = $(loading_extension)
-        Base.include_package_for_output($(_pkg_str(pkg)), $(repr(abspath(input.path))), $(repr(input.julia_syntax_version)), $(repr(depot_path)), $(repr(dl_load_path)),
+        Base.include_package_for_output($(_pkg_str(pkg)), $(repr(abspath(input.path))), $(repr(input.julia_syntax_version)), $(_pkg_str(input.syntax_parser)), $(repr(depot_path)), $(repr(dl_load_path)),
             $(repr(load_path)), $(_pkg_str(concrete_deps)), $(repr(source_path(nothing))))
         """)
     close(io.in)
@@ -4288,9 +4399,10 @@ function any_includes_stale(includes::Vector{CacheHeaderIncludes}, cachefile::St
     return false
 end
 
-function cache_syntax_version(ver::VersionNumber)
-    UInt8(clamp(ver.minor - 13, 0, 255))
-end
+cache_syntax_version(ver::VersionNumber) = cache_syntax_version(ver, nothing)
+cache_syntax_version(ver::VersionNumber, parser_pkg::Nothing) =
+    UInt8(clamp(ver.minor - 13, 0, 254))
+cache_syntax_version(ver::VersionNumber, parser_pkg::PkgId) = UInt8(255)
 
 # This custom equality predicate is analogous to `===`, except that it also
 # compares mutable containers structurally. This allows us to differentiate
@@ -4379,9 +4491,15 @@ end
             record_reason(reasons, "different compilation options")
             return true
         end
-        if stalecheck && syntax_version != cache_syntax_version(modspec.julia_syntax_version)
+        if stalecheck && syntax_version != cache_syntax_version(modspec.julia_syntax_version, modspec.syntax_parser)
             @debug "Rejecting cache file $cachefile for $modkey since it was parsed for a different Julia syntax version"
             record_reason(reasons, "different Julia syntax version")
+            return true
+        end
+        if stalecheck && modspec.syntax_parser !== nothing &&
+                !any(req -> req[1] == modspec.syntax_parser, required_modules)
+            @debug "Rejecting cache file $cachefile for $modkey since it was parsed with a different syntax parser"
+            record_reason(reasons, "different Julia syntax parser")
             return true
         end
         pkgimage = !isempty(clone_targets)

--- a/base/show.jl
+++ b/base/show.jl
@@ -2242,8 +2242,9 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             print(io, "end")
         end
 
-    elseif head === :module && nargs==4 && isa(args[1],VersionNumber) && isa(args[2],Bool)
-        # New 4-argument form: (version, baremodule_flag, name, body)
+    elseif head === :module && nargs == 4 &&
+            (isa(args[1], GlobalRef) || isa(args[1], VersionNumber)) && isa(args[2], Bool)
+        # 4-argument form: (parser_ref/version, baremodule_flag, name, body)
         show_block(IOContext(io, beginsym=>false), args[2] ? :module : :baremodule, args[3], args[4], indent, quote_level)
         print(io, "end")
     elseif head === :module && nargs==3 && isa(args[1],Bool)

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -57,8 +57,8 @@ precompile(Tuple{typeof(Base.Compiler.ir_to_codeinf!), Base.Compiler.Optimizatio
 precompile(Tuple{typeof(Base.getindex), Type{Pair{Base.PkgId, UInt128}}, Pair{Base.PkgId, UInt128}, Pair{Base.PkgId, UInt128}, Pair{Base.PkgId, UInt128}, Vararg{Pair{Base.PkgId, UInt128}}})
 precompile(Tuple{typeof(Base.Compiler.ir_to_codeinf!), Base.Compiler.OptimizationState{Base.Compiler.NativeInterpreter}, Core.SimpleVector})
 precompile(Tuple{typeof(Base.Compiler.ir_to_codeinf!), Base.Compiler.OptimizationState{Base.Compiler.NativeInterpreter}})
-precompile(include_package_for_output, (PkgId, String, VersionNumber, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), Nothing)) || @assert false
-precompile(include_package_for_output, (PkgId, String, VersionNumber, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), String)) || @assert false
+precompile(include_package_for_output, (PkgId, String, VersionNumber, Union{Nothing,PkgId}, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), Nothing)) || @assert false
+precompile(include_package_for_output, (PkgId, String, VersionNumber, Union{Nothing,PkgId}, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), String)) || @assert false
 precompile(create_expr_cache, (PkgId, PkgLoadSpec, String, String, typeof(_concrete_dependencies), Cmd, CacheFlags, IO, IO)) || @assert false
 precompile(create_expr_cache, (PkgId, PkgLoadSpec, String, Nothing, typeof(_concrete_dependencies), Cmd, CacheFlags, IO, IO)) || @assert false
 

--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -464,6 +464,20 @@ The syntax version for a package is determined by the loading mechanism in the f
 
 3. If neither is specified, the current Julia version is used.
 
+The parser implementation can be selected separately with `syntax.version`, whose value is the name of a package
+listed in `[deps]`. That package must define a `core_parser_hook` entry point with Julia's internal parser hook
+signature. Modules parsed with that project use the dependency's parser entry point for nested `include` calls and
+submodules:
+
+```toml
+name = "MyPackage"
+uuid = "..."
+syntax.version = "MyParser"
+
+[deps]
+MyParser = "..."
+```
+
 #### In scripts and the REPL
 
 Scripts and the REPL use the active project's syntax version. This determination happens:

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -2106,6 +2106,14 @@ module M58272_to end
         @test invokelatest(getglobal, (@eval (using Versioned4; Versioned4)), :ver) == VersionNumber(VERSION.major, VERSION.minor)
         # Inherited from compat.julia = "1.14-2"
         @test invokelatest(getglobal, (@eval (using Versioned5; Versioned5)), :ver) == v"1.14"
+        # syntax.version selects a parser entry point from a dependency package.
+        versioned_custom = @eval (using VersionedCustom; VersionedCustom)
+        @test invokelatest(getglobal, versioned_custom, :custom_parser_used)
+        @test invokelatest(getglobal, versioned_custom, :parser_installed)
+        @test invokelatest(getglobal, versioned_custom, :child_parser_installed)
+        @test_throws ErrorException Base.project_get_syntax_spec(
+            Dict{String, Any}("syntax" => Dict{String, Any}("version" => "MissingParser")),
+            "Project.toml")
     finally
         copy!(LOAD_PATH, old_load_path)
     end

--- a/test/project/SyntaxVersioning/implicit/CustomParser/Project.toml
+++ b/test/project/SyntaxVersioning/implicit/CustomParser/Project.toml
@@ -1,0 +1,3 @@
+name = "CustomParser"
+uuid = "6cf8f07a-0a4d-4fb8-8ad8-b571fa5ee9d5"
+

--- a/test/project/SyntaxVersioning/implicit/CustomParser/src/CustomParser.jl
+++ b/test/project/SyntaxVersioning/implicit/CustomParser/src/CustomParser.jl
@@ -1,0 +1,20 @@
+module CustomParser
+
+function rewrite_marker!(ex)
+    ex === :CUSTOM_PARSER_MARKER && return true
+    if ex isa Expr
+        for i in eachindex(ex.args)
+            ex.args[i] = rewrite_marker!(ex.args[i])
+        end
+    end
+    return ex
+end
+
+function core_parser_hook(code, filename::String, lineno::Int, offset::Int, options::Symbol)
+    ret = Base.JuliaSyntax.core_parser_hook(code, filename, lineno, offset, options;
+        syntax_version=v"1.14", module_parser=GlobalRef(@__MODULE__, :core_parser_hook))
+    rewrite_marker!(ret[1])
+    return ret
+end
+
+end

--- a/test/project/SyntaxVersioning/implicit/VersionedCustom/Project.toml
+++ b/test/project/SyntaxVersioning/implicit/VersionedCustom/Project.toml
@@ -1,0 +1,7 @@
+name = "VersionedCustom"
+uuid = "8a930b9e-36a2-401f-aa8e-44e2578942c2"
+syntax.version = "CustomParser"
+
+[deps]
+CustomParser = "6cf8f07a-0a4d-4fb8-8ad8-b571fa5ee9d5"
+

--- a/test/project/SyntaxVersioning/implicit/VersionedCustom/src/VersionedCustom.jl
+++ b/test/project/SyntaxVersioning/implicit/VersionedCustom/src/VersionedCustom.jl
@@ -1,0 +1,16 @@
+module VersionedCustom
+
+using CustomParser
+
+const custom_parser_used = CUSTOM_PARSER_MARKER
+const parser_ref = GlobalRef(CustomParser, :core_parser_hook)
+const parser_installed =
+    getglobal(@__MODULE__, Symbol("#_internal_julia_parse")).parser_ref == parser_ref
+
+module Child
+end
+
+const child_parser_installed =
+    getglobal(Child, Symbol("#_internal_julia_parse")).parser_ref == parser_ref
+
+end


### PR DESCRIPTION
This is a multi use feature that several people have asked me about, most recently @rayegun who wants to use it for a JuliaCon project. The basic idea is a further evolution (pun intended) of syntax evolution feature to allow wholesale replacement of the frontend. The idea is to allow packages whose entry files may not otherwise be parseable with the julia parser. Example use cases included:

1. Packages written in non-Julia languages and DSL for which Julia has good FFI support and that can be loaded as Julia packages (examples include Dyad and Verilog-A on the DSL side and Python on the FFI side). In particular, this makes it a bit friendlier for upstream developers to maintain installability as a julia package without having to have extra julia files in tree.

2. Backport of syntax changes. Suppose you are writing a package that really needs some hypothetical julia 1.15 syntax sugar, but really needs to run on Julia 1.14 - you could use this feature to parse 1.15 syntax with a forward installed copy of JuliaSyntax.

3. Experimenting with syntax changes. Similarly, the parser could be pointed at a fork of JuliaSyntax in order to explore speculative or experimental new syntax features in a full package environment without having to rebuild julia.

The way this works is that you declare a parser dependency in `syntax.parser = MyParser` in your Project.toml (`MyParser` also needs to be in the `[deps]` section) and the runtime system will arrange to use `MyParser.core_parser_hook` (name to be fixed) as the parser. Note that the change here is the loading support - the underlying system did already support custom parsers.

One additional change that this PR makes is to represent the lowered form of syntax evolution as a GlobalRef rather than a VersionNumber, both to support this feature, but also to be somewhat friendlier to bootstrap. VersionNumber is defined somewhat late in the system and if it's in the AST non-opaquely, bootstrap needs to understand it.