### PR TITLE
Libdl: Avoid scanning filesystem when computing shlib dir

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -322,8 +322,15 @@ Base.print(io::IO, llp::LazyLibraryPath) = print(io, string(llp))
 # Helper to get `$(private_shlibdir)` at runtime
 struct PrivateShlibdirGetter; end
 const private_shlibdir = Base.OncePerProcess{String}() do
-    libname = ifelse(isdebugbuild(), "libjulia-internal-debug", "libjulia-internal")
-    dirname(dlpath(libname))
+    sym = cglobal(:ijl_load_dynamic_library)
+    p = ccall(:jl_pathname_for_symbol, Cstring, (Ptr{Cvoid},), sym)
+    path = unsafe_string(p)
+    Sys.iswindows() && Libc.free(p)
+    if isempty(path)
+        p = ccall(:jl_exepath, Cstring, ())
+        path = unsafe_string(p)
+    end
+    return dirname(path)
 end
 Base.string(::PrivateShlibdirGetter) = private_shlibdir()
 

--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -322,8 +322,22 @@ Base.print(io::IO, llp::LazyLibraryPath) = print(io, string(llp))
 # Helper to get `$(private_shlibdir)` at runtime
 struct PrivateShlibdirGetter; end
 const private_shlibdir = Base.OncePerProcess{String}() do
-    libname = ifelse(isdebugbuild(), "libjulia-internal-debug", "libjulia-internal")
-    dirname(dlpath(libname))
+    sym = try
+        cglobal(:ijl_load_dynamic_library)
+    catch
+        C_NULL
+    end
+    if sym == C_NULL || ccall(:jl_symbol_in_executable, Cint, (Ptr{Cvoid},), sym) != 0
+        # libjulia-internal is linked into the executable, so it cannot tell us
+        # where the private libraries live. Assume the installed layout, which
+        # keeps them in `$(private_shlibdir)` relative to the executable.
+        return Sys.iswindows() ? Sys.BINDIR : abspath(Sys.BINDIR, Base.PRIVATE_LIBDIR)
+    end
+    p = ccall(:jl_pathname_for_symbol, Cstring, (Ptr{Cvoid},), sym)
+    p == C_NULL && error("unable to locate the shared library containing libjulia-internal")
+    path = unsafe_string(p)
+    Sys.iswindows() && Libc.free(p)
+    return dirname(path)
 end
 Base.string(::PrivateShlibdirGetter) = private_shlibdir()
 

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -122,6 +122,7 @@
     XX(jl_exception_clear) \
     XX(jl_exception_occurred) \
     XX(jl_excstack_state) \
+    XX(jl_exepath) \
     XX(jl_exit) \
     XX(jl_exit_on_sigint) \
     XX(jl_exit_threaded_region) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -456,6 +456,7 @@
     XX(jl_switch) \
     XX(jl_switchto) \
     XX(jl_symbol) \
+    XX(jl_symbol_in_executable) \
     XX(jl_symbol_lookup) \
     XX(jl_symbol_n) \
     XX(jl_tagged_gensym) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -2411,6 +2411,7 @@ JL_DLLEXPORT void JL_NORETURN jl_raise(int signo);
 JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_pathname_for_symbol(void *symbol) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void) JL_CANSAFEPOINT_ENTER;
+JL_DLLEXPORT int jl_symbol_in_executable(void *symbol) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
 JL_DLLEXPORT jl_image_buf_t jl_preload_sysimg(const char *fname) JL_NOTSAFEPOINT;

--- a/src/sys.c
+++ b/src/sys.c
@@ -825,6 +825,30 @@ JL_DLLEXPORT const char *jl_pathname_for_symbol(void *symbol) JL_NOTSAFEPOINT
 #endif
 }
 
+// Returns the absolute path of the running executable, or NULL on error.
+JL_DLLEXPORT const char *jl_exepath(void) JL_NOTSAFEPOINT
+{
+    static _Atomic(char*) exepath_cache;
+    char *path = jl_atomic_load_acquire(&exepath_cache);
+    if (path != NULL)
+        return path;
+
+    char buf[JL_PATH_MAX];
+    size_t sz = sizeof(buf);
+    if (uv_exepath(buf, &sz) || sz >= JL_PATH_MAX)
+        return NULL;
+    path = (char*)malloc_s(sz + 1);
+    memcpy(path, buf, sz);
+    path[sz] = '\0';
+
+    char *expected = NULL;
+    if (!jl_atomic_cmpswap_acqrel(&exepath_cache, &expected, path)) {
+        free(path);
+        path = expected;
+    }
+    return path;
+}
+
 #ifdef _OS_WINDOWS_
 // Get a list of all the modules in this process.
 JL_DLLEXPORT int jl_dllist(jl_array_t *list)

--- a/src/sys.c
+++ b/src/sys.c
@@ -900,6 +900,42 @@ JL_DLLEXPORT const char *jl_pathname_for_symbol(void *symbol) JL_NOTSAFEPOINT
 #endif
 }
 
+// Returns 1 if `symbol` lies within the main executable's image, 0 otherwise
+JL_DLLEXPORT int jl_symbol_in_executable(void *symbol) JL_NOTSAFEPOINT
+{
+    if (!symbol)
+        return 0;
+#ifdef _OS_WINDOWS_
+    HMODULE handle;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            (LPCWSTR)symbol, &handle))
+        return 0;
+    // GetModuleHandleW(NULL) is the module used to create the calling process.
+    return handle == GetModuleHandleW(NULL);
+#elif defined(__APPLE__)
+    // dyld guarantees that image index 0 is the main executable.
+    Dl_info info;
+    if (!dladdr(symbol, &info) || !info.dli_fbase)
+        return 0;
+    return info.dli_fbase == (const void *)_dyld_get_image_header(0);
+#elif defined(__GLIBC__)
+    // glibc: the main program's link_map has an empty `l_name`.
+    Dl_info info;
+    struct link_map *map = NULL;
+    if (!dladdr1(symbol, &info, (void **)&map, RTLD_DL_LINKMAP) || map == NULL)
+        return 0;
+    msan_unpoison(&map, sizeof(struct link_map *));
+    msan_unpoison(map, sizeof(struct link_map));
+    msan_unpoison_string(map->l_name);
+    return map->l_name[0] == '\0';
+#else
+    // Other libc: dl_iterate_phdr reports the main program first.
+    struct sym_phdr_query q = { (uintptr_t)symbol, NULL, 0, 0, 0 };
+    dl_iterate_phdr(&sym_phdr_helper, &q);
+    return q.found && q.is_main_exe;
+#endif
+}
+
 #ifdef _OS_WINDOWS_
 // Get a list of all the modules in this process.
 JL_DLLEXPORT int jl_dllist(jl_array_t *list)

--- a/stdlib/Libdl/test/runtests.jl
+++ b/stdlib/Libdl/test/runtests.jl
@@ -44,6 +44,23 @@ else
     dirname(abspath(Libdl.dlpath("libjulia-internal")))
 end
 
+@test ccall(:jl_symbol_in_executable, Cint, (Ptr{Cvoid},), C_NULL) == 0
+@test ccall(:jl_symbol_in_executable, Cint, (Ptr{Cvoid},), cglobal(:ijl_load_dynamic_library)) == 0
+# An address that lives in the executable itself must be detected as such. On Unix the
+# loader executable exports `main`; Windows executables export nothing, so use the module
+# base address, which lies inside the executable's image.
+exe_addr = if Sys.iswindows()
+    ccall(:GetModuleHandleW, stdcall, Ptr{Cvoid}, (Ptr{Cvoid},), C_NULL)
+else
+    exe_handle = ccall(:jl_dlopen, Ptr{Cvoid}, (Ptr{Cvoid}, UInt32), C_NULL, UInt32(Libdl.RTLD_NOW | Libdl.RTLD_NOLOAD))
+    Libdl.dlsym(exe_handle, :main)
+end
+@test exe_addr != C_NULL
+@test ccall(:jl_symbol_in_executable, Cint, (Ptr{Cvoid},), exe_addr) == 1
+if !Base.DARWIN_FRAMEWORK
+    @test realpath(Base.Libc.Libdl.private_shlibdir()) == realpath(private_libdir)
+end
+
 @test !isempty(Libdl.find_library(["libccalltest"], [private_libdir]))
 @test !isempty(Libdl.find_library("libccalltest", [private_libdir]))
 @test !isempty(Libdl.find_library(:libccalltest, [private_libdir]))


### PR DESCRIPTION
`dlpath(::String)` is a bit of a footgun to the extent that it relies on either:
1. exactly matching the SONAME (Unix) / filename (Windows), OR
2. re-discovering the already-loaded library by the linker search path

The first check fails essentially automatically on Unixes, since we don't provide the versioned SONAME to this lookup (and we want to be able to change SONAME after-the-fact when packaging Julia anyway). The fallback also ends up occasionally unreliable, for the same reasons that we avoid `dlopen(...)` with relative paths / bare library names in general. On FreeBSD for example, `dlopen` uses a different linker search path than an equivalent `DT_NEEDED` entry (it uses the executable's rpath, not the library's).

The solution is to avoid `dlpath` and instead query the path for a symbol in `libjulia-internal` (which is already loaded / accessible) directly.

Investigated w/ Claude Opus 4.8 🤖