### PR TITLE
Fix false recursive cycle in `rm(...)` on Windows

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -328,10 +328,10 @@ end
 # delayed_delete_dll(path) does so temporarily, until later cleanup by Pkg.gc().
 function delayed_delete_dll(path)
     # in-use DLL must be kept on the same drive
-    temp_path = tempname(abspath(dirname(path)); cleanup=false, suffix=string("_", basename(path)))
+    temp_path = _tempname(abspath(dirname(path)), string("_", basename(path)))
     @debug "Could not delete DLL most likely because it is loaded, moving to a temporary path" path temp_path
     mkpath(delayed_delete_ref())
-    io = last(mktemp(delayed_delete_ref(); cleanup=false))
+    io = Base.open(_win_mkstemp(delayed_delete_ref()), "r+")
     try
         print(io, temp_path) # record the temporary path for Pkg.gc()
     finally
@@ -741,6 +741,12 @@ end
 
 # Obtain a temporary filename.
 function tempname(parent::AbstractString=tempdir(); max_tries::Int = 100, cleanup::Bool=true, suffix::AbstractString="")
+    filename = _tempname(parent, suffix, max_tries)
+    cleanup && temp_cleanup_later(filename)
+    return filename
+end
+
+function _tempname(parent::AbstractString, suffix::AbstractString, max_tries::Int = 100)
     isdir(parent) || throw(ArgumentError("$(repr(parent)) is not a directory"))
 
     prefix = joinpath(parent, temp_prefix)
@@ -758,7 +764,6 @@ function tempname(parent::AbstractString=tempdir(); max_tries::Int = 100, cleanu
         error("tempname: max_tries exhausted")
     end
 
-    cleanup && temp_cleanup_later(filename)
     return filename
 end
 

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -62,7 +62,7 @@ if Sys.iswindows()
     WindowsRawSocket(handle::WindowsRawSocket) = handle
 
     Base.cconvert(::Type{Ptr{Cvoid}}, fd::WindowsRawSocket) = bitcast(Ptr{Cvoid}, fd)
-    show(io::IO, fd::WindowsRawSocket) = print(io, "WindowsRawSocket(", bitcast(Ptr{Cvoid}, fd), ')')  # avoids invalidation via show_default
+    show(io::IO, fd::WindowsRawSocket) = (print(io, "WindowsRawSocket("); show(io, bitcast(UInt, fd)); print(io, ')'))  # avoids invalidation via show_default
     _get_osfhandle(fd::RawFD) = ccall(:_get_osfhandle, WindowsRawSocket, (RawFD,), fd)
     _get_osfhandle(fd::WindowsRawSocket) = fd
     function dup(src::WindowsRawSocket)


### PR DESCRIPTION
Also fix-up `show` implementation for `WindowsRawSocket`, for `--trim` compat in both cases.

This was improved in #62158 but not completely fixed.