### PR TITLE
Fix AllocUseInfo::getField combining adjacent non-overlapping fields

### DIFF
--- a/src/llvm-alloc-helpers.cpp
+++ b/src/llvm-alloc-helpers.cpp
@@ -47,6 +47,7 @@ AllocUseInfo::getField(uint32_t offset, uint32_t size, Type *elty)
             lb = it;
             ub = it;
         }
+        ++it;
     }
     else {
         it = memops.begin();

--- a/test/llvmpasses/alloc-opt-pass.ll
+++ b/test/llvmpasses/alloc-opt-pass.ll
@@ -371,6 +371,29 @@ define ptr addrspace(10) @atomicrmw_ref_split(ptr addrspace(10) %val) {
 }
 ; CHECK-LABEL: }{{$}}
 
+; Test that two disjoint objref fields (offsets 0 and 8) stay separate fields.
+; Regression test for the buggy version of AllocUseInfo::getField that would
+; merge these into a single multiloc=1 field and fail to promote the allocation
+; to an alloca.
+; CHECK-LABEL: @two_objref_fields_no_merge
+; CHECK-NOT: @julia.gc_alloc_obj
+; CHECK: ret ptr addrspace(10)
+define ptr addrspace(10) @two_objref_fields_no_merge(ptr addrspace(10) %a, ptr addrspace(10) %b) {
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %ptls = call ptr @julia.ptls_states()
+  %v = call noalias nonnull align 8 dereferenceable(16) ptr addrspace(10) @julia.gc_alloc_obj(ptr %ptls, i64 16, ptr addrspace(10) @tag) #7
+  %v_derived = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
+  store ptr addrspace(10) %a, ptr addrspace(11) %v_derived, align 8, !tbaa !20
+  %f1 = getelementptr inbounds i8, ptr addrspace(11) %v_derived, i64 8
+  store ptr addrspace(10) %b, ptr addrspace(11) %f1, align 8, !tbaa !20
+  %tok = call token (...) @llvm.julia.gc_preserve_begin(ptr addrspace(10) %v)
+  %l0 = load ptr addrspace(10), ptr addrspace(11) %v_derived, align 8, !tbaa !20
+  %l1 = load ptr addrspace(10), ptr addrspace(11) %f1, align 8, !tbaa !20
+  call void @llvm.julia.gc_preserve_end(token %tok)
+  ret ptr addrspace(10) %l1
+}
+; CHECK-LABEL: }{{$}}
+
 declare ptr @julia.ptls_states()
 
 declare ptr @julia.pointer_from_objref(ptr addrspace(11))


### PR DESCRIPTION
The algorithm used in `AllocUseInfo::getField` would incorrectly merge two adjacent fields, if the field with the lower offset was already into the `memops` map.  When we make it to the loop that accumulates all the adjacent fields that overlap with our field, we would set `lb` to `it`, even when it doesn't overlap.  Since that loop has `it->first < offset + size` in the condition, we can safely increment `it` to the next field and skip over the loop entirely to get the right answer `lb == ub == end`.

Here's an example:

```llvm
; struct S
;   a::Int
;   b::Any
; end

@jltype = external global ptr, !julia.constgv !0

define swiftcc i64 @f(ptr nonnull swiftself "gcstack" %pgcstack, i64 %i) {
  %task = getelementptr inbounds i8, ptr %pgcstack, i32 -152
  %jltype = load ptr addrspace(10), ptr @jltype
  %s = call ptr addrspace(10) @julia.gc_alloc_obj(ptr %task, i64 16, ptr addrspace(10) %jltype)

  %s1 = addrspacecast ptr addrspace(10) %s to ptr addrspace(11)

  store i64 123, ptr addrspace(11) %s1

  %ib = call nonnull align 8 dereferenceable(8) ptr addrspace(10) @ijl_box_int64(i64 %i)
  %s2 = getelementptr i8, ptr addrspace(11) %s1, i64 8
  store ptr addrspace(10) %ib, ptr addrspace(11) %s2

  call void (ptr addrspace(10), ...) @julia.write_barrier(ptr addrspace(10) %s, ptr addrspace(10) %ib)

  %r = load i64, ptr addrspace(11) %s1

  ret i64 %r
}

declare void @julia.safepoint(ptr) memory(argmem: readwrite, inaccessiblemem: readwrite)
declare noalias nonnull ptr addrspace(10) @julia.gc_alloc_obj(ptr, i64, ptr addrspace(10)) nounwind willreturn allockind("alloc") allocsize(1) memory(argmem: read, inaccessiblemem: readwrite)
declare nonnull align 8 dereferenceable(8) ptr addrspace(10) @ijl_box_int64(i64 signext) nounwind willreturn memory(read, inaccessiblemem: readwrite)
declare void @julia.write_barrier(ptr addrspace(10) readonly, ...) norecurse nounwind memory(inaccessiblemem: readwrite)

!0 = !{}
```

Before the fix, these were the escape analysis results:
```
remark: <unknown>:0:0: escape analysis for   %s = call ptr addrspace(10) @julia.gc_alloc_obj(ptr %task, i64 16, ptr addrspace(10) %jltype)
AllocUseInfo:
escaped: 0
addrescaped: 0
returned: 0
haserror: 0
hasload: 1
haspreserve: 0
hasunknownmem: 0
hastypeof: 0
refload: 0
refstore: 1
allockind:
Uses: 6
  call void (ptr addrspace(10), ...) @julia.write_barrier(ptr addrspace(10) %s, ptr addrspace(10) %ib)
  %s1 = addrspacecast ptr addrspace(10) %s to ptr addrspace(11)
  %r = load i64, ptr addrspace(11) %s1, align 4
  %s2 = getelementptr i8, ptr addrspace(11) %s1, i64 8
  store ptr addrspace(10) %ib, ptr addrspace(11) %s2, align 8
  store i64 123, ptr addrspace(11) %s1, align 4
MemOps: 1
  offset: 0
  size: 16
  hasobjref: 1
  hasload: 1
  hasaggr: 0
  multiloc: 1
  hasunboxed: 1
  accesses: 3
      %r = load i64, ptr addrspace(11) %s1, align 4
    scalar
    bits
    0
    8
      store ptr addrspace(10) %ib, ptr addrspace(11) %s2, align 8
    scalar
    objref
    8
    8
      store i64 123, ptr addrspace(11) %s1, align 4
    scalar
    bits
    0
    8
```

After:
```
remark: <unknown>:0:0: escape analysis for   %s = call ptr addrspace(10) @julia.gc_alloc_obj(ptr %task, i64 16, ptr addrspace(10) %jltype)
AllocUseInfo:
escaped: 0
addrescaped: 0
returned: 0
haserror: 0
hasload: 1
haspreserve: 0
hasunknownmem: 0
hastypeof: 0
refload: 0
refstore: 1
allockind:
Uses: 6
  call void (ptr addrspace(10), ...) @julia.write_barrier(ptr addrspace(10) %s, ptr addrspace(10) %ib)
  %s1 = addrspacecast ptr addrspace(10) %s to ptr addrspace(11)
  %r = load i64, ptr addrspace(11) %s1, align 4
  %s2 = getelementptr i8, ptr addrspace(11) %s1, i64 8
  store ptr addrspace(10) %ib, ptr addrspace(11) %s2, align 8
  store i64 123, ptr addrspace(11) %s1, align 4
MemOps: 2
  offset: 0
  size: 8
  hasobjref: 0
  hasload: 1
  hasaggr: 0
  multiloc: 0
  hasunboxed: 1
  accesses: 2
      %r = load i64, ptr addrspace(11) %s1, align 4
    scalar
    bits
    0
    8
      store i64 123, ptr addrspace(11) %s1, align 4
    scalar
    bits
    0
    8
  offset: 8
  size: 8
  hasobjref: 1
  hasload: 0
  hasaggr: 0
  multiloc: 0
  hasunboxed: 0
  accesses: 1
      store ptr addrspace(10) %ib, ptr addrspace(11) %s2, align 8
    scalar
    objref
    8
    8
```

The regression test for this was slopped.