### PR TITLE
Fix-up new `trim` test harness

### DIFF
--- a/test/trim.jl
+++ b/test/trim.jl
@@ -4,7 +4,7 @@
 # By default a project is built as a trimmed executable (`--output-exe`) bundled
 # into a temporary directory. A project may instead provide a `build.jl` (see
 # `LibSimple`) that is `include`d here to perform a custom build using the
-# `run_juliac` and `c_compiler` helpers below; `ARGS[1]` is the bundle directory.
+# `run_juliac` and `run_cc` helpers below; `ARGS[1]` is the bundle directory.
 # Each project's `runtests.jl` is then run in a subprocess (activated in the
 # project's own environment) with the bundle directory as `ARGS[1]`.
 using Test
@@ -43,7 +43,12 @@ function run_juliac(args::Vector{String})
     return nothing
 end
 
-c_compiler() = something(Sys.which("cc"), Sys.which("clang"), Sys.which("gcc"), nothing)
+function run_cc(args::Vector{String})
+    code = "using JuliaC; run(`\$(JuliaC.get_compiler_cmd()) \$ARGS`)"
+    cmd = `$(Base.julia_cmd()) --startup-file=no --history-file=no --project=$JULIAC_PROJECT -e $code -- $args`
+    run(addenv(cmd, "JULIA_DEPOT_PATH" => depot_env()))
+    return nothing
+end
 
 @testset "trim" begin
     @test isdir(JULIAC_PROJECT)

--- a/test/trim/BasicJLL/runtests.jl
+++ b/test/trim/BasicJLL/runtests.jl
@@ -6,7 +6,7 @@ outdir = ARGS[1]
 @testset "BasicJLL" begin
     exe_suffix = splitext(Base.julia_exename())[2]
     basic_jll_exe = joinpath(outdir, "bin", "basicjll" * exe_suffix)
-    lines = split(readchomp(`$basic_jll_exe`), "\n")
+    lines = readlines(`$basic_jll_exe`)
     @test lines[1] == "Julia! Hello, world!"
     @test lines[2] == lines[3]
     @test Base.VersionNumber(lines[2]) ≥ v"1.5.7"

--- a/test/trim/LibSimple/build.jl
+++ b/test/trim/LibSimple/build.jl
@@ -1,7 +1,7 @@
 # Custom build: produce a trimmed C-callable shared library (with an ABI export)
 # and compile a C application that loads it via `dlopen` at run-time.
 #
-# Included in-process by `test/trim.jl`, so `run_juliac` and `c_compiler` (defined
+# Included in-process by `test/trim.jl`, so `run_juliac` and `run_cc` (defined
 # there) are in scope. `ARGS[1]` is the output/bundle directory.
 outdir = ARGS[1]
 projdir = @__DIR__
@@ -31,11 +31,9 @@ isfile(libpath) || error("expected bundled library at $libpath")
 bindir = joinpath(outdir, "bin")
 mkpath(bindir)
 exe = joinpath(bindir, "capplication" * (Sys.iswindows() ? ".exe" : ""))
-cc = c_compiler()
-cc === nothing && error("no C compiler found (cc/clang/gcc)")
 csrc = joinpath(projdir, "capplication.c")
 if Sys.islinux()
-    run(`$cc -o $exe $csrc -ldl`)
+    run_cc(["-o", exe, csrc, "-ldl"])
 else
-    run(`$cc -o $exe $csrc`)
+    run_cc(["-o", exe, csrc])
 end

--- a/test/trim/LibSimple/runtests.jl
+++ b/test/trim/LibSimple/runtests.jl
@@ -14,7 +14,7 @@ outdir = ARGS[1]
     # The shared library can be used in a C application
     capplication_exe = joinpath(outdir, "bin", "capplication" * exe_suffix)
     libpath = joinpath(outdir, libdir, "libsimple." * dlext)
-    lines = split(readchomp(`$capplication_exe $libpath`), "\n")
+    lines = readlines(`$capplication_exe $libpath`)
     @test length(lines) == 2
     @test lines[1] == "Sum of copied values: 6.000000"
     @test lines[2] == "Count of same vectors: 1"

--- a/test/trim/Trimmability/runtests.jl
+++ b/test/trim/Trimmability/runtests.jl
@@ -6,7 +6,7 @@ outdir = ARGS[1]
 @testset "Trimmability" begin
     exe_suffix = splitext(Base.julia_exename())[2]
     trimmability_exe = joinpath(outdir, "bin", "trimmability" * exe_suffix)
-    lines = split(readchomp(`$trimmability_exe arg1 arg2`), "\n")
+    lines = readlines(`$trimmability_exe arg1 arg2`)
     @test lines[1] == "Hello, world!"
     @test lines[2] == trimmability_exe
     @test lines[3] == "arg1"


### PR DESCRIPTION
Together with https://github.com/JuliaLang/julia/pull/62165, this should be enough to enable the new, multi-platform `trim` tests.