### PR TITLE
[JuliaLowering] Fix nested opaque closure captures

### DIFF
--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -523,14 +523,26 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
                                     ctx.closure_bindings, capture_rewrites, ctx.lambda_bindings,
                                     false, ctx.toplevel_pure, ctx.toplevel_stmts, ctx.closure_infos)
 
+        argt = _convert_closures(ctx, ex[2])
+        rt_lb = _convert_closures(ctx, ex[3])
+        rt_ub = _convert_closures(ctx, ex[4])
+
         init_closure_args = SyntaxList(ctx)
         for id in field_orig_bindings
-            push!(init_closure_args, binding_ex(ctx, id))
+            init_arg = binding_ex(ctx, id)
+            # Closure initialization passes capture storage. For captures of the
+            # enclosing closure, use that closure's field rather than leaving a
+            # BindingId that is not native to the current lambda. Don't lower
+            # boxed captures to their contents; the nested closure needs the Box.
+            if is_self_captured(ctx, init_arg)
+                init_arg = captured_var_access(ctx, init_arg)
+            end
+            push!(init_closure_args, init_arg)
         end
         @ast ctx ex [K"new_opaque_closure"
-            ex[2] # arg type tuple
-            ex[3] # return_lower_bound
-            ex[4] # return_upper_bound
+            argt # arg type tuple
+            rt_lb # return_lower_bound
+            rt_ub # return_upper_bound
             ex[5] # allow_partial
             [K"opaque_closure_method"
                 (::K"nothing")

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -530,10 +530,6 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
         init_closure_args = SyntaxList(ctx)
         for id in field_orig_bindings
             init_arg = binding_ex(ctx, id)
-            # Closure initialization passes capture storage. For captures of the
-            # enclosing closure, use that closure's field rather than leaving a
-            # BindingId that is not native to the current lambda. Don't lower
-            # boxed captures to their contents; the nested closure needs the Box.
             if is_self_captured(ctx, init_arg)
                 init_arg = captured_var_access(ctx, init_arg)
             end

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -233,11 +233,67 @@ let
 end
 """) == (3,4,5)
 
+# Opaque closure inside a closure can capture the enclosing closure's captures
+@test JuliaLowering.include_string(test_mod, """
+let y = [1]
+    outer = () -> begin
+        inner = Base.Experimental.@opaque n -> n in y
+        inner(1)
+    end
+    outer()
+end
+""") === true
+
+# Nested opaque closure capture preserves boxed variable sharing
+@test JuliaLowering.include_string(test_mod, """
+let y = 1
+    outer = () -> begin
+        inner = Base.Experimental.@opaque () -> begin
+            y = y + 1
+        end
+        inner()
+    end
+    outer()
+    y
+end
+""") === 2
+
+# Opaque closure nested in another opaque closure can capture the outer OC environment
+@test JuliaLowering.include_string(test_mod, """
+let y = [1]
+    outer = Base.Experimental.@opaque () -> begin
+        inner = Base.Experimental.@opaque n -> n in y
+        inner(1)
+    end
+    outer()
+end
+""") === true
+
+# Opaque closure type-bound expressions can capture enclosing closure captures
+@test JuliaLowering.include_string(test_mod, """
+let T = Tuple{Int}
+    outer = () -> begin
+        inner = Base.Experimental.@opaque T -> _ (n) -> n
+        inner(1)
+    end
+    outer()
+end
+""") === 1
+@test JuliaLowering.include_string(test_mod, """
+let RT = Float64
+    outer = () -> begin
+        inner = Base.Experimental.@opaque _ -> RT () -> 1.0
+        inner()
+    end
+    outer()
+end
+""") === 1.0
+
 # OC in lambda
 @test JuliaLowering.include_string(test_mod, """
 (x->(y->(z->(Base.Experimental.@opaque ()->"opaque"))('z'))('y'))('x')()
 """) == "opaque"
-@test_broken JuliaLowering.include_string(test_mod, """
+@test JuliaLowering.include_string(test_mod, """
 (x->(y->(z->(Base.Experimental.@opaque ()->(x,y,z)))('z'))('y'))('x')()
 """) == ('x','y','z')
 


### PR DESCRIPTION
Opaque closures created inside another closure could leave captured locals from the enclosing closure as raw `BindingId` nodes in the `new_opaque_closure` arguments. Linearization then failed because those bindings were not native slots of the current lambda:
```julia-repl
julia> JuliaLowering.include_string(Main, """
       let y = [1]
           outer = Base.Experimental.@opaque () -> begin
               inner = Base.Experimental.@opaque n -> n in y
               inner(1)
           end
           outer()
       end
       """)
ERROR: LoweringError:
let y = [1]
    outer = Base.Experimental.@opaque () -> begin
        inner = Base.Experimental.@opaque n -> n in y

Detailed provenance:
  #₄/y @#= /Users/aviatesk/julia/julia/JuliaLowering/src/bindings.jl:123 =#
  └─ y
     └─ y
        └─ @ string:1

Stacktrace:
  [1] _renumber(ctx::JuliaLowering.LinearIRContext{…}, ssa_rewrites::Dict{…}, slot_rewrites::Dict{…}, label_table::Dict{…}, ex::JuliaSyntax.SyntaxTree{…})
    @ JuliaLowering ~/julia/julia/JuliaLowering/src/linear_ir.jl:1097
  [2] (::JuliaLowering.var"#_renumber##2#_renumber##3"{JuliaLowering.LinearIRContext{…}, Dict{…}, Dict{…}, Dict{…}})(e::JuliaSyntax.SyntaxTree{Dict{…}})
    @ JuliaLowering ~/julia/julia/JuliaLowering/src/linear_ir.jl:1120 [inlined]
  [3] mapchildren(f::JuliaLowering.var"#_renumber##2#_renumber##3"{…}, ctx::JuliaLowering.LinearIRContext{…}, ex::JuliaSyntax.SyntaxTree{…})
    @ JuliaSyntax ~/julia/julia/JuliaSyntax/src/porcelain/syntax_graph.jl:722
...
```

Convert opaque closure type bounds in the current closure-conversion context and initialize capture arguments from the enclosing closure's capture storage when needed. This preserves boxed storage for mutable captures while allowing nested opaque closures to capture values from their enclosing closure.