### PR TITLE
staticdata: Restore custom MethodTable dispatch status

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2768,6 +2768,23 @@ JL_DLLEXPORT jl_value_t *jl_as_global_root(jl_value_t *val, int insert)
     return val;
 }
 
+// Companion to jl_collect_methtable_from_mod: method tables owned by the worklist
+// are serialized without their contents, since all of their (currently valid)
+// methods were collected as extext methods, to be re-added and re-activated on
+// load by jl_add_methods / jl_activate_methods, which also restores their
+// dispatch status.
+static int jl_prune_internal_mtable(jl_methtable_t *mt, void *env)
+{
+    (void)env;
+    if (jl_object_in_image((jl_value_t*)mt))
+        return 1;
+    record_field_change((jl_value_t**)&mt->defs, jl_nothing);
+    jl_methcache_t *mc = mt->cache;
+    record_field_change((jl_value_t**)&mc->cache, jl_nothing);
+    record_field_change((jl_value_t**)&mc->leafcache, jl_an_empty_memory_any);
+    return 1;
+}
+
 // In addition to the system image (where `worklist = NULL`), this can also save incremental images with external linkage
 static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
                                            jl_array_t *module_init_order, jl_array_t *worklist, jl_array_t *extext_methods,
@@ -2775,6 +2792,8 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
 {
     htable_new(&field_replace, 0);
     htable_new(&bits_replace, 0);
+    if (worklist)
+        jl_foreach_reachable_mtable(jl_prune_internal_mtable, mod_array, NULL);
     // strip metadata and IR when requested
     if (jl_options.strip_metadata || jl_options.strip_ir) {
         if (jl_options.strip_metadata) {

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -575,18 +575,30 @@ static int jl_collect_methcache_from_mod(jl_typemap_entry_t *ml, void *closure)
 {
     jl_array_t *s = (jl_array_t*)closure;
     jl_method_t *m = ml->func.method;
-    if (!jl_object_in_image((jl_value_t*)m->module)) {
-        if (s)
-            jl_array_ptr_1d_push(s, (jl_value_t*)m); // extext
-    }
+    if (!jl_object_in_image((jl_value_t*)m->module))
+        jl_array_ptr_1d_push(s, (jl_value_t*)m); // extext
+    return 1;
+}
+
+// Collect every currently-valid method of a worklist-owned method table, whose
+// contents are dropped from the image (see jl_prune_internal_mtable)
+static int jl_collect_methcache_internal(jl_typemap_entry_t *ml, void *closure)
+{
+    jl_array_t *s = (jl_array_t*)closure;
+    if (jl_atomic_load_relaxed(&ml->max_world) == ~(size_t)0)
+        jl_array_ptr_1d_push(s, (jl_value_t*)ml->func.method); // extext
     return 1;
 }
 
 static int jl_collect_methtable_from_mod(jl_methtable_t *mt, void *env)
 {
-    if (!jl_object_in_image((jl_value_t*)mt))
-        env = NULL; // mark internal, not extext
-    jl_typemap_visitor(jl_atomic_load_relaxed(&mt->defs), jl_collect_methcache_from_mod, env);
+    // Custom method tables owned by the worklist are serialized without their
+    // contents (jl_prune_internal_mtable), so all of their methods are treated
+    // as extending an "external" table, to be re-added and re-activated on load.
+    jl_typemap_visitor(jl_atomic_load_relaxed(&mt->defs),
+                       jl_object_in_image((jl_value_t*)mt) ? jl_collect_methcache_from_mod
+                                                           : jl_collect_methcache_internal,
+                       env);
     return 1;
 }
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1995,6 +1995,76 @@ precompile_test_harness("PkgCacheInspector") do load_path
     end
 end
 
+precompile_test_harness("custom MethodTable dispatch status") do load_path
+    # Custom method-table methods loaded from a package image need dispatch fast-path bits restored.
+    pkg = :OverlayDispatchStatus
+    write(joinpath(load_path, "OverlayDispatchStatus.jl"),
+        """
+        module OverlayDispatchStatus
+        function f end
+        Base.Experimental.@MethodTable(mt)
+        Base.Experimental.@overlay mt f(x::Int) = x + 1
+        # generic code that resolves `f` through the overlay table when inferred
+        # with an overlay-aware interpreter (like GPU runtime library functions)
+        g(x) = f(x) * 2
+        end
+        """)
+    # A dependent package whose image holds CodeInstances with call edges that
+    # were resolved through the dependency's overlay table: without the dispatch
+    # bits restored on the overlay method, edge revalidation drops these CIs on
+    # image load (the whole cross-session cache of GPUCompiler-style consumers).
+    newinterp_path = abspath(joinpath(@__DIR__, "../Compiler/test/newinterp.jl"))
+    write(joinpath(load_path, "OverlayDispatchStatusUser.jl"),
+        """
+        module OverlayDispatchStatusUser
+        import OverlayDispatchStatus
+
+        module Custom
+            import Base.Compiler: Compiler
+            include($(repr(newinterp_path)))
+            @newinterp OverlayDispatchStatusInterp
+            import OverlayDispatchStatus
+            Compiler.method_table(interp::OverlayDispatchStatusInterp) =
+                Compiler.OverlayMethodTable(Compiler.get_inference_world(interp),
+                                            OverlayDispatchStatus.mt)
+        end
+
+        # a call edge directly to the dependency's overlay method
+        caller(x) = OverlayDispatchStatus.f(x)
+        # an overlay-resolved edge reached through generic code in the dependency
+        chain(x) = OverlayDispatchStatus.g(x)
+
+        let interp = Custom.OverlayDispatchStatusInterp()
+            Base.return_types(caller, (Int,); interp)
+            Base.return_types(chain, (Int,); interp)
+        end
+        end
+        """)
+    Base.compilecache(Base.PkgId(string(pkg)))
+    @eval using $pkg
+    M = invokelatest(getglobal, @__MODULE__, pkg)
+    invokelatest() do
+        ms = Base._methods_by_ftype(Tuple{typeof(M.f), Int}, M.mt, 1, Base.get_world_counter())
+        method = only(ms).method
+        @test method.module === M
+        @test !iszero(method.dispatch_status & Base.ReinferUtils.METHOD_SIG_LATEST_WHICH)
+        @test !iszero(method.dispatch_status & Base.ReinferUtils.METHOD_SIG_LATEST_ONLY)
+    end
+    Base.compilecache(Base.PkgId("OverlayDispatchStatusUser"))
+    @eval using OverlayDispatchStatusUser
+    invokelatest() do
+        U = OverlayDispatchStatusUser
+        owner = U.Custom.OverlayDispatchStatusInterp
+        # dependent CIs with overlay-resolved call edges must survive loading U's image
+        for m in (only(methods(U.caller)),          # edge to the overlay method itself
+                  only(methods(U.chain)),           # edge into dependency generic code
+                  only(methods(M.g)))               # dependency code with the overlay edge
+            mi = only(Base.specializations(m))
+            @test check_presence(mi, owner) !== nothing
+        end
+    end
+end
+
 precompile_test_harness("DynamicExpressions") do load_path
     # https://github.com/JuliaLang/julia/pull/47184#issuecomment-1364716312
     write(joinpath(load_path, "Float16MWE.jl"),


### PR DESCRIPTION
When a package image is loaded, methods in a worklist-owned custom `@MethodTable` used to be restored in place as internal typemap entries, skipping `jl_method_table_activate` and coming back with a cleared `dispatch_status` (no `METHOD_SIG_LATEST_WHICH`/`METHOD_SIG_LATEST_ONLY`). This made `queue_external_cis` drop foreign `CodeInstance`s cached on such methods during downstream precompilation, and made on-load edge revalidation treat calls to them as invalidated, so GPUCompiler-style compilation caches never survived a package image when the overlay method and the cached code live in the same package.

Fix this by treating all custom method tables as external, as suggested in review: method tables owned by the worklist are now serialized without their contents (their defs and dispatch caches are dropped), and all of their still-valid methods are collected as extext methods, so `jl_add_methods` / `jl_activate_methods` re-add and re-activate them on load through the same batched, `allow_new_worlds`-gated path used for methods extending tables owned by other modules. Activation restores the dispatch fast-path bits.

x-ref: #58291, which added the on-load edge revalidation gated on these dispatch bits, but only restored them for methods activated through the external path.

---

This PR was written with the assistance of generative AI (Claude).