### PR TITLE
🤖 processor: clamp pkgimage clone targets to sysimage vector width

### DIFF
--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -378,6 +378,47 @@ static std::pair<uint32_t, int> match_image_targets(
     return {(uint32_t)match.best_idx, match.vreg_size};
 }
 
+// Clamp a target spec's vector features to a maximum vector width (`vreg_limit`,
+// in bytes). On x86, AVX/AVX-512 change the ABI for VecElement tuples (they map
+// to xmm/ymm/zmm), so images that call into each other must agree on vector
+// width. Used both when loading the sysimage (clamp the JIT target to the
+// matched sysimage clone) and when building a pkgimage (clamp its clone targets
+// to the loaded sysimage's clone), so a pkgimage never requires/emits wider
+// vectors than the sysimage it runs against.
+static void clamp_vector_features(tp::LLVMTargetSpec &target, int vreg_limit)
+{
+#if defined(_CPU_X86_64_) || defined(_CPU_X86_)
+    if (vreg_limit < 64) {
+        static const char *avx512[] = {
+            "avx512f", "avx512dq", "avx512ifma", "avx512cd",
+            "avx512bw", "avx512vl", "avx512vbmi", "avx512vpopcntdq",
+            "avx512vbmi2", "avx512vnni", "avx512bitalg",
+            "avx512vp2intersect", "avx512bf16", "avx512fp16", nullptr
+        };
+        for (const char **f = avx512; *f; f++) {
+            const tp::FeatureEntry *fe = tp::find_feature(*f);
+            if (fe) feature_clear(&target.en_features, fe->bit);
+        }
+    }
+    if (vreg_limit < 32) {
+        static const char *avx[] = {
+            "avx", "avx2", "fma", "f16c", "fma4", "xop",
+            "vaes", "vpclmulqdq", nullptr
+        };
+        for (const char **f = avx; *f; f++) {
+            const tp::FeatureEntry *fe = tp::find_feature(*f);
+            if (fe) feature_clear(&target.en_features, fe->bit);
+        }
+    }
+    for (int w = 0; w < TARGET_FEATURE_WORDS; w++)
+        target.dis_features.bits[w] = tp::llvm_feature_mask.bits[w] & ~target.en_features.bits[w];
+    target.cpu_features = tp::build_llvm_feature_string(target.en_features, target.dis_features);
+#else
+    (void)target;
+    (void)vreg_limit;
+#endif
+}
+
 static uint32_t match_sysimg_target(void *ctx, const void *id, jl_value_t **rejection_reason)
 {
     const char *cpu_target = (const char *)ctx;
@@ -427,38 +468,8 @@ static uint32_t match_sysimg_target(void *ctx, const void *id, jl_value_t **reje
     // support.
     int matched_vreg = match_result.second;
     int host_vreg = tp::max_vector_size(target.en_features);
-#if defined(_CPU_X86_64_) || defined(_CPU_X86_)
-    if (matched_vreg != host_vreg) {
-        if (matched_vreg < 64) {
-            static const char *avx512[] = {
-                "avx512f", "avx512dq", "avx512ifma", "avx512cd",
-                "avx512bw", "avx512vl", "avx512vbmi", "avx512vpopcntdq",
-                "avx512vbmi2", "avx512vnni", "avx512bitalg",
-                "avx512vp2intersect", "avx512bf16", "avx512fp16", nullptr
-            };
-            for (const char **f = avx512; *f; f++) {
-                const tp::FeatureEntry *fe = tp::find_feature(*f);
-                if (fe) feature_clear(&target.en_features, fe->bit);
-            }
-        }
-        if (matched_vreg < 32) {
-            static const char *avx[] = {
-                "avx", "avx2", "fma", "f16c", "fma4", "xop",
-                "vaes", "vpclmulqdq", nullptr
-            };
-            for (const char **f = avx; *f; f++) {
-                const tp::FeatureEntry *fe = tp::find_feature(*f);
-                if (fe) feature_clear(&target.en_features, fe->bit);
-            }
-        }
-        for (int w = 0; w < TARGET_FEATURE_WORDS; w++)
-            target.dis_features.bits[w] = tp::llvm_feature_mask.bits[w] & ~target.en_features.bits[w];
-        target.cpu_features = tp::build_llvm_feature_string(target.en_features, target.dis_features);
-    }
-#else
-    (void)matched_vreg;
-    (void)host_vreg;
-#endif
+    if (matched_vreg != host_vreg)
+        clamp_vector_features(target, matched_vreg);
 
     jit_targets.push_back(std::move(target));
     return match_result.first;
@@ -468,6 +479,28 @@ static uint32_t match_pkgimg_target(void *ctx, const void *id, jl_value_t **reje
 {
     auto &target = jit_targets.front();
     auto result = match_image_targets(id, target, rejection_reason);
+    if (result.first == UINT32_MAX)
+        return UINT32_MAX;
+#if defined(_CPU_X86_64_) || defined(_CPU_X86_)
+    // ABI correctness: a pkgimage links directly into the base image / JIT, so
+    // its clone must have been built for the *same* vector width, not merely a
+    // compatible (narrower) one. `match_targets` only enforces an upper bound
+    // (a clone may not require features the JIT disabled), so it can select a
+    // clone narrower than the base -- e.g. a pkgimage built against a 256-bit
+    // sysimage being loaded against a 512-bit one (the pkgimage cache is keyed
+    // by the cpu_target string, not the sysimage's vector width). A width
+    // mismatch passes VecElement tuples in the wrong registers, so reject the
+    // cache (forcing recompilation at the correct width) rather than load it.
+    int jit_vreg = tp::max_vector_size(target.en_features);
+    if (result.second != jit_vreg) {
+        CF_DEBUG("[cpufeatures]   vreg mismatch: image=%d base=%d\n", result.second, jit_vreg);
+        if (rejection_reason) {
+            std::string msg = "Cached code image vector width does not match the base image.";
+            *rejection_reason = jl_pchar_to_string(msg.data(), msg.size());
+        }
+        return UINT32_MAX;
+    }
+#endif
     return result.first;
 }
 
@@ -662,6 +695,18 @@ extern "C" jl_clone_targets_t jl_get_llvm_clone_targets(const char *cpu_target)
 
     if (specs.empty())
         jl_error("No targets specified");
+
+    // When building a pkgimage incrementally on top of an already-loaded
+    // sysimage, its code only ever runs against the sysimage clone this process
+    // matched. Clamp the pkgimage clone targets to that clone's vector width so
+    // the pkgimage never requires (or emits) wider vectors than the sysimage it
+    // links against -- otherwise the resulting image would be unloadable, since
+    // the JIT/load target is itself clamped (see match_sysimg_target).
+    if (jl_options.incremental && !jit_targets.empty()) {
+        int sys_vreg = tp::max_vector_size(jit_targets.front().en_features);
+        for (auto &s : specs)
+            clamp_vector_features(s, sys_vreg);
+    }
 
     jl_clone_targets_t result;
 


### PR DESCRIPTION
I had a problem loading a package on a remote machine with the symptom:

```
~/julia$ manyjulias  $(git rev-parse HEAD)  -q --project=@cairomakie
Precompiling manyjulias finished.
  25 dependencies successfully precompiled in 18 seconds. 28 already precompiled.

julia> using Preferences
[ Info: Precompiling Preferences [21216c6a-2e73-6563-6e65-726566657250]
Precompiling project...
Precompiling Preferences finished.
  1 dependency successfully precompiled in 2 seconds. 4 already precompiled.
ERROR: Unable to find compatible target in cached code image.
Stacktrace:
  [1] _include_from_serialized(pkg::Base.PkgId, path::String, ocachepath::String, depmods::Vector{Any}; register::Bool)
    @ Base loading.jl:1462
  [2] _tryrequire_from_serialized(pkg::Base.PkgId, path::String, ocachepath::String)
    @ Base loading.jl:2172
```

so the package compiles ok but then rejects being loaded. The bot came up with this patch + explanation. Opening in case it is useful:

---------

🤖 


When a sysimage is loaded, `match_sysimg_target` clamps the JIT target down
to the vector width of the matched sysimage clone, stripping AVX/AVX-512
features. This is required for ABI correctness, since on x86 the vector width
determines how `VecElement` tuples are passed in registers (xmm/ymm/zmm), so
the running code must not use wider vectors than the sysimage clone it calls
into.

Package image generation did not apply the same clamp. The precompile worker
is launched with the raw `-C` target (typically `native`), and
`jl_get_llvm_clone_targets` re-resolved that string from scratch, expanding it
to the full host width regardless of the sysimage it was building against. On a
host wider than the sysimage (e.g. an AVX-512 machine running a sysimage built
for a narrower target), the worker emitted an AVX-512 pkgimage that embedded an
AVX-512 requirement. The loading process, whose JIT target is clamped down to
the sysimage width, could then never satisfy that requirement, failing with
"Unable to find compatible target in cached code image" even immediately after
a successful precompile.

Factor the feature-clamping logic into a shared `clamp_vector_features` helper
and apply it to the pkgimage clone targets in `jl_get_llvm_clone_targets`,
clamping them to the loaded sysimage clone's vector width. This is guarded on
`jl_options.incremental` so that full sysimage builds still emit their complete
multi-versioned target set.

This pull request was written with the assistance of generative AI.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

------------