### PR TITLE
agents: Add Compiler/JuliaSyntax/JuliaLowering skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,8 @@ canonical `SKILL.md` directly.
 - [`doc/src/devdocs/agents/skills/c-static-analysis/`](doc/src/devdocs/agents/skills/c-static-analysis/SKILL.md) — Clang static analysis and GC-rooting for C/C++ changes under `src/`.
 - [`doc/src/devdocs/agents/skills/external-deps/`](doc/src/devdocs/agents/skills/external-deps/SKILL.md) — modifying external dependencies (`deps/`, patches) and JLLs.
 - [`doc/src/devdocs/agents/skills/buildkite-logs/`](doc/src/devdocs/agents/skills/buildkite-logs/SKILL.md) — fetching and inspecting Buildkite CI logs without web sign-in.
+- [`doc/src/devdocs/agents/skills/compiler-jl/`](doc/src/devdocs/agents/skills/compiler-jl/SKILL.md) — developing and testing Compiler.jl.
+- [`doc/src/devdocs/agents/skills/julia-syntax-lowering/`](doc/src/devdocs/agents/skills/julia-syntax-lowering/SKILL.md) — developing and testing JuliaSyntax and JuliaLowering.
 
 ## Commit messages and pull requests
 

--- a/doc/src/devdocs/agents/README.md
+++ b/doc/src/devdocs/agents/README.md
@@ -16,3 +16,5 @@ The documentation build renders each canonical `SKILL.md` with its Agent Skill m
 - [`c-static-analysis`](skills/c-static-analysis/index.md) — Clang static analysis and GC-rooting for C/C++ changes under `src/`.
 - [`external-deps`](skills/external-deps/index.md) — modifying external dependencies (`deps/`, patches) and JLLs.
 - [`buildkite-logs`](skills/buildkite-logs/index.md) — fetching and inspecting Buildkite CI logs without web sign-in.
+- [`compiler-jl`](skills/compiler-jl/index.md) — developing and testing Compiler.jl.
+- [`julia-syntax-lowering`](skills/julia-syntax-lowering/index.md) — developing and testing JuliaSyntax and JuliaLowering.

--- a/doc/src/devdocs/agents/skills/compiler-jl/SKILL.md
+++ b/doc/src/devdocs/agents/skills/compiler-jl/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: compiler-jl
+description: Develop and test Julia's Compiler.jl. Use when modifying Compiler/, debugging compiler behavior, or activating stdlib Compiler for reflection/native-codegen experiments instead of using sysimage Base.Compiler.
+---
+
+# Compiler.jl development
+
+Use this when modifying `Compiler/` source, tests, or package metadata.
+
+## Compiler modules in Julia
+
+During bootstrap, `Compiler/` is built into the sysimage as `Base.Compiler`.
+That in-sysimage compiler is what Julia normally uses for native compilation.
+Because it is baked into the sysimage, changes made to `Compiler/` after the
+sysimage was built are not reflected in `Base.Compiler` unless Julia is rebuilt.
+
+`Compiler/` can also be loaded as a stdlib package, producing a separate
+`Compiler` module from `Base.Compiler`. For day-to-day development, testing, and
+debugging of post-sysimage source changes, prefer this stdlib `Compiler` module
+over trying to replace `Base.Compiler` with Revise. It is usually reliable except
+for failures caused by compatibility with the `src/` runtime or other
+sysimage/native-codegen integration issues.
+
+When investigating a runtime compatibility issue, `make -C src` can update the
+runtime faster than rebuilding the full Julia sysimage. Rebuild Julia when the
+updated `Compiler/` code needs to be baked into `Base.Compiler` or when checking
+sysimage/native-codegen integration.
+
+## Experimenting with Compiler as a stdlib
+
+Run the in-tree Julia runtime with the `Compiler` project:
+
+```sh
+./usr/bin/julia --project=Compiler
+```
+
+### Reflection backend
+
+For reflection-oriented debugging, activate the stdlib `Compiler` module:
+
+```julia
+using InteractiveUtils, Compiler
+@activate Compiler
+```
+
+`@activate Compiler` is equivalent to `@activate Compiler[:reflection]`: Base and
+InteractiveUtils reflection utilities such as `code_typed`, `@code_typed`, and
+`code_warntype` will use the loaded stdlib `Compiler` module. This is useful for
+trying compiler changes without rebuilding the sysimage.
+
+### Native compilation backend
+
+If you specifically need to exercise the loaded stdlib `Compiler` as the native
+compilation backend, use:
+
+```julia
+using InteractiveUtils, Compiler
+@activate Compiler[:codegen]
+```
+
+This is broader than reflection activation: it makes the runtime invoke the
+loaded compiler for compilation requests. Use it only when debugging native
+compilation/codegen behavior, and expect failures here to involve sysimage,
+runtime, native-codegen, or compiler-cache interactions.
+
+For ordinary debugging, prefer reflection activation. Use `[:codegen]` only when
+you specifically need to test the native compilation backend; for final
+integration checks, rebuild Julia and test the in-sysimage `Base.Compiler`.
+
+## Testing Compiler as a stdlib package
+
+Run package tests from the repository root with the in-tree Julia runtime:
+
+```sh
+./usr/bin/julia --project=Compiler -e 'using Pkg; Pkg.test()'
+```
+
+To run a single test file, include it directly under a `Test.@testset`:
+
+```sh
+./usr/bin/julia --project=Compiler -e 'using Test; @testset "inline" include("Compiler/test/inline.jl")'
+```
+
+Most `Compiler/test/` files include `Compiler/test/setup_Compiler.jl`, which
+activates or imports the appropriate `Compiler` module for this workflow.
+
+## Testing `Base.Compiler`
+
+Use the top-level test entry point when the goal is to test the `Base.Compiler`
+that is baked into the sysimage:
+
+```sh
+./usr/bin/julia test/runtests.jl Compiler
+```
+
+If you changed `Compiler/` and need those changes reflected in `Base.Compiler`,
+rebuild Julia first so the sysimage contains the updated compiler code.

--- a/doc/src/devdocs/agents/skills/julia-syntax-lowering/SKILL.md
+++ b/doc/src/devdocs/agents/skills/julia-syntax-lowering/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: julia-syntax-lowering
+description: Develop and test JuliaSyntax and JuliaLowering in Julia's source tree. Use when modifying JuliaSyntax/ or JuliaLowering/, running package or targeted tests, or checking JuliaLowering execution.
+---
+
+# JuliaSyntax & JuliaLowering development
+
+Use this when modifying `JuliaSyntax/` or `JuliaLowering/` source, tests, or
+package metadata.
+
+## Testing JuliaSyntax
+
+Run package tests from the repository root:
+
+```sh
+julia --project=JuliaSyntax -e 'using Pkg; Pkg.test()'
+```
+
+`JuliaSyntax` is not tied only to the in-tree Julia runtime; if a change may be
+version-sensitive, test it with the relevant installed Julia version(s).
+
+## Testing JuliaLowering
+
+Prefer the in-tree Julia runtime because compatibility with the Julia runtime
+may matter:
+
+```sh
+./usr/bin/julia --project=JuliaLowering -e 'using Pkg; Pkg.test()'
+```
+
+If `./usr/bin/julia` is unavailable, note that limitation and use an available
+`julia` executable only for preliminary validation.
+
+In this repository, `JuliaLowering/Project.toml` points its `JuliaSyntax`
+dependency at the sibling `JuliaSyntax` checkout
+(`path = "../JuliaSyntax"`). Therefore, `JuliaSyntax` changes can affect
+`JuliaLowering`. When a `JuliaSyntax` change may affect lowering behavior or
+syntax data consumed by `JuliaLowering`, run the `JuliaLowering` test command as
+well.
+
+### Targeted JuliaLowering tests
+
+For targeted `JuliaLowering` test execution, include
+`JuliaLowering/test/utils.jl` before the test file, matching
+`JuliaLowering/test/runtests.jl`:
+
+```sh
+./usr/bin/julia --project=JuliaLowering -e 'cd("JuliaLowering/test") do; include("utils.jl"); include("scopes.jl"); end'
+```
+
+For `_ir.jl` fixtures, call `test_ir_cases` after loading `utils.jl`:
+
+```sh
+./usr/bin/julia --project=JuliaLowering -e 'cd("JuliaLowering/test") do; include("utils.jl"); test_ir_cases("scopes_ir.jl"); end'
+```
+
+## Trying JuliaLowering execution
+
+For quick execution checks, run with the in-tree Julia runtime and the
+`JuliaLowering` project:
+
+```sh
+./usr/bin/julia --project=JuliaLowering
+```
+
+Then either evaluate code explicitly through `JuliaLowering`:
+
+```julia
+using JuliaLowering
+JuliaLowering.include_string(Main, "1 + 2")
+```
+
+or activate `JuliaLowering` as the process lowerer, then evaluate subsequent
+code normally:
+
+```julia
+using JuliaLowering
+JuliaLowering.activate!()
+
+1 + 2
+```
+
+Use `include("path/to/file.jl")` after activation when checking a file. When
+using `JuliaLowering.activate!()` from `-e`, make the code under test a separate
+top-level statement after activation, or put it in `include(...)`.


### PR DESCRIPTION
Add two project-local Agent Skills and Claude discovery symlinks, and list them from AGENTS.md.

The JuliaSyntax/JuliaLowering skill captures the package-test commands, notes that JuliaLowering should be tested with the in-tree runtime, records the JuliaLowering dependency on the sibling JuliaSyntax checkout, documents targeted JuliaLowering test execution through the shared test utilities, and notes quick JuliaLowering execution checks.

The Compiler.jl skill records the distinction between the sysimage `Base.Compiler` and the stdlib `Compiler` module, explains reflection and native-codegen activation via `@activate`, and documents the preferred stdlib package test workflow alongside sysimg-baked `Base.Compiler` testing.