### PR TITLE
src: check Julia annotations are on a function's first declaration

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -593,12 +593,14 @@ libjulia-codegen-debug libjulia-codegen-release: $(PUBLIC_HEADER_TARGETS)
 $(OBJS) $(DOBJS): FLAGS_COMMON += -DJL_LIBRARY_EXPORTS_INTERNAL -DBUILDING_UV_SHARED
 $(CODEGEN_OBJS) $(CODEGEN_DOBJS): FLAGS_COMMON += -DJL_LIBRARY_EXPORTS_CODEGEN -DUSING_UV_SHARED
 # set the exports for the source files based on where they are getting linked
-$(addprefix clang-sa-,$(SRCS)):      FLAGS_COMMON += -DJL_LIBRARY_EXPORTS_INTERNAL
-$(addprefix clang-sagc-,$(SRCS)):    FLAGS_COMMON += -DJL_LIBRARY_EXPORTS_INTERNAL
-$(addprefix clang-tidy-,$(SRCS)):    FLAGS_COMMON += -DJL_LIBRARY_EXPORTS_INTERNAL
-$(addprefix clang-sa-,$(CODEGEN_SRCS)):   FLAGS_COMMON += -DJL_LIBRARY_EXPORTS_CODEGEN
-$(addprefix clang-sagc-,$(CODEGEN_SRCS)): FLAGS_COMMON += -DJL_LIBRARY_EXPORTS_CODEGEN
-$(addprefix clang-tidy-,$(CODEGEN_SRCS)): FLAGS_COMMON += -DJL_LIBRARY_EXPORTS_CODEGEN
+$(addprefix clang-sa-,$(SRCS)) \
+$(addprefix clang-sagc-,$(SRCS)) \
+$(addprefix clang-tidy-,$(SRCS)): \
+	FLAGS_COMMON += -DJL_LIBRARY_EXPORTS_INTERNAL
+$(addprefix clang-sa-,$(CODEGEN_SRCS)) \
+$(addprefix clang-sagc-,$(CODEGEN_SRCS)) \
+$(addprefix clang-tidy-,$(CODEGEN_SRCS)): \
+	FLAGS_COMMON += -DJL_LIBRARY_EXPORTS_CODEGEN
 
 # Common flag patterns for all clang tooling (clang-sa, clang-tidy, compile-database)
 CLANG_TOOLING_C_FLAGS = $(CLANGSA_FLAGS) $(LLVM_CFLAGS) $(DEBUGFLAGS_CLANG) $(JCPPFLAGS_CLANG) $(JCFLAGS_CLANG)
@@ -700,6 +702,7 @@ endif
 
 clangsa: $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
 clangsa: $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
+clangsa: $(build_shlibdir)/libFirstDeclAnnotationsPlugin.$(SHLIB_EXT)
 
 # optarg is a required_argument for these
 SA_EXCEPTIONS-jloptions.c                   := -Xanalyzer -analyzer-config -Xanalyzer silence-checkers="core.NonNullParamChecker;unix.cstring.NullArg"
@@ -737,15 +740,36 @@ clang-sa-%: $(SRCDIR)/%.cpp .FORCE | analyzegc-deps-check
 		$(SA_EXCEPTIONS-$(notdir $<)) \
 		$(CLANG_TOOLING_CXX_FLAGS) -fcolor-diagnostics -Werror -x c++ $<)
 
-clang-tidy-%: $(SRCDIR)/%.c $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
+# Run the clang-tidy plugins: concurrency-implicit-atomics (see
+# src/clangsa/ImplicitAtomics.cpp) and julia-first-decl-annotations, which flags
+# Julia annotations (JL_NOTSAFEPOINT, JL_PROPAGATES_ROOT, ...) written only on a
+# redeclaration instead of on the first declaration (see
+# src/clangsa/FirstDeclAnnotations.cpp). `-header-filter='.*'` so the first
+# (header) declarations participate in the comparison. The annotation macros
+# only expand to an `annotate` attribute under `-D__clang_gcanalyzer__` (see
+# src/support/analyzer_annotations.h), so run the checks once in the normal
+# build configuration and once with the analyzer define active (when the
+# annotations are visible).
+TIDY_PLUGINS := -load $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) -load $(build_shlibdir)/libFirstDeclAnnotationsPlugin.$(SHLIB_EXT)
+TIDY_CHECKS := -clang-analyzer-*$(COMMA)-clang-diagnostic-*$(COMMA)concurrency-implicit-atomics$(COMMA)julia-first-decl-annotations
+clang-tidy-%: $(SRCDIR)/%.c $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) $(build_shlibdir)/libFirstDeclAnnotationsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang-tidy $< -header-filter='.*' --quiet \
-		-load $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) --checks='-clang-analyzer-*$(COMMA)-clang-diagnostic-*$(COMMA)concurrency-implicit-atomics' --warnings-as-errors='*' \
+		$(TIDY_PLUGINS) --checks='$(TIDY_CHECKS)' --warnings-as-errors='*' \
 		-- $(CLANG_TOOLING_C_FLAGS) -fcolor-diagnostics -fno-caret-diagnostics -x c)
-clang-tidy-%: $(SRCDIR)/%.cpp $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang-tidy $< -header-filter='.*' --quiet \
-		-load $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) --checks='-clang-analyzer-*$(COMMA)-clang-diagnostic-*$(COMMA)concurrency-implicit-atomics' --warnings-as-errors='*' \
+		$(TIDY_PLUGINS) --checks='$(TIDY_CHECKS)' --warnings-as-errors='*' \
+		-- $(CLANG_TOOLING_C_FLAGS) -D__clang_gcanalyzer__ -fcolor-diagnostics -fno-caret-diagnostics -x c)
+clang-tidy-%: $(SRCDIR)/%.cpp $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) $(build_shlibdir)/libFirstDeclAnnotationsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
+	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang-tidy $< -header-filter='.*' --quiet \
+		$(TIDY_PLUGINS) --checks='$(TIDY_CHECKS)' --warnings-as-errors='*' \
 		-- $(CLANG_TOOLING_CXX_FLAGS) -fcolor-diagnostics --system-header-prefix=llvm -Wno-deprecated-declarations -fno-caret-diagnostics -x c++)
+	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang-tidy $< -header-filter='.*' --quiet \
+		$(TIDY_PLUGINS) --checks='$(TIDY_CHECKS)' --warnings-as-errors='*' \
+		-- $(CLANG_TOOLING_CXX_FLAGS) -D__clang_gcanalyzer__ -fcolor-diagnostics --system-header-prefix=llvm -Wno-deprecated-declarations -fno-caret-diagnostics -x c++)
 
+# Flag functions with external linkage that are neither declared in a header nor
+# marked `static` (see src/clangsa/StaticOrDeclared.cpp). Kept as its own target
+# rather than folded into `clang-tidy-%` so it can be run independently.
 # Add C files as a target of `analyzesrc` and `analyzegc` and `tidysrc`
 .PHONY: tidysrc
 tidysrc: $(addprefix clang-tidy-,$(CODEGEN_SRCS) $(SRCS))
@@ -764,6 +788,7 @@ $(addprefix analyze-,$(filter-out $(basename $(SKIP_GC_CHECK)),$(CODEGEN_SRCS) $
 clean-analyzegc:
 	rm -f $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
 	rm -f $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
+	rm -f $(build_shlibdir)/libFirstDeclAnnotationsPlugin.$(SHLIB_EXT)
 
 # Compilation database generation using existing clang infrastructure
 .PHONY: regenerate-compile_commands

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2631,6 +2631,7 @@ extern "C" JL_DLLEXPORT_CODEGEN
 void jl_get_llvmf_defn_impl(jl_llvmf_dump_t *dump, jl_method_instance_t *mi, jl_code_info_t *src, char getwrapper, char optimize, const char *llvm_options, const jl_cgparams_t params)
 {
     // emit this function into a new llvm module
+    jl_task_t *ct = jl_current_task;
     dump->F = nullptr;
     dump->TSM = nullptr;
     dump->pass_output = nullptr;
@@ -2681,7 +2682,9 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t *dump, jl_method_instance_t *mi, jl_
                 decl_names.specptr = decls->specptr ? decls->specptr->getName() : "";
                 // if compilation succeeded, prepare to return the result
                 if (!jl_options.image_codegen) {
+                    int8_t gc_state = jl_gc_safe_enter(ct->ptls);
                     optimizeDLSyms(output.get_module());
+                    jl_gc_safe_leave(ct->ptls, gc_state);
                 }
                 assert(!verifyLLVMIR(output.get_module()));
                 if (optimize) {
@@ -2722,7 +2725,6 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t *dump, jl_method_instance_t *mi, jl_
         if (F) {
             dump->TSM = wrap(new orc::ThreadSafeModule(std::move(mod), std::move(ctx)));
             dump->F = wrap(F);
-            return;
-        }
+       }
     }
 }

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2716,6 +2716,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t *dump, jl_method_instance_t *mi, jl_
                 else
                     fname = &decl_names.invoke;
                 F = output.get_module().getFunction(*fname);
+                assert(F);
             }
             if (measure_compile_time_enabled) {
                 auto end = jl_hrtime();

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2604,7 +2604,7 @@ static void add_intrinsic(jl_module_t *inm, const char *name, enum intrinsic f) 
     jl_set_initial_const(inm, sym, i, 1);
 }
 
-void jl_init_intrinsic_properties(void) JL_GC_DISABLED
+void jl_init_intrinsic_properties(void)
 {
 #define ADD_I(name, nargs) add_intrinsic_properties(name, nargs, (void(*)(void))&jl_##name);
 #define ADD_HIDDEN ADD_I
@@ -2615,7 +2615,7 @@ void jl_init_intrinsic_properties(void) JL_GC_DISABLED
 #undef ALIAS
 }
 
-void jl_init_intrinsic_functions(void) JL_GC_DISABLED
+void jl_init_intrinsic_functions(void)
 {
     jl_module_t *inm = jl_new_module_(jl_symbol("Intrinsics"), jl_core_module, 0, 1);
     jl_set_initial_const(jl_core_module, jl_symbol("Intrinsics"), (jl_value_t*)inm, 0);

--- a/src/clangsa/FirstDeclAnnotations.cpp
+++ b/src/clangsa/FirstDeclAnnotations.cpp
@@ -1,0 +1,332 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// FirstDeclAnnotations: a clang-tidy check that enforces that every Julia
+// attribute that callers must see -- the `JL_*` macros that expand to
+// `__attribute__((annotate("julia_...")))`, e.g. JL_NOTSAFEPOINT,
+// JL_PROPAGATES_ROOT, JL_GLOBALLY_ROOTED, JL_ROOTED_BY_ARG(n), as well as the
+// visibility/linkage macros JL_DLLEXPORT, JL_DLLIMPORT and JL_HIDDEN (which
+// expand to `__attribute__((visibility(...)))` or `__declspec(dllexport/
+// dllimport)`) -- is written on the first declaration of a function, which is
+// normally the prototype in a header, rather than only on a later
+// redeclaration such as the definition in a .c/.cpp file.
+//
+// Why: these attributes are consumed per-declaration -- the analyzer
+// annotations by the static analyzer, and the visibility/linkage attributes by
+// the compiler when emitting references. Callers in other translation units
+// only ever see the header prototype, so an attribute that appears only on the
+// definition is invisible to them and to the analyzer at those call sites. The
+// attribute belongs on the first (header) declaration so that every caller
+// sees it. While often the compiler may be able to flag some of these (like
+// dllexport), in practice that has seemed to be platform-specific and poorly
+// worded and doesn't have auto-fix.
+//
+// Two cases are exempt:
+//
+//   * A block-scope prototype (a local extern declaration written inside a
+//   function body) may add an annotation that is valid only for that one
+//   caller -- e.g. jl_read_codeinst_invoke is redeclared JL_NOTSAFEPOINT
+//   inside a caller that passes waitcompile = 0. That narrower annotation
+//   deliberately does not belong on the global first declaration, so such
+//   declarations are not flagged. This applies only when the function also has
+//   a global prototype that the block-scope declaration is narrowing; a
+//   block-scope annotation on a function with no global prototype is still
+//   flagged.
+//
+//   * A first declaration in a system header (e.g. an upstream LLVM header
+//   reached via --system-header-prefix, as for llvmGetPassPluginInfo). That
+//   header is not ours to edit, so the annotation cannot be hoisted onto it
+//   and the later declaration is not flagged.
+//
+// Each diagnostic carries a fix-it that moves the attribute: it copies the
+// original macro spelling (e.g. JL_NOTSAFEPOINT, JL_ROOTED_BY_ARG(1),
+// JL_DLLEXPORT) onto the first declaration and removes the misplaced copy from
+// the later declaration. The fix is only offered when the attribute is written
+// through such a macro -- a raw `__attribute__((...))` is still diagnosed but
+// without a fix, since clang only records its inner-argument range (not the
+// enclosing `__attribute__((...))` syntax, which a sibling attribute may
+// share), so the spelling cannot be moved safely. Pass `--fix` (or
+// `--fix-notes`) to clang-tidy to apply the fixes automatically.
+//
+// Usage (see src/Makefile): clang-tidy foo.c --quiet \ -load
+// libFirstDeclAnnotationsPlugin.so \
+// --checks='-*,julia-first-decl-annotations' [--fix] \ -- <compiler flags>
+
+#include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/TypeLoc.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Lex/Lexer.h"
+#include "clang-tidy/ClangTidyCheck.h"
+#include "clang-tidy/ClangTidyModule.h"
+#include "clang-tidy/ClangTidyModuleRegistry.h"
+
+using namespace clang;
+using namespace clang::tidy;
+using namespace clang::ast_matchers;
+
+namespace {
+
+class FirstDeclAnnotationsCheck : public ClangTidyCheck {
+public:
+    FirstDeclAnnotationsCheck(StringRef Name, ClangTidyContext *Context)
+        : ClangTidyCheck(Name, Context) {}
+
+    void registerMatchers(MatchFinder *Finder) override {
+        // Match every function declaration; the matcher fires once per
+        // declaration node (each prototype, plus the definition), and the
+        // comparison against the first declaration happens in check().
+        Finder->addMatcher(functionDecl().bind("fn"), this);
+    }
+
+    void check(const MatchFinder::MatchResult &Result) override {
+        const auto *FD = Result.Nodes.getNodeAs<FunctionDecl>("fn");
+        if (!FD || FD->isImplicit())
+            return;
+
+        const FunctionDecl *First = FD->getFirstDecl();
+        if (First == FD)
+            return;
+
+        SourceManager &SM = Result.Context->getSourceManager();
+
+        // If the first declaration lives in a system header (e.g. an upstream
+        // LLVM header reached via --system-header-prefix, as for
+        // llvmGetPassPluginInfo), it is not ours to edit: the annotation cannot
+        // be hoisted onto it. Flagging a later declaration here would be a
+        // false positive with no applicable fix, so skip it.
+        if (SM.isInSystemHeader(First->getLocation()))
+            return;
+
+        // A block-scope redeclaration (a prototype written inside a function
+        // body, i.e. a local extern declaration) is intentionally allowed to
+        // add an annotation that holds only for that specific caller -- e.g.
+        // jl_read_codeinst_invoke is redeclared JL_NOTSAFEPOINT inside a caller
+        // that passes waitcompile = 0. Such a narrower annotation must NOT be
+        // hoisted onto the global first declaration, so do not flag it.
+        // This exemption only applies when the function also has a global
+        // prototype: the block-scope declaration is then understood to be
+        // narrowing that shared declaration. A block-scope annotation on a
+        // function with no global prototype is still flagged.
+        if (FD->isLocalExternDecl() && hasGlobalPrototype(FD))
+            return;
+
+        const LangOptions &LO = getLangOpts();
+
+        // Function-level annotations (e.g. JL_NOTSAFEPOINT) are written after
+        // the parameter list, so the fix inserts them just after the first
+        // declaration's closing `)`.
+        checkDecl(FD, First, FD, /*ParamIndex=*/-1,
+                  endOfToken(functionRParenLoc(First), SM, LO), SM, LO);
+
+        // Parameter-level annotations (e.g. JL_PROPAGATES_ROOT,
+        // JL_ROOTED_BY_ARG). Compare by position; redeclarations of the same
+        // function have the same parameters. The fix inserts them just after
+        // the matching parameter on the first declaration.
+        unsigned NumParams =
+            std::min(FD->getNumParams(), First->getNumParams());
+        for (unsigned I = 0; I < NumParams; ++I) {
+            const ParmVarDecl *FirstParam = First->getParamDecl(I);
+            checkDecl(FD->getParamDecl(I), FirstParam, FD,
+                      static_cast<int>(I),
+                      endOfToken(FirstParam->getEndLoc(), SM, LO), SM, LO);
+        }
+    }
+
+private:
+    // Report any governed Julia attribute that is written on `Later` (a
+    // parameter or function from a non-first declaration) but missing from
+    // `First` (the corresponding declaration on the function's first
+    // declaration). `FD`/`ParamIndex` are used only to phrase the diagnostic;
+    // ParamIndex < 0 means the function itself. `InsertLoc` is where on the
+    // first declaration an attribute should be inserted to fix the problem.
+    void checkDecl(const Decl *Later, const Decl *First,
+                   const FunctionDecl *FD, int ParamIndex,
+                   SourceLocation InsertLoc, SourceManager &SM,
+                   const LangOptions &LO) {
+        for (const auto *A : Later->attrs()) {
+            if (A->isInherited())
+                continue;
+            std::string Key = attrKey(A);
+            if (Key.empty())
+                continue;
+            if (hasAttrLike(First, Key))
+                continue;
+            std::string Name = attrName(A);
+
+            SourceLocation Loc = A->getLocation();
+            if (Loc.isInvalid())
+                Loc = Later->getLocation();
+
+            // Build a fix that moves the attribute to the first declaration:
+            // copy the exact macro spelling (e.g. "JL_ROOTED_BY_ARG(1)",
+            // "JL_DLLEXPORT") onto the first declaration and delete it where it
+            // is misplaced.
+            //
+            // Only do this when the attribute was written through a macro: its
+            // expansion range is then the single, self-contained macro
+            // invocation token, which is exactly what we want to move. A raw
+            // `__attribute__((visibility("default")))` instead reports a range
+            // covering only the inner `visibility("default")`, with no record of
+            // the enclosing `__attribute__((...))`/`[[...]]`/`__declspec(...)`
+            // syntax (which a sibling attribute may share), so copying or
+            // deleting just that inner part would corrupt the source. For raw
+            // attributes we still report the problem but offer no fix-it; Julia
+            // sources use the macros, so the fix applies in practice. Only offer
+            // the fix when both edits can be expressed against real file
+            // locations.
+            llvm::SmallVector<FixItHint, 2> Fixes;
+            bool FromMacro = A->getRange().getBegin().isMacroID();
+            CharSourceRange Spelling = SM.getExpansionRange(A->getRange());
+            StringRef Text =
+                Spelling.getBegin().isFileID() && Spelling.getEnd().isFileID()
+                    ? Lexer::getSourceText(Spelling, SM, LO)
+                    : StringRef();
+            if (FromMacro && InsertLoc.isValid() && !Text.empty()) {
+                Fixes.push_back(
+                    FixItHint::CreateInsertion(InsertLoc, (" " + Text).str()));
+                // Also drop one preceding space along with the misplaced
+                // annotation so the source does not keep a double space.
+                CharSourceRange Removal = Spelling;
+                SourceLocation B = Spelling.getBegin();
+                if (B.isFileID()) {
+                    bool Invalid = false;
+                    const char *Prev =
+                        SM.getCharacterData(B.getLocWithOffset(-1), &Invalid);
+                    if (!Invalid && Prev && (*Prev == ' ' || *Prev == '\t'))
+                        Removal.setBegin(B.getLocWithOffset(-1));
+                }
+                Fixes.push_back(FixItHint::CreateRemoval(Removal));
+            }
+
+            if (ParamIndex < 0) {
+                auto Diag = diag(Loc,
+                     "Julia annotation \"%0\" is on this declaration of %1 but "
+                     "missing from its first declaration; move it to the first "
+                     "declaration so callers and the analyzer see it");
+                Diag << Name << FD;
+                for (const FixItHint &F : Fixes)
+                    Diag << F;
+            } else {
+                auto Diag = diag(Loc,
+                     "Julia annotation \"%0\" is on parameter %1 of this "
+                     "declaration of %2 but missing from its first "
+                     "declaration; move it to the first declaration so callers "
+                     "and the analyzer see it");
+                Diag << Name << (ParamIndex + 1) << FD;
+                for (const FixItHint &F : Fixes)
+                    Diag << F;
+            }
+            diag(First->getLocation(), "first declaration is here",
+                 DiagnosticIDs::Note);
+        }
+    }
+
+    // True if the function has a global prototype: some declaration other
+    // than FD that is a file-scope declaration.
+    static bool hasGlobalPrototype(const FunctionDecl *FD) {
+        for (const FunctionDecl *R : FD->redecls()) {
+            if (R == FD)
+                continue;
+            if (!R->isLocalExternDecl())
+                return true;
+        }
+        return false;
+    }
+
+    // Location just past the end of the token at `Loc` (where a following
+    // annotation would be inserted), or an invalid location if unavailable.
+    static SourceLocation endOfToken(SourceLocation Loc, SourceManager &SM,
+                                     const LangOptions &LO) {
+        if (Loc.isInvalid())
+            return SourceLocation();
+        return Lexer::getLocForEndOfToken(Loc, 0, SM, LO);
+    }
+
+    // The closing `)` of a function declaration's parameter list, or an invalid
+    // location if it cannot be determined.
+    static SourceLocation functionRParenLoc(const FunctionDecl *FD) {
+        if (TypeSourceInfo *TSI = FD->getTypeSourceInfo()) {
+            TypeLoc TL = TSI->getTypeLoc().IgnoreParens();
+            if (auto FTL = TL.getAs<FunctionTypeLoc>())
+                return FTL.getRParenLoc();
+        }
+        return SourceLocation();
+    }
+
+    // Identify which attributes this check governs and how to compare them
+    // across declarations. Returns a key that is equal for two attributes that
+    // represent the same Julia attribute, or an empty string for attributes we
+    // do not check. Two declarations "have the same attribute" iff their keys
+    // match -- this is what lets us tell a missing attribute from a present one.
+    static std::string attrKey(const Attr *A) {
+        if (const auto *Ann = dyn_cast<AnnotateAttr>(A))
+            return ("annotate:" + Ann->getAnnotation()).str();
+        if (const auto *Vis = dyn_cast<VisibilityAttr>(A))
+            return "visibility:" + std::to_string(Vis->getVisibility());
+        if (isa<DLLExportAttr>(A))
+            return "dllexport";
+        if (isa<DLLImportAttr>(A))
+            return "dllimport";
+        return std::string();
+    }
+
+    // Human-readable name of a governed attribute, used for the diagnostic's
+    // "%0". For analyzer annotations this is the `julia_...` string; for the
+    // visibility/linkage attributes it is their spelling.
+    static std::string attrName(const Attr *A) {
+        if (const auto *Ann = dyn_cast<AnnotateAttr>(A))
+            return Ann->getAnnotation().str();
+        if (const auto *Vis = dyn_cast<VisibilityAttr>(A)) {
+            switch (Vis->getVisibility()) {
+            case VisibilityAttr::Default:
+                return "visibility(\"default\")";
+            case VisibilityAttr::Hidden:
+                return "visibility(\"hidden\")";
+            case VisibilityAttr::Protected:
+                return "visibility(\"protected\")";
+            }
+        }
+        if (isa<DLLExportAttr>(A))
+            return "dllexport";
+        if (isa<DLLImportAttr>(A))
+            return "dllimport";
+        return std::string();
+    }
+
+    // True if `D` carries a governed attribute whose key matches `Key`.
+    static bool hasAttrLike(const Decl *D, StringRef Key) {
+        for (const auto *A : D->attrs())
+            if (attrKey(A) == Key)
+                return true;
+        return false;
+    }
+};
+
+class FirstDeclAnnotationsModule : public ClangTidyModule {
+public:
+    void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+        CheckFactories.registerCheck<FirstDeclAnnotationsCheck>(
+            "julia-first-decl-annotations");
+    }
+};
+
+} // namespace
+
+namespace clang {
+namespace tidy {
+
+// Register the FirstDeclAnnotationsModule using this statically initialized
+// variable.
+static ClangTidyModuleRegistry::Add<::FirstDeclAnnotationsModule>
+    X("julia-first-decl-annotations-module",
+      "Adds the julia-first-decl-annotations check.");
+
+// This anchor is used to force the linker to link in the generated object file
+// and thus register the FirstDeclAnnotationsModule.
+volatile int FirstDeclAnnotationsModuleAnchorSource = 0;
+
+} // namespace tidy
+} // namespace clang

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -133,7 +133,7 @@ JL_DLLEXPORT jl_value_t *jl_get_libllvm_fallback(void) JL_NOTSAFEPOINT
     return jl_nothing;
 }
 
-JL_DLLEXPORT uint64_t jl_getUnwindInfo_fallback(uint64_t dwAddr)
+JL_DLLEXPORT uint64_t jl_getUnwindInfo_fallback(uint64_t dwAddr) JL_NOTSAFEPOINT
 {
     return 0;
 }

--- a/src/coverage.c
+++ b/src/coverage.c
@@ -264,7 +264,7 @@ static void write_lcov_data(logdata_t *logData, const char *outfile) JL_NOTSAFEP
     fclose(outf);
 }
 
-JL_DLLEXPORT void jl_write_coverage_data(const char *output) JL_NOTSAFEPOINT
+JL_DLLEXPORT void jl_write_coverage_data(const char *output)
 {
     pthread_mutex_lock(&coverage_lock);
     if (output) {
@@ -283,7 +283,7 @@ JL_DLLEXPORT void jl_write_coverage_data(const char *output) JL_NOTSAFEPOINT
     pthread_mutex_unlock(&coverage_lock);
 }
 
-void jl_write_malloc_log(void) JL_NOTSAFEPOINT
+void jl_write_malloc_log(void)
 {
     pthread_mutex_lock(&coverage_lock);
     char stm[32];
@@ -292,7 +292,7 @@ void jl_write_malloc_log(void) JL_NOTSAFEPOINT
     pthread_mutex_unlock(&coverage_lock);
 }
 
-void jl_init_coverage(void) JL_NOTSAFEPOINT
+void jl_init_coverage(void)
 {
     strhash_new(&coverageData, 0);
     strhash_new(&mallocData, 0);

--- a/src/coverage.c
+++ b/src/coverage.c
@@ -1,7 +1,6 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include <stdint.h>
-#include <pthread.h>
 #include <string.h>
 #include <stdio.h>
 #include <inttypes.h>
@@ -53,7 +52,7 @@ static logdata_vec_t *logdata_get_or_create(logdata_t *ld, const char *filename)
     return (logdata_vec_t *)*bp;
 }
 
-pthread_mutex_t coverage_lock = PTHREAD_MUTEX_INITIALIZER;
+static uv_mutex_t coverage_lock;
 
 static uint64_t *allocLine(logdata_vec_t *vec, int line) JL_NOTSAFEPOINT
 {
@@ -89,16 +88,16 @@ JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line) JL_NOTS
     assert(!codegen_imaging_mode());
     if (is_skip_filename(filename) || line < 0)
         return;
-    pthread_mutex_lock(&coverage_lock);
+    uv_mutex_lock(&coverage_lock);
     allocLine(logdata_get_or_create(&coverageData, filename), line);
-    pthread_mutex_unlock(&coverage_lock);
+    uv_mutex_unlock(&coverage_lock);
 }
 
 JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT
 {
-    pthread_mutex_lock(&coverage_lock);
+    uv_mutex_lock(&coverage_lock);
     uint64_t *ret = allocLine(logdata_get_or_create(&coverageData, filename), line);
-    pthread_mutex_unlock(&coverage_lock);
+    uv_mutex_unlock(&coverage_lock);
     return ret;
 }
 
@@ -109,11 +108,11 @@ JL_DLLEXPORT void jl_coverage_visit_line(const char *filename, size_t len, int l
     assert(filename[len] == '\0');
     if (codegen_imaging_mode() || is_skip_filename(filename) || line < 0)
         return;
-    pthread_mutex_lock(&coverage_lock);
+    uv_mutex_lock(&coverage_lock);
     logdata_vec_t *vec = logdata_get_or_create(&coverageData, filename);
     uint64_t *ptr = allocLine(vec, line);
     (*ptr)++;
-    pthread_mutex_unlock(&coverage_lock);
+    uv_mutex_unlock(&coverage_lock);
 }
 
 // Memory allocation log (malloc_log)
@@ -122,9 +121,9 @@ static logdata_t mallocData;
 
 JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT
 {
-    pthread_mutex_lock(&coverage_lock);
+    uv_mutex_lock(&coverage_lock);
     uint64_t *ret = allocLine(logdata_get_or_create(&mallocData, filename), line);
-    pthread_mutex_unlock(&coverage_lock);
+    uv_mutex_unlock(&coverage_lock);
     return ret;
 }
 
@@ -152,17 +151,17 @@ static void clear_log_data(logdata_t *logData, int resetValue) JL_NOTSAFEPOINT
 // Resets the malloc counts.
 JL_DLLEXPORT void jl_clear_malloc_data(void) JL_NOTSAFEPOINT
 {
-    pthread_mutex_lock(&coverage_lock);
+    uv_mutex_lock(&coverage_lock);
     clear_log_data(&mallocData, 1);
-    pthread_mutex_unlock(&coverage_lock);
+    uv_mutex_unlock(&coverage_lock);
 }
 
 // Resets the code coverage
 JL_DLLEXPORT void jl_clear_coverage_data(void) JL_NOTSAFEPOINT
 {
-    pthread_mutex_lock(&coverage_lock);
+    uv_mutex_lock(&coverage_lock);
     clear_log_data(&coverageData, 0);
-    pthread_mutex_unlock(&coverage_lock);
+    uv_mutex_unlock(&coverage_lock);
 }
 
 static void write_log_data(logdata_t *logData, const char *extension) JL_NOTSAFEPOINT
@@ -266,7 +265,7 @@ static void write_lcov_data(logdata_t *logData, const char *outfile) JL_NOTSAFEP
 
 JL_DLLEXPORT void jl_write_coverage_data(const char *output)
 {
-    pthread_mutex_lock(&coverage_lock);
+    uv_mutex_lock(&coverage_lock);
     if (output) {
         size_t len = strlen(output);
         if (len >= 5 && strcmp(output + len - 5, ".info") == 0) {
@@ -280,20 +279,21 @@ JL_DLLEXPORT void jl_write_coverage_data(const char *output)
         snprintf(stm, sizeof(stm), ".%d.cov", uv_os_getpid());
         write_log_data(&coverageData, stm);
     }
-    pthread_mutex_unlock(&coverage_lock);
+    uv_mutex_unlock(&coverage_lock);
 }
 
 void jl_write_malloc_log(void)
 {
-    pthread_mutex_lock(&coverage_lock);
+    uv_mutex_lock(&coverage_lock);
     char stm[32];
     snprintf(stm, sizeof(stm), ".%d.mem", uv_os_getpid());
     write_log_data(&mallocData, stm);
-    pthread_mutex_unlock(&coverage_lock);
+    uv_mutex_unlock(&coverage_lock);
 }
 
 void jl_init_coverage(void)
 {
+    uv_mutex_init(&coverage_lock);
     strhash_new(&coverageData, 0);
     strhash_new(&mallocData, 0);
 }

--- a/src/gc-common.h
+++ b/src/gc-common.h
@@ -82,10 +82,6 @@ extern jl_gc_callback_list_t *gc_cblist_notify_gc_pressure;
         } \
     } while (0)
 
-#ifdef __cplusplus
-}
-#endif
-
 // =========================================================================== //
 // malloc wrappers, aligned allocation
 // =========================================================================== //
@@ -226,5 +222,9 @@ extern int gc_logging_enabled;
 
 void _jl_free_stack(jl_ptls_t ptls, void *stkbuf, size_t bufsz) JL_NOTSAFEPOINT;
 void sweep_mtarraylist_buffers(void) JL_NOTSAFEPOINT;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // JL_GC_COMMON_H

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -263,11 +263,11 @@ struct _jl_value_t *jl_gc_permobj(struct _jl_tls_states_t *ptls, size_t sz, void
 // This function notifies the GC about memory addresses that are set when loading the boot image.
 // The GC may use that information to, for instance, determine that such objects should
 // be treated as marked and belonged to the old generation in nursery collections.
-void jl_gc_notify_image_load(const char* img_data, size_t len);
+void jl_gc_notify_image_load(const char* img_data, size_t len) JL_NOTSAFEPOINT;
 // This function notifies the GC about memory addresses that are set when allocating the boot image.
 // The GC may use that information to, for instance, determine that all objects in that chunk of memory should
 // be treated as marked and belonged to the old generation in nursery collections.
-void jl_gc_notify_image_alloc(const char* img_data, size_t len);
+void jl_gc_notify_image_alloc(const char* img_data, size_t len) JL_NOTSAFEPOINT;
 
 // ========================================================================= //
 // Runtime Write-Barriers

--- a/src/gc-page-profiler.h
+++ b/src/gc-page-profiler.h
@@ -69,7 +69,7 @@ STATIC_INLINE void gc_page_profile_write_live_obj(gc_page_profiler_serializer_t 
         jl_value_t *t = jl_typeof(a);
         ios_t str_;
         int ios_need_close = 0;
-        char *type_name = NULL;
+        const char *type_name = NULL;
         char *type_name_in_serializer = NULL;
         if (t == (jl_value_t *)jl_get_buff_tag()) {
             type_name = "Buffer";

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -623,7 +623,7 @@ static void reset_thread_gc_counts(void) JL_NOTSAFEPOINT
     }
 }
 
-void jl_gc_reset_alloc_count(void) JL_NOTSAFEPOINT
+void jl_gc_reset_alloc_count(void)
 {
     combine_thread_gc_counts(&gc_num, 0);
     int64_t alloc_increment = gc_num.deferred_alloc + gc_num.allocd;

--- a/src/gf.c
+++ b/src/gf.c
@@ -3466,7 +3466,7 @@ STATIC_INLINE jl_value_t *_jl_rettype_inferred(jl_value_t *owner, jl_method_inst
     return (jl_value_t*)jl_nothing;
 }
 
-JL_DLLEXPORT jl_value_t *jl_rettype_inferred(jl_value_t *owner, jl_method_instance_t *mi, size_t min_world, size_t max_world) JL_NOTSAFEPOINT
+JL_DLLEXPORT jl_value_t *jl_rettype_inferred(jl_value_t *owner, jl_method_instance_t *mi, size_t min_world, size_t max_world)
 {
     return (jl_value_t*)_jl_rettype_inferred(owner, mi, min_world, max_world);
 }

--- a/src/init.c
+++ b/src/init.c
@@ -230,7 +230,7 @@ JL_DLLEXPORT void jl_raise(int signo)
 #endif
 }
 
-JL_DLLEXPORT void jl_atexit_hook(int exitcode) JL_NOTSAFEPOINT_ENTER
+JL_DLLEXPORT void jl_atexit_hook(int exitcode)
 {
     uv_tty_reset_mode();
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2,6 +2,7 @@
 
 #include "llvm-version.h"
 #include "platform.h"
+#include <pthread.h>
 #include <stdint.h>
 #include <string>
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1676,7 +1676,7 @@ struct JuliaOJIT::DLSymOptimizer {
     bool named;
 };
 
-void optimizeDLSyms(Module &M) JL_NOTSAFEPOINT_LEAVE JL_NOTSAFEPOINT_ENTER {
+void optimizeDLSyms(Module &M) {
     JuliaOJIT::DLSymOptimizer(true)(M);
 }
 
@@ -2416,7 +2416,7 @@ void JuliaOJIT::printTimers()
     reportAndResetTimings();
 }
 
-void JuliaOJIT::optimizeDLSyms(Module &M) JL_NOTSAFEPOINT_LEAVE JL_NOTSAFEPOINT_ENTER {
+void JuliaOJIT::optimizeDLSyms(Module &M) {
     (*DLSymOpt)(M);
 }
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -74,6 +74,8 @@ inline int jl_is_timing_trace = 0;
 inline unsigned jl_timing_trace_granularity = 500;
 inline std::string jl_timing_trace_file;
 
+inline LLVMOrcThreadSafeContextRef wrap(const orc::ThreadSafeContext *P) JL_NOTSAFEPOINT;
+inline LLVMOrcThreadSafeModuleRef wrap(const orc::ThreadSafeModule *P) JL_NOTSAFEPOINT;
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(orc::ThreadSafeContext, LLVMOrcThreadSafeContextRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(orc::ThreadSafeModule, LLVMOrcThreadSafeModuleRef)
 
@@ -421,14 +423,14 @@ private:
     jl_name_counter_t names;
 
 public:
-    LLVMContext &get_context() { return M.getContext(); }
-    Module &get_module() { return M; }
+    LLVMContext &get_context() JL_NOTSAFEPOINT { return M.getContext(); }
+    Module &get_module() JL_NOTSAFEPOINT { return M; }
 
-    StringRef strip_linux(StringRef name);
+    StringRef strip_linux(StringRef name) JL_NOTSAFEPOINT;
     std::string make_name(jl_symbol_prefix_t type, jl_invoke_api_t api,
-                          StringRef orig_name);
-    std::string make_name(StringRef prefix, StringRef orig_name);
-    std::string make_name(StringRef orig_name);
+                          StringRef orig_name) JL_NOTSAFEPOINT;
+    std::string make_name(StringRef prefix, StringRef orig_name) JL_NOTSAFEPOINT;
+    std::string make_name(StringRef orig_name) JL_NOTSAFEPOINT;
 
     StringRef get_call_target(jl_code_instance_t *ci, bool specsig, bool always_inline);
 
@@ -481,7 +483,7 @@ public:
     bool safepoint_on_entry = true;
     bool use_swiftcc = true;
 
-    jl_codegen_output_t(Module &M)
+    jl_codegen_output_t(Module &M) JL_NOTSAFEPOINT
       : M(M), DL(M.getDataLayout()), TargetTriple(M.getTargetTriple())
     {
         if (TargetTriple.isRISCV())
@@ -856,7 +858,7 @@ public:
     std::string getMangledName(const GlobalValue *GV) JL_NOTSAFEPOINT;
 
     // Note that this is a potential safepoint due to jl_get_library_ and jl_dlsym calls
-    // but may be called from inside safe-regions due to jit compilation locks
+    // and must be called from inside safe-regions due to internal use of locks
     void optimizeDLSyms(Module &M) JL_NOTSAFEPOINT_LEAVE JL_NOTSAFEPOINT_ENTER;
 
 protected:
@@ -945,7 +947,7 @@ extern JuliaOJIT *jl_ExecutionEngine;
 
 void fixupTM(TargetMachine &TM) JL_NOTSAFEPOINT;
 
-void optimizeDLSyms(Module &M);
+void optimizeDLSyms(Module &M) JL_NOTSAFEPOINT_LEAVE JL_NOTSAFEPOINT_ENTER;
 
 static inline const char *jl_symbol_prefix(jl_symbol_prefix_t type,
                                            jl_invoke_api_t api) JL_NOTSAFEPOINT

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -40,7 +40,7 @@ extern "C" {
 #define FE_TOWARDZERO 0xc00
 #endif
 
-static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel, const char* julia_bindir);
+static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel, const char* julia_bindir) JL_NOTSAFEPOINT;
 
 /**
  * @brief Check if Julia is already initialized.
@@ -1042,7 +1042,7 @@ static NOINLINE int true_main(int argc, char *argv[])
     return 0;
 }
 
-static void lock_low32(void)
+static void lock_low32(void) JL_NOTSAFEPOINT
 {
 #if defined(_OS_WINDOWS_) && defined(_P64) && defined(JL_DEBUG_BUILD)
     // Prevent usage of the 32-bit address space on Win64, to catch pointer cast errors.
@@ -1084,7 +1084,7 @@ static void lock_low32(void)
 void jl_lisp_prompt(void);
 
 #ifdef _OS_LINUX_
-static void rr_detach_teleport(void) {
+static void rr_detach_teleport(void) JL_NOTSAFEPOINT {
 #define RR_CALL_BASE 1000
 #define SYS_rrcall_detach_teleport (RR_CALL_BASE + 9)
     int err = syscall(SYS_rrcall_detach_teleport, 0, 0, 0, 0, 0, 0);
@@ -1101,7 +1101,7 @@ static void rr_detach_teleport(void) {
  * @param argv Array of command-line arguments.
  * @return An integer indicating the exit status of the REPL session.
  */
-JL_DLLEXPORT int jl_repl_entrypoint(int argc, char *argv[])
+JL_DLLEXPORT int jl_repl_entrypoint(int argc, char *argv[]) JL_NOTSAFEPOINT_ENTER
 {
 #ifdef USE_TRACY
     if (getenv("JULIA_WAIT_FOR_TRACY"))
@@ -1157,7 +1157,7 @@ JL_DLLEXPORT int jl_repl_entrypoint(int argc, char *argv[])
 // create an absolute-path copy of the input path format string
 // formed as `joinpath(replace(pwd(), "%" => "%%"), in)`
 // unless `in` starts with `%`
-static const char *absformat(const char *in)
+static const char *absformat(const char *in) JL_NOTSAFEPOINT
 {
     if (in[0] == '%' || jl_isabspath(in))
         return in;
@@ -1184,7 +1184,7 @@ static const char *absformat(const char *in)
     return out;
 }
 
-static char *absrealpath(const char *in, int nprefix)
+static char *absrealpath(const char *in, int nprefix) JL_NOTSAFEPOINT
 { // compute an absolute realpath location, so that chdir doesn't change the file reference
   // ignores (copies directly over) nprefix characters at the start of abspath
     char *out;

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -21,7 +21,7 @@ char *shlib_ext = ".so";
 
 /* This simple hand-crafted tolower exists to avoid locale-dependent effects in
  * behaviors (and utf8proc_tolower wasn't linking properly on all platforms) */
-static char ascii_tolower(char c)
+static char ascii_tolower(char c) JL_NOTSAFEPOINT
 {
     if ('A' <= c && c <= 'Z')
         return c - 'A' + 'a';
@@ -558,13 +558,13 @@ restart_switch:
             }
             break;
         case 'v': // version
-            jl_printf(JL_STDOUT, "julia version %s\n", JULIA_VERSION_STRING);
+            jl_safe_fprintf(ios_stdout, "julia version %s\n", JULIA_VERSION_STRING);
             exit(0);
         case 'h': // help
-            jl_printf(JL_STDOUT, "%s%s", usage, opts);
+            jl_safe_fprintf(ios_stdout, "%s%s", usage, opts);
             exit(0);
         case opt_help_hidden:
-            jl_printf(JL_STDOUT, "%s%s", usage, opts_hidden);
+            jl_safe_fprintf(ios_stdout, "%s%s", usage, opts_hidden);
             exit(0);
         case 'g': // debug info
             if (optarg != NULL) {
@@ -645,7 +645,7 @@ restart_switch:
                 if (jl_options.depwarn == JL_OPTIONS_DEPWARN_ERROR)
                     jl_errorf("julia: --sysimage-native-code=no is deprecated");
                 else if (jl_options.depwarn == JL_OPTIONS_DEPWARN_ON)
-                    jl_printf(JL_STDERR, "WARNING: --sysimage-native-code=no is deprecated\n");
+                    jl_safe_printf("WARNING: --sysimage-native-code=no is deprecated\n");
             }
             else {
                 jl_errorf("julia: invalid argument to --sysimage-native-code={yes|no} (%s)", optarg);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2268,14 +2268,14 @@ typedef struct {
 struct _jl_image_t;
 typedef struct _jl_image_t jl_image_t;
 
-JL_DLLIMPORT const char *jl_get_libdir(void);
+JL_DLLIMPORT const char *jl_get_libdir(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_init(void);
 JL_DLLEXPORT void jl_init_with_image_file(const char *julia_bindir,
                                           const char *image_path);
 JL_DLLEXPORT void jl_init_with_image_handle(void *handle);
-JL_DLLEXPORT const char *jl_get_default_sysimg_path(void);
-JL_DLLEXPORT int jl_is_initialized(void);
-JL_DLLEXPORT void jl_atexit_hook(int status);
+JL_DLLEXPORT const char *jl_get_default_sysimg_path(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_is_initialized(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_atexit_hook(int status) JL_NOTSAFEPOINT_ENTER;
 JL_DLLEXPORT void jl_task_wait_empty(void);
 JL_DLLEXPORT void jl_postoutput_hook(void);
 JL_DLLEXPORT void JL_NORETURN jl_exit(int status);
@@ -2286,7 +2286,7 @@ JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void);
 
 JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
 JL_DLLEXPORT jl_image_buf_t jl_preload_sysimg(const char *fname);
-JL_DLLEXPORT jl_image_buf_t jl_set_sysimg_so(void *handle);
+JL_DLLEXPORT jl_image_buf_t jl_set_sysimg_so(void *handle) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_create_system_image(void **, jl_array_t *worklist, bool_t emit_split, ios_t **s, ios_t **z, jl_array_t **udeps JL_REQUIRE_ROOTED_SLOT, int64_t *srctextpos, jl_array_t *module_init_order);
 JL_DLLEXPORT void jl_restore_system_image(jl_image_t *image, jl_image_buf_t buf);
 JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname, jl_array_t *depmods, int complete, const char *pkgimage);
@@ -2440,7 +2440,7 @@ struct _jl_handler_t {
 #define JL_TASK_STATE_FAILED   2
 
 JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t*, jl_value_t*, size_t);
-JL_DLLEXPORT void jl_switchto(jl_task_t **pt);
+JL_DLLEXPORT void jl_switchto(jl_task_t **pt) JL_NOTSAFEPOINT_ENTER;
 JL_DLLEXPORT int jl_set_task_tid(jl_task_t *task, int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_set_task_threadpoolid(jl_task_t *task, int8_t tpid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e JL_MAYBE_UNROOTED);
@@ -2639,14 +2639,14 @@ JL_DLLEXPORT void jl__(void *jl_value) JL_NOTSAFEPOINT;
 
 // julia options -----------------------------------------------------------
 
-JL_DLLEXPORT ssize_t jl_sizeof_jl_options(void);
+JL_DLLEXPORT ssize_t jl_sizeof_jl_options(void) JL_NOTSAFEPOINT;
 
 // Parse an argc/argv pair to extract general julia options, passing back out
 // any arguments that should be passed on to the script.
-JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp);
+JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp) JL_NOTSAFEPOINT;
 JL_DLLEXPORT char *jl_format_filename(const char *output_pattern) JL_NOTSAFEPOINT;
 
-uint64_t parse_heap_size_option(const char *optarg, const char *option_name, int allow_pct);
+uint64_t parse_heap_size_option(const char *optarg, const char *option_name, int allow_pct) JL_NOTSAFEPOINT;
 
 // Set julia-level ARGS array according to the arguments provided in
 // argc/argv

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2234,7 +2234,7 @@ JL_DLLIMPORT void jl_init_codegen(void);
 JL_DLLIMPORT void jl_teardown_codegen(void) JL_NOTSAFEPOINT;
 JL_DLLIMPORT int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline) JL_NOTSAFEPOINT;
 // n.b. this might be called from unmanaged thread:
-JL_DLLIMPORT uint64_t jl_getUnwindInfo(uint64_t dwBase);
+JL_DLLIMPORT uint64_t jl_getUnwindInfo(uint64_t dwBase) JL_NOTSAFEPOINT;
 JL_DLLIMPORT void jl_jit_register_ci(jl_code_instance_t *ci) JL_NOTSAFEPOINT;
 JL_DLLIMPORT void jl_jit_unregister_ci(jl_code_instance_t *ci) JL_NOTSAFEPOINT;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -752,7 +752,7 @@ void jl_gc_add_finalizer_(jl_ptls_t ptls, void *v, void *f) JL_NOTSAFEPOINT;
 void jl_gc_debug_fprint_status(ios_t *s) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_gc_debug_fprint_critical_error(ios_t *s) JL_NOTSAFEPOINT;
 void jl_print_gc_stats(JL_STREAM *s);
-void jl_gc_reset_alloc_count(void);
+void jl_gc_reset_alloc_count(void) JL_NOTSAFEPOINT;
 uint32_t jl_get_gs_ctr(void);
 void jl_set_gs_ctr(uint32_t ctr);
 
@@ -1344,8 +1344,8 @@ void jl_init_common_symbols(void) JL_NOTSAFEPOINT;
 void jl_init_primitives(void) JL_GC_DISABLED;
 void jl_init_llvm(void);
 void jl_init_runtime_ccall(void);
-void jl_init_intrinsic_functions(void);
-void jl_init_intrinsic_properties(void);
+void jl_init_intrinsic_functions(void) JL_GC_DISABLED;
+void jl_init_intrinsic_properties(void) JL_GC_DISABLED;
 void jl_init_staticdata(void);
 // TypeApp: immutable struct with head::Any, param::Any
 // Represents a single lazy type application step (like UnionAll for where bindings).
@@ -1454,7 +1454,7 @@ JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *mo
 JL_DLLEXPORT jl_methcache_t *jl_new_method_cache(void);
 JL_DLLEXPORT jl_value_t *jl_get_specialization1(jl_tupletype_t *types JL_PROPAGATES_ROOT, size_t world);
 jl_method_instance_t *jl_get_specialized(jl_method_t *m, jl_value_t *types, jl_svec_t *sp) JL_PROPAGATES_ROOT;
-JL_DLLEXPORT jl_value_t *jl_rettype_inferred(jl_value_t *owner, jl_method_instance_t *li JL_PROPAGATES_ROOT, size_t min_world, size_t max_world);
+JL_DLLEXPORT jl_value_t *jl_rettype_inferred(jl_value_t *owner, jl_method_instance_t *li JL_PROPAGATES_ROOT, size_t min_world, size_t max_world) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_rettype_inferred_native(jl_method_instance_t *mi, size_t min_world, size_t max_world) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t world) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_value_t *type, size_t world) JL_GLOBALLY_ROOTED;
@@ -1762,7 +1762,7 @@ STATIC_INLINE uint64_t cong(uint64_t max, uint64_t *seed) JL_NOTSAFEPOINT // Ope
 
 JL_DLLEXPORT uint64_t jl_rand(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_srand(uint64_t) JL_NOTSAFEPOINT;
-JL_DLLEXPORT void jl_init_rand(void);
+JL_DLLEXPORT void jl_init_rand(void) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT extern void *jl_exe_handle;
 JL_DLLEXPORT extern void *jl_libjulia_handle;
@@ -2136,9 +2136,9 @@ JL_DLLEXPORT enum jl_memory_order jl_get_atomic_order_checked(jl_sym_t *order, c
 
 struct _jl_image_fptrs_t;
 
-void jl_init_coverage(void);
-void jl_write_malloc_log(void);
-JL_DLLEXPORT void jl_write_coverage_data(const char*);
+void jl_init_coverage(void) JL_NOTSAFEPOINT;
+void jl_write_malloc_log(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_write_coverage_data(const char*) JL_NOTSAFEPOINT;
 
 extern uv_mutex_t symtab_lock;
 jl_sym_t *_jl_symbol(const char *str, size_t len) JL_NOTSAFEPOINT;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -17,7 +17,7 @@
 #include "gc-tls-common.h"
 #include "julia_atomics.h"
 #ifndef _OS_WINDOWS_
-#include "pthread.h"
+#include <pthread.h>
 #endif
 // threading ------------------------------------------------------------------
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -376,8 +376,8 @@ JL_DLLEXPORT void jl_gc_run_pending_finalizers(struct _jl_task_t *ct);
 extern JL_DLLEXPORT _Atomic(int) jl_gc_have_pending_finalizers;
 JL_DLLEXPORT int8_t jl_gc_is_in_finalizer(void) JL_NOTSAFEPOINT;
 
-JL_DLLEXPORT void jl_wakeup_thread(int16_t tid);
-JL_DLLEXPORT void jl_wakeup_threadpool(int8_t tpid);
+JL_DLLEXPORT void jl_wakeup_thread(int16_t tid) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_wakeup_threadpool(int8_t tpid) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT int jl_getaffinity(int16_t tid, char *mask, int cpumasksize);
 JL_DLLEXPORT int jl_setaffinity(int16_t tid, char *mask, int cpumasksize);

--- a/src/null_sysimage.c
+++ b/src/null_sysimage.c
@@ -10,4 +10,4 @@
  * together (the default build configuration). The 0 value of jl_image_unpack
  * is used as a sentinel to indicate that the sysimage should be loaded externally.
  **/
-jl_image_unpack_func_t *jl_image_unpack = NULL;
+jl_image_unpack_func_t jl_image_unpack = NULL;

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -566,7 +566,7 @@ JL_DLLEXPORT jl_value_t *jl_cpu_has_fma(int bits)
 
 // Validate cpu_target string before any processing.
 // Called from init.c early in startup.
-extern "C" JL_DLLEXPORT void jl_check_cpu_target(const char *cpu_target, int imaging)
+extern "C" void jl_check_cpu_target(const char *cpu_target, int imaging)
 {
 
     if (!cpu_target || !*cpu_target)

--- a/src/processor.h
+++ b/src/processor.h
@@ -204,8 +204,8 @@ JL_DLLEXPORT int32_t jl_get_default_nans(void);
  * libjulia-* and the sysimage together (see null_sysimage.c), in which
  * case they allow accessing the local copy of the sysimage.
  **/
-typedef void jl_image_unpack_func_t(void *handle, jl_image_buf_t *image);
-extern jl_image_unpack_func_t *jl_image_unpack;
+typedef void (JL_NOTSAFEPOINT *jl_image_unpack_func_t)(void *handle, jl_image_buf_t *image);
+extern jl_image_unpack_func_t jl_image_unpack;
 
 /**
  * CPU name and feature string for LLVM.

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -293,7 +293,7 @@ void wakeup_thread(jl_task_t *ct, int16_t tid) JL_NOTSAFEPOINT { // Pass in ptls
 }
 
 /* ensure thread tid is awake if necessary */
-JL_DLLEXPORT void jl_wakeup_thread(int16_t tid) JL_NOTSAFEPOINT
+JL_DLLEXPORT void jl_wakeup_thread(int16_t tid)
 {
     jl_task_t *ct = jl_current_task;
     wakeup_thread(ct, tid);
@@ -313,7 +313,7 @@ static pool_wake_hint_t pool_wake_hints[POOL_WAKE_HINT_STRIPES];
 // candidate's sleep_check_state under a fence ([^store_buffering_1]); do not
 // short-circuit on n_threads_running, which can be stale and is not pool-local.
 // See devdocs/scheduler-wakeup.
-JL_DLLEXPORT void jl_wakeup_threadpool(int8_t tpid) JL_NOTSAFEPOINT
+JL_DLLEXPORT void jl_wakeup_threadpool(int8_t tpid)
 {
     if (tpid < 0 || tpid >= jl_n_threadpools) {
         wakeup_thread(jl_current_task, -1);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3502,17 +3502,18 @@ JL_DLLEXPORT void jl_image_unpack_zstd(void *handle, jl_image_buf_t *image)
 }
 
 // From a shared library handle, verify consistency and return a jl_image_buf_t
-static jl_image_buf_t get_image_buf(void *handle, int is_pkgimage)
+static jl_image_buf_t get_image_buf(void *handle, int is_pkgimage) JL_NOTSAFEPOINT
 {
     // verify that the linker resolved the symbols in this image against ourselves (libjulia-internal)
-    void** (*get_jl_RTLD_DEFAULT_handle_addr)(void) = NULL;
+    typedef void** (JL_NOTSAFEPOINT *jl_RTLD_DEFAULT_handle_func_t)(void);
+    jl_RTLD_DEFAULT_handle_func_t get_jl_RTLD_DEFAULT_handle_addr = NULL;
     if (handle != jl_RTLD_DEFAULT_handle) {
         int symbol_found = jl_dlsym(handle, "get_jl_RTLD_DEFAULT_handle_addr", (void **)&get_jl_RTLD_DEFAULT_handle_addr, 0, 0);
         if (!symbol_found || (void*)&jl_RTLD_DEFAULT_handle != (get_jl_RTLD_DEFAULT_handle_addr()))
             jl_error("Image file failed consistency check: maybe opened the wrong version?");
     }
 
-    jl_image_unpack_func_t **unpack;
+    jl_image_unpack_func_t *unpack;
     jl_image_buf_t image = {
         .kind = JL_IMAGE_KIND_SO,
         .pointers = NULL,

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -1052,6 +1052,16 @@ ios_t *ios_safe_stderr = NULL;
 
 void ios_init_stdstreams(void)
 {
+#ifdef _OS_WINDOWS_
+    // Set stdio writes to binary mode
+    fflush(stdin);
+    _setmode(STDIN_FILENO, _O_BINARY);
+    fflush(stdout);
+    _setmode(STDOUT_FILENO, _O_BINARY);
+    fflush(stderr);
+    _setmode(STDERR_FILENO, _O_BINARY);
+#endif
+
     ios_stdin = (ios_t*)malloc_s(sizeof(ios_t));
     ios_fd(ios_stdin, STDIN_FILENO, 0, 0);
 

--- a/src/support/libsupport.h
+++ b/src/support/libsupport.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-JL_DLLEXPORT void libsupport_init(void);
+JL_DLLEXPORT void libsupport_init(void) JL_NOTSAFEPOINT;
 
 #ifdef __cplusplus
 }

--- a/src/sys.c
+++ b/src/sys.c
@@ -1061,7 +1061,7 @@ JL_DLLEXPORT void jl_srand(uint64_t rngseed) JL_NOTSAFEPOINT
     jl_atomic_store_relaxed(&g_rngseed, rngseed);
 }
 
-void jl_init_rand(void) JL_NOTSAFEPOINT
+void jl_init_rand(void)
 {
     uint64_t rngseed;
     if (uv_random(NULL, NULL, &rngseed, sizeof(rngseed), 0, NULL)) {

--- a/src/task.c
+++ b/src/task.c
@@ -713,7 +713,7 @@ JL_DLLEXPORT void jl_switch(void) JL_NOTSAFEPOINT_LEAVE JL_NOTSAFEPOINT_ENTER
     jl_gc_unsafe_leave(ptls, gc_state);
 }
 
-JL_DLLEXPORT void jl_switchto(jl_task_t **pt) JL_NOTSAFEPOINT_ENTER // n.b. this does not actually enter a safepoint
+JL_DLLEXPORT void jl_switchto(jl_task_t **pt) // n.b. this does not actually enter a safepoint
 {
     jl_set_next_task(*pt);
     jl_switch();

--- a/src/threading.c
+++ b/src/threading.c
@@ -59,7 +59,7 @@ JL_DLLEXPORT void *jl_get_ptls_states(void)
     return jl_current_task->ptls;
 }
 
-static void jl_delete_thread(void*);
+static void jl_delete_thread(void*) JL_NOTSAFEPOINT_ENTER;
 
 #if !defined(_OS_WINDOWS_)
 static pthread_key_t jl_task_exit_key;
@@ -495,7 +495,7 @@ void jl_task_frame_noreturn(jl_task_t *ct) JL_NOTSAFEPOINT;
 void scheduler_delete_thread(jl_ptls_t ptls) JL_NOTSAFEPOINT;
 void _jl_free_stack(jl_ptls_t ptls, void *stkbuf, size_t bufsz) JL_NOTSAFEPOINT;
 
-static void jl_delete_thread(void *value) JL_NOTSAFEPOINT_ENTER
+static void jl_delete_thread(void *value)
 {
 #ifndef _OS_WINDOWS_
     pthread_setspecific(jl_task_exit_key, NULL);

--- a/src/timing.h
+++ b/src/timing.h
@@ -27,7 +27,7 @@ typedef struct {
 extern "C" {
 #endif
 
-void jl_init_timing(void);
+void jl_init_timing(void) JL_NOTSAFEPOINT;
 void jl_destroy_timing(void) JL_NOTSAFEPOINT;
 
 // Update the enable bit-mask to enable/disable tracing events for

--- a/test/clangsa/FirstDeclAnnotationsTest.c
+++ b/test/clangsa/FirstDeclAnnotationsTest.c
@@ -1,0 +1,92 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// RUN: clang-tidy %s --checks=-*,julia-first-decl-annotations -header-filter='.*' -load libFirstDeclAnnotationsPlugin%shlibext -- -D__clang_gcanalyzer__ -I%julia_home/src -I%julia_home/src/support -I%julia_home/usr/include ${CLANGSA_FLAGS} ${CLANGSA_CXXFLAGS} ${CPPFLAGS} ${CFLAGS} -x c -std=c11 | FileCheck --check-prefixes=CHECK --implicit-check-not=warning: %s
+// RUN: clang-tidy %s --checks=-*,julia-first-decl-annotations -header-filter='.*' -load libFirstDeclAnnotationsPlugin%shlibext -- -D__clang_gcanalyzer__ -I%julia_home/src -I%julia_home/src/support -I%julia_home/usr/include ${CLANGSA_FLAGS} ${CLANGSA_CXXFLAGS} ${CPPFLAGS} ${CFLAGS} ${CXXFLAGS} -x c++ -std=c++11 | FileCheck --check-prefixes=CHECK,CHECK-CXX --implicit-check-not=warning: %s
+
+// Each diagnostic carries a fix-it that moves the annotation to the first
+// declaration. Copy the test and its header into a temp directory, apply the
+// fixes with --fix, and check both files: the definitions in the .c lose their
+// annotations (CHECK-FIXES) and the header gains them (CHECK-FIXES-H). The
+// patterns are anchored with {{^}}/{{$}} so they match the rewritten source
+// lines and never the CHECK comment lines that contain the same text.
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: cp %s %t/FirstDeclAnnotationsTest.c
+// RUN: cp %S/FirstDeclAnnotationsTest.h %t/FirstDeclAnnotationsTest.h
+// RUN: clang-tidy %t/FirstDeclAnnotationsTest.c --checks=-*,julia-first-decl-annotations -header-filter='.*' --fix -load libFirstDeclAnnotationsPlugin%shlibext -- -D__clang_gcanalyzer__ -I%t -I%julia_home/src -I%julia_home/src/support -I%julia_home/usr/include ${CLANGSA_FLAGS} ${CLANGSA_CXXFLAGS} ${CPPFLAGS} ${CFLAGS} -x c -std=c11
+// RUN: FileCheck --check-prefix=CHECK-FIXES --input-file=%t/FirstDeclAnnotationsTest.c %s
+// RUN: FileCheck --check-prefix=CHECK-FIXES-H --input-file=%t/FirstDeclAnnotationsTest.h %s
+
+#include "FirstDeclAnnotationsTest.h"
+
+void fda_ok_both(void) JL_NOTSAFEPOINT {}
+void fda_ok_header_only(void) {}
+// CHECK: warning: Julia annotation "julia_not_safepoint" is on this declaration of 'fda_missing_func' but missing from its first declaration
+// CHECK-FIXES: {{^}}void fda_missing_func(void) {}{{$}}
+// CHECK-FIXES-H: {{^}}void fda_missing_func(void) JL_NOTSAFEPOINT;{{$}}
+void fda_missing_func(void) JL_NOTSAFEPOINT {}
+
+int fda_ok_param(int *p) { return *p; }
+// CHECK: warning: Julia annotation "julia_propagates_root" is on parameter 1 of this declaration of 'fda_missing_param' but missing from its first declaration
+// CHECK-FIXES: {{^}}int fda_missing_param(int *p) { return *p; }{{$}}
+// CHECK-FIXES-H: {{^}}int fda_missing_param(int *p JL_PROPAGATES_ROOT);{{$}}
+int fda_missing_param(int *p JL_PROPAGATES_ROOT) { return *p; }
+
+void fda_ok_vis(void) JL_DLLEXPORT {}
+// CHECK: warning: Julia annotation "visibility("default")" is on this declaration of 'fda_missing_vis' but missing from its first declaration
+// CHECK-FIXES: {{^}}void fda_missing_vis(void) {}{{$}}
+// CHECK-FIXES-H: {{^}}void fda_missing_vis(void) JL_DLLEXPORT;{{$}}
+void fda_missing_vis(void) JL_DLLEXPORT {}
+
+// CHECK: warning: Julia annotation "visibility("default")" is on this declaration of 'fda_raw_vis' but missing from its first declaration
+// CHECK-FIXES: {{^}}void fda_raw_vis(void) __attribute__((visibility("default"))) {}{{$}}
+void fda_raw_vis(void) __attribute__((visibility("default"))) {}
+
+// CHECK: warning: Julia annotation "julia_not_safepoint" is on this declaration of 'fda_chain' but missing from its first declaration
+// CHECK-FIXES: {{^}}void fda_chain(void) JL_NOTSAFEPOINT;{{$}}
+// CHECK-FIXES: {{^}}void fda_chain(void);{{$}}
+void fda_chain(void);
+void fda_chain(void) JL_NOTSAFEPOINT;
+void fda_chain(void) {}
+
+// CHECK-FIXES: {{^}}void fda_local(void);{{$}}
+// CHECK-FIXES: {{^ *}}void fda_local(void) JL_NOTSAFEPOINT;{{$}}
+void fda_local(void);
+void fda_local_caller(void) {
+    void fda_local(void) JL_NOTSAFEPOINT;
+    fda_local();
+}
+void fda_local(void) {}
+
+// CHECK-FIXES: {{^}}void fda_localdef(void) {}{{$}}
+// CHECK-FIXES: {{^ *}}void fda_localdef(void) JL_NOTSAFEPOINT;{{$}}
+void fda_localdef(void) {}
+void fda_localdef_caller(void) {
+    void fda_localdef(void) JL_NOTSAFEPOINT;
+    fda_localdef();
+}
+
+// CHECK: warning: Julia annotation "julia_not_safepoint" is on this declaration of 'fda_blockonly' but missing from its first declaration
+void fda_blockonly_caller1(void) {
+    void fda_blockonly(void);
+    fda_blockonly();
+}
+void fda_blockonly_caller2(void) {
+    void fda_blockonly(void) JL_NOTSAFEPOINT;
+    fda_blockonly();
+}
+
+#ifdef __cplusplus
+// CHECK-CXX: warning: Julia annotation "julia_not_safepoint" is on this declaration of 'm' but missing from its first declaration
+struct fda_S { void m(void); };
+void fda_S::m(void) JL_NOTSAFEPOINT {}
+#endif
+
+// The system header is simulated with a GCC line marker whose '3' flag marks
+// the region as a system header.
+// Kept last so the line-marker renumbering does not affect the cases above.
+// CHECK-FIXES: {{^}}void fda_sysproto(void);{{$}}
+// CHECK-FIXES: {{^}}void fda_sysproto(void) JL_NOTSAFEPOINT {}{{$}}
+# 1 "fda_first_decl_annotations_fake_sys.h" 1 3
+void fda_sysproto(void);
+# 1 "FirstDeclAnnotationsTest.c" 2
+void fda_sysproto(void) JL_NOTSAFEPOINT {}

--- a/test/clangsa/FirstDeclAnnotationsTest.h
+++ b/test/clangsa/FirstDeclAnnotationsTest.h
@@ -1,0 +1,28 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// First (header) declarations for FirstDeclAnnotationsTest. The
+// julia-first-decl-annotations check requires that every Julia annotation a
+// function (or its parameters) carries is present on this first declaration.
+
+#include "analyzer_annotations.h"
+
+// Mimic the visibility/linkage macros from src/support/dtypes.h as expanded on
+// the (non-Windows) analyzer platform, so the check sees the same attributes
+// and the fix moves the same macro spelling that real Julia sources use.
+#define JL_DLLEXPORT __attribute__((visibility("default")))
+#define JL_HIDDEN __attribute__((visibility("hidden")))
+
+// Annotation present here: definitions may repeat it or inherit it -> OK.
+void fda_ok_both(void) JL_NOTSAFEPOINT;
+void fda_ok_header_only(void) JL_NOTSAFEPOINT;
+int fda_ok_param(int *p JL_PROPAGATES_ROOT);
+
+// No annotation here: a definition that adds one is what the check flags.
+void fda_missing_func(void);
+int fda_missing_param(int *p);
+
+// Visibility attribute (as JL_DLLEXPORT/JL_HIDDEN expand to) present here -> OK;
+// absent here but added on the definition is what the check flags.
+void fda_ok_vis(void) JL_DLLEXPORT;
+void fda_missing_vis(void);
+void fda_raw_vis(void);


### PR DESCRIPTION
Add a clang-tidy check, julia-first-decl-annotations, that flags function annotations (e.g. JL_NOTSAFEPOINT, JL_PROPAGATES_ROOT, JL_ROOTED_BY_ARG, ...) written only on a later redeclaration, such as the definition in a .c/.cpp file, rather than on the function's first declaration. Callers in other translation units and the analyzer only see the first declaration (normally the header prototype), so an annotation that appears only on the definition is invisible to them and is silently not enforced at those call sites. Both function-level and parameter-level annotations are checked.

Each diagnostic carries a fix-it that moves the annotation onto the first declaration, reusing the exact macro spelling, so the check can be applied automatically with clang-tidy --fix.

Two redeclarations are exempt: a block-scope (local extern) prototype that narrows a globally-declared function for one caller, as `jl_read_codeinst_invoke` does with JL_NOTSAFEPOINT when waitcompile = 0; and a first declaration that lives in a system header, such as `llvmGetPassPluginInfo` whose prototype is in an upstream LLVM header that is not ours to edit.

The annotation macros only expand to an `annotate` attribute under `-D__clang_gcanalyzer__`, so the check is folded into the clang-tidy-% rule and run both in the normal build configuration and with the analyzer define active.

This helps to catch more mistakes (such as the possible gc-deadlock in `jl_get_llvmf_defn`, Claude mistakenly adding a dependency on winpthreads, etc)

This incidentally highlighted an issue with our iostream implementation, when IO is not routed via libuv, that it is in `_O_TEXT` mode and so mutates that output (e.g. for `jl_safe_fprintf`).