### PR TITLE
support: Restore classic _tzname[] declaration on Windows

### DIFF
--- a/src/support/strptime.c
+++ b/src/support/strptime.c
@@ -47,6 +47,18 @@ typedef _locale_t locale_t;
 #define _current_locale() NULL
 #define localtime_r(timep, result) (localtime_s(result, timep) ? NULL : result)
 
+/*
+ * Newer mingw-w64 redirects the _tzname macro to a CRT symbol (__tzname,
+ * i.e. __imp___tzname) that the bundled msvcrt import library does not
+ * export, breaking the link when the host headers are newer than that
+ * library. For non-UCRT targets, restore the classic dllimport _tzname[]
+ * declaration, whose __imp__tzname symbol the bundled library does provide.
+ */
+#if !defined(_UCRT)
+#undef _tzname
+__MINGW_IMPORT char *_tzname[2];
+#endif
+
 __declspec(dllexport) char *
 strptime(const char *buf, const char *fmt, struct tm *tm);
 __declspec(dllexport) char *


### PR DESCRIPTION
The Windows strptime matches %Z against the process timezone names via the _tzname global. Newer mingw-w64 redirects the _tzname macro to a different CRT symbol (__tzname / __imp___tzname); when the host compiler's headers are newer than the bundled CompilerSupportLibraries CRT import library (as after #62152) that symbol is not exported by the bundled library and the link fails:

  src/support/strptime.c:625: undefined reference to `__imp___tzname'

For non-UCRT targets, #undef the macro and re-declare the classic dllimport char *_tzname[2]. That references the __imp__tzname symbol, which the bundled msvcrt import library still provides, so it links regardless of the host header vintage and across both 32- and 64-bit mingw-w64.