### PR TITLE
staticdata: relink precompiled opaque closures

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1815,6 +1815,16 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                 assert(f == s->s);
                 record_memoryref(s, reloc_offset, *(jl_genericmemoryref_t*)v);
             }
+            else if (jl_is_opaque_closure(v)) {
+                assert(f == s->s);
+                // issue #62180: `invoke` and `specptr` are native-code pointers into
+                // the serializing process; they are meaningless in any process that
+                // loads this image. Null them here and re-derive them at load time.
+                jl_opaque_closure_t *newoc = (jl_opaque_closure_t*)&f->buf[reloc_offset];
+                newoc->invoke = NULL;
+                newoc->specptr = NULL;
+                arraylist_push(&s->fixup_objs, (void*)reloc_offset);
+            }
             else {
                 write_padding(f, jl_datatype_size(t) - tot);
             }
@@ -4089,6 +4099,25 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                 jl_globalref_t *gr = (jl_globalref_t*)jl_module_globalref(r->mod, r->name);
                 jl_gc_write(r, r->binding, gr->binding);
             }
+        }
+        else if (jl_is_opaque_closure(obj)) {
+            // issue #62180: the native-code pointers were nulled during serialization.
+            // Route calls through the interpreter, which reconstructs execution from
+            // the (serialized) source rather than a stale compiled-code pointer.
+            jl_opaque_closure_t *oc = (jl_opaque_closure_t*)obj;
+            oc->invoke = (jl_fptr_args_t)jl_interpret_opaque_closure;
+            oc->specptr = NULL;
+            // `world` pins the world the closure body executes in, fixing what its
+            // calls dispatch to; the closure is never invalidated, so this stays
+            // fixed and the body keeps reaching the definitions present when the
+            // image was built. The stored value is the serializing process's world
+            // age and is meaningless here, so re-pin it: for an incremental image to
+            // the world the package's methods are activated in (jl_activate_methods),
+            // otherwise to the world established when this image is loaded.
+            if (s.incremental)
+                jl_array_ptr_1d_push(*internal_methods, obj);
+            else
+                oc->world = jl_atomic_load_acquire(&jl_world_counter);
         }
         else if (jl_is_module(obj)) {
             // rebuild the usings table for module v

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -909,6 +909,12 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
             jl_atomic_store_relaxed(&ci->min_world, world);
             // n.b. ci->max_world is not updated until edges are verified
         }
+        else if (jl_is_opaque_closure(obj)) {
+            // issue #62180: a precompiled opaque closure runs in the world its
+            // package's methods become active in, so its body sees them.
+            jl_opaque_closure_t *oc = (jl_opaque_closure_t*)obj;
+            oc->world = world;
+        }
         else {
             abort();
         }

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2228,6 +2228,28 @@ precompile_test_harness("Generated Opaque") do load_path
     end
 end
 
+# A `Core.OpaqueClosure` instance stored in a package image (here a top-level `const`) must remain
+# callable once the package is loaded, returning what it returned in the precompiling process. The
+# call runs in a subprocess so it is isolated from the test runner. See JuliaLang/julia#62180.
+@testset "call precompiled opaque closure instance" begin
+    load_path = mktempdir(); depot = mktempdir()
+    try
+        modname = "OpaqueClosureInstancePrecompile"
+        write(joinpath(load_path, "$modname.jl"),
+              "module $modname\n    const oc = Base.Experimental.@opaque x -> x\nend\n")
+        sep = Sys.iswindows() ? ";" : ":"
+        code = "Base.compilecache(Base.PkgId($(repr(modname)))); using $modname; print($modname.oc(41))"
+        cmd = addenv(`$(Base.julia_cmd()) --startup-file=no -e $code`,
+                     "JULIA_LOAD_PATH" => load_path * sep * "@stdlib",
+                     "JULIA_DEPOT_PATH" => depot * sep)
+        out = read(pipeline(ignorestatus(cmd); stderr=devnull), String)
+        @test out == "41"
+    finally
+        rm(load_path; recursive=true, force=true)
+        rm(depot; recursive=true, force=true)
+    end
+end
+
 precompile_test_harness("Issue #52063") do load_path
     fname = joinpath(load_path, "i_do_not_exist.jl")
     @test try


### PR DESCRIPTION
An OpaqueClosure is an immutable struct whose `invoke` and `specptr` fields hold native-code pointers into the process that created it. The generic serializer wrote those pointers verbatim (the Ptr reset applies only to mutable types, and OpaqueClosure had no special handling), so a precompiled instance carried dangling pointers into any loading process and segfaulted the first time it was called.

Null those fields on serialization and re-establish them on load: route calls through the interpreter, which reconstructs execution from the serialized source, and remap the stored world age to the world in which the loaded package's methods become active so the closure body can see them.

Fixes #62180.