### PR TITLE
[backports-release-1.12] staticdata: Fix undefined `.super` when canonicalizing types

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -4062,8 +4062,18 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                 assert(tag == 0);
                 arraylist_push(&delay_list, obj);
                 arraylist_push(&delay_list, pfld);
-                ptrhash_put(&new_dt_objs, (void*)obj, obj); // mark obj as invalid
-                *pfld = (uintptr_t)NULL;
+                // FIXME: leaving the `super` field populated here and then performing
+                // type canonicalization is unsound since it intentionally exposes sub-
+                // typing to non-canonicalized types (c.f. `jl_type_equality_is_identity`)
+                //
+                // Type canonicalization requires that any queried types are already
+                // canonicalized or that `super` is not needed to decide type-equality.
+                // The latter is essentially never true in general (proof is left to the
+                // reader) and the former is not possible in the presence of circular types.
+                //
+                // For now we blindly hope that subtyping rarely inspects `super` and, if
+                // it does, that it doesn't compare it against any equal-but-not-yet-
+                // canonicalized-to types so that the result is unaffected.
                 continue;
             }
         }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -303,6 +303,7 @@ static htable_t nullptrs;
 static arraylist_t serialization_queue;
 static arraylist_t layout_table;     // cache of `position(s)` for each `id` in `serialization_order`
 static arraylist_t object_worklist;  // used to mimic recursion by jl_serialize_reachable
+static arraylist_t deferred_supers;  // deferred datatype super fields, handled by jl_serialize_reachable once the pre-order recursion has unwound
 
 // Permanent list of void* (begin, end+1) pairs of system/package images we've loaded previously
 // together with their module build_ids (used for external linkage)
@@ -1079,12 +1080,13 @@ done_fields: ;
     // try to promote itself to be immediate)
     if (s->incremental && jl_is_datatype(v) && immediate && recursive) {
         jl_datatype_t *dt = (jl_datatype_t*)v;
-        void **bp = ptrhash_bp(&serialization_order, (void*)dt->super);
-        if (*bp != (void*)-2) {
-            // if super is already on the stack of things to handle when this returns, do
-            // not try to handle it now
-            jl_queue_for_serialization_(s, (jl_value_t*)dt->super, 1, immediate);
-        }
+        // do not handle the super field now: the supertype's parameters can reach back to
+        // objects that are still on the recursion stack (e.g. `struct Baz{T} <: Bar{Foo{Baz{T}}} end`),
+        // which would order the supertype before its own parameters in the queue. Defer it
+        // until the recursion unwinds; any forward reference this creates in the image is
+        // handled at load time by the uniquing_super/delay_list machinery.
+        if (jl_needs_serialization(s, (jl_value_t*)dt->super))
+            arraylist_push(&deferred_supers, (void*)dt->super);
         immediate = 0;
         char *data = (char*)jl_data_ptr(v);
         size_t i, np = layout->npointers;
@@ -1150,7 +1152,15 @@ static void jl_queue_for_serialization_(jl_serializer_state *s, jl_value_t *v, i
 static void jl_serialize_reachable(jl_serializer_state *s) JL_GC_DISABLED
 {
     size_t i, prevlen = 0;
-    while (object_worklist.len) {
+    while (1) {
+        // handle deferred super fields now: the recursion stack is unwound here, so
+        // everything reachable through their parameters is already validly ordered
+        while (deferred_supers.len) {
+            jl_value_t *super = (jl_value_t*)deferred_supers.items[--deferred_supers.len];
+            jl_queue_for_serialization_(s, super, 1, 1);
+        }
+        if (object_worklist.len == 0)
+            break;
         // reverse!(object_worklist.items, prevlen:end);
         // prevlen is the index of the first new object
         for (i = prevlen; i < object_worklist.len; i++) {
@@ -1539,9 +1549,11 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                     continue;
                 }
                 else if (jl_is_datatype(v)) {
-                    for (size_t i = 0; i < s->uniquing_super.len; i++) {
-                        if (s->uniquing_super.items[i] == (void*)v) {
-                            s->uniquing_super.items[i] = arraylist_pop(&s->uniquing_super);
+                    // iterate in reverse, so that the element swapped in from the back upon
+                    // removal is always one we have already examined
+                    for (size_t i = s->uniquing_super.len; i > 0; i--) {
+                        if (s->uniquing_super.items[i - 1] == (void*)v) {
+                            s->uniquing_super.items[i - 1] = arraylist_pop(&s->uniquing_super);
                             arraylist_push(&s->uniquing_types, (void*)(uintptr_t)(reloc_offset|3));
                         }
                     }
@@ -3147,6 +3159,7 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
     htable_new(&serialization_order, 25000);
     htable_new(&nullptrs, 0);
     arraylist_new(&object_worklist, 0);
+    arraylist_new(&deferred_supers, 0);
     arraylist_new(&serialization_queue, 0);
     ios_t sysimg, const_data, symbols, relocs, gvar_record, fptr_record;
     ios_mem(&sysimg, 0);
@@ -3436,6 +3449,8 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
 
     assert(object_worklist.len == 0);
     arraylist_free(&object_worklist);
+    assert(deferred_supers.len == 0);
+    arraylist_free(&deferred_supers);
     arraylist_free(&serialization_queue);
     arraylist_free(&layout_table);
     arraylist_free(&s.uniquing_types);

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -759,6 +759,58 @@ precompile_test_harness(false) do dir
 end
 end
 
+# Test for regression due to #62050: "circular type parameter constraint in definition of LittleDict"
+#
+# Canonicalization of recursive supertypes is fragile / unsound, due to subtyping's limitations
+# to handle non-canonicalized types. Nonetheless this tests that the bugfix from #62050 does not
+# regress patterns in OrderedCollections.jl, etc.
+precompile_test_harness("issue #62050") do load_path
+    write(joinpath(load_path, "LD62050.jl"),
+          """
+          module LD62050
+              export LittleDict, freeze
+              const StoreType{T} = Union{Tuple{Vararg{T}}, AbstractVector{T}}
+              struct LittleDict{K, V, KS<:StoreType{K}, VS<:StoreType{V}} <: AbstractDict{K, V}
+                  keys::KS
+                  vals::VS
+                  function LittleDict{K, V, KS, VS}(keys, vals) where {K, V, KS, VS}
+                      return new{K, V, KS, VS}(keys, vals)
+                  end
+              end
+              LittleDict{K,V}(ks::KS, vs::VS) where {K,V, KS<:StoreType,VS<:StoreType} = LittleDict{K, V, KS, VS}(ks, vs)
+              LittleDict(ks::KS, vs::VS) where {KS<:StoreType,VS<:StoreType} = LittleDict{eltype(KS), eltype(VS)}(ks, vs)
+              freeze(d::LittleDict) = LittleDict(Tuple(d.keys), Tuple(d.vals))
+              # a `Type{Union{...}}` whose members differ in typename, baked into the type cache
+              struct RectA{T} end
+              struct RectB{T} end
+              const RectOrDiag{T} = Union{RectA{T}, RectB{T}}
+              _seed(::Type{RectOrDiag}) = 1
+              const _seeded = _seed(RectOrDiag)
+          end
+          """)
+    write(joinpath(load_path, "PartialB62050.jl"),
+          """
+          module PartialB62050
+              using LD62050
+              struct ConfusionMatrix{N,O,L}
+                  index_given_level::LittleDict{L, I, NTuple{N,L}, NTuple{N,I}} where I<:Integer
+              end
+              function ConfusionMatrix(dic::LittleDict{L, I, NTuple{N,L}, NTuple{N,I}}; ordered=false) where {L,I<:Integer,N}
+                  ConfusionMatrix{N,ordered,L}(dic)
+              end
+              ConfusionMatrix(dic::AbstractDict; ordered=false) = ConfusionMatrix(freeze(dic); ordered)
+              function ConfusionMatrix(levels::AbstractVector{L}) where L
+                  igl = LittleDict{L, Int, Vector{L}, Vector{Int}}(levels, collect(eachindex(levels)))
+                  ConfusionMatrix(igl; ordered=false)
+              end
+              const _warm = ConfusionMatrix(["a", "b"])
+          end
+          """)
+    # Loading PartialB62050 pulls in its dependency LD62050 first (caching the `Type{Union{...}}`),
+    # then deserializes PartialB62050's pkgimage — where the deferred-super climb fires.
+    @test Base.require(Main, :PartialB62050) isa Module
+end
+
 # method root provenance & external code caching
 precompile_test_harness("code caching") do dir
     Cache_module = :Cacheb8321416e8a3e2f1

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -95,6 +95,12 @@ precompile_test_harness(false) do dir
               end
               abstract type AbstractAlgebraMap{A} end
               struct GAPGroupHomomorphism{A, B} <: AbstractAlgebraMap{GAPGroupHomomorphism{B, A}} end
+              # issue #62047: supertype whose parameters reach back through the subtype
+              struct Wrap62047{T} end
+              struct Recur62047{T} <: AbstractAlgebraMap{Wrap62047{Recur62047{T}}} end
+              # two types sharing the identical supertype object
+              struct ShareA62047{T} <: AbstractAlgebraMap{T} end
+              struct ShareB62047{T} <: AbstractAlgebraMap{T} end
 
               global process_state_calls::Int = 0
               const process_state = Base.OncePerProcess{typeof(getpid())}() do
@@ -127,6 +133,7 @@ precompile_test_harness(false) do dir
           """
           module $Foo_module
               import $FooBase_module, $FooBase_module.typeA, $FooBase_module.GAPGroupHomomorphism
+              import $FooBase_module: Wrap62047, Recur62047, ShareA62047, ShareB62047
               import $Foo2_module: $Foo2_module, override, overridenc
               import $FooBase_module.hash
               import Test
@@ -211,6 +218,10 @@ precompile_test_harness(false) do dir
 
               const GAPType1 = GAPGroupHomomorphism{Nothing, Nothing}
               const GAPType2 = GAPGroupHomomorphism{1, 2}
+
+              # issue #62047
+              const Type62047 = Wrap62047{Recur62047{Int}}
+              const Shared62047 = (ShareA62047{Int}, ShareB62047{Int})
 
               # issue #28297
               mutable struct Result


### PR DESCRIPTION
MWE reduction by Claude Opus 4.8 🤖 .

I am still investigating the root cause here, but this fix is plausible. This will need a separate PkgEval on the affected packages to avoid interrupting @KristofferC 's release flow, but with luck this will fix https://github.com/JuliaLang/julia/pull/62003#issuecomment-4759671400 on Julia 1.12

This exact MWE is not an issue on `master` because of https://github.com/JuliaLang/julia/pull/61915, but I still need to check if it can be hit via another route.