### PR TITLE
codegen: store constant union members inline instead of boxing

### DIFF
--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -20,8 +20,8 @@ function libjulia_codegen_name()
 end
 
 # The tests below assume a certain format and safepoint_on_entry=true breaks that.
-function get_llvm(@nospecialize(f), @nospecialize(t), raw=true, dump_module=false, optimize=true)
-    params = Base.CodegenParams(safepoint_on_entry=false, gcstack_arg = false, debug_info_level=Cint(2))
+function get_llvm(@nospecialize(f), @nospecialize(t), raw=true, dump_module=false, optimize=true;
+                  params=Base.CodegenParams(safepoint_on_entry=false, gcstack_arg=false, debug_info_level=Cint(2)))
     d = InteractiveUtils._dump_function(InteractiveUtils.ArgInfo(f, t), false, false, raw, dump_module, :att, optimize, :none, false, "", params)
     sprint(print, d)
 end
@@ -590,6 +590,26 @@ end
         return cond
     end
     @test occursin("llvm.julia.gc_preserve_begin", get_llvm(f4, Tuple{Bool}, true, false, false))
+end
+
+# a constant leaf of a small isbits union phi should be stored inline, not boxed,
+# when embedded object pointers are disabled (regression from #55045)
+# (use Int64(0) rather than 0 so the union is Union{Int32,Int64} regardless of the width of Int)
+function f_const_union_phi(cond::Bool, a::Int32)
+    x = cond ? a : Int64(0)
+    return x
+end
+let ir = get_llvm(f_const_union_phi, Tuple{Bool, Int32})
+    @test only(Base.return_types(f_const_union_phi, Tuple{Bool, Int32})) === Union{Int32, Int64}
+    @test !isempty(ir)
+    @test f_const_union_phi(true, Int32(7)) === Int32(7)
+    @test f_const_union_phi(false, Int32(7)) === Int64(0)
+
+    params = Base.CodegenParams(safepoint_on_entry=false, gcstack_arg=false,
+        debug_info_level=Cint(2), embed_pointers=false)
+    ir = get_llvm(f_const_union_phi, Tuple{Bool, Int32}; params)
+    @test occursin("store i64 0", ir)  # constant member stored inline
+    @test !occursin("jl_global", ir)   # not boxed (no embedded object pointer)
 end
 
 # issue #32843

--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -592,24 +592,39 @@ end
     @test occursin("llvm.julia.gc_preserve_begin", get_llvm(f4, Tuple{Bool}, true, false, false))
 end
 
-# a constant leaf of a small isbits union phi should be stored inline, not boxed,
-# when embedded object pointers are disabled (regression from #55045)
+# Constant leaves of small isbits unions should be stored inline, not boxed,
+# when embedded object pointers are disabled (regression from #55045).
 # (use Int64(0) rather than 0 so the union is Union{Int32,Int64} regardless of the width of Int)
 function f_const_union_phi(cond::Bool, a::Int32)
     x = cond ? a : Int64(0)
     return x
 end
+function f_const_union_ifelse(cond::Bool, a::Int32)
+    return ifelse(cond, a, Int64(0))
+end
+function f_const_union_float(cond::Bool, a::Float32)
+    x = cond ? a : 1.0
+    return x
+end
 let ir = get_llvm(f_const_union_phi, Tuple{Bool, Int32})
     @test only(Base.return_types(f_const_union_phi, Tuple{Bool, Int32})) === Union{Int32, Int64}
+    @test only(Base.return_types(f_const_union_ifelse, Tuple{Bool, Int32})) === Union{Int32, Int64}
+    @test only(Base.return_types(f_const_union_float, Tuple{Bool, Float32})) === Union{Float32, Float64}
     @test !isempty(ir)
     @test f_const_union_phi(true, Int32(7)) === Int32(7)
     @test f_const_union_phi(false, Int32(7)) === Int64(0)
+    @test f_const_union_ifelse(true, Int32(7)) === Int32(7)
+    @test f_const_union_ifelse(false, Int32(7)) === Int64(0)
+    @test f_const_union_float(true, 7.0f0) === 7.0f0
+    @test f_const_union_float(false, 7.0f0) === 1.0
 
     params = Base.CodegenParams(safepoint_on_entry=false, gcstack_arg=false,
         debug_info_level=Cint(2), embed_pointers=false)
     ir = get_llvm(f_const_union_phi, Tuple{Bool, Int32}; params)
     @test occursin("store i64 0", ir)  # constant member stored inline
     @test !occursin("jl_global", ir)   # not boxed (no embedded object pointer)
+    @test !occursin("jl_global", get_llvm(f_const_union_ifelse, Tuple{Bool, Int32}; params))
+    @test !occursin("jl_global", get_llvm(f_const_union_float, Tuple{Bool, Float32}; params))
 end
 
 # issue #32843

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -190,13 +190,20 @@ struct CodegenParams
     """
     unique_names::Cint
 
+    """
+    If enabled, generated code may embed pointers to host-resident boxed Julia
+    objects. Disable this for targets that cannot dereference such pointers
+    when codegen can instead use an unboxed representation.
+    """
+    embed_pointers::Cint
+
     function CodegenParams(; track_allocations::Bool=true, code_coverage::Bool=true,
                    prefer_specsig::Bool=false,
                    gnu_pubnames::Bool=true, debug_info_kind::Cint = default_debug_info_kind(),
                    debug_info_level::Cint = Cint(JLOptions().debug_level), safepoint_on_entry::Bool=true,
                    gcstack_arg::Bool=true, use_jlplt::Bool=true, force_emit_all::Bool=false,
                    sanitize_memory::Bool=false, sanitize_thread::Bool=false, sanitize_address::Bool=false,
-                   unique_names::Bool=false)
+                   unique_names::Bool=false, embed_pointers::Bool=true)
         return new(
             Cint(track_allocations), Cint(code_coverage),
             Cint(prefer_specsig),
@@ -204,7 +211,7 @@ struct CodegenParams
             debug_info_level, Cint(safepoint_on_entry),
             Cint(gcstack_arg), Cint(use_jlplt), Cint(force_emit_all),
             Cint(sanitize_memory), Cint(sanitize_thread), Cint(sanitize_address),
-            Cint(unique_names))
+            Cint(unique_names), Cint(embed_pointers))
     end
 end
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -4171,6 +4171,22 @@ static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool is_promotab
     return box;
 }
 
+static jl_cgval_t maybe_boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo)
+{
+    if (ctx.params->embed_pointers || !vinfo.constant)
+        return vinfo;
+
+    jl_value_t *typ = jl_typeof(vinfo.constant);
+    if (!deserves_stack(typ))
+        return vinfo;
+
+    Constant *bits = julia_const_to_llvm(ctx, vinfo.constant);
+    if (!bits)
+        return vinfo;
+
+    return mark_julia_type(ctx, bits, false, typ);
+}
+
 // copy src to dest, if src is justbits. if skip is true, the value of dest is undefined
 // TODO: rename this to just `emit_typed_move`
 static void emit_unionmove(jl_codectx_t &ctx, Value *dest, jl_value_t *desttype,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10030,8 +10030,17 @@ static jl_llvm_functions_t
                 SmallVector<Value*,0> lroots(roots.size(), Vnull);
                 Value *RTindex = new_union.TIndex;
                 Value *V = nullptr;
+                // When host object pointers are disabled, store constants whose type
+                // is an unboxed leaf of the union inline.
+                size_t const_leaf_tindex = 0;
+                if (!ctx.params->embed_pointers && dest && val.constant &&
+                        new_union.typ != (jl_value_t*)jl_bottom_type &&
+                        deserves_stack(jl_typeof(val.constant)))
+                    const_leaf_tindex = get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), phiType);
                 if (VN) {
-                    if (new_union.Vboxed)
+                    if (const_leaf_tindex)
+                        V = Constant::getNullValue(ctx.types().T_prjlvalue);
+                    else if (new_union.Vboxed)
                         V = new_union.Vboxed;
                     else if (new_union.constant)
                         V = boxed(ctx, new_union);
@@ -10042,8 +10051,13 @@ static jl_llvm_functions_t
                     RTindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER);
                 }
                 else if (jl_is_concrete_type(val.typ) || val.constant) {
-                    size_t tindex = get_box_tindex((jl_datatype_t*)(val.constant ? jl_typeof(val.constant) : val.typ), phiType);
-                    if (tindex && dest && (!VN || !val.isboxed)) {
+                    size_t tindex = const_leaf_tindex ? const_leaf_tindex :
+                        get_box_tindex((jl_datatype_t*)(val.constant ? jl_typeof(val.constant) : val.typ), phiType);
+                    if (const_leaf_tindex) {
+                        emit_unionmove(ctx, dest, phiType, ctx.tbaa().tbaa_stack, val, nullptr, nullptr);
+                        RTindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), tindex);
+                    }
+                    else if (tindex && dest && (!VN || !val.isboxed)) {
                         emit_unionmove(ctx, dest, phiType, ctx.tbaa().tbaa_stack, val, RTindex, nullptr);
                     }
                 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2691,12 +2691,13 @@ static void CreateConditionalAbort(IRBuilder<> &irbuilder, Value *test)
 
 // new value is a split union and needs to be converted to that format
 // this always sets TIndex (or returns unreachable)
-static jl_cgval_t convert_julia_type_to_union(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t *typ, bool allow_mismatch)
+static jl_cgval_t convert_julia_type_to_union(jl_codectx_t &ctx, const jl_cgval_t &v0, jl_value_t *typ, bool allow_mismatch)
 {
-    if (v.typ == jl_bottom_type || (v.TIndex && jl_egal(v.typ, typ)))
-        return v; // fast-path
+    if (v0.typ == jl_bottom_type || (v0.TIndex && jl_egal(v0.typ, typ)))
+        return v0; // fast-path
     assert(jl_is_uniontype(typ));
 
+    jl_cgval_t v = maybe_boxed(ctx, v0);
     Value *union_box_tindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER);
     Value *new_tindex = union_box_tindex;
     bool computed_new_index_early = v.TIndex == nullptr;
@@ -10025,22 +10026,14 @@ static jl_llvm_functions_t
                 assert(jl_is_uniontype(phiType));
                 // must compute skip here, since the runtime type of val might not be in phiType
                 // caution: only Phi and PhiC are allowed to do this (and maybe sometimes Pi)
-                jl_cgval_t new_union = convert_julia_type_to_union(ctx, val, phiType, true);
+                jl_cgval_t move_val = maybe_boxed(ctx, val);
+                jl_cgval_t new_union = convert_julia_type_to_union(ctx, move_val, phiType, true);
                 Value *Vnull = Constant::getNullValue(ctx.types().T_prjlvalue);
                 SmallVector<Value*,0> lroots(roots.size(), Vnull);
                 Value *RTindex = new_union.TIndex;
                 Value *V = nullptr;
-                // When host object pointers are disabled, store constants whose type
-                // is an unboxed leaf of the union inline.
-                size_t const_leaf_tindex = 0;
-                if (!ctx.params->embed_pointers && dest && val.constant &&
-                        new_union.typ != (jl_value_t*)jl_bottom_type &&
-                        deserves_stack(jl_typeof(val.constant)))
-                    const_leaf_tindex = get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), phiType);
                 if (VN) {
-                    if (const_leaf_tindex)
-                        V = Constant::getNullValue(ctx.types().T_prjlvalue);
-                    else if (new_union.Vboxed)
+                    if (new_union.Vboxed)
                         V = new_union.Vboxed;
                     else if (new_union.constant)
                         V = boxed(ctx, new_union);
@@ -10050,15 +10043,10 @@ static jl_llvm_functions_t
                 if (new_union.typ == (jl_value_t*)jl_bottom_type) {
                     RTindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER);
                 }
-                else if (jl_is_concrete_type(val.typ) || val.constant) {
-                    size_t tindex = const_leaf_tindex ? const_leaf_tindex :
-                        get_box_tindex((jl_datatype_t*)(val.constant ? jl_typeof(val.constant) : val.typ), phiType);
-                    if (const_leaf_tindex) {
-                        emit_unionmove(ctx, dest, phiType, ctx.tbaa().tbaa_stack, val, nullptr, nullptr);
-                        RTindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), tindex);
-                    }
-                    else if (tindex && dest && (!VN || !val.isboxed)) {
-                        emit_unionmove(ctx, dest, phiType, ctx.tbaa().tbaa_stack, val, RTindex, nullptr);
+                else if (jl_is_concrete_type(move_val.typ) || move_val.constant) {
+                    size_t tindex = get_box_tindex((jl_datatype_t*)(move_val.constant ? jl_typeof(move_val.constant) : move_val.typ), phiType);
+                    if (tindex && dest && (!VN || !move_val.isboxed)) {
+                        emit_unionmove(ctx, dest, phiType, ctx.tbaa().tbaa_stack, move_val, RTindex, nullptr);
                     }
                 }
                 else {

--- a/src/init.c
+++ b/src/init.c
@@ -684,6 +684,8 @@ JL_DLLEXPORT jl_cgparams_t jl_default_cgparams = {
 #else
         /* sanitize_address */ 0,
 #endif
+        /* unique_names */ 0,
+        /* embed_pointers */ 1,
 };
 
 static void init_global_mutexes(void) {

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1225,6 +1225,14 @@ static jl_cgval_t emit_ifelse(jl_codectx_t &ctx, jl_cgval_t c, jl_cgval_t x, jl_
         Value *x_tindex = x.TIndex;
         Value *y_tindex = y.TIndex;
         if (x_tindex || y_tindex) {
+            if (!x.isghost && x.constant) {
+                x = maybe_boxed(ctx, x);
+                x_tindex = x.TIndex;
+            }
+            if (!y.isghost && y.constant) {
+                y = maybe_boxed(ctx, y);
+                y_tindex = y.TIndex;
+            }
             Value *x_vboxed = x.Vboxed;
             Value *y_vboxed = y.Vboxed;
             Value *x_ptr = NULL;
@@ -1233,12 +1241,16 @@ static jl_cgval_t emit_ifelse(jl_codectx_t &ctx, jl_cgval_t c, jl_cgval_t x, jl_
                 x_ptr = data_pointer(ctx, x);
                 x_vboxed = boxed(ctx, x);
             } else if (!x.isghost && x.V != NULL) {
+                if (jl_is_concrete_type(x.typ) && (!x.inline_roots.empty() || !x.ispointer()))
+                    x = value_to_pointer(ctx, x);
                 x_ptr = maybe_decay_tracked(ctx, x.V);
             }
             if (!y.isghost && y.constant) {
                 y_ptr = data_pointer(ctx, y);
                 y_vboxed = boxed(ctx, y);
             } else if (!y.isghost && y.V != NULL) {
+                if (jl_is_concrete_type(y.typ) && (!y.inline_roots.empty() || !y.ispointer()))
+                    y = value_to_pointer(ctx, y);
                 y_ptr = maybe_decay_tracked(ctx, y.V);
             }
             jl_gc_roots_t x_roots = x.inline_roots;
@@ -1284,8 +1296,18 @@ static jl_cgval_t emit_ifelse(jl_codectx_t &ctx, jl_cgval_t c, jl_cgval_t x, jl_
             if (!x_tindex && x.constant) {
                 x_tindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x80 | get_box_tindex((jl_datatype_t*)jl_typeof(x.constant), rt_hint));
             }
+            else if (!x_tindex && !x.isboxed && jl_is_concrete_type(x.typ)) {
+                unsigned idx = get_box_tindex((jl_datatype_t*)x.typ, rt_hint);
+                if (idx)
+                    x_tindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), idx);
+            }
             if (!y_tindex && y.constant) {
                 y_tindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x80 | get_box_tindex((jl_datatype_t*)jl_typeof(y.constant), rt_hint));
+            }
+            else if (!y_tindex && !y.isboxed && jl_is_concrete_type(y.typ)) {
+                unsigned idx = get_box_tindex((jl_datatype_t*)y.typ, rt_hint);
+                if (idx)
+                    y_tindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), idx);
             }
             if (x_tindex && y_tindex) {
                 tindex = ctx.builder.CreateSelect(isfalse, y_tindex, x_tindex);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2790,6 +2790,7 @@ typedef struct {
     int sanitize_address;
 
     int unique_names;   // Emit globally unique names
+    int embed_pointers; // May codegen embed pointers to host-resident boxed objects?
 } jl_cgparams_t;
 extern JL_DLLEXPORT int jl_default_debug_info_kind;
 extern JL_DLLEXPORT jl_cgparams_t jl_default_cgparams;


### PR DESCRIPTION
Since #55045 a small isbits `Union` built from a constant (e.g. `x = cond ? a::Int32 : 0`) is represented fully boxed: the unboxed payload slot is never written and consumers read the value back through a `literal_pointer_val` of the boxed constant. `mark_julia_const` marks constants as `isboxed`, so the union-phi path keeps them boxed rather than storing them inline as it did before. The embedded object pointer is dead weight and breaks consumers that can't dereference host addresses (e.g. GPU back-ends). Detect a constant whose type is an unboxed leaf of the target union and store its bits inline with an unmarked tindex, restoring the pre-#55045 representation.