### PR TITLE
[JuliaLowering] Keep generator iteration vars local

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -785,6 +785,14 @@ function check_no_return(ex)
     end
 end
 
+function lhs_local_defs(ctx, lhs)
+    defs = SyntaxList(ctx)
+    foreach_lhs_name(lhs) do var
+        push!(defs, @ast ctx var [K"local" var])
+    end
+    return defs
+end
+
 # Return the anonymous function taking an iterated value, for use with the
 # first argument to `Base.Generator`
 function func_for_generator(ctx, body, iter_value_destructuring)
@@ -798,6 +806,7 @@ function func_for_generator(ctx, body, iter_value_destructuring)
         @ast ctx body [K"->"
             [K"tuple" arg]
             [K"block"
+                lhs_local_defs(ctx, iter_value_destructuring)...
                 [K"=" iter_value_destructuring arg]
                 body]]
     else

--- a/JuliaLowering/test/generators.jl
+++ b/JuliaLowering/test/generators.jl
@@ -136,6 +136,21 @@ collect((h, i, j) for (h, i..., j) in ((1,2,3,4),(5,6,7,8)))
     """) == 1:5
 end
 
+@testset "generator iteration variables are local" begin
+    @test JuliaLowering.include_string(test_mod, """
+    let x = 0
+        ys = [x for x::Int in 1:3]
+        (x, ys)
+    end
+    """) == (0, [1,2,3])
+    @test JuliaLowering.include_string(test_mod, """
+    let x = collect(1:3)
+        ys = [x for (i, x) in enumerate(x)]
+        (x, ys)
+    end
+    """) == (collect(1:3), [1,2,3])
+end
+
 @testset "compat: comprehension with non-generator arg" begin
     let ex = Expr(:comprehension, :i, Expr(:(=), :i, Expr(:call, :(:), 1, 3)))
         @test jl_eval(test_mod, ex) == fl_eval(test_mod, ex)


### PR DESCRIPTION
Generator lowering for non-identifier iteration variables used an assignment inside the generated closure body without first declaring the assigned names as local to the closure. Cases such as `[x for x::Int in xs]` and `[x for (i, x) in enumerate(xs)]` could therefore resolve `x` to an outer local and mutate or capture it.

Declare all names found in the generated assignment left-hand side as locals before assigning the incoming generator argument. This preserves the assignment-based lowering needed for typed and destructuring iteration variables while keeping their bindings scoped to the generator closure.

Following up JuliaLang/julia#62177.