### PR TITLE
codegen: Add C-API for jl_decorate_module

### DIFF
--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -84,6 +84,11 @@ JL_DLLEXPORT void jl_teardown_codegen_fallback(void) JL_NOTSAFEPOINT
 {
 }
 
+JL_DLLEXPORT void jl_decorate_llvm_module_fallback(LLVMModuleRef m) JL_NOTSAFEPOINT
+{
+    (void)m;
+}
+
 JL_DLLEXPORT size_t jl_jit_total_bytes_fallback(void)
 {
     return 0;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -163,7 +163,7 @@ void jl_dump_llvm_opt_impl(void *s)
     **jl_ExecutionEngine->get_dump_llvm_opt_stream() = (ios_t*)s;
 }
 
-static void jl_decorate_module(Module &M) JL_NOTSAFEPOINT;
+static void decorate_module(Module &M) JL_NOTSAFEPOINT;
 
 // convert local roots into global roots, if they are needed
 static void jl_promote_method_roots(jl_codegen_output_t &out, jl_method_instance_t *mi)
@@ -1456,7 +1456,7 @@ struct JuliaOJIT::JITPointersT {
         // Windows needs some inline asm to help
         // build unwind tables, if they have any functions to decorate
         if (!M.functions().empty())
-            jl_decorate_module(M);
+            decorate_module(M);
     }
     void operator()(Module &M, orc::MaterializationResponsibility &R) JL_NOTSAFEPOINT {
         return operator()(M);
@@ -2462,7 +2462,7 @@ TargetIRAnalysis JuliaOJIT::getTargetIRAnalysis() const {
     return TM->getTargetIRAnalysis();
 }
 
-static void jl_decorate_module(Module &M) {
+static void decorate_module(Module &M) {
     auto TT = Triple(M.getTargetTriple());
     if (TT.isOSWindows() && TT.getArch() == Triple::x86_64) {
         // Add special values used by debuginfo to build the UnwindData table registration for Win64
@@ -2525,6 +2525,12 @@ static void jl_decorate_module(Module &M) {
         M.appendModuleInlineAsm(inline_asm);
     }
 #undef ASM_USES_ELF
+}
+
+extern "C" JL_DLLEXPORT_CODEGEN
+void jl_decorate_llvm_module_impl(LLVMModuleRef m) JL_NOTSAFEPOINT
+{
+    decorate_module(*unwrap(m));
 }
 
 // helper function for adding a DLLImport (dlsym) address to the execution engine

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -542,6 +542,7 @@
     YY(jl_generate_fptr_for_unspecialized) \
     YY(jl_compile_codeinst) \
     YY(jl_teardown_codegen) \
+    YY(jl_decorate_llvm_module) \
     YY(jl_jit_total_bytes) \
     YY(jl_create_native) \
     YY(jl_dump_compiles) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2232,6 +2232,7 @@ JL_DLLIMPORT void jl_get_llvm_cis(void *native_code, size_t *num_els,
                                   jl_code_instance_t **CIs);
 JL_DLLIMPORT void jl_init_codegen(void);
 JL_DLLIMPORT void jl_teardown_codegen(void) JL_NOTSAFEPOINT;
+JL_DLLIMPORT void jl_decorate_llvm_module(LLVMModuleRef m) JL_NOTSAFEPOINT;
 JL_DLLIMPORT int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline) JL_NOTSAFEPOINT;
 // n.b. this might be called from unmanaged thread:
 JL_DLLIMPORT uint64_t jl_getUnwindInfo(uint64_t dwBase);


### PR DESCRIPTION
Expose jl_decorate_module through the codegen plugin interface so that
external consumers can apply the same platform-specific
module setup that the JIT performs.

Fixes #62195

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
