### PR TITLE
clangsa: handle noreturn exits in GC frame check

### DIFF
--- a/src/clangsa/GCCheckerPropagation.cpp
+++ b/src/clangsa/GCCheckerPropagation.cpp
@@ -1520,22 +1520,30 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
   const CallExpr *CE = dyn_cast<CallExpr>(Call.getOriginExpr());
   unsigned CurrentDepth = C.getState()->get<GCDepth>();
   auto name = CE ? C.getCalleeName(CE) : "";
+
+  // Helper for the checker’s symbolic GC stack state: drop all frame roots
+  // and root-map entries from NewDepth up to OldDepth, then set GCDepth to
+  // NewDepth
+  auto PopGCFramesToDepth = [&](ProgramStateRef State, unsigned OldDepth,
+                                unsigned NewDepth) {
+    State = State->set<GCDepth>(NewDepth);
+    for (unsigned Depth = NewDepth; Depth < OldDepth; ++Depth) {
+      State = removeFrameRoots(State, Depth);
+      GCRootMapTy AMap = State->get<GCRootMap>();
+      for (auto I = AMap.begin(), E = AMap.end(); I != E; ++I) {
+        if (I.getData() == (int)Depth)
+          State = State->remove<GCRootMap>(I.getKey());
+      }
+    }
+    return State;
+  };
   if (name == "JL_GC_POP") {
     if (CurrentDepth == 0) {
       report_error(C, "JL_GC_POP without corresponding push");
       return true;
     }
-    CurrentDepth -= 1;
-    // Go through all roots, see which ones are no longer with us.
-    // Then go through the values and unroot those for which those were our
-    // roots.
-    ProgramStateRef State = C.getState()->set<GCDepth>(CurrentDepth);
-    State = removeFrameRoots(State, CurrentDepth);
-    GCRootMapTy AMap = State->get<GCRootMap>();
-    for (auto I = AMap.begin(), E = AMap.end(); I != E; ++I) {
-      if (I.getData() == (int)CurrentDepth)
-        State = State->remove<GCRootMap>(I.getKey());
-    }
+    ProgramStateRef State =
+        PopGCFramesToDepth(C.getState(), CurrentDepth, CurrentDepth - 1);
     C.addTransition(State);
     return true;
   } else if (name == "JL_GC_PUSH1" || name == "JL_GC_PUSH2" ||
@@ -1716,6 +1724,15 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
   {
     auto *Decl = Call.getDecl();
     const FunctionDecl *FD = Decl ? Decl->getAsFunction() : nullptr;
+
+    if (FD && FD->isNoReturn() && CurrentDepth != 0) {
+      // Model noreturn calls as terminating the current symbolic GC frame stack
+      // so the synthetic end-of-function callback only diagnoses true fallthrough
+      // exits.
+      ProgramStateRef State = PopGCFramesToDepth(C.getState(), CurrentDepth, 0);
+      C.addTransition(State);
+      return true;
+    }
     if (isMutexLock(name) ||
         (FD && declHasAnnotation(FD, "julia_notsafepoint_enter"))) {
       ProgramStateRef State = C.getState();

--- a/test/clangsa/GCPushPop.cpp
+++ b/test/clangsa/GCPushPop.cpp
@@ -22,6 +22,13 @@ void superfluousPop() {
   JL_GC_POP(); // expected-warning{{JL_GC_POP without corresponding push}}
 }              // expected-note@-1{{JL_GC_POP without corresponding push}}
 
+extern void JL_NORETURN no_return_error(void);
+void noreturnAfterPush() {
+  jl_value_t *x = NULL;
+  JL_GC_PUSH1(&x);
+  no_return_error();
+}
+
 // From gc.c, jl_gc_push_arraylist creates a custom stack frame.
 extern void jl_gc_push_arraylist(jl_ptls_t ptls, arraylist_t *list);
 extern void run_finalizer(jl_ptls_t ptls, jl_value_t *o, jl_value_t *ff);


### PR DESCRIPTION
Avoid reporting a missing GC pop when the analyzed path actually terminates in a noreturn call or noreturn CFG block (e.g. a call to jl_error or jl_throw, both of which clean up the GC stack).

Co-authored-by: Codex <codex@openai.com>

---

Right now the Julia kernel avoids this problem, but I am working on some C code that builds on and links to the Julia kernel, and uses the Julia GC, and of course I want to benefit from the analyzer. But there is quite some code in there that would be cumbersome to rewrite to pass because it basically does the equivalent of `jl_error` between a `GC_PUSH` and `GC_POP`.

Since `jl_error` and `jl_throw` among others will end up cleaning the GC stack, they are actually safe there.

One counter argument to this PR could be that there can be NORETURN functions that don't properly clean the GC stack. If we are truly concerned about that, one option would be to introduce another annotation to be used in addition, say `JL_NORETURN_HANDLES_GC_STACK`, and then only honor noreturn calls that have this additional annotation.