### PR TITLE
Describe 2-arg `show` and `repr` consistently

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -471,8 +471,13 @@ end
 
 Write a text representation of a value `x` to the output stream `io`. New types `T`
 should overload `show(io::IO, x::T)`. The representation used by `show` generally
-includes Julia-specific formatting and type information, and should be parseable
-Julia code when possible.
+includes Julia-specific formatting and type information.
+
+The output _should_ be parseable Julia code that, after parsing and evaluation,
+_should_ be equal to the value, i.e. `eval(Meta.parse(repr(x))) == x` _should_
+hold `true` if there are no technical reasons against it or if such an output
+is not considered to be too verbose for a representation in the REPL. So `show`
+is not a text-based serialization format.
 
 [`repr`](@ref) returns the output of `show` as a string.
 
@@ -491,6 +496,37 @@ julia> show("Hello World!")
 "Hello World!"
 julia> print("Hello World!")
 Hello World!
+```
+
+Example of round-tripping:
+```jldoctest
+julia> Int8(2) == eval(Meta.parse(repr(Int8(2))))
+true
+```
+
+Example of a technical reason preventing round-tripping (a self-referential object):
+```julia
+mutable struct X
+    x::X
+    function X()
+        x = new()
+        x.x = x
+    end
+end
+```
+
+Example of intentionally not round-tripping to avoid verbose output:
+```jldoctest
+julia> struct A a end
+
+julia> x = 2 |> Int8 |> A
+A(2)
+
+julia> y = x.a |> repr |> Meta.parse |> eval |> A
+A(2)
+
+julia> x == y
+false
 ```
 """
 show(io::IO, @nospecialize(x)) = show_default(io, x)

--- a/base/show.jl
+++ b/base/show.jl
@@ -473,8 +473,8 @@ Write a text representation of a value `x` to the output stream `io`. New types 
 should overload `show(io::IO, x::T)`. The representation used by `show` generally
 includes Julia-specific formatting and type information.
 
-The output *should* be parseable Julia code that, after parsing and evaluation,
-is equal to the value: that is, `eval(Meta.parse(repr(x))) == x` *should*
+The output should typically be parseable Julia code that, after parsing and evaluation,
+is equal to the value: that is, `eval(Meta.parse(repr(x))) == x` should typically
 be `true`. However, there are occasional counter-examples of types where
 this is impractical, such as self-referential data structures or cases
 where accurate parsing would require a verbose and awkward `show` format.

--- a/base/show.jl
+++ b/base/show.jl
@@ -473,8 +473,10 @@ Write a text representation of a value `x` to the output stream `io`. New types 
 should overload `show(io::IO, x::T)`. The representation used by `show` generally
 includes Julia-specific formatting and type information.
 
-The output should typically be parseable Julia code that, after parsing and evaluation,
-is equal to the value: that is, `eval(Meta.parse(repr(x))) == x` should typically
+[`repr`](@ref) returns the output of `show` as a string.
+
+The output *should* be parseable Julia code that, after parsing and evaluation,
+is equal to the value: that is, `eval(Meta.parse(repr(x))) == x` *should*
 be `true`. However, there are occasional counter-examples of types where
 this is impractical, such as self-referential data structures or cases
 where accurate parsing would require a verbose and awkward `show` format.
@@ -482,8 +484,6 @@ where accurate parsing would require a verbose and awkward `show` format.
 `show` is not a text-based serialization format. For more reliable serialization
 of *arbitrary* Julia types, use the `Serialization` standard library or similar
 packages rather than `show`.
-
-[`repr`](@ref) returns the output of `show` as a string.
 
 For a more verbose human-readable text output for objects of type `T`, define
 `show(io::IO, ::MIME"text/plain", ::T)` in addition. Checking the `:compact`

--- a/base/show.jl
+++ b/base/show.jl
@@ -473,11 +473,15 @@ Write a text representation of a value `x` to the output stream `io`. New types 
 should overload `show(io::IO, x::T)`. The representation used by `show` generally
 includes Julia-specific formatting and type information.
 
-The output _should_ be parseable Julia code that, after parsing and evaluation,
-_should_ be equal to the value, i.e. `eval(Meta.parse(repr(x))) == x` _should_
-hold `true` if there are no technical reasons against it or if such an output
-is not considered to be too verbose for a representation in the REPL. So `show`
-is not a text-based serialization format.
+The output *should* be parseable Julia code that, after parsing and evaluation,
+is equal to the value: that is, `eval(Meta.parse(repr(x))) == x` *should*
+be `true`. However, there are occasional counter-examples of types where
+this is impractical, such as self-referential data structures or cases
+where accurate parsing would require a verbose and awkward `show` format.
+
+`show` is not a text-based serialization format. For more reliable serialization
+of *arbitrary* Julia types, use the `Serialization` standard library or similar
+packages rather than `show`.
 
 [`repr`](@ref) returns the output of `show` as a string.
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -498,6 +498,8 @@ julia> print("Hello World!")
 Hello World!
 ```
 
+# Extended help
+
 Example of round-tripping:
 ```jldoctest
 julia> Int8(2) == eval(Meta.parse(repr(Int8(2))))

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -241,10 +241,12 @@ print(io::IO, s::Union{String,SubString{String}}) = (write(io, s); nothing)
 """
     repr(x; context=nothing)
 
-Create a string representation of any value using the 2-argument `show(io, x)` function,
-which aims to produce a string that is parseable Julia code, where possible.
-i.e. `eval(Meta.parse(repr(x))) == x` should hold true.
-You should not add methods to `repr`; define a [`show`](@ref) method instead.
+Create a string representation of any value using the 2-argument `show(io, x)`
+function. You should not add methods to `repr`; define a [`show`](@ref) method
+instead.
+
+The resulting string is often parseable Julia code. See [`show`](@ref) for
+details on this (non-binding) parseability/round-trip contract and its caveats.
 
 The optional keyword argument `context` can be set to a `:key=>value` pair, a
 tuple of `:key=>value` pairs, or an `IO` or [`IOContext`](@ref) object whose


### PR DESCRIPTION
This lists the reasons why this is not a text-based serialization.

Fixes: #62134

The [approach kind of is already reviewed](https://github.com/JuliaLang/julia/issues/62036#issuecomment-4675292012), but not this PR specifically.