### PR TITLE
JuliaSyntax: allow exponent literals before ..

### DIFF
--- a/JuliaSyntax/src/julia/tokenize.jl
+++ b/JuliaSyntax/src/julia/tokenize.jl
@@ -1005,7 +1005,7 @@ function lex_digit(l::Lexer, kind)
             accept(l, "+-−")
             if accept_batch(l, isdigit)
                 pc,ppc = dpeekchar(l)
-                if pc === '.' && !is_dottable_operator_start_char(ppc)
+                if pc === '.' && ppc != '.' && !is_dottable_operator_start_char(ppc)
                     readchar(l)
                     return emit(l, K"ErrorInvalidNumericConstant") # `1.e1.`
                 end
@@ -1026,7 +1026,7 @@ function lex_digit(l::Lexer, kind)
         accept(l, "+-−")
         if accept_batch(l, isdigit)
             pc,ppc = dpeekchar(l)
-            if pc === '.' && !is_dottable_operator_start_char(ppc)
+            if pc === '.' && ppc != '.' && !is_dottable_operator_start_char(ppc)
                 accept(l, '.')
                 return emit(l, K"ErrorInvalidNumericConstant") # `1e1.`
             end
@@ -1055,8 +1055,8 @@ function lex_digit(l::Lexer, kind)
                 end
                 # Check for invalid trailing decimal point
                 # https://github.com/JuliaLang/julia/issues/60189
-                pc = peekchar(l)
-                if pc == '.'
+                pc,ppc = dpeekchar(l)
+                if pc == '.' && ppc != '.' && !is_dottable_operator_start_char(ppc)
                     accept_batch(l, c->(c == '.' || isdigit(c)))
                     # `0x1p3.` `0x1p3.2` `0x1.5p2.3`
                     return emit(l, K"ErrorInvalidNumericConstant")

--- a/JuliaSyntax/test/parser.jl
+++ b/JuliaSyntax/test/parser.jl
@@ -157,6 +157,8 @@ tests = [
     ],
     JuliaSyntax.parse_range => [
         "a..b"       => "(call-i a (DotsIdentifier-2) b)"
+        "-1e10..2"   => "(call-i -1.0e10 (DotsIdentifier-2) 2)"
+        "0x1p3..2"   => "(call-i 8.0 (DotsIdentifier-2) 2)"
         "a..+b"      => "(call-i a (DotsIdentifier-2) (error-t) (call-pre + b))"
         # `..` may be directly followed by the operand-starting operators `: :: $ '`
         "a..:b"      => "(call-i a (DotsIdentifier-2) (quote-: b))"

--- a/JuliaSyntax/test/tokenize.jl
+++ b/JuliaSyntax/test/tokenize.jl
@@ -750,6 +750,9 @@ end
     @test toks("1...")   == ["1"=>K"Integer",  "."=>K".", "."=>K".", "."=>K"."]
     @test toks(".1..")   == [".1"=>K"Float",    "."=>K".", "."=>K"."]
     @test toks("0x01..") == ["0x01"=>K"HexInt", "."=>K".", "."=>K"."]
+    @test toks("1e1..2") == ["1e1"=>K"Float", "."=>K".", "."=>K".", "2"=>K"Integer"]
+    @test toks("1.1e1..2") == ["1.1e1"=>K"Float", "."=>K".", "."=>K".", "2"=>K"Integer"]
+    @test toks("0x1p3..2") == ["0x1p3"=>K"Float", "."=>K".", "."=>K".", "2"=>K"Integer"]
 
     # Dotted operators and other dotted suffixes
     @test toks("1234 .+1") == ["1234"=>K"Integer", " "=>K"Whitespace", "."=>K".", "+"=>K"+", "1"=>K"Integer"]
@@ -766,6 +769,7 @@ end
     @test toks("1.1.⫪")  == ["1.1"=>K"Float", "."=>K".", "⫪"=>K"Operator"]
     @test toks("1e1.−")  == ["1e1"=>K"Float", "."=>K".", "−"=>K"-"]
     @test toks("1.1.−")  == ["1.1"=>K"Float", "."=>K".", "−"=>K"-"]
+    @test toks("0x1p3.−") == ["0x1p3"=>K"Float", "."=>K".", "−"=>K"-"]
     # ... including operators which have their own kind rather than being in
     # the generic operator table
     @test toks("1e1.∈")  == ["1e1"=>K"Float", "."=>K".", "∈"=>K"∈"]

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1881,6 +1881,7 @@ end
 @test Meta.parse("1…2") == Expr(:call, :…, 1, 2)
 @test Meta.parse("1⁝2") == Expr(:call, :⁝, 1, 2)
 @test Meta.parse("1..2") == Expr(:call, :.., 1, 2)
+@test Meta.parse("-1e10..2") == Expr(:call, :.., -1e10, 2)
 # we don't parse chains of these since the associativity and meaning aren't clear
 @test_parseerror "1..2..3"
 


### PR DESCRIPTION
Allow numeric literals with exponent parts to be followed by the .. operator without being tokenized as invalid numeric constants. This keeps malformed trailing decimal-point literals invalid while preserving interval-operator syntax after decimal and hex float literals.

Fixes #62200