### PR TITLE
gf: cache single-dispatch and simple signatures in the call cache

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -4546,6 +4546,15 @@ STATIC_INLINE int sig_match_fast(jl_value_t *arg1t, jl_value_t **args, jl_value_
     return 1;
 }
 
+// quick inline rejection before the full jl_typemap_entry_sig_match test: a
+// simple signature whose first parameter is a concrete type can only match a
+// call of that callee type
+STATIC_INLINE int sig_match_simple_maybe(jl_typemap_entry_t *entry, jl_value_t *FT) JL_NOTSAFEPOINT
+{
+    jl_value_t *d0 = jl_svec_data(entry->sig->parameters)[0];
+    return d0 == FT || !jl_is_datatype(d0) || !((jl_datatype_t*)d0)->isconcretetype;
+}
+
 _Atomic(jl_typemap_entry_t*) call_cache[N_CALL_CACHE] JL_GLOBALLY_ROOTED;
 static _Atomic(uint8_t) pick_which[N_CALL_CACHE];
 #ifdef JL_GF_PROFILE
@@ -4598,11 +4607,47 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
         (callsite >> 8) & (N_CALL_CACHE - 1),
         (callsite >> 16) & (N_CALL_CACHE - 1),
         (callsite >> 24 | callsite << 8) & (N_CALL_CACHE - 1)};
+    // one additional slot hashed on the callee itself: most callees dispatch to a
+    // single cache entry regardless of callsite ("single dispatch"), so this slot is
+    // checked first and usually hits, from any callsite (including ones that thrash
+    // the callsite-hashed slots, such as the interpreter's few C callsites). hashing
+    // the value instead of its type keeps constructors (where the callee is the type
+    // itself, but its type is nearly always DataType) in separate slots.
+    uint32_t f_idx = (((uintptr_t)F >> 4) ^ ((uintptr_t)F >> 16)) & (N_CALL_CACHE - 1);
     jl_typemap_entry_t *entry = NULL;
     int i;
     jl_tupletype_t *tt = NULL;
     int64_t last_alloc = 0;
-    // check each cache entry to see if it matches
+    // check the callee-hashed slot first
+    entry = jl_atomic_load_relaxed(&call_cache[f_idx]);
+    if (entry) {
+        if (entry->isleafsig) {
+            if (nargs == jl_svec_len(entry->sig->parameters) &&
+                sig_match_fast(FT, args, jl_svec_data(entry->sig->parameters), nargs) &&
+                world >= jl_atomic_load_relaxed(&entry->min_world) &&
+                world <= jl_atomic_load_relaxed(&entry->max_world))
+                goto have_entry;
+        }
+        else {
+            // an entry whose signature is Tuple{typeof(f), Vararg{Any}} (notably
+            // builtins and intrinsic calls) matches every call of f: accept it with
+            // an inline shape test, since those calls are too hot for the general matcher
+            if (entry->simplesig == (void*)jl_nothing &&
+                jl_svec_len(entry->sig->parameters) == 2 &&
+                jl_svec_data(entry->sig->parameters)[0] == FT) {
+                jl_value_t *va = jl_svec_data(entry->sig->parameters)[1];
+                if (jl_is_vararg(va) && ((jl_vararg_t*)va)->T == (jl_value_t*)jl_any_type &&
+                    ((jl_vararg_t*)va)->N == NULL &&
+                    world >= jl_atomic_load_relaxed(&entry->min_world) &&
+                    world <= jl_atomic_load_relaxed(&entry->max_world))
+                    goto have_entry;
+            }
+            if (sig_match_simple_maybe(entry, FT) &&
+                jl_typemap_entry_sig_match(entry, F, args, nargs, world))
+                goto have_entry;
+        }
+    }
+    // then check each callsite-hashed entry to see if it matches
     //#pragma unroll
     //for (i = 0; i < 4; i++) {
     //    LOOP_BODY(i);
@@ -4610,10 +4655,17 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
 #define LOOP_BODY(_i) do { \
             i = _i; \
             entry = jl_atomic_load_relaxed(&call_cache[cache_idx[i]]); \
-            if (entry && nargs == jl_svec_len(entry->sig->parameters) && \
-                sig_match_fast(FT, args, jl_svec_data(entry->sig->parameters), nargs) && \
-                world >= jl_atomic_load_relaxed(&entry->min_world) && world <= jl_atomic_load_relaxed(&entry->max_world)) { \
-                goto have_entry; \
+            if (entry) { \
+                if (entry->isleafsig) { \
+                    if (nargs == jl_svec_len(entry->sig->parameters) && \
+                        sig_match_fast(FT, args, jl_svec_data(entry->sig->parameters), nargs) && \
+                        world >= jl_atomic_load_relaxed(&entry->min_world) && world <= jl_atomic_load_relaxed(&entry->max_world)) \
+                        goto have_entry; \
+                } \
+                else if (sig_match_simple_maybe(entry, FT) && \
+                         jl_typemap_entry_sig_match(entry, F, args, nargs, world)) { \
+                    goto have_entry; \
+                } \
             } \
         } while (0);
     LOOP_BODY(0);
@@ -4646,9 +4698,14 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
                 }
             }
         }
-        if (entry != NULL && entry->isleafsig && entry->simplesig == (void*)jl_nothing && entry->guardsigs == jl_emptysvec) {
-            // put the entry into the cache if it's valid for a leafsig lookup,
-            // using pick_which to slightly randomize where it ends up
+        if (entry != NULL && entry->guardsigs == jl_emptysvec &&
+            (entry->isleafsig ? entry->simplesig == (void*)jl_nothing : entry->issimplesig)) {
+            // cache the entry if a probe can re-match it without the rest of the
+            // typemap: guarded entries never qualify, since a guard rejection must
+            // fall through to later entries. store it both by callee and by callsite
+            // so both probe patterns can find it.
+            jl_atomic_store_release(&call_cache[f_idx], entry);
+            // for the callsite slots, use pick_which to slightly randomize where it ends up
             // (intentionally not atomically synchronized, since we're just using it for randomness)
             // TODO: use the thread's `cong` instead as a source of randomness
             int which = jl_atomic_load_relaxed(&pick_which[cache_idx[0]]) + 1;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1903,6 +1903,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
 
 jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t *arg1, jl_value_t **args, size_t n, int8_t offs, size_t world);
 jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *mn, jl_value_t *arg1, jl_value_t **args, size_t n, size_t world);
+int jl_typemap_entry_sig_match(jl_typemap_entry_t *ml, jl_value_t *arg1, jl_value_t **args, size_t n, size_t world);
 STATIC_INLINE jl_typemap_entry_t *jl_typemap_assoc_exact(
     jl_typemap_t *ml_or_cache JL_PROPAGATES_ROOT,
     jl_value_t *arg1, jl_value_t **args, size_t n, int8_t offs, size_t world)

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -291,6 +291,8 @@ static inline int sig_match_simple(jl_value_t *arg1, jl_value_t **args, size_t n
                 return 0;
         }
         jl_value_t *t = jl_unwrap_vararg(decl);
+        if (t == (jl_value_t*)jl_any_type)
+            return 1;
         for (; i < n; i++) {
             jl_value_t *a = (i == 0 ? arg1 : args[i - 1]);
             if (!jl_isa(a, t))
@@ -299,6 +301,32 @@ static inline int sig_match_simple(jl_value_t *arg1, jl_value_t **args, size_t n
         return 1;
     }
     return 1;
+}
+
+// Test whether a single typemap entry matches the given call, mirroring the
+// per-entry logic of jl_typemap_entry_assoc_exact, excluding guardsigs (callers
+// caching entries for re-matching must not cache guarded entries).
+int jl_typemap_entry_sig_match(jl_typemap_entry_t *ml, jl_value_t *arg1, jl_value_t **args, size_t n, size_t world)
+{
+    assert(ml->guardsigs == jl_emptysvec);
+    if (world < jl_atomic_load_relaxed(&ml->min_world) || world > jl_atomic_load_relaxed(&ml->max_world))
+        return 0;
+    size_t lensig = jl_nparams(ml->sig);
+    if (!(lensig == n || (ml->va && lensig <= n + 1)))
+        return 0;
+    if (ml->simplesig != (void*)jl_nothing) {
+        size_t lensimplesig = jl_nparams(ml->simplesig);
+        int isva = lensimplesig > 0 && jl_is_vararg(jl_tparam(ml->simplesig, lensimplesig - 1));
+        if (!(lensimplesig == n || (isva && lensimplesig <= n + 1)))
+            return 0;
+        if (!sig_match_simple(arg1, args, n, jl_svec_data(ml->simplesig->parameters), isva, lensimplesig))
+            return 0;
+    }
+    if (ml->isleafsig)
+        return sig_match_leaf(arg1, args, jl_svec_data(ml->sig->parameters), n);
+    if (ml->issimplesig)
+        return sig_match_simple(arg1, args, n, jl_svec_data(ml->sig->parameters), ml->va, lensig);
+    return jl_tuple1_isa(arg1, args, n, ml->sig);
 }
 
 


### PR DESCRIPTION
Dynamic calls to builtins and intrinsics (from the interpreter and from inference's concrete evaluation) went through a full non-leaf typemap lookup on every call, since their methods have `Vararg{Any}` signatures that are never eligible for the leaf-only call cache. The same held for widened `@nospecialize` cache entries such as `Tuple{typeof(objectid), Any}` or `Expr`'s constructor, which were 82% of the remaining slow-path lookups during bootstrap and 94% in the dict test suite.

Following the review discussion, this generalizes the call cache in two ways instead of special-casing builtins ahead of dispatch:

First, add one extra cache slot hashed on the callee value itself, checked before the callsite-hashed slots: most callees dispatch to a single cache entry regardless of callsite ("single dispatch"), so this probe usually hits first, from any callsite — including ones that thrash the callsite-hashed slots, such as the interpreter's few C callsites. Entries whose signature is exactly `Tuple{typeof(f), Vararg{Any}}` (builtins and intrinsic calls) match every call of `f` and are accepted with an inline shape test.

Second, allow cached entries to be non-leaf simple signatures, re-matched with `sig_match_simple` via a new `jl_typemap_entry_sig_match` helper that mirrors the per-entry logic of `jl_typemap_entry_assoc_exact`. An inline pre-rejection test keeps the cost of probing a foreign entry to a single comparison. Guarded entries are never cached, since a guard rejection must fall through to the rest of the typemap. Cacheable entries are inserted both by callee and by callsite so both probe patterns can find them.

Dynamic dispatch of the affected calls becomes 1.3-3.3x cheaper (`===` 45ns → 14ns, `add_int` 56ns → 21ns, `getfield` 63ns → 23ns, `Expr(:call, :f)` 159ns → 57ns, `Core.Typeof` 31ns → 21ns), and ordinary leaf dispatch of a monomorphic callee gets slightly faster since it now hits the first probe (`+` 14.8ns → 14.3ns). The one small loser is a callee dispatched with alternating argument types from a single callsite, which pays one extra probe (18.4ns → 20.5ns).

Interpreter- and concrete-eval-heavy work benefits the most: a from-scratch sysimage bootstrap (including stdlib precompilation) goes from **11m26s to 8m47s (-23%)** on this machine (both measured at the same base commit with the same procedure), and compiling the compiler (#62198) and package precompilation see similar wins.

This pull request was written with the assistance of generative AI (Claude).