### PR TITLE
inference: keep undef refinement for `@isdefined` of `MustAlias` slots

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -4911,6 +4911,12 @@ function conditional_change(𝕃ᵢ::AbstractLattice, currstate::VarTable, condt
         # approximate test for `typ ∩ oldtyp` being better than `oldtyp`
         # since we probably formed these types with `typesubstract`,
         # the comparison is likely simple
+    elseif condt.isdefined
+        # An `@isdefined slot` Conditional exists to refine `undef`, not the type.
+        # If the (widened) type can't be narrowed against `oldtyp` — e.g. `oldtyp`
+        # is a `MustAlias` and `newtyp` is its widened form — keep `oldtyp` and still
+        # apply the `undef` refinement below, rather than dropping it entirely.
+        newtyp = oldtyp
     else
         return nothing
     end

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -4911,12 +4911,10 @@ function conditional_change(𝕃ᵢ::AbstractLattice, currstate::VarTable, condt
         # approximate test for `typ ∩ oldtyp` being better than `oldtyp`
         # since we probably formed these types with `typesubstract`,
         # the comparison is likely simple
-    elseif condt.isdefined
-        # An `@isdefined slot` Conditional exists to refine `undef`, not the type.
-        # If the (widened) type can't be narrowed against `oldtyp` — e.g. `oldtyp`
-        # is a `MustAlias` and `newtyp` is its widened form — keep `oldtyp` and still
-        # apply the `undef` refinement below, rather than dropping it entirely.
-        newtyp = oldtyp
+    elseif condt.isdefined && then_or_else === :then && vtype.undef
+         # For `@isdefined slot`, the type may not be a refinement
+         # but the `.undef` information still can be
+         return StateRefinement(condt.slot, oldtyp, #= undef =# false)
     else
         return nothing
     end

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1023,6 +1023,19 @@ end
     @isdefined($(gensym("some_undef_symbol")))
 end |> !Compiler.is_consistent
 
+# `@isdefined`-guarded read of a slot whose value is a `MustAlias` must still refine
+# the slot's `undef` info
+function isdefined_alias_loop(t::Tuple)
+    local prev
+    s = ""
+    for x in t
+        @isdefined(prev) && (s = prev)
+        prev = x
+    end
+    return s
+end
+@test Compiler.is_nothrow(Base.infer_effects(isdefined_alias_loop, (Tuple{String,String},)))
+
 # Effects of Base.hasfield (#50198)
 hf50198(s) = hasfield(typeof((;x=1, y=2)), s)
 f50198() = (hf50198(Ref(:x)[]); nothing)


### PR DESCRIPTION
After backporting https://github.com/JuliaLang/julia/pull/55601 to 1.12 I saw PkgEval failures from JET. The robot minimized this to the following (with a test that fails on master but passes here).

----------

:robot: 

inference: keep `undef` refinement for `@isdefined` of `MustAlias` slots

`conditional_change` couples two jobs: narrowing a slot's type (the `⊑`
check) and refining its `undef` flag. For an `@isdefined slot` Conditional
the then/else type is `widenslotwrapper(slot)`, so when the slot's value is
tracked as a `MustAlias`, `widened ⋢ MustAlias` and the function hit
`return nothing` — silently dropping the `undef` refinement. A guarded read
inside a loop was then left as possibly-undefined and merged monotonically
across the back-edge, so it never recovered, marking the read as not
`:nothrow`.

This regressed in #55601, which removed eager `invalidate_slotwrapper` so
slots retain `MustAlias` types across reassignment. It surfaced as a JET
false positive ("local variable `prev` may be undefined") on `Base.join`,
and on master — where `MustAliasesLattice` is in the default lattice — it
affects the native compiler's effect analysis directly.
Fix: for `@isdefined` Conditionals, keep `oldtyp` instead of bailing, so the
`undef` refinement is still applied.
