### PR TITLE
gf: cache dynamic dispatch on type-valued arguments

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -4399,6 +4399,8 @@ JL_DLLEXPORT jl_value_t *jl_invoke_oc(jl_value_t *F, jl_value_t **args, uint32_t
 STATIC_INLINE int sig_match_fast(jl_value_t *arg1t, jl_value_t **args, jl_value_t **sig, size_t n)
 {
     // NOTE: This function is a huge performance hot spot!!
+    // Matches a dispatch-tuple signature: each slot is a concrete type (matched by
+    // `typeof(a)`) or `Type{X}` (matched by the type value `X`). Types are hash-consed.
     if (arg1t != sig[0])
         return 0;
     size_t i;
@@ -4406,11 +4408,9 @@ STATIC_INLINE int sig_match_fast(jl_value_t *arg1t, jl_value_t **args, jl_value_
         jl_value_t *decl = sig[i];
         jl_value_t *a = args[i - 1];
         if (jl_typeof(a) != decl) {
-            /*
-              we are only matching concrete types here, and those types are
-              hash-consed, so pointer comparison should work.
-            */
-            return 0;
+            // a `Type{X}` slot is matched by the type value `X` itself
+            if (!(jl_is_typeeq(decl) && a == jl_typeeq_T(decl)))
+                return 0;
         }
     }
     return 1;
@@ -4516,9 +4516,14 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
                 }
             }
         }
-        if (entry != NULL && entry->isleafsig && entry->simplesig == (void*)jl_nothing && entry->guardsigs == jl_emptysvec) {
-            // put the entry into the cache if it's valid for a leafsig lookup,
-            // using pick_which to slightly randomize where it ends up
+        if (entry != NULL && jl_is_datatype((jl_value_t*)entry->sig) &&
+                ((jl_datatype_t*)entry->sig)->isdispatchtuple && !entry->va &&
+                entry->guardsigs == jl_emptysvec) {
+            // Cache any fixed-arity dispatch-tuple signature with no guards: it is
+            // maximally specific (concrete or `Type{X}` slots), so `sig_match_fast`
+            // validates a hit exactly. Unlike isleafsig this also covers `Type{}` slots,
+            // so dispatch on type-valued arguments can hit the cache, not the typemap walk.
+            // Use pick_which to slightly randomize where it ends up
             // (intentionally not atomically synchronized, since we're just using it for randomness)
             // TODO: use the thread's `cong` instead as a source of randomness
             int which = jl_atomic_load_relaxed(&pick_which[cache_idx[0]]) + 1;
@@ -4576,14 +4581,20 @@ jl_method_instance_t *jl_apply_lookup(jl_value_t **args, size_t nargs, size_t wo
             jl_int32hash_fast(jl_return_address()), world, 0);
 }
 
-JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint32_t nargs)
+// jl_apply_generic with an explicit call-cache key. The interpreter passes the call
+// site (Expr) identity so each interpreted call site keys its own cache slots, rather
+// than all sharing the one return address of the interpreter's apply site.
+JL_DLLEXPORT jl_value_t *jl_apply_generic_callsite(jl_value_t *F, jl_value_t **args, uint32_t nargs, uint32_t callsite)
 {
     size_t world = jl_current_task->world_age;
-    jl_method_instance_t *mfunc = jl_lookup_generic_(F, args, nargs,
-                                                     jl_int32hash_fast(jl_return_address()),
-                                                     world, 1);
+    jl_method_instance_t *mfunc = jl_lookup_generic_(F, args, nargs, callsite, world, 1);
     JL_GC_PROMISE_ROOTED(mfunc);
     return _jl_invoke(F, args, nargs, mfunc, world, TRIGGER_DISPATCH);
+}
+
+JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint32_t nargs)
+{
+    return jl_apply_generic_callsite(F, args, nargs, jl_int32hash_fast(jl_return_address()));
 }
 
 // buggy way to lookup a method given a list of arguments

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -112,7 +112,7 @@ static jl_value_t *eval_methoddef(jl_expr_t *ex, interpreter_state *s)
 
 // expression evaluator
 
-static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s)
+static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s, uint32_t callsite)
 {
     jl_value_t **argv;
     assert(nargs >= 1);
@@ -120,7 +120,7 @@ static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s
     size_t i;
     for (i = 0; i < nargs; i++)
         argv[i] = eval_value(args[i], s);
-    jl_value_t *result = jl_apply(argv, nargs);
+    jl_value_t *result = jl_apply_generic_callsite(argv[0], &argv[1], nargs - 1, callsite);
     JL_GC_POP();
     return result;
 }
@@ -240,13 +240,13 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
     size_t nargs = jl_array_nrows(ex->args);
     jl_sym_t *head = ex->head;
     if (head == jl_call_sym) {
-        return do_call(args, nargs, s);
+        return do_call(args, nargs, s, jl_int32hash_fast((uint32_t)(uintptr_t)ex));
     }
     else if (head == jl_invoke_sym) {
         return do_invoke(args, nargs, s);
     }
     else if (head == jl_invoke_modify_sym) {
-        return do_call(args + 1, nargs - 1, s);
+        return do_call(args + 1, nargs - 1, s, jl_int32hash_fast((uint32_t)(uintptr_t)ex));
     }
     else if (head == jl_isdefined_sym) {
         jl_value_t *sym = args[0];

--- a/src/julia.h
+++ b/src/julia.h
@@ -2396,6 +2396,7 @@ STATIC_INLINE int jl_vinfo_usedundef(uint8_t vi)
 // calling into julia ---------------------------------------------------------
 
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_apply_generic_callsite(jl_value_t *F, jl_value_t **args, uint32_t nargs, uint32_t callsite);
 JL_DLLEXPORT jl_value_t *jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *meth);
 JL_DLLEXPORT jl_value_t *jl_invoke_oc(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *meth);
 JL_DLLEXPORT int32_t jl_invoke_api(jl_code_instance_t *linfo);


### PR DESCRIPTION
A dynamic call whose matched method dispatches on a type-valued argument (e.g.
convert(T, x), or any method with a Type{T} parameter) was never eligible for the
4-way call cache: its signature is a dispatch tuple containing Type{X}, which is
not a leaf signature, so every such call fell through to the full typemap walk
(an isa-based match, plus an arg-tuple type-cache lookup to form the key). This is
very common in inference and is a large part of the interpreted dispatch cost of
compiling the compiler (#62198).

Cache these the same way as leaf signatures. A fixed-arity dispatch tuple with no
ambiguity guards is maximally specific, so a call whose arguments match it exactly
resolves uniquely to that entry -- the same condition the typemap checks. Widen
the cache population test from isleafsig to "entry->sig is an isdispatchtuple",
which admits concrete and Type{X} slots but excludes kinds and Any (whose slots
would over-match), and extend sig_match_fast to match a Type{X} slot by the type
value itself. Validation reads entry->sig directly (which is the concrete
arg-tuple for these entries), so no extra per-slot state is required, and the
existing world-bounds check continues to reject stale entries on invalidation.

The interpreter previously routed every call through the single return address of
its apply site, so all interpreted calls shared (and thrashed) the same four cache
slots. Pass the call site (Expr) identity as the cache key so each interpreted
call site keys its own slots; this is what lets the caching above take effect for
interpreter- and inference-heavy work.

Dynamic dispatch on a type-valued argument drops from ~38ns to ~8ns (leaf-dispatch
parity), and bootstrap shortens by ~12s on top of the other dispatch fixes.

This change was written with the assistance of generative AI (Claude).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
