### PR TITLE
require all src functions are declared in a header (or are not expected necessary due to static/extern/dllexport)

### DIFF
--- a/src/APInt.c
+++ b/src/APInt.c
@@ -10,11 +10,6 @@
 #include <math.h>
 #include <string.h>
 
-// bfloat conversion functions defined in runtime_intrinsics.c
-// (half-float equivalents are declared in julia_internal.h)
-extern uint16_t julia_float_to_bfloat(float param) JL_NOTSAFEPOINT;
-extern float julia_bfloat_to_float(uint16_t param) JL_NOTSAFEPOINT;
-
 // ---- Constants and macros ----
 
 #define WORD_SIZE 64

--- a/src/Makefile
+++ b/src/Makefile
@@ -674,7 +674,7 @@ GC_CHECKER_SOURCES := \
 	$(SRCDIR)/clangsa/GCCheckerReporting.cpp \
 	$(SRCDIR)/clangsa/GCCheckerPropagation.cpp
 
-CLANGSA_PLUGIN_NAMES := GCChecker ImplicitAtomics FirstDeclAnnotations
+CLANGSA_PLUGIN_NAMES := GCChecker ImplicitAtomics FirstDeclAnnotations StaticOrDeclared
 CLANGSA_PLUGINS := $(addsuffix Plugin.$(SHLIB_EXT),$(addprefix $(build_shlibdir)/lib,$(CLANGSA_PLUGIN_NAMES)))
 GCCHECKER_PLUGIN := $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
 
@@ -749,11 +749,7 @@ clang-sa-%: $(SRCDIR)/%.cpp .FORCE | analyzegc-deps-check
 		$(SA_EXCEPTIONS-$(notdir $<)) \
 		$(CLANG_TOOLING_CXX_FLAGS) -fcolor-diagnostics -Werror -x c++ $<)
 
-# Run the clang-tidy plugins: concurrency-implicit-atomics (see
-# src/clangsa/ImplicitAtomics.cpp) and julia-first-decl-annotations, which flags
-# Julia annotations (JL_NOTSAFEPOINT, JL_PROPAGATES_ROOT, ...) written only on a
-# redeclaration instead of on the first declaration (see
-# src/clangsa/FirstDeclAnnotations.cpp). `-header-filter='.*'` so the first
+# Run clang-tidy with our plugins: `-header-filter='.*'` so the first
 # (header) declarations participate in the comparison. The annotation macros
 # only expand to an `annotate` attribute under `-D__clang_gcanalyzer__` (see
 # src/support/analyzer_annotations.h), so run the checks once in the normal
@@ -762,7 +758,7 @@ clang-sa-%: $(SRCDIR)/%.cpp .FORCE | analyzegc-deps-check
 TIDY_PLUGIN_NAMES := $(filter-out GCChecker,$(CLANGSA_PLUGIN_NAMES))
 TIDY_PLUGIN_LIBS := $(addsuffix Plugin.$(SHLIB_EXT),$(addprefix $(build_shlibdir)/lib,$(TIDY_PLUGIN_NAMES)))
 TIDY_PLUGINS := $(addprefix -load ,$(TIDY_PLUGIN_LIBS))
-TIDY_CHECKS := -clang-analyzer-*,-clang-diagnostic-*,concurrency-implicit-atomics,julia-first-decl-annotations
+TIDY_CHECKS := -clang-analyzer-*,-clang-diagnostic-*,concurrency-implicit-atomics,julia-first-decl-annotations,julia-static-or-declared
 clang-tidy-%: $(SRCDIR)/%.c $(TIDY_PLUGIN_LIBS) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang-tidy $< -header-filter='.*' --quiet \
 		$(TIDY_PLUGINS) --checks='$(TIDY_CHECKS)' --warnings-as-errors='*' \

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -501,30 +501,6 @@ static void aot_optimize_roots(jl_codegen_output_t &out, egal_set &method_roots)
     }
 }
 
-/// Link the function in the source module into the destination module if
-/// needed, setting up mapping information.
-/// Similar to orc::cloneFunctionDecl, but more complete for greater correctness
-Function *IRLinker_copyFunctionProto(Module *DstM, Function *SF) {
-  // If there is no linkage to be performed or we are linking from the source,
-  // bring SF over, if we haven't already.
-  if (SF->getParent() == DstM)
-    return SF;
-  if (auto *F = DstM->getNamedValue(SF->getName()))
-      return cast<Function>(F);
-  auto *F = Function::Create(SF->getFunctionType(), SF->getLinkage(),
-                             SF->getAddressSpace(), SF->getName(), DstM);
-  F->copyAttributesFrom(SF);
-#if JL_LLVM_VERSION < 210000
-  F->IsNewDbgInfoFormat = SF->IsNewDbgInfoFormat;
-#endif
-
-  // Remove these copied constants since they point to the source module.
-  F->setPersonalityFn(nullptr);
-  F->setPrefixData(nullptr);
-  F->setPrologueData(nullptr);
-  return F;
-}
-
 static Function *aot_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_code_instance_t *codeinst, Function *func, Function *specfunc, bool target_specsig)
 {
     std::string gf_thunk_name;
@@ -1041,8 +1017,6 @@ static void injectCRTAlias(Module &M, StringRef name, StringRef alias, FunctionT
     builder.CreateRet(val);
 }
 
-void multiversioning_preannotate(Module &M);
-
 // See src/processor.h for documentation about this table. Corresponds to jl_image_shard_t.
 static GlobalVariable *emit_shard_table(Module &M, Type *T_size, Type *T_psize, unsigned threads) {
     SmallVector<Constant *, 0> tables(sizeof(jl_image_shard_t) / sizeof(void *) * threads);
@@ -1196,7 +1170,7 @@ struct ModuleInfo {
 };
 }  // anonymous namespace
 
-ModuleInfo compute_module_info(Module &M) {
+static ModuleInfo compute_module_info(Module &M) {
     ModuleInfo info;
     info.globals = 0;
     info.funcs = 0;
@@ -2177,7 +2151,7 @@ static unsigned compute_image_thread_count(const ModuleInfo &info, bool jobserve
 
 jl_emission_params_t default_emission_params = { 1 };
 
-void jl_dump_native_locked(jl_native_code_desc_t *data, const char *bc_fname,
+static void jl_dump_native_locked(jl_native_code_desc_t *data, const char *bc_fname,
                            const char *unopt_bc_fname, const char *obj_fname,
                            const char *asm_fname, ios_t *z, ios_t *s,
                            jl_emission_params_t *params, Module &dataM)

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1152,12 +1152,14 @@ static void get_fvars_gvars(Module &M, DenseMap<GlobalValue *, unsigned> &fvars,
 // among the threads equally. The weight calculated here is an estimation of
 // how expensive a particular function is going to be to compile.
 
+namespace {
 struct FunctionInfo {
     size_t weight;
     size_t bbs;
     size_t insts;
     size_t clones;
 };
+}  // anonymous namespace
 
 static FunctionInfo getFunctionWeight(const Function &F)
 {
@@ -1183,6 +1185,7 @@ static FunctionInfo getFunctionWeight(const Function &F)
     return info;
 }
 
+namespace {
 struct ModuleInfo {
     size_t globals;
     size_t funcs;
@@ -1191,6 +1194,7 @@ struct ModuleInfo {
     size_t clones;
     size_t weight;
 };
+}  // anonymous namespace
 
 ModuleInfo compute_module_info(Module &M) {
     ModuleInfo info;
@@ -1219,12 +1223,14 @@ ModuleInfo compute_module_info(Module &M) {
     return info;
 }
 
+namespace {
 struct Partition {
     StringMap<bool> globals;
     StringMap<unsigned> fvars;
     StringMap<unsigned> gvars;
     size_t weight;
 };
+}  // anonymous namespace
 
 static inline bool verify_partitioning(const SmallVectorImpl<Partition> &partitions, const Module &M, DenseMap<GlobalValue *, unsigned> &fvars, DenseMap<GlobalValue *, unsigned> &gvars) {
     bool bad = false;
@@ -1443,6 +1449,7 @@ static SmallVector<Partition, 32> partitionModule(Module &M, unsigned threads) {
     return partitions;
 }
 
+namespace {
 struct ImageTimer {
     uint64_t elapsed = 0;
     std::string name;
@@ -1491,7 +1498,9 @@ struct ImageTimer {
             elapsed = 0;
     }
 };
+}  // anonymous namespace
 
+namespace {
 struct ShardTimers {
     ImageTimer deserialize;
     ImageTimer materialize;
@@ -1523,10 +1532,13 @@ struct ShardTimers {
         out << llvm::formatv("{0:F3}  total  Total time taken\n", total / 1e9);
     }
 };
+}  // anonymous namespace
 
+namespace {
 struct AOTOutputs {
     SmallVector<char, 0> unopt, opt, obj, asm_;
 };
+}  // anonymous namespace
 
 // Perform the actual optimization and emission of the output files
 static AOTOutputs add_output_impl(Module &M, TargetMachine &SourceTM, ShardTimers &timers,

--- a/src/array.c
+++ b/src/array.c
@@ -88,10 +88,6 @@ STATIC_INLINE jl_array_t *new_array(jl_value_t *atype, uint32_t ndims, size_t *d
     return a;
 }
 
-jl_genericmemory_t *_new_genericmemory_(jl_value_t *mtype, size_t nel, int8_t isunion, int8_t zeroinit, size_t elsz);
-
-JL_DLLEXPORT jl_genericmemory_t *jl_string_to_genericmemory(jl_value_t *str);
-
 JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
                                             size_t nel, int own_buffer)
 {
@@ -272,8 +268,6 @@ JL_DLLEXPORT void jl_array_ptr_1d_append(jl_array_t *a, jl_array_t *a2)
         jl_array_ptr_set(a, n + i, jl_array_ptr_ref(a2, i));
     }
 }
-
-JL_DLLEXPORT jl_genericmemory_t *jl_genericmemory_copy_slice(jl_genericmemory_t *mem, void *data, size_t len);
 
 JL_DLLEXPORT jl_array_t *jl_array_copy(jl_array_t *ary)
 {

--- a/src/ast.c
+++ b/src/ast.c
@@ -45,7 +45,7 @@ typedef struct _jl_ast_context_t {
 static jl_ast_context_t jl_ast_main_ctx;
 
 #ifdef __clang_gcanalyzer__
-jl_ast_context_t *jl_ast_ctx(fl_context_t *fl) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT;
+extern jl_ast_context_t *jl_ast_ctx(fl_context_t *fl) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT;
 #else
 #define jl_ast_ctx(fl_ctx) container_of(fl_ctx, jl_ast_context_t, fl)
 #endif
@@ -332,7 +332,7 @@ void jl_init_common_symbols(void)
     jl_latestworld_sym = jl_symbol("latestworld");
 }
 
-JL_DLLEXPORT void jl_lisp_prompt(void)
+void jl_lisp_prompt(void)
 {
     // Make `--lisp` sigatomic in order to avoid triggering the sigint safepoint.
     // We don't have our signal handler registered in that case anyway...
@@ -989,7 +989,7 @@ static int is_self_escaping_expr(jl_expr_t *e) JL_NOTSAFEPOINT
 
 // any AST, except those that cannot contain symbols
 // and have no side effects
-int need_esc_node(jl_value_t *e) JL_NOTSAFEPOINT
+static int need_esc_node(jl_value_t *e) JL_NOTSAFEPOINT
 {
     if (jl_is_linenode(e)
         || jl_is_ssavalue(e)

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -7,6 +7,7 @@
 #include <llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h>
 #include <llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include "llvm-codegen-shared.h"
 
 #include "julia.h"
 #include "julia_internal.h"
@@ -786,151 +787,6 @@ get_preferred_allocators() JL_NOTSAFEPOINT
     return {};
 }
 
-class RTDyldMemoryManagerJL : public SectionMemoryManager {
-    struct EHFrame {
-        uint8_t *addr;
-        size_t size;
-    };
-    RTDyldMemoryManagerJL(const RTDyldMemoryManagerJL&) = delete;
-    void operator=(const RTDyldMemoryManagerJL&) = delete;
-    SmallVector<EHFrame, 16> pending_eh;
-    RWAllocator rw_alloc;
-    std::unique_ptr<ROAllocator> ro_alloc;
-    std::unique_ptr<ROAllocator> exe_alloc;
-    size_t total_allocated;
-
-public:
-    RTDyldMemoryManagerJL() JL_NOTSAFEPOINT
-        : SectionMemoryManager(),
-          pending_eh(),
-          rw_alloc(),
-          total_allocated(0)
-    {
-        std::tie(ro_alloc, exe_alloc) = get_preferred_allocators();
-    }
-    ~RTDyldMemoryManagerJL() override JL_NOTSAFEPOINT
-    {
-    }
-    size_t getTotalBytes() JL_NOTSAFEPOINT { return total_allocated; }
-    void registerEHFrames(uint8_t *Addr, uint64_t LoadAddr,
-                          size_t Size) override JL_NOTSAFEPOINT;
-#if 0
-    // Disable for now since we are not actually using this.
-    void deregisterEHFrames(uint8_t *Addr, uint64_t LoadAddr,
-                            size_t Size) override;
-#endif
-    uint8_t *allocateCodeSection(uintptr_t Size, unsigned Alignment,
-                                 unsigned SectionID,
-                                 StringRef SectionName) override JL_NOTSAFEPOINT;
-    uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
-                                 unsigned SectionID, StringRef SectionName,
-                                 bool isReadOnly) override JL_NOTSAFEPOINT;
-    using SectionMemoryManager::notifyObjectLoaded;
-    void notifyObjectLoaded(RuntimeDyld &Dyld,
-                            const object::ObjectFile &Obj) override JL_NOTSAFEPOINT;
-    bool finalizeMemory(std::string *ErrMsg = nullptr) override JL_NOTSAFEPOINT;
-    template <typename DL, typename Alloc>
-    void mapAddresses(DL &Dyld, Alloc &&allocator) JL_NOTSAFEPOINT
-    {
-        for (auto &alloc: allocator->allocations) {
-            if (alloc.rt_addr == alloc.wr_addr || alloc.relocated)
-                continue;
-            alloc.relocated = true;
-            Dyld.mapSectionAddress(alloc.wr_addr, (uintptr_t)alloc.rt_addr);
-        }
-    }
-    template <typename DL>
-    void mapAddresses(DL &Dyld) JL_NOTSAFEPOINT
-    {
-        if (!ro_alloc)
-            return;
-        mapAddresses(Dyld, ro_alloc);
-        mapAddresses(Dyld, exe_alloc);
-    }
-};
-
-uint8_t *RTDyldMemoryManagerJL::allocateCodeSection(uintptr_t Size,
-                                                    unsigned Alignment,
-                                                    unsigned SectionID,
-                                                    StringRef SectionName) JL_NOTSAFEPOINT
-{
-    // allocating more than one code section can confuse libunwind.
-    total_allocated += Size;
-    jl_timing_counter_inc(JL_TIMING_COUNTER_JITSize, Size);
-    jl_timing_counter_inc(JL_TIMING_COUNTER_JITCodeSize, Size);
-    if (exe_alloc)
-        return (uint8_t*)exe_alloc->alloc(Size, Alignment).wr_addr;
-    return SectionMemoryManager::allocateCodeSection(Size, Alignment, SectionID,
-                                                     SectionName);
-}
-
-uint8_t *RTDyldMemoryManagerJL::allocateDataSection(uintptr_t Size,
-                                                    unsigned Alignment,
-                                                    unsigned SectionID,
-                                                    StringRef SectionName,
-                                                    bool isReadOnly) JL_NOTSAFEPOINT
-{
-    total_allocated += Size;
-    jl_timing_counter_inc(JL_TIMING_COUNTER_JITSize, Size);
-    jl_timing_counter_inc(JL_TIMING_COUNTER_JITDataSize, Size);
-    if (!isReadOnly)
-        return (uint8_t*)rw_alloc.alloc(Size, Alignment).wr_addr;
-    if (ro_alloc)
-        return (uint8_t*)ro_alloc->alloc(Size, Alignment).wr_addr;
-    return SectionMemoryManager::allocateDataSection(Size, Alignment, SectionID,
-                                                     SectionName, isReadOnly);
-}
-
-void RTDyldMemoryManagerJL::notifyObjectLoaded(RuntimeDyld &Dyld,
-                                               const object::ObjectFile &Obj) JL_NOTSAFEPOINT
-{
-    if (!ro_alloc) {
-        assert(!exe_alloc);
-        SectionMemoryManager::notifyObjectLoaded(Dyld, Obj);
-        return;
-    }
-    assert(exe_alloc);
-    mapAddresses(Dyld);
-}
-
-bool RTDyldMemoryManagerJL::finalizeMemory(std::string *ErrMsg) JL_NOTSAFEPOINT
-{
-    if (ro_alloc) {
-        ro_alloc->finalize();
-        assert(exe_alloc);
-        exe_alloc->finalize();
-        for (auto &frame: pending_eh)
-            register_eh_frames(frame.addr, frame.size);
-        pending_eh.clear();
-        return false;
-    }
-    else {
-        assert(!exe_alloc);
-        return SectionMemoryManager::finalizeMemory(ErrMsg);
-    }
-}
-
-void RTDyldMemoryManagerJL::registerEHFrames(uint8_t *Addr,
-                                             uint64_t LoadAddr,
-                                             size_t Size) JL_NOTSAFEPOINT
-{
-    if (uintptr_t(Addr) == LoadAddr) {
-        register_eh_frames(Addr, Size);
-    }
-    else {
-        pending_eh.push_back(EHFrame{(uint8_t*)(uintptr_t)LoadAddr, Size});
-    }
-}
-
-#if 0
-void RTDyldMemoryManagerJL::deregisterEHFrames(uint8_t *Addr,
-                                               uint64_t LoadAddr,
-                                               size_t Size) JL_NOTSAFEPOINT
-{
-    deregister_eh_frames((uint8_t*)LoadAddr, Size);
-}
-#endif
-
 class JLJITLinkMemoryManager : public jitlink::JITLinkMemoryManager {
     using OnFinalizedFunction =
         jitlink::JITLinkMemoryManager::InFlightAlloc::OnFinalizedFunction;
@@ -945,7 +801,7 @@ class JLJITLinkMemoryManager : public jitlink::JITLinkMemoryManager {
 public:
     class InFlightAlloc;
 
-    static std::unique_ptr<JITLinkMemoryManager> Create()
+    static std::unique_ptr<JITLinkMemoryManager> Create() JL_NOTSAFEPOINT
     {
         auto [ROAlloc, ExeAlloc] = get_preferred_allocators();
         if (ROAlloc && ExeAlloc)
@@ -969,7 +825,7 @@ public:
 
 protected:
     JLJITLinkMemoryManager(std::unique_ptr<ROAllocator> ROAlloc,
-                           std::unique_ptr<ROAllocator> ExeAlloc)
+                           std::unique_ptr<ROAllocator> ExeAlloc) JL_NOTSAFEPOINT
       : ROAlloc(std::move(ROAlloc)), ExeAlloc(std::move(ExeAlloc))
     {
     }
@@ -1001,9 +857,11 @@ class JLJITLinkMemoryManager::InFlightAlloc
     jitlink::LinkGraph &G;
 
 public:
-    InFlightAlloc(JLJITLinkMemoryManager &MM, jitlink::LinkGraph &G) : MM(MM), G(G) {}
+    InFlightAlloc(JLJITLinkMemoryManager &MM, jitlink::LinkGraph &G) JL_NOTSAFEPOINT
+        : MM(MM), G(G) {}
 
-    void abandon(OnAbandonedFunction OnAbandoned) override {
+    void abandon(OnAbandonedFunction OnAbandoned) override
+    {
         OnAbandoned(Error::success());
     }
 
@@ -1074,17 +932,7 @@ void JLJITLinkMemoryManager::allocate(const jitlink::JITLinkDylib *JD,
 }
 }
 
-RTDyldMemoryManager* createRTDyldMemoryManager() JL_NOTSAFEPOINT
-{
-    return new RTDyldMemoryManagerJL();
-}
-
-size_t getRTDyldMemoryManagerTotalBytes(RTDyldMemoryManager *mm) JL_NOTSAFEPOINT
-{
-    return ((RTDyldMemoryManagerJL*)mm)->getTotalBytes();
-}
-
-std::unique_ptr<jitlink::JITLinkMemoryManager> createJITLinkMemoryManager()
+std::unique_ptr<jitlink::JITLinkMemoryManager> createJITLinkMemoryManager() JL_NOTSAFEPOINT
 {
     return JLJITLinkMemoryManager::Create();
 }

--- a/src/clangsa/StaticOrDeclared.cpp
+++ b/src/clangsa/StaticOrDeclared.cpp
@@ -1,0 +1,353 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// StaticOrDeclared: a clang-tidy check that enforces that every function with
+// external linkage defined in a source file is either
+//
+//   (a) declared in some header (i.e. it has a non-defining redeclaration that
+//       comes from an #included file, so the function is part of an API that
+//       other translation units can call), or
+//   (b) declared `static` (internal linkage), so it is private to its
+//       translation unit, or
+//
+//   (c) explicitly exported with `JL_DLLEXPORT` -- i.e. it carries an explicit
+//       `__declspec(dllexport)` (on Windows) and/or
+//       `__attribute__((visibility("default")))` (elsewhere). Such a function
+//       is deliberately part of the public ABI even without a prototype, so it
+//       is permitted. Which attribute is present depends on the platform the
+//       analysis runs on, so both are accepted, or
+//
+//   (d) explicitly annotated with the `extern` keyword in this file. Functions
+//       are external by default, so spelling out `extern` is a deliberate
+//       statement that the external linkage is intended, which overrides the
+//       warning. (This is the storage class `extern`, not the `extern "C"`
+//       language-linkage specifier.)
+//
+// A function definition that is neither is potentially a mistake: it pollutes
+// the global namespace with a symbol nobody can correctly call (there is no
+// prototype to call it against) and prevents the compiler from optimizing it as
+// a file-local function. The fix is to either add a prototype to the relevant
+// header or to mark the definition `static`.
+//
+// The same expectation is imposed on C++ class/struct/union definitions: a type
+// defined in a source file must either be declared in a header (so it is a real
+// API type), be explicitly exported, or -- since a type cannot be `static` --
+// live in an anonymous namespace, which is how C++ marks a type as local to its
+// translation unit. A type with external linkage that is defined only in a .cpp
+// has the same problems as such a function (ODR hazards across translation
+// units, an emitted vtable/typeinfo nobody can name).
+//
+// Usage (see src/Makefile):
+//   clang-tidy foo.c --quiet \
+//       -load libStaticOrDeclaredPlugin.so \
+//       --checks='-*,julia-static-or-declared' \
+//       -- <compiler flags>
+
+#include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Lex/Lexer.h"
+#include "clang-tidy/ClangTidyCheck.h"
+#include "clang-tidy/ClangTidyModule.h"
+#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+#include <utility>
+
+using namespace clang;
+using namespace clang::tidy;
+using namespace clang::ast_matchers;
+
+namespace {
+
+class StaticOrDeclaredCheck : public ClangTidyCheck {
+public:
+    StaticOrDeclaredCheck(StringRef Name, ClangTidyContext *Context)
+        : ClangTidyCheck(Name, Context) {}
+
+    void registerMatchers(MatchFinder *Finder) override {
+        Finder->addMatcher(functionDecl().bind("fn"), this);
+        Finder->addMatcher(cxxRecordDecl(isDefinition()).bind("rec"), this);
+    }
+
+    void check(const MatchFinder::MatchResult &Result) override {
+        SourceManager &SM = Result.Context->getSourceManager();
+
+        if (const auto *FD = Result.Nodes.getNodeAs<FunctionDecl>("fn")) {
+            if (!shouldCheck(FD))
+                return;
+            // Report each function once, at its anchor declaration, and skip
+            // functions with no declaration in this file. Every redeclaration
+            // is matched, so all but the anchor are dropped here.
+            const FunctionDecl *Anchor = anchorDecl(FD, SM);
+            if (!Anchor || FD != Anchor)
+                return;
+            // Explicit `extern` is the deliberate opt-out (option (d)); it is
+            // also the temporary escape hatch for forward declarations that
+            // have not yet been migrated into a header.
+            if (isExplicitlyExtern(FD))
+                return;
+            if (Anchor->isThisDeclarationADefinition()) {
+                // The definition lives in this file: it is fine if declared in
+                // a header (a) or explicitly exported (c).
+                if (!isDeclaredInHeader(FD, SM) && !isExplicitlyExported(FD)) {
+                    auto Diag =
+                        diag(Anchor->getLocation(),
+                             "function %0 has external linkage but is not "
+                             "declared in any header; declare it in a header or "
+                             "make it 'static'")
+                        << Anchor;
+                    addStaticFixIt(Diag, FD, SM,
+                                   Result.Context->getLangOpts());
+                }
+            } else {
+                // Only a forward declaration lives in this file; the definition
+                // is in another translation unit.
+                if (isExplicitlyExported(FD) && FD->getDefinition())
+                    return;
+                diag(Anchor->getLocation(),
+                     "function %0 is forward-declared in a source file rather "
+                     "than a header; move the declaration to a header or mark "
+                     "it 'extern'")
+                    << Anchor;
+            }
+        }
+        if (const auto *RD = Result.Nodes.getNodeAs<CXXRecordDecl>("rec")) {
+            if (shouldCheck(RD, SM) && !isDeclaredInHeader(RD, SM) &&
+                !isExplicitlyExported(RD)) {
+                auto Diag = diag(RD->getLocation(),
+                                 "type '%0' has external linkage but is not "
+                                 "declared in any header; declare it in a "
+                                 "header or move it into an anonymous namespace")
+                            << RD->getName();
+                addAnonNamespaceFixIt(Diag, RD, SM,
+                                      Result.Context->getLangOpts());
+            }
+        }
+    }
+
+private:
+    // Decide whether FD's function is one we hold to the rule. This is a
+    // property of the function rather than of a single declaration: kind and
+    // linkage are shared across all of its redeclarations.
+    static bool shouldCheck(const FunctionDecl *FD) {
+        if (FD->isImplicit())
+            return false;
+        // Only free functions: methods are declared in their class body and
+        // templates, specializations and instantiations are skipped.
+        if (isa<CXXMethodDecl>(FD) ||
+            FD->getTemplatedKind() != FunctionDecl::TK_NonTemplate)
+            return false;
+        if (FD->isMain())
+            return false;
+        // Check for a `static` function or one in an anonymous namespace.
+        if (FD->getFormalLinkage() != Linkage::External)
+            return false;
+        return true;
+    }
+
+    // Pick the single declaration to anchor the diagnostic on, so each function
+    // is reported at most once even though every redeclaration is matched.
+    // Prefer the definition when it is written in the main file (the natural
+    // place to point, and the one that can be made `static`); otherwise the
+    // first forward declaration in the main file.
+    static const FunctionDecl *anchorDecl(const FunctionDecl *FD,
+                                          SourceManager &SM) {
+        FileID MainID = SM.getMainFileID();
+        const FunctionDecl *First = nullptr;
+        for (const auto *R : FD->redecls()) {
+            // Step out of any `extern "C"` specifier to find the real lexical
+            // context, then keep only declarations written at file scope.
+            const DeclContext *LDC = R->getLexicalDeclContext();
+            while (const auto *LSD = dyn_cast<LinkageSpecDecl>(LDC))
+                LDC = LSD->getLexicalDeclContext();
+            if (!LDC->isFileContext())
+                continue;
+            SourceLocation Loc = SM.getExpansionLoc(R->getLocation());
+            if (Loc.isInvalid() || SM.getFileID(Loc) != MainID)
+                continue;
+            if (R->isThisDeclarationADefinition())
+                return R;
+            if (!First)
+                First = R;
+        }
+        return First;
+    }
+
+    // Decide whether RD is a class/struct/union definition we should hold to the rule.
+    static bool shouldCheck(const CXXRecordDecl *RD, SourceManager &SM) {
+        // Skip compiler-synthesized records, lambda closures and the injected
+        // class name (`Foo` inside `class Foo`).
+        if (RD->isImplicit() || RD->isLambda() || RD->isInjectedClassName())
+            return false;
+        // Anonymous structs/unions have no name to collide on.
+        if (!RD->getIdentifier())
+            return false;
+        // Member types are governed by their enclosing class.
+        if (RD->getDeclContext()->isRecord())
+            return false;
+        // Templates, specializations and instantiations can be ignored.
+        if (RD->getDescribedClassTemplate() ||
+            isa<ClassTemplateSpecializationDecl>(RD))
+            return false;
+        // A type in an anonymous namespace (or a local class) has internal/no
+        // linkage: that is the C++ way to mark it local, so it is correct.
+        if (RD->getFormalLinkage() != Linkage::External)
+            return false;
+        // Only flag definitions written in the main source file.
+        SourceLocation Loc = SM.getExpansionLoc(RD->getLocation());
+        return Loc.isValid() && SM.getFileID(Loc) == SM.getMainFileID();
+    }
+
+    // Compute the textual range of a single standalone declaration, from its
+    // begin location to just past the terminating `;`, if possible.
+    static bool getWrapRange(const Decl *D, const SourceManager &SM,
+                             const LangOptions &LangOpts, SourceLocation &Begin,
+                             SourceLocation &AfterSemi) {
+        Begin = D->getBeginLoc();
+        SourceLocation End = D->getEndLoc();
+        if (Begin.isInvalid() || End.isInvalid() || Begin.isMacroID() ||
+            End.isMacroID())
+            return false;
+        std::optional<Token> Semi = Lexer::findNextToken(End, SM, LangOpts);
+        if (!Semi || !Semi->is(tok::semi) || Semi->getLocation().isMacroID())
+            return false;
+        AfterSemi =
+            Lexer::getLocForEndOfToken(Semi->getLocation(), 0, SM, LangOpts);
+        return AfterSemi.isValid();
+    }
+
+    // Offer a fix-it that makes a function internal by prefixing `static`:
+    //     static void foo(void) { ... }
+    static void addStaticFixIt(DiagnosticBuilder &Diag, const FunctionDecl *FD,
+                               const SourceManager &SM,
+                               const LangOptions &LangOpts) {
+        FileID MainID = SM.getMainFileID();
+        llvm::SmallVector<SourceLocation, 4> Inserts;
+        for (const auto *R : FD->redecls()) {
+            SourceLocation Loc = SM.getExpansionLoc(R->getLocation());
+            if (Loc.isInvalid() || SM.getFileID(Loc) != MainID)
+                continue;
+            if (R->getStorageClass() != SC_None)
+                return;
+            // `extern "C" void f();` -- a linkage-specification directly
+            // prefixing the declaration with no braces -- cannot be prefixed
+            // with `static`: the resulting `extern "C" static` is ill-formed. A
+            // braced `extern "C" { ... }` block is fine, since `static` then
+            // lands inside the braces.
+            if (const auto *LSD =
+                    dyn_cast<LinkageSpecDecl>(R->getLexicalDeclContext()))
+                if (!LSD->hasBraces())
+                    return;
+            SourceLocation Begin = R->getBeginLoc();
+            if (Begin.isInvalid() || Begin.isMacroID())
+                return;
+            Inserts.push_back(Begin);
+        }
+        for (SourceLocation L : Inserts)
+            Diag << FixItHint::CreateInsertion(L, "static ");
+    }
+
+    // Offer a fix-it that wraps the type in an anonymous namespace:
+    //
+    //     namespace {
+    //     struct Foo { ... };
+    //     }  // anonymous namespace
+    //
+    // The fix is all-or-nothing: if any one of those declarations is not a
+    // simple standalone `struct Foo ...;` (or is macro-spelled), no fix is
+    // offered at all, rather than emitting a partial wrap that would change the
+    // program's meaning.
+    static void addAnonNamespaceFixIt(DiagnosticBuilder &Diag,
+                                      const CXXRecordDecl *RD,
+                                      const SourceManager &SM,
+                                      const LangOptions &LangOpts) {
+        FileID MainID = SM.getMainFileID();
+        llvm::SmallVector<std::pair<SourceLocation, SourceLocation>, 4> Ranges;
+        for (const auto *R : RD->redecls()) {
+            SourceLocation Loc = SM.getExpansionLoc(R->getLocation());
+            if (Loc.isInvalid() || SM.getFileID(Loc) != MainID)
+                continue;
+            SourceLocation Begin, AfterSemi;
+            if (!getWrapRange(R, SM, LangOpts, Begin, AfterSemi))
+                return;
+            Ranges.emplace_back(Begin, AfterSemi);
+        }
+        for (const auto &R : Ranges)
+            Diag << FixItHint::CreateInsertion(R.first, "namespace {\n")
+                 << FixItHint::CreateInsertion(R.second,
+                                               "\n}  // anonymous namespace");
+    }
+
+    // An entity is "declared in a header" when it has any non-defining
+    // redeclaration whose location is in a file other than the main source
+    // file -- i.e. a prototype (or forward declaration) that was #included
+    // rather than written inline in the source next to the definition.
+    template <typename DeclT>
+    static bool isDeclaredInHeader(const DeclT *D, SourceManager &SM) {
+        FileID MainID = SM.getMainFileID();
+        for (auto *R : D->redecls()) {
+            if (R->isThisDeclarationADefinition())
+                continue;
+            SourceLocation Loc = SM.getExpansionLoc(R->getLocation());
+            if (Loc.isValid() && SM.getFileID(Loc) != MainID)
+                return true;
+        }
+        return false;
+    }
+
+    // An entity is explicitly exported when any of its declarations carries an
+    // explicit `__declspec(dllexport)` or `__attribute__((visibility("default")))`.
+    template <typename DeclT>
+    static bool isExplicitlyExported(const DeclT *D) {
+        for (auto *R : D->redecls()) {
+            if (R->template hasAttr<DLLExportAttr>())
+                return true;
+            if (const auto *VA = R->template getAttr<VisibilityAttr>())
+                if (VA->getVisibility() == VisibilityAttr::Default)
+                    return true;
+        }
+        return false;
+    }
+
+    // A function whose definition or any of its declarations in this file is
+    // explicitly annotated with the `extern` keyword. Functions have external
+    // linkage by default, so a plain definition needs no `extern` -- writing it
+    // out is a deliberate statement that the external linkage is intended, which
+    // overrides the warning.
+    static bool isExplicitlyExtern(const FunctionDecl *FD) {
+        for (const auto *R : FD->redecls())
+            if (R->getStorageClass() == SC_Extern)
+                return true;
+        return false;
+    }
+};
+
+class StaticOrDeclaredModule : public ClangTidyModule {
+public:
+    void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+        CheckFactories.registerCheck<StaticOrDeclaredCheck>(
+            "julia-static-or-declared");
+    }
+};
+
+} // namespace
+
+namespace clang {
+namespace tidy {
+
+// Register the StaticOrDeclaredModule using this statically initialized
+// variable.
+static ClangTidyModuleRegistry::Add<::StaticOrDeclaredModule>
+    X("julia-static-or-declared-module",
+      "Adds the julia-static-or-declared check.");
+
+// This anchor is used to force the linker to link in the generated object file
+// and thus register the StaticOrDeclaredModule.
+volatile int StaticOrDeclaredModuleAnchorSource = 0;
+
+} // namespace tidy
+} // namespace clang

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -267,6 +267,7 @@ extern void _chkstk(void);
 #define prepare_call(Callee) prepare_call_in(jl_Module, (Callee))
 
 // types
+namespace {
 struct jl_typecache_t {
     PointerType *T_ptr;
     Type *T_size;
@@ -326,7 +327,9 @@ struct jl_typecache_t {
         T_pjlarray = getPointerTy(context);
     }
 };
+}  // anonymous namespace
 
+namespace {
 struct jl_tbaacache_t {
     // type-based alias analysis nodes.  Indentation of comments indicates hierarchy.
     MDNode *tbaa_root;     // Everything
@@ -404,7 +407,9 @@ struct jl_tbaacache_t {
         tbaa_const = tbaa_make_child(mbuilder, "jtbaa_const", nullptr, true).first;
     }
 };
+}  // anonymous namespace
 
+namespace {
 struct jl_noaliascache_t {
     // Each domain operates completely independently.
     // "No aliasing" is inferred if it is implied by any domain.
@@ -455,7 +460,9 @@ struct jl_noaliascache_t {
         aliasscope.initialize(context);
     }
 };
+}  // anonymous namespace
 
+namespace {
 struct jl_debugcache_t {
     // Basic DITypes
     DIDerivedType *jl_pvalue_dillvmt;
@@ -470,6 +477,7 @@ struct jl_debugcache_t {
 
     void initialize(Module *m);
 };
+}  // anonymous namespace
 
 
 // constants
@@ -487,7 +495,10 @@ static bool is_uniquerep_Type(jl_value_t *t)
     return jl_is_typeegal(t);
 }
 
+namespace {
 class jl_codectx_t;
+}  // anonymous namespace
+namespace {
 struct JuliaVariable {
 public:
     StringLiteral name;
@@ -507,8 +518,8 @@ public:
             var->setDLLStorageClass(GlobalValue::DLLStorageClassTypes::DLLImportStorageClass); // Cross-library imports must be explicit for COFF (Windows)
         return var;
     }
-    GlobalVariable *realize(jl_codectx_t &ctx);
 };
+}  // anonymous namespace
 static inline void add_named_global(JuliaVariable *name, void *addr)
 {
     add_named_global(name->name, addr);
@@ -1689,6 +1700,7 @@ static void union_alloca_type(jl_uniontype_t *ut,
         bool &allunbox, size_t &nbytes, size_t &align, size_t &min_align, size_t &inline_roots);
 
 // Alias Analysis Info (analogous to llvm::AAMDNodes)
+namespace {
 struct jl_aliasinfo_t {
     MDNode *tbaa = nullptr;          // '!tbaa': Struct-path TBAA. TBAA graph forms a tree (indexed by offset).
                                      //          Two pointers do not alias if they are not transitive parents
@@ -1760,11 +1772,13 @@ struct jl_aliasinfo_t {
 #endif
     }
 };
+}  // anonymous namespace
 
 // A class to hold GC roots that can be either:
 // 1. Materialized: a SmallVector of Value* that have already been loaded
 // 2. Lazy: a pointer + count + tbaa that allows loading on demand
 // This allows deferring the load of GC roots until they are actually needed.
+namespace {
 struct jl_gc_roots_t {
 private:
     // Materialized roots (when ptr is null)
@@ -1826,9 +1840,11 @@ public:
     // Extract roots from [first, first+numel), lazily
     jl_gc_roots_t slice(jl_codectx_t &ctx, size_t first, size_t numel) const;
 };
+}  // anonymous namespace
 
 // metadata tracking for a llvm Value* during codegen
 const uint8_t UNION_BOX_MARKER = 0x80;
+namespace {
 struct jl_cgval_t {
     Value *V; // may be of type T* or T, or set to NULL if ghost (or if the value has not been initialized yet, for a variable definition)
     // For unions, we may need to keep a reference to the boxed part individually.
@@ -2002,8 +2018,10 @@ struct jl_cgval_t {
     {
     }
 };
+}  // anonymous namespace
 
 // per-local-variable information
+namespace {
 struct jl_varinfo_t {
     Instruction *boxroot; // an address, if the var might be in a jl_value_t** stack slot (marked ctx.tbaa().tbaa_const, if appropriate)
     jl_cgval_t value; // a stack slot or constant value
@@ -2035,9 +2053,11 @@ struct jl_varinfo_t {
     {
     }
 };
+}  // anonymous namespace
 
 // information about the context of a piece of code: its enclosing
 // function and module, and visible local variables and labels.
+namespace {
 class jl_codectx_t {
 public:
     IRBuilder<> builder;
@@ -2113,12 +2133,9 @@ public:
         return aliasscope_cache;
     }
 };
+}  // anonymous namespace
 
 static void jl_temporary_root(jl_codectx_t &ctx, jl_value_t *val);
-
-GlobalVariable *JuliaVariable::realize(jl_codectx_t &ctx) {
-    return realize(jl_Module);
-}
 
 jl_aliasinfo_t::jl_aliasinfo_t(jl_codectx_t &ctx, Region r, MDNode *tbaa): tbaa(tbaa), tbaa_struct(nullptr) {
     MDNode *alias_scope = nullptr;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -80,6 +80,7 @@
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Linker/Linker.h>
 #include <llvm/CodeGen/MachineModuleInfo.h>
+#include <llvm/CodeGen/MIRPrinter.h>
 
 #ifdef USE_ITTAPI
 #include "ittapi/ittnotify.h"
@@ -96,43 +97,43 @@ static bool jl_floattemp_var_needed(const Triple &TT) {
 
 //Drag some useful type functions into our namespace
 //to reduce verbosity of our code
-auto getInt1Ty(LLVMContext &ctxt) {
+static auto getInt1Ty(LLVMContext &ctxt) {
     return Type::getInt1Ty(ctxt);
 }
-auto getInt8Ty(LLVMContext &ctxt) {
+static auto getInt8Ty(LLVMContext &ctxt) {
     return Type::getInt8Ty(ctxt);
 }
-auto getInt16Ty(LLVMContext &ctxt) {
+static auto getInt16Ty(LLVMContext &ctxt) {
     return Type::getInt16Ty(ctxt);
 }
-auto getInt32Ty(LLVMContext &ctxt) {
+static auto getInt32Ty(LLVMContext &ctxt) {
     return Type::getInt32Ty(ctxt);
 }
-auto getInt64Ty(LLVMContext &ctxt) {
+static auto getInt64Ty(LLVMContext &ctxt) {
     return Type::getInt64Ty(ctxt);
 }
-auto getHalfTy(LLVMContext &ctxt) {
+static auto getHalfTy(LLVMContext &ctxt) {
     return Type::getHalfTy(ctxt);
 }
-auto getFloatTy(LLVMContext &ctxt) {
+static auto getFloatTy(LLVMContext &ctxt) {
     return Type::getFloatTy(ctxt);
 }
-auto getDoubleTy(LLVMContext &ctxt) {
+static auto getDoubleTy(LLVMContext &ctxt) {
     return Type::getDoubleTy(ctxt);
 }
-auto getBFloatTy(LLVMContext &ctxt) {
+static auto getBFloatTy(LLVMContext &ctxt) {
     return Type::getBFloatTy(ctxt);
 }
-auto getFP128Ty(LLVMContext &ctxt) {
+static auto getFP128Ty(LLVMContext &ctxt) {
     return Type::getFP128Ty(ctxt);
 }
-auto getVoidTy(LLVMContext &ctxt) {
+static auto getVoidTy(LLVMContext &ctxt) {
     return Type::getVoidTy(ctxt);
 }
-auto getCharTy(LLVMContext &ctxt) {
+static auto getCharTy(LLVMContext &ctxt) {
     return getInt32Ty(ctxt);
 }
-auto getPointerTy(LLVMContext &ctxt) {
+static auto getPointerTy(LLVMContext &ctxt) {
     return PointerType::get(ctxt, 0);
 }
 
@@ -149,7 +150,7 @@ typedef Instruction TerminatorInst;
 #undef DEBUG_TYPE //LLVM occasionally likes to set DEBUG_TYPE in a header...
 #define DEBUG_TYPE "julia_irgen_codegen"
 
-void setName(jl_codegen_output_t &out, Value *V, const Twine &Name)
+static void setName(jl_codegen_output_t &out, Value *V, const Twine &Name)
 {
     // we do the constant check again later, duplicating it here just makes sure the assertion
     // fires on debug builds even if debug info is not enabled
@@ -162,21 +163,21 @@ void setName(jl_codegen_output_t &out, Value *V, const Twine &Name)
     }
 }
 
-void maybeSetName(jl_codegen_output_t &out, Value *V, const Twine &Name)
+static void maybeSetName(jl_codegen_output_t &out, Value *V, const Twine &Name)
 {
     // To be used when we may get an Instruction or something that is not an instruction i.e Constants/Arguments
     if (isa<Instruction>(V))
         V->setName(Name);
 }
 
-void setName(jl_codegen_output_t &out, Value *V, std::function<std::string()> GetName)
+static void setName(jl_codegen_output_t &out, Value *V, std::function<std::string()> GetName)
 {
     assert((isa<Constant>(V) || isa<Instruction>(V)) && "Should only set names on instructions!");
     if (!out.get_context().shouldDiscardValueNames() && !isa<Constant>(V))
         V->setName(Twine(GetName()));
 }
 
-void setNameWithField(jl_codegen_output_t &out, Value *V, std::function<StringRef()> GetObjName, jl_datatype_t *jt, unsigned idx, const Twine &suffix)
+static void setNameWithField(jl_codegen_output_t &out, Value *V, std::function<StringRef()> GetObjName, jl_datatype_t *jt, unsigned idx, const Twine &suffix)
 {
     assert((isa<Constant>(V) || isa<Instruction>(V)) && "Should only set names on instructions!");
     if (!out.get_context().shouldDiscardValueNames() && !isa<Constant>(V)) {
@@ -530,17 +531,17 @@ typedef FunctionType *(*TypeFnContextOnly)(LLVMContext &C);
 typedef FunctionType *(*TypeFnContextAndSizeT)(LLVMContext &C, Type *T_size);
 typedef FunctionType *(*TypeFnContextAndTriple)(LLVMContext &C, const Triple &triple);
 
-FunctionType *invoke_type(TypeFnContextOnly f, Module &M)
+static FunctionType *invoke_type(TypeFnContextOnly f, Module &M)
 {
     return f(M.getContext());
 }
 
-FunctionType *invoke_type(TypeFnContextAndSizeT f, Module &M)
+static FunctionType *invoke_type(TypeFnContextAndSizeT f, Module &M)
 {
     return f(M.getContext(), M.getDataLayout().getIntPtrType(M.getContext()));
 }
 
-FunctionType *invoke_type(TypeFnContextAndTriple f, Module &M)
+static FunctionType *invoke_type(TypeFnContextAndTriple f, Module &M)
 {
     return f(M.getContext(), Triple(M.getTargetTriple()));
 }
@@ -588,7 +589,7 @@ static inline void add_named_global(StringRef name, T *addr)
     add_named_global(name, (void*)(uintptr_t)addr);
 }
 
-AttributeSet Attributes(LLVMContext &C, std::initializer_list<Attribute::AttrKind> attrkinds, std::initializer_list<Attribute> extra={})
+static AttributeSet Attributes(LLVMContext &C, std::initializer_list<Attribute::AttrKind> attrkinds, std::initializer_list<Attribute> extra={})
 {
     SmallVector<Attribute, 8> attrs(attrkinds.size() + extra.size());
     for (size_t i = 0; i < attrkinds.size(); i++)
@@ -3159,10 +3160,6 @@ static std::pair<bool, bool> uses_specsig(jl_value_t *abi, jl_method_instance_t 
 
 
 // Logging for code coverage and memory allocation
-
-extern "C" JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line);
-extern "C" JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line);
-extern "C" JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line);
 
 static void visitLine(jl_codectx_t &ctx, uint64_t *ptr, Value *addend, const char *name)
 {
@@ -7242,7 +7239,7 @@ static Function *emit_modifyhelper(jl_codectx_t &ctx2, const jl_cgval_t &op, con
 }
 
 
-Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Value *theFunc, jl_codegen_output_t &out) JL_NOTSAFEPOINT
+static Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Value *theFunc, jl_codegen_output_t &out) JL_NOTSAFEPOINT
 {
     ++EmittedToJLInvokes;
     jl_codectx_t ctx(out, codeinst);
@@ -10839,71 +10836,60 @@ extern "C" JL_DLLEXPORT_CODEGEN void jl_teardown_codegen_impl() JL_NOTSAFEPOINT
 
 // the rest of this file are convenience functions
 // that are exported for assisting with debugging from gdb
-extern "C" void jl_dump_llvm_value(void *v)
+extern "C" JL_DLLEXPORT_CODEGEN void jl_dump_llvm_value(void *v)
 {
     llvm_dump((Value*)v);
 }
 
-extern "C" void jl_dump_llvm_inst_function(void *v)
+extern "C" JL_DLLEXPORT_CODEGEN void jl_dump_llvm_inst_function(void *v)
 {
     llvm_dump(cast<Instruction>(((Value*)v))->getParent()->getParent());
 }
 
-extern "C" void jl_dump_llvm_type(void *v)
+extern "C" JL_DLLEXPORT_CODEGEN void jl_dump_llvm_type(void *v)
 {
     llvm_dump((Type*)v);
 }
 
-extern "C" void jl_dump_llvm_module(void *v)
+extern "C" JL_DLLEXPORT_CODEGEN void jl_dump_llvm_module(void *v)
 {
     llvm_dump((Module*)v);
 }
 
-extern "C" void jl_dump_llvm_metadata(void *v)
+extern "C" JL_DLLEXPORT_CODEGEN void jl_dump_llvm_metadata(void *v)
 {
     llvm_dump((Metadata*)v);
 }
 
-extern "C" void jl_dump_llvm_debugloc(void *v)
+extern "C" JL_DLLEXPORT_CODEGEN void jl_dump_llvm_debugloc(void *v)
 {
     llvm_dump((DebugLoc*)v);
 }
 
-namespace llvm {
-    class MachineBasicBlock;
-    class MachineFunction;
-    raw_ostream& operator<<(raw_ostream &OS, const MachineBasicBlock &MBB);
-#if JL_LLVM_VERSION >= 200000
-    void printMIR(raw_ostream &OS, const MachineModuleInfo &MMI,
-                const MachineFunction &MF);
-#else
-    void printMIR(raw_ostream &OS, const MachineFunction &MF);
-#endif
-}
-extern "C" void jl_dump_llvm_mbb(void *v)
+extern "C" JL_DLLEXPORT_CODEGEN void jl_dump_llvm_mbb(void *v)
 {
     errs() << *(llvm::MachineBasicBlock*)v;
 }
 #if JL_LLVM_VERSION >= 200000
-extern "C" void jl_dump_llvm_mfunction(void *m, void *v)
+extern "C" JL_DLLEXPORT_CODEGEN void jl_dump_llvm_mfunction(void *m, void *v)
 {
     llvm::printMIR(errs(), *(llvm::MachineModuleInfo*)v,
                 *(llvm::MachineFunction*)v);
 }
 #else
-extern "C" void jl_dump_llvm_mfunction(void *v)
+extern "C" JL_DLLEXPORT_CODEGEN void jl_dump_llvm_mfunction(void *v)
 {
     llvm::printMIR(errs(), *(llvm::MachineFunction*)v);
 }
 #endif
 
-extern void jl_write_bitcode_func(void *F, char *fname) {
+extern "C" JL_DLLEXPORT_CODEGEN void jl_write_bitcode_func(void *F, char *fname) {
     std::error_code EC;
     raw_fd_ostream OS(fname, EC, sys::fs::OF_None);
     llvm::WriteBitcodeToFile(*((llvm::Function*)F)->getParent(), OS);
 }
 
-extern void jl_write_bitcode_module(void *M, char *fname) {
+extern "C" JL_DLLEXPORT_CODEGEN void jl_write_bitcode_module(void *M, char *fname) {
     std::error_code EC;
     raw_fd_ostream OS(fname, EC, sys::fs::OF_None);
     llvm::WriteBitcodeToFile(*(llvm::Module*)M, OS);

--- a/src/coverage.c
+++ b/src/coverage.c
@@ -83,7 +83,7 @@ static int is_skip_filename(const char *filename) JL_NOTSAFEPOINT
     return 0;
 }
 
-JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line) JL_NOTSAFEPOINT
+JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line)
 {
     assert(!codegen_imaging_mode());
     if (is_skip_filename(filename) || line < 0)
@@ -93,7 +93,7 @@ JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line) JL_NOTS
     uv_mutex_unlock(&coverage_lock);
 }
 
-JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT
+JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line)
 {
     uv_mutex_lock(&coverage_lock);
     uint64_t *ret = allocLine(logdata_get_or_create(&coverageData, filename), line);
@@ -101,7 +101,7 @@ JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) 
     return ret;
 }
 
-JL_DLLEXPORT void jl_coverage_visit_line(const char *filename, size_t len, int line) JL_NOTSAFEPOINT
+JL_DLLEXPORT void jl_coverage_visit_line(const char *filename, size_t len, int line)
 {
     // TODO: remove `len` and use C-style strings exclusively
     //       (kept for backwards-compatibility with JuliaInterpreter)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -181,7 +181,7 @@ static int layout_eq(void *_l1, void *_l2, void *unused) JL_NOTSAFEPOINT
 static void **layoutcache_lookup_bp_r_impl(htable_t *h, void *key, void *ctx, int key_owned) JL_NOTSAFEPOINT;
 static void **layoutcache_lookup_bp_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;
 static void **layoutcache_peek_bp_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;
-HTPROT_R(layoutcache)
+HTPROT_R(layoutcache, static JL_UNUSED)
 HTIMPL_R(layoutcache, _hash_layout_djb2, layout_eq, _HTIMPL_IDENTITY_KEYALLOC, _HTIMPL_NOOP_KEYFREE)
 static htable_t layoutcache;
 static int layoutcache_initialized = 0;
@@ -513,7 +513,7 @@ static int is_type_identityfree(jl_value_t *t)
 }
 
 // make a copy of the layout of st, but with nfields=0
-void jl_get_genericmemory_layout(jl_datatype_t *st)
+static void jl_get_genericmemory_layout(jl_datatype_t *st)
 {
     jl_value_t *kind = jl_tparam0(st);
     jl_value_t *eltype = normalize_typeofbottom_layout_alias(jl_tparam1(st));
@@ -1494,7 +1494,7 @@ JL_DLLEXPORT int jl_atomic_storeonce_bits(jl_datatype_t *dt, char *dst, const jl
 }
 
 #define PERMBOXN_FUNC(nb)                                                  \
-    jl_value_t *jl_permbox##nb(jl_datatype_t *t, uintptr_t tag, uint##nb##_t x) JL_NOTSAFEPOINT \
+    extern jl_value_t *jl_permbox##nb(jl_datatype_t *t, uintptr_t tag, uint##nb##_t x) JL_NOTSAFEPOINT \
     {   /* n.b. t must be a concrete isbits datatype of the right size */               \
         jl_task_t *ct = jl_current_task;                                                \
         jl_value_t *v = jl_gc_permobj(ct->ptls, LLT_ALIGN(nb, sizeof(void*)), t, 0);    \
@@ -2369,7 +2369,7 @@ JL_DLLEXPORT size_t jl_get_field_offset(jl_datatype_t *ty, int field)
     return jl_field_offset(ty, field - 1);
 }
 
-jl_value_t *get_nth_pointer(jl_value_t *v, size_t i)
+static jl_value_t *get_nth_pointer(jl_value_t *v, size_t i)
 {
     jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(v);
     const jl_datatype_layout_t *ly = dt->layout;

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -58,8 +58,10 @@ struct debug_link_info {
 }  // anonymous namespace
 
 #if (defined(_OS_LINUX_) || defined(_OS_FREEBSD_) || (defined(_OS_DARWIN_) && defined(LLVM_SHLIB)))
-extern "C" void __register_frame(void*) JL_NOTSAFEPOINT;
-extern "C" void __deregister_frame(void*) JL_NOTSAFEPOINT;
+extern "C" {
+    JL_DLLIMPORT extern void __register_frame(void*) JL_NOTSAFEPOINT;
+    JL_DLLIMPORT extern void __deregister_frame(void*) JL_NOTSAFEPOINT;
+}
 
 template <typename callback>
 static void processFDEs(const char *EHFrameAddr, size_t EHFrameSize, callback f) JL_NOTSAFEPOINT
@@ -1322,7 +1324,7 @@ extern "C" JL_DLLEXPORT_CODEGEN int jl_getFunctionInfo_impl(jl_frame_t **frames_
     return jl_getDylibFunctionInfo(frames_out, pointer, skipC, noInline);
 }
 
-extern "C" jl_code_instance_t *jl_gdblookupci(void *p) JL_NOTSAFEPOINT
+extern "C" JL_DLLEXPORT_CODEGEN jl_code_instance_t *jl_gdblookupci(void *p) JL_NOTSAFEPOINT
 {
     return getJITDebugRegistry().lookupCodeInstance((size_t)p);
 }

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -50,10 +50,12 @@ static JITDebugInfoRegistry &getJITDebugRegistry() JL_NOTSAFEPOINT {
     return *DebugRegistry;
 }
 
+namespace {
 struct debug_link_info {
     StringRef filename;
     uint32_t crc32;
 };
+}  // anonymous namespace
 
 #if (defined(_OS_LINUX_) || defined(_OS_FREEBSD_) || (defined(_OS_DARWIN_) && defined(LLVM_SHLIB)))
 extern "C" void __register_frame(void*) JL_NOTSAFEPOINT;
@@ -122,11 +124,13 @@ JITDebugInfoRegistry::get_objfile_map() {
 
 JITDebugInfoRegistry::JITDebugInfoRegistry() { }
 
+namespace {
 struct unw_table_entry
 {
     int32_t start_ip_offset;
     int32_t fde_offset;
 };
+}  // anonymous namespace
 
 // some actions aren't signal (especially profiler) safe so we acquire a lock
 // around them to establish a mutual exclusion with unwinding from a signal

--- a/src/debuginfo.h
+++ b/src/debuginfo.h
@@ -1,8 +1,6 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 // Declarations for debuginfo.cpp
-void jl_jit_add_bytes(size_t bytes) JL_NOTSAFEPOINT;
-
 int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
         llvm::object::SectionRef *Section, llvm::DIContext **context) JL_NOTSAFEPOINT;
 

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -118,6 +118,7 @@ using namespace llvm;
 #include "julia_assert.h"
 
 // helper class for tracking inlining context while printing debug info
+namespace {
 class DILineInfoPrinter {
     // internal state:
     SmallVector<DILineInfo, 0> context;
@@ -193,6 +194,7 @@ public:
         emit_finish(OS);
     }
 };
+}  // anonymous namespace
 
 static raw_ostream &operator<<(raw_ostream &Out, struct DILineInfoPrinter::repeat i) JL_NOTSAFEPOINT
 {
@@ -330,6 +332,7 @@ void DILineInfoPrinter::emit_lineinfo(raw_ostream &Out, SmallVectorImpl<DILineIn
 
 
 // adaptor class for printing line numbers before llvm IR lines
+namespace {
 class LineNumberAnnotatedWriter : public AssemblyAnnotationWriter {
     const DILocation *InstrLoc = nullptr;
     DILineInfoPrinter LinePrinter;
@@ -362,6 +365,7 @@ public:
         DebugLoc[I] = Loc;
     }
 };
+}  // anonymous namespace
 
 void LineNumberAnnotatedWriter::emitFunctionAnnot(
       const Function *F, formatted_raw_ostream &Out)
@@ -1174,6 +1178,7 @@ addPassesToGenerateCode(LLVMTargetMachine *TM, PassManagerBase &PM) {
     return &MMIWP->getMMI().getContext();
 }
 
+namespace {
 class LineNumberPrinterHandler : public AsmPrinterHandler {
     MCStreamer &S;
     LineNumberAnnotatedWriter LinePrinter;
@@ -1223,6 +1228,7 @@ public:
     }
     virtual void endInstruction() override {}
 };
+}  // anonymous namespace
 
 // get a native assembly for llvm::Function
 extern "C" JL_DLLEXPORT_CODEGEN

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -485,12 +485,7 @@ static void jl_strip_llvm_debug(Module *m, bool all_meta, LineNumberAnnotatedWri
     //    m->eraseNamedMetadata(md);
 }
 
-void jl_strip_llvm_debug(Module *m) JL_NOTSAFEPOINT
-{
-    jl_strip_llvm_debug(m, false, NULL);
-}
-
-void jl_strip_llvm_addrspaces(Module *m) JL_NOTSAFEPOINT
+static void jl_strip_llvm_addrspaces(Module *m) JL_NOTSAFEPOINT
 {
     PassBuilder PB;
     AnalysisManagers AM(PB);
@@ -837,7 +832,7 @@ static int OpInfoLookup(void *DisInfo, uint64_t PC,
 } // namespace
 
 // Stringify raw bytes as a comment string.
-std::string rawCodeComment(const llvm::ArrayRef<uint8_t>& Memory, const llvm::Triple& Triple) JL_NOTSAFEPOINT
+static std::string rawCodeComment(const llvm::ArrayRef<uint8_t>& Memory, const llvm::Triple& Triple) JL_NOTSAFEPOINT
 {
     std::string Buffer{"; "};
     llvm::raw_string_ostream Stream{Buffer};

--- a/src/flisp/equalhash.h
+++ b/src/flisp/equalhash.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-HTPROT_R(equalhash)
+HTPROT_R(equalhash,)
 
 #ifdef __cplusplus
 }

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -277,8 +277,6 @@ static void jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NO
 
 static uint64_t finalizer_rngState[JL_RNG_SIZE];
 
-void jl_rng_split(uint64_t dst[JL_RNG_SIZE], uint64_t src[JL_RNG_SIZE]) JL_NOTSAFEPOINT;
-
 JL_DLLEXPORT void jl_gc_init_finalizer_rng_state(void)
 {
     jl_rng_split(finalizer_rngState, jl_current_task->rngState);

--- a/src/gc-common.h
+++ b/src/gc-common.h
@@ -223,6 +223,9 @@ extern int gc_logging_enabled;
 void _jl_free_stack(jl_ptls_t ptls, void *stkbuf, size_t bufsz) JL_NOTSAFEPOINT;
 void sweep_mtarraylist_buffers(void) JL_NOTSAFEPOINT;
 
+int gc_slot_to_fieldidx(void *_obj, void *slot, jl_datatype_t *vt) JL_NOTSAFEPOINT;
+int gc_slot_to_arrayidx(void *_obj, void *begin) JL_NOTSAFEPOINT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -18,8 +18,8 @@
 extern "C" {
 #endif
 
-// Useful function in debugger to find page metadata
-jl_gc_pagemeta_t *jl_gc_page_metadata(void *data)
+// Useful function in debugger to find page metadata.
+JL_DLLEXPORT jl_gc_pagemeta_t *jl_gc_page_metadata(void *data)
 {
     return page_metadata(data);
 }
@@ -1080,7 +1080,8 @@ static void gc_count_pool_pagetable(void)
     }
 }
 
-void gc_count_pool(void)
+// Useful function in debugger to inspect memory-leak-like issues.
+JL_DLLEXPORT void gc_count_pool(void)
 {
     memset(&poolobj_sizes, 0, sizeof(poolobj_sizes));
     empty_pages = 0;

--- a/src/gc-heap-snapshot.c
+++ b/src/gc-heap-snapshot.c
@@ -366,7 +366,7 @@ static void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597
 // returns the index of the new node
-size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
+static size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
 {
     size_t idx;
     if (!snapshot_insert_node(g_snapshot, a, &idx))
@@ -556,7 +556,7 @@ void _gc_heap_snapshot_record_finlist(jl_value_t *obj, size_t index) JL_NOTSAFEP
 // Each task points at a stack frame, which points at the stack frame of
 // the function it's currently calling, forming a linked list.
 // Stack frame nodes point at the objects they have as local variables.
-size_t _record_stack_frame_node(HeapSnapshot *snapshot, void *frame) JL_NOTSAFEPOINT
+static size_t _record_stack_frame_node(HeapSnapshot *snapshot, void *frame) JL_NOTSAFEPOINT
 {
     size_t idx;
     if (!snapshot_insert_node(g_snapshot, frame, &idx))

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -5,6 +5,7 @@
 
 #include "julia.h"
 #include "ios.h"
+#include "gc-common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,9 +39,6 @@ void _gc_heap_snapshot_record_binding_partition_edge(jl_value_t *from, jl_value_
 extern int gc_heap_snapshot_enabled;
 extern int prev_sweep_full;
 extern jl_mutex_t heapsnapshot_lock;
-
-int gc_slot_to_fieldidx(void *_obj, void *slot, jl_datatype_t *vt) JL_NOTSAFEPOINT;
-int gc_slot_to_arrayidx(void *_obj, void *begin) JL_NOTSAFEPOINT;
 
 static inline void gc_heap_snapshot_record_frame_to_object_edge(void *from, jl_value_t *to) JL_NOTSAFEPOINT
 {

--- a/src/gc-page-profiler.c
+++ b/src/gc-page-profiler.c
@@ -73,7 +73,7 @@ int gc_page_profile_is_enabled(void) JL_NOTSAFEPOINT
     return page_profile_enabled;
 }
 
-void gc_page_profile_write_preamble(gc_page_profiler_serializer_t *serializer)
+static void gc_page_profile_write_preamble(gc_page_profiler_serializer_t *serializer)
     JL_NOTSAFEPOINT
 {
     if (__unlikely(page_profile_enabled)) {
@@ -85,7 +85,7 @@ void gc_page_profile_write_preamble(gc_page_profiler_serializer_t *serializer)
     }
 }
 
-void gc_page_profile_write_epilogue(gc_page_profiler_serializer_t *serializer)
+static void gc_page_profile_write_epilogue(gc_page_profiler_serializer_t *serializer)
     JL_NOTSAFEPOINT
 {
     if (__unlikely(page_profile_enabled)) {
@@ -94,7 +94,7 @@ void gc_page_profile_write_epilogue(gc_page_profiler_serializer_t *serializer)
     }
 }
 
-void gc_page_profile_write_comma(gc_page_profiler_serializer_t *serializer) JL_NOTSAFEPOINT
+static void gc_page_profile_write_comma(gc_page_profiler_serializer_t *serializer) JL_NOTSAFEPOINT
 {
     if (__unlikely(page_profile_enabled)) {
         // write comma if not first page
@@ -143,7 +143,7 @@ void gc_page_profile_write_to_file(gc_page_profiler_serializer_t *serializer)
     }
 }
 
-void gc_page_profile_write_json_preamble(ios_t *stream) JL_NOTSAFEPOINT
+static void gc_page_profile_write_json_preamble(ios_t *stream) JL_NOTSAFEPOINT
 {
     if (__unlikely(page_profile_enabled)) {
         uv_mutex_lock(&page_profile_lock);
@@ -153,7 +153,7 @@ void gc_page_profile_write_json_preamble(ios_t *stream) JL_NOTSAFEPOINT
     }
 }
 
-void gc_page_profile_write_json_epilogue(ios_t *stream) JL_NOTSAFEPOINT
+static void gc_page_profile_write_json_epilogue(ios_t *stream) JL_NOTSAFEPOINT
 {
     if (__unlikely(page_profile_enabled)) {
         uv_mutex_lock(&page_profile_lock);

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -40,7 +40,7 @@ void jl_gc_init_page(void)
 
 // Try to allocate a memory block for multiple pages
 // Return `NULL` if allocation failed. Result is aligned to `GC_PAGE_SZ`.
-char *jl_gc_try_alloc_pages_(int pg_cnt) JL_NOTSAFEPOINT
+static char *jl_gc_try_alloc_pages_(int pg_cnt) JL_NOTSAFEPOINT
 {
     size_t pages_sz = GC_PAGE_SZ * pg_cnt;
 #ifdef _OS_WINDOWS_
@@ -72,7 +72,7 @@ char *jl_gc_try_alloc_pages_(int pg_cnt) JL_NOTSAFEPOINT
 // smaller `MIN_BLOCK_PG_ALLOC` a `jl_memory_exception` is thrown.
 // Assumes `gc_pages_lock` is acquired, the lock is released before the
 // exception is thrown.
-char *jl_gc_try_alloc_pages(void) JL_NOTSAFEPOINT
+static char *jl_gc_try_alloc_pages(void) JL_NOTSAFEPOINT
 {
     unsigned pg_cnt = block_pg_cnt;
     char *mem = NULL;

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -326,7 +326,7 @@ STATIC_INLINE void gc_setmark(jl_ptls_t ptls, jl_taggedvalue_t *o,
     }
 }
 
-STATIC_INLINE void gc_setmark_buf_(jl_ptls_t ptls, void *o, uint8_t mark_mode, size_t minsz) JL_NOTSAFEPOINT
+STATIC_INLINE void gc_setmark_buf(jl_ptls_t ptls, void *o, uint8_t mark_mode, size_t minsz) JL_NOTSAFEPOINT
 {
     jl_taggedvalue_t *buf = jl_astaggedvalue(o);
     uint8_t bits = (gc_old(buf->header) && !mark_reset_age) ? GC_OLD_MARKED : GC_MARKED;;
@@ -344,11 +344,6 @@ STATIC_INLINE void gc_setmark_buf_(jl_ptls_t ptls, void *o, uint8_t mark_mode, s
         }
         gc_setmark_big(ptls, buf, bits);
     }
-}
-
-void gc_setmark_buf(jl_ptls_t ptls, void *o, uint8_t mark_mode, size_t minsz) JL_NOTSAFEPOINT
-{
-    gc_setmark_buf_(ptls, o, mark_mode, minsz);
 }
 
 STATIC_INLINE void maybe_collect(jl_ptls_t ptls)
@@ -1014,7 +1009,7 @@ static void gc_sweep_other(jl_ptls_t ptls, int sweep_full) JL_NOTSAFEPOINT
 }
 
 // wake up all threads to sweep the stacks
-void gc_sweep_wake_all_stacks(jl_ptls_t ptls) JL_NOTSAFEPOINT
+static void gc_sweep_wake_all_stacks(jl_ptls_t ptls) JL_NOTSAFEPOINT
 {
     uv_mutex_lock(&gc_threads_lock);
     int first = gc_first_parallel_collector_thread_id();
@@ -1029,7 +1024,7 @@ void gc_sweep_wake_all_stacks(jl_ptls_t ptls) JL_NOTSAFEPOINT
     return;
 }
 
-void gc_sweep_wait_for_all_stacks(void) JL_NOTSAFEPOINT
+static void gc_sweep_wait_for_all_stacks(void) JL_NOTSAFEPOINT
 {
     while ((jl_atomic_load_acquire(&gc_ptls_sweep_idx) >= 0 ) || jl_atomic_load_acquire(&gc_n_threads_sweeping_stacks) != 0) {
         jl_cpu_pause();
@@ -1038,7 +1033,7 @@ void gc_sweep_wait_for_all_stacks(void) JL_NOTSAFEPOINT
 
 extern const unsigned pool_sizes[];
 
-void sweep_stack_pool_loop(void) JL_NOTSAFEPOINT
+static void sweep_stack_pool_loop(void) JL_NOTSAFEPOINT
 {
     // Stack sweeping algorithm:
     //    // deallocate stacks if we have too many sitting around unused
@@ -1167,7 +1162,7 @@ static void gc_pool_sync_nfree(jl_gc_pagemeta_t *pg, jl_taggedvalue_t *last) JL_
 
 // pre-scan pages to check whether there are enough pages so that's worth parallelizing
 // also sweeps pages that don't need to be linearly scanned
-int gc_sweep_prescan(jl_ptls_t ptls, jl_gc_padded_page_stack_t *new_gc_allocd_scratch) JL_NOTSAFEPOINT
+static int gc_sweep_prescan(jl_ptls_t ptls, jl_gc_padded_page_stack_t *new_gc_allocd_scratch) JL_NOTSAFEPOINT
 {
     // 4MB worth of pages is worth parallelizing
     const int n_pages_worth_parallel_sweep = (int)(4 * (1 << 20) / GC_PAGE_SZ);
@@ -1226,7 +1221,7 @@ int gc_sweep_prescan(jl_ptls_t ptls, jl_gc_padded_page_stack_t *new_gc_allocd_sc
 }
 
 // wake up all threads to sweep the pages
-void gc_sweep_wake_all_pages(jl_ptls_t ptls, jl_gc_padded_page_stack_t *new_gc_allocd_scratch) JL_NOTSAFEPOINT
+static void gc_sweep_wake_all_pages(jl_ptls_t ptls, jl_gc_padded_page_stack_t *new_gc_allocd_scratch) JL_NOTSAFEPOINT
 {
     int parallel_sweep_worthwhile = gc_sweep_prescan(ptls, new_gc_allocd_scratch);
     if (parallel_sweep_worthwhile && !page_profile_enabled) {
@@ -1262,7 +1257,7 @@ void gc_sweep_wake_all_pages(jl_ptls_t ptls, jl_gc_padded_page_stack_t *new_gc_a
 }
 
 // wait for all threads to finish sweeping
-void gc_sweep_wait_for_all_pages(void) JL_NOTSAFEPOINT
+static void gc_sweep_wait_for_all_pages(void) JL_NOTSAFEPOINT
 {
     jl_atomic_store(&gc_allocd_scratch, NULL);
     while (jl_atomic_load_acquire(&gc_n_threads_sweeping_pools) != 0) {
@@ -1271,7 +1266,7 @@ void gc_sweep_wait_for_all_pages(void) JL_NOTSAFEPOINT
 }
 
 // sweep all pools
-void gc_sweep_pool_parallel(jl_ptls_t ptls) JL_NOTSAFEPOINT
+static void gc_sweep_pool_parallel(jl_ptls_t ptls) JL_NOTSAFEPOINT
 {
     jl_atomic_fetch_add(&gc_n_threads_sweeping_pools, 1);
     jl_gc_padded_page_stack_t *allocd_scratch = jl_atomic_load(&gc_allocd_scratch);
@@ -1324,7 +1319,7 @@ void gc_sweep_pool_parallel(jl_ptls_t ptls) JL_NOTSAFEPOINT
 }
 
 // free all pages (i.e. through `madvise` on Linux) that were lazily freed
-void gc_free_pages(void) JL_NOTSAFEPOINT
+static void gc_free_pages(void) JL_NOTSAFEPOINT
 {
     size_t n_pages_seen = 0;
     jl_gc_page_stack_t tmp;
@@ -1687,7 +1682,7 @@ STATIC_INLINE jl_gc_chunk_t gc_chunkqueue_pop(jl_gc_markqueue_t *mq) JL_NOTSAFEP
 }
 
 // Dump mark queue on critical error
-JL_NORETURN NOINLINE void gc_dump_queue_and_abort(jl_ptls_t ptls, jl_datatype_t *vt) JL_NOTSAFEPOINT
+static JL_NORETURN NOINLINE void gc_dump_queue_and_abort(jl_ptls_t ptls, jl_datatype_t *vt) JL_NOTSAFEPOINT
 {
     ios_t *const s = ios_safe_stderr;
     jl_safe_fprintf(s, "GC error (probable corruption)\n");
@@ -2162,7 +2157,7 @@ STATIC_INLINE void gc_mark_module_binding(jl_ptls_t ptls, jl_module_t *mb_parent
     }
 }
 
-void gc_mark_finlist_(jl_gc_markqueue_t *mq, jl_value_t *fl_parent, jl_value_t **fl_begin, jl_value_t **fl_end) JL_NOTSAFEPOINT
+static void gc_mark_finlist_(jl_gc_markqueue_t *mq, jl_value_t *fl_parent, jl_value_t **fl_begin, jl_value_t **fl_end) JL_NOTSAFEPOINT
 {
     jl_value_t *new_obj;
     // Decide whether need to chunk finlist
@@ -2348,7 +2343,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
         #ifdef COPY_STACKS
                 void *stkbuf = ta->ctx.stkbuf;
                 if (stkbuf && ta->ctx.copy_stack) {
-                    gc_setmark_buf_(ptls, stkbuf, bits, ta->ctx.bufsz);
+                    gc_setmark_buf(ptls, stkbuf, bits, ta->ctx.bufsz);
                     // For gc_heap_snapshot_record:
                     // TODO: attribute size of stack
                     // TODO: edge to stack data
@@ -2380,7 +2375,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     jl_excstack_t *excstack = ta->excstack;
                     gc_heap_snapshot_record_task_to_frame_edge(ta, excstack);
                     size_t itr = ta->excstack->top;
-                    gc_setmark_buf_(ptls, excstack, bits,
+                    gc_setmark_buf(ptls, excstack, bits,
                                     sizeof(jl_excstack_t) +
                                         sizeof(uintptr_t) * excstack->reserved_size);
                     gc_mark_excstack(ptls, excstack, itr);
@@ -2577,7 +2572,7 @@ void gc_collect_neighbors(jl_ptls_t ptls, jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
     }
 }
 
-void gc_mark_and_steal(jl_ptls_t ptls) JL_NOTSAFEPOINT
+static void gc_mark_and_steal(jl_ptls_t ptls) JL_NOTSAFEPOINT
 {
     jl_gc_markqueue_t *mq = &ptls->gc_tls.mark_queue;
     jl_gc_markqueue_t *mq_initiator = mq;
@@ -2665,7 +2660,7 @@ void gc_mark_and_steal(jl_ptls_t ptls) JL_NOTSAFEPOINT
     }
 }
 
-size_t gc_count_work_in_queue(jl_ptls_t ptls) JL_NOTSAFEPOINT
+static size_t gc_count_work_in_queue(jl_ptls_t ptls) JL_NOTSAFEPOINT
 {
     assert(ptls != NULL);
     // assume each chunk is worth 256 units of work and each pointer
@@ -2701,7 +2696,7 @@ size_t gc_count_work_in_queue(jl_ptls_t ptls) JL_NOTSAFEPOINT
  * the mark-loop after `gc_n_threads_marking` reaches zero.
  */
 
-int gc_should_mark(void) JL_NOTSAFEPOINT
+static int gc_should_mark(void) JL_NOTSAFEPOINT
 {
     int should_mark = 0;
     uv_mutex_lock(&gc_queue_observer_lock);
@@ -2734,14 +2729,14 @@ int gc_should_mark(void) JL_NOTSAFEPOINT
     return should_mark;
 }
 
-void gc_wake_all_for_marking(jl_ptls_t ptls) JL_NOTSAFEPOINT
+static void gc_wake_all_for_marking(jl_ptls_t ptls) JL_NOTSAFEPOINT
 {
     uv_mutex_lock(&gc_threads_lock);
     uv_cond_broadcast(&gc_threads_cond);
     uv_mutex_unlock(&gc_threads_lock);
 }
 
-void gc_mark_loop(jl_ptls_t ptls, int mark_loop_initiator) JL_NOTSAFEPOINT
+static void gc_mark_loop(jl_ptls_t ptls, int mark_loop_initiator) JL_NOTSAFEPOINT
 {
     if (mark_loop_initiator) {
         jl_atomic_store(&gc_initiator_tid, ptls->tid);
@@ -2760,13 +2755,13 @@ void gc_mark_loop(jl_ptls_t ptls, int mark_loop_initiator) JL_NOTSAFEPOINT
     }
 }
 
-void gc_mark_loop_barrier(void) JL_NOTSAFEPOINT
+static void gc_mark_loop_barrier(void) JL_NOTSAFEPOINT
 {
     assert(jl_atomic_load_relaxed(&gc_n_threads_marking) == 0);
     jl_atomic_store_relaxed(&gc_initiator_tid, -1);
 }
 
-void gc_mark_clean_reclaim_sets(void) JL_NOTSAFEPOINT
+static void gc_mark_clean_reclaim_sets(void) JL_NOTSAFEPOINT
 {
     // Clean up `reclaim-sets`
     for (int i = 0; i < gc_n_threads; i++) {
@@ -3029,7 +3024,7 @@ JL_DLLEXPORT int64_t jl_gc_live_bytes(void)
     return live_bytes;
 }
 
-uint64_t jl_gc_smooth(uint64_t old_val, uint64_t new_val, double factor) JL_NOTSAFEPOINT
+static uint64_t jl_gc_smooth(uint64_t old_val, uint64_t new_val, double factor) JL_NOTSAFEPOINT
 {
     double est = factor * old_val + (1 - factor) * new_val;
     if (est <= 1)
@@ -3062,9 +3057,7 @@ static uint64_t overallocation(uint64_t old_val, uint64_t val, uint64_t max_val)
     return inc;
 }
 
-size_t jl_maxrss(void);
-
-void _report_gc_finished(uint64_t pause, uint64_t freed, int full, int recollect, int64_t live_bytes) JL_NOTSAFEPOINT {
+static void _report_gc_finished(uint64_t pause, uint64_t freed, int full, int recollect, int64_t live_bytes) JL_NOTSAFEPOINT {
     if (!gc_logging_enabled) {
         return;
     }
@@ -4004,7 +3997,7 @@ STATIC_INLINE void *gc_try_perm_alloc_pool(size_t sz, unsigned align, unsigned o
 }
 
 // **NOT** a safepoint
-void *jl_gc_perm_alloc_nolock(size_t sz, int zero, unsigned align, unsigned offset) JL_NOTSAFEPOINT
+static void *jl_gc_perm_alloc_nolock(size_t sz, int zero, unsigned align, unsigned offset) JL_NOTSAFEPOINT
 {
     // The caller should have acquired `gc_perm_lock`
     assert(align < GC_PERM_POOL_LIMIT);

--- a/src/gc-stock.h
+++ b/src/gc-stock.h
@@ -714,9 +714,6 @@ extern int gc_verifying;
 #define gc_verifying (0)
 #endif
 
-int gc_slot_to_fieldidx(void *_obj, void *slot, jl_datatype_t *vt) JL_NOTSAFEPOINT;
-int gc_slot_to_arrayidx(void *_obj, void *begin) JL_NOTSAFEPOINT;
-
 #ifdef GC_DEBUG_ENV
 JL_DLLEXPORT extern jl_gc_debug_env_t jl_gc_debug_env;
 int jl_gc_debug_check_other(void);

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -53,7 +53,7 @@ JL_DLLEXPORT jl_genericmemory_t *jl_alloc_genericmemory_unchecked(jl_ptls_t ptls
     return m;
 }
 
-jl_genericmemory_t *_new_genericmemory_(jl_value_t *mtype, size_t nel, int8_t isunion, int8_t zeroinit, size_t elsz)
+static jl_genericmemory_t *_new_genericmemory_(jl_value_t *mtype, size_t nel, int8_t isunion, int8_t zeroinit, size_t elsz)
 {
     if (nel == 0) // zero-sized allocation optimization
         return (jl_genericmemory_t*)((jl_datatype_t*)mtype)->instance;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1699,7 +1699,7 @@ JL_DLLEXPORT jl_typemap_entry_t *jl_mt_find_cache_entry(jl_methcache_t *cache, j
     return mt_find_cache_entry(&cache->cache, &cache->leafcache, tt, world, jl_cachearg_offset());
 }
 
-jl_value_t *compute_simplett(jl_tupletype_t *cachett)
+static jl_value_t *compute_simplett(jl_tupletype_t *cachett)
 {
     // now scan `cachett` and ensure that `Type{T}` in the cache will be matched exactly by `typeof(T)`
     // and also reduce the complexity of rejecting this entry in the cache
@@ -3782,14 +3782,14 @@ JL_DLLEXPORT int jl_method_is_macro(jl_method_t *m)
     return jl_symbol_name(m->name)[0] == '@';
 }
 
-int need_copy_to_mi_cache(jl_method_instance_t *mi, jl_method_instance_t *mi2,
+static int need_copy_to_mi_cache(jl_method_instance_t *mi, jl_method_instance_t *mi2,
     enum internal_compilation_triggers cause)
 {
     return cause == TRIGGER_FOREIGN ||
         !jl_egal((jl_value_t*)mi->sparam_vals, (jl_value_t*)mi2->sparam_vals);
 }
 
-jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi JL_PROPAGATES_ROOT, jl_code_instance_t *codeinst2)
+static jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi JL_PROPAGATES_ROOT, jl_code_instance_t *codeinst2)
 {
     jl_code_instance_t *codeinst = jl_get_method_uninferred(
             mi, codeinst2->rettype,
@@ -4090,7 +4090,7 @@ jl_value_t *jl_fptr_sparam(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_
     return invoke(f, args, nargs, sparams);
 }
 
-jl_value_t *jl_fptr_wait_for_compiled(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
+static jl_value_t *jl_fptr_wait_for_compiled(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
 {
     jl_callptr_t invoke = jl_atomic_load_acquire(&m->invoke);
     if (invoke == &jl_fptr_wait_for_compiled) {
@@ -4126,7 +4126,6 @@ JL_DLLEXPORT const jl_callptr_t jl_fptr_const_return_addr = &jl_fptr_const_retur
 
 JL_DLLEXPORT const jl_callptr_t jl_fptr_sparam_addr = &jl_fptr_sparam;
 
-JL_CALLABLE(jl_f_opaque_closure_call);
 JL_DLLEXPORT const jl_callptr_t jl_f_opaque_closure_call_addr = (jl_callptr_t)&jl_f_opaque_closure_call;
 
 JL_DLLEXPORT const jl_callptr_t jl_fptr_wait_for_compiled_addr = &jl_fptr_wait_for_compiled;
@@ -4851,7 +4850,7 @@ jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value
     return _jl_invoke(gf, args, nargs - 1, mfunc, world, TRIGGER_INVOKE);
 }
 
-jl_sym_t *jl_gf_supertype_name(jl_sym_t *name)
+static jl_sym_t *jl_gf_supertype_name(jl_sym_t *name)
 {
     size_t l = strlen(jl_symbol_name(name));
     char *prefixed;

--- a/src/init.c
+++ b/src/init.c
@@ -190,10 +190,6 @@ static void jl_close_item_atexit(uv_handle_t *handle)
     }
 }
 
-// This prevents `ct` from returning via error handlers or other unintentional
-// means by destroying some old state before we start destroying that state in atexit hooks.
-void jl_task_frame_noreturn(jl_task_t *ct) JL_NOTSAFEPOINT;
-
 // cause this process to exit with WEXITSTATUS(exitcode), after waiting to finish all julia, C, and C++ cleanup
 JL_DLLEXPORT void jl_exit(int exitcode)
 {
@@ -382,8 +378,6 @@ JL_DLLEXPORT void jl_postoutput_hook(void)
     }
     return;
 }
-
-void post_boot_hooks(void);
 
 JL_DLLEXPORT void *jl_libjulia_internal_handle;
 JL_DLLEXPORT void *jl_libjulia_handle;

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -630,8 +630,6 @@ static jl_genericmemory_t *jl_decode_value_memory(jl_ircode_state *s, jl_value_t
     return m;
 }
 
-JL_DLLEXPORT jl_array_t *jl_alloc_array_nd(jl_value_t *atype, size_t *dims, size_t ndims);
-
 static jl_value_t *jl_decode_value_array1d(jl_ircode_state *s, uint8_t tag)
 {
     int16_t ndims = 1;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -660,10 +660,6 @@ static void selectOptLevel(Module &M) JL_NOTSAFEPOINT {
     M.addModuleFlag(Module::Warning, "julia.optlevel", opt_level);
 }
 
-void jl_register_jit_object(const object::ObjectFile &Object,
-                            std::function<uint64_t(const StringRef &)> getLoadAddress,
-                            const jl_linker_info_t &Info);
-
 static bool isJITLinkEHFrameSection(StringRef Name) JL_NOTSAFEPOINT
 {
     // EH-frame sections are handled by the EH-frame registration plugin. Its
@@ -1017,12 +1013,12 @@ private:
 
 #if defined(LLVM_SHLIB)
 namespace JLEHFrames {
-Error registerEHFrames(orc::ExecutorAddrRange EHFrameSection) {
+static Error registerEHFrames(orc::ExecutorAddrRange EHFrameSection) {
     register_eh_frames(EHFrameSection.Start.toPtr<uint8_t *>(), static_cast<size_t>(EHFrameSection.size()));
     return Error::success();
 }
 
-Error deregisterEHFrames(orc::ExecutorAddrRange EHFrameSection) {
+static Error deregisterEHFrames(orc::ExecutorAddrRange EHFrameSection) {
     deregister_eh_frames(EHFrameSection.Start.toPtr<uint8_t *>(), static_cast<size_t>(EHFrameSection.size()));
     return Error::success();
 }
@@ -1058,9 +1054,6 @@ namespace JLEHFrames {
 }
 #endif
 #endif
-
-RTDyldMemoryManager *createRTDyldMemoryManager(void) JL_NOTSAFEPOINT;
-std::unique_ptr<jitlink::JITLinkMemoryManager> createJITLinkMemoryManager() JL_NOTSAFEPOINT;
 
 // A simple forwarding class, since OrcJIT v2 needs a unique_ptr, while we have a shared_ptr
 namespace {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1063,6 +1063,7 @@ RTDyldMemoryManager *createRTDyldMemoryManager(void) JL_NOTSAFEPOINT;
 std::unique_ptr<jitlink::JITLinkMemoryManager> createJITLinkMemoryManager() JL_NOTSAFEPOINT;
 
 // A simple forwarding class, since OrcJIT v2 needs a unique_ptr, while we have a shared_ptr
+namespace {
 class ForwardingMemoryManager : public RuntimeDyld::MemoryManager {
 private:
     std::shared_ptr<RuntimeDyld::MemoryManager> MemMgr;
@@ -1109,6 +1110,7 @@ public:
         return MemMgr->notifyObjectLoaded(RTDyld, Obj);
     }
 };
+}  // anonymous namespace
 
 namespace {
     static std::unique_ptr<TargetMachine> createTargetMachine() JL_NOTSAFEPOINT {

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -644,7 +644,7 @@ public:
                                      jitlink::LinkGraph &G, MemoryBufferRef InputObject,
                                      std::unique_ptr<jl_linker_info_t> LinkerInfo)
         JL_NOTSAFEPOINT;
-    Error notifyEmitted(orc::MaterializationResponsibility &MR) override;
+    Error notifyEmitted(orc::MaterializationResponsibility &MR) override JL_NOTSAFEPOINT_ENTER JL_NOTSAFEPOINT_LEAVE;
     Error notifyFailed(orc::MaterializationResponsibility &MR) override;
     Error notifyRemovingResources(orc::JITDylib &JD, orc::ResourceKey K) override;
     void notifyTransferringResources(orc::JITDylib &JD, orc::ResourceKey DstKey,
@@ -997,3 +997,9 @@ CodeGenOptLevel CodeGenOptLevelFor(int optlevel) JL_NOTSAFEPOINT;
 #else
 CodeGenOpt::Level CodeGenOptLevelFor(int optlevel) JL_NOTSAFEPOINT;
 #endif
+
+void jl_jit_add_bytes(size_t bytes) JL_NOTSAFEPOINT;
+
+void jl_register_jit_object(const object::ObjectFile &Object,
+                            std::function<uint64_t(const StringRef &)> getLoadAddress,
+                            const jl_linker_info_t &Info) JL_NOTSAFEPOINT_ENTER JL_NOTSAFEPOINT_LEAVE;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -181,7 +181,6 @@
     XX(jl_gc_sync_total_bytes) \
     XX(jl_gc_total_hrtime) \
     XX(jl_gc_wb_cold) \
-    XX(jl_gdblookup) \
     XX(jl_generating_output) \
     XX(jl_declare_const_gf) \
     XX(jl_declare_constant_val) \
@@ -289,7 +288,6 @@
     XX(jl_is_unary_and_binary_operator) \
     XX(jl_is_unary_operator) \
     XX(jl_lazy_load_and_lookup) \
-    XX(jl_lisp_prompt) \
     XX(jl_load) \
     XX(jl_load_) \
     XX(jl_load_and_lookup) \

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -1214,13 +1214,13 @@ struct work_baton {
 #include <sys/syscall.h>
 #endif
 
-void jl_work_wrapper(uv_work_t *req)
+static void jl_work_wrapper(uv_work_t *req)
 {
     struct work_baton *baton = (struct work_baton*) req->data;
     baton->work_func(baton->ccall_fptr, baton->work_args, baton->work_retval);
 }
 
-void jl_work_notifier(uv_work_t *req, int status)
+static void jl_work_notifier(uv_work_t *req, int status)
 {
     struct work_baton *baton = (struct work_baton*) req->data;
     baton->notify_func(baton->notify_idx);

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -1080,9 +1080,6 @@ static void lock_low32(void) JL_NOTSAFEPOINT
     return;
 }
 
-// Actual definition in `ast.c`
-void jl_lisp_prompt(void);
-
 #ifdef _OS_LINUX_
 static void rr_detach_teleport(void) JL_NOTSAFEPOINT {
 #define RR_CALL_BASE 1000

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -649,7 +649,7 @@ static void isort_union(jl_value_t **a, size_t len) JL_NOTSAFEPOINT
     }
 }
 
-static int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion)
+int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion)
 {
     assert(hasfree == (jl_has_free_typevars(a) | (jl_has_free_typevars(b) << 1)));
     if (a == jl_bottom_type || b == (jl_value_t*)jl_any_type)
@@ -888,8 +888,6 @@ jl_value_t *simple_union(jl_value_t *a, jl_value_t *b)
     JL_GC_POP();
     return tu;
 }
-
-int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity) JL_NOTSAFEPOINT;
 
 jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi)
 {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -957,6 +957,7 @@ enum atomic_kind {
 };
 
 JL_DLLEXPORT int jl_has_intersect_type_not_kind(jl_value_t *t);
+int jl_has_intersect_kind_not_type(jl_value_t *t);
 int jl_subtype_invariant(jl_value_t *a, jl_value_t *b, int ta);
 JL_DLLEXPORT int jl_has_concrete_subtype(jl_value_t *typ);
 jl_tupletype_t *jl_inst_arg_tuple_type(jl_value_t *arg1, jl_value_t **args, size_t nargs, int leaf);
@@ -1179,88 +1180,7 @@ struct restriction_kind_pair {
 };
 JL_DLLEXPORT int jl_get_binding_leaf_partitions_restriction_kind(jl_binding_t *b JL_PROPAGATES_ROOT, struct restriction_kind_pair *rkp, size_t min_world, size_t max_world) JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT jl_value_t *jl_get_binding_leaf_partitions_value_if_const(jl_binding_t *b JL_PROPAGATES_ROOT, int *maybe_depwarn, size_t min_world, size_t max_world);
-
-#ifndef __clang_analyzer__
-STATIC_INLINE void jl_walk_binding_inplace(jl_binding_t **bnd, jl_binding_partition_t **bpart, size_t world) JL_NOTSAFEPOINT
-{
-    while (1) {
-        enum jl_partition_kind kind = jl_binding_kind(*bpart);
-        if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL)
-            return;
-        *bnd = (jl_binding_t*)(*bpart)->restriction;
-        *bpart = jl_get_binding_partition(*bnd, world);
-    }
-}
-
-STATIC_INLINE void jl_walk_binding_inplace_depwarn(jl_binding_t **bnd, jl_binding_partition_t **bpart, size_t world, int *depwarn) JL_NOTSAFEPOINT
-{
-    int passed_explicit = 0;
-    while (1) {
-        enum jl_partition_kind kind = jl_binding_kind(*bpart);
-        if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL) {
-            if (!passed_explicit && depwarn)
-                *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
-            return;
-        }
-        if (!passed_explicit && depwarn)
-            *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
-        if (kind != PARTITION_KIND_IMPLICIT_GLOBAL)
-            passed_explicit = 1;
-        *bnd = (jl_binding_t*)(*bpart)->restriction;
-        *bpart = jl_get_binding_partition(*bnd, world);
-    }
-}
-
-
-STATIC_INLINE void jl_walk_binding_inplace_all(jl_binding_t **bnd, jl_binding_partition_t **bpart, int *depwarn, size_t min_world, size_t max_world) JL_NOTSAFEPOINT
-{
-    int passed_explicit = 0;
-    while (*bpart) {
-        enum jl_partition_kind kind = jl_binding_kind(*bpart);
-        if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL) {
-            if (!passed_explicit && depwarn)
-                *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
-            return;
-        }
-        if (!passed_explicit && depwarn)
-            *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
-        if (kind != PARTITION_KIND_IMPLICIT_GLOBAL)
-            passed_explicit = 1;
-        *bnd = (jl_binding_t*)(*bpart)->restriction;
-        *bpart = jl_get_binding_partition_all(*bnd, min_world, max_world);
-    }
-}
-
-STATIC_INLINE void jl_walk_binding_inplace_worlds(jl_binding_t **bnd, jl_binding_partition_t **bpart, size_t *min_world, size_t *max_world, int *depwarn, size_t world) JL_NOTSAFEPOINT
-{
-    int passed_explicit = 0;
-    while (*bpart) {
-        if (*min_world < (*bpart)->min_world)
-            *min_world = (*bpart)->min_world;
-        size_t bpart_max_world = jl_atomic_load_relaxed(&(*bpart)->max_world);
-        if (*max_world > bpart_max_world)
-            *max_world = bpart_max_world;
-        enum jl_partition_kind kind = jl_binding_kind(*bpart);
-        if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL) {
-            if (!passed_explicit && depwarn)
-                *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
-            return;
-        }
-        if (!passed_explicit && depwarn)
-            *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
-        if (kind != PARTITION_KIND_IMPLICIT_GLOBAL)
-            passed_explicit = 1;
-        *bnd = (jl_binding_t*)(*bpart)->restriction;
-        *bpart = jl_get_binding_partition(*bnd, world);
-    }
-}
-#endif
-
-void jl_walk_binding_inplace(jl_binding_t **bnd, jl_binding_partition_t **bpart JL_PROPAGATES_ROOT, size_t world) JL_NOTSAFEPOINT;
-void jl_walk_binding_inplace_depwarn(jl_binding_t **bnd, jl_binding_partition_t **bpart, size_t world, int *depwarn) JL_NOTSAFEPOINT;
-void jl_walk_binding_inplace_all(jl_binding_t **bnd, jl_binding_partition_t **bpart JL_PROPAGATES_ROOT, int *depwarn, size_t min_world, size_t max_world) JL_NOTSAFEPOINT;
-void jl_walk_binding_inplace_worlds(jl_binding_t **bnd, jl_binding_partition_t **bpart, size_t *min_world, size_t *max_world, int *depwarn, size_t world) JL_NOTSAFEPOINT;
-
+void check_safe_newbinding(jl_module_t *m, jl_sym_t *var);
 
 STATIC_INLINE int is10digit(char c) JL_NOTSAFEPOINT
 {
@@ -1683,7 +1603,6 @@ JL_DLLEXPORT jl_value_t *jl_get_backtrace(void);
 JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp, int skip);
 void jl_fprint_critical_error(ios_t *t, int sig, int si_code, bt_context_t *context, jl_task_t *ct);
 JL_DLLEXPORT void jl_raise_debugger(void) JL_NOTSAFEPOINT;
-JL_DLLEXPORT void jl_gdblookup(void* ip) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_print_task_backtraces(int show_done) JL_NOTSAFEPOINT;
 void jl_fprint_native_codeloc(ios_t *s, uintptr_t ip) JL_NOTSAFEPOINT;
 void jl_fprint_bt_entry_codeloc(ios_t *s, jl_bt_element_t *bt_data) JL_NOTSAFEPOINT;
@@ -1935,6 +1854,9 @@ JL_DLLEXPORT void jl_set_next_task(jl_task_t *task) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint16_t julia_double_to_half(double param) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint16_t julia_float_to_half(float param) JL_NOTSAFEPOINT;
 JL_DLLEXPORT float julia_half_to_float(uint16_t param) JL_NOTSAFEPOINT;
+uint16_t julia_float_to_bfloat(float param) JL_NOTSAFEPOINT;
+float julia_bfloat_to_float(uint16_t param) JL_NOTSAFEPOINT;
+
 
 // -- synchronization utilities -- //
 
@@ -2174,6 +2096,42 @@ JL_DLLEXPORT void jl_write_coverage_data(const char*) JL_NOTSAFEPOINT;
 
 extern uv_mutex_t symtab_lock;
 jl_sym_t *_jl_symbol(const char *str, size_t len) JL_NOTSAFEPOINT;
+
+// This prevents `ct` from returning via error handlers or other unintentional
+// means by destroying some old state before we start destroying that state in atexit hooks.
+void post_boot_hooks(void);
+JL_DLLEXPORT jl_genericmemory_t *jl_genericmemory_copy_slice(jl_genericmemory_t *mem, void *data, size_t len);
+int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity) JL_NOTSAFEPOINT;
+JL_CALLABLE(jl_f_opaque_closure_call);
+uint_t bindingkey_hash(size_t idx, jl_value_t *data);
+uint_t speccache_hash(size_t idx, jl_value_t *data);
+void JL_NORETURN jl_finish_task(jl_task_t *ct);
+void jl_wait_empty_begin(void);
+void jl_wait_empty_end(void);
+// concurrent reads are permitted, using the same pattern as mtsmall_arraylist
+// it is implemented separately because the API of direct jl_all_tls_states use is already widely prevalent
+void jl_init_thread_scheduler(jl_ptls_t ptls) JL_NOTSAFEPOINT;
+void jl_lisp_prompt(void);
+void jl_task_frame_noreturn(jl_task_t *ct) JL_NOTSAFEPOINT;
+void scheduler_delete_thread(jl_ptls_t ptls) JL_NOTSAFEPOINT;
+void surprise_wakeup(jl_ptls_t ptls) JL_NOTSAFEPOINT;
+void _jl_free_stack(jl_ptls_t ptls, void *stkbuf, size_t bufsz) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_id_start_char(uint32_t wc) JL_NOTSAFEPOINT; // declared also in flisp.h
+JL_DLLEXPORT int jl_id_char(uint32_t wc) JL_NOTSAFEPOINT; // declared also in flisp.h
+jl_value_t *simple_union(jl_value_t *a, jl_value_t *b);
+jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi);
+int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion);
+void jl_rng_split(uint64_t dst[JL_RNG_SIZE], uint64_t src[JL_RNG_SIZE]) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;
+JL_DLLEXPORT NOINLINE int failed_to_sample_task_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
+JL_DLLEXPORT NOINLINE int failed_to_stop_thread_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
+int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT;
+void export_jl_small_typeof(void);
+void export_jl_sysimg_globals(void);
+
+
 
 // Tools for locally disabling spurious compiler warnings
 //

--- a/src/llvm-codegen-shared.h
+++ b/src/llvm-codegen-shared.h
@@ -6,6 +6,7 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/IR/Attributes.h>
+#include <llvm/IR/Module.h>
 #include <llvm/IR/DebugLoc.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/MDBuilder.h>
@@ -516,3 +517,12 @@ void ConstantUses<U>::forward()
     }
 }
 }
+
+
+void multiversioning_preannotate(llvm::Module &M);
+std::optional<bool> always_have_fma(Function&, const Triple &TT) JL_NOTSAFEPOINT;
+
+namespace llvm::jitlink {
+    class JITLinkMemoryManager;
+}
+std::unique_ptr<jitlink::JITLinkMemoryManager> createJITLinkMemoryManager() JL_NOTSAFEPOINT;

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -75,7 +75,7 @@ static bool have_fma(Function &intr, Function &caller, const Triple &TT) JL_NOTS
     return false;
 }
 
-void lowerHaveFMA(Function &intr, Function &caller, const Triple &TT, CallInst *I) JL_NOTSAFEPOINT {
+static void lowerHaveFMA(Function &intr, Function &caller, const Triple &TT, CallInst *I) JL_NOTSAFEPOINT {
     if (have_fma(intr, caller, TT)) {
         ++LoweredWithFMA;
         I->replaceAllUsesWith(ConstantInt::get(I->getType(), 1));
@@ -86,7 +86,7 @@ void lowerHaveFMA(Function &intr, Function &caller, const Triple &TT, CallInst *
     return;
 }
 
-bool lowerCPUFeatures(Module &M) JL_NOTSAFEPOINT
+static bool lowerCPUFeatures(Module &M) JL_NOTSAFEPOINT
 {
     auto TT = Triple(M.getTargetTriple());
     SmallVector<Instruction*,6> Materialized;

--- a/src/llvm-expand-atomic-modify.cpp
+++ b/src/llvm-expand-atomic-modify.cpp
@@ -143,6 +143,7 @@ std::pair<Value *, Value *> insertRMWCmpXchgLoop(
 
 // from AtomicExpandImpl
 // IRBuilder to be used for replacement atomic instructions.
+namespace {
 struct ReplacementIRBuilder
     : IRBuilder<InstSimplifyFolder, IRBuilderCallbackInserter> {
   MDNode *MMRAMD = nullptr;
@@ -166,6 +167,7 @@ struct ReplacementIRBuilder
       I->setMetadata(LLVMContext::MD_mmra, MMRAMD);
   }
 };
+}  // anonymous namespace
 
 // Must check that either Target cannot observe or mutate global state
 // or that no trailing instructions does so either.

--- a/src/llvm-expand-atomic-modify.cpp
+++ b/src/llvm-expand-atomic-modify.cpp
@@ -79,7 +79,7 @@ static void createWeakCmpXchgInstFun(IRBuilderBase &Builder, Value *Addr,
 }
 
 // from AtomicExpandImpl, with modification of values returned
-std::pair<Value *, Value *> insertRMWCmpXchgLoop(
+static std::pair<Value *, Value *> insertRMWCmpXchgLoop(
     IRBuilderBase &Builder, Type *ResultTy, Value *Addr, Align AddrAlign,
     AtomicOrdering MemOpOrder, SyncScope::ID SSID, Instruction &Attributes,
     const std::function<Value *(IRBuilderBase &, Value *)> &PerformOp,
@@ -325,7 +325,7 @@ static std::variant<AtomicRMWInst::BinOp,bool> patternMatchAtomicRMWOp(Value *Ol
   return false;
 }
 
-void expandAtomicModifyToCmpXchg(CallInst &Modify,
+static void expandAtomicModifyToCmpXchg(CallInst &Modify,
                                  const CreateWeakCmpXchgInstFun &CreateWeakCmpXchg) {
   Value *Ptr = Modify.getOperand(0);
   Function *Op = dyn_cast<Function>(Modify.getOperand(1));

--- a/src/llvm-gc-invariant-verifier.cpp
+++ b/src/llvm-gc-invariant-verifier.cpp
@@ -33,6 +33,7 @@
 
 using namespace llvm;
 
+namespace {
 struct GCInvariantVerifier : public InstVisitor<GCInvariantVerifier> {
     bool Broken = false;
     bool Strong;
@@ -60,6 +61,7 @@ public:
 
     void checkStoreInst(Type *VTy, unsigned AS, Value &SI);
 };
+}  // anonymous namespace
 
 void GCInvariantVerifier::visitAddrSpaceCastInst(AddrSpaceCastInst &I) {
     unsigned FromAS = I.getSrcTy()->getPointerAddressSpace();

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1703,6 +1703,7 @@ void LateLowerGCFrame::ComputeLiveSets(State &S) {
  * greedy coloring gives an optimal coloring. Since our roots are in SSA form,
  * the interference should be chordal.
  */
+namespace {
 struct PEOIterator {
     struct Element {
         unsigned weight;
@@ -1759,6 +1760,7 @@ struct PEOIterator {
         return NextElement;
     }
 };
+}  // anonymous namespace
 
 JL_USED_FUNC static void dumpColorAssignments(const State &S, const ArrayRef<int> &Colors)
 {

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -53,7 +53,7 @@ CountTrackedPointers::CountTrackedPointers(Type *T, bool ignore_loaded) {
         all = false;
 }
 
-bool hasLoadedTy(Type *T) {
+static bool hasLoadedTy(Type *T) {
     if (isa<PointerType>(T)) {
         if (T->getPointerAddressSpace() == AddressSpace::Loaded)
             return true;
@@ -67,7 +67,7 @@ bool hasLoadedTy(Type *T) {
 }
 
 
-unsigned getCompositeNumElements(Type *T) {
+static unsigned getCompositeNumElements(Type *T) {
     if (auto *ST = dyn_cast<StructType>(T))
         return ST->getNumElements();
     else if (auto *AT = dyn_cast<ArrayType>(T))
@@ -1851,7 +1851,7 @@ static inline void UpdatePtrNumbering(Value *From, Value *To, State *S)
     }
 }
 
-MDNode *createMutableTBAAAccessTag(MDNode *Tag) {
+static MDNode *createMutableTBAAAccessTag(MDNode *Tag) {
     return MDBuilder(Tag->getContext()).createMutableTBAAAccessTag(Tag);
 }
 

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -47,8 +47,6 @@
 
 using namespace llvm;
 
-extern std::optional<bool> always_have_fma(Function&, const Triple &TT);
-
 // Per-function clone categories (set by IR analysis)
 enum {
     JL_CLONE_LOOP     = 1 << 0,
@@ -1220,7 +1218,7 @@ static bool runMultiVersioning(Module &M, bool allow_bad_fvars)
 
 } // anonymous namespace
 
-void multiversioning_preannotate(Module &M)
+extern void multiversioning_preannotate(Module &M)
 {
     annotate_module_clones(M);
     M.addModuleFlag(Module::ModFlagBehavior::Error, "julia.mv.enable", 1);

--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -287,7 +287,7 @@ void PropagateJuliaAddrspacesVisitor::visitMemTransferInst(MemTransferInst &MTI)
     MTI.setArgOperand(1, Src);
 }
 
-bool propagateJuliaAddrspaces(Function &F) {
+static bool propagateJuliaAddrspaces(Function &F) {
     PropagateJuliaAddrspacesVisitor visitor;
     visitor.visit(F);
     for (auto it : visitor.ToInsert)

--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -39,6 +39,7 @@ using namespace llvm;
     optimizations.
 */
 
+namespace {
 struct PropagateJuliaAddrspacesVisitor : public InstVisitor<PropagateJuliaAddrspacesVisitor> {
     DenseMap<Value *, Value *> LiftingMap;
     SmallPtrSet<Value *, 4> Visited;
@@ -58,6 +59,7 @@ public:
 private:
     void PoisonValues(SmallVectorImpl<Value *> &Worklist);
 };
+}  // anonymous namespace
 
 static unsigned getValueAddrSpace(Value *V) {
     return V->getType()->getPointerAddressSpace();

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -26,6 +26,7 @@ using AddrspaceRemapFunction = std::function<unsigned(unsigned)>;
 // Helpers
 //
 
+namespace {
 class AddrspaceRemoveTypeRemapper : public ValueMapTypeRemapper {
     AddrspaceRemapFunction ASRemapper;
 
@@ -106,8 +107,10 @@ public:
 private:
     DenseMap<Type *, Type *> MappedTypes;
 };
+}  // anonymous namespace
 
 
+namespace {
 class AddrspaceRemoveValueMaterializer : public ValueMaterializer {
     ValueToValueMapTy &VM;
     RemapFlags Flags;
@@ -177,6 +180,7 @@ private:
         return MapValue(V, VM, Flags, TypeMapper, this);
     }
 };
+}  // anonymous namespace
 
 bool RemoveNoopAddrSpaceCasts(Function *F)
 {

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -182,7 +182,7 @@ private:
 };
 }  // anonymous namespace
 
-bool RemoveNoopAddrSpaceCasts(Function *F)
+static bool RemoveNoopAddrSpaceCasts(Function *F)
 {
     bool Changed = false;
 
@@ -224,12 +224,12 @@ static void copyComdat(GlobalObject *Dst, const GlobalObject *Src)
 // Actual pass
 //
 
-unsigned removeAllAddrspaces(unsigned AS)
+static unsigned removeAllAddrspaces(unsigned AS)
 {
     return AddressSpace::Generic;
 }
 
-bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
+static bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
 {
     ValueToValueMapTy VMap;
     AddrspaceRemoveTypeRemapper TypeRemapper(ASRemapper);
@@ -447,7 +447,7 @@ PreservedAnalyses RemoveAddrspacesPass::run(Module &M, ModuleAnalysisManager &AM
 // Julia-specific pass
 //
 
-unsigned removeJuliaAddrspaces(unsigned AS)
+static unsigned removeJuliaAddrspaces(unsigned AS)
 {
     if (AddressSpace::FirstSpecial <= AS && AS <= AddressSpace::LastSpecial)
         return AddressSpace::Generic;

--- a/src/method.c
+++ b/src/method.c
@@ -326,7 +326,7 @@ JL_DLLEXPORT void jl_resolve_definition_effects_in_ir(jl_array_t *stmts, jl_modu
     }
 }
 
-jl_value_t *expr_arg1(jl_value_t *expr) {
+static jl_value_t *expr_arg1(jl_value_t *expr) {
     jl_array_t *args = ((jl_expr_t*)expr)->args;
     return jl_array_ptr_ref(args, 0);
 }
@@ -404,7 +404,7 @@ static void add_edge(arraylist_t *edges_list, arraylist_t *inlinestack, int32_t 
     *p_pc = (i - 2) / 3 + 1;
 }
 
-jl_debuginfo_t *jl_linetable_to_debuginfo(jl_array_t *codelocs_any, jl_array_t *linetable)
+static jl_debuginfo_t *jl_linetable_to_debuginfo(jl_array_t *codelocs_any, jl_array_t *linetable)
 {
     size_t nlocs = jl_array_nrows(codelocs_any);
     jl_value_t *toplocinfo = jl_array_ptr_ref(linetable, 0);

--- a/src/module.c
+++ b/src/module.c
@@ -206,7 +206,7 @@ retry:
 }
 
 // find a binding from a module's `usings` list
-struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t *b, modstack_t *st, size_t world, int trust_cache)
+static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t *b, modstack_t *st, size_t world, int trust_cache)
 {
     // First check if we've hit a cycle in this resolution
     {
@@ -395,6 +395,68 @@ JL_DLLEXPORT void jl_update_loaded_bpart(jl_binding_t *b, jl_binding_partition_t
     jl_atomic_store_relaxed(&bpart->max_world, resolution.max_world);
     jl_gc_write(bpart, bpart->restriction, jl_value_t, resolution.binding_or_const);
     bpart->kind = resolution.ultimate_kind;
+}
+
+static void jl_walk_binding_inplace(jl_binding_t **bnd, jl_binding_partition_t **pbpart, size_t world)
+{
+    jl_binding_partition_t *bpart = *pbpart;
+    while (1) {
+        enum jl_partition_kind kind = jl_binding_kind(bpart);
+        if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL) {
+            break;
+        }
+        *bnd = (jl_binding_t*)bpart->restriction;
+        bpart = jl_get_binding_partition(*bnd, world);
+    }
+    *pbpart = bpart;
+}
+
+static void jl_walk_binding_inplace_depwarn(jl_binding_t **bnd, jl_binding_partition_t **pbpart, size_t world, int *depwarn)
+{
+    int passed_explicit = 0;
+    jl_binding_partition_t *bpart = *pbpart;
+    while (1) {
+        enum jl_partition_kind kind = jl_binding_kind(bpart);
+        if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL) {
+            if (!passed_explicit && depwarn)
+                *depwarn |= bpart->kind & PARTITION_FLAG_DEPWARN;
+            break;
+        }
+        if (!passed_explicit && depwarn)
+            *depwarn |= bpart->kind & PARTITION_FLAG_DEPWARN;
+        if (kind != PARTITION_KIND_IMPLICIT_GLOBAL)
+            passed_explicit = 1;
+        *bnd = (jl_binding_t*)bpart->restriction;
+        bpart = jl_get_binding_partition(*bnd, world);
+    }
+    *pbpart = bpart;
+}
+
+static void jl_walk_binding_inplace_worlds(jl_binding_t **bnd, jl_binding_partition_t **pbpart, size_t *min_world, size_t *max_world, int *depwarn, size_t world)
+{
+    int passed_explicit = 0;
+    jl_binding_partition_t *bpart = *pbpart;
+    while (bpart) {
+        size_t bpart_min_world = jl_atomic_load_relaxed(&bpart->min_world);
+        if (*min_world < bpart_min_world)
+            *min_world = bpart_min_world;
+        size_t bpart_max_world = jl_atomic_load_relaxed(&bpart->max_world);
+        if (*max_world > bpart_max_world)
+            *max_world = bpart_max_world;
+        enum jl_partition_kind kind = jl_binding_kind(bpart);
+        if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL) {
+            if (!passed_explicit && depwarn)
+                *depwarn |= bpart->kind & PARTITION_FLAG_DEPWARN;
+            break;
+        }
+        if (!passed_explicit && depwarn)
+            *depwarn |= bpart->kind & PARTITION_FLAG_DEPWARN;
+        if (kind != PARTITION_KIND_IMPLICIT_GLOBAL)
+            passed_explicit = 1;
+        *bnd = (jl_binding_t*)bpart->restriction;
+        bpart = jl_get_binding_partition(*bnd, world);
+    }
+    *pbpart = bpart;
 }
 
 STATIC_INLINE jl_binding_partition_t *jl_get_binding_partition_(jl_binding_t *b JL_PROPAGATES_ROOT, jl_value_t *parent, _Atomic(jl_binding_partition_t *)*insert, size_t world, size_t max_world, modstack_t *st) JL_GLOBALLY_ROOTED
@@ -820,7 +882,7 @@ static int is_module_open(jl_module_t *m)
     return open;
 }
 
-extern void check_safe_newbinding(jl_module_t *m, jl_sym_t *var)
+void check_safe_newbinding(jl_module_t *m, jl_sym_t *var)
 {
     if (jl_current_task->ptls->in_pure_callback)
         jl_errorf("new strong globals cannot be created in a generated function. Declare them outside using `global x::Any`.");
@@ -935,6 +997,7 @@ JL_DLLEXPORT jl_value_t *jl_get_binding_value_in_world(jl_binding_t *b, size_t w
 
 static jl_value_t *jl_get_binding_value_depwarn(jl_binding_t *b, size_t world)
 {
+    assert(b); // alloc=1 parameter ensured that jl_get_module_binding returns a valid binding
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
     if (jl_options.depwarn) {
         int needs_depwarn = 0;
@@ -1692,7 +1755,7 @@ JL_DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val JL
     jl_gc_write(bpart, bpart->restriction, jl_value_t, val);
 }
 
-void jl_invalidate_binding_refs(jl_globalref_t *ref, jl_binding_partition_t *invalidated_bpart, jl_binding_partition_t *new_bpart, size_t new_world)
+static void jl_invalidate_binding_refs(jl_globalref_t *ref, jl_binding_partition_t *invalidated_bpart, jl_binding_partition_t *new_bpart, size_t new_world)
 {
     jl_value_t *invalidate_code_for_globalref = NULL;
     if (jl_base_module != NULL)
@@ -2062,7 +2125,7 @@ JL_DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
     return (jl_value_t*)a;
 }
 
-void _append_symbol_to_bindings_array(jl_array_t* a, jl_sym_t *name) {
+static void _append_symbol_to_bindings_array(jl_array_t* a, jl_sym_t *name) {
     jl_array_grow_end(a, 1);
     //XXX: change to jl_arrayset if array storage allocation for Array{Symbols,1} changes:
     jl_array_ptr_set(a, jl_array_dim0(a)-1, (jl_value_t*)name);
@@ -2113,7 +2176,7 @@ static void _materialize_reexported_bindings(jl_module_t *m, size_t world, jl_ar
     }
 }
 
-void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, int usings, size_t world)
+static void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, int usings, size_t world)
 {
     // Materialize reexported bindings first
     jl_array_t *visited_modules = jl_alloc_vec_any(0);
@@ -2161,7 +2224,7 @@ void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, i
     }
 }
 
-void append_exported_names(jl_array_t* a, jl_module_t *m, int all, size_t world)
+static void append_exported_names(jl_array_t* a, jl_module_t *m, int all, size_t world)
 {
     // First, materialize all reexported bindings
     jl_array_t *visited_modules = jl_alloc_vec_any(0);

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -3,12 +3,12 @@
 #include "julia.h"
 #include "julia_internal.h"
 
-jl_value_t *jl_fptr_const_opaque_closure(jl_opaque_closure_t *oc, jl_value_t **args, size_t nargs)
+static jl_value_t *jl_fptr_const_opaque_closure(jl_opaque_closure_t *oc, jl_value_t **args, size_t nargs)
 {
     return oc->captures;
 }
 
-jl_value_t *jl_fptr_const_opaque_closure_typeerror(jl_opaque_closure_t *oc, jl_value_t **args, size_t nargs)
+static jl_value_t *jl_fptr_const_opaque_closure_typeerror(jl_opaque_closure_t *oc, jl_value_t **args, size_t nargs)
 {
     jl_type_error("OpaqueClosure", jl_tparam1(jl_typeof(oc)), oc->captures);
 }

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -21,7 +21,7 @@ JL_DLLEXPORT int jl_generating_output(void)
     return jl_options.outputo || jl_options.outputbc || jl_options.outputunoptbc || jl_options.outputji || jl_options.outputasm;
 }
 
-void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
+static void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
     // Write the source-text for the dependent files
     if (udeps) {
         // Go back and update the source-text position to point to the current position

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -550,7 +550,7 @@ JL_DLLEXPORT jl_value_t *jl_check_pkgimage_clones(char *data)
     return jl_nothing;
 }
 
-JL_DLLEXPORT jl_value_t *jl_cpu_has_fma(int bits)
+jl_value_t *jl_cpu_has_fma(int bits)
 {
 #if defined(_CPU_X86_64_) || defined(_CPU_X86_)
     if ((bits == 32 || bits == 64) && !jit_targets.empty()) {
@@ -889,7 +889,6 @@ JL_DLLEXPORT jl_value_t *jl_get_cpu_features(void)
     return jl_cstr_to_string(get_host_feature_string().c_str());
 }
 
-#ifndef __clang_analyzer__
 extern "C" JL_DLLEXPORT jl_value_t* jl_reflect_clone_targets() {
     // Return the actual JIT target(s) chosen after sysimage matching, so that
     // debug output reflects what pkgimage clones are compared against rather
@@ -907,7 +906,6 @@ extern "C" JL_DLLEXPORT jl_value_t* jl_reflect_clone_targets() {
     memcpy(out, data.data(), data.size());
     return arr;
 }
-#endif
 
 extern "C" JL_DLLEXPORT jl_value_t *jl_get_sysimage_cpu_target(void) {
     if (sysimage_cpu_target.empty()) {

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -622,9 +622,6 @@ static size_t jl_show_svec(JL_STREAM *out, jl_svec_t *t, const char *head, const
     return n;
 }
 
-JL_DLLEXPORT int jl_id_start_char(uint32_t wc) JL_NOTSAFEPOINT;
-JL_DLLEXPORT int jl_id_char(uint32_t wc) JL_NOTSAFEPOINT;
-
 JL_DLLEXPORT int jl_is_identifier(const char *str) JL_NOTSAFEPOINT
 {
     size_t i = 0;

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -10,6 +10,7 @@
 #include "julia.h"
 #include "julia_internal.h"
 #include "llvm-version.h"
+#include "processor.h"
 
 const unsigned int host_char_bit = 8;
 
@@ -356,10 +357,10 @@ static inline float bfloat_to_float(uint16_t param) JL_NOTSAFEPOINT
 // bfloat16 conversion API
 
 // for use in APInt (without the ABI shenanigans from below)
-uint16_t julia_float_to_bfloat(float param) {
+uint16_t julia_float_to_bfloat(float param) JL_NOTSAFEPOINT {
     return float_to_bfloat(param);
 }
-float julia_bfloat_to_float(uint16_t param) {
+float julia_bfloat_to_float(uint16_t param) JL_NOTSAFEPOINT {
     return bfloat_to_float(param);
 }
 
@@ -1386,7 +1387,7 @@ bi_fintrinsic(sub,sub_float)
 bi_fintrinsic(mul,mul_float)
 bi_fintrinsic(div,div_float)
 
-float min_float(float x, float y) JL_NOTSAFEPOINT
+static float min_float(float x, float y) JL_NOTSAFEPOINT
 {
     float diff = x - y;
     float argmin = signbit(diff) ? x : y;
@@ -1394,7 +1395,7 @@ float min_float(float x, float y) JL_NOTSAFEPOINT
     return is_nan ? diff : argmin;
 }
 
-double min_double(double x, double y) JL_NOTSAFEPOINT
+static double min_double(double x, double y) JL_NOTSAFEPOINT
 {
     double diff = x - y;
     double argmin = signbit(diff) ? x : y;
@@ -1405,7 +1406,7 @@ double min_double(double x, double y) JL_NOTSAFEPOINT
 #define _min(a, b) sizeof(a) == sizeof(float) ? min_float(a, b) : min_double(a, b)
 bi_fintrinsic(_min, min_float)
 
-float max_float(float x, float y) JL_NOTSAFEPOINT
+static float max_float(float x, float y) JL_NOTSAFEPOINT
 {
     float diff = x - y;
     float argmax = signbit(diff) ? y : x;
@@ -1413,7 +1414,7 @@ float max_float(float x, float y) JL_NOTSAFEPOINT
     return is_nan ? diff : argmax;
 }
 
-double max_double(double x, double y) JL_NOTSAFEPOINT
+static double max_double(double x, double y) JL_NOTSAFEPOINT
 {
     double diff = x - y;
     double argmax = signbit(diff) ? y : x;
@@ -1743,7 +1744,6 @@ un_fintrinsic(trunc_float,trunc_llvm)
 un_fintrinsic(rint_float,rint_llvm)
 un_fintrinsic(sqrt_float,sqrt_llvm)
 un_fintrinsic(sqrt_float,sqrt_llvm_fast)
-jl_value_t *jl_cpu_has_fma(int bits);
 
 JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *typ)
 {

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -126,7 +126,7 @@ void jl_safepoint_init(void)
     jl_safepoint_pages = addr;
 }
 
-void jl_gc_wait_for_the_world(jl_ptls_t* gc_all_tls_states, int gc_n_threads)
+extern void jl_gc_wait_for_the_world(jl_ptls_t* gc_all_tls_states, int gc_n_threads)
 {
     JL_TIMING(GC, GC_Stop);
 #ifdef USE_TRACY

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -95,9 +95,6 @@ void jl_init_threadinginfra(void)
     }
 }
 
-
-void JL_NORETURN jl_finish_task(jl_task_t *ct);
-
 // thread function: used by all mutator threads except the main thread
 void jl_threadfun(void *arg)
 {
@@ -240,7 +237,7 @@ static void wake_libuv(void) JL_NOTSAFEPOINT
     JULIA_DEBUG_SLEEPWAKE( io_wakeup_leave = cycleclock() );
 }
 
-void wakeup_thread(jl_task_t *ct, int16_t tid) JL_NOTSAFEPOINT { // Pass in ptls when we have it already available to save a lookup
+static void wakeup_thread(jl_task_t *ct, int16_t tid) JL_NOTSAFEPOINT { // Pass in ptls when we have it already available to save a lookup
     int16_t self = jl_atomic_load_relaxed(&ct->tid);
     if (tid != self)
         jl_fence(); // [^store_buffering_1]
@@ -388,8 +385,6 @@ static int check_empty(jl_value_t *checkempty)
 }
 
 jl_task_t *wait_empty JL_GLOBALLY_ROOTED;
-void jl_wait_empty_begin(void);
-void jl_wait_empty_end(void);
 
 void jl_task_wait_empty(void)
 {

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -218,9 +218,6 @@ JL_DLLEXPORT int jl_profile_is_buffer_full(void)
     return profile_bt_size_cur + ((JL_BT_MAX_ENTRY_SIZE + 1) + 6) > profile_bt_size_max;
 }
 
-NOINLINE int failed_to_sample_task_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
-NOINLINE int failed_to_stop_thread_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
-
 #define PROFILE_TASK_DEBUG_FORCE_SAMPLING_FAILURE (0)
 #define PROFILE_TASK_DEBUG_FORCE_STOP_THREAD_FAILURE (0)
 
@@ -381,7 +378,7 @@ JL_DLLEXPORT void jl_exit_on_sigint(int on)
 }
 
 static uintptr_t jl_get_pc_from_ctx(const void *_ctx);
-void jl_fprint_sigill(ios_t *s, void *_ctx);
+static void jl_fprint_sigill(ios_t *s, void *_ctx);
 #if defined(_CPU_X86_64_) || defined(_CPU_X86_) \
     || (defined(_OS_LINUX_) && defined(_CPU_AARCH64_)) \
     || (defined(_OS_LINUX_) && defined(_CPU_ARM_)) \
@@ -591,7 +588,7 @@ static uintptr_t jl_get_pc_from_ctx(const void *_ctx)
 #endif
 }
 
-void jl_fprint_sigill(ios_t *s, void *_ctx)
+static void jl_fprint_sigill(ios_t *s, void *_ctx)
 {
     char *pc = (char*)jl_get_pc_from_ctx(_ctx);
     // unsupported platform
@@ -681,8 +678,6 @@ void jl_fprint_sigill(ios_t *s, void *_ctx)
     (void)_ctx;
 #endif
 }
-
-void surprise_wakeup(jl_ptls_t ptls) JL_NOTSAFEPOINT;
 
 // make it invalid for a task to return from this point to its stack
 // this is generally quite a foolish operation, but does free you up to do

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -47,8 +47,7 @@ static const size_t sig_stack_size = 8 * 1024 * 1024;
 #include "julia_assert.h"
 
 // helper function for returning the unw_context_t inside a ucontext_t
-// (also used by stackwalk.c)
-bt_context_t *jl_to_bt_context(void *sigctx) JL_NOTSAFEPOINT
+static bt_context_t *jl_to_bt_context(void *sigctx) JL_NOTSAFEPOINT
 {
 #ifdef __APPLE__
     return (bt_context_t*)&((ucontext64_t*)sigctx)->uc_mcontext64->__ss;
@@ -65,8 +64,6 @@ bt_context_t *jl_to_bt_context(void *sigctx) JL_NOTSAFEPOINT
 
 static int thread0_exit_count = 0;
 static void jl_exit_thread0(int signo, jl_bt_element_t *bt_data, size_t bt_size);
-
-int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT;
 static void jl_longjmp_in_ctx(int sig, void *_ctx, jl_jmp_buf jmpbuf);
 
 #if !defined(_OS_DARWIN_)

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -139,9 +139,9 @@ void restore_signals(void)
     SetConsoleCtrlHandler(NULL, 0);
 }
 
-int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c);
+int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT;
 
-static void jl_throw_in_ctx(jl_task_t *ct, jl_value_t *excpt, PCONTEXT ctxThread)
+static void jl_throw_in_ctx(jl_task_t *ct, jl_value_t *excpt, PCONTEXT ctxThread) JL_NOTSAFEPOINT
 {
     jl_jmp_buf *saferestore = jl_get_safe_restore();
     if (saferestore) { // restarting jl_ or profile

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -231,7 +231,7 @@ NOINLINE size_t rec_backtrace(jl_bt_element_t *bt_data, size_t maxsize, int skip
     return bt_size;
 }
 
-NOINLINE int failed_to_sample_task_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT
+JL_DLLEXPORT NOINLINE int failed_to_sample_task_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT
 {
     if (maxsize < 1) {
         return 0;
@@ -240,7 +240,7 @@ NOINLINE int failed_to_sample_task_fun(jl_bt_element_t *bt_data, size_t maxsize,
     return 1;
 }
 
-NOINLINE int failed_to_stop_thread_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT
+JL_DLLEXPORT NOINLINE int failed_to_stop_thread_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT
 {
     if (maxsize < 1) {
         return 0;
@@ -1117,8 +1117,6 @@ _os_ptr_munge(uintptr_t ptr) JL_NOTSAFEPOINT
 #endif
 
 
-extern bt_context_t *jl_to_bt_context(void *sigctx) JL_NOTSAFEPOINT;
-
 // Some notes: this simulates a longjmp call occurring in context `c`, as if the
 // user was to set the PC in `c` to call longjmp and the PC in the longjmp to
 // return here. This helps work around many cases where siglongjmp out of a
@@ -1518,7 +1516,7 @@ JL_DLLEXPORT jl_record_backtrace_result_t jl_record_backtrace(jl_task_t *t, jl_b
 //--------------------------------------------------
 // Tools for interactive debugging in gdb
 
-JL_DLLEXPORT void jl_gdblookup(void* ip)
+JL_DLLEXPORT void jl_gdblookup(void* ip) JL_NOTSAFEPOINT
 {
     jl_fprint_native_codeloc(ios_safe_stderr, (uintptr_t)ip);
 }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2389,9 +2389,6 @@ static void jl_prune_binding_backedges(jl_array_t *backedges)
     jl_array_del_end(backedges, n - ins);
 }
 
-uint_t bindingkey_hash(size_t idx, jl_value_t *data);
-uint_t speccache_hash(size_t idx, jl_value_t *data);
-
 static void jl_prune_idset(_Atomic(jl_svec_t*) *pkeys, _Atomic(jl_genericmemory_t*) *pkeyset, uint_t (*key_hash)(size_t, jl_value_t*), jl_value_t *parent) JL_GC_DISABLED
 {
     jl_svec_t *keys = jl_atomic_load_relaxed(pkeys);
@@ -3570,9 +3567,6 @@ JL_DLLEXPORT jl_image_buf_t jl_set_sysimg_so(void *handle)
 //     return jl_subtype((jl_value_t*)a, (jl_value_t*)b) && jl_subtype((jl_value_t*)b, (jl_value_t*)a);
 // }
 #endif
-
-extern void export_jl_small_typeof(void);
-extern void export_jl_sysimg_globals(void);
 
 // When an image is loaded with ignore_native, all subsequent image loads must ignore
 // native code in the cache-file since we can't gurantuee that there are no call edges

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -249,6 +249,8 @@ static jl_varbinding_t *lookup_binding(jl_stenv_t *e, jl_tvar_t *v, int *innerva
     }
     return NULL;
 }
+#else
+extern jl_varbinding_t *lookup_binding(jl_stenv_t *e, jl_tvar_t *v, int *innervar) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT;
 #endif
 jl_varbinding_t *lookup_binding(jl_stenv_t *e, jl_tvar_t *v, int *innervar) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT;
 
@@ -812,7 +814,6 @@ int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity) JL_NOTSAFE
     return 0;
 }
 
-jl_value_t *simple_union(jl_value_t *a, jl_value_t *b);
 // compute a least upper bound of `a` and `b`
 static jl_value_t *simple_join(jl_value_t *a, jl_value_t *b)
 {
@@ -840,7 +841,6 @@ static jl_value_t *simple_join(jl_value_t *a, jl_value_t *b)
     return simple_union(a, b);
 }
 
-jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi);
 // Compute a greatest lower bound of `a` and `b`
 // For the subtype path, we need to over-estimate this by returning `b` in many cases.
 // But for `merge_env`, we'd better under-estimate and return a `Union{}`
@@ -7052,7 +7052,7 @@ static int num_occurs(jl_tvar_t *v, jl_typeenv_t *env)
     return 0;
 }
 
-int tuple_cmp_typeofbottom(jl_datatype_t *a, jl_datatype_t *b)
+static int tuple_cmp_typeofbottom(jl_datatype_t *a, jl_datatype_t *b)
 {
     size_t i, la = jl_nparams(a), lb = jl_nparams(b);
     for (i = 0; i < la || i < lb; i++) {

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -120,9 +120,6 @@ typedef intptr_t ssize_t;
 #define STATIC_INLINE static inline
 #define FORCE_INLINE static inline __attribute__((always_inline))
 
-#define EXTERN_INLINE_DECLARE inline __attribute__ ((visibility("default")))
-#define EXTERN_INLINE_DEFINE extern inline JL_DLLEXPORT
-
 #if defined(_OS_WINDOWS_) && !defined(_COMPILER_GCC_)
 #  define NOINLINE __declspec(noinline)
 #  define NOINLINE_DECL(f) __declspec(noinline) f

--- a/src/support/htable.h
+++ b/src/support/htable.h
@@ -49,13 +49,13 @@ int HTNAME##_has(htable_t *h, void *key) JL_NOTSAFEPOINT;               \
 int HTNAME##_remove(htable_t *h, void *key) JL_NOTSAFEPOINT;            \
 void **HTNAME##_bp(htable_t *h, void *key) JL_NOTSAFEPOINT;
 
-#define HTPROT_R(HTNAME)                                                                \
-void *HTNAME##_get_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;                \
-void HTNAME##_put_r(htable_t *h, void *key, void *val, void *ctx) JL_NOTSAFEPOINT;      \
-void HTNAME##_adjoin_r(htable_t *h, void *key, void *val, void *ctx) JL_NOTSAFEPOINT;   \
-int HTNAME##_has_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;                  \
-int HTNAME##_remove_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;               \
-void **HTNAME##_bp_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;
+#define HTPROT_R(HTNAME, _STATIC)                                                               \
+_STATIC void *HTNAME##_get_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;                \
+_STATIC void HTNAME##_put_r(htable_t *h, void *key, void *val, void *ctx) JL_NOTSAFEPOINT;      \
+_STATIC void HTNAME##_adjoin_r(htable_t *h, void *key, void *val, void *ctx) JL_NOTSAFEPOINT;   \
+_STATIC int HTNAME##_has_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;                  \
+_STATIC int HTNAME##_remove_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;               \
+_STATIC void **HTNAME##_bp_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;
 
 #ifdef __cplusplus
 }

--- a/src/sys.c
+++ b/src/sys.c
@@ -624,30 +624,6 @@ JL_DLLEXPORT uint64_t jl_hrtime(void) JL_NOTSAFEPOINT
     return uv_hrtime();
 }
 
-// -- child process status --
-
-#if defined _OS_WINDOWS_
-/* Native Woe32 API.  */
-#include <process.h>
-#define waitpid(pid,statusp,options) _cwait (statusp, pid, WAIT_CHILD)
-#define WAIT_T int
-#define WTERMSIG(x) ((x) & 0xff) /* or: SIGABRT ?? */
-#define WCOREDUMP(x) 0
-#define WEXITSTATUS(x) (((x) >> 8) & 0xff) /* or: (x) ?? */
-#define WIFSIGNALED(x) (WTERMSIG (x) != 0) /* or: ((x) == 3) ?? */
-#define WIFEXITED(x) (WTERMSIG (x) == 0) /* or: ((x) != 3) ?? */
-#define WIFSTOPPED(x) 0
-#define WSTOPSIG(x) 0 //Is this correct?
-#endif
-
-int jl_process_exited(int status)      { return WIFEXITED(status); }
-int jl_process_signaled(int status)    { return WIFSIGNALED(status); }
-int jl_process_stopped(int status)     { return WIFSTOPPED(status); }
-
-int jl_process_exit_status(int status) { return WEXITSTATUS(status); }
-int jl_process_term_signal(int status) { return WTERMSIG(status); }
-int jl_process_stop_signal(int status) { return WSTOPSIG(status); }
-
 // -- access to std filehandles --
 
 JL_STREAM *JL_STDIN  = (JL_STREAM*)STDIN_FILENO;

--- a/src/task.c
+++ b/src/task.c
@@ -844,41 +844,6 @@ JL_DLLEXPORT void jl_rethrow_other(jl_value_t *e JL_MAYBE_UNROOTED)
     throw_internal(ct, NULL);
 }
 
-/* This is xoshiro256++ 1.0, used for tasklocal random number generation in Julia.
-   This implementation is intended for embedders and internal use by the runtime, and is
-   based on the reference implementation at https://prng.di.unimi.it
-
-   Credits go to David Blackman and Sebastiano Vigna for coming up with this PRNG.
-   They described xoshiro256++ in "Scrambled Linear Pseudorandom Number Generators",
-   ACM Trans. Math. Softw., 2021.
-
-   There is a pure Julia implementation in stdlib that tends to be faster when used from
-   within Julia, due to inlining and more aggressive architecture-specific optimizations.
-*/
-uint64_t jl_genrandom(uint64_t rngState[4]) JL_NOTSAFEPOINT
-{
-    uint64_t s0 = rngState[0];
-    uint64_t s1 = rngState[1];
-    uint64_t s2 = rngState[2];
-    uint64_t s3 = rngState[3];
-
-    uint64_t t = s1 << 17;
-    uint64_t tmp = s0 + s3;
-    uint64_t res = ((tmp << 23) | (tmp >> 41)) + s0;
-    s2 ^= s0;
-    s3 ^= s1;
-    s1 ^= s2;
-    s0 ^= s3;
-    s2 ^= t;
-    s3 = (s3 << 45) | (s3 >> 19);
-
-    rngState[0] = s0;
-    rngState[1] = s1;
-    rngState[2] = s2;
-    rngState[3] = s3;
-    return res;
-}
-
 /*
 The jl_rng_split function forks a task's RNG state in a way that is essentially
 guaranteed to avoid collisions between the RNG streams of all tasks. The main

--- a/src/threading.c
+++ b/src/threading.c
@@ -65,7 +65,7 @@ static void jl_delete_thread(void*) JL_NOTSAFEPOINT_ENTER;
 static pthread_key_t jl_task_exit_key;
 static pthread_key_t jl_safe_restore_key;
 
-__attribute__((constructor)) void _jl_init_safe_restore(void)
+static __attribute__((constructor)) void _jl_init_safe_restore(void)
 {
     pthread_key_create(&jl_safe_restore_key, NULL);
     pthread_key_create(&jl_task_exit_key, jl_delete_thread);
@@ -280,9 +280,6 @@ static uv_mutex_t tls_lock; // controls write-access to these variables:
 _Atomic(jl_ptls_t*) jl_all_tls_states JL_GLOBALLY_ROOTED;
 int jl_all_tls_states_size;
 static uv_cond_t cond;
-// concurrent reads are permitted, using the same pattern as mtsmall_arraylist
-// it is implemented separately because the API of direct jl_all_tls_states use is already widely prevalent
-void jl_init_thread_scheduler(jl_ptls_t ptls) JL_NOTSAFEPOINT;
 
 // return calling thread's ID
 JL_DLLEXPORT int16_t jl_threadid(void)
@@ -487,10 +484,6 @@ void jl_safepoint_resume_all_threads(jl_task_t *ct)
             jl_safepoint_resume_thread(tid);
     };
 }
-
-void jl_task_frame_noreturn(jl_task_t *ct) JL_NOTSAFEPOINT;
-void scheduler_delete_thread(jl_ptls_t ptls) JL_NOTSAFEPOINT;
-void _jl_free_stack(jl_ptls_t ptls, void *stkbuf, size_t bufsz) JL_NOTSAFEPOINT;
 
 static void jl_delete_thread(void *value)
 {

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -286,7 +286,6 @@ static jl_value_t *jl_eval_dot_expr(jl_task_t *ct, jl_module_t *m, jl_value_t *x
     return args[0];
 }
 
-extern void check_safe_newbinding(jl_module_t *m, jl_sym_t *var);
 void jl_declare_global(jl_module_t *m, jl_value_t *arg, jl_value_t *set_type, int strong) {
     // create uninitialized mutable binding for "global x" decl sometimes or probably
     jl_module_t *gm;
@@ -493,7 +492,7 @@ int jl_is_toplevel_only_expr(jl_value_t *e) JL_NOTSAFEPOINT
          ((jl_expr_t*)e)->head == jl_incomplete_sym);
 }
 
-int jl_needs_lowering(jl_value_t *e) JL_NOTSAFEPOINT
+static int jl_needs_lowering(jl_value_t *e) JL_NOTSAFEPOINT
 {
     if (!jl_is_expr(e))
         return 0;

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -612,11 +612,8 @@ static int jl_typemap_intersection_node_visitor(jl_typemap_entry_t *ml, struct t
     return 1;
 }
 
-int jl_has_intersect_type_not_kind(jl_value_t *t);
-int jl_has_intersect_kind_not_type(jl_value_t *t);
-
 // if TypeVar tv is used covariantly, it cannot be Union{}
-int has_covariant_var(jl_datatype_t *ttypes, jl_tvar_t *tv)
+static int has_covariant_var(jl_datatype_t *ttypes, jl_tvar_t *tv)
 {
     size_t i, l = jl_nparams(ttypes);
     for (i = 0; i < l; i++)

--- a/test/clangsa/StaticOrDeclaredTest.c
+++ b/test/clangsa/StaticOrDeclaredTest.c
@@ -1,0 +1,99 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// RUN: clang-tidy %s --checks=-*,julia-static-or-declared -load libStaticOrDeclaredPlugin%shlibext -- -I%julia_home/src -I%julia_home/src/support -I%julia_home/usr/include ${CLANGSA_FLAGS} ${CLANGSA_CXXFLAGS} ${CPPFLAGS} ${CFLAGS} -x c -std=c11 | FileCheck --check-prefixes=CHECK %s
+// RUN: clang-tidy %s --checks=-*,julia-static-or-declared -load libStaticOrDeclaredPlugin%shlibext -- -I%julia_home/src -I%julia_home/src/support -I%julia_home/usr/include ${CLANGSA_FLAGS} ${CLANGSA_CXXFLAGS} ${CPPFLAGS} ${CFLAGS} ${CXXFLAGS} -x c++ -std=c++11 | FileCheck --check-prefixes=CHECK,CHECK-CXX %s
+// RUN: clang-tidy %s --checks=-*,julia-static-or-declared -load libStaticOrDeclaredPlugin%shlibext -- --target=x86_64-w64-windows-gnu -I%julia_home/src -I%julia_home/src/support -x c -std=c11 | FileCheck --check-prefixes=CHECK %s
+//
+// Each flagged C++ type gets a fix-it that wraps it in an anonymous namespace.
+// The fixes are checked from the exported-fixes YAML (the source itself already
+// contains `namespace {` blocks, which would defeat a fixed-source CHECK).
+// RUN: clang-tidy %s --quiet --checks=-*,julia-static-or-declared -load libStaticOrDeclaredPlugin%shlibext --export-fixes=%t.yaml -- -I%julia_home/src -I%julia_home/src/support -I%julia_home/usr/include ${CLANGSA_FLAGS} ${CLANGSA_CXXFLAGS} ${CPPFLAGS} ${CFLAGS} ${CXXFLAGS} -x c++ -std=c++11
+// RUN: FileCheck --check-prefix=FIXYAML %s < %t.yaml
+
+// FIXYAML: Message:{{.*}}sod_vis_hidden
+// FIXYAML: ReplacementText: 'static '
+// FIXYAML: Message:{{.*}}sod_fwd_local
+// FIXYAML: ReplacementText: 'static '
+// FIXYAML: ReplacementText: 'static '
+// FIXYAML: Message:{{.*}}sod_orphan
+// FIXYAML: ReplacementText: 'static '
+// FIXYAML: Message:{{.*}}sod_extern_c
+// FIXYAML-NOT: ReplacementText
+// FIXYAML: Message:{{.*}}sod_LocalType
+// FIXYAML: ReplacementText: "namespace {\n"
+// FIXYAML: ReplacementText: "\n}  // anonymous namespace"
+// FIXYAML: Message:{{.*}}sod_LocalUnion
+// FIXYAML: ReplacementText: "namespace {\n"
+// FIXYAML: ReplacementText: "\n}  // anonymous namespace"
+// FIXYAML: Message:{{.*}}sod_Outer
+// FIXYAML: ReplacementText: "namespace {\n"
+// FIXYAML: ReplacementText: "\n}  // anonymous namespace"
+// FIXYAML: Message:{{.*}}sod_FwdDeclared
+// FIXYAML: ReplacementText: "namespace {\n"
+// FIXYAML: ReplacementText: "\n}  // anonymous namespace"
+// FIXYAML: ReplacementText: "namespace {\n"
+// FIXYAML: ReplacementText: "\n}  // anonymous namespace"
+// FIXYAML-NOT: ReplacementText: "namespace {\n"
+
+#include "StaticOrDeclaredTest.h"
+
+void sod_public(void) {} // CHECK-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+int sod_public_val(int x) { return x; } // CHECK-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+static int sod_static(int x) { return x + 1; } // CHECK-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+__attribute__((visibility("default"))) void sod_vis_default(void) {} // CHECK-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+__attribute__((visibility("hidden"))) void sod_vis_hidden(void) {} // CHECK: [[@LINE]]:44: warning: function 'sod_vis_hidden' has external linkage but is not declared in any header; declare it in a header or make it 'static'
+extern void sod_extern_marked(void) {} // CHECK-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+
+#ifdef _WIN32
+__declspec(dllexport) void sod_dllexport(void) {} // CHECK-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+#endif
+
+void sod_fwd_local(void);
+void sod_fwd_local(void) {} // CHECK: [[@LINE]]:6: warning: function 'sod_fwd_local' has external linkage but is not declared in any header; declare it in a header or make it 'static'
+
+int sod_orphan(int x) { return sod_static(x); } // CHECK: [[@LINE]]:5: warning: function 'sod_orphan' has external linkage but is not declared in any header; declare it in a header or make it 'static'
+
+void sod_redundant_hdr(void); // CHECK: [[@LINE]]:6: warning: function 'sod_redundant_hdr' is forward-declared in a source file rather than a header; move the declaration to a header or mark it 'extern'
+void sod_fwd_undef(void); // CHECK: [[@LINE]]:6: warning: function 'sod_fwd_undef' is forward-declared in a source file rather than a header; move the declaration to a header or mark it 'extern'
+extern void sod_fwd_extern(void); // CHECK-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+
+__attribute__((visibility("default"))) void sod_fwd_exported(void); // CHECK-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+__attribute__((visibility("default"))) void sod_fwd_exported_undef(void); // CHECK: [[@LINE]]:45: warning: function 'sod_fwd_exported_undef' is forward-declared in a source file rather than a header; move the declaration to a header or mark it 'extern'
+
+#ifdef __cplusplus
+void sod_HdrType::method() {} // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+namespace {
+void sod_anon(void) {} // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+}
+
+template <typename T> T sod_tmpl(T x) { return x; } // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+template int sod_tmpl<int>(int); // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+extern "C" void sod_extern_c(void) {} // CHECK-CXX: [[@LINE]]:17: warning: function 'sod_extern_c' has external linkage but is not declared in any header; declare it in a header or make it 'static'
+struct sod_FwdDeclared; // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+class sod_Opaque { int z; }; // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+struct sod_LocalType { int y; }; // CHECK-CXX: [[@LINE]]:8: warning: type 'sod_LocalType' has external linkage but is not declared in any header; declare it in a header or move it into an anonymous namespace
+union sod_LocalUnion { int u; float f; }; // CHECK-CXX: [[@LINE]]:7: warning: type 'sod_LocalUnion' has external linkage but is not declared in any header; declare it in a header or move it into an anonymous namespace
+namespace {
+struct sod_AnonType { int a; }; // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+}
+
+struct __attribute__((visibility("default"))) sod_ExportedType { int e; }; // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+
+struct sod_Outer { // CHECK-CXX: [[@LINE]]:8: warning: type 'sod_Outer' has external linkage but is not declared in any header; declare it in a header or move it into an anonymous namespace
+    struct sod_Inner { int i; }; // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+};
+
+static void sod_uses_local() {
+    struct sod_FnLocal { int l; }; // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+    (void)sizeof(sod_FnLocal);
+}
+
+template <typename T> struct sod_TmplType { T t; }; // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+template struct sod_TmplType<int>; // CHECK-CXX-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+
+struct sod_FwdDeclared { int f; }; // CHECK-CXX: [[@LINE]]:8: warning: type 'sod_FwdDeclared' has external linkage but is not declared in any header; declare it in a header or move it into an anonymous namespace
+#endif
+
+int main(void) { // CHECK-NOT: :[[@LINE]]:{{[0-9]+}}: warning
+    return sod_orphan(0) + sod_public_val(0);
+}

--- a/test/clangsa/StaticOrDeclaredTest.h
+++ b/test/clangsa/StaticOrDeclaredTest.h
@@ -1,0 +1,18 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// Public prototypes for StaticOrDeclaredTest: a function defined in the test
+// file whose prototype lives here is "declared in a header" and must not be
+// flagged by the julia-static-or-declared check.
+
+void sod_public(void);
+int sod_public_val(int x);
+void sod_redundant_hdr(void);
+__attribute__((visibility("default"))) void sod_fwd_exported(void) {}
+
+#ifdef __cplusplus
+struct sod_HdrType {
+    void method();
+};
+
+class sod_Opaque;
+#endif


### PR DESCRIPTION
Add a StaticOrDeclared clang-tidy check that enforces that every function with
external linkage defined in a source file is either:

  (a) declared in some header (i.e. it has a non-defining redeclaration that
      comes from an #included file, so the function is part of an API that
      other translation units can call), or
  (b) declared `static` (internal linkage), so it is private to its
      translation unit, or

  (c) explicitly exported with `JL_DLLEXPORT` -- i.e. it carries an explicit
      `__declspec(dllexport)` (on Windows) and/or
      `__attribute__((visibility("default")))` (elsewhere). Such a function
      is deliberately part of the public ABI even without a prototype, so it
      is permitted. Which attribute is present depends on the platform the
      analysis runs on, so both are accepted, or

  (d) explicitly annotated with the `extern` keyword in this file. Functions
      are external by default, so spelling out `extern` is a deliberate
      statement that the external linkage is intended, which overrides the
      warning. (This is the storage class `extern`, not the `extern "C"`
      language-linkage specifier.)

This is intended to help ensure we discourage local prototypes, which can drift out of sync with their global prototype. It also lets the compiler generate slightly better code optimizations (inlining decisions) and minimizes the list of exported symbols for the linker.