### PR TITLE
compiler: fix broken cycle backedges

### DIFF
--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -145,7 +145,7 @@ function add_one_edge!(edges::Vector{Any}, edge::CodeInstance)
                 # found edge we can upgrade
                 edges[i] = edge
                 return
-            elseif edgeᵢ_orig === edge || codeinst_edges_sub(edgeᵢ_orig, edge.min_world, edge.max_world, edge.edges)
+            elseif edgeᵢ_orig === edge || (isdefined(edge, :inferred) && codeinst_edges_sub(edgeᵢ_orig, edge.min_world, edge.max_world, edge.edges))
                 # existing CodeInstance is identical
                 return
             end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -184,13 +184,10 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
         time_now = _time_ns()
         time_self_ns = caller.time_self_ns + (time_now - time_before)
         time_total = (time_now - caller.time_start - caller.time_paused) * 1e-9
-        ccall(:jl_fill_codeinst, Cvoid, (Any, Any, Any, Any, Int32, UInt, UInt, UInt32, Any, Any, Any),
-            ci, widenconst(result_type), widenconst(result.exc_result), rettype_const, const_flags,
-            min_world, max_world,
-            ipo_effects, result.analysis_results, debuginfo, edges)
-        ccall(:jl_update_codeinst, Cvoid, (Any, Any, Int32, UInt, UInt, UInt32, Any, Float64, Float64, Float64, Any, Any),
-            ci, inferred_result, const_flag, min_world, max_world, ipo_effects,
-            result.analysis_results, time_total, caller.time_caches, time_self_ns * 1e-9, debuginfo, edges)
+        ccall(:jl_fill_codeinst, Cvoid, (Any, Any, Any, Any, Any, Int32, UInt, UInt, UInt32, Any, Float64, Float64, Float64, Any, Any),
+            ci, widenconst(result_type), widenconst(result.exc_result), rettype_const, inferred_result,
+            const_flags, min_world, max_world,
+            ipo_effects, result.analysis_results, time_total, caller.time_caches, time_self_ns * 1e-9, debuginfo, edges)
     elseif caller.cache_mode === CACHE_MODE_LOCAL
         result.src = transform_result_for_local_cache(interp, result)
     end
@@ -241,7 +238,6 @@ end
 function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstance, src::CodeInfo)
     user_edges = src.edges
     edges = user_edges isa SimpleVector ? user_edges : user_edges === nothing ? Core.svec() : Core.svec(user_edges...)
-    const_flag = false
     di = src.debuginfo
     rettype = Any
     exctype = Any
@@ -257,10 +253,8 @@ function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstan
         # we can now widen our applicability in the global cache too
         store_backedges(ci, edges)
     end
-    ccall(:jl_fill_codeinst, Cvoid, (Any, Any, Any, Any, Int32, UInt, UInt, UInt32, Any, Any, Any),
-        ci, rettype, exctype, nothing, const_flags, min_world, max_world, ipo_effects, nothing, di, edges)
-    ccall(:jl_update_codeinst, Cvoid, (Any, Any, Int32, UInt, UInt, UInt32, Any, Float64, Float64, Float64, Any, Any),
-        ci, nothing, const_flag, min_world, max_world, ipo_effects, nothing, 0.0, 0.0, 0.0, di, edges)
+    ccall(:jl_fill_codeinst, Cvoid, (Any, Any, Any, Any, Any, Int32, UInt, UInt, UInt32, Any, Float64, Float64, Float64, Any, Any),
+        ci, rettype, exctype, nothing, nothing, const_flags, min_world, max_world, ipo_effects, nothing, 0.0, 0.0, 0.0, di, edges)
     code_cache(interp)[mi] = ci
     codegen = codegen_cache(interp)
     if codegen !== nothing
@@ -1125,10 +1119,9 @@ function _schedule_edge_infer_task!(caller::AbsIntState, frame::InferenceState, 
         update_valid_age!(caller, get_inference_world(interp), frame.valid_worlds)
         isinferred = is_inferred(frame)
         effects = nothing
-        edge = nothing
         call_result = nothing
+        edge = result.ci
         if isinferred
-            edge = result.ci
             if edge_ci isa CodeInstance && codeinst_edges_sub(edge_ci, edge.min_world, edge.max_world, edge.edges)
                 edge = edge_ci # override the edge for tracking invalidation
             end
@@ -1263,7 +1256,8 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
     bestguess = frame.bestguess
     exc_bestguess = refine_exception_type(frame.exc_bestguess, effects)
     add_cycle_backedge!(caller, frame)
-    return Future(MethodCallResult(interp, caller, method, bestguess, exc_bestguess, effects, nothing, edgecycle, edgelimited))
+    result = frame.result
+    return Future(MethodCallResult(interp, caller, method, bestguess, exc_bestguess, effects, isdefined(result, :ci) ? result.ci : nothing, edgecycle, edgelimited))
 end
 
 # The `:terminates` effect bit must be conservatively tainted unless recursion cycle has

--- a/src/gf.c
+++ b/src/gf.c
@@ -684,37 +684,14 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
     return codeinst;
 }
 
-JL_DLLEXPORT void jl_update_codeinst(
-        jl_code_instance_t *codeinst, jl_value_t *inferred,
-        int32_t const_flags, size_t min_world, size_t max_world,
-        uint32_t effects, jl_value_t *analysis_results,
-        double time_infer_total, double time_infer_cache_saved, double time_infer_self,
-        jl_debuginfo_t *di, jl_svec_t *edges /* , int absolute_max*/)
-{
-    assert(min_world <= max_world && "attempting to set invalid world constraints");
-    //assert((!jl_is_method(codeinst->def->def.value) || max_world != ~(size_t)0 || min_world <= 1 || jl_svec_len(edges) != 0) && "missing edges");
-    jl_gc_write(codeinst, codeinst->analysis_results, jl_value_t, analysis_results);
-    codeinst->time_infer_total = julia_double_to_half(time_infer_total);
-    codeinst->time_infer_cache_saved = julia_double_to_half(time_infer_cache_saved);
-    codeinst->time_infer_self = julia_double_to_half(time_infer_self);
-    jl_atomic_store_relaxed(&codeinst->ipo_purity_bits, effects);
-    jl_gc_write_atomic(codeinst, codeinst->debuginfo, jl_debuginfo_t, di, relaxed);
-    jl_gc_write_atomic(codeinst, codeinst->edges, jl_svec_t, edges, relaxed);
-    if ((const_flags & 1) != 0) {
-        assert(codeinst->rettype_const);
-        jl_atomic_store_release(&codeinst->invoke, jl_fptr_const_return);
-    }
-    jl_gc_write_atomic(codeinst, codeinst->inferred, jl_value_t, inferred, release);
-    jl_atomic_store_relaxed(&codeinst->min_world, min_world); // XXX: these should be unchanged?
-    jl_atomic_store_relaxed(&codeinst->max_world, max_world); // since the edges shouldn't change after jl_fill_codeinst
-}
-
 JL_DLLEXPORT void jl_fill_codeinst(
         jl_code_instance_t *codeinst,
         jl_value_t *rettype, jl_value_t *exctype,
         jl_value_t *inferred_const,
+        jl_value_t *inferred,
         int32_t const_flags, size_t min_world, size_t max_world,
         uint32_t effects, jl_value_t *analysis_results,
+        double time_infer_total, double time_infer_cache_saved, double time_infer_self,
         jl_debuginfo_t *di, jl_svec_t *edges /* , int absolute_max*/)
 {
     assert(min_world <= max_world && "attempting to set invalid world constraints");
@@ -724,20 +701,21 @@ JL_DLLEXPORT void jl_fill_codeinst(
     if ((const_flags & 2) != 0) {
         jl_gc_write(codeinst, codeinst->rettype_const, jl_value_t, inferred_const);
     }
+    jl_gc_write(codeinst, codeinst->analysis_results, jl_value_t, analysis_results);
+    codeinst->time_infer_total = julia_double_to_half(time_infer_total);
+    codeinst->time_infer_cache_saved = julia_double_to_half(time_infer_cache_saved);
+    codeinst->time_infer_self = julia_double_to_half(time_infer_self);
+    jl_atomic_store_relaxed(&codeinst->ipo_purity_bits, effects);
+    jl_gc_write_atomic(codeinst, codeinst->debuginfo, jl_debuginfo_t, di, relaxed);
     jl_gc_write_atomic(codeinst, codeinst->edges, jl_svec_t, edges, relaxed);
-    if ((jl_value_t*)di != jl_nothing) {
-        jl_gc_write_atomic(codeinst, codeinst->debuginfo, jl_debuginfo_t, di, relaxed);
-    }
     if ((const_flags & 1) != 0) {
         // TODO: may want to follow ordering restrictions here (see jitlayers.cpp)
         assert(const_flags & 2);
         jl_atomic_store_release(&codeinst->invoke, jl_fptr_const_return);
     }
-    jl_atomic_store_relaxed(&codeinst->ipo_purity_bits, effects);
-    jl_gc_write(codeinst, codeinst->analysis_results, jl_value_t, analysis_results);
     assert(jl_atomic_load_relaxed(&codeinst->min_world) == 1);
     assert(jl_atomic_load_relaxed(&codeinst->max_world) == 0);
-    jl_gc_write_atomic(codeinst, codeinst->inferred, jl_value_t, jl_nothing, release);
+    jl_gc_write_atomic(codeinst, codeinst->inferred, jl_value_t, inferred, relaxed);
     jl_atomic_store_release(&codeinst->min_world, min_world);
     jl_atomic_store_release(&codeinst->max_world, max_world);
 }
@@ -745,7 +723,7 @@ JL_DLLEXPORT void jl_fill_codeinst(
 JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst_uninit(jl_method_instance_t *mi, jl_value_t *owner)
 {
     jl_code_instance_t *codeinst = jl_new_codeinst(mi, owner, NULL, NULL, NULL, NULL, 0, 0, 0, 0, NULL, NULL, NULL);
-    jl_atomic_store_relaxed(&codeinst->min_world, 1); // make temporarily invalid before returning, so that jl_fill_codeinst is valid later
+    jl_atomic_store_relaxed(&codeinst->min_world, 1); // sentinel: temporarily invalid so jl_fill_codeinst can assert correct initial state
     return codeinst;
 }
 

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -627,3 +627,17 @@ let
     @test rettype_side_effect == "blah"
     ccall(:strlen, rettype_with_side_effect(), (Cstring,), "xx")
 end
+
+# issue #62022 - missing invalidation with CI equivalence swaps during expansive recursion
+# When inference hits recursion limits and reuses cached CIs, the swapped CIs must have
+# proper edges/backedges so that subsequent method additions correctly invalidate them.
+struct W62022{T}; x::T; end
+@noinline leaf62022() = true
+# grow the type up to a fixed limit (inference's recursion limits will trigger first)
+@noinline foo62022(w::W62022)::Bool = foo62022(W62022(w))
+@noinline foo62022(::W62022{W62022{W62022{W62022{W62022{W62022{T}}}}}}) where {T} = leaf62022()
+@test foo62022(W62022(1)) === true # trigger compilation
+# add a new method that bottoms out the recursion earlier, but after the limit
+@noinline foo62022(::W62022{W62022{W62022{W62022{Int}}}}) = false
+@test foo62022(W62022(1)) === false # test for invalidation
+@test foo62022(W62022(W62022(W62022(1)))) === false


### PR DESCRIPTION
Return computed call edges even for recursive calls. These aren't converged during `finishinfer!` (which is also likely feasible, but hard to do correctly), so we need to make sure that the backedges are stored when we first encounter the call.

Fixes #62022