### PR TITLE
jitlink: Retarget external symbol renames

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2250,8 +2250,6 @@ renameLinkGraphSymbol(jitlink::LinkGraph &G, jitlink::Symbol &Sym,
         Dest->setTargetFlags(Dest->getTargetFlags() | Sym.getTargetFlags());
     }
     retargetLinkGraphEdges(G, Sym, *Dest);
-    if (Dest != &Sym)
-        G.removeExternalSymbol(Sym);
     return Dest;
 }
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2250,6 +2250,20 @@ static void retargetLinkGraphEdges(jitlink::LinkGraph &G, jitlink::Symbol &From,
 }
 
 static jitlink::Symbol *
+makeAnonymousLinkGraphSymbol(jitlink::LinkGraph &G,
+                             jitlink::Symbol &Sym) JL_NOTSAFEPOINT
+{
+    assert(Sym.isDefined());
+    auto &Anon = G.addAnonymousSymbol(Sym.getBlock(), Sym.getOffset(),
+                                      Sym.getSize(), Sym.isCallable(),
+                                      Sym.isLive());
+    Anon.setTargetFlags(Sym.getTargetFlags());
+    retargetLinkGraphEdges(G, Sym, Anon);
+    G.removeDefinedSymbol(Sym);
+    return &Anon;
+}
+
+static jitlink::Symbol *
 renameLinkGraphSymbol(jitlink::LinkGraph &G, jitlink::Symbol &Sym,
                       const orc::SymbolStringPtr &Name) JL_NOTSAFEPOINT
 {
@@ -2290,6 +2304,9 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
         assert(It != Syms.end());
         It->second = renameLinkGraphSymbol(G, *It->second, Dest);
     };
+    SmallSet<SymbolStringPtr, 2> OwnedSyms;
+    for (auto &KV : MR.getSymbols())
+        OwnedSyms.insert(KV.first);
     for (auto &[CI, Funcs] : Info->ci_funcs) {
         auto &S = CISymbols.at(CI);
         if (Funcs.invoke)
@@ -2304,11 +2321,41 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
         auto It = Syms.find(T);
         if (It == Syms.end())
             continue;
+        if (!It->second->isExternal()) {
+            // Non-primary call target bodies are local copies. Keep them out
+            // of ORC's public symbols instead of publishing duplicate CI
+            // definitions under the target's global name.
+            if (!OwnedSyms.contains(It->second->getName()))
+                It->second = makeAnonymousLinkGraphSymbol(G, *It->second);
+            continue;
+        }
         JL_GC_PROMISE_ROOTED(CI);
         auto Dest = linkCallTarget(MR, CI, API);
         if (!Dest)
             return false;
+        if (auto *DestSym = findLinkGraphSymbolByName(G, Dest);
+            DestSym && !DestSym->isExternal() && !OwnedSyms.contains(Dest))
+            makeAnonymousLinkGraphSymbol(G, *DestSym);
         It->second = renameLinkGraphSymbol(G, *It->second, Dest);
+    }
+    SmallSet<SymbolStringPtr, 0> KnownCISyms;
+    for (auto &KV : CISymbols) {
+        auto &S = KV.second;
+        if (S.invoke)
+            KnownCISyms.insert(S.invoke);
+        if (S.specptr)
+            KnownCISyms.insert(S.specptr);
+    }
+    SmallVector<jitlink::Symbol *, 0> DefinedSyms;
+    for (auto *Sym : G.defined_symbols())
+        DefinedSyms.push_back(Sym);
+    // Another thread may have claimed a CI after this module was emitted but
+    // before this materialization unit registered its interface. Any body that
+    // remains in this graph for that CI must not be exported here.
+    for (auto *Sym : DefinedSyms) {
+        if (Sym->hasName() && KnownCISyms.contains(Sym->getName()) &&
+            !OwnedSyms.contains(Sym->getName()))
+            makeAnonymousLinkGraphSymbol(G, *Sym);
     }
 
     // Rename globals and add mappings

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2226,15 +2226,15 @@ static void retargetLinkGraphEdges(jitlink::LinkGraph &G, jitlink::Symbol &From,
     jitlink::visitExistingEdges(G, RetargetEdgeVisitor{From, To});
 }
 
-static void
+static jitlink::Symbol *
 renameLinkGraphSymbol(jitlink::LinkGraph &G, jitlink::Symbol &Sym,
                       const orc::SymbolStringPtr &Name) JL_NOTSAFEPOINT
 {
     if (Sym.getName() == Name)
-        return;
+        return &Sym;
     if (!Sym.isExternal()) {
         Sym.setName(Name);
-        return;
+        return &Sym;
     }
     // External symbols are keyed by name inside LinkGraph, so retarget rather
     // than renaming in place and leaving the external symbol map stale.
@@ -2244,7 +2244,15 @@ renameLinkGraphSymbol(jitlink::LinkGraph &G, jitlink::Symbol &Sym,
         Dest->setCallable(Sym.isCallable());
         Dest->setTargetFlags(Sym.getTargetFlags());
     }
+    else if (Dest->isExternal()) {
+        Dest->setWeaklyReferenced(Dest->isWeaklyReferenced() && Sym.isWeaklyReferenced());
+        Dest->setCallable(Dest->isCallable() || Sym.isCallable());
+        Dest->setTargetFlags(Dest->getTargetFlags() | Sym.getTargetFlags());
+    }
     retargetLinkGraphEdges(G, Sym, *Dest);
+    if (Dest != &Sym)
+        G.removeExternalSymbol(Sym);
+    return Dest;
 }
 
 bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferRef ObjBuf,
@@ -2257,7 +2265,9 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
     // Rename the defined CI functions.
     auto RenameDef = [&](const SymbolStringPtr &Orig, const SymbolStringPtr &Dest)
                              JL_NOTSAFEPOINT {
-        renameLinkGraphSymbol(G, *Syms.at(Orig), Dest);
+        auto It = Syms.find(Orig);
+        assert(It != Syms.end());
+        It->second = renameLinkGraphSymbol(G, *It->second, Dest);
     };
     for (auto &[CI, Funcs] : Info->ci_funcs) {
         auto &S = CISymbols.at(CI);
@@ -2270,13 +2280,14 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
     // Rename referenced CIs in the workqueue.
     for (auto &[Call, T] : Info->call_targets) {
         auto [CI, API] = Call;
-        if (!Syms.contains(T))
+        auto It = Syms.find(T);
+        if (It == Syms.end())
             continue;
         JL_GC_PROMISE_ROOTED(CI);
         auto Dest = linkCallTarget(MR, CI, API);
         if (!Dest)
             return false;
-        renameLinkGraphSymbol(G, *Syms.at(T), Dest);
+        It->second = renameLinkGraphSymbol(G, *It->second, Dest);
     }
 
     // Rename globals and add mappings
@@ -2296,7 +2307,7 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
         auto It = Syms.find(Orig);
         if (It == Syms.end())
             continue;
-        renameLinkGraphSymbol(G, *It->second, Sym);
+        It->second = renameLinkGraphSymbol(G, *It->second, Sym);
         Ptrs[i] = Addr;
         GlobalSyms[Sym] = {ExecutorAddr::fromPtr(Ptrs + i), JITSymbolFlags::Exported};
         ++i;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -796,21 +796,12 @@ public:
                           jitlink::LinkGraph &,
                           jitlink::PassConfiguration &Config) override {
         Config.PostAllocationPasses.push_back([this](jitlink::LinkGraph &G) {
+            // `G.blocks()` is exactly the union of the sections' blocks, so a
+            // single pass over the (non-EH-frame) sections counts every block
+            // once; `graph_size == code_size + data_size`
             size_t graph_size = 0;
             size_t code_size = 0;
             size_t data_size = 0;
-            DenseSet<jitlink::Block *> SkippedBlocks;
-            for (auto &section : G.sections()) {
-                if (!isJITLinkEHFrameSection(section.getName()))
-                    continue;
-                for (auto block : section.blocks())
-                    SkippedBlocks.insert(block);
-            }
-            for (auto block : G.blocks()) {
-                if (SkippedBlocks.contains(block))
-                    continue;
-                graph_size += block->getSize();
-            }
             for (auto &section : G.sections()) {
                 if (isJITLinkEHFrameSection(section.getName()))
                     continue;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -657,6 +657,14 @@ void jl_register_jit_object(const object::ObjectFile &Object,
                             std::function<uint64_t(const StringRef &)> getLoadAddress,
                             const jl_linker_info_t &Info);
 
+static bool isJITLinkEHFrameSection(StringRef Name) JL_NOTSAFEPOINT
+{
+    // EH-frame sections are handled by the EH-frame registration plugin. Its
+    // post-allocation graph state is not suitable for generic section range
+    // walks here.
+    return Name == ".eh_frame" || Name == "__eh_frame" || Name.ends_with(",__eh_frame");
+}
+
 void JLDebuginfoPlugin::notifyMaterializingWithInfo(
     orc::MaterializationResponsibility &MR, jitlink::LinkGraph &G,
     MemoryBufferRef InputObject, std::unique_ptr<jl_linker_info_t> LinkerInfo)
@@ -750,8 +758,12 @@ void JLDebuginfoPlugin::modifyPassConfig(MaterializationResponsibility &MR, jitl
 #else
             auto SecName = Sec.getName();
 #endif
+            if (isJITLinkEHFrameSection(SecName))
+                continue;
+            if (Sec.blocks().empty())
+                continue;
             // https://github.com/llvm/llvm-project/commit/118e953b18ff07d00b8f822dfbf2991e41d6d791
-           Info.SectionLoadAddresses[SecName] = jitlink::SectionRange(Sec).getStart().getValue();
+            Info.SectionLoadAddresses[SecName] = jitlink::SectionRange(Sec).getStart().getValue();
         }
         return Error::success();
     });
@@ -787,10 +799,21 @@ public:
             size_t graph_size = 0;
             size_t code_size = 0;
             size_t data_size = 0;
+            DenseSet<jitlink::Block *> SkippedBlocks;
+            for (auto &section : G.sections()) {
+                if (!isJITLinkEHFrameSection(section.getName()))
+                    continue;
+                for (auto block : section.blocks())
+                    SkippedBlocks.insert(block);
+            }
             for (auto block : G.blocks()) {
+                if (SkippedBlocks.contains(block))
+                    continue;
                 graph_size += block->getSize();
             }
             for (auto &section : G.sections()) {
+                if (isJITLinkEHFrameSection(section.getName()))
+                    continue;
                 size_t secsize = 0;
                 for (auto block : section.blocks()) {
                     secsize += block->getSize();

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2194,6 +2194,59 @@ linkGraphSymbols(jitlink::LinkGraph &G) JL_NOTSAFEPOINT
     return Syms;
 }
 
+static jitlink::Symbol *
+findLinkGraphSymbolByName(jitlink::LinkGraph &G,
+                          const orc::SymbolStringPtr &Name) JL_NOTSAFEPOINT
+{
+    if (auto *Sym = G.findDefinedSymbolByName(Name))
+        return Sym;
+    if (auto *Sym = G.findExternalSymbolByName(Name))
+        return Sym;
+    if (auto *Sym = G.findAbsoluteSymbolByName(Name))
+        return Sym;
+    return nullptr;
+}
+
+static void retargetLinkGraphEdges(jitlink::LinkGraph &G, jitlink::Symbol &From,
+                                   jitlink::Symbol &To) JL_NOTSAFEPOINT
+{
+    struct RetargetEdgeVisitor {
+        jitlink::Symbol &From;
+        jitlink::Symbol &To;
+
+        bool visitEdge(jitlink::LinkGraph &, jitlink::Block *,
+                       jitlink::Edge &Edge) JL_NOTSAFEPOINT
+        {
+            if (&Edge.getTarget() != &From)
+                return false;
+            Edge.setTarget(To);
+            return true;
+        }
+    };
+    jitlink::visitExistingEdges(G, RetargetEdgeVisitor{From, To});
+}
+
+static void
+renameLinkGraphSymbol(jitlink::LinkGraph &G, jitlink::Symbol &Sym,
+                      const orc::SymbolStringPtr &Name) JL_NOTSAFEPOINT
+{
+    if (Sym.getName() == Name)
+        return;
+    if (!Sym.isExternal()) {
+        Sym.setName(Name);
+        return;
+    }
+    // External symbols are keyed by name inside LinkGraph, so retarget rather
+    // than renaming in place and leaving the external symbol map stale.
+    auto *Dest = findLinkGraphSymbolByName(G, Name);
+    if (!Dest) {
+        Dest = &G.addExternalSymbol(Name, Sym.getSize(), Sym.isWeaklyReferenced());
+        Dest->setCallable(Sym.isCallable());
+        Dest->setTargetFlags(Sym.getTargetFlags());
+    }
+    retargetLinkGraphEdges(G, Sym, *Dest);
+}
+
 bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferRef ObjBuf,
                            jitlink::LinkGraph &G, std::unique_ptr<jl_linker_info_t> Info)
 {
@@ -2203,7 +2256,9 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
 
     // Rename the defined CI functions.
     auto RenameDef = [&](const SymbolStringPtr &Orig, const SymbolStringPtr &Dest)
-                             JL_NOTSAFEPOINT { Syms.at(Orig)->setName(Dest); };
+                             JL_NOTSAFEPOINT {
+        renameLinkGraphSymbol(G, *Syms.at(Orig), Dest);
+    };
     for (auto &[CI, Funcs] : Info->ci_funcs) {
         auto &S = CISymbols.at(CI);
         if (Funcs.invoke)
@@ -2221,7 +2276,7 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
         auto Dest = linkCallTarget(MR, CI, API);
         if (!Dest)
             return false;
-        Syms.at(T)->setName(Dest);
+        renameLinkGraphSymbol(G, *Syms.at(T), Dest);
     }
 
     // Rename globals and add mappings
@@ -2241,7 +2296,7 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
         auto It = Syms.find(Orig);
         if (It == Syms.end())
             continue;
-        It->second->setName(Sym);
+        renameLinkGraphSymbol(G, *It->second, Sym);
         Ptrs[i] = Addr;
         GlobalSyms[Sym] = {ExecutorAddr::fromPtr(Ptrs + i), JITSymbolFlags::Exported};
         ++i;

--- a/test/jit.jl
+++ b/test/jit.jl
@@ -54,6 +54,25 @@ ci = compile_no_deps(M2.bar, (Int,))
 @test check_edges_not_compiled(ci, M2.foo)
 @test invoke(M2.bar, ci, 5) == 210
 
+# External symbol renames must keep JITLink's external symbol map consistent.
+@testset "JITLink external symbol rename" begin
+    jitlink_rename_resolve(chunks, i, x) =
+        jitlink_rename_resolve(Base.tail(chunks), i,
+            map(tuple, x, i[1] === Colon() ? (1, (), 1) : (1, 1, ())))
+    jitlink_rename_resolve(::Tuple{}, i, x) = x
+    function jitlink_rename_reproducer(i)
+        x = jitlink_rename_resolve(Base.inferencebarrier(true) ? (1,) :
+            map(+, Tuple([]), (1, 1)), i, ((), (), ()))
+        y = x[1] == x[1] ? :a : :b
+        if y === :a; elseif y === :b
+            jitlink_rename_reproducer(x[3])
+        else
+            0[x[2]]
+        end
+    end
+    @test precompile(jitlink_rename_reproducer, (Tuple{Colon},))
+end
+
 # Each `eval` must compile (because of the ccall) a top-level thunk.  The
 # CodeInstance for this thunk becomes garbage-collectable after being invoked,
 # but before returning, because of wait().  If the invoke must return for the

--- a/test/jit.jl
+++ b/test/jit.jl
@@ -63,7 +63,7 @@ ci = compile_no_deps(M2.bar, (Int,))
     function jitlink_rename_reproducer(i)
         x = jitlink_rename_resolve(Base.inferencebarrier(true) ? (1,) :
             map(+, Tuple([]), (1, 1)), i, ((), (), ()))
-        y = x[1] == x[1] ? :a : :b
+        y = Base.inferencebarrier(true) ? :a : :b
         if y === :a; elseif y === :b
             jitlink_rename_reproducer(x[3])
         else


### PR DESCRIPTION
JITLink stores external symbols in a name-keyed map, so renaming an external symbol in place can leave the graph's external symbol table stale. Retarget edges to a destination symbol instead, while keeping direct renames for non-external symbols.

The included regression test does not fail on master. It needs the inference/codegen improvements from the TypeEgal branch to exercise this stale external-symbol path.