### PR TITLE
Aggressively propagate constant bases through `ndigits` and `string(::Integer)`

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1066,8 +1066,8 @@ function _base(base::Integer, x::Integer, pad::Int, neg::Bool)
     return str
 end
 
-split_sign(n::Integer) = unsigned(abs(n)), n < 0
-split_sign(n::Unsigned) = n, false
+split_sign(n::Integer) = (unsigned(abs(n)), n < 0)
+split_sign(n::Unsigned) = (n, false)
 
 """
     string(n::Integer; base::Integer = 10, pad::Integer = 1)
@@ -1096,6 +1096,7 @@ julia> @sprintf("%4i", 5)
 ```
 """
 function string(n::Integer; base::Integer = 10, pad::Integer = 1)
+    @constprop :aggressive
     pad = (min(max(pad, typemin(Int)), typemax(Int)) % Int)::Int
     if base == 2
         (n_positive, neg) = split_sign(n)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -758,6 +758,7 @@ ndigits0znb(x::Bool, b::Integer) = x % Int
 
 # The suffix "pb" stands for "positive base"
 function ndigits0zpb(x::Integer, b::Integer)
+    @constprop :aggressive
     # precondition: b > 1
     x == 0 && return 0
     b = Int(b)
@@ -822,6 +823,7 @@ julia> Base.ndigits0z(10)
 See also [`ndigits`](@ref).
 """
 function ndigits0z(x::Integer, b::Integer)
+    @constprop :aggressive
     if b < -1
         ndigits0znb(x, b)
     elseif b > 1


### PR DESCRIPTION
By annotating `ndigits0zpb`, `ndigits0z`, and `string(::Integer)` with `@constprop :aggressive`.

This helps `ndigits(x; base)` with the common constant bases of 10 or a small power of 2, removing two extra function calls (`ndigits0z`, `ndigits0zpb`) when optimized.

Also does the same with `string(::Integer; base)` for constant bases 2, 8, 16, and 10 (the default), so the function would then be inlined to just a call to `bin`, `oct`, `hex`, or `dec`.

On 1.13-rc1:

```julia-repl
julia> f1(n) = ndigits(n; base=2)
f1 (generic function with 1 method)

julia> @code_typed optimize=true f1(8)
CodeInfo(
1 ─ %1 =    invoke Base.ndigits0z(n::Int64, 2::Int64)::Int64
│   %2 = intrinsic Base.slt_int(%1, 1)::Bool
│   %3 =   builtin (Core.ifelse)(%2, 1, %1)::Int64
└──      return %3
) => Int64

julia> @code_typed optimize=true string(5)
CodeInfo(
1 ─ %1 =    invoke Base.:(var"#string#391")(10::Int64, 1::Int64, #self#::typeof(string), n::Int64)::String
└──      return %1
) => String
```

PR:

```julia-repl
julia> @code_typed optimize=true f1(8)
CodeInfo(
1 ─ %1  =   builtin (n === 0)::Bool
└──       goto #3 if not %1
2 ─       goto #4
3 ─ %4  = intrinsic Base.flipsign_int(n, n)::Int64
│   %5  = intrinsic Base.bitcast(UInt64, %4)::UInt64
│   %6  = intrinsic Base.ctlz_int(%5)::UInt64
│   %7  = intrinsic Base.bitcast(Int64, %6)::Int64
│   %8  = intrinsic Base.sub_int(64, %7)::Int64
└──       goto #4
4 ┄ %10 = φ (#2 => 0, #3 => %8)::Int64
│   %11 = intrinsic Base.slt_int(%10, 1)::Bool
│   %12 =   builtin (Core.ifelse)(%11, 1, %10)::Int64
└──       goto #5
5 ─       return %12
) => Int64

julia> @code_typed optimize=true string(5)
CodeInfo(
1 ─ %1 = intrinsic Base.flipsign_int(n, n)::Int64
│   %2 = intrinsic Base.bitcast(UInt64, %1)::UInt64
│   %3 = intrinsic Base.slt_int(n, 0)::Bool
│   %4 =    invoke Main.dec(%2::UInt64, 1::Int64, %3::Bool)::String
└──      return %4
) => String
```