### PR TITLE
devdocs/agents: Clarify C static analysis commands

### DIFF
--- a/doc/src/devdocs/agents/skills/c-static-analysis/SKILL.md
+++ b/doc/src/devdocs/agents/skills/c-static-analysis/SKILL.md
@@ -29,13 +29,22 @@ Run static analysis checks:
 
 ## Fixing the GC-rooting checker (clang-sagc)
 
-If `clang-sagc-<file-stem>` fails, it may require adding `JL_GC_PUSH` statements,
-or `JL_GC_PROMISE_ROOTED` statements, or require fixing locks.
+If `clang-sagc-<file-stem>` fails, first look for fixes that establish real
+rooting, such as adding appropriate `JL_GC_PUSH`/`JL_GC_POP` scopes, or for
+lock/control-flow fixes.
+
+Do not add `JL_GC_PROMISE_ROOTED` without explicit user or maintainer
+confirmation. `JL_GC_PROMISE_ROOTED` asserts that a value is already rooted; it
+does not root the value. If it appears necessary, stop and ask for confirmation,
+showing the exact expression, the existing root that makes it safe, and the
+safepoints considered.
 
 - Remember arguments are assumed rooted, so check the callers to make sure that
   is handled.
-- If the value is being temporarily moved around in a struct or arraylist,
-  `JL_GC_PROMISE_ROOTED(struct->field)` may be needed as a statement (it returns
-  void) immediately after reloading the struct before any use of struct.
-- Put that promise as early in the code as is legal, near the definition not the
-  use.
+- As a diagnostic hint when asking for confirmation: if the value is temporarily
+  moved through a struct or arraylist and then reloaded, the promised expression
+  may need to refer to the reloaded field, such as
+  `JL_GC_PROMISE_ROOTED(struct->field)`, immediately after the reload and before
+  any use of that field.
+- If confirmed, put the promise as early in the code as is legal, near the
+  definition or reload rather than the use.

--- a/doc/src/devdocs/agents/skills/c-static-analysis/SKILL.md
+++ b/doc/src/devdocs/agents/skills/c-static-analysis/SKILL.md
@@ -1,22 +1,35 @@
 ---
 name: c-static-analysis
-description: Run Clang static analysis on Julia's C/C++ runtime and codegen, and satisfy the GC-rooting checker. Use after modifying any .c/.cpp file under src/ (excluding headers), before opening a PR.
+description: Run Clang static analysis on Julia's C/C++ runtime and codegen, and satisfy the GC-rooting checker. Use after modifying runtime/codegen .c/.cpp files under src/ (excluding headers), before opening a PR.
 ---
 
 # C/C++ static analysis (src/)
 
-Use this after you modify a C/C++ source file under `src/` (not headers). Note
-that runtime changes also require a rebuild (`make -j`).
+Use this after you modify a runtime/codegen C/C++ source file under `src/` (not
+headers). Note that runtime changes also require a rebuild (`make -j`).
 
 Run static analysis checks:
 
-- First run `make -C src install-analysis-deps` to initialize dependencies (only needed once the first time).
-- Run `make -C src analyze-<filename> --output-sync -j8` (replace `<filename>` with the basename of any C or C++ file you modified, excluding headers).
-- Tests can also be rerun individually with `clang-sa-<filename>`, `clang-sagc-<filename>` or `clang-tidy-<filename>`.
+- First run `make -C src install-analysis-deps` to initialize dependencies (only
+  needed once the first time, or after the LLVM/Clang toolchain dependencies
+  change). This may download and install LLVM/Clang artifacts.
+- For a source file such as `src/jloptions.c` or `src/codegen.cpp`, use the file
+  stem without the `.c`/`.cpp` extension:
+  ```sh
+  make -C src analyze-<file-stem> -j8 [--output-sync]
+  ```
+  For example, to analyze `src/jloptions.c`, run:
+  ```sh
+  make -C src analyze-jloptions -j8
+  ```
+  Add `--output-sync` when your `make` supports it to keep parallel output
+  grouped; otherwise omit it.
+- Checks can also be rerun individually with `clang-sa-<file-stem>`,
+  `clang-sagc-<file-stem>` or `clang-tidy-<file-stem>`.
 
 ## Fixing the GC-rooting checker (clang-sagc)
 
-If `clang-sagc-<filename>` fails, it may require adding `JL_GC_PUSH` statements,
+If `clang-sagc-<file-stem>` fails, it may require adding `JL_GC_PUSH` statements,
 or `JL_GC_PROMISE_ROOTED` statements, or require fixing locks.
 
 - Remember arguments are assumed rooted, so check the callers to make sure that


### PR DESCRIPTION
Update the `c-static-analysis` skill to document the actual analyze target form, using file stems such as `analyze-jloptions` rather than source filenames with extensions.

Also `make --output-sync` optional, since it is only a log-grouping convenience and is not supported by every make implementation.