### PR TITLE
tanpi for Complex - fixed issue #57450

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1082,7 +1082,15 @@ sinpi(x::AbstractFloat) = sin(pi*x)
 cospi(x::AbstractFloat) = cos(pi*x)
 sincospi(x::AbstractFloat) = sincos(pi*x)
 tanpi(x::AbstractFloat) = tan(pi*x)
-tanpi(x::Complex) = sinpi(x) / cospi(x) # Is there a better way to do this?
+
+function tanpi(z::Complex)
+    zr, zi = reim(z)
+    iszero(zi) && return Complex(tanpi(zr))
+    sr, cr = sincospi(zr)
+    ti = tanh(zi * pi)
+    cz = Complex(cr, ti * sr)
+    Complex(sr, ti * cr) * cz / abs2(cz)
+end
 
 function sinpi(z::Complex{T}) where T
     F = float(T)

--- a/test/math.jl
+++ b/test/math.jl
@@ -652,7 +652,7 @@ end
             # issue #57450
             y = Complex{T}(0.5, 1000)
             @test isfinite(tanpi(y))
-            @test tanpi(b) ≈ im
+            @test tanpi(y) ≈ im
         end
     end
     scdm = sincosd(missing)

--- a/test/math.jl
+++ b/test/math.jl
@@ -621,7 +621,7 @@ end
                 end
             end
         end
-        @testset begin
+        @testset "trig d/pi functions exactness" begin
             # If the machine supports fma (fused multiply add), we require exact equality.
             # Otherwise, we only require approximate equality.
             if has_fma[T]
@@ -644,6 +644,15 @@ end
                 T == Rational{Int} && @test my_eq(sinpi(5//6), 0.5)
                 T == Rational{Int} && @test my_eq(sincospi(5//6)[1], 0.5)
             end
+        end
+
+        @testset "tanpi for Complex argument" begin
+            x = Complex{T}(12/11, 2/7)
+            @test tanpi(x) ≈ sinpi(x) / cospi(x)
+            # issue #57450
+            y = Complex{T}(0.5, 1000)
+            @test isfinite(tanpi(y))
+            @test tanpi(b) ≈ im
         end
     end
     scdm = sincosd(missing)


### PR DESCRIPTION
fixed #57450

now `tanpi(0.5 + 1000im) == 0.0 + 1.0im`
and  `tanpi(500 * exp(im * 3pi/4)) == 0.0 + 1.0im` (and not `Nan + 0.0im`)