### PR TITLE
inference: Model always-throwing `modifyfield!`/`replacefield!` as `Bottom`

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1355,6 +1355,8 @@ end
     return getfield_tfunc(𝕃, o, f)
 end
 @nospecs function modifyfield!_tfunc(𝕃::AbstractLattice, o, f, op, v, order=Symbol)
+    # the stored value is `op(o.f, v)`, so check only that `o.f` is writable at all
+    setfield!_tfunc(𝕃, o, f, Any) === Bottom && return Bottom
     o′ = widenconst(o)
     T = _fieldtype_tfunc(𝕃, o′, f, isconcretetype(o′))
     T === Bottom && return Bottom
@@ -1362,6 +1364,10 @@ end
     return instanceof_tfunc(apply_type_tfunc(𝕃, Any[PT, T, T]), true)[1]
 end
 @nospecs function replacefield!_tfunc(𝕃::AbstractLattice, o, f, x, v, success_order=Symbol, failure_order=Symbol)
+    # `replacefield!` type-checks the replacement `v` before the comparison, so a
+    # non-writable field or a `v` that cannot be stored always throws (even when the
+    # comparison would have failed)
+    setfield!_tfunc(𝕃, o, f, v) === Bottom && return Bottom
     o′ = widenconst(o)
     T = _fieldtype_tfunc(𝕃, o′, f, isconcretetype(o′))
     T === Bottom && return Bottom

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -1902,6 +1902,37 @@ let setfield!_nothrow(@nospecialize xs...) =
     @test !setfield!_nothrow(Any, Any, Int)
 end
 
+mutable struct AtomicFields
+    @atomic a::Int
+    b::Int
+    const c::Int
+end
+let modifyfield!_tfunc(@nospecialize xs...) =
+        Compiler.modifyfield!_tfunc(Compiler.fallback_lattice, xs...)
+    replacefield!_tfunc(@nospecialize xs...) =
+        Compiler.replacefield!_tfunc(Compiler.fallback_lattice, xs...)
+    cmpswap_Int = ccall(:jl_apply_cmpswap_type, Any, (Any,), Int)
+    # writable fields (`@atomic` and plain) of a mutable struct
+    @test modifyfield!_tfunc(AtomicFields, Const(:a), Any, Any) === Pair{Int,Int}
+    @test replacefield!_tfunc(AtomicFields, Const(:a), Int, Int) === cmpswap_Int
+    @test modifyfield!_tfunc(AtomicFields, Const(:b), Any, Any) === Pair{Int,Int}
+    @test replacefield!_tfunc(AtomicFields, Const(:b), Int, Int) === cmpswap_Int
+    # `replacefield!` type-checks the replacement value unconditionally, so a value that
+    # can never be stored always throws
+    @test replacefield!_tfunc(AtomicFields, Const(:a), Int, String) === Union{}
+    @test replacefield!_tfunc(AtomicFields, Const(:b), Int, String) === Union{}
+    # `const` fields can never be written, so the operation always throws
+    @test modifyfield!_tfunc(AtomicFields, Const(:c), Any, Any) === Union{}
+    @test modifyfield!_tfunc(AtomicFields, Const(3), Any, Any) === Union{}
+    @test replacefield!_tfunc(AtomicFields, Const(:c), Int, Int) === Union{}
+    @test replacefield!_tfunc(AtomicFields, Const(3), Int, Int) === Union{}
+    # immutable types can never be written, so the operation always throws
+    @test modifyfield!_tfunc(Some{Int}, Const(:value), Any, Any) === Union{}
+    @test replacefield!_tfunc(Some{Int}, Const(:value), Int, Int) === Union{}
+    @test modifyfield!_tfunc(Some, Const(:value), Any, Any) === Union{}
+    @test replacefield!_tfunc(Some, Const(:value), Any, Any) === Union{}
+end
+
 struct Foo_22708
     x::Ptr{Foo_22708}
 end


### PR DESCRIPTION
`setfield!_tfunc`, `swapfield!_tfunc` and `setfieldonce!_tfunc` already return `Bottom` when the targeted field can never be written, namely a `const` field or a field of an immutable type, since the underlying store always throws. `modifyfield!_tfunc` and `replacefield!_tfunc` did not perform that check and instead reported a `Pair`/cmpswap result type, so an operation that can only ever throw was not recognized as such.

Guard both tfuncs through `setfield!_tfunc`. `modifyfield!` stores `op(o.f, v)` rather than `v`, so the simple tfunc only consults field writability (passing `Any` as the value; the result is refined precisely in `abstract_modifyop!`, the direct-call path that derives its return type from `modifyfield!_tfunc`). `replacefield!` type-checks the replacement `v` before the comparison and therefore throws even when the comparison would have failed, so `v` is consulted as well — this also models a replacement value that can never be stored into the field.