### PR TITLE
Docs: avoid spurious struct field from `@doc` expansion

### DIFF
--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1344,8 +1344,10 @@ end
 19  (call core.apply_type %₁₈)
 20  (call core.apply_type %₁₇ %₁₉)
 21  (call Base.Docs.doc! TestMod %₁₃ %₁₆ %₂₀)
-22  slot₁/val
-23  (return %₂₂)
+22  (gotoifnot true label₂₅)
+23  slot₁/val
+24  (return %₂₃)
+25  (return core.nothing)
 
 ########################################
 # Binding docs to callable type
@@ -1374,8 +1376,10 @@ end
 15  (call core.apply_type %₁₄)
 16  (call core.apply_type %₁₃ %₁₅)
 17  (call Base.Docs.doc! TestMod %₉ %₁₂ %₁₆)
-18  slot₁/val
-19  (return %₁₈)
+18  (gotoifnot true label₂₁)
+19  slot₁/val
+20  (return %₁₉)
+21  (return core.nothing)
 
 ########################################
 # Keyword function with defaults.

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1321,33 +1321,35 @@ some docs
 function f()
 end
 #---------------------
-1   (method TestMod.f)
-2   latestworld
-3   TestMod.f
-4   (call core.Typeof %₃)
-5   (call core.svec %₄)
-6   (call core.svec)
-7   SourceLocation:nothing:4:0
-8   (call core.svec %₅ %₆ %₇)
-9   --- method TestMod.f %₈
+1   (newvar slot₁/val)
+2   (gotoifnot true label₁₅)
+3   (method TestMod.f)
+4   latestworld
+5   TestMod.f
+6   (call core.Typeof %₅)
+7   (call core.svec %₆)
+8   (call core.svec)
+9   SourceLocation:nothing:4:0
+10  (call core.svec %₇ %₈ %₉)
+11  --- method TestMod.f %₁₀
     slots: [slot₁/#self#(!read)]
     1   (return core.nothing)
-10  latestworld
-11  TestMod.f
-12  (= slot₁/val %₁₁)
-13  (call Base.Docs.Binding TestMod :f)
-14  (call Core.svec "some docs\n")
-15  (call Dict{Symbol, Any} :path => "none" :linenumber => 1 :module => TestMod)
-16  (call Base.Docs.docstr %₁₄ %₁₅)
-17  TestMod.Union
-18  TestMod.Tuple
-19  (call core.apply_type %₁₈)
-20  (call core.apply_type %₁₇ %₁₉)
-21  (call Base.Docs.doc! TestMod %₁₃ %₁₆ %₂₀)
-22  (gotoifnot true label₂₅)
-23  slot₁/val
-24  (return %₂₃)
-25  (return core.nothing)
+12  latestworld
+13  TestMod.f
+14  (= slot₁/val %₁₃)
+15  (call Base.Docs.Binding TestMod :f)
+16  (call Core.svec "some docs\n")
+17  (call Dict{Symbol, Any} :path => "none" :linenumber => 1 :module => TestMod)
+18  (call Base.Docs.docstr %₁₆ %₁₇)
+19  TestMod.Union
+20  TestMod.Tuple
+21  (call core.apply_type %₂₀)
+22  (call core.apply_type %₁₉ %₂₁)
+23  (call Base.Docs.doc! TestMod %₁₅ %₁₈ %₂₂)
+24  (gotoifnot true label₂₇)
+25  slot₁/val
+26  (return %₂₅)
+27  (return core.nothing)
 
 ########################################
 # Binding docs to callable type
@@ -1357,29 +1359,31 @@ some docs
 function (x::T)()
 end
 #---------------------
-1   TestMod.T
-2   (call core.svec %₁)
-3   (call core.svec)
-4   SourceLocation:nothing:4:0
-5   (call core.svec %₂ %₃ %₄)
-6   --- method core.nothing %₅
+1   (newvar slot₁/val)
+2   (gotoifnot true label₁₁)
+3   TestMod.T
+4   (call core.svec %₃)
+5   (call core.svec)
+6   SourceLocation:nothing:4:0
+7   (call core.svec %₄ %₅ %₆)
+8   --- method core.nothing %₇
     slots: [slot₁/x(!read)]
     1   (return core.nothing)
-7   latestworld
-8   (= slot₁/val core.nothing)
-9   (call Base.Docs.Binding TestMod :T)
-10  (call Core.svec "some docs\n")
-11  (call Dict{Symbol, Any} :path => "none" :linenumber => 1 :module => TestMod)
-12  (call Base.Docs.docstr %₁₀ %₁₁)
-13  TestMod.Union
-14  TestMod.Tuple
-15  (call core.apply_type %₁₄)
-16  (call core.apply_type %₁₃ %₁₅)
-17  (call Base.Docs.doc! TestMod %₉ %₁₂ %₁₆)
-18  (gotoifnot true label₂₁)
-19  slot₁/val
-20  (return %₁₉)
-21  (return core.nothing)
+9   latestworld
+10  (= slot₁/val core.nothing)
+11  (call Base.Docs.Binding TestMod :T)
+12  (call Core.svec "some docs\n")
+13  (call Dict{Symbol, Any} :path => "none" :linenumber => 1 :module => TestMod)
+14  (call Base.Docs.docstr %₁₂ %₁₃)
+15  TestMod.Union
+16  TestMod.Tuple
+17  (call core.apply_type %₁₆)
+18  (call core.apply_type %₁₅ %₁₇)
+19  (call Base.Docs.doc! TestMod %₁₁ %₁₄ %₁₈)
+20  (gotoifnot true label₂₃)
+21  slot₁/val
+22  (return %₂₁)
+23  (return core.nothing)
 
 ########################################
 # Keyword function with defaults.

--- a/JuliaLowering/test/typedefs_ir.jl
+++ b/JuliaLowering/test/typedefs_ir.jl
@@ -613,8 +613,10 @@ end
 41  TestMod.Union
 42  (call core.apply_type %₄₁)
 43  (call Base.Docs.doc! TestMod %₃₃ %₄₀ %₄₂)
-44  slot₁/val
-45  (return %₄₄)
+44  (gotoifnot true label₄₇)
+45  slot₁/val
+46  (return %₄₅)
+47  (return core.nothing)
 
 ########################################
 # Struct with outer constructor

--- a/JuliaLowering/test/typedefs_ir.jl
+++ b/JuliaLowering/test/typedefs_ir.jl
@@ -571,52 +571,53 @@ struct X
 end
 #---------------------
 1   (newvar slot₁/val)
-2   (call core.declare_global TestMod :X false)
-3   latestworld
-4   (call core.svec)
-5   (call core.svec :a :b)
-6   (call core.svec)
-7   (call core._structtype TestMod :X %₄ %₅ %₆ false 2)
-8   (= slot₂/X %₇)
-9   (call core._setsuper! %₇ core.Any)
-10  (call core.isdefinedglobal TestMod :X false)
-11  (gotoifnot %₁₀ label₁₅)
-12  TestMod.X
-13  (= slot₃/if_val (call core._equiv_typedef %₁₂ %₇))
-14  (goto label₁₆)
-15  (= slot₃/if_val false)
-16  slot₃/if_val
-17  (gotoifnot %₁₆ label₂₁)
-18  TestMod.X
-19  (= slot₄/if_val %₁₈)
-20  (goto label₂₂)
-21  (= slot₄/if_val false)
-22  slot₄/if_val
-23  (gotoifnot %₁₆ label₂₄)
-24  (call core.svec core.Any core.Any)
-25  (call core._typebody! %₂₂ %₇ %₂₄)
-26  (call core.declare_const TestMod :X %₂₅)
-27  latestworld
-28  TestMod.X
-29  SourceLocation:none:1:0
-30  (call top._defaultctors %₂₈ %₂₉)
-31  latestworld
-32  (= slot₁/val core.nothing)
-33  (call Base.Docs.Binding TestMod :X)
-34  (call Core.svec "X docs\n")
-35  (call Pair{Symbol, Any} :a "field a docs")
-36  (call Pair{Symbol, Any} :b "field b docs")
-37  (call Dict{Symbol, Any} %₃₅ %₃₆)
-38  (call Pair :fields %₃₇)
-39  (call Dict{Symbol, Any} :path => "none" :linenumber => 1 :module => TestMod %₃₈)
-40  (call Base.Docs.docstr %₃₄ %₃₉)
-41  TestMod.Union
-42  (call core.apply_type %₄₁)
-43  (call Base.Docs.doc! TestMod %₃₃ %₄₀ %₄₂)
-44  (gotoifnot true label₄₇)
-45  slot₁/val
-46  (return %₄₅)
-47  (return core.nothing)
+2   (gotoifnot true label₃₄)
+3   (call core.declare_global TestMod :X false)
+4   latestworld
+5   (call core.svec)
+6   (call core.svec :a :b)
+7   (call core.svec)
+8   (call core._structtype TestMod :X %₅ %₆ %₇ false 2)
+9   (= slot₂/X %₈)
+10  (call core._setsuper! %₈ core.Any)
+11  (call core.isdefinedglobal TestMod :X false)
+12  (gotoifnot %₁₁ label₁₆)
+13  TestMod.X
+14  (= slot₃/if_val (call core._equiv_typedef %₁₃ %₈))
+15  (goto label₁₇)
+16  (= slot₃/if_val false)
+17  slot₃/if_val
+18  (gotoifnot %₁₇ label₂₂)
+19  TestMod.X
+20  (= slot₄/if_val %₁₉)
+21  (goto label₂₃)
+22  (= slot₄/if_val false)
+23  slot₄/if_val
+24  (gotoifnot %₁₇ label₂₅)
+25  (call core.svec core.Any core.Any)
+26  (call core._typebody! %₂₃ %₈ %₂₅)
+27  (call core.declare_const TestMod :X %₂₆)
+28  latestworld
+29  TestMod.X
+30  SourceLocation:none:1:0
+31  (call top._defaultctors %₂₉ %₃₀)
+32  latestworld
+33  (= slot₁/val core.nothing)
+34  (call Base.Docs.Binding TestMod :X)
+35  (call Core.svec "X docs\n")
+36  (call Pair{Symbol, Any} :a "field a docs")
+37  (call Pair{Symbol, Any} :b "field b docs")
+38  (call Dict{Symbol, Any} %₃₆ %₃₇)
+39  (call Pair :fields %₃₈)
+40  (call Dict{Symbol, Any} :path => "none" :linenumber => 1 :module => TestMod %₃₉)
+41  (call Base.Docs.docstr %₃₅ %₄₀)
+42  TestMod.Union
+43  (call core.apply_type %₄₂)
+44  (call Base.Docs.doc! TestMod %₃₄ %₄₁ %₄₃)
+45  (gotoifnot true label₄₈)
+46  slot₁/val
+47  (return %₄₆)
+48  (return core.nothing)
 
 ########################################
 # Struct with outer constructor

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -413,10 +413,12 @@ function objectdoc(__source__, __module__, str, def, expr, sig = :(Union{}))
                 exdef = Expr(:block, exdef)
             end
             val = :val
-            exdef = Expr(:(=), val, exdef)
+            # if-true hack: val should not be recognized as a struct field,
+            # including by @kwdef
+            exdef = Expr(:if, true, Expr(:(=), val, exdef))
         end
         # Note: we want to avoid introducing line number nodes here (issue #24468) for def
-        return Expr(:block, exdef, docex, val)
+        return Expr(:block, exdef, docex, Expr(:if, true, val))
     end
 end
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1395,34 +1395,39 @@
          `(call (core apply_type_or_typeapp) ,@(map replace-type-constructors (cddr expr))))
         (else (map replace-type-constructors expr))))
 
-;; Extract a struct definition from a typegroup block child.
+;; Hack: Extract a struct definition from a typegroup block child.
 ;; Returns (values struct-expr doc-calls) where doc-calls is a list of
 ;; documentation expressions to emit after the types are bound.
-;; A child may be a bare (struct ...) or a block from @doc macro expansion:
-;;   (block (= gensym (struct ...)) (call Docs.doc! ...) gensym)
+;; A child may be a bare (struct ...) or a block from @doc macro expansion
+;; (block (if true (= gensym (struct ...))) doc-calls... ignored_gensym)
 (define (typegroup-extract-struct x)
   (cond ((and (pair? x) (eq? (car x) 'struct))
          (values x '()))
+        ;; Expanded @doc block
         ((and (pair? x) (eq? (car x) 'block)
               (let ((body (cdr x)))
                 (and (pair? body)
-                     (pair? (car body))
-                     (eq? (caar body) '=)
-                     (pair? (cddar body))
-                     (let ((rhs (caddar body)))
-                       (and (pair? rhs) (eq? (car rhs) 'struct))))))
-         ;; Expanded @doc block: (block (= gensym (struct ...)) doc-calls... gensym)
-         (let* ((body (cdr x))
-                (struct-expr (caddar body))   ; the (struct ...) from (= gensym (struct ...))
-                (rest (cdr body))             ; everything after the assignment
-                ;; Drop the trailing gensym return value, keep the doc calls
-                (doc-calls (if (and (pair? rest) (not (null? (cdr rest))))
-                               (let loop ((r rest) (acc '()))
-                                 (if (null? (cdr r))
-                                     (reverse acc)  ; skip last element (the gensym)
-                                     (loop (cdr r) (cons (car r) acc))))
-                               '())))
-           (values struct-expr doc-calls)))
+                     (length= (car body) 3)
+                     (eq? (caar body) 'if)
+                     (equal? (cadar body) '(true))
+                     (let* ((doc-val-assign (caddar body)))
+                       (eq? (car doc-val-assign) '=)
+                       (pair? (cddr doc-val-assign))
+                       (let* ((rhs (caddr doc-val-assign)))
+                         (and (pair? rhs)
+                              (eq? (car rhs) 'struct)
+                              (cons rhs (cdr body))))))))
+         => (lambda (extracted)
+              (let* ((struct-expr (car extracted))
+                     (rest (cdr extracted))
+                     ;; Drop the trailing gensym return value, keep the doc calls
+                     (doc-calls (if (and (pair? rest) (not (null? (cdr rest))))
+                                    (let loop ((r rest) (acc '()))
+                                      (if (null? (cdr r))
+                                          (reverse acc)  ; skip last element (the gensym)
+                                          (loop (cdr r) (cons (car r) acc))))
+                                    '())))
+                (values struct-expr doc-calls))))
         (else
          (error (string "typegroup only supports struct definitions, got: " (deparse x))))))
 

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1672,3 +1672,28 @@ Bar59949{T}
 """
 Bar59949{T} = Foo59949{T}
 @test docstrings_equal(@doc(Bar59949), doc"Bar59949{T}")
+
+# https://github.com/JuliaLang/julia/issues/60871
+"""
+    Bug60871(; x)
+
+kw constructor for `struct Bug60871`
+"""
+@kwdef struct Bug60871
+    x
+
+    @doc """
+        Bug60871(x)
+
+    normal constructor with input check
+    """
+    function Bug60871(x)
+        @assert x == 1
+        return new(x)
+    end
+end
+
+@test Bug60871 isa DataType
+@test Bug60871(1).x == 1
+@test_throws AssertionError Bug60871(2)
+@test length(fieldnames(Bug60871)) == 1


### PR DESCRIPTION
Attempt to fix #60871 