### PR TITLE
clangsa: Share non-safepoint heuristics across plugins

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -667,11 +667,15 @@ GC_CHECKER_SOURCES := \
 	$(SRCDIR)/clangsa/GCCheckerReporting.cpp \
 	$(SRCDIR)/clangsa/GCCheckerPropagation.cpp
 
-$(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT): $(GC_CHECKER_SOURCES) $(SRCDIR)/clangsa/GCChecker.h $(LLVM_CONFIG_ABSOLUTE)
+CLANGSA_PLUGIN_NAMES := GCChecker ImplicitAtomics FirstDeclAnnotations
+CLANGSA_PLUGINS := $(addsuffix Plugin.$(SHLIB_EXT),$(addprefix $(build_shlibdir)/lib,$(CLANGSA_PLUGIN_NAMES)))
+GCCHECKER_PLUGIN := $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
+
+$(GCCHECKER_PLUGIN): $(GC_CHECKER_SOURCES) $(SRCDIR)/clangsa/GCChecker.h $(SRCDIR)/clangsa/HelpersCommon.hpp $(LLVM_CONFIG_ABSOLUTE)
 	@$(call PRINT_CC, $(CXX) -g $(fPIC) -shared -o $@ -DCLANG_PLUGIN -I$(build_includedir) -L$(build_libdir) \
 		$(LLVM_CXXFLAGS) $(CLANG_LDFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(CXXLDFLAGS) $(GC_CHECKER_SOURCES))
 
-$(build_shlibdir)/lib%Plugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/%.cpp $(LLVM_CONFIG_ABSOLUTE)
+$(build_shlibdir)/lib%Plugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/%.cpp $(SRCDIR)/clangsa/HelpersCommon.hpp $(LLVM_CONFIG_ABSOLUTE)
 	@$(call PRINT_CC, $(CXX) -g $(fPIC) -shared -o $@ -DCLANG_PLUGIN -I$(build_includedir) -L$(build_libdir) \
 		$(LLVM_CXXFLAGS) $(CLANG_LDFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(CXXLDFLAGS) $<)
 
@@ -700,9 +704,7 @@ ifneq ($(BUILD_LLVM_CLANG),1)
 endif
 endif
 
-clangsa: $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
-clangsa: $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
-clangsa: $(build_shlibdir)/libFirstDeclAnnotationsPlugin.$(SHLIB_EXT)
+clangsa: $(CLANGSA_PLUGINS)
 
 # optarg is a required_argument for these
 SA_EXCEPTIONS-jloptions.c                   := -Xanalyzer -analyzer-config -Xanalyzer silence-checkers="core.NonNullParamChecker;unix.cstring.NullArg"
@@ -717,14 +719,14 @@ SKIP_GC_CHECK := codegen.cpp rtutils.c
 
 # make sure LLVM's invariant information is not discarded with -DNDEBUG
 clang-sagc-%: JCXXFLAGS_COMMON += -UNDEBUG
-clang-sagc-%: $(SRCDIR)/%.c $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
+clang-sagc-%: $(SRCDIR)/%.c $(GCCHECKER_PLUGIN) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text --analyzer-no-default-checks \
-		-Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
+		-Xclang -load -Xclang $(GCCHECKER_PLUGIN) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
 		$(SA_EXCEPTIONS-$(notdir $<)) \
 		$(CLANG_TOOLING_C_FLAGS) -fcolor-diagnostics -x c $<)
-clang-sagc-%: $(SRCDIR)/%.cpp $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
+clang-sagc-%: $(SRCDIR)/%.cpp $(GCCHECKER_PLUGIN) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text --analyzer-no-default-checks \
-		-Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
+		-Xclang -load -Xclang $(GCCHECKER_PLUGIN) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
 		$(SA_EXCEPTIONS-$(notdir $<)) \
 		$(CLANG_TOOLING_CXX_FLAGS) -fcolor-diagnostics -x c++ $<)
 
@@ -750,16 +752,18 @@ clang-sa-%: $(SRCDIR)/%.cpp .FORCE | analyzegc-deps-check
 # src/support/analyzer_annotations.h), so run the checks once in the normal
 # build configuration and once with the analyzer define active (when the
 # annotations are visible).
-TIDY_PLUGINS := -load $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) -load $(build_shlibdir)/libFirstDeclAnnotationsPlugin.$(SHLIB_EXT)
-TIDY_CHECKS := -clang-analyzer-*$(COMMA)-clang-diagnostic-*$(COMMA)concurrency-implicit-atomics$(COMMA)julia-first-decl-annotations
-clang-tidy-%: $(SRCDIR)/%.c $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) $(build_shlibdir)/libFirstDeclAnnotationsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
+TIDY_PLUGIN_NAMES := $(filter-out GCChecker,$(CLANGSA_PLUGIN_NAMES))
+TIDY_PLUGIN_LIBS := $(addsuffix Plugin.$(SHLIB_EXT),$(addprefix $(build_shlibdir)/lib,$(TIDY_PLUGIN_NAMES)))
+TIDY_PLUGINS := $(addprefix -load ,$(TIDY_PLUGIN_LIBS))
+TIDY_CHECKS := -clang-analyzer-*,-clang-diagnostic-*,concurrency-implicit-atomics,julia-first-decl-annotations
+clang-tidy-%: $(SRCDIR)/%.c $(TIDY_PLUGIN_LIBS) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang-tidy $< -header-filter='.*' --quiet \
 		$(TIDY_PLUGINS) --checks='$(TIDY_CHECKS)' --warnings-as-errors='*' \
 		-- $(CLANG_TOOLING_C_FLAGS) -fcolor-diagnostics -fno-caret-diagnostics -x c)
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang-tidy $< -header-filter='.*' --quiet \
 		$(TIDY_PLUGINS) --checks='$(TIDY_CHECKS)' --warnings-as-errors='*' \
 		-- $(CLANG_TOOLING_C_FLAGS) -D__clang_gcanalyzer__ -fcolor-diagnostics -fno-caret-diagnostics -x c)
-clang-tidy-%: $(SRCDIR)/%.cpp $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) $(build_shlibdir)/libFirstDeclAnnotationsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
+clang-tidy-%: $(SRCDIR)/%.cpp $(TIDY_PLUGIN_LIBS) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang-tidy $< -header-filter='.*' --quiet \
 		$(TIDY_PLUGINS) --checks='$(TIDY_CHECKS)' --warnings-as-errors='*' \
 		-- $(CLANG_TOOLING_CXX_FLAGS) -fcolor-diagnostics --system-header-prefix=llvm -Wno-deprecated-declarations -fno-caret-diagnostics -x c++)
@@ -767,9 +771,6 @@ clang-tidy-%: $(SRCDIR)/%.cpp $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB
 		$(TIDY_PLUGINS) --checks='$(TIDY_CHECKS)' --warnings-as-errors='*' \
 		-- $(CLANG_TOOLING_CXX_FLAGS) -D__clang_gcanalyzer__ -fcolor-diagnostics --system-header-prefix=llvm -Wno-deprecated-declarations -fno-caret-diagnostics -x c++)
 
-# Flag functions with external linkage that are neither declared in a header nor
-# marked `static` (see src/clangsa/StaticOrDeclared.cpp). Kept as its own target
-# rather than folded into `clang-tidy-%` so it can be run independently.
 # Add C files as a target of `analyzesrc` and `analyzegc` and `tidysrc`
 .PHONY: tidysrc
 tidysrc: $(addprefix clang-tidy-,$(CODEGEN_SRCS) $(SRCS))
@@ -786,9 +787,7 @@ $(addprefix analyze-,$(filter-out $(basename $(SKIP_GC_CHECK)),$(CODEGEN_SRCS) $
 
 .PHONY: clean-analyzegc
 clean-analyzegc:
-	rm -f $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
-	rm -f $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
-	rm -f $(build_shlibdir)/libFirstDeclAnnotationsPlugin.$(SHLIB_EXT)
+	rm -f $(CLANGSA_PLUGINS)
 
 # Compilation database generation using existing clang infrastructure
 .PHONY: regenerate-compile_commands

--- a/src/clangsa/FirstDeclAnnotations.cpp
+++ b/src/clangsa/FirstDeclAnnotations.cpp
@@ -104,6 +104,8 @@
 #include "clang-tidy/ClangTidyModuleRegistry.h"
 #include "llvm/ADT/StringSet.h"
 
+#include "HelpersCommon.hpp"
+
 using namespace clang;
 using namespace clang::tidy;
 using namespace clang::ast_matchers;
@@ -158,6 +160,14 @@ public:
         if (!FD || FD->isImplicit())
             return;
 
+        // Never act on a template instantiation: its declarations are generated
+        // from the pattern and their locations map back to it, so a fix here
+        // would edit (and could duplicate at) the pattern's source. The pattern
+        // itself and explicit specializations are not instantiations and are
+        // still handled.
+        if (FD->isTemplateInstantiation())
+            return;
+
         const FunctionDecl *First = FD->getFirstDecl();
         if (First == FD)
             return;
@@ -188,10 +198,10 @@ public:
         const LangOptions &LO = getLangOpts();
 
         // Function-level annotations (e.g. JL_NOTSAFEPOINT) are written after
-        // the parameter list, so the fix inserts them just after the first
-        // declaration's closing `)`.
+        // the parameter list and any trailing qualifiers, so the fix inserts
+        // them just after the first declaration's declarator suffix.
         checkDecl(FD, First, FD, /*ParamIndex=*/-1,
-                  endOfToken(functionRParenLoc(First), SM, LO), SM, LO);
+                  endOfToken(declaratorSuffixEnd(First, SM), SM, LO), SM, LO);
 
         // Parameter-level annotations (e.g. JL_PROPAGATES_ROOT,
         // JL_ROOTED_BY_ARG). Compare by position; redeclarations of the same
@@ -539,24 +549,14 @@ private:
         const FunctionDecl *First = FD->getFirstDecl();
         if (SM.isInSystemHeader(First->getLocation()))
             return true;
-        StringRef File = llvm::sys::path::filename(
-            SM.getFilename(First->getLocation()));
-        if (File.starts_with("llvm-"))
+        if (jl_clangsa::isInLLVMHeaderFile(First->getLocation(), SM))
             return true;
-        for (const DeclContext *DC = FD->getDeclContext(); DC;
-             DC = DC->getParent())
-            if (const auto *NS = dyn_cast<NamespaceDecl>(DC))
-                if (NS->getName() == "llvm" || NS->getName() == "std" ||
-                    NS->getName() == "tp")
-                    return true;
+        if (jl_clangsa::isInNonSafepointNamespace(FD->getDeclContext()))
+            return true;
         if (FD->getBuiltinID() != 0)
             return true;
         StringRef Name = FD->getDeclName().isIdentifier() ? FD->getName() : "";
-        if ((Name.starts_with("uv_") || Name.starts_with("unw_") ||
-             Name.starts_with("_U")) &&
-            Name != "uv_run")
-            return true;
-        return false;
+        return jl_clangsa::nameIsNonSafepointRuntimeHelper(Name);
     }
 
     // True if the function has a global prototype: some declaration other
@@ -580,15 +580,41 @@ private:
         return Lexer::getLocForEndOfToken(Loc, 0, SM, LO);
     }
 
-    // The closing `)` of a function declaration's parameter list, or an invalid
-    // location if it cannot be determined.
-    static SourceLocation functionRParenLoc(const FunctionDecl *FD) {
-        if (TypeSourceInfo *TSI = FD->getTypeSourceInfo()) {
-            TypeLoc TL = TSI->getTypeLoc().IgnoreParens();
-            if (auto FTL = TL.getAs<FunctionTypeLoc>())
-                return FTL.getRParenLoc();
-        }
-        return SourceLocation();
+    // The later of two locations in the translation unit (ignoring invalid
+    // ones), used to find the last token of a function's declarator suffix.
+    static SourceLocation later(SourceLocation A, SourceLocation B,
+                                SourceManager &SM) {
+        if (A.isInvalid())
+            return B;
+        if (B.isInvalid())
+            return A;
+        return SM.isBeforeInTranslationUnit(A, B) ? B : A;
+    }
+
+    // The start of the last token of the function declarator's suffix -- the
+    // parameter list's `)` plus any trailing qualifiers that a function-level
+    // annotation must follow: cv-/ref-qualifiers and the exception specification
+    // (carried by the FunctionTypeLoc), and the `override`/`final` virt
+    // specifiers (carried as attributes). A member function `f() const` thus
+    // gets its annotation after `const` (`f() const JL_NOTSAFEPOINT`) rather
+    // than the ill-formed `f() JL_NOTSAFEPOINT const`. Reading this from the AST
+    // avoids re-lexing the source, which could be confused by macros.
+    static SourceLocation declaratorSuffixEnd(const FunctionDecl *FD,
+                                              SourceManager &SM) {
+        TypeSourceInfo *TSI = FD->getTypeSourceInfo();
+        if (!TSI)
+            return SourceLocation();
+        auto FTL = TSI->getTypeLoc().IgnoreParens().getAs<FunctionTypeLoc>();
+        if (!FTL)
+            return SourceLocation();
+        SourceLocation End = later(FTL.getRParenLoc(), FTL.getLocalRangeEnd(), SM);
+        if (auto FPTL = FTL.getAs<FunctionProtoTypeLoc>())
+            End = later(End, FPTL.getExceptionSpecRange().getEnd(), SM);
+        if (const auto *A = FD->getAttr<OverrideAttr>())
+            End = later(End, A->getLocation(), SM);
+        if (const auto *A = FD->getAttr<FinalAttr>())
+            End = later(End, A->getLocation(), SM);
+        return End;
     }
 
     // Identify which attributes this check governs and how to compare them

--- a/src/clangsa/GCChecker.h
+++ b/src/clangsa/GCChecker.h
@@ -18,6 +18,8 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
+#include "HelpersCommon.hpp"
+
 #include <memory>
 #include <optional>
 #include <utility>

--- a/src/clangsa/GCCheckerPropagation.cpp
+++ b/src/clangsa/GCCheckerPropagation.cpp
@@ -302,12 +302,7 @@ bool GCChecker::isFDAnnotatedNotSafepoint(const clang::FunctionDecl *FD, const S
       return false;
   if (declHasAnnotation(FD, "julia_not_safepoint"))
       return true;
-  SourceLocation Loc = FD->getLocation();
-  StringRef Name = SM.getFilename(Loc);
-  Name = llvm::sys::path::filename(Name);
-  if (Name.starts_with("llvm-"))
-      return true;
-  return false;
+  return jl_clangsa::isInLLVMHeaderFile(FD->getLocation(), SM);
 }
 
 static bool isMutexLock(StringRef name) {
@@ -523,14 +518,9 @@ bool GCChecker::isSafepoint(const CallEvent &Call, CheckerContext &C) const {
       if (Decl == nullptr)
           Decl = CE->getCalleeDecl(); // ignores dyn_cast<FunctionDecl>, so it could also be a MemberDecl, etc.
     }
-    const DeclContext *DC = Decl ? Decl->getDeclContext() : nullptr;
-    while (DC) {
-      // Anything in llvm or std is not a safepoint
-      if (const NamespaceDecl *NDC = dyn_cast<NamespaceDecl>(DC))
-        if (NDC->getName() == "llvm" || NDC->getName() == "std" || NDC->getName() == "tp")
-          return false;
-      DC = DC->getParent();
-    }
+    // Anything in llvm, std, or tp is not a safepoint
+    if (Decl && jl_clangsa::isInNonSafepointNamespace(Decl->getDeclContext()))
+      return false;
     const FunctionDecl *FD = Decl ? Decl->getAsFunction() : nullptr;
     if (!Decl || !FD) {
       if (Callee == nullptr) {
@@ -553,10 +543,7 @@ bool GCChecker::isSafepoint(const CallEvent &Call, CheckerContext &C) const {
           FD->getDeclName().isIdentifier() ? FD->getName() : "";
       if (FD->getBuiltinID() != 0 || FD->isTrivial())
         isCalleeSafepoint = false;
-      else if ((FDName.starts_with("uv_") ||
-                FDName.starts_with("unw_") ||
-                FDName.starts_with("_U")) &&
-               FDName != "uv_run")
+      else if (jl_clangsa::nameIsNonSafepointRuntimeHelper(FDName))
         isCalleeSafepoint = false;
       else
         isCalleeSafepoint = !isFDAnnotatedNotSafepoint(FD, getSM(C));

--- a/src/clangsa/HelpersCommon.hpp
+++ b/src/clangsa/HelpersCommon.hpp
@@ -1,0 +1,53 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// HelpersCommon: small predicates shared between the Julia clang plugins.
+//
+// This is deliberately a `.hpp` of `inline` definitions rather than a library:
+// each plugin (libGCCheckerPlugin, libFirstDeclAnnotationsPlugin, ...) is built
+// and loaded separately, so there is no common object file to link against.
+// Including the definitions here compiles a private copy into each plugin.
+
+#ifndef JULIA_CLANGSA_HELPERSCOMMON_HPP
+#define JULIA_CLANGSA_HELPERSCOMMON_HPP
+
+#include "clang/AST/DeclBase.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Path.h"
+
+namespace jl_clangsa {
+using namespace clang;
+
+// True if any enclosing namespace of `DC` is one the analyzer treats as never
+// reaching a safepoint: `llvm`, `std`, or `tp`. A null `DC` (e.g. a decl with
+// no resolved context) is simply not in such a namespace.
+inline bool isInNonSafepointNamespace(const DeclContext *DC) {
+  for (; DC; DC = DC->getParent())
+    if (const auto *NS = dyn_cast<NamespaceDecl>(DC))
+      if (NS->getName() == "llvm" || NS->getName() == "std" ||
+          NS->getName() == "tp")
+        return true;
+  return false;
+}
+
+// True if `Loc` is in a file named like an upstream LLVM header (`llvm-*`),
+// which the analyzer treats as external and therefore never a safepoint.
+inline bool isInLLVMHeaderFile(SourceLocation Loc, const SourceManager &SM) {
+  StringRef Name = llvm::sys::path::filename(SM.getFilename(Loc));
+  return Name.starts_with("llvm-");
+}
+
+// True if `Name` is one of the `uv_`/`unw_`/`_U` runtime helpers the analyzer
+// treats as a non-safepoint. `uv_run` is the sole exception: it drives the
+// event loop and can reach arbitrary safepoints.
+inline bool nameIsNonSafepointRuntimeHelper(StringRef Name) {
+  return (Name.starts_with("uv_") || Name.starts_with("unw_") ||
+          Name.starts_with("_U")) &&
+         Name != "uv_run";
+}
+
+} // namespace jl_clangsa
+
+#endif


### PR DESCRIPTION
Deduplicate some code into a new header clangsa/HelpersCommon.hpp to avoid redundancy and keep them in sync. Because each plugin is built and loaded as its own shared library, the helper is a header of inline definitions compiled privately into each plugin rather than a separate library.

Improves the fix-it suggested location of attributes, which needs to come last on a declaration (e.g. after `const`) in C++.

Also do some some cleanup DRY on the Makefile: derive the clangsa plugin path lists in src/Makefile (the clangsa and clean targets, the clang-sagc plugin path, and the clang-tidy -load flags and prerequisites) from a single CLANGSA_PLUGIN_NAMES list via addprefix, instead of repeating each library path.