### PR TITLE
Package load time optimizations

### DIFF
--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -464,6 +464,11 @@ function method_morespecific_via_interferences(method1::Method, method2::Method)
     return false
 end
 
+# Max interference-set size for which n==1 uses the interference fast path instead of
+# `ml_matches`: the scan probes every member with `typeintersect`, so above this size the
+# pruned `ml_matches` lookup is cheaper (~8 is the empirical crossover).
+const VERIFY_INTERF_CAP = 8
+
 function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n::Int, world::UInt, fully_covers::Bool, matches::Vector{Any})
     # verify that these edges intersect with the same methods as before
     mi = nothing
@@ -480,36 +485,48 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         if _jl_debug_method_invalidation[] === nothing && world == get_world_counter()
             return UInt(1), UInt(0)
         end
-    elseif n == 1
-        # first, fast-path a check if the expected method simply dominates its sig anyways
-        # so the result of ml_matches is already simply known
-        let t = expecteds[i], meth, minworld, maxworld
-            meth = get_method_from_edge(t)
-            if !(t isa Method)
-                if t isa CodeInstance
-                    mi = get_ci_mi(t)::MethodInstance
-                else
-                    mi = t::MethodInstance
+    else # n >= 1
+        if n == 1
+            # first, fast-path a check if the expected method simply dominates its sig anyways
+            # so the result of ml_matches is already simply known
+            let t = expecteds[i], meth, minworld, maxworld
+                meth = get_method_from_edge(t)
+                if !(t isa Method)
+                    if t isa CodeInstance
+                        mi = get_ci_mi(t)::MethodInstance
+                    else
+                        mi = t::MethodInstance
+                    end
+                    # Fast path is legal when fully_covers=true
+                    if fully_covers && !iszero(mi.dispatch_status & METHOD_SIG_LATEST_ONLY)
+                        minworld = meth.primary_world
+                        @assert minworld ≤ world "expected method not present in verification world"
+                        maxworld = typemax(UInt)
+                        return minworld, maxworld
+                    end
                 end
                 # Fast path is legal when fully_covers=true
-                if fully_covers && !iszero(mi.dispatch_status & METHOD_SIG_LATEST_ONLY)
+                if fully_covers && !iszero(meth.dispatch_status & METHOD_SIG_LATEST_ONLY)
                     minworld = meth.primary_world
                     @assert minworld ≤ world "expected method not present in verification world"
                     maxworld = typemax(UInt)
                     return minworld, maxworld
                 end
             end
-            # Fast path is legal when fully_covers=true
-            if fully_covers && !iszero(meth.dispatch_status & METHOD_SIG_LATEST_ONLY)
-                minworld = meth.primary_world
-                @assert minworld ≤ world "expected method not present in verification world"
-                maxworld = typemax(UInt)
-                return minworld, maxworld
+        end
+        # Try the interference set fast path (used by both n==1, when the O(1) checks above
+        # did not resolve it, and n>1): the result is unchanged as long as no interfering
+        # method intersects sig outside of what the expected method(s) cover.
+        interference_fast_path_success = fully_covers
+        if interference_fast_path_success && n == 1
+            # Skip to ml_matches for large interference sets (see VERIFY_INTERF_CAP). The set
+            # is packed, so isassigned(., cap+1) tests "size > cap" without any typeintersect.
+            let interf = get_method_from_edge(expecteds[i]).interferences, cap = VERIFY_INTERF_CAP
+                if length(interf) > cap && isassigned(interf, cap + 1)
+                    interference_fast_path_success = false
+                end
             end
         end
-    elseif n > 1
-        # Try the interference set fast path: check if all interference sets are covered by expecteds
-        interference_fast_path_success = fully_covers
         # If it didn't fail yet, then check that all interference methods are either expected, or not applicable.
         if interference_fast_path_success
             local interference_minworld::UInt = 1

--- a/src/gf.c
+++ b/src/gf.c
@@ -2368,6 +2368,25 @@ static void _invalidate_backedges(jl_method_instance_t *replaced_mi, jl_code_ins
 static int jl_type_intersection2(jl_value_t *t1, jl_value_t *t2, jl_value_t **isect JL_REQUIRE_ROOTED_SLOT, jl_value_t **isect2 JL_REQUIRE_ROOTED_SLOT)
 {
     *isect2 = NULL;
+    // Fast path: a dispatch tuple is a concrete leaf type, so its intersection with any
+    // other type is just itself (when it is a subtype) or empty. This avoids full type
+    // intersection for the common case of concrete specialization/backedge signatures.
+    if (jl_is_dispatch_tupletype(t2)) {
+        if (jl_subtype(t2, t1)) {
+            *isect = t2;
+            return 1;
+        }
+        *isect = jl_bottom_type;
+        return 0;
+    }
+    if (jl_is_dispatch_tupletype(t1)) {
+        if (jl_subtype(t1, t2)) {
+            *isect = t1;
+            return 1;
+        }
+        *isect = jl_bottom_type;
+        return 0;
+    }
     int is_subty = 0;
     *isect = jl_type_intersection_env_s(t1, t2, NULL, &is_subty);
     if (*isect == jl_bottom_type)


### PR DESCRIPTION
Some optimizations motivated by speeding up package load time:

Fastest times shown for a few runs of `using GLMakie` per commit
- master -  4.469244 seconds
- 69bf4aadaef44f99ff311f03abd8666ac6462c72 `Compiler: extend backedge-verify interference fast path to n==1 edges` -   4.370297 seconds
- 69bf4aadaef44f99ff311f03abd8666ac6462c72 + d5ac850b8ad4f49e8ec70034f2cc10fb12f2dab1 `gf: fast-path jl_type_intersection2 for dispatch-tuple arguments` - 4.186908 seconds
