### PR TITLE
Add `ABIAdapter` / `DispatchTrampoline` and use for `@ccallable` / `@cfunction`

### DIFF
--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -393,7 +393,9 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
             atype = argtypes_to_type(argtypes)
 
             mi = compileable_specialization_for_call(interp, atype)
-            if mi !== nothing
+            # A partially-covering method is served by call-time dispatch, which is
+            # unavailable under --trim.
+            if mi !== nothing && atype <: (mi.def::Method).sig
                 # n.b.: Codegen may choose unpredictably to emit this `@cfunction` as a dynamic invoke or a full
                 # dynamic call, but in either case it guarantees that the required adapter(s) are emitted. All
                 # that we are required to verify here is that the callee CodeInstance is covered.
@@ -462,8 +464,11 @@ function get_verify_typeinf_trim(codeinfos::Vector{Any})
             sig = item[2]::Type
             mi = ccall(:jl_get_specialization1, Any, (Any, Csize_t), sig, this_world)
             asrt = Any
-            valid = if mi !== nothing
-                mi = mi::MethodInstance
+            # A partially-covering method requires dynamic dispatch to check for Method
+            # coverage. We could allow this but we choose not to because of the implicitly
+            # degraded ABI (better to point this out to the user instead of having
+            # `@ccallable` allocating on an important function boundary etc)
+            valid = if mi isa MethodInstance && sig <: (mi.def::Method).sig
                 ci = get(caches, mi, nothing)
                 if ci isa CodeInstance
                     # TODO: should we find a way to indicate to the user that this gets called via ccallable?

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -388,6 +388,32 @@ show(io::IO, ms::MethodList) = show_method_table(io, ms)
 show(io::IO, ::MIME"text/plain", ms::MethodList) = show_method_table(io, ms)
 show(io::IO, mt::Core.MethodTable) = print(io, mt.module, ".", mt.name, " is a Core.MethodTable with ", length(mt), " methods.")
 
+# Total ABIAdapters / DispatchTrampolines in a `jl_typemap_list_t`
+function _cache_item_count(c)
+    n = 0
+    function count_chain(@nospecialize r)
+        while true
+            n += 1
+            isdefined(r, :next, :acquire) || break
+            r = getfield(r, :next, :acquire)
+        end
+    end
+    function count_bucket(@nospecialize b)
+        if b isa Memory{Any}
+            for i in 1:2:length(b)
+                isassigned(b, i) && count_chain(b[i + 1])
+            end
+        else
+            count_chain(b)
+        end
+    end
+    tm = getfield(c, :cache)
+    tm === nothing || visit(count_bucket, tm)
+    return n
+end
+show(io::IO, c::Core.ABIAdapterCache) = print(io, "Core.ABIAdapterCache with ",
+    _cache_item_count(c), " adapters.")
+
 function inbase(m::Module)
     if m == Base
         true

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -413,6 +413,8 @@ function _cache_item_count(c)
 end
 show(io::IO, c::Core.ABIAdapterCache) = print(io, "Core.ABIAdapterCache with ",
     _cache_item_count(c), " adapters.")
+show(io::IO, c::Core.DispatchTrampolineCache) = print(io, "Core.DispatchTrampolineCache with ",
+    _cache_item_count(c), " trampolines.")
 
 function inbase(m::Module)
     if m == Base

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -388,28 +388,32 @@ show(io::IO, ms::MethodList) = show_method_table(io, ms)
 show(io::IO, ::MIME"text/plain", ms::MethodList) = show_method_table(io, ms)
 show(io::IO, mt::Core.MethodTable) = print(io, mt.module, ".", mt.name, " is a Core.MethodTable with ", length(mt), " methods.")
 
+# Items in one `jl_typemap_list_t` bucket: an intrusive `next`-linked list, or, once
+# re-indexed, an open-addressed table holding one item per assigned slot (re-indexing
+# abandons the `next` links rather than relinking, so they must not be followed there).
+function _cache_bucket_count(@nospecialize b)
+    n = 0
+    if b isa Memory{Any}
+        for i in 1:length(b)
+            isassigned(b, i) && (n += 1)
+        end
+        return n
+    end
+    r = b
+    while true
+        n += 1
+        isdefined(r, :next, :acquire) || break
+        r = getfield(r, :next, :acquire)
+    end
+    return n
+end
+
 # Total ABIAdapters / DispatchTrampolines in a `jl_typemap_list_t`
 function _cache_item_count(c)
-    n = 0
-    function count_chain(@nospecialize r)
-        while true
-            n += 1
-            isdefined(r, :next, :acquire) || break
-            r = getfield(r, :next, :acquire)
-        end
-    end
-    function count_bucket(@nospecialize b)
-        if b isa Memory{Any}
-            for i in 1:2:length(b)
-                isassigned(b, i) && count_chain(b[i + 1])
-            end
-        else
-            count_chain(b)
-        end
-    end
+    total = Ref(0)
     tm = getfield(c, :cache)
-    tm === nothing || visit(count_bucket, tm)
-    return n
+    tm === nothing || visit(b -> (total[] += _cache_bucket_count(b); nothing), tm)
+    return total[]
 end
 show(io::IO, c::Core.ABIAdapterCache) = print(io, "Core.ABIAdapterCache with ",
     _cache_item_count(c), " adapters.")

--- a/src/Makefile
+++ b/src/Makefile
@@ -67,7 +67,7 @@ SRCS := \
 	simplevector runtime_intrinsics precompile jloptions mtarraylist \
 	threading scheduler stackwalk null_sysimage \
 	method jlapi signal-handling safepoint timing subtype rtutils \
-	crc32c APInt processor ircode opaque_closure abi_adapter codegen-stubs coverage runtime_ccall engine \
+	crc32c APInt processor ircode opaque_closure abi_adapter dispatch_trampoline codegen-stubs coverage runtime_ccall engine \
 	$(GC_SRCS)
 
 RT_LLVMLINK :=

--- a/src/Makefile
+++ b/src/Makefile
@@ -67,7 +67,7 @@ SRCS := \
 	simplevector runtime_intrinsics precompile jloptions mtarraylist \
 	threading scheduler stackwalk null_sysimage \
 	method jlapi signal-handling safepoint timing subtype rtutils \
-	crc32c APInt processor ircode opaque_closure codegen-stubs coverage runtime_ccall engine \
+	crc32c APInt processor ircode opaque_closure abi_adapter codegen-stubs coverage runtime_ccall engine \
 	$(GC_SRCS)
 
 RT_LLVMLINK :=

--- a/src/abi_adapter.c
+++ b/src/abi_adapter.c
@@ -1,0 +1,231 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include "julia.h"
+#include "julia_internal.h"
+
+// A jl_typemap_list_t cache keyed by `sigt`; ABIAdapters within a sigt bucket are
+// distinguished by (rt, ci, specsig, kind) and hash-indexed once a bucket grows.
+// An optimistic lookup miss is definitive only under the writelock.
+
+#define MAX_ADAPTER_LIST_COUNT 6 // mirror MAX_METHLIST_COUNT: hash-index buckets above this
+
+typedef struct {
+    jl_value_t *rt;
+    jl_code_instance_t *ci;
+    int specsig;
+    jl_abi_kind_t kind;
+} abi_adapter_key_t;
+
+// Match `rt` by type equality, as the TypeMap does for `sigt`.
+static int abi_adapter_match(jl_value_t *item, void *keyv) JL_CANSAFEPOINT
+{
+    jl_abi_adapter_t *e = (jl_abi_adapter_t*)item;
+    abi_adapter_key_t *k = (abi_adapter_key_t*)keyv;
+    return e->ci == k->ci
+        && (int)e->specsig == (k->specsig ? 1 : 0)
+        && (jl_abi_kind_t)e->kind == k->kind
+        && (e->rt == k->rt || jl_types_equal(e->rt, k->rt)); // rt lives in the bucket (key is sigt alone)
+}
+
+static uintptr_t abi_adapter_hash_key(jl_code_instance_t *ci, int specsig, jl_abi_kind_t kind) JL_NOTSAFEPOINT
+{
+    // rt is intentionally omitted from this hash (type hashes have many bugs / limitations) but
+    // ci dominates the fan-out anyway since we expect many callee CIs with the same (effectively
+    // type-erased) `sigt` in their `from_abi`
+    return int64hash((uintptr_t)ci ^ ((uintptr_t)(specsig ? 1 : 0) << 8) ^ (uintptr_t)kind);
+}
+
+static uintptr_t abi_adapter_hash(jl_value_t *item) JL_NOTSAFEPOINT
+{
+    jl_abi_adapter_t *e = (jl_abi_adapter_t*)item;
+    return abi_adapter_hash_key(e->ci, e->specsig, (jl_abi_kind_t)e->kind);
+}
+
+static const jl_typemap_list_config_t abi_adapter_cache_config = {
+    offsetof(jl_abi_adapter_t, next),
+    MAX_ADAPTER_LIST_COUNT,
+    abi_adapter_hash,
+    abi_adapter_match,
+};
+
+JL_DLLEXPORT void jl_reinit_abi_adapter_cache(jl_abi_adapter_cache_t *c) JL_NOTSAFEPOINT
+{
+    c->cache.config = &abi_adapter_cache_config;
+    JL_MUTEX_INIT(&c->writelock, "jl_abi_adapters->writelock");
+}
+
+// Return whether the target entry point already satisfies `from_abi`.
+JL_DLLEXPORT int jl_abi_matches_invoke_api(jl_abi_t from_abi, jl_invoke_api_t api,
+        jl_method_instance_t *mi, jl_value_t *rettype) JL_CANSAFEPOINT
+{
+    // Non-standard kinds require their own frame conversion.
+    if (from_abi.kind != JL_ABI_STD)
+        return 0;
+    if (api == JL_INVOKE_ARGS)
+        return !from_abi.specsig && jl_subtype(rettype, from_abi.rt);
+    if (api == JL_INVOKE_SPECSIG)
+        return from_abi.specsig && jl_egal(mi->specTypes, from_abi.sigt) && jl_egal(rettype, from_abi.rt);
+    return 0;
+}
+
+// Return a directly compatible specptr, or describe the target to create an adapter for.
+static void *abi_adapter_resolve_target(jl_abi_t from_abi, jl_code_instance_t *codeinst,
+        void **target, int *target_specsig, jl_callptr_t *invoke) JL_CANSAFEPOINT
+{
+    *target = NULL;
+    *target_specsig = 0;
+    *invoke = NULL;
+    if (codeinst == NULL)
+        return NULL;
+    uint8_t specsigflags;
+    jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
+    void *specptr = NULL;
+    jl_callptr_t invoke_ = NULL;
+    jl_read_codeinst_invoke(codeinst, &specsigflags, &invoke_, &specptr, /* waitcompile */ 0);
+    *invoke = invoke_;
+    if (invoke_ == NULL)
+        return NULL;
+    if (invoke_ == jl_fptr_const_return_addr) {
+        return NULL;
+    }
+    else if (invoke_ == jl_fptr_args_addr) {
+        assert(specptr != NULL);
+        if (jl_abi_matches_invoke_api(from_abi, JL_INVOKE_ARGS, mi, codeinst->rettype))
+            return specptr; // no adapter required
+        *target = specptr;
+        *target_specsig = 0;
+    }
+    else if (specsigflags & JL_CI_FLAGS_SPECPTR_SPECIALIZED) {
+        assert(specptr != NULL);
+        if (jl_abi_matches_invoke_api(from_abi, JL_INVOKE_SPECSIG, mi, codeinst->rettype))
+            return specptr; // no adapter required
+        *target = specptr;
+        *target_specsig = 1;
+    }
+    return NULL;
+}
+
+// Return the target's directly compatible specptr (for a from_abi call), if any.
+JL_DLLEXPORT void *jl_abi_matching_specptr(jl_abi_t from_abi, jl_code_instance_t *codeinst) JL_CANSAFEPOINT
+{
+    void *target;
+    int target_specsig;
+    jl_callptr_t invoke;
+    return abi_adapter_resolve_target(from_abi, codeinst, &target, &target_specsig, &invoke);
+}
+
+// Fallible lock-free lookup; NULL indicates absence - or a concurrent write
+static jl_abi_adapter_t *abi_adapter_lookup(jl_value_t *sigt, jl_value_t *rt,
+        jl_code_instance_t *ci, int specsig, jl_abi_kind_t kind) JL_CANSAFEPOINT
+{
+    abi_adapter_key_t key = { rt, ci, specsig, kind };
+    return (jl_abi_adapter_t*)jl_typemap_list_lookup(&jl_abi_adapters->cache, sigt,
+            abi_adapter_hash_key(ci, specsig, kind), &key);
+}
+
+// Return a matching target entry point or cached adapter without compiling.
+// On a miss, the optional target outputs describe the adapter to compile.
+JL_DLLEXPORT void *jl_lookup_abi_adapter(jl_abi_t from_abi, jl_code_instance_t *codeinst,
+        void **target, int *target_specsig, jl_callptr_t *invoke, jl_value_t **invokee) JL_CANSAFEPOINT
+{
+    void *tgt = NULL;
+    int ts = 0;
+    jl_callptr_t invoke_ = NULL;
+    if (invokee)
+        *invokee = NULL;
+    void *shortcut = abi_adapter_resolve_target(from_abi, codeinst, &tgt, &ts, &invoke_);
+    if (target)
+        *target = tgt;
+    if (target_specsig)
+        *target_specsig = ts;
+    if (invoke)
+        *invoke = invoke_;
+    if (shortcut != NULL) {
+        if (invokee)
+            *invokee = (jl_value_t*)codeinst; // bare CI: no ABIAdapter required
+        return shortcut;
+    }
+    jl_abi_adapter_t *e = abi_adapter_lookup(from_abi.sigt, from_abi.rt, codeinst,
+            from_abi.specsig, from_abi.kind);
+    if (e == NULL) {
+        JL_LOCK(&jl_abi_adapters->writelock);
+        e = abi_adapter_lookup(from_abi.sigt, from_abi.rt, codeinst,
+                from_abi.specsig, from_abi.kind);
+        JL_UNLOCK(&jl_abi_adapters->writelock);
+    }
+    if (e == NULL)
+        return NULL;
+    // Cached ABIAdapters always carry a valid fptr, set before publication.
+    void *f = jl_atomic_load_relaxed(&e->fptr);
+    assert(f != NULL);
+    if (invokee)
+        *invokee = (jl_value_t*)e;
+    return f;
+}
+
+// Caller holds the writelock and has confirmed that `entry` is absent.
+static void abi_adapter_insert(jl_abi_adapter_t *entry) JL_CANSAFEPOINT
+{
+    jl_typemap_list_insert(&jl_abi_adapters->cache, (jl_value_t*)jl_abi_adapters,
+            entry->sigt, (jl_value_t*)entry);
+}
+
+// Allocate a detached ABIAdapter; the caller roots its key fields.
+JL_DLLEXPORT jl_abi_adapter_t *jl_new_abi_adapter(jl_value_t *sigt, jl_value_t *rt,
+        jl_code_instance_t *ci, int specsig, jl_abi_kind_t kind, void *fptr) JL_CANSAFEPOINT
+{
+    jl_task_t *ct = jl_current_task;
+    jl_abi_adapter_t *e = (jl_abi_adapter_t*)jl_gc_alloc(ct->ptls, sizeof(jl_abi_adapter_t), jl_abi_adapter_type);
+    e->sigt = sigt;
+    e->rt = rt;
+    e->specsig = specsig ? 1 : 0;
+    e->kind = kind;
+    e->ci = ci;
+    jl_atomic_store_relaxed(&e->fptr, fptr);
+    jl_atomic_store_relaxed(&e->next, (jl_abi_adapter_t*)NULL);
+    return e;
+}
+
+// Publish `fptr`, returning the winner if the key is already cached.
+JL_DLLEXPORT void *jl_insert_abi_adapter(jl_abi_t from_abi, jl_code_instance_t *codeinst,
+        void *fptr, jl_value_t **invokee) JL_CANSAFEPOINT
+{
+    assert(fptr != NULL);
+    jl_abi_adapter_t *e = NULL;
+    JL_GC_PUSH1(&e);
+    JL_LOCK(&jl_abi_adapters->writelock);
+    e = abi_adapter_lookup(from_abi.sigt, from_abi.rt, codeinst,
+            from_abi.specsig, from_abi.kind);
+    if (e != NULL) {
+        // Cached ABIAdapters always carry a valid fptr; keep the winner.
+        fptr = jl_atomic_load_relaxed(&e->fptr);
+        assert(fptr != NULL);
+    }
+    else {
+        e = jl_new_abi_adapter(from_abi.sigt, from_abi.rt, codeinst,
+                from_abi.specsig, from_abi.kind, fptr);
+        abi_adapter_insert(e);
+    }
+    if (invokee)
+        *invokee = (jl_value_t*)e;
+    JL_UNLOCK(&jl_abi_adapters->writelock);
+    JL_GC_POP();
+    return fptr;
+}
+
+// Reinsert an ABIAdapter into the cache, unless an equivalent is already present.
+JL_DLLEXPORT jl_abi_adapter_t *jl_reinsert_abi_adapter(jl_abi_adapter_t *e) JL_CANSAFEPOINT
+{
+    assert(jl_atomic_load_relaxed(&e->fptr) != NULL);
+    jl_abi_adapter_t *canonical = NULL;
+    JL_GC_PUSH2(&e, &canonical);
+    JL_LOCK(&jl_abi_adapters->writelock);
+    canonical = abi_adapter_lookup(e->sigt, e->rt, e->ci, e->specsig, (jl_abi_kind_t)e->kind);
+    if (canonical == NULL) {
+        abi_adapter_insert(e);
+        canonical = e;
+    }
+    JL_UNLOCK(&jl_abi_adapters->writelock);
+    JL_GC_POP();
+    return canonical;
+}

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -178,6 +178,8 @@ typedef struct {
     // were presented in `codeinfos`; consumed by staticdata.c to rewrite each
     // MethodInstance's `cache` field into a `next`-linked list
     SmallVector<jl_code_instance_t*, 0> jl_ci_order;
+    // AOT-resolved trampoline targets retained for serialization.
+    std::map<jl_dispatch_trampoline_t*, jl_value_t*> trampoline_invokee_map;
 } jl_native_code_desc_t;
 
 // Look up the fvar IDs for a code-carrying object (CodeInstance or ABIAdapter).
@@ -195,6 +197,17 @@ void jl_get_function_id_impl(void *native_code, jl_value_t *codeinst_or_adapter,
             std::tie(*func_idx, *specfunc_idx) = it->second;
         }
     }
+}
+
+// Return the trampoline target (ABIAdapter / CodeInstance) eagerly emitted during code generation.
+extern "C" JL_DLLEXPORT_CODEGEN
+jl_value_t *jl_get_trampoline_invokee_impl(void *native_code, jl_dispatch_trampoline_t *tr)
+{
+    jl_native_code_desc_t *data = (jl_native_code_desc_t*)native_code;
+    if (!data)
+        return NULL;
+    auto it = data->trampoline_invokee_map.find(tr);
+    return it == data->trampoline_invokee_map.end() ? NULL : it->second;
 }
 
 extern "C" JL_DLLEXPORT_CODEGEN void
@@ -549,8 +562,91 @@ static Function *aot_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, 
     return F;
 }
 
+// AOT counterpart of jl_resolve_trampoline: resolve the target for `tr` at the build world,
+// emit its ABI adapter, and record the materialized ABIAdapter record in
+// `out.trampoline_invokees` / `out.adapter_funcs`. When the target's compiled ABI already
+// satisfies the declared C ABI, `trampoline_invokees` maps to the bare `CodeInstance` instead and
+// no adapter is emitted.
+static void emit_trampoline_adapter(jl_codegen_output_t &out, jl_dispatch_trampoline_t *tr,
+        jl_abi_t from_abi, DenseMap<jl_method_instance_t*, jl_code_instance_t*> &compiled_mi,
+        size_t latestworld) JL_CANSAFEPOINT
+{
+    JL_GC_PROMISE_ROOTED(tr);
+    jl_value_t *sigt = from_abi.sigt;
+    JL_GC_PROMISE_ROOTED(sigt);
+    jl_value_t *declrt = from_abi.rt;
+    JL_GC_PROMISE_ROOTED(declrt);
+    jl_method_instance_t *mi = (jl_method_instance_t*)jl_get_specialization1((jl_tupletype_t*)sigt, latestworld);
+    jl_code_instance_t *codeinst = nullptr;
+    if ((jl_value_t*)mi != jl_nothing) {
+        auto it = compiled_mi.find(mi);
+        if (it != compiled_mi.end())
+            codeinst = it->second;
+    }
+    Function *F;
+    if (codeinst) {
+        JL_GC_PROMISE_ROOTED(codeinst);
+        jl_value_t *astrt = codeinst->rettype;
+        if (astrt != (jl_value_t*)jl_bottom_type &&
+            jl_type_intersection(astrt, declrt) == jl_bottom_type) {
+            // Do not warn if the function never returns since it is occasionally required by
+            // the C API (typically error callbacks) even though we're likely to encounter
+            // memory errors in that case.
+            jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name_from_method_instance(mi));
+        }
+        const auto &decls = out.ci_funcs.find(codeinst)->second;
+        // If the target's own compiled ABI already satisfies the declared C ABI, no adapter
+        // is needed: map to the bare CodeInstance so the first post-load call derives `fptr`
+        // from its (independently wired) specptr.
+        if (jl_abi_matches_invoke_api(from_abi, decls.invoke_api, mi, codeinst->rettype)) {
+            out.trampoline_invokees[tr] = (jl_value_t*)codeinst; // bare CI: no adapter thunk emitted
+            return;
+        }
+        if (decls.invoke_api == JL_INVOKE_CONST) {
+            std::string n = emit_abi_constreturn(out, from_abi, codeinst->rettype_const);
+            F = out.get_module().getFunction(n);
+            assert(F);
+        }
+        else if (decls.invoke_api == JL_INVOKE_SPARAM) {
+            // no specptr prototype declared; route through jl_invoke via the dispatcher
+            F = aot_abi_converter(out, from_abi, codeinst, nullptr, nullptr, false);
+        }
+        else if (decls.invoke_api == JL_INVOKE_ARGS) {
+            assert(decls.specptr);
+            F = aot_abi_converter(out, from_abi, codeinst, nullptr, decls.specptr, false);
+        }
+        else {
+            assert(decls.specptr);
+            F = aot_abi_converter(out, from_abi, codeinst, nullptr, decls.specptr, true);
+        }
+    }
+    else {
+        // no method at the build world: emit the shared dynamic-dispatch adapter
+        F = aot_abi_converter(out, from_abi, nullptr, nullptr, nullptr, false);
+    }
+    // A real thunk was needed: materialize the ABIAdapter record (its `fptr` is wired from the
+    // fvar on load) and map the trampoline to it. The record reaches the image via the
+    // serializer's `last_invokee` override (and `emitted_adapters`); the first post-load call
+    // restores `fptr` straight from it.
+    jl_abi_adapter_t *rec = jl_new_abi_adapter(sigt, declrt, codeinst,
+            from_abi.specsig, from_abi.kind, /*fptr*/nullptr);
+    // Nothing else roots the record until it is pushed to `emitted_adapters`.
+    JL_GC_PUSH1(&rec);
+    jl_array_ptr_1d_push(out.temporary_roots, (jl_value_t*)rec);
+    JL_GC_POP();
+    out.trampoline_invokees[tr] = (jl_value_t*)rec;
+    out.adapter_funcs.push_back({rec, F});
+}
+
+// Emit the adapter for each @cfunction/@ccallable dispatch trampoline (kind=STD, so the
+// adapter sig is the call sig as-is). Replaces the old cfuncdata-array fill; the serializer
+// wires the adapter into the image trampoline's `last_invokee` (jl_get_trampoline_invokee).
+// Call sites sharing one interned trampoline (same sigt/rt/specsig) are deduplicated here, so
+// each trampoline yields exactly one adapter record and one unspecialized record.
 static void generate_cfunc_thunks(jl_codegen_output_t &out) JL_CANSAFEPOINT
 {
+    if (out.cfuncs.empty())
+        return;
     DenseMap<jl_method_instance_t*, jl_code_instance_t*> compiled_mi;
     for (auto &[ci, _] : out.ci_funcs) {
         jl_method_instance_t *mi = jl_get_ci_mi(ci);
@@ -560,77 +656,25 @@ static void generate_cfunc_thunks(jl_codegen_output_t &out) JL_CANSAFEPOINT
     }
     size_t latestworld = jl_atomic_load_acquire(&jl_world_counter);
     for (cfunc_decl_t &cfunc : out.cfuncs) {
-        jl_value_t *sigt = cfunc.abi.sigt;
-        JL_GC_PROMISE_ROOTED(sigt);
-        jl_value_t *declrt = cfunc.abi.rt;
-        JL_GC_PROMISE_ROOTED(declrt);
-        Function *unspec = aot_abi_converter(out, cfunc.abi, nullptr, nullptr, nullptr, false);
-        jl_code_instance_t *codeinst = nullptr;
-        auto assign_fptr = [&out, &cfunc, &codeinst, &unspec](Function *f) JL_CANSAFEPOINT {
-            ConstantArray *init = cast<ConstantArray>(cfunc.cfuncdata->getInitializer());
-            SmallVector<Constant*,8> initvals;
-            for (unsigned i = 0; i < init->getNumOperands(); ++i)
-                initvals.push_back(init->getOperand(i));
-            assert(initvals.size() == 8);
-            assert(initvals[0]->isNullValue());
-            assert(initvals[2]->isNullValue());
-            if (codeinst) {
-                Constant *llvmcodeinst = literal_pointer_val_slot(out, (jl_value_t*)codeinst);
-                initvals[2] = llvmcodeinst; // plast_codeinst
-            }
-            assert(initvals[4]->isNullValue());
-            initvals[4] = unspec;
-            initvals[0] = f;
-            cfunc.cfuncdata->setInitializer(ConstantArray::get(init->getType(), initvals));
-        };
-        jl_method_instance_t *mi = (jl_method_instance_t*)jl_get_specialization1((jl_tupletype_t*)sigt, latestworld);
-        Function *func = nullptr;
-        if ((jl_value_t*)mi != jl_nothing) {
-            auto it = compiled_mi.find(mi);
-            if (it != compiled_mi.end()) {
-                codeinst = it->second;
-                JL_GC_PROMISE_ROOTED(codeinst);
-                const auto &decls = out.ci_funcs.find(codeinst)->second;
-                jl_value_t *astrt = codeinst->rettype;
-                if (astrt != (jl_value_t*)jl_bottom_type &&
-                    jl_type_intersection(astrt, declrt) == jl_bottom_type) {
-                    // Do not warn if the function never returns since it is
-                    // occasionally required by the C API (typically error callbacks)
-                    // even though we're likely to encounter memory errors in that case
-                    jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name_from_method_instance(mi));
-                }
-                if (decls.invoke_api == JL_INVOKE_CONST) {
-                    std::string gf_thunk_name = emit_abi_constreturn(out, cfunc.abi, codeinst->rettype_const);
-                    auto F = out.get_module().getFunction(gf_thunk_name);
-                    assert(F);
-                    assign_fptr(F);
-                    continue;
-                }
-                else if (decls.invoke_api == JL_INVOKE_ARGS) {
-                    assert(decls.specptr);
-                    if (!cfunc.abi.specsig && jl_subtype(astrt, declrt)) {
-                        assign_fptr(decls.specptr);
-                        continue;
-                    }
-                    assign_fptr(aot_abi_converter(out, cfunc.abi, codeinst, nullptr, decls.specptr, false));
-                    continue;
-                }
-                else if (decls.invoke_api == JL_INVOKE_SPARAM) {
-                    func = nullptr; // use jl_invoke instead for these, since we don't declare these prototypes
-                }
-                else {
-                    assert(decls.specptr);
-                    if (jl_egal(mi->specTypes, sigt) && jl_egal(declrt, astrt)) {
-                        assign_fptr(decls.specptr);
-                        continue;
-                    }
-                    assign_fptr(aot_abi_converter(out, cfunc.abi, codeinst, func, decls.specptr, true));
-                    continue;
-                }
-            }
+        if (out.trampoline_invokees.count(cfunc.trampoline))
+            continue; // another call site already emitted this trampoline's adapter
+        emit_trampoline_adapter(out, cfunc.trampoline, cfunc.abi, compiled_mi, latestworld);
+        // Outside --trim, also emit the dynamic-dispatch ("unspecialized", ci == NULL)
+        // adapter for this signature, so a codegen-free run can dispatch this
+        // @cfunction/@ccallable even when the resolved target shifts (julia#61949). No
+        // trampoline owns it; it survives via the `emitted_adapters` report (see
+        // jl_create_native_impl). Under --trim, dynamic dispatch is unavailable, so skip it.
+        if (!jl_options.trim) {
+            Function *uf = aot_abi_converter(out, cfunc.abi, nullptr, nullptr, nullptr, false);
+            jl_abi_adapter_t *urec = jl_new_abi_adapter(cfunc.abi.sigt, cfunc.abi.rt,
+                    /*ci*/nullptr, cfunc.abi.specsig, cfunc.abi.kind,
+                    /*fptr*/nullptr);
+            JL_GC_PUSH1(&urec);
+            // Nothing else roots the record until it is pushed to `emitted_adapters`.
+            jl_array_ptr_1d_push(out.temporary_roots, (jl_value_t*)urec);
+            JL_GC_POP();
+            out.adapter_funcs.push_back({urec, uf});
         }
-        Function *f = codeinst ? aot_abi_converter(out, cfunc.abi, codeinst, func, nullptr, false) : unspec;
-        assign_fptr(f);
     }
 }
 
@@ -960,7 +1004,7 @@ static void jl_emit_native_to_output(jl_native_code_desc_t *data, jl_array_t *co
     generate_cfunc_thunks(out);
     // Transfer the emitted ABIAdapters to the caller while temporary_roots still protects them.
     if (emitted_adapters)
-        for (auto &[adapter, F] : out.abi_adapter_records)
+        for (auto &[adapter, F] : out.adapter_funcs)
             jl_array_ptr_1d_push(emitted_adapters, (jl_value_t*)adapter);
     aot_optimize_roots(out, method_roots);
     out.temporary_roots = nullptr;
@@ -1006,10 +1050,12 @@ static void jl_emit_native_to_output(jl_native_code_desc_t *data, jl_array_t *co
         data->jl_fvar_map[(jl_value_t*)ci] = {invoke_id, specptr_id};
     }
     // Register one fvar per ABIAdapter
-    for (auto &[adapter, F] : out.abi_adapter_records) {
+    for (auto &[adapter, F] : out.adapter_funcs) {
         data->jl_sysimg_fvars.push_back(F);
         data->jl_fvar_map[(jl_value_t*)adapter] = {0, (uint32_t)data->jl_sysimg_fvars.size()};
     }
+    for (auto &[tr, invokee] : out.trampoline_invokees)
+        data->trampoline_invokee_map[tr] = invokee;
 }
 
 // also be used by extern consumers like GPUCompiler.jl to obtain a module containing

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -169,7 +169,9 @@ typedef struct {
     std::unique_ptr<jl_codegen_output_t> out;
     SmallVector<GlobalValue*, 0> jl_sysimg_fvars;
     SmallVector<GlobalValue*, 0> jl_sysimg_gvars;
-    std::map<jl_code_instance_t*, std::tuple<uint32_t, uint32_t>> jl_fvar_map;
+    // CodeInstance / ABIAdapter -> {invoke, specptr} fvar IDs (ABIAdapters have no invoke wrapper)
+    // fvar slots are 1:1 with code-carrying objects (CIs / Adapters) - each corresponds to a unique LLVM Function
+    std::map<jl_value_t*, std::tuple<uint32_t, uint32_t>> jl_fvar_map;
     SmallVector<void*, 0> jl_value_to_llvm;
     SmallVector<jl_code_instance_t*, 0> jl_external_to_llvm;
     // ordered list of CodeInstances emitted for this image, in the order they
@@ -178,14 +180,17 @@ typedef struct {
     SmallVector<jl_code_instance_t*, 0> jl_ci_order;
 } jl_native_code_desc_t;
 
+// Look up the fvar IDs for a code-carrying object (CodeInstance or ABIAdapter).
+// CodeInstances yield {invoke, specptr} (invoke may be negative, encoding a
+// jl_invoke_api_t); ABIAdapters yield {0, fvar} since they have no invoke wrapper.
 extern "C" JL_DLLEXPORT_CODEGEN
-void jl_get_function_id_impl(void *native_code, jl_code_instance_t *codeinst,
+void jl_get_function_id_impl(void *native_code, jl_value_t *codeinst_or_adapter,
         int32_t *func_idx, int32_t *specfunc_idx)
 {
     jl_native_code_desc_t *data = (jl_native_code_desc_t*)native_code;
     if (data) {
         // get the function index in the fvar lookup table
-        auto it = data->jl_fvar_map.find(codeinst);
+        auto it = data->jl_fvar_map.find(codeinst_or_adapter);
         if (it != data->jl_fvar_map.end()) {
             std::tie(*func_idx, *specfunc_idx) = it->second;
         }
@@ -199,15 +204,19 @@ jl_get_llvm_cis_impl(void *native_code, size_t *num_elements, jl_code_instance_t
     auto &map = desc->jl_fvar_map;
 
     if (data == NULL) {
-        *num_elements = map.size();
+        size_t n = 0;
+        for (auto &e : map)
+            n += jl_is_code_instance(e.first);
+        *num_elements = n;
         return;
     }
 
-    assert(*num_elements == map.size());
     size_t i = 0;
-    for (auto &ci : map) {
-        data[i++] = ci.first;
+    for (auto &e : map) {
+        if (jl_is_code_instance(e.first))
+            data[i++] = (jl_code_instance_t*)e.first;
     }
+    assert(i == *num_elements);
 }
 
 // get the ordered list of CodeInstances that were emitted for this image, in
@@ -523,6 +532,11 @@ static void aot_optimize_roots(jl_codegen_output_t &out, egal_set &method_roots)
     }
 }
 
+// Emit a fresh, uniquely-named adapter Function. Like each CodeInstance, every ABIAdapter record
+// gets its own distinct Function, so the fvar table has no duplicates (get_fvars_gvars) and
+// `fptr_record` stays 1:1 (fvar id -> one record). Two @cfunctions resolving to equivalent adapters
+// emit their own thunks -- as CodeInstances do for equivalent code -- rather than sharing one
+// (which would break that 1:1 mapping); adapters are not deduplicated at emission.
 static Function *aot_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_code_instance_t *codeinst, Function *func, Function *specfunc, bool target_specsig) JL_CANSAFEPOINT
 {
     std::string gf_thunk_name;
@@ -630,7 +644,7 @@ static bool canPartition(const Function &F)
 // `external_linkage` create linkages between pkgimages.
 extern "C" JL_DLLEXPORT_CODEGEN
 void *jl_create_native_impl(LLVMOrcThreadSafeModuleRef llvmmod, int trim, int external_linkage, size_t world,
-                           jl_array_t *mod_array, jl_array_t *worklist, int all, jl_array_t *module_init_order, jl_array_t *ext_foreign_cis)
+                           jl_array_t *mod_array, jl_array_t *worklist, int all, jl_array_t *module_init_order, jl_array_t *ext_foreign_cis, jl_array_t *emitted_adapters)
 {
     JL_TIMING(INFERENCE, INFERENCE);
     auto ct = jl_current_task;
@@ -682,7 +696,7 @@ void *jl_create_native_impl(LLVMOrcThreadSafeModuleRef llvmmod, int trim, int ex
     jl_value_t *ci_order = jl_svecref(result, 1);
     JL_TYPECHK(jl_create_native, array_any, codeinfos);
     JL_TYPECHK(jl_create_native, array_any, ci_order);
-    auto data = (jl_native_code_desc_t *)jl_emit_native((jl_array_t*)codeinfos, (jl_array_t*)ci_order, llvmmod, NULL, external_linkage ? 1 : 0);
+    auto data = (jl_native_code_desc_t *)jl_emit_native((jl_array_t*)codeinfos, (jl_array_t*)ci_order, emitted_adapters, llvmmod, NULL, external_linkage ? 1 : 0);
     JL_GC_POP();
 
     // move everything inside, now that we've merged everything
@@ -868,7 +882,8 @@ static void aot_link_output(jl_codegen_output_t &out) JL_CANSAFEPOINT
 }
 
 static void jl_emit_native_to_output(jl_native_code_desc_t *data, jl_array_t *codeinfos,
-                                      jl_array_t *ci_order, const jl_cgparams_t *cgparams,
+                                      jl_array_t *ci_order, jl_array_t *emitted_adapters,
+                                      const jl_cgparams_t *cgparams,
                                       int external_linkage) JL_CANSAFEPOINT
 {
     jl_cgparams_t target_cgparams = *cgparams;
@@ -943,6 +958,10 @@ static void jl_emit_native_to_output(jl_native_code_desc_t *data, jl_array_t *co
     aot_link_output(out);
     // including generating cfunction thunks
     generate_cfunc_thunks(out);
+    // Transfer the emitted ABIAdapters to the caller while temporary_roots still protects them.
+    if (emitted_adapters)
+        for (auto &[adapter, F] : out.abi_adapter_records)
+            jl_array_ptr_1d_push(emitted_adapters, (jl_value_t*)adapter);
     aot_optimize_roots(out, method_roots);
     out.temporary_roots = nullptr;
     out.temporary_roots_set.clear();
@@ -984,14 +1003,19 @@ static void jl_emit_native_to_output(jl_native_code_desc_t *data, jl_array_t *co
             data->jl_sysimg_fvars.push_back(funcs.specptr);
             specptr_id = data->jl_sysimg_fvars.size();
         }
-        data->jl_fvar_map[ci] = {invoke_id, specptr_id};
+        data->jl_fvar_map[(jl_value_t*)ci] = {invoke_id, specptr_id};
+    }
+    // Register one fvar per ABIAdapter
+    for (auto &[adapter, F] : out.abi_adapter_records) {
+        data->jl_sysimg_fvars.push_back(F);
+        data->jl_fvar_map[(jl_value_t*)adapter] = {0, (uint32_t)data->jl_sysimg_fvars.size()};
     }
 }
 
 // also be used by extern consumers like GPUCompiler.jl to obtain a module containing
 // all reachable & inferrrable functions.
 extern "C" JL_DLLEXPORT_CODEGEN
-void *jl_emit_native_impl(jl_array_t *codeinfos, jl_array_t *ci_order, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int external_linkage)
+void *jl_emit_native_impl(jl_array_t *codeinfos, jl_array_t *ci_order, jl_array_t *emitted_adapters, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int external_linkage)
 {
     JL_TIMING(NATIVE_AOT, NATIVE_Create);
     ++CreateNativeCalls;
@@ -1013,7 +1037,7 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, jl_array_t *ci_order, LLVMOrcTh
 
     data->TSM_ref->withModuleDo([&](Module &M) JL_CANSAFEPOINT {
         data->out = std::make_unique<jl_codegen_output_t>(M);
-        jl_emit_native_to_output(data, codeinfos, ci_order, cgparams, external_linkage);
+        jl_emit_native_to_output(data, codeinfos, ci_order, emitted_adapters, cgparams, external_linkage);
     });
 
     return (void *)data;

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -545,11 +545,7 @@ static void aot_optimize_roots(jl_codegen_output_t &out, egal_set &method_roots)
     }
 }
 
-// Emit a fresh, uniquely-named adapter Function. Like each CodeInstance, every ABIAdapter record
-// gets its own distinct Function, so the fvar table has no duplicates (get_fvars_gvars) and
-// `fptr_record` stays 1:1 (fvar id -> one record). Two @cfunctions resolving to equivalent adapters
-// emit their own thunks -- as CodeInstances do for equivalent code -- rather than sharing one
-// (which would break that 1:1 mapping); adapters are not deduplicated at emission.
+// Emit a distinct Function for each adapter
 static Function *aot_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_code_instance_t *codeinst, Function *func, Function *specfunc, bool target_specsig) JL_CANSAFEPOINT
 {
     std::string gf_thunk_name;
@@ -562,53 +558,56 @@ static Function *aot_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, 
     return F;
 }
 
-// AOT counterpart of jl_resolve_trampoline: resolve the target for `tr` at the build world,
-// emit its ABI adapter, and record the materialized ABIAdapter record in
-// `out.trampoline_invokees` / `out.adapter_funcs`. When the target's compiled ABI already
-// satisfies the declared C ABI, `trampoline_invokees` maps to the bare `CodeInstance` instead and
-// no adapter is emitted.
-static void emit_trampoline_adapter(jl_codegen_output_t &out, jl_dispatch_trampoline_t *tr,
-        jl_abi_t from_abi, DenseMap<jl_method_instance_t*, jl_code_instance_t*> &compiled_mi,
+// Resolve a trampoline's invokee at the build world: the compiled CodeInstance for the
+// current dispatch target, or NULL if calls must go through dynamic dispatch (multiple
+// targets, ambiguous, or no matching method).
+static jl_code_instance_t *resolve_trampoline_invokee(jl_abi_t from_abi,
+        DenseMap<jl_method_instance_t*, jl_code_instance_t*> &compiled_mi,
         size_t latestworld) JL_CANSAFEPOINT
 {
-    JL_GC_PROMISE_ROOTED(tr);
     jl_value_t *sigt = from_abi.sigt;
     JL_GC_PROMISE_ROOTED(sigt);
     jl_value_t *declrt = from_abi.rt;
     JL_GC_PROMISE_ROOTED(declrt);
     jl_method_instance_t *mi = (jl_method_instance_t*)jl_get_specialization1((jl_tupletype_t*)sigt, latestworld);
-    jl_code_instance_t *codeinst = nullptr;
-    if ((jl_value_t*)mi != jl_nothing) {
-        auto it = compiled_mi.find(mi);
-        if (it != compiled_mi.end())
-            codeinst = it->second;
+    if ((jl_value_t*)mi == jl_nothing)
+        return nullptr;
+    auto it = compiled_mi.find(mi);
+    if (it == compiled_mi.end())
+        return nullptr;
+    jl_code_instance_t *codeinst = it->second;
+    JL_GC_PROMISE_ROOTED(codeinst);
+    jl_value_t *astrt = codeinst->rettype;
+    if (astrt != (jl_value_t*)jl_bottom_type &&
+        jl_type_intersection(astrt, declrt) == jl_bottom_type) {
+        // Do not warn if the function never returns since it is occasionally required by
+        // the C API (typically error callbacks) even though we're likely to encounter
+        // memory errors in that case.
+        jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name_from_method_instance(mi));
     }
+    return codeinst;
+}
+
+// Emit the ABI thunk and materialize the ABIAdapter for `codeinst`, or an
+// "unspecialized" adapter to dynamic dispatch if `codeinst` is NULL.
+static jl_abi_adapter_t *emit_abi_adapter(jl_codegen_output_t &out, jl_abi_t from_abi,
+        jl_code_instance_t *codeinst) JL_CANSAFEPOINT
+{
+    jl_value_t *sigt = from_abi.sigt;
+    JL_GC_PROMISE_ROOTED(sigt);
+    jl_value_t *declrt = from_abi.rt;
+    JL_GC_PROMISE_ROOTED(declrt);
     Function *F;
     if (codeinst) {
         JL_GC_PROMISE_ROOTED(codeinst);
-        jl_value_t *astrt = codeinst->rettype;
-        if (astrt != (jl_value_t*)jl_bottom_type &&
-            jl_type_intersection(astrt, declrt) == jl_bottom_type) {
-            // Do not warn if the function never returns since it is occasionally required by
-            // the C API (typically error callbacks) even though we're likely to encounter
-            // memory errors in that case.
-            jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name_from_method_instance(mi));
-        }
         const auto &decls = out.ci_funcs.find(codeinst)->second;
-        // If the target's own compiled ABI already satisfies the declared C ABI, no adapter
-        // is needed: map to the bare CodeInstance so the first post-load call derives `fptr`
-        // from its (independently wired) specptr.
-        if (jl_abi_matches_invoke_api(from_abi, decls.invoke_api, mi, codeinst->rettype)) {
-            out.trampoline_invokees[tr] = (jl_value_t*)codeinst; // bare CI: no adapter thunk emitted
-            return;
-        }
         if (decls.invoke_api == JL_INVOKE_CONST) {
             std::string n = emit_abi_constreturn(out, from_abi, codeinst->rettype_const);
             F = out.get_module().getFunction(n);
             assert(F);
         }
         else if (decls.invoke_api == JL_INVOKE_SPARAM) {
-            // no specptr prototype declared; route through jl_invoke via the dispatcher
+            // No specptr prototype; route through jl_invoke.
             F = aot_abi_converter(out, from_abi, codeinst, nullptr, nullptr, false);
         }
         else if (decls.invoke_api == JL_INVOKE_ARGS) {
@@ -621,28 +620,19 @@ static void emit_trampoline_adapter(jl_codegen_output_t &out, jl_dispatch_trampo
         }
     }
     else {
-        // no method at the build world: emit the shared dynamic-dispatch adapter
         F = aot_abi_converter(out, from_abi, nullptr, nullptr, nullptr, false);
     }
-    // A real thunk was needed: materialize the ABIAdapter record (its `fptr` is wired from the
-    // fvar on load) and map the trampoline to it. The record reaches the image via the
-    // serializer's `last_invokee` override (and `emitted_adapters`); the first post-load call
-    // restores `fptr` straight from it.
-    jl_abi_adapter_t *rec = jl_new_abi_adapter(sigt, declrt, codeinst,
+    jl_abi_adapter_t *adapter = jl_new_abi_adapter(sigt, declrt, codeinst,
             from_abi.specsig, from_abi.kind, /*fptr*/nullptr);
-    // Nothing else roots the record until it is pushed to `emitted_adapters`.
-    JL_GC_PUSH1(&rec);
-    jl_array_ptr_1d_push(out.temporary_roots, (jl_value_t*)rec);
+    // Nothing else roots the ABIAdapter until it is pushed to `emitted_adapters`.
+    JL_GC_PUSH1(&adapter);
+    jl_array_ptr_1d_push(out.temporary_roots, (jl_value_t*)adapter);
     JL_GC_POP();
-    out.trampoline_invokees[tr] = (jl_value_t*)rec;
-    out.adapter_funcs.push_back({rec, F});
+    out.adapter_funcs.push_back({adapter, F});
+    return adapter;
 }
 
-// Emit the adapter for each @cfunction/@ccallable dispatch trampoline (kind=STD, so the
-// adapter sig is the call sig as-is). Replaces the old cfuncdata-array fill; the serializer
-// wires the adapter into the image trampoline's `last_invokee` (jl_get_trampoline_invokee).
-// Call sites sharing one interned trampoline (same sigt/rt/specsig) are deduplicated here, so
-// each trampoline yields exactly one adapter record and one unspecialized record.
+// Emit each canonical trampoline's adapters.
 static void generate_cfunc_thunks(jl_codegen_output_t &out) JL_CANSAFEPOINT
 {
     if (out.cfuncs.empty())
@@ -655,26 +645,28 @@ static void generate_cfunc_thunks(jl_codegen_output_t &out) JL_CANSAFEPOINT
             compiled_mi[mi] = ci;
     }
     size_t latestworld = jl_atomic_load_acquire(&jl_world_counter);
-    for (cfunc_decl_t &cfunc : out.cfuncs) {
-        if (out.trampoline_invokees.count(cfunc.trampoline))
+    for (jl_dispatch_trampoline_t *tr : out.cfuncs) {
+        if (out.trampoline_invokees.count(tr))
             continue; // another call site already emitted this trampoline's adapter
-        emit_trampoline_adapter(out, cfunc.trampoline, cfunc.abi, compiled_mi, latestworld);
-        // Outside --trim, also emit the dynamic-dispatch ("unspecialized", ci == NULL)
-        // adapter for this signature, so a codegen-free run can dispatch this
-        // @cfunction/@ccallable even when the resolved target shifts (julia#61949). No
-        // trampoline owns it; it survives via the `emitted_adapters` report (see
-        // jl_create_native_impl). Under --trim, dynamic dispatch is unavailable, so skip it.
-        if (!jl_options.trim) {
-            Function *uf = aot_abi_converter(out, cfunc.abi, nullptr, nullptr, nullptr, false);
-            jl_abi_adapter_t *urec = jl_new_abi_adapter(cfunc.abi.sigt, cfunc.abi.rt,
-                    /*ci*/nullptr, cfunc.abi.specsig, cfunc.abi.kind,
-                    /*fptr*/nullptr);
-            JL_GC_PUSH1(&urec);
-            // Nothing else roots the record until it is pushed to `emitted_adapters`.
-            jl_array_ptr_1d_push(out.temporary_roots, (jl_value_t*)urec);
-            JL_GC_POP();
-            out.adapter_funcs.push_back({urec, uf});
-        }
+        jl_abi_t abi = jl_trampoline_abi(tr);
+        jl_code_instance_t *codeinst = nullptr;
+        JL_GC_PUSH1(&codeinst);
+        codeinst = resolve_trampoline_invokee(abi, compiled_mi, latestworld);
+        // If the target's own compiled ABI already satisfies the declared C ABI, no adapter
+        // is needed: map to the bare CodeInstance so the first post-load call derives `fptr`
+        // from its (independently wired) specptr.
+        if (codeinst && jl_abi_matches_invoke_api(abi, out.ci_funcs.find(codeinst)->second.invoke_api,
+                                                  jl_get_ci_mi(codeinst), codeinst->rettype))
+            out.trampoline_invokees[tr] = (jl_value_t*)codeinst;
+        else
+            out.trampoline_invokees[tr] = (jl_value_t*)emit_abi_adapter(out, abi, codeinst);
+        // Non-trimmed images rely on having "unspecialized" ABIAdapters (which branch directly
+        // to a dynamic dispatch) available in the cache. This is used to enter the interpreter
+        // from a compiled ABI if the JIT is unavailable and the invokee is invalidated.
+        // (If resolution failed above, the invokee adapter is already unspecialized.)
+        if (!jl_options.trim && codeinst != nullptr)
+            emit_abi_adapter(out, abi, nullptr);
+        JL_GC_POP();
     }
 }
 
@@ -2740,8 +2732,8 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t *dump, jl_method_instance_t *mi, jl_
             // since otherwise it is challenging to see all relevant codes
             // jl_compiled_functions_t compiled_functions;
             size_t latestworld = jl_atomic_load_acquire(&jl_world_counter);
-            for (cfunc_decl_t &cfunc : output.cfuncs) {
-                jl_value_t *sigt = cfunc.abi.sigt;
+            for (jl_dispatch_trampoline_t *tr : output.cfuncs) {
+                jl_value_t *sigt = tr->sigt;
                 JL_GC_PROMISE_ROOTED(sigt);
                 jl_value_t *mi = jl_get_specialization1((jl_tupletype_t*)sigt, latestworld);
                 if (mi == jl_nothing)

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -572,6 +572,10 @@ static jl_code_instance_t *resolve_trampoline_invokee(jl_abi_t from_abi,
     jl_method_instance_t *mi = (jl_method_instance_t*)jl_get_specialization1((jl_tupletype_t*)sigt, latestworld);
     if ((jl_value_t*)mi == jl_nothing)
         return nullptr;
+    // A match that only partially covers `sigt` must keep dispatching at call time:
+    // wiring it directly would bypass the MethodError for uncovered calls.
+    if (!jl_subtype(sigt, mi->def.method->sig))
+        return nullptr;
     auto it = compiled_mi.find(mi);
     if (it == compiled_mi.end())
         return nullptr;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2771,12 +2771,13 @@ void jl_init_primitives(void) JL_GC_DISABLED
 
     add_builtin("Module", (jl_value_t*)jl_module_type);
     add_builtin("MethodTable", (jl_value_t*)jl_methtable_type);
-    add_builtin("methodtable", (jl_value_t*)jl_method_table);
     add_builtin("MethodCache", (jl_value_t*)jl_methcache_type);
     add_builtin("Method", (jl_value_t*)jl_method_type);
     add_builtin("CodeInstance", (jl_value_t*)jl_code_instance_type);
     add_builtin("TypeMapEntry", (jl_value_t*)jl_typemap_entry_type);
     add_builtin("TypeMapLevel", (jl_value_t*)jl_typemap_level_type);
+    add_builtin("ABIAdapter", (jl_value_t*)jl_abi_adapter_type);
+    add_builtin("ABIAdapterCache", (jl_value_t*)jl_abi_adapter_cache_type);
     add_builtin("Symbol", (jl_value_t*)jl_symbol_type);
     add_builtin("SSAValue", (jl_value_t*)jl_ssavalue_type);
     add_builtin("SlotNumber", (jl_value_t*)jl_slotnumber_type);
@@ -2834,6 +2835,10 @@ void jl_init_primitives(void) JL_GC_DISABLED
 
     add_builtin("AbstractString", (jl_value_t*)jl_abstractstring_type);
     add_builtin("String", (jl_value_t*)jl_string_type);
+
+    // global cache singletons
+    add_builtin("abi_adapters", (jl_value_t*)jl_abi_adapters);
+    add_builtin("methodtable", (jl_value_t*)jl_method_table);
 
     // ensure that primitive types are fully allocated (since jl_init_types is incomplete)
     assert(jl_atomic_load_relaxed(&jl_world_counter) == 1);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2778,6 +2778,8 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("TypeMapLevel", (jl_value_t*)jl_typemap_level_type);
     add_builtin("ABIAdapter", (jl_value_t*)jl_abi_adapter_type);
     add_builtin("ABIAdapterCache", (jl_value_t*)jl_abi_adapter_cache_type);
+    add_builtin("DispatchTrampoline", (jl_value_t*)jl_dispatch_trampoline_type);
+    add_builtin("DispatchTrampolineCache", (jl_value_t*)jl_dispatch_trampoline_cache_type);
     add_builtin("Symbol", (jl_value_t*)jl_symbol_type);
     add_builtin("SSAValue", (jl_value_t*)jl_ssavalue_type);
     add_builtin("SlotNumber", (jl_value_t*)jl_slotnumber_type);
@@ -2838,6 +2840,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
 
     // global cache singletons
     add_builtin("abi_adapters", (jl_value_t*)jl_abi_adapters);
+    add_builtin("dispatch_trampolines", (jl_value_t*)jl_dispatch_trampolines);
     add_builtin("methodtable", (jl_value_t*)jl_method_table);
 
     // ensure that primitive types are fully allocated (since jl_init_types is incomplete)

--- a/src/clangsa/GCCheckerPropagation.cpp
+++ b/src/clangsa/GCCheckerPropagation.cpp
@@ -367,6 +367,8 @@ bool GCChecker::isGCTrackedType(QualType QT) {
                    Name.ends_with_insensitive("jl_unionall_t") ||
                    Name.ends_with_insensitive("jl_methtable_t") ||
                    Name.ends_with_insensitive("jl_methcache_t") ||
+                   Name.ends_with_insensitive("jl_abi_adapter_t") ||
+                   Name.ends_with_insensitive("jl_abi_adapter_cache_t") ||
                    Name.ends_with_insensitive("jl_cgval_t") ||
                    Name.ends_with_insensitive("jl_codectx_t") ||
                    Name.ends_with_insensitive("jl_code_instance_t") ||

--- a/src/clangsa/GCCheckerPropagation.cpp
+++ b/src/clangsa/GCCheckerPropagation.cpp
@@ -385,6 +385,7 @@ bool GCChecker::isGCTrackedType(QualType QT) {
                    Name.ends_with_insensitive("interpreter_state") ||
                    Name.ends_with_insensitive("jl_typeenv_t") ||
                    Name.ends_with_insensitive("jl_stenv_t") ||
+                   Name.ends_with_insensitive("jl_typemap_list_t") ||
                    Name.ends_with_insensitive("set_world") ||
                    Name.ends_with_insensitive("jl_codectx_t") ||
                    Name.ends_with_insensitive("jl_codegen_params_t") ||

--- a/src/clangsa/GCCheckerPropagation.cpp
+++ b/src/clangsa/GCCheckerPropagation.cpp
@@ -369,6 +369,8 @@ bool GCChecker::isGCTrackedType(QualType QT) {
                    Name.ends_with_insensitive("jl_methcache_t") ||
                    Name.ends_with_insensitive("jl_abi_adapter_t") ||
                    Name.ends_with_insensitive("jl_abi_adapter_cache_t") ||
+                   Name.ends_with_insensitive("jl_dispatch_trampoline_t") ||
+                   Name.ends_with_insensitive("jl_dispatch_trampoline_cache_t") ||
                    Name.ends_with_insensitive("jl_cgval_t") ||
                    Name.ends_with_insensitive("jl_codectx_t") ||
                    Name.ends_with_insensitive("jl_code_instance_t") ||

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -108,8 +108,8 @@ JL_DLLEXPORT void jl_jit_unregister_ci_fallback(jl_code_instance_t *ci)
 {
 }
 
-JL_DLLEXPORT void *jl_create_native_fallback(LLVMOrcThreadSafeModuleRef llvmmod, int trim, int cache, size_t world, jl_array_t *mod_array, jl_array_t *worklist, int all, jl_array_t *module_init_order, jl_array_t *ext_foreign_cis) UNAVAILABLE
-JL_DLLEXPORT void *jl_emit_native_fallback(jl_array_t *codeinfos, jl_array_t *ci_order, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _external_linkage) UNAVAILABLE
+JL_DLLEXPORT void *jl_create_native_fallback(LLVMOrcThreadSafeModuleRef llvmmod, int trim, int cache, size_t world, jl_array_t *mod_array, jl_array_t *worklist, int all, jl_array_t *module_init_order, jl_array_t *ext_foreign_cis, jl_array_t *emitted_adapters) UNAVAILABLE
+JL_DLLEXPORT void *jl_emit_native_fallback(jl_array_t *codeinfos, jl_array_t *ci_order, jl_array_t *emitted_adapters, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _external_linkage) UNAVAILABLE
 
 JL_DLLEXPORT void jl_dump_compiles_fallback(void *s)
 {
@@ -127,9 +127,10 @@ JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm_fallback(uint64_t fptr, char emit_mc, 
 
 JL_DLLEXPORT jl_value_t *jl_dump_function_asm_fallback(jl_llvmf_dump_t* dump, char emit_mc, const char* asm_variant, const char *debuginfo, char binary, char raw) UNAVAILABLE
 
-JL_DLLEXPORT void jl_get_function_id_fallback(void *native_code, jl_code_instance_t *ncode,
+JL_DLLEXPORT void jl_get_function_id_fallback(void *native_code, jl_value_t *codeinst_or_adapter,
         int32_t *func_idx, int32_t *specfunc_idx) UNAVAILABLE
 
+JL_DLLEXPORT jl_value_t *jl_get_trampoline_invokee_fallback(void *native_code, jl_dispatch_trampoline_t *tr) UNAVAILABLE
 
 JL_DLLEXPORT void *jl_get_llvm_function_fallback(void *native_code, uint32_t idx) UNAVAILABLE
 
@@ -151,7 +152,24 @@ JL_DLLEXPORT uint64_t jl_getUnwindInfo_fallback(uint64_t dwAddr) JL_NOTSAFEPOINT
 
 JL_DLLEXPORT void jl_register_passbuilder_callbacks_fallback(void *PB) { }
 
-JL_DLLEXPORT void *jl_jit_abi_converter_fallback(jl_task_t *ct, jl_abi_t from_abi, jl_code_instance_t *codeinst) UNAVAILABLE
+JL_DLLEXPORT void *jl_jit_abi_converter_fallback(jl_task_t *ct, jl_abi_t from_abi, jl_code_instance_t *codeinst, jl_value_t **invokee) JL_CANSAFEPOINT
+{
+    // Lookup and use the cached dynamic-dispatch adapter, which is required when:
+    //   1. The compiled target CI is unique + available + valid, but due to ambiguities
+    //      / partial method coverage, etc. the dispatch must still be checked by gf.c
+    //   2. The compiled target CI was invalidated but we'd like to re-enter the
+    //      interpreter from a compiled ABI
+    // See https://github.com/JuliaLang/julia/issues/61949
+    (void)ct;
+    void *f = jl_lookup_abi_adapter(from_abi, codeinst, NULL, NULL, NULL, invokee);
+    if (f == NULL && codeinst != NULL)
+        f = jl_lookup_abi_adapter(from_abi, NULL, NULL, NULL, NULL, invokee);
+    if (f != NULL)
+        return f;
+    jl_errorf("cfunction: no ABI adapter is available for this signature in a build without "
+              "codegen (none was compiled into a loaded image)");
+    return NULL;
+}
 
 //LLVM C api to the julia JIT
 JL_DLLEXPORT void* JLJITGetLLVMOrcExecutionSession_fallback(void* JIT) UNAVAILABLE

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7599,6 +7599,7 @@ std::string emit_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_c
     // build a args1 -> specsig converter thunk (gen_invoke_wrapper)
     // build a args1 -> args1 converter thunk (to add typeassert on result)
     Module *M = &out.get_module();
+    bool is_opaque_closure = from_abi.kind == JL_ABI_OPAQUE_CLOSURE;
     bool needsparams = false;
     bool target_is_opaque_closure = false;
     jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
@@ -7608,14 +7609,14 @@ std::string emit_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_c
         jl_value_t *abi = get_ci_abi(codeinst);
         jl_returninfo_t targetspec = get_specsig_function(out, M, target, "", abi, codeinst->rettype, target_is_opaque_closure);
         if (from_abi.specsig)
-            emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, from_abi.is_opaque_closure, out,
+            emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, is_opaque_closure, out,
                     target, mi->specTypes, codeinst->rettype, &targetspec, nullptr);
         else
-            gen_invoke_wrapper(mi, abi, codeinst->rettype, from_abi.rt, targetspec, -1, from_abi.is_opaque_closure, gf_thunk_name, M, out);
+            gen_invoke_wrapper(mi, abi, codeinst->rettype, from_abi.rt, targetspec, -1, is_opaque_closure, gf_thunk_name, M, out);
     }
     else {
         if (from_abi.specsig)
-            emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, from_abi.is_opaque_closure, out,
+            emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, is_opaque_closure, out,
                     target, mi->specTypes, codeinst->rettype, nullptr, nullptr);
         else
             emit_fptr1_wrapper(M, gf_thunk_name, target, nullptr, from_abi.rt, codeinst->rettype, out);
@@ -7631,6 +7632,7 @@ std::string emit_abi_dispatcher(jl_codegen_output_t &out, jl_abi_t from_abi, jl_
     // build a args1 -> args1 call (emit_fptr1_wrapper)
     // build a args1 -> invoke call (emit_tojlinvoke)
     Module *M = &out.get_module();
+    bool is_opaque_closure = from_abi.kind == JL_ABI_OPAQUE_CLOSURE;
     Value *target;
     if (!codeinst)
         target = prepare_call_in(M, jlapplygeneric_func);
@@ -7643,7 +7645,7 @@ std::string emit_abi_dispatcher(jl_codegen_output_t &out, jl_abi_t from_abi, jl_
         raw_string_ostream(gf_thunk_name) << JL_SYM_PROTO_SPECSIG;
     raw_string_ostream(gf_thunk_name) << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1) << "_gfthunk";
     if (from_abi.specsig)
-        emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, from_abi.is_opaque_closure, out,
+        emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, is_opaque_closure, out,
                 target, from_abi.sigt, codeinst ? codeinst->rettype : (jl_value_t*)jl_any_type, nullptr, nullptr);
     else
         emit_fptr1_wrapper(M, gf_thunk_name, target, nullptr, from_abi.rt, codeinst ? codeinst->rettype : (jl_value_t*)jl_any_type, out);
@@ -7653,10 +7655,11 @@ std::string emit_abi_dispatcher(jl_codegen_output_t &out, jl_abi_t from_abi, jl_
 std::string emit_abi_constreturn(jl_codegen_output_t &out, jl_abi_t from_abi, jl_value_t *rettype_const)
 {
     Module *M = &out.get_module();
+    bool is_opaque_closure = from_abi.kind == JL_ABI_OPAQUE_CLOSURE;
     std::string gf_thunk_name;
     raw_string_ostream(gf_thunk_name) << JL_SYM_SPECPTR_CONST << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
     if (from_abi.specsig) {
-        emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, from_abi.is_opaque_closure, out,
+        emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, is_opaque_closure, out,
                 nullptr, from_abi.sigt, jl_typeof(rettype_const), nullptr, rettype_const);
     }
     else {
@@ -7673,7 +7676,7 @@ std::string emit_abi_constreturn(jl_codegen_output_t &out, bool specsig, jl_code
     jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
     bool is_opaque_closure = jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
 
-    jl_abi_t abi = {sigt, rt, specsig, is_opaque_closure};
+    jl_abi_t abi = {sigt, rt, specsig, is_opaque_closure ? JL_ABI_OPAQUE_CLOSURE : JL_ABI_STD};
 
     return emit_abi_constreturn(out, abi, codeinst->rettype_const);
 }
@@ -7698,7 +7701,8 @@ static jl_cgval_t emit_abi_call(jl_codectx_t &ctx, jl_value_t *declrt, jl_value_
         jl_temporary_root(ctx, sigt);
         assert(nargs == jl_nparams(sigt));
         bool needsparams = false;
-        bool is_opaque_closure = false;
+        jl_abi_kind_t kind = JL_ABI_STD;
+        bool is_opaque_closure = kind == JL_ABI_OPAQUE_CLOSURE;
         bool specsig = uses_specsig(sigt, needsparams, declrt, ctx.params->prefer_specsig);
         PointerType *T_ptr = ctx.types().T_ptr;
         Type *T_size = ctx.types().T_size;
@@ -7733,7 +7737,7 @@ static jl_cgval_t emit_abi_call(jl_codectx_t &ctx, jl_value_t *declrt, jl_value_
                 cw->setAttributes(getcaller->getAttributes());
                 return cw;
             });
-        jl_abi_t cfuncabi = {sigt, declrt, specsig, is_opaque_closure};
+        jl_abi_t cfuncabi = {sigt, declrt, specsig, kind};
         ctx.emission_context.cfuncs.push_back({cfuncabi, cfuncdata});
         if (specsig) {
             // TODO: could we force this to guarantee passing a box for `f` here (since we

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1406,11 +1406,12 @@ static const auto jlgetcfunctiontrampoline_func = new JuliaFunction<>{
             Attributes(C, {Attribute::NonNull}),
             {}); },
 };
-static const auto jlgetabiconverter_func = new JuliaFunction<TypeFnContextAndSizeT>{
-    XSTR(jl_get_abi_converter),
-    [](LLVMContext &C, Type *T_size) {
+static const auto jlupdatetrampoline_func = new JuliaFunction<>{
+    XSTR(jl_update_dispatch_trampoline),
+    [](LLVMContext &C) {
         Type *T_ptr = getPointerTy(C);
-        return FunctionType::get(T_ptr, {T_ptr, T_ptr}, false);
+        Type *T_prjlvalue = JuliaType::get_prjlvalue_ty(C);
+        return FunctionType::get(T_ptr, {T_ptr, T_prjlvalue}, false);
     },
     nullptr,
 };
@@ -7604,7 +7605,7 @@ std::string emit_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_c
     bool target_is_opaque_closure = false;
     jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
     std::string gf_thunk_name = get_function_name(from_abi.specsig, needsparams, name_from_method_instance(mi), out.TargetTriple);
-    gf_thunk_name += "_gfthunk";
+    raw_string_ostream(gf_thunk_name) << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1) << "_gfthunk";
     if (target_specsig) {
         jl_value_t *abi = get_ci_abi(codeinst);
         jl_returninfo_t targetspec = get_specsig_function(out, M, target, "", abi, codeinst->rettype, target_is_opaque_closure);
@@ -7704,41 +7705,34 @@ static jl_cgval_t emit_abi_call(jl_codectx_t &ctx, jl_value_t *declrt, jl_value_
         jl_abi_kind_t kind = JL_ABI_STD;
         bool is_opaque_closure = kind == JL_ABI_OPAQUE_CLOSURE;
         bool specsig = uses_specsig(sigt, needsparams, declrt, ctx.params->prefer_specsig);
-        PointerType *T_ptr = ctx.types().T_ptr;
         Type *T_size = ctx.types().T_size;
-        Constant *Vnull = ConstantPointerNull::get(T_ptr);
         Module *M = jl_Module;
-        ArrayType *T_cfuncdata = ArrayType::get(T_ptr, 8);
-        size_t flags = specsig;
-        GlobalVariable *cfuncdata = new GlobalVariable(*M, T_cfuncdata, false,
-                GlobalVariable::PrivateLinkage,
-                ConstantArray::get(T_cfuncdata, {
-                    Vnull,
-                    Vnull,
-                    Vnull,
-                    Vnull,
-                    Vnull,
-                    literal_pointer_val_slot(ctx.emission_context, declrt),
-                    literal_pointer_val_slot(ctx.emission_context, sigt),
-                    literal_static_pointer_val((void*)flags, T_ptr)}));
-        Value *last_world_p = ctx.builder.CreateConstInBoundsGEP1_32(ctx.types().T_size, cfuncdata, 1);
-        LoadInst *last_world_v = ctx.builder.CreateAlignedLoad(T_size, last_world_p, ctx.types().alignof_ptr);
+        // Share one latest-world trampoline per sigt + ABI (return type, adapter kind, etc.)
+        jl_dispatch_trampoline_t *tr = NULL;
+        JL_GC_PUSH1(&tr);
+        tr = jl_get_dispatch_trampoline(sigt, declrt, specsig, kind);
+        jl_temporary_root(ctx, (jl_value_t*)tr); // keep alive through codegen + serialization
+        JL_GC_POP();
+        ctx.emission_context.cfuncs.push_back(tr);
+        Value *trampoline_box = boxed(ctx, mark_julia_const(ctx, (jl_value_t*)tr));
+        Value *trampoline_d = decay_derived(ctx, trampoline_box);
+        Value *lw_p = emit_ptrgep(ctx, trampoline_d, offsetof(jl_dispatch_trampoline_t, last_world));
+        LoadInst *last_world_v = ctx.builder.CreateAlignedLoad(T_size, lw_p, ctx.types().alignof_ptr);
         last_world_v->setOrdering(AtomicOrdering::Acquire);
-        LoadInst *callee = ctx.builder.CreateAlignedLoad(T_ptr, cfuncdata, ctx.types().alignof_ptr);
-        callee->setOrdering(AtomicOrdering::Acquire);
-        LoadInst *world_v = ctx.builder.CreateAlignedLoad(ctx.types().T_size,
+        Value *fptr_p = emit_ptrgep(ctx, trampoline_d, offsetof(jl_dispatch_trampoline_t, fptr));
+        LoadInst *cached_fptr = ctx.builder.CreateAlignedLoad(ctx.types().T_ptr, fptr_p, ctx.types().alignof_ptr);
+        cached_fptr->setOrdering(AtomicOrdering::Acquire);
+        LoadInst *world_v = ctx.builder.CreateAlignedLoad(T_size,
             prepare_global_in(M, jlgetworld_global), ctx.types().alignof_ptr);
         world_v->setOrdering(AtomicOrdering::Monotonic);
         ctx.builder.CreateStore(world_v, world_age_field);
         Value *age_not_ok = ctx.builder.CreateICmpNE(last_world_v, world_v);
-        Value *target = emit_guarded_test(ctx, age_not_ok, callee, [&] () {
-                Function *getcaller = prepare_call(jlgetabiconverter_func);
-                CallInst *cw = ctx.builder.CreateCall(getcaller, {get_current_task(ctx), cfuncdata});
-                cw->setAttributes(getcaller->getAttributes());
+        Value *target = emit_guarded_test(ctx, age_not_ok, cached_fptr, [&] () {
+                Function *resolver = prepare_call(jlupdatetrampoline_func);
+                CallInst *cw = ctx.builder.CreateCall(resolver, {get_current_task(ctx), trampoline_box});
+                cw->setAttributes(resolver->getAttributes());
                 return cw;
             });
-        jl_abi_t cfuncabi = {sigt, declrt, specsig, kind};
-        ctx.emission_context.cfuncs.push_back({cfuncabi, cfuncdata});
         if (specsig) {
             // TODO: could we force this to guarantee passing a box for `f` here (since we
             // know we had it here) and on the receiver end (emit_abi_converter /
@@ -10668,7 +10662,7 @@ static void init_jit_functions(void)
     add_named_global(jlunlockvalue_func, &jl_unlock_value);
     add_named_global(jllockfield_func, &jl_lock_field);
     add_named_global(jlunlockfield_func, &jl_unlock_field);
-    add_named_global(jlgetabiconverter_func, &jl_get_abi_converter);
+    add_named_global(jlupdatetrampoline_func, &jl_update_dispatch_trampoline);
 
     jl_get_pgcstack_func_t get_pgcstack;
     jl_pgcstack_key_t pgcstack_key;

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -51,6 +51,17 @@ JL_DLLEXPORT jl_methcache_t *jl_new_method_cache(void)
     return mc;
 }
 
+JL_DLLEXPORT jl_abi_adapter_cache_t *jl_new_abi_adapter_cache(void)
+{
+    jl_task_t *ct = jl_current_task;
+    jl_abi_adapter_cache_t *c =
+        (jl_abi_adapter_cache_t*)jl_gc_alloc(ct->ptls, sizeof(jl_abi_adapter_cache_t),
+                                             jl_abi_adapter_cache_type);
+    jl_atomic_store_relaxed(&c->cache.root, (jl_typemap_t*)jl_nothing);
+    jl_reinit_abi_adapter_cache(c);
+    return c;
+}
+
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module)
 {
     jl_methcache_t *mc = jl_new_method_cache();

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -62,6 +62,17 @@ JL_DLLEXPORT jl_abi_adapter_cache_t *jl_new_abi_adapter_cache(void)
     return c;
 }
 
+JL_DLLEXPORT jl_dispatch_trampoline_cache_t *jl_new_dispatch_trampoline_cache(void)
+{
+    jl_task_t *ct = jl_current_task;
+    jl_dispatch_trampoline_cache_t *c =
+        (jl_dispatch_trampoline_cache_t*)jl_gc_alloc(ct->ptls, sizeof(jl_dispatch_trampoline_cache_t),
+                                                   jl_dispatch_trampoline_cache_type);
+    jl_atomic_store_relaxed(&c->cache.root, (jl_typemap_t*)jl_nothing);
+    jl_reinit_dispatch_trampoline_cache(c);
+    return c;
+}
+
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module)
 {
     jl_methcache_t *mc = jl_new_method_cache();

--- a/src/dispatch_trampoline.c
+++ b/src/dispatch_trampoline.c
@@ -1,0 +1,109 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include "julia.h"
+#include "julia_internal.h"
+
+// ---- dispatch-trampoline cache (invokelatest trampoline) ----
+// Maps (sigt, rt, specsig, kind) -> jl_dispatch_trampoline_t, keyed on the dispatch sig
+// `sigt` = `Tuple{typeof(f), A...}` and located by (rt, specsig, kind) within each bucket
+
+static jl_dispatch_trampoline_t *trampoline_alloc_entry(jl_task_t *ct, jl_value_t *sigt, jl_value_t *rt,
+                                          int specsig, jl_abi_kind_t kind) JL_CANSAFEPOINT
+{
+    jl_dispatch_trampoline_t *e = (jl_dispatch_trampoline_t*)jl_gc_alloc(ct->ptls, sizeof(jl_dispatch_trampoline_t), jl_dispatch_trampoline_type);
+    e->sigt = sigt;
+    e->rt = rt;
+    e->last_invokee = NULL; // unresolved
+    jl_atomic_store_relaxed(&e->fptr, (void*)NULL);
+    jl_atomic_store_relaxed(&e->last_world, (size_t)0);
+    jl_atomic_store_relaxed(&e->next, (jl_dispatch_trampoline_t*)NULL);
+    e->specsig = specsig ? 1 : 0;
+    e->kind = (uint8_t)kind;
+    return e;
+}
+
+typedef struct {
+    jl_value_t *rt;
+    int specsig;
+    jl_abi_kind_t kind;
+} trampoline_key_t;
+
+static int trampoline_match(jl_value_t *item, void *keyv) JL_CANSAFEPOINT
+{
+    jl_dispatch_trampoline_t *e = (jl_dispatch_trampoline_t*)item;
+    trampoline_key_t *k = (trampoline_key_t*)keyv;
+    return (int)e->specsig == (k->specsig ? 1 : 0)
+        && (jl_abi_kind_t)e->kind == k->kind
+        && (e->rt == k->rt || jl_types_equal(e->rt, k->rt));
+}
+
+// `rt` is compared by type-equality (no sound hash) and buckets stay tiny, so use a
+// constant hash and keep plain lists at any size.
+static uintptr_t trampoline_hash(jl_value_t *item) JL_NOTSAFEPOINT
+{
+    (void)item;
+    return 0;
+}
+
+static const jl_typemap_list_config_t dispatch_trampoline_cache_config = {
+    offsetof(jl_dispatch_trampoline_t, next),
+    JL_TYPEMAP_LIST_NO_HASHMAP,
+    trampoline_hash,
+    trampoline_match,
+};
+
+JL_DLLEXPORT void jl_reinit_dispatch_trampoline_cache(jl_dispatch_trampoline_cache_t *c) JL_NOTSAFEPOINT
+{
+    c->cache.config = &dispatch_trampoline_cache_config;
+    JL_MUTEX_INIT(&c->writelock, "jl_dispatch_trampolines->writelock");
+}
+
+// Fallible lock-free lookup; NULL indicates absence - or a concurrent write
+static jl_dispatch_trampoline_t *trampoline_map_lookup(jl_value_t *sigt, jl_value_t *rt, int specsig, jl_abi_kind_t kind) JL_CANSAFEPOINT
+{
+    trampoline_key_t key = { rt, specsig, kind };
+    return (jl_dispatch_trampoline_t*)jl_typemap_list_lookup(&jl_dispatch_trampolines->cache,
+            sigt, /*hash*/0, &key);
+}
+
+// Caller holds the writelock and has confirmed that `tr` is absent.
+static void trampoline_map_insert(jl_value_t *sigt, jl_dispatch_trampoline_t *tr) JL_CANSAFEPOINT
+{
+    jl_typemap_list_insert(&jl_dispatch_trampolines->cache, (jl_value_t*)jl_dispatch_trampolines,
+            sigt, (jl_value_t*)tr);
+}
+
+// Return the canonical trampoline for (sigt, rt, specsig, kind).
+JL_DLLEXPORT jl_dispatch_trampoline_t *jl_get_dispatch_trampoline(jl_value_t *sigt, jl_value_t *rt, int specsig, jl_abi_kind_t kind) JL_CANSAFEPOINT
+{
+    jl_dispatch_trampoline_t *e = NULL;
+    JL_GC_PUSH1(&e);
+    e = trampoline_map_lookup(sigt, rt, specsig, kind);
+    if (e == NULL) {
+        JL_LOCK(&jl_dispatch_trampolines->writelock);
+        e = trampoline_map_lookup(sigt, rt, specsig, kind);
+        if (e == NULL) {
+            e = trampoline_alloc_entry(jl_current_task, sigt, rt, specsig, kind);
+            trampoline_map_insert(sigt, e);
+        }
+        JL_UNLOCK(&jl_dispatch_trampolines->writelock);
+    }
+    JL_GC_POP();
+    return e;
+}
+
+// Reinsert a DispatchTrampoline into the cache, unless an equivalent is already present.
+JL_DLLEXPORT jl_dispatch_trampoline_t *jl_insert_dispatch_trampoline(jl_dispatch_trampoline_t *tr) JL_CANSAFEPOINT
+{
+    jl_dispatch_trampoline_t *e = NULL;
+    JL_GC_PUSH2(&tr, &e);
+    JL_LOCK(&jl_dispatch_trampolines->writelock);
+    e = trampoline_map_lookup(tr->sigt, tr->rt, tr->specsig, (jl_abi_kind_t)tr->kind);
+    if (e == NULL) {
+        trampoline_map_insert(tr->sigt, tr);
+        e = tr;
+    }
+    JL_UNLOCK(&jl_dispatch_trampolines->writelock);
+    JL_GC_POP();
+    return e;
+}

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -313,47 +313,10 @@ jl_emitted_output_t jl_codegen_output_t::finish(std::unique_ptr<LLVMContext> ctx
     return {std::move(ctx), std::move(mod), std::move(info)};
 }
 
-// Return a specptr that is ABI-compatible with `from_abi` which invokes `codeinst`.
-//
-// If `codeinst` is NULL, the returned specptr instead performs a standard `apply_generic`
-// call via a dynamic dispatch.
-extern "C" JL_DLLEXPORT_CODEGEN
-void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
-                                jl_code_instance_t *codeinst)
+// JIT an adapter from `from_abi` to `target`, returning its specptr
+static void *jit_adapter(jl_abi_t from_abi, jl_code_instance_t *codeinst,
+                         void *target, bool target_specsig, jl_callptr_t invoke) JL_CANSAFEPOINT
 {
-    void *target = nullptr;
-    bool target_specsig = false;
-    jl_callptr_t invoke = nullptr;
-    if (codeinst != nullptr) {
-        uint8_t specsigflags;
-        jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
-        void *specptr = nullptr;
-        jl_read_codeinst_invoke(codeinst, &specsigflags, &invoke, &specptr, /* waitcompile */ 1);
-        if (invoke != nullptr) {
-            if (invoke == jl_fptr_const_return_addr) {
-                target = nullptr;
-                target_specsig = false;
-            }
-            else if (invoke == jl_fptr_args_addr) {
-                assert(specptr != nullptr);
-                if (!from_abi.specsig && jl_subtype(codeinst->rettype, from_abi.rt))
-                    return specptr; // no adapter required
-
-                target = specptr;
-                target_specsig = false;
-            }
-            else if (specsigflags & JL_CI_FLAGS_SPECPTR_SPECIALIZED) {
-                assert(specptr != nullptr);
-                if (from_abi.specsig && jl_egal(mi->specTypes, from_abi.sigt) && jl_egal(codeinst->rettype, from_abi.rt))
-                    return specptr; // no adapter required
-
-                target = specptr;
-                target_specsig = true;
-            }
-        }
-    }
-
-    orc::ThreadSafeModule result_m;
     std::string gf_thunk_name;
     auto ctx = std::make_unique<LLVMContext>();
     auto mod = jl_create_llvm_module("gfthunk", *ctx, jl_ExecutionEngine->getDataLayout(),
@@ -388,6 +351,39 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
     uintptr_t Addr = jl_ExecutionEngine->getFunctionAddress(gf_thunk_name);
     assert(Addr);
     return (void*)Addr;
+}
+
+// Return a specptr that is ABI-compatible with `from_abi` which invokes `codeinst`.
+//
+// If `codeinst` is NULL, the returned specptr instead performs a standard `apply_generic`
+// call via a dynamic dispatch.
+// If `invokee` is non-NULL, it is set to the owner of the specptr, either the provided
+// `codeinst` or an ABIAdapter if one was required.
+static void *jl_get_abi_adapter(jl_abi_t from_abi, jl_code_instance_t *codeinst,
+                                jl_value_t **invokee) JL_CANSAFEPOINT
+{
+    void *target = nullptr;
+    int target_specsig = 0;
+    jl_callptr_t invoke = nullptr;
+    void *f = jl_lookup_abi_adapter(from_abi, codeinst, &target, &target_specsig, &invoke, invokee);
+    if (f != nullptr)
+        return f;
+
+    // Compile outside the cache lock; insertion chooses a winner.
+    void *fptr = jit_adapter(from_abi, codeinst, target, target_specsig, invoke);
+    if (codeinst != nullptr && invoke == nullptr) {
+        // Do not cache an adapter built while the target was unpublished.
+        return fptr;
+    }
+    return jl_insert_abi_adapter(from_abi, codeinst, fptr, invokee);
+}
+
+extern "C" JL_DLLEXPORT_CODEGEN
+void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
+                                jl_code_instance_t *codeinst, jl_value_t **invokee) JL_CANSAFEPOINT
+{
+    (void)ct;
+    return jl_get_abi_adapter(from_abi, codeinst, invokee);
 }
 
   // lock for places where only single threaded behavior is implemented, so we need GC support

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -375,11 +375,11 @@ struct jl_codegen_call_target_t {
     // neither = unused
 };
 
-// reification of a call to jl_jit_abi_convert, so that it isn't necessary to parse the Modules to recover this info
-struct cfunc_decl_t {
-    jl_abi_t abi;
-    llvm::GlobalVariable *cfuncdata;
-};
+// The caller ABI a DispatchTrampoline was keyed on (canonical type objects).
+inline jl_abi_t jl_trampoline_abi(jl_dispatch_trampoline_t *tr) JL_NOTSAFEPOINT
+{
+    return {tr->sigt, tr->rt, tr->specsig != 0, (jl_abi_kind_t)tr->kind};
+}
 
 std::unique_ptr<Module> jl_create_llvm_module(StringRef name, LLVMContext &ctx,
                                               const DataLayout &DL, const Triple &triple,
@@ -461,15 +461,11 @@ public:
     DenseMap<jl_code_instance_t *, jl_llvm_functions_t> ci_funcs;
     SmallVector<std::pair<jl_code_instance_t *, GlobalVariable *>, 0> external_fns;
 
-    SmallVector<cfunc_decl_t,0> cfuncs;
-    // ABIAdapter records compiled for @cfunction/@ccallable serialization: each entry pairs a
-    // materialized ABIAdapter record with the Function emitted for its resolved target, so the
-    // serialized record's `fptr` is wired to that Function on load without a JIT.
+    // Trampolines for reified @cfunction/@ccallable constructions.
+    SmallVector<jl_dispatch_trampoline_t*,0> cfuncs;
+    // Materialized ABIAdapters and their emitted functions, retained for serialization.
     SmallVector<std::pair<jl_abi_adapter_t*, Function*>, 0> adapter_funcs;
-    // The AOT-resolved target per @cfunction/@ccallable trampoline: Union{CodeInstance,
-    // ABIAdapter} (a bare CodeInstance when the declared ABI matches its specptr). The
-    // serializer's code edge for trampoline resolutions (jl_get_trampoline_invokee) in every
-    // image; materialized into the serialized `last_invokee` only for non-incremental images.
+    // AOT-resolved trampoline targets retained for serialization.
     DenseMap<jl_dispatch_trampoline_t*, jl_value_t*> trampoline_invokees;
     std::map<void*, GlobalVariable*> global_targets;
     jl_array_t *temporary_roots = nullptr;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -462,6 +462,10 @@ public:
     SmallVector<std::pair<jl_code_instance_t *, GlobalVariable *>, 0> external_fns;
 
     SmallVector<cfunc_decl_t,0> cfuncs;
+    // ABIAdapter records compiled for @cfunction/@ccallable serialization: each entry pairs a
+    // materialized ABIAdapter record with the Function emitted for its resolved target, so the
+    // serialized record's `fptr` is wired to that Function on load without a JIT.
+    SmallVector<std::pair<jl_abi_adapter_t*, Function*>, 0> abi_adapter_records;
     std::map<void*, GlobalVariable*> global_targets;
     jl_array_t *temporary_roots = nullptr;
     SmallSet<jl_value_t *, 8> temporary_roots_set;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -465,7 +465,12 @@ public:
     // ABIAdapter records compiled for @cfunction/@ccallable serialization: each entry pairs a
     // materialized ABIAdapter record with the Function emitted for its resolved target, so the
     // serialized record's `fptr` is wired to that Function on load without a JIT.
-    SmallVector<std::pair<jl_abi_adapter_t*, Function*>, 0> abi_adapter_records;
+    SmallVector<std::pair<jl_abi_adapter_t*, Function*>, 0> adapter_funcs;
+    // The AOT-resolved target per @cfunction/@ccallable trampoline: Union{CodeInstance,
+    // ABIAdapter} (a bare CodeInstance when the declared ABI matches its specptr). The
+    // serializer's code edge for trampoline resolutions (jl_get_trampoline_invokee) in every
+    // image; materialized into the serialized `last_invokee` only for non-incremental images.
+    DenseMap<jl_dispatch_trampoline_t*, jl_value_t*> trampoline_invokees;
     std::map<void*, GlobalVariable*> global_targets;
     jl_array_t *temporary_roots = nullptr;
     SmallSet<jl_value_t *, 8> temporary_roots_set;

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -2,6 +2,9 @@
 
 // Pointers that are exposed through the public libjulia
 #define JL_EXPORTED_DATA_POINTERS(XX) \
+    XX(abi_adapter_type, jl_datatype_t*) \
+    XX(abi_adapter_cache_type, jl_datatype_t*) \
+    XX(abi_adapters, jl_abi_adapter_cache_t*) \
     XX(abioverride_type, jl_datatype_t*) \
     XX(abstractarray_type, jl_unionall_t*) \
     XX(abstractstring_type, jl_datatype_t*) \

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -5,6 +5,8 @@
     XX(abi_adapter_type, jl_datatype_t*) \
     XX(abi_adapter_cache_type, jl_datatype_t*) \
     XX(abi_adapters, jl_abi_adapter_cache_t*) \
+    XX(dispatch_trampoline_cache_type, jl_datatype_t*) \
+    XX(dispatch_trampolines, jl_dispatch_trampoline_cache_t*) \
     XX(abioverride_type, jl_datatype_t*) \
     XX(abstractarray_type, jl_unionall_t*) \
     XX(abstractstring_type, jl_datatype_t*) \
@@ -131,6 +133,7 @@
     XX(top_module, jl_module_t*) \
     XX(trimfailure_type, jl_datatype_t*) \
     XX(tuple_typename, jl_typename_t*) \
+    XX(dispatch_trampoline_type, jl_datatype_t*) \
     XX(tvar_type, jl_datatype_t*) \
     XX(typeerror_type, jl_datatype_t*) \
     XX(typeeq_type, jl_datatype_t*) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -553,6 +553,7 @@
     YY(jl_dump_fptr_asm) \
     YY(jl_emit_native) \
     YY(jl_get_function_id) \
+    YY(jl_get_trampoline_invokee) \
     YY(jl_struct_to_llvm) \
     YY(jl_type_to_llvm) \
     YY(jl_getUnwindInfo) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3905,6 +3905,31 @@ void jl_init_types(void) JL_GC_DISABLED
     const static uint32_t abi_adapter_atomicfields[1] = { 0b1100000 }; // fptr (field 5), next (field 6)
     jl_abi_adapter_type->name->atomicfields = abi_adapter_atomicfields;
 
+    jl_dispatch_trampoline_type =
+        jl_new_datatype(jl_symbol("DispatchTrampoline"), core, jl_any_type, jl_emptysvec,
+                        jl_perm_symsvec(8,
+                            "sigt", // resolution sig (not the same as the fptr ABI sig)
+                            "rt",   // declared return type (declrt for @cfunction)
+                            "kind", // jl_abi_kind_t of the invokee / fptr ABI
+                            "specsig", // 1 if fptr is a specsig adapter
+                            "last_invokee", // resolved dispatch target: Union{CodeInstance, ABIAdapter}
+                            "fptr", // ABI adapter
+                            "last_world",
+                            "next"), // next DispatchTrampoline in the `sigt` bucket chain (may be NULL)
+                        jl_svec(8,
+                            jl_any_type,   // hash-consed Tuple type
+                            jl_any_type,   // hash-consed return type
+                            jl_uint8_type, // kind
+                            jl_uint8_type, // specsig
+                            jl_any_type,   // Union{CodeInstance, ABIAdapter} (may be #undef)
+                            pointer_void,  // cached resolved adapter (atomic)
+                            jl_ulong_type, // last_world (atomic)
+                            jl_any_type),  // next (atomic)
+                        jl_emptysvec,
+                        0, 1, 4);
+    const static uint32_t dispatch_trampoline_atomicfields[1] = { 0b11100000 };
+    jl_dispatch_trampoline_type->name->atomicfields = dispatch_trampoline_atomicfields;
+
     // N.B. `jl_abi_adapter_cache_t` has trailing hidden fields (typemap-list config,
     // writelock) excluded here, similar to jl_method_t
     jl_abi_adapter_cache_type =
@@ -3915,6 +3940,17 @@ void jl_init_types(void) JL_GC_DISABLED
                         0, 1, 1);
     const static uint32_t abi_adapter_cache_atomicfields[1] = { 0b1 }; // adapters
     jl_abi_adapter_cache_type->name->atomicfields = abi_adapter_cache_atomicfields;
+
+    // N.B. `jl_dispatch_trampoline_cache_t` has trailing hidden fields (typemap-list
+    // config, writelock) excluded here, similar to jl_method_t
+    jl_dispatch_trampoline_cache_type =
+        jl_new_datatype(jl_symbol("DispatchTrampolineCache"), core, jl_any_type, jl_emptysvec,
+                        jl_perm_symsvec(1, "cache"),
+                        jl_svec1(jl_any_type), // trampolines: TypeMap root (jl_nothing when empty)
+                        jl_emptysvec,
+                        0, 1, 1);
+    const static uint32_t dispatch_trampoline_cache_atomicfields[1] = { 0b1 }; // trampolines
+    jl_dispatch_trampoline_cache_type->name->atomicfields = dispatch_trampoline_cache_atomicfields;
 
     tv = jl_svec2(tvar("T"), tvar("N"));
     jl_abstractarray_type = (jl_unionall_t*)
@@ -3978,6 +4014,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_an_empty_vec_any = (jl_value_t*)jl_alloc_vec_any(0); // used internally
     jl_an_empty_memory_any = (jl_value_t*)jl_alloc_memory_any(0); // used internally
     jl_abi_adapters = jl_new_abi_adapter_cache(); // process-global ABI-adapter cache
+    jl_dispatch_trampolines = jl_new_dispatch_trampoline_cache(); // process-global @cfunction/@ccallable trampoline cache
 
     // finish initializing module Core
     core = jl_core_module;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3882,6 +3882,40 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_value_t *pointer_void = jl_apply_type1((jl_value_t*)jl_pointer_type, (jl_value_t*)jl_nothing_type);
     jl_voidpointer_type = (jl_datatype_t*)pointer_void;
 
+    jl_abi_adapter_type =
+        jl_new_datatype(jl_symbol("ABIAdapter"), core, jl_any_type, jl_emptysvec,
+                        jl_perm_symsvec(7,
+                            "sigt",
+                            "rt",
+                            "specsig",
+                            "kind",
+                            "ci",
+                            "fptr",
+                            "next"),
+                        jl_svec(7,
+                            jl_any_type,   // hash-consed Tuple type
+                            jl_any_type,   // hash-consed return type
+                            jl_uint8_type, // specsig
+                            jl_uint8_type, // kind
+                            jl_any_type,   // CodeInstance (NULL/#undef for dynamic-dispatch adapters)
+                            pointer_void,  // JITed adapter address
+                            jl_any_type),  // next ABIAdapter in the sigt bucket chain (may be NULL)
+                        jl_emptysvec,
+                        0, 1, 4);
+    const static uint32_t abi_adapter_atomicfields[1] = { 0b1100000 }; // fptr (field 5), next (field 6)
+    jl_abi_adapter_type->name->atomicfields = abi_adapter_atomicfields;
+
+    // N.B. `jl_abi_adapter_cache_t` has trailing hidden fields (typemap-list config,
+    // writelock) excluded here, similar to jl_method_t
+    jl_abi_adapter_cache_type =
+        jl_new_datatype(jl_symbol("ABIAdapterCache"), core, jl_any_type, jl_emptysvec,
+                        jl_perm_symsvec(1, "cache"),
+                        jl_svec1(jl_any_type), // adapters: TypeMap root (jl_nothing when empty)
+                        jl_emptysvec,
+                        0, 1, 1);
+    const static uint32_t abi_adapter_cache_atomicfields[1] = { 0b1 }; // adapters
+    jl_abi_adapter_cache_type->name->atomicfields = abi_adapter_cache_atomicfields;
+
     tv = jl_svec2(tvar("T"), tvar("N"));
     jl_abstractarray_type = (jl_unionall_t*)
         jl_new_abstracttype((jl_value_t*)jl_symbol("AbstractArray"), core,
@@ -3943,6 +3977,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_array_uint64_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_uint64_type, jl_box_long(1));
     jl_an_empty_vec_any = (jl_value_t*)jl_alloc_vec_any(0); // used internally
     jl_an_empty_memory_any = (jl_value_t*)jl_alloc_memory_any(0); // used internally
+    jl_abi_adapters = jl_new_abi_adapter_cache(); // process-global ABI-adapter cache
 
     // finish initializing module Core
     core = jl_core_module;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1053,6 +1053,23 @@ typedef struct _jl_methtable_t {
     jl_genericmemory_t *backedges; // IdDict{top typenames, Vector{uncovered (sig => caller::CodeInstance)}}
 } jl_methtable_t;
 
+// A cached thunk from a caller ABI to a CodeInstance (or `jl_apply_generic`).
+typedef struct _jl_abi_adapter_t {
+    JL_DATA_TYPE
+
+    // caller ABI
+    jl_value_t *sigt;
+    jl_value_t *rt;
+    uint8_t specsig;
+    uint8_t kind;                // jl_abi_kind_t of the caller ABI
+
+    // callee target
+    jl_code_instance_t *ci;      // target CodeInstance - NULL for an adapter to dynamic dispatch (`jl_apply_generic`)
+    _Atomic(void*) fptr;         // adapter fptr
+
+    _Atomic(struct _jl_abi_adapter_t*) next;
+} jl_abi_adapter_t;
+
 #define JL_TYPEMAP_LIST_NO_HASHMAP (~(unsigned)0)
 
 // Named so the safepoint annotations attach to the function type itself: on a member
@@ -1072,6 +1089,13 @@ typedef struct _jl_typemap_list_t {
 // hidden fields:
     const jl_typemap_list_config_t *config;
 } jl_typemap_list_t;
+
+typedef struct _jl_abi_adapter_cache_t {
+    JL_DATA_TYPE
+    jl_typemap_list_t cache;
+// hidden fields:
+    jl_mutex_t writelock;
+} jl_abi_adapter_cache_t;
 
 typedef struct {
     JL_DATA_TYPE
@@ -1790,6 +1814,8 @@ static inline int jl_field_isconst(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 #define jl_is_module(v)      jl_typetagis(v,jl_module_tag<<4)
 #define jl_is_mtable(v)      jl_typetagis(v,jl_methtable_type)
 #define jl_is_mcache(v)      jl_typetagis(v,jl_methcache_type)
+#define jl_is_dispatch_trampoline(v)  jl_typetagis(v,jl_dispatch_trampoline_type)
+#define jl_is_abi_adapter(v) jl_typetagis(v,jl_abi_adapter_type)
 #define jl_is_task(v)        jl_typetagis(v,jl_task_tag<<4)
 #define jl_is_cancel_source(v) jl_typetagis(v,jl_cancel_source_tag<<4)
 #define jl_is_string(v)      jl_typetagis(v,jl_string_tag<<4)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1070,6 +1070,28 @@ typedef struct _jl_abi_adapter_t {
     _Atomic(struct _jl_abi_adapter_t*) next;
 } jl_abi_adapter_t;
 
+// Latest-world dispatch "trampoline" (cache) for a single invoke target.
+typedef struct _jl_dispatch_trampoline_t {
+    JL_DATA_TYPE
+
+    // dispatch target
+    jl_value_t *sigt;
+
+    // fptr ABI
+    jl_value_t *rt;              // declared return type
+    uint8_t kind;                // invokee / fptr jl_abi_kind_t
+    uint8_t specsig;
+
+    // Note that `sigt` is *not* the same as the ABI / `sigt` corresponding to fptr.
+    // The invokee ABI is a fixed function of the target + ABI details above though.
+
+    jl_value_t *last_invokee;
+    _Atomic(void*) fptr;         // copied from last_invokee
+    _Atomic(size_t) last_world;  // world for which `fptr`/`last_invokee` are valid, 0 = unresolved
+
+    _Atomic(struct _jl_dispatch_trampoline_t*) next;
+} jl_dispatch_trampoline_t;
+
 #define JL_TYPEMAP_LIST_NO_HASHMAP (~(unsigned)0)
 
 // Named so the safepoint annotations attach to the function type itself: on a member
@@ -1096,6 +1118,13 @@ typedef struct _jl_abi_adapter_cache_t {
 // hidden fields:
     jl_mutex_t writelock;
 } jl_abi_adapter_cache_t;
+
+typedef struct _jl_dispatch_trampoline_cache_t {
+    JL_DATA_TYPE
+    jl_typemap_list_t cache;
+// hidden fields:
+    jl_mutex_t writelock;
+} jl_dispatch_trampoline_cache_t;
 
 typedef struct {
     JL_DATA_TYPE

--- a/src/julia.h
+++ b/src/julia.h
@@ -1053,6 +1053,26 @@ typedef struct _jl_methtable_t {
     jl_genericmemory_t *backedges; // IdDict{top typenames, Vector{uncovered (sig => caller::CodeInstance)}}
 } jl_methtable_t;
 
+#define JL_TYPEMAP_LIST_NO_HASHMAP (~(unsigned)0)
+
+// Named so the safepoint annotations attach to the function type itself: on a member
+// declarator they would apply to the member, leaving calls through the pointer unanalyzed.
+typedef uintptr_t (*jl_typemap_list_hash_t)(jl_value_t *item) JL_NOTSAFEPOINT;
+typedef int (*jl_typemap_list_match_t)(jl_value_t *item, void *key) JL_CANSAFEPOINT;
+
+typedef struct {
+    size_t next_offset;           // offsetof the item's intrusive `next` field
+    unsigned max_list_count;      // max bucket size before switch from linked-list to hashmap
+    jl_typemap_list_hash_t hash;
+    jl_typemap_list_match_t match;
+} jl_typemap_list_config_t;
+
+typedef struct _jl_typemap_list_t {
+    _Atomic(jl_typemap_t*) root;
+// hidden fields:
+    const jl_typemap_list_config_t *config;
+} jl_typemap_list_t;
+
 typedef struct {
     JL_DATA_TYPE
     jl_sym_t *head;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1929,6 +1929,11 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
         struct jl_typemap_assoc *search,
         int8_t offs, uint8_t subtype) JL_CANSAFEPOINT;
 
+JL_DLLEXPORT jl_value_t *jl_typemap_list_lookup(jl_typemap_list_t *map JL_PROPAGATES_ROOT,
+        jl_value_t *sigt, uintptr_t hash, void *key) JL_CANSAFEPOINT;
+JL_DLLEXPORT void jl_typemap_list_insert(jl_typemap_list_t *map, jl_value_t *owner,
+        jl_value_t *sigt, jl_value_t *item) JL_CANSAFEPOINT;
+
 jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t *arg1, jl_value_t **args, size_t n, int8_t offs, size_t world) JL_CANSAFEPOINT;
 jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *mn, jl_value_t *arg1, jl_value_t **args, size_t n, size_t world) JL_CANSAFEPOINT;
 STATIC_INLINE jl_typemap_entry_t *jl_typemap_assoc_exact(

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -431,12 +431,29 @@ static inline void memassign_safe(int hasptr, char *dst, const jl_value_t *src, 
 #define GC_IN_IMAGE_NOT_REMSET (GC_IN_IMAGE) // permalloc'd and not yet modified
 
 // data structures for runtime codegen
+
+// ABI "bridge" behavior enum
+//
+// Beyond the caller ABI and invokee, an ABIAdapter is characterized by its
+// "internal" transformation, usually responsible for world-handling and arg0
+// unpacking (type-erasure).
+//
+// XXX: These responsibilities could be moved to the caller and we could remove
+// this from ABIAdapter, but it would require that we have a type-erased `arg0`
+// ABI by default, which would also allow us to omit ABIAdapters for
+// TypedCallable / OpaqueClosure in many cases.
+typedef enum {
+    // no special type-erasure or world-handling
+    JL_ABI_STD = 0,
+    // slot 0 of `sigt` is the captures environment and type-erased (::Any ABI)
+    JL_ABI_OPAQUE_CLOSURE = 1,
+} jl_abi_kind_t;
+
 typedef struct _jl_abi_t {
     jl_value_t *sigt;
     jl_value_t *rt;
     int specsig; // bool
-    // OpaqueClosure Methods override the first argument of their signature
-    int is_opaque_closure;
+    jl_abi_kind_t kind;
 } jl_abi_t;
 
 // The compiler uses the specific integer values returned by jl_invoke_api
@@ -1762,7 +1779,21 @@ JL_DLLEXPORT jl_value_t *jl_get_cfunction_trampoline(
     void *(*init_trampoline)(void *tramp, void **nval),
     jl_unionall_t *env, jl_value_t **vals) JL_CANSAFEPOINT;
 JL_DLLEXPORT void *jl_get_abi_converter(jl_task_t *ct, void *data) JL_CANSAFEPOINT;
-JL_DLLIMPORT void *jl_jit_abi_converter(jl_task_t *ct, jl_abi_t from_abi, jl_code_instance_t *codeinst) JL_CANSAFEPOINT;
+
+JL_DLLIMPORT void *jl_jit_abi_converter(jl_task_t *ct, jl_abi_t from_abi, jl_code_instance_t *codeinst, jl_value_t **invokee) JL_CANSAFEPOINT;
+
+JL_DLLEXPORT jl_abi_adapter_cache_t *jl_new_abi_adapter_cache(void) JL_CANSAFEPOINT;
+JL_DLLEXPORT void jl_reinit_abi_adapter_cache(jl_abi_adapter_cache_t *c) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_abi_matches_invoke_api(jl_abi_t from_abi, jl_invoke_api_t api,
+        jl_method_instance_t *mi, jl_value_t *rettype) JL_CANSAFEPOINT;
+JL_DLLEXPORT void *jl_abi_matching_specptr(jl_abi_t from_abi, jl_code_instance_t *codeinst) JL_CANSAFEPOINT;
+JL_DLLEXPORT void *jl_lookup_abi_adapter(jl_abi_t from_abi, jl_code_instance_t *codeinst,
+        void **target, int *target_specsig, jl_callptr_t *invoke, jl_value_t **invokee) JL_CANSAFEPOINT;
+JL_DLLEXPORT void *jl_insert_abi_adapter(jl_abi_t from_abi, jl_code_instance_t *codeinst,
+        void *fptr, jl_value_t **invokee) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_abi_adapter_t *jl_new_abi_adapter(jl_value_t *sigt, jl_value_t *rt,
+        jl_code_instance_t *ci, int specsig, jl_abi_kind_t kind, void *fptr) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_abi_adapter_t *jl_reinsert_abi_adapter(jl_abi_adapter_t *e) JL_CANSAFEPOINT;
 
 
 // Special filenames used to refer to internal julia libraries
@@ -2240,8 +2271,8 @@ JL_DLLIMPORT jl_value_t *jl_dump_function_ir(jl_llvmf_dump_t *dump, char strip_i
 JL_DLLIMPORT jl_value_t *jl_dump_function_asm(jl_llvmf_dump_t *dump, char emit_mc, const char* asm_variant, const char *debuginfo, char binary, char raw) JL_CANSAFEPOINT;
 
 typedef jl_value_t *(*jl_codeinstance_lookup_t)(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t min_world, size_t max_world);
-JL_DLLIMPORT void *jl_create_native(LLVMOrcThreadSafeModuleRef llvmmod, int trim, int cache, size_t world, jl_array_t *mod_array, jl_array_t *worklist, int all, jl_array_t *module_init_order, jl_array_t *ext_foreign_cis) JL_CANSAFEPOINT;
-JL_DLLIMPORT void *jl_emit_native(jl_array_t *codeinfos, jl_array_t *ci_order, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _external_linkage) JL_CANSAFEPOINT;
+JL_DLLIMPORT void *jl_create_native(LLVMOrcThreadSafeModuleRef llvmmod, int trim, int cache, size_t world, jl_array_t *mod_array, jl_array_t *worklist, int all, jl_array_t *module_init_order, jl_array_t *ext_foreign_cis, jl_array_t *emitted_adapters) JL_CANSAFEPOINT;
+JL_DLLIMPORT void *jl_emit_native(jl_array_t *codeinfos, jl_array_t *ci_order, jl_array_t *emitted_adapters, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _external_linkage) JL_CANSAFEPOINT;
 JL_DLLIMPORT void jl_dump_native(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         ios_t *z, ios_t *s, jl_emission_params_t *params);
@@ -2249,7 +2280,7 @@ JL_DLLIMPORT void jl_get_llvm_gvs(void *native_code, size_t *num_els, void **gvs
 JL_DLLIMPORT void jl_get_llvm_gv_inits(void *native_code, size_t *num_els, void **inits);
 JL_DLLIMPORT void jl_get_llvm_external_fns(void *native_code, size_t *num_els,
                                            jl_code_instance_t *fns);
-JL_DLLIMPORT void jl_get_function_id(void *native_code, jl_code_instance_t *ncode,
+JL_DLLIMPORT void jl_get_function_id(void *native_code, jl_value_t *codeinst_or_adapter,
         int32_t *func_idx, int32_t *specfunc_idx);
 JL_DLLIMPORT void jl_register_fptrs(uint64_t image_base, const struct _jl_image_fptrs_t *fptrs,
                                     jl_code_instance_t **linfos, size_t n);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -432,8 +432,6 @@ static inline void memassign_safe(int hasptr, char *dst, const jl_value_t *src, 
 
 // data structures for runtime codegen
 
-// ABI "bridge" behavior enum
-//
 // Beyond the caller ABI and invokee, an ABIAdapter is characterized by its
 // "internal" transformation, usually responsible for world-handling and arg0
 // unpacking (type-erasure).
@@ -1778,10 +1776,8 @@ JL_DLLEXPORT jl_value_t *jl_get_cfunction_trampoline(
     jl_value_t *fobj, jl_datatype_t *result, htable_t *cache, jl_svec_t *fill,
     void *(*init_trampoline)(void *tramp, void **nval),
     jl_unionall_t *env, jl_value_t **vals) JL_CANSAFEPOINT;
-JL_DLLEXPORT void *jl_get_abi_converter(jl_task_t *ct, void *data) JL_CANSAFEPOINT;
 
 JL_DLLIMPORT void *jl_jit_abi_converter(jl_task_t *ct, jl_abi_t from_abi, jl_code_instance_t *codeinst, jl_value_t **invokee) JL_CANSAFEPOINT;
-
 JL_DLLEXPORT jl_abi_adapter_cache_t *jl_new_abi_adapter_cache(void) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_dispatch_trampoline_cache_t *jl_new_dispatch_trampoline_cache(void) JL_CANSAFEPOINT;
 JL_DLLEXPORT void jl_reinit_abi_adapter_cache(jl_abi_adapter_cache_t *c) JL_NOTSAFEPOINT;
@@ -1798,7 +1794,6 @@ JL_DLLEXPORT jl_abi_adapter_t *jl_new_abi_adapter(jl_value_t *sigt, jl_value_t *
 JL_DLLEXPORT jl_dispatch_trampoline_t *jl_get_dispatch_trampoline(jl_value_t *sigt, jl_value_t *rt, int specsig, jl_abi_kind_t kind) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_dispatch_trampoline_t *jl_insert_dispatch_trampoline(jl_dispatch_trampoline_t *tr) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_abi_adapter_t *jl_reinsert_abi_adapter(jl_abi_adapter_t *e) JL_CANSAFEPOINT;
-// Refresh a dispatch trampoline for dispatch in the current latest world.
 JL_DLLEXPORT void *jl_update_dispatch_trampoline(jl_task_t *ct, jl_dispatch_trampoline_t *tr) JL_CANSAFEPOINT;
 
 
@@ -2288,6 +2283,7 @@ JL_DLLIMPORT void jl_get_llvm_external_fns(void *native_code, size_t *num_els,
                                            jl_code_instance_t *fns);
 JL_DLLIMPORT void jl_get_function_id(void *native_code, jl_value_t *codeinst_or_adapter,
         int32_t *func_idx, int32_t *specfunc_idx);
+JL_DLLIMPORT jl_value_t *jl_get_trampoline_invokee(void *native_code, jl_dispatch_trampoline_t *tr);
 JL_DLLIMPORT void jl_register_fptrs(uint64_t image_base, const struct _jl_image_fptrs_t *fptrs,
                                     jl_code_instance_t **linfos, size_t n);
 JL_DLLIMPORT void jl_get_llvm_cis(void *native_code, size_t *num_els,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1783,7 +1783,9 @@ JL_DLLEXPORT void *jl_get_abi_converter(jl_task_t *ct, void *data) JL_CANSAFEPOI
 JL_DLLIMPORT void *jl_jit_abi_converter(jl_task_t *ct, jl_abi_t from_abi, jl_code_instance_t *codeinst, jl_value_t **invokee) JL_CANSAFEPOINT;
 
 JL_DLLEXPORT jl_abi_adapter_cache_t *jl_new_abi_adapter_cache(void) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_dispatch_trampoline_cache_t *jl_new_dispatch_trampoline_cache(void) JL_CANSAFEPOINT;
 JL_DLLEXPORT void jl_reinit_abi_adapter_cache(jl_abi_adapter_cache_t *c) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_reinit_dispatch_trampoline_cache(jl_dispatch_trampoline_cache_t *c) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_abi_matches_invoke_api(jl_abi_t from_abi, jl_invoke_api_t api,
         jl_method_instance_t *mi, jl_value_t *rettype) JL_CANSAFEPOINT;
 JL_DLLEXPORT void *jl_abi_matching_specptr(jl_abi_t from_abi, jl_code_instance_t *codeinst) JL_CANSAFEPOINT;
@@ -1793,7 +1795,11 @@ JL_DLLEXPORT void *jl_insert_abi_adapter(jl_abi_t from_abi, jl_code_instance_t *
         void *fptr, jl_value_t **invokee) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_abi_adapter_t *jl_new_abi_adapter(jl_value_t *sigt, jl_value_t *rt,
         jl_code_instance_t *ci, int specsig, jl_abi_kind_t kind, void *fptr) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_dispatch_trampoline_t *jl_get_dispatch_trampoline(jl_value_t *sigt, jl_value_t *rt, int specsig, jl_abi_kind_t kind) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_dispatch_trampoline_t *jl_insert_dispatch_trampoline(jl_dispatch_trampoline_t *tr) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_abi_adapter_t *jl_reinsert_abi_adapter(jl_abi_adapter_t *e) JL_CANSAFEPOINT;
+// Refresh a dispatch trampoline for dispatch in the current latest world.
+JL_DLLEXPORT void *jl_update_dispatch_trampoline(jl_task_t *ct, jl_dispatch_trampoline_t *tr) JL_CANSAFEPOINT;
 
 
 // Special filenames used to refer to internal julia libraries

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -429,7 +429,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
     if (codeinst == NULL) {
         // Generate an adapter to a dynamic dispatch
         if (cfuncdata->unspecialized == NULL)
-            cfuncdata->unspecialized = jl_jit_abi_converter(ct, from_abi, NULL);
+            cfuncdata->unspecialized = jl_jit_abi_converter(ct, from_abi, NULL, NULL);
 
         f = cfuncdata->unspecialized;
     } else {
@@ -441,7 +441,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
             // even though we're likely to encounter memory errors in that case
             jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name_from_method_instance((jl_method_instance_t*)mi));
         }
-        f = jl_jit_abi_converter(ct, from_abi, codeinst);
+        f = jl_jit_abi_converter(ct, from_abi, codeinst, NULL);
     }
 
     cfuncdata->plast_codeinst = &cfuncdata->last_codeinst;

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -414,12 +414,20 @@ void *jl_update_dispatch_trampoline(jl_task_t *ct, jl_dispatch_trampoline_t *tr)
                 return f;
             }
         }
-        JL_UNLOCK(&trampoline_lock);
-        // slow: infer the target outside the lock (this is very slow)
-        codeinst = mi != jl_nothing ? jl_type_infer((jl_method_instance_t*)mi, world, SOURCE_MODE_ABI, jl_options.trim) : NULL;
-        if (codeinst != NULL)
-            jl_compile_codeinst(codeinst);
-        JL_LOCK(&trampoline_lock);
+        // Prefer an already-compiled target: no inference / JIT required.
+        codeinst = mi != jl_nothing ? jl_method_compiled((jl_method_instance_t*)mi, world) : NULL;
+        // An ABI-override CodeInstance is compiled for a different ABI than its
+        // MethodInstance declares; the adapter shortcut must not match against it.
+        if (codeinst != NULL && codeinst->def != mi)
+            codeinst = NULL;
+        if (mi != jl_nothing && codeinst == NULL) {
+            JL_UNLOCK(&trampoline_lock);
+            // slow: infer the target outside the lock (this is very slow)
+            codeinst = jl_type_infer((jl_method_instance_t*)mi, world, SOURCE_MODE_ABI, jl_options.trim);
+            if (codeinst != NULL)
+                jl_compile_codeinst(codeinst);
+            JL_LOCK(&trampoline_lock);
+        }
     } while (jl_atomic_load_acquire(&jl_world_counter) != world); // restart if the world moved under us
     // double-check another thread didn't already install for this world
     size_t lwv = jl_atomic_load_relaxed(&tr->last_world);

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -183,7 +183,7 @@ JL_DLLEXPORT char *jl_format_filename(const char *output_pattern) JL_NOTSAFEPOIN
 }
 
 
-static uv_mutex_t trampoline_lock; // for accesses to the cache and freelist
+static uv_mutex_t cfun_lock; // for accesses to the @cfunction nest cache and freelist
 
 static void *trampoline_freelist;
 
@@ -236,14 +236,14 @@ static void trampoline_deleter(void **f) JL_NOTSAFEPOINT
     f[0] = NULL;
     f[2] = NULL;
     f[3] = NULL;
-    uv_mutex_lock(&trampoline_lock);
+    uv_mutex_lock(&cfun_lock);
     if (tramp)
         trampoline_free(tramp);
     if (fobj && cache)
         ptrhash_remove((htable_t*)cache, fobj);
     if (nval)
         free(nval);
-    uv_mutex_unlock(&trampoline_lock);
+    uv_mutex_unlock(&cfun_lock);
 }
 
 typedef void *(*init_trampoline_t)(void *tramp, void **nval) JL_NOTSAFEPOINT;
@@ -263,7 +263,7 @@ jl_value_t *jl_get_cfunction_trampoline(
     jl_value_t **vals)
 {
     // lookup (fobj, vals) in cache
-    uv_mutex_lock(&trampoline_lock);
+    uv_mutex_lock(&cfun_lock);
     if (!cache->table)
         htable_new(cache, 1);
     if (fill != jl_emptysvec) {
@@ -275,7 +275,7 @@ jl_value_t *jl_get_cfunction_trampoline(
         }
     }
     void *tramp = ptrhash_get(cache, (void*)fobj);
-    uv_mutex_unlock(&trampoline_lock);
+    uv_mutex_unlock(&cfun_lock);
     if (tramp != HT_NOTFOUND) {
         assert((jl_datatype_t*)jl_typeof(tramp) == result_type);
         return (jl_value_t*)tramp;
@@ -326,26 +326,15 @@ jl_value_t *jl_get_cfunction_trampoline(
         free(nval);
         jl_rethrow();
     }
-    uv_mutex_lock(&trampoline_lock);
+    uv_mutex_lock(&cfun_lock);
     tramp = trampoline_alloc();
     ((void**)result)[0] = tramp;
     init_trampoline(tramp, nval);
     ptrhash_put(cache, (void*)fobj, result);
-    uv_mutex_unlock(&trampoline_lock);
+    uv_mutex_unlock(&cfun_lock);
     return result;
 }
 JL_GCC_IGNORE_STOP
-
-struct cfuncdata_t {
-    _Atomic(void *) fptr;
-    _Atomic(size_t) last_world;
-    jl_code_instance_t** plast_codeinst;
-    jl_code_instance_t* last_codeinst;
-    void *unspecialized;
-    jl_value_t *const *const declrt;
-    jl_value_t *const *const sigt;
-    size_t flags;
-};
 
 static inline const char *name_from_method_instance(jl_method_instance_t *mi) JL_NOTSAFEPOINT
 {
@@ -353,7 +342,7 @@ static inline const char *name_from_method_instance(jl_method_instance_t *mi) JL
     return jl_is_method(mi->def.method) ? jl_symbol_name(mi->def.method->name) : "top-level scope";
 }
 
-static jl_mutex_t cfun_lock;
+static jl_mutex_t trampoline_lock; // guards dispatch-trampoline resolve / publish
 
 // (get_abi_converter / method table mutating thread)
 // release jl_world_counter
@@ -368,87 +357,104 @@ static jl_mutex_t cfun_lock;
 // The above ordering requirements are intended to guarantee that if the
 // dispatch site observes last_world == jl_world_counter then the loaded
 // fptr is consistent with both of them, meaning it was published for
-// exactly that world.
-JL_DLLEXPORT
-void *jl_get_abi_converter(jl_task_t *ct, void *data)
+// exactly that world. fptr must never be reset to NULL after it is
+// published as valid.
+static jl_code_instance_t *invokee_ci(jl_value_t *last_invokee) JL_NOTSAFEPOINT
 {
-    struct cfuncdata_t *cfuncdata = (struct cfuncdata_t*)data;
-    jl_value_t *sigt = *cfuncdata->sigt;
+    if (last_invokee == NULL)
+        return NULL;
+    if (jl_is_abi_adapter(last_invokee))
+        return ((jl_abi_adapter_t*)last_invokee)->ci;
+    return (jl_code_instance_t*)last_invokee; // a bare CodeInstance (declared ABI matched its specptr)
+}
+
+// Refresh a dispatch trampoline for dispatch in the current latest world.
+JL_DLLEXPORT
+void *jl_update_dispatch_trampoline(jl_task_t *ct, jl_dispatch_trampoline_t *tr) JL_CANSAFEPOINT
+{
+    jl_value_t *sigt = tr->sigt;
     JL_GC_PROMISE_ROOTED(sigt);
-    jl_value_t *declrt = *cfuncdata->declrt;
-    JL_GC_PROMISE_ROOTED(declrt);
-    int specsig = cfuncdata->flags & 1;
+    jl_value_t *rt = tr->rt;
+    JL_GC_PROMISE_ROOTED(rt);
+    jl_abi_t from_abi = { sigt, rt, tr->specsig, (jl_abi_kind_t)tr->kind };
     jl_value_t *mi;
     jl_code_instance_t *codeinst;
     size_t world;
-    // check first, while behind this lock, of the validity of the current contents of this cfunc thunk
-    JL_LOCK(&cfun_lock);
+    JL_LOCK(&trampoline_lock);
     do {
-        size_t last_world_v = jl_atomic_load_relaxed(&cfuncdata->last_world);
-        void *f = jl_atomic_load_relaxed(&cfuncdata->fptr);
-        jl_code_instance_t *last_ci = cfuncdata->plast_codeinst ? *cfuncdata->plast_codeinst : NULL;
-        JL_GC_PROMISE_ROOTED(last_ci); // cached CI is retained by the MI cache or by an image literal root slot
+        size_t last_world_v = jl_atomic_load_relaxed(&tr->last_world);
+        void *f = jl_atomic_load_relaxed(&tr->fptr);
         world = jl_atomic_load_acquire(&jl_world_counter);
         ct->world_age = world;
         if (world == last_world_v) {
-            JL_UNLOCK(&cfun_lock);
+            assert(f != NULL); // `last_world` is only ever published after `fptr`
+            JL_UNLOCK(&trampoline_lock);
             return f;
         }
         mi = jl_get_specialization1((jl_tupletype_t*)sigt, world);
+        // Reuse the adapter if its target remains valid.
         if (f != NULL) {
-            if (last_ci == NULL) {
-                if (mi == jl_nothing) {
-                    jl_atomic_store_release(&cfuncdata->last_world, world);
-                    JL_UNLOCK(&cfun_lock);
-                    return f;
-                }
-            }
-            else {
-                if ((jl_value_t*)jl_get_ci_mi(last_ci) == mi && jl_atomic_load_relaxed(&last_ci->max_world) >= world) { // same dispatch and source
-                    jl_atomic_store_release(&cfuncdata->last_world, world);
-                    JL_UNLOCK(&cfun_lock);
-                    return f;
-                }
+            jl_value_t *last_invokee = tr->last_invokee;
+            JL_GC_PROMISE_ROOTED(last_invokee); // retained by the adapter/MI cache
+            assert(last_invokee != NULL); // published together with `fptr` (see below)
+            jl_code_instance_t *last_ci = invokee_ci(last_invokee);
+            int still_valid;
+            if (last_ci == NULL) // dynamic-dispatch adapter: correct while dispatch finds no specialization
+                still_valid = mi == jl_nothing;
+            else
+                still_valid = (jl_value_t*)jl_get_ci_mi(last_ci) == mi &&
+                              jl_atomic_load_relaxed(&last_ci->max_world) >= world;
+            if (still_valid) {
+                jl_atomic_store_release(&tr->last_world, world);
+                JL_UNLOCK(&trampoline_lock);
+                return f;
             }
         }
-        JL_UNLOCK(&cfun_lock);
-        // next, try to figure out what the target should look like (outside of the lock since this is very slow)
+        JL_UNLOCK(&trampoline_lock);
+        // slow: infer the target outside the lock (this is very slow)
         codeinst = mi != jl_nothing ? jl_type_infer((jl_method_instance_t*)mi, world, SOURCE_MODE_ABI, jl_options.trim) : NULL;
-        // relock for the remainder of the function
-        JL_LOCK(&cfun_lock);
-    } while (jl_atomic_load_acquire(&jl_world_counter) != world); // restart entirely, since jl_world_counter changed thus jl_get_specialization1 might have changed
-    // double-check if the values were set on another thread
-    size_t last_world_v = jl_atomic_load_relaxed(&cfuncdata->last_world);
-    void *f = jl_atomic_load_relaxed(&cfuncdata->fptr);
-    if (world == last_world_v) {
-        JL_UNLOCK(&cfun_lock);
-        return f; // another thread fixed this up while we were away
+        if (codeinst != NULL)
+            jl_compile_codeinst(codeinst);
+        JL_LOCK(&trampoline_lock);
+    } while (jl_atomic_load_acquire(&jl_world_counter) != world); // restart if the world moved under us
+    // double-check another thread didn't already install for this world
+    size_t lwv = jl_atomic_load_relaxed(&tr->last_world);
+    void *f = jl_atomic_load_relaxed(&tr->fptr);
+    if (world == lwv) {
+        assert(f != NULL); // `last_world` is only ever published after `fptr`
+        JL_UNLOCK(&trampoline_lock);
+        return f;
     }
-    int is_opaque_closure = 0;
-    jl_abi_t from_abi = { sigt, declrt, specsig, is_opaque_closure };
-    if (codeinst == NULL) {
-        // Generate an adapter to a dynamic dispatch
-        if (cfuncdata->unspecialized == NULL)
-            cfuncdata->unspecialized = jl_jit_abi_converter(ct, from_abi, NULL, NULL);
-
-        f = cfuncdata->unspecialized;
-    } else {
+    // If the world advanced but the dispatch target is unchanged from the one `fptr` was
+    // built for, the existing adapter is still correct -- reuse it (no re-JIT).
+    if (f != NULL && codeinst == invokee_ci(tr->last_invokee)) {
+        jl_atomic_store_release(&tr->last_world, world);
+        JL_UNLOCK(&trampoline_lock);
+        return f;
+    }
+    // @cfunction warns when the declared C return type cannot match the resolved target's
+    // rettype (skip must-not-return targets, occasionally required by the C API for error
+    // callbacks even though memory errors are then likely).
+    if (codeinst != NULL) {
         jl_value_t *astrt = codeinst->rettype;
         if (astrt != (jl_value_t*)jl_bottom_type &&
-            jl_type_intersection(astrt, declrt) == jl_bottom_type) {
-            // Do not warn if the function never returns since it is
-            // occasionally required by the C API (typically error callbacks)
-            // even though we're likely to encounter memory errors in that case
-            jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name_from_method_instance((jl_method_instance_t*)mi));
-        }
-        f = jl_jit_abi_converter(ct, from_abi, codeinst, NULL);
+            jl_type_intersection(astrt, rt) == jl_bottom_type)
+            jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n",
+                      name_from_method_instance((jl_method_instance_t*)mi));
     }
-
-    cfuncdata->plast_codeinst = &cfuncdata->last_codeinst;
-    cfuncdata->last_codeinst = codeinst;
-    jl_atomic_store_release(&cfuncdata->fptr, f);
-    jl_atomic_store_release(&cfuncdata->last_world, world);
-    JL_UNLOCK(&cfun_lock);
+    // Fall back to dynamic dispatch if emission left the target unpublished.
+    // This should only happen if the emission failed due to a compilation error, etc.
+    if (codeinst != NULL && !jl_is_compiled_codeinst(codeinst))
+        codeinst = NULL;
+    // Keep the CodeInstance or ABIAdapter used to derive fptr.
+    jl_value_t *new_invokee = NULL;
+    f = jl_jit_abi_converter(ct, from_abi, codeinst, &new_invokee);
+    // Published fptrs always have an invokee for later validation.
+    assert(new_invokee != NULL);
+    jl_gc_write(tr, tr->last_invokee, jl_value_t, new_invokee);
+    jl_atomic_store_release(&tr->fptr, f);
+    jl_atomic_store_release(&tr->last_world, world);
+    JL_UNLOCK(&trampoline_lock);
     return f;
 }
 
@@ -456,5 +462,5 @@ void jl_init_runtime_ccall(void)
 {
     JL_MUTEX_INIT(&libmap_lock, "libmap_lock");
     strhash_new(&libMap, 16);
-    uv_mutex_init(&trampoline_lock);
+    uv_mutex_init(&cfun_lock);
 }

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -392,6 +392,10 @@ void *jl_update_dispatch_trampoline(jl_task_t *ct, jl_dispatch_trampoline_t *tr)
             return f;
         }
         mi = jl_get_specialization1((jl_tupletype_t*)sigt, world);
+        // A match that only partially covers `sigt` must keep dispatching at call
+        // time: wiring it directly would bypass the MethodError for uncovered calls.
+        if (mi != jl_nothing && !jl_subtype(sigt, ((jl_method_instance_t*)mi)->def.method->sig))
+            mi = jl_nothing;
         // Reuse the adapter if its target remains valid.
         if (f != NULL) {
             jl_value_t *last_invokee = tr->last_invokee;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -770,12 +770,16 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
     if (jl_is_dispatch_trampoline(v)) {
         jl_dispatch_trampoline_t *tr = (jl_dispatch_trampoline_t*)v;
         record_field_change((jl_value_t**)&tr->next, NULL); // don't follow cache-only edge
+        jl_value_t *invokee = native_functions ?
+            jl_get_trampoline_invokee(native_functions, tr) : NULL;
+        if (invokee)
+            jl_queue_for_serialization(s, invokee);
+        // Invokee is resolved on first use after load.
+        record_field_change((jl_value_t**)&tr->last_invokee, NULL);
     }
     if (jl_is_abi_adapter(v)) {
-        // Like the cache itself, the adapter's `sigt` bucket chain is process-local and
-        // rebuilt on load (jl_insert_abi_adapter), so drop `next`.
         jl_abi_adapter_t *ad = (jl_abi_adapter_t*)v;
-        record_field_change((jl_value_t**)&ad->next, NULL);
+        record_field_change((jl_value_t**)&ad->next, NULL); // don't follow cache-only edge
     }
     if (jl_is_code_instance(v)) {
         jl_code_instance_t *ci = (jl_code_instance_t*)v;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -757,6 +757,17 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
             }
         }
     }
+    if (jl_typetagis(v, jl_abi_adapter_cache_type)) {
+        // Rebuilt from the reinserted ABIAdapters, drop it for now.
+        jl_abi_adapter_cache_t *c = (jl_abi_adapter_cache_t*)v;
+        record_field_change((jl_value_t**)&c->cache.root, jl_nothing);
+    }
+    if (jl_is_abi_adapter(v)) {
+        // Like the cache itself, the adapter's `sigt` bucket chain is process-local and
+        // rebuilt on load (jl_insert_abi_adapter), so drop `next`.
+        jl_abi_adapter_t *ad = (jl_abi_adapter_t*)v;
+        record_field_change((jl_value_t**)&ad->next, NULL);
+    }
     if (jl_is_code_instance(v)) {
         jl_code_instance_t *ci = (jl_code_instance_t*)v;
         jl_method_instance_t *mi = jl_get_ci_mi(ci);
@@ -1094,6 +1105,17 @@ static void write_padding(ios_t *s, size_t nb) JL_NOTSAFEPOINT
     }
     if (nb != 0)
         ios_write(s, zeros, nb);
+}
+
+static void write_reloc_slot(ios_t *s, size_t fptr_id, uintptr_t reloc_id) JL_NOTSAFEPOINT
+{
+    ios_ensureroom(s, fptr_id * sizeof(void*));
+    ios_seek(s, (fptr_id - 1) * sizeof(void*));
+    write_reloc_t(s, reloc_id);
+#ifdef _P64
+    if (sizeof(reloc_t) < 8)
+        write_padding(s, 8 - sizeof(reloc_t));
+#endif
 }
 
 static void write_pointer(ios_t *s) JL_NOTSAFEPOINT
@@ -1822,29 +1844,17 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                         else {
                             int32_t invokeptr_id = 0;
                             int32_t specfptr_id = 0;
-                            jl_get_function_id(native_functions, ci, &invokeptr_id, &specfptr_id); // see if we generated code for it
+                            jl_get_function_id(native_functions, (jl_value_t*)ci, &invokeptr_id, &specfptr_id); // see if we generated code for it
                             if (invokeptr_id) {
                                 if (invokeptr_id < 0) {
                                     fptr_type = (jl_invoke_api_t)-invokeptr_id;
                                     assert(fptr_type != JL_INVOKE_SPECSIG);
                                 } else {
-                                    ios_ensureroom(s->fptr_record, invokeptr_id * sizeof(void*));
-                                    ios_seek(s->fptr_record, (invokeptr_id - 1) * sizeof(void*));
-                                    write_reloc_t(s->fptr_record, (reloc_t)~reloc_offset);
-#ifdef _P64
-                                    if (sizeof(reloc_t) < 8)
-                                        write_padding(s->fptr_record, 8 - sizeof(reloc_t));
-#endif
+                                    write_reloc_slot(s->fptr_record, invokeptr_id, (reloc_t)~reloc_offset);
                                 }
                                 if (specfptr_id) {
                                     assert(specfptr_id > invokeptr_id && specfptr_id > 0);
-                                    ios_ensureroom(s->fptr_record, specfptr_id * sizeof(void*));
-                                    ios_seek(s->fptr_record, (specfptr_id - 1) * sizeof(void*));
-                                    write_reloc_t(s->fptr_record, reloc_offset);
-#ifdef _P64
-                                    if (sizeof(reloc_t) < 8)
-                                        write_padding(s->fptr_record, 8 - sizeof(reloc_t));
-#endif
+                                    write_reloc_slot(s->fptr_record, specfptr_id, reloc_offset);
                                 }
                             }
                         }
@@ -1860,6 +1870,39 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                     arraylist_push(&s->relocs_list, (void*)(reloc_offset + offsetof(jl_code_instance_t, specptr.fptr))); // relocation location
                     arraylist_push(&s->relocs_list, (void*)(((uintptr_t)FunctionRef << RELOC_TAG_OFFSET) + BuiltinFunctionTag + builtin_id - 2)); // relocation target
                 }
+            }
+            else if (jl_is_abi_adapter(v)) {
+                assert(f == s->s);
+                // The compiled adapter thunk lives in the image as an fvar. Null the record's
+                // process-local `fptr` and record the wiring in `fptr_record` keyed on that fvar
+                // id, so jl_update_all_fptrs sets `fptr` from the fvar on load (parallels the
+                // CodeInstance specptr; CI vs record disambiguated by the object's type tag).
+                jl_abi_adapter_t *newad = (jl_abi_adapter_t*)&f->buf[reloc_offset];
+                jl_atomic_store_relaxed(&newad->fptr, NULL);
+                int32_t invokeptr_id = 0, adapter_id = 0;
+                jl_get_function_id(native_functions, v, &invokeptr_id, &adapter_id);
+                assert(invokeptr_id == 0); (void)invokeptr_id; // adapters have no invoke wrapper
+                if (adapter_id > 0) {
+                    ios_ensureroom(s->fptr_record, adapter_id * sizeof(void*));
+                    ios_seek(s->fptr_record, (adapter_id - 1) * sizeof(void*));
+                    write_reloc_t(s->fptr_record, reloc_offset);
+#ifdef _P64
+                    if (sizeof(reloc_t) < 8)
+                        write_padding(s->fptr_record, 8 - sizeof(reloc_t));
+#endif
+                    // Re-insert this record into the running adapters cache on load. Records
+                    // with no fvar slot (adapter_id == 0, e.g. a runtime-created record
+                    // reached through user data) have no thunk to wire, so they serialize as
+                    // inert data and are never published to the cache.
+                    arraylist_push(&s->fixup_objs, (void*)reloc_offset);
+                }
+            }
+            else if (jl_typetagis(v, jl_abi_adapter_cache_type)) {
+                assert(f == s->s);
+                // The cache's `writelock` is a hidden trailing C field (not a datatype field);
+                // pad the serialized object out to the full struct size so the restored lock
+                // is zero-initialized (mirrors the jl_method_t writelock handling above).
+                write_padding(f, sizeof(jl_abi_adapter_cache_t) - tot);
             }
             else if (jl_is_datatype(v)) {
                 assert(f == s->s);
@@ -2309,10 +2352,7 @@ static void jl_update_all_fptrs(jl_serializer_state *s, jl_image_t *image)
                 specfunc = 0;
                 offset = ~offset;
             }
-            jl_code_instance_t *codeinst = (jl_code_instance_t*)(base + offset);
-            assert(jl_is_method(jl_get_ci_mi(codeinst)->def.method) && jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return);
-            assert(specfunc ? jl_atomic_load_relaxed(&codeinst->invoke) != NULL : jl_atomic_load_relaxed(&codeinst->invoke) == NULL);
-            linfos[i] = codeinst;
+            void *obj = (void*)(base + offset);
             void *fptr = fvars.ptrs[i];
             for (; clone_idx < fvars.nclones; clone_idx++) {
                 uint32_t idx = fvars.clone_idxs[clone_idx] & jl_sysimg_val_mask;
@@ -2322,17 +2362,30 @@ static void jl_update_all_fptrs(jl_serializer_state *s, jl_image_t *image)
                     fptr = fvars.clone_ptrs[clone_idx];
                 break;
             }
-            if (specfunc) {
-                uint8_t flags = jl_atomic_load_relaxed(&codeinst->flags);
-                flags |= JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR | JL_CI_FLAGS_FROM_IMAGE;
-                if (jl_callptr_invoke_api(jl_atomic_load_relaxed(&codeinst->invoke)) ==
-                    JL_INVOKE_SPECSIG)
-                    flags |= JL_CI_FLAGS_SPECPTR_SPECIALIZED;
-                jl_atomic_store_relaxed(&codeinst->specptr.fptr, fptr);
-                jl_atomic_store_relaxed(&codeinst->flags, flags);
-            }
-            else {
-                jl_atomic_store_relaxed(&codeinst->invoke, (jl_callptr_t)fptr);
+            if (jl_is_abi_adapter(obj)) {
+                jl_abi_adapter_t *ad = (jl_abi_adapter_t*)obj;
+                assert(specfunc); // adapter slots are always specfunc
+                assert(jl_atomic_load_relaxed(&ad->fptr) == NULL && fptr != NULL);
+                jl_atomic_store_relaxed(&ad->fptr, fptr);
+            } else if (jl_is_code_instance(obj)) {
+                jl_code_instance_t *codeinst = (jl_code_instance_t*)obj;
+                assert(jl_is_method(jl_get_ci_mi(codeinst)->def.method) && jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return);
+                assert(specfunc ? jl_atomic_load_relaxed(&codeinst->invoke) != NULL : jl_atomic_load_relaxed(&codeinst->invoke) == NULL);
+                linfos[i] = codeinst;
+                if (specfunc) {
+                    uint8_t flags = jl_atomic_load_relaxed(&codeinst->flags);
+                    flags |= JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR | JL_CI_FLAGS_FROM_IMAGE;
+                    if (jl_callptr_invoke_api(jl_atomic_load_relaxed(&codeinst->invoke)) ==
+                        JL_INVOKE_SPECSIG)
+                        flags |= JL_CI_FLAGS_SPECPTR_SPECIALIZED;
+                    jl_atomic_store_relaxed(&codeinst->specptr.fptr, fptr);
+                    jl_atomic_store_relaxed(&codeinst->flags, flags);
+                }
+                else {
+                    jl_atomic_store_relaxed(&codeinst->invoke, (jl_callptr_t)fptr);
+                }
+            } else {
+                jl_unreachable();
             }
         }
     }
@@ -2907,7 +2960,7 @@ static int jl_prune_internal_mtable(jl_methtable_t *mt, void *env)
 // In addition to the system image (where `worklist = NULL`), this can also save incremental images with external linkage
 static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
                                            jl_array_t *module_init_order, jl_array_t *worklist, jl_array_t *extext_methods,
-                                           jl_array_t *new_ext, jl_query_cache *query_cache) JL_CANSAFEPOINT
+                                           jl_array_t *new_ext, jl_array_t *emitted_adapters, jl_query_cache *query_cache) JL_CANSAFEPOINT
 {
     htable_new(&field_replace, 0);
     htable_new(&bits_replace, 0);
@@ -3112,8 +3165,13 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
         if (extext_methods) {
             // Queue method extensions
             jl_queue_for_serialization(&s, extext_methods);
-            // Queue the new specializations
-            jl_queue_for_serialization(&s, new_ext);
+            for (size_t i = 0; i < jl_array_nrows(new_ext); i++)
+                jl_queue_for_serialization(&s, jl_array_ptr_ref(new_ext, i));
+        }
+        if (emitted_adapters) {
+            // Queue ABIAdapters (whether external or internal)
+            for (size_t i = 0; i < jl_array_nrows(emitted_adapters); i++)
+                jl_queue_for_serialization(&s, jl_array_ptr_ref(emitted_adapters, i));
         }
         jl_serialize_reachable(&s);
         // step 1.2: ensure all gvars are part of the sysimage too
@@ -3303,7 +3361,6 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             }
             jl_write_value(&s, module_init_order);
             jl_write_value(&s, extext_methods);
-            jl_write_value(&s, new_ext);
             jl_write_value(&s, s.method_roots_list);
         }
         write_uint32(f, jl_array_len(s.link_ids_gctags));
@@ -3406,20 +3463,21 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
         ff = f;
     }
 
-    jl_array_t *mod_array = NULL, *extext_methods = NULL, *new_ext = NULL, *ext_foreign_cis = NULL;
+    jl_array_t *mod_array = NULL, *extext_methods = NULL, *new_ext = NULL, *ext_foreign_cis = NULL, *emitted_adapters = NULL;
     int64_t checksumpos = 0;
     int64_t checksumpos_ff = 0;
     int64_t datastartpos = 0;
-    JL_GC_PUSH4(&mod_array, &extext_methods, &new_ext, &ext_foreign_cis);
+    JL_GC_PUSH5(&mod_array, &extext_methods, &new_ext, &ext_foreign_cis, &emitted_adapters);
 
     ext_foreign_cis = jl_alloc_vec_any(0);
+    emitted_adapters = jl_alloc_vec_any(0);
 
     mod_array = jl_get_loaded_modules();  // __toplevel__ modules loaded in this session (from Base.loaded_modules_array)
     if (worklist) {
         if (_native_data != NULL) {
             if (suppress_precompile)
                 newly_inferred = NULL;
-            *_native_data = jl_create_native(NULL, 0, 1, jl_atomic_load_acquire(&jl_world_counter), NULL, suppress_precompile ? (jl_array_t*)jl_an_empty_vec_any : worklist, 0, module_init_order, ext_foreign_cis);
+            *_native_data = jl_create_native(NULL, 0, 1, jl_atomic_load_acquire(&jl_world_counter), NULL, suppress_precompile ? (jl_array_t*)jl_an_empty_vec_any : worklist, 0, module_init_order, ext_foreign_cis, emitted_adapters);
         }
         jl_write_header_for_incremental(f, worklist, mod_array, udeps, srctextpos, &checksumpos);
         if (emit_split) {
@@ -3433,7 +3491,7 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
         }
     }
     else if (_native_data != NULL) {
-        *_native_data = jl_create_native(NULL, jl_options.trim, 0, jl_atomic_load_acquire(&jl_world_counter), mod_array, NULL, jl_options.compile_enabled == JL_OPTIONS_COMPILE_ALL, module_init_order, ext_foreign_cis);
+        *_native_data = jl_create_native(NULL, jl_options.trim, 0, jl_atomic_load_acquire(&jl_world_counter), mod_array, NULL, jl_options.compile_enabled == JL_OPTIONS_COMPILE_ALL, module_init_order, ext_foreign_cis, emitted_adapters);
     }
     if (_native_data != NULL)
         native_functions = *_native_data;
@@ -3490,7 +3548,7 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
     jl_query_cache query_cache;
     init_query_cache(&query_cache);
     jl_finalize_precompile_inferred(worklist != NULL && _native_data != NULL && jl_options.outputo != NULL);
-    jl_save_system_image_to_stream(ff, mod_array, module_init_order, worklist, extext_methods, new_ext, &query_cache);
+    jl_save_system_image_to_stream(ff, mod_array, module_init_order, worklist, extext_methods, new_ext, emitted_adapters, &query_cache);
     if (_native_data != NULL)
         native_functions = NULL;
     // make sure we don't run any Julia code concurrently before this point
@@ -3897,7 +3955,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     ios_seek(f, LLT_ALIGN(ios_pos(f), 8));
     assert(!ios_eof(f));
     s.s = f;
-    uintptr_t offset_restored = 0, offset_init_order = 0, offset_extext_methods = 0, offset_new_ext = 0, offset_method_roots_list = 0;
+    uintptr_t offset_restored = 0, offset_init_order = 0, offset_extext_methods = 0, offset_method_roots_list = 0;
     if (!s.incremental) {
         size_t i;
         for (i = 0; tags[i] != NULL; i++) {
@@ -3932,7 +3990,6 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         offset_restored = jl_read_offset(&s);
         offset_init_order = jl_read_offset(&s);
         offset_extext_methods = jl_read_offset(&s);
-        offset_new_ext = jl_read_offset(&s);
         offset_method_roots_list = jl_read_offset(&s);
     }
     s.buildid_depmods_idxs = depmod_to_imageidx(depmods);
@@ -3962,7 +4019,6 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         *restored = (jl_array_t*)jl_delayed_reloc(&s, offset_restored);
         *init_order = (jl_array_t*)jl_delayed_reloc(&s, offset_init_order);
         *extext_methods = (jl_array_t*)jl_delayed_reloc(&s, offset_extext_methods);
-        (void)(jl_array_t*)jl_delayed_reloc(&s, offset_new_ext);
         *method_roots_list = (jl_array_t*)jl_delayed_reloc(&s, offset_method_roots_list);
         *internal_methods = jl_alloc_vec_any(0);
     }
@@ -4223,12 +4279,20 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         o->bits.in_image = 1;
     }
     arraylist_free(&cleanup_list);
+    // Restored ABI-adapter records, re-inserted into the running cache after
+    // jl_update_all_fptrs below (see the comment there).
+    arraylist_t reinsert_objs;
+    arraylist_new(&reinsert_objs, 0);
     for (size_t i = 0; i < s.fixup_objs.len; i++) {
         uintptr_t item = (uintptr_t)s.fixup_objs.items[i];
         jl_value_t *obj = (jl_value_t*)(image_base + item);
         if (jl_typetagis(obj, jl_typemap_entry_type) || jl_is_method(obj) || jl_is_code_instance(obj)) {
             jl_array_ptr_1d_push(*internal_methods, obj);
             assert(s.incremental);
+        }
+        else if (jl_is_abi_adapter(obj)) {
+            // Deferred (see reinsert_objs above): re-inserted after jl_update_all_fptrs.
+            arraylist_push(&reinsert_objs, (void*)obj);
         }
         else if (jl_is_method_instance(obj)) {
             jl_method_instance_t *newobj = jl_specializations_get_or_insert((jl_method_instance_t*)obj);
@@ -4339,6 +4403,19 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     s.s = &sysimg;
     jl_update_all_fptrs(&s, image); // fptr relocs and registration
     s.s = NULL;
+
+    if (!s.incremental)
+        jl_reinit_abi_adapter_cache(jl_abi_adapters);
+
+    // This publication must happen only after fptr relocation.
+    for (size_t i = 0; i < reinsert_objs.len; i++) {
+        // Only completed ABIAdapters enter the cache; skip any whose thunk was
+        // not wired (the JIT rebuilds them on demand).
+        jl_abi_adapter_t *adapter = (jl_abi_adapter_t*)reinsert_objs.items[i];
+        if (jl_atomic_load_relaxed(&adapter->fptr) != NULL)
+            jl_reinsert_abi_adapter(adapter);
+    }
+    arraylist_free(&reinsert_objs);
 
     ios_close(&fptr_record);
     ios_close(&sysimg);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -762,6 +762,15 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
         jl_abi_adapter_cache_t *c = (jl_abi_adapter_cache_t*)v;
         record_field_change((jl_value_t**)&c->cache.root, jl_nothing);
     }
+    if (jl_typetagis(v, jl_dispatch_trampoline_cache_type)) {
+        // Rebuilt from the reinserted DispatchTrampolines, drop it for now.
+        jl_dispatch_trampoline_cache_t *c = (jl_dispatch_trampoline_cache_t*)v;
+        record_field_change((jl_value_t**)&c->cache.root, jl_nothing);
+    }
+    if (jl_is_dispatch_trampoline(v)) {
+        jl_dispatch_trampoline_t *tr = (jl_dispatch_trampoline_t*)v;
+        record_field_change((jl_value_t**)&tr->next, NULL); // don't follow cache-only edge
+    }
     if (jl_is_abi_adapter(v)) {
         // Like the cache itself, the adapter's `sigt` bucket chain is process-local and
         // rebuilt on load (jl_insert_abi_adapter), so drop `next`.
@@ -1871,38 +1880,33 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                     arraylist_push(&s->relocs_list, (void*)(((uintptr_t)FunctionRef << RELOC_TAG_OFFSET) + BuiltinFunctionTag + builtin_id - 2)); // relocation target
                 }
             }
+            else if (jl_is_dispatch_trampoline(v)) {
+                assert(f == s->s);
+                // Invokee will be resolved on first-use after load, set the sentinel here.
+                jl_dispatch_trampoline_t *newtr = (jl_dispatch_trampoline_t*)&f->buf[reloc_offset];
+                jl_atomic_store_relaxed(&newtr->fptr, NULL);
+                jl_atomic_store_relaxed(&newtr->last_world, 0);
+                arraylist_push(&s->fixup_objs, (void*)reloc_offset);
+            }
             else if (jl_is_abi_adapter(v)) {
                 assert(f == s->s);
-                // The compiled adapter thunk lives in the image as an fvar. Null the record's
-                // process-local `fptr` and record the wiring in `fptr_record` keyed on that fvar
-                // id, so jl_update_all_fptrs sets `fptr` from the fvar on load (parallels the
-                // CodeInstance specptr; CI vs record disambiguated by the object's type tag).
-                jl_abi_adapter_t *newad = (jl_abi_adapter_t*)&f->buf[reloc_offset];
-                jl_atomic_store_relaxed(&newad->fptr, NULL);
+                jl_abi_adapter_t *newadapter = (jl_abi_adapter_t*)&f->buf[reloc_offset];
+                jl_atomic_store_relaxed(&newadapter->fptr, NULL);
                 int32_t invokeptr_id = 0, adapter_id = 0;
                 jl_get_function_id(native_functions, v, &invokeptr_id, &adapter_id);
                 assert(invokeptr_id == 0); (void)invokeptr_id; // adapters have no invoke wrapper
                 if (adapter_id > 0) {
-                    ios_ensureroom(s->fptr_record, adapter_id * sizeof(void*));
-                    ios_seek(s->fptr_record, (adapter_id - 1) * sizeof(void*));
-                    write_reloc_t(s->fptr_record, reloc_offset);
-#ifdef _P64
-                    if (sizeof(reloc_t) < 8)
-                        write_padding(s->fptr_record, 8 - sizeof(reloc_t));
-#endif
-                    // Re-insert this record into the running adapters cache on load. Records
-                    // with no fvar slot (adapter_id == 0, e.g. a runtime-created record
-                    // reached through user data) have no thunk to wire, so they serialize as
-                    // inert data and are never published to the cache.
+                    write_reloc_slot(s->fptr_record, adapter_id, reloc_offset);
                     arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                 }
             }
             else if (jl_typetagis(v, jl_abi_adapter_cache_type)) {
                 assert(f == s->s);
-                // The cache's `writelock` is a hidden trailing C field (not a datatype field);
-                // pad the serialized object out to the full struct size so the restored lock
-                // is zero-initialized (mirrors the jl_method_t writelock handling above).
-                write_padding(f, sizeof(jl_abi_adapter_cache_t) - tot);
+                write_padding(f, sizeof(jl_abi_adapter_cache_t) - tot); // hidden fields
+            }
+            else if (jl_typetagis(v, jl_dispatch_trampoline_cache_type)) {
+                assert(f == s->s);
+                write_padding(f, sizeof(jl_dispatch_trampoline_cache_t) - tot); // hidden fields
             }
             else if (jl_is_datatype(v)) {
                 assert(f == s->s);
@@ -4279,8 +4283,6 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         o->bits.in_image = 1;
     }
     arraylist_free(&cleanup_list);
-    // Restored ABI-adapter records, re-inserted into the running cache after
-    // jl_update_all_fptrs below (see the comment there).
     arraylist_t reinsert_objs;
     arraylist_new(&reinsert_objs, 0);
     for (size_t i = 0; i < s.fixup_objs.len; i++) {
@@ -4290,8 +4292,8 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
             jl_array_ptr_1d_push(*internal_methods, obj);
             assert(s.incremental);
         }
-        else if (jl_is_abi_adapter(obj)) {
-            // Deferred (see reinsert_objs above): re-inserted after jl_update_all_fptrs.
+        else if (jl_is_dispatch_trampoline(obj) || jl_is_abi_adapter(obj)) {
+            // Re-insert into code cache after fptrs are restored
             arraylist_push(&reinsert_objs, (void*)obj);
         }
         else if (jl_is_method_instance(obj)) {
@@ -4404,16 +4406,24 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     jl_update_all_fptrs(&s, image); // fptr relocs and registration
     s.s = NULL;
 
-    if (!s.incremental)
+    if (!s.incremental) {
         jl_reinit_abi_adapter_cache(jl_abi_adapters);
+        jl_reinit_dispatch_trampoline_cache(jl_dispatch_trampolines);
+    }
 
     // This publication must happen only after fptr relocation.
     for (size_t i = 0; i < reinsert_objs.len; i++) {
-        // Only completed ABIAdapters enter the cache; skip any whose thunk was
-        // not wired (the JIT rebuilds them on demand).
-        jl_abi_adapter_t *adapter = (jl_abi_adapter_t*)reinsert_objs.items[i];
-        if (jl_atomic_load_relaxed(&adapter->fptr) != NULL)
-            jl_reinsert_abi_adapter(adapter);
+        jl_value_t *obj = (jl_value_t*)reinsert_objs.items[i];
+        if (jl_is_dispatch_trampoline(obj)) {
+            jl_insert_dispatch_trampoline((jl_dispatch_trampoline_t*)obj);
+        }
+        else {
+            // Only completed ABIAdapters enter the cache; skip any whose thunk was
+            // not wired (the JIT rebuilds them on demand).
+            jl_abi_adapter_t *adapter = (jl_abi_adapter_t*)obj;
+            if (jl_atomic_load_relaxed(&adapter->fptr) != NULL)
+                jl_reinsert_abi_adapter(adapter);
+        }
     }
     arraylist_free(&reinsert_objs);
 

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -455,6 +455,197 @@ exit:
     }
 }
 
+// jl_typemap_list_t: two-tier cache that:
+//  1. Maps `sigt` to a list of items, then
+//  2. Selects an item from the list via a user-provided `match` / `hash`
+//
+// Intrusive data structure. Uses a combined linked-list / hashmap representation
+// for buckets, depending on size. Entry objects must have a `next` field for the
+// linked-list representation and encode their own keys for `match` / `hash`.
+//
+// Same concurrency requirements as the underlying TypeMap: Mutation is serialized
+// by the owning cache's writelock; readers need no lock, but a cache miss is
+// possibly spurious in the presence of concurrent writers.
+
+static inline _Atomic(jl_value_t*) *typemap_list_next(jl_value_t *v, size_t next_offset) JL_NOTSAFEPOINT
+{
+    return (_Atomic(jl_value_t*)*)((char*)v + next_offset);
+}
+
+// Return the first matching item in the list.
+static jl_value_t *typemap_list_find(jl_typemap_list_t *map, jl_value_t *head JL_PROPAGATES_ROOT,
+        void *key) JL_CANSAFEPOINT
+{
+    const jl_typemap_list_config_t *cfg = map->config;
+    for (jl_value_t *e = head; e != NULL; e = jl_atomic_load_acquire(typemap_list_next(e, cfg->next_offset))) {
+        JL_GC_PROMISE_ROOTED(e); // rooted by the cache (items are never removed)
+        if (cfg->match(e, key))
+            return e;
+    }
+    return NULL;
+}
+
+// Return the exact TypeMap entry for `sigt`.
+static jl_typemap_entry_t *typemap_list_entry(jl_typemap_list_t *map JL_PROPAGATES_ROOT,
+        jl_value_t *sigt) JL_CANSAFEPOINT
+{
+    jl_typemap_t *tm = jl_atomic_load_relaxed(&map->root);
+    if ((jl_value_t*)tm == jl_nothing)
+        return NULL;
+    struct jl_typemap_assoc search = { sigt, jl_atomic_load_acquire(&jl_world_counter), NULL };
+    return jl_typemap_assoc_by_type(tm, &search, /*offs*/0, /*subtype*/0);
+}
+
+// Caller holds the cache writelock; `v`'s next field is NULL.
+static void typemap_list_append(jl_value_t *head, jl_value_t *v,
+        size_t next_offset) JL_NOTSAFEPOINT
+{
+    jl_value_t *tail = head;
+    for (;;) {
+        jl_value_t *n = jl_atomic_load_relaxed(typemap_list_next(tail, next_offset));
+        if (n == NULL)
+            break;
+        tail = n;
+    }
+    jl_gc_write_atomic(tail, *typemap_list_next(tail, next_offset), jl_value_t, v, release);
+}
+
+static size_t typemap_table_maxprobe(size_t len) JL_NOTSAFEPOINT
+{
+    return len > 128 ? len >> 3 : 16;
+}
+
+static jl_value_t *typemap_table_find(jl_typemap_list_t *map, jl_genericmemory_t *tbl,
+        uintptr_t hash, void *key) JL_CANSAFEPOINT
+{
+    const jl_typemap_list_config_t *cfg = map->config;
+    size_t len = tbl->length;
+    size_t mask = len - 1;
+    size_t maxprobe = typemap_table_maxprobe(len);
+    _Atomic(jl_value_t*) *slots = (_Atomic(jl_value_t*)*)tbl->ptr;
+    for (size_t i = hash & mask, p = 0; p < maxprobe; i = (i + 1) & mask, p++) {
+        jl_value_t *e = jl_atomic_load_acquire(&slots[i]);
+        if (e == NULL)
+            return NULL;
+        JL_GC_PROMISE_ROOTED(e); // rooted by the table (rooted by the caller)
+        if (cfg->match(e, key))
+            return e;
+    }
+    return NULL;
+}
+
+// Caller holds the cache writelock.
+static int typemap_table_assign(const jl_typemap_list_config_t *cfg, jl_genericmemory_t *tbl,
+        jl_value_t *v) JL_NOTSAFEPOINT
+{
+    size_t len = tbl->length;
+    size_t mask = len - 1;
+    size_t maxprobe = typemap_table_maxprobe(len);
+    _Atomic(jl_value_t*) *slots = (_Atomic(jl_value_t*)*)tbl->ptr;
+    uintptr_t hash = cfg->hash(v);
+    for (size_t i = hash & mask, p = 0; p < maxprobe; i = (i + 1) & mask, p++) {
+        if (jl_atomic_load_relaxed(&slots[i]) == NULL) {
+            jl_atomic_store_release(&slots[i], v);
+            jl_gc_wb(tbl, v);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+// Build a `len`-slot table holding `v` plus every item in `old` (a list or a
+// smaller table); NULL if `len` cannot satisfy the probe bound.
+static jl_genericmemory_t *typemap_table_rebuild(jl_typemap_list_t *map, jl_value_t *old,
+        jl_value_t *v, size_t len) JL_CANSAFEPOINT
+{
+    const jl_typemap_list_config_t *cfg = map->config;
+    jl_genericmemory_t *tbl = jl_alloc_memory_any(len);
+    JL_GC_PUSH1(&tbl);
+    int ok = typemap_table_assign(cfg, tbl, v);
+    if (ok && jl_is_genericmemory(old)) {
+        jl_genericmemory_t *old_table = (jl_genericmemory_t*)old;
+        _Atomic(jl_value_t*) *slots = (_Atomic(jl_value_t*)*)old_table->ptr;
+        for (size_t i = 0; ok && i < old_table->length; i++) {
+            jl_value_t *e = jl_atomic_load_relaxed(&slots[i]);
+            if (e != NULL)
+                ok = typemap_table_assign(cfg, tbl, e);
+        }
+    }
+    else if (ok) {
+        // The list's links are left untouched, so concurrent readers of the old
+        // representation keep a complete view of pre-existing items.
+        for (jl_value_t *e = old; ok && e != NULL;
+             e = jl_atomic_load_relaxed(typemap_list_next(e, cfg->next_offset)))
+            ok = typemap_table_assign(cfg, tbl, e);
+    }
+    JL_GC_POP();
+    return ok ? tbl : NULL;
+}
+
+// Return the item matching (`sigt`, `match(key)`); NULL if absent. `hash` is the
+// query key's hash under the cache's scheme.
+//
+// A miss may be spurious due to a concurrent writer, unless holding the owning
+// cache's writelock.
+JL_DLLEXPORT jl_value_t *jl_typemap_list_lookup(jl_typemap_list_t *map JL_PROPAGATES_ROOT,
+        jl_value_t *sigt, uintptr_t hash, void *key) JL_CANSAFEPOINT
+{
+    jl_typemap_entry_t *te = typemap_list_entry(map, sigt);
+    if (te == NULL)
+        return NULL;
+    jl_value_t *bucket = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&te->func.value);
+    if (bucket == NULL)
+        return NULL;
+    jl_value_t *r;
+    // Keep a concurrently swapped-out table alive across safepoints in `match`.
+    JL_GC_PUSH1(&bucket);
+    if (jl_is_genericmemory(bucket))
+        r = typemap_table_find(map, (jl_genericmemory_t*)bucket, hash, key);
+    else
+        r = typemap_list_find(map, bucket, key);
+    JL_GC_POP();
+    return r;
+}
+
+// Insert an absent item. Caller holds the cache writelock.
+JL_DLLEXPORT void jl_typemap_list_insert(jl_typemap_list_t *map, jl_value_t *owner,
+        jl_value_t *sigt, jl_value_t *v) JL_CANSAFEPOINT
+{
+    const jl_typemap_list_config_t *cfg = map->config;
+    jl_typemap_entry_t *te = typemap_list_entry(map, sigt);
+    if (te == NULL) {
+        jl_typemap_entry_t *newentry = jl_typemap_alloc((jl_tupletype_t*)sigt, NULL,
+                jl_emptysvec, v, 1, ~(size_t)0);
+        JL_GC_PUSH1(&newentry);
+        jl_typemap_insert(&map->root, owner, newentry, /*offs*/0);
+        JL_GC_POP();
+        return;
+    }
+    jl_value_t *repr = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&te->func.value);
+    if (!jl_is_genericmemory(repr)) {
+        size_t count = 1;
+        for (jl_value_t *n = repr; (n = jl_atomic_load_relaxed(typemap_list_next(n, cfg->next_offset))) != NULL; )
+            count++;
+        if (count < cfg->max_list_count) {
+            typemap_list_append(repr, v, cfg->next_offset);
+            return;
+        }
+    }
+    else if (typemap_table_assign(cfg, (jl_genericmemory_t*)repr, v)) {
+        return;
+    }
+    // Promote the list or grow the table. The old representation is left intact, so
+    // concurrent readers can only miss `v` itself (rechecked under the writelock).
+    jl_genericmemory_t *tbl = NULL;
+    JL_GC_PUSH1(&tbl);
+    size_t len = jl_is_genericmemory(repr) ? ((jl_genericmemory_t*)repr)->length * 2 : 16;
+    while ((tbl = typemap_table_rebuild(map, repr, v, len)) == NULL)
+        len *= 2;
+    jl_atomic_store_release((_Atomic(jl_value_t*)*)&te->func.value, (jl_value_t*)tbl);
+    jl_gc_wb(te, tbl);
+    JL_GC_POP();
+}
+
 static unsigned jl_supertype_height(jl_datatype_t *dt) JL_NOTSAFEPOINT
 {
     unsigned height = 1;

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -2129,6 +2129,7 @@ abi_narrow_target(x::Cint) = Core.compilerbarrier(:type, x + Cint(1))     # infe
 abi_const_target(x::Cint) = Cint(42)                                      # const-return (JL_INVOKE_CONST)
 abi_args_target(x::Cint...) = length(x) % Cint                            # vararg (JL_INVOKE_ARGS)
 abi_unresolved_target(x::Float64) = x                                     # no method for (Cint,)
+abi_partial_target(x::Float32, y::Cint) = x + Float32(y)                  # partially covers (Any, Cint)
 abi_uncompilable_target(x::Cint) =                                        # codegen fails to emit
     Base.llvmcall("this is not LLVM IR", Cint, Tuple{Cint}, x)
 
@@ -2212,6 +2213,16 @@ end
             n0 = adapter_count()
             @test ccall(fptr, Any, (Any,), Cint(3)) === Cint(4)
             @test adapter_count() > n0
+        end
+    end
+
+    # A single partially-covering method keeps dispatching at call time, so uncovered
+    # arguments raise MethodError instead of being reinterpreted (#62246).
+    let cf = @cfunction(abi_partial_target, Any, (Any, Cint))
+        GC.@preserve cf begin
+            fptr = Base.unsafe_convert(Ptr{Cvoid}, cf)
+            @test ccall(fptr, Any, (Any, Cint), Float32(1.5), Cint(2)) === Float32(3.5)
+            @test_throws MethodError ccall(fptr, Any, (Any, Cint), 1.5, Cint(2))
         end
     end
 

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -2120,3 +2120,141 @@ const sym = :ZSTD_versionString
 get_zstd_version() = prefix * unsafe_string(ccall((sym, libzstd), Cstring, ()))
 @test startswith(get_zstd_version(), "Zstd")
 end
+
+# Exercise matching, converting, constant, boxed, and dynamic-dispatch adapter paths.
+# Targets are global because bare-name `@cfunction` requires a compile-time-known function.
+abi_match_target(x::Cint) = x + Cint(1)                                   # Cint -> Cint
+abi_widen_target(x::Cint) = x                                             # well-inferred Cint
+abi_narrow_target(x::Cint) = Core.compilerbarrier(:type, x + Cint(1))     # inferred ::Any
+abi_const_target(x::Cint) = Cint(42)                                      # const-return (JL_INVOKE_CONST)
+abi_args_target(x::Cint...) = length(x) % Cint                            # vararg (JL_INVOKE_ARGS)
+abi_unresolved_target(x::Float64) = x                                     # no method for (Cint,)
+abi_uncompilable_target(x::Cint) =                                        # codegen fails to emit
+    Base.llvmcall("this is not LLVM IR", Cint, Tuple{Cint}, x)
+
+# Count TypeMap entries, one per distinct `sigt`.
+function typemap_entry_count(cache)
+    n = 0
+    cache === nothing || Base.visit(_ -> (n += 1), cache)
+    return n
+end
+
+@testset "abi adapter cache" begin
+    adapter_count() = typemap_entry_count(getfield(Core.abi_adapters, :cache))
+
+    # Matching ABI uses the target specptr directly.
+    let cf = @cfunction(abi_match_target, Cint, (Cint,))
+        GC.@preserve cf begin
+            fptr = Base.unsafe_convert(Ptr{Cvoid}, cf)
+            n0 = adapter_count()
+            @test ccall(fptr, Cint, (Cint,), Cint(3)) == Cint(4)
+            @test adapter_count() == n0
+        end
+    end
+
+    # Widening requires a cached boxing adapter.
+    let cf = @cfunction(abi_widen_target, Any, (Cint,))
+        GC.@preserve cf begin
+            fptr = Base.unsafe_convert(Ptr{Cvoid}, cf)
+            n0 = adapter_count()
+            @test ccall(fptr, Any, (Cint,), Cint(5)) === Cint(5)
+            n1 = adapter_count()
+            @test n1 > n0
+            @test ccall(fptr, Any, (Cint,), Cint(6)) === Cint(6)
+            @test adapter_count() == n1
+        end
+    end
+
+    # Narrowing converts a boxed result to the declared C type.
+    let cf = @cfunction(abi_narrow_target, Cint, (Cint,))
+        GC.@preserve cf begin
+            fptr = Base.unsafe_convert(Ptr{Cvoid}, cf)
+            n0 = adapter_count()
+            @test ccall(fptr, Cint, (Cint,), Cint(7)) == Cint(8)
+            @test adapter_count() > n0
+        end
+    end
+
+    # Const-return CodeInstances require an adapter.
+    let cf = @cfunction(abi_const_target, Cint, (Cint,))
+        GC.@preserve cf begin
+            fptr = Base.unsafe_convert(Ptr{Cvoid}, cf)
+            n0 = adapter_count()
+            @test ccall(fptr, Cint, (Cint,), Cint(3)) == Cint(42)
+            @test adapter_count() > n0
+        end
+    end
+
+    # Varargs exercise the boxed-args ABI.
+    let cf = @cfunction(abi_args_target, Cint, (Cint,))
+        GC.@preserve cf begin
+            fptr = Base.unsafe_convert(Ptr{Cvoid}, cf)
+            n0 = adapter_count()
+            @test ccall(fptr, Cint, (Cint,), Cint(9)) == Cint(1)
+            @test adapter_count() > n0
+        end
+    end
+
+    # A missing specialization uses dynamic dispatch.
+    let cf = @cfunction(abi_unresolved_target, Cint, (Cint,))
+        GC.@preserve cf begin
+            fptr = Base.unsafe_convert(Ptr{Cvoid}, cf)
+            n0 = adapter_count()
+            @test_throws MethodError ccall(fptr, Cint, (Cint,), Cint(3))
+            @test adapter_count() > n0
+        end
+    end
+
+    # An abstract signature dispatches successfully at call time.
+    let cf = @cfunction(abi_match_target, Any, (Any,))
+        GC.@preserve cf begin
+            fptr = Base.unsafe_convert(Ptr{Cvoid}, cf)
+            n0 = adapter_count()
+            @test ccall(fptr, Any, (Any,), Cint(3)) === Cint(4)
+            @test adapter_count() > n0
+        end
+    end
+
+    # Failed emission falls back to dynamic dispatch instead of caching a broken target.
+    let cf = @cfunction(abi_uncompilable_target, Cint, (Cint,))
+        GC.@preserve cf begin
+            fptr = Base.unsafe_convert(Ptr{Cvoid}, cf)
+            @test_throws ErrorException ccall(fptr, Cint, (Cint,), Cint(3))
+        end
+    end
+end
+
+# A fresh sysimage should contain fallback dynamic-dispatch adapters to be able to re-enter the
+# interpreter if invalidated + running without JIT available (#61949).
+@testset "eager-unspecialized adapters serialized into the sysimage" begin
+    countexpr = "n = 0; c = getfield(Core.abi_adapters, :cache); c === nothing || Base.visit(_ -> (global n += 1), c); print(n)"
+    out = readchomp(`$(Base.julia_cmd()) --startup-file=no -e $countexpr`)
+    @test parse(Int, out) > 0
+end
+
+# Trampolines are canonicalized by (sigt, rt, specsig, kind) by type-equality, not by type-identity
+@testset "dispatch trampoline cache" begin
+    trampoline_target(x::Int) = x
+    entries() = typemap_entry_count(getfield(Core.dispatch_trampolines, :cache))
+    get_trampoline(sigt, rt, specsig=true) = ccall(:jl_get_dispatch_trampoline, Any,
+                             (Any, Any, Cint, Cint), sigt, rt, Cint(specsig), Cint(0))::Core.DispatchTrampoline
+    sigt = Tuple{typeof(trampoline_target), Int}
+    n0 = entries()
+    a = get_trampoline(sigt, Int)
+    b = get_trampoline(sigt, Int)
+    @test a === b                            # canonical: same (sigt, rt, specsig) -> same DispatchTrampoline
+    @test getfield(a, :sigt) === sigt
+    @test getfield(a, :rt) === Int
+    @test entries() == n0 + 1
+    c = get_trampoline(sigt, Float64)        # same sigt, different rt -> distinct DispatchTrampoline, same entry
+    @test c !== a
+    @test entries() == n0 + 1
+    s = get_trampoline(sigt, Int, false)     # same (sigt, rt), different specsig -> distinct DispatchTrampoline, same entry
+    @test s !== a
+    @test getfield(s, :specsig) === UInt8(0)
+    @test entries() == n0 + 1
+    @test get_trampoline(sigt, Int) === a    # original DispatchTrampoline still canonical for specsig=true
+    d = get_trampoline(Tuple{typeof(trampoline_target), Float64}, Int) # different sigt -> new entry
+    @test d !== a
+    @test entries() == n0 + 2
+end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1169,6 +1169,244 @@ precompile_test_harness("precompiletools") do dir
     end
 end
 
+precompile_test_harness("cfunction adapter serialization") do dir
+    CFuncMod = :CFuncAdapter0x6f2c1d8a
+    write(joinpath(dir, "$CFuncMod.jl"),
+          """
+          module $CFuncMod
+              llvm_version() = ccall(:jl_get_LLVM_VERSION, UInt32, ())       # 0 = no-codegen stub
+              box_target(x::Cint) = x                                        # well-inferred Cint
+              any_target(x::Cint) = Core.compilerbarrier(:type, x + Cint(1)) # inferred ::Any
+              const_target(x::Cint) = Cint(42)                               # const-return
+              args_target(x::Cint...) = length(x) % Cint                     # vararg (boxed args ABI)
+              unresolved_target(x::Float64) = x                              # no method for (Cint,)
+              function run_widen(x::Cint)
+                  cf = @cfunction(box_target, Any, (Cint,))
+                  GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Any, (Cint,), x)
+              end
+              function run_narrow(x::Cint)
+                  cf = @cfunction(any_target, Cint, (Cint,))
+                  GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Cint, (Cint,), x)
+              end
+              function run_const(x::Cint)
+                  cf = @cfunction(const_target, Cint, (Cint,))
+                  GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Cint, (Cint,), x)
+              end
+              function run_args(x::Cint)
+                  cf = @cfunction(args_target, Cint, (Cint,))
+                  GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Cint, (Cint,), x)
+              end
+              function run_unresolved(x::Cint)
+                  cf = @cfunction(unresolved_target, Cint, (Cint,))
+                  GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Cint, (Cint,), x)
+              end
+              function run_dispatch(x::Cint)      # abstract `Any` arg -> dynamic-dispatch adapter
+                  cf = @cfunction(box_target, Any, (Any,))
+                  GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Any, (Any,), x)
+              end
+              function run_dup(x::Cint)           # two call sites, same (sigt, rt) -> one trampoline
+                  cf1 = @cfunction(box_target, Any, (Cint,))
+                  cf2 = @cfunction(box_target, Any, (Cint,))
+                  r1 = GC.@preserve cf1 ccall(Base.unsafe_convert(Ptr{Cvoid}, cf1), Any, (Cint,), x)
+                  r2 = GC.@preserve cf2 ccall(Base.unsafe_convert(Ptr{Cvoid}, cf2), Any, (Cint,), x)
+                  (r1, r2)
+              end
+              precompile(run_widen, (Cint,))
+              precompile(run_narrow, (Cint,))
+              precompile(run_const, (Cint,))
+              precompile(run_args, (Cint,))
+              precompile(run_unresolved, (Cint,))
+              precompile(run_dispatch, (Cint,))
+              precompile(run_dup, (Cint,))
+              precompile(llvm_version, ())
+          end
+          """)
+    Base.compilecache(Base.PkgId(string(CFuncMod)))
+    M = Base.require(Main, CFuncMod)
+    function adapter_count()
+        n = 0
+        cache = getfield(Core.abi_adapters, :cache)
+        cache === nothing || Base.visit(_ -> (n += 1), cache)
+        return n
+    end
+    n0 = adapter_count()
+    # invokelatest: the run_* methods are defined in a world newer than this function's.
+    @test Base.invokelatest(M.run_widen, Cint(5)) === Cint(5)
+    @test Base.invokelatest(M.run_narrow, Cint(7)) == Cint(8)
+    @test Base.invokelatest(M.run_const, Cint(3)) == Cint(42)
+    @test Base.invokelatest(M.run_args, Cint(9)) == Cint(1)
+    @test_throws MethodError Base.invokelatest(M.run_unresolved, Cint(3))
+    @test Base.invokelatest(M.run_dispatch, Cint(5)) === Cint(5)
+    @test Base.invokelatest(M.run_dup, Cint(5)) === (Cint(5), Cint(5))
+    if Bool(Base.JLOptions().use_pkgimages)
+        # First use reuses the adapters restored from the pkgimage.
+        @test adapter_count() == n0
+
+        # Repeat with codegen disabled, including retargeting after method redefinition
+        # through the serialized dynamic-dispatch adapter (julia#61949).
+        sep = Sys.iswindows() ? ";" : ":"
+        script = """
+            using $CFuncMod
+            const M = $CFuncMod
+            println("llvm=", M.llvm_version())
+            println("widen=", M.run_widen(Cint(5)))
+            println("narrow=", M.run_narrow(Cint(7)))
+            println("const=", M.run_const(Cint(3)))
+            println("args=", M.run_args(Cint(9)))
+            println("dispatch=", M.run_dispatch(Cint(5)))
+            println("dup=", M.run_dup(Cint(5)))
+            println("unresolved=", try; M.run_unresolved(Cint(3)); "no-error"; catch e; e isa MethodError ? "MethodError" : "other-error"; end)
+            @eval M box_target(x::Cint) = x + Cint(100)
+            println("redef=", Base.invokelatest(M.run_widen, Cint(5)))
+            """
+        outbuf = IOBuffer(); errbuf = IOBuffer()
+        cmd = addenv(`$(Base.julia_cmd()) --startup-file=no -e $script`,
+                     "JULIA_LOAD_CODEGEN_LIB" => "0",
+                     "JULIA_LOAD_PATH" => dir * sep * "@stdlib",
+                     "JULIA_DEPOT_PATH" => first(DEPOT_PATH) * sep)
+        proc = run(pipeline(ignorestatus(cmd), stdout=outbuf, stderr=errbuf))
+        out = String(take!(outbuf))
+        success(proc) || println(stderr, "codegen-free child failed:\n", String(take!(errbuf)))
+        @test success(proc)
+        @test occursin("llvm=0", out)              # codegen really was absent
+        @test occursin("widen=5", out)             # cached specsig-widening adapter
+        @test occursin("narrow=8", out)            # cached narrowing adapter
+        @test occursin("const=42", out)            # cached const-return adapter
+        @test occursin("args=1", out)              # cached boxed-args adapter
+        @test occursin("dispatch=5", out)          # cached dynamic-dispatch adapter
+        @test occursin("dup=(5, 5)", out)          # shared trampoline, both sites wired
+        @test occursin("unresolved=MethodError", out)
+        @test occursin("redef=105", out)           # dispatcher re-query after redefinition
+    end
+end
+
+# Shared trampolines load unresolved and retarget through adapters from the composed images.
+precompile_test_harness("cross-image dispatch trampolines") do dir
+    write(joinpath(dir, "CrossTrampolineA.jl"),
+          """
+          module CrossTrampolineA
+          target(x::Integer) = Cint(x + 1)
+          function run(x::Cint)
+              cf = @cfunction(target, Cint, (Cint,))
+              GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Cint, (Cint,), x)
+          end
+          # Canonical trampoline for `run`.
+          trampoline() = ccall(:jl_get_dispatch_trampoline, Any, (Any, Any, Cint, Cint),
+                          Tuple{typeof(target), Cint}, Cint, Cint(1), Cint(0))
+          precompile(run, (Cint,))
+          precompile(trampoline, ())
+          # Ensure serialization sanitizes a previously resolved record.
+          const warm = run(Cint(0))
+          end
+          """)
+    Base.compilecache(Base.PkgId("CrossTrampolineA"))
+    write(joinpath(dir, "CrossTrampolineB.jl"),
+          """
+          module CrossTrampolineB
+          using CrossTrampolineA
+          CrossTrampolineA.target(x::Cint) = x + Cint(100)   # more specific: retargets A's trampoline
+          function runb(x::Cint)
+              cf = @cfunction(CrossTrampolineA.target, Cint, (Cint,))
+              GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Cint, (Cint,), x)
+          end
+          precompile(runb, (Cint,))
+          precompile(CrossTrampolineA.run, (Cint,))
+          end
+          """)
+    Base.compilecache(Base.PkgId("CrossTrampolineB"))
+    write(joinpath(dir, "CrossTrampolineC.jl"),
+          """
+          module CrossTrampolineC
+          using CrossTrampolineA
+          CrossTrampolineA.target(x::Signed) = Cint(x + 1000)   # between A's Integer and B's Cint
+          function runc(x::Cint)
+              cf = @cfunction(CrossTrampolineA.target, Cint, (Cint,))
+              GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Cint, (Cint,), x)
+          end
+          precompile(runc, (Cint,))
+          precompile(CrossTrampolineA.run, (Cint,))
+          end
+          """)
+    Base.compilecache(Base.PkgId("CrossTrampolineC"))
+    write(joinpath(dir, "CrossTrampolineAll.jl"),
+          """
+          module CrossTrampolineAll
+          using CrossTrampolineA, CrossTrampolineB, CrossTrampolineC
+          # Materialize every entry point needed without codegen.
+          precompile(CrossTrampolineA.run, (Cint,))
+          precompile(CrossTrampolineB.runb, (Cint,))
+          precompile(CrossTrampolineC.runc, (Cint,))
+          end
+          """)
+    Base.compilecache(Base.PkgId("CrossTrampolineAll"))
+    if Bool(Base.JLOptions().use_pkgimages)
+        sep = Sys.iswindows() ? ";" : ":"
+        function crosstrampoline_child(script; codegen::Bool)
+            outbuf = IOBuffer(); errbuf = IOBuffer()
+            cmd = `$(Base.julia_cmd()) --startup-file=no -e $script`
+            cmd = addenv(cmd, "JULIA_LOAD_PATH" => dir * sep * "@stdlib",
+                              "JULIA_DEPOT_PATH" => first(DEPOT_PATH) * sep)
+            codegen || (cmd = addenv(cmd, "JULIA_LOAD_CODEGEN_LIB" => "0"))
+            proc = run(pipeline(ignorestatus(cmd), stdout=outbuf, stderr=errbuf))
+            success(proc) || println(stderr, "cross-image child failed:\n", String(take!(errbuf)))
+            @test success(proc)
+            return String(take!(outbuf))
+        end
+        # The hot record loads unresolved and retargets to B without codegen.
+        out = crosstrampoline_child("""
+            using CrossTrampolineA, CrossTrampolineB
+            GC.gc(); GC.gc(); GC.gc()
+            tr = CrossTrampolineA.trampoline()
+            println("pre_invokee_defined=", isdefined(tr, :last_invokee))
+            println("pre_fptr_null=", getfield(tr, :fptr, :monotonic) == C_NULL)
+            println("pre_world=", getfield(tr, :last_world, :acquire))
+            println("a_run=", CrossTrampolineA.run(Cint(1)))
+            println("b_runb=", CrossTrampolineB.runb(Cint(1)))
+            println("post_world_current=", getfield(tr, :last_world, :acquire) == Base.get_world_counter())
+            println("post_fptr_set=", getfield(tr, :fptr, :monotonic) != C_NULL)
+            println("invokee_ok=", getfield(tr, :last_invokee) isa Union{Core.ABIAdapter, Core.CodeInstance})
+            """; codegen = false)
+        @test occursin("pre_invokee_defined=false", out)  # incremental images carry no hint
+        @test occursin("pre_fptr_null=true", out)   # hot record sanitized at serialization
+        @test occursin("pre_world=0", out)          # unresolved sentinel: no validity claim
+        @test occursin("a_run=101", out)            # A-image site reaches B-image target
+        @test occursin("b_runb=101", out)
+        @test occursin("post_world_current=true", out)  # poll published validity
+        @test occursin("post_fptr_set=true", out)
+        @test occursin("invokee_ok=true", out)
+        # The same record can instead retarget to C.
+        out = crosstrampoline_child("""
+            using CrossTrampolineA, CrossTrampolineC
+            GC.gc(); GC.gc()
+            println("a_run=", CrossTrampolineA.run(Cint(1)))
+            println("c_runc=", CrossTrampolineC.runc(Cint(1)))
+            """; codegen = false)
+        @test occursin("a_run=1001", out)
+        @test occursin("c_runc=1001", out)
+        # The composed world chooses B's most-specific target.
+        out = crosstrampoline_child("""
+            using CrossTrampolineAll, CrossTrampolineA, CrossTrampolineB, CrossTrampolineC
+            println("a_run=", CrossTrampolineA.run(Cint(1)))
+            println("b_runb=", CrossTrampolineB.runb(Cint(1)))
+            println("c_runc=", CrossTrampolineC.runc(Cint(1)))
+            """; codegen = false)
+        @test occursin("a_run=101", out)
+        @test occursin("b_runb=101", out)
+        @test occursin("c_runc=101", out)
+        # An in-session definition retargets every image-loaded site.
+        out = crosstrampoline_child("""
+            using CrossTrampolineA, CrossTrampolineB
+            println("before=", CrossTrampolineA.run(Cint(1)))
+            @eval CrossTrampolineA target(x::Cint) = x + Cint(7)
+            println("a_run=", Base.invokelatest(CrossTrampolineA.run, Cint(1)))
+            println("b_runb=", Base.invokelatest(CrossTrampolineB.runb, Cint(1)))
+            """; codegen = true)
+        @test occursin("before=101", out)
+        @test occursin("a_run=8", out)
+        @test occursin("b_runb=8", out)
+    end
+end
+
 precompile_test_harness("invoke") do dir
     InvokeModule = :Invoke0x030e7e97c2365aad
     CallerModule = :Caller0x030e7e97c2365aad

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1180,6 +1180,7 @@ precompile_test_harness("cfunction adapter serialization") do dir
               const_target(x::Cint) = Cint(42)                               # const-return
               args_target(x::Cint...) = length(x) % Cint                     # vararg (boxed args ABI)
               unresolved_target(x::Float64) = x                              # no method for (Cint,)
+              partial_target(x::Float32) = x + Float32(1)                    # partially covers (Any,)
               function run_widen(x::Cint)
                   cf = @cfunction(box_target, Any, (Cint,))
                   GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Any, (Cint,), x)
@@ -1200,6 +1201,10 @@ precompile_test_harness("cfunction adapter serialization") do dir
                   cf = @cfunction(unresolved_target, Cint, (Cint,))
                   GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Cint, (Cint,), x)
               end
+              function run_partial(x)             # partial cover -> dynamic-dispatch adapter (#62246)
+                  cf = @cfunction(partial_target, Any, (Any,))
+                  GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Any, (Any,), x)
+              end
               function run_dispatch(x::Cint)      # abstract `Any` arg -> dynamic-dispatch adapter
                   cf = @cfunction(box_target, Any, (Any,))
                   GC.@preserve cf ccall(Base.unsafe_convert(Ptr{Cvoid}, cf), Any, (Any,), x)
@@ -1216,6 +1221,9 @@ precompile_test_harness("cfunction adapter serialization") do dir
               precompile(run_const, (Cint,))
               precompile(run_args, (Cint,))
               precompile(run_unresolved, (Cint,))
+              precompile(run_partial, (Float32,))
+              precompile(run_partial, (Cint,))
+              precompile(partial_target, (Float32,))
               precompile(run_dispatch, (Cint,))
               precompile(run_dup, (Cint,))
               precompile(llvm_version, ())
@@ -1236,6 +1244,8 @@ precompile_test_harness("cfunction adapter serialization") do dir
     @test Base.invokelatest(M.run_const, Cint(3)) == Cint(42)
     @test Base.invokelatest(M.run_args, Cint(9)) == Cint(1)
     @test_throws MethodError Base.invokelatest(M.run_unresolved, Cint(3))
+    @test Base.invokelatest(M.run_partial, Float32(1.5)) === Float32(2.5)
+    @test_throws MethodError Base.invokelatest(M.run_partial, Cint(3))
     @test Base.invokelatest(M.run_dispatch, Cint(5)) === Cint(5)
     @test Base.invokelatest(M.run_dup, Cint(5)) === (Cint(5), Cint(5))
     if Bool(Base.JLOptions().use_pkgimages)
@@ -1256,6 +1266,8 @@ precompile_test_harness("cfunction adapter serialization") do dir
             println("dispatch=", M.run_dispatch(Cint(5)))
             println("dup=", M.run_dup(Cint(5)))
             println("unresolved=", try; M.run_unresolved(Cint(3)); "no-error"; catch e; e isa MethodError ? "MethodError" : "other-error"; end)
+            println("partial=", M.run_partial(Float32(1.5)))
+            println("partial_miss=", try; M.run_partial(Cint(3)); "no-error"; catch e; e isa MethodError ? "MethodError" : "other-error"; end)
             @eval M box_target(x::Cint) = x + Cint(100)
             println("redef=", Base.invokelatest(M.run_widen, Cint(5)))
             """
@@ -1276,6 +1288,8 @@ precompile_test_harness("cfunction adapter serialization") do dir
         @test occursin("dispatch=5", out)          # cached dynamic-dispatch adapter
         @test occursin("dup=(5, 5)", out)          # shared trampoline, both sites wired
         @test occursin("unresolved=MethodError", out)
+        @test occursin("partial=2.5", out)         # partial cover dispatches via the unspecialized adapter
+        @test occursin("partial_miss=MethodError", out)
         @test occursin("redef=105", out)           # dispatcher re-query after redefinition
     end
 end
@@ -1295,7 +1309,7 @@ precompile_test_harness("cross-image dispatch trampolines") do dir
                           Tuple{typeof(target), Cint}, Cint, Cint(1), Cint(0))
           precompile(run, (Cint,))
           precompile(trampoline, ())
-          # Ensure serialization sanitizes a previously resolved record.
+          # Ensure serialization sanitizes a previously resolved DispatchTrampoline.
           const warm = run(Cint(0))
           end
           """)
@@ -1352,7 +1366,7 @@ precompile_test_harness("cross-image dispatch trampolines") do dir
             @test success(proc)
             return String(take!(outbuf))
         end
-        # The hot record loads unresolved and retargets to B without codegen.
+        # The hot DispatchTrampoline loads unresolved and retargets to B without codegen.
         out = crosstrampoline_child("""
             using CrossTrampolineA, CrossTrampolineB
             GC.gc(); GC.gc(); GC.gc()
@@ -1367,14 +1381,14 @@ precompile_test_harness("cross-image dispatch trampolines") do dir
             println("invokee_ok=", getfield(tr, :last_invokee) isa Union{Core.ABIAdapter, Core.CodeInstance})
             """; codegen = false)
         @test occursin("pre_invokee_defined=false", out)  # incremental images carry no hint
-        @test occursin("pre_fptr_null=true", out)   # hot record sanitized at serialization
+        @test occursin("pre_fptr_null=true", out)   # hot DispatchTrampoline sanitized at serialization
         @test occursin("pre_world=0", out)          # unresolved sentinel: no validity claim
         @test occursin("a_run=101", out)            # A-image site reaches B-image target
         @test occursin("b_runb=101", out)
         @test occursin("post_world_current=true", out)  # poll published validity
         @test occursin("post_fptr_set=true", out)
         @test occursin("invokee_ok=true", out)
-        # The same record can instead retarget to C.
+        # The same DispatchTrampoline can instead retarget to C.
         out = crosstrampoline_child("""
             using CrossTrampolineA, CrossTrampolineC
             GC.gc(); GC.gc()

--- a/test/trim/Trimmability/runtests.jl
+++ b/test/trim/Trimmability/runtests.jl
@@ -16,4 +16,6 @@ outdir = ARGS[1]
     @test parse(Float64, lines[6]) isa Float64
     @test lines[7] == "Version: 1.1.0"
     @test lines[8] == "# preferences: 0"
+    @test lines[9] == "cfunc: 42"
+    @test lines[10] == "cfunc_any: 7"
 end

--- a/test/trim/Trimmability/src/Trimmability.jl
+++ b/test/trim/Trimmability/src/Trimmability.jl
@@ -27,6 +27,9 @@ function add_one(x::Cint)::Cint
     return x + 1
 end
 
+cfunc_target(x::Cint) = x + Cint(1)
+cfunc_any(@nospecialize(x)) = Cint(7)
+
 function _test_cat()
     # hcat
     _cat1a = hcat(randn(3), rand(3), randn(3))
@@ -113,6 +116,11 @@ function @main(args::Vector{String})::Cint
     println(Core.stdout, _test_cat())
     println(Core.stdout, "Version: ", v"1.1")
     println(Core.stdout, "# preferences: ", length(Base.get_preferences()))
+
+    cf1 = @cfunction(cfunc_target, Cint, (Cint,))
+    println(Core.stdout, "cfunc: ", GC.@preserve cf1 ccall(Base.unsafe_convert(Ptr{Cvoid}, cf1), Cint, (Cint,), Cint(41)))
+    cf2 = @cfunction(cfunc_any, Cint, (Any,))
+    println(Core.stdout, "cfunc_any: ", GC.@preserve cf2 ccall(Base.unsafe_convert(Ptr{Cvoid}, cf2), Cint, (Any,), 1.5))
 
     for i = 1:10
         # https://github.com/JuliaLang/julia/issues/60846


### PR DESCRIPTION
Dependent on #62555 #62556

This introduces first-class types for the adapters / trampolines we already generate for `@cfunction` / `@ccallable`:
  - ABIAdapter (currently `emit_abi_converter`, et al)
  - DispatchTrampoline (currently the "dispatch trampoline" encoded in `cfuncdata_t`)

which allows them to be cached and serialized independently.

The adapter / trampoline split is designed to support:
  1. `@cfunction`: trampoline + adapter (sometimes)
  2. `TypedCallable`: trampoline + adapter (always) + runtime cache
  3. `OpaqueClosure`: adapter (always) + runtime cache
 
Since TypedCallable does not have the top-level eval / type-restrictions that `@cfunction` has where the ABI is fixed at definition time, the runtime cache implemented here is required so that we can provide ABI adapters for `TypedCallable` construction in type-unstable / interpreted code while leaving JIT work bounded (under type-stability assumptions). It also allows us to re-use ABI adapters / trampolines across multiple `@cfunction` sites, altough that's a fairly marginal benefit.

Both caches use a new `jl_typemap_list_t` which is a linked-list / hashmap bolted onto a `TypeMap` (same lockfree reader pattern as the usual typemap). The "unspecialized" dynamic dispatch ABIAdapter fallbacks are stored in the cache rather than the DispatchTrampoline, and trampolines are initialized on first-invoke after load by loading from the ABIAdapter cache too.

Fixes #62246. Fixes #61949.

Co-developed by Claude Opus 5 🤖