### PR TITLE
runtime: Fix missing Type{Union{}} normalization

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -656,6 +656,12 @@ function aligned_sizeof(@nospecialize T::Type)
             return LLT_ALIGN(sz, al)
         end
     elseif allocatedinline(T)
+        if T === Type{Union{}}
+            # allocated with the layout of the `typeof(Union{})` singleton
+            # (cf. `normalize_typeofbottom_layout_alias`), which is what the
+            # `DataType`-only layout queries below expect
+            T = Core.TypeofBottom
+        end
         al = datatype_alignment(T)
         return LLT_ALIGN(Core.sizeof(T), al)
     end

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -515,7 +515,7 @@ static int is_type_identityfree(jl_value_t *t)
 void jl_get_genericmemory_layout(jl_datatype_t *st)
 {
     jl_value_t *kind = jl_tparam0(st);
-    jl_value_t *eltype = jl_tparam1(st);
+    jl_value_t *eltype = normalize_typeofbottom_layout_alias(jl_tparam1(st));
     jl_value_t *addrspace = jl_tparam2(st);
     if (!st->isconcretetype) {
         // Since parent dt has an opaque layout, we may end up here being asked to copy that layout to subtypes,

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -344,7 +344,7 @@ JL_DLLEXPORT jl_value_t *jl_memoryrefget(jl_genericmemoryref_t m, int isatomic)
     assert(isatomic == (layout->flags.arrayelem_isatomic || layout->flags.arrayelem_islocked));
     if (layout->flags.arrayelem_isboxed)
         return jl_ptrmemrefget(m, isatomic);
-    jl_value_t *eltype = jl_tparam1(jl_typetagof(m.mem));
+    jl_value_t *eltype = normalize_typeofbottom_layout_alias(jl_tparam1(jl_typetagof(m.mem)));
     char *data = (char*)m.ptr_or_offset;
     if (layout->flags.arrayelem_isunion) {
         assert(!isatomic);
@@ -421,7 +421,7 @@ JL_DLLEXPORT void jl_memoryrefunset(jl_genericmemoryref_t m, int isatomic)
         return;
     if (layout->first_ptr < 0)
         return;
-    jl_datatype_t *dt = (jl_datatype_t*)jl_tparam1(jl_typetagof(m.mem));
+    jl_datatype_t *dt = (jl_datatype_t*)normalize_typeofbottom_layout_alias(jl_tparam1(jl_typetagof(m.mem)));
     assert(jl_is_datatype(dt)); // implied by !isboxed && !isunion
     size_t fsz = jl_datatype_size(dt);
     char *data = (char*)m.ptr_or_offset;
@@ -445,7 +445,7 @@ JL_DLLEXPORT void jl_memoryrefset(jl_genericmemoryref_t m, jl_value_t *rhs JL_RO
 {
     const jl_datatype_layout_t *layout = ((jl_datatype_t*)jl_typetagof(m.mem))->layout;
     assert(isatomic == (layout->flags.arrayelem_isatomic || layout->flags.arrayelem_islocked));
-    jl_value_t *eltype = jl_tparam1(jl_typetagof(m.mem));
+    jl_value_t *eltype = normalize_typeofbottom_layout_alias(jl_tparam1(jl_typetagof(m.mem)));
     if (eltype != (jl_value_t*)jl_any_type && !jl_typeis(rhs, eltype)) {
         JL_GC_PUSH1(&rhs);
         if (!jl_isa(rhs, eltype))
@@ -501,7 +501,7 @@ JL_DLLEXPORT void jl_memoryrefset(jl_genericmemoryref_t m, jl_value_t *rhs JL_RO
 
 JL_DLLEXPORT jl_value_t *jl_memoryrefswap(jl_genericmemoryref_t m, jl_value_t *rhs, int isatomic)
 {
-    jl_value_t *eltype = jl_tparam1(jl_typetagof(m.mem));
+    jl_value_t *eltype = normalize_typeofbottom_layout_alias(jl_tparam1(jl_typetagof(m.mem)));
     if (eltype != (jl_value_t*)jl_any_type && !jl_typeis(rhs, eltype)) {
         if (!jl_isa(rhs, eltype))
             jl_type_error("memoryrefswap!", eltype, rhs);
@@ -535,7 +535,7 @@ JL_DLLEXPORT jl_value_t *jl_memoryrefswap(jl_genericmemoryref_t m, jl_value_t *r
 
 JL_DLLEXPORT jl_value_t *jl_memoryrefmodify(jl_genericmemoryref_t m, jl_value_t *op, jl_value_t *rhs, int isatomic)
 {
-    jl_value_t *eltype = jl_tparam1(jl_typetagof(m.mem));
+    jl_value_t *eltype = normalize_typeofbottom_layout_alias(jl_tparam1(jl_typetagof(m.mem)));
     const jl_datatype_layout_t *layout = ((jl_datatype_t*)jl_typetagof(m.mem))->layout;
     jl_value_t *owner = jl_genericmemory_owner(m.mem);
     char *data = (char*)m.ptr_or_offset;
@@ -558,7 +558,7 @@ JL_DLLEXPORT jl_value_t *jl_memoryrefmodify(jl_genericmemoryref_t m, jl_value_t 
 
 JL_DLLEXPORT jl_value_t *jl_memoryrefreplace(jl_genericmemoryref_t m, jl_value_t *expected, jl_value_t *rhs, int isatomic)
 {
-    jl_value_t *eltype = jl_tparam1(jl_typetagof(m.mem));
+    jl_value_t *eltype = normalize_typeofbottom_layout_alias(jl_tparam1(jl_typetagof(m.mem)));
     if (eltype != (jl_value_t*)jl_any_type && !jl_typeis(rhs, eltype)) {
         if (!jl_isa(rhs, eltype))
             jl_type_error("memoryrefreplace!", eltype, rhs);
@@ -584,7 +584,7 @@ JL_DLLEXPORT jl_value_t *jl_memoryrefreplace(jl_genericmemoryref_t m, jl_value_t
 
 JL_DLLEXPORT jl_value_t *jl_memoryrefsetonce(jl_genericmemoryref_t m, jl_value_t *rhs, int isatomic)
 {
-    jl_value_t *eltype = jl_tparam1(jl_typetagof(m.mem));
+    jl_value_t *eltype = normalize_typeofbottom_layout_alias(jl_tparam1(jl_typetagof(m.mem)));
     if (eltype != (jl_value_t*)jl_any_type && !jl_typeis(rhs, eltype)) {
         if (!jl_isa(rhs, eltype))
             jl_type_error("memoryrefsetonce!", eltype, rhs);

--- a/test/core.jl
+++ b/test/core.jl
@@ -9042,3 +9042,26 @@ let T = TypeVar(:T)
     a = UnionAll(T, Union{Vector{T}, Int64})
     @test Union{T, a} == Union{a, T} == Union{T, Int64, Vector}
 end
+
+# Vector/Memory with Type{Union{}} elements: the element layout aliases the
+# typeof(Union{}) singleton (cf. normalize_typeofbottom_layout_alias), so the
+# elements are stored inline with zero size and reads produce the value
+# Union{} itself
+let v = Vector{Type{Union{}}}()
+    push!(v, Union{})
+    @test v[1] === Union{}
+    @test length(v) == 1
+    @test Base.elsize(typeof(v)) == 0
+    @test Base.aligned_sizeof(Type{Union{}}) == 0
+    @test copy(v)[1] === Union{}
+    @test eltype(similar(v)) == Type{Union{}}
+    # the type object Type{Union{}} is not an element of Type{Union{}}
+    @test_throws MethodError push!(v, Type{Union{}})
+    m = Memory{Type{Union{}}}(undef, 2)
+    m[1] = Union{}
+    @test m[1] === Union{} && m[2] === Union{}
+    u = Vector{Union{Type{Union{}},Int}}()
+    push!(u, 3)
+    push!(u, Union{})
+    @test u[1] === 3 && u[2] === Union{}
+end


### PR DESCRIPTION
Claude description below. That said, the number of places that need this normalization is creeping a lot, so I probably want to revisit that, but this fixes the crashiness for now.

`jl_get_genericmemory_layout` and the genericmemory.c element accessors performed raw DataType field access on the element type, guarded only by a compiled-out assert. For an element type in the bottom singleton class -- `Type{Union{}}`, a TypeEq node laid out as the typeof(Union{}) singleton, cf. normalize_typeofbottom_layout_alias -- this read garbage and crashed at type instantiation: plain `Vector{Type{Union{}}}` segfaulted before any element was stored. Normalize the element type in the layout computation and at each access site, matching the existing field-layout sites in datatype.c.

The Julia-level mirror `aligned_sizeof` had the same hole: after `allocatedinline` (which normalizes internally) it calls the DataType-only layout queries on the raw TypeEq node. Alias the class there as well. Element storage is then coherent on both sides: the zero-size singleton layout (`Base.elsize(Vector{Type{Union{}}}) == 0`), with reads producing the value `Union{}` itself, and a clean MethodError when attempting to store anything else.