### PR TITLE
jitlink: Implement PLT mechanism to heal tojlinvoke wrappers

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10541,10 +10541,6 @@ static void init_jit_functions(void)
 char jl_using_intel_jitevents = 0; // Non-zero if running under Intel VTune Amplifier
 #endif
 
-#ifdef JL_USE_OPROFILE_JITEVENTS
-char jl_using_oprofile_jitevents = 0; // Non-zero if running under OProfile
-#endif
-
 #ifdef JL_USE_PERF_JITEVENTS
 char jl_using_perf_jitevents = 0;
 #endif
@@ -10656,7 +10652,6 @@ extern "C" void jl_init_llvm(void)
         jl_ExecutionEngine->enableJITDebuggingSupport();
 
 #if defined(JL_USE_INTEL_JITEVENTS) || \
-    defined(JL_USE_OPROFILE_JITEVENTS) || \
     defined(JL_USE_PERF_JITEVENTS)
     const char *jit_profiling = getenv("ENABLE_JITPROFILING");
 
@@ -10674,12 +10669,6 @@ extern "C" void jl_init_llvm(void)
     }
 #endif
 
-#if defined(JL_USE_OPROFILE_JITEVENTS)
-    if (jit_profiling && atoi(jit_profiling)) {
-        jl_using_oprofile_jitevents = 1;
-    }
-#endif
-
 #if defined(JL_USE_PERF_JITEVENTS)
     if (jit_profiling && atoi(jit_profiling)) {
         jl_using_perf_jitevents = 1;
@@ -10689,11 +10678,6 @@ extern "C" void jl_init_llvm(void)
 #ifdef JL_USE_INTEL_JITEVENTS
     if (jl_using_intel_jitevents)
         jl_ExecutionEngine->enableIntelJITEventListener();
-#endif
-
-#ifdef JL_USE_OPROFILE_JITEVENTS
-    if (jl_using_oprofile_jitevents)
-        jl_ExecutionEngine->enableOProfileJITEventListener();
 #endif
 
 #ifdef JL_USE_PERF_JITEVENTS

--- a/src/gf.c
+++ b/src/gf.c
@@ -3653,6 +3653,24 @@ void jl_read_codeinst_invoke(jl_code_instance_t *ci, uint8_t *specsigflags, jl_c
     }
 }
 
+// Return the compiled specsig entry point of `ci` if one has been published,
+// NULL otherwise. Used by the JIT's stub-patching handshake: a call edge that
+// must be linked while its target is still compiling goes through a
+// redirectable jump stub, which is repointed from the boxing `tojlinvoke`
+// thunk to the target's compiled specsig once it publishes (see
+// `JuliaOJIT::patchPendingStub`).
+JL_DLLEXPORT void *jl_specsig_fptr_if_compiled(jl_code_instance_t *ci)
+{
+    uint8_t specsigflags;
+    jl_callptr_t invoke;
+    void *specptr;
+    jl_read_codeinst_invoke(ci, &specsigflags, &invoke, &specptr, 0);
+    if ((specsigflags & JL_CI_FLAGS_SPECPTR_SPECIALIZED) &&
+        (specsigflags & JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR))
+        return specptr;
+    return NULL;
+}
+
 JL_DLLEXPORT jl_method_instance_t *jl_normalize_to_compilable_mi(jl_method_instance_t *mi JL_PROPAGATES_ROOT);
 
 JL_DLLEXPORT void jl_add_codeinsts_to_jit(jl_array_t *codeinsts, jl_array_t *srcs)

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -814,6 +814,81 @@ public:
 };
 } // namespace anonymous
 
+// Tracks trampoline modules carrying a synthesized PLT stub: captures the
+// stub's pointer-slot address once the graph's fixups have run, and arms the
+// slot for patching (JuliaOJIT::armStubSlot) once the graph has been emitted,
+// so a patch can never race the linker's own writes to the slot.
+class JLPLTPlugin : public orc::ObjectLinkingLayer::Plugin {
+public:
+    JLPLTPlugin(JuliaOJIT &JIT) JL_NOTSAFEPOINT : JIT(JIT) {}
+
+    // Called (with LinkerMutex held) before the trampoline module is emitted.
+    void expectStub(orc::MaterializationResponsibility &MR, jl_code_instance_t *CI) JL_NOTSAFEPOINT
+    {
+        std::lock_guard<std::mutex> Lock(PluginMutex);
+        Pending[&MR] = {CI, orc::ExecutorAddr()};
+    }
+
+    void modifyPassConfig(orc::MaterializationResponsibility &MR, jitlink::LinkGraph &,
+                          jitlink::PassConfiguration &PassConfig) override
+    {
+        {
+            std::lock_guard<std::mutex> Lock(PluginMutex);
+            if (!Pending.count(&MR))
+                return;
+        }
+        PassConfig.PostFixupPasses.push_back([this, &MR](jitlink::LinkGraph &G) -> Error {
+            for (auto &Sec : G.sections()) {
+                if (Sec.getName() != "$__jl_plt.ptr")
+                    continue;
+                for (auto *B : Sec.blocks()) {
+                    std::lock_guard<std::mutex> Lock(PluginMutex);
+                    auto It = Pending.find(&MR);
+                    if (It != Pending.end())
+                        It->second.second = B->getAddress();
+                }
+            }
+            return Error::success();
+        });
+    }
+
+    Error notifyEmitted(orc::MaterializationResponsibility &MR) override
+    {
+        jl_code_instance_t *CI = nullptr;
+        orc::ExecutorAddr Addr;
+        {
+            std::lock_guard<std::mutex> Lock(PluginMutex);
+            auto It = Pending.find(&MR);
+            if (It == Pending.end())
+                return Error::success();
+            std::tie(CI, Addr) = It->second;
+            Pending.erase(It);
+        }
+        if (Addr)
+            JIT.armStubSlot(CI, Addr.toPtr<_Atomic(void*)*>());
+        return Error::success();
+    }
+
+    Error notifyFailed(orc::MaterializationResponsibility &MR) override
+    {
+        std::lock_guard<std::mutex> Lock(PluginMutex);
+        Pending.erase(&MR);
+        return Error::success();
+    }
+
+    Error notifyRemovingResources(orc::JITDylib &, orc::ResourceKey) override
+    {
+        return Error::success();
+    }
+
+    void notifyTransferringResources(orc::JITDylib &, orc::ResourceKey, orc::ResourceKey) override {}
+
+private:
+    JuliaOJIT &JIT;
+    std::mutex PluginMutex;
+    DenseMap<orc::MaterializationResponsibility*, std::pair<jl_code_instance_t*, orc::ExecutorAddr>> Pending;
+};
+
 class JLMaterializationUnit : public orc::MaterializationUnit {
 public:
     // Must hold LinkerMutex when calling Create and until the
@@ -861,6 +936,10 @@ public:
             Syms[S] = Flags;
         }
 
+        if (Out.linker_info->plt_stub_sym)
+            Syms[Out.linker_info->plt_stub_sym] =
+                JITSymbolFlags::Exported | JITSymbolFlags::Callable;
+
         return JLMaterializationUnit{JIT, OL, std::move(Out), std::move(I)};
     }
 
@@ -898,6 +977,33 @@ public:
 #endif
             R->failMaterialization();
             return;
+        }
+
+        if (Out.linker_info->plt_target_ci) {
+            // Synthesize the PLT stub for this tojlinvoke thunk directly into
+            // its LinkGraph: a pointer slot initialized (by relocation) to the
+            // thunk, and an exported jump stub through it. The slot's address
+            // is captured post-fixup and armed for patching once the graph is
+            // emitted (see JLPLTPlugin), after which either side of the
+            // publish handshake repoints it at the target's compiled specsig.
+            jitlink::Symbol *Thunk = nullptr;
+            for (auto *S : (*G)->defined_symbols()) {
+                if (S->hasName() && S->getName() == Out.linker_info->plt_thunk_sym) {
+                    Thunk = S;
+                    break;
+                }
+            }
+            assert(Thunk && "trampoline module lost its thunk symbol");
+            auto &PtrSec = (*G)->createSection("$__jl_plt.ptr",
+                                               orc::MemProt::Read | orc::MemProt::Write);
+            auto &StubSec = (*G)->createSection("$__jl_plt.stub",
+                                                orc::MemProt::Read | orc::MemProt::Exec);
+            auto &Ptr = JIT.PLTPointerCreator(**G, PtrSec, Thunk, 0);
+            auto &Stub = JIT.PLTStubCreator(**G, StubSec, Ptr);
+            Stub.setName(Out.linker_info->plt_stub_sym);
+            Stub.setScope(jitlink::Scope::Default);
+            Stub.setLive(true);
+            JIT.PLTPlugin->expectStub(*R, Out.linker_info->plt_target_ci);
         }
 
         // Causes the invoke/specptr to be published when the symbols are emitted
@@ -941,18 +1047,29 @@ class JLTrampolineMaterializationUnit : public orc::MaterializationUnit {
 public:
     JLTrampolineMaterializationUnit(JuliaOJIT &JIT, ObjectLinkingLayer &OL,
                                     SymbolStringPtr Sym, jl_code_instance_t *CI,
-                                    jl_invoke_api_t API) JL_NOTSAFEPOINT
-      : orc::MaterializationUnit({{{JIT.mangle(*Sym),
-                                    JITSymbolFlags::Exported | JITSymbolFlags::Callable}},
-                                  {}}),
+                                    jl_invoke_api_t API,
+                                    SymbolStringPtr StubSym = nullptr) JL_NOTSAFEPOINT
+      : orc::MaterializationUnit(MakeInterface(JIT, Sym, StubSym)),
         JIT(JIT),
         OL(OL),
         Sym(Sym),
+        StubSym(std::move(StubSym)),
         CI(CI),
         API(API)
     {
         assert(API == JL_INVOKE_ARGS || API == JL_INVOKE_SPECSIG);
+        assert(!this->StubSym || API == JL_INVOKE_SPECSIG);
     };
+
+    static Interface MakeInterface(JuliaOJIT &JIT, const SymbolStringPtr &Sym,
+                                   const SymbolStringPtr &StubSym) JL_NOTSAFEPOINT
+    {
+        SymbolFlagsMap Syms;
+        Syms[JIT.mangle(*Sym)] = JITSymbolFlags::Exported | JITSymbolFlags::Callable;
+        if (StubSym)
+            Syms[StubSym] = JITSymbolFlags::Exported | JITSymbolFlags::Callable;
+        return Interface(std::move(Syms), nullptr);
+    }
 
     // During materialization: finalizers disabled, GC safe
     void materialize(std::unique_ptr<MaterializationResponsibility> R) JL_NOTSAFEPOINT_ENTER JL_NOTSAFEPOINT_LEAVE override
@@ -971,12 +1088,17 @@ public:
         F->setLinkage(GlobalValue::ExternalLinkage);
         F->setName(*Sym);
 
+        auto Emitted = Out.finish(std::move(Ctx), std::move(Mod),
+                                  *R->getExecutionSession().getSymbolStringPool());
+        if (StubSym) {
+            Emitted.linker_info->plt_target_ci = CI;
+            Emitted.linker_info->plt_thunk_sym = JIT.mangle(*Sym);
+            Emitted.linker_info->plt_stub_sym = StubSym;
+        }
         std::unique_lock Lock{JIT.LinkerMutex};
         if (auto Err = R->replace(
                 std::make_unique<JLMaterializationUnit>(JLMaterializationUnit::Create(
-                    JIT, OL,
-                    Out.finish(std::move(Ctx), std::move(Mod),
-                               *R->getExecutionSession().getSymbolStringPool()))))) {
+                    JIT, OL, std::move(Emitted))))) {
             R->getExecutionSession().reportError(std::move(Err));
             R->failMaterialization();
         }
@@ -990,6 +1112,7 @@ private:
     JuliaOJIT &JIT;
     ObjectLinkingLayer &OL;
     SymbolStringPtr Sym;
+    SymbolStringPtr StubSym;
     jl_code_instance_t *CI;
     jl_invoke_api_t API;
 };
@@ -1725,6 +1848,18 @@ JuliaOJIT::JuliaOJIT()
     ObjectLayer.addPlugin(DebuginfoPlugin);
     ObjectLayer.addPlugin(std::make_unique<JLMemoryUsagePlugin>(&jit_bytes_size));
 
+    // Pointer jump stubs are supported by JITLink on all of our targets; hard
+    // error if a new target ever lacks them, rather than silently linking
+    // permanently-boxing tojlinvoke thunks into callers.
+    PLTPointerCreator = jitlink::getAnonymousPointerCreator(TM->getTargetTriple());
+    PLTStubCreator = jitlink::getPointerJumpStubCreator(TM->getTargetTriple());
+    if (!PLTPointerCreator || !PLTStubCreator) {
+        jl_safe_printf("fatal: no jump-stub support for this target\n");
+        abort();
+    }
+    PLTPlugin = std::make_shared<JLPLTPlugin>(*this);
+    ObjectLayer.addPlugin(PLTPlugin);
+
     SetVector<void*> libhandles;
     // Make sure that libjulia-internal is loaded and placed first in the
     // DynamicLibrary order so that calls to runtime intrinsics are resolved
@@ -2052,6 +2187,16 @@ void JuliaOJIT::publishCIs(ArrayRef<jl_code_instance_t *> CIs, bool Wait)
             if (S.specptr)
                 Addrs.specptr = (void *)Syms.at(S.specptr).getAddress().getValue();
             jl_publish_compiled_ci(CI, Addrs);
+            // Repoint any armed PLT stub at the published specsig, so calls
+            // through the edge stop going through the tojlinvoke thunk.
+            if (Addrs.invoke_api == JL_INVOKE_SPECSIG && Addrs.specptr) {
+                auto PIt = PendingStubs.find(CI);
+                if (PIt != PendingStubs.end() && PIt->second.Slot) {
+                    jl_atomic_store_release(PIt->second.Slot, Addrs.specptr);
+                    PendingStubs.erase(PIt);
+                }
+                // else: armStubSlot patches once the stub graph is emitted
+            }
         }
         if (P)
             P->set_value();
@@ -2077,6 +2222,7 @@ void JuliaOJIT::unregisterCI(jl_code_instance_t *CI)
 {
     std::unique_lock Lock{LinkerMutex};
     CISymbols.erase(CI);
+    PendingStubs.erase(CI);
 }
 
 #define addAbsoluteToMap(map,name) \
@@ -2248,6 +2394,24 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
     return true;
 }
 
+// Record the (finalized) pointer slot of the PLT stub for `CI` and patch it
+// immediately if the target has already published its compiled specsig. The
+// other half of the handshake lives in publishCIs.
+void JuliaOJIT::armStubSlot(jl_code_instance_t *CI, _Atomic(void*) *Slot)
+{
+    std::unique_lock Lock{LinkerMutex};
+    auto PIt = PendingStubs.find(CI);
+    if (PIt == PendingStubs.end())
+        return; // unregistered
+    PIt->second.Slot = Slot;
+    // n.b. the pending entry guarantees `CI` has not been unregistered/freed
+    void *fptr = jl_specsig_fptr_if_compiled(CI);
+    if (fptr) {
+        jl_atomic_store_release(Slot, fptr);
+        PendingStubs.erase(PIt);
+    }
+}
+
 // Must hold LinkerMutex.
 orc::SymbolStringPtr JuliaOJIT::linkCallTarget(orc::MaterializationResponsibility &MR,
                                                jl_code_instance_t *CI, jl_invoke_api_t API)
@@ -2271,12 +2435,31 @@ orc::SymbolStringPtr JuliaOJIT::linkCallTarget(orc::MaterializationResponsibilit
     // We also generate a tojlinvoke to handle args1 -> specsig.
     CISymbolPtr Trampoline;
     if (!Sym || Sym->invoke_api != API) {
+        if (API == JL_INVOKE_SPECSIG) {
+            // Reuse the existing pending stub for this CI, if any.
+            auto PIt = PendingStubs.find(CI);
+            if (PIt != PendingStubs.end()) {
+                Trampoline.specptr = PIt->second.Sym;
+                Trampoline.invoke_api = API;
+                return Trampoline.specptr;
+            }
+        }
         auto TSym = ES.intern(Names("tojlinvoke#", name_from_method_instance(jl_get_ci_mi(CI)), "#"));
         Trampoline.specptr = mangle(*TSym);
         Trampoline.invoke_api = API;
         Sym = &Trampoline;
+        SymbolStringPtr StubSym;
+        if (API == JL_INVOKE_SPECSIG) {
+            // Interpose a patchable jump stub over the thunk (synthesized into
+            // the trampoline's LinkGraph), so the edge can be repointed
+            // directly at the target's compiled specsig (same ABI) once it
+            // exists (see publishCIs / armStubSlot).
+            StubSym = mangle(Names("plt.tojlinvoke#", name_from_method_instance(jl_get_ci_mi(CI)), "#"));
+            PendingStubs[CI] = {StubSym, nullptr};
+            Trampoline.specptr = StubSym;
+        }
         auto Err = JD.define(std::make_unique<JLTrampolineMaterializationUnit>(
-            *this, ObjectLayer, TSym, CI, API));
+            *this, ObjectLayer, TSym, CI, API, StubSym));
         if (Err) {
 #ifndef __clang_analyzer__ // reportError calls an arbitrary function, which the static analyzer thinks might be a safepoint
             MR.getExecutionSession().reportError(std::move(Err));

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2121,11 +2121,6 @@ void JuliaOJIT::enableIntelJITEventListener()
 #endif
 }
 
-void JuliaOJIT::enableOProfileJITEventListener()
-{
-    // implement when available in LLVM
-}
-
 void JuliaOJIT::enablePerfJITEventListener()
 {
 #if JL_LLVM_VERSION >= 180000

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2412,6 +2412,17 @@ void JuliaOJIT::armStubSlot(jl_code_instance_t *CI, _Atomic(void*) *Slot)
     }
 }
 
+// Number of tojlinvoke trampolines defined by linkCallTarget, i.e. of call
+// edges that had to be linked while their target was not compiled (or had the
+// wrong invoke API). Exposed for tests: compilation schemes that batch or
+// claim work so that call edges stay direct must not define any.
+static _Atomic(uint64_t) tojlinvoke_trampolines_created{0};
+
+extern "C" JL_DLLEXPORT uint64_t jl_tojlinvoke_trampoline_count(void) JL_NOTSAFEPOINT
+{
+    return jl_atomic_load_relaxed(&tojlinvoke_trampolines_created);
+}
+
 // Must hold LinkerMutex.
 orc::SymbolStringPtr JuliaOJIT::linkCallTarget(orc::MaterializationResponsibility &MR,
                                                jl_code_instance_t *CI, jl_invoke_api_t API)
@@ -2467,6 +2478,7 @@ orc::SymbolStringPtr JuliaOJIT::linkCallTarget(orc::MaterializationResponsibilit
             MR.failMaterialization();
             return {};
         }
+        jl_atomic_fetch_add_relaxed(&tojlinvoke_trampolines_created, 1);
     }
 
     assert(Sym->invoke_api == API);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -380,7 +380,15 @@ private:
     StringMap<unsigned> counter;
 };
 
+class JLPLTPlugin;
+
 struct jl_linker_info_t {
+    // For tojlinvoke trampoline modules: the target CodeInstance plus the
+    // thunk/stub symbols, used to synthesize a patchable PLT stub into the
+    // module's LinkGraph (see JLMaterializationUnit::materialize).
+    jl_code_instance_t *plt_target_ci = nullptr;
+    orc::SymbolStringPtr plt_thunk_sym;
+    orc::SymbolStringPtr plt_stub_sym;
     DenseMap<jl_code_instance_t *, jl_codeinst_funcs_t<orc::SymbolStringPtr>> ci_funcs;
     DenseMap<std::pair<jl_code_instance_t *, jl_invoke_api_t>, orc::SymbolStringPtr>
         call_targets;
@@ -642,6 +650,7 @@ public:
 class JuliaOJIT {
     friend JLMaterializationUnit;
     friend JLTrampolineMaterializationUnit;
+    friend class JLPLTPlugin;
 private:
     // any verification the user wants to do when adding an OwningResource to the pool
     template <typename AnyT>
@@ -813,6 +822,9 @@ public:
     // entries in CISymbols, to prevent invokes to a new CodeInstance with the
     // same address from being linked to old symbol.
     void unregisterCI(jl_code_instance_t *CI) JL_NOTSAFEPOINT;
+    // Stub-side half of the PLT patching handshake, called when a stub graph
+    // has been emitted (see JLPLTPlugin); takes LinkerMutex.
+    void armStubSlot(jl_code_instance_t *CI, _Atomic(void*) *Slot);
 
     orc::ThreadSafeContext makeContext() JL_NOTSAFEPOINT;
     const DataLayout& getDataLayout() const JL_NOTSAFEPOINT;
@@ -900,13 +912,28 @@ private:
     std::mutex SharedBytesMutex{};
     SharedBytesT SharedBytes;
 
-    // LinkerMutex protects CISymbols, Names
+    // LinkerMutex protects CISymbols, Names, PendingStubs
     std::mutex LinkerMutex;
     // CISymbols maps CodeInstance pointers to their ORC symbols.  If a
     // CodeInstance is eligible for garbage collection, it must be removed from
     // this map first, with unregisterCI.
     CISymbolMap CISymbols;
     jl_name_counter_t Names;
+    // PLT-style stubs for specsig tojlinvoke trampolines: call edges to a
+    // not-yet-compiled CodeInstance link against a jump stub (synthesized into
+    // the trampoline's own LinkGraph) that jumps through a pointer slot. The
+    // slot initially holds the boxing thunk and is repointed directly at the
+    // target's compiled specsig when both the stub graph has been emitted and
+    // the target has published, whichever happens last (see linkCallTarget,
+    // publishCIs and armStubSlot).
+    struct PendingStubInfo {
+        orc::SymbolStringPtr Sym;       // caller-facing stub symbol
+        _Atomic(void*) *Slot = nullptr; // stub pointer slot, set once emitted
+    };
+    DenseMap<jl_code_instance_t*, PendingStubInfo> PendingStubs;
+    jitlink::AnonymousPointerCreator PLTPointerCreator;
+    jitlink::PointerJumpStubCreator PLTStubCreator;
+    std::shared_ptr<JLPLTPlugin> PLTPlugin;
 
     std::unique_ptr<DLSymOptimizer> DLSymOpt;
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -38,34 +38,20 @@
 #include <queue>
 #include <tuple>
 
-// As of LLVM 13, there are two runtime JIT linker implementations, the older
-// RuntimeDyld (used via orc::RTDyldObjectLinkingLayer) and the newer JITLink
-// (used via orc::ObjectLinkingLayer).
-//
-// JITLink is not only more flexible (which isn't of great importance for us, as
-// we do only single-threaded in-process codegen), but crucially supports using
-// the Small code model, where the linker needs to fix up relocations between
-// object files that end up far apart in address space. RuntimeDyld can't do
-// that and relies on the Large code model instead, which is broken on
-// aarch64-darwin (macOS on ARM64), and not likely to ever be supported there
-// (see https://bugs.llvm.org/show_bug.cgi?id=52029).
-//
-// JITLink is now used on all platforms by default.  The support for RuntimeDyld
-// will be removed when we need the ability to manipulate JITLink LinkGraphs.
-//
-// Of the supported profilers, only OProfile has not been ported to JITLink.
+// The JIT is linked with JITLink (orc::ObjectLinkingLayer) on all platforms:
+// we rely on manipulating JITLink LinkGraphs (see linkOutput), on the Small
+// code model, and on JITLink-based stub redirection for call edges to
+// still-compiling targets. The older RuntimeDyld linker is not supported.
 
 #if defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_MSAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_)
 # define HAS_SANITIZER
 #endif
 
-#ifndef JL_USE_OPROFILE_JITEVENTS
-#define JL_USE_JITLINK
+#ifdef JL_USE_OPROFILE_JITEVENTS
+#error "OProfile JIT events were only supported by RuntimeDyld, which is no longer used"
 #endif
 
-# include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
-# include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
-# include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
+#include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 
 using namespace llvm;
 
@@ -802,7 +788,6 @@ public:
 
     void enableJITDebuggingSupport();
     void enableIntelJITEventListener() JL_NOTSAFEPOINT;
-    void enableOProfileJITEventListener() JL_NOTSAFEPOINT;
     void enablePerfJITEventListener() JL_NOTSAFEPOINT;
 
     orc::SymbolStringPtr mangle(StringRef Name) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -822,6 +822,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_uninferred(
         size_t min_world, size_t max_world, jl_debuginfo_t *di, jl_svec_t *edges);
 JL_DLLEXPORT int jl_mi_cache_has_ci(jl_method_instance_t *mi, jl_code_instance_t *ci) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_read_codeinst_invoke(jl_code_instance_t *ci, uint8_t *specsigflags, jl_callptr_t *invoke, void **specptr, int waitcompile);
+JL_DLLEXPORT void *jl_specsig_fptr_if_compiled(jl_code_instance_t *ci);
 JL_DLLEXPORT void jl_add_codeinsts_to_jit(jl_array_t *codeinsts, jl_array_t *srcs);
 
 JL_DLLEXPORT jl_value_t *jl_invoke_oneshot(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *meth);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -823,6 +823,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_uninferred(
 JL_DLLEXPORT int jl_mi_cache_has_ci(jl_method_instance_t *mi, jl_code_instance_t *ci) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_read_codeinst_invoke(jl_code_instance_t *ci, uint8_t *specsigflags, jl_callptr_t *invoke, void **specptr, int waitcompile);
 JL_DLLEXPORT void *jl_specsig_fptr_if_compiled(jl_code_instance_t *ci);
+JL_DLLEXPORT uint64_t jl_tojlinvoke_trampoline_count(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_add_codeinsts_to_jit(jl_array_t *codeinsts, jl_array_t *srcs);
 
 JL_DLLEXPORT jl_value_t *jl_invoke_oneshot(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *meth);

--- a/test/jit.jl
+++ b/test/jit.jl
@@ -54,6 +54,21 @@ ci = compile_no_deps(M2.bar, (Int,))
 @test check_edges_not_compiled(ci, M2.foo)
 @test invoke(M2.bar, ci, 5) == 210
 
+# A specsig tojlinvoke trampoline must heal once its target is compiled:
+# after the target publishes its specsig, the edge forwards the caller's
+# unboxed arguments instead of boxing through `jl_invoke`.
+module M2b
+    @noinline foo(x) = x + 100
+    bar(x) = 2 * foo(x)
+end
+let ci = compile_no_deps(M2b.bar, (Int,))
+    @test check_edges_not_compiled(ci, M2b.foo)
+    # The first call dispatches through `jl_invoke`, compiling the target.
+    @test invoke(M2b.bar, ci, 5) == 210
+    invoke(M2b.bar, ci, 5) # warm the measurement path
+    @test (@allocations invoke(M2b.bar, ci, 5)) == 0
+end
+
 # Each `eval` must compile (because of the ccall) a top-level thunk.  The
 # CodeInstance for this thunk becomes garbage-collectable after being invoked,
 # but before returning, because of wait().  If the invoke must return for the

--- a/test/jit.jl
+++ b/test/jit.jl
@@ -61,10 +61,15 @@ module M2b
     @noinline foo(x) = x + 100
     bar(x) = 2 * foo(x)
 end
-let ci = compile_no_deps(M2b.bar, (Int,))
+let c0 = ccall(:jl_tojlinvoke_trampoline_count, UInt64, ())
+    ci = compile_no_deps(M2b.bar, (Int,))
     @test check_edges_not_compiled(ci, M2b.foo)
     # The first call dispatches through `jl_invoke`, compiling the target.
     @test invoke(M2b.bar, ci, 5) == 210
+    # The edge to the (deliberately) not-compiled target must have gone
+    # through a counted trampoline; this keeps the counter assertion in the
+    # threads_exec.jl race test honest.
+    @test ccall(:jl_tojlinvoke_trampoline_count, UInt64, ()) > c0
     invoke(M2b.bar, ci, 5) # warm the measurement path
     @test (@allocations invoke(M2b.bar, ci, 5)) == 0
 end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1769,11 +1769,16 @@ include("threads_comprehensions.jl")
 #     call f()
 #       f() already materialized
 #
-# We can tell the trampoline was generated if calling f() with a large integer
-# allocates (the trampoline will box the integer).
+# The property #60241 asks for is that these edges stay direct: no tojlinvoke
+# trampoline may be created at all, which the trampoline counter checks
+# directly. Allocations alone can no longer tell (a trampoline's PLT stub is
+# patched to the compiled specsig and stops boxing once g() publishes), but
+# still guard that patching behavior: a trampoline, if any existed, must not
+# box after its target compiles.
 
 @testset "Race invoke trampolines" begin
     for i=1:10
+        c0 = ccall(:jl_tojlinvoke_trampoline_count, UInt64, ())
         @eval begin
             @noinline function g(x)
                 x = @big_expr(4000, x)
@@ -1797,7 +1802,10 @@ include("threads_comprehensions.jl")
             wait(t)
         end
 
+        # See above: allocations guard the (healed) boxing behavior, the
+        # counter guards that batching/claiming kept the edges direct.
         @test @eval @allocations(f(10000)) == 0
+        @test ccall(:jl_tojlinvoke_trampoline_count, UInt64, ()) == c0
     end
 end
 


### PR DESCRIPTION
Addresses an existing todo in our jitlink code. Claude ended up writing this for me while debugging another issue, but I think it's useful to have in general, so PRing it here.