### PR TITLE
gf: match without materializing intersections during method insertion

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -2177,7 +2177,8 @@ static jl_value_t *get_intersect_matches(jl_typemap_t *defs, jl_typemap_entry_t 
     // search for all intersecting methods active in the previous world, to determine the changes needed to be made for the next world
     struct matches_env env = {{get_intersect_visitor, (jl_value_t*)type, va, /* .search_slurp = */ 0,
             /* .min_valid = */ world, /* .max_valid = */ world,
-            /* .ti = */ NULL, /* .env = */ jl_emptysvec, /* .issubty = */ 0},
+            /* .ti = */ NULL, /* .env = */ NULL, /* .issubty = */ 0,
+            /* .emptiness_only = */ 1},
         /* .newentry = */ newentry, /* .shadowed */ NULL, /* .replaced */ NULL};
     JL_GC_PUSH3(&env.match.env, &env.match.ti, &env.shadowed);
     jl_typemap_intersection_visitor(defs, 0, &env.match);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1987,6 +1987,9 @@ struct typemap_intersection_env {
     jl_value_t *ti; // intersection type
     jl_svec_t *env; // intersection env (initialize to null to perform intersection without an environment)
     int issubty;    // if `a <: b` is true in `intersect(a,b)`
+    int emptiness_only; // if set, `ti` and `env` are not materialized (`ti` is only a
+                        // nonempty/bottom placeholder); the callback may consume just
+                        // the match verdict and `issubty`
 };
 int jl_typemap_intersection_visitor(jl_typemap_t *a, int offs, struct typemap_intersection_env *closure);
 void typemap_slurp_search(jl_typemap_entry_t *ml, struct typemap_intersection_env *closure);

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -566,13 +566,27 @@ static int jl_typemap_intersection_node_visitor(jl_typemap_entry_t *ml, struct t
             continue;
         if (closure->min_valid > jl_atomic_load_relaxed(&ml->max_world))
             continue;
-        jl_svec_t **penv = NULL;
-        if (closure->env) {
-            closure->env = jl_emptysvec;
-            penv = &closure->env;
+        int nonempty;
+        if (closure->emptiness_only) {
+            // The callback consumes only the match verdict and `issubty`; skip
+            // materializing the intersection type and the typevar environment.
+            // (`issubty` matches the full path: jl_type_intersection_env_s
+            // reports `type <: ml->sig`; the emptiness verdict is the same
+            // conservative one the full intersection would give.)
+            closure->issubty = jl_subtype(closure->type, (jl_value_t*)ml->sig);
+            nonempty = closure->issubty || !jl_has_empty_intersection(closure->type, (jl_value_t*)ml->sig);
+            closure->ti = nonempty ? (jl_value_t*)jl_any_type : jl_bottom_type;
         }
-        closure->ti = jl_type_intersection_env_s(closure->type, (jl_value_t*)ml->sig, penv, &closure->issubty);
-        if (closure->ti != (jl_value_t*)jl_bottom_type) {
+        else {
+            jl_svec_t **penv = NULL;
+            if (closure->env) {
+                closure->env = jl_emptysvec;
+                penv = &closure->env;
+            }
+            closure->ti = jl_type_intersection_env_s(closure->type, (jl_value_t*)ml->sig, penv, &closure->issubty);
+            nonempty = closure->ti != (jl_value_t*)jl_bottom_type;
+        }
+        if (nonempty) {
             // In some corner cases type intersection is conservative and returns something
             // for intersect(A, B) even though A is a dispatch tuple and !(A <: B).
             // For dispatch purposes in such a case we know there's no match. This check


### PR DESCRIPTION
get_intersect_matches consumes only the match verdict and issubty from the typemap intersection visitor, but requested a full intersection with a typevar environment: the environment was never read, and passing it also disables the jl_obvious_subtype short-circuit on the leading subtype check of every scanned pair. Add an emptiness_only mode to struct typemap_intersection_env that computes the same conservative match verdict via jl_subtype + jl_has_empty_intersection without materializing the intersection type or the environment, and use it for method insertion.

During a post-precompilation load of CairoMakie, the insertion scan performs 539k visitor intersections with a 3.3% match rate; this change halves the scan's kernel time (1.20s to 0.59s) and cuts total load time by about 7.5% (7.6s to 7.0s), with identical match verdicts. Verified with the subtype, ambiguous, and worlds test suites.