### PR TITLE
Introduce `path_list_separator` instead of duplicating logic

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -537,7 +537,7 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_f
         invokelatest(run_std_repl, REPL, quiet, banner, history_file)
     else
         if !fallback_repl && interactive && !quiet
-            @warn "REPL provider not available: using basic fallback" LOAD_PATH=join(Base.LOAD_PATH, Sys.iswindows() ? ';' : ':')
+            @warn "REPL provider not available: using basic fallback" LOAD_PATH=join(Base.LOAD_PATH, Filesystem.path_list_separator)
         end
         run_fallback_repl(interactive)
     end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -148,7 +148,7 @@ function init_depot_path()
         # otherwise, populate the depot path with the entries in JULIA_DEPOT_PATH,
         # expanding empty strings to the bundled depot
         pushfirst_default = true
-        for (i, path) in enumerate(eachsplit(str, Sys.iswindows() ? ';' : ':'))
+        for (i, path) in enumerate(eachsplit(str, Filesystem.path_list_separator))
             if isempty(path)
                 append_bundled_depot_path!(DEPOT_PATH)
             else
@@ -261,7 +261,7 @@ end
 function parse_load_path(str::String)
     envs = String[]
     isempty(str) && return envs
-    for env in eachsplit(str, Sys.iswindows() ? ';' : ':')
+    for env in eachsplit(str, Filesystem.path_list_separator)
         if isempty(env)
             for env′ in DEFAULT_LOAD_PATH
                 env′ in envs || push!(envs, env′)

--- a/base/linking.jl
+++ b/base/linking.jl
@@ -11,16 +11,14 @@ const dsymutil_exe = Sys.iswindows() ? "dsymutil.exe" : "dsymutil"
 if Sys.iswindows()
     const LIBPATH_env = "PATH"
     const LIBPATH_default = ""
-    const pathsep = ';'
 elseif Sys.isapple()
     const LIBPATH_env = "DYLD_FALLBACK_LIBRARY_PATH"
     const LIBPATH_default = "~/lib:/usr/local/lib:/lib:/usr/lib"
-    const pathsep = ':'
 else
     const LIBPATH_env = "LD_LIBRARY_PATH"
     const LIBPATH_default = ""
-    const pathsep = ':'
 end
+const pathsep = Base.Filesystem.path_list_separator
 
 function adjust_ENV!(env::Dict, PATH::String, LIBPATH::String, adjust_PATH::Bool, adjust_LIBPATH::Bool)
     if adjust_LIBPATH

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3242,12 +3242,12 @@ function load_path_setup_code(load_path::Bool=true)
     """
     if load_path
         load_path = map(abspath, Base.load_path())
-        path_sep = Sys.iswindows() ? ';' : ':'
+        path_sep = Filesystem.path_list_separator
         any(path -> path_sep in path, load_path) &&
             error("LOAD_PATH entries cannot contain $(repr(path_sep))")
         code *= """
         append!(empty!(Base.LOAD_PATH), $(repr(load_path)))
-        ENV["JULIA_LOAD_PATH"] = $(repr(join(load_path, Sys.iswindows() ? ';' : ':')))
+        ENV["JULIA_LOAD_PATH"] = $(repr(join(load_path, Filesystem.path_list_separator)))
         Base.set_active_project(nothing)
         """
     end
@@ -3267,7 +3267,7 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
     append!(empty!(Base.DEPOT_PATH), depot_path)
     append!(empty!(Base.DL_LOAD_PATH), dl_load_path)
     append!(empty!(Base.LOAD_PATH), load_path)
-    ENV["JULIA_LOAD_PATH"] = join(load_path, Sys.iswindows() ? ';' : ':')
+    ENV["JULIA_LOAD_PATH"] = join(load_path, Filesystem.path_list_separator)
     set_active_project(nothing)
     Base._track_dependencies[] = true
     get!(Base.PkgOrigin, Base.pkgorigins, pkg).path = input

--- a/base/path.jl
+++ b/base/path.jl
@@ -23,13 +23,15 @@ export
     splitpath
 
 if Sys.isunix()
-    const path_separator    = "/"
+    const path_separator      = "/"
+    const path_list_separator = ':'
     @inline isseparator(c::Char) = c === '/'
     @inline isseparator(c::UInt8) = c === UInt8('/')
 
     splitdrive(path::String) = ("",path)
 elseif Sys.iswindows()
-    const path_separator    = "\\"
+    const path_separator      = "\\"
+    const path_list_separator = ';'
     @inline isseparator(c::Char) = c === '/' || c === '\\'
     @inline isseparator(c::UInt8) = c === UInt8('/') || c === UInt8('\\')
 

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -490,7 +490,7 @@ function which(program_name::String)
     if isempty(program_dirname)
         # If we have been given just a program name (not a relative or absolute
         # path) then we should search `PATH` for it here:
-        pathsep = iswindows() ? ';' : ':'
+        pathsep = Base.Filesystem.path_list_separator
         path_dirs = map(abspath, eachsplit(get(ENV, "PATH", ""), pathsep))
 
         # On windows we always check the current directory as well

--- a/base/util.jl
+++ b/base/util.jl
@@ -708,7 +708,7 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.EFFECTIVE_CPU_THR
     seed !== nothing && push!(tests, "--seed=0x$(string(seed % UInt128, base=16))") # cast to UInt128 to avoid a minus sign
     ENV2 = copy(ENV)
     ENV2["JULIA_CPU_THREADS"] = "$ncores"
-    pathsep = Sys.iswindows() ? ";" : ":"
+    pathsep = Filesystem.path_list_separator
     ENV2["JULIA_DEPOT_PATH"] = string(mktempdir(; cleanup = true), pathsep) # make sure the default depots can be loaded
     ENV2["JULIA_LOAD_PATH"] = string("@", pathsep, "@stdlib")
     ENV2["JULIA_TESTS"] = "true"

--- a/stdlib/LibGit2/src/repository.jl
+++ b/stdlib/LibGit2/src/repository.jl
@@ -21,7 +21,7 @@ user must be a member of a special access group to read `path`).
 """
 function GitRepoExt(path::AbstractString, flags::Cuint = Cuint(Consts.REPOSITORY_OPEN_DEFAULT))
     ensure_initialized()
-    separator = @static Sys.iswindows() ? ";" : ":"
+    separator = string(Base.Filesystem.path_list_separator)
     repo_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_repository_open_ext, libgit2), Cint,
                  (Ptr{Ptr{Cvoid}}, Cstring, Cuint, Cstring),

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -458,7 +458,7 @@ function cache_PATH()
     this_PATH_cache = Set{String}()
 
     @debug "caching PATH files" PATH=path
-    pathdirs = split(path, @static Sys.iswindows() ? ";" : ":")
+    pathdirs = split(path, Base.Filesystem.path_list_separator)
 
     next_yield_time = time() + 0.01
 


### PR DESCRIPTION
The scope is deliberately limited to the (hopefully uncontroversial) implementation of the logic. The decision of whether we want functionality like this to be `public` should be part of a potential follow-up.

Claude Opus 4.8 helped in creating the PR