### PR TITLE
WIP: subtype: Fix correctness for matching union upper bounds against invariants

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1260,7 +1260,8 @@ static void jl_compilation_sig(
             // and the result of matching the type signature
             // needs to be restricted to the concrete type 'kind'
             jl_value_t *kind = jl_typeof(jl_some_Type_T(elt));
-            if (!jl_has_free_typevars(decl_i) &&
+            if (!(jl_is_typeeq(elt) && jl_is_bottom_singleton_class(jl_typeeq_T(elt))) &&
+                    !jl_has_free_typevars(decl_i) &&
                     jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {
                 // if we can prove the match was against the kind (not a Type)
                 // it's simpler (and thus better) to put that cache instead
@@ -1581,9 +1582,10 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
             // and the result of matching the type signature
             // needs to be corrected to the concrete type 'kind' (and not to Type)
             jl_value_t *kind = jl_typeof(jl_some_Type_T(elt));
-            if (kind == jl_bottom_type) {
+            if (kind == jl_bottom_type ||
+                (jl_is_typeeq(elt) && jl_is_bottom_singleton_class(jl_typeeq_T(elt)))) {
                 JL_GC_POP();
-                return 0; // Type{Union{}} gets normalized to typeof(Union{})
+                return 0; // the bottom singleton class is under no single kind
             }
             if (!jl_has_free_typevars(decl_i) &&
                     jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1345,6 +1345,18 @@ STATIC_INLINE jl_value_t *normalize_typeofbottom_layout_alias(jl_value_t *ty JL_
     return ty;
 }
 
+// `Type{Union{}}` and `typeof(Union{})` denote the same singleton set
+// {Union{}} but with different kinds (a `TypeEq` node vs the `TypeofBottom`
+// `DataType`), so the type-equality class of the bottom singleton type spans
+// more than one kind: `Type{typeof(Union{})}` contains both a `DataType`
+// instance and `TypeEq` instances, and `TypeEq(T) <: kind(typeof(T))`
+// reasoning (subtyping, method matching, cache guards) does not apply to it.
+STATIC_INLINE int jl_is_bottom_singleton_class(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    return t == (jl_value_t*)jl_typeofbottom_type ||
+           (jl_is_typeeq(t) && jl_typeeq_T(t) == jl_bottom_type);
+}
+
 STATIC_INLINE size_t jl_vararg_length(jl_value_t *v) JL_NOTSAFEPOINT
 {
     assert(jl_is_vararg(v));

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1628,6 +1628,143 @@ static jl_value_t *subtype_unionall_envout_value(jl_value_t *t, jl_unionall_t *u
     return wrap_tvar_env(*new_tvar, constrained);
 }
 
+// Helpers for the exhaustive enumeration ("exhaustiveness certificate") of a
+// `∀` variable whose upper bound is a union of atoms in `subtype_unionall`
+// below.
+//
+// A type is an "atom" if it has no proper nonempty subtypes: any X <: A is
+// equal either to A or to Union{}. Values of a concrete non-kind datatype A
+// satisfy typeof(v) == A exactly, so atoms have pairwise disjoint value sets
+// and any type contains either all or none of each atom's values. Kinds are
+// excluded (Type{X} <: DataType is proper and nonempty); TypeEq nodes are not
+// datatypes. A concrete Tuple additionally requires atom parameters: e.g.
+// Tuple{DataType} has the proper nonempty subtype Tuple{Type{Int}}. (Concrete
+// tuples of atoms do have proper subtypes like Tuple{Union{A,B}} below
+// Union{Tuple{A},Tuple{B}}, but those are *equal* to unions of atom tuples,
+// which a sub-union enumeration covers up to type equality.)
+static int is_atom_type(jl_value_t *a) JL_NOTSAFEPOINT
+{
+    if (!jl_is_datatype(a))
+        return 0;
+    jl_datatype_t *d = (jl_datatype_t*)a;
+    if (!d->isconcretetype || jl_is_kind(a))
+        return 0;
+    if (d->name == jl_tuple_typename) {
+        for (size_t i = 0; i < jl_nparams(d); i++) {
+            if (!is_atom_type(jl_tparam(d, i)))
+                return 0;
+        }
+    }
+    return 1;
+}
+
+// Count the arms of union `u`, returning 0 if any arm is not an atom or if
+// there are more than `limit` arms.
+static int count_atom_arms(jl_value_t *u, int limit) JL_NOTSAFEPOINT
+{
+    if (jl_is_uniontype(u)) {
+        int a = count_atom_arms(((jl_uniontype_t*)u)->a, limit);
+        if (a == 0)
+            return 0;
+        int b = count_atom_arms(((jl_uniontype_t*)u)->b, limit - a);
+        if (b == 0)
+            return 0;
+        return a + b;
+    }
+    return (limit >= 1 && is_atom_type(u)) ? 1 : 0;
+}
+
+// Does `var` occur in a Vararg length position anywhere within `t`? Such a
+// variable is integer-valued rather than ranging over the subtypes of its
+// upper bound, so the exhaustive enumeration below does not apply to it.
+static int var_occurs_in_vararg_len(jl_value_t *t, jl_tvar_t *var) JL_NOTSAFEPOINT
+{
+    if (jl_is_uniontype(t) || jl_is_intersecttype(t)) {
+        return var_occurs_in_vararg_len(((jl_uniontype_t*)t)->a, var) ||
+               var_occurs_in_vararg_len(((jl_uniontype_t*)t)->b, var);
+    }
+    else if (jl_is_unionall(t)) {
+        jl_unionall_t *ua = (jl_unionall_t*)t;
+        if (ua->var == var)
+            return 0;
+        return var_occurs_in_vararg_len(ua->var->lb, var) ||
+               var_occurs_in_vararg_len(ua->var->ub, var) ||
+               var_occurs_in_vararg_len(ua->body, var);
+    }
+    else if (jl_is_vararg(t)) {
+        jl_vararg_t *vm = (jl_vararg_t*)t;
+        if (vm->N && jl_has_typevar(vm->N, var))
+            return 1;
+        return vm->T != NULL && var_occurs_in_vararg_len(vm->T, var);
+    }
+    else if (jl_is_typeeq(t)) {
+        return var_occurs_in_vararg_len(jl_typeeq_T(t), var);
+    }
+    else if (jl_is_datatype(t)) {
+        for (size_t i = 0; i < jl_nparams(t); i++) {
+            if (var_occurs_in_vararg_len(jl_tparam(t, i), var))
+                return 1;
+        }
+    }
+    return 0;
+}
+
+// Would substituting Union{} for `var` make `t` uninhabited? Union{} in a
+// fixed covariant Tuple slot (or in the element of a Vararg of positive
+// constant length) empties the tuple, while under an invariant constructor
+// the type stays inhabited (Ref{Union{}} has instances). Conservative:
+// returning 0 causes the Union{} branch of the enumeration below to be
+// checked rather than skipped, which can only lose precision, not soundness.
+static int bottom_inst_uninhabited(jl_value_t *t, jl_tvar_t *var) JL_NOTSAFEPOINT
+{
+    if (t == (jl_value_t*)var)
+        return 1;
+    if (jl_is_uniontype(t)) {
+        return bottom_inst_uninhabited(((jl_uniontype_t*)t)->a, var) &&
+               bottom_inst_uninhabited(((jl_uniontype_t*)t)->b, var);
+    }
+    if (jl_is_datatype(t) && jl_is_tuple_type(t)) {
+        for (size_t i = 0; i < jl_nparams(t); i++) {
+            jl_value_t *p = jl_tparam(t, i);
+            if (jl_is_vararg(p)) {
+                jl_vararg_t *vm = (jl_vararg_t*)p;
+                if (vm->T && vm->N && jl_is_long(vm->N) && jl_unbox_long(vm->N) > 0 &&
+                    bottom_inst_uninhabited(vm->T, var))
+                    return 1;
+            }
+            else if (bottom_inst_uninhabited(p, var)) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+// Consume one left-union decision per arm of `u` (0 = keep the arm, 1 = drop
+// it) and return the union of the kept arms: Union{} if all are dropped, `u`
+// itself if all are kept. The enclosing ∀∃ loop enumerates all 2^n subsets.
+static jl_value_t *pick_union_subset(jl_value_t *u, jl_stenv_t *e)
+{
+    if (!jl_is_uniontype(u))
+        return pick_union_decision(e, 0) ? jl_bottom_type : u;
+    jl_uniontype_t *uu = (jl_uniontype_t*)u;
+    jl_value_t *a = NULL, *b = NULL;
+    JL_GC_PUSH2(&a, &b);
+    a = pick_union_subset(uu->a, e);
+    b = pick_union_subset(uu->b, e);
+    jl_value_t *res;
+    if (a == jl_bottom_type)
+        res = b;
+    else if (b == jl_bottom_type)
+        res = a;
+    else if (a == uu->a && b == uu->b)
+        res = u;
+    else
+        res = jl_new_struct(jl_uniontype_type, a, b);
+    JL_GC_POP();
+    return res;
+}
+
 static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8_t R, jl_param_pos_t param)
 {
     u = unalias_unionall(u, e);
@@ -1664,9 +1801,47 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
         // Split the bound here by registering one ordinary left-union decision
         // per Union node, so that the enclosing ∀∃ loop enumerates all arms.
         if (!e->intersection && vb.lb == jl_bottom_type && jl_is_uniontype(vb.ub) &&
-            !body_occurs_inv && var_occurs_covariant_only(u->body, u->var, 1))
+            !body_occurs_inv && var_occurs_covariant_only(u->body, u->var, 1)) {
             vb.ub = pick_union_element(vb.ub, e, 0);
-        ans = subtype(u->body, t, e, param);
+            ans = subtype(u->body, t, e, param);
+        }
+        // Exhaustiveness certificate: when every arm of the upper bound is an
+        // atom (see is_atom_type), every admissible instantiation of the
+        // variable equals a sub-union of the arms -- including Union{} itself
+        // (non-type values do not qualify since the bound is not Any, cf.
+        // var_gt). The ∀ judgment is therefore decided exactly by re-checking
+        // the body with the variable pinned (lb == ub) to each of the 2^n
+        // subsets, consuming one left-union decision per arm so the enclosing
+        // ∀∃ loop enumerates them. Unlike the covariant arm-split above, this
+        // handles invariant occurrences, e.g. it proves
+        //   (Tuple{T,Ref{T}} where T<:Union{Float64,Int64}) <:
+        //       Union{Tuple{Float64,Ref{Float64}}, Tuple{Int64,Ref{Int64}},
+        //             Tuple{Union{Float64,Int64},Ref{Union{Float64,Int64}}}}
+        // Pinning to Union{} would wrongly reject bodies that the substitution
+        // makes uninhabited (slots are compared independently), so that branch
+        // is short-circuited when the body is statically known to become
+        // empty. Integer-valued variables (Vararg length positions) do not
+        // range over the subtypes of their bound and are excluded. Gating on
+        // the static occurs-invariantly bit keeps this path off the diagonal
+        // rule (`diagonal` below is 0 when body_occurs_inv is set) and leaves
+        // covariant-only variables to the cheaper arm-split above.
+        else if (!e->intersection && vb.lb == jl_bottom_type && body_occurs_inv &&
+                 count_atom_arms(vb.ub, 4) > 0 &&
+                 !var_occurs_in_vararg_len(u->body, u->var)) {
+            vb.ub = pick_union_subset(vb.ub, e);
+            if (vb.ub == jl_bottom_type && bottom_inst_uninhabited(u->body, u->var)) {
+                // the body instantiates to an uninhabited type; this branch of
+                // the enumeration holds vacuously
+                ans = 1;
+            }
+            else {
+                vb.lb = vb.ub;
+                ans = subtype(u->body, t, e, param);
+            }
+        }
+        else {
+            ans = subtype(u->body, t, e, param);
+        }
     }
 
     // handle the "diagonal dispatch" rule, which says that a type var occurring more

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2884,16 +2884,43 @@ static int forall_exists_equal(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
     return sub;
 }
 
-static int exists_subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_savedenv_t *se, jl_param_pos_t param)
+// If `probe`, first re-run with the ∃ decision vector left in `e->Runions` by
+// the previous ∀ branch before enumerating from scratch; `*niter` is set to
+// the number of leaf evaluations the from-scratch enumeration used to find a
+// witness (0 if the probe hit or no witness was found).
+static int exists_subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_savedenv_t *se, jl_param_pos_t param, int probe, int *niter)
 {
-    e->Runions.used = 0;
-    while (1) {
+    *niter = 0;
+    if (probe) {
+        // ∃-witness caching (the oracle analogue of solution/phase saving and
+        // of the incremental per-block solvers in CEGAR-style QBF solving):
+        // before enumerating the ∃ decision space from scratch, re-run with
+        // the decision vector that satisfied the previous ∀ branch --
+        // adjacent branches often admit the same witness. A hit needs no
+        // further justification, since success requires only one witness and
+        // any successful run corresponds to a leaf the enumeration below
+        // would eventually reach. On a miss, fall back to the full
+        // enumeration (which may revisit the probed vector once).
         e->Runions.depth = 0;
         e->Runions.more = 0;
         e->Lunions.depth = 0;
         e->Lunions.more = 0;
         if (subtype(x, y, e, param))
             return 1;
+        restore_env(e, se, 1);
+    }
+    e->Runions.used = 0;
+    int count = 0;
+    while (1) {
+        e->Runions.depth = 0;
+        e->Runions.more = 0;
+        e->Lunions.depth = 0;
+        e->Lunions.more = 0;
+        count++;
+        if (subtype(x, y, e, param)) {
+            *niter = count;
+            return 1;
+        }
         if (next_union_state(e, 1)) {
             // We preserve `envout` here as `subtype_unionall` needs previous assigned env values.
             int oldidx = e->envidx;
@@ -2920,11 +2947,30 @@ static int forall_exists_subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl
 
     e->Lunions.used = 0;
     int sub;
+    // Adaptive ∃-witness caching across ∀ branches (see exists_subtype).
+    // Probe only when the last from-scratch search was deep enough that a hit
+    // saves work (a probe miss costs one extra leaf evaluation), and stop
+    // after two consecutive misses (branches whose witnesses track the ∀
+    // decisions, e.g. per-arm union matches, would miss every time). Not
+    // applied when environment output is requested, where the choice of
+    // witness is user-visible through the computed variable values.
+    int misses = 0, deep = 0;
     while (1) {
-        sub = exists_subtype(x, y, e, &se, param);
+        int probe = deep && misses < 2 && e->envsz == 0;
+        int niter = 0;
+        sub = exists_subtype(x, y, e, &se, param, probe, &niter);
         if (!sub || !next_union_state(e, 0))
             break;
         re_save_env(e, &se, 1);
+        if (niter > 0) {
+            // a from-scratch enumeration ran (no probe, or probe missed)
+            deep = niter > 2;
+            if (probe)
+                misses++;
+        }
+        else if (probe) {
+            misses = 0; // probe hit
+        }
     }
 
     free_env(&se);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1658,20 +1658,22 @@ static int is_atom_type(jl_value_t *a) JL_NOTSAFEPOINT
     return 1;
 }
 
-// Count the arms of union `u`, returning 0 if any arm is not an atom or if
-// there are more than `limit` arms.
-static int count_atom_arms(jl_value_t *u, int limit) JL_NOTSAFEPOINT
+// Classify the arms of union `u` for the exhaustive ∀ enumeration below:
+// count atom arms (see is_atom_type) and non-atom arms. Returns 0 if there
+// are more than `limit` arms in total, 1 otherwise.
+static int classify_union_arms(jl_value_t *u, int limit, int *natoms, int *nother) JL_NOTSAFEPOINT
 {
     if (jl_is_uniontype(u)) {
-        int a = count_atom_arms(((jl_uniontype_t*)u)->a, limit);
-        if (a == 0)
-            return 0;
-        int b = count_atom_arms(((jl_uniontype_t*)u)->b, limit - a);
-        if (b == 0)
-            return 0;
-        return a + b;
+        return classify_union_arms(((jl_uniontype_t*)u)->a, limit, natoms, nother) &&
+               classify_union_arms(((jl_uniontype_t*)u)->b, limit, natoms, nother);
     }
-    return (limit >= 1 && is_atom_type(u)) ? 1 : 0;
+    if (*natoms + *nother >= limit)
+        return 0;
+    if (is_atom_type(u))
+        (*natoms)++;
+    else
+        (*nother)++;
+    return 1;
 }
 
 // Does `var` occur in a Vararg length position anywhere within `t`? Such a
@@ -1740,41 +1742,59 @@ static int bottom_inst_uninhabited(jl_value_t *t, jl_tvar_t *var) JL_NOTSAFEPOIN
     return 0;
 }
 
-// Consume one left-union decision per arm of `u` (0 = keep the arm, 1 = drop
-// it) and return the union of the kept arms: Union{} if all are dropped, `u`
-// itself if all are kept. The enclosing ∀∃ loop enumerates all 2^n subsets.
-static jl_value_t *pick_union_subset(jl_value_t *u, jl_stenv_t *e)
+// Walk the arms of `u`, consuming one left-union decision per atom arm
+// (0 = keep the arm, 1 = drop it), and return the union of the kept atom
+// arms: Union{} if all are dropped, `u` itself if everything is kept.
+// Non-atom arms are accumulated as a union into `*rest`, which must be a
+// GC-rooted slot holding NULL on entry. The enclosing ∀∃ loop enumerates
+// all subsets of the atom arms.
+static jl_value_t *pick_atom_subset(jl_value_t *u, jl_value_t **rest, jl_stenv_t *e)
 {
-    if (!jl_is_uniontype(u))
+    if (jl_is_uniontype(u)) {
+        jl_uniontype_t *uu = (jl_uniontype_t*)u;
+        jl_value_t *a = NULL, *b = NULL;
+        JL_GC_PUSH2(&a, &b);
+        a = pick_atom_subset(uu->a, rest, e);
+        b = pick_atom_subset(uu->b, rest, e);
+        jl_value_t *res;
+        if (a == jl_bottom_type)
+            res = b;
+        else if (b == jl_bottom_type)
+            res = a;
+        else if (a == uu->a && b == uu->b)
+            res = u;
+        else
+            res = jl_new_struct(jl_uniontype_type, a, b);
+        JL_GC_POP();
+        return res;
+    }
+    if (is_atom_type(u))
         return pick_union_decision(e, 0) ? jl_bottom_type : u;
-    jl_uniontype_t *uu = (jl_uniontype_t*)u;
-    jl_value_t *a = NULL, *b = NULL;
-    JL_GC_PUSH2(&a, &b);
-    a = pick_union_subset(uu->a, e);
-    b = pick_union_subset(uu->b, e);
-    jl_value_t *res;
-    if (a == jl_bottom_type)
-        res = b;
-    else if (b == jl_bottom_type)
-        res = a;
-    else if (a == uu->a && b == uu->b)
-        res = u;
-    else
-        res = jl_new_struct(jl_uniontype_type, a, b);
-    JL_GC_POP();
-    return res;
+    *rest = *rest == NULL ? u : jl_new_struct(jl_uniontype_type, *rest, u);
+    return jl_bottom_type;
 }
 
 static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8_t R, jl_param_pos_t param)
 {
     u = unalias_unionall(u, e);
     jl_value_t *new_tvar = NULL;
+    jl_value_t *new_rtvar = NULL;
+    jl_value_t *rest = NULL;
     jl_varbinding_t vb;
     memset(&vb, 0, sizeof(vb));
     vb.existential = R;
     vb.depth0 = e->invdepth;
     vb.prev = e->vars;
-    JL_GC_PUSH5(&u, &vb.lb, &vb.ub, &vb.innervars, &new_tvar);
+    // binding for the residual variable of the exhaustive ∀ enumeration
+    // below; inactive (never linked into e->vars) unless rvb.var != NULL.
+    // rvb.lb is always Union{} and rvb.ub always aliases `rest`, which are
+    // rooted, so the binding's own fields need no separate roots.
+    jl_varbinding_t rvb;
+    memset(&rvb, 0, sizeof(rvb));
+    rvb.depth0 = e->invdepth;
+    rvb.prev = &vb;
+    JL_GC_PUSH8(&u, &vb.lb, &vb.ub, &vb.innervars, &new_tvar,
+                &rvb.var, &rest, &new_rtvar);
     if (jl_has_typevar(t, u->var))
         u = jl_rename_unionall(u);
     int body_occurs_inv = var_occurs_invariant(u->body, u->var);
@@ -1805,37 +1825,69 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
             vb.ub = pick_union_element(vb.ub, e, 0);
             ans = subtype(u->body, t, e, param);
         }
-        // Exhaustiveness certificate: when every arm of the upper bound is an
-        // atom (see is_atom_type), every admissible instantiation of the
-        // variable equals a sub-union of the arms -- including Union{} itself
-        // (non-type values do not qualify since the bound is not Any, cf.
-        // var_gt). The ∀ judgment is therefore decided exactly by re-checking
-        // the body with the variable pinned (lb == ub) to each of the 2^n
-        // subsets, consuming one left-union decision per arm so the enclosing
-        // ∀∃ loop enumerates them. Unlike the covariant arm-split above, this
-        // handles invariant occurrences, e.g. it proves
+        // Exhaustiveness certificate: every admissible instantiation of the
+        // variable decomposes as Union{S, X}, where S is a subset of the atom
+        // arms of the upper bound (see is_atom_type) and X is some subtype of
+        // the union of the non-atom arms: unions are covered arm-wise,
+        // covariant tuples distribute over their union-typed slots into atom
+        // tuples, and any other type lands wholly below a single arm. (S may
+        // be empty and X may be Union{}; non-type values never qualify since
+        // the bound is not Any, cf. var_gt.) The ∀ judgment is therefore
+        // decided exactly by re-checking the body with the variable pinned
+        // (lb == ub) to Union{S}, or to Union{S, TR} where TR is a fresh
+        // universal "residual" variable ranging below the non-atom arms, for
+        // every subset S -- consuming one left-union decision per atom arm
+        // plus one for the residual, so the enclosing ∀∃ loop enumerates all
+        // combinations. Unlike the covariant arm-split above, this handles
+        // invariant occurrences, e.g. it proves
         //   (Tuple{T,Ref{T}} where T<:Union{Float64,Int64}) <:
         //       Union{Tuple{Float64,Ref{Float64}}, Tuple{Int64,Ref{Int64}},
         //             Tuple{Union{Float64,Int64},Ref{Union{Float64,Int64}}}}
-        // Pinning to Union{} would wrongly reject bodies that the substitution
-        // makes uninhabited (slots are compared independently), so that branch
-        // is short-circuited when the body is statically known to become
-        // empty. Integer-valued variables (Vararg length positions) do not
-        // range over the subtypes of their bound and are excluded. Gating on
-        // the static occurs-invariantly bit keeps this path off the diagonal
-        // rule (`diagonal` below is 0 when body_occurs_inv is set) and leaves
-        // covariant-only variables to the cheaper arm-split above.
+        // and, with a residual variable for the abstract arm,
+        //   (Ref{T} where T<:Union{Nothing,Integer}) <:
+        //       Union{Ref{Nothing}, Ref{S} where S<:Integer,
+        //             Ref{Union{Nothing,S}} where S<:Integer}
+        // With no atom arms the enumeration proves nothing new (the T == ub
+        // instantiation forces a single covering component on the right,
+        // which the ordinary variable machinery already finds), so at least
+        // one atom is required. Pinning to Union{} would wrongly reject
+        // bodies that the substitution makes uninhabited (slots are compared
+        // independently), so that branch is short-circuited when the body is
+        // statically known to become empty. Integer-valued variables (Vararg
+        // length positions) do not range over the subtypes of their bound and
+        // are excluded. Gating on the static occurs-invariantly bit keeps
+        // this path off the diagonal rule (`diagonal` below is 0 when
+        // body_occurs_inv is set) and leaves covariant-only variables to the
+        // cheaper arm-split above.
         else if (!e->intersection && vb.lb == jl_bottom_type && body_occurs_inv &&
-                 count_atom_arms(vb.ub, 4) > 0 &&
                  !var_occurs_in_vararg_len(u->body, u->var)) {
-            vb.ub = pick_union_subset(vb.ub, e);
-            if (vb.ub == jl_bottom_type && bottom_inst_uninhabited(u->body, u->var)) {
-                // the body instantiates to an uninhabited type; this branch of
-                // the enumeration holds vacuously
-                ans = 1;
+            int natoms = 0, nother = 0;
+            if (classify_union_arms(vb.ub, 4, &natoms, &nother) && natoms >= 1) {
+                vb.ub = pick_atom_subset(vb.ub, &rest, e);
+                int residual = nother >= 1 && !pick_union_decision(e, 0);
+                if (residual) {
+                    rvb.lb = jl_bottom_type;
+                    rvb.ub = rest;
+                    rvb.var = jl_new_typevar(u->var->name, rvb.lb, rvb.ub);
+                    if (vb.ub == jl_bottom_type)
+                        vb.ub = (jl_value_t*)rvb.var;
+                    else
+                        vb.ub = jl_new_struct(jl_uniontype_type, vb.ub, (jl_value_t*)rvb.var);
+                    vb.lb = vb.ub;
+                    e->vars = &rvb;
+                    ans = subtype(u->body, t, e, param);
+                }
+                else if (vb.ub == jl_bottom_type && bottom_inst_uninhabited(u->body, u->var)) {
+                    // the body instantiates to an uninhabited type; this
+                    // branch of the enumeration holds vacuously
+                    ans = 1;
+                }
+                else {
+                    vb.lb = vb.ub;
+                    ans = subtype(u->body, t, e, param);
+                }
             }
             else {
-                vb.lb = vb.ub;
                 ans = subtype(u->body, t, e, param);
             }
         }
@@ -1872,6 +1924,13 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
             ans = 0;
         }
     }
+    // A residual enumeration variable stands for arbitrary, possibly
+    // abstract, subtypes of the non-atom arms; a constraint forcing it
+    // concrete is therefore unsatisfiable over the whole branch unless its
+    // bound is itself concrete, matching the conservative rule for an
+    // unsplit variable above.
+    if (ans && rvb.var != NULL && rvb.concrete && !is_leaf_bound(rvb.ub))
+        ans = 0;
     e->vars = vb.prev;
 
     if (!ans) {
@@ -1961,6 +2020,38 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
                 JL_GC_POP();
             }
             JL_GC_POP();
+        }
+    }
+
+    // The pinned value of the enumeration variable may have leaked its
+    // residual variable into outer existential bounds (directly, or via the
+    // substitution above); rename it the same way.
+    if (rvb.var != NULL) {
+        for (jl_varbinding_t *btemp = vb.prev; btemp; btemp = btemp->prev) {
+            if (!btemp->existential)
+                continue;
+            int ub_has_var = jl_has_typevar(btemp->ub, rvb.var);
+            int lb_has_var = jl_has_typevar(btemp->lb, rvb.var);
+            if (!ub_has_var && !lb_has_var)
+                continue;
+            if (btemp->depth0 != rvb.depth0) {
+                // as for the enumeration variable itself: the residual is
+                // universally quantified over a nontrivial range, which a
+                // single existential value cannot span across an invariant
+                // constructor boundary
+                JL_GC_POP();
+                return 0;
+            }
+            btemp->tainted_inner = 1;
+            if (!new_rtvar) {
+                new_rtvar = (jl_value_t*)jl_new_typevar(rvb.var->name, rvb.lb, rvb.ub);
+                if (outermost != NULL)
+                    push_innervar(outermost, new_rtvar);
+            }
+            if (ub_has_var)
+                btemp->ub = jl_substitute_var(btemp->ub, rvb.var, new_rtvar);
+            if (lb_has_var)
+                btemp->lb = jl_substitute_var(btemp->lb, rvb.var, new_rtvar);
         }
     }
 

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -123,8 +123,11 @@ static int sig_match_by_type_leaf(jl_value_t **types, jl_tupletype_t *sig, size_
     for (i = 0; i < n; i++) {
         jl_value_t *decl = jl_tparam(sig, i);
         jl_value_t *a = types[i];
-        if (jl_is_some_Type(a)) // decl is not Type, because it wouldn't be leafsig
+        if (jl_is_some_Type(a)) { // decl is not Type, because it would not be leafsig
+            if (jl_is_typeeq(a) && jl_is_bottom_singleton_class(jl_typeeq_T(a)))
+                return 0; // spans two kinds, so it matches no concrete kind decl
             a = jl_typeof(jl_some_Type_T(a));
+        }
         if (!jl_types_equal(a, decl))
             return 0;
     }
@@ -186,6 +189,8 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
         else {
             assert(jl_is_concrete_type(decl));
             if (jl_is_some_Type(a)) { // decl is not TypeEq/TypeEgal or AnyType, because it would be caught above, so it must be concrete
+                if (jl_is_typeeq(a) && jl_is_bottom_singleton_class(jl_typeeq_T(a)))
+                    return 0; // spans two kinds, so it matches no concrete kind decl
                 a = jl_typeof(jl_some_Type_T(a));
             }
             if (!jl_types_equal(a, decl))

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -733,3 +733,16 @@ end
     @test new_d[:m] isa Memory
     @test new_d[:m][5] == 125
 end
+
+# Type{Union{}} is a TypeEq node that used to dispatch (incorrectly) to the
+# DataType serialize method and crash on its layout
+@testset "Type{Union{}} round trip" begin
+    # n.b. Vector{Type{Union{}}} still crashes in array element layout, a
+    # separate pre-existing bug in the TypeofBottom layout aliasing
+    for t in (Type{Union{}}, Ref{Tuple{Type{Union{}}, Int}})
+        b = IOBuffer()
+        serialize(b, t)
+        seekstart(b)
+        @test deserialize(b) == t
+    end
+end

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -3407,3 +3407,36 @@ end
 @test !((Tuple{T,Ref{T}} where T<:Union{DataType,String}) <:
         Union{Tuple{DataType,Ref{DataType}}, Tuple{String,Ref{String}},
               Tuple{Union{DataType,String},Ref{Union{DataType,String}}}})
+
+# Hybrid enumeration: atom arms plus a universal residual variable standing
+# for the abstract arms, covering the common Union{Nothing,<:Abstract} bound.
+let LHS = Tuple{T,Ref{T}} where T<:Union{Nothing,Integer},
+    RHS = Union{Tuple{Nothing,Ref{Nothing}},
+                Tuple{S,Ref{S}} where S<:Integer,
+                Tuple{Union{Nothing,S},Ref{Union{Nothing,S}}} where S<:Integer}
+    @test LHS <: RHS
+    @test LHS == RHS
+    # a missing residual-only arm must fail
+    @test !(LHS <: Union{Tuple{Nothing,Ref{Nothing}},
+                         Tuple{Union{Nothing,S},Ref{Union{Nothing,S}}} where S<:Integer})
+end
+@test (Ref{T} where T<:Union{Nothing,Integer}) <:
+    Union{Ref{Nothing}, Ref{S} where S<:Integer, Ref{Union{Nothing,S}} where S<:Integer}
+# ... but the mixed atom+residual instantiations must be covered
+@test !((Ref{T} where T<:Union{Nothing,Integer}) <:
+    Union{Ref{Nothing}, Ref{S} where S<:Integer})
+# two atoms and an abstract arm: all four atom subsets, each with and without
+# the residual
+@test (Ref{T} where T<:Union{Nothing,Missing,Integer}) <:
+    Union{Ref{Nothing}, Ref{Missing}, Ref{Union{Nothing,Missing}},
+          Ref{S} where S<:Integer, Ref{Union{Nothing,S}} where S<:Integer,
+          Ref{Union{Missing,S}} where S<:Integer,
+          Ref{Union{Nothing,Missing,S}} where S<:Integer}
+# reflexivity survives the residual enumeration
+@test (Ref{T} where T<:Union{Nothing,Integer}) == (Ref{S} where S<:Union{Nothing,Integer})
+@test (Vector{Ref{T}} where T<:Union{Nothing,Integer}) ==
+      (Vector{Ref{S}} where S<:Union{Nothing,Integer})
+# a bound with no atom arms is not enumerated: mixed abstract instantiations
+# (e.g. Union{Int64,String}) are not expressible as a finite case split
+@test !((Tuple{T,Ref{T}} where T<:Union{Integer,AbstractString}) <:
+    Union{Tuple{S,Ref{S}} where S<:Integer, Tuple{S,Ref{S}} where S<:AbstractString})

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -3361,3 +3361,49 @@ _typeegal_id(::Type{T}) where {T} = T
         end
     end
 end
+
+# Exhaustiveness certificate: a `∀` variable whose upper bound is a union of
+# atoms (types with no proper nonempty subtypes) ranges over exactly the
+# sub-unions of the arms (including Union{}), so the check can enumerate all
+# of them even for invariant occurrences of the variable.
+let LHS = Tuple{T,Ref{T}} where T<:Union{Float64,Int64},
+    RHS = Union{Tuple{Int64,Ref{Int64}}, Tuple{Float64,Ref{Float64}},
+                Tuple{Union{Int64,Float64},Ref{Union{Int64,Float64}}}}
+    @test LHS <: RHS
+    @test LHS == RHS
+    # a missing mixed-union arm must still fail
+    @test !(LHS <: Union{Tuple{Int64,Ref{Int64}}, Tuple{Float64,Ref{Float64}}})
+end
+# Union{} is an admissible instantiation: with the variable only under an
+# invariant constructor the body stays inhabited, so Ref{Union{}} is required
+@test !((Ref{T} where T<:Union{Float64,Int64}) <:
+        Union{Ref{Float64},Ref{Int64},Ref{Union{Float64,Int64}}})
+@test (Ref{T} where T<:Union{Float64,Int64}) <:
+        Union{Ref{Union{}},Ref{Float64},Ref{Int64},Ref{Union{Float64,Int64}}}
+# ... but a fixed covariant slot makes the Union{} instantiation uninhabited
+@test (Tuple{T,Ref{T}} where T<:Int64) <: Tuple{Int64,Ref{Int64}}
+@test (Tuple{T,Ref{T}} where T<:Int64) == Tuple{Int64,Ref{Int64}}
+# reflexivity survives the enumeration
+@test (Ref{T} where T<:Union{Float64,Int64}) == (Ref{S} where S<:Union{Float64,Int64})
+@test (Tuple{T,Ref{T}} where T<:Union{Float64,Int64}) ==
+      (Tuple{S,Ref{S}} where S<:Union{Float64,Int64})
+# three atoms: all 2^3 subsets are enumerated
+@test (Tuple{T,Ref{T}} where T<:Union{Int8,Int16,Int32}) <:
+    Union{Tuple{Int8,Ref{Int8}}, Tuple{Int16,Ref{Int16}}, Tuple{Int32,Ref{Int32}},
+          Tuple{Union{Int8,Int16},Ref{Union{Int8,Int16}}},
+          Tuple{Union{Int8,Int32},Ref{Union{Int8,Int32}}},
+          Tuple{Union{Int16,Int32},Ref{Union{Int16,Int32}}},
+          Tuple{Union{Int8,Int16,Int32},Ref{Union{Int8,Int16,Int32}}}}
+@test !((Tuple{T,Ref{T}} where T<:Union{Int8,Int16,Int32}) <:
+    Union{Tuple{Int8,Ref{Int8}}, Tuple{Int16,Ref{Int16}}, Tuple{Int32,Ref{Int32}},
+          Tuple{Union{Int8,Int32},Ref{Union{Int8,Int32}}},
+          Tuple{Union{Int16,Int32},Ref{Union{Int16,Int32}}},
+          Tuple{Union{Int8,Int16,Int32},Ref{Union{Int8,Int16,Int32}}}})
+# abstract arms are not atoms: mixed instantiations are not enumerable
+@test !((Tuple{T,Ref{T}} where T<:Union{Integer,AbstractString}) <:
+        Union{Tuple{Integer,Ref{Integer}}, Tuple{AbstractString,Ref{AbstractString}},
+              Tuple{Union{Integer,AbstractString},Ref{Union{Integer,AbstractString}}}})
+# kinds are not atoms (Type{Int} <: DataType is a proper nonempty subtype)
+@test !((Tuple{T,Ref{T}} where T<:Union{DataType,String}) <:
+        Union{Tuple{DataType,Ref{DataType}}, Tuple{String,Ref{String}},
+              Tuple{Union{DataType,String},Ref{Union{DataType,String}}}})


### PR DESCRIPTION
This fixes various subtype cases left as todo in https://github.com/JuliaLang/julia/pull/62074#issuecomment-4774837994. The biggest problem is that this requires an exponential enumeration of the union. Subtyping already has various exponential cases but adding another one is risky of course. As a partial mitigation to any subtype perf issues, re-use a trick from QBF solvers by caching a matching union path early and re-trying it first before looking at the full enumeration. There's additional improvements that could be made to the search strategy, but my efforts ended up focusing on reducing the number of subtype queries (#62254) rather than making them individually faster because this particular case is fairly rare (after all, it gives the wrong answer at the moment, so if it were common we'd get more complaints about it). 