### PR TITLE
gf: Match type-valued arguments at bare-typevar slots against the kind

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1075,7 +1075,8 @@ JL_DLLEXPORT void jl_set_compile_and_emit_func(jl_value_t *f)
 
 static int very_general_type(jl_value_t *t)
 {
-    return (t == (jl_value_t*)jl_any_type || jl_types_equal(t, (jl_value_t*)jl_type_type));
+    // accepts every type object: `Any`, `Type`, `Union{Type, Missing}`, ...
+    return jl_subtype((jl_value_t*)jl_type_type, t);
 }
 
 jl_value_t *jl_nth_slot_type(jl_value_t *sig, size_t i) JL_NOTSAFEPOINT
@@ -1298,7 +1299,7 @@ static void jl_compilation_sig(
             // be spelled; it normalizes to `typeof(Union{})`).
             jl_value_t *kind = jl_typeof(jl_some_Type_T(elt));
             if (!jl_has_free_typevars(decl_i) &&
-                    jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {
+                    jl_subtype(kind, type_i) && !very_general_type(type_i)) {
                 // if the declared type was not Any or Union{Type, ...},
                 // then the match must been with the kind (e.g. UnionAll or DataType)
                 // and it's simpler (and thus better) to put that in the cache instead
@@ -1330,7 +1331,7 @@ static void jl_compilation_sig(
                 // Preserve the singleton `Type{Union{}}` dispatch key. Widening it to
                 // `Type` loses static parameters for compiled calls to `::Type{T}`.
             }
-            else if (!(jl_subtype(elt, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i))) {
+            else if (!(jl_subtype(elt, type_i) && !very_general_type(type_i))) {
                 if (!*newparams) *newparams = jl_svec_copy(tt->parameters);
                 elt = (jl_value_t*)jl_type_type;
                 jl_svecset(*newparams, i, elt);
@@ -1591,7 +1592,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
             if (elt == (jl_value_t*)jl_typeofbottom_type && jl_subtype(elt, type_i))
                 continue;
             // kind slots always get guard entries (checking for subtypes of Type)
-            if (jl_subtype(elt, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i))
+            if (jl_subtype(elt, type_i) && !very_general_type(type_i))
                 continue;
             // jl_compilation_sig keeps a slot declared as a concrete kind (e.g.
             // `::DataType`) equal to that kind, making it the canonical form
@@ -1645,7 +1646,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
                 return 0; // Type{Union{}} gets normalized to typeof(Union{})
             }
             if (!jl_has_free_typevars(decl_i) &&
-                    jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {
+                    jl_subtype(kind, type_i) && !very_general_type(type_i)) {
                 JL_GC_POP();
                 return 0; // gets turned into a kind
             }

--- a/src/gf.c
+++ b/src/gf.c
@@ -1108,6 +1108,39 @@ jl_value_t *jl_nth_slot_type(jl_value_t *sig, size_t i) JL_NOTSAFEPOINT
 //    return 1;
 //}
 
+// look up the value bound for method typevar `tv` in the ordered environment
+// `sparams` (which parallels the unionall binders of `decl`); NULL if absent
+static jl_value_t *env_lookup_tvar(jl_value_t *decl, jl_svec_t *sparams JL_PROPAGATES_ROOT, jl_tvar_t *tv) JL_NOTSAFEPOINT
+{
+    size_t i = 0;
+    for (jl_value_t *ua = decl; jl_is_unionall(ua); ua = ((jl_unionall_t*)ua)->body, i++) {
+        if (((jl_unionall_t*)ua)->var == tv) {
+            if (sparams && i < jl_svec_len(sparams))
+                return jl_svecref(sparams, i);
+            return NULL;
+        }
+    }
+    return NULL;
+}
+
+// whether a slot declared as the bare method typevar `tv` binds the typevar
+// through `typeof` for an argument of type `kind`, making the kind the exact
+// specialization key for such arguments (no Type structure in the declaration
+// means the typevar cannot capture the type's identity, only its tag).
+// The environment's binding for `tv` decides: if it is itself Type-structured
+// (e.g. `K == Type{Int}` or `K == TypeEgal{Int}` pinned by a `Dict{K,V}`
+// argument), the slot does dispatch on type identity and must keep exact
+// specialization; requiring `kind <: binding` also keeps the widened
+// signature inside the method signature.
+static int typevar_slot_binds_kind(jl_value_t *decl, jl_svec_t *sparams, jl_tvar_t *tv, jl_value_t *kind)
+{
+    if (tv->lb != jl_bottom_type)
+        return 0;
+    jl_value_t *sp = env_lookup_tvar(decl, sparams, tv);
+    return sp != NULL && !jl_is_svec(sp) && !jl_is_typevar(sp) && jl_is_type(sp) &&
+           !jl_has_free_typevars(sp) && jl_subtype(kind, sp);
+}
+
 static jl_value_t *inst_varargp_in_env(jl_value_t *decl, jl_svec_t *sparams)
 {
     jl_value_t *unw = jl_unwrap_unionall(decl);
@@ -1254,16 +1287,36 @@ static void jl_compilation_sig(
             elt = type_i;
             jl_svecset(*newparams, i, elt);
         }
-        else if (jl_is_some_Type(elt)) {
-            // if the declared type was not Any or Union{Type, ...},
-            // then the match must been with the kind (e.g. UnionAll or DataType)
-            // and the result of matching the type signature
-            // needs to be restricted to the concrete type 'kind'
+        else if (jl_is_typeegal(elt) ||
+                 (jl_is_typeeq(elt) && jl_typeeq_T(elt) == jl_bottom_type)) {
+            // Only an egality-keyed slot pins the argument's kind: `TypeEgal{X}`'s
+            // sole member is the object X, of kind `typeof(X)`. An equality-keyed
+            // `Type{X}` covers every `==`-equal spelling of X, whose kinds may
+            // differ (e.g. `Union{S1,S2} where {S1<:Int,S2<:Int} == Int` is a
+            // UnionAll). `Type{Union{}}` is exempt: the bottom object is the
+            // unique member of its `==` class (and `TypeEgal{Union{}}` cannot
+            // be spelled; it normalizes to `typeof(Union{})`).
             jl_value_t *kind = jl_typeof(jl_some_Type_T(elt));
             if (!jl_has_free_typevars(decl_i) &&
                     jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {
-                // if we can prove the match was against the kind (not a Type)
-                // it's simpler (and thus better) to put that cache instead
+                // if the declared type was not Any or Union{Type, ...},
+                // then the match must been with the kind (e.g. UnionAll or DataType)
+                // and it's simpler (and thus better) to put that in the cache instead
+                if (!*newparams) *newparams = jl_svec_copy(tt->parameters);
+                elt = kind;
+                jl_svecset(*newparams, i, elt);
+            }
+            else if (jl_is_typevar(decl_i) &&
+                     typevar_slot_binds_kind(decl, sparams, (jl_tvar_t*)decl_i, kind) &&
+                     !(i_arg > 0 && i_arg <= 8 && (definition->called & (1 << (i_arg - 1))))) {
+                // a slot declared as a bare method typevar (e.g. the `key::K` of
+                // `setindex!(h::Dict{K,V}, v0, key::K)`) also matches type-valued
+                // arguments against the kind: with no Type structure in the
+                // effective slot type, the typevar binds `typeof(arg)`, not the
+                // type's identity, so the kind is the exact cache key. Without
+                // this we would specialize (and compile) such methods once per
+                // distinct type value passed. Skip called slots, as for the
+                // Type slot heuristic below (issue #36783).
                 if (!*newparams) *newparams = jl_svec_copy(tt->parameters);
                 elt = kind;
                 jl_svecset(*newparams, i, elt);
@@ -1543,6 +1596,12 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
             // jl_compilation_sig keeps a slot declared as a concrete kind (e.g.
             // `::DataType`) equal to that kind, making it the canonical form
             if (jl_is_kind(type_i) && jl_egal(elt, type_i))
+                continue;
+            // a bare-typevar slot matches type-valued arguments against the
+            // kind (see the matching heuristic in jl_compilation_sig)
+            if (jl_is_typevar(decl_i) &&
+                    typevar_slot_binds_kind(decl, sparams, (jl_tvar_t*)decl_i, elt) &&
+                    !(i_arg > 0 && i_arg <= 8 && (definition->called & (1 << (i_arg - 1)))))
                 continue;
             // TODO: other code paths that could reach here?
             JL_GC_POP();

--- a/src/gf.c
+++ b/src/gf.c
@@ -1109,8 +1109,8 @@ jl_value_t *jl_nth_slot_type(jl_value_t *sig, size_t i) JL_NOTSAFEPOINT
 //    return 1;
 //}
 
-// look up the value bound for method typevar `tv` in the ordered environment
-// `sparams` (which parallels the unionall binders of `decl`); NULL if absent
+// the value bound to method typevar `tv` in `sparams` (ordered as the
+// unionall binders of `decl`), or NULL
 static jl_value_t *env_lookup_tvar(jl_value_t *decl, jl_svec_t *sparams JL_PROPAGATES_ROOT, jl_tvar_t *tv) JL_NOTSAFEPOINT
 {
     size_t i = 0;
@@ -1124,15 +1124,11 @@ static jl_value_t *env_lookup_tvar(jl_value_t *decl, jl_svec_t *sparams JL_PROPA
     return NULL;
 }
 
-// whether a slot declared as the bare method typevar `tv` binds the typevar
-// through `typeof` for an argument of type `kind`, making the kind the exact
-// specialization key for such arguments (no Type structure in the declaration
-// means the typevar cannot capture the type's identity, only its tag).
-// The environment's binding for `tv` decides: if it is itself Type-structured
-// (e.g. `K == Type{Int}` or `K == TypeEgal{Int}` pinned by a `Dict{K,V}`
-// argument), the slot does dispatch on type identity and must keep exact
-// specialization; requiring `kind <: binding` also keeps the widened
-// signature inside the method signature.
+// whether a slot declared as the bare method typevar `tv` binds only the kind
+// of a type-valued argument: true unless the environment pins `tv` to a
+// Type-structured type (e.g. `K == Type{Int}` via another argument), in which
+// case the slot does dispatch on type identity. `kind <: binding` also keeps
+// the widened signature inside the method signature.
 static int typevar_slot_binds_kind(jl_value_t *decl, jl_svec_t *sparams, jl_tvar_t *tv, jl_value_t *kind)
 {
     if (tv->lb != jl_bottom_type)
@@ -1290,19 +1286,16 @@ static void jl_compilation_sig(
         }
         else if (jl_is_typeegal(elt) ||
                  (jl_is_typeeq(elt) && jl_typeeq_T(elt) == jl_bottom_type)) {
-            // Only an egality-keyed slot pins the argument's kind: `TypeEgal{X}`'s
-            // sole member is the object X, of kind `typeof(X)`. An equality-keyed
-            // `Type{X}` covers every `==`-equal spelling of X, whose kinds may
-            // differ (e.g. `Union{S1,S2} where {S1<:Int,S2<:Int} == Int` is a
-            // UnionAll). `Type{Union{}}` is exempt: the bottom object is the
-            // unique member of its `==` class (and `TypeEgal{Union{}}` cannot
-            // be spelled; it normalizes to `typeof(Union{})`).
+            // only an egality-keyed slot pins the argument's kind: a `Type{X}`
+            // matches every `==`-equal spelling of X, whose kinds may differ
+            // (except `Type{Union{}}`, which is alone in its `==` class)
             jl_value_t *kind = jl_typeof(jl_some_Type_T(elt));
             if (!jl_has_free_typevars(decl_i) &&
                     jl_subtype(kind, type_i) && !very_general_type(type_i)) {
-                // if the declared type was not Any or Union{Type, ...},
-                // then the match must been with the kind (e.g. UnionAll or DataType)
-                // and it's simpler (and thus better) to put that in the cache instead
+                // the declared type does not accept all type objects (that case
+                // takes the `Type`-widening path below), so the match must have been
+                // with the kind (e.g. UnionAll or DataType) and it's simpler (and
+                // thus better) to put that in the cache instead
                 if (!*newparams) *newparams = jl_svec_copy(tt->parameters);
                 elt = kind;
                 jl_svecset(*newparams, i, elt);
@@ -1311,13 +1304,10 @@ static void jl_compilation_sig(
                      typevar_slot_binds_kind(decl, sparams, (jl_tvar_t*)decl_i, kind) &&
                      !(i_arg > 0 && i_arg <= 8 && (definition->called & (1 << (i_arg - 1))))) {
                 // a slot declared as a bare method typevar (e.g. the `key::K` of
-                // `setindex!(h::Dict{K,V}, v0, key::K)`) also matches type-valued
-                // arguments against the kind: with no Type structure in the
-                // effective slot type, the typevar binds `typeof(arg)`, not the
-                // type's identity, so the kind is the exact cache key. Without
-                // this we would specialize (and compile) such methods once per
-                // distinct type value passed. Skip called slots, as for the
-                // Type slot heuristic below (issue #36783).
+                // `setindex!(h::Dict{K,V}, v0, key::K)`) binds only the kind of a
+                // type-valued argument, so cache the kind rather than specializing
+                // on every distinct type value passed (unless the argument is
+                // called, as for the heuristic below, issue #36783)
                 if (!*newparams) *newparams = jl_svec_copy(tt->parameters);
                 elt = kind;
                 jl_svecset(*newparams, i, elt);

--- a/test/core.jl
+++ b/test/core.jl
@@ -655,10 +655,9 @@ let m = only(methods(anytype_compilesig_61915))
     end
 end
 
-# a slot declared as a bare method typevar (`key::K`) matches type-valued
-# arguments against the kind — the typevar binds `typeof(arg)`, not the type's
-# identity — so the kind-widened signature is the compileable, cached form and
-# distinct type values do not each mint (and compile) a fresh specialization
+# a slot declared as a bare method typevar (`key::K`) binds only the kind of a
+# type-valued argument, so the kind-widened signature is the compileable form
+# and distinct type values don't each mint (and compile) a fresh specialization
 barekindspec(h::Dict{K,V}, key::K) where {K,V} = (K, V)
 let m = only(methods(barekindspec))
     exact = Tuple{typeof(barekindspec), Dict{Any,Nothing}, Core.TypeEgal{Int}}

--- a/test/core.jl
+++ b/test/core.jl
@@ -655,6 +655,54 @@ let m = only(methods(anytype_compilesig_61915))
     end
 end
 
+# a slot declared as a bare method typevar (`key::K`) matches type-valued
+# arguments against the kind — the typevar binds `typeof(arg)`, not the type's
+# identity — so the kind-widened signature is the compileable, cached form and
+# distinct type values do not each mint (and compile) a fresh specialization
+barekindspec(h::Dict{K,V}, key::K) where {K,V} = (K, V)
+let m = only(methods(barekindspec))
+    exact = Tuple{typeof(barekindspec), Dict{Any,Nothing}, Core.TypeEgal{Int}}
+    widened = Tuple{typeof(barekindspec), Dict{Any,Nothing}, DataType}
+    tienv = ccall(:jl_type_intersection_with_env, Any, (Any, Any), exact, m.sig)
+    @test ccall(:jl_normalize_to_compilable_sig, Any, (Any, Any, Any, Cint),
+                exact, tienv[2], m, 1) == widened
+    tienv = ccall(:jl_type_intersection_with_env, Any, (Any, Any), widened, m.sig)
+    @test ccall(:jl_isa_compileable_sig, Cint, (Any, Any, Any), widened, tienv[2], m) == 1
+    # dynamic dispatch caches through the widened entry: distinct type values
+    # do not accumulate specializations
+    d = Dict{Any,Nothing}()
+    for i in 1:40
+        @test barekindspec(d, Tuple{Val{i}}) === (Any, Nothing)
+    end
+    @test barekindspec(d, Vector) === (Any, Nothing) # UnionAll values use their own kind
+    @test length(Base.specializations(m)) <= 6
+    # when the typevar is pinned to a Type-structured key type, the slot does
+    # dispatch on type identity and must keep exact specialization
+    for KT in (Type{Int}, Core.TypeEgal{Int})
+        exact2 = Tuple{typeof(barekindspec), Dict{KT,Nothing}, Core.TypeEgal{Int}}
+        tienv2 = ccall(:jl_type_intersection_with_env, Any, (Any, Any), exact2, m.sig)
+        @test ccall(:jl_normalize_to_compilable_sig, Any, (Any, Any, Any, Cint),
+                    exact2, tienv2[2], m, 0) == exact2
+        widened2 = Tuple{typeof(barekindspec), Dict{KT,Nothing}, DataType}
+        tienv2 = ccall(:jl_type_intersection_with_env, Any, (Any, Any), widened2, m.sig)
+        @test ccall(:jl_isa_compileable_sig, Cint, (Any, Any, Any), widened2, tienv2[2], m) == 0
+    end
+    # an equality-keyed elt (`Type{X}`) covers every `==`-equal spelling of X,
+    # whose kinds may differ, so only egality-keyed elts kind-widen
+    exact3 = Tuple{typeof(barekindspec), Dict{Any,Nothing}, Type{Int}}
+    tienv3 = ccall(:jl_type_intersection_with_env, Any, (Any, Any), exact3, m.sig)
+    @test ccall(:jl_normalize_to_compilable_sig, Any, (Any, Any, Any, Cint),
+                exact3, tienv3[2], m, 0) == exact3
+end
+# but a called bare-typevar slot keeps exact specialization (issue #36783)
+barekindcalled(T::K, x) where {K} = T(x)
+let m = only(methods(barekindcalled))
+    @test barekindcalled(Int, 3.0) === 3
+    sig = Tuple{typeof(barekindcalled), DataType, Float64}
+    tienv = ccall(:jl_type_intersection_with_env, Any, (Any, Any), sig, m.sig)
+    @test ccall(:jl_isa_compileable_sig, Cint, (Any, Any, Any), sig, tienv[2], m) == 0
+end
+
 @test promote_type(Bool,Bottom) === Bool
 
 # type declarations

--- a/test/core.jl
+++ b/test/core.jl
@@ -702,6 +702,24 @@ let m = only(methods(barekindcalled))
     tienv = ccall(:jl_type_intersection_with_env, Any, (Any, Any), sig, m.sig)
     @test ccall(:jl_isa_compileable_sig, Cint, (Any, Any, Any), sig, tienv[2], m) == 0
 end
+# a slot that accepts every type object widens to `Type`, like `::Any`/`::Type`
+# slots, rather than specializing per type value
+verygeneralspec(x::Union{Type,Missing}) = x
+let m = only(methods(verygeneralspec))
+    for i in 1:20
+        @test verygeneralspec(Tuple{Val{i}}) === Tuple{Val{i}}
+    end
+    @test verygeneralspec(Vector) === Vector
+    @test verygeneralspec(missing) === missing
+    @test length(Base.specializations(m)) <= 5
+    widened = Tuple{typeof(verygeneralspec), Type}
+    tienv = ccall(:jl_type_intersection_with_env, Any, (Any, Any), widened, m.sig)
+    @test ccall(:jl_isa_compileable_sig, Cint, (Any, Any, Any), widened, tienv[2], m) == 1
+    exact = Tuple{typeof(verygeneralspec), Core.TypeEgal{Int}}
+    tienv = ccall(:jl_type_intersection_with_env, Any, (Any, Any), exact, m.sig)
+    @test ccall(:jl_normalize_to_compilable_sig, Any, (Any, Any, Any, Cint),
+                exact, tienv[2], m, 1) == widened
+end
 
 @test promote_type(Bool,Bottom) === Bool
 


### PR DESCRIPTION
A slot declared as a bare method typevar — e.g. the `key::K` of `setindex!(h::Dict{K,V}, v0, key::K)` — cannot capture a type-valued argument's identity, only its tag: the typevar binds `typeof(arg)` for such arguments. Nevertheless, `jl_compilation_sig` specialized these slots on the exact type value passed, because the existing kind-widening heuristic is guarded by `!jl_has_free_typevars(decl_i)`, which a bare typevar fails. As a result, inserting N distinct types into a `Dict{Any}`/`Set{Any}` minted (and natively compiled) N fresh MethodInstances of `setindex!`, at 10-200ms each.

This went from a latent wart to a CI outage with the Revise bump in e7fe47b022: Revise#1091's sigtest builds a Set of every Base method signature and queries it, which put ~2xN such dispatches on the `test revise` Buildkite job and pushed it past its 30-minute timeout on master and all PRs based on it (e.g.
https://buildkite.com/julialang/julia-pr/builds/72, where the job dies 18 minutes into silence after "beginning signatures tests"). The TypeEgal change made each per-value compile about twice as expensive, but the minting itself reproduces on 1.12.

Teach `jl_compilation_sig` (and symmetrically `jl_isa_compileable_sig`) to widen a type-valued argument at a bare-typevar slot to its kind, the exact key the typevar binds. The environment's binding for the typevar gates the widening: `kind <: binding` must hold, so a typevar pinned to a Type-structured key type (e.g. `K == Type{Int}` or `K == TypeEgal{Int}` via a `Dict{K,V}` argument) — where the slot does dispatch on type identity — keeps exact specialization, and the widened signature stays inside the method signature by construction. Called slots also keep exact specialization, as for the `Type` slot heuristic (issue #36783).

While there, restrict the surrounding kind-computation branch to egality-keyed elements: `typeof(jl_some_Type_T(elt))` is only the kind of the matched argument for `TypeEgal{X}` (whose sole member is X, plus the `Type{Union{}}` singleton); an equality-keyed `Type{X}` covers every `==`-equal spelling of X, and those spellings' kinds may differ (e.g. `Union{S1,S2} where {S1<:Int,S2<:Int} == Int` is a UnionAll), so its representative's tag is not a sound cover.

With this, inserting 300 distinct types into a `Set{Any}` drops from 7.3s to 0.05s (one compile instead of 300), and Revise's "Base signatures" testset completes in ~3.5 minutes instead of timing out.