### PR TITLE
[docs] Document `WITH_NVTX` build option

### DIFF
--- a/doc/src/devdocs/external_profilers.md
+++ b/doc/src/devdocs/external_profilers.md
@@ -140,9 +140,9 @@ Julia emits the same `JL_TIMING` zones used by Tracy and ITTAPI as NVTX ranges, 
 
 NVTX is header-only and its calls are cheap no-ops unless a tool is actively attached and capturing, so building with NVTX support does not require a CUDA toolkit installation and has minimal overhead when no profiler is attached.
 
-### Building Julia with NVTX
+### Building Julia with NVTX support
 
-To enable NVTX integration, build Julia with the extra option `WITH_NVTX := 1` in the `Make.user` file, or with `make ... WITH_NVTX=1` from the command line.
+To enable NVTX instrumentation of the Julia runtime, build Julia with the extra option `WITH_NVTX := 1` in the `Make.user` file, or with `make ... WITH_NVTX=1` from the command line.
 
 ### Profiling Julia with Nsight Systems
 
@@ -153,6 +153,11 @@ nsys profile -o my_julia_trace ./julia -e '...'
 ```
 
 Open the resulting `my_julia_trace.nsys-rep` file in the Nsight Systems UI to view Julia's timing zones on the NVTX row of the timeline, grouped and colored by subsystem in the same way as with Tracy.
+
+### Instrumenting arbitrary Julia code
+
+If you want to additionally annotate your Julia code with custom markers see [`NVTX.jl`](https://github.com/JuliaGPU/NVTX.jl), which works independently of the `WITH_NVTX=1` build option.
+You can still use the Nsight Systems profiler as explained above.
 
 ## Apple Instruments (OSLog)
 

--- a/doc/src/devdocs/external_profilers.md
+++ b/doc/src/devdocs/external_profilers.md
@@ -5,6 +5,7 @@ Julia provides explicit support for some external tracing profilers, enabling yo
 The currently supported profilers are:
 - [Tracy](https://github.com/wolfpld/tracy)
 - [Intel VTune (ITTAPI)](https://github.com/intel/ittapi)
+- [NVIDIA Nsight Systems (NVTX)](#NVIDIA-Nsight-Systems-(NVTX))
 - [Apple Instruments](#Apple-Instruments-(OSLog)) (macOS only)
 
 ### Adding New Zones
@@ -131,6 +132,27 @@ Note that the Julia JIT runtime does not yet have integration for Tracy's symbol
 ## Intel VTune (ITTAPI) Profiler
 
 *This section is yet to be written.*
+
+## NVIDIA Nsight Systems (NVTX)
+
+[NVTX](https://github.com/NVIDIA/NVTX) is NVIDIA's lightweight instrumentation API for annotating events, code ranges, and resources so they can be visualized by NVIDIA profiling tools.
+Julia emits the same `JL_TIMING` zones used by Tracy and ITTAPI as NVTX ranges, grouped and colored by subsystem, which can then be viewed in [NVIDIA Nsight Systems](https://developer.nvidia.com/nsight-systems).
+
+NVTX is header-only and its calls are cheap no-ops unless a tool is actively attached and capturing, so building with NVTX support does not require a CUDA toolkit installation and has minimal overhead when no profiler is attached.
+
+### Building Julia with NVTX
+
+To enable NVTX integration, build Julia with the extra option `WITH_NVTX := 1` in the `Make.user` file, or with `make ... WITH_NVTX=1` from the command line.
+
+### Profiling Julia with Nsight Systems
+
+With [Nsight Systems](https://developer.nvidia.com/nsight-systems) installed, you can record a trace from the command line using `nsys`:
+
+```
+nsys profile -o my_julia_trace ./julia -e '...'
+```
+
+Open the resulting `my_julia_trace.nsys-rep` file in the Nsight Systems UI to view Julia's timing zones on the NVTX row of the timeline, grouped and colored by subsystem in the same way as with Tracy.
 
 ## Apple Instruments (OSLog)
 


### PR DESCRIPTION
Add a section to external_profilers.md describing how to build Julia with NVTX support (`WITH_NVTX := 1`) and how to profile it with NVIDIA Nsight Systems, following the same pattern already used for Tracy and Intel VTune (ITTAPI).  CC @jackdfranklin

This commit was written with the assistance of generative AI, but I reviewed it and believe it's correct to the best of my knowledge.