### PR TITLE
signals-win: include the accessed address in exception reports

### DIFF
--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -345,8 +345,21 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
     default:
         jl_safe_fprintf(&summary, "UNKNOWN"); break;
     }
-    jl_safe_fprintf(&summary, " at 0x%zx -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+    jl_safe_fprintf(&summary, " at 0x%zx", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+    if (ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION ||
+        ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_IN_PAGE_ERROR) {
+        jl_safe_fprintf(&summary, " (%s 0x%zx)",
+                        ExceptionInfo->ExceptionRecord->ExceptionInformation[0] == 1 ? "writing" :
+                        ExceptionInfo->ExceptionRecord->ExceptionInformation[0] == 8 ? "executing" : "reading",
+                        (size_t)ExceptionInfo->ExceptionRecord->ExceptionInformation[1]);
+    }
+    jl_safe_fprintf(&summary, " -- ");
     jl_fprint_native_codeloc(&summary, (uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+    // runtime state that distinguishes crash classes (e.g. a NULL task->ptls
+    // from a corrupted pointer) without needing a debugger on the machine
+    jl_safe_fprintf(&summary, "current task: 0x%zx (ptls 0x%zx, eh 0x%zx)\n", (size_t)ct,
+                    (size_t)(ct == NULL ? NULL : (void*)ct->ptls),
+                    (size_t)(ct == NULL ? NULL : (void*)ct->eh));
     ios_write(&full_error, summary.buf, ios_pos(&summary));
     ios_puts("\nSee Application log in Event Viewer for more information.\n", &summary);
 


### PR DESCRIPTION
Windows crash reports printed only the faulting instruction pointer, not the address the instruction tried to access, so an access violation report could not distinguish e.g. a NULL-field dereference from a wild pointer or an unrecognized safepoint fault. In the julia-ci build 30 ccall-test crash, the faulting instruction was `mov 0x10(%r12),%rax` and knowing the accessed address (~0x10, implying ptls == NULL) required downloading the build artifact and disassembling it by hand:
https://buildkite.com/julialang/julia-ci/builds/30

Print the access kind (reading/writing/executing) and the accessed address for EXCEPTION_ACCESS_VIOLATION and EXCEPTION_IN_PAGE_ERROR, matching the information Unix signal reports get from si_addr.

This change was written with the assistance of generative AI (Claude).