### PR TITLE
gc: check for commit failure when allocating a pool page on Windows

### DIFF
--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -157,7 +157,20 @@ NOINLINE jl_gc_pagemeta_t *jl_gc_alloc_page(void) JL_NOTSAFEPOINT
     }
 exit:
 #ifdef _OS_WINDOWS_
-    VirtualAlloc(meta->data, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);
+    // The page was previously only reserved (jl_gc_try_alloc_pages_) or has been
+    // decommitted (jl_gc_free_page), so it needs to be committed before use. This
+    // charges the page against the system commit limit and can fail when that is
+    // exhausted; returning it anyway would hand out memory that raises an access
+    // violation on first touch, so undo and report out-of-memory instead (as
+    // jl_gc_try_alloc_pages does when the reservation itself fails).
+    if (VirtualAlloc(meta->data, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE) == NULL) {
+        gc_alloc_map_set(meta->data, GC_PAGE_FREED);
+        push_lf_back(&global_page_pool_freed, meta);
+        jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_resident, -(int64_t)GC_PAGE_SZ);
+        SetLastError(last_error);
+        errno = last_errno;
+        jl_throw(jl_memory_exception);
+    }
     SetLastError(last_error);
 #endif
     errno = last_errno;


### PR DESCRIPTION
On Windows, GC pool page blocks are only reserved (MEM_RESERVE) up front and each page is committed on demand in jl_gc_alloc_page -- but the result of that VirtualAlloc(MEM_COMMIT) was never checked. Unlike mmap on overcommitting systems, committing charges the page against the system commit limit and fails outright when RAM + pagefile are exhausted. The allocator then handed out a page that raises an access violation on first touch: a write while a handler is active surfaces as a spurious ReadOnlyMemoryError (as seen mid-inference on a memory-exhausted Windows CI tester in
https://buildkite.com/julialang/julia-ci/builds/23#019f29dd-d978-4a88-8393-4e3927decbd6), and a read produces a fatal EXCEPTION_ACCESS_VIOLATION crash report, both far from the actual failure.

Check the commit result: on failure, return the page to the decommitted pool and throw OutOfMemoryError, matching what jl_gc_try_alloc_pages already does when the reservation fails.

This change was written with the assistance of generative AI (Claude).