### PR TITLE
method: normalize kwcall callee self-type to the equality kind

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -1297,6 +1297,13 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
         jl_svecset(new_atypes, 0, ft);
         atypes = new_atypes;
     }
+    else if (jl_kwcall_type && ft == (jl_value_t*)jl_kwcall_type && nargs >= 3 &&
+             jl_is_typeegal(jl_svecref(atypes, 2))) {
+        // likewise for a keyword sorter, whose callee self-type is argument 2
+        new_atypes = jl_svec_copy(atypes);
+        jl_svecset(new_atypes, 2, jl_wrap_Type(jl_typeegal_T(jl_svecref(new_atypes, 2))));
+        atypes = new_atypes;
+    }
 
     argtype = jl_apply_tuple_type(atypes, 1);
     if (!jl_is_datatype(argtype))

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -400,3 +400,13 @@ function f50518(xs...=["a", "b", "c"]...; debug=false)
     return xs[1]
 end
 @test f50518() == f50518(;debug=false) == "a"
+
+# issue #62277
+struct Issue62277
+    S::Vector{Symbol}
+    Issue62277(s::Vector{Symbol}; cached=false) = new(s)
+end
+Issue62277(s::AbstractVector{<:Union{Char,AbstractString,Symbol}}; cached=false) =
+    Issue62277(Symbol.(s); cached)
+@test Issue62277([:a, :b]; cached=false).S == [:a, :b]
+@test Issue62277(['a', 'b']).S == [:a, :b]


### PR DESCRIPTION
thought I'd donate some tokens
cc @benlorenz

---------------------------------------------
A keyword sorter is defined as `kwcall(::NamedTuple, callee, args...)`, where the callee's self-type is spelled by lowering with `Core.Typeof`. Since #62001, `Core.Typeof` of a type value yields the egality `Core.TypeEgal` kind, and `jl_method_def` only normalized that back to the equality `Type` kind for the method's own function argument (position 0). The keyword sorter carries the real callee at argument 2, so its self-type stayed at the egality kind while the matching primary method used `Type`, making an inner and an outer keyword constructor mutually ambiguous.

Normalize the kwcall callee self-type the same way as the function argument, so the sorter and its primary method agree on the callee kind.

This pull request was written with the assistance of generative AI (Claude Fable 5).

Fixes #62277