### PR TITLE
fix minmax for missing

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -126,7 +126,7 @@ div(::Missing, ::Missing, r::RoundingMode) = missing
 div(::Missing, ::Number, r::RoundingMode) = missing
 div(::Number, ::Missing, r::RoundingMode) = missing
 
-for (f, result) in ((min, missing), (max, missing), (minmax, (missing, missing)))
+for (f, result) in ((:min, missing), (:max, missing), (:minmax, (missing, missing)))
     @eval begin
         $f(::Missing, ::Missing) = $result
         $f(::Missing, ::Any)     = $result

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -126,12 +126,14 @@ div(::Missing, ::Missing, r::RoundingMode) = missing
 div(::Missing, ::Number, r::RoundingMode) = missing
 div(::Number, ::Missing, r::RoundingMode) = missing
 
-min(::Missing, ::Missing) = missing
-min(::Missing, ::Any)     = missing
-min(::Any,     ::Missing) = missing
-max(::Missing, ::Missing) = missing
-max(::Missing, ::Any)     = missing
-max(::Any,     ::Missing) = missing
+for (f, result) in ((min, missing), (max, missing), (minmax, (missing, missing)))
+    @eval begin
+        $f(::Missing, ::Missing) = $result
+        $f(::Missing, ::Any)     = $result
+        $f(::Any,     ::Missing) = $result
+        $f(::Missing) = $result
+    end
+end
 clamp(::Missing, lo, hi) = missing
 
 missing_conversion_msg(@nospecialize T) =

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -100,12 +100,12 @@ end
         @test ismissing(f(missing, 1))
     end
 
-    @test ismissing(min(missing, missing))
-    @test ismissing(max(missing, missing))
-    for f in [min, max]
+    for (f, result) in ((min, missing), (max, missing), (minmax, (missing, missing)))
+        @test f(missing, missing) === result
+        @test f(missing) === result
         for arg in ["", "a", 1, -1.0, [2]]
-            @test ismissing(f(missing, arg))
-            @test ismissing(f(arg, missing))
+            @test f(missing, arg) === result
+            @test f(arg, missing) === result
         end
     end
 end


### PR DESCRIPTION
Fixes two parts of #61841 that were clear bugs and hence should hopefully be uncontroversial: `minmax(1, missing)` was returning `(1, missing)`, which is simply wrong, and the single-argument variants of `min`, `max`, and `minmax` didn't accept `missing` arguments even though the 2-argument variants supported `missing`.