### PR TITLE
cgmemmgr: suppress bogus -Warray-bounds from GCC 16 on LLVM headers

### DIFF
--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -1,5 +1,13 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+// GCC 16's `-Warray-bounds=` raises false positives against the inline storage of
+// llvm::unique_function (FunctionExtras.h, via PointerIntPair.h) as inlined into
+// JLJITLinkMemoryManager::InFlightAlloc::finalize below, and merely emitting those
+// diagnostics can crash GCC 16.1 outright (ICE in action_after_output, observed on the
+// mingw64 CI builders). The warnings are attributed to the LLVM headers, so the
+// suppression must precede their inclusion.
+#pragma GCC diagnostic ignored "-Warray-bounds"
+
 #include "llvm-version.h"
 #include "platform.h"
 


### PR DESCRIPTION
[Cherry-Picked from #62257, since the same issue has shown up on master now]

GCC 16.1 raises false-positive `-Warray-bounds=` warnings against the inline storage of llvm::unique_function (FunctionExtras.h, via PointerIntPair.h) as inlined into
JLJITLinkMemoryManager::InFlightAlloc::finalize, and merely emitting those diagnostics can crash the compiler outright with

    internal compiler error: in action_after_output, at context.cc:1055

as observed (nondeterministically) on the mingw64 CI builders, e.g. https://buildkite.com/julialang/julia-pr/builds/45#019f2929-01a7-42bf-a992-f711e5cab0e7 The ICE fires in the diagnostics machinery while the warning is being printed (other builds emit the same warnings and survive), so suppressing the known-bogus diagnostic also sidesteps the crash. The warnings are attributed to the LLVM header lines, so the suppression must precede their inclusion.