### PR TITLE
div: fix integer rem(x, y, RoundUp) negation overflow

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -127,6 +127,13 @@ rem(x, y, r::RoundingMode)
 rem(x, y, ::RoundingMode{:ToZero}) = rem(x, y)
 rem(x, y, ::RoundingMode{:Down}) = mod(x, y)
 rem(x, y, ::RoundingMode{:Up}) = mod(x, -y)
+# For integers, the `-y` above overflows when `y == typemin(typeof(y))` (and
+# wraps for all unsigned `y`), so `mod` is passed a divisor of the wrong sign;
+# this made `rem` disagree with `divrem`, return values outside the documented
+# interval, and violate `x == div(x, y, r)*y + rem(x, y, r)` — even though the
+# exact remainder is always representable.  Go through `divrem`, which computes
+# the remainder without negating the divisor.
+rem(x::Integer, y::Integer, r::RoundingMode{:Up}) = divrem(x, y, r)[2]
 rem(x, y, r::RoundingMode{:Nearest}) = x - y * div(x, y, r)
 rem(x::Integer, y::Integer, r::RoundingMode{:Nearest}) = divrem(x, y, r)[2]
 function rem(x::Integer, y::Integer, rnd::Union{typeof(RoundNearestTiesAway),

--- a/test/int.jl
+++ b/test/int.jl
@@ -440,18 +440,36 @@ end
     @test div(typemax(Int)-2, typemax(Int), RoundNearest) === 1
 
     # Exhaustively test (U)Int8 to catch any overflow-style issues
-    for r in (RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp, RoundFromZero)
+    for r in (RoundToZero, RoundDown, RoundUp, RoundFromZero,
+              RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp)
         for T in (UInt8, Int8)
             for x in typemin(T):typemax(T)
                 for y in typemin(T):typemax(T)
                     if y == 0 || (T <: Signed && x == typemin(T) && y == -1)
                         @test_throws DivideError div(x, y, r)
                     else
-                        @test div(x, y, r) == T(div(widen(T)(x), widen(T)(y), r))
+                        d = div(x, y, r)
+                        @test d == T(div(widen(T)(x), widen(T)(y), r))
+                        # rem must agree with divrem and, modulo 2^nbits, with
+                        # the exact remainder x - y*d.  rem(x, y, RoundUp) used
+                        # to be computed as mod(x, -y), whose -y overflows at
+                        # y == typemin(T) and wraps for all unsigned y, breaking
+                        # both properties (RoundFromZero delegates to RoundUp).
+                        @test divrem(x, y, r) === (d, rem(x, y, r))
+                        @test rem(x, y, r) === (widen(x) - widen(y) * widen(d)) % T
                     end
                 end
             end
         end
+    end
+
+    # the rem(x, y, RoundUp) negation-overflow corner at every signed width
+    for T in Base.BitSigned_types
+        tm = typemin(T)
+        @test rem(T(7), tm, RoundUp) === T(7)
+        @test divrem(T(7), tm, RoundUp) === (T(0), T(7))
+        @test rem(T(-7), tm, RoundFromZero) === typemax(T) - T(6)
+        @test div(T(-7), tm, RoundFromZero) * tm + rem(T(-7), tm, RoundFromZero) === T(-7)
     end
 end
 


### PR DESCRIPTION
`rem(x, y, ::RoundingMode{:Up})` is implemented as `mod(x, -y)`. For integers the negation overflows at `y == typemin(typeof(y))` (and wraps for every unsigned `y`), passing `mod` a divisor of the wrong sign. The result then disagrees with `divrem(x, y, RoundUp)[2]` (which the docstring calls equivalent), lies outside the documented result interval, and violates `x == div(x, y, r)*y + rem(x, y, r)`, even though the exact remainder is always representable:

```
    julia> rem(7, typemin(Int64), RoundUp)
    -9223372036854775801       # should be 7

    julia> divrem(7, typemin(Int64), RoundUp)
    (0, 7)                     # divrem is correct

    julia> rem(0x07, 0x02, RoundUp), divrem(0x07, 0x02, RoundUp)
    (0x07, (0x04, 0xff))       # unsigned: broken for any inexact quotient
```

`RoundFromZero` delegates to the `RoundUp` method and inherited the problem. Fix by giving `rem` an `Integer` method that goes through `divrem`, which computes the remainder without negating the divisor — the same pattern the `RoundNearest` modes already use. The float/generic path is unchanged. Also document that for unsigned arguments a remainder that would be mathematically negative wraps (matching `divrem`).

The defect was found by attempting to machine-prove the identity `rem(a, b, RoundUp) == a - b*div(a, b, RoundUp)` over all Int64 pairs with an SMT solver; the counterexample search pinned `b == typemin` as the only failing region. It reproduces on every version tested back to 1.6; the 1.9 `divrem` rework (which computes the pair correctly) is what opened the `rem`/`divrem` disagreement.