### PR TITLE
ranges: fix internal overflow in mod(x, r::AbstractUnitRange)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1535,7 +1535,38 @@ julia> mod(3, 0:2)  # mod(3, 3)
      This method requires at least Julia 1.3.
 """
 mod(i::Integer, r::OneTo) = mod1(i, last(r))
-mod(i::Integer, r::AbstractUnitRange{<:Integer}) = mod(i-first(r), length(r)) + first(r)
+function mod(i::Integer, r::AbstractUnitRange{<:Integer})
+    # The naive `mod(i - first(r), length(r)) + first(r)` overflows in
+    # `i - first(r)` (yielding a wrong residue whenever the length does not
+    # divide 2^nbits) and, for ranges of more than `typemax` values, uses a
+    # wrapped `length` (yielding results outside the range).
+    fst, lst = first(r), last(r)
+    R = promote_type(typeof(i), eltype(r), typeof(length(r)))
+    # no division at all when `i` is already a member
+    fst <= i <= lst && return convert(R, i)
+    if i isa BitInteger && eltype(r) <: BitInteger
+        # Reduce the DISTANCE from `i` to the range instead of `i - first(r)`:
+        # unsigned differences of promoted values are exact, so a single
+        # unsigned `rem` is overflow-free for EVERY span (`i ∉ r` rules out the
+        # full range; the empty range gives `nu == 0` and throws DivideError,
+        # as before).  The results below are members of `r`, so the wrapping
+        # `% P` arithmetic reproduces them exactly.
+        P = promote_type(typeof(i), eltype(r))
+        U = unsigned(P)
+        ip, fstp, lstp = P(i), P(fst), P(lst)
+        nu = ((lstp % U) - (fstp % U)) + one(U)         # == length(r), exactly
+        if ip > lstp
+            m = ((ip % U) - (fstp % U)) % nu            # (i - first(r)) mod length
+            return convert(R, fstp + (m % P))
+        else
+            m = ((fstp % U) - (ip % U)) % nu            # (first(r) - i) mod length
+            return convert(R, m == zero(U) ? fstp : lstp - ((m - one(U)) % P))
+        end
+    end
+    # generic path (e.g. BigInt), where the arithmetic cannot silently wrap;
+    # `checked_length` guards the (BitInteger-range) spans longer than typemax
+    return convert(R, mod(i - fst, checked_length(r)) + fst)
+end
 
 
 """

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2137,6 +2137,32 @@ end
     @test_throws MethodError mod(3, UnitRange(1.0,5.0))
     @test_throws MethodError mod(3, 1:2:7)
     @test_throws DivideError mod(3, 1:0)
+
+    # mod used to be computed as `mod(i - first(r), length(r)) + first(r)`,
+    # where `i - first(r)` can overflow (wrong residue) and, for ranges of more
+    # than `typemax` values, `length(r)` wraps (results outside the range).
+    @test mod(typemax(Int), -10:10) == 7
+    @test mod(typemin(Int), 3:23) == 13
+    @test mod(typemax(Int), typemin(Int):typemin(Int)+8) == typemin(Int) + 6
+    @test mod(5, 0:typemax(Int)) == 5
+    @test mod(-5, 0:typemax(Int)) == typemax(Int) - 4
+    @test mod(5, typemin(Int):typemax(Int)) == 5
+    @test mod(5, typemin(Int):0) == typemin(Int) + 4
+    # exhaustive over Int8 triples, against exact (widened) arithmetic
+    let bad = nothing
+        for x in typemin(Int8):typemax(Int8), lo in typemin(Int8):typemax(Int8), hi in typemin(Int8):typemax(Int8)
+            lo <= hi || continue
+            y = mod(x, lo:hi)
+            if !(y in lo:hi && mod(Int(x) - Int(y), Int(hi) - Int(lo) + 1) == 0)
+                bad = (x, lo, hi, y)
+                break
+            end
+        end
+        @test bad === nothing
+    end
+    # a dividend wider than the range's element type is reduced exactly
+    @test mod(Int128(2)^100, -3:11) == mod(Int128(2)^100 + 3, 15) - 3
+    @test mod(typemax(Int64), Int8(-10):Int8(10)) == 7
 end
 
 @testset "clamp with unitrange" begin


### PR DESCRIPTION
`mod(i, r)` was computed as `mod(i - first(r), length(r)) + first(r)`, which overflows in two ways, both breaking the documented contract ("Find `y` in the range `r` such that x ≡ y (mod n)"):

* `i - first(r)` wraps whenever the true difference exceeds typemax, silently changing the residue for any length that does not divide 2^nbits (present since the method was added in 1.3):

      julia> mod(typemax(Int), -10:10)
      -9                        # should be 7

* `length(r)` wraps for ranges of more than `typemax` values, producing results outside the range, or a DivideError for the full range (Julia 1.6 threw OverflowError here; the silent wrong answers are a ~1.9 regression):

      julia> mod(5, 0:typemax(Int))
      -9223372036854775803      # not in the range; should be 5

Fix by testing membership first (no division at all in that case, which is also faster than the old unconditional division) and otherwise reducing the exact unsigned distance from `i` to the nearer endpoint with a single unsigned `rem` — unsigned differences of promoted values cannot overflow for any span, so this returns the mathematically correct member for every nonempty range, including those longer than `typemax` (the empty range still throws DivideError). Non-BitInteger integers (e.g. BigInt) keep the original formula, which cannot silently wrap for them, with `checked_length` guarding the huge-range case.

The defect was found by attempting to machine-prove the documented contract over all Int64 triples with an SMT solver, which instead returned counterexamples for each overflow mode; with this fix the membership half of the contract machine-proves over all Int64 triples, and the residue half verifies exhaustively at Int8.