### PR TITLE
lowering: spell method self-types with new Core.TypeEqOf

### DIFF
--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -487,7 +487,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
                        (ex, "function_type of local without known closure type"))
             ctx.closure_infos[func_name.var_id].type_name
         else
-            @ast ctx ex [K"call" "Typeof"::K"core" _convert_closures(ctx, func_name)]
+            @ast ctx ex [K"call" "TypeEqOf"::K"core" _convert_closures(ctx, func_name)]
         end
     elseif k == K"method_defs"
         name = ex[1]

--- a/JuliaLowering/test/assignments_ir.jl
+++ b/JuliaLowering/test/assignments_ir.jl
@@ -48,7 +48,7 @@ end
 1   (method TestMod.b)
 2   latestworld
 3   TestMod.b
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
 7   SourceLocation::3:9

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -115,7 +115,7 @@ end
     4   (return %₁)
 13  latestworld
 14  TestMod.f
-15  (call core.Typeof %₁₄)
+15  (call core.TypeEqOf %₁₄)
 16  (call core.svec %₁₅ core.Any)
 17  (call core.svec)
 18  SourceLocation::1:10
@@ -171,7 +171,7 @@ end
     2   (return %₁)
 13  latestworld
 14  TestMod.foo
-15  (call core.Typeof %₁₄)
+15  (call core.TypeEqOf %₁₄)
 16  (call core.svec %₁₅ core.Any)
 17  (call core.svec)
 18  SourceLocation::1:10
@@ -227,7 +227,7 @@ end
     3   (return %₁)
 13  latestworld
 14  TestMod.f
-15  (call core.Typeof %₁₄)
+15  (call core.TypeEqOf %₁₄)
 16  (call core.svec %₁₅ core.Any)
 17  (call core.svec)
 18  SourceLocation::1:10
@@ -274,7 +274,7 @@ end
 13  latestworld
 14  (= slot₁/T (call core.TypeVar :T))
 15  TestMod.f
-16  (call core.Typeof %₁₅)
+16  (call core.TypeEqOf %₁₅)
 17  slot₁/T
 18  (call core.svec %₁₆ %₁₇)
 19  slot₁/T
@@ -331,7 +331,7 @@ end
     6   (return %₅)
 13  latestworld
 14  TestMod.f
-15  (call core.Typeof %₁₄)
+15  (call core.TypeEqOf %₁₄)
 16  (call core.svec %₁₅ core.Any)
 17  (call core.svec)
 18  SourceLocation::1:10
@@ -396,7 +396,7 @@ end
 5   (method TestMod.f)
 6   latestworld
 7   TestMod.f
-8   (call core.Typeof %₇)
+8   (call core.TypeEqOf %₇)
 9   (call core.svec %₈)
 10  (call core.svec)
 11  SourceLocation::3:14
@@ -785,7 +785,7 @@ end
     2   (return %₁)
 13  latestworld
 14  TestMod.f_after_if
-15  (call core.Typeof %₁₄)
+15  (call core.TypeEqOf %₁₄)
 16  (call core.svec %₁₅ core.Any)
 17  (call core.svec)
 18  SourceLocation::1:10
@@ -832,7 +832,7 @@ end
     2   (return %₁)
 13  latestworld
 14  TestMod.f_ternary
-15  (call core.Typeof %₁₄)
+15  (call core.TypeEqOf %₁₄)
 16  (call core.svec %₁₅ core.Any)
 17  (call core.svec)
 18  SourceLocation::1:10
@@ -885,7 +885,7 @@ end
     2   (return %₁)
 13  latestworld
 14  TestMod.f_or_guard
-15  (call core.Typeof %₁₄)
+15  (call core.TypeEqOf %₁₄)
 16  (call core.svec %₁₅ core.Any)
 17  (call core.svec)
 18  SourceLocation::1:10
@@ -944,7 +944,7 @@ end
     2   (return %₁)
 13  latestworld
 14  TestMod.f_arg_reassign
-15  (call core.Typeof %₁₄)
+15  (call core.TypeEqOf %₁₄)
 16  (call core.svec %₁₅ core.Any)
 17  (call core.svec)
 18  SourceLocation::1:10
@@ -1033,7 +1033,7 @@ end
     2   (return %₁)
 13  latestworld
 14  TestMod.f_local_no_box
-15  (call core.Typeof %₁₄)
+15  (call core.TypeEqOf %₁₄)
 16  (call core.svec %₁₅)
 17  (call core.svec)
 18  SourceLocation::1:10
@@ -1077,7 +1077,7 @@ end
     2   (return %₁)
 13  latestworld
 14  TestMod.f_typed_local_no_box
-15  (call core.Typeof %₁₄)
+15  (call core.TypeEqOf %₁₄)
 16  (call core.svec %₁₅)
 17  (call core.svec)
 18  SourceLocation::1:10

--- a/JuliaLowering/test/decls_ir.jl
+++ b/JuliaLowering/test/decls_ir.jl
@@ -377,7 +377,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -460,7 +460,7 @@ end
 3   (call core.declare_global TestMod :x false)
 4   latestworld
 5   TestMod.f
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   (call core.svec %₆)
 8   (call core.svec)
 9   SourceLocation::1:10
@@ -490,7 +490,7 @@ end
 5   (call core.declare_global TestMod :x true)
 6   latestworld
 7   TestMod.f
-8   (call core.Typeof %₇)
+8   (call core.TypeEqOf %₇)
 9   (call core.svec %₈)
 10  (call core.svec)
 11  SourceLocation::1:10
@@ -526,7 +526,7 @@ end
 3   (call core.declare_global TestMod :x false)
 4   latestworld
 5   TestMod.f
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   (call core.svec %₆)
 8   (call core.svec)
 9   SourceLocation::1:10

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -17,7 +17,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -40,7 +40,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   TestMod.T
 6   (call core.svec %₄ %₅ core.Any)
 7   (call core.svec)
@@ -63,7 +63,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   TestMod.T
 6   (call core.svec %₄ core.Any %₅)
 7   (call core.svec)
@@ -86,7 +86,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.apply_type core.Vararg core.Any)
 6   (call core.svec %₄ core.Any %₅)
 7   (call core.svec)
@@ -109,7 +109,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   TestMod.T
 6   (call core.apply_type core.Vararg %₅)
 7   (call core.svec %₄ core.Any %₆)
@@ -148,7 +148,7 @@ end
 4   (= slot₂/V (call core.TypeVar :V))
 5   (= slot₃/T (call core.TypeVar :T))
 6   TestMod.f
-7   (call core.Typeof %₆)
+7   (call core.TypeEqOf %₆)
 8   slot₃/T
 9   slot₁/U
 10  slot₂/V
@@ -182,7 +182,7 @@ end
 4   TestMod.Y
 5   (= slot₁/T (call core.TypeVar :T %₃ %₄))
 6   TestMod.f
-7   (call core.Typeof %₆)
+7   (call core.TypeEqOf %₆)
 8   TestMod.S
 9   slot₁/T
 10  (call core.apply_type %₈ %₉)
@@ -210,7 +210,7 @@ end
 3   TestMod.X
 4   (= slot₁/T (call core.TypeVar :T %₃ core.Any))
 5   TestMod.f
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   TestMod.S
 8   slot₁/T
 9   (call core.apply_type %₇ %₈)
@@ -242,7 +242,7 @@ end
 6   (call core.apply_type %₄ %₅)
 7   (= slot₂/S (call core.TypeVar :S %₆))
 8   TestMod.f
-9   (call core.Typeof %₈)
+9   (call core.TypeEqOf %₈)
 10  slot₂/S
 11  (call core.svec %₉ core.Any %₁₀)
 12  slot₁/T
@@ -272,7 +272,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -308,7 +308,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -418,7 +418,7 @@ end
 #---------------------
 1   TestMod.A
 2   (call top.getproperty %₁ :f)
-3   (call core.Typeof %₂)
+3   (call core.TypeEqOf %₂)
 4   (call core.svec %₃)
 5   (call core.svec)
 6   SourceLocation::1:10
@@ -456,7 +456,7 @@ function var".f"(); end
 1   (method TestMod..f)
 2   latestworld
 3   TestMod..f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -487,7 +487,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   TestMod.T
 6   (call core.svec %₄ %₅)
 7   (call core.svec)
@@ -501,7 +501,7 @@ end
     4   (return %₃)
 11  latestworld
 12  TestMod.f
-13  (call core.Typeof %₁₂)
+13  (call core.TypeEqOf %₁₂)
 14  TestMod.T
 15  TestMod.S
 16  (call core.svec %₁₃ %₁₄ %₁₅)
@@ -514,7 +514,7 @@ end
     2   (return %₁)
 21  latestworld
 22  TestMod.f
-23  (call core.Typeof %₂₂)
+23  (call core.TypeEqOf %₂₂)
 24  TestMod.T
 25  TestMod.S
 26  TestMod.U
@@ -539,7 +539,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -553,7 +553,7 @@ end
     5   (return %₄)
 10  latestworld
 11  TestMod.f
-12  (call core.Typeof %₁₁)
+12  (call core.TypeEqOf %₁₁)
 13  (call core.svec %₁₂ core.Any)
 14  (call core.svec)
 15  SourceLocation::1:10
@@ -564,7 +564,7 @@ end
     2   (return %₁)
 18  latestworld
 19  TestMod.f
-20  (call core.Typeof %₁₉)
+20  (call core.TypeEqOf %₁₉)
 21  (call core.svec %₂₀ core.Any core.Any)
 22  (call core.svec)
 23  SourceLocation::1:10
@@ -586,7 +586,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   TestMod.Int
 6   (call core.svec %₄ %₅)
 7   (call core.svec)
@@ -600,7 +600,7 @@ end
     4   (return %₃)
 11  latestworld
 12  TestMod.f
-13  (call core.Typeof %₁₂)
+13  (call core.TypeEqOf %₁₂)
 14  TestMod.Int
 15  (call core.svec %₁₃ %₁₄ core.Any)
 16  (call core.svec)
@@ -612,7 +612,7 @@ end
     2   (return %₁)
 20  latestworld
 21  TestMod.f
-22  (call core.Typeof %₂₁)
+22  (call core.TypeEqOf %₂₁)
 23  TestMod.Int
 24  (call core.svec %₂₂ %₂₃ core.Any core.Any)
 25  (call core.svec)
@@ -635,7 +635,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   TestMod.Int
 6   (call core.svec %₄ %₅)
 7   (call core.svec)
@@ -647,7 +647,7 @@ end
     2   (return %₁)
 11  latestworld
 12  TestMod.f
-13  (call core.Typeof %₁₂)
+13  (call core.TypeEqOf %₁₂)
 14  TestMod.Int
 15  (call core.svec %₁₃ %₁₄ core.Any)
 16  (call core.svec)
@@ -671,7 +671,7 @@ end
 2   latestworld
 3   (= slot₁/T (call core.TypeVar :T))
 4   TestMod.f
-5   (call core.Typeof %₄)
+5   (call core.TypeEqOf %₄)
 6   slot₁/T
 7   (call core.svec %₅ %₆)
 8   slot₁/T
@@ -689,7 +689,7 @@ end
 15  slot₁/T
 16  (= slot₂/S (call core.TypeVar :S %₁₅))
 17  TestMod.f
-18  (call core.Typeof %₁₇)
+18  (call core.TypeEqOf %₁₇)
 19  slot₁/T
 20  slot₂/S
 21  (call core.svec %₁₈ %₁₉ %₂₀)
@@ -709,7 +709,7 @@ end
 32  slot₂/S
 33  (= slot₃/U (call core.TypeVar :U %₃₂))
 34  TestMod.f
-35  (call core.Typeof %₃₄)
+35  (call core.TypeEqOf %₃₄)
 36  slot₁/T
 37  slot₂/S
 38  slot₃/U
@@ -739,7 +739,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -757,7 +757,7 @@ end
 14  (call core.apply_type %₁₂ %₁₃)
 15  (= slot₂/S (call core.TypeVar :S %₁₄))
 16  TestMod.f
-17  (call core.Typeof %₁₆)
+17  (call core.TypeEqOf %₁₆)
 18  slot₂/S
 19  (call core.svec %₁₇ core.Any %₁₈)
 20  slot₁/T
@@ -777,7 +777,7 @@ end
 31  (= slot₂/S (call core.TypeVar :S %₃₀))
 32  (= slot₃/U (call core.TypeVar :U))
 33  TestMod.f
-34  (call core.Typeof %₃₃)
+34  (call core.TypeEqOf %₃₃)
 35  slot₂/S
 36  slot₃/U
 37  (call core.svec %₃₄ core.Any %₃₅ %₃₆)
@@ -807,7 +807,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -818,7 +818,7 @@ end
     2   (return %₁)
 10  latestworld
 11  TestMod.f
-12  (call core.Typeof %₁₁)
+12  (call core.TypeEqOf %₁₁)
 13  (call core.apply_type core.Vararg core.Any)
 14  (call core.svec %₁₂ core.Any %₁₃)
 15  (call core.svec)
@@ -853,7 +853,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -864,7 +864,7 @@ end
     2   (return %₁)
 10  latestworld
 11  TestMod.f
-12  (call core.Typeof %₁₁)
+12  (call core.TypeEqOf %₁₁)
 13  (call core.apply_type core.Vararg core.Any)
 14  (call core.svec %₁₂ %₁₃)
 15  (call core.svec)
@@ -887,7 +887,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -899,7 +899,7 @@ end
     3   (return %₂)
 10  latestworld
 11  TestMod.f
-12  (call core.Typeof %₁₁)
+12  (call core.TypeEqOf %₁₁)
 13  (call core.apply_type core.Vararg core.Any)
 14  (call core.svec %₁₂ %₁₃)
 15  (call core.svec)
@@ -921,7 +921,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -947,7 +947,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -959,7 +959,7 @@ end
     3   (return %₂)
 10  latestworld
 11  TestMod.f
-12  (call core.Typeof %₁₁)
+12  (call core.TypeEqOf %₁₁)
 13  TestMod.T
 14  (call core.apply_type core.Vararg %₁₃)
 15  (call core.svec %₁₂ %₁₄)
@@ -1119,7 +1119,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -1131,7 +1131,7 @@ end
     3   (return %₂)
 10  latestworld
 11  TestMod.f
-12  (call core.Typeof %₁₁)
+12  (call core.TypeEqOf %₁₁)
 13  (call core.svec %₁₂ core.Any)
 14  (call core.svec)
 15  SourceLocation::1:10
@@ -1158,7 +1158,7 @@ function f(_, _); end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -1178,7 +1178,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -1203,7 +1203,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -1277,7 +1277,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -1300,7 +1300,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -1326,7 +1326,7 @@ end
 3   (method TestMod.f)
 4   latestworld
 5   TestMod.f
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   (call core.svec %₆)
 8   (call core.svec)
 9   SourceLocation:nothing:4:0
@@ -1404,11 +1404,11 @@ end
 3   (method TestMod.f_kw_simple)
 4   latestworld
 5   TestMod.#kw_body#f_kw_simple#0
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   TestMod.Char
 8   TestMod.Bool
 9   TestMod.f_kw_simple
-10  (call core.Typeof %₉)
+10  (call core.TypeEqOf %₉)
 11  TestMod.Int
 12  TestMod.Float64
 13  (call core.svec %₆ %₇ %₈ %₁₀ %₁₁ %₁₂)
@@ -1422,7 +1422,7 @@ end
     3   (return %₂)
 18  latestworld
 19  TestMod.f_kw_simple
-20  (call core.Typeof %₁₉)
+20  (call core.TypeEqOf %₁₉)
 21  (call core.svec %₂₀)
 22  (call core.svec)
 23  SourceLocation::1:10
@@ -1435,7 +1435,7 @@ end
     4   (return %₃)
 26  latestworld
 27  TestMod.f_kw_simple
-28  (call core.Typeof %₂₇)
+28  (call core.TypeEqOf %₂₇)
 29  TestMod.Int
 30  (call core.svec %₂₈ %₂₉)
 31  (call core.svec)
@@ -1447,7 +1447,7 @@ end
     2   (return %₁)
 35  latestworld
 36  TestMod.f_kw_simple
-37  (call core.Typeof %₃₆)
+37  (call core.TypeEqOf %₃₆)
 38  TestMod.Int
 39  TestMod.Float64
 40  (call core.svec %₃₇ %₃₈ %₃₉)
@@ -1462,7 +1462,7 @@ end
 45  latestworld
 46  (call core.typeof core.kwcall)
 47  TestMod.f_kw_simple
-48  (call core.Typeof %₄₇)
+48  (call core.TypeEqOf %₄₇)
 49  (call core.svec %₄₆ core.NamedTuple %₄₈)
 50  (call core.svec)
 51  SourceLocation::1:10
@@ -1476,7 +1476,7 @@ end
 54  latestworld
 55  (call core.typeof core.kwcall)
 56  TestMod.f_kw_simple
-57  (call core.Typeof %₅₆)
+57  (call core.TypeEqOf %₅₆)
 58  TestMod.Int
 59  (call core.svec %₅₅ core.NamedTuple %₅₇ %₅₈)
 60  (call core.svec)
@@ -1489,7 +1489,7 @@ end
 64  latestworld
 65  (call core.typeof core.kwcall)
 66  TestMod.f_kw_simple
-67  (call core.Typeof %₆₆)
+67  (call core.TypeEqOf %₆₆)
 68  TestMod.Int
 69  TestMod.Float64
 70  (call core.svec %₆₅ core.NamedTuple %₆₇ %₆₈ %₆₉)
@@ -1553,9 +1553,9 @@ function f_kw_placeholders(; _=1, _=2); end
 3   (method TestMod.f_kw_placeholders)
 4   latestworld
 5   TestMod.#kw_body#f_kw_placeholders#0
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   TestMod.f_kw_placeholders
-8   (call core.Typeof %₇)
+8   (call core.TypeEqOf %₇)
 9   (call core.svec %₆ core.Any core.Any %₈)
 10  (call core.svec)
 11  SourceLocation::1:10
@@ -1566,7 +1566,7 @@ function f_kw_placeholders(; _=1, _=2); end
     2   (return core.nothing)
 14  latestworld
 15  TestMod.f_kw_placeholders
-16  (call core.Typeof %₁₅)
+16  (call core.TypeEqOf %₁₅)
 17  (call core.svec %₁₆)
 18  (call core.svec)
 19  SourceLocation::1:10
@@ -1579,7 +1579,7 @@ function f_kw_placeholders(; _=1, _=2); end
 22  latestworld
 23  (call core.typeof core.kwcall)
 24  TestMod.f_kw_placeholders
-25  (call core.Typeof %₂₄)
+25  (call core.TypeEqOf %₂₄)
 26  (call core.svec %₂₃ core.NamedTuple %₂₅)
 27  (call core.svec)
 28  SourceLocation::1:10
@@ -1624,10 +1624,10 @@ end
 3   (method TestMod.f_kw_slurp_simple)
 4   latestworld
 5   TestMod.#kw_body#f_kw_slurp_simple#0
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   (call top.pairs core.NamedTuple)
 8   TestMod.f_kw_slurp_simple
-9   (call core.Typeof %₈)
+9   (call core.TypeEqOf %₈)
 10  (call core.svec %₆ %₇ %₉)
 11  (call core.svec)
 12  SourceLocation::1:10
@@ -1639,7 +1639,7 @@ end
     3   (return %₂)
 15  latestworld
 16  TestMod.f_kw_slurp_simple
-17  (call core.Typeof %₁₆)
+17  (call core.TypeEqOf %₁₆)
 18  (call core.svec %₁₇)
 19  (call core.svec)
 20  SourceLocation::1:10
@@ -1654,7 +1654,7 @@ end
 23  latestworld
 24  (call core.typeof core.kwcall)
 25  TestMod.f_kw_slurp_simple
-26  (call core.Typeof %₂₅)
+26  (call core.TypeEqOf %₂₅)
 27  (call core.svec %₂₄ core.NamedTuple %₂₆)
 28  (call core.svec)
 29  SourceLocation::1:10
@@ -1680,10 +1680,10 @@ end
 3   (method TestMod.f_kw_slurp)
 4   latestworld
 5   TestMod.#kw_body#f_kw_slurp#0
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   (call top.pairs core.NamedTuple)
 8   TestMod.f_kw_slurp
-9   (call core.Typeof %₈)
+9   (call core.TypeEqOf %₈)
 10  (call core.svec %₆ core.Any %₇ %₉)
 11  (call core.svec)
 12  SourceLocation::1:10
@@ -1695,7 +1695,7 @@ end
     3   (return %₂)
 15  latestworld
 16  TestMod.f_kw_slurp
-17  (call core.Typeof %₁₆)
+17  (call core.TypeEqOf %₁₆)
 18  (call core.svec %₁₇)
 19  (call core.svec)
 20  SourceLocation::1:10
@@ -1711,7 +1711,7 @@ end
 23  latestworld
 24  (call core.typeof core.kwcall)
 25  TestMod.f_kw_slurp
-26  (call core.Typeof %₂₅)
+26  (call core.TypeEqOf %₂₅)
 27  (call core.svec %₂₄ core.NamedTuple %₂₆)
 28  (call core.svec)
 29  SourceLocation::1:10
@@ -1752,10 +1752,10 @@ end
 3   (method TestMod.f_kw_slurp_dep)
 4   latestworld
 5   TestMod.#kw_body#f_kw_slurp_dep#0
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   (call top.pairs core.NamedTuple)
 8   TestMod.f_kw_slurp_dep
-9   (call core.Typeof %₈)
+9   (call core.TypeEqOf %₈)
 10  (call core.svec %₆ core.Any core.Any %₇ %₉)
 11  (call core.svec)
 12  SourceLocation::1:10
@@ -1767,7 +1767,7 @@ end
     3   (return %₂)
 15  latestworld
 16  TestMod.f_kw_slurp_dep
-17  (call core.Typeof %₁₆)
+17  (call core.TypeEqOf %₁₆)
 18  (call core.svec %₁₇)
 19  (call core.svec)
 20  SourceLocation::1:10
@@ -1786,7 +1786,7 @@ end
 23  latestworld
 24  (call core.typeof core.kwcall)
 25  TestMod.f_kw_slurp_dep
-26  (call core.Typeof %₂₅)
+26  (call core.TypeEqOf %₂₅)
 27  (call core.svec %₂₄ core.NamedTuple %₂₆)
 28  (call core.svec)
 29  SourceLocation::1:10
@@ -1837,11 +1837,11 @@ end
 5   (= slot₁/X (call core.TypeVar :X))
 6   (= slot₂/A (call core.TypeVar :A))
 7   TestMod.#kw_body#f_kw_sparams#0
-8   (call core.Typeof %₇)
+8   (call core.TypeEqOf %₇)
 9   slot₂/A
 10  slot₁/X
 11  TestMod.f_kw_sparams
-12  (call core.Typeof %₁₁)
+12  (call core.TypeEqOf %₁₁)
 13  slot₁/X
 14  (call core.svec %₈ %₉ %₁₀ %₁₂ %₁₃)
 15  slot₁/X
@@ -1859,7 +1859,7 @@ end
 21  latestworld
 22  (= slot₃/X (call core.TypeVar :X))
 23  TestMod.f_kw_sparams
-24  (call core.Typeof %₂₃)
+24  (call core.TypeEqOf %₂₃)
 25  slot₃/X
 26  (call core.svec %₂₄ %₂₅)
 27  slot₃/X
@@ -1877,7 +1877,7 @@ end
 33  (= slot₄/X (call core.TypeVar :X))
 34  (call core.typeof core.kwcall)
 35  TestMod.f_kw_sparams
-36  (call core.Typeof %₃₅)
+36  (call core.TypeEqOf %₃₅)
 37  slot₄/X
 38  (call core.svec %₃₄ core.NamedTuple %₃₆ %₃₇)
 39  slot₄/X
@@ -1936,10 +1936,10 @@ end
 3   (method TestMod.f_kw_slurp)
 4   latestworld
 5   TestMod.#kw_body#f_kw_slurp#1
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   (call top.pairs core.NamedTuple)
 8   TestMod.f_kw_slurp
-9   (call core.Typeof %₈)
+9   (call core.TypeEqOf %₈)
 10  (call core.svec %₆ core.Any core.Any %₇ %₉ core.Any)
 11  (call core.svec)
 12  SourceLocation::1:10
@@ -1951,7 +1951,7 @@ end
     3   (return core.nothing)
 15  latestworld
 16  TestMod.f_kw_slurp
-17  (call core.Typeof %₁₆)
+17  (call core.TypeEqOf %₁₆)
 18  (call core.svec %₁₇ core.Any)
 19  (call core.svec)
 20  SourceLocation::1:10
@@ -1969,7 +1969,7 @@ end
 23  latestworld
 24  (call core.typeof core.kwcall)
 25  TestMod.f_kw_slurp
-26  (call core.Typeof %₂₅)
+26  (call core.TypeEqOf %₂₅)
 27  (call core.svec %₂₄ core.NamedTuple %₂₆ core.Any)
 28  (call core.svec)
 29  SourceLocation::1:10
@@ -2074,7 +2074,7 @@ end
 5   (method TestMod.#f_only_generated@generator#0)
 6   latestworld
 7   TestMod.#f_only_generated@generator#0
-8   (call core.Typeof %₇)
+8   (call core.TypeEqOf %₇)
 9   (call core.svec %₈ JuliaLowering.MacroContext core.Any core.Any core.Any)
 10  (call core.svec)
 11  SourceLocation::1:21
@@ -2089,7 +2089,7 @@ end
     6   (return %₅)
 14  latestworld
 15  TestMod.f_only_generated
-16  (call core.Typeof %₁₅)
+16  (call core.TypeEqOf %₁₅)
 17  (call core.svec %₁₆ core.Any core.Any)
 18  (call core.svec)
 19  SourceLocation::1:21
@@ -2124,7 +2124,7 @@ end
 5   (method TestMod.#f_partially_generated@generator#0)
 6   latestworld
 7   TestMod.#f_partially_generated@generator#0
-8   (call core.Typeof %₇)
+8   (call core.TypeEqOf %₇)
 9   (call core.svec %₈ JuliaLowering.MacroContext core.Any core.Any core.Any)
 10  (call core.svec)
 11  SourceLocation::1:10
@@ -2138,7 +2138,7 @@ end
     5   (return %₄)
 14  latestworld
 15  TestMod.f_partially_generated
-16  (call core.Typeof %₁₅)
+16  (call core.TypeEqOf %₁₅)
 17  (call core.svec %₁₆ core.Any core.Any)
 18  (call core.svec)
 19  SourceLocation::1:10

--- a/JuliaLowering/test/macros_ir.jl
+++ b/JuliaLowering/test/macros_ir.jl
@@ -43,7 +43,7 @@ end
 1   (method TestMod.@add_one)
 2   latestworld
 3   TestMod.@add_one
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ JuliaLowering.MacroContext core.Any)
 6   (call core.svec)
 7   SourceLocation::1:7
@@ -66,7 +66,7 @@ end
 1   (method TestMod.@foo)
 2   latestworld
 3   TestMod.@foo
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ JuliaLowering.MacroContext core.Any)
 6   (call core.svec)
 7   SourceLocation::1:7
@@ -206,7 +206,7 @@ end
 1   (method TestMod.foo)
 2   latestworld
 3   TestMod.foo
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -229,7 +229,7 @@ end
 1   (method TestMod.foo)
 2   latestworld
 3   TestMod.foo
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -254,7 +254,7 @@ end
 1   (method TestMod.foo)
 2   latestworld
 3   TestMod.foo
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10

--- a/JuliaLowering/test/misc_ir.jl
+++ b/JuliaLowering/test/misc_ir.jl
@@ -560,7 +560,7 @@ const f(x::Int)::Int = x+1
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   TestMod.Int
 6   (call core.svec %₄ %₅)
 7   (call core.svec)

--- a/JuliaLowering/test/quoting_ir.jl
+++ b/JuliaLowering/test/quoting_ir.jl
@@ -77,7 +77,7 @@ function Base.:(==)() end
 #---------------------
 1   TestMod.Base
 2   (call top.getproperty %₁ :==)
-3   (call core.Typeof %₂)
+3   (call core.TypeEqOf %₂)
 4   (call core.svec %₃)
 5   (call core.svec)
 6   SourceLocation::1:10

--- a/JuliaLowering/test/scopes_ir.jl
+++ b/JuliaLowering/test/scopes_ir.jl
@@ -141,7 +141,7 @@ end
 2   (method TestMod.f)
 3   latestworld
 4   TestMod.f
-5   (call core.Typeof %₄)
+5   (call core.TypeEqOf %₄)
 6   (call core.svec %₅ core.Any)
 7   (call core.svec)
 8   SourceLocation::3:14
@@ -193,7 +193,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.f
-4   (call core.Typeof %₃)
+4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
@@ -407,7 +407,7 @@ end
 6   (method TestMod.f)
 7   latestworld
 8   TestMod.f
-9   (call core.Typeof %₈)
+9   (call core.TypeEqOf %₈)
 10  (call core.svec %₉ core.Any)
 11  (call core.svec)
 12  SourceLocation::2:12
@@ -427,7 +427,7 @@ end
 21  (method TestMod.g)
 22  latestworld
 23  TestMod.g
-24  (call core.Typeof %₂₃)
+24  (call core.TypeEqOf %₂₃)
 25  (call core.svec %₂₄)
 26  (call core.svec)
 27  SourceLocation::3:12
@@ -463,7 +463,7 @@ end
 6   (method TestMod.f)
 7   latestworld
 8   TestMod.f
-9   (call core.Typeof %₈)
+9   (call core.TypeEqOf %₈)
 10  (call core.svec %₉)
 11  (call core.svec)
 12  SourceLocation::2:12

--- a/JuliaLowering/test/typedefs_ir.jl
+++ b/JuliaLowering/test/typedefs_ir.jl
@@ -1168,7 +1168,7 @@ A{<:Real}() = A(1)
 3   TestMod.A
 4   (call core.apply_type %₃ %₂)
 5   (call core.UnionAll %₂ %₄)
-6   (call core.Typeof %₅)
+6   (call core.TypeEqOf %₅)
 7   (call core.svec %₆)
 8   (call core.svec)
 9   SourceLocation::1:1

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -302,6 +302,18 @@ ccall(:jl_toplevel_eval_in, Any, (Any, Any),
       end
       end)
 
+# like `Typeof`, but yields the equality kind `Type{x}` for type values; used
+# by lowering to spell the callee self-type of method definitions, so equal
+# UnionAll spellings share the constructor method they define
+function TypeEqOf end
+ccall(:jl_toplevel_eval_in, Any, (Any, Any),
+      Core, quote
+      (f::typeof(TypeEqOf))(x) = begin
+          $(_expr(:meta,:nospecialize,:x))
+          isa(x,Type) ? Type{x} : typeof(x)
+      end
+      end)
+
 function iterate end
 
 macro nospecialize(x)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1221,7 +1221,7 @@
                                             n)))
                   (farg    (if (decl? argname)
                                (adj-decl argname)
-                               `(|::| |#self#| (call (core Typeof) ,argname))))
+                               `(|::| |#self#| (call (core TypeEqOf) ,argname))))
                   (body       (insert-after-meta body (cdr argl-stmts)))
                   (argl    (cdr argl))
                   (argl    (fix-arglist
@@ -3964,7 +3964,7 @@ f(x) = yt(x)
 (define (rename-sig-types ex namemap)
   (pattern-replace
    (pattern-set
-    (pattern-lambda (call (core (-/ Typeof)) name)
+    (pattern-lambda (call (core (-/ TypeEqOf)) name)
                     (sig-type-expr namemap name __)))
    ex))
 

--- a/src/method.c
+++ b/src/method.c
@@ -1284,26 +1284,8 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     jl_sym_t *name;
     jl_method_t *m = NULL;
     jl_value_t *argtype = NULL;
-    jl_svec_t *new_atypes = NULL;
-    JL_GC_PUSH5(&ft, &f, &m, &argtype, &new_atypes);
+    JL_GC_PUSH4(&ft, &f, &m, &argtype);
     size_t i, na = jl_svec_len(atypes);
-
-    if (jl_is_typeegal(ft)) {
-        // Lowering spells callable-value method definitions with `Core.Typeof`.
-        // Type-valued callees still define methods at the equality level, so
-        // equal UnionAll spellings share the constructor method they define.
-        ft = (jl_value_t*)jl_wrap_Type(jl_typeegal_T(ft));
-        new_atypes = jl_svec_copy(atypes);
-        jl_svecset(new_atypes, 0, ft);
-        atypes = new_atypes;
-    }
-    else if (jl_kwcall_type && ft == (jl_value_t*)jl_kwcall_type && nargs >= 3 &&
-             jl_is_typeegal(jl_svecref(atypes, 2))) {
-        // likewise for a keyword sorter, whose callee self-type is argument 2
-        new_atypes = jl_svec_copy(atypes);
-        jl_svecset(new_atypes, 2, jl_wrap_Type(jl_typeegal_T(jl_svecref(new_atypes, 2))));
-        atypes = new_atypes;
-    }
 
     argtype = jl_apply_tuple_type(atypes, 1);
     if (!jl_is_datatype(argtype))


### PR DESCRIPTION
Since #62001, `Core.Typeof` of a type value yields the egality `Core.TypeEgal` kind, but method definitions are still made at the equality level, so `jl_method_def` had to normalize the self-type back to the `Type` kind — first for the method's own function argument (#62001), then again for the kwcall callee (#62278), which had been missed and made inner and outer keyword constructors mutually ambiguous.

Fix this in lowering instead, as suggested in #62278: add `Core.TypeEqOf`, which yields the equality kind `Type{x}` for type values (the pre-#62001 `Core.Typeof` semantics), spell the implicit self-type of method definitions with it in both flisp lowering and JuliaLowering, and drop both normalization branches from `jl_method_def`.