### PR TITLE
subtype: move dispatch-tuple intersection fast path into jl_type_intersection_env_s

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -2429,25 +2429,6 @@ static void _invalidate_backedges(jl_method_instance_t *replaced_mi, jl_code_ins
 static int jl_type_intersection2(jl_value_t *t1, jl_value_t *t2, jl_value_t **isect JL_REQUIRE_ROOTED_SLOT, jl_value_t **isect2 JL_REQUIRE_ROOTED_SLOT)
 {
     *isect2 = NULL;
-    // Fast path: a dispatch tuple is a concrete leaf type, so its intersection with any
-    // other type is just itself (when it is a subtype) or empty. This avoids full type
-    // intersection for the common case of concrete specialization/backedge signatures.
-    if (jl_is_dispatch_tupletype(t2)) {
-        if (jl_subtype(t2, t1)) {
-            *isect = t2;
-            return 1;
-        }
-        *isect = jl_bottom_type;
-        return 0;
-    }
-    if (jl_is_dispatch_tupletype(t1)) {
-        if (jl_subtype(t1, t2)) {
-            *isect = t1;
-            return 1;
-        }
-        *isect = jl_bottom_type;
-        return 0;
-    }
     int is_subty = 0;
     *isect = jl_type_intersection_env_s(t1, t2, NULL, &is_subty);
     if (*isect == jl_bottom_type)

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -6314,6 +6314,11 @@ jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t *
             goto bot;
         if (ltb && !might_intersect_concrete(a))
             goto bot;
+        // A dispatch tuple is a concrete leaf type, so its intersection with any other
+        // type is just itself (when it is a subtype) or empty. The subtype checks above
+        // having failed, the intersection must be empty.
+        if (jl_is_dispatch_tupletype(a) || jl_is_dispatch_tupletype(b))
+            goto bot;
         jl_stenv_t e;
         init_stenv(&e, NULL, 0);
         e.intersection = 1;


### PR DESCRIPTION
Addresses post-merge review feedback https://github.com/JuliaLang/julia/pull/62238#discussion_r3536889174

Claude:

---

A dispatch tuple is a concrete leaf type, so its intersection with any other type is just itself (when it is a subtype) or empty. This fast path was added to jl_type_intersection2 in gf.c, but that duplicates logic that belongs in the shared intersection routine and is not covered by the type intersection correctness tests. The equivalent check already existed in intersect_types but was missing from jl_type_intersection_env_s.

Move the check into jl_type_intersection_env_s, after the subtype tests have already failed, so the disjoint case short-circuits before the full intersect_all path for all callers, and remove the duplicate from gf.c.