### PR TITLE
precompilepkgs: only emit ANSI erase codes in fancy mode

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -2043,7 +2043,8 @@ function precompilepkgs_monitor_std(s::PrecompileSession, pkg_config, pipe, sing
                     liveprinting = true
                     s.pkg_liveprinted = pkg
                 end
-                print(s.io, ansi_cleartoendofline, str)
+                # in fancy mode clear the progress bar residue from the line first
+                print(s.io, s.fancyprint ? ansi_cleartoendofline : "", str)
             end
         end
         write(s.jobs[pkg_config].output, str)
@@ -2056,7 +2057,7 @@ function precompilepkgs_monitor_std(s::PrecompileSession, pkg_config, pipe, sing
         elseif !thistaskwaiting
             # XXX: don't just re-enable IO for random packages without printing the context for them first
             !liveprinting && !s.fancyprint && BG.monitoring && @lock s.print_lock begin
-                print(s.io, ansi_cleartoendofline, str)
+                print(s.io, str)
             end
         end
     end


### PR DESCRIPTION
I saw some random escape codes in redirected precompile output. Put the bot on it. 

----

🤖 

Output forwarded from precompile workers was unconditionally prefixed
with the erase-to-end-of-line escape (\e[0K), which is only needed to
clear progress bar residue in fancy mode. In non-fancy mode (piped
output, CI logs, redirected files) the escape ended up verbatim in the
captured text, polluting every forwarded line. The non-fancy forwarding
branch runs only when no progress bar is drawn, so it never needs the
escape; the live-print branch now emits it only under fancyprint.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
