### PR TITLE
fix `@nospecialize`/`@specialize` when given comma separated arguments to not silently do nothing useful

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -124,10 +124,15 @@ and this is still used in optimizing the callers of `f` and `g`.
 """
 macro nospecialize(vars...)
     if nfields(vars) === 1
-        # in argument position, need to fix `@nospecialize x=v` to `@nospecialize (kw x v)`
         var = getfield(vars, 1)
-        if isa(var, Expr) && var.head === :(=)
-            var.head = :kw
+        if isa(var, Expr)
+            if var.head === :(=)
+                # in argument position, need to fix `@nospecialize x=v` to `@nospecialize (kw x v)`
+                var.head = :kw
+            elseif var.head === :tuple
+                # `@nospecialize a, b` parses as a single tuple expression
+                return Expr(:meta, :nospecialize, var.args...)
+            end
         end
     end
     return Expr(:escape, Expr(:meta, :nospecialize, vars...))
@@ -141,10 +146,15 @@ For details, see [`@nospecialize`](@ref).
 """
 macro specialize(vars...)
     if nfields(vars) === 1
-        # in argument position, need to fix `@specialize x=v` to `@specialize (kw x v)`
         var = getfield(vars, 1)
-        if isa(var, Expr) && var.head === :(=)
-            var.head = :kw
+        if isa(var, Expr)
+            if var.head === :(=)
+                # in argument position, need to fix `@specialize x=v` to `@specialize (kw x v)`
+                var.head = :kw
+            elseif var.head === :tuple
+                # `@specialize a, b` parses as a single tuple expression
+                return Expr(:meta, :specialize, var.args...)
+            end
         end
     end
     return Expr(:escape, Expr(:meta, :specialize, vars...))

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -154,6 +154,17 @@ function _nospec_some_args2(x, y, z)
     return 0
 end
 @test first(methods(_nospec_some_args2)).nospecialize == 3
+function _nospec_some_args3(x, y, z)
+    @nospecialize x, z
+    return 0
+end
+@test first(methods(_nospec_some_args3)).nospecialize == 5
+function _spec_some_args(x, y, z)
+    @nospecialize
+    @specialize x, z
+    return 0
+end
+@test first(methods(_spec_some_args)).nospecialize & 0b111 == 0b010
 function _nospec_with_default(@nospecialize x = 1)
     2x
 end


### PR DESCRIPTION
Found in the wild at https://github.com/SciML/ModelingToolkit.jl/blob/3239ad1184c38d26e62ce8f0e80b1c623e22574d/lib/ModelingToolkitBase/src/problems/linearproblem.jl#L140 where it silently did nothing and caused multiple methods to be compiled for the arguments that were supposed to be not specialized.