### PR TITLE
[JuliaLowering] Allow `@nospecialize` tuple in the function body

### DIFF
--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -23,6 +23,10 @@ function Base.var"@nospecialize"(__context__::MacroContext, exs::SyntaxTree...)
         eq = exs[1]
         @ast __context__ __context__.macrocall [K"meta"
             "nospecialize"::K"Identifier" [K"kw"(eq) children(eq)...]]
+    elseif length(exs) == 1 && kind(exs[1]) === K"tuple"
+        # @nospecialize(x,y,z) in function body
+        @ast __context__ __context__.macrocall [K"meta"
+            "nospecialize"::K"Identifier" children(exs[1])...]
     else
         @ast __context__ __context__.macrocall [K"meta"
             "nospecialize"::K"Identifier" exs...]

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -506,6 +506,19 @@ end
     """) == (1, 2, 3, 4)
     @test only(methods(test_mod.f_nospecialize_multi_body)).nospecialize == 0b1101
 
+    # @nospecialize tuple in function body
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_nospecialize_body_tuple(a, b, c, d)
+            @nospecialize a,c,d
+            (a, b, c, d)
+        end
+
+        f_nospecialize_body_tuple(1, 2, 3, 4)
+    end
+    """) == (1, 2, 3, 4)
+    @test only(methods(test_mod.f_nospecialize_body_tuple)).nospecialize == 0b1101
+
     # @nospecialize with single arg in function body
     @test JuliaLowering.include_string(test_mod, """
     begin


### PR DESCRIPTION
Equivalent to #62293, cc @KristofferC (I was about to push to your branch, but I'm assuming a separate one will make for smoother backporting.)