### PR TITLE
optimizer: renumber the scope operand of frame-less EnterNodes

### DIFF
--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -1589,17 +1589,16 @@ function renumber_ir_elements!(body::Vector{Any}, ssachangemap::Vector{Int}, lab
             end
         elseif isa(el, EnterNode)
             tgt = el.catch_dest
-            if tgt != 0
-                was_deleted = labelchangemap[tgt] == typemin(Int)
-                if was_deleted
-                    @assert !isdefined(el, :scope)
-                    body[i] = nothing
+            if tgt != 0 && labelchangemap[tgt] == typemin(Int)
+                @assert !isdefined(el, :scope)
+                body[i] = nothing  # the enclosing catch block was deleted
+            else
+                # renumber the catch destination (tgt == 0 stays frame-less) and the scope operand
+                newdest = tgt == 0 ? 0 : tgt + labelchangemap[tgt]
+                if isdefined(el, :scope) && isa(el.scope, SSAValue)
+                    body[i] = EnterNode(newdest, SSAValue(el.scope.id + ssachangemap[el.scope.id]))
                 else
-                    if isdefined(el, :scope) && isa(el.scope, SSAValue)
-                        body[i] = EnterNode(tgt + labelchangemap[tgt], SSAValue(el.scope.id + ssachangemap[el.scope.id]))
-                    else
-                        body[i] = EnterNode(el, tgt + labelchangemap[tgt])
-                    end
+                    body[i] = EnterNode(el, newdest)
                 end
             end
         elseif isa(el, Expr)

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -1892,6 +1892,20 @@ let (ir,rt) = only(Base.code_ircode((Int,)) do y
     @test rt == Union{Nothing,Float64}
 end
 
+# issue #62082: a frame-less (`catch_dest == 0`) EnterNode's scope operand must be
+# renumbered too, else `Core.current_scope()` reads a stale value in the scoped region
+let sval = ScopedValue(1)
+    @noinline observe_scope() = Core.current_scope()
+    function scope_renumber(c::Bool)
+        if c
+            error("x")
+        end
+        @with sval => 2 observe_scope()
+    end
+    @test scope_renumber(false) isa Base.ScopedValues.Scope
+    @test_throws ErrorException scope_renumber(true)
+end
+
 # Test that adce_pass! sets Refined on PhiNode values
 let code = Any[
     # Basic Block 1


### PR DESCRIPTION
`renumber_ir_elements!` only renumbered an `EnterNode`'s operands when `catch_dest != 0`, but frame-less enters (`catch_dest == 0`) still carry a `scope` SSA operand. When `convert_to_ircode` inserts statements earlier in the function that reference goes stale, so `Core.current_scope()` observes an arbitrary value:

```julia
using Base.ScopedValues
const sval = ScopedValue(1)
@noinline getscope() = Core.current_scope()
function f(c::Bool)
    c && error("x")
    @with sval => 2 getscope()
end
f(false)   # returns `sval => 2`, should be a `Scope`
```

Frame-less enters only arise from the nothrow try/catch elision (#52527), so the `@with` body must be nothrow; present since 1.11.

Fixes #62082.

Written with AI assistance (Claude).
