### PR TITLE
staticdata: rebuild image method caches from an ordered CodeInstance list

### DIFF
--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -341,7 +341,6 @@ function enqueue_specialization!(all::Bool, worklist, mi::MethodInstance)
 end
 
 # Main unified compilation and emission function
-# This replaces the functionality from jl_precompile
 function compile_and_emit_native(worlds::Vector{UInt},
                                  trim_mode::UInt8,
                                  external_linkage::Bool,
@@ -350,6 +349,7 @@ function compile_and_emit_native(worlds::Vector{UInt},
                                  all::Bool,
                                  module_init_order::Vector{Any}, # Vector{Module}
                                  ext_foreign_cis::Vector{Any}) # Vector{CodeInstance}
+    @nospecialize
     latestworld = worlds[end]
 
     # Step 1: Precompile all __init__ methods that will be required
@@ -426,7 +426,10 @@ function compile_and_emit_native(worlds::Vector{UInt},
     end
 
     # Step 4: Perform type inference on tocompile to create codeinfos
-    codeinfos = try
+    # Returns svec(codeinfos, cis): the interleaved CodeInstance/CodeInfo work
+    # list for codegen, plus the ordered CodeInstances to place in the method
+    # caches of the output image.
+    result = try
         typeinf_ext_toplevel(tocompile, worlds, trim_mode)
     catch exc
         # Handle trimming failures
@@ -436,7 +439,7 @@ function compile_and_emit_native(worlds::Vector{UInt},
         invokelatest(invokelatest(getglobal, Base, :exit), 1)
     end
 
-    return codeinfos
+    return result
 
 end
 

--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -375,18 +375,20 @@ function compile_and_emit_native(worlds::Vector{UInt},
         if newmodules === nothing
             infer_all_method_defs!(all, newmethods, latestworld, specialization_worklist)
         else
-            # Compute new_ext_cis using queue_external_cis with global newly_inferred
-            new_ext = ccall(:jl_compute_new_ext, Any, ())
-            if new_ext !== nothing
-                for i in 1:length(new_ext::Vector{Any})
-                    ci = new_ext[i]
+            # Compute new_used using queue_used with global newly_inferred
+            new_used = ccall(:jl_compute_new_used_ci, Any, ())
+            if new_used !== nothing
+                for i in 1:length(new_used::Vector{Any})
+                    ci = new_used[i]
                     if ci isa MethodInstance
                         push!(specialization_worklist, ci)
                     elseif ci isa CodeInstance
                         if ci.owner !== nothing
                             # enqueue_specialization will skip over CIs from foreign interpreters
                             # and currently will visit at most one (do_compile) CI per method instance
-                            push!(ext_foreign_cis, ci)
+                            if ci.max_world === typemax(UInt)
+                                push!(ext_foreign_cis, ci)
+                            end
                         else
                             enqueue_specialization!(all, specialization_worklist, get_ci_mi(ci))
                         end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1889,7 +1889,65 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim_m
     if trim_mode != TRIM_NO && trim_mode != TRIM_UNSAFE
         verify_typeinf_trim(codeinfos, trim_mode == TRIM_UNSAFE_WARN)
     end
-    return codeinfos
+
+    # Build the ordered list of CodeInstances to store in the image's method
+    # caches. This is kept as its own array (rather than being recovered from
+    # `codeinfos` by the caller) so the set and ordering of cached entries can be
+    # chosen independently of what native code gets emitted. The linked list of
+    # each MethodInstance's cache is rebuilt from this order during serialization
+    # (see jl_rewrite_mi_caches in staticdata.c).
+    #
+    # First the compiled entries, in compilation order: every entry paired with a
+    # CodeInfo in `codeinfos` is inferred and about to be compiled, so it lands in
+    # the single invoke+inferred group that jl_mi_cache_insert (gf.c) keeps at the
+    # front, and the compilation order already lists higher-`max_world` entries
+    # first (worlds are processed newest-first).
+    cis = Any[]
+    seen = IdSet{CodeInstance}()
+    for i = 1:length(codeinfos)
+        item = codeinfos[i]
+        if item isa CodeInstance && !(item in seen)
+            push!(seen, item)
+            push!(cis, item)
+        end
+    end
+
+    # Then walk each CodeInstance's forward `edges` recursively and append every
+    # reachable CodeInstance. These callees are inferred but were not compiled
+    # (no `invoke` assigned), so appending them after the compiled entries places
+    # them in gf.c's inferred (post-invoke) group within each MethodInstance's
+    # cache. Preserving them keeps the inference results callers depend on from
+    # being dropped by the cache-clearing pass in staticdata.c. `cis` doubles as
+    # the worklist, so edges discovered from appended entries are visited too.
+    i = 1
+    while i <= length(cis)
+        ci = cis[i]::CodeInstance
+        if isdefined(ci, :edges)
+            edges = ci.edges
+            for j = 1:length(edges)
+                isassigned(edges, j) || continue
+                edge = edges[j]
+                if edge isa CodeInstance && !(edge in seen)
+                    push!(seen, edge)
+                    push!(cis, edge)
+                end
+            end
+        end
+        i += 1
+    end
+
+    # Keep cache CodeInstances that represent an existing cache entry: either they are
+    # already linked into their MethodInstance's cache, or jl_get_ci_equiv finds
+    # another equivalent already cached for them.
+    # This hack avoids putting badly inferred edges in the cache, while still trying to populate the cache sufficiently.
+    filter!(cis) do ci
+        ci = ci::CodeInstance
+        mi = get_ci_mi(ci)
+        return !iszero(ccall(:jl_mi_cache_has_ci, Cint, (Any, Any), mi, ci)) ||
+            ccall(:jl_get_ci_equiv, Any, (Any, UInt), ci, ci.min_world)::CodeInstance !== ci
+    end
+
+    return Core.svec(codeinfos, cis)
 end
 
 const _verify_trim_world_age = RefValue{UInt}(typemax(UInt))

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1922,21 +1922,26 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim_m
     # cache. Preserving them keeps the inference results callers depend on from
     # being dropped by the cache-clearing pass in staticdata.c. `cis` doubles as
     # the worklist, so edges discovered from appended entries are visited too.
-    i = 1
-    while i <= length(cis)
-        ci = cis[i]::CodeInstance
-        if isdefined(ci, :edges)
-            edges = ci.edges
-            for j = 1:length(edges)
-                isassigned(edges, j) || continue
-                edge = edges[j]
-                if edge isa CodeInstance && !(edge in seen)
-                    push!(seen, edge)
-                    push!(cis, edge)
+    #
+    # Skip under `--trim` where inferred-but-not-compiled entries are not useful
+    # at runtime without a Compiler / JIT.
+    if trim_mode == TRIM_NO
+        i = 1
+        while i <= length(cis)
+            ci = cis[i]::CodeInstance
+            if isdefined(ci, :edges)
+                edges = ci.edges
+                for j = 1:length(edges)
+                    isassigned(edges, j) || continue
+                    edge = edges[j]
+                    if edge isa CodeInstance && !(edge in seen)
+                        push!(seen, edge)
+                        push!(cis, edge)
+                    end
                 end
             end
+            i += 1
         end
-        i += 1
     end
 
     # Keep cache CodeInstances that represent an existing cache entry: either they are

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7063,7 +7063,7 @@ function tt57873(a::Vector{String}, pref)
     end
     return ret
 end
-let code = Compiler.typeinf_ext_toplevel(Any[Core.svec(Any,Tuple{typeof(tt57873),Vector{String},Tuple{String}})], [Base.get_world_counter()], Base.Compiler.TRIM_NO)
+let code = Compiler.typeinf_ext_toplevel(Any[Core.svec(Any,Tuple{typeof(tt57873),Vector{String},Tuple{String}})], [Base.get_world_counter()], Base.Compiler.TRIM_NO)[1]
     @test !isempty(code)
     ## If we were to run trim here, we should fail with:
     #    Verifier error #1: unresolved invoke from statement tt57873(::Vector{String}, ::Tuple{String, String})::Vector{String}

--- a/Compiler/test/verifytrim.jl
+++ b/Compiler/test/verifytrim.jl
@@ -20,7 +20,7 @@ end
 
 finalizer(@nospecialize(f), @nospecialize(o)) = Core.finalizer(f, o)
 
-let infos = typeinf_ext_toplevel(Any[Core.svec(Nothing, Tuple{typeof(finalizer), typeof(identity), Any})], [Base.get_world_counter()], TRIM_UNSAFE)
+let infos = typeinf_ext_toplevel(Any[Core.svec(Nothing, Tuple{typeof(finalizer), typeof(identity), Any})], [Base.get_world_counter()], TRIM_UNSAFE)[1]
     errors, parents = get_verify_typeinf_trim(infos)
     @test !isempty(errors) # unresolvable finalizer
 
@@ -40,14 +40,14 @@ end
 
 # test that basic `cfunction` generation is allowed, when the dispatch target can be resolved
 make_cfunction() = @cfunction(+, Float64, (Int64,Int64))
-let infos = typeinf_ext_toplevel(Any[Core.svec(Ptr{Cvoid}, Tuple{typeof(make_cfunction)})], [Base.get_world_counter()], TRIM_UNSAFE)
+let infos = typeinf_ext_toplevel(Any[Core.svec(Ptr{Cvoid}, Tuple{typeof(make_cfunction)})], [Base.get_world_counter()], TRIM_UNSAFE)[1]
     errors, parents = get_verify_typeinf_trim(infos)
     @test isempty(errors)
 end
 
 # use TRIM_UNSAFE to bypass verifier inside typeinf_ext_toplevel
 make_cfunction_bad(@nospecialize(f::Any)) = @cfunction($f, Float64, (Int64,Int64))::Base.CFunction
-let infos = typeinf_ext_toplevel(Any[Core.svec(Base.CFunction, Tuple{typeof(make_cfunction_bad), Any})], [Base.get_world_counter()], TRIM_UNSAFE)
+let infos = typeinf_ext_toplevel(Any[Core.svec(Base.CFunction, Tuple{typeof(make_cfunction_bad), Any})], [Base.get_world_counter()], TRIM_UNSAFE)[1]
     errors, parents = get_verify_typeinf_trim(infos)
     @test !isempty(errors) # missing cfunction
 
@@ -72,7 +72,7 @@ let infos = typeinf_ext_toplevel(Any[Core.svec(Base.CFunction, Tuple{typeof(make
     @test repr == "unresolved ccallable for Tuple{$(typeof(make_cfunction_bad)), Any} => Base.CFunction\n\n"
 end
 
-let infos = typeinf_ext_toplevel(Any[Core.svec(Base.SecretBuffer, Tuple{Type{Base.SecretBuffer}})], [Base.get_world_counter()], TRIM_UNSAFE)
+let infos = typeinf_ext_toplevel(Any[Core.svec(Base.SecretBuffer, Tuple{Type{Base.SecretBuffer}})], [Base.get_world_counter()], TRIM_UNSAFE)[1]
     @test length(infos) > 4
     errors, parents = get_verify_typeinf_trim(infos)
     @test isempty(errors)
@@ -90,7 +90,7 @@ let infos = typeinf_ext_toplevel(Any[Core.svec(Base.SecretBuffer, Tuple{Type{Bas
     @test repr == "unresolved ccallable for Tuple{Type{Base.SecretBuffer}} => Base.SecretBuffer\n\n"
 end
 
-let infos = typeinf_ext_toplevel(Any[Core.svec(Float64, Tuple{typeof(+), Int32, Int64})], [Base.get_world_counter()], TRIM_UNSAFE)
+let infos = typeinf_ext_toplevel(Any[Core.svec(Float64, Tuple{typeof(+), Int32, Int64})], [Base.get_world_counter()], TRIM_UNSAFE)[1]
     errors, parents = get_verify_typeinf_trim(infos)
     (warn, desc) = only(errors)
     @test !warn
@@ -102,7 +102,7 @@ let infos = typeinf_ext_toplevel(Any[Core.svec(Float64, Tuple{typeof(+), Int32, 
     @test repr == "ccallable declared return type does not match inference for Tuple{typeof(+), Int32, Int64} => Int64\n\n"
 end
 
-let infos = typeinf_ext_toplevel(Any[Core.svec(Int64, Tuple{typeof(ifelse), Bool, Int64, UInt64})], [Base.get_world_counter()], TRIM_UNSAFE)
+let infos = typeinf_ext_toplevel(Any[Core.svec(Int64, Tuple{typeof(ifelse), Bool, Int64, UInt64})], [Base.get_world_counter()], TRIM_UNSAFE)[1]
     errors, parents = get_verify_typeinf_trim(infos)
     (warn, desc) = only(errors)
     @test warn  # this is a warning since Union{Int64, UInt64} <: Int64 is false but not an error
@@ -112,17 +112,17 @@ let infos = typeinf_ext_toplevel(Any[Core.svec(Int64, Tuple{typeof(ifelse), Bool
     @test repr == "ccallable declared return type does not match inference for Tuple{typeof(ifelse), Bool, Int64, UInt64} => Union{Int64, UInt64}\n\n"
 end
 
-let infos = typeinf_ext_toplevel(Any[Core.svec(Union{Int64,UInt64}, Tuple{typeof(ifelse), Bool, Int64, UInt64})], [Base.get_world_counter()], TRIM_SAFE)
+let infos = typeinf_ext_toplevel(Any[Core.svec(Union{Int64,UInt64}, Tuple{typeof(ifelse), Bool, Int64, UInt64})], [Base.get_world_counter()], TRIM_SAFE)[1]
     errors, parents = get_verify_typeinf_trim(infos)
     @test isempty(errors)
-    infos = typeinf_ext_toplevel(Any[Core.svec(Real, Tuple{typeof(ifelse), Bool, Int64, UInt64})], [Base.get_world_counter()], TRIM_SAFE)
+    infos = typeinf_ext_toplevel(Any[Core.svec(Real, Tuple{typeof(ifelse), Bool, Int64, UInt64})], [Base.get_world_counter()], TRIM_SAFE)[1]
     errors, parents = get_verify_typeinf_trim(infos)
     @test isempty(errors)
 end
 
 
 mi = Base.method_instance(sum, (Vector{Union{Int64,Float64, Float32,UInt32}},))
-let infos = typeinf_ext_toplevel(Any[mi], [Base.get_world_counter()], TRIM_UNSAFE)
+let infos = typeinf_ext_toplevel(Any[mi], [Base.get_world_counter()], TRIM_UNSAFE)[1]
     errors, parents = get_verify_typeinf_trim(infos)
     @test !isempty(errors)
 end

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -172,6 +172,10 @@ typedef struct {
     std::map<jl_code_instance_t*, std::tuple<uint32_t, uint32_t>> jl_fvar_map;
     SmallVector<void*, 0> jl_value_to_llvm;
     SmallVector<jl_code_instance_t*, 0> jl_external_to_llvm;
+    // ordered list of CodeInstances emitted for this image, in the order they
+    // were presented in `codeinfos`; consumed by staticdata.c to rewrite each
+    // MethodInstance's `cache` field into a `next`-linked list
+    SmallVector<jl_code_instance_t*, 0> jl_ci_order;
 } jl_native_code_desc_t;
 
 extern "C" JL_DLLEXPORT_CODEGEN
@@ -204,6 +208,24 @@ jl_get_llvm_cis_impl(void *native_code, size_t *num_elements, jl_code_instance_t
     for (auto &ci : map) {
         data[i++] = ci.first;
     }
+}
+
+// get the ordered list of CodeInstances that were emitted for this image, in
+// the order they appeared in `codeinfos`. staticdata.c uses this to rewrite the
+// `cache` field of each MethodInstance into a `next`-linked list.
+extern "C" JL_DLLEXPORT_CODEGEN void
+jl_get_llvm_mi_cache_order_impl(void *native_code, size_t *num_elements, jl_code_instance_t **data)
+{
+    jl_native_code_desc_t *desc = (jl_native_code_desc_t *)native_code;
+    auto &order = desc->jl_ci_order;
+
+    if (data == NULL) {
+        *num_elements = order.size();
+        return;
+    }
+
+    assert(*num_elements == order.size());
+    memcpy(data, order.data(), *num_elements * sizeof(jl_code_instance_t *));
 }
 
 // get the list of global variables managed by the compiler
@@ -643,16 +665,23 @@ void *jl_create_native_impl(LLVMOrcThreadSafeModuleRef llvmmod, int trim, int ex
     fargs[4] = worklist ? (jl_value_t*)worklist : jl_nothing; // worklist (or nothing)
     fargs[5] = mod_array ? (jl_value_t*)mod_array : jl_nothing; // mod_array (or nothing)
     fargs[6] = jl_box_bool(all);
-    fargs[7] = module_init_order ? (jl_value_t*)module_init_order : jl_nothing; // module_init_order (or nothing)
+    fargs[7] = (jl_value_t*)module_init_order; // module_init_order
     fargs[8] = ext_foreign_cis ? (jl_value_t*)ext_foreign_cis : jl_nothing; // ext_foreign_cis (or nothing)
     size_t last_age = ct->world_age;
     ct->world_age = jl_typeinf_world;
     fargs[0] = jl_apply(fargs, 9);
     fargs[1] = fargs[2] = fargs[3] = fargs[4] = fargs[5] = fargs[6] = fargs[7] = fargs[8] = NULL;
     ct->world_age = last_age;
-    jl_value_t *codeinfos = fargs[0];
+    // the bridge returns svec(codeinfos, ci_order): the interleaved
+    // CodeInstance/CodeInfo work list to emit, and the ordered CodeInstances to
+    // store in the method caches of the output image
+    jl_value_t *result = fargs[0];
+    assert(jl_is_svec(result) && jl_svec_len(result) == 2);
+    jl_value_t *codeinfos = jl_svecref(result, 0);
+    jl_value_t *ci_order = jl_svecref(result, 1);
     JL_TYPECHK(jl_create_native, array_any, codeinfos);
-    auto data = (jl_native_code_desc_t *)jl_emit_native((jl_array_t*)codeinfos, llvmmod, NULL, external_linkage ? 1 : 0);
+    JL_TYPECHK(jl_create_native, array_any, ci_order);
+    auto data = (jl_native_code_desc_t *)jl_emit_native((jl_array_t*)codeinfos, (jl_array_t*)ci_order, llvmmod, NULL, external_linkage ? 1 : 0);
     JL_GC_POP();
 
     // move everything inside, now that we've merged everything
@@ -847,13 +876,25 @@ static void aot_link_output(jl_codegen_output_t &out)
 }
 
 static void jl_emit_native_to_output(jl_native_code_desc_t *data, jl_array_t *codeinfos,
-                                      const jl_cgparams_t *cgparams, int external_linkage)
+                                      jl_array_t *ci_order, const jl_cgparams_t *cgparams,
+                                      int external_linkage)
 {
     jl_cgparams_t target_cgparams = *cgparams;
     target_cgparams.sanitize_memory = jl_options.target_sanitize_memory;
     target_cgparams.sanitize_thread = jl_options.target_sanitize_thread;
     target_cgparams.sanitize_address = jl_options.target_sanitize_address;
     auto &out = *data->out;
+    // record the caller-provided ordering of CodeInstances to store in the
+    // image's method caches (see jl_get_llvm_mi_cache_order / jl_rewrite_mi_caches)
+    if (ci_order) {
+        size_t nci = jl_array_nrows(ci_order);
+        data->jl_ci_order.reserve(nci);
+        for (size_t k = 0; k < nci; k++) {
+            jl_value_t *ci = jl_array_ptr_ref(ci_order, k);
+            assert(jl_is_code_instance(ci));
+            data->jl_ci_order.push_back((jl_code_instance_t*)ci);
+        }
+    }
     // compile all methods for the current world and type-inference world
     DenseMap<jl_code_instance_t *, jl_code_info_t *> ci_infos;
     egal_set method_roots;
@@ -958,7 +999,7 @@ static void jl_emit_native_to_output(jl_native_code_desc_t *data, jl_array_t *co
 // also be used by extern consumers like GPUCompiler.jl to obtain a module containing
 // all reachable & inferrrable functions.
 extern "C" JL_DLLEXPORT_CODEGEN
-void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int external_linkage)
+void *jl_emit_native_impl(jl_array_t *codeinfos, jl_array_t *ci_order, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int external_linkage)
 {
     JL_TIMING(NATIVE_AOT, NATIVE_Create);
     ++CreateNativeCalls;
@@ -980,7 +1021,7 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
 
     data->TSM_ref->withModuleDo([&](Module &M) {
         data->out = std::make_unique<jl_codegen_output_t>(M);
-        jl_emit_native_to_output(data, codeinfos, cgparams, external_linkage);
+        jl_emit_native_to_output(data, codeinfos, ci_order, cgparams, external_linkage);
     });
 
     return (void *)data;

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -17,6 +17,7 @@ JL_DLLEXPORT void jl_get_llvm_gvs_fallback(void *native_code, size_t *num, void 
 JL_DLLEXPORT void jl_get_llvm_gv_inits_fallback(void *native_code, size_t *num, void **inits) UNAVAILABLE
 JL_DLLEXPORT void jl_get_llvm_external_fns_fallback(void *native_code, size_t *num_els, jl_code_instance_t *fns) UNAVAILABLE
 JL_DLLEXPORT void jl_get_llvm_cis_fallback(void *native_code, size_t *num_els, jl_code_instance_t **CIs) UNAVAILABLE
+JL_DLLEXPORT void jl_get_llvm_mi_cache_order_fallback(void *native_code, size_t *num_els, jl_code_instance_t **CIs) UNAVAILABLE
 
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm_fallback(jl_method_instance_t *linfo, size_t world,
         char emit_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char binary) UNAVAILABLE
@@ -103,7 +104,7 @@ JL_DLLEXPORT void jl_jit_unregister_ci_fallback(jl_code_instance_t *ci)
 }
 
 JL_DLLEXPORT void *jl_create_native_fallback(LLVMOrcThreadSafeModuleRef llvmmod, int trim, int cache, size_t world, jl_array_t *mod_array, jl_array_t *worklist, int all, jl_array_t *module_init_order, jl_array_t *ext_foreign_cis) UNAVAILABLE
-JL_DLLEXPORT void *jl_emit_native_fallback(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _external_linkage) UNAVAILABLE
+JL_DLLEXPORT void *jl_emit_native_fallback(jl_array_t *codeinfos, jl_array_t *ci_order, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _external_linkage) UNAVAILABLE
 
 JL_DLLEXPORT void jl_dump_compiles_fallback(void *s)
 {

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -534,6 +534,7 @@
     YY(jl_get_llvm_gv_inits) \
     YY(jl_get_llvm_external_fns) \
     YY(jl_get_llvm_cis) \
+    YY(jl_get_llvm_mi_cache_order) \
     YY(jl_dump_function_asm) \
     YY(jl_LLVMCreateDisasm) \
     YY(jl_LLVMDisasmInstruction) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2206,7 +2206,7 @@ JL_DLLIMPORT jl_value_t *jl_dump_function_asm(jl_llvmf_dump_t *dump, char emit_m
 
 typedef jl_value_t *(*jl_codeinstance_lookup_t)(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t min_world, size_t max_world);
 JL_DLLIMPORT void *jl_create_native(LLVMOrcThreadSafeModuleRef llvmmod, int trim, int cache, size_t world, jl_array_t *mod_array, jl_array_t *worklist, int all, jl_array_t *module_init_order, jl_array_t *ext_foreign_cis);
-JL_DLLIMPORT void *jl_emit_native(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _external_linkage);
+JL_DLLIMPORT void *jl_emit_native(jl_array_t *codeinfos, jl_array_t *ci_order, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _external_linkage);
 JL_DLLIMPORT void jl_dump_native(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         ios_t *z, ios_t *s, jl_emission_params_t *params);
@@ -2220,6 +2220,8 @@ JL_DLLIMPORT void jl_register_fptrs(uint64_t image_base, const struct _jl_image_
                                     jl_code_instance_t **linfos, size_t n);
 JL_DLLIMPORT void jl_get_llvm_cis(void *native_code, size_t *num_els,
                                   jl_code_instance_t **CIs);
+JL_DLLIMPORT void jl_get_llvm_mi_cache_order(void *native_code, size_t *num_els,
+                                             jl_code_instance_t **CIs);
 JL_DLLIMPORT void jl_init_codegen(void);
 JL_DLLIMPORT void jl_teardown_codegen(void) JL_NOTSAFEPOINT;
 JL_DLLIMPORT void jl_decorate_llvm_module(LLVMModuleRef m) JL_NOTSAFEPOINT;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -423,16 +423,16 @@ static int needs_uniquing(jl_value_t *v, jl_query_cache *query_cache) JL_NOTSAFE
     return caching_tag(v, query_cache) == 1;
 }
 
-static void record_field_change(jl_value_t **addr, jl_value_t *newval) JL_NOTSAFEPOINT
-{
-    if (*addr != newval)
-        ptrhash_put(&field_replace, (void*)addr, newval);
-}
-
 // whether `record_field_change` has already registered a replacement for `addr`
 static int has_field_change(jl_value_t **addr) JL_NOTSAFEPOINT
 {
     return ptrhash_get(&field_replace, (void*)addr) != HT_NOTFOUND;
+}
+
+static void record_field_change(jl_value_t **addr, jl_value_t *newval) JL_NOTSAFEPOINT
+{
+    if (has_field_change(addr) || *addr != newval)
+        ptrhash_put(&field_replace, (void*)addr, newval);
 }
 
 static jl_value_t *get_replaceable_field(jl_value_t **addr, int mutabl) JL_GC_DISABLED
@@ -641,14 +641,14 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
         // cache was not rewritten gets an empty cache here, rather than leaking
         // whatever the live runtime cache happened to contain. Builtin functions
         // are an exception: their cache is not part of the codegen ordering and
-        // is not repopulated at load, so keep it. Builtins are recognized by
-        // their method having neither source nor a generator (cf. the
-        // jl_is_builtinfunc heuristic in gf.c).
+        // is not repopulated at load, so keep it. Builtin-like functions are
+        //  recognized by their method having neither source nor a generator
+        // (cf. the jl_is_builtinfunc computation).
         jl_value_t *midef = mi->def.value;
         int is_builtin = jl_is_method(midef) &&
             ((jl_method_t*)midef)->source == NULL &&
             ((jl_method_t*)midef)->generator == NULL;
-        if (!is_builtin && !has_field_change((jl_value_t**)&mi->cache))
+        if (native_functions && !is_builtin && !has_field_change((jl_value_t**)&mi->cache))
             record_field_change((jl_value_t**)&mi->cache, NULL);
         // don't recurse into all backedges memory (yet)
         jl_value_t *backedges = get_replaceable_field((jl_value_t**)&mi->backedges, 1);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -740,6 +740,10 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
     if (jl_is_code_instance(v)) {
         jl_code_instance_t *ci = (jl_code_instance_t*)v;
         jl_method_instance_t *mi = jl_get_ci_mi(ci);
+        if (jl_options.strip_ir)
+            record_field_change((jl_value_t**)&ci->edges, (jl_value_t*)jl_emptysvec);
+        if (jl_options.strip_metadata)
+            record_field_change((jl_value_t**)&ci->debuginfo, (jl_value_t*)jl_nulldebuginfo);
         if (s->incremental) {
             // make sure we don't serialize other reachable cache entries of foreign methods
             // Should this now be:
@@ -2563,10 +2567,8 @@ static void strip_specializations_(jl_method_instance_t *mi)
                 jl_atomic_cmpswap_relaxed(&codeinst->inferred, &inferred, stripped);
             }
         }
-        if (jl_options.strip_ir)
-            record_field_change((jl_value_t**)&codeinst->edges, (jl_value_t*)jl_emptysvec);
-        if (jl_options.strip_metadata)
-            record_field_change((jl_value_t**)&codeinst->debuginfo, (jl_value_t*)jl_nulldebuginfo);
+        // n.b. `edges` and `debuginfo` are stripped in jl_insert_into_serialization_queue,
+        // which covers every serialized CodeInstance regardless of how it is reached
         codeinst = jl_atomic_load_relaxed(&codeinst->next);
     }
     if (jl_options.trim || jl_options.strip_ir) {
@@ -2852,6 +2854,10 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             if (jl_nulldebuginfo == NULL)
                 jl_errorf("Core.NullDebugInfo required for --strip-metadata option");
         }
+        // FIXME: stripping should not rely on objects being installed in the
+        // (JIT) cache to be reached for stripping / pruning in this step
+        // the AOT-compiled CodeInstances etc. are (partially) provided up-front
+        // to the serializer and may not be in the cache at all in this process
         jl_strip_all_codeinfos(mod_array);
         jl_strip_all_docmeta(mod_array);
     }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -429,6 +429,12 @@ static void record_field_change(jl_value_t **addr, jl_value_t *newval) JL_NOTSAF
         ptrhash_put(&field_replace, (void*)addr, newval);
 }
 
+// whether `record_field_change` has already registered a replacement for `addr`
+static int has_field_change(jl_value_t **addr) JL_NOTSAFEPOINT
+{
+    return ptrhash_get(&field_replace, (void*)addr) != HT_NOTFOUND;
+}
+
 static jl_value_t *get_replaceable_field(jl_value_t **addr, int mutabl) JL_GC_DISABLED
 {
     jl_value_t *fld = (jl_value_t*)ptrhash_get(&field_replace, addr);
@@ -445,6 +451,49 @@ static jl_value_t *get_replaceable_field(jl_value_t **addr, int mutabl) JL_GC_DI
         return fld;
     }
     return fld;
+}
+
+// Rewrite the `cache` field of each MethodInstance (and the `next` chain of the
+// CodeInstances it points to) so the image stores exactly the ordered list of
+// CodeInstances `cis` that codegen produced, converted to a linked list via the
+// `next` field, instead of whatever the live runtime cache happened to contain.
+// CodeInstances are grouped by their owning MethodInstance, preserving the order
+// in which they appear in `cis`. These changes are recorded through the normal
+// `field_replace` machinery, so they must be applied before the serialization
+// queue pass runs (both queueing and writing consult `get_replaceable_field`).
+static void jl_rewrite_mi_caches(jl_code_instance_t **cis, size_t n) JL_GC_DISABLED
+{
+    htable_t mi_last; // MethodInstance -> last CodeInstance recorded for it
+    htable_t seen;    // CodeInstances already placed, to guard against duplicates
+    htable_new(&mi_last, 0);
+    htable_new(&seen, 0);
+    for (size_t i = 0; i < n; i++) {
+        jl_code_instance_t *ci = cis[i];
+        // ignore any repeated CodeInstance: chaining it twice would corrupt the list
+        if (ptrhash_get(&seen, ci) != HT_NOTFOUND)
+            continue;
+        ptrhash_put(&seen, ci, ci);
+        jl_method_instance_t *mi = jl_get_ci_mi(ci);
+        // this CodeInstance terminates its MethodInstance's chain, unless a
+        // later CodeInstance for the same MethodInstance extends it below
+        record_field_change((jl_value_t**)&ci->next, NULL);
+        void **bp = ptrhash_bp(&mi_last, mi);
+        // Register unconditionally (not via record_field_change) so this
+        // cache rebuilds correctly, even if it matches what was there (which would
+        // accidentally excise the item with the next write to field_replace).
+        if (*bp == HT_NOTFOUND) {
+            // first CodeInstance seen for this MethodInstance becomes the head.
+            ptrhash_put(&field_replace, (void*)&mi->cache, (void*)ci);
+        }
+        else {
+            // link this CodeInstance after the previous one for the same MethodInstance
+            jl_code_instance_t *prev = (jl_code_instance_t*)*bp;
+            ptrhash_put(&field_replace, (void*)&prev->next, (void*)ci);
+        }
+        *bp = ci;
+    }
+    htable_free(&seen);
+    htable_free(&mi_last);
 }
 
 static uintptr_t jl_fptr_id(void *fptr)
@@ -586,6 +635,21 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
             // prevent this from happening, so we do not need to detect that user
             // error now.
         }
+        // Only the CodeInstances deliberately selected for the image caches
+        // should be reachable through `cache`; jl_rewrite_mi_caches records the
+        // chosen ordering for those MethodInstances. Any MethodInstance whose
+        // cache was not rewritten gets an empty cache here, rather than leaking
+        // whatever the live runtime cache happened to contain. Builtin functions
+        // are an exception: their cache is not part of the codegen ordering and
+        // is not repopulated at load, so keep it. Builtins are recognized by
+        // their method having neither source nor a generator (cf. the
+        // jl_is_builtinfunc heuristic in gf.c).
+        jl_value_t *midef = mi->def.value;
+        int is_builtin = jl_is_method(midef) &&
+            ((jl_method_t*)midef)->source == NULL &&
+            ((jl_method_t*)midef)->generator == NULL;
+        if (!is_builtin && !has_field_change((jl_value_t**)&mi->cache))
+            record_field_change((jl_value_t**)&mi->cache, NULL);
         // don't recurse into all backedges memory (yet)
         jl_value_t *backedges = get_replaceable_field((jl_value_t**)&mi->backedges, 1);
         if (backedges) {
@@ -2827,6 +2891,16 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
 
     int en = jl_gc_enable(0);
     if (native_functions) {
+        // Rewrite each MethodInstance's cache to the ordered list of
+        // CodeInstances codegen emitted for this image (see jl_rewrite_mi_caches).
+        size_t num_ci_order = 0;
+        jl_get_llvm_mi_cache_order(native_functions, &num_ci_order, NULL);
+        if (num_ci_order) {
+            jl_code_instance_t **ci_order = (jl_code_instance_t**)malloc_s(num_ci_order * sizeof(jl_code_instance_t*));
+            jl_get_llvm_mi_cache_order(native_functions, &num_ci_order, ci_order);
+            jl_rewrite_mi_caches(ci_order, num_ci_order);
+            free(ci_order);
+        }
         size_t num_gvars, num_external_fns;
         jl_get_llvm_gv_inits(native_functions, &num_gvars, NULL);
         arraylist_grow(&gvars, num_gvars);

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -152,17 +152,17 @@ JL_DLLEXPORT void jl_finalize_precompile_inferred(int8_t cleanup_keep_ir)
     }
 }
 
-static jl_array_t *queue_external(jl_array_t *list, jl_query_cache *query_cache);
+static jl_array_t *queue_used(jl_array_t *list, jl_query_cache *query_cache);
 
-JL_DLLEXPORT jl_array_t* jl_compute_new_ext(void)
+JL_DLLEXPORT jl_array_t* jl_compute_new_used_ci(void)
 {
     if (newly_inferred == NULL)
         return jl_alloc_vec_any(0);
     jl_query_cache query_cache;
     init_query_cache(&query_cache);
-    jl_array_t *new_ext = queue_external(newly_inferred, &query_cache);
+    jl_array_t *new_used = queue_used(newly_inferred, &query_cache);
     destroy_query_cache(&query_cache);
-    return new_ext;
+    return new_used;
 }
 
 JL_DLLEXPORT void jl_push_newly_inferred(jl_value_t* ci)
@@ -514,11 +514,11 @@ static int has_backedge_to_worklist(jl_method_instance_t *mi, htable_t *visited,
     return final_result;
 }
 
-// Given the list of CodeInstances or MethodInstances that were inferred during the build,
-// select those that are (1) external, (2) still valid, (3) are inferred to be called from
-// the worklist or explicitly added by a `precompile` statement, and (4) are the most
-// recently computed result for that method. These will be preserved in the image.
-static jl_array_t *queue_external(jl_array_t *list, jl_query_cache *query_cache)
+// Given the list of CodeInstances or MethodInstances that were inferred during
+// the build, select those that are (1) internal or are inferred to be called
+// from the worklist or explicitly added by a `precompile` statement. This will
+// be used as roots for exploring what to include in the final image.
+static jl_array_t *queue_used(jl_array_t *list, jl_query_cache *query_cache)
 {
     if (list == NULL)
         return NULL;
@@ -529,8 +529,8 @@ static jl_array_t *queue_external(jl_array_t *list, jl_query_cache *query_cache)
     size_t n0 = jl_array_nrows(list);
     htable_new(&visited, n0);
     arraylist_new(&stack, 0);
-    jl_array_t *new_ext = jl_alloc_vec_any(0);
-    JL_GC_PUSH1(&new_ext);
+    jl_array_t *new_used = jl_alloc_vec_any(0);
+    JL_GC_PUSH1(&new_used);
     for (i = n0; i-- > 0; ) {
         jl_value_t *v = jl_array_ptr_ref(list, i);
         if (jl_is_code_instance(v)) {
@@ -540,31 +540,31 @@ static jl_array_t *queue_external(jl_array_t *list, jl_query_cache *query_cache)
             int dispatch_status = jl_atomic_load_relaxed(&m->dispatch_status);
             if (!(dispatch_status & METHOD_SIG_LATEST_WHICH))
                 continue; // ignore replaced methods
-            if (jl_atomic_load_relaxed(&ci->inferred) && jl_is_method(m) && jl_object_in_image((jl_value_t*)m->module)) {
-                int found = has_backedge_to_worklist(mi, &visited, &stack, query_cache);
+            if (jl_atomic_load_relaxed(&ci->inferred) && jl_is_method(m)) {
+                int found = jl_object_in_image((jl_value_t*)m->module) ? has_backedge_to_worklist(mi, &visited, &stack, query_cache) : 1;
                 assert(found == 0 || found == 1 || found == 2);
                 assert(stack.len == 0);
                 if (found == 1) {
-                    jl_array_ptr_1d_push(new_ext, (jl_value_t*)ci);
+                    jl_array_ptr_1d_push(new_used, (jl_value_t*)ci);
                 }
             }
         }
         else if (jl_is_method_instance(v)) {
-            jl_array_ptr_1d_push(new_ext, v);
+            jl_array_ptr_1d_push(new_used, v);
         }
     }
     htable_free(&visited);
     arraylist_free(&stack);
     JL_GC_POP();
-    // reverse new_ext
-    n0 = jl_array_nrows(new_ext);
-    jl_value_t **news = jl_array_data(new_ext, jl_value_t*);
+    // reverse new_used
+    n0 = jl_array_nrows(new_used);
+    jl_value_t **news = jl_array_data(new_used, jl_value_t*);
     for (i = 0; i < n0 / 2; i++) {
         jl_value_t *temp = news[i];
         news[i] = news[n0 - i - 1];
         news[n0 - i - 1] = temp;
     }
-    return new_ext;
+    return new_used;
 }
 
 // For every method:

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1324,9 +1324,9 @@ precompile_test_harness("invoke") do dir
         end
 
         m = get_method_for_type(M.h, Real)
-        @test nvalid(m.specializations::Core.MethodInstance) == 1
+        @test m.specializations === Core.svec()
         m = get_method_for_type(M.hnc, Real)
-        @test nvalid(m.specializations::Core.MethodInstance) == 1
+        @test m.specializations === Core.svec()
         m = only(methods(M.callq))
         @test nvalid(m.specializations::Core.MethodInstance) == 1
         m = only(methods(M.callqnc))

--- a/test/precompile_absint1.jl
+++ b/test/precompile_absint1.jl
@@ -44,11 +44,7 @@ precompile_test_harness() do load_path
             mi = only(Base.specializations(m))
             ci = mi.cache
             ci = check_presence(mi, nothing)
-            @test ci !== nothing
-            @test ci.owner === nothing
-            @test ci.max_world == typemax(UInt)
-            @test Base.module_build_id(TestAbsIntPrecompile1) ==
-                Base.object_build_id(ci)
+            @test ci === nothing
             ci = check_presence(mi, cache_owner)
             @test ci !== nothing
             @test ci.owner === cache_owner
@@ -60,10 +56,7 @@ precompile_test_harness() do load_path
             for mi in Base.specializations(m)
                 if mi isa Core.MethodInstance && mi.specTypes == Tuple{typeof(sum),Vector{Float64}}
                     ci = check_presence(mi, nothing)
-                    @test ci !== nothing
-                    @test ci.owner === nothing
-                    @test ci.max_world == typemax(UInt)
-                    @test Base.module_build_id(TestAbsIntPrecompile1) == Base.object_build_id(ci)
+                    @test ci === nothing
                     ci = check_presence(mi, cache_owner)
                     @test ci !== nothing
                     @test ci.owner === cache_owner

--- a/test/precompile_absint2.jl
+++ b/test/precompile_absint2.jl
@@ -64,11 +64,7 @@ precompile_test_harness() do load_path
             mi = only(Base.specializations(m))
 
             ci = check_presence(mi, nothing)
-            @test ci !== nothing
-            @test ci.owner === nothing
-            @test ci.max_world == typemax(UInt)
-            @test Base.module_build_id(TestAbsIntPrecompile2) ==
-                Base.object_build_id(ci)
+            @test ci === nothing
             ci = check_presence(mi, cache_owner)
             @test ci !== nothing
             @test ci.owner === cache_owner
@@ -79,10 +75,7 @@ precompile_test_harness() do load_path
             for mi = Base.specializations(m)
                 if mi isa Core.MethodInstance && mi.specTypes == Tuple{typeof(sum),Vector{Float64}}
                     ci = check_presence(mi, nothing)
-                    @test ci !== nothing
-                    @test ci.owner === nothing
-                    @test ci.max_world == typemax(UInt)
-                    @test Base.module_build_id(TestAbsIntPrecompile2) == Base.object_build_id(ci)
+                    @test ci === nothing
                     ci = check_presence(mi, cache_owner)
                     @test ci !== nothing
                     @test ci.owner === cache_owner

--- a/test/precompile_extmi.jl
+++ b/test/precompile_extmi.jl
@@ -64,9 +64,11 @@ precompile_test_harness() do load_path
         using ExampleUser
         cache_owner = :ExampleInterpreter
 
+        # square is not tagged, so all garbage should be discarded
         mi_square = Base.method_instance(ExampleUser.square, (Float64,))
-        @test check_presence(mi_square, :ExampleInterpreter) !== nothing
+        @test check_presence(mi_square, :ExampleInterpreter) === nothing
 
+        # identity might be tagged, so any garbage should be preserved
         mi_identity = Base.method_instance(identity, (Float64,))
         @test check_presence(mi_identity, :ExampleInterpreter) !== nothing
     end

--- a/test/precompile_extmi.jl
+++ b/test/precompile_extmi.jl
@@ -64,11 +64,9 @@ precompile_test_harness() do load_path
         using ExampleUser
         cache_owner = :ExampleInterpreter
 
-        # square is not tagged, so all garbage should be discarded
         mi_square = Base.method_instance(ExampleUser.square, (Float64,))
-        @test check_presence(mi_square, :ExampleInterpreter) === nothing
+        @test check_presence(mi_square, :ExampleInterpreter) !== nothing
 
-        # identity might be tagged, so any garbage should be preserved
         mi_identity = Base.method_instance(identity, (Float64,))
         @test check_presence(mi_identity, :ExampleInterpreter) !== nothing
     end


### PR DESCRIPTION
When emitting a system or package image, the `cache` field of each MethodInstance (and the `next` chain of the CodeInstances hanging off it) was serialized directly from whatever the live runtime cache happened to contain. Replace that with an explicit, ordered list of CodeInstances chosen during inference: serialization now rebuilds each MethodInstance's cache as a `next`-linked list from that list, and clears the `cache` of every other MethodInstance to NULL. Builtin functions are excepted, since their caches are not part of the ordering and are not repopulated on load.

The list is produced by `typeinf_ext_toplevel`, which returns it alongside `codeinfos`, and is threaded as a distinct argument through `jl_create_native` and `jl_emit_native` into the native-code descriptor. During serialization it is read back with `jl_get_llvm_mi_cache_order` and applied by `jl_rewrite_mi_caches`, recorded through the existing field-replacement machinery so that both the queueing and writing passes observe it.

This lets us dead-code-eliminate the cache better during writing. (about 169 MB -> 164 MB, given that we'd just recently grown this by about 10% for unrelated reasons)