### PR TITLE
Base.Iterators: Add invalidation guard method for `iterate(::Reverse{Union{}})`

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -149,6 +149,10 @@ function iterate(A::Reverse, state=(reverse(eachindex(A.itr)),))
     (A.itr[idx], (state[1], itrs))
 end
 
+# Guard against invalidations due to spurious `Reverse{Union{}}` intersections
+iterate(r::Reverse{Union{}}) = throw(ArgumentError("cannot iterate a reversed iterator of type Union{}"))
+iterate(r::Reverse{Union{}}, state) = throw(ArgumentError("cannot iterate a reversed iterator of type Union{}"))
+
 reverse(R::AbstractRange) = Base.reverse(R) # copying ranges is cheap
 reverse(G::Generator) = Generator(G.f, reverse(G.iter))
 reverse(r::Reverse) = r.itr


### PR DESCRIPTION
`Base.Iterators.Reverse` instructs downstream users to implement `iterate(::Reverse{<:Foo})`, which requires this guard.

This shape for a Method extension is vulnerable (100% of the time) to spurious invalidations unless the owner of the `Reverse` type knows to add a magic `iterate(::Reverse{Union{}})` method to cover up the intersection with another type's `iterate(::Reverse{<:Bar})` method.

Improves invalidations from OrderedCollections.jl.