### PR TITLE
[JuliaLowering] Add precompile workload for generators, kwargs, etc.

### DIFF
--- a/JuliaLowering/src/precompile.jl
+++ b/JuliaLowering/src/precompile.jl
@@ -24,4 +24,29 @@ if Base.get_bool_env("JULIA_LOWERING_PRECOMPILE", true)
         lwr = to_lowered_expr(lwrst)
         @assert Meta.isexpr(lwr, :thunk) && only(lwr.args) isa Core.CodeInfo
     end
+
+    workload = raw"""
+    _precompile_kwf(x; y=1, z=2) = x + y + z
+
+    function _precompile_destr(t)
+        (a, b) = t
+        a + b
+    end
+
+    macro _precompile_plus1(ex)
+        :($ex + 1)
+    end
+    _precompile_usemac(x) = @_precompile_plus1(x)
+
+    @generated function _precompile_genf(x)
+        :(x + 1)
+    end
+
+    # Fire everything so inference and the generator run during the build.
+    _precompile_kwf(1; y = 2)
+    _precompile_destr((1, 2))
+    _precompile_usemac(3)
+    _precompile_genf(1.0)
+    """
+    include_string(@__MODULE__, workload, @__FILE__)
 end


### PR DESCRIPTION
@mlechu We may want to gate this on `DEBUG`, but this improves lowering time from ~20+ seconds to 0.53 s on a similar test package (StaticArrays / IntervalArithmetic are the motivation)