### PR TITLE
doc: update buildkite-logs agent skill for the new CI pipelines

### DIFF
--- a/doc/src/devdocs/agents/skills/buildkite-logs/SKILL.md
+++ b/doc/src/devdocs/agents/skills/buildkite-logs/SKILL.md
@@ -9,21 +9,41 @@ Use this when investigating Julia Buildkite CI failures, especially if the
 Buildkite MCP is unavailable. The recipe requires `gh`, `curl`, `python3`, and
 network access to GitHub and Buildkite.
 
-Julia's CI runs on Buildkite (pipeline `julialang/julia-master`). The public web
-UI requires sign-in to download `raw_log`, but the Buildkite frontend's JSON log
-endpoint is anonymously accessible for public pipelines. Recipe:
+Julia's CI runs on Buildkite. PR builds run in the `julialang/julia-pr`
+pipeline, post-merge master builds in `julialang/julia-ci`, and scheduled runs
+in `julialang/julia-master-scheduled` (the old `julia-master` pipeline no
+longer exists). The public web UI requires sign-in to download `raw_log`, but
+two frontend JSON endpoints are anonymously accessible for public pipelines.
+Recipe:
 
-1. List failing jobs and their UUIDs (the fragment after `#` in the URL):
+1. Find the build number. `gh pr checks <PR-number>` gives launcher-job URLs
+   like `https://buildkite.com/julialang/julia-pr/builds/<BUILD>#<uuid>`; for a
+   master commit, use the commit statuses
+   (`gh api repos/JuliaLang/julia/commits/<sha>/status`). The `#<uuid>`
+   fragments there are only the top-level launcher jobs (Build/Check/Test/…),
+   not the per-platform jobs.
 
-   ```sh
-   gh pr checks <PR-number> | grep -E "fail|pending"
-   ```
-
-2. Fetch the log JSON (replace `<BUILD>` and `<JOB-UUID>`):
+2. List all jobs in the build, with names, states, exit statuses, and UUIDs:
 
    ```sh
    curl -sS -H "Accept: application/json" \
-     "https://buildkite.com/organizations/julialang/pipelines/julia-master/builds/<BUILD>/jobs/<JOB-UUID>/log" \
+     "https://buildkite.com/julialang/<PIPELINE>/builds/<BUILD>/data/jobs" \
+     -o /tmp/bkjobs.json
+   python3 -c "import json; [print(j['state'],'|',j.get('exit_status'),'|',j['name'],'|',j['id']) \
+   for j in json.load(open('/tmp/bkjobs.json'))['records']]"
+   ```
+
+   This `/data/jobs` endpoint is what the build page's frontend uses; it
+   returns every job in one page (`records`, plus `has_next_page`). Do NOT use
+   `builds/<BUILD>.json` for job discovery — anonymously it returns build
+   metadata with an *empty* `jobs` array (the `statistics` field still shows
+   the true job count).
+
+3. Fetch a job's log JSON (replace `<PIPELINE>`, `<BUILD>`, `<JOB-UUID>`):
+
+   ```sh
+   curl -sS -H "Accept: application/json" \
+     "https://buildkite.com/organizations/julialang/pipelines/<PIPELINE>/builds/<BUILD>/jobs/<JOB-UUID>/log" \
      -o /tmp/bk.json
    ```
 
@@ -33,10 +53,15 @@ endpoint is anonymously accessible for public pipelines. Recipe:
 
    ```sh
    python3 -c "import json,re,html; s=json.load(open('/tmp/bk.json'))['output']; \
-   s=re.sub(r'<[^>]+>','',s); print(html.unescape(s))" | tail -200
+   s=re.sub(r'<[^>]+>','',s); print(html.unescape(s))" > /tmp/bk.txt
    ```
 
-The same JSON endpoint also serves still-running jobs (partial output). Note
-that the top-level Build/Check/Test jobs on a PR are pipeline launchers — the
-actual per-platform builds are spawned as child jobs whose UUIDs only appear
-once they start.
+   Write the stripped log to a file and search it (logs can be hundreds of KB);
+   piping the whole thing into context wastes tokens.
+
+The log endpoint also serves still-running jobs (partial output). For a test
+job that hung, the in-tree watchdog (`.buildkite/utilities/timeout.jl`,
+`JL_TERM_TIMEOUT`) prints per-task Julia backtraces of every worker before
+killing it, and core dumps are uploaded as artifacts with an `lldb bt all`
+summary in the log — search the log for `---- Task`, `Waiting for`, and
+`core dumped`.


### PR DESCRIPTION
This broke with the CI changes.

It'd be nice if we didn't need to go so deep to get these, but this works for now, and I guess we're unlikely to change it again soon.

Claude:

---

Julia's Buildkite CI moved from the single julia-master pipeline to julia-pr (PR builds), julia-ci (post-merge), and julia-master-scheduled. On the new pipelines the anonymous builds/<N>.json endpoint returns an empty jobs array, which broke the skill's job-discovery step. Document the /data/jobs frontend endpoint (used by the build page itself), which anonymously lists every job with name, state, exit status, and UUID, and generalize the log-fetch recipe over the pipeline name. Also note where to find watchdog task backtraces and core-dump summaries in hung test job logs.