### PR TITLE
Add `@methods` macro

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -154,6 +154,8 @@ Standard library changes
 #### InteractiveUtils
 
 * `less`/`@less` and `edit`/`@edit` are now supported for documented variables ([#53539]).
+* A new `@methods` macro lists all methods applicable to a call expression, using the types of
+  the given arguments, e.g. `@methods isvalid('a', 1)` or `@methods isvalid(::AbstractChar, ::Integer)`.
 
 #### Dates
 

--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -23,6 +23,7 @@ InteractiveUtils.less(::AbstractString)
 InteractiveUtils.less(::Any)
 InteractiveUtils.@less
 InteractiveUtils.@which
+InteractiveUtils.@methods
 InteractiveUtils.@functionloc
 InteractiveUtils.@code_lowered
 InteractiveUtils.@code_typed

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -10,7 +10,7 @@ module InteractiveUtils
 Base.Experimental.@optlevel 1
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
-    versioninfo, subtypes, supertypes, @which, @edit, @less, @functionloc, @code_warntype,
+    versioninfo, subtypes, supertypes, @which, @methods, @edit, @less, @functionloc, @code_warntype,
     @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard,
     has_system_clipboard, @trace_compile, @trace_dispatch, @activate
 

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -561,13 +561,14 @@ function gen_call_with_extracted_types_and_kwargs(__module__, fcn, ex0; is_sourc
     return gen_call_with_extracted_types(__module__, fcn, arg, kws; is_source_reflection, supports_binding_reflection, use_signature_tuple)
 end
 
-for fname in [:which, :less, :edit, :functionloc]
+for fname in [:which, :less, :edit, :functionloc, :methods]
     @eval begin
         macro ($fname)(ex0)
             gen_call_with_extracted_types(__module__, $(Expr(:quote, fname)), ex0, Expr[];
                                           is_source_reflection = true,
                                           supports_binding_reflection = $(fname in (:which,:less,:edit)),
-                                          use_signature_tuple = true)
+                                          # `methods` takes a `(f, types)` pair rather than a signature tuple
+                                          use_signature_tuple = $(fname !== :methods))
         end
     end
 end
@@ -606,9 +607,36 @@ returns the `Method` object for the method that would be called for those argume
 to a variable, it returns the module in which the variable was bound. It calls out to the
 [`which`](@ref) function.
 
-See also: [`@less`](@ref), [`@edit`](@ref).
+See also: [`@less`](@ref), [`@edit`](@ref), [`@methods`](@ref).
 """
 :@which
+
+"""
+    @methods
+
+Applied to a function call, it uses the types of the given arguments to return the list of
+`Method`s that could be applicable, i.e. all methods whose signature is compatible with those
+argument types. It calls out to the [`methods`](@ref) function.
+
+Just like [`@which`](@ref), the arguments are interpreted as values, so their concrete types
+are used. To query against another type, annotate the argument with `::`, e.g.
+`@methods f(::Integer)`. Unlike `@which`, which returns the single method that would be
+dispatched for a concrete call, `@methods` lists every matching method, which is particularly
+useful when the argument types are non-concrete (abstract types, `Union`s or `UnionAll`s).
+
+# Examples
+```julia-repl
+julia> @methods isvalid(::AbstractChar, ::Integer)
+
+julia> @methods isvalid('a', 1)
+```
+
+!!! compat "Julia 1.14"
+    This macro requires at least Julia 1.14.
+
+See also: [`@which`](@ref), [`methods`](@ref).
+"""
+:@methods
 
 """
     @less

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -271,6 +271,18 @@ const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
 # issue #13264
 @test (@which vcat(1...)).name === :vcat
 
+@testset "@methods" begin
+    ms = @methods sort(::AbstractVector)
+    @test ms isa Base.MethodList
+    @test ms == methods(sort, (AbstractVector,))
+    # arguments are interpreted as values, like `@which`
+    @test (@methods sort([1, 2, 3])) == methods(sort, (Vector{Int},))
+    # qualified callable
+    @test (@methods Base.sort(::AbstractVector)) == methods(sort, (AbstractVector,))
+    # unlike `@which`, lists every matching method when types are abstract
+    @test length(@methods +(::Integer, ::Integer)) > 1
+end
+
 # PR #28122, issue #25474
 @test (@which [1][1]).name === :getindex
 @test (@which [1][1] = 2).name === :setindex!


### PR DESCRIPTION
Add a `@methods` macro which lists all methods applicable to a call expression, using the types of the given arguments, e.g. `@methods isvalid('a', 1)` or `@methods isvalid(::AbstractChar, ::Integer)`.

This is the logical superposition of `@which` and `methods` having
- the convenient syntax from `@which`
- the ability to return more than one match for non-concrete type constraints