### PR TITLE
[1.13] coverage: skip instrumentation invalidation for foreign CodeInstances #62260)

### DIFF
--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -124,6 +124,8 @@ function gen_staged_sig(def::Method, mi::MethodInstance)
 end
 
 function needs_instrumentation(codeinst::CodeInstance, mi::MethodInstance, def::Method, validation_world::UInt)
+    # foreign CIs (owner !== nothing) aren't run as native code here, so instrumenting them is moot
+    codeinst.owner === nothing || return false
     if JLOptions().code_coverage != 0 || JLOptions().malloc_log != 0
         # test if the code needs to run with instrumentation, in which case we cannot use existing generated code
         if isdefined(def, :debuginfo) ? # generated_only functions do not have debuginfo, so fall back to considering their codeinst debuginfo though this may be slower and less reliable


### PR DESCRIPTION
This fixes a GPUCompiler test issue where we precompile code and make sure it doesn't recompile. However, because precompilation doesn't generate instrumented cache entries, and testing runs with code coverage enabled, we can never reuse cache entries. "Fix" this by not invalidating foreign CodeInstances for instrumentation, where that doesn't make sense anyway: they never run as native code here.

(cherry picked from commit 8048a05448664e97ff479314222f2794d4b992ed)