### PR TITLE
reinfer: retain invalidated code instances in the method instance cache

### DIFF
--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -321,14 +321,17 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
             if result.result_maxworld == 0 || result.child_cycle == work.depth
                 while length(workspace.stack) ≥ work.depth
                     child = pop!(workspace.stack)
-                    if result.result_maxworld ≠ 0
-                        @atomic :monotonic child.min_world = result.result_minworld
-                        # Finally, if this CI is still valid in some world age and marked as valid in the native cache, poke it in that mi's cache now
-                        if child.flags & CI_FLAGS_NATIVE_CACHE_VALID == CI_FLAGS_NATIVE_CACHE_VALID
-                            @ccall jl_mi_cache_insert(get_ci_mi(child)::Any, child::Any)::Cvoid
-                        end
-                    end
+                    @atomic :monotonic child.min_world = result.result_minworld
                     @atomic :monotonic child.max_world = result.result_maxworld
+                    # Poke this CI back into its mi's cache if it was in the native cache, using
+                    # the computed world age. We do this even when the CI is now invalidated
+                    # (max_world below the validation world): keeping the invalidated CI in the
+                    # cache leaves it discoverable so it can be recompiled on demand, instead of
+                    # leaving the cache empty and silently dropping a precompiled-but-invalidated
+                    # (foreign) method.
+                    if child.flags & CI_FLAGS_NATIVE_CACHE_VALID == CI_FLAGS_NATIVE_CACHE_VALID
+                        @ccall jl_mi_cache_insert(get_ci_mi(child)::Any, child::Any)::Cvoid
+                    end
                     if result.result_maxworld == validation_world && validation_world == get_world_counter() && isdefined(child, :edges)
                         store_backedges(child, child.edges)
                     end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1128,6 +1128,67 @@ precompile_test_harness("code caching") do dir
     end
 end
 
+precompile_test_harness("invalidated foreign cache is retained") do dir
+    # A precompiled *foreign* specialization that is invalidated at load time (via
+    # the reinfer/verify_methods path) must be kept in its MethodInstance cache
+    # with its world age set, rather than dropped to a NULL cache.
+    InvLow = :InvLow_0x5b8f2a1c
+    InvUse = :InvUse_0x5b8f2a1c
+    InvExt = :InvExt_0x5b8f2a1c
+    write(joinpath(dir, "$InvLow.jl"),
+        """
+        module $InvLow
+        low(x) = 1
+        mid(x) = low(x)
+        end
+        """)
+    write(joinpath(dir, "$InvUse.jl"),
+        """
+        module $InvUse
+        using $InvLow
+        # Precompiles the foreign specialization $InvLow.mid(::String) and its edge
+        # to $InvLow.low(::String). $InvUse does not know about $InvExt.
+        top() = $InvLow.mid("hi")
+        begin
+            Base.Experimental.@force_compile
+            @noinline top()
+        end
+        end
+        """)
+    write(joinpath(dir, "$InvExt.jl"),
+        """
+        module $InvExt
+        using $InvLow
+        $InvLow.low(x::String) = 2
+        end
+        """)
+    for pkg in (InvLow, InvUse, InvExt)
+        Base.compilecache(Base.PkgId(string(pkg)))
+    end
+    # Load the invalidator first, then the package whose precompiled foreign
+    # specialization is now stale.
+    @eval using $InvExt
+    @eval using $InvUse
+    invokelatest() do
+        ML = Base.root_module(Base.PkgId(string(InvLow)))
+        world = Base.get_world_counter()
+        m = only(methods(ML.mid))
+        mis = filter(x -> x isa Core.MethodInstance, collect(Base.specializations(m)))
+        mi = only(mis)  # InvLow.mid(::String)
+        @test mi.specTypes.parameters[end] === String
+        # The invalidated CI is retained (not dropped to a NULL cache) ...
+        @test isdefined(mi, :cache)
+        # ... still considered invalidated in the current world ...
+        @test mi.cache.max_world < world
+        # ... with a sane, non-sentinel world age ...
+        @test mi.cache.min_world != ~zero(UInt)
+        @test mi.cache.max_world != Base.ReinferUtils.WORLD_AGE_REVALIDATION_SENTINEL
+        # ... and it recompiles on demand.
+        MU = Base.root_module(Base.PkgId(string(InvUse)))
+        @test invokelatest(MU.top) == 2
+    end
+end
+
 precompile_test_harness("precompiletools") do dir
     PrecompileToolsModule = :PCTb8321416e8a3e2f1
     write(joinpath(dir, "$PrecompileToolsModule.jl"),


### PR DESCRIPTION
:man: 

Me and @topolarity was debugging (a couple of months ago) why some precompiled methods from packages didn't "stick" in a custom sysimage and noticed that if they were already invalid when they loaded, they ended up getting completely ignored (as opposed to methods that got invalidated in other ways were they get recompiled for the latest world age and serialized into the sysimage). We debugged this to the point that in this bad case the `mi.cache` field of these got set to NULL and then the ``enqueue_specialization!` skipped them:

https://github.com/JuliaLang/julia/blob/8561b1c8955cc7b5eefba72b7302e55f226674eb/Compiler/src/precompile.jl#L315-L332

---

:robot: 

When loading a precompiled package image, backedge verification only
re-inserted a CodeInstance into its MethodInstance cache when it verified
as still valid. For a foreign method's specialization (whose `mi.cache` is
serialized as NULL, expecting re-insertion on load), an invalidated
CodeInstance was therefore left out, leaving `mi.cache` NULL.

The output collector (`enqueue_specialization!`) decides what to recompile
by walking `mi.cache`, so a NULL cache caused the invalidated method to be
skipped and dropped from a subsequently produced sysimage instead of being
recompiled for the new world.

Set the world age and re-insert the CodeInstance into the cache even when it
is invalidated, matching how runtime invalidation leaves the capped instance
in place.
