### PR TITLE
support: Fix Eytzinger range containment for boundaries and abutting ranges

### DIFF
--- a/src/support/.gitignore
+++ b/src/support/.gitignore
@@ -5,3 +5,5 @@
 /*.pdb
 /libsupport.a
 /libsupport-debug.a
+/rletest
+/eytzingertest

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -115,6 +115,20 @@ regenerate-compile_commands:
 compile-database: regenerate-compile_commands
 	@echo "Compilation database created for src/support"
 
+# Standalone unit tests for support utilities. Built with assertions enabled
+# so the internal consistency checks in the tested code are exercised too.
+TEST_SRCS := rletest eytzingertest
+TEST_BINS := $(TEST_SRCS:%=$(BUILDDIR)/%$(EXE))
+
+$(TEST_BINS): $(BUILDDIR)/%$(EXE): $(SRCDIR)/test/%.c $(BUILDDIR)/libsupport-debug.a $(HEADERS) | $(BUILDDIR)
+	@$(call PRINT_CC, $(CC) $(JCPPFLAGS) $(JCFLAGS) $(DEBUGFLAGS) $< \
+		$(BUILDDIR)/libsupport-debug.a $(LIBUV) -o $@ -lpthread -ldl -lm)
+
+test: $(TEST_BINS)
+	@for t in $(TEST_BINS); do echo "  RUN     $$t"; $$t || exit 1; done
+
+.PHONY: test
+
 clean:
 	rm -f $(BUILDDIR)/*.o
 	rm -f $(BUILDDIR)/*.dbg.obj
@@ -125,5 +139,6 @@ clean:
 	rm -f $(BUILDDIR)/libsupport-debug.a
 	rm -f $(BUILDDIR)/compile_commands.json*
 	rm -f $(BUILDDIR)/host/*
+	rm -f $(TEST_BINS)
 
 .PHONY: compile-database

--- a/src/support/eytzinger.c
+++ b/src/support/eytzinger.c
@@ -45,14 +45,25 @@ static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
         eyt_range_t *r = &t->ranges[i / 2];
         uintptr_t val = (i & 1) ? r->end : r->start;
         assert(val % 4 == 0 && "Range boundary not 4-byte aligned!");
-        // We abuse the pointer here a little so that a couple of properties are true:
-        // 1. a start and an end are never the same value. This simplifies the binary search.
-        // 2. ends are always after starts. This also simplifies the binary search.
-        // We assume that there exist no 0-size ranges, but that's a safe assumption
-        // since it means nothing could be there anyways
-        //
-        // FIXME: https://github.com/JuliaLang/julia/issues/61385
-        idxs[i] = val + (i & 1);
+        // Encode each boundary so that the strictly-less-than predecessor search
+        // in _eyt_obj_idx answers half-open [start, end) containment queries
+        // correctly, including for abutting ranges. All boundaries are 4-byte
+        // aligned (asserted above), so the low two bits are free; we offset a
+        // start boundary by +2 and an end boundary by +1:
+        //   start(s) -> s + 2   (s % 4 == 0, so this is even; low bit 0)
+        //   end(e)   -> e + 1   (odd; low bit 1)
+        // This gives three useful properties:
+        // 1. A start and an end never encode to the same value, so all boundaries
+        //    are distinct (required to build the Eytzinger tree).
+        // 2. When a range ends exactly where the next one starts (abutting), the
+        //    start boundary (e + 2) sorts *after* the coincident end boundary
+        //    (e + 1), so a lookup at that address lands in the later range.
+        // 3. The low bit distinguishes starts (even, in-range) from ends (odd,
+        //    out-of-range), which eyt_tree_is_in_range tests directly.
+        // We assume there are no 0-size ranges, which is safe since nothing could
+        // be stored there anyway. See _eyt_obj_idx for how the query value for a
+        // given address is chosen to match this encoding.
+        idxs[i] = val + ((i & 1) ? 1 : 2);
     }
     qsort(idxs, end, sizeof(uintptr_t), ptr_cmp);
     t->min_addr = idxs[0];
@@ -65,7 +76,7 @@ static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
         eyt_range_t *r = &t->ranges[i / 2];
         uintptr_t val = (i & 1) ? r->end : r->start;
         // This is the same computation as in the prior for loop
-        uintptr_t eyt_val = val + (i & 1);
+        uintptr_t eyt_val = val + ((i & 1) ? 1 : 2);
         size_t eyt_idx = _eyt_obj_idx(eyt_val + 1, tree, end, t->min_addr, t->max_addr);
         assert(eyt_idx < end);
         assert(tree[eyt_idx] == eyt_val &&

--- a/src/support/eytzinger.h
+++ b/src/support/eytzinger.h
@@ -14,29 +14,44 @@
 extern "C" {
 #endif
 
-// Search an Eytzinger tree for the predecessor boundary of `addr`.
-// Returns the tree index (0-based) of the predecessor, or `n`
-// (the sentinel) if `addr` is outside all ranges.
-// `items` has `n + 1` entries (n boundaries + 1 sentinel).
-static inline size_t _eyt_obj_idx(uintptr_t addr, uintptr_t *tree, size_t n,
+// Search an Eytzinger tree for the largest boundary strictly less than the
+// query value `q`. Returns the tree index (0-based) of that boundary, or `n`
+// (the sentinel) if there is none.
+// `tree` has `n + 1` entries (n boundaries + 1 sentinel).
+//
+// The boundaries are encoded by rebuild_tree (see there): a start boundary `s`
+// is stored as `s + 2` and an end boundary `e` as `e + 1`. To ask whether a
+// 4-byte-aligned address `addr` is contained in a half-open range, query with
+// `q = addr + 3` (see _eyt_addr_query). Because `addr % 4 == 0`, this query is
+// `== 3 (mod 4)` and so never coincides with any boundary (which are 1 or 2 mod
+// 4), and its strictly-less-than predecessor is the range's start boundary iff
+// `start <= addr < end`.
+static inline size_t _eyt_obj_idx(uintptr_t q, uintptr_t *tree, size_t n,
                                   uintptr_t min_addr, uintptr_t max_addr) JL_NOTSAFEPOINT
 {
     if (n == 0)
         return n;
     assert(n % 2 == 0 && "Eytzinger tree not even length!");
-    if (addr <= min_addr || addr > max_addr)
+    if (q <= min_addr || q > max_addr)
         return n;
     size_t k = 1;
     while (k <= n) {
-        int greater = (addr > tree[k - 1]);
+        int greater = (q > tree[k - 1]);
         k <<= 1;
         k |= greater;
     }
     k >>= (__builtin_ctzll(k) + 1);
     assert(k != 0);
     assert(k <= n && "Eytzinger tree index out of bounds!");
-    assert(tree[k - 1] < addr && "Failed to find lower bound for object!");
+    assert(tree[k - 1] < q && "Failed to find lower bound for object!");
     return k - 1;
+}
+
+// Map a 4-byte-aligned address to the query value used to test containment in
+// the encoded tree. See _eyt_obj_idx and rebuild_tree for the encoding.
+static inline uintptr_t _eyt_addr_query(uintptr_t addr) JL_NOTSAFEPOINT
+{
+    return addr + 3;
 }
 
 typedef struct {
@@ -72,7 +87,7 @@ JL_DLLEXPORT void eyt_tree_add_range(eyt_tree_t *t, uintptr_t start, uintptr_t e
 static inline int eyt_tree_is_in_range(eyt_tree_t *t, uintptr_t addr) JL_NOTSAFEPOINT
 {
     uv_rwlock_rdlock(&t->rwlock);
-    size_t idx = _eyt_obj_idx(addr, (uintptr_t*)t->tree.items, t->n, t->min_addr, t->max_addr);
+    size_t idx = _eyt_obj_idx(_eyt_addr_query(addr), (uintptr_t*)t->tree.items, t->n, t->min_addr, t->max_addr);
     int result = ((uintptr_t)t->tree.items[idx] & 1) == 0;
     uv_rwlock_rdunlock(&t->rwlock);
     return result;
@@ -83,7 +98,7 @@ static inline int eyt_tree_is_in_range(eyt_tree_t *t, uintptr_t addr) JL_NOTSAFE
 static inline void *eyt_tree_find_data(eyt_tree_t *t, uintptr_t addr) JL_NOTSAFEPOINT
 {
     uv_rwlock_rdlock(&t->rwlock);
-    size_t idx = _eyt_obj_idx(addr, (uintptr_t*)t->tree.items, t->n, t->min_addr, t->max_addr);
+    size_t idx = _eyt_obj_idx(_eyt_addr_query(addr), (uintptr_t*)t->tree.items, t->n, t->min_addr, t->max_addr);
     void *result = t->idxs.items[idx];
     uv_rwlock_rdunlock(&t->rwlock);
     return result;

--- a/src/support/test/eytzingertest.c
+++ b/src/support/test/eytzingertest.c
@@ -1,0 +1,128 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// Regression tests for the Eytzinger address-range tree (see eytzinger.h).
+// Covers the half-open [start, end) semantics and abutting ranges that were
+// mishandled in https://github.com/JuliaLang/julia/issues/61385.
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include "../eytzinger.h"
+
+static int in_range(eyt_tree_t *t, uintptr_t a) { return eyt_tree_is_in_range(t, a); }
+static void *find(eyt_tree_t *t, uintptr_t a) { return eyt_tree_find_data(t, a); }
+
+// Brute-force reference over a set of non-overlapping (possibly abutting) ranges.
+typedef struct { uintptr_t s, e; void *d; } rng_t;
+static void *ref_find(rng_t *ranges, int nr, uintptr_t a) {
+    for (int i = 0; i < nr; i++)
+        if (a >= ranges[i].s && a < ranges[i].e)
+            return ranges[i].d;
+    return EYT_NOTFOUND;
+}
+
+int main(void)
+{
+    // Empty tree: nothing is in range.
+    {
+        eyt_tree_t t; eyt_tree_init(&t);
+        assert(!in_range(&t, 0));
+        assert(!in_range(&t, 100));
+        assert(find(&t, 100) == EYT_NOTFOUND);
+    }
+
+    // Single range [100, 200): start inclusive, end exclusive.
+    {
+        eyt_tree_t t; eyt_tree_init(&t);
+        eyt_tree_add_range(&t, 100, 200, (void*)0x10);
+        assert(!in_range(&t, 96));   // before
+        assert(in_range(&t, 100));   // start (inclusive)
+        assert(in_range(&t, 104));
+        assert(in_range(&t, 196));   // last element
+        assert(!in_range(&t, 200));  // end (exclusive)
+        assert(!in_range(&t, 204));  // after
+        assert(find(&t, 100) == (void*)0x10);
+        assert(find(&t, 196) == (void*)0x10);
+        assert(find(&t, 200) == EYT_NOTFOUND);
+    }
+
+    // Two disjoint ranges [100, 200) and [300, 400).
+    {
+        eyt_tree_t t; eyt_tree_init(&t);
+        eyt_tree_add_range(&t, 100, 200, (void*)0x10);
+        eyt_tree_add_range(&t, 300, 400, (void*)0x20);
+        assert(in_range(&t, 100) && find(&t, 100) == (void*)0x10);
+        assert(!in_range(&t, 200));
+        assert(!in_range(&t, 252));  // gap
+        assert(in_range(&t, 300) && find(&t, 300) == (void*)0x20);
+        assert(in_range(&t, 396));
+        assert(!in_range(&t, 400));
+    }
+
+    // Abutting ranges [100, 200) and [200, 300): the shared boundary belongs
+    // to the second range.
+    {
+        eyt_tree_t t; eyt_tree_init(&t);
+        eyt_tree_add_range(&t, 100, 200, (void*)0x10);
+        eyt_tree_add_range(&t, 200, 300, (void*)0x20);
+        assert(in_range(&t, 100) && find(&t, 100) == (void*)0x10);
+        assert(in_range(&t, 196) && find(&t, 196) == (void*)0x10);
+        assert(in_range(&t, 200) && find(&t, 200) == (void*)0x20);
+        for (uintptr_t a = 204; a < 300; a += 4)
+            assert(in_range(&t, a) && find(&t, a) == (void*)0x20);
+        assert(!in_range(&t, 300));
+    }
+
+    // Ranges added out of address order are still handled correctly.
+    {
+        eyt_tree_t t; eyt_tree_init(&t);
+        eyt_tree_add_range(&t, 300, 400, (void*)0x20);
+        eyt_tree_add_range(&t, 100, 200, (void*)0x10);
+        eyt_tree_add_range(&t, 200, 300, (void*)0x30);  // abuts both neighbors
+        assert(find(&t, 100) == (void*)0x10);
+        assert(find(&t, 200) == (void*)0x30);
+        assert(find(&t, 300) == (void*)0x20);
+        assert(!in_range(&t, 400));
+        assert(!in_range(&t, 96));
+    }
+
+    // Deterministic fuzz: random non-overlapping ranges (some abutting), added
+    // in random order, exhaustively compared against the brute-force reference.
+    {
+        srand(20250709);
+        for (int trial = 0; trial < 3000; trial++) {
+            int nr = 1 + rand() % 6;
+            rng_t ranges[8];
+            uintptr_t cur = 4 * (1 + rand() % 10);
+            eyt_tree_t t; eyt_tree_init(&t);
+            for (int i = 0; i < nr; i++) {
+                uintptr_t gap = 4 * (rand() % 4);      // 0 (abut) .. 12
+                uintptr_t len = 4 * (1 + rand() % 8);  // 4 .. 32
+                cur += gap;
+                ranges[i].s = cur;
+                ranges[i].e = cur + len;
+                ranges[i].d = (void*)(uintptr_t)(0x100 + i);
+                cur += len;
+            }
+            int order[8];
+            for (int i = 0; i < nr; i++) order[i] = i;
+            for (int i = nr - 1; i > 0; i--) {
+                int j = rand() % (i + 1);
+                int tmp = order[i]; order[i] = order[j]; order[j] = tmp;
+            }
+            for (int i = 0; i < nr; i++)
+                eyt_tree_add_range(&t, ranges[order[i]].s, ranges[order[i]].e, ranges[order[i]].d);
+
+            uintptr_t lo = ranges[0].s > 16 ? ranges[0].s - 16 : 0;
+            uintptr_t hi = ranges[nr - 1].e + 16;
+            for (uintptr_t a = lo; a <= hi; a += 4) {
+                void *ref = ref_find(ranges, nr, a);
+                assert(find(&t, a) == ref);
+                assert(in_range(&t, a) == (ref != EYT_NOTFOUND));
+            }
+        }
+    }
+
+    printf("eytzingertest: all tests passed\n");
+    return 0;
+}

--- a/src/support/test/rletest.c
+++ b/src/support/test/rletest.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "../rle.h"
 
-int main()
+int main(void)
 {
     /* Iteration */
     rle_iter_state state = rle_iter_init(22);


### PR DESCRIPTION
The Eytzinger address-range tree used to answer "is this object inside a loaded sys/pkg image" queries encoded its range boundaries incorrectly. Range starts (img_min) were reported as outside the range and exclusive range ends (img_max) as inside it, inverting the intended half-open [start, end) semantics. Additionally, if one range ended exactly where the next began, the shared boundary and the entire interior of the following range were reported as out of range, because end boundaries sorted after coincident start boundaries. This didn't matter for images, since they had padding around them, so we would avoid those queries. But it affects the general correctness / re-usability of the data structure.

Since all boundaries are 4-byte aligned, encode a start boundary s as s + 2 (even, in-range) and an end boundary e as e + 1 (odd, out-of-range) so that at a shared address the start wins the tie, and query a 4-byte aligned address with addr + 3, which is congruent to 3 (mod 4) and so never coincides with any boundary. Its strict predecessor is then the range's start boundary exactly when start <= addr < end.

Also wire up a `make test` target under src/support that runs the standalone unit tests, since none were previously reachable.

Fixes #61385