### PR TITLE
partr: wake task's owner thread when skipping it in scheduler

### DIFF
--- a/base/partr.jl
+++ b/base/partr.jl
@@ -210,7 +210,14 @@ function multiq_deletemin()
         heap = tpheaps[rn1]
         task = heap.tasks[1]
         if ccall(:jl_set_task_tid, Cint, (Any, Cint), task, tid-1) == 0
+            # This task is sticky to a different thread, so we can't run it.
+            # Wake that thread so it can come pick up its own work, then keep
+            # looking for something we are allowed to run.
+            task_tid = ccall(:jl_get_task_tid, Int16, (Any,), task)
             unlock(heap.lock)
+            if task_tid != Int16(-1)
+                ccall(:jl_wakeup_thread, Cvoid, (Int16,), task_tid)
+            end
             continue
         end
         break


### PR DESCRIPTION
When multiq_deletemin finds that the highest-priority task in the chosen heap is sticky to a different thread, it cannot claim the task and moves on to look for other work. If the thread that task is pinned to is asleep, nothing wakes it, so the task can stall until some other event happens to rouse that thread.

Before continuing the scan, read the task's owning thread id and wake it so it can come pick up its own work.