### PR TITLE
div: Return exact rounded integer remainders

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -104,6 +104,11 @@ without any intermediate rounding.
   ``[0, -y)`` otherwise. The result may not be exact if `x` and `y` have the same sign, and
   `abs(x) < abs(y)`. See also [`RoundFromZero`](@ref).
 
+For integer arguments, `RoundUp` and the nearest rounding modes return the same type as
+`mod(x, -signed(y))`; `RoundFromZero` does so when it rounds upward. If the exact
+remainder is not representable in that type, an `InexactError` is thrown instead of
+returning a modularly equivalent value.
+
 !!! compat "Julia 1.9"
     `RoundFromZero` requires at least Julia 1.9.
 
@@ -123,10 +128,38 @@ true
 """
 rem(x, y, r::RoundingMode)
 
+@inline _rounded_rem_type(x, y) = typeof(mod(oneunit(x), -oneunit(signed(y))))
+@inline _mod_result_type(x, y) = typeof(mod(oneunit(x), oneunit(y)))
+@inline _signed_widen(x::Bool) = Int(x)
+@inline _signed_widen(x::Integer) = signed(widen(x))
+
+@inline function _widened_add(x::Integer, y::Integer)
+    x, y = promote(_signed_widen(x), _signed_widen(y))
+    x + y
+end
+@inline function _widened_sub(x::Integer, y::Integer)
+    x, y = promote(_signed_widen(x), _signed_widen(y))
+    x - y
+end
+
 # TODO: Make these primitive and have the two-argument version call these
 rem(x, y, ::RoundingMode{:ToZero}) = rem(x, y)
 rem(x, y, ::RoundingMode{:Down}) = mod(x, y)
 rem(x, y, ::RoundingMode{:Up}) = mod(x, -y)
+function rem(x, y::Unsigned, ::RoundingMode{:Up})
+    R = _rounded_rem_type(x, y)
+    convert(R, mod(x, -signed(widen(y))))
+end
+function rem(x::Integer, y::Unsigned, ::RoundingMode{:Up})
+    R = _rounded_rem_type(x, y)
+    x, y = promote(_signed_widen(x), _signed_widen(y))
+    convert(R, mod(x, -y))
+end
+function rem(x, y::T, ::RoundingMode{:Up}) where {T<:BitSigned}
+    y == typemin(T) || return mod(x, -y)
+    R = _rounded_rem_type(x, y)
+    convert(R, mod(x, -widen(y)))
+end
 rem(x, y, r::RoundingMode{:Nearest}) = x - y * div(x, y, r)
 rem(x::Integer, y::Integer, r::RoundingMode{:Nearest}) = divrem(x, y, r)[2]
 function rem(x::Integer, y::Integer, rnd::Union{typeof(RoundNearestTiesAway),
@@ -275,71 +308,86 @@ function divrem(a, b, r::RoundingMode)
         (div(a, b, r), rem(a, b, r))
     end
 end
-# avoids calling rem for Integers-Integers (all modes),
-# a - d * b not precise for Floats - AbstractFloat, AbstractIrrational.
-# Rationals are still slower
-function divrem(a::Integer, b::Integer, r::Union{typeof(RoundUp),
-                                                typeof(RoundDown),
-                                                typeof(RoundToZero)})
-    if r === RoundToZero
-        # For compat. Remove in 2.0.
-        d = div(a, b)
-        (d, a - d * b)
-    elseif r === RoundDown
-        # For compat. Remove in 2.0.
-        d = fld(a, b)
-        (d, a - d * b)
-    elseif r === RoundUp
-        # For compat. Remove in 2.0.
-        d = div(a, b, r)
-        (d, a - d * b)
-    end
+# Avoids calling rem for Integers-Integers. Rationals are still slower, and
+# a - d * b is not precise for AbstractFloats and AbstractIrrationals.
+function divrem(a::Integer, b::Integer, ::typeof(RoundToZero))
+    # For compat. Remove in 2.0.
+    d = div(a, b)
+    (d, a - d * b)
+end
+
+@inline _divrem_keep(::Type{R}, q, r) where {R} = (q, convert(R, r))
+@inline _divrem_inc(::Type{R}, q, r, y) where {R} =
+    (q + true, convert(R, _widened_sub(r, y)))
+@inline _divrem_dec(::Type{R}, q, r, y) where {R} =
+    (q - true, convert(R, _widened_add(r, y)))
+
+function divrem(a::Integer, b::Integer, ::typeof(RoundDown))
+    q, r = divrem(a, b)
+    R = _mod_result_type(a, b)
+    signbit(a) != signbit(b) && !iszero(r) ? _divrem_dec(R, q, r, b) :
+                                             _divrem_keep(R, q, r)
+end
+function divrem(a::Integer, b::Integer, ::typeof(RoundUp))
+    q, r = divrem(a, b)
+    R = _rounded_rem_type(a, b)
+    signbit(a) == signbit(b) && !iszero(r) ? _divrem_inc(R, q, r, b) :
+                                             _divrem_keep(R, q, r)
 end
 function divrem(x::Integer, y::Integer, rnd::typeof(RoundNearest))
     (q, r) = divrem(x, y)
+    R = _rounded_rem_type(x, y)
     if x >= 0
         if y >= 0
-            r >=        (y÷2) + (isodd(y) | iseven(q)) ? (q+true, r-y) : (q, r)
+            r >= (y÷2) + (isodd(y) | iseven(q)) ?
+                _divrem_inc(R, q, r, y) : _divrem_keep(R, q, r)
         else
-            r >=       -(y÷2) + (isodd(y) | iseven(q)) ? (q-true, r+y) : (q, r)
+            r >= -(y÷2) + (isodd(y) | iseven(q)) ?
+                _divrem_dec(R, q, r, y) : _divrem_keep(R, q, r)
         end
     else
         if y >= 0
-            r <= -signed(y÷2) - (isodd(y) | iseven(q)) ? (q-true, r+y) : (q, r)
+            r <= -signed(y÷2) - (isodd(y) | iseven(q)) ?
+                _divrem_dec(R, q, r, y) : _divrem_keep(R, q, r)
         else
-            r <=        (y÷2) - (isodd(y) | iseven(q)) ? (q+true, r-y) : (q, r)
+            r <= (y÷2) - (isodd(y) | iseven(q)) ?
+                _divrem_inc(R, q, r, y) : _divrem_keep(R, q, r)
         end
     end
 end
 function divrem(x::Integer, y::Integer, rnd:: typeof(RoundNearestTiesAway))
     (q, r) = divrem(x, y)
+    R = _rounded_rem_type(x, y)
     if x >= 0
         if y >= 0
-            r >=        (y÷2) + isodd(y) ? (q+true, r-y) : (q, r)
+            r >= (y÷2) + isodd(y) ? _divrem_inc(R, q, r, y) : _divrem_keep(R, q, r)
         else
-            r >=       -(y÷2) + isodd(y) ? (q-true, r+y) : (q, r)
+            r >= -(y÷2) + isodd(y) ? _divrem_dec(R, q, r, y) : _divrem_keep(R, q, r)
         end
     else
         if y >= 0
-            r <= -signed(y÷2) - isodd(y) ? (q-true, r+y) : (q, r)
+            r <= -signed(y÷2) - isodd(y) ?
+                _divrem_dec(R, q, r, y) : _divrem_keep(R, q, r)
         else
-            r <=        (y÷2) - isodd(y) ? (q+true, r-y) : (q, r)
+            r <= (y÷2) - isodd(y) ? _divrem_inc(R, q, r, y) : _divrem_keep(R, q, r)
         end
     end
 end
 function divrem(x::Integer, y::Integer, rnd::typeof(RoundNearestTiesUp))
     (q, r) = divrem(x, y)
+    R = _rounded_rem_type(x, y)
     if x >= 0
         if y >= 0
-            r >=        (y÷2) + isodd(y) ? (q+true, r-y) : (q, r)
+            r >= (y÷2) + isodd(y) ? _divrem_inc(R, q, r, y) : _divrem_keep(R, q, r)
         else
-            r >=       -(y÷2) + true     ? (q-true, r+y) : (q, r)
+            r >= -(y÷2) + true ? _divrem_dec(R, q, r, y) : _divrem_keep(R, q, r)
         end
     else
         if y >= 0
-            r <= -signed(y÷2) - true     ? (q-true, r+y) : (q, r)
+            r <= -signed(y÷2) - true ?
+                _divrem_dec(R, q, r, y) : _divrem_keep(R, q, r)
         else
-            r <=        (y÷2) - isodd(y) ? (q+true, r-y) : (q, r)
+            r <= (y÷2) - isodd(y) ? _divrem_inc(R, q, r, y) : _divrem_keep(R, q, r)
         end
     end
 end

--- a/test/int.jl
+++ b/test/int.jl
@@ -453,6 +453,49 @@ end
             end
         end
     end
+
+    # Exact rounded remainders must not silently wrap for mixed signedness (#34325).
+    for X in (Int8, UInt8), Y in (Int8, UInt8)
+        rounded_type = typeof(mod(one(X), -signed(one(Y))))
+        mod_type = typeof(mod(one(X), one(Y)))
+        for x in typemin(X):typemax(X), y in typemin(Y):typemax(Y)
+            if y == 0 || (X === Int8 && Y === Int8 && x == typemin(X) && y == -1)
+                continue
+            end
+            for r in (RoundDown, RoundUp, RoundFromZero,
+                      RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp)
+                d = div(Int16(x), Int16(y), r)
+                exact = Int16(x) - Int16(y) * d
+                R = r === RoundDown ||
+                    (r === RoundFromZero && signbit(x) != signbit(y)) ? mod_type : rounded_type
+                if typemin(R) <= exact <= typemax(R)
+                    expected = R(exact)
+                    @test rem(x, y, r) === expected
+                    @test divrem(x, y, r) === (div(x, y, r), expected)
+                else
+                    @test_throws InexactError rem(x, y, r)
+                    @test_throws InexactError divrem(x, y, r)
+                end
+            end
+        end
+    end
+
+    for T in Base.BitSigned_types
+        U = unsigned(T)
+        tm = typemin(T)
+        @test rem(T(7), tm, RoundUp) === T(7)
+        @test divrem(T(7), tm, RoundUp) === (T(0), T(7))
+        @test rem(T(-7), tm, RoundFromZero) === typemax(T) - T(6)
+        @test divrem(T(-7), tm, RoundFromZero) === (T(1), typemax(T) - T(6))
+        @test rem(U(7), U(2), RoundUp) === T(-1)
+        @test divrem(U(7), U(2), RoundUp) === (U(4), T(-1))
+        @test rem(U(7), U(2), RoundNearest) === T(-1)
+        @test_throws InexactError rem(U(1), typemax(U), RoundUp)
+        @test_throws InexactError divrem(U(1), typemax(U), RoundFromZero)
+    end
+    @test rem(3.0, UInt8(2), RoundUp) === -1.0
+    @test rem(true, UInt8(2), RoundUp) === Int8(-1)
+    @test divrem(true, UInt8(2), RoundUp) === (UInt8(1), Int8(-1))
 end
 
 @testset "bitreverse" begin


### PR DESCRIPTION
Rebase #39318 and implement the semantics requested by triage there.

Compute rounded remainders in widened signed arithmetic and convert them only when the exact result is representable in the documented result type. Keep rem and divrem consistent for unsigned and mixed-signedness inputs, and avoid negating signed typemin divisors.

This also covers the signed-divisor overflow reported in JuliaLang/julia#62283.

Fixes #34325