### PR TITLE
Add `PossiblyAmbiguous` marker + ambiguous call edge handling

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -38,7 +38,7 @@ else
 using Core.Intrinsics, Core.IR
 
 using Core: ABIOverride, Builtin, CodeInstance, IntrinsicFunction, AnyType, MethodInstance, MethodMatch,
-    MethodTable, MethodCache, PartialOpaque, SimpleVector, TypeofVararg,
+    MethodTable, MethodCache, PartialOpaque, PossiblyAmbiguous, SimpleVector, TypeofVararg,
     TypeEq,
     _apply_iterate, apply_type, compilerbarrier, donotdelete, memoryref_isassigned,
     memoryrefget, memoryrefnew, memoryrefoffset, memoryrefset!, memoryrefunset!, print, println, show, svec,

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -232,6 +232,11 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                         j += 1
                     elseif edge isa Int
                         sig = initial.callees[j+1]
+                        # the signature slot may carry the `Core.PossiblyAmbiguous` marker
+                        marked = sig isa Core.PossiblyAmbiguous
+                        if marked
+                            sig = (sig::Core.PossiblyAmbiguous).sig
+                        end
                         nmatches = abs(edge)
                         fully_covers = edge > 0
                         min_valid2, max_valid2 = verify_call(sig, initial.callees, j+2, nmatches, world, fully_covers, matches)

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -593,6 +593,11 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         empty!(matches)
         maxworld[] = 0
     else
+        # FIXME: the edge format does not encode whether or not this ambiguity was accounted
+        # for in inference / optimizer / etc. so we are forced to invalidate conservatively.
+        if has_ambig[] != 0
+            maxworld[] = 0
+        end
         # setdiff!(result, expected)
         if length(result) ≠ n
             maxworld[] = 0

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -228,7 +228,8 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
 
                     if edge isa MethodInstance
                         sig = edge.specTypes
-                        min_valid2, max_valid2 = verify_call(sig, initial.callees, j, 1, world, true, matches)
+                        # the optimized single-edge format is never ambiguity-tolerant
+                        min_valid2, max_valid2 = verify_call(sig, initial.callees, j, 1, world, true, false, matches)
                         j += 1
                     elseif edge isa Int
                         sig = initial.callees[j+1]
@@ -239,7 +240,7 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                         end
                         nmatches = abs(edge)
                         fully_covers = edge > 0
-                        min_valid2, max_valid2 = verify_call(sig, initial.callees, j+2, nmatches, world, fully_covers, matches)
+                        min_valid2, max_valid2 = verify_call(sig, initial.callees, j+2, nmatches, world, fully_covers, marked, matches)
                         j += 2 + nmatches
                         edge = sig
                     elseif edge isa Core.Binding
@@ -474,7 +475,7 @@ end
 # pruned `ml_matches` lookup is cheaper (~8 is the empirical crossover).
 const VERIFY_INTERF_CAP = 8
 
-function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n::Int, world::UInt, fully_covers::Bool, matches::Vector{Any})
+function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n::Int, world::UInt, fully_covers::Bool, marked::Bool, matches::Vector{Any})
     # verify that these edges intersect with the same methods as before
     mi = nothing
     expected_deleted = false
@@ -598,9 +599,14 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         empty!(matches)
         maxworld[] = 0
     else
-        # FIXME: the edge format does not encode whether or not this ambiguity was accounted
-        # for in inference / optimizer / etc. so we are forced to invalidate conservatively.
-        if has_ambig[] != 0
+        # A fresh ambiguity can make dispatch throw a MethodError at points the recorded
+        # matches used to win (a method whose overlap is fully covered by an ambiguity is
+        # pruned from this include_ambiguous=false lookup, so the set comparison below
+        # cannot see it). A call edge recorded with its signature wrapped in
+        # `Core.PossiblyAmbiguous` was inferred with that pessimization (may-throw
+        # MethodError, no devirtualized targets), so any such change is tolerable there;
+        # for a plain edge it must invalidate.
+        if has_ambig[] != 0 && !marked
             maxworld[] = 0
         end
         # setdiff!(result, expected)

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -79,7 +79,14 @@ function _add_edges_impl(edges::Vector{Any}, info::MethodMatchInfo, mi_edge::Boo
         end
     end
     nmatches = length(info.results)
-    if nmatches == length(info.edges) == 1 && fully_covering(info)
+    # A call inferred in the presence of a possible ambiguity records its edge group
+    # with the signature wrapped in `Core.PossiblyAmbiguous`: inference pessimized the
+    # call for a MethodError from ambiguous dispatch and the optimizer devirtualized
+    # nothing, so the compiled code tolerates method additions that merely introduce or
+    # extend an ambiguity over this signature. The optimized single-edge format has no
+    # signature slot to carry the marker, so such calls always use the group format.
+    marked = any_ambig(info)
+    if !marked && nmatches == length(info.edges) == 1 && fully_covering(info)
         # try the optimized format for the representation, if possible and applicable
         # if this doesn't succeed, the backedge will be less precise,
         # but the forward edge will maintain the precision
@@ -100,12 +107,22 @@ function _add_edges_impl(edges::Vector{Any}, info::MethodMatchInfo, mi_edge::Boo
     # encode nmatches as negative if fully_covers is false
     encoded_nmatches = fully_covering(info) ? nmatches : -nmatches
     for i in 1:length(edges)
-        if edges[i] === encoded_nmatches && edges[i+1] == info.atype
-            # TODO: must also verify the CodeInstance match too
-            return nothing
+        if edges[i] === encoded_nmatches
+            atypeᵢ = edges[i+1]
+            markedᵢ = atypeᵢ isa PossiblyAmbiguous
+            markedᵢ && (atypeᵢ = atypeᵢ.sig)
+            if atypeᵢ == info.atype
+                # TODO: must also verify the CodeInstance match too
+                if markedᵢ && !marked
+                    # a plain group wins over a marked one: some call site with this
+                    # signature does not tolerate ambiguous dispatch
+                    edges[i+1] = info.atype
+                end
+                return nothing
+            end
         end
     end
-    push!(edges, encoded_nmatches, info.atype)
+    push!(edges, encoded_nmatches, marked ? PossiblyAmbiguous(info.atype) : info.atype)
     for i = 1:nmatches
         edge = info.edges[i]
         m = info.results[i]

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -612,6 +612,18 @@ struct PartialOpaque
     PartialOpaque(@nospecialize(typ::Type), @nospecialize(env), parent::MethodInstance, source) = new(typ, env, parent, source)
 end
 
+# Wraps the signature type of a recorded call edge to mark that the enclosing
+# CodeInstance was inferred in the presence of a possible method ambiguity for that
+# call: the inferred results already account for a MethodError from ambiguous dispatch
+# and no call target was devirtualized, so they remain valid when a method addition
+# merely introduces or extends an ambiguity over the signature (an addition that can
+# win the dispatch still invalidates). The wrapper appears only in the signature slot
+# of a call-edge group; callee objects are never wrapped.
+struct PossiblyAmbiguous
+    sig
+    PossiblyAmbiguous(@nospecialize(sig)) = new(sig)
+end
+
 eval(Core, quote
     GotoNode(label::Int) = $(Expr(:new, :GotoNode, :label))
     NewvarNode(slot::SlotNumber) = $(Expr(:new, :NewvarNode, :slot))

--- a/src/gf.c
+++ b/src/gf.c
@@ -2520,6 +2520,50 @@ static int _invalidate_dispatch_backedges(jl_method_instance_t *mi, jl_value_t *
         else {
             replaced_edge = replaced_dispatch;
         }
+        if (replaced_edge && invokeTypes == NULL && ambig) {
+            // The new method is (pairwise) ambiguous with `mi`'s method, so over this
+            // edge it can only replace "dispatch to `mi`" with "throw a MethodError".
+            // A call-edge group whose signature slot is marked `PossiblyAmbiguous` was
+            // recorded at a call site that already accounts for a MethodError from
+            // ambiguous dispatch; keep the backedge if every record of `mi` in the
+            // caller is such a group (a later addition that wins the dispatch outright
+            // still invalidates via `is_replacing`). Any unmarked group, optimized
+            // single-edge record, or invoke record for `mi` demands invalidation.
+            jl_svec_t *edges = jl_atomic_load_relaxed(&caller->edges);
+            size_t nedges = jl_svec_len(edges);
+            int found_marked = 0;
+            for (size_t j = 0; j < nedges; ) {
+                jl_value_t *edge = jl_svecref(edges, j);
+                if (jl_is_long(edge)) { // a call-edge group: (±n, sig, callees...)
+                    ssize_t nmatches = jl_unbox_long(edge);
+                    if (nmatches < 0)
+                        nmatches = -nmatches;
+                    int marked = j + 1 < nedges && jl_typetagis(jl_svecref(edges, j + 1), jl_possibly_ambiguous_type);
+                    for (ssize_t k = 0; k < nmatches && j + 2 + (size_t)k < nedges; k++) {
+                        jl_value_t *callee = jl_svecref(edges, j + 2 + (size_t)k);
+                        if (jl_is_code_instance(callee))
+                            callee = (jl_value_t*)jl_get_ci_mi((jl_code_instance_t*)callee);
+                        if (callee == (jl_value_t*)mi) {
+                            if (!marked)
+                                goto found_plain;
+                            found_marked = 1;
+                        }
+                    }
+                    j += 2 + (size_t)nmatches;
+                    continue;
+                }
+                if (jl_is_code_instance(edge))
+                    edge = (jl_value_t*)jl_get_ci_mi((jl_code_instance_t*)edge);
+                if (edge == (jl_value_t*)mi)
+                    goto found_plain;
+                j += 1;
+            }
+            if (found_marked) {
+                insb = set_next_edge(backedges, insb, invokeTypes, caller);
+                continue;
+            }
+        found_plain:;
+        }
         if (replaced_edge) {
             invalidate_code_instance(caller, max_world, 1);
             insb = clear_next_edge(backedges, insb, invokeTypes, caller);

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -104,6 +104,7 @@
     XX(opaque_closure_typename, jl_typename_t*) \
     XX(pair_type, jl_value_t*) \
     XX(partial_opaque_type, jl_datatype_t*) \
+    XX(possibly_ambiguous_type, jl_datatype_t*) \
     XX(partial_struct_type, jl_datatype_t*) \
     XX(phicnode_type, jl_datatype_t*) \
     XX(phinode_type, jl_datatype_t*) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4397,6 +4397,7 @@ void post_boot_hooks(void)
     jl_partial_struct_type = (jl_datatype_t*)core("PartialStruct");
     jl_interconditional_type = (jl_datatype_t*)core("InterConditional");
     jl_partial_opaque_type = (jl_datatype_t*)core("PartialOpaque");
+    jl_possibly_ambiguous_type = (jl_datatype_t*)core("PossiblyAmbiguous");
     jl_inter_must_alias_type = (jl_datatype_t*)core("InterMustAlias");
 
     export_jl_small_typeof();

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -481,3 +481,45 @@ let ambig = Ref{Int32}(0)
 end
 
 nothing
+
+# strict specificity cycle: `morespecific` detects and neutralizes pairwise 2-cycles
+# into mutual ambiguities, but longer cycles have every pairwise edge strictly ordered,
+# so no pairwise probe can see them; the sort in `ml_matches` detects them (as an SCC
+# through the interference sets) and reports them via the result-wide ambiguity output
+# that package-image edge validation relies on. The construction mirrors the classic
+# Complex/AbstractComplex chain:
+#   Complex -> AbstractComplex -> Union{Float64, AbstractComplex}
+#           -> AbstractFloat -> Union{ComplexF64, AbstractFloat} -> Complex
+abstract type AmbigCycAbsC end               # ~ AbstractComplex
+abstract type AmbigCycCplx <: AmbigCycAbsC end  # ~ Complex
+struct AmbigCycCplxF64 <: AmbigCycCplx end   # ~ ComplexF64
+abstract type AmbigCycAbsF end               # ~ AbstractFloat
+struct AmbigCycF <: AmbigCycAbsF end         # ~ Float64
+struct AmbigCycOtherC <: AmbigCycAbsC end    # applicable subset strictly ordered here
+let sigs = Any[AmbigCycCplx, AmbigCycAbsC, Union{AmbigCycF, AmbigCycAbsC},
+               AmbigCycAbsF, Union{AmbigCycCplxF64, AmbigCycAbsF}]
+    for i in 1:5
+        j = mod1(i + 1, 5)
+        a = Tuple{typeof(sin), sigs[i]}
+        b = Tuple{typeof(sin), sigs[j]}
+        @test Base.morespecific(a, b)
+        @test !Base.morespecific(b, a)
+    end
+end
+ambcyc(::AmbigCycCplx) = 1
+ambcyc(::AmbigCycAbsC) = 2
+ambcyc(::Union{AmbigCycF, AmbigCycAbsC}) = 3
+ambcyc(::AmbigCycAbsF) = 4
+ambcyc(::Union{AmbigCycCplxF64, AmbigCycAbsF}) = 5
+let has_ambig = Ref{Int32}(0)
+    ms = Base._methods_by_ftype(Tuple{typeof(ambcyc), Any}, nothing, -1, Base.get_world_counter(),
+                                false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), has_ambig)
+    @test ms isa Vector
+    @test length(ms) == 5
+    @test has_ambig[] == 1
+end
+# points inside the cycle's contested regions throw; a point whose applicable subset is
+# strictly ordered still dispatches
+@test_throws MethodError ambcyc(AmbigCycCplxF64())
+@test_throws MethodError ambcyc(AmbigCycF())
+@test ambcyc(AmbigCycOtherC()) == 2

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3524,7 +3524,10 @@ precompile_test_harness("Ambiguity-pruned dispatch edge revalidation") do load_p
         end
         @test !revalidated
         # Dispatch in the tied region must now throw rather than return the stale result.
-        @test_throws MethodError AmbigPruneB.caller(Int8(1), "hi")
+        # The call must go through `inferencebarrier`: a direct call would be inferred
+        # when this closure is compiled, creating a fresh, valid CodeInstance for the
+        # same `@nospecialize`-widened MethodInstance before the scan above runs.
+        @test_throws MethodError Base.inferencebarrier(AmbigPruneB.caller)(Int8(1), "hi")
     end
 end
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3468,4 +3468,64 @@ precompile_test_harness("cache rejection reasons") do dir
     @test_logs (:debug, r"Caches not reused: 2 for different build identifier") min_level=Logging.Debug match_mode=:any Base.list_reasons(Dict(:buildid_mismatch => 2))
 end
 
+precompile_test_harness("Ambiguity-pruned dispatch edge revalidation") do load_path
+    # A method added after an image is built can be pairwise-ambiguous with a recorded
+    # dispatch match without changing the count returned by the include_ambiguous=false
+    # lookup used at load time: the newcomer is pruned from the result when the expected
+    # match fully covers its overlap with the call signature. Such a package image must
+    # NOT be revalidated, because dispatch in the now-tied region throws MethodError.
+    write(joinpath(load_path, "AmbigPruneA.jl"),
+        """
+        module AmbigPruneA
+        m(x::Integer, y) = 1
+        end
+        """)
+    write(joinpath(load_path, "AmbigPruneB.jl"),
+        """
+        module AmbigPruneB
+        using AmbigPruneA
+        caller(x::Int8, @nospecialize(y)) = AmbigPruneA.m(x, y)
+        precompile(caller, (Int8, Any))
+        end
+        """)
+    # Precompile B (which pulls in A) without loading either into this session.
+    Base.compilecache(Base.PkgId("AmbigPruneB"))
+
+    @eval using AmbigPruneA
+    # Introduce a method pairwise-ambiguous with m(::Integer, ::Any): the first slot is
+    # wider, the second narrower, and the overlap (Integer, AbstractString) is non-empty.
+    @eval AmbigPruneA.m(x, y::AbstractString) = 2
+    # Loading B now verifies its image in a world that already contains the tie.
+    @eval using AmbigPruneB
+
+    invokelatest() do
+        m = only(methods(AmbigPruneB.caller))
+        target = Tuple{typeof(AmbigPruneB.caller), Int8, Any}
+        mi = nothing
+        for spec in Base.specializations(m)
+            spec === nothing && continue
+            if spec.specTypes == target
+                mi = spec
+                break
+            end
+        end
+        @test mi !== nothing
+        # The precompiled CodeInstance for this specialization must have been invalidated
+        # (max_world != typemax) by load-time revalidation. Check before calling caller,
+        # since calling it would create a fresh, valid CodeInstance.
+        ci = isdefined(mi, :cache) ? mi.cache : nothing
+        revalidated = false
+        while ci !== nothing
+            if ci.max_world == typemax(UInt)
+                revalidated = true
+                break
+            end
+            ci = isdefined(ci, :next) ? ci.next : nothing
+        end
+        @test !revalidated
+        # Dispatch in the tied region must now throw rather than return the stale result.
+        @test_throws MethodError AmbigPruneB.caller(Int8(1), "hi")
+    end
+end
+
 finish_precompile_test!()

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3531,4 +3531,352 @@ precompile_test_harness("Ambiguity-pruned dispatch edge revalidation") do load_p
     end
 end
 
+precompile_test_harness("PossiblyAmbiguous edge tolerates build-time ambiguity") do load_path
+    # When the ambiguity already existed when the image was built, inference was
+    # pessimized for it (may-throw MethodError, no devirtualization) and recorded the
+    # call edge with its signature wrapped in `Core.PossiblyAmbiguous`. Loading in a
+    # world with the same ambiguity must revalidate the image rather than
+    # conservatively invalidating.
+    write(joinpath(load_path, "AmbigTolA.jl"),
+        """
+        module AmbigTolA
+        m(x::Integer, y) = 1
+        m(x, y::AbstractString) = 2
+        end
+        """)
+    write(joinpath(load_path, "AmbigTolB.jl"),
+        """
+        module AmbigTolB
+        using AmbigTolA
+        caller(x::Int8, @nospecialize(y)) = AmbigTolA.m(x, y)
+        precompile(caller, (Int8, Any))
+        end
+        """)
+    Base.compilecache(Base.PkgId("AmbigTolB"))
+
+    @eval using AmbigTolA
+    # No new methods: the ambiguity recorded at build time is unchanged at load time.
+    @eval using AmbigTolB
+
+    invokelatest() do
+        m = only(methods(AmbigTolB.caller))
+        target = Tuple{typeof(AmbigTolB.caller), Int8, Any}
+        mi = nothing
+        for spec in Base.specializations(m)
+            spec === nothing && continue
+            if spec.specTypes == target
+                mi = spec
+                break
+            end
+        end
+        @test mi !== nothing
+        # The precompiled CodeInstance must have survived revalidation. Check before
+        # calling caller, since calling it would create a fresh, valid CodeInstance.
+        ci = isdefined(mi, :cache) ? mi.cache : nothing
+        revalidated = false
+        while ci !== nothing
+            if ci.max_world == typemax(UInt)
+                revalidated = true
+                break
+            end
+            ci = isdefined(ci, :next) ? ci.next : nothing
+        end
+        @test revalidated
+        # Behavior is unchanged from build time: the covered region dispatches, the
+        # ambiguous region throws. The calls go through `inferencebarrier` so that compiling
+        # this closure does not itself create a CodeInstance for `caller` before the
+        # scan above runs (which would make the scan pass spuriously).
+        @test Base.inferencebarrier(AmbigTolB.caller)(Int8(1), 2) === 1
+        @test_throws MethodError Base.inferencebarrier(AmbigTolB.caller)(Int8(1), "hi")
+    end
+end
+
+precompile_test_harness("Post-build pruned-only ambiguity conservatively invalidates") do load_path
+    # Methods added after the build that are mutually ambiguous over their entire
+    # intersection with the call signature are both pruned from the fresh lookup, so the
+    # recorded match set is unchanged, but the fresh lookup reports the ambiguity. The
+    # call was built without any ambiguity (its edge is not marked), and the call-level
+    # marker cannot distinguish which region the new ambiguity affects, so the image is
+    # conservatively invalidated (the addition only changes a no-method MethodError into
+    # an ambiguity MethodError here, but proving that requires per-callee information).
+    write(joinpath(load_path, "AmbigElseA.jl"),
+        """
+        module AmbigElseA
+        n(x::Integer, y::Integer) = 1
+        end
+        """)
+    write(joinpath(load_path, "AmbigElseB.jl"),
+        """
+        module AmbigElseB
+        using AmbigElseA
+        caller(x::Int8, @nospecialize(y)) = AmbigElseA.n(x, y)
+        precompile(caller, (Int8, Any))
+        end
+        """)
+    Base.compilecache(Base.PkgId("AmbigElseB"))
+
+    @eval using AmbigElseA
+    # A mutually-ambiguous pair whose ambiguity fully covers both intersections with the call
+    # signature Tuple{typeof(n), Int8, Any}: both are pruned from the include_ambiguous=false
+    # lookup, and neither intersects the recorded match n(::Integer, ::Integer).
+    @eval AmbigElseA.n(x::Union{Int8,Int16}, y::String) = 2
+    @eval AmbigElseA.n(x::Union{Int8,Int32}, y::String) = 3
+    @eval using AmbigElseB
+
+    invokelatest() do
+        m = only(methods(AmbigElseB.caller))
+        target = Tuple{typeof(AmbigElseB.caller), Int8, Any}
+        mi = nothing
+        for spec in Base.specializations(m)
+            spec === nothing && continue
+            if spec.specTypes == target
+                mi = spec
+                break
+            end
+        end
+        @test mi !== nothing
+        # The precompiled CodeInstance must have survived revalidation. Check before
+        # calling caller, since calling it would create a fresh, valid CodeInstance.
+        ci = isdefined(mi, :cache) ? mi.cache : nothing
+        revalidated = false
+        while ci !== nothing
+            if ci.max_world == typemax(UInt)
+                revalidated = true
+                break
+            end
+            ci = isdefined(ci, :next) ? ci.next : nothing
+        end
+        @test !revalidated
+        # Behavior after re-inference is unchanged either way: the covered region
+        # dispatches to the recorded match, the newly-ambiguous region throws. The calls
+        # go through `inferencebarrier` so that compiling this closure does not itself
+        # create a CodeInstance for `caller` before the scan above runs.
+        @test Base.inferencebarrier(AmbigElseB.caller)(Int8(1), 2) === 1
+        @test_throws MethodError Base.inferencebarrier(AmbigElseB.caller)(Int8(1), "hi")
+    end
+end
+
+precompile_test_harness("Marked call edge does not tolerate a new winning method") do load_path
+    # A caller built against a known ambiguity records its dispatch edge wrapped in
+    # `Core.PossiblyAmbiguous`, which tolerates additional ambiguities. A method added after
+    # the build that outright WINS part of the recorded match's coverage appears in the
+    # fresh (pruned) lookup result, so the set comparison must invalidate the image
+    # regardless of the wrapper: the stale rettype does not account for the newcomer.
+    write(joinpath(load_path, "AmbigWinA.jl"),
+        """
+        module AmbigWinA
+        m(x::Integer, y) = 1
+        m(x, y::AbstractString) = 2
+        end
+        """)
+    write(joinpath(load_path, "AmbigWinB.jl"),
+        """
+        module AmbigWinB
+        using AmbigWinA
+        caller(x::Int8, @nospecialize(y)) = AmbigWinA.m(x, y)
+        precompile(caller, (Int8, Any))
+        end
+        """)
+    Base.compilecache(Base.PkgId("AmbigWinB"))
+
+    @eval using AmbigWinA
+    # Strictly more specific than m(::Integer, ::Any) over (Int8, Int) and disjoint
+    # from m(::Any, ::AbstractString): a genuine new dispatch winner, no new ambiguity.
+    @eval AmbigWinA.m(x::Int8, y::Int) = 3
+    @eval using AmbigWinB
+
+    invokelatest() do
+        m = only(methods(AmbigWinB.caller))
+        target = Tuple{typeof(AmbigWinB.caller), Int8, Any}
+        mi = nothing
+        for spec in Base.specializations(m)
+            spec === nothing && continue
+            if spec.specTypes == target
+                mi = spec
+                break
+            end
+        end
+        @test mi !== nothing
+        ci = isdefined(mi, :cache) ? mi.cache : nothing
+        revalidated = false
+        while ci !== nothing
+            if ci.max_world == typemax(UInt)
+                revalidated = true
+                break
+            end
+            ci = isdefined(ci, :next) ? ci.next : nothing
+        end
+        @test !revalidated
+        # the newcomer wins in its region; the old match still wins elsewhere; the
+        # build-time ambiguity still throws (inferencebarrier: see the comment in the
+        # "Ambiguity-pruned dispatch edge revalidation" test)
+        @test Base.inferencebarrier(AmbigWinB.caller)(Int8(1), 2) === 3
+        @test Base.inferencebarrier(AmbigWinB.caller)(Int8(1), 1.5) === 1
+        @test_throws MethodError Base.inferencebarrier(AmbigWinB.caller)(Int8(1), "hi")
+    end
+end
+
+precompile_test_harness("Deleted ambiguity partner still revalidates a marked call edge") do load_path
+    # Deleting the ambiguity partner before load leaves the fresh lookup with the same single
+    # match, now unflagged. The recorded wrapped edge demanded less than what the new
+    # world provides (the pessimized inference results remain sound when the ambiguity
+    # disappears), so the image must be revalidated.
+    write(joinpath(load_path, "AmbigDelA.jl"),
+        """
+        module AmbigDelA
+        m(x::Integer, y) = 1
+        m(x, y::AbstractString) = 2
+        end
+        """)
+    write(joinpath(load_path, "AmbigDelB.jl"),
+        """
+        module AmbigDelB
+        using AmbigDelA
+        caller(x::Int8, @nospecialize(y)) = AmbigDelA.m(x, y)
+        precompile(caller, (Int8, Any))
+        end
+        """)
+    Base.compilecache(Base.PkgId("AmbigDelB"))
+
+    @eval using AmbigDelA
+    invokelatest() do
+        m2 = only(filter(mm -> mm.sig == Tuple{typeof(AmbigDelA.m), Any, AbstractString},
+                         collect(methods(AmbigDelA.m))))
+        Base.delete_method(m2)
+    end
+    @eval using AmbigDelB
+
+    invokelatest() do
+        m = only(methods(AmbigDelB.caller))
+        target = Tuple{typeof(AmbigDelB.caller), Int8, Any}
+        mi = nothing
+        for spec in Base.specializations(m)
+            spec === nothing && continue
+            if spec.specTypes == target
+                mi = spec
+                break
+            end
+        end
+        @test mi !== nothing
+        ci = isdefined(mi, :cache) ? mi.cache : nothing
+        revalidated = false
+        while ci !== nothing
+            if ci.max_world == typemax(UInt)
+                revalidated = true
+                break
+            end
+            ci = isdefined(ci, :next) ? ci.next : nothing
+        end
+        @test revalidated
+        # the formerly-ambiguous region now dispatches to the surviving method
+        @test Base.inferencebarrier(AmbigDelB.caller)(Int8(1), "hi") === 1
+        @test Base.inferencebarrier(AmbigDelB.caller)(Int8(1), 2) === 1
+    end
+end
+
+precompile_test_harness("Marked group edge tolerates an unchanged ambiguity") do load_path
+    # A build-time partial ambiguity where BOTH matches survive the pruned lookup: the
+    # call records the section (Int-header) edge format with each member wrapped in
+    # `Core.PossiblyAmbiguous`. Loading with the ambiguity unchanged must revalidate; a
+    # post-build method that wins part of the ambiguous region must invalidate.
+    write(joinpath(load_path, "AmbigPairA.jl"),
+        """
+        module AmbigPairA
+        m(x::Int8, y) = 1
+        m(x, y::AbstractString) = 2
+        end
+        """)
+    write(joinpath(load_path, "AmbigPairB1.jl"),
+        """
+        module AmbigPairB1
+        using AmbigPairA
+        caller(@nospecialize(x), @nospecialize(y)) = AmbigPairA.m(x, y)
+        precompile(caller, (Any, Any))
+        end
+        """)
+    write(joinpath(load_path, "AmbigPairB2.jl"),
+        """
+        module AmbigPairB2
+        using AmbigPairA
+        caller(@nospecialize(x), @nospecialize(y)) = AmbigPairA.m(x, y)
+        precompile(caller, (Any, Any))
+        end
+        """)
+    Base.compilecache(Base.PkgId("AmbigPairB1"))
+    Base.compilecache(Base.PkgId("AmbigPairB2"))
+
+    @eval using AmbigPairA
+    # B1 loads with the build-time ambiguity unchanged: must revalidate
+    @eval using AmbigPairB1
+    invokelatest() do
+        m = only(methods(AmbigPairB1.caller))
+        target = Tuple{typeof(AmbigPairB1.caller), Any, Any}
+        mi = nothing
+        for spec in Base.specializations(m)
+            spec === nothing && continue
+            if spec.specTypes == target
+                mi = spec
+                break
+            end
+        end
+        @test mi !== nothing
+        ci = isdefined(mi, :cache) ? mi.cache : nothing
+        validated_ci = nothing
+        while ci !== nothing
+            if ci.max_world == typemax(UInt)
+                validated_ci = ci
+                break
+            end
+            ci = isdefined(ci, :next) ? ci.next : nothing
+        end
+        @test validated_ci !== nothing
+        if validated_ci !== nothing
+            # the pair does not fully cover, so the group has a -2 Int header; the
+            # signature slot carries the marker and the member edges stay plain
+            edgelist = collect(Any, validated_ci.edges)
+            idx = findfirst(e -> e isa Int && e == -2, edgelist)
+            @test idx !== nothing
+            if idx !== nothing
+                @test edgelist[idx+1] isa Core.PossiblyAmbiguous
+                @test edgelist[idx+2] isa Core.CodeInstance
+                @test edgelist[idx+3] isa Core.CodeInstance
+            end
+            @test count(e -> e isa Core.PossiblyAmbiguous, edgelist) == 1
+        end
+        @test Base.inferencebarrier(AmbigPairB1.caller)(Int8(1), 1.5) === 1
+        @test Base.inferencebarrier(AmbigPairB1.caller)("a", "b") === 2
+        @test_throws MethodError Base.inferencebarrier(AmbigPairB1.caller)(Int8(1), "hi")
+    end
+
+    # a post-build method that wins part of the ambiguous region: B2 must NOT revalidate
+    @eval AmbigPairA.m(x::Int8, y::String) = 3
+    @eval using AmbigPairB2
+    invokelatest() do
+        m = only(methods(AmbigPairB2.caller))
+        target = Tuple{typeof(AmbigPairB2.caller), Any, Any}
+        mi = nothing
+        for spec in Base.specializations(m)
+            spec === nothing && continue
+            if spec.specTypes == target
+                mi = spec
+                break
+            end
+        end
+        @test mi !== nothing
+        ci = isdefined(mi, :cache) ? mi.cache : nothing
+        revalidated = false
+        while ci !== nothing
+            if ci.max_world == typemax(UInt)
+                revalidated = true
+                break
+            end
+            ci = isdefined(ci, :next) ? ci.next : nothing
+        end
+        @test !revalidated
+        @test Base.inferencebarrier(AmbigPairB2.caller)(Int8(1), "hi") === 3
+    end
+end
+
+
+
 finish_precompile_test!()

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -653,3 +653,146 @@ struct W62022{T}; x::T; end
 @noinline foo62022(::W62022{W62022{W62022{W62022{Int}}}}) = false
 @test foo62022(W62022(1)) === false # test for invalidation
 @test foo62022(W62022(W62022(W62022(1)))) === false
+
+
+# Ambiguity-tolerant backedges (Core.PossiblyAmbiguous call-edge marker): a
+# newly-inserted method that is pairwise-ambiguous with a callee can only turn
+# "dispatch to the callee" into "throw a MethodError" over the affected intersection.
+# A caller whose call-edge group for the callee carries the marker on its signature
+# slot was inferred with that pessimization (may-throw MethodError, no
+# devirtualization) and must survive such an insertion; a caller recording the callee
+# through a plain group or the optimized single-edge format must be invalidated. A new
+# method that outright wins part of the callee's dispatch must invalidate either way:
+# the marker tolerates ambiguities only.
+function ambig_rt_find_mi(f, target::Type)
+    for m in methods(f)
+        for spec in Base.specializations(m)
+            spec === nothing && continue
+            spec.specTypes == target && return spec
+        end
+    end
+    return nothing
+end
+function ambig_rt_edge_counts(ci::Core.CodeInstance, callee_mi::Core.MethodInstance)
+    # count records of `callee_mi`, split by whether the containing call-edge group is
+    # marked with `Core.PossiblyAmbiguous` on its signature slot (records outside a
+    # marked group, e.g. the optimized single-edge format, count as plain)
+    marked = plain = 0
+    isdefined(ci, :edges) || return (marked, plain)
+    edges = ci.edges
+    i = 1
+    while i <= length(edges)
+        e = edges[i]
+        if e isa Int
+            n = abs(e)
+            groupmarked = edges[i+1] isa Core.PossiblyAmbiguous
+            for j in i+2:i+1+n
+                x = edges[j]
+                x isa Core.CodeInstance && (x = x.def)
+                if x === callee_mi
+                    groupmarked ? (marked += 1) : (plain += 1)
+                end
+            end
+            i += 2 + n
+        else
+            x = e
+            x isa Core.CodeInstance && (x = x.def)
+            x === callee_mi && (plain += 1)
+            i += 1
+        end
+    end
+    return (marked, plain)
+end
+
+# callee with a pre-existing ambiguity: the caller records a wrapped edge
+ambig_rt_q(x::Integer, y) = 1
+ambig_rt_q(x, y::AbstractString) = 2
+ambig_rt_qcaller(x::Int8, @nospecialize(y)) = ambig_rt_q(x, y)
+# a second-level caller, to observe that invalidation still cascades
+ambig_rt_qouter(@nospecialize(y)) = ambig_rt_qcaller(Int8(1), y)
+let
+    @test precompile(ambig_rt_qcaller, (Int8, Any))
+    @test precompile(ambig_rt_qouter, (Any,))
+    qmi = ambig_rt_find_mi(ambig_rt_qcaller, Tuple{typeof(ambig_rt_qcaller), Int8, Any})
+    calleemi = ambig_rt_find_mi(ambig_rt_q, Tuple{typeof(ambig_rt_q), Int8, Any})
+    outermi = ambig_rt_find_mi(ambig_rt_qouter, Tuple{typeof(ambig_rt_qouter), Any})
+    @test qmi !== nothing && calleemi !== nothing && outermi !== nothing
+    qci = qmi.cache
+    outerci = outermi.cache
+    @test qci.max_world == typemax(UInt)
+    @test outerci.max_world == typemax(UInt)
+    # the ambiguity was visible at inference time, so the call-edge group must be marked
+    @test ambig_rt_edge_counts(qci, calleemi) == (1, 0)
+    # insert a method pairwise-ambiguous with ambig_rt_q(::Integer, ::Any) whose overlap
+    # with the call signature is fully covered by the ambiguity: the caller tolerates it
+    @eval ambig_rt_q(x, y::AbstractChar) = 3
+    @test qci.max_world == typemax(UInt)
+    @test outerci.max_world == typemax(UInt)
+    # dispatch behaves per the new world through the surviving CodeInstance
+    @test Base.inferencebarrier(ambig_rt_qcaller)(Int8(1), 2) === 1
+    @test_throws MethodError Base.inferencebarrier(ambig_rt_qcaller)(Int8(1), "s")
+    @test_throws MethodError Base.inferencebarrier(ambig_rt_qcaller)(Int8(1), 'c')
+    # insert a method that outright wins part of the callee's dispatch: despite the
+    # wrapped edge this must invalidate, and the invalidation must cascade to callers
+    # of the surviving CodeInstance
+    @eval ambig_rt_q(x::Int8, y::Integer) = 4
+    @test qci.max_world != typemax(UInt)
+    @test outerci.max_world != typemax(UInt)
+    @test Base.inferencebarrier(ambig_rt_qcaller)(Int8(1), 2) === 4
+end
+
+# callee without an ambiguity: the caller records a plain edge, which a new pairwise-ambiguous
+# method must invalidate even though the pruned lookup result is unchanged
+ambig_rt_p(x::Integer, y) = 1
+ambig_rt_pcaller(x::Int8, @nospecialize(y)) = ambig_rt_p(x, y)
+let
+    @test precompile(ambig_rt_pcaller, (Int8, Any))
+    pmi = ambig_rt_find_mi(ambig_rt_pcaller, Tuple{typeof(ambig_rt_pcaller), Int8, Any})
+    calleemi = ambig_rt_find_mi(ambig_rt_p, Tuple{typeof(ambig_rt_p), Int8, Any})
+    @test pmi !== nothing && calleemi !== nothing
+    pci = pmi.cache
+    @test pci.max_world == typemax(UInt)
+    @test ambig_rt_edge_counts(pci, calleemi) == (0, 1)
+    @eval ambig_rt_p(x, y::AbstractString) = 2
+    @test pci.max_world != typemax(UInt)
+    @test_throws MethodError Base.inferencebarrier(ambig_rt_pcaller)(Int8(1), "s")
+    @test Base.inferencebarrier(ambig_rt_pcaller)(Int8(1), 2) === 1
+end
+
+# closing a strict specificity cycle by method insertion: a 4-method chain has strict
+# pairwise specificity everywhere (no ambiguity anywhere, all edges plain), but adding
+# the fifth method closes a specificity cycle (see the "strict specificity cycle" block
+# in test/ambiguous.jl), which changes dispatch in regions the new method does not win —
+# e.g. a point that used to select the chain's third method now throws. The caller must
+# be invalidated (via the pairwise ambiguity between the closing method and the union member
+# of the chain).
+abstract type AmbigCycRTAbsC end
+abstract type AmbigCycRTCplx <: AmbigCycRTAbsC end
+struct AmbigCycRTCplxF64 <: AmbigCycRTCplx end
+abstract type AmbigCycRTAbsF end
+struct AmbigCycRTF <: AmbigCycRTAbsF end
+struct AmbigCycRTOtherC <: AmbigCycRTAbsC end
+Base.Experimental.@max_methods 5 function ambig_rt_cyc end
+ambig_rt_cyc(::AmbigCycRTCplx) = 1
+ambig_rt_cyc(::AmbigCycRTAbsC) = 2
+ambig_rt_cyc(::Union{AmbigCycRTF, AmbigCycRTAbsC}) = 3
+ambig_rt_cyc(::AmbigCycRTAbsF) = 4
+ambig_rt_cyccaller(@nospecialize(x)) = ambig_rt_cyc(x)
+let
+    @test Base.inferencebarrier(ambig_rt_cyccaller)(AmbigCycRTF()) === 3
+    @test precompile(ambig_rt_cyccaller, (Any,))
+    cmi = ambig_rt_find_mi(ambig_rt_cyccaller, Tuple{typeof(ambig_rt_cyccaller), Any})
+    @test cmi !== nothing
+    cci = cmi.cache
+    @test cci.max_world == typemax(UInt)
+    # no ambiguity exists yet, so no call-edge group may be marked
+    @test !any(e -> e isa Core.PossiblyAmbiguous, cci.edges)
+    # close the cycle
+    @eval ambig_rt_cyc(::Union{AmbigCycRTCplxF64, AmbigCycRTAbsF}) = 5
+    @test cci.max_world != typemax(UInt)
+    # dispatch in the newly-contested region now throws
+    @test_throws MethodError Base.inferencebarrier(ambig_rt_cyccaller)(AmbigCycRTF())
+    @test_throws MethodError Base.inferencebarrier(ambig_rt_cyccaller)(AmbigCycRTCplxF64())
+    # a point whose applicable subset is still strictly ordered keeps dispatching
+    @test Base.inferencebarrier(ambig_rt_cyccaller)(AmbigCycRTOtherC()) === 2
+end


### PR DESCRIPTION
This adds a new `Core.PossiblyAmbiguous` wrapper type to mark the presence of a call with a method ambiguity.

These calls optimize poorly but infer well (inference can explore the callees just fine, but our `:invoke` and other codegen optimizations do not apply), which is unchanged by this PR. This merely adds sufficient edge information to make the current behavior sound (and effectively avoid / revert https://github.com/JuliaLang/julia/pull/62297).

I briefly considered refining this to a per-callee-region flag which I do think would work + enable some extra optimizations (ambiguous calls would be eligible for partial union-splitting), but resolved ambiguities are so rare that it's probably not worth it. Left to future work for now.

Draft until I can clean up the "AI effect" (implementation is mostly fine as-is, but messy)