### PR TITLE
[JuliaLowering] Fix two labeled-break bugs

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -354,7 +354,7 @@ name_hint(name) = JuliaSyntax.CompileHints(:name_hint, name)
 # Predicates and accessors working on expression trees
 
 function is_quoted(ex)
-    kind(ex) in KSet"Symbol quote top core globalref break inert
+    kind(ex) in KSet"Symbol quote top core globalref inert
                      syntaxinert meta inbounds inline noinline loopinfo"
 end
 

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -816,11 +816,6 @@ function analyze_variables!(ctx, ex)
         end
     elseif k == K"Identifier"
         @jl_assert false ex
-    elseif k == K"break" && numchildren(ex) >= 2
-        # For break with value, only analyze the value expression (second child), not the label
-        # This must come BEFORE !needs_resolution check since K"break" is in is_quoted
-        analyze_variables!(ctx, ex[2])
-        return
     elseif !needs_resolution(ex)
         return
     elseif k == K"static_eval" || k == K"foreignsymbol"

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -177,7 +177,10 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
         @fail(st, "`return` not allowed inside comprehension or generator")
     ([K"continue"], when=vcx.in_loop) -> pass()
     ([K"continue" lab], when=vcx.in_loop) -> vst1_ident(vcx, lab; lhs=true)
-    ([K"break"], when=vcx.in_loop) -> pass()
+    # An unlabeled break is also allowed inside anonymous `@label` blocks;
+    # breaking through a named block is rejected with a precise error during
+    # linearization.
+    ([K"break"], when=vcx.in_loop||vcx.in_symblock) -> pass()
     ([K"break" lab], when=vcx.in_loop||vcx.in_symblock) ->
         vst1_ident(vcx, lab; lhs=true)
     ([K"break" lab x], when=vcx.in_loop||vcx.in_symblock) ->

--- a/JuliaLowering/test/loops.jl
+++ b/JuliaLowering/test/loops.jl
@@ -239,6 +239,52 @@ let
 end
 """) == [(1,1), (2,1), (3,1)]
 
+# An unlabeled break exits an anonymous `@label` block
+@test JuliaLowering.include_string(test_mod, """
+@label begin
+    break
+    error("unreached")
+end
+""") === nothing
+
+# ... but breaking through a named block is still an error
+@test_throws LoweringError JuliaLowering.include_string(test_mod, """
+@label named begin
+    break
+end
+""")
+
+# Values of labeled breaks are scope-resolved: variables (not just
+# literals) work as break values, including from inside nested scopes
+@test JuliaLowering.include_string(test_mod, """
+@label begin
+    let
+        local t = 1
+        break _ t
+    end
+    0
+end
+""") == 1
+
+@test JuliaLowering.include_string(test_mod, """
+@label myblock begin
+    let v = 21
+        break myblock 2v
+    end
+    0
+end
+""") == 42
+
+@test JuliaLowering.include_string(test_mod, """
+let a = []
+    @label outer for i = 1:10
+        x = i * 2
+        i == 3 && break outer x
+        push!(a, i)
+    end
+end
+""") == 6
+
 end
 
 


### PR DESCRIPTION
Fix two bugs in the JuliaLowering implementation of labeled break (#60481):

1. The values of valued breaks (`break label value`) were skipped during scope resolution because `K"break"` is a quoted kind, so any value other than a literal failed an internal assertion during linearization. Resolve the value expression (but not the symbolic label), matching the analogous special case in the variable analysis pass.

2. Validation rejected unlabeled `break` inside an anonymous `@label` block with "unlabeled `break` outside of a `while` or `for` loop", even though anonymous blocks participate in the default break scope and accept plain `break` (as the flisp lowering does). Validation now defers to linearization, which enforces the precise rule: plain `break` through a *named* block remains an error with a targeted message.

Found while building the `match` statement prototype on top of the labeled-break machinery.