### PR TITLE
codegen: Add `compilerbarrier(:escape, ...)` and use it in `@threadcall`

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -800,6 +800,11 @@ add_tfunc(donotdelete, 0, INT_INF, @nospecs((𝕃::AbstractLattice, args...)->No
         return Any
     elseif setting === :blackbox
         return widenconst(val)
+    elseif setting === :escape
+        # `:escape` is a barrier on memory optimization only: it models `val` as
+        # escaping to an unknowable global memory location, without affecting
+        # any information inference derives about it.
+        return val
     else
         return Bottom
     end
@@ -808,7 +813,7 @@ add_tfunc(compilerbarrier, 2, 2, compilerbarrier_tfunc, 5)
 add_tfunc(Core.finalizer, 2, 4, @nospecs((𝕃::AbstractLattice, args...)->Nothing), 5)
 
 @nospecs function compilerbarrier_nothrow(setting, val)
-    return isa(setting, Const) && contains_is((:type, :const, :conditional, :blackbox), setting.val)
+    return isa(setting, Const) && contains_is((:type, :const, :conditional, :blackbox, :escape), setting.val)
 end
 
 # more accurate typeof_tfunc for vararg tuples abstract only in length
@@ -2955,6 +2960,16 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argty
     elseif f === compilerbarrier
         length(argtypes) == 2 || return Effects(EFFECTS_THROWS; consistent=ALWAYS_FALSE)
         setting = argtypes[1]
+        if isa(setting, Const) && setting.val === :escape
+            # `compilerbarrier(:escape, x)` models a store of `x` to an unknowable
+            # global memory location: it must not be deleted even if the result is
+            # unused, so that `x` is treated as escaped by memory optimizations.
+            return Effects(EFFECTS_TOTAL;
+                consistent = ALWAYS_FALSE,
+                effect_free = ALWAYS_FALSE,
+                inaccessiblememonly = ALWAYS_FALSE,
+                nothrow = true)
+        end
         return Effects(EFFECTS_TOTAL;
             consistent = (isa(setting, Const) && setting.val === :conditional) ? ALWAYS_TRUE : ALWAYS_FALSE,
             nothrow = compilerbarrier_nothrow(setting, nothing))

--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -1142,6 +1142,54 @@ loop_preserve_any_ea(10)
     @test Base.return_types() do; Base.blackbox(42); end |> only === Int
 end
 
+# compilerbarrier(:escape, x) models x as escaped to unknowable global memory:
+# the allocation must stay on the heap and cannot be elided or stack-promoted
+@testset "compilerbarrier :escape codegen" begin
+    # The raw pointer of the Ref is handed to foreign code inside GC.@preserve
+    # (the pattern from `do_threadcall`); with the barrier, the object must
+    # stay a heap allocation instead of being moved to the task stack.
+    function escape_ref(x::Int)
+        r = Ref(x)
+        Core.compilerbarrier(:escape, r)
+        GC.@preserve r begin
+            p = Base.unsafe_convert(Ptr{Int}, r)
+            ccall(:jl_breakpoint, Cvoid, (Ptr{Cvoid},), p)
+            unsafe_load(p)
+        end
+    end
+    # pre-optimization: the julia.escape intrinsic is emitted
+    ir_unopt = get_llvm(escape_ref, Tuple{Int}, true, false, false)
+    @test occursin("julia.escape", ir_unopt)
+    # optimized: the allocation survives on the heap (not moved to an alloca)
+    # and the intrinsic has been deleted by GC lowering
+    ir_opt = get_llvm(escape_ref, Tuple{Int})
+    heapallocregex = r"ijl_gc_(?:small|big|pool)_alloc|ijl_gc_alloc_typed|julia\.gc_alloc_obj|gc_alloc_bytes"
+    @test occursin(heapallocregex, ir_opt)
+    @test !occursin("julia.escape", ir_opt)
+    # control: without the barrier the same object is moved to the stack
+    function plain_ref(x::Int)
+        r = Ref(x)
+        GC.@preserve r begin
+            p = Base.unsafe_convert(Ptr{Int}, r)
+            ccall(:jl_breakpoint, Cvoid, (Ptr{Cvoid},), p)
+            unsafe_load(p)
+        end
+    end
+    ir_plain = get_llvm(plain_ref, Tuple{Int})
+    @test !occursin(heapallocregex, ir_plain)
+
+    # runtime semantics: identity, for both boxed and unboxed values
+    @test Core.compilerbarrier(:escape, 42) === 42
+    let v = [1, 2, 3]
+        @test Core.compilerbarrier(:escape, v) === v
+    end
+
+    # :escape is not an inference barrier: constant information flows through
+    @test Base.return_types() do
+        Val(Core.compilerbarrier(:escape, 2))
+    end |> only === Val{2}
+end
+
 # sret parameters must have an alignment attribute (required by LLVM LangRef).
 @testset "sret alignment attribute" begin
     struct SretAlignTest

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1081,6 +1081,12 @@ f3_compilerbarrier(b) = Base.compilerbarrier(:blackbox, b)
 # :blackbox is not consistent (prevents CSE/constant-folding) but is nothrow
 @test !Compiler.is_consistent(Base.infer_effects(f3_compilerbarrier, (Bool,)))
 @test Compiler.is_nothrow(Base.infer_effects(f3_compilerbarrier, (Bool,)))
+f4_compilerbarrier(b) = Base.compilerbarrier(:escape, b)
+# :escape models a store to unknowable global memory: nothrow, but not
+# effect-free (must never be deleted, even if the result is unused)
+@test Compiler.is_nothrow(Base.infer_effects(f4_compilerbarrier, (Base.RefValue{Int},)))
+@test !Compiler.is_effect_free(Base.infer_effects(f4_compilerbarrier, (Base.RefValue{Int},)))
+@test !Compiler.is_removable_if_unused(Base.infer_effects(f4_compilerbarrier, (Base.RefValue{Int},)))
 
 # Optimizer-refined effects
 function f1_optrefine(b)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -5599,7 +5599,7 @@ end)[2] == Union{}
 # compilerbarrier builtin
 import Core: compilerbarrier
 # runtime semantics
-for setting = (:type, :const, :conditional, :blackbox)
+for setting = (:type, :const, :conditional, :blackbox, :escape)
     @test compilerbarrier(setting, 42) == 42
     @test compilerbarrier(setting, :sym) == :sym
 end
@@ -5643,6 +5643,15 @@ end |> only === Int
 @test Base.return_types() do
     compilerbarrier(:blackbox, 42)
 end |> only === Int  # must not be Const(42)
+
+# :escape is not an inference barrier at all: type and constant information
+# both flow through (it only affects memory optimization)
+@test Base.return_types((Int,)) do a
+    compilerbarrier(:escape, a)
+end |> only === Int
+@test Base.return_types() do
+    Val(compilerbarrier(:escape, 2))
+end |> only === Val{2}
 
 # https://github.com/JuliaLang/julia/issues/46426
 @noinline typebarrier() = Base.inferencebarrier(0.0)

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4110,6 +4110,18 @@ Currently either of the following `setting`s is allowed:
   * `:blackbox`: treat the returned value as if it came from an unknowable black-box
     source, preventing common-subexpression elimination (CSE) and loop-invariant code motion on any computation that
     depends on it. See [`blackbox`](@ref) for a convenience wrapper.
+  * `:escape`: model `val` as escaping to an unknowable global memory location.
+    The compiler must then assume the object stays reachable (and its memory
+    readable and writable) through pointers it cannot see, so memory
+    optimizations cannot elide the allocation, split it into registers, or move
+    it to the stack. Unlike the other settings, this does not affect inference
+    at all: the return value keeps the full type (and constant) information of
+    `val`. Use this when the object's memory is exposed to code the compiler
+    cannot track, for example when a raw pointer obtained inside `GC.@preserve`
+    is handed to foreign code that may access it from another thread or after a
+    task switch. Note that this is a barrier on memory placement only; it does
+    not root `val`, so its lifetime must still be ensured separately (e.g. with
+    `GC.@preserve` or a `ccall` argument root).
 
 !!! note
     This function is expected to be used with `setting` known precisely at compile-time.

--- a/base/threadcall.jl
+++ b/base/threadcall.jl
@@ -80,6 +80,15 @@ function do_threadcall(fun_ptr::Ptr{Cvoid}, cfptr::Ptr{Cvoid}, rettype::Type, ar
     # create return buffer
     ret_arr = Vector{UInt8}(undef, Core.sizeof(rettype))
 
+    # The worker thread accesses these buffers through raw pointers while this
+    # task is blocked in `wait` below, so they must stay at stable heap
+    # addresses: model them as escaped so memory optimizations cannot move
+    # them (e.g. to this task's stack). `roots` transitively covers the
+    # `cconvert`ed argument objects whose pointers were stored into `args_arr`.
+    compilerbarrier(:escape, args_arr)
+    compilerbarrier(:escape, ret_arr)
+    compilerbarrier(:escape, roots)
+
     # wait for a worker thread to be available
     acquire(threadcall_restrictor)
     idx = -1

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2257,8 +2257,9 @@ JL_CALLABLE(jl_f_compilerbarrier)
     if (!(setting == jl_symbol("type") ||
           setting == jl_symbol("const") ||
           setting == jl_symbol("conditional") ||
-          setting == jl_symbol("blackbox")))
-        jl_error("The first argument of `compilerbarrier` must be either of `:type`, `:const`, `:conditional` or `:blackbox`.");
+          setting == jl_symbol("blackbox") ||
+          setting == jl_symbol("escape")))
+        jl_error("The first argument of `compilerbarrier` must be either of `:type`, `:const`, `:conditional`, `:blackbox` or `:escape`.");
     jl_value_t *val = args[1];
     return val;
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1234,6 +1234,35 @@ static const auto jl_blackbox_func = new JuliaFunction<>{
             {}); },
 };
 
+// `julia.escape` models its argument escaping to an unknowable global memory
+// location: the object must be assumed reachable (and its memory readable and
+// writable) through unknown pointers from here on, so it cannot be elided,
+// split, or moved to the stack by memory optimizations. It has no runtime
+// effect and is deleted during GC frame lowering. Note that it does not root
+// the object; lifetime must still be ensured separately (e.g. `GC.@preserve`).
+// The `inaccessiblemem: readwrite` memory effects keep LLVM from deleting the
+// otherwise-unused call while still permitting optimizations of accessible
+// memory around it; the (absent) `nocapture`/`memory(argmem: ...)` argument
+// attributes are what force alias analyses to treat the object as escaped.
+static const auto jl_escape_func = new JuliaFunction<>{
+    "julia.escape",
+    [](LLVMContext &C) {
+        auto T_prjlvalue = JuliaType::get_prjlvalue_ty(C);
+        return FunctionType::get(getVoidTy(C), {T_prjlvalue}, false);
+    },
+    [](LLVMContext &C) {
+        AttrBuilder FnAttrs(C);
+        FnAttrs.addMemoryAttr(MemoryEffects::inaccessibleMemOnly());
+        FnAttrs.addAttribute(Attribute::NoUnwind);
+        FnAttrs.addAttribute(Attribute::NoRecurse);
+        FnAttrs.addAttribute(Attribute::WillReturn);
+        FnAttrs.addAttribute(Attribute::NoSync);
+        return AttributeList::get(C,
+            AttributeSet::get(C, FnAttrs),
+            AttributeSet(),
+            {}); },
+};
+
 static const auto jl_write_barrier_func = new JuliaFunction<>{
     "julia.write_barrier",
     [](LLVMContext &C) { return FunctionType::get(getVoidTy(C),
@@ -5416,6 +5445,31 @@ isdefined_unknown_idx:
                 // Ghost type (e.g. Nothing) — pass through
                 *ret = obj;
             }
+        } else if (setting.constant && setting.constant == (jl_value_t*)jl_symbol("escape")) {
+            const jl_cgval_t &obj = argv[2];
+            // Model the object as escaping to an unknowable global memory
+            // location, so that memory optimizations cannot elide it or move
+            // it to the stack. The value itself passes through unchanged. The
+            // intrinsic is deleted during GC frame lowering. Compile-time
+            // constants are global objects already and unboxed values without
+            // heap references have no object memory, so neither needs this.
+            // An unboxed value that does contain heap references is boxed
+            // first; the referenced objects then escape transitively through
+            // the (escaped) box.
+            bool needs_escape;
+            if (obj.constant || obj.V == nullptr)
+                needs_escape = false;
+            else if (obj.isboxed || obj.TIndex != nullptr)
+                needs_escape = true;
+            else {
+                needs_escape = !jl_is_datatype(obj.typ) || ((jl_datatype_t*)obj.typ)->layout == NULL ||
+                               ((jl_datatype_t*)obj.typ)->layout->npointers > 0;
+            }
+            if (needs_escape) {
+                Function *esc = prepare_call(jl_escape_func);
+                ctx.builder.CreateCall(esc, {boxed(ctx, obj)});
+            }
+            *ret = obj;
         } else {
             *ret = argv[2];
         }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1302,7 +1302,7 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                         // Known functions emitted in codegen that are not safepoints
                         if (callee == pointer_from_objref_func || callee == gc_preserve_begin_func ||
                             callee == gc_preserve_end_func || callee == typeof_func ||
-                            callee == blackbox_func ||
+                            callee == blackbox_func || callee == escape_func ||
                             callee == pgcstack_getter || callee->getName() == XSTR(jl_egal__unboxed) ||
                             callee->getName() == XSTR(jl_lock_value) || callee->getName() == XSTR(jl_unlock_value) ||
                             callee->getName() == XSTR(jl_lock_field) || callee->getName() == XSTR(jl_unlock_field) ||
@@ -1934,8 +1934,9 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
             }
 
             if (callee && (callee == gcroot_flush_func || callee == gc_preserve_begin_func
-                        || callee == gc_preserve_end_func)) {
-                /* No replacement */
+                        || callee == gc_preserve_end_func || callee == escape_func)) {
+                /* No replacement: `julia.escape` only exists to inform middle-end
+                   memory optimizations and has no runtime effect. */
             } else if (pointer_from_objref_func != nullptr && callee == pointer_from_objref_func) {
                 auto *obj = CI->getOperand(0);
 #if JL_LLVM_VERSION >= 200000

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -31,7 +31,7 @@ JuliaPassContext::JuliaPassContext()
         pgcstack_getter(nullptr), adoptthread_func(nullptr), gcroot_flush_func(nullptr),
         gc_preserve_begin_func(nullptr), gc_preserve_end_func(nullptr),
         pointer_from_objref_func(nullptr), gc_loaded_func(nullptr), alloc_obj_func(nullptr),
-        typeof_func(nullptr), blackbox_func(nullptr), write_barrier_func(nullptr), pop_handler_noexcept_func(nullptr),
+        typeof_func(nullptr), blackbox_func(nullptr), escape_func(nullptr), write_barrier_func(nullptr), pop_handler_noexcept_func(nullptr),
         call_func(nullptr), call2_func(nullptr), call3_func(nullptr), module(nullptr)
 {
 }
@@ -56,6 +56,7 @@ void JuliaPassContext::initFunctions(Module &M)
     gc_loaded_func = M.getFunction("julia.gc_loaded");
     typeof_func = M.getFunction("julia.typeof");
     blackbox_func = M.getFunction("julia.blackbox");
+    escape_func = M.getFunction("julia.escape");
     write_barrier_func = M.getFunction("julia.write_barrier");
     alloc_obj_func = M.getFunction("julia.gc_alloc_obj");
     pop_handler_noexcept_func = M.getFunction(XSTR(jl_pop_handler_noexcept));

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -60,6 +60,7 @@ struct JuliaPassContext {
     llvm::Function *alloc_obj_func;
     llvm::Function *typeof_func;
     llvm::Function *blackbox_func;
+    llvm::Function *escape_func;
     llvm::Function *write_barrier_func;
     llvm::Function *pop_handler_noexcept_func;
     llvm::Function *call_func;

--- a/test/llvmpasses/alloc-opt-pass.ll
+++ b/test/llvmpasses/alloc-opt-pass.ll
@@ -394,9 +394,30 @@ define ptr addrspace(10) @two_objref_fields_no_merge(ptr addrspace(10) %a, ptr a
 }
 ; CHECK-LABEL: }{{$}}
 
+; Test that an allocation passed to `julia.escape` stays on the heap: the
+; intrinsic models the object escaping to an unknowable global memory location,
+; so it may be reached (and its memory accessed) through pointers the compiler
+; cannot see, e.g. from another thread while this task is suspended.
+; CHECK-LABEL: @escape_no_stack
+; CHECK-NOT: alloca
+; CHECK: call{{.*}}@julia.gc_alloc_obj
+; CHECK: ret void
+define void @escape_no_stack() {
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %ptls = call ptr @julia.ptls_states()
+  %v = call noalias nonnull align 8 dereferenceable(16) ptr addrspace(10) @julia.gc_alloc_obj(ptr %ptls, i64 16, ptr addrspace(10) @tag) #7
+  call void @julia.escape(ptr addrspace(10) %v) #8
+  %v_derived = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
+  %val = load i64, ptr addrspace(11) %v_derived, align 8
+  ret void
+}
+; CHECK-LABEL: }{{$}}
+
 declare ptr @julia.ptls_states()
 
 declare ptr @julia.pointer_from_objref(ptr addrspace(11))
+
+declare void @julia.escape(ptr addrspace(10)) #8
 
 declare token @llvm.julia.gc_preserve_begin(...)
 


### PR DESCRIPTION
Adds an `:escape` setting to `Core.compilerbarrier`, backed by a new `julia.escape` LLVM intrinsic, which models its argument escaping to an unknowable global memory location: the object must be assumed reachable (and its memory readable and writable) through pointers the compiler cannot see, so memory optimizations may not elide it, split it into registers, or move it to the (possibly copied) task stack. Unlike the other settings, `:escape` is not an inference barrier at all: type and constant information flow through unchanged. It also does not root the object; lifetime must still be ensured separately (e.g. `GC.@preserve`).

At the Julia level, the barrier has `effect_free=ALWAYS_FALSE` so it is never deleted even when its result is unused. At the LLVM level, codegen emits `julia.escape` on the boxed object (boxing first if an unboxed value contains heap references, which escapes the referenced objects transitively); the intrinsic is opaque to alloc-opt's escape analysis, declared `memory(inaccessiblemem: readwrite)` so LLVM keeps it while still optimizing accessible memory around it, and is deleted during GC frame lowering. An object that provably has no other uses at all may still be deleted late in the pipeline; the barrier only pins memory placement, matching the discussion in #61926 that leaking an object globally must be modeled as an actual (fictitious) global store rather than inferred from `GC.@preserve`.

`do_threadcall` now applies the barrier to its argument and return buffers (and the `cconvert` roots, whose pointers are stored into the argument buffer): the libuv worker thread accesses these buffers through raw pointers while the calling task is blocked in `wait`, so they must stay at stable heap addresses.

This fixes the recent x86_64 Windows CI crashes in the `@threadcall` stress test at `test/ccall.jl:1066` (`EXCEPTION_ACCESS_VIOLATION` in `jl_gc_state_set`/`maybe_collect`). Since #62166 made alloc-opt's field analysis precise enough to stack-promote constant-size `Memory` allocations whose data pointer escapes through a ccall, and #62001 made `do_threadcall`'s `rettype::Type` argument an egal-constant in its specialization (const-folding `Core.sizeof(rettype)` and making the buffers constant-size), `@threadcall`'s buffers were moved to the task stack. Under load the stack pool is exhausted and tasks fall back to copied stacks, whose frames are vacated while switched out at `wait`, so the worker's result store landed in (and read arguments from) stack memory reused by other tasks: `@threadcall` returned unstored results (~20% of calls in the stress test on a 32-core machine), and the stray 4-byte stores corrupted other tasks' frames, including spilled task pointer slots, producing the safepoint crashes seen on CI. With this change the stress test passes with 0 failures under `JULIA_COPY_STACKS=1` where it previously failed ~70% of calls.