### PR TITLE
contrib/mac: Replace AppleScript app entry point with julia-terminal …

### DIFF
--- a/cli/loader_exe.c
+++ b/cli/loader_exe.c
@@ -14,6 +14,47 @@ extern "C" {
 
 JULIA_DEFINE_FAST_TLS
 
+#ifdef _OS_DARWIN_
+// The macOS application bundle (contrib/mac/app) uses `julia-terminal` as its
+// double-clickable entry point (CFBundleExecutable). `julia-terminal` is a hardlink
+// to the julia binary sitting next to it in `bin/`. When the loader is invoked under
+// that name, we don't start the REPL in-process (a Finder-launched bundle has no
+// controlling terminal); instead we relaunch the sibling `julia` binary inside a new
+// Terminal.app window so the user gets an interactive session.
+//
+// A hardlink (rather than a symlink) is what makes this work: LaunchServices resolves
+// a symlinked CFBundleExecutable down to its target, discarding the `julia-terminal`
+// name, whereas a hardlink keeps its own name. That distinct name is also how we avoid
+// hijacking ordinary `julia` invocations (e.g. non-interactive `julia script.jl`).
+static void maybe_launch_terminal(void)
+{
+    char exe_path[JL_PATH_MAX];
+    uint32_t bufsize = sizeof(exe_path);
+    if (_NSGetExecutablePath(exe_path, &bufsize) != 0)
+        return;
+    // Resolve any intermediate symlinks (the bundle's Contents/MacOS/julia-terminal
+    // is a symlink into bin/) to land on the real `julia-terminal` hardlink.
+    char self_path[JL_PATH_MAX];
+    if (realpath(exe_path, self_path) == NULL)
+        return;
+
+    // Only take over when invoked as `julia-terminal`.
+    char * base = strrchr(self_path, '/');
+    if (base == NULL)
+        return;
+    base++;
+    if (strcmp(base, "julia-terminal") != 0)
+        return;
+
+    // The real julia binary is the sibling `julia`. Hand it to Terminal.app, which
+    // opens a window and runs the REPL there.
+    strcpy(base, "julia");
+    execl("/usr/bin/open", "open", "-a", "Terminal", self_path, (char *)NULL);
+    jl_loader_print_stderr("ERROR: Failed to launch Terminal.app!\n");
+    exit(1);
+}
+#endif
+
 #ifdef _COMPILER_ASAN_ENABLED_
 JL_DLLEXPORT const char* __asan_default_options(void)
 {
@@ -40,6 +81,10 @@ int main(int argc, char * argv[])
     // ASAN/TSAN do not support RTLD_DEEPBIND
     // https://github.com/google/sanitizers/issues/611
     putenv("LBT_USE_RTLD_DEEPBIND=0");
+#endif
+
+#ifdef _OS_DARWIN_
+    maybe_launch_terminal();
 #endif
 
     // Convert Windows wchar_t values to UTF8

--- a/contrib/mac/app/Info.plist.in
+++ b/contrib/mac/app/Info.plist.in
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Julia</string>
+	<key>CFBundleExecutable</key>
+	<string>julia-terminal</string>
+	<key>CFBundleIconFile</key>
+	<string>julia.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>@APP_ID@</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Julia</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@JULIA_VERSION_MAJOR_MINOR_PATCH@</string>
+	<key>CFBundleVersion</key>
+	<string>@JULIA_VERSION_OPT_COMMIT@</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.9</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>@APP_COPYRIGHT@</string>
+</dict>
+</plist>

--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -33,29 +33,28 @@ dmg/Applications:
 	-mkdir -p dmg
 	ln -fs /Applications $@
 
-dmg/$(APP_NAME): startup.applescript julia.icns
-	-mkdir -p dmg
-	osacompile -o $@ startup.applescript
-	rm $@/Contents/Resources/applet.icns
-	# Newer osacompile ships the applet icon as a compiled asset catalog
-	# (Assets.car, referenced by CFBundleIconName) which modern macOS prefers
-	# over CFBundleIconFile -- so just dropping applet.icns/setting julia.icns
-	# below leaves the generic AppleScript applet icon showing. Remove the stale
-	# catalog and its key so CFBundleIconFile=julia.icns is authoritative.
-	rm -f $@/Contents/Resources/Assets.car
-	-plutil -remove CFBundleIconName $@/Contents/Info.plist
-	cp julia.icns $@/Contents/Resources/
-	plutil -replace CFBundleDevelopmentRegion  -string "en" $@/Contents/Info.plist
-	plutil -insert  CFBundleDisplayName        -string "Julia" $@/Contents/Info.plist
-	plutil -replace CFBundleIconFile           -string "julia.icns" $@/Contents/Info.plist
-	plutil -insert  CFBundleIdentifier         -string "$(APP_ID)" $@/Contents/Info.plist
-	plutil -replace CFBundleName               -string "Julia" $@/Contents/Info.plist
-	plutil -insert  CFBundleShortVersionString -string "$(JULIA_VERSION_MAJOR_MINOR_PATCH)" $@/Contents/Info.plist
-	plutil -insert  CFBundleVersion            -string "$(JULIA_VERSION_OPT_COMMIT)" $@/Contents/Info.plist
-	plutil -insert  NSHumanReadableCopyright   -string "$(APP_COPYRIGHT)" $@/Contents/Info.plist
+dmg/$(APP_NAME): Info.plist.in julia.icns
+	-mkdir -p $@/Contents/MacOS
 	-mkdir -p $@/Contents/Resources/julia
+	# Author the bundle's Info.plist from the template, substituting version info.
+	sed -e 's|@APP_ID@|$(APP_ID)|g' \
+	    -e 's|@APP_COPYRIGHT@|$(APP_COPYRIGHT)|g' \
+	    -e 's|@JULIA_VERSION_MAJOR_MINOR_PATCH@|$(JULIA_VERSION_MAJOR_MINOR_PATCH)|g' \
+	    -e 's|@JULIA_VERSION_OPT_COMMIT@|$(JULIA_VERSION_OPT_COMMIT)|g' \
+	    Info.plist.in > $@/Contents/Info.plist
+	printf 'APPL????' > $@/Contents/PkgInfo
+	cp julia.icns $@/Contents/Resources/
 	$(MAKE) -C $(JULIAHOME) binary-dist
 	$(TAR) -xzf $(JULIAHOME)/$(JULIA_BINARYDIST_FILENAME).tar.gz -C $@/Contents/Resources/julia --strip-components 1
+	# The app's double-clickable entry point is `julia-terminal`. It is a hardlink to
+	# the bundled julia binary (NOT a symlink: LaunchServices resolves a symlinked
+	# CFBundleExecutable down to its target, discarding the name the loader keys off).
+	# When the loader is invoked under this name it relaunches julia inside Terminal.app
+	# (see cli/loader_exe.c) instead of starting the REPL in the windowless bundle
+	# process. Contents/MacOS/julia-terminal is a symlink to that hardlink, so the real
+	# executable keeps its bin/ location and thus its relative rpath to the libraries.
+	ln -f $@/Contents/Resources/julia/bin/julia $@/Contents/Resources/julia/bin/julia-terminal
+	ln -fs ../Resources/julia/bin/julia-terminal $@/Contents/MacOS/julia-terminal
 	find $@/Contents/Resources/julia -type f -exec chmod -w {} \;
 	# Even though the tarball may already be signed, we re-sign here to make it easier to add
 	# unsigned executables (like the app launcher) and whatnot, without needing to maintain lists

--- a/contrib/mac/app/README.md
+++ b/contrib/mac/app/README.md
@@ -4,13 +4,21 @@ Julia OS X packaging
 This builds the Julia OS X application bundle (.app folder), and stores it in a disk image
 (.dmg file).
 
-The application bundle is actually just a bundled applet which opens Terminal.app and
-executes the julia binary (which opens the REPL). All the Julia binary files and their
-dependencies are bundled inside this.
+The application bundle opens Terminal.app and executes the julia binary (which opens
+the REPL). All the Julia binary files and their dependencies are bundled inside this.
+
+Its double-clickable entry point is `julia-terminal`, a hardlink to the bundled julia
+binary (`Contents/Resources/julia/bin/julia-terminal`, reached via a
+`Contents/MacOS/julia-terminal` symlink). When the loader is invoked under the name
+`julia-terminal` it relaunches julia inside a new Terminal.app window rather than starting
+the REPL directly in the (windowless) bundle process. See `cli/loader_exe.c` for that
+logic. A hardlink is used rather than a symlink because LaunchServices resolves a
+symlinked `CFBundleExecutable` down to its target, discarding the `julia-terminal` name
+that the loader keys off.
 
 Run `make` to build.
 
 Other files in this directory
 
-* `startup.applescript` is the script which is compiled to the applet.
+* `Info.plist.in` is the template for the bundle's `Info.plist`.
 * `julia.icns` is the Julia icon file.

--- a/contrib/mac/app/startup.applescript
+++ b/contrib/mac/app/startup.applescript
@@ -1,3 +1,0 @@
-set RootPath to (path to me)
-set JuliaPath to POSIX path of ((RootPath as text) & "Contents:Resources:julia:bin:julia")
-do shell script "open -a Terminal '" & JuliaPath & "'"


### PR DESCRIPTION
…loader

The macOS application bundle previously used an osacompile'd AppleScript applet as its entry point, whose only job was to run `open -a Terminal` on the bundled julia binary. Replace that applet with a small amount of logic in the loader itself.

The bundle's entry point is now `julia-terminal`, a hardlink to the bundled julia binary. When the loader detects it was invoked under that name, it relaunches the sibling `julia` binary inside a new Terminal.app window instead of starting the REPL in the (windowless) bundle process. Plain `julia` keeps its own name and is unaffected, including non-interactive invocations.

A hardlink is required rather than a symlink because LaunchServices resolves a symlinked CFBundleExecutable down to its target before exec, discarding the `julia-terminal` name the loader keys off; a hardlink keeps its own name. The Info.plist, formerly generated and patched via plutil, is now authored from a checked-in template.

This PR will let us stop building the .app on mac CI and instead just repackage the .tar as a .app in the final publish step, saving us CI latency.