### PR TITLE
intrinsics: add `Base.assume_range` range-hint intrinsic

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -335,6 +335,7 @@ add_tfunc(Core.Intrinsics.llvmcall, 3, INT_INF, llvmcall_tfunc, 10)
 end
 add_tfunc(Core.Intrinsics.cglobal, 1, 2, cglobal_tfunc, 5)
 
+add_tfunc(Core.Intrinsics.assume_range, 3, 3, math_tfunc, 0)
 add_tfunc(Core.Intrinsics.have_fma, 1, 1, @nospecs((𝕃::AbstractLattice, x)->Bool), 1)
 
 # builtin functions

--- a/NEWS.md
+++ b/NEWS.md
@@ -99,6 +99,10 @@ New library functions
   `mod`, keyed by `(including_module, absolute_path)`. The table is stored inside the package
   image, so it survives precompilation; revision tools (e.g. Revise) use it to re-apply the
   original transform when an `include(mapexpr, …)`-ed file is edited.
+- `Base.assume_range(x, lo, hi)` returns the integer `x` unchanged while asserting to the
+  compiler that `lo <= x <= hi`, letting the optimizer fold range-dependent code (bounds
+  checks, comparisons against out-of-range constants) at no runtime cost. It is an unchecked
+  assertion: out-of-range values are undefined behavior.
 
 New library features
 --------------------

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1517,3 +1517,32 @@ Clamp `x` to lie within range `r`.
      This method requires at least Julia 1.6.
 """
 clamp(x::Integer, r::AbstractUnitRange{<:Integer}) = clamp(x, first(r), last(r))
+
+"""
+    Base.assume_range(x::T, lo::T, hi::T) where {T<:Base.BitInteger} -> x
+
+Return `x` unchanged while asserting to the compiler that `lo <= x <= hi` (an
+inclusive range). Knowing the range lets the optimizer fold range-dependent code
+at the use site for free — for example an `@boundscheck` or a comparison against
+an out-of-range constant collapses to a constant — at no runtime cost, since the
+assertion produces no machine instruction.
+
+`lo` and `hi` should be compile-time constants; if they are not, the assertion is
+ignored and `x` is returned unchanged.
+
+The hint is local to the function it is compiled into: it is only exploited where
+the value is used within that same (post-inlining) function, and is *not* recorded
+in the method's inferred return type. It therefore does not propagate across a
+non-inlined call boundary — for a caller to benefit, the code consuming the value
+must be inlined together with the `assume_range` call.
+
+Unlike [`clamp`](@ref), this does not coerce out-of-range values — it *asserts*
+they cannot occur.
+
+!!! warning
+    This is an unchecked assertion. If `x` ever lies outside `[lo, hi]`, the
+    program has undefined behavior, exactly like an out-of-bounds `@inbounds`
+    access. Only use it when the range is guaranteed by construction.
+"""
+@inline assume_range(x::T, lo::T, hi::T) where {T<:BitInteger} =
+    Core.Intrinsics.assume_range(x, lo, hi)

--- a/base/public.jl
+++ b/base/public.jl
@@ -86,6 +86,7 @@ public
 # Integer math
     uabs,
     mul_hi,
+    assume_range,
 
 # C interface
     cconvert,

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -8,6 +8,8 @@ namespace JL_I {
 #include <bitset>
 #include <string>
 
+#include <llvm/IR/ConstantRange.h>
+
 #include "ccall.cpp"
 
 //Mark our stats as being from intrinsics irgen
@@ -1343,6 +1345,30 @@ static jl_cgval_t emit_ifelse(jl_codectx_t &ctx, jl_cgval_t c, jl_cgval_t x, jl_
     return mark_julia_type(ctx, ifelse_result, isboxed, jt);
 }
 
+// Advertise that `v` lies in the (inclusive) constant range `CR` by routing it
+// through an `alwaysinline` identity carrier whose return carries an LLVM `range`
+// attribute. After inlining the carrier leaves no instruction — only the range
+// fact, which LLVM propagates to the use site.
+static Value *emit_assume_range_hint(jl_codectx_t &ctx, Value *v, const ConstantRange &CR)
+{
+    Type *t = v->getType();
+    std::string fname;
+    raw_string_ostream(fname) << "julia.range_hint.i" << t->getIntegerBitWidth()
+        << "." << CR.getLower() << "." << CR.getUpper();
+    Function *F = jl_Module->getFunction(fname);
+    if (!F) {
+        FunctionType *FT = FunctionType::get(t, {t}, false);
+        F = Function::Create(FT, GlobalValue::InternalLinkage, fname, jl_Module);
+        F->addFnAttr(Attribute::AlwaysInline);
+        F->addFnAttr(Attribute::NoUnwind);
+        F->addRetAttr(Attribute::get(ctx.builder.getContext(), Attribute::Range, CR));
+        BasicBlock *BB = BasicBlock::Create(ctx.builder.getContext(), "top", F);
+        IRBuilder<> B(BB);
+        B.CreateRet(F->getArg(0));
+    }
+    return ctx.builder.CreateCall(F, {v});
+}
+
 static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **args, size_t nargs)
 {
     auto &DL = ctx.emission_context.DL;
@@ -1451,6 +1477,34 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         Value *from = emit_unbox(ctx, xt, x);
         Value *ans = ctx.builder.CreateNot(from);
         return mark_julia_type(ctx, ans, false, x.typ);
+    }
+
+    case assume_range: {
+        assert(nargs == 3);
+        const jl_cgval_t &x = argv[0];
+        const jl_cgval_t &lo = argv[1];
+        const jl_cgval_t &hi = argv[2];
+        // require three values of the same primitive integer type
+        if (!jl_is_primitivetype(x.typ) || x.typ != lo.typ || x.typ != hi.typ)
+            return emit_runtime_call(ctx, f, argv, nargs);
+        Type *xt = INTT(bitstype_to_llvm(x.typ, ctx.builder.getContext(), true), DL);
+        if (!xt || !xt->isIntegerTy())
+            return emit_runtime_call(ctx, f, argv, nargs);
+        Value *xv = emit_unbox(ctx, xt, x);
+        Value *lov = emit_unbox(ctx, xt, lo);
+        Value *hiv = emit_unbox(ctx, xt, hi);
+        // the range can only be advertised when the bounds fold to constants;
+        // otherwise this is a plain identity (the hint is silently dropped).
+        if (auto *loc = dyn_cast<ConstantInt>(lov)) {
+            if (auto *hic = dyn_cast<ConstantInt>(hiv)) {
+                // assume_range is inclusive [lo, hi]; ConstantRange is half-open.
+                APInt hiEx = hic->getValue() + 1;
+                ConstantRange CR(loc->getValue(), hiEx);
+                if (!CR.isFullSet() && !CR.isEmptySet())
+                    xv = emit_assume_range_hint(ctx, xv, CR);
+            }
+        }
+        return mark_julia_type(ctx, xv, false, x.typ);
     }
 
     case have_fma: {

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -104,6 +104,8 @@
     /*  c interface */ \
     ADD_I(cglobal, 2) \
     ALIAS(llvmcall, llvmcall) \
+    /*  compiler hints (keep before have_fma: Compiler sizes T_IFUNC as index(have_fma)+1, see N_IFUNC in Compiler/src/tfuncs.jl) */ \
+    ADD_I(assume_range, 3) \
     /*  cpu feature tests */ \
     ADD_I(have_fma, 1) \
     /*  hidden intrinsics */ \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1752,6 +1752,7 @@ STATIC_INLINE int is_valid_intrinsic_elptr(jl_value_t *ety)
     return ety == (jl_value_t*)jl_any_type || (jl_is_concrete_type(ety) && !jl_is_layout_opaque(((jl_datatype_t*)ety)->layout) && !jl_is_array_type(ety));
 }
 JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v);
+JL_DLLEXPORT jl_value_t *jl_assume_range(jl_value_t *a, jl_value_t *lo, jl_value_t *hi);
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align);
 JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i);
 JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order, jl_value_t *syncscope);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -419,6 +419,17 @@ JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v)
     return jl_new_bits(ty, jl_data_ptr(v));
 }
 
+// run time version of assume_range intrinsic: identity, the range is only a
+// codegen hint so there is nothing to do at run time (interpreter/constant eval).
+JL_DLLEXPORT jl_value_t *jl_assume_range(jl_value_t *a, jl_value_t *lo, jl_value_t *hi)
+{
+    if (!jl_is_primitivetype(jl_typeof(a)))
+        jl_error("assume_range: value is not a primitive type");
+    if (jl_typeof(lo) != jl_typeof(a) || jl_typeof(hi) != jl_typeof(a))
+        jl_error("assume_range: bounds must have the same type as the value");
+    return a;
+}
+
 // run time version of pointerref intrinsic (warning: i is not rooted)
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align)
 {

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -5,6 +5,8 @@
 # For curmod_*
 include("testenv.jl")
 
+import InteractiveUtils
+
 # bits types
 @test isa((() -> Core.Intrinsics.bitcast(Ptr{Int8}, 0))(), Ptr{Int8})
 @test isa(convert(Char, 65), Char)
@@ -621,3 +623,17 @@ tofloat(x) = Core.Intrinsics.uitofp(Float64, x)
 # https://github.com/JuliaLang/julia/issues/61436
 primitive type UIntN256 <: Unsigned 256 end
 @test tofloat(reinterpret(UIntN256, (zeros(UInt8, 32)...,))) == 0.0
+
+@testset "assume_range" begin
+    ar = Base.assume_range
+    icmps(f, ts) = count("icmp", sprint(io -> InteractiveUtils.code_llvm(io, f, ts; debuginfo=:none)))
+    # identity semantics (incl. non-constant bounds, where the hint is silently dropped)
+    @test all(ar(x, 0x00, 0xff) === x for x in 0x00:0xff)
+    @test ((x, lo, hi) -> ar(x, lo, hi))(0x2a, 0x00, 0x40) === 0x2a
+    # a narrow constant range folds an out-of-range comparison to a constant (unsigned + signed)
+    @test icmps(x::UInt8 -> ar(x, 0x00, 0x07) < 0x08, (UInt8,)) == 0
+    @test icmps(x::Int8 -> ar(x, Int8(-4), Int8(3)) > Int8(3), (Int8,)) == 0
+    # inference: identity return type, and nothrow
+    @test Base.infer_return_type(ar, (UInt16, UInt16, UInt16)) === UInt16
+    @test Base.infer_effects(ar, (UInt16, UInt16, UInt16)).nothrow
+end


### PR DESCRIPTION
This is something I implemented in EmulatedBitIntegers.jl and I thought this might be generally useful.

Summary (and most of the code) from Claude Opus 4.8:

`Base.assume_range(x, lo, hi)` returns the integer `x` unchanged while asserting to the compiler that `lo <= x <= hi`. The bound is carried as an LLVM `range` return attribute on an `alwaysinline` identity carrier, so it adds no instruction of its own and lets the optimizer fold range-dependent code — bounds checks, comparisons against out-of-range constants — at the use site.

    julia> f(x::UInt8) = x < 0x08;

    julia> @code_llvm debuginfo=:none f
    define i8 @julia_f_0(i8 zeroext %x) {
    top:
      %0 = icmp ult i8 %x, 8
      %1 = zext i1 %0 to i8
      ret i8 %1
    }

    julia> g(x::UInt8) = Base.assume_range(x, 0x00, 0x07) < 0x08;

    julia> @code_llvm debuginfo=:none g
    define i8 @julia_g_0(i8 zeroext %x) {
    top:
      ret i8 1
    }

The assertion is unchecked: if `x` ever falls outside `[lo, hi]`, the program has undefined behavior, like an out-of-bounds `@inbounds` access. The hint is local to the function it is compiled into and is not recorded in the inferred return type, so it does not cross a non-inlined call boundary.