### PR TITLE
Run SparseArrays tests early in the parallel test schedule

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,11 +89,13 @@ move_to_node1("stress")
 # since it starts a lot of workers and can easily exceed the maximum memory
 limited_worker_rss && move_to_node1("Distributed")
 
-# Move LinearAlgebra and Pkg tests to the front, because they take a while, so we might
-# as well get them all started early. JuliaLowering_stdlibs both takes a while and
-# uses a lot of memory at the beginning so try to run it early to keep total memory
-# use flatter.
-for prependme in ["LinearAlgebra", "Pkg", "JuliaLowering_stdlibs"]
+# Move LinearAlgebra, Pkg and SparseArrays tests to the front, because they take a
+# while, so we might as well get them all started early. SparseArrays in particular
+# runs as a single test set for close to an hour on slow platforms (e.g. i686) and
+# dominates the critical path if started late. JuliaLowering_stdlibs both takes a
+# while and uses a lot of memory at the beginning so try to run it early to keep
+# total memory use flatter.
+for prependme in ["LinearAlgebra", "Pkg", "SparseArrays", "JuliaLowering_stdlibs"]
     prependme_test_ids = findall(x->occursin(prependme, x), tests)
     prependme_tests = tests[prependme_test_ids]
     deleteat!(tests, prependme_test_ids)


### PR DESCRIPTION
The SparseArrays test set runs as one monolithic job that takes close to an hour on slow platforms. On the i686 testers it currently starts ~35 minutes into the run (stdlib tests are appended at the end of the schedule by `choosetests.jl`), and since the node-1-only tests (`ccall`, `precompile`, `SharedArrays`, `threads`, `Distributed`) cannot start until every parallel test has finished, it regularly pushes those CI jobs past their internal `JL_TERM_TIMEOUT` of 110 minutes.

Concretely, in [this julia-release-1.12 build](https://buildkite.com/julialang/julia-release-1-dot-12/builds/635#019f3767-374d-44fd-a6a8-0707cc560ff5), SparseArrays ran 13:43→14:36 (52.6 min), the serialized node-1 tail then ran until the timeout killed the job at 14:59 — with 228 of 229 test sets already passed and only `Distributed` (started 15 seconds earlier) remaining.

This adds `SparseArrays` to the existing list of long-running tests that are moved to the front of the parallel queue, so it starts at t=0 and stops dominating the critical path. In the build above this would have pulled the finish forward by ~30 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)