### PR TITLE
threadcall: modernize @threadcall to use native Julia objects

### DIFF
--- a/base/threadcall.jl
+++ b/base/threadcall.jl
@@ -28,21 +28,32 @@ macro threadcall(f, rettype, argtypes, argvals...)
     argtypes = map(esc, argtypes.args)
     argvals = map(esc, argvals)
 
-    # bind the argument values and a result cell to local variables so the
-    # wrapper closure below captures native Julia objects. Closing over them
-    # keeps everything the worker thread needs rooted for the duration of the
-    # call, without serializing into a raw buffer or any manual GC.@preserve.
-    args = [Symbol("arg", i) for i in 1:length(argvals)]
-    argbinds = [:($(args[i]) = $(argvals[i])) for i in 1:length(argvals)]
+    # `cconvert` and `unsafe_convert` each argument on the calling thread:
+    # cconvert may allocate or run arbitrary Julia code, and computing the
+    # unsafe_convert'd C representation here keeps all of that off the libuv
+    # worker thread, which only makes the raw call. The cconverted values are
+    # captured by the wrapper closure and GC.@preserve'd around the worker-thread
+    # ccall so their C representations (e.g. interior pointers) stay valid.
+    roots = [Symbol("root", i) for i in 1:length(argvals)]
+    args  = [Symbol("arg", i) for i in 1:length(argvals)]
+    rootbinds = [:($(roots[i]) = cconvert($(argtypes[i]), $(argvals[i]))) for i in 1:length(argvals)]
+    argbinds  = [:($(args[i]) = unsafe_convert($(argtypes[i]), $(roots[i]))) for i in 1:length(argvals)]
+    call = :(result[] = ccall(cfptr, $rettype, ($(argtypes...),), $(args...)))
+    # keep the cconverted values alive while their C representations are in use
+    body = isempty(roots) ? call : :(GC.@preserve $(roots...) $call)
 
     return quote
         # use cglobal to look up the function on the calling thread
         cfptr = cglobal($f)
+        $(rootbinds...)
         $(argbinds...)
         result = Ref{$rettype}()
         # closure that performs the actual call on the worker thread and stores
         # the result into the captured cell
-        wrapper = () -> (result[] = ccall(cfptr, $rettype, ($(argtypes...),), $(args...)); nothing)
+        wrapper = function ()
+            $body
+            return
+        end
         do_threadcall(wrapper, result)
     end
 end

--- a/base/threadcall.jl
+++ b/base/threadcall.jl
@@ -1,9 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 const max_ccall_threads = parse(Int, get(ENV, "UV_THREADPOOL_SIZE", "4"))
-const thread_notifiers = Union{Event, Nothing}[nothing for i in 1:max_ccall_threads]
 const threadcall_restrictor = Semaphore(max_ccall_threads)
-const threadcall_lock = Threads.SpinLock()
 
 """
     @threadcall((cfunc, clib), rettype, (argtypes...), argvals...)
@@ -30,78 +28,71 @@ macro threadcall(f, rettype, argtypes, argvals...)
     argtypes = map(esc, argtypes.args)
     argvals = map(esc, argvals)
 
-    # construct non-allocating wrapper to call C function
-    wrapper = :(function (fptr::Ptr{Cvoid}, args_ptr::Ptr{Cvoid}, retval_ptr::Ptr{Cvoid})
-        p = args_ptr
-        # the rest of the body is created below
-    end)
-    body = wrapper.args[2].args
-    args = Symbol[]
-    for (i, T) in enumerate(argtypes)
-        arg = Symbol("arg", i)
-        push!(body, :($arg = unsafe_load(convert(Ptr{$T}, p))))
-        push!(body, :(p += Core.sizeof($T)))
-        push!(args, arg)
-    end
-    push!(body, :(ret = ccall(fptr, $rettype, ($(argtypes...),), $(args...))))
-    push!(body, :(unsafe_store!(convert(Ptr{$rettype}, retval_ptr), ret)))
-    push!(body, :(return Int(Core.sizeof($rettype))))
+    # bind the argument values and a result cell to local variables so the
+    # wrapper closure below captures native Julia objects. Closing over them
+    # keeps everything the worker thread needs rooted for the duration of the
+    # call, without serializing into a raw buffer or any manual GC.@preserve.
+    args = [Symbol("arg", i) for i in 1:length(argvals)]
+    argbinds = [:($(args[i]) = $(argvals[i])) for i in 1:length(argvals)]
 
-    # return code to generate wrapper function and send work request to thread queue
-    wrapper = Expr(:var"hygienic-scope", wrapper, @__MODULE__, __source__)
-    return :(let fun_ptr = @cfunction($wrapper, Int, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}))
+    return quote
         # use cglobal to look up the function on the calling thread
-        do_threadcall(fun_ptr, cglobal($f), $rettype, Any[$(argtypes...)], Any[$(argvals...)])
-    end)
+        cfptr = cglobal($f)
+        $(argbinds...)
+        result = Ref{$rettype}()
+        # closure that performs the actual call on the worker thread and stores
+        # the result into the captured cell
+        wrapper = () -> (result[] = ccall(cfptr, $rettype, ($(argtypes...),), $(args...)); nothing)
+        do_threadcall(wrapper, result)
+    end
 end
 
-function do_threadcall(fun_ptr::Ptr{Cvoid}, cfptr::Ptr{Cvoid}, rettype::Type, argtypes::Vector, argvals::Vector)
-    # generate function pointer
-    c_notify_fun = @cfunction(
-        function notify_fun(idx)
-            global thread_notifiers
-            notify(thread_notifiers[idx])
-            return
-        end, Cvoid, (Cint,))
+# call wrapper invoked on the libuv worker thread. `F` is the concrete type of
+# the work closure, so `f()` is fully devirtualized; the closure is delivered
+# by value through the `Ref{F}` cfunction argument in `do_threadcall`.
+function threadcall_run(f::F) where F
+    f()
+    return
+end
 
-    # cconvert, root and unsafe_convert arguments
-    roots = Any[]
-    args_size = isempty(argtypes) ? 0 : sum(Core.sizeof, argtypes)
-    args_arr = Vector{UInt8}(undef, args_size)
-    ptr = pointer(args_arr)
-    for (T, x) in zip(argtypes, argvals)
-        isbitstype(T) || throw(ArgumentError("threadcall requires isbits argument types"))
-        y = cconvert(T, x)
-        push!(roots, y)
-        unsafe_store!(convert(Ptr{T}, ptr), unsafe_convert(T, y)::T)
-        ptr += Core.sizeof(T)
-    end
+# called from the libuv event loop once the queued work has finished, to wake
+# up the task waiting in `do_threadcall`
+function threadcall_notify(ct::Task, ctx::RefValue{Any})
+    schedule(ct)
+    unpreserve_handle(ct)
+    unpreserve_handle(ctx)
+    return
+end
 
-    # create return buffer
-    ret_arr = Vector{UInt8}(undef, Core.sizeof(rettype))
+function do_threadcall(wrapper::F, result::Ref{T}) where {F, T}
+    # a plain (non-closure) call wrapper, specialized to `F` via the `Ref{F}`
+    # argument type; the closure is handed to C as an opaque context pointer
+    c_run = @cfunction(threadcall_run, Cvoid, (Ref{F},))
+    # function pointer used to notify us when the work is done
+    c_notify_fun = @cfunction(threadcall_notify, Cvoid, (Ref{Task}, Ref{RefValue{Any}},))
+
+    # box the closure so wrapper has a stable address to preserve
+    # pass as Ptr{Cvoid} to pass that stable address
+    ctx = RefValue{Any}(wrapper)
 
     # wait for a worker thread to be available
     acquire(threadcall_restrictor)
-    idx = -1
-    @lock threadcall_lock begin
-        idx = findfirst(isequal(nothing), thread_notifiers)::Int
-        thread_notifiers[idx] = Event()
-    end
-
-    GC.@preserve args_arr ret_arr roots begin
+    try
+        ct = current_task()
+        # keep the waiting task and the boxed closure alive until the worker thread
+        # has finished and woken us back up: the task so the notifier can find it by
+        # pointer, and the closure box so its captured values survive
+        preserve_handle(ct)
+        preserve_handle(ctx)
         # queue up the work to be done
         ccall(:jl_queue_work, Cvoid,
-            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{UInt8}, Ptr{UInt8}, Ptr{Cvoid}, Cint),
-            fun_ptr, cfptr, args_arr, ret_arr, c_notify_fun, idx)
+            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Any, Ref{RefValue{Any}}),
+            c_run, ctx, c_notify_fun, ct, ctx)
 
-        # wait for a result & return it
-        wait(thread_notifiers[idx])
-        @lock threadcall_lock begin
-            thread_notifiers[idx] = nothing
-        end
+        # wait for a result
+        wait()
+    finally
         release(threadcall_restrictor)
-
-        r = unsafe_load(convert(Ptr{rettype}, pointer(ret_arr)))
     end
-    return r
+    return result[]
 end

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -1197,17 +1197,19 @@ JL_DLLEXPORT int jl_tty_set_mode(uv_tty_t *handle, int mode)
     return uv_tty_set_mode(handle, mode_enum);
 }
 
-typedef int (*work_cb_t)(void *, void *, void *);
-typedef void (*notify_cb_t)(int);
+// work_func is a call wrapper that is handed work_ctx, an opaque context that
+// carries everything needed to perform the call; notify_func wakes up the
+// waiting task once the work has finished.
+typedef void (*work_cb_t)(void *);
+typedef void (*notify_cb_t)(void *, void *);
 
 struct work_baton {
     uv_work_t req;
     work_cb_t work_func;
-    void      *ccall_fptr;
-    void      *work_args;
-    void      *work_retval;
+    void      *work_ctx;
     notify_cb_t notify_func;
-    int       notify_idx;
+    void      *notify_data1;
+    void      *notify_data2;
 };
 
 #ifdef _OS_LINUX_
@@ -1217,27 +1219,28 @@ struct work_baton {
 static void jl_work_wrapper(uv_work_t *req)
 {
     struct work_baton *baton = (struct work_baton*) req->data;
-    baton->work_func(baton->ccall_fptr, baton->work_args, baton->work_retval);
+    baton->work_func(baton->work_ctx);
 }
 
 static void jl_work_notifier(uv_work_t *req, int status)
 {
     struct work_baton *baton = (struct work_baton*) req->data;
-    baton->notify_func(baton->notify_idx);
+    baton->notify_func(baton->notify_data1, baton->notify_data2);
     free(baton);
 }
 
-JL_DLLEXPORT int jl_queue_work(work_cb_t work_func, void *ccall_fptr, void *work_args, void *work_retval,
-                               notify_cb_t notify_func, int notify_idx)
+JL_DLLEXPORT int jl_queue_work(work_cb_t work_func, void *work_ctx,
+                               notify_cb_t notify_func,
+                               void *notify_data1,
+                               void *notify_data2)
 {
     struct work_baton *baton = (struct work_baton*)malloc_s(sizeof(struct work_baton));
     baton->req.data = (void*) baton;
     baton->work_func = work_func;
-    baton->ccall_fptr = ccall_fptr;
-    baton->work_args = work_args;
-    baton->work_retval = work_retval;
+    baton->work_ctx = work_ctx;
     baton->notify_func = notify_func;
-    baton->notify_idx = notify_idx;
+    baton->notify_data1 = notify_data1;
+    baton->notify_data2 = notify_data2;
 
     JL_UV_LOCK();
     uv_queue_work(jl_io_loop, &baton->req, jl_work_wrapper, jl_work_notifier);


### PR DESCRIPTION
The `@threadcall` implementation relied on a legacy notification scheme: Events stored in a fixed-size thread_notifiers array indexed by an integer handed through to C, together with serializing the call arguments and return value into raw Vector{UInt8} buffers passed as pointers.

Replace this with native Julia objects. The calling Task is kept alive with preserve_handle and rescheduled directly with schedule from the libuv notify callback, mirroring how uv_writecb_task wakes the waiter on a write completion. Arguments are still cconvert'd and unsafe_convert'd on the calling thread. They are captured by a small closure that is boxed and handed
to C as an opaque context pointer, then run on the worker through a static call wrapper that recovers it as a concrete f::F. This lifts the previous restriction that argument types be isbits.

Targeted at fixes the same issue as https://github.com/JuliaLang/julia/pull/62324, though doesn't replace that PR.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
