### PR TITLE
runtime: normalize layout-aliased isbits-union components

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -122,7 +122,7 @@ static int NOINLINE compare_fields(const jl_value_t *a, const jl_value_t *b, jl_
                 uint8_t bsel = ((uint8_t*)bo)[idx];
                 if (asel != bsel)
                     return 0;
-                ft = (jl_datatype_t*)jl_nth_union_component((jl_value_t*)ft, asel);
+                ft = (jl_datatype_t*)normalize_typeofbottom_layout_alias(jl_nth_union_component((jl_value_t*)ft, asel));
             }
             else if (ft->layout->first_ptr >= 0) {
                 // If the field is a inline immutable that can be undef
@@ -482,7 +482,7 @@ static uintptr_t immut_id_(jl_datatype_t *dt, jl_value_t *v, uintptr_t h) JL_NOT
             jl_datatype_t *fieldtype = (jl_datatype_t*)jl_field_type_concrete(dt, f);
             if (jl_is_uniontype(fieldtype)) {
                 uint8_t sel = ((uint8_t*)vo)[jl_field_size(dt, f) - 1];
-                fieldtype = (jl_datatype_t*)jl_nth_union_component((jl_value_t*)fieldtype, sel);
+                fieldtype = (jl_datatype_t*)normalize_typeofbottom_layout_alias(jl_nth_union_component((jl_value_t*)fieldtype, sel));
             }
             assert(jl_is_datatype(fieldtype) && !fieldtype->name->abstract && !fieldtype->name->mutabl);
             int32_t first_ptr = fieldtype->layout->first_ptr;

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -353,7 +353,11 @@ JL_DLLEXPORT jl_value_t *jl_memoryrefget(jl_genericmemoryref_t m, int isatomic)
         assert(i < m.mem->length);
         // isbits union selector bytes are always stored directly after the last memory element
         uint8_t sel = jl_genericmemory_typetagdata(m.mem)[i];
-        eltype = jl_nth_union_component(eltype, sel);
+        // the component may be a layout-aliased type (e.g. Type{Union{}}) that
+        // is not a datatype until normalized
+        eltype = normalize_typeofbottom_layout_alias(jl_nth_union_component(eltype, sel));
+        if (jl_is_datatype_singleton((jl_datatype_t*)eltype))
+            return ((jl_datatype_t*)eltype)->instance;
         data = (char*)m.mem->ptr + i * layout->size;
     }
     if (layout->size == 0) {

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1410,7 +1410,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
                         ptr += lock_size;
                     }
                     n += jl_static_show_x_(out, (jl_value_t*)ptr,
-                            (jl_datatype_t*)(typetagdata ? jl_nth_union_component(el_type, typetagdata[j]) : el_type),
+                            (jl_datatype_t*)(typetagdata ? normalize_typeofbottom_layout_alias(jl_nth_union_component(el_type, typetagdata[j])) : el_type),
                             depth, ctx);
                 }
                 if (j != tlen - 1)
@@ -1505,7 +1505,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
                     jl_datatype_t *ft = (jl_datatype_t*)jl_field_type_concrete(vt, i);
                     if (jl_is_uniontype(ft)) {
                         uint8_t sel = ((uint8_t*)fld_ptr)[jl_field_size(vt, i) - 1];
-                        ft = (jl_datatype_t*)jl_nth_union_component((jl_value_t*)ft, sel);
+                        ft = (jl_datatype_t*)normalize_typeofbottom_layout_alias(jl_nth_union_component((jl_value_t*)ft, sel));
                     }
                     n += jl_static_show_x_(out, (jl_value_t*)fld_ptr, ft, depth, ctx);
                 }

--- a/test/core.jl
+++ b/test/core.jl
@@ -9201,6 +9201,17 @@ let v = Vector{Type{Union{}}}()
     push!(u, 3)
     push!(u, Union{})
     @test u[1] === 3 && u[2] === Union{}
+    # the runtime builtin paths (interpreter, --compile=min, dynamically-called
+    # builtins) must also normalize the layout-aliased union component
+    mref = memoryref(getfield(u, :ref).mem, 2)
+    @test Base.inferencebarrier(Core.memoryrefget)(mref, :not_atomic, false) === Union{}
+end
+struct HasAliasedUnionField9196
+    x::Union{Type{Union{}},Int}
+end
+let a = HasAliasedUnionField9196(Union{}), b = HasAliasedUnionField9196(Union{})
+    @test Base.inferencebarrier(===)(a, b)
+    @test objectid(a) == objectid(b)
 end
 
 # Pinned static-parameter uncertainty markers (`==`-only bindings) must be

--- a/test/show.jl
+++ b/test/show.jl
@@ -1546,6 +1546,16 @@ end
 # Test for PR 17803
 @test static_shown(Int128(-1)) == "Int128(0xffffffffffffffffffffffffffffffff)"
 
+# isbits-union elements/fields whose selected component is the layout-aliased
+# Type{Union{}} must not crash static show
+let u = Union{Type{Union{}},Int}[3, Union{}]
+    @test occursin("TypeofBottom", static_shown(u))
+end
+struct HasAliasedUnionFieldShow
+    x::Union{Type{Union{}},Int}
+end
+@test occursin("TypeofBottom", static_shown(HasAliasedUnionFieldShow(Union{})))
+
 # PR #22160
 @test static_shown(:aa) == ":aa"
 @test static_shown(:+) == ":+"


### PR DESCRIPTION
`Type{Union{}}` is a Core.TypeEgal node, not a jl_datatype_t; isbits-union
layouts alias it to the typeof(Union{}) singleton. Several runtime readers
of jl_nth_union_component used the raw component and dereferenced its NULL
layout: jl_memoryrefget (segfault reading a Union{Type{Union{}},Int}
element whose selector picks that component), egal's compare_fields,
immut_id_, and two jl_static_show paths. jl_get_nth_field and the write
side (union_component_matches) already normalize; these were missed.

Reproduces on nightly with --compile=min:

    u = Vector{Union{Type{Union{}},Int}}(); push!(u, 3); push!(u, Union{})
    u[2]   # segfault in jl_memoryrefget -> jl_datatype_layout

Compiled code normalizes in codegen, so the hole only shows on paths that
reach the runtime builtins.

This was found in the tiering PR
Wrap the five sites in normalize_typeofbottom_layout_alias and return the
singleton instance for the zero-size component in jl_memoryrefget.

This commit was written with the assistance of generative AI (Claude).

