### PR TITLE
runtime: make forbidden-context task-switch errors deterministic

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -664,16 +664,21 @@ JL_DLLEXPORT void jl_switch(void) JL_CANSAFEPOINT_ENTER_LEAVE
     jl_task_t *ct = jl_current_task;
     jl_ptls_t ptls = ct->ptls;
     jl_task_t *t = ptls->next_task;
-    if (t == ct) {
+    if (t == ct && !ptls->in_finalizer && !ptls->in_pure_callback) {
+        // switching to self is a no-op, but only when a task switch would
+        // have been permitted at all: the forbidden-context errors below must
+        // not depend on whether the scheduler happened to have another
+        // runnable task (e.g. `yield()` on an otherwise idle thread pops the
+        // current task itself)
         return;
     }
     int8_t gc_state = jl_gc_unsafe_enter(ptls);
-    if (t->ctx.started && t->ctx.stkbuf == NULL)
-        jl_error("attempt to switch to exited task");
     if (ptls->in_finalizer)
         jl_error("task switch not allowed from inside gc finalizer");
     if (ptls->in_pure_callback)
         jl_error("task switch not allowed from inside staged nor pure functions");
+    if (t->ctx.started && t->ctx.stkbuf == NULL)
+        jl_error("attempt to switch to exited task");
     if (!jl_set_task_tid(t, jl_atomic_load_relaxed(&ct->tid))) // manually yielding to a task
         jl_error("cannot switch to task running on another thread");
 

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -188,6 +188,22 @@ let gf_err, tsk = @async nothing # create a Task for yield to try to run
     @test gf_err_ref[] < 1000
 end
 
+# the error must fire even when the scheduler holds no other runnable task:
+# `yield()` then pops the current task itself, and the switch-to-self fast
+# path must not skip the forbidden-context checks
+gf_err_ref[] = 0
+let
+    @generated function gf_err_yield_to_self()
+        gf_err_ref[] += 1
+        yield()
+        gf_err_ref[] += 1000
+    end
+    Expected = ErrorException("task switch not allowed from inside staged nor pure functions")
+    @test_throws Expected gf_err_yield_to_self()
+    @test_throws Expected gf_err_yield_to_self()
+    @test gf_err_ref[] < 1000
+end
+
 gf_err_ref[] = 0
 let gf_err2
     @generated function gf_err2(::f) where {f}


### PR DESCRIPTION
jl_switch returned early on a switch-to-self before checking the
in_finalizer/in_pure_callback guards, so the "task switch not allowed"
errors depended on whether the scheduler happened to hold another
runnable task: `yield()` on an otherwise idle thread pops the current
task itself and silently no-ops, while the same code errors on a busy
thread. A generator that must always error (e.g. one calling yield())
can therefore expand "successfully" and cache its bogus result when
inference runs on a thread with an empty run queue.

Check the forbidden-context guards before the switch-to-self fast path
so the error fires on any switch attempt. The exited-task check stays
after them: a root task's stkbuf can be NULL, and the context error is
the more informative one.

This commit was written with the assistance of generative AI (Claude).

