### PR TITLE
gf: guard speccache_eq against unpublished specialization slots

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -154,12 +154,6 @@ uint_t speccache_hash(size_t idx, jl_value_t *data)
 
 static int speccache_eq(size_t idx, const void *ty, jl_value_t *data, uint_t hv)
 {
-    // The lock-free reader captures m->specializations before it acquires
-    // this keyset entry, so a concurrent grow can pair a fresh index with the
-    // now-stale svec: the index may be past the stale svec's length, or point
-    // at a slot that was only filled in the replacement. Both reads are
-    // ordered (the entry is release-stored after the slot), just against the
-    // wrong array; returning a miss sends the caller to the locked retry.
     if (idx >= jl_svec_len(data))
         return 0; // We got a OOB access, probably due to a data race
     jl_method_instance_t *ml = (jl_method_instance_t*)jl_svecref(data, idx);

--- a/src/gf.c
+++ b/src/gf.c
@@ -157,6 +157,8 @@ static int speccache_eq(size_t idx, const void *ty, jl_value_t *data, uint_t hv)
     if (idx >= jl_svec_len(data))
         return 0; // We got a OOB access, probably due to a data race
     jl_method_instance_t *ml = (jl_method_instance_t*)jl_svecref(data, idx);
+    if (ml == NULL || (jl_value_t*)ml == jl_nothing)
+        return 0; // slot not yet published, probably due to a data race
     jl_value_t *sig = ml->specTypes;
     if (ty == sig)
         return 1;

--- a/src/gf.c
+++ b/src/gf.c
@@ -154,6 +154,12 @@ uint_t speccache_hash(size_t idx, jl_value_t *data)
 
 static int speccache_eq(size_t idx, const void *ty, jl_value_t *data, uint_t hv)
 {
+    // The lock-free reader captures m->specializations before it acquires
+    // this keyset entry, so a concurrent grow can pair a fresh index with the
+    // now-stale svec: the index may be past the stale svec's length, or point
+    // at a slot that was only filled in the replacement. Both reads are
+    // ordered (the entry is release-stored after the slot), just against the
+    // wrong array; returning a miss sends the caller to the locked retry.
     if (idx >= jl_svec_len(data))
         return 0; // We got a OOB access, probably due to a data race
     jl_method_instance_t *ml = (jl_method_instance_t*)jl_svecref(data, idx);

--- a/src/idset.c
+++ b/src/idset.c
@@ -3,6 +3,8 @@
 
 static uint_t idset_hash(size_t idx, jl_value_t *data)
 {
+    if (idx >= ((jl_genericmemory_t*)data)->length)
+        return 0; // We got a OOB access, probably due to a data race
     jl_value_t *x = jl_genericmemory_ptr_ref(data, idx);
     // x should not be NULL, unless there was concurrent corruption
     return x == NULL ? 0 : jl_object_id(x);
@@ -10,6 +12,8 @@ static uint_t idset_hash(size_t idx, jl_value_t *data)
 
 static int idset_eq(size_t idx, const void *y, jl_value_t *data, uint_t hv)
 {
+    if (idx >= ((jl_genericmemory_t*)data)->length)
+        return 0; // We got a OOB access, probably due to a data race
     jl_value_t *x = jl_genericmemory_ptr_ref(data, idx);
     // x should not be NULL, unless there was concurrent corruption
     return x == NULL ? 0 : jl_egal(x, (jl_value_t*)y);

--- a/src/module.c
+++ b/src/module.c
@@ -1648,6 +1648,8 @@ static int bindingkey_eq(size_t idx, const void *var, jl_value_t *data, uint_t h
     if (idx >= jl_svec_len(data))
         return 0; // We got a OOB access, probably due to a data race
     jl_binding_t *b = (jl_binding_t*)jl_svecref(data, idx);
+    if (b == NULL || (jl_value_t*)b == jl_nothing)
+        return 0; // slot not yet published, probably due to a data race
     jl_sym_t *name = b->globalref->name;
     return var == name;
 }


### PR DESCRIPTION
A lock-free speccache reader racing a concurrent insertion/grow can
observe an index whose svec slot still holds the jl_nothing fill (the
function already guards the analogous out-of-bounds case). Observed as
a SIGSEGV in speccache_eq under the threads test on macOS aarch64:
https://buildkite.com/julialang/julia-pr/builds/214#019f43ed-012a-40be-8643-f9456f3dc961
Returning a miss is correct: the caller retries under the method
writelock before inserting.

This commit was written with the assistance of generative AI (Claude).

