### PR TITLE
docs: improve `esc` docstring and manual section

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -853,9 +853,36 @@ ifelse(condition::Bool, x, y) = Core.ifelse(condition, x, y)
 """
     esc(e)
 
-Only valid in the context of an [`Expr`](@ref) returned from a macro. Prevents the macro hygiene
-pass from turning embedded variables into gensym variables. See the [Macros](@ref man-macros)
-section of the Metaprogramming chapter of the manual for more details and examples.
+Wrap `e` in `Expr(:escape, e)`. The `:escape` expression head signals to the
+macro hygiene pass that the wrapped subexpression should be left untouched — its
+symbols will resolve in the *macro call site's* scope rather than the macro
+definition's scope.
+
+`esc` does not validate or error at call time; it merely constructs an [`Expr`](@ref).
+The `:escape` head is only meaningful during [macro expansion](@ref man-macros):
+when the macro expander walks the expression tree returned by a macro, any node
+wrapped in `:escape` is pasted into the output verbatim, bypassing hygienic renaming.
+Calling `esc` on an expression that is never returned from a macro has no effect —
+the `:escape` node is inert data, and attempting to [`eval`](@ref) it directly will
+produce a syntax error.
+
+See [Hygiene](@ref man-hygiene) in the Metaprogramming chapter of the manual for a
+full explanation, common pitfalls, and worked examples.
+
+See also [`macroexpand`](@ref), [`@__MODULE__`](@ref).
+
+# Examples
+```jldoctest
+julia> esc(:x)
+:($(Expr(:escape, :x)))
+
+julia> macro set_x(val)
+           :(x = $(esc(val)))
+       end;
+
+julia> macroexpand(@__MODULE__, :(@set_x 42))
+:(x = 42)
+```
 """
 esc(@nospecialize(e)) = Expr(:escape, e)
 

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -782,7 +782,7 @@ for the complete implementation.
 The `@assert` macro makes great use of splicing into quoted expressions to simplify the manipulation
 of expressions inside the macro body.
 
-### Hygiene
+### [Hygiene](@id man-hygiene)
 
 An issue that arises in more complex macros is that of [hygiene](https://en.wikipedia.org/wiki/Hygienic_macro).
 In short, macros must ensure that the variables they introduce in their returned expressions do
@@ -900,6 +900,72 @@ end
 However, we don't do this for a good reason: wrapping the `expr` in a new scope block (the anonymous function)
 also slightly changes the meaning of the expression (the scope of any variables in it),
 while we want `@time` to be usable with minimum impact on the wrapped code.
+
+#### How `esc` works — a before/after example
+
+[`esc`](@ref) wraps its argument in `Expr(:escape, ...)`. The macro expander treats any
+`:escape` node as belonging to the *call site*, so its symbols are not renamed. To see why
+this matters, consider a macro that assigns to a caller-visible variable:
+
+**Without `esc`** — the assignment targets a hygienic (gensym'd) variable, so the caller's
+`x` is never modified:
+
+```jldoctest esc_example; filter = r"#\d+#"
+julia> macro set_x_bad(val)
+           :(x = $val)
+       end;
+
+julia> macroexpand(@__MODULE__, :(@set_x_bad 42))
+:(var"x" = 42)
+```
+
+The local variable `var"#7#x"` is invisible to the caller; the intended assignment to `x`
+silently does nothing.
+
+**With `esc`** — escaping the entire returned expression (or selectively escaping the
+variable `x`) ensures the name resolves at the call site:
+
+```jldoctest esc_example
+julia> macro set_x_good(val)
+           :(x = $(esc(val)))
+       end;
+
+julia> macroexpand(@__MODULE__, :(@set_x_good 42))
+:(x = 42)
+```
+
+Now `x` refers to whatever `x` exists in the caller's scope, and the assignment works as
+intended.
+
+!!! note "esc is just data outside of macros"
+    `esc(expr)` always succeeds — it simply returns `Expr(:escape, expr)`. The resulting
+    expression only acquires meaning when it is part of a tree returned from a macro and
+    processed by the macro expander. If you try to `eval` an escaped expression directly,
+    Julia raises a syntax error because `:escape` is not valid surface syntax:
+    ```julia
+    julia> eval(esc(:(x, )))
+    ERROR: syntax: invalid syntax (escape ...)
+    ```
+
+#### Common pitfalls
+
+Two mistakes come up frequently when using [`esc`](@ref):
+
+1. **Forgetting to escape user-supplied expressions** (under-escaping).
+   When a macro receives an expression from the caller and interpolates it back into
+   generated code, the hygiene pass will rename variables inside it to gensyms. The caller's
+   code then silently refers to the wrong bindings. Always wrap user-supplied expressions
+   with `esc` when splicing them into the returned quote.
+
+2. **Escaping too much** (over-escaping).
+   Wrapping the *entire* macro return value in `esc` disables hygiene for every symbol in
+   the expansion, including the macro's own internal temporaries. This leaks implementation
+   details into the caller's scope, can shadow the caller's variables, and makes the macro
+   fragile. Prefer escaping only the specific subexpressions that need call-site resolution.
+
+See also [`macroexpand`](@ref) for inspecting the fully expanded form of a macro call,
+and [`@__MODULE__`](@ref) for obtaining the module in which the macro is being expanded.
+
 
 ### Macros and dispatch
 


### PR DESCRIPTION
-> Improve documentation for `esc`

Closes #37122

->Problem

The docstring for `esc` says it's "only valid in the context of an Expr 
returned from a macro." This is confusing. You *can* call `esc` anywhere — 
it just wraps your expression in `Expr(:escape, e)`, no error. But that 
`:escape` wrapper only does something during macro expansion. Outside of 
that, it's just inert data, and if you try to `eval` it yourself, you'll get 
a syntax error.

-> Changes

- Reworded the `esc` docstring to say clearly:
  - `esc(e)` just wraps `e` — it doesn't check or validate anything.
  - The wrapper only matters during macro expansion (the hygiene pass).
  - Outside a macro, it does nothing useful, and evaluating it directly 
    will error.
  - Added a short note on two common mistakes: forgetting to escape a 
    user's expression (breaks hygiene) and escaping too much (leaks macro 
    internals into the caller's scope).
- Added a small example to the macro hygiene section of the manual, showing 
  a macro that assigns to `x` and what happens if you forget `esc`.
- Linked the docstring to that manual section.

->Notes

- Docs only, no code changes.
- Open to wording tweaks if maintainers want a different style.