### PR TITLE
REPL: fix BoundsError in history search match highlighting

### DIFF
--- a/stdlib/REPL/src/History/resumablefiltering.jl
+++ b/stdlib/REPL/src/History/resumablefiltering.jl
@@ -343,6 +343,7 @@ function matchregions(spec::FilterSpec, candidate::AbstractString)
         i == length(matches) && break
         nextmatch = matches[i + 1]
         nxt = nextind(candidate, last(match))
+        nxt > ncodeunits(candidate) && continue
         if nextind(candidate, nxt) == first(nextmatch) && candidate[nxt] == ' '
             matches[i] = first(match):last(nextmatch)
             matches[i+1] = nextind(candidate, last(nextmatch)):last(nextmatch)

--- a/stdlib/REPL/test/history.jl
+++ b/stdlib/REPL/test/history.jl
@@ -416,6 +416,14 @@ end
             spec_ascii = FilterSpec(ConditionSet("=foo;=bar"))
             @test matchregions(spec_ascii, "foo bar") == [1:7]
         end
+        @testset "matchregions at end of string" begin
+            # Duplicate terms matching at the end of the string (issue 62341)
+            spec_dup = FilterSpec(ConditionSet("test\\; test\\;"))
+            @test matchregions(spec_dup, "test test;") == [6:10, 6:10]
+            # Overlapping matches extending to the end of the string
+            spec_overlap = FilterSpec(ConditionSet("=st;=test"))
+            @test matchregions(spec_overlap, "test") == [1:4, 3:4]
+        end
         @testset "Strictness comparison" begin
             c1 = ConditionSet("hello world")
             c2 = ConditionSet("hello world more")


### PR DESCRIPTION
👨 You could replicate the issue easily via:

```
julia> using REPL

julia> spec = REPL.History.FilterSpec(REPL.History.ConditionSet("test\\; test\\;"))
REPL.History.FilterSpec(String[], String[], Regex[r"\Qtest;\E"i, r"\Qtest;\E"i], ^[[B
Symbol[])

julia> REPL.History.matchregions(spec, "test test;")
ERROR: BoundsError: attempt to access 10-codeunit String at index [11]
Stacktrace:
 [1] _nextind_str(s::String, i::Int64)
   @ Base strings/string.jl:279 [inlined]
 [2] nextind(s::String, i::Int64)
   @ Base strings/string.jl:273 [inlined]
 [3] matchregions(spec::REPL.History.FilterSpec, candidate::String)
   @ REPL.History ~/.julia/juliaup/julia-nightly/Julia-1.14.app/Contents/Resources/julia/share/julia/stdlib/v1.14/REPL/src/History/resumablefiltering.jl:346
 [4] top-level scope
   @ REPL[2]:1
```



---

🤖 

When highlighting matches in the history search UI, matchregions
merges adjacent match regions separated by a single space. If a match
ends at the last index of the candidate string and is followed by
another (duplicate or overlapping) region in the sorted list,
nextind was called past the end of the string, throwing a BoundsError
that killed the search display task. Skip the merge check when the
match extends to the end of the string.

This pull request was written with the assistance of generative AI.

Fixes #62341

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
