### PR TITLE
gf: widen kind-typed slots to the Type umbrella in the backedge scan

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -814,8 +814,8 @@ JL_DLLEXPORT int jl_mi_try_insert(jl_method_instance_t *mi,
 
 enum top_typename_facts {
     EXACTLY_ANY = 1 << 0,
-    HAVE_TYPE = 1 << 1,
-    EXACTLY_TYPE = 1 << 2,
+    HAVE_ANYTYPE = 1 << 1,
+    EXACTLY_ANYTYPE = 1 << 2,
     HAVE_FUNCTION = 1 << 3,
     EXACTLY_FUNCTION = 1 << 4,
     HAVE_KWCALL = 1 << 5,
@@ -839,7 +839,7 @@ static void foreach_top_nth_typename(void (*f)(jl_typename_t*, int, void*), jl_v
         JL_GC_PROMISE_ROOTED(current_a);
 
         if (jl_is_some_Type(current_a)) {
-            *facts |= HAVE_TYPE;
+            *facts |= HAVE_ANYTYPE;
             arraylist_push(&workqueue, jl_some_Type_T(current_a));
             arraylist_push(&workqueue, (void*)(uintptr_t)-1);
         }
@@ -847,14 +847,14 @@ static void foreach_top_nth_typename(void (*f)(jl_typename_t*, int, void*), jl_v
             if (current_n <= 0) {
                 jl_datatype_t *dt = ((jl_datatype_t*)current_a);
                 if (dt == jl_function_type) {
-                    if (current_n == -1) // key Type{>:Function} as Type instead of Function
-                        *facts |= EXACTLY_TYPE; // HAVE_TYPE is already set
+                    if (current_n == -1) // key Type{>:Function} as the AnyType umbrella instead of Function
+                        *facts |= EXACTLY_ANYTYPE; // HAVE_ANYTYPE is already set
                     else
                         *facts |= HAVE_FUNCTION | EXACTLY_FUNCTION;
                 }
                 else if (dt == jl_any_type) {
-                    if (current_n == -1) // key Type{>:Any} and kinds as Type instead of Any
-                        *facts |= EXACTLY_TYPE; // HAVE_TYPE is already set
+                    if (current_n == -1) // key Type{>:Any} and kinds as the AnyType umbrella instead of Any
+                        *facts |= EXACTLY_ANYTYPE; // HAVE_ANYTYPE is already set
                     else
                         *facts |= EXACTLY_ANY;
                 }
@@ -863,6 +863,17 @@ static void foreach_top_nth_typename(void (*f)(jl_typename_t*, int, void*), jl_v
                         *facts |= EXACTLY_KWCALL;
                     else
                         *facts |= HAVE_KWCALL;
+                }
+                else if (jl_is_kind((jl_value_t*)dt)) {
+                    // instances of a kind are type objects, whose backedge
+                    // keys are their payload-class typenames, which the kind
+                    // itself cannot enumerate: the type object `Int` is keyed
+                    // as `Number` when reached through a `Type{Int}` call
+                    // site and must be found from a `(::DataType)(...)`
+                    // insertion too, so cover kinds through the `AnyType`
+                    // umbrella and its whole-table fallback instead of
+                    // keying by the kind's own supertype chain
+                    *facts |= HAVE_ANYTYPE | EXACTLY_ANYTYPE;
                 }
                 else {
                     while (1) {
@@ -931,14 +942,14 @@ static int jl_foreach_top_typename_for(void (*f)(jl_typename_t*, int, void*), jl
             kwfacts |= (all_subtypes ? EXACTLY_ANY : EXACTLY_KWCALL);
         facts |= kwfacts;
     }
-    if (all_subtypes && (facts & (EXACTLY_FUNCTION | EXACTLY_TYPE | EXACTLY_ANY)))
+    if (all_subtypes && (facts & (EXACTLY_FUNCTION | EXACTLY_ANYTYPE | EXACTLY_ANY)))
         // flag that we have an explicit match that is necessitating a full table scan
         return 0;
     // or inform caller of only which supertypes are applicable
     if (facts & HAVE_FUNCTION)
         f(jl_function_type->name, facts & EXACTLY_FUNCTION ? 1 : 0, env);
-    if (facts & HAVE_TYPE)
-        f(jl_type_typename, facts & EXACTLY_TYPE ? 1 : 0, env);
+    if (facts & HAVE_ANYTYPE)
+        f(jl_anytype_type->name, facts & EXACTLY_ANYTYPE ? 1 : 0, env);
     if (facts & (HAVE_KWCALL | EXACTLY_KWCALL))
         f(jl_kwcall_type->name, facts & EXACTLY_KWCALL ? 1 : 0, env);
     f(jl_any_type->name, facts & EXACTLY_ANY ? 1 : 0, env);

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -653,3 +653,14 @@ struct W62022{T}; x::T; end
 @noinline foo62022(::W62022{W62022{W62022{W62022{Int}}}}) = false
 @test foo62022(W62022(1)) === false # test for invalidation
 @test foo62022(W62022(W62022(W62022(1)))) === false
+
+# a kind-typed slot admits type objects, whose canonical backedge keys come
+# from their payload class (a `Type{Int}` call site keys under `Number`); a
+# `(::DataType)(...)` insertion must widen to the `Type` umbrella to find
+# such missing-match edges rather than keying by the kind's supertype chain
+struct KindCtor67 end
+struct KindArg67 end  # private argument type so the pirate method stays inert
+callctor67(x) = KindCtor67(x)
+@test_throws MethodError callctor67(KindArg67())
+(t::DataType)(x::KindArg67) = t === KindCtor67 ? 67 : 0
+@test callctor67(KindArg67()) === 67


### PR DESCRIPTION
[Found by Claude while working on an unrelated branch - I assume this broke somewhere during the TypeEq refactor]

The missing-match backedge table is keyed canonically: a call site's edge is filed under keys derived from its first argument slot, and a method insertion visits the keys derived from its own signature to find the edges it might now satisfy. For this to be sound, the key of a value must not depend on which signature shape reached it — but a kind-typed slot (`(::DataType)(x)`) walked the kind's own supertype chain to a key that no `Type{...}`-shaped call site ever files under (a `Type{Int}` call site keys under `Number`, its payload's class). Defining such a method therefore never invalidated existing callers holding missing-constructor edges:

    struct K end
    f(x) = K(x)
    f(1)                  # MethodError, compiled with a missing edge
    (t::DataType)(x) = 42
    f(1)                  # still MethodError from stale code

Instances of a kind are type objects whose payload-class keys the kind itself cannot enumerate, so key kind slots through the `Type` umbrella (and its whole-table fallback on the invalidation side), the same way an unbounded `(::Type{T})(x)` slot is handled.