### PR TITLE
[1.13] codegen: propagate caller GC stack argument to JIT ABI converter

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -555,7 +555,7 @@ static Function *aot_abi_converter(jl_codegen_params_t &params, Module *M, jl_ab
     std::string gf_thunk_name;
     if (!specfunc.empty()) {
         Value *llvmtarget = IRLinker_copyFunctionProto(M, defM->getFunction(specfunc));
-        gf_thunk_name = emit_abi_converter(M, params, from_abi, codeinst, llvmtarget, target_specsig);
+        gf_thunk_name = emit_abi_converter(M, params, from_abi, codeinst, llvmtarget, target_specsig, params.params->gcstack_arg);
     }
     else {
         Value *llvmtarget = func.empty() ? nullptr : IRLinker_copyFunctionProto(M, defM->getFunction(func));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5062,7 +5062,7 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
 {
     ++EmittedSpecfunCalls;
     // emit specialized call site
-    bool gcstack_arg = JL_FEAT_TEST(ctx, gcstack_arg);
+    bool gcstack_arg = returninfo.gcstack_arg;
     size_t nfargs = returninfo.decl.getFunctionType()->getNumParams();
     SmallVector<Value *, 0> argvals(nfargs);
     unsigned idx = 0;
@@ -7154,7 +7154,7 @@ static void emit_specsig_to_specsig(
     emit_specsig_to_specsig(gf_thunk, returninfo.cc, returninfo.return_roots, calltype, rettype, is_for_opaque_closure, nargs, params, target, targetsig, targetrt, targetspec, rettype_const);
 }
 
-std::string emit_abi_converter(Module *M, jl_codegen_params_t &params, jl_abi_t from_abi, jl_code_instance_t *codeinst, Value *target, bool target_specsig)
+std::string emit_abi_converter(Module *M, jl_codegen_params_t &params, jl_abi_t from_abi, jl_code_instance_t *codeinst, Value *target, bool target_specsig, bool target_gcstack_arg)
 {
     // this builds a method that calls a method with the same arguments but a different specsig
     // build a specsig -> specsig converter thunk
@@ -7168,7 +7168,12 @@ std::string emit_abi_converter(Module *M, jl_codegen_params_t &params, jl_abi_t 
     gf_thunk_name += "_gfthunk";
     if (target_specsig) {
         jl_value_t *abi = get_ci_abi(codeinst);
+        jl_cgparams_t local_params = *params.params;
+        local_params.gcstack_arg = target_gcstack_arg;
+        const jl_cgparams_t *old_params = params.params;
+        params.params = &local_params;
         jl_returninfo_t targetspec = get_specsig_function(params, M, target, "", abi, codeinst->rettype, target_is_opaque_closure);
+        params.params = old_params;
         if (from_abi.specsig)
             emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, from_abi.is_opaque_closure, from_abi.nargs, params,
                     target, mi->specTypes, codeinst->rettype, &targetspec, nullptr);
@@ -7264,6 +7269,8 @@ static jl_cgval_t emit_abi_call(jl_codectx_t &ctx, jl_value_t *declrt, jl_value_
         Module *M = jl_Module;
         ArrayType *T_cfuncdata = ArrayType::get(T_ptr, 8);
         size_t flags = specsig;
+        if (ctx.params->gcstack_arg)
+            flags |= 2;
         GlobalVariable *cfuncdata = new GlobalVariable(*M, T_cfuncdata, false,
                 GlobalVariable::PrivateLinkage,
                 ConstantArray::get(T_cfuncdata, {
@@ -7952,6 +7959,7 @@ static jl_returninfo_t get_specsig_function(jl_codegen_params_t &params, Module 
 {
     bool gcstack_arg = params.params->gcstack_arg;
     jl_returninfo_t props = {};
+    props.gcstack_arg = gcstack_arg;
     SmallVector<Type*,8> fsig;
     SmallVector<std::string,4> argnames;
     Type *rt = NULL;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -288,7 +288,8 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
             }
             else if (specsigflags & JL_CI_FLAGS_SPECPTR_SPECIALIZED) {
                 assert(specptr != nullptr);
-                if (from_abi.specsig && jl_egal(mi->specTypes, from_abi.sigt) && jl_egal(codeinst->rettype, from_abi.rt))
+                bool callee_gcstack_arg = true;
+                if (from_abi.specsig && jl_egal(mi->specTypes, from_abi.sigt) && jl_egal(codeinst->rettype, from_abi.rt) && (from_abi.gcstack_arg == callee_gcstack_arg))
                     return specptr; // no adapter required
 
                 target = specptr;
@@ -299,8 +300,11 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
 
     orc::ThreadSafeModule result_m;
     std::string gf_thunk_name;
+    jl_cgparams_t local_params = jl_default_cgparams;
+    local_params.gcstack_arg = from_abi.gcstack_arg;
     {
         jl_codegen_params_t params(std::make_unique<LLVMContext>(), jl_ExecutionEngine->getDataLayout(), jl_ExecutionEngine->getTargetTriple()); // Locks the context
+        params.params = &local_params;
         params.getContext().setDiscardValueNames(true);
         params.cache = true;
         params.imaging_mode = 0;
@@ -308,7 +312,7 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
         Module *M = result_m.getModuleUnlocked();
         if (target) {
             Value *llvmtarget = literal_static_pointer_val((void*)target, PointerType::get(M->getContext(), 0));
-            gf_thunk_name = emit_abi_converter(M, params, from_abi, codeinst, llvmtarget, target_specsig);
+            gf_thunk_name = emit_abi_converter(M, params, from_abi, codeinst, llvmtarget, target_specsig, true);
         }
         else if (invoke == jl_fptr_const_return_addr) {
             gf_thunk_name = emit_abi_constreturn(M, params, from_abi, codeinst->rettype_const);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -203,6 +203,7 @@ struct jl_returninfo_t {
     size_t union_minalign;
     unsigned return_roots;
     bool all_roots;
+    bool gcstack_arg;
 };
 
 struct jl_codegen_call_target_t {
@@ -325,7 +326,7 @@ Function *jl_cfunction_object(jl_value_t *f, jl_value_t *rt, jl_tupletype_t *arg
 extern "C" JL_DLLEXPORT_CODEGEN
 void *jl_jit_abi_convert(jl_task_t *ct, jl_abi_t from_abi, _Atomic(void*) *fptr, _Atomic(size_t) *last_world, void *data);
 std::string emit_abi_dispatcher(Module *M, jl_codegen_params_t &params, jl_abi_t from_abi, jl_code_instance_t *codeinst, Value *invoke);
-std::string emit_abi_converter(Module *M, jl_codegen_params_t &params, jl_abi_t from_abi, jl_code_instance_t *codeinst, Value *target, bool target_specsig);
+std::string emit_abi_converter(Module *M, jl_codegen_params_t &params, jl_abi_t from_abi, jl_code_instance_t *codeinst, Value *target, bool target_specsig, bool target_gcstack_arg);
 std::string emit_abi_constreturn(Module *M, jl_codegen_params_t &params, jl_abi_t from_abi, jl_value_t *rettype_const);
 std::string emit_abi_constreturn(Module *M, jl_codegen_params_t &params, bool specsig, jl_code_instance_t *codeinst);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -426,6 +426,7 @@ typedef struct _jl_abi_t {
     int specsig; // bool
     // OpaqueClosure Methods override the first argument of their signature
     int is_opaque_closure;
+    int gcstack_arg;
 } jl_abi_t;
 
 // useful constants

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -383,6 +383,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
     jl_value_t *declrt = *cfuncdata->declrt;
     JL_GC_PROMISE_ROOTED(declrt);
     bool specsig = cfuncdata->flags & 1;
+    bool gcstack_arg = (cfuncdata->flags & 2) != 0;
     size_t nargs = jl_nparams(sigt);
     jl_value_t *mi;
     jl_code_instance_t *codeinst;
@@ -438,7 +439,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
         return f;
     };
     bool is_opaque_closure = false;
-    jl_abi_t from_abi = { sigt, declrt, nargs, specsig, is_opaque_closure };
+    jl_abi_t from_abi = { sigt, declrt, nargs, specsig, is_opaque_closure, gcstack_arg };
     if (codeinst == nullptr) {
         // Generate an adapter to a dynamic dispatch
         if (cfuncdata->unspecialized == nullptr)


### PR DESCRIPTION
When calling specializations using the JIT ABI converter on Julia 1.13, the caller's GC stack expectations were not fully propagated to the JIT converter, causing calling convention mismatches and segfaults.

This change updates the JIT ABI converter to correctly track and configure the GC stack argument:
- Add `gcstack_arg` field to `jl_abi_t` to hold the caller's GC stack expectations.
- Update `jl_get_abi_converter` in `runtime_ccall.cpp` to extract `gcstack_arg` from `cfuncdata->flags` and populate it in `jl_abi_t`.
- Update `jl_jit_abi_converter_impl` in `jitlayers.cpp` to use the passed `from_abi.gcstack_arg` to configure `local_params.gcstack_arg`.
- Ensure we do not bypass wrapper generation if the compiled method's GC stack expectations do not match the caller's.
- Propagate `target_gcstack_arg` to `emit_abi_converter` and configure codegen parameters accordingly.

1.13 version of https://github.com/JuliaLang/julia/pull/62346/changes

Julia 1.10 & 1.11: The JIT ABI converter architecture (jl_jit_abi_converter and associated logic) was not yet introduced in these versions. Therefore, Julia 1.10 and 1.11 are not affected by this bug and do not require this JIT fix.

Written with gemini

cc @ChrisRackauckas @vchuravy @gbaraldi @oscardssmith