### PR TITLE
[main] codegen: propagate caller GC stack argument to JIT ABI converter

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -505,7 +505,7 @@ static Function *aot_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, 
 {
     std::string gf_thunk_name;
     if (specfunc)
-        gf_thunk_name = emit_abi_converter(out, from_abi, codeinst, specfunc, target_specsig);
+        gf_thunk_name = emit_abi_converter(out, from_abi, codeinst, specfunc, target_specsig, out.params->gcstack_arg);
     else
         gf_thunk_name = emit_abi_dispatcher(out, from_abi, codeinst, func);
     auto F = out.get_module().getFunction(gf_thunk_name);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5465,7 +5465,7 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
 {
     ++EmittedSpecfunCalls;
     // emit specialized call site
-    bool gcstack_arg = JL_FEAT_TEST(ctx, gcstack_arg);
+    bool gcstack_arg = returninfo.gcstack_arg;
     size_t nfargs = returninfo.decl.getFunctionType()->getNumParams();
     SmallVector<Value *, 0> argvals(nfargs);
     unsigned idx = 0;
@@ -7533,7 +7533,7 @@ static void emit_specsig_to_specsig(
     emit_specsig_to_specsig(gf_thunk, returninfo.cc, returninfo.return_roots, calltype, rettype, is_for_opaque_closure, nargs, out, target, targetsig, targetrt, targetspec, rettype_const);
 }
 
-std::string emit_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_code_instance_t *codeinst, Value *target, bool target_specsig)
+std::string emit_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_code_instance_t *codeinst, Value *target, bool target_specsig, bool target_gcstack_arg)
 {
     // this builds a method that calls a method with the same arguments but a different specsig
     // build a specsig -> specsig converter thunk
@@ -7548,7 +7548,12 @@ std::string emit_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_c
     gf_thunk_name += "_gfthunk";
     if (target_specsig) {
         jl_value_t *abi = get_ci_abi(codeinst);
+        jl_cgparams_t local_params = *out.params;
+        local_params.gcstack_arg = target_gcstack_arg;
+        const jl_cgparams_t *old_params = out.params;
+        out.params = &local_params;
         jl_returninfo_t targetspec = get_specsig_function(out, M, target, "", abi, codeinst->rettype, target_is_opaque_closure);
+        out.params = old_params;
         if (from_abi.specsig)
             emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, from_abi.is_opaque_closure, from_abi.nargs, out,
                     target, mi->specTypes, codeinst->rettype, &targetspec, nullptr);
@@ -7649,6 +7654,8 @@ static jl_cgval_t emit_abi_call(jl_codectx_t &ctx, jl_value_t *declrt, jl_value_
         Module *M = jl_Module;
         ArrayType *T_cfuncdata = ArrayType::get(T_ptr, 8);
         size_t flags = specsig;
+        if (ctx.params->gcstack_arg)
+            flags |= 2;
         GlobalVariable *cfuncdata = new GlobalVariable(*M, T_cfuncdata, false,
                 GlobalVariable::PrivateLinkage,
                 ConstantArray::get(T_cfuncdata, {
@@ -8352,6 +8359,7 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
 {
     bool gcstack_arg = out.params->gcstack_arg;
     jl_returninfo_t props = {};
+    props.gcstack_arg = gcstack_arg;
     SmallVector<Type*,8> fsig;
     SmallVector<std::string,4> argnames;
     Type *rt = NULL;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -344,7 +344,8 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
             }
             else if (specsigflags & JL_CI_FLAGS_SPECPTR_SPECIALIZED) {
                 assert(specptr != nullptr);
-                if (from_abi.specsig && jl_egal(mi->specTypes, from_abi.sigt) && jl_egal(codeinst->rettype, from_abi.rt))
+                bool callee_gcstack_arg = true;
+                if (from_abi.specsig && jl_egal(mi->specTypes, from_abi.sigt) && jl_egal(codeinst->rettype, from_abi.rt) && (from_abi.gcstack_arg == callee_gcstack_arg))
                     return specptr; // no adapter required
 
                 target = specptr;
@@ -358,7 +359,10 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
     auto ctx = std::make_unique<LLVMContext>();
     auto mod = jl_create_llvm_module("gfthunk", *ctx, jl_ExecutionEngine->getDataLayout(),
                                      jl_ExecutionEngine->getTargetTriple());
+    jl_cgparams_t local_params = jl_default_cgparams;
+    local_params.gcstack_arg = from_abi.gcstack_arg;
     jl_codegen_output_t out{*mod};
+    out.params = &local_params;
     // root the wrapper types that `mark_julia_const` mints for egality-pinned
     // (`TypeEgal`) argument slots while the thunk is emitted
     out.temporary_roots = jl_alloc_array_1d(jl_array_any_type, 0);
@@ -368,7 +372,7 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
         out.imaging_mode = 0;
         if (target) {
             Value *llvmtarget = literal_static_pointer_val((void*)target, PointerType::get(*ctx, 0));
-            gf_thunk_name = emit_abi_converter(out, from_abi, codeinst, llvmtarget, target_specsig);
+            gf_thunk_name = emit_abi_converter(out, from_abi, codeinst, llvmtarget, target_specsig, true);
         }
         else if (invoke == jl_fptr_const_return_addr) {
             assert(codeinst);   // Convince the static analyzer

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -363,6 +363,7 @@ struct jl_returninfo_t {
     unsigned return_roots;
     bool all_roots;
     uint32_t effects = 0;  // ipo_purity_bits, applied to CallInst and Function
+    bool gcstack_arg;
 };
 
 struct jl_codegen_call_target_t {
@@ -543,7 +544,7 @@ Function *jl_cfunction_object(jl_value_t *f, jl_value_t *rt, jl_tupletype_t *arg
 extern "C" JL_DLLEXPORT_CODEGEN
 void *jl_jit_abi_convert(jl_task_t *ct, jl_abi_t from_abi, _Atomic(void*) *fptr, _Atomic(size_t) *last_world, void *data);
 std::string emit_abi_dispatcher(jl_codegen_output_t &out, jl_abi_t from_abi, jl_code_instance_t *codeinst, Value *invoke);
-std::string emit_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_code_instance_t *codeinst, Value *target, bool target_specsig);
+std::string emit_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_code_instance_t *codeinst, Value *target, bool target_specsig, bool target_gcstack_arg);
 std::string emit_abi_constreturn(jl_codegen_output_t &out, jl_abi_t from_abi, jl_value_t *rettype_const);
 std::string emit_abi_constreturn(jl_codegen_output_t &out, bool specsig, jl_code_instance_t *codeinst);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -437,6 +437,7 @@ typedef struct _jl_abi_t {
     int specsig; // bool
     // OpaqueClosure Methods override the first argument of their signature
     int is_opaque_closure;
+    int gcstack_arg;
 } jl_abi_t;
 
 // The compiler uses the specific integer values returned by jl_invoke_api

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -378,6 +378,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
     jl_value_t *declrt = *cfuncdata->declrt;
     JL_GC_PROMISE_ROOTED(declrt);
     int specsig = cfuncdata->flags & 1;
+    int gcstack_arg = (cfuncdata->flags & 2) != 0;
     size_t nargs = jl_nparams(sigt);
     jl_value_t *mi;
     jl_code_instance_t *codeinst;
@@ -426,7 +427,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
         return f; // another thread fixed this up while we were away
     }
     int is_opaque_closure = 0;
-    jl_abi_t from_abi = { sigt, declrt, nargs, specsig, is_opaque_closure };
+    jl_abi_t from_abi = { sigt, declrt, nargs, specsig, is_opaque_closure, gcstack_arg };
     if (codeinst == NULL) {
         // Generate an adapter to a dynamic dispatch
         if (cfuncdata->unspecialized == NULL)


### PR DESCRIPTION
When calling specializations using the JIT ABI converter on master, the caller's GC stack expectations were not fully propagated to the JIT converter, causing calling convention mismatches and segfaults.

This change updates the JIT ABI converter to correctly track and configure the GC stack argument:
- Add `gcstack_arg` field to `jl_abi_t` to hold the caller's GC stack expectations.
- Update `jl_get_abi_converter` in `runtime_ccall.c` to extract `gcstack_arg` from `cfuncdata->flags` and populate it in `jl_abi_t`.
- Update `jl_jit_abi_converter_impl` in `jitlayers.cpp` to use the passed `from_abi.gcstack_arg` to configure `out.params->gcstack_arg`.
- Ensure we do not bypass wrapper generation if the compiled method's GC stack expectations do not match the caller's.
- Propagate `target_gcstack_arg` to `emit_abi_converter` and configure codegen parameters accordingly.

main version of https://github.com/JuliaLang/julia/pull/62346/changes (1.12) / https://github.com/JuliaLang/julia/pull/62347 (1.13)

Julia 1.10 & 1.11: The JIT ABI converter architecture (jl_jit_abi_converter and associated logic) was not yet introduced in these versions. Therefore, Julia 1.10 and 1.11 are not affected by this bug and do not require this JIT fix.

Written with gemini

cc @ChrisRackauckas @vchuravy @gbaraldi @oscardssmith