### PR TITLE
compiler: Separate local inference proofs from code instances

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -53,6 +53,7 @@ end
 struct MethodMatchTarget
     match::MethodMatch
     edges::Vector{Union{Nothing,CodeInstance}}
+    needs_mi_edges::BitVector
     call_results::Vector{Union{Nothing,InferredCallResult}}
     edge_idx::Int
 end
@@ -172,7 +173,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
         local napplicable = length(applicable)
         local multiple_matches = multiple_methods(matches)
         while state.inferidx <= napplicable
-            (; match, edges, call_results, edge_idx) = applicable[state.inferidx]
+            (; match, edges, needs_mi_edges, call_results, edge_idx) = applicable[state.inferidx]
             local method = match.method
             local sig = match.spec_types
             if bail_out_call(interp, InferenceLoopState(state.rettype, state.all_effects), sv)
@@ -192,7 +193,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
             #end
             mresult = abstract_call_method(interp, method, sig, match.sparams, multiple_matches, si, sv)::Future
             function handle1(interp, sv)
-                local (; rt, exct, effects, edge, call_result) = mresult[]
+                local (; rt, exct, effects, edge, needs_mi_edge, call_result) = mresult[]
                 this_conditional = ignorelimited(rt)
                 this_rt = widenwrappedconditional(rt)
                 this_exct = exct
@@ -206,7 +207,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
                 if const_call_result !== nothing
                     this_const_conditional = ignorelimited(const_call_result.rt)
                     this_const_rt = widenwrappedconditional(const_call_result.rt)
-                    const_result = const_edge = nothing
+                    const_result = nothing
                     if this_const_rt ⊑ₚ this_rt
                         # As long as the const-prop result we have is not *worse* than
                         # what we found out on types, we'd like to use it. Even if the
@@ -217,9 +218,9 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
                         # e.g. in cases when there are cycles but cached result is still accurate
                         this_conditional = this_const_conditional
                         this_rt = this_const_rt
-                        (; effects, const_result, const_edge) = const_call_result
+                        (; effects, const_result) = const_call_result
                     elseif is_better_effects(const_call_result.effects, effects)
-                        (; effects, const_result, const_edge) = const_call_result
+                        (; effects, const_result) = const_call_result
                     else
                         add_remark!(interp, sv, "[constprop] Discarded because the result was wider than inference")
                     end
@@ -227,15 +228,13 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
                     # because consistent-cy does not apply to exceptions.
                     if const_call_result.exct ⋤ this_exct
                         this_exct = const_call_result.exct
-                        (; const_result, const_edge) = const_call_result
+                        (; const_result) = const_call_result
                     else
                         add_remark!(interp, sv, "[constprop] Discarded exception type because result was wider than inference")
                     end
-                    if const_edge !== nothing
-                        edge = const_edge
-                        update_valid_age!(sv, get_inference_world(interp), world_range(const_edge))
-                    end
                     if const_result !== nothing
+                        update_valid_age!(sv, get_inference_world(interp),
+                            proof_worlds(inference_proof(const_result)))
                         call_result = const_result
                     end
                 end
@@ -266,6 +265,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
                     end
                 end
                 edges[edge_idx] = edge
+                needs_mi_edges[edge_idx] = needs_mi_edge
                 call_results[edge_idx] = call_result
 
                 state.inferidx += 1
@@ -330,7 +330,8 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
                     local sig = match.spec_types
                     local mi = specialize_method(match; preexisting=true)
                     local call_result = call_results[edge_idx]
-                    if mi === nothing || !(call_result isa InferenceResult) || !const_prop_methodinstance_heuristic(interp, call_result, mi, arginfo, sv)
+                    if (mi === nothing || !(call_result isa LocalInferenceResult) ||
+                        !const_prop_methodinstance_heuristic(interp, call_result.result, mi, arginfo, sv))
                         csig = get_compileable_sig(method, sig, match.sparams)
                         if csig !== nothing && (!seenall || csig !== sig) # corresponds to whether the first look already looked at this, so repeating abstract_call_method is not useful
                             #println(sig, " changed to ", csig, " for ", method)
@@ -406,7 +407,8 @@ function find_union_split_method_matches(interp::AbstractInterpreter, argtypes::
         thisinfo = MethodMatchInfo(thismatches, mt, sig_n, thisfullmatch)
         push!(infos, thisinfo)
         for idx = 1:length(thismatches)
-            push!(applicable, MethodMatchTarget(thismatches[idx], thisinfo.edges, thisinfo.call_results, idx))
+            push!(applicable, MethodMatchTarget(thismatches[idx], thisinfo.edges,
+                thisinfo.needs_mi_edges, thisinfo.call_results, idx))
             push!(applicable_argtypes, arg_n)
         end
     end
@@ -425,7 +427,8 @@ function find_simple_method_matches(interp::AbstractInterpreter, @nospecialize(a
     fullmatch = any(match::MethodMatch->match.fully_covers, matches)
     mt = Core.methodtable
     info = MethodMatchInfo(matches, mt, atype, fullmatch)
-    applicable = MethodMatchTarget[MethodMatchTarget(matches[idx], info.edges, info.call_results, idx) for idx = 1:length(matches)]
+    applicable = MethodMatchTarget[MethodMatchTarget(matches[idx], info.edges,
+        info.needs_mi_edges, info.call_results, idx) for idx = 1:length(matches)]
     return MethodMatches(applicable, info, matches.valid_worlds)
 end
 
@@ -865,11 +868,13 @@ function matches_sv(parent::AbsIntState, sv::AbsIntState)
             method_for_inference_limit_heuristics(sv) === method_for_inference_limit_heuristics(parent))
 end
 
-function is_edge_recursed(edge::CodeInstance, caller::AbsIntState)
+function is_edge_recursed(edge::MethodInstance, caller::AbsIntState)
     return any(AbsIntStackUnwind(caller)) do sv::AbsIntState
-        return edge.def === frame_instance(sv)
+        return edge === frame_instance(sv)
     end
 end
+is_edge_recursed(edge::CodeInstance, caller::AbsIntState) =
+    is_edge_recursed(edge.def, caller)
 
 function is_method_recursed(method::Method, caller::AbsIntState)
     return any(AbsIntStackUnwind(caller)) do sv::AbsIntState
@@ -899,10 +904,14 @@ struct MethodCallResult
     edgecycle::Bool
     edgelimited::Bool
     call_result::Union{Nothing,InferredCallResult}
+    needs_mi_edge::Bool # targetless body-derived facts require an invalidation target
     function MethodCallResult(@nospecialize(rt), @nospecialize(exct), effects::Effects,
                               edge::Union{Nothing,CodeInstance}, edgecycle::Bool, edgelimited::Bool,
-                              call_result::Union{Nothing,InferredCallResult} = nothing)
-        return new(rt, exct, effects, edge, edgecycle, edgelimited, call_result)
+                              call_result::Union{Nothing,InferredCallResult} = nothing;
+                              needs_mi_edge::Bool = false)
+        @assert !needs_mi_edge || (edge === nothing && call_result === nothing)
+        return new(rt, exct, effects, edge, edgecycle, edgelimited, call_result,
+            needs_mi_edge)
     end
 end
 
@@ -916,19 +925,16 @@ struct ConstCallResult
     exct::Any
     const_result::InferredCallResult
     effects::Effects
-    const_edge::Union{Nothing,CodeInstance}
     function ConstCallResult(
         @nospecialize(rt), @nospecialize(exct),
-        const_result::InferredCallResult, effects::Effects,
-        const_edge::Union{Nothing,CodeInstance})
-        return new(rt, exct, const_result, effects, const_edge)
+        const_result::InferredCallResult, effects::Effects)
+        return new(rt, exct, const_result, effects)
     end
     function ConstCallResult(
             result::ConstCallResult;
-            effects::Effects = result.effects,
-            const_edge::Union{Nothing,CodeInstance} = result.const_edge
+            effects::Effects = result.effects
         )
-        return new(result.rt, result.exct, result.const_result, effects, const_edge)
+        return new(result.rt, result.exct, result.const_result, effects)
     end
 end
 
@@ -982,14 +988,15 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
     if eligibility === :none
         # const-prop' may have refined effects to be foldable when the original
         # call was not; in that case, prefer concrete eval over the const-prop' result
+        proof = inference_proof(new_result.const_result)
         new_eligibility = _concrete_eval_eligible(
-            interp, f, new_result.effects, new_result.const_edge, arginfo, sv)
+            interp, f, new_result.effects, proof, arginfo, sv)
         if new_eligibility === :concrete_eval
             new_concrete_eval_result = _concrete_eval_call(
-                interp, f, new_result.const_edge::CodeInstance, new_result.effects, arginfo, sv, invokecall)
+                interp, f, result.edge, new_result.effects, arginfo, sv, invokecall; proof)
             if new_concrete_eval_result !== nothing
                 if use_concrete_eval_result(interp, new_concrete_eval_result)
-                    return ConstCallResult(new_concrete_eval_result; const_edge = new_result.const_edge)
+                    return new_concrete_eval_result
                 elseif new_concrete_eval_result.rt !== Bottom
                     always_nothrow = true
                 end
@@ -1041,12 +1048,13 @@ function concrete_eval_eligible(
         interp::AbstractInterpreter, @nospecialize(f), result::MethodCallResult,
         arginfo::ArgInfo, sv::AbsIntState
     )
-    return _concrete_eval_eligible(interp, f, result.effects, result.edge, arginfo, sv)
+    proof = result.call_result === nothing ? result.edge : inference_proof(result.call_result)
+    return _concrete_eval_eligible(interp, f, result.effects, proof, arginfo, sv)
 end
 
 function _concrete_eval_eligible(
         interp::AbstractInterpreter, @nospecialize(f), effects::Effects,
-        edge::Union{Nothing,CodeInstance}, arginfo::ArgInfo, sv::AbsIntState
+        proof::Union{Nothing,InferenceProof}, arginfo::ArgInfo, sv::AbsIntState
     )
     if inbounds_option() === :off
         if !is_nothrow(effects)
@@ -1055,7 +1063,7 @@ function _concrete_eval_eligible(
             return :none
         end
     end
-    if edge !== nothing && is_foldable(effects, #=check_rtcall=#true)
+    if proof !== nothing && is_foldable(effects, #=check_rtcall=#true)
         if f !== nothing && is_all_const_arg(arginfo, #=start=#2)
             if (is_nonoverlayed(interp) || is_nonoverlayed(effects) ||
                 # Even if overlay methods are involved, when `:consistent_overlay` is
@@ -1117,13 +1125,15 @@ function concrete_eval_call(
         interp::AbstractInterpreter, @nospecialize(f), result::MethodCallResult,
         arginfo::ArgInfo, sv::AbsIntState, invokecall::Union{InvokeCall,Nothing} = nothing
     )
+    proof = result.call_result === nothing ? result.edge : inference_proof(result.call_result)
     return _concrete_eval_call(
-        interp, f, result.edge::CodeInstance, result.effects, arginfo, sv, invokecall)
+        interp, f, result.edge, result.effects, arginfo, sv, invokecall; proof)
 end
 
 function _concrete_eval_call(
-        interp::AbstractInterpreter, @nospecialize(f), edge::CodeInstance, effects::Effects,
-        arginfo::ArgInfo, ::AbsIntState, invokecall::Union{InvokeCall,Nothing} = nothing
+        interp::AbstractInterpreter, @nospecialize(f), edge::Union{Nothing,CodeInstance}, effects::Effects,
+        arginfo::ArgInfo, ::AbsIntState, invokecall::Union{InvokeCall,Nothing} = nothing;
+        proof::Union{Nothing,InferenceProof} = nothing
     )
     args = collect_const_args(arginfo, #=start=#2)
     if invokecall !== nothing
@@ -1137,11 +1147,11 @@ function _concrete_eval_call(
     catch
         # The evaluation threw. By :consistent-cy, we're guaranteed this would have happened at runtime.
         # However, at present, :consistency does not mandate the type of the exception
-        concrete_result = ConcreteResult(edge, effects)
-        return ConstCallResult(Bottom, Any, concrete_result, effects, #=const_edge=#nothing)
+        concrete_result = ConcreteResult(edge, effects; proof)
+        return ConstCallResult(Bottom, Any, concrete_result, effects)
     end
-    concrete_result = ConcreteResult(edge, EFFECTS_TOTAL, value)
-    return ConstCallResult(Const(value), Bottom, concrete_result, EFFECTS_TOTAL, #=const_edge=#nothing)
+    concrete_result = ConcreteResult(edge, EFFECTS_TOTAL, value; proof)
+    return ConstCallResult(Const(value), Bottom, concrete_result, EFFECTS_TOTAL)
 end
 
 # check if there is a cycle and duplicated inference of `mi`
@@ -1185,8 +1195,8 @@ function maybe_get_const_prop_profitable(interp::AbstractInterpreter,
         return nothing
     end
     mi = mi::MethodInstance
-    inf_result = result.call_result
-    inf_result = inf_result isa InferenceResult ? inf_result : nothing
+    call_result = result.call_result
+    inf_result = call_result isa LocalInferenceResult ? call_result.result : nothing
     if !force && !const_prop_methodinstance_heuristic(interp, inf_result, mi, arginfo, sv)
         add_remark!(interp, sv, "[constprop] Disabled by method instance heuristic")
         return nothing
@@ -1386,12 +1396,15 @@ end
 function semi_concrete_eval_call(interp::AbstractInterpreter,
     mi::MethodInstance, result::MethodCallResult, arginfo::ArgInfo, sv::AbsIntState)
     call_result = result.call_result
-    call_result isa InferenceResult || return nothing
-    codeinst = call_result.ci
-    codeinst isa CodeInstance || return nothing
-    inferred = call_result.src
+    call_result isa LocalInferenceResult || return nothing
+    inf_result = call_result.result
+    edge = result.edge
+    edge isa CodeInstance || return nothing
+    proof = inference_proof(call_result)
+    inferred = inf_result.src
     src_inlining_policy(interp, mi, inferred, NoCallInfo(), IR_FLAG_NULL) || return nothing # hack to work-around test failures caused by #58183 until both it and #48913 are fixed
-    irsv = IRInterpretationState(interp, codeinst, mi, arginfo.argtypes, inferred)
+    irsv = IRInterpretationState(interp, edge, mi, arginfo.argtypes, inferred,
+                                 proof_worlds(proof))
     irsv === nothing && return nothing
     assign_parentchild!(irsv, sv)
     rt, (nothrow, noub) = ir_abstract_constant_propagation(interp, irsv)
@@ -1410,23 +1423,51 @@ function semi_concrete_eval_call(interp::AbstractInterpreter,
             effects = Effects(effects; noub=ALWAYS_TRUE)
         end
         exct = refine_exception_type(result.exct, effects)
-        # TODO: SemiConcreteResult fails to preserve the ci_as_edge value
-        semi_concrete_result = SemiConcreteResult(codeinst, ir, effects, spec_info(irsv))
-        const_edge = nothing # TODO use the edges from irsv?
-        return ConstCallResult(rt, exct, semi_concrete_result, effects, const_edge)
+        proof_edges = Any[]
+        add_inference_proof!(proof_edges, proof, edge)
+        for info in ir.stmts.info
+            add_edges!(proof_edges, info)
+        end
+        append!(proof_edges, irsv.edges)
+        semi_concrete_proof = LocalInferenceProof(irsv.valid_worlds,
+            Core.svec(proof_edges...))
+        semi_concrete_result = SemiConcreteResult(edge, ir, effects, spec_info(irsv);
+                                                  proof = semi_concrete_proof)
+        return ConstCallResult(rt, exct, semi_concrete_result, effects)
     end
     nothing
 end
 
-function const_prop_result(inf_result::InferenceResult)
-    @assert isdefined(inf_result, :ci_as_edge) "InferenceResult without ci_as_edge"
-    return ConstCallResult(inf_result.result, inf_result.exc_result, inf_result,
-                           inf_result.ipo_effects, inf_result.ci_as_edge)
+function const_prop_result(local_result::LocalInferenceResult)
+    inf_result = local_result.result
+    return ConstCallResult(inf_result.result, inf_result.exc_result, local_result,
+                           inf_result.ipo_effects)
 end
 
 # return cached result of constant analysis
-return_localcache_result(::AbstractInterpreter, inf_result::InferenceResult, ::AbsIntState) =
-    const_prop_result(inf_result)
+return_localcache_result(::AbstractInterpreter, local_result::LocalInferenceResult, ::AbsIntState) =
+    const_prop_result(local_result)
+
+function const_prop_inference_proof(frame::InferenceState, result::MethodCallResult,
+                                    concrete_eval_result::Union{Nothing,ConstCallResult})
+    proof_edges = Any[]
+    valid_worlds = frame.valid_worlds
+    # This proof is cached independently of the executable target chosen at a
+    # particular call site, so it must remain self-contained. Pairing/elision is
+    # only valid later, when the cached result is attached to a concrete CallInfo.
+    add_result_proof!(proof_edges, result.call_result)
+    if result.call_result !== nothing
+        valid_worlds = intersect(valid_worlds,
+            proof_worlds(inference_proof(result.call_result)))
+    end
+    if concrete_eval_result !== nothing
+        add_result_proof!(proof_edges, concrete_eval_result.const_result)
+        valid_worlds = intersect(valid_worlds,
+            proof_worlds(inference_proof(concrete_eval_result.const_result)))
+    end
+    append!(proof_edges, frame.edges)
+    return LocalInferenceProof(valid_worlds, Core.svec(proof_edges...))
+end
 
 function compute_forwarded_argtypes(interp::AbstractInterpreter, arginfo::ArgInfo, sv::AbsIntState)
     𝕃ᵢ = typeinf_lattice(interp)
@@ -1443,27 +1484,29 @@ function const_prop_call(interp::AbstractInterpreter,
     forwarded_argtypes = compute_forwarded_argtypes(interp, arginfo, sv)
     # use `cache_argtypes` that has been constructed for fresh regular inference if available
     call_result = result.call_result
-    if call_result isa InferenceResult
-        cache_argtypes = call_result.argtypes
+    if call_result isa LocalInferenceResult
+        cache_argtypes = call_result.result.argtypes
     else
         cache_argtypes = matching_cache_argtypes(𝕃ᵢ, mi)
     end
     argtypes = matching_cache_argtypes(𝕃ᵢ, mi, forwarded_argtypes, cache_argtypes)
     argtypes = get_nospecializeinfer_argtypes(argtypes, cache_argtypes, mi.def::Method)
-    inf_result = constprop_cache_lookup(𝕃ᵢ, mi, argtypes, get_inference_cache(interp))
+    inf_result = constprop_cache_lookup(𝕃ᵢ, mi, argtypes, get_inference_cache(interp),
+        get_inference_world(interp))
     if inf_result === missing
         # a previous const-prop attempt hit a cycle and produced a limited result;
         # don't re-attempt the same work that would lead to the same limited outcome
         add_remark!(interp, sv, "[constprop] Found cached but limited constant inference result")
         return nothing
-    elseif inf_result isa InferenceResult
+    elseif inf_result isa LocalInferenceResult
         # found the cache for this constant prop'
-        if inf_result.result === nothing
-            add_remark!(interp, sv, "[constprop] Found cached constant inference in a cycle")
-            return nothing
-        end
-        @assert inf_result.linfo === mi "MethodInstance for cached inference result does not match"
+        @assert inf_result.result.linfo === mi "MethodInstance for cached inference result does not match"
         return return_localcache_result(interp, inf_result, sv)
+    elseif inf_result isa InferenceResult
+        # Raw entries are internal sentinels for an unresolved constant-inference cycle.
+        @assert inf_result.result === nothing
+        add_remark!(interp, sv, "[constprop] Found cached constant inference in a cycle")
+        return nothing
     end
     overridden_by_const = falses(length(argtypes))
     for i = 1:length(argtypes)
@@ -1492,6 +1535,7 @@ function const_prop_call(interp::AbstractInterpreter,
         @assert callstack[end] === frame && length(callstack) == frame.frameid
         pop!(callstack)
         # add to the cache to record that this will always fail
+        inf_result.cache_world = get_inference_world(interp)
         push!(get_inference_cache(interp), inf_result)
         return nothing
     end
@@ -1502,8 +1546,6 @@ function const_prop_call(interp::AbstractInterpreter,
         add_remark!(interp, sv, "[constprop] Constant inference produced a limited result")
         return nothing
     end
-    existing_edge = result.edge
-    inf_result.ci_as_edge = codeinst_as_edge(interp, frame, existing_edge)
     @assert frame.frameid != 0 && frame.cycleid == frame.frameid
     @assert frame.parentid == sv.frameid
     @assert inf_result.result !== nothing
@@ -1515,7 +1557,14 @@ function const_prop_call(interp::AbstractInterpreter,
         inf_result.result = concrete_eval_result.rt
         inf_result.ipo_effects = concrete_eval_result.effects
     end
-    return const_prop_result(inf_result)
+    # The caller may retain regular-inference return/exception facts while taking
+    # only an effect (or another component) from constant propagation. Make the
+    # const result's proof certify every input to that component-wise merge, not
+    # merely the const-prop frame itself.
+    proof = const_prop_inference_proof(frame, result, concrete_eval_result)
+    local_result = LocalInferenceResult(inf_result, proof, get_inference_world(interp))
+    push!(get_inference_cache(interp), local_result)
+    return const_prop_result(local_result)
 end
 
 struct ForwardableArgtypes
@@ -2569,23 +2618,22 @@ function abstract_invoke(interp::AbstractInterpreter, arginfo::ArgInfo, si::Stmt
         const_call_result = abstract_call_method_with_const_args(interp,
             result, f, arginfo′, si, match, sv, invokecall)
         if const_call_result !== nothing
-            const_result = const_edge = nothing
+            const_result = nothing
             if const_call_result.rt ⊑ rt
-                (; rt, effects, const_result, const_edge) = const_call_result
+                (; rt, effects, const_result) = const_call_result
             end
             if const_call_result.exct ⋤ exct
-                (; exct, const_result, const_edge) = const_call_result
-            end
-            if const_edge !== nothing
-                edge = const_edge
-                update_valid_age!(sv, get_inference_world(interp), world_range(const_edge))
+                (; exct, const_result) = const_call_result
             end
             if const_result !== nothing
+                update_valid_age!(sv, get_inference_world(interp),
+                    proof_worlds(inference_proof(const_result)))
                 call_result = const_result
             end
         end
         rt = from_interprocedural!(interp, rt, sv, arginfo′, sig, vtypes)
-        info = InvokeCallInfo(edge, match, call_result, lookupsig_box.contents)
+        info = InvokeCallInfo(edge, match, call_result, lookupsig_box.contents,
+            result.needs_mi_edge)
         if !match.fully_covers
             effects = Effects(effects; nothrow=false)
             exct = exct ⊔ TypeError
@@ -3108,18 +3156,16 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter, closure::Part
             const_call_result = abstract_call_method_with_const_args(interp, result,
                 #=f=#nothing, arginfo, si, match, sv)
             if const_call_result !== nothing
-                const_result = const_edge = nothing
+                const_result = nothing
                 if const_call_result.rt ⊑ rt
-                    (; rt, effects, const_result, const_edge) = const_call_result
+                    (; rt, effects, const_result) = const_call_result
                 end
                 if const_call_result.exct ⋤ exct
-                    (; exct, const_result, const_edge) = const_call_result
-                end
-                if const_edge !== nothing
-                    edge = const_edge
-                    update_valid_age!(sv, get_inference_world(interp), world_range(const_edge))
+                    (; exct, const_result) = const_call_result
                 end
                 if const_result !== nothing
+                    update_valid_age!(sv, get_inference_world(interp),
+                        proof_worlds(inference_proof(const_result)))
                     call_result = const_result
                 end
             end
@@ -3134,7 +3180,7 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter, closure::Part
             end
         end
         rt = from_interprocedural!(interp, rt, sv, arginfo, match.spec_types, vtypes)
-        info = OpaqueClosureCallInfo(edge, match, call_result)
+        info = OpaqueClosureCallInfo(edge, match, call_result, result.needs_mi_edge)
         return CallMeta(rt, exct, effects, info)
     end
 end

--- a/Compiler/src/inferenceresult.jl
+++ b/Compiler/src/inferenceresult.jl
@@ -213,12 +213,19 @@ function elim_free_typevars(@nospecialize t)
     end
 end
 
-function constprop_cache_lookup(𝕃::AbstractLattice, mi::MethodInstance, given_argtypes::Vector{Any}, cache::InferenceCache)
+function constprop_cache_lookup(𝕃::AbstractLattice, mi::MethodInstance,
+                                given_argtypes::Vector{Any}, cache::InferenceCache,
+                                world::UInt)
     nargtypes = length(given_argtypes)
     indices = get_indices(cache, mi)
     found_tombstone = false
     for idx in indices
-        cached_result = cache.results[idx]
+        cached = cache.results[idx]
+        cached_result = cached isa LocalInferenceResult ? cached.result : cached
+        cached_result.cache_world == world || continue
+        valid_worlds = cached isa LocalInferenceResult ?
+            proof_worlds(cached.proof) : cached_result.valid_worlds
+        world in valid_worlds || continue
         cache_argtypes = cached_result.argtypes
         if length(cache_argtypes) != nargtypes
             # A `MethodInstance` whose `specTypes` ends in an unbounded `Vararg` (i.e. its
@@ -246,7 +253,7 @@ function constprop_cache_lookup(𝕃::AbstractLattice, mi::MethodInstance, given
             found_tombstone = true
             @goto next_cache
         end
-        return cached_result
+        return cached
         @label next_cache
     end
     return found_tombstone ? missing : nothing

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -1063,7 +1063,8 @@ IRInterpretationState(interp::I, spec_info::SpecInfo, ir::IRCode,
 
 function IRInterpretationState(
         interp::AbstractInterpreter, codeinst::CodeInstance, mi::MethodInstance,
-        argtypes::Vector{Any}, @nospecialize(src)
+        argtypes::Vector{Any}, @nospecialize(src),
+        valid_worlds::WorldRange = WorldRange(codeinst.min_world, codeinst.max_world)
     )
     @assert get_ci_mi(codeinst) === mi "method instance is not synced with code instance"
     if isa(src, String)
@@ -1075,7 +1076,7 @@ function IRInterpretationState(
     ir = inflate_ir(src, mi)
     argtypes = va_process_argtypes(optimizer_lattice(interp), argtypes, src.nargs, src.isva, mi)
     return IRInterpretationState(interp, spec_info, ir, mi, argtypes,
-                                 codeinst.min_world, codeinst.max_world)
+                                 first(valid_worlds), last(valid_worlds))
 end
 
 # AbsIntState

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -28,8 +28,7 @@ end
 
 struct ConstantCase
     val::Any
-    edge::CodeInstance
-    ConstantCase(@nospecialize(val), edge::CodeInstance) = new(val, edge)
+    ConstantCase(@nospecialize(val)) = new(val)
 end
 
 struct SomeCase
@@ -806,7 +805,6 @@ function compileable_specialization(code::Union{MethodInstance,CodeInstance}, ef
     keep_direct_edge = code isa CodeInstance && mi !== mi_invoke && has_typeegal_slot(atype)
     if !keep_direct_edge
         cached = get(code_cache(state), mi_invoke, nothing)
-        cached isa InferenceResult && (cached = cached.ci)
         if cached isa CodeInstance
             code = cached
         elseif !(code isa CodeInstance && code.def === mi_invoke)
@@ -821,49 +819,72 @@ end
 struct InferredCode
     src::Any # CodeInfo or IRCode
     effects::Effects
-    edge::CodeInstance
-    InferredCode(@nospecialize(src), effects::Effects, edge::CodeInstance) = new(src, effects, edge)
+    InferredCode(@nospecialize(src), effects::Effects) = new(src, effects)
 end
-@inline function get_local_code(inf_result::InferenceResult)
-    @assert isdefined(inf_result, :ci_as_edge) "InferenceResult without ci_as_edge"
+@inline function get_local_code(local_result::LocalInferenceResult)
+    inf_result = local_result.result
     effects = inf_result.ipo_effects
     if is_foldable_nothrow(effects)
         res = inf_result.result
         if isa(res, Const) && is_inlineable_constant(res.val)
             # use constant calling convention
-            return ConstantCase(quoted(res.val), inf_result.ci_as_edge)
+            return SomeCase(quoted(res.val))
         end
     end
-    return InferredCode(inf_result.src, effects, inf_result.ci_as_edge)
+    return InferredCode(inf_result.src, effects)
+end
+
+function add_inlining_dispatch_edge!(edges::Vector{Any}, mi::MethodInstance,
+                                     @nospecialize(info::CallInfo))
+    if info isa InvokeCallInfo
+        add_invoke_edge!(edges, info.atype, mi)
+    elseif info isa VirtualMethodMatchInfo
+        add_inlining_dispatch_edge!(edges, mi, info.info)
+    else
+        add_one_edge!(edges, mi)
+    end
+    return nothing
 end
 
 # the general resolver for usual and const-prop'ed calls
-function resolve_todo(mi::MethodInstance, call_result::Union{Nothing,InferenceResult},
+function resolve_todo(mi::MethodInstance, call_result::Union{Nothing,LocalInferenceResult},
+    call_edge::Union{Nothing,MethodInstance,CodeInstance},
     @nospecialize(info::CallInfo), flag::UInt32, state::InliningState)
     et = InliningEdgeTracker(state)
+    target = call_edge === nothing ? mi : call_edge
 
     if call_result === nothing
         # there is no cached source available for this, but there might be code for the compilation sig
-        return compileable_specialization(mi, Effects(), et, info, state)
+        item = compileable_specialization(target, Effects(), et, info, state)
+        if item !== nothing && call_edge === nothing
+            # The inlining edge added above certifies the selected method body, but
+            # a target synthesized by the optimizer must separately certify how the
+            # runtime call selected that method. Add this after the identity edge so
+            # edge deduplication cannot upgrade the dispatch edge into an invoke edge.
+            add_inlining_dispatch_edge!(et.edges, mi, info)
+        end
+        return item
     end
 
+    # The local result's proof justifies its inferred facts and retained source. The
+    # ordinary call edge remains a separate executable target.
+    add_inlining_edge!(et, target)
+    add_inference_proof!(et.edges, inference_proof(call_result), target)
     inferred_result = get_local_code(call_result)
-    if inferred_result isa ConstantCase
-        add_inlining_edge!(et, inferred_result.edge)
-        return inferred_result
+    if inferred_result isa SomeCase
+        return ConstantCase(inferred_result.val)
     end
-    (; src, effects, edge) = inferred_result
+    (; src, effects) = inferred_result
 
     # the duplicated check might have been done already within `analyze_method!`, but still
     # we need it here too since we may come here directly using a constant-prop' result
     if !OptimizationParams(state.interp).inlining || is_stmt_noinline(flag)
-        return compileable_specialization(edge, effects, et, info, state)
+        return compileable_specialization(target, effects, et, info, state)
     end
 
     src_inlining_policy(state.interp, mi, src, info, flag) ||
-        return compileable_specialization(edge, effects, et, info, state)
+        return compileable_specialization(target, effects, et, info, state)
 
-    add_inlining_edge!(et, edge)
     ir, spec_info, debuginfo = retrieve_ir_for_inlining(mi, src, true)
     return InliningTodo(mi, ir, spec_info, debuginfo, effects)
 end
@@ -884,7 +905,9 @@ function may_have_fcalls(m::Method)
 end
 
 function analyze_method!(
-        call_result::Union{Nothing,InferenceResult}, match::MethodMatch, argtypes::Vector{Any},
+        call_result::Union{Nothing,LocalInferenceResult},
+        call_edge::Union{Nothing,MethodInstance,CodeInstance},
+        match::MethodMatch, argtypes::Vector{Any},
         @nospecialize(info::CallInfo), flag::UInt32, state::InliningState;
         allow_typevars::Bool
     )
@@ -917,7 +940,7 @@ function analyze_method!(
     # Get the specialization for this method signature
     # (later we will decide what to do with it)
     mi = specialize_method(match)
-    return resolve_todo(mi, call_result, info, flag, state)
+    return resolve_todo(mi, call_result, call_edge, info, flag, state)
 end
 
 function retrieve_ir_for_inlining(cached_result::CodeInstance, src::String)
@@ -1152,21 +1175,22 @@ function handle_invoke_call!(todo::Vector{Pair{Int,Any}},
     end
     result = getresult(info, 1)
     if isa(result, ConcreteResult)
-        item = concrete_result_item(result, info, state)
+        item = concrete_result_item(result, info.edge, match, info, state)
     elseif isa(result, SemiConcreteResult)
         item = semiconcrete_result_item(result, info, flag, state)
     else
         argtypes = invoke_rewrite(sig.argtypes)
-        if isa(result, InferenceResult)
-            mi = result.linfo
+        if isa(result, LocalInferenceResult)
+            mi = result.result.linfo
             validate_sparams(mi.sparam_vals) || return nothing
             if Union{} !== argtypes_to_type(argtypes) <: mi.def.sig
-                item = resolve_todo(mi, result, info, flag, state)
+                item = resolve_todo(mi, result, info.edge, info, flag, state)
                 handle_single_case!(todo, ir, idx, stmt, item, true)
                 return nothing
             end
         end
-        item = analyze_method!(result, match, argtypes, info, flag, state; allow_typevars=false)
+        item = analyze_method!(result, info.edge, match, argtypes, info, flag, state;
+            allow_typevars=false)
     end
     handle_single_case!(todo, ir, idx, stmt, item, true)
     return nothing
@@ -1315,24 +1339,26 @@ end
 
 function handle_any_call_result!(
         cases::Vector{InliningCase}, @nospecialize(call_result::Union{Nothing,InferredCallResult}),
-        match::MethodMatch, argtypes::Vector{Any}, @nospecialize(info::CallInfo),
+        call_edge::Union{Nothing,CodeInstance}, match::MethodMatch, argtypes::Vector{Any},
+        @nospecialize(info::CallInfo),
         flag::UInt32, state::InliningState;
         allow_typevars::Bool
     )
     if isa(call_result, ConcreteResult)
-        return handle_concrete_result!(cases, call_result, match, info, state)
+        return handle_concrete_result!(cases, call_result, call_edge, match, info, state)
     elseif isa(call_result, SemiConcreteResult)
         return handle_semi_concrete_result!(cases, call_result, match, info, flag, state)
     else
-        return handle_call_result!(cases, call_result, match, argtypes, info, flag, state; allow_typevars)
+        return handle_call_result!(cases, call_result, call_edge, match, argtypes, info, flag,
+            state; allow_typevars)
     end
 end
 
 function info_effects(@nospecialize(call_result::Union{Nothing,InferredCallResult}), match::MethodMatch, state::InliningState)
     if call_result === nothing
         return Effects()
-    elseif isa(call_result, InferenceResult)
-        return call_result.ipo_effects
+    elseif isa(call_result, LocalInferenceResult)
+        return call_result.result.ipo_effects
     elseif isa(call_result, ConcreteResult)
         return call_result.effects
     elseif isa(call_result, SemiConcreteResult)
@@ -1361,6 +1387,7 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
         for (j, match) in enumerate(meth)
             all_result_count += 1
             call_result = getresult(info, all_result_count)
+            call_edge = getedge(info, all_result_count)
             joint_effects = merge_effects(joint_effects, info_effects(call_result, match, state))
             split_fully_covered |= match.fully_covers
             if !validate_sparams(match.sparams)
@@ -1378,7 +1405,8 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
                 handled_all_cases = false
             else
                 handled_all_cases &= handle_any_call_result!(cases,
-                    call_result, match, argtypes, info, flag, state; allow_typevars=false)
+                    call_result, call_edge, match, argtypes, info, flag, state;
+                    allow_typevars=false)
             end
         end
         fully_covered &= split_fully_covered
@@ -1393,8 +1421,10 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
             (i, j, k) = revisit_idx
             match = getsplit(info, i)[j]
             call_result = getresult(info, k)
+            call_edge = getedge(info, k)
             handled_all_cases &= handle_any_call_result!(cases,
-                call_result, match, argtypes, info, flag, state; allow_typevars=true)
+                call_result, call_edge, match, argtypes, info, flag, state;
+                allow_typevars=true)
         end
         if !fully_covered
             # We will emit an inline MethodError in this case, but that info already came inference, so we must already have the uncovered edge for it
@@ -1418,8 +1448,9 @@ function handle_call!(todo::Vector{Pair{Int,Any}},
 end
 
 function handle_call_result!(
-        cases::Vector{InliningCase}, call_result::Union{Nothing,InferenceResult},
-        match::MethodMatch, argtypes::Vector{Any}, @nospecialize(info::CallInfo), flag::UInt32,
+        cases::Vector{InliningCase}, call_result::Union{Nothing,LocalInferenceResult},
+        call_edge::Union{Nothing,CodeInstance}, match::MethodMatch, argtypes::Vector{Any},
+        @nospecialize(info::CallInfo), flag::UInt32,
         state::InliningState;
         allow_typevars::Bool
     )
@@ -1428,7 +1459,8 @@ function handle_call_result!(
     # processing this dispatch candidate (unless unmatched type parameters are present)
     !allow_typevars && any(case::InliningCase->case.sig === match.spec_types, cases) && return true
 
-    item = analyze_method!(call_result, match, argtypes, info, flag, state; allow_typevars)
+    item = analyze_method!(call_result, call_edge, match, argtypes, info, flag, state;
+        allow_typevars)
     item === nothing && return false
     push!(cases, InliningCase(match.spec_types, item))
     return true
@@ -1439,6 +1471,8 @@ function semiconcrete_result_item(result::SemiConcreteResult,
     code = result.edge
     mi = get_ci_mi(code)
     et = InliningEdgeTracker(state)
+    add_inlining_edge!(et, code)
+    add_inference_proof!(et.edges, inference_proof(result), code)
 
     if (!OptimizationParams(state.interp).inlining || is_stmt_noinline(flag) ||
         # For `NativeInterpreter`, `SemiConcreteResult` may be produced for
@@ -1450,7 +1484,6 @@ function semiconcrete_result_item(result::SemiConcreteResult,
     src_inlining_policy(state.interp, mi, result.ir, info, flag) ||
         return compileable_specialization(code, result.effects, et, info, state)
 
-    add_inlining_edge!(et, result.edge)
     preserve_local_sources = OptimizationParams(state.interp).preserve_local_sources
     ir, _, debuginfo = retrieve_ir_for_inlining(mi, result.ir, preserve_local_sources)
     return InliningTodo(mi, ir, result.spec_info, debuginfo, result.effects)
@@ -1467,8 +1500,9 @@ function handle_semi_concrete_result!(cases::Vector{InliningCase}, result::SemiC
 end
 
 function handle_concrete_result!(cases::Vector{InliningCase}, result::ConcreteResult,
-    match::MethodMatch, @nospecialize(info::CallInfo), state::InliningState)
-    case = concrete_result_item(result, info, state)
+    call_edge::Union{Nothing,CodeInstance}, match::MethodMatch,
+    @nospecialize(info::CallInfo), state::InliningState)
+    case = concrete_result_item(result, call_edge, match, info, state)
     case === nothing && return false
     push!(cases, InliningCase(match.spec_types, case))
     return true
@@ -1477,13 +1511,20 @@ end
 may_inline_concrete_result(result::ConcreteResult) =
     isdefined(result, :result) && is_inlineable_constant(result.result)
 
-function concrete_result_item(result::ConcreteResult, @nospecialize(info::CallInfo), state::InliningState)
+function concrete_result_item(result::ConcreteResult,
+        call_edge::Union{Nothing,CodeInstance}, match::MethodMatch,
+        @nospecialize(info::CallInfo), state::InliningState)
+    target = result.edge === nothing ? call_edge : result.edge
+    target === nothing && (target = specialize_method(match))
+    target === nothing && return nothing
+    et = InliningEdgeTracker(state)
+    add_inlining_edge!(et, target)
+    add_inference_proof!(et.edges, inference_proof(result), target)
     if !may_inline_concrete_result(result)
-        et = InliningEdgeTracker(state)
-        return compileable_specialization(result.edge, result.effects, et, info, state)
+        return compileable_specialization(target, result.effects, et, info, state)
     end
     @assert result.effects === EFFECTS_TOTAL
-    return ConstantCase(quoted(result.result), result.edge)
+    return ConstantCase(quoted(result.result))
 end
 
 function handle_cases!(todo::Vector{Pair{Int,Any}}, ir::IRCode, idx::Int, stmt::Expr,
@@ -1511,11 +1552,12 @@ function handle_opaque_closure_call!(todo::Vector{Pair{Int,Any}},
     flag::UInt32, sig::Signature, state::InliningState)
     result = info.result
     if isa(result, ConcreteResult)
-        item = concrete_result_item(result, info, state)
+        item = concrete_result_item(result, info.edge, info.match, info, state)
     elseif isa(result, SemiConcreteResult)
         item = semiconcrete_result_item(result, info, flag, state)
     else
-        item = analyze_method!(result, info.match, sig.argtypes, info, flag, state; allow_typevars=false)
+        item = analyze_method!(result, info.edge, info.match, sig.argtypes, info, flag, state;
+            allow_typevars=false)
     end
     handle_single_case!(todo, ir, idx, stmt, item)
     return nothing
@@ -1538,6 +1580,10 @@ function handle_finalizer_call!(ir::IRCode, idx::Int, stmt::Expr, info::Finalize
     # Finalizers don't return values, so if their execution is not observable,
     # we can just not register them
     if is_removable_if_unused(info.effects)
+        # The inferred effects are what make deleting this registration legal.
+        # Preserve their dispatch and inference proof so redefining the finalizer
+        # invalidates code in which the registration was removed.
+        add_edges!(state.edges, info.info)
         ir[SSAValue(idx)] = nothing
         return nothing
     end
@@ -1563,7 +1609,6 @@ function handle_finalizer_call!(ir::IRCode, idx::Int, stmt::Expr, info::Finalize
         item1 = cases[1].item
         if isa(item1, InliningTodo)
             code = get(code_cache(state), item1.mi, nothing) # COMBAK: this seems like a bad design, can we use stmt_info instead to store the correct info?
-            code isa InferenceResult && (code = code.ci)
             if code isa CodeInstance
                 push!(stmt.args, true)
                 push!(stmt.args, code)
@@ -1598,7 +1643,7 @@ function handle_invoke_expr!(todo::Vector{Pair{Int,Any}}, ir::IRCode,
             end
         end
     end
-    item = resolve_todo(mi, call_result, info, flag, state)
+    item = resolve_todo(mi, call_result, edge, info, flag, state)
     handle_single_case!(todo, ir, idx, stmt, item)
     return nothing
 end

--- a/Compiler/src/ssair/irinterp.jl
+++ b/Compiler/src/ssair/irinterp.jl
@@ -35,7 +35,16 @@ function concrete_eval_invoke(interp::AbstractInterpreter, ci::CodeInstance, arg
         newirsv = IRInterpretationState(interp, ci, mi, argtypes, src)
         if newirsv !== nothing
             assign_parentchild!(newirsv, parent)
-            return ir_abstract_constant_propagation(interp, newirsv)
+            result = ir_abstract_constant_propagation(interp, newirsv)
+            update_valid_age!(parent, world, newirsv.valid_worlds)
+            proof_edges = Any[]
+            for info in newirsv.ir.stmts.info
+                add_edges!(proof_edges, info)
+            end
+            append!(proof_edges, newirsv.edges)
+            proof = LocalInferenceProof(newirsv.valid_worlds, Core.svec(proof_edges...))
+            add_inference_proof!(parent.edges, proof)
+            return result
         end
         return Pair{Any,Tuple{Bool,Bool}}(nothing, (is_nothrow(effects), is_noub(effects)))
     end
@@ -48,10 +57,12 @@ function abstract_eval_invoke_inst(interp::AbstractInterpreter, inst::Instructio
         mi_cache = code_cache(interp)
         code = get(mi_cache, ci, nothing)
         code === nothing && return Pair{Any,Tuple{Bool,Bool}}(nothing, (false, false))
-        code isa InferenceResult && (code = code.ci) # COMBAK: we shouldn't discard the src so easily here, as we might not be able to get it back again
+        code = code::CodeInstance
     else
         code = ci::CodeInstance
     end
+    update_valid_age!(irsv, get_inference_world(interp), proof_worlds(code))
+    add_inference_proof!(irsv.edges, code)
     argtypes = collect_argtypes(interp, stmt.args[2:end], StatementState(nothing, false), irsv)
     argtypes === nothing && return Pair{Any,Tuple{Bool,Bool}}(Bottom, (false, false))
     return concrete_eval_invoke(interp, code, argtypes, irsv)

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -24,14 +24,24 @@ end
 struct NoCallInfo <: CallInfo end
 add_edges_impl(::Vector{Any}, ::NoCallInfo) = nothing
 
-# InferredCallResult is defined in types.jl so that InferenceResult can inherit from it
+# InferredCallResult is defined in types.jl with LocalInferenceResult
 
 struct ConcreteResult <: InferredCallResult
-    edge::CodeInstance
+    edge::Union{Nothing,CodeInstance}
     effects::Effects
+    proof::Union{Nothing,InferenceProof}
     result
-    ConcreteResult(edge::CodeInstance, effects::Effects) = new(edge, effects)
-    ConcreteResult(edge::CodeInstance, effects::Effects, @nospecialize val) = new(edge, effects, val)
+    function ConcreteResult(edge::Union{Nothing,CodeInstance}, effects::Effects;
+                            proof::Union{Nothing,InferenceProof}=nothing)
+        @assert edge !== nothing || proof !== nothing
+        return new(edge, effects, proof)
+    end
+    function ConcreteResult(edge::Union{Nothing,CodeInstance}, effects::Effects,
+                            @nospecialize(val);
+                            proof::Union{Nothing,InferenceProof}=nothing)
+        @assert edge !== nothing || proof !== nothing
+        return new(edge, effects, proof, val)
+    end
 end
 
 struct SemiConcreteResult <: InferredCallResult
@@ -39,6 +49,162 @@ struct SemiConcreteResult <: InferredCallResult
     ir::IRCode
     effects::Effects
     spec_info::SpecInfo
+    proof::Union{Nothing,InferenceProof}
+    SemiConcreteResult(edge::CodeInstance, ir::IRCode, effects::Effects, spec_info::SpecInfo;
+                       proof::Union{Nothing,InferenceProof}=nothing) =
+        new(edge, ir, effects, spec_info, proof)
+end
+
+inference_proof(result::ConcreteResult) =
+    result.proof === nothing ? result.edge::CodeInstance : result.proof
+inference_proof(result::SemiConcreteResult) = something(result.proof, result.edge)
+
+function materialize_inference_proof!(edges::Vector{Any}, proof::CodeInstance,
+                                      @nospecialize(paired_edge=nothing))
+    # This CI certifies the inferred facts of its defining method; it does not
+    # necessarily represent ordinary dispatch on its MethodInstance signature
+    # (for example, it may have been reached through `invoke`). Encode the proof
+    # as an identity edge to that method, just as we do for an inlined CI.
+    proof === paired_edge || add_inlining_edge!(edges, proof)
+    return nothing
+end
+
+function record_invoke_edge!(invokes::IdDict{Any,Vector{Any}},
+                             @nospecialize(signature), @nospecialize(target))
+    signatures = get!(Vector{Any}, invokes, target)
+    for previous in signatures
+        previous == signature && return false
+    end
+    push!(signatures, signature)
+    return true
+end
+
+function record_materialized_edges!(standalone::IdSet{Any},
+                                    invokes::IdDict{Any,Vector{Any}}, source)
+    i = 1
+    while i <= length(source)
+        edge = source[i]
+        if edge isa Int
+            n = abs(edge)
+            last = i + 1 + n
+            last <= length(source) || break
+            for j = i + 2:last
+                target = source[j]
+                if target isa Union{Method,MethodInstance,CodeInstance,Core.Binding}
+                    push!(standalone, target)
+                end
+            end
+            i = last + 1
+        elseif edge isa Union{Method,MethodInstance,CodeInstance,Core.Binding}
+            push!(standalone, edge)
+            i += 1
+        elseif edge isa LocalInferenceProof
+            i += 1
+        else
+            i == length(source) && break
+            record_invoke_edge!(invokes, edge, source[i + 1])
+            i += 2
+        end
+    end
+    return nothing
+end
+
+function _materialize_inference_edges!(edges::Vector{Any}, source,
+                                       seen_proofs::IdSet{LocalInferenceProof},
+                                       standalone::IdSet{Any},
+                                       invokes::IdDict{Any,Vector{Any}})
+    i = 1
+    while i <= length(source)
+        edge = source[i]
+        if edge isa LocalInferenceProof
+            i += 1
+            edge in seen_proofs && continue
+            push!(seen_proofs, edge)
+            _materialize_inference_edges!(
+                edges, edge.edges, seen_proofs, standalone, invokes)
+        elseif edge isa Int
+            # Encoded lookup groups are positional: `nmatches, atype, matches...`.
+            # Preserve each complete group, while recording its targets so an
+            # identical standalone proof edge later in the stream can be omitted.
+            n = abs(edge)
+            last = i + 1 + n
+            @assert last <= length(source)
+            for j = i:last
+                push!(edges, source[j])
+            end
+            for j = i + 2:last
+                target = source[j]
+                if target isa Union{Method,MethodInstance,CodeInstance,Core.Binding}
+                    push!(standalone, target)
+                end
+            end
+            i = last + 1
+        elseif edge isa Union{Method,MethodInstance,CodeInstance,Core.Binding}
+            i += 1
+            edge in standalone && continue
+            push!(standalone, edge)
+            push!(edges, edge)
+        else
+            # Everything else is an invoke signature paired with its target. Keep
+            # distinct signatures, and deduplicate only the identical pair.
+            @assert i < length(source)
+            target = source[i + 1]
+            i += 2
+            record_invoke_edge!(invokes, edge, target) || continue
+            push!(edges, edge, target)
+        end
+    end
+    return nothing
+end
+
+function materialize_inference_proof!(edges::Vector{Any}, proof::LocalInferenceProof,
+                                      @nospecialize(paired_edge=nothing))
+    seen_proofs = IdSet{LocalInferenceProof}()
+    standalone = IdSet{Any}()
+    invokes = IdDict{Any,Vector{Any}}()
+    record_materialized_edges!(standalone, invokes, edges)
+    paired_edge === nothing || push!(standalone, paired_edge)
+    push!(seen_proofs, proof)
+    _materialize_inference_edges!(
+        edges, proof.edges, seen_proofs, standalone, invokes)
+    return nothing
+end
+
+function materialize_inference_edges(source)
+    has_local_proof = false
+    for edge in source
+        if edge isa LocalInferenceProof
+            has_local_proof = true
+            break
+        end
+    end
+    if !has_local_proof
+        return source isa SimpleVector ? source : Core.svec(source...)
+    end
+    edges = Any[]
+    sizehint!(edges, length(source))
+    _materialize_inference_edges!(edges, source,
+        IdSet{LocalInferenceProof}(), IdSet{Any}(), IdDict{Any,Vector{Any}}())
+    return Core.svec(edges...)
+end
+
+function add_inference_proof!(edges::Vector{Any}, proof::CodeInstance,
+                              @nospecialize(paired_edge=nothing))
+    materialize_inference_proof!(edges, proof, paired_edge)
+    return nothing
+end
+
+function add_inference_proof!(edges::Vector{Any}, proof::LocalInferenceProof,
+                              @nospecialize(paired_edge=nothing))
+    any(edge -> edge === proof, edges) || push!(edges, proof)
+    return nothing
+end
+
+function add_result_proof!(edges::Vector{Any}, result::Union{Nothing,InferredCallResult},
+                           @nospecialize(paired_edge=nothing))
+    result === nothing && return nothing
+    add_inference_proof!(edges, inference_proof(result), paired_edge)
+    return nothing
 end
 
 """
@@ -55,15 +221,68 @@ struct MethodMatchInfo <: CallInfo
     atype
     fullmatch::Bool
     edges::Vector{Union{Nothing,CodeInstance}}
+    needs_mi_edges::BitVector
     call_results::Vector{Union{Nothing,InferredCallResult}}
     function MethodMatchInfo(
         results::MethodLookupResult, mt::MethodTable, @nospecialize(atype), fullmatch::Bool)
         edges = fill!(Vector{Union{Nothing,CodeInstance}}(undef, length(results)), nothing)
+        needs_mi_edges = falses(length(results))
         call_results = fill!(Vector{Union{Nothing,InferredCallResult}}(undef, length(results)), nothing)
-        return new(results, mt, atype, fullmatch, edges, call_results)
+        return new(results, mt, atype, fullmatch, edges, needs_mi_edges, call_results)
     end
 end
 add_edges_impl(edges::Vector{Any}, info::MethodMatchInfo) = _add_edges_impl(edges, info)
+
+function method_match_edge(info::MethodMatchInfo, i::Int, mi_edge::Bool)
+    edge = info.edges[i]
+    edge !== nothing && return edge
+    match = info.results[i]
+    # A proof-carrying result may carry facts about this specialization without an
+    # executable CI of its own. The same is true when a scheduled call consumed
+    # provisional SCC facts before a CI or local result was available. A completed
+    # tombstone similarly carries its proof separately from the dispatch target. Keep
+    # the MethodInstance as an invalidation target in these cases; a bare Method in an
+    # encoded lookup is intentionally ignored by the backedge iterator and therefore
+    # cannot certify those facts.
+    return (mi_edge || info.needs_mi_edges[i] || info.call_results[i] !== nothing) ?
+        specialize_method(match) : match.method
+end
+
+function has_encoded_lookup(edges::Vector{Any}, info::MethodMatchInfo,
+                            encoded_nmatches::Int, mi_edge::Bool)
+    i = 1
+    while i <= length(edges)
+        entry = edges[i]
+        if entry isa Int
+            n = abs(entry)
+            next_i = i + 2 + n
+            if next_i - 1 <= length(edges) && entry === encoded_nmatches &&
+                    edges[i + 1] == info.atype
+                matches = true
+                for j = 1:n
+                    if edges[i + 1 + j] !== method_match_edge(info, j, mi_edge)
+                        matches = false
+                        break
+                    end
+                end
+                matches && return true
+            end
+            i = next_i
+        else
+            i += 1
+        end
+    end
+    return false
+end
+
+function add_method_match_proofs!(edges::Vector{Any}, info::MethodMatchInfo,
+                                  mi_edge::Bool)
+    for i = 1:length(info.call_results)
+        add_result_proof!(edges, info.call_results[i], method_match_edge(info, i, mi_edge))
+    end
+    return nothing
+end
+
 function _add_edges_impl(edges::Vector{Any}, info::MethodMatchInfo, mi_edge::Bool=false)
     if !fully_covering(info)
         exists = false
@@ -93,29 +312,24 @@ function _add_edges_impl(edges::Vector{Any}, info::MethodMatchInfo, mi_edge::Boo
         end
         if mi.specTypes === m.spec_types
             add_one_edge!(edges, edge)
+            add_result_proof!(edges, info.call_results[1], edge)
             return nothing
         end
     end
     # add check for whether this lookup already existed in the edges list
     # encode nmatches as negative if fully_covers is false
     encoded_nmatches = fully_covering(info) ? nmatches : -nmatches
-    for i in 1:length(edges)
-        if edges[i] === encoded_nmatches && edges[i+1] == info.atype
-            # TODO: must also verify the CodeInstance match too
-            return nothing
+    if !has_encoded_lookup(edges, info, encoded_nmatches, mi_edge)
+        push!(edges, encoded_nmatches, info.atype)
+        for i = 1:nmatches
+            edge = method_match_edge(info, i, mi_edge)
+            if edge isa CodeInstance
+                @assert edge.def.def === info.results[i].method
+            end
+            push!(edges, edge)
         end
     end
-    push!(edges, encoded_nmatches, info.atype)
-    for i = 1:nmatches
-        edge = info.edges[i]
-        m = info.results[i]
-        if edge === nothing
-            edge = mi_edge ? specialize_method(m) : m.method
-        else
-            @assert edge.def.def === m.method
-        end
-        push!(edges, edge)
-    end
+    add_method_match_proofs!(edges, info, mi_edge)
     nothing
 end
 function add_one_edge!(edges::Vector{Any}, edge::MethodInstance)
@@ -145,14 +359,13 @@ function add_one_edge!(edges::Vector{Any}, edge::CodeInstance)
                 # found edge we can upgrade
                 edges[i] = edge
                 return
-            elseif edgeᵢ_orig === edge || (isdefined(edge, :inferred) && codeinst_edges_sub(edgeᵢ_orig, edge.min_world, edge.max_world, edge.edges))
-                # existing CodeInstance is identical
+            elseif edgeᵢ_orig === edge
+                # Only the identical CodeInstance certifies the same inference proof.
                 return
             end
-            # Different CodeInstance for the same MethodInstance with distinct
-            # edge information (e.g. two const-prop'd pseudo CIs of the same
-            # method recording different `Binding` edges). Keep both so that
-            # backedges are registered for each.
+            # Different CodeInstances for the same MethodInstance may certify
+            # different inference facts. Keep both, irrespective of whether their
+            # current forward-edge streams happen to compare equal.
         end
         i += 1
     end
@@ -162,6 +375,7 @@ end
 nsplit_impl(::MethodMatchInfo) = 1
 getsplit_impl(info::MethodMatchInfo, idx::Int) = (@assert idx == 1; info.results)
 getresult_impl(info::MethodMatchInfo, idx::Int) = info.call_results[idx]
+getedge_impl(info::MethodMatchInfo, idx::Int) = info.edges[idx]
 
 """
     info::UnionSplitInfo <: CallInfo
@@ -190,6 +404,17 @@ function getresult_impl(info::UnionSplitInfo, idx::Int)
             idx -= n
         end
     end
+end
+function getedge_impl(info::UnionSplitInfo, idx::Int)
+    for split in info.split
+        n = length(split.edges)
+        if idx ≤ n
+            return split.edges[idx]
+        else
+            idx -= n
+        end
+    end
+    return nothing
 end
 
 """
@@ -274,57 +499,82 @@ nsplit_impl(::InvokeCICallInfo) = 0
 
 Represents a resolved call to `Core.invoke`, carrying the `info.match::MethodMatch` of
 the method that has been processed.
-Optionally keeps `info.result::InferenceResult` that keeps constant information.
+Optionally keeps a proof-carrying `info.result` with constant information.
 """
 struct InvokeCallInfo <: CallInfo
     edge::Union{Nothing,CodeInstance}
     match::MethodMatch
     result::Union{Nothing,InferredCallResult}
     atype # ::Type
+    needs_mi_edge::Bool # targetless body-derived facts require an invalidation target
 end
+InvokeCallInfo(edge::Union{Nothing,CodeInstance}, match::MethodMatch,
+               result::Union{Nothing,InferredCallResult}, @nospecialize(atype)) =
+    InvokeCallInfo(edge, match, result, atype, false)
 add_edges_impl(edges::Vector{Any}, info::InvokeCallInfo) =
     _add_edges_impl(edges, info)
 function _add_edges_impl(edges::Vector{Any}, info::InvokeCallInfo, mi_edge::Bool=false)
     edge = info.edge
     if edge === nothing
-        edge = mi_edge ? specialize_method(info.match) : info.match.method
+        edge = (mi_edge || info.needs_mi_edge || info.result !== nothing) ?
+            specialize_method(info.match) : info.match.method
     end
     add_invoke_edge!(edges, info.atype, edge)
+    add_result_proof!(edges, info.result, edge)
     nothing
 end
 function add_invoke_edge!(edges::Vector{Any}, @nospecialize(atype), edge::Union{MethodInstance,Method})
-    for i in 2:length(edges)
+    i = 1
+    while i <= length(edges)
         edgeᵢ = edges[i]
+        if edgeᵢ isa Int
+            i += 2 + abs(edgeᵢ)
+            continue
+        end
         edgeᵢ isa CodeInstance && (edgeᵢ = edgeᵢ.def)
-        edgeᵢ isa MethodInstance || edgeᵢ isa Method || continue
+        if !(edgeᵢ isa MethodInstance || edgeᵢ isa Method)
+            i += 1
+            continue
+        end
         if edgeᵢ === edge
-            edge_minus_1 = edges[i-1]
+            i == 1 && (i += 1; continue)
+            edge_minus_1 = edges[i - 1]
             if edge_minus_1 isa Type && edge_minus_1 == atype
                 return # found existing covered edge
             end
         end
+        i += 1
     end
     push!(edges, atype)
     push!(edges, edge)
     nothing
 end
 function add_invoke_edge!(edges::Vector{Any}, @nospecialize(atype), edge::CodeInstance)
-    for i in 2:length(edges)
+    i = 1
+    while i <= length(edges)
         edgeᵢ_orig = edgeᵢ = edges[i]
+        if edgeᵢ isa Int
+            i += 2 + abs(edgeᵢ)
+            continue
+        end
         edgeᵢ isa CodeInstance && (edgeᵢ = edgeᵢ.def)
         if ((edgeᵢ isa MethodInstance && edgeᵢ === edge.def) ||
             (edgeᵢ isa Method && edgeᵢ === edge.def.def))
-            edge_minus_1 = edges[i-1]
+            i == 1 && (i += 1; continue)
+            edge_minus_1 = edges[i - 1]
             if edge_minus_1 isa Type && edge_minus_1 == atype
                 if edgeᵢ_orig isa MethodInstance || edgeᵢ_orig isa Method
                     # found edge we can upgrade
                     edges[i] = edge
                     return
-                elseif true # XXX compare `CodeInstance` identify?
+                elseif edgeᵢ_orig === edge
                     return
                 end
+                # A distinct CodeInstance for the same MethodInstance may carry a
+                # distinct proof, so retain it as a separate invoke edge.
             end
         end
+        i += 1
     end
     push!(edges, atype)
     push!(edges, edge)
@@ -336,6 +586,10 @@ function add_inlining_edge!(edges::Vector{Any}, edge::MethodInstance)
     i = 1
     while i <= length(edges)
         edgeᵢ = edges[i]
+        if edgeᵢ isa Int
+            i += 2 + abs(edgeᵢ)
+            continue
+        end
         if edgeᵢ isa Method && edgeᵢ === edge.def
             # found edge we can upgrade
             edges[i] = edge
@@ -357,6 +611,10 @@ function add_inlining_edge!(edges::Vector{Any}, edge::CodeInstance)
     i = 1
     while i <= length(edges)
         edgeᵢ = edges[i]
+        if edgeᵢ isa Int
+            i += 2 + abs(edgeᵢ)
+            continue
+        end
         if edgeᵢ isa Method && edgeᵢ === edge.def.def
             # found edge we can upgrade
             edges[i] = edge
@@ -367,11 +625,12 @@ function add_inlining_edge!(edges::Vector{Any}, edge::CodeInstance)
             edges[i] = edge
             return
         end
-        if edgeᵢ isa CodeInstance && edgeᵢ.def === edge.def
-            # found existing edge
-            # XXX compare `CodeInstance` identify?
+        if edgeᵢ === edge
+            # found the identical existing edge
             return
         end
+        # A distinct CodeInstance for the same MethodInstance may carry a
+        # distinct proof, so do not deduplicate it by `def` alone.
         i += 1
     end
     # add_invoke_edge alone
@@ -384,26 +643,36 @@ nsplit_impl(::InvokeCallInfo) = 1
 getsplit_impl(info::InvokeCallInfo, idx::Int) = (@assert idx == 1; MethodLookupResult(Core.MethodMatch[info.match],
     WorldRange(typemin(UInt), typemax(UInt)), false))
 getresult_impl(info::InvokeCallInfo, idx::Int) = (@assert idx == 1; info.result)
+getedge_impl(info::InvokeCallInfo, idx::Int) = (@assert idx == 1; info.edge)
 
 """
     info::OpaqueClosureCallInfo
 
 Represents a resolved call of opaque closure, carrying the `info.match::MethodMatch` of
 the method that has been processed.
-Optionally keeps `info.result::InferenceResult` that keeps constant information.
+Optionally keeps a proof-carrying `info.result` with constant information.
 """
 struct OpaqueClosureCallInfo <: CallInfo
     edge::Union{Nothing,CodeInstance}
     match::MethodMatch
     result::Union{Nothing,InferredCallResult}
+    needs_mi_edge::Bool # targetless body-derived facts require an invalidation target
 end
+OpaqueClosureCallInfo(edge::Union{Nothing,CodeInstance}, match::MethodMatch,
+                      result::Union{Nothing,InferredCallResult}) =
+    OpaqueClosureCallInfo(edge, match, result, false)
 function add_edges_impl(edges::Vector{Any}, info::OpaqueClosureCallInfo)
     edge = info.edge
+    if edge === nothing && (info.needs_mi_edge || info.result !== nothing)
+        edge = specialize_method(info.match)
+    end
     if edge !== nothing
         add_one_edge!(edges, edge)
     end
+    add_result_proof!(edges, info.result, edge)
     nothing
 end
+getedge_impl(info::OpaqueClosureCallInfo, idx::Int) = (@assert idx == 1; info.edge)
 
 """
     info::OpaqueClosureCreateInfo <: CallInfo
@@ -485,6 +754,10 @@ struct VirtualMethodMatchInfo <: CallInfo
 end
 add_edges_impl(edges::Vector{Any}, info::VirtualMethodMatchInfo) =
     _add_edges_impl(edges, info.info, #=mi_edge=#true)
+nsplit_impl(info::VirtualMethodMatchInfo) = nsplit(info.info)
+getsplit_impl(info::VirtualMethodMatchInfo, idx::Int) = getsplit(info.info, idx)
+getresult_impl(info::VirtualMethodMatchInfo, idx::Int) = getresult(info.info, idx)
+getedge_impl(info::VirtualMethodMatchInfo, idx::Int) = getedge(info.info, idx)
 
 """
     info::GlobalAccessInfo <: CallInfo

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -59,16 +59,6 @@ inference_proof(result::ConcreteResult) =
     result.proof === nothing ? result.edge::CodeInstance : result.proof
 inference_proof(result::SemiConcreteResult) = something(result.proof, result.edge)
 
-function materialize_inference_proof!(edges::Vector{Any}, proof::CodeInstance,
-                                      @nospecialize(paired_edge=nothing))
-    # This CI certifies the inferred facts of its defining method; it does not
-    # necessarily represent ordinary dispatch on its MethodInstance signature
-    # (for example, it may have been reached through `invoke`). Encode the proof
-    # as an identity edge to that method, just as we do for an inlined CI.
-    proof === paired_edge || add_inlining_edge!(edges, proof)
-    return nothing
-end
-
 function record_invoke_edge!(invokes::IdDict{Any,Vector{Any}},
                              @nospecialize(signature), @nospecialize(target))
     signatures = get!(Vector{Any}, invokes, target)
@@ -77,36 +67,6 @@ function record_invoke_edge!(invokes::IdDict{Any,Vector{Any}},
     end
     push!(signatures, signature)
     return true
-end
-
-function record_materialized_edges!(standalone::IdSet{Any},
-                                    invokes::IdDict{Any,Vector{Any}}, source)
-    i = 1
-    while i <= length(source)
-        edge = source[i]
-        if edge isa Int
-            n = abs(edge)
-            last = i + 1 + n
-            last <= length(source) || break
-            for j = i + 2:last
-                target = source[j]
-                if target isa Union{Method,MethodInstance,CodeInstance,Core.Binding}
-                    push!(standalone, target)
-                end
-            end
-            i = last + 1
-        elseif edge isa Union{Method,MethodInstance,CodeInstance,Core.Binding}
-            push!(standalone, edge)
-            i += 1
-        elseif edge isa LocalInferenceProof
-            i += 1
-        else
-            i == length(source) && break
-            record_invoke_edge!(invokes, edge, source[i + 1])
-            i += 2
-        end
-    end
-    return nothing
 end
 
 function _materialize_inference_edges!(edges::Vector{Any}, source,
@@ -157,19 +117,6 @@ function _materialize_inference_edges!(edges::Vector{Any}, source,
     return nothing
 end
 
-function materialize_inference_proof!(edges::Vector{Any}, proof::LocalInferenceProof,
-                                      @nospecialize(paired_edge=nothing))
-    seen_proofs = IdSet{LocalInferenceProof}()
-    standalone = IdSet{Any}()
-    invokes = IdDict{Any,Vector{Any}}()
-    record_materialized_edges!(standalone, invokes, edges)
-    paired_edge === nothing || push!(standalone, paired_edge)
-    push!(seen_proofs, proof)
-    _materialize_inference_edges!(
-        edges, proof.edges, seen_proofs, standalone, invokes)
-    return nothing
-end
-
 function materialize_inference_edges(source)
     has_local_proof = false
     for edge in source
@@ -190,7 +137,11 @@ end
 
 function add_inference_proof!(edges::Vector{Any}, proof::CodeInstance,
                               @nospecialize(paired_edge=nothing))
-    materialize_inference_proof!(edges, proof, paired_edge)
+    # This CI certifies the inferred facts of its defining method; it does not
+    # necessarily represent ordinary dispatch on its MethodInstance signature
+    # (for example, it may have been reached through `invoke`). Encode the proof
+    # as an identity edge to that method, just as we do for an inlined CI.
+    proof === paired_edge || add_inlining_edge!(edges, proof)
     return nothing
 end
 

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1625,40 +1625,6 @@ function ci_cache_next(code::CodeInstance)
     return @atomic :acquire code.next
 end
 
-struct CodeInstanceCacheIterator
-    head::Union{Nothing,CodeInstance}
-end
-Base.IteratorSize(::Type{CodeInstanceCacheIterator}) = Base.SizeUnknown()
-Base.eltype(::Type{CodeInstanceCacheIterator}) = CodeInstance
-
-function ci_cache_iteration_state(code::CodeInstance,
-                                  fast::Union{Nothing,CodeInstance})
-    next_code = ci_cache_next(code)
-    # If the hare reached the previous end, restart it from the tortoise: a
-    # concurrent insertion may since have created a cycle farther down the list.
-    fast === nothing && (fast = code)
-    fast = ci_cache_next(fast)
-    fast === nothing || (fast = ci_cache_next(fast))
-    # `jl_mi_cache_insert` can briefly make the list circular while moving an
-    # existing CI. Stop at a Floyd tortoise/hare collision; a cache miss is safe,
-    # whereas following the transient cycle would make inference unbounded.
-    next_code !== nothing && next_code === fast && (next_code = nothing)
-    return next_code, fast
-end
-
-function Base.iterate(iter::CodeInstanceCacheIterator)
-    code = iter.head
-    code === nothing && return nothing
-    return code, ci_cache_iteration_state(code, code)
-end
-
-function Base.iterate(::CodeInstanceCacheIterator,
-                      state::Tuple{Union{Nothing,CodeInstance},Union{Nothing,CodeInstance}})
-    code, fast = state
-    code === nothing && return nothing
-    return code, ci_cache_iteration_state(code, fast)
-end
-
 function find_cached_ci(interp::AbstractInterpreter, mi::MethodInstance,
                         valid_worlds::WorldRange, source_mode::UInt8)
     cache = code_cache(interp, valid_worlds)
@@ -1690,14 +1656,19 @@ function find_cached_ci(interp::AbstractInterpreter, cache::InternalCodeCache,
     # that entry would publish a new source-capable CI for every ABI/source request.
     # Walk the native cache chain to find the first entry that satisfies the full
     # request. Cache wrappers dispatch back to this implementation through their
-    # underlying global cache.
-    for code in CodeInstanceCacheIterator(ci_cache_head(mi))
+    # underlying global cache. A concurrent `jl_mi_cache_insert` may briefly make
+    # the chain circular while moving an existing CI; like the C-side walkers
+    # (e.g. `jl_get_ci_equiv`), keep following `next` until the writer's fixup
+    # store lands.
+    code = ci_cache_head(mi)
+    while code !== nothing
         if (ci_worlds_cover(code, valid_worlds) &&
                 code.owner === cache.owner &&
                 isdefined(code, :inferred, :acquire) &&
                 ci_meets_requirement(interp, code, source_mode))
             return code
         end
+        code = ci_cache_next(code)
     end
     return nothing
 end
@@ -1730,9 +1701,10 @@ end
 function find_equivalent_cached_ci(::AbstractInterpreter,
                                    ::InternalCodeCache, ci::CodeInstance,
                                    valid_worlds::WorldRange)
-    mi = get_ci_mi(ci)
-    for candidate in CodeInstanceCacheIterator(ci_cache_head(mi))
+    candidate = ci_cache_head(get_ci_mi(ci))
+    while candidate !== nothing
         ci_is_equivalent_winner(candidate, ci, valid_worlds) && return candidate
+        candidate = ci_cache_next(candidate)
     end
     return nothing
 end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -89,26 +89,29 @@ If set to `true`, record per-method-instance timings within type inference in th
 __set_measure_typeinf(onoff::Bool) = __measure_typeinf__[] = onoff
 const __measure_typeinf__ = RefValue{Bool}(false)
 
-function result_edges(::AbstractInterpreter, caller::InferenceState)
+function internal_result_edges(caller::InferenceState)
     result = caller.result
     opt = result.src
     if isa(opt, OptimizationState)
-        return Core.svec(opt.inlining.edges...)
+        return opt.inlining.edges
     else
-        return Core.svec(caller.edges...)
+        return caller.edges
     end
 end
 
+result_edges(::AbstractInterpreter, caller::InferenceState) =
+    materialize_inference_edges(internal_result_edges(caller))
+
 function finish!(interp::AbstractInterpreter, caller::InferenceState, validation_world::UInt, time_before::UInt64)
     result = caller.result
-    edges = result_edges(interp, caller)
     valid_worlds = caller.valid_worlds
     min_world, max_world = first(valid_worlds), last(valid_worlds)
     result.valid_worlds = valid_worlds
     caller.src.min_world = min_world
     caller.src.max_world = max_world
-    #@assert max_world <= get_world_counter() || isempty(edges)
     if isdefined(result, :ci)
+        edges = result_edges(interp, caller)
+        #@assert max_world <= get_world_counter() || isempty(edges)
         ci = result.ci
         mi = result.linfo
         result_type = result.result
@@ -149,8 +152,6 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
             if inferred_result !== nothing
                 result.src = inferred_result
                 debuginfo = get_debuginfo(inferred_result)
-                # Inlining may fast-path the global cache via InferenceResult, so store it back here
-                result.src = inferred_result
             else
                 if isa(result.src, OptimizationState)
                     debuginfo = get_debuginfo(ir_to_codeinf!(result.src))
@@ -202,14 +203,30 @@ function promotecache!(interp::AbstractInterpreter, caller::InferenceState)
     if isdefined(result, :ci)
         ci = result.ci
         mi = result.linfo
-        if is_already_cached(interp, result)
-            # convert to a local cache or insert it now globally
-            engine_reject(interp, ci)
-            caller.cache_mode = CACHE_MODE_LOCAL
+        # Only an early winner kept `ci` out of `opt_cache`, so only that case may
+        # still be demoted here. If a winner appeared during optimization, `ci` may
+        # already occur in optimized IR and must be published even if equivalent.
+        if result.replacement_ci !== nothing
+            equivalent = find_equivalent_cached_ci(
+                interp, ci, result.valid_worlds)
+            if equivalent === nothing
+                # The early winner was sufficient to keep this provisional CI out
+                # of optimizer state, but it cannot represent the completed result's
+                # return ABI. Publish the now-complete CI normally.
+                caller.cache_mode |= CACHE_MODE_GLOBAL
+                caller.cache_mode &= ~CACHE_MODE_LOCAL
+                result.replacement_ci = nothing
+            else
+                result.replacement_ci = equivalent
+            end
         end
         if !iszero(caller.cache_mode & CACHE_MODE_GLOBAL)
             code_cache(interp)[mi] = ci
         end
+        # A globally committed exact CI becomes visible before its reservation is
+        # released and any waiters wake. A publication loser is still filled as a
+        # session-local ephemeral CI before its reservation is released: it may carry
+        # source required by this interpreter even when the global winner does not.
         engine_reject(interp, ci)
         codegen = codegen_cache(interp)
         if codegen !== nothing
@@ -233,7 +250,21 @@ function promotecache!(interp::AbstractInterpreter, caller::InferenceState)
         end
     end
     if !iszero(caller.cache_mode & CACHE_MODE_LOCAL)
-        push!(get_inference_cache(interp), result)
+        if result.tombstone
+            # Preserve rejected constant-propagation work as an internal marker. It is
+            # never exposed as a completed call result.
+            result.cache_world = get_inference_world(interp)
+            push!(get_inference_cache(interp), result)
+        elseif result.result !== nothing && result.overridden_by_const === nothing
+            # Local work is reusable only through its explicit dependency proof. Its
+            # provisional CI, if any, is deliberately not allowed to escape as a target.
+            proof = LocalInferenceProof(result.valid_worlds,
+                Core.svec(internal_result_edges(caller)...))
+            local_result = LocalInferenceResult(result, proof, get_inference_world(interp))
+            push!(get_inference_cache(interp), local_result)
+        end
+        # Successful constant propagation is published by `const_prop_call` only after
+        # concrete-evaluation overrides have been finalized.
     end
     nothing
 end
@@ -281,7 +312,8 @@ function finish_nocycle(interp::AbstractInterpreter, frame::InferenceState{I}, t
     validation_world = get_world_counter()
     finish!(interp::I, frame, validation_world, time_before)
     promotecache!(interp::I, frame)
-    if isdefined(frame.result, :ci)
+    if (!iszero(frame.cache_mode & CACHE_MODE_GLOBAL) &&
+            isdefined(frame.result, :ci))
         # After validation, under the world_counter_lock, set max_world to typemax(UInt) for all dependencies
         # (recursively). From that point onward the ordinary backedge mechanism is responsible for maintaining
         # validity.
@@ -291,6 +323,43 @@ function finish_nocycle(interp::AbstractInterpreter, frame::InferenceState{I}, t
         frames = frame.callstack
         @assert frames[end] === frame
         pop!(frames)
+    end
+    return nothing
+end
+
+function propagate_unpublished_cycle_proof!(
+        frames::Vector{AbsIntState{I}}, cycleid::Int, world::UInt,
+        cycle_valid_worlds::WorldRange
+    ) where {I<:AbstractInterpreter}
+    unpublished = InferenceState{I}[]
+    for frameid = cycleid:length(frames)
+        caller = frames[frameid]::InferenceState
+        if iszero(caller.cache_mode & CACHE_MODE_GLOBAL)
+            push!(unpublished, caller)
+        end
+    end
+    isempty(unpublished) && return nothing
+
+    proof_edges = Any[]
+    for frameid = cycleid:length(frames)
+        append!(proof_edges, internal_result_edges(frames[frameid]::InferenceState))
+    end
+    cycle_proof = LocalInferenceProof(cycle_valid_worlds, Core.svec(proof_edges...))
+    # An unpublished member needs the shared fixed-point proof for later local
+    # reuse. Any caller that directly consumed that member while it was in progress
+    # needs the same proof. Other published SCC members remain connected through
+    # their ordinary CI edges, so copying the union onto every member would only
+    # multiply serialized edge streams by the SCC size.
+    consumers = IdSet{InferenceState{I}}()
+    for callee in unpublished
+        push!(consumers, callee)
+        for (caller, _) in callee.cycle_backedges
+            push!(consumers, caller)
+        end
+    end
+    for caller in consumers
+        add_inference_proof!(internal_result_edges(caller), cycle_proof)
+        update_valid_age!(caller, world, proof_worlds(cycle_proof))
     end
     return nothing
 end
@@ -335,6 +404,13 @@ function finish_cycle(interp::AbstractInterpreter, frames::Vector{AbsIntState{I}
         caller.time_paused = UInt64(0)
         caller.time_caches = 0.0
     end
+    # Calls to an already in-progress SCC member consume its current facts
+    # immediately and record only a cycle backedge. Usually the member's published
+    # CI later certifies those facts. If any member will not publish its exact CI
+    # (for example, it was demoted in favor of a reentrant cached winner or its
+    # source was tombstoned), preserve the SCC's external dependencies explicitly.
+    # One shared proof for the whole SCC avoids constructing a cyclic proof graph.
+    propagate_unpublished_cycle_proof!(frames, cycleid, world, cycle_valid_worlds)
     empty!(opt_cache)
     cycletop = frames[cycleid]::InferenceState
     time_start = cycletop.time_start
@@ -347,9 +423,6 @@ function finish_cycle(interp::AbstractInterpreter, frames::Vector{AbsIntState{I}
         caller.time_paused = time_paused
         update_valid_age!(caller, world, cycle_valid_worlds)
         finish!(caller.interp::I, caller, validation_world, time_before)
-        if isdefined(caller.result, :ci)
-            push!(cis, caller.result.ci)
-        end
     end
     if cycletop.parentid != 0
         parent = frames[cycletop.parentid]
@@ -360,6 +433,10 @@ function finish_cycle(interp::AbstractInterpreter, frames::Vector{AbsIntState{I}
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
         promotecache!(caller.interp::I, caller)
+        if (!iszero(caller.cache_mode & CACHE_MODE_GLOBAL) &&
+                isdefined(caller.result, :ci))
+            push!(cis, caller.result.ci)
+        end
     end
     # After validation, under the world_counter_lock, set max_world to typemax(UInt) for all dependencies
     # (recursively). From that point onward the ordinary backedge mechanism is responsible for maintaining
@@ -666,6 +743,7 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
     src.rettype = widenconst(ignorelimited(bestguess))
     src.ssaflags = me.ssaflags
     valid_worlds = me.valid_worlds
+    result.valid_worlds = valid_worlds
     min_world, max_world = first(valid_worlds), last(valid_worlds)
     src.min_world = min_world
     src.max_world = max_world
@@ -713,9 +791,13 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
         ci.analysis_results = result.analysis_results
         if !iszero(me.cache_mode & CACHE_MODE_GLOBAL)
             ci = result.ci
-            if is_already_cached(interp, result)
-                # convert to a local cache
-                engine_reject(interp, ci)
+            replacement_ci = find_cached_ci(interp, result)
+            if replacement_ci !== nothing
+                # Make the publication decision before this CI can enter `opt_cache`.
+                # The provisional object remains private to this inference session and
+                # is filled only after optimization, so no published caller can observe
+                # it as an executable edge.
+                result.replacement_ci = replacement_ci
                 me.cache_mode = CACHE_MODE_LOCAL
             else
                 opt_cache[result.linfo] = ci
@@ -725,19 +807,13 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
     nothing
 end
 
-function is_already_cached(interp::AbstractInterpreter, result::InferenceResult)
-    # check if the existing linfo metadata is also sufficient to describe the current inference result
-    # to decide if it is worth caching this right now
-    mi = result.linfo
-    cache = code_cache(interp, result.valid_worlds)
-    if haskey(cache, mi)
-        # n.b.: accurate edge representation might cause the CodeInstance for this to be constructed later
-        cached = cache[mi]
-        ci = cached isa InferenceResult ? cached.ci : cached
-        @assert isdefined(ci, :inferred)
-        return true
-    end
-    return false
+function find_cached_ci(interp::AbstractInterpreter, result::InferenceResult)
+    # Any inferred global CI covering this result is sufficient to defer publication
+    # until the new result's ABI is known. `promotecache!` then keeps an equivalent
+    # result local, or publishes the completed CI normally when no equivalent winner
+    # exists.
+    return find_cached_ci(interp, result.linfo, result.valid_worlds,
+        SOURCE_MODE_NOT_REQUIRED)
 end
 
 # Iterate a series of back-edges that need registering, based on the provided forward edge list.
@@ -796,26 +872,31 @@ function store_backedges(caller::CodeInstance, edges::SimpleVector)
     isa(get_ci_mi(caller).def, Method) || return # don't add backedges to toplevel method instance
 
     backedges = ForwardToBackedgeIterator(edges)
-    for (i, (invokesig, item)) in enumerate(backedges)
-        # check for any duplicate edges we've already registered
-        duplicate_found = false
-        for (i′, (invokesig′, item′)) in enumerate(backedges)
-            i == i′ && break
-            if item′ === item && invokesig′ == invokesig
-                duplicate_found = true
-                break
+    # `Compiler` is loaded before `Set` during bootstrap, so keep the signatures
+    # for each identity-keyed dependency in a small vector.
+    seen = IdDict{Any,Vector{Any}}()
+    for (invokesig, item) in backedges
+        if haskey(seen, item)
+            signatures = seen[item]
+            duplicate_found = false
+            for signature in signatures
+                if signature == invokesig
+                    duplicate_found = true
+                    break
+                end
             end
+            duplicate_found && continue
+            push!(signatures, invokesig)
+        else
+            seen[item] = Any[invokesig]
         end
-
-        if !duplicate_found
-            if item isa Core.Binding
-                maybe_add_binding_backedge!(item, caller)
-            elseif item isa MethodTable
-                ccall(:jl_method_table_add_backedge, Cvoid, (Any, Any), invokesig, caller)
-            else
-                item::MethodInstance
-                ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any, Any), item, invokesig, caller)
-            end
+        if item isa Core.Binding
+            maybe_add_binding_backedge!(item, caller)
+        elseif item isa MethodTable
+            ccall(:jl_method_table_add_backedge, Cvoid, (Any, Any), invokesig, caller)
+        else
+            item::MethodInstance
+            ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any, Any), item, invokesig, caller)
         end
     end
     nothing
@@ -840,6 +921,8 @@ function compute_recursive_worlds(edges::Vector{Any})
             wr = WorldRange(edge.min_world, edge.max_world)
             iszero(last(wr.max_world)) && continue # part of the current cycle, not yet valid
             range = intersect(range, wr)
+        elseif edge isa LocalInferenceProof
+            range = intersect(range, edge.valid_worlds)
         end
     end
     return range
@@ -1024,38 +1107,76 @@ function return_cached_result(interp::AbstractInterpreter, method::Method, codei
         inf_result.exc_result = exct
         inf_result.src = src::CodeInfo
         inf_result.ipo_effects = effects
-        inf_result.ci_as_edge = inf_result.ci = codeinst
+        inf_result.ci = codeinst
         inf_result.valid_worlds = valid_worlds
-        push!(get_inference_cache(interp), inf_result)
+        local_result = LocalInferenceResult(inf_result, codeinst, get_inference_world(interp))
+        push!(get_inference_cache(interp), local_result)
     else
-        inf_result = nothing
+        local_result = nothing
     end
     update_valid_age!(caller, get_inference_world(interp), valid_worlds)
     caller.time_caches += reinterpret(Float16, codeinst.time_infer_total)
     caller.time_caches += reinterpret(Float16, codeinst.time_infer_cache_saved)
-    return Future(MethodCallResult(interp, caller, method, rt, exct, effects, codeinst, edgecycle, edgelimited, inf_result))
+    return Future(MethodCallResult(interp, caller, method, rt, exct, effects, codeinst,
+        edgecycle, edgelimited, local_result))
 end
 
-function return_cached_result(interp::AbstractInterpreter, method::Method, inf_result::InferenceResult, @nospecialize(src), caller::AbsIntState, edgecycle::Bool, edgelimited::Bool)
+function return_cached_result(interp::AbstractInterpreter, method::Method,
+                              local_result::LocalInferenceResult,
+                              codeinst::Union{Nothing,CodeInstance},
+                              caller::AbsIntState, edgecycle::Bool, edgelimited::Bool)
+    inf_result = local_result.result
     rt = inf_result.result
     exct = inf_result.exc_result
-    if src !== nothing
-        inf_result.src = src::CodeInfo
-    end
     effects = inf_result.ipo_effects
-    codeinst = inf_result.ci
-    update_valid_age!(caller, get_inference_world(interp), inf_result.valid_worlds)
-    caller.time_caches += reinterpret(Float16, codeinst.time_infer_total)
-    caller.time_caches += reinterpret(Float16, codeinst.time_infer_cache_saved)
-    return Future(MethodCallResult(interp, caller, method, rt, exct, effects, codeinst, edgecycle, edgelimited, inf_result))
+    world = get_inference_world(interp)
+    update_valid_age!(caller, world, proof_worlds(local_result.proof))
+    if codeinst !== nothing
+        update_valid_age!(caller, world, WorldRange(codeinst.min_world, codeinst.max_world))
+        caller.time_caches += reinterpret(Float16, codeinst.time_infer_total)
+        caller.time_caches += reinterpret(Float16, codeinst.time_infer_cache_saved)
+    end
+    return Future(MethodCallResult(interp, caller, method, rt, exct, effects,
+        codeinst, edgecycle, edgelimited, local_result))
+end
+
+function lookup_cached_edge(interp::AbstractInterpreter, method::Method,
+                            mi::MethodInstance, caller::AbsIntState, force_inline::Bool,
+                            edgecycle::Bool, edgelimited::Bool)
+    local_result = lookup_local_inference_result(interp, mi)
+    codeinst = get(code_cache(interp), mi, nothing)
+    if !(codeinst isa CodeInstance)
+        local_result === nothing && return nothing, nothing
+        return return_cached_result(interp, method, local_result, nothing, caller,
+            edgecycle, edgelimited), nothing
+    end
+    @assert codeinst.def === mi "MethodInstance for cached edge does not match"
+
+    if local_result !== nothing
+        return return_cached_result(interp, method, local_result, codeinst, caller,
+            edgecycle, edgelimited), nothing
+    end
+
+    inferred = @atomic :monotonic codeinst.inferred
+    need_inlineable_code = (may_optimize(interp) &&
+        (force_inline || is_inlineable(inferred) || use_const_api(codeinst)))
+    if need_inlineable_code
+        src = ci_get_source(interp, codeinst, inferred)
+        src === nothing && return nothing, codeinst
+        return return_cached_result(interp, method, codeinst, src, caller,
+            edgecycle, edgelimited), nothing
+    end
+    return return_cached_result(interp, method, codeinst, nothing, caller,
+        edgecycle, edgelimited), nothing
 end
 
 
 function MethodCallResult(::AbstractInterpreter, sv::AbsIntState, method::Method,
                           @nospecialize(rt), @nospecialize(exct), effects::Effects,
                           edge::Union{Nothing,CodeInstance}, edgecycle::Bool, edgelimited::Bool,
-                          call_result::Union{Nothing,InferredCallResult} = nothing)
-    if edge === nothing
+                          call_result::Union{Nothing,InferredCallResult} = nothing;
+                          force_edgecycle::Bool = true, needs_mi_edge::Bool = false)
+    if force_edgecycle && edge === nothing && call_result === nothing
         edgecycle = edgelimited = true
     end
 
@@ -1069,7 +1190,12 @@ function MethodCallResult(::AbstractInterpreter, sv::AbsIntState, method::Method
         effects = Effects(effects; terminates=true)
     elseif edgecycle
         # Some sort of recursion was detected.
-        if edge !== nothing && !edgelimited && !is_edge_recursed(edge, sv)
+        edge_mi = if edge !== nothing
+            edge.def
+        elseif call_result isa LocalInferenceResult
+            call_result.result.linfo
+        end
+        if edge_mi !== nothing && !edgelimited && !is_edge_recursed(edge_mi, sv)
             # no `MethodInstance` cycles -- don't taint :terminate
         else
             # we cannot guarantee that the call will terminate
@@ -1077,41 +1203,30 @@ function MethodCallResult(::AbstractInterpreter, sv::AbsIntState, method::Method
         end
     end
 
-    return MethodCallResult(rt, exct, effects, edge, edgecycle, edgelimited, call_result)
+    return MethodCallResult(rt, exct, effects, edge, edgecycle, edgelimited, call_result;
+        needs_mi_edge)
 end
 
-function codeinst_edges_sub(existing_edge::CodeInstance, min_world::UInt, max_world::UInt, edges::SimpleVector)
-    # return if the existing edge has more restrictions than the other arguments (more edges and narrower worlds)
-    if existing_edge.min_world >= min_world &&
-       existing_edge.max_world <= max_world &&
-       existing_edge.edges == edges
-        return true
+function completed_inference_result(interp::AbstractInterpreter, frame::InferenceState)
+    result = frame.result
+    @assert result.result !== nothing
+    @assert !result.tombstone
+    if (!iszero(frame.cache_mode & CACHE_MODE_GLOBAL) && isdefined(result, :ci) &&
+            get(code_cache(interp, result.valid_worlds), result.linfo, nothing) === result.ci)
+        proof = result.ci
+    else
+        cache = get_inference_cache(interp)
+        indices = get_indices(cache, result.linfo)
+        for i in length(indices):-1:1
+            cached = cache.results[indices[i]]
+            if cached isa LocalInferenceResult && cached.result === result
+                return cached
+            end
+        end
+        proof = LocalInferenceProof(result.valid_worlds,
+            Core.svec(internal_result_edges(frame)...))
     end
-    return false
-end
-
-# allocate a dummy `edge::CodeInstance` to be added by `add_edges!`, reusing an existing_edge if possible
-# TODO: fill this in fully correctly (currently IPO info such as effects and return types are lost)
-function codeinst_as_edge(interp::AbstractInterpreter, sv::InferenceState, @nospecialize existing_edge)
-    edges = Core.svec(sv.edges...)
-    min_world, max_world = first(sv.valid_worlds), last(sv.valid_worlds)
-    if max_world >= get_world_counter()
-        max_world = typemax(UInt)
-    end
-    if existing_edge isa CodeInstance && codeinst_edges_sub(existing_edge, min_world, max_world, edges)
-        return existing_edge
-    end
-    mi = sv.linfo
-    ci = CodeInstance(mi, cache_owner(interp), Any, Any, nothing, nothing, zero(Int32),
-        min_world, max_world, zero(UInt32), nothing, nothing, edges)
-    if max_world == typemax(UInt)
-        # if we can record all of the backedges in the global reverse-cache,
-        # we can now widen our applicability in the global cache too
-        # XXX: this should come after we decide this edge is even useful
-        # (e.g. this is the job of jl_promote_ci_to_current)
-        store_backedges(ci, edges)
-    end
-    return ci
+    return LocalInferenceResult(result, proof, get_inference_world(interp))
 end
 
 function _schedule_edge_infer_task!(caller::AbsIntState, frame::InferenceState, result::InferenceResult,
@@ -1123,24 +1238,50 @@ function _schedule_edge_infer_task!(caller::AbsIntState, frame::InferenceState, 
         isinferred = is_inferred(frame)
         effects = nothing
         call_result = nothing
-        edge = result.ci
+        edge = edge_ci
         if isinferred
-            if edge_ci isa CodeInstance && codeinst_edges_sub(edge_ci, edge.min_world, edge.max_world, edge.edges)
-                edge = edge_ci # override the edge for tracking invalidation
+            if !result.tombstone
+                call_result = completed_inference_result(interp, frame)
+                update_valid_age!(caller, get_inference_world(interp),
+                    proof_worlds(call_result.proof))
+            else
+                # A limited source can still produce clean return/effect facts. Retain
+                # their dependencies without exposing the tombstoned source as reusable.
+                proof = LocalInferenceProof(result.valid_worlds,
+                    Core.svec(internal_result_edges(frame)...))
+                add_inference_proof!(caller.edges, proof)
+                update_valid_age!(caller, get_inference_world(interp), proof_worlds(proof))
             end
-            result.ci_as_edge = edge # override the edge for tracking purposes
             effects = result.ipo_effects # effects are adjusted already within `finish` for ipo_effects
-            call_result = result
+            if !iszero(frame.cache_mode & CACHE_MODE_GLOBAL) && isdefined(result, :ci)
+                edge = result.ci
+            else
+                cached = get(code_cache(interp), result.linfo, nothing)
+                cached isa CodeInstance && (edge = cached)
+            end
         else
+            # Do not expose this frame's provisional CI. The ordinary Method/MI lookup
+            # edge is sufficient until the cycle resolves, and an existing published
+            # target may still be reused when one was available at scheduling time.
             effects = adjust_effects(effects_for_cycle(frame.ipo_effects), method)
             add_cycle_backedge!(caller, frame)
         end
+        # Both provisional SCC results and completed tombstones can contribute body
+        # facts without a CI target or reusable local result. Their transitive proof
+        # edges do not replace the dispatch dependency on this MethodInstance.
+        needs_mi_edge = edge === nothing && call_result === nothing
+        if edge !== nothing
+            update_valid_age!(caller, get_inference_world(interp), proof_worlds(edge))
+        end
         bestguess = frame.bestguess
         exc_bestguess = refine_exception_type(frame.exc_bestguess, effects)
-        # propagate newly inferred source to the inliner, allowing efficient inlining w/o deserialization:
-        # note that this result is cached globally exclusively, so we can use this local result destructively
+        # Propagate newly inferred source to the inliner, allowing efficient inlining
+        # without deserialization.
+        # A missing target here is deliberate; preserve the cycle/limiting decision made
+        # by `abstract_call_method` instead of inferring a new cycle from target absence.
         mresult[] = MethodCallResult(interp, caller, method, bestguess, exc_bestguess, effects,
-            edge, edgecycle, edgelimited, call_result)
+            edge, edgecycle, edgelimited, call_result;
+            force_edgecycle=false, needs_mi_edge)
         return true
     end)
     return mresult
@@ -1152,33 +1293,15 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
     cache_mode = CACHE_MODE_GLOBAL # cache edge targets globally by default
     force_inline = is_stmt_inline(get_curr_ssaflag(caller))
     edge_ci = nothing
-    let code = get(code_cache(interp), mi, nothing)
-        codeinst = code
-        if code isa InferenceResult
-            inferred = code.src
-            codeinst = code.ci
-        elseif code isa CodeInstance # return existing rettype if the code is already inferred
-            inferred = @atomic :monotonic code.inferred
-        else
-            inferred = nothing
-        end
-        if codeinst isa CodeInstance
-            need_inlineable_code = may_optimize(interp) && (force_inline || is_inlineable(inferred) || use_const_api(codeinst))
-            if need_inlineable_code
-                src = ci_get_source(interp, codeinst, inferred)
-                if src === nothing
-                    # Re-infer to get the appropriate source representation
-                    cache_mode = CACHE_MODE_LOCAL
-                    edge_ci = codeinst
-                else # no reinference needed
-                    @assert codeinst.def === mi "MethodInstance for cached edge does not match"
-                    return return_cached_result(interp, method, code, src, caller, edgecycle, edgelimited)
-                end
-            else # no reinference needed
-                @assert codeinst.def === mi "MethodInstance for cached edge does not match"
-                return return_cached_result(interp, method, code, nothing, caller, edgecycle, edgelimited)
-            end
-        end
+    cached, missing_source_edge = lookup_cached_edge(interp, method, mi, caller,
+        force_inline, edgecycle, edgelimited)
+    if cached !== nothing
+        return cached
+    elseif missing_source_edge !== nothing
+        # A globally published executable target exists, but its source was discarded.
+        # Re-infer only the source/facts and certify that local work with a local proof.
+        cache_mode = CACHE_MODE_LOCAL
+        edge_ci = missing_source_edge
     end
     if !InferenceParams(interp).force_enable_inference && ccall(:jl_get_module_infer, Cint, (Any,), method.module) == 0
         add_remark!(interp, caller, "[typeinf_edge] Inference is disabled for the target module")
@@ -1197,43 +1320,27 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
             reserve_start = _time_ns() # subtract engine_reserve (thread-synchronization) time from callers to avoid double-counting
             ci_from_engine = engine_reserve(interp, mi)
             caller.time_paused += (_time_ns() - reserve_start)
-            code = get(code_cache(interp), mi, nothing)
-            codeinst = code
-            if code isa InferenceResult
-                inferred = code.src
-                codeinst = code.ci
-            elseif code isa CodeInstance # return existing rettype if the code is already inferred
-                inferred = @atomic :monotonic code.inferred
-            else
-                inferred = nothing
-            end
-            if codeinst isa CodeInstance # return existing rettype if the code is already inferred
+            cached, missing_source_edge = lookup_cached_edge(interp, method, mi, caller,
+                force_inline, edgecycle, edgelimited)
+            if cached !== nothing
+                engine_reject(interp, ci_from_engine)
+                return cached
+            elseif missing_source_edge !== nothing
                 engine_reject(interp, ci_from_engine)
                 ci_from_engine = nothing
-                need_inlineable_code = may_optimize(interp) && (force_inline || is_inlineable(inferred) || use_const_api(codeinst))
-                if need_inlineable_code
-                    src = ci_get_source(interp, codeinst, inferred)
-                    if src === nothing
-                        cache_mode = CACHE_MODE_LOCAL
-                        edge_ci = codeinst
-                    else
-                        @assert codeinst.def === mi "MethodInstance for cached edge does not match"
-                        return return_cached_result(interp, method, code, src, caller, edgecycle, edgelimited)
-                    end
-                else
-                    @assert codeinst.def === mi "MethodInstance for cached edge does not match"
-                    return return_cached_result(interp, method, code, nothing, caller, edgecycle, edgelimited)
-                end
+                cache_mode = CACHE_MODE_LOCAL
+                edge_ci = missing_source_edge
             end
         else
             ci_from_engine = nothing
         end
         result = InferenceResult(mi, typeinf_lattice(interp))
-        result.ci = if ci_from_engine !== nothing
-                ci_from_engine
-            else
-                ccall(:jl_new_codeinst_uninit, Any, (Any, Any), mi, cache_owner(interp))::CodeInstance
-            end
+        if ci_from_engine !== nothing
+            result.ci = ci_from_engine
+        elseif !iszero(cache_mode & CACHE_MODE_GLOBAL)
+            result.ci = ccall(:jl_new_codeinst_uninit, Any, (Any, Any),
+                mi, cache_owner(interp))::CodeInstance
+        end
         frame = InferenceState(result, cache_mode, interp) # always use the cache for edge targets
         if frame === nothing
             add_remark!(interp, caller, "[typeinf_edge] Failed to retrieve source")
@@ -1260,7 +1367,14 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
     exc_bestguess = refine_exception_type(frame.exc_bestguess, effects)
     add_cycle_backedge!(caller, frame)
     result = frame.result
-    return Future(MethodCallResult(interp, caller, method, bestguess, exc_bestguess, effects, isdefined(result, :ci) ? result.ci : nothing, edgecycle, edgelimited))
+    edge = get(code_cache(interp), result.linfo, nothing)
+    edge isa CodeInstance || (edge = nothing)
+    if edge !== nothing
+        update_valid_age!(caller, get_inference_world(interp), proof_worlds(edge))
+    end
+    return Future(MethodCallResult(interp, caller, method, bestguess, exc_bestguess, effects,
+        edge, edgecycle, edgelimited;
+        force_edgecycle=false, needs_mi_edge=edge === nothing))
 end
 
 # The `:terminates` effect bit must be conservatively tainted unless recursion cycle has
@@ -1381,11 +1495,12 @@ function typeinf_frame(interp::AbstractInterpreter, mi::MethodInstance, run_opti
     if run_optimizer
         if result_is_constabi(interp, frame.result)
             rt = frame.result.result::Const
-            src = codeinfo_for_const(interp, frame.linfo, frame.valid_worlds, Core.svec(frame.edges...), rt.val)
+            edges = materialize_inference_edges(frame.edges)
+            src = codeinfo_for_const(interp, frame.linfo, frame.valid_worlds, edges, rt.val)
         else
             opt = OptimizationState(frame, interp)
             optimize(interp, opt, frame.result)
-            src = ir_to_codeinf!(opt, frame, Core.svec(opt.inlining.edges...))
+            src = ir_to_codeinf!(opt, frame, materialize_inference_edges(opt.inlining.edges))
         end
         result.src = frame.src = src
     end
@@ -1494,31 +1609,188 @@ function ci_meets_requirement(interp::AbstractInterpreter, code::CodeInstance, s
     return false
 end
 
+function ci_worlds_cover(code::CodeInstance, valid_worlds::WorldRange)
+    min_world = @atomic :acquire code.min_world
+    max_world = @atomic :acquire code.max_world
+    return min_world <= first(valid_worlds) && last(valid_worlds) <= max_world
+end
+
+function ci_cache_head(mi::MethodInstance)
+    isdefined(mi, :cache, :acquire) || return nothing
+    return @atomic :acquire mi.cache
+end
+
+function ci_cache_next(code::CodeInstance)
+    isdefined(code, :next, :acquire) || return nothing
+    return @atomic :acquire code.next
+end
+
+struct CodeInstanceCacheIterator
+    head::Union{Nothing,CodeInstance}
+end
+Base.IteratorSize(::Type{CodeInstanceCacheIterator}) = Base.SizeUnknown()
+Base.eltype(::Type{CodeInstanceCacheIterator}) = CodeInstance
+
+function ci_cache_iteration_state(code::CodeInstance,
+                                  fast::Union{Nothing,CodeInstance})
+    next_code = ci_cache_next(code)
+    # If the hare reached the previous end, restart it from the tortoise: a
+    # concurrent insertion may since have created a cycle farther down the list.
+    fast === nothing && (fast = code)
+    fast = ci_cache_next(fast)
+    fast === nothing || (fast = ci_cache_next(fast))
+    # `jl_mi_cache_insert` can briefly make the list circular while moving an
+    # existing CI. Stop at a Floyd tortoise/hare collision; a cache miss is safe,
+    # whereas following the transient cycle would make inference unbounded.
+    next_code !== nothing && next_code === fast && (next_code = nothing)
+    return next_code, fast
+end
+
+function Base.iterate(iter::CodeInstanceCacheIterator)
+    code = iter.head
+    code === nothing && return nothing
+    return code, ci_cache_iteration_state(code, code)
+end
+
+function Base.iterate(::CodeInstanceCacheIterator,
+                      state::Tuple{Union{Nothing,CodeInstance},Union{Nothing,CodeInstance}})
+    code, fast = state
+    code === nothing && return nothing
+    return code, ci_cache_iteration_state(code, fast)
+end
+
+function find_cached_ci(interp::AbstractInterpreter, mi::MethodInstance,
+                        valid_worlds::WorldRange, source_mode::UInt8)
+    cache = code_cache(interp, valid_worlds)
+    return find_cached_ci(interp, cache, mi, valid_worlds, source_mode)
+end
+
+function find_cached_ci(interp::AbstractInterpreter, cache, mi::MethodInstance,
+                        valid_worlds::WorldRange, source_mode::UInt8)
+    code = get(cache, mi, nothing)
+    if (code isa CodeInstance &&
+            ci_worlds_cover(code, valid_worlds) &&
+            isdefined(code, :inferred, :acquire) &&
+            ci_meets_requirement(interp, code, source_mode))
+        return code
+    end
+    return nothing
+end
+
+function find_cached_ci(interp::AbstractInterpreter, cache::OverlayCodeCache,
+                        mi::MethodInstance, valid_worlds::WorldRange, source_mode::UInt8)
+    return find_cached_ci(interp, cache.globalcache, mi, valid_worlds, source_mode)
+end
+
+function find_cached_ci(interp::AbstractInterpreter, cache::InternalCodeCache,
+                        mi::MethodInstance, valid_worlds::WorldRange, source_mode::UInt8)
+    # `jl_rettype_inferred` returns the first inferred CI spanning the requested
+    # worlds, without considering whether it carries source or an ABI. Once a
+    # source-less CI is at the head of the native cache, repeatedly looking only at
+    # that entry would publish a new source-capable CI for every ABI/source request.
+    # Walk the native cache chain to find the first entry that satisfies the full
+    # request. Cache wrappers dispatch back to this implementation through their
+    # underlying global cache.
+    for code in CodeInstanceCacheIterator(ci_cache_head(mi))
+        if (ci_worlds_cover(code, valid_worlds) &&
+                code.owner === cache.owner &&
+                isdefined(code, :inferred, :acquire) &&
+                ci_meets_requirement(interp, code, source_mode))
+            return code
+        end
+    end
+    return nothing
+end
+
+function ci_is_equivalent_winner(candidate::CodeInstance, ci::CodeInstance,
+                                 valid_worlds::WorldRange)
+    return (candidate !== ci &&
+        ci_worlds_cover(candidate, valid_worlds) &&
+        candidate.def === ci.def &&
+        candidate.owner === ci.owner &&
+        isdefined(candidate, :inferred, :acquire) &&
+        isdefined(candidate, :rettype) &&
+        candidate.rettype === ci.rettype)
+end
+
+function find_equivalent_cached_ci(interp::AbstractInterpreter, cache,
+                                   ci::CodeInstance, valid_worlds::WorldRange)
+    candidate = get(cache, get_ci_mi(ci), nothing)
+    return (candidate isa CodeInstance &&
+        ci_is_equivalent_winner(candidate, ci, valid_worlds)) ? candidate : nothing
+end
+
+function find_equivalent_cached_ci(interp::AbstractInterpreter,
+                                   cache::OverlayCodeCache, ci::CodeInstance,
+                                   valid_worlds::WorldRange)
+    return find_equivalent_cached_ci(
+        interp, cache.globalcache, ci, valid_worlds)
+end
+
+function find_equivalent_cached_ci(::AbstractInterpreter,
+                                   ::InternalCodeCache, ci::CodeInstance,
+                                   valid_worlds::WorldRange)
+    mi = get_ci_mi(ci)
+    for candidate in CodeInstanceCacheIterator(ci_cache_head(mi))
+        ci_is_equivalent_winner(candidate, ci, valid_worlds) && return candidate
+    end
+    return nothing
+end
+
+function find_equivalent_cached_ci(interp::AbstractInterpreter, ci::CodeInstance,
+                                   valid_worlds::WorldRange)
+    cache = code_cache(interp, valid_worlds)
+    return find_equivalent_cached_ci(interp, cache, ci, valid_worlds)
+end
+
+function find_local_cached_ci(interp::AbstractInterpreter, mi::MethodInstance,
+                              valid_worlds::WorldRange, source_mode::UInt8)
+    cache = get_inference_cache(interp)
+    indices = get_indices(cache, mi)
+    world = get_inference_world(interp)
+    for i in length(indices):-1:1
+        cached = cache.results[indices[i]]
+        cached isa LocalInferenceResult || continue
+        result = cached.result
+        result.overridden_by_const === nothing || continue
+        result.cache_world == world || continue
+        world in proof_worlds(cached.proof) || continue
+        isdefined(result, :ci) || continue
+        code = result.ci
+        if (ci_worlds_cover(code, valid_worlds) &&
+                isdefined(code, :inferred, :acquire) &&
+                ci_meets_requirement(interp, code, source_mode))
+            return code
+        end
+    end
+    return nothing
+end
+
+function find_typeinf_cached_ci(interp::AbstractInterpreter, mi::MethodInstance,
+                                valid_worlds::WorldRange, source_mode::UInt8)
+    code = find_cached_ci(interp, mi, valid_worlds, source_mode)
+    code === nothing || return code
+    return find_local_cached_ci(interp, mi, valid_worlds, source_mode)
+end
+
 # compute (and cache) an inferred AST and return type
 function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance, source_mode::UInt8)
     start_time = ccall(:jl_typeinf_timing_begin, UInt64, ())
-    let code = get(code_cache(interp), mi, nothing)
-        code isa InferenceResult && (code = code.ci)
-        if code isa CodeInstance
-            # see if this code already exists in the cache
-            if ci_meets_requirement(interp, code, source_mode)
-                ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
-                return code
-            end
+    valid_worlds = WorldRange(get_inference_world(interp))
+    let code = find_typeinf_cached_ci(interp, mi, valid_worlds, source_mode)
+        if code !== nothing
+            ccall(:jl_typeinf_timing_end, Cvoid, (UInt64, Cint), start_time, 0)
+            return code
         end
     end
     def = mi.def
     ci = engine_reserve(interp, mi)
     # check cache again if it is still new after reserving in the engine
-    let code = get(code_cache(interp), mi, nothing)
-        code isa InferenceResult && (code = code.ci)
-        if code isa CodeInstance
-            # see if this code already exists in the cache
-            if ci_meets_requirement(interp, code, source_mode)
-                engine_reject(interp, ci)
-                ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
-                return code
-            end
+    let code = find_typeinf_cached_ci(interp, mi, valid_worlds, source_mode)
+        if code !== nothing
+            engine_reject(interp, ci)
+            ccall(:jl_typeinf_timing_end, Cvoid, (UInt64, Cint), start_time, 0)
+            return code
         end
     end
     if !InferenceParams(interp).force_enable_inference
@@ -1528,28 +1800,39 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance, source_mod
                 finish!(interp, mi, ci, src)
             else
                 engine_reject(interp, ci)
+                ccall(:jl_typeinf_timing_end, Cvoid, (UInt64, Cint), start_time, 0)
+                return nothing
             end
-            ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
+            ccall(:jl_typeinf_timing_end, Cvoid, (UInt64, Cint), start_time, 0)
             return ci
         end
     end
     result = InferenceResult(mi, typeinf_lattice(interp))
-    result.ci = result.ci_as_edge = ci
+    result.ci = ci
     frame = InferenceState(result, #=cache_mode=#:global, interp)
     if frame === nothing
         engine_reject(interp, ci)
-        ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
+        ccall(:jl_typeinf_timing_end, Cvoid, (UInt64, Cint), start_time, 0)
         return nothing
     end
     typeinf(interp, frame)
-    ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
+    ccall(:jl_typeinf_timing_end, Cvoid, (UInt64, Cint), start_time, 0)
 
-    ci = result.ci # reload from result in case it changed
+    publication_winner = result.replacement_ci
+    ci = if (publication_winner !== nothing &&
+             ci_meets_requirement(interp, publication_winner, source_mode))
+        publication_winner
+    else
+        result.ci
+    end
     codegen = codegen_cache(interp)
     @assert frame.cache_mode != CACHE_MODE_NULL
-    @assert is_result_constabi_eligible(result) || codegen === nothing || haskey(codegen, ci)
-    @assert is_result_constabi_eligible(result) == use_const_api(ci)
     @assert isdefined(ci, :inferred) "interpreter did not fulfill our expectations"
+    @assert codegen === nothing || ci_meets_requirement(interp, ci, source_mode)
+    if ci === result.ci
+        @assert is_result_constabi_eligible(result) || codegen === nothing || haskey(codegen, ci)
+        @assert is_result_constabi_eligible(result) == use_const_api(ci)
+    end
     return ci
 end
 
@@ -1751,15 +2034,16 @@ function add_codeinsts_to_jit!(interp::AbstractInterpreter, ci, source_mode::UIn
         sptypes = sptypes_from_meth_instance(mi)
         collectinvokes!(workqueue, src, sptypes)
         if iszero(ccall(:jl_mi_cache_has_ci, Cint, (Any, Any), mi, callee))
-            let cached = ccall(:jl_get_ci_equiv, Any, (Any, UInt), callee, 0x0)::CodeInstance
-                if cached === callee
-                    # make sure callee is gc-rooted and cached, as required by jl_add_codeinsts_to_jit
-                    code_cache(workqueue.interp)[mi] = callee
-                else
-                    # use an existing CI from the cache, if there is available one that is compatible
-                    callee === ci && (ci = cached)
-                    callee = cached
-                end
+            valid_worlds = WorldRange(get_inference_world(workqueue.interp))
+            cached = find_equivalent_cached_ci(
+                workqueue.interp, callee, valid_worlds)
+            if cached === nothing
+                # make sure callee is gc-rooted and cached, as required by jl_add_codeinsts_to_jit
+                code_cache(workqueue.interp)[mi] = callee
+            else
+                # use an existing CI from the cache, if there is available one that is compatible
+                callee === ci && (ci = cached)
+                callee = cached
             end
         end
         push!(codeinsts, callee)
@@ -1848,13 +2132,13 @@ function compile!(codeinfos::Vector{Any}, workqueue::CompilationQueue;
                                 enqueue_unprepared_invokes)
                 # try to reuse an existing CodeInstance from before to avoid making duplicates in the cache
                 if iszero(ccall(:jl_mi_cache_has_ci, Cint, (Any, Any), mi, callee))
-                    let cached = ccall(:jl_get_ci_equiv, Any, (Any, UInt), callee, 0x0)::CodeInstance
-                        if cached === callee
-                            code_cache(interp)[mi] = callee
-                        else
-                            # Use an existing CI from the cache, if there is available one that is compatible
-                            callee = cached
-                        end
+                    cached = find_equivalent_cached_ci(
+                        interp, callee, WorldRange(world))
+                    if cached === nothing
+                        code_cache(interp)[mi] = callee
+                    else
+                        # Use an existing CI from the cache, if there is available one that is compatible
+                        callee = cached
                     end
                 end
                 push!(codeinfos, callee)

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -99,8 +99,7 @@ struct AnalysisResults
 end
 const NULL_ANALYSIS_RESULTS = AnalysisResults(nothing)
 
-# Abstract type for call inference results that can be stored in CallInfo
-# This is defined here so that InferenceResult can inherit from it
+# Abstract type for completed call inference results that can be stored in CallInfo
 abstract type InferredCallResult end
 
 """
@@ -113,7 +112,7 @@ There are two constructor available:
 - `InferenceResult(mi::MethodInstance, argtypes::Vector{Any}, overridden_by_const::BitVector)`
   for constant inference, with extended lattice information included in `result.argtypes`.
 """
-mutable struct InferenceResult <: InferredCallResult
+mutable struct InferenceResult
     #=== constant fields ===#
     const linfo::MethodInstance
     const argtypes::Vector{Any}
@@ -127,20 +126,92 @@ mutable struct InferenceResult <: InferredCallResult
     ipo_effects::Effects              # if inference is finished
     effects::Effects                  # if optimization is finished
     analysis_results::AnalysisResults # AnalysisResults with e.g. result::ArgEscapeCache if optimized, otherwise NULL_ANALYSIS_RESULTS
+    cache_world::UInt                 # exact inference world for session-local reuse, or zero
     tombstone::Bool
+    replacement_ci::Union{Nothing,CodeInstance} # global publication winner selected before optimizer exposure
 
     #=== uninitialized fields ===#
     ci::CodeInstance                  # CodeInstance that will contain the result in full
-    ci_as_edge::CodeInstance          # CodeInstance, that is preferred just for use when representing the result as the edge
     function InferenceResult(mi::MethodInstance, argtypes::Vector{Any}, overridden_by_const::Union{Nothing,BitVector})
         result = exc_result = src = nothing
         valid_worlds = WorldRange()
         ipo_effects = effects = Effects()
         analysis_results = NULL_ANALYSIS_RESULTS
         return new(mi, argtypes, overridden_by_const, result, exc_result, src,
-            valid_worlds, ipo_effects, effects, analysis_results, false)
+            valid_worlds, ipo_effects, effects, analysis_results, zero(UInt),
+            false, nothing)
     end
 end
+
+"""
+    LocalInferenceProof
+
+A dependency certificate for inference work that is not represented by a published
+[`CodeInstance`](@ref). `edges` is an internal forward-edge stream whose entries may
+include other `LocalInferenceProof`s. Keeping those references as a shared graph avoids
+repeatedly copying the transitive dependency closure; the graph is flattened only when a
+result is published as a `CodeInstance`. The type is mutable only to give each proof a
+stable identity; both fields are immutable.
+"""
+mutable struct LocalInferenceProof
+    const valid_worlds::WorldRange
+    const edges::SimpleVector
+    function LocalInferenceProof(valid_worlds::WorldRange, edges::SimpleVector)
+        # Local proofs are not registered with the global invalidation machinery.
+        # Inference states cap their range at the current world counter, and exact-world
+        # local-cache reuse relies on that cap to keep an unregistered proof from
+        # claiming validity in a future world.
+        @assert first(valid_worlds) <= last(valid_worlds) <= get_world_counter()
+        for edge in edges
+            edge_worlds = if edge isa LocalInferenceProof
+                edge.valid_worlds
+            elseif edge isa CodeInstance && edge.min_world <= edge.max_world
+                # Skip a provisional CI (`min_world > max_world`); an SCC fills it
+                # before any proof containing it can escape.
+                WorldRange(edge.min_world, edge.max_world)
+            else
+                continue
+            end
+            @assert (first(edge_worlds) <= first(valid_worlds) &&
+                last(valid_worlds) <= last(edge_worlds))
+        end
+        return new(valid_worlds, edges)
+    end
+end
+
+const InferenceProof = Union{CodeInstance,LocalInferenceProof}
+
+proof_worlds(proof::CodeInstance) = WorldRange(proof.min_world, proof.max_world)
+proof_worlds(proof::LocalInferenceProof) = proof.valid_worlds
+
+"""
+    LocalInferenceResult
+
+The completed, reusable view of an [`InferenceResult`](@ref). `result` owns the inferred
+source and facts, while `proof` certifies them. The executable edge for a particular call
+is deliberately stored separately in its `CallInfo`.
+"""
+struct LocalInferenceResult <: InferredCallResult
+    result::InferenceResult
+    proof::InferenceProof
+    function LocalInferenceResult(result::InferenceResult, proof::InferenceProof, world::UInt)
+        @assert result.result !== nothing "cannot complete an unfinished InferenceResult"
+        @assert !result.tombstone "cannot complete a tombstoned InferenceResult"
+        @assert world in proof_worlds(proof) "inference proof does not cover its cache world"
+        @assert iszero(result.cache_world) || result.cache_world == world
+        result.cache_world = world
+        if proof isa CodeInstance
+            @assert proof.def === result.linfo "CodeInstance proof does not match InferenceResult"
+        else
+            @assert first(proof.valid_worlds) <= last(proof.valid_worlds)
+        end
+        return new(result, proof)
+    end
+end
+
+inference_proof(result::LocalInferenceResult) = result.proof
+
+const InferenceCacheEntry = Union{InferenceResult,LocalInferenceResult}
 function InferenceResult(mi::MethodInstance, 𝕃::AbstractLattice=fallback_lattice)
     argtypes = matching_cache_argtypes(𝕃, mi)
     return InferenceResult(mi, argtypes, #=overridden_by_const=#nothing)
@@ -164,19 +235,26 @@ end
 """
     InferenceCache
 
-A cache for `InferenceResult` objects that maintains an index for fast lookups by `MethodInstance`.
-This is used as the local inference cache for `AbstractInterpreter` implementations.
+A cache for local inference work that maintains an index for fast lookups by
+`MethodInstance`. Successful entries are stored as [`LocalInferenceResult`](@ref), while
+raw `InferenceResult` entries are retained only as internal unresolved-cycle or tombstone
+markers for constant propagation. Entries are reused only at their exact `cache_world`;
+their static world range is not itself registered for invalidation while they remain local.
 """
 struct InferenceCache
-    results::Vector{InferenceResult}
+    results::Vector{InferenceCacheEntry}
     # Index from MethodInstance to indices in `results` where linfo === mi
     index::IdDict{MethodInstance, Vector{Int}}
 end
 
-InferenceCache() = InferenceCache(Vector{InferenceResult}(), IdDict{MethodInstance, Vector{Int}}())
+InferenceCache() = InferenceCache(Vector{InferenceCacheEntry}(), IdDict{MethodInstance, Vector{Int}}())
 
-function Base.push!(cache::InferenceCache, result::InferenceResult)
-    push!(cache.results, result)
+function Base.push!(cache::InferenceCache, entry::InferenceCacheEntry)
+    if entry isa InferenceResult
+        @assert (entry.result === nothing || entry.tombstone) "completed InferenceResult must be wrapped before caching"
+    end
+    push!(cache.results, entry)
+    result = entry isa LocalInferenceResult ? entry.result : entry
     mi = result.linfo
     idx = length(cache.results)
     if haskey(cache.index, mi)
@@ -192,7 +270,7 @@ Base.isempty(cache::InferenceCache) = isempty(cache.results)
 
 Base.iterate(cache::InferenceCache) = iterate(cache.results)
 Base.iterate(cache::InferenceCache, state) = iterate(cache.results, state)
-Base.eltype(::Type{InferenceCache}) = InferenceResult
+Base.eltype(::Type{InferenceCache}) = InferenceCacheEntry
 Base.getindex(cache::InferenceCache, i::Int) = cache.results[i]
 
 # Get indices for a specific MethodInstance (returns empty vector if not found)
@@ -572,48 +650,52 @@ typeinf_lattice(::AbstractInterpreter) = InferenceLattice(BaseInferenceLattice.i
 ipo_lattice(::AbstractInterpreter) = InferenceLattice(IPOResultLattice.instance)
 optimizer_lattice(::AbstractInterpreter) = SimpleInferenceLattice.instance
 
+"""
+    OverlayCodeCache(globalcache, localcache)
+
+Compatibility wrapper for custom interpreters that keep an executable cache and an
+inference cache together. Executable lookup delegates exclusively to `globalcache`;
+completed local inference results are accessed through `get_inference_cache` instead.
+"""
 struct OverlayCodeCache{Cache}
     globalcache::Cache
     localcache::InferenceCache
 end
 
-setindex!(cache::OverlayCodeCache, ci::CodeInstance, mi::MethodInstance) = (setindex!(cache.globalcache, ci, mi); cache)
-
-haskey(cache::OverlayCodeCache, mi::MethodInstance) = get(cache, mi, nothing) !== nothing
-
-function get(cache::OverlayCodeCache, mi::MethodInstance, default)
-    localcache = cache.localcache
-    indices = get_indices(localcache, mi)
-    # Iterate in reverse to get the most recent matching entry
-    for i in length(indices):-1:1
-        cached_result = localcache.results[indices[i]]
-        cached_result.tombstone && continue # ignore deleted entries (due to LimitedAccuracy)
-        cached_result.overridden_by_const === nothing || continue
-        isdefined(cached_result, :ci) || continue
-        ci = cached_result.ci
-        isdefined(ci, :inferred) || continue
-        return cached_result
-    end
-    return get(cache.globalcache, mi, default)
+function setindex!(cache::OverlayCodeCache, ci::CodeInstance, mi::MethodInstance)
+    setindex!(cache.globalcache, ci, mi)
+    return cache
 end
-
-function getindex(cache::OverlayCodeCache, mi::MethodInstance)
-    r = get(cache, mi, nothing)
-    r === nothing && throw(KeyError(mi))
-    return r
-end
+haskey(cache::OverlayCodeCache, mi::MethodInstance) = haskey(cache.globalcache, mi)
+get(cache::OverlayCodeCache, mi::MethodInstance, default) =
+    get(cache.globalcache, mi, default)
+getindex(cache::OverlayCodeCache, mi::MethodInstance) = getindex(cache.globalcache, mi)
 
 code_cache(interp::AbstractInterpreter, #=extended_range=#::WorldRange) = code_cache(interp)
 
 function code_cache(interp::AbstractInterpreter)
-    cache = InternalCodeCache(cache_owner(interp), get_inference_world(interp))
-    return OverlayCodeCache(cache, get_inference_cache(interp))
+    return InternalCodeCache(cache_owner(interp), get_inference_world(interp))
 end
 
 function code_cache(interp::NativeInterpreter, extended_range::WorldRange)
     @assert get_inference_world(interp) in extended_range
-    cache = InternalCodeCache(cache_owner(interp), extended_range)
-    return OverlayCodeCache(cache, get_inference_cache(interp))
+    return InternalCodeCache(cache_owner(interp), extended_range)
+end
+
+function lookup_local_inference_result(interp::AbstractInterpreter, mi::MethodInstance)
+    cache = get_inference_cache(interp)
+    indices = get_indices(cache, mi)
+    world = get_inference_world(interp)
+    for i in length(indices):-1:1
+        cached = cache.results[indices[i]]
+        cached isa LocalInferenceResult || continue
+        result = cached.result
+        result.overridden_by_const === nothing || continue
+        result.cache_world == world || continue
+        world in proof_worlds(cached.proof) || continue
+        return cached
+    end
+    return nothing
 end
 
 get_escape_cache(interp::AbstractInterpreter) = GetNativeEscapeCache(interp)
@@ -631,7 +713,8 @@ function add_edges!(edges::Vector{Any}, info::CallInfo)
 end
 nsplit(info::CallInfo) = nsplit_impl(info)::Union{Nothing,Int}
 getsplit(info::CallInfo, idx::Int) = getsplit_impl(info, idx)::MethodLookupResult
-getresult(info::CallInfo, idx::Int) = getresult_impl(info, idx)#=::Union{Nothing,InferenceResult}=#
+getresult(info::CallInfo, idx::Int) = getresult_impl(info, idx)#=::Union{Nothing,InferredCallResult}=#
+getedge(info::CallInfo, idx::Int) = getedge_impl(info, idx)::Union{Nothing,CodeInstance}
 
 add_edges_impl(::Vector{Any}, ::CallInfo) = error("""
     All `CallInfo` is required to implement `add_edges_impl(::Vector{Any}, ::CallInfo)`""")
@@ -640,5 +723,6 @@ getsplit_impl(::CallInfo, ::Int) = error("""
     A `info::CallInfo` that implements `nsplit_impl(info::CallInfo)::Int` must implement `getsplit_impl(info::CallInfo, idx::Int)::MethodLookupResult`
     in order to correctly opt in to inlining""")
 getresult_impl(::CallInfo, ::Int) = nothing
+getedge_impl(::CallInfo, ::Int) = nothing
 
 @specialize

--- a/Compiler/test/AbstractInterpreter.jl
+++ b/Compiler/test/AbstractInterpreter.jl
@@ -575,16 +575,130 @@ let interp = InvokeInterp()
     @test contains(result, "[1] error(::Char, ::Char, ::Char, ::Char)")
 end
 
-# Test that is_already_cached handles OverlayCodeCache returning InferenceResult.
-# Regression test: OverlayCodeCache.getindex may return InferenceResult (from the
-# local inference cache) rather than CodeInstance, which lacks an :inferred field.
+# Global publication and per-interpreter source/ABI capability are selected separately,
+# including when a winner appears while inference is running.
+@newinterp SourceModeWinnerInterp
+global source_mode_codegen::IdDict{CodeInstance,CodeInfo} = IdDict{CodeInstance,CodeInfo}()
+Compiler.codegen_cache(::SourceModeWinnerInterp) = source_mode_codegen
+
+source_mode_inadequate_winner(x::Int) = x + 1
+let interp = SourceModeWinnerInterp()
+    mi = Base.method_instance(source_mode_inadequate_winner, (Int,))
+    inadequate = Core.CodeInstance(mi, Compiler.cache_owner(interp), Int, Any,
+        nothing, nothing, zero(Int32), UInt(1), typemax(UInt), zero(UInt32),
+        nothing, nothing, Core.svec())
+    Compiler.code_cache(interp)[mi] = inadequate
+    @test !Compiler.ci_has_source(interp, inadequate)
+
+    ci = Compiler.typeinf_ext(interp, mi, Compiler.SOURCE_MODE_ABI)
+    @test ci !== inadequate
+    @test Compiler.ci_has_source(interp, ci)
+    @test iszero(@ccall jl_mi_cache_has_ci(mi::Any, ci::Any)::Cint)
+    # The capability-blind global winner remains unique. The source-capable result
+    # is session-local and can be reused by this interpreter without allowing it to
+    # escape into the global executable cache.
+    @test get(Compiler.code_cache(interp), mi, nothing) === inadequate
+    @test Compiler.typeinf_ext(interp, mi, Compiler.SOURCE_MODE_ABI) === ci
+    overlay = Compiler.OverlayCodeCache(
+        Compiler.code_cache(interp), Compiler.InferenceCache())
+    valid_worlds = Compiler.WorldRange(interp.world)
+    @test Compiler.find_cached_ci(interp, overlay, mi,
+        valid_worlds, Compiler.SOURCE_MODE_ABI) === nothing
+    @test Compiler.find_local_cached_ci(interp, mi,
+        valid_worlds, Compiler.SOURCE_MODE_ABI) === ci
+
+    # JIT compilation uses the local source to compile the ABI-equivalent global
+    # winner; the local CI itself remains outside the executable cache.
+    @test Compiler.typeinf_ext_toplevel(
+        interp, mi, Compiler.SOURCE_MODE_ABI) === inadequate
+    @test Compiler.ci_has_invoke(inadequate)
+    @test iszero(@ccall jl_mi_cache_has_ci(mi::Any, ci::Any)::Cint)
+end
+
+# A source-inadequate winner with a different return ABI cannot suppress normal
+# publication. The completed CI is globally inserted and promoted before JIT use.
+source_mode_nonequivalent_winner(x::Int) = x + 1
+let interp = SourceModeWinnerInterp()
+    mi = Base.method_instance(source_mode_nonequivalent_winner, (Int,))
+    inadequate = Core.CodeInstance(mi, Compiler.cache_owner(interp), Any, Any,
+        nothing, nothing, zero(Int32), UInt(1), typemax(UInt), zero(UInt32),
+        nothing, nothing, Core.svec())
+    Compiler.code_cache(interp)[mi] = inadequate
+
+    ci = Compiler.typeinf_ext_toplevel(interp, mi, Compiler.SOURCE_MODE_ABI)
+    @test ci !== inadequate
+    @test ci.rettype === Int
+    @test !iszero(@ccall jl_mi_cache_has_ci(mi::Any, ci::Any)::Cint)
+    @test ci.max_world == typemax(UInt)
+
+    @eval source_mode_world_bump_62338() = nothing
+    newer = SourceModeWinnerInterp(; world=Base.get_world_counter())
+    @test Compiler.typeinf_ext_toplevel(
+        newer, mi, Compiler.SOURCE_MODE_ABI) === ci
+end
+
+# Equivalent-winner selection also goes through the cache abstraction rather than
+# assuming that every executable cache is the native MethodInstance chain.
+@newinterp SourceModeEphemeralInterp true
+global source_mode_ephemeral_codegen::IdDict{CodeInstance,CodeInfo} =
+    IdDict{CodeInstance,CodeInfo}()
+Compiler.codegen_cache(::SourceModeEphemeralInterp) = source_mode_ephemeral_codegen
+source_mode_ephemeral_winner(x::Int) = x + 1
+let interp = SourceModeEphemeralInterp()
+    mi = Base.method_instance(source_mode_ephemeral_winner, (Int,))
+    winner = Core.CodeInstance(mi, Compiler.cache_owner(interp), Int, Any,
+        nothing, nothing, zero(Int32), UInt(1), typemax(UInt), zero(UInt32),
+        nothing, nothing, Core.svec())
+    Compiler.code_cache(interp)[mi] = winner
+
+    @test Compiler.typeinf_ext_toplevel(
+        interp, mi, Compiler.SOURCE_MODE_ABI) === winner
+    @test Compiler.code_cache(interp)[mi] === winner
+    @test Compiler.ci_has_invoke(winner)
+    empty!(source_mode_ephemeral_codegen)
+end
+
+const source_mode_interp_ref = Ref{Any}()
+const source_mode_winner_ref = Ref{Any}()
+@generated function source_mode_publish_winner()
+    interp = source_mode_interp_ref[]::SourceModeWinnerInterp
+    winner = source_mode_winner_ref[]::Core.CodeInstance
+    Compiler.code_cache(interp)[winner.def] = winner
+    return :(nothing)
+end
+source_mode_qualifying_winner(x::Int) = (source_mode_publish_winner(); x + 1)
+let interp = SourceModeWinnerInterp()
+    mi = Base.method_instance(source_mode_qualifying_winner, (Int,))
+    winner = Core.CodeInstance(mi, Compiler.cache_owner(interp), Int, Any,
+        nothing, nothing, zero(Int32), UInt(1), typemax(UInt), zero(UInt32),
+        nothing, nothing, Core.svec())
+    source_mode_codegen[winner] = Compiler.retrieve_code_info(mi, interp.world)
+    source_mode_interp_ref[] = interp
+    source_mode_winner_ref[] = winner
+
+    ci = Compiler.typeinf_ext(interp, mi, Compiler.SOURCE_MODE_ABI)
+    @test ci === winner
+    local_results = [
+        entry for entry in Compiler.get_inference_cache(interp).results
+        if entry isa Compiler.LocalInferenceResult && entry.result.linfo === mi
+    ]
+    @test length(local_results) == 1
+    local_result = only(local_results)
+    @test local_result.result.replacement_ci === winner
+    @test iszero(@ccall jl_mi_cache_has_ci(mi::Any, local_result.result.ci::Any)::Cint)
+    source_mode_interp_ref[] = nothing
+    source_mode_winner_ref[] = nothing
+    empty!(source_mode_codegen)
+end
+
+# The executable cache for a custom interpreter remains CodeInstance-only even when
+# inference also retains completed local source/proof entries.
 using REPL.REPLCompletions: completions
 @newinterp OverlayCacheInterp true
 @test let
     interp = OverlayCacheInterp()
-    # completions has a call graph deep enough that during inference the same
-    # MethodInstance is encountered through different callers, exercising the
-    # OverlayCodeCache local-cache path in is_already_cached.
+    # `completions` has a call graph deep enough to exercise repeated global and local
+    # cache lookups for the same MethodInstances.
     f = completions
     args = ("", 0)
     mi = @ccall jl_method_lookup(Any[f, args...]::Ptr{Any}, (1+length(args))::Csize_t,

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -27,6 +27,622 @@ end
 @test Compiler.limit_type_size(Ref{Complex{T} where T}, Ref, Ref, 100, 0) == Ref
 @test Compiler.limit_type_size(Ref{Complex{T} where T}, Ref{Complex{T} where T}, Ref, 100, 0) == Ref{Complex{T} where T}
 
+# Local-cache entries contain reusable source plus a proof, while executable targets
+# remain exclusively in the global CodeInstance cache.
+local_wrapper62338(x::Int) = x + 1
+let
+    precompile(local_wrapper62338, (Int,))
+    interp = Compiler.NativeInterpreter(Base.get_world_counter())
+    mi = Base.method_instance(local_wrapper62338, (Int,))
+    ci = get(Compiler.code_cache(interp), mi, nothing)
+    @test ci isa Core.CodeInstance
+
+    pending = Compiler.InferenceResult(mi, Compiler.typeinf_lattice(interp))
+    pending.ci = ci
+    push!(Compiler.get_inference_cache(interp), pending)
+    @test get(Compiler.code_cache(interp), mi, nothing) === ci
+
+    artifact = Compiler.InferenceResult(mi, Compiler.typeinf_lattice(interp))
+    artifact.result = Int
+    artifact.exc_result = Any
+    artifact.src = Compiler.retrieve_code_info(mi, Base.get_world_counter())
+    artifact.ci = ci
+    artifact.valid_worlds = Compiler.WorldRange(ci.min_world, Base.get_world_counter())
+    proof = Compiler.LocalInferenceProof(artifact.valid_worlds, Core.svec())
+    local_result = Compiler.LocalInferenceResult(artifact, proof, Base.get_world_counter())
+    push!(Compiler.get_inference_cache(interp), local_result)
+    got = Compiler.lookup_local_inference_result(interp, mi)
+    @test got === local_result
+    @test got.proof === proof
+    @test got.result.ci === ci
+    @test get(Compiler.code_cache(interp), mi, nothing) === ci
+    @test last(collect(Compiler.get_inference_cache(interp))) === local_result
+    cache = Compiler.get_inference_cache(interp)
+    @test cache[length(cache)] === local_result
+    @test eltype(Compiler.get_inference_cache(interp)) === Compiler.InferenceCacheEntry
+    @test_throws AssertionError push!(Compiler.get_inference_cache(interp), artifact)
+end
+
+# A nested inference session can publish a global CI while an outer SCC member is still
+# in progress. No provisional CI that is later kept local may escape into a published
+# caller, and every exact CI used by a published SCC edge must itself be published.
+wrapper62338_bump() = 0
+wrapper62338_a(x::Int) = x <= 0 ? wrapper62338_bump() : wrapper62338_req(x - 1)
+wrapper62338_req(x::Int) = x <= 0 ? 1 : wrapper62338_v(x - 1) + 1
+wrapper62338_v(x::Int) = x <= 0 ? 2 : wrapper62338_w(x - 1) + 2
+wrapper62338_trigger(x::Int) = wrapper62338_v(x)
+@generated function wrapper62338_gencache(x)
+    precompile(wrapper62338_trigger, (Int,))
+    return :(x)
+end
+wrapper62338_w(x::Int) = x <= 0 ? 3 : (r = wrapper62338_a(x - 1); wrapper62338_gencache(x); r + 3)
+wrapper62338_root(x::Int) = wrapper62338_a(x) + wrapper62338_v(x)
+wrapper62338_bump() = 1
+let interp = Compiler.NativeInterpreter(Base.get_world_counter())
+    @test code_typed(wrapper62338_root, (Int,); interp) isa Vector
+    cycle_methods = (which(wrapper62338_a, (Int,)), which(wrapper62338_req, (Int,)),
+        which(wrapper62338_v, (Int,)), which(wrapper62338_w, (Int,)))
+    cache_entries = Compiler.get_inference_cache(interp).results
+    local_cycle_entries = [
+        entry for entry in cache_entries
+        if entry isa Compiler.LocalInferenceResult && entry.result.linfo.def in cycle_methods
+    ]
+    local_cycle_results = map(entry -> entry.result, local_cycle_entries)
+    @test !isempty(local_cycle_results)
+    @test any(result -> result.replacement_ci !== nothing, local_cycle_results)
+    @test all(result -> result.replacement_ci === nothing ||
+                        isdefined(result.replacement_ci, :inferred), local_cycle_results)
+
+    published = Core.CodeInstance[]
+    for f in (wrapper62338_a, wrapper62338_req, wrapper62338_v, wrapper62338_w,
+              wrapper62338_root)
+        mi = Base.method_instance(f, (Int,))
+        ci = get(Compiler.code_cache(interp), mi, nothing)
+        if ci isa Core.CodeInstance
+            push!(published, ci)
+        end
+        live_cis = Core.CodeInstance[]
+        if isdefined(mi, :cache)
+            cached_ci = mi.cache
+            while cached_ci isa Core.CodeInstance
+                if cached_ci.owner === Compiler.cache_owner(interp) &&
+                        cached_ci.min_world <= interp.world <= cached_ci.max_world
+                    push!(live_cis, cached_ci)
+                end
+                isdefined(cached_ci, :next) || break
+                cached_ci = cached_ci.next
+            end
+        end
+        @test length(live_cis) <= 1
+    end
+    @test !isempty(published)
+    bump_method = which(wrapper62338_bump, ())
+    @test all(local_cycle_entries) do entry
+        edges = Compiler.materialize_inference_edges(entry.proof.edges)
+        any(edges) do edge
+            edge === bump_method ||
+                (edge isa Core.MethodInstance && edge.def === bump_method) ||
+                (edge isa Core.CodeInstance && edge.def.def === bump_method)
+        end
+    end
+    for caller in published, edge in caller.edges
+        if edge isa Core.CodeInstance
+            @test !iszero(ccall(:jl_mi_cache_has_ci, Cint, (Any, Any), edge.def, edge))
+        end
+    end
+    for result in local_cycle_results
+        isdefined(result, :ci) || continue
+        if iszero(ccall(:jl_mi_cache_has_ci, Cint, (Any, Any), result.linfo, result.ci))
+            @test all(caller -> all(edge -> edge !== result.ci, caller.edges), published)
+        end
+    end
+end
+
+# A limited source may still return clean facts. Its scheduled consumer must retain the
+# dependency proof even though the tombstoned source itself is not reusable.
+module LimitedSrcTombstoneProof62338
+    const FLAG = true
+    callee() = FLAG ? 1 : 2
+    bystander() = 3
+    entry() = 1
+end
+
+# A deferred mutual-SCC edge may consume provisional facts even when the original
+# recursion heuristic did not mark the call as an edge cycle. Preserve that as an
+# independent invalidation requirement.
+let
+    interp = Compiler.NativeInterpreter(Base.get_world_counter())
+    outer_mi = Base.method_instance(LimitedSrcTombstoneProof62338.entry, ())
+    outer_result = Compiler.InferenceResult(outer_mi, Compiler.typeinf_lattice(interp))
+    outer = Compiler.InferenceState(outer_result, Compiler.CACHE_MODE_LOCAL, interp)
+
+    child_mi = Base.method_instance(LimitedSrcTombstoneProof62338.callee, ())
+    child_result = Compiler.InferenceResult(child_mi, Compiler.typeinf_lattice(interp))
+    child = Compiler.InferenceState(child_result, Compiler.CACHE_MODE_LOCAL, interp)
+    Compiler.assign_parentchild!(child, outer)
+
+    mresult = Compiler._schedule_edge_infer_task!(
+        outer, child, child.result, child_mi.def, nothing, false, false)
+    @test Compiler.doworkloop(interp, outer)
+    @test isready(mresult)
+    scheduled = mresult[]
+    @test !scheduled.edgecycle
+    @test scheduled.needs_mi_edge
+end
+
+let
+    world = Base.get_world_counter()
+    inf_params = Compiler.InferenceParams(; cache_owner=LimitedSrcTombstoneProof62338)
+    interp = Compiler.NativeInterpreter(world; inf_params)
+    binding = convert(Core.Binding, GlobalRef(LimitedSrcTombstoneProof62338, :FLAG))
+
+    outer_mi = Base.method_instance(LimitedSrcTombstoneProof62338.entry, ())
+    outer_result = Compiler.InferenceResult(outer_mi, Compiler.typeinf_lattice(interp))
+    outer_result.ci = Compiler.engine_reserve(interp, outer_mi)
+    outer = Compiler.InferenceState(outer_result, Compiler.CACHE_MODE_GLOBAL, interp)
+
+    child_mi = Base.method_instance(LimitedSrcTombstoneProof62338.callee, ())
+    child_result = Compiler.InferenceResult(child_mi, Compiler.typeinf_lattice(interp))
+    child = Compiler.InferenceState(child_result, Compiler.CACHE_MODE_LOCAL, interp)
+    Compiler.assign_parentchild!(child, outer)
+
+    bystander_mi = Base.method_instance(LimitedSrcTombstoneProof62338.bystander, ())
+    bystander_result = Compiler.InferenceResult(
+        bystander_mi, Compiler.typeinf_lattice(interp))
+    bystander = Compiler.InferenceState(
+        bystander_result, Compiler.CACHE_MODE_GLOBAL, interp)
+    Compiler.assign_parentchild!(bystander, child)
+
+    # Model a clean return with a limited intermediate statement, then finalize it
+    # through the ordinary tombstone path.
+    empty!(child.ip)
+    fill!(child.ssavaluetypes, Any)
+    causes = Compiler.IdSet{Compiler.InferenceState}()
+    push!(causes, outer)
+    child.ssavaluetypes[1] = Compiler.LimitedAccuracy(Int, causes)
+    child.bestguess = Core.Const(1)
+    child.exc_bestguess = Union{}
+    child.ipo_effects = Compiler.EFFECTS_TOTAL
+    push!(child.edges, binding)
+    Compiler.finishinfer!(child, interp, child.cycleid,
+        IdDict{Core.MethodInstance,Core.CodeInstance}())
+
+    @test child.result.tombstone
+    @test child.ssavaluetypes[1] isa Compiler.LimitedAccuracy
+    @test child.result.result === Core.Const(1)
+    @test child.result.src === nothing
+
+    # Model the direct, already-in-progress SCC edge. Unlike the deferred task
+    # below, this path consumed the child's clean facts before its tombstone was
+    # known and therefore needs proof propagation when the SCC is finalized.
+    Compiler.add_cycle_backedge!(outer, child)
+    cycle_worlds = child.valid_worlds
+    Compiler.propagate_unpublished_cycle_proof!(
+        child.callstack, 2, world, cycle_worlds)
+    cycle_proofs = filter(edge -> edge isa Compiler.LocalInferenceProof, outer.edges)
+    @test length(cycle_proofs) == 1
+    @test any(edge -> edge === binding,
+        Compiler.materialize_inference_edges(only(cycle_proofs).edges))
+    @test !any(edge -> edge isa Compiler.LocalInferenceProof, bystander.edges)
+
+    resize!(outer.callstack, 1)
+    mresult = Compiler._schedule_edge_infer_task!(
+        outer, child, child.result, child_mi.def, nothing, false, false)
+
+    @test Compiler.typeinf(interp, outer)
+    @test isready(mresult)
+    @test mresult[].needs_mi_edge
+    ci = outer.result.ci
+    @test get(Compiler.code_cache(interp), outer_mi, nothing) === ci
+    @test ci.rettype_const === 1
+    @test any(edge -> edge === binding, ci.edges)
+end
+
+# Local constant inference keeps its dependency proof separate from the executable target.
+module LocalProofConstpropCache
+    const SINK = Ref{Any}()
+    const VALUE = "v1"
+
+    @noinline Base.@constprop :aggressive function readglobal(M::Module, s::Symbol)
+        SINK[] = s
+        return getglobal(M, s)
+    end
+
+    probe_twice() = (
+        readglobal(LocalProofConstpropCache, :VALUE)::String,
+        readglobal(LocalProofConstpropCache, :VALUE)::String,
+    )
+    probe_once() = readglobal(LocalProofConstpropCache, :VALUE)::String
+end
+
+let interp = Compiler.NativeInterpreter(Base.get_world_counter())
+    mi = Base.method_instance(LocalProofConstpropCache.probe_twice, ())
+    frame = Compiler.typeinf_frame(interp, mi, false)
+    infos = [info for info in frame.stmt_info if info isa Compiler.MethodMatchInfo]
+    @test length(infos) == 2
+
+    results = [only(info.call_results) for info in infos]
+    targets = [only(info.edges) for info in infos]
+    callee_mi = Base.method_instance(LocalProofConstpropCache.readglobal, (Module, Symbol))
+    cache_entries = Compiler.get_inference_cache(interp).results
+    cached = [
+        entry for entry in cache_entries
+        if entry isa Compiler.LocalInferenceResult &&
+           entry.result.linfo === callee_mi &&
+           entry.result.overridden_by_const !== nothing
+    ]
+    @test length(cached) == 1
+    @test cached[1] === results[1] === results[2]
+    @test targets[1] === targets[2]
+    @test targets[1] === get(Compiler.code_cache(interp), callee_mi, nothing)
+    @test all(i -> Compiler.getedge(infos[i], 1) === targets[i], eachindex(infos))
+
+    proofs = map(Compiler.inference_proof, results)
+    binding = convert(Core.Binding, GlobalRef(LocalProofConstpropCache, :VALUE))
+    @test all(proof -> proof isa Compiler.LocalInferenceProof, proofs)
+    @test all(proofs) do proof
+        edges = Compiler.materialize_inference_edges(proof.edges)
+        any(edge -> edge === binding, edges)
+    end
+    callee_edges = [
+        edge for edge in frame.edges
+        if edge isa Core.CodeInstance && edge.def === callee_mi
+    ]
+    @test only(callee_edges) === targets[1]
+end
+
+let interp = Compiler.NativeInterpreter(Base.get_world_counter())
+    callee_mi = Base.method_instance(LocalProofConstpropCache.readglobal, (Module, Symbol))
+    caller_mi = Base.method_instance(LocalProofConstpropCache.probe_once, ())
+    frame = Compiler.typeinf_frame(interp, caller_mi, true)
+    src = frame.src
+    invokes = [stmt for stmt in src.code if stmt isa Expr && stmt.head === :invoke]
+    @test length(invokes) == 1
+    target = only(invokes).args[1]
+    @test target === get(Compiler.code_cache(interp), callee_mi, nothing)
+
+    binding = convert(Core.Binding, GlobalRef(LocalProofConstpropCache, :VALUE))
+    @test any(edge -> edge === binding, src.edges)
+    callee_edges = [
+        edge for edge in src.edges
+        if edge isa Core.CodeInstance && edge.def === callee_mi
+    ]
+    @test only(callee_edges) === target
+end
+
+stmtinfo_edge_target(x::Int) = x
+function stmtinfo_codeinstance(mi::Core.MethodInstance, owner,
+                               edges::Core.SimpleVector=Core.svec())
+    return Core.CodeInstance(mi, owner, Any, Any, nothing, nothing, zero(Int32),
+        typemin(UInt), typemax(UInt), zero(UInt32), nothing, nothing, edges)
+end
+
+@testset "inference proof edge materialization" begin
+    world = Base.get_world_counter()
+    atype = Tuple{typeof(stmtinfo_edge_target),Int}
+    match = only(Base._methods_by_ftype(atype, -1, world))
+    mi = Compiler.specialize_method(match)
+    interp = Compiler.NativeInterpreter(world)
+    owner = Compiler.cache_owner(interp)
+    ci1 = stmtinfo_codeinstance(mi, owner)
+    ci2 = stmtinfo_codeinstance(mi, owner)
+    @test_throws AssertionError Compiler.LocalInferenceProof(
+        Compiler.WorldRange(world, world + 1), Core.svec())
+
+    @testset "constprop cache worlds" begin
+        lattice = Compiler.typeinf_lattice(interp)
+        argtypes = Compiler.matching_cache_argtypes(lattice, mi)
+        argtypes[2] = Compiler.Const(1)
+        overridden = falses(length(argtypes))
+        overridden[2] = true
+
+        result = Compiler.InferenceResult(mi, copy(argtypes), overridden)
+        result.result = Int
+        result.valid_worlds = Compiler.WorldRange(UInt(1), UInt(3))
+        proof = Compiler.LocalInferenceProof(result.valid_worlds, Core.svec())
+        local_result = Compiler.LocalInferenceResult(result, proof, UInt(2))
+        cache = Compiler.InferenceCache()
+        push!(cache, local_result)
+        @test Compiler.constprop_cache_lookup(
+            lattice, mi, argtypes, cache, UInt(2)) === local_result
+        @test Compiler.constprop_cache_lookup(
+            lattice, mi, argtypes, cache, UInt(3)) === nothing
+
+        tombstone = Compiler.InferenceResult(mi, copy(argtypes), overridden)
+        tombstone.result = Int
+        tombstone.tombstone = true
+        tombstone.cache_world = UInt(2)
+        tombstone.valid_worlds = Compiler.WorldRange(UInt(1), UInt(3))
+        cache = Compiler.InferenceCache()
+        push!(cache, tombstone)
+        @test ismissing(Compiler.constprop_cache_lookup(
+            lattice, mi, argtypes, cache, UInt(2)))
+        @test Compiler.constprop_cache_lookup(
+            lattice, mi, argtypes, cache, UInt(3)) === nothing
+    end
+
+    @testset "proof streams and paired edges" begin
+        plain_edges = Core.svec(ci1, ci2)
+        @test Compiler.materialize_inference_edges(plain_edges) === plain_edges
+
+        edges = Any[]
+        Compiler.materialize_inference_proof!(edges, ci1, ci1)
+        @test isempty(edges)
+        Compiler.materialize_inference_proof!(edges, ci2, ci1)
+        @test edges == Any[match.method.sig, ci2]
+
+        encoded = Core.svec(-1, atype, ci1, atype, mi)
+        proof = Compiler.LocalInferenceProof(Compiler.WorldRange(UInt(1), UInt(2)), encoded)
+        Compiler.materialize_inference_proof!(edges, proof, ci1)
+        @test length(edges) == 2 + length(encoded)
+        @test all(i -> edges[i + 2] === encoded[i], eachindex(encoded))
+
+        leaf = Compiler.LocalInferenceProof(Compiler.WorldRange(world), Core.svec(ci2))
+        root = Compiler.LocalInferenceProof(Compiler.WorldRange(world), Core.svec(leaf, leaf))
+        internal_edges = Any[]
+        Compiler.add_inference_proof!(internal_edges, root)
+        Compiler.add_inference_proof!(internal_edges, root)
+        @test internal_edges == Any[root]
+        @test Compiler.materialize_inference_edges(internal_edges) == Core.svec(ci2)
+
+        duplicate_leaf = Compiler.LocalInferenceProof(
+            Compiler.WorldRange(world), Core.svec(ci2))
+        duplicate_root = Compiler.LocalInferenceProof(
+            Compiler.WorldRange(world), Core.svec(leaf, duplicate_leaf))
+        @test Compiler.materialize_inference_edges(duplicate_root.edges) ==
+            Core.svec(ci2)
+
+        invoke_leaf1 = Compiler.LocalInferenceProof(
+            Compiler.WorldRange(world), Core.svec(atype, ci1))
+        invoke_leaf2 = Compiler.LocalInferenceProof(
+            Compiler.WorldRange(world), Core.svec(atype, ci1))
+        invoke_root = Compiler.LocalInferenceProof(
+            Compiler.WorldRange(world), Core.svec(invoke_leaf1, invoke_leaf2))
+        @test Compiler.materialize_inference_edges(invoke_root.edges) ==
+            Core.svec(atype, ci1)
+
+        encoded_leaf = Compiler.LocalInferenceProof(
+            Compiler.WorldRange(world), Core.svec(1, atype, ci1))
+        standalone_leaf = Compiler.LocalInferenceProof(
+            Compiler.WorldRange(world), Core.svec(ci1))
+        encoded_root = Compiler.LocalInferenceProof(
+            Compiler.WorldRange(world), Core.svec(encoded_leaf, standalone_leaf))
+        @test Compiler.materialize_inference_edges(encoded_root.edges) ==
+            Core.svec(1, atype, ci1)
+
+        regular_inf = Compiler.InferenceResult(mi, Compiler.typeinf_lattice(interp))
+        regular_inf.result = Int
+        regular_inf.valid_worlds = Compiler.WorldRange(world - 2, world)
+        regular_proof = Compiler.LocalInferenceProof(
+            regular_inf.valid_worlds, Core.svec(ci2))
+        regular_result = Compiler.LocalInferenceResult(regular_inf, regular_proof, world)
+        frame_result = Compiler.InferenceResult(mi, Compiler.typeinf_lattice(interp))
+        frame = Compiler.InferenceState(frame_result, Compiler.CACHE_MODE_LOCAL, interp)
+        push!(frame.edges, ci1)
+        method_result = Compiler.MethodCallResult(
+            Int, Any, Compiler.Effects(), ci1, false, false, regular_result)
+        concrete_proof = Compiler.LocalInferenceProof(
+            Compiler.WorldRange(world - 1, world), Core.svec(match.method))
+        concrete_result = Compiler.ConcreteResult(
+            ci1, Compiler.Effects(); proof=concrete_proof)
+        concrete_call = Compiler.ConstCallResult(
+            Int, Any, concrete_result, Compiler.Effects())
+        composite = Compiler.const_prop_inference_proof(
+            frame, method_result, concrete_call)
+        @test composite.valid_worlds == Compiler.WorldRange(world - 1, world)
+        @test Compiler.materialize_inference_edges(composite.edges) ==
+            Core.svec(ci2, match.method, ci1)
+
+        concrete = Compiler.ConcreteResult(ci1, Compiler.Effects(); proof)
+        @test Compiler.inference_proof(concrete) === proof
+        @test !isdefined(concrete, :result)
+        concrete_with_value = Compiler.ConcreteResult(ci1, Compiler.Effects(), 1; proof)
+        @test concrete_with_value.result === 1
+
+        cycle1 = stmtinfo_codeinstance(mi, owner)
+        cycle2 = stmtinfo_codeinstance(mi, owner)
+        cycle3 = stmtinfo_codeinstance(mi, owner)
+        @atomic cycle1.next = cycle2
+        @atomic cycle2.next = cycle3
+        @atomic cycle3.next = cycle2
+        @test collect(Compiler.CodeInstanceCacheIterator(cycle1)) == [cycle1, cycle2]
+
+        late_cycle1 = stmtinfo_codeinstance(mi, owner)
+        late_cycle2 = stmtinfo_codeinstance(mi, owner)
+        @atomic late_cycle1.next = late_cycle2
+        late_iter = Compiler.CodeInstanceCacheIterator(late_cycle1)
+        entry, state = iterate(late_iter)
+        @test entry === late_cycle1
+        @atomic late_cycle2.next = late_cycle2
+        entry, state = iterate(late_iter, state)
+        @test entry === late_cycle2
+        @test iterate(late_iter, state) === nothing
+    end
+
+    @testset "lookup edges precede their proofs" begin
+        results = Compiler.MethodLookupResult(Any[match],
+            Compiler.WorldRange(typemin(UInt), typemax(UInt)), false)
+        singleton = Compiler.MethodMatchInfo(results, Core.methodtable, atype, true)
+        singleton.edges[1] = ci1
+        singleton.call_results[1] = Compiler.ConcreteResult(ci2, Compiler.Effects())
+        edges = Any[]
+        Compiler.add_edges!(edges, singleton)
+        @test edges == Any[ci1, match.method.sig, ci2]
+
+        singleton.call_results[1] = Compiler.ConcreteResult(ci1, Compiler.Effects())
+        empty!(edges)
+        Compiler.add_edges!(edges, singleton)
+        @test edges == Any[ci1]
+
+        flat_stream = Core.svec(1, atype, ci2)
+        flat = Compiler.LocalInferenceProof(Compiler.WorldRange(world), flat_stream)
+        singleton.call_results[1] = Compiler.ConcreteResult(ci1, Compiler.Effects(); proof=flat)
+        empty!(edges)
+        Compiler.add_edges!(edges, singleton)
+        @test edges == Any[ci1, flat]
+        materialized = Compiler.materialize_inference_edges(edges)
+        @test materialized[1] === ci1
+        @test all(i -> materialized[i + 1] === flat_stream[i], eachindex(flat_stream))
+
+        invoke = Compiler.InvokeCallInfo(ci1, match,
+            Compiler.ConcreteResult(ci2, Compiler.Effects()), atype)
+        empty!(edges)
+        Compiler.add_edges!(edges, invoke)
+        @test edges == Any[atype, ci1, match.method.sig, ci2]
+
+        local_inf = Compiler.InferenceResult(mi, Compiler.typeinf_lattice(interp))
+        local_inf.result = Int
+        local_inf.valid_worlds = Compiler.WorldRange(world)
+        local_proof = Compiler.LocalInferenceProof(local_inf.valid_worlds, Core.svec())
+        local_result = Compiler.LocalInferenceResult(local_inf, local_proof, world)
+
+        multi_results = Compiler.MethodLookupResult(
+            Any[match, match], Compiler.WorldRange(), false)
+        multi = Compiler.MethodMatchInfo(multi_results, Core.methodtable, atype, true)
+        multi.call_results[1] = local_result
+        empty!(edges)
+        Compiler.add_edges!(edges, multi)
+        @test edges[3] === mi
+        has_mi_backedge = false
+        flat_edges = Compiler.materialize_inference_edges(edges)
+        for (_, edge) in Compiler.ForwardToBackedgeIterator(flat_edges)
+            has_mi_backedge |= edge === mi
+        end
+        @test has_mi_backedge
+
+        multi.call_results[1] = nothing
+        multi.needs_mi_edges[1] = true
+        empty!(edges)
+        Compiler.add_edges!(edges, multi)
+        @test edges[3] === mi
+        flat_edges = Compiler.materialize_inference_edges(edges)
+        @test any(Compiler.ForwardToBackedgeIterator(flat_edges)) do (_, edge)
+            edge === mi
+        end
+        multi.needs_mi_edges[1] = false
+
+        invoke_local = Compiler.InvokeCallInfo(nothing, match, local_result, atype)
+        empty!(edges)
+        Compiler.add_edges!(edges, invoke_local)
+        @test edges[2] === mi
+
+        opaque_local = Compiler.OpaqueClosureCallInfo(nothing, match, local_result)
+        empty!(edges)
+        Compiler.add_edges!(edges, opaque_local)
+        @test first(edges) === mi
+
+        targetless_concrete = Compiler.ConcreteResult(
+            nothing, Compiler.Effects(); proof=local_proof)
+
+        multi.call_results[1] = targetless_concrete
+        empty!(edges)
+        Compiler.add_edges!(edges, multi)
+        @test edges[3] === mi
+        flat_edges = Compiler.materialize_inference_edges(edges)
+        @test any(Compiler.ForwardToBackedgeIterator(flat_edges)) do (_, edge)
+            edge === mi
+        end
+
+        invoke_provisional = Compiler.InvokeCallInfo(
+            nothing, match, nothing, atype, true)
+        empty!(edges)
+        Compiler.add_edges!(edges, invoke_provisional)
+        @test edges[2] === mi
+        flat_edges = Compiler.materialize_inference_edges(edges)
+        @test any(Compiler.ForwardToBackedgeIterator(flat_edges)) do (_, edge)
+            edge === mi
+        end
+
+        opaque_provisional = Compiler.OpaqueClosureCallInfo(
+            nothing, match, nothing, true)
+        empty!(edges)
+        Compiler.add_edges!(edges, opaque_provisional)
+        @test first(edges) === mi
+        flat_edges = Compiler.materialize_inference_edges(edges)
+        @test any(Compiler.ForwardToBackedgeIterator(flat_edges)) do (_, edge)
+            edge === mi
+        end
+
+        invoke_concrete = Compiler.InvokeCallInfo(
+            nothing, match, targetless_concrete, atype)
+        empty!(edges)
+        Compiler.add_edges!(edges, invoke_concrete)
+        @test edges[2] === mi
+        flat_edges = Compiler.materialize_inference_edges(edges)
+        @test any(Compiler.ForwardToBackedgeIterator(flat_edges)) do (_, edge)
+            edge === mi
+        end
+
+        opaque_concrete = Compiler.OpaqueClosureCallInfo(
+            nothing, match, targetless_concrete)
+        empty!(edges)
+        Compiler.add_edges!(edges, opaque_concrete)
+        @test first(edges) === mi
+        flat_edges = Compiler.materialize_inference_edges(edges)
+        @test any(Compiler.ForwardToBackedgeIterator(flat_edges)) do (_, edge)
+            edge === mi
+        end
+    end
+
+    @testset "lookup identity and edge access" begin
+        results = Compiler.MethodLookupResult(Any[match], Compiler.WorldRange(), false)
+        info1 = Compiler.MethodMatchInfo(results, Core.methodtable, atype, false)
+        info1.edges[1] = ci1
+        info2 = Compiler.MethodMatchInfo(results, Core.methodtable, atype, false)
+        info2.edges[1] = ci2
+
+        edges = Any[]
+        Compiler.add_edges!(edges, info1)
+        Compiler.add_edges!(edges, info1)
+        @test count(edge -> edge isa Int, edges) == 1
+        Compiler.add_edges!(edges, info2)
+        @test count(edge -> edge isa Int, edges) == 2
+        starts = findall(edge -> edge isa Int, edges)
+        @test edges[starts[1] + 2] === ci1
+        @test edges[starts[2] + 2] === ci2
+
+        @test Compiler.getedge(info1, 1) === ci1
+        split = Compiler.UnionSplitInfo([info1, info2])
+        @test Compiler.getedge(split, 1) === ci1
+        @test Compiler.getedge(split, 2) === ci2
+        @test Compiler.getedge(Compiler.InvokeCallInfo(ci1, match, nothing, atype), 1) === ci1
+        @test Compiler.getedge(Compiler.OpaqueClosureCallInfo(ci2, match, nothing), 1) === ci2
+        @test Compiler.getedge(Compiler.VirtualMethodMatchInfo(split), 2) === ci2
+    end
+
+    @testset "encoded groups are immutable units" begin
+        encoded = Any[1, atype, mi]
+        Compiler.add_one_edge!(encoded, ci1)
+        Compiler.add_one_edge!(encoded, ci2)
+        Compiler.add_one_edge!(encoded, ci1)
+        @test encoded == Any[1, atype, mi, ci1, ci2]
+
+        invoke_edges = Any[1, atype, mi]
+        Compiler.add_invoke_edge!(invoke_edges, atype, ci1)
+        Compiler.add_invoke_edge!(invoke_edges, atype, ci2)
+        Compiler.add_invoke_edge!(invoke_edges, atype, ci1)
+        @test invoke_edges == Any[1, atype, mi, atype, ci1, atype, ci2]
+
+        inline_edges = Any[1, atype, mi]
+        Compiler.add_inlining_edge!(inline_edges, ci1)
+        Compiler.add_inlining_edge!(inline_edges, ci2)
+        Compiler.add_inlining_edge!(inline_edges, ci1)
+        @test inline_edges[3] === mi
+        @test inline_edges[5] === ci1
+        @test inline_edges[7] === ci2
+
+        upgraded = Any[mi]
+        Compiler.add_one_edge!(upgraded, ci1)
+        @test only(upgraded) === ci1
+        invoke_upgraded = Any[atype, mi]
+        Compiler.add_invoke_edge!(invoke_upgraded, atype, ci1)
+        @test invoke_upgraded[2] === ci1
+        inline_upgraded = Any[match.method]
+        Compiler.add_inlining_edge!(inline_upgraded, ci1)
+        @test only(inline_upgraded) === ci1
+    end
+end
+
 let comparison = Tuple{X, X} where X<:Tuple
     sig = Tuple{X, X} where X<:comparison
     ref = Tuple{X, X} where X
@@ -6663,7 +7279,8 @@ function test_func_cached_conditional(y)
 end;
 let interp = CachedConditionalInterp();
     @test Base.infer_return_type(test_func_cached_conditional, (Any,); interp) == Tuple{Float64, Float64}
-    @test count(interp.inf_cache) do result
+    @test count(interp.inf_cache) do entry
+        result = entry isa Compiler.LocalInferenceResult ? entry.result : entry
         result.linfo.def.name === :func_cached_conditional
     end == 1
 end

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -56,10 +56,6 @@ let
     @test got.proof === proof
     @test got.result.ci === ci
     @test get(Compiler.code_cache(interp), mi, nothing) === ci
-    @test last(collect(Compiler.get_inference_cache(interp))) === local_result
-    cache = Compiler.get_inference_cache(interp)
-    @test cache[length(cache)] === local_result
-    @test eltype(Compiler.get_inference_cache(interp)) === Compiler.InferenceCacheEntry
     @test_throws AssertionError push!(Compiler.get_inference_cache(interp), artifact)
 end
 
@@ -366,16 +362,18 @@ end
         @test Compiler.materialize_inference_edges(plain_edges) === plain_edges
 
         edges = Any[]
-        Compiler.materialize_inference_proof!(edges, ci1, ci1)
+        Compiler.add_inference_proof!(edges, ci1, ci1)
         @test isempty(edges)
-        Compiler.materialize_inference_proof!(edges, ci2, ci1)
+        Compiler.add_inference_proof!(edges, ci2, ci1)
         @test edges == Any[match.method.sig, ci2]
 
         encoded = Core.svec(-1, atype, ci1, atype, mi)
         proof = Compiler.LocalInferenceProof(Compiler.WorldRange(UInt(1), UInt(2)), encoded)
-        Compiler.materialize_inference_proof!(edges, proof, ci1)
-        @test length(edges) == 2 + length(encoded)
-        @test all(i -> edges[i + 2] === encoded[i], eachindex(encoded))
+        Compiler.add_inference_proof!(edges, proof, ci1)
+        @test edges[end] === proof
+        flat = Compiler.materialize_inference_edges(edges)
+        @test length(flat) == 2 + length(encoded)
+        @test all(i -> flat[i + 2] === encoded[i], eachindex(encoded))
 
         leaf = Compiler.LocalInferenceProof(Compiler.WorldRange(world), Core.svec(ci2))
         root = Compiler.LocalInferenceProof(Compiler.WorldRange(world), Core.svec(leaf, leaf))
@@ -438,25 +436,6 @@ end
         @test !isdefined(concrete, :result)
         concrete_with_value = Compiler.ConcreteResult(ci1, Compiler.Effects(), 1; proof)
         @test concrete_with_value.result === 1
-
-        cycle1 = stmtinfo_codeinstance(mi, owner)
-        cycle2 = stmtinfo_codeinstance(mi, owner)
-        cycle3 = stmtinfo_codeinstance(mi, owner)
-        @atomic cycle1.next = cycle2
-        @atomic cycle2.next = cycle3
-        @atomic cycle3.next = cycle2
-        @test collect(Compiler.CodeInstanceCacheIterator(cycle1)) == [cycle1, cycle2]
-
-        late_cycle1 = stmtinfo_codeinstance(mi, owner)
-        late_cycle2 = stmtinfo_codeinstance(mi, owner)
-        @atomic late_cycle1.next = late_cycle2
-        late_iter = Compiler.CodeInstanceCacheIterator(late_cycle1)
-        entry, state = iterate(late_iter)
-        @test entry === late_cycle1
-        @atomic late_cycle2.next = late_cycle2
-        entry, state = iterate(late_iter, state)
-        @test entry === late_cycle2
-        @test iterate(late_iter, state) === nothing
     end
 
     @testset "lookup edges precede their proofs" begin
@@ -521,47 +500,11 @@ end
         end
         multi.needs_mi_edges[1] = false
 
-        invoke_local = Compiler.InvokeCallInfo(nothing, match, local_result, atype)
-        empty!(edges)
-        Compiler.add_edges!(edges, invoke_local)
-        @test edges[2] === mi
-
-        opaque_local = Compiler.OpaqueClosureCallInfo(nothing, match, local_result)
-        empty!(edges)
-        Compiler.add_edges!(edges, opaque_local)
-        @test first(edges) === mi
-
+        # Each CallInfo type implements the targetless-facts upgrade separately;
+        # cover both triggers (attached result, needs-mi-edge bit) per type, and
+        # every result representation (local, targetless concrete) at least once.
         targetless_concrete = Compiler.ConcreteResult(
             nothing, Compiler.Effects(); proof=local_proof)
-
-        multi.call_results[1] = targetless_concrete
-        empty!(edges)
-        Compiler.add_edges!(edges, multi)
-        @test edges[3] === mi
-        flat_edges = Compiler.materialize_inference_edges(edges)
-        @test any(Compiler.ForwardToBackedgeIterator(flat_edges)) do (_, edge)
-            edge === mi
-        end
-
-        invoke_provisional = Compiler.InvokeCallInfo(
-            nothing, match, nothing, atype, true)
-        empty!(edges)
-        Compiler.add_edges!(edges, invoke_provisional)
-        @test edges[2] === mi
-        flat_edges = Compiler.materialize_inference_edges(edges)
-        @test any(Compiler.ForwardToBackedgeIterator(flat_edges)) do (_, edge)
-            edge === mi
-        end
-
-        opaque_provisional = Compiler.OpaqueClosureCallInfo(
-            nothing, match, nothing, true)
-        empty!(edges)
-        Compiler.add_edges!(edges, opaque_provisional)
-        @test first(edges) === mi
-        flat_edges = Compiler.materialize_inference_edges(edges)
-        @test any(Compiler.ForwardToBackedgeIterator(flat_edges)) do (_, edge)
-            edge === mi
-        end
 
         invoke_concrete = Compiler.InvokeCallInfo(
             nothing, match, targetless_concrete, atype)
@@ -573,15 +516,22 @@ end
             edge === mi
         end
 
-        opaque_concrete = Compiler.OpaqueClosureCallInfo(
-            nothing, match, targetless_concrete)
+        invoke_provisional = Compiler.InvokeCallInfo(
+            nothing, match, nothing, atype, true)
         empty!(edges)
-        Compiler.add_edges!(edges, opaque_concrete)
+        Compiler.add_edges!(edges, invoke_provisional)
+        @test edges[2] === mi
+
+        opaque_local = Compiler.OpaqueClosureCallInfo(nothing, match, local_result)
+        empty!(edges)
+        Compiler.add_edges!(edges, opaque_local)
         @test first(edges) === mi
-        flat_edges = Compiler.materialize_inference_edges(edges)
-        @test any(Compiler.ForwardToBackedgeIterator(flat_edges)) do (_, edge)
-            edge === mi
-        end
+
+        opaque_provisional = Compiler.OpaqueClosureCallInfo(
+            nothing, match, nothing, true)
+        empty!(edges)
+        Compiler.add_edges!(edges, opaque_provisional)
+        @test first(edges) === mi
     end
 
     @testset "lookup identity and edge access" begin

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -641,7 +641,6 @@ function getcacheci(mi::Core.MethodInstance)
     cache = Compiler.code_cache(Compiler.NativeInterpreter())
     codeinst = Compiler.get(cache, mi, nothing)
     codeinst === nothing && return nothing
-    codeinst isa Compiler.InferenceResult && (codeinst = codeinst.ci)
     return codeinst
 end
 @noinline f42078(a) = sum(sincos(a))

--- a/Compiler/test/invalidation.jl
+++ b/Compiler/test/invalidation.jl
@@ -30,6 +30,61 @@ Compiler.get_inference_world(interp::InvalidationTester) = interp.world
 Compiler.get_inference_cache(interp::InvalidationTester) = interp.inf_cache
 Compiler.cache_owner(::InvalidationTester) = InvalidationTesterToken()
 
+# Local constprop proofs expose same-module binding dependencies on the published caller.
+module LocalProofBindingInvalidation61752
+    _getproperty(M::Module, s::Symbol) = getglobal(M, s)
+
+    const VALUE = "v1"
+    probe() = _getproperty(LocalProofBindingInvalidation61752, :VALUE)::String
+end
+
+let interp = InvalidationTester()
+    @test Base.infer_return_type(LocalProofBindingInvalidation61752.probe, (); interp) === String
+
+    mi = Base.method_instance(LocalProofBindingInvalidation61752.probe, ())
+    ci = mi.cache
+    @test ci.owner === InvalidationTesterToken()
+    @test ci.max_world === typemax(UInt)
+
+    binding = convert(Core.Binding,
+        GlobalRef(LocalProofBindingInvalidation61752, :VALUE))
+    @test any(edge -> edge === binding, ci.edges)
+    callee_mi = Base.method_instance(
+        LocalProofBindingInvalidation61752._getproperty, (Module, Symbol))
+    @test any(edge -> edge isa Core.CodeInstance && edge.def === callee_mi, ci.edges)
+
+    world_before = Base.get_world_counter()
+    @eval LocalProofBindingInvalidation61752 const VALUE = "v2"
+    @test ci.max_world != typemax(UInt)
+    @test ci.max_world <= world_before
+end
+
+# Eliding a finalizer registration based on inferred effects must keep the proof
+# for those effects on the caller's CodeInstance.
+module FinalizerEffectInvalidation62338
+    mutable struct Target end
+    callback(::Target) = nothing
+    register(x::Target) = finalizer(callback, x)
+end
+
+let
+    inf_params = Compiler.InferenceParams(
+        ; cache_owner=FinalizerEffectInvalidation62338)
+    interp = Compiler.NativeInterpreter(Base.get_world_counter(); inf_params)
+    mi = Base.method_instance(FinalizerEffectInvalidation62338.register,
+        (FinalizerEffectInvalidation62338.Target,))
+    ci = Compiler.typeinf_ext(interp, mi, Compiler.SOURCE_MODE_GET_SOURCE)
+    src = Compiler.ci_get_source(interp, ci)
+    @test !any(iscall((src, Core.finalizer)), src.code)
+    @test ci.max_world == typemax(UInt)
+
+    world_before = Base.get_world_counter()
+    @eval FinalizerEffectInvalidation62338 callback(::Target) =
+        (global callback_ran = true; nothing)
+    @test world_before < Base.get_world_counter()
+    @test ci.max_world < Base.get_world_counter()
+end
+
 # basic functionality test
 # ------------------------
 

--- a/Compiler/test/newinterp.jl
+++ b/Compiler/test/newinterp.jl
@@ -54,7 +54,7 @@ macro newinterp(InterpName, ephemeral_cache::Bool=false)
         $Compiler.get_inference_cache(interp::$InterpName) = interp.inf_cache
         $Compiler.cache_owner(::$InterpName) = $InterpName
         $(ephemeral_cache && quote
-        $Compiler.code_cache(interp::$InterpName) = $Compiler.OverlayCodeCache(interp.global_cache, interp.inf_cache)
+        $Compiler.code_cache(interp::$InterpName) = interp.global_cache
         $Compiler.get(cache::$InterpCacheName, mi::$C.MethodInstance, default) = get(cache.dict, mi, default)
         $Compiler.getindex(cache::$InterpCacheName, mi::$C.MethodInstance) = getindex(cache.dict, mi)
         $Compiler.haskey(cache::$InterpCacheName, mi::$C.MethodInstance) = haskey(cache.dict, mi)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -917,25 +917,35 @@ precompile_test_harness("code caching") do dir
         MA = getfield(@__MODULE__, RootA)
         MB = getfield(@__MODULE__, RootB)
         M = getfield(MA, RootModule)
+        function backedge_callers(mi::Core.MethodInstance)
+            callers = Any[]
+            i = 1
+            while i <= length(mi.backedges)
+                mi.backedges[i] isa Type && (i += 1)
+                caller = mi.backedges[i]
+                @assert caller isa Union{Core.MethodInstance,Core.CodeInstance}
+                push!(callers, caller)
+                i += 1
+            end
+            return callers
+        end
+        caller_method(caller::Core.MethodInstance) = caller.def::Method
+        caller_method(caller::Core.CodeInstance) = caller_method(caller.def)
         m = which(M.f, (Any,))
         for mi in Base.specializations(m)
             mi === nothing && continue
             mi = mi::Core.MethodInstance
             if mi.specTypes.parameters[2] === Int8
                 # external callers
-                mods = Module[]
-                for be in mi.backedges
-                    push!(mods, ((be.def::Core.MethodInstance).def::Method).module) # XXX
-                end
+                mods = Set(caller_method(caller).module
+                    for caller in backedge_callers(mi))
                 @test MA ∈ mods
                 @test MB ∈ mods
                 @test length(mods) == 2
             elseif mi.specTypes.parameters[2] === Int16
                 # internal callers
-                meths = Method[]
-                for be in mi.backedges
-                    push!(meths, (be.def::Method).def) # XXX
-                end
+                meths = Set(caller_method(caller)
+                    for caller in backedge_callers(mi))
                 @test which(M.g1, ()) ∈ meths
                 @test which(M.g2, ()) ∈ meths
                 @test length(meths) == 2
@@ -1127,13 +1137,19 @@ precompile_test_harness("code caching") do dir
 
         idxb = findfirst(x -> x isa Core.Binding, invalidations)
         @test invalidations[idxb+1] == "insert_backedges_callee"
-        idxv = findnext(==("verify_methods"), invalidations, idxb)
-        if invalidations[idxv-1].def.def.name === :getproperty
-            idxv = findnext(==("verify_methods"), invalidations, idxv+1)
+        # Proof flattening may change the path from the binding to `flbi`, but the
+        # downstream `useflbi` invalidation must still identify `flbi` as its cause.
+        useflbi_method = only(methods(MB.useflbi))
+        flbi_method = only(methods(MA.flbi))
+        idxv = findfirst(eachindex(invalidations)) do i
+            1 < i < length(invalidations) || return false
+            invalidations[i] == "verify_methods" || return false
+            caller = invalidations[i-1]
+            cause = invalidations[i+1]
+            return caller isa Core.CodeInstance && cause isa Core.CodeInstance &&
+                caller.def.def === useflbi_method && cause.def.def === flbi_method
         end
-        idxv = findnext(==(invalidations[idxv-1]), invalidations, idxv+1)
-        @test invalidations[idxv-1] == "verify_methods"
-        @test invalidations[idxv-2].def.def.name === :useflbi
+        @test idxv !== nothing
 
         m = only(methods(MB.map_nbits))
         @test !hasvalid(m.specializations::Core.MethodInstance, world+1) # insert_backedges invalidations also trigger their backedges


### PR DESCRIPTION
On master, InferenceResult has three jobs: it is mutable inference work state, the container for reusable local source and facts, and an InferredCallResult stored in CallInfo. Its ci field is the reservation intended for global publication, while ci_as_edge is a CodeInstance chosen or synthesized to stand for the dependencies of those facts. The overlay cache then exposes local InferenceResults through the same lookup interface as globally published CodeInstances.

Those identities diverge under reentrant inference. A nested inference session can publish a CodeInstance for an outer SCC member before that member finishes. The outer result then loses the publication race and is demoted to the local cache, and its reserved ci is rejected. A scheduled consumer may nevertheless have captured that provisional ci. Constant propagation can also manufacture a dummy CodeInstance whose only purpose is to hold a different dependency edge set. Either object can flow through CallInfo and inlining as though it were an invoke target, despite never being published or carrying usable code.

JuliaLang/julia#62338 avoids serving a local entry when ci_as_edge was never initialized, which fixes the observed assertion. Definedness is not the needed invariant, however: ci_as_edge may still be a rejected provisional CI or a synthetic proof-only CI. Substituting an older published CI solves the target problem but creates the dual problem: that CI certifies the edges from its own inference, not the binding, constant-propagation, or SCC dependencies that justify the newer local facts. Because local cache entries have no registered reverse edges, a published caller can then survive a change that invalidates facts used to optimize it.

Make InferenceResult internal unfinished state rather than an InferredCallResult. A completed local computation is represented by LocalInferenceResult, which pairs its inferred facts and source with an InferenceProof. CallInfo stores the executable target independently. The global code cache consequently contains only CodeInstances, and no local result can be mistaken for an executable cache entry.

A LocalInferenceProof is a range-checked DAG of forward edges and nested proofs. Regular inference, constant propagation, semi-concrete interpretation, limited results, and recursive SCC consumers propagate this proof independently of the selected target. When a caller is finally published, the DAG is flattened once into the positional CodeInstance edge grammar and normal reverse edges are registered. Proof-carrying calls with no CI target retain a specialized MethodInstance edge so dispatch changes still invalidate the caller.

An existing global winner is selected before a provisional CI can enter optimizer state. If such a winner exists, the completed result remains local only when the winner covers the inferred worlds and has the same owner and return ABI. Otherwise the new CI is published normally. A winner that appears after the provisional CI was exposed to optimized IR cannot demote it. For ABI requests, local source may compile an equivalent published winner without publishing the local source carrier. Capability-aware cache lookup scans the native CI chain with acquire loads and a transient-cycle guard.

The resulting invariant is that every CI which escapes as an invoke target in published IR is itself globally published, while every locally inferred fact that reaches published code has a separate dependency proof. Local results are reused only at their exact inference world, and their proofs become ordinary invalidation edges only when materialized into a published caller.

The same rule preserves the call dependencies that justify deleting an unobservable finalizer registration, rather than dropping those edges with the call.

Largely written by GPT 5.6.