### PR TITLE
codegen: check type of jl_value_t ccall argument

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1602,7 +1602,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             retval = emit_pointer_from_objref(ctx, retval /*T_prjlvalue*/);
         }
         else if (tti == (jl_value_t*)jl_voidpointer_type) {
-            retval = emit_unbox(ctx, largty, argv[0]);
+            retval = emit_unbox(ctx, largty, voidpointer_update(ctx, argv[0], make_errmsg("ccall", 1, "")));
         }
         else {
             retval = emit_unbox(ctx, largty, update_julia_type(ctx, argv[0], tti));

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -2028,6 +2028,15 @@ cglobal_non_static2() = cglobal(the_sym)
 @test_throws TypeError cglobal_non_static1()
 @test_throws TypeError cglobal_non_static2()
 
+# a ccall pointer argument whose unsafe_convert returns a small union must
+# extract and convert the Ptr and typecheck the other options
+struct UnionConvertPtr; flag::Cint; end
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, w::UnionConvertPtr) = w.flag == 1 ? C_NULL : (w.flag == 2 ? Ptr{Cint}(1) : (:x,))
+union_convert_ptr(w) = ccall(:jl_value_ptr, Ptr{Cvoid}, (Ptr{Cvoid},), w)
+@test union_convert_ptr(UnionConvertPtr(1)) == C_NULL
+@test union_convert_ptr(UnionConvertPtr(2)) == Ptr{Cvoid}(1)
+@test_throws TypeError union_convert_ptr(UnionConvertPtr(3))
+
 @generated function generated_world_counter()
     return :($(Base.get_world_counter()))
 end


### PR DESCRIPTION
Post-review update of #62317

Note that we are still missing a consistent use of `typeassert_input` on most of these hand-crafted inlining implementations.