### PR TITLE
scheduler: fall back to a pool wake when the targeted thread wake is a no-op

### DIFF
--- a/base/partr.jl
+++ b/base/partr.jl
@@ -216,7 +216,7 @@ function multiq_deletemin()
             task_tid = ccall(:jl_get_task_tid, Int16, (Any,), task)
             unlock(heap.lock)
             if task_tid != Int16(-1)
-                ccall(:jl_wakeup_thread, Cvoid, (Int16,), task_tid)
+                ccall(:jl_wakeup_thread, Cint, (Int16,), task_tid)
             end
             continue
         end

--- a/base/task.jl
+++ b/base/task.jl
@@ -988,11 +988,17 @@ function enq_work(t::Task)
             Partr.multiq_insert(t, t.priority)
             tid = Threads.threadid(t)
             if tid != 0 && tid != Threads.threadid()
-                # The task's tid is pinned to another thread: it is that thread's current
-                # task, parked hosting its thread-sleep logic in wait(), and can only be
-                # resumed by that thread. A pool wake could pick a thread that cannot run
-                # this task, leaving it stranded and its host asleep (#58689).
-                ccall(:jl_wakeup_thread, Cvoid, (Int16,), (tid - 1) % Int16)
+                # The task's tid is pinned to another thread: typically it is that
+                # thread's current task, parked hosting its thread-sleep logic in
+                # wait(), and only that thread can resume it, so wake it directly
+                # (#58689). If that thread was already awake (busy with other work),
+                # this wake added no running thread; wake a pool thread too so the
+                # number of running threads still scales with enqueued work — the
+                # task is not sticky, so its tid may be cleared later, making it
+                # runnable by any pool thread.
+                if ccall(:jl_wakeup_thread, Cint, (Int16,), (tid - 1) % Int16) == 0
+                    ccall(:jl_wakeup_threadpool, Cvoid, (Int8,), Threads._sym_to_tpid(tp))
+                end
             else
                 # Wake one sleeping thread in the task's pool rather than all of them. See #61820, #50425.
                 ccall(:jl_wakeup_threadpool, Cvoid, (Int8,), Threads._sym_to_tpid(tp))

--- a/base/task.jl
+++ b/base/task.jl
@@ -1006,7 +1006,7 @@ function enq_work(t::Task)
             return t
         end
     end
-    ccall(:jl_wakeup_thread, Cvoid, (Int16,), (tid - 1) % Int16)
+    ccall(:jl_wakeup_thread, Cint, (Int16,), (tid - 1) % Int16)
     return t
 end
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -376,7 +376,7 @@ JL_DLLEXPORT void jl_gc_run_pending_finalizers(struct _jl_task_t *ct);
 extern JL_DLLEXPORT _Atomic(int) jl_gc_have_pending_finalizers;
 JL_DLLEXPORT int8_t jl_gc_is_in_finalizer(void) JL_NOTSAFEPOINT;
 
-JL_DLLEXPORT void jl_wakeup_thread(int16_t tid) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_wakeup_thread(int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_wakeup_threadpool(int8_t tpid) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT int jl_getaffinity(int16_t tid, char *mask, int cpumasksize);

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -237,7 +237,10 @@ static void wake_libuv(void) JL_NOTSAFEPOINT
     JULIA_DEBUG_SLEEPWAKE( io_wakeup_leave = cycleclock() );
 }
 
-static void wakeup_thread(jl_task_t *ct, int16_t tid) JL_NOTSAFEPOINT { // Pass in ptls when we have it already available to save a lookup
+// Returns 1 if a sleeping thread was transitioned to running (i.e. the wake
+// added a running thread), 0 if the target was already awake or is the caller.
+static int wakeup_thread(jl_task_t *ct, int16_t tid) JL_NOTSAFEPOINT { // Pass in ptls when we have it already available to save a lookup
+    int woke = 0;
     int16_t self = jl_atomic_load_relaxed(&ct->tid);
     if (tid != self)
         jl_fence(); // [^store_buffering_1]
@@ -259,16 +262,19 @@ static void wakeup_thread(jl_task_t *ct, int16_t tid) JL_NOTSAFEPOINT { // Pass 
     }
     else {
         // something added to the sticky-queue: notify that thread
-        if (wake_thread(tid) && uvlock != ct) {
-            // check if we need to notify uv_run too
-            jl_fence();
-            jl_ptls_t other = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
-            jl_task_t *tid_task = jl_atomic_load_relaxed(&other->current_task);
-            // now that we have changed the thread to not-sleeping, ensure that
-            // either it has not yet acquired the libuv lock, or that it will
-            // observe the change of state to not_sleeping
-            if (jl_atomic_load_relaxed(&jl_uv_mutex.owner) == tid_task)
-                wake_libuv();
+        if (wake_thread(tid)) {
+            woke = 1;
+            if (uvlock != ct) {
+                // check if we need to notify uv_run too
+                jl_fence();
+                jl_ptls_t other = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+                jl_task_t *tid_task = jl_atomic_load_relaxed(&other->current_task);
+                // now that we have changed the thread to not-sleeping, ensure that
+                // either it has not yet acquired the libuv lock, or that it will
+                // observe the change of state to not_sleeping
+                if (jl_atomic_load_relaxed(&jl_uv_mutex.owner) == tid_task)
+                    wake_libuv();
+            }
         }
     }
     if (tid == -1) {
@@ -279,6 +285,7 @@ static void wakeup_thread(jl_task_t *ct, int16_t tid) JL_NOTSAFEPOINT { // Pass 
             if (tid != self)
                 anysleep |= wake_thread(tid);
         }
+        woke = anysleep;
         // check if we need to notify uv_run too
         if (uvlock != ct && anysleep) {
             jl_fence();
@@ -287,13 +294,15 @@ static void wakeup_thread(jl_task_t *ct, int16_t tid) JL_NOTSAFEPOINT { // Pass 
         }
     }
     JULIA_DEBUG_SLEEPWAKE( wakeup_leave = cycleclock() );
+    return woke;
 }
 
-/* ensure thread tid is awake if necessary */
-JL_DLLEXPORT void jl_wakeup_thread(int16_t tid)
+/* ensure thread tid is awake if necessary; returns 1 if a sleeping thread was
+   woken (a running thread was added), 0 otherwise */
+JL_DLLEXPORT int jl_wakeup_thread(int16_t tid)
 {
     jl_task_t *ct = jl_current_task;
-    wakeup_thread(ct, tid);
+    return wakeup_thread(ct, tid);
 }
 
 // Round-robin start hint for jl_wakeup_threadpool, sharded across cache-line-padded


### PR DESCRIPTION
Addresses post merge review: https://github.com/JuliaLang/julia/pull/62298#discussion_r3573777824

Claude:

---

Waking only the pinned task's host thread guarantees at least one running thread (preventing the #58689 deadlock) but not one *more* running thread when that host was already awake, which hurts scaling.

Make `jl_wakeup_thread` return whether it actually transitioned a sleeping thread to running. In `enq_work`, when the targeted wake of a non-sticky task's pinned thread reports the thread was already awake, additionally call `jl_wakeup_threadpool` so the number of running threads still scales with enqueued work.