### PR TITLE
partr: fix lost tasks when threads race to grow a pool's multiqueue

### DIFF
--- a/base/partr.jl
+++ b/base/partr.jl
@@ -119,6 +119,9 @@ function multiq_size(tpid::Int8)
     end
 
     @lock heaps_lock[tp] begin
+        # Re-read under the lock; growing from a stale copy would replace the
+        # current heaps and orphan tasks concurrently inserted into them (#62144).
+        tpheaps = heaps[tp]
         heap_p = UInt32(length(tpheaps))
         nt = UInt32(Threads._nthreads_in_pool(tpid))
         if heap_c * nt <= heap_p


### PR DESCRIPTION
Fixes #62144

Claude:

---

`multiq_size` reads `tpheaps = heaps[tp]` before taking `heaps_lock[tp]`, and then re-checks `length(tpheaps)` on that stale local after acquiring the lock. When several threads concurrently perform the first inserts into a pool (e.g. many default-pool tasks spawning `:interactive` tasks at once), each of them sees the pre-growth length, so each one in turn allocates a fresh heaps vector and publishes it with `heaps[tp] = newheaps`, replacing the vector the previous thread just published. Any task inserted into one of the replaced vectors in that window is orphaned: it is unreachable from `heaps[tp]`, so no thread can ever pop it, and anything waiting on it hangs. With `-t 8,4` and a burst of cross-pool spawn/fetch pairs this reproduces within seconds.

Re-read `heaps[tp]` under the lock so the re-check and the `copyto!` operate on the current vector, making the grow-if-needed check correct and the publication monotonic.

