### PR TITLE
staticdata: close check-then-act race on `newly_inferred`

### DIFF
--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -119,7 +119,9 @@ JL_DLLEXPORT void jl_set_newly_inferred(jl_value_t* _newly_inferred)
     assert(_newly_inferred == NULL || _newly_inferred == jl_nothing || jl_is_array_any(_newly_inferred));
     if (_newly_inferred == jl_nothing)
         _newly_inferred = NULL;
+    JL_LOCK(&newly_inferred_mutex);
     newly_inferred = (jl_array_t*) _newly_inferred;
+    JL_UNLOCK(&newly_inferred_mutex);
 }
 
 // Null `CodeInstance.inferred` for native-owned CIs where it is still a raw
@@ -178,9 +180,14 @@ JL_DLLEXPORT void jl_push_newly_inferred(jl_value_t* ci)
         }
     }
     JL_LOCK(&newly_inferred_mutex);
-    size_t end = jl_array_nrows(newly_inferred);
-    jl_array_grow_end(newly_inferred, 1);
-    jl_array_ptr_set(newly_inferred, end, ci);
+    // re-check under the lock: a concurrent jl_set_newly_inferred may have
+    // cleared or replaced the array since the unlocked fast-path check above
+    jl_array_t *arr = newly_inferred;
+    if (arr != NULL) {
+        size_t end = jl_array_nrows(arr);
+        jl_array_grow_end(arr, 1);
+        jl_array_ptr_set(arr, end, ci);
+    }
     JL_UNLOCK(&newly_inferred_mutex);
 }
 


### PR DESCRIPTION
I asked Claude to find any similar bugs to https://github.com/JuliaLang/julia/pull/62372 and this was the only one it found in Base/src.

---

`jl_push_newly_inferred` checked `newly_inferred` for NULL before taking `newly_inferred_mutex` without re-checking under the lock, while `jl_set_newly_inferred` swapped the global with no lock at all. A clear or replacement racing a push could dereference NULL or append to a replaced (orphaned) array. Take the mutex in `jl_set_newly_inferred` and re-check the array under the lock in `jl_push_newly_inferred`.