### PR TITLE
[JuliaLowering] Implement static parameter capture

### DIFF
--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -6,6 +6,7 @@ struct ClosureInfo{Attrs}
     # Map from the original BindingId of closed-over vars to the index of the
     # associated field in the closure type.
     field_inds::Dict{IdTag,Int}
+    capt_sp::SyntaxList{Attrs, Vector{NodeId}}
 end
 
 struct ClosureConversionCtx{Attrs} <: AbstractLoweringContext
@@ -16,9 +17,12 @@ struct ClosureConversionCtx{Attrs} <: AbstractLoweringContext
     capture_rewriting::Union{Nothing,ClosureInfo{Attrs},
                              SyntaxList{Attrs, Vector{NodeId}}}
     lambda_bindings::LambdaBindings
+    sp_typevars::Dict{IdTag, IdTag}
     # True if we're in a section of code which preserves top-level sequencing
     # such that closure types can be emitted inline with other code.
-    is_toplevel_seq_point::Bool
+    toplevel::Bool
+    # toplevel, or contained by method_defs and no lambda within it
+    lifted::Bool
     # True if this expression should not have toplevel effects, namely, it
     # should not declare the globals it references.  This allows generated
     # functions to refer to globals that have already been declared, without
@@ -69,7 +73,7 @@ function get_box_contents(ctx::ClosureConversionCtx, var, box_ex)
                 box
                 "contents"::K"Symbol"
             ]
-            ::K"TOMBSTONE"
+            (::K"TOMBSTONE")
             [K"block"
                  [K"newvar" undef_var]
                  undef_var
@@ -128,7 +132,7 @@ function make_globaldecl(ctx, src_ex, mod, name, strong=false, type=nothing)
         (::K"nothing")
     ]
     ctx.toplevel_pure && return newleaf(ctx, decl, K"TOMBSTONE")
-    if !ctx.is_toplevel_seq_point
+    if !ctx.toplevel
         push!(ctx.toplevel_stmts, decl)
         newleaf(ctx, decl, K"TOMBSTONE")
     else
@@ -191,7 +195,7 @@ function convert_assignment(ctx, ex)
     if binfo.kind == :global
         convert_global_assignment(ctx, ex, var, rhs0)
     else
-        @jl_assert binfo.kind == :local || binfo.kind == :argument ex
+        @jl_assert binfo.kind in (:local, :argument, :typevar) ex
         boxed = is_boxed(binfo)
         if isnothing(binfo.type) && !boxed
             @ast ctx ex [K"=" var rhs0]
@@ -224,18 +228,21 @@ end
 
 # Compute fields for a closure type, one field for each captured variable.
 function closure_type_fields(ctx, srcref, closure_binds, is_opaque)
-    capture_ids = Set{IdTag}()
+    capt_locals = Set{IdTag}()
+    capt_sp = Set{IdTag}()
+    add_capt(id) = push!(
+        get_binding(ctx, id).kind !== :static_parameter || is_opaque ?
+            capt_locals : capt_sp, id)
     for lambda_bindings in closure_binds.lambdas
         for (id, is_capt) in lambda_bindings.locals_capt
-            is_capt && push!(capture_ids, id)
+            is_capt && add_capt(id)
         end
     end
-    # sort here to avoid depending on undefined Set iteration order
-    capture_ids = sort!(collect(capture_ids))
+    foreach(add_capt, closure_binds.capt_sp)
 
     field_syms = SyntaxList(ctx)
     if is_opaque
-        field_orig_bindings = capture_ids
+        field_orig_bindings = sort!(collect(capt_locals))
         # For opaque closures we don't try to generate sensible names for the
         # fields as there's no closure type to generate.
         for i in eachindex(field_orig_bindings)
@@ -243,7 +250,7 @@ function closure_type_fields(ctx, srcref, closure_binds, is_opaque)
         end
     else
         field_names = Dict{String,IdTag}()
-        for id in capture_ids
+        for id in sort!(collect(capt_locals))
             binfo = get_binding(ctx, id)
             # We name each field of the closure after the variable which was closed
             # over, for clarity. Adding a suffix can be necessary when collisions
@@ -269,27 +276,12 @@ function closure_type_fields(ctx, srcref, closure_binds, is_opaque)
         push!(field_is_box, is_boxed(ctx, id))
         field_inds[id] = i
     end
+    capt_sp2 = SyntaxList(ctx)
+    for sp in sort!(collect(capt_sp))
+        push!(capt_sp2, binding_ex(ctx, sp))
+    end
 
-    return field_syms, field_orig_bindings, field_inds, field_is_box
-end
-
-# Return a thunk which creates a new type for a closure with `field_syms` named
-# fields. The new type will be named `name_str` which must be an unassigned
-# name in the module.
-function type_for_closure(ctx::ClosureConversionCtx, srcref, name_str, field_syms, field_is_box)
-    # New closure types always belong to the module we're expanding into - they
-    # need to be serialized there during precompile.
-    mod = ctx.mod
-    type_binding = new_global_binding(ctx, srcref, name_str, mod)
-    type_ex = @ast ctx srcref [K"call"
-        #"_call_latest"::K"core"
-        eval_closure_type::K"Value"
-        ctx.mod::K"Value"
-        name_str::K"Symbol"
-        [K"call" "svec"::K"core" field_syms...]
-        [K"call" "svec"::K"core" [f::K"Bool" for f in field_is_box]...]
-    ]
-    type_ex, type_binding
+    return field_syms, field_orig_bindings, field_inds, field_is_box, capt_sp2
 end
 
 # No box needed for:
@@ -298,6 +290,7 @@ end
 # - any local our optimizations have determined to be unboxed
 function is_boxed(binfo::BindingInfo)
     binfo.kind === :static_parameter && return false
+    binfo.kind === :typevar && return false
     binfo.unboxed && return false
     binfo.kind === :argument && !binfo.is_assigned && return false
     return binfo.is_captured
@@ -307,27 +300,95 @@ function is_boxed(ctx, x)
     is_boxed(get_binding(ctx, x))
 end
 
-# Is captured in the closure's `self` argument
+# Is a field in the closure argument `self`.  Exception: non-OC sparams are type
+# params to the `self` type, and are rewritten later in linearization.
 function is_self_captured(ctx, x)
-    get(ctx.lambda_bindings.locals_capt, _binding_id(x), false)
+    b = get_binding(ctx, x)
+    out = get(ctx.lambda_bindings.locals_capt, b.id, false)
+    if out && (b.kind === :static_parameter || b.kind === :typevar)
+        ctx.capture_rewriting isa ClosureInfo &&
+            haskey(ctx.capture_rewriting.field_inds, b.id)
+    else
+        out
+    end
+end
+
+function convert_local_function_decl(ctx, ex)
+    fid = ex[1].var_id::IdTag
+    haskey(ctx.closure_infos, fid) && return @ast ctx ex (::K"TOMBSTONE")
+
+    closure_binds = ctx.closure_bindings[fid]
+    field_syms, field_orig_bindings, field_inds, field_is_box, capt_sp =
+        closure_type_fields(ctx, ex, closure_binds, false)
+    name_str = reserve_module_binding_i(
+        ctx.mod,
+        string("#", join(closure_binds.name_stack, "#"), "##"))
+    global_clstruct = new_global_binding(ctx, ex, name_str, ctx.mod)
+    sp_syms = mapsyntax(sp->newleaf(ctx, sp, K"Symbol",
+                                    get_binding(ctx, sp.var_id::IdTag).name),
+                        capt_sp)
+    define_clstruct = type_ex = @ast ctx ex [K"call"
+        eval_closure_type::K"Value"
+        ctx.mod::K"Value"
+        name_str::K"Symbol"
+        [K"call" "svec"::K"core" sp_syms...]
+        [K"call" "svec"::K"core" field_syms...]
+        [K"call" "svec"::K"core" [f::K"Bool" for f in field_is_box]...]
+    ]
+    if !ctx.toplevel
+        push!(ctx.toplevel_stmts, define_clstruct)
+        push!(ctx.toplevel_stmts, @ast ctx ex (::K"latestworld_if_toplevel"))
+        define_clstruct = nothing
+    end
+    closure_info = ClosureInfo(global_clstruct, field_syms, field_inds, capt_sp)
+    ctx.closure_infos[fid] = closure_info
+    type_params = mapsyntax(capt_sp) do sp
+        is_self_captured(ctx, sp) ? captured_var_access(ctx, sp) : sp
+    end
+    init_closure_args = SyntaxList(ctx)
+    for (id, boxed) in zip(field_orig_bindings, field_is_box)
+        field_val = binding_ex(ctx, id)
+        if is_self_captured(ctx, field_val)
+            # Access from outer closure if necessary but do not
+            # unbox to feed into the inner nested closure.
+            field_val = captured_var_access(ctx, field_val)
+        end
+        push!(init_closure_args, field_val)
+        if !boxed
+            push!(type_params, @ast ctx ex [K"call"
+                  "_typeof_captured_variable"::K"core"
+                  field_val])
+        end
+    end
+    @ast ctx ex [K"block"
+        define_clstruct
+        (::K"latestworld_if_toplevel")
+        closure_type := if isempty(type_params)
+            global_clstruct
+        else
+            [K"call" "apply_type"::K"core" global_clstruct type_params...]
+        end
+        closure_val := [K"new" closure_type init_closure_args...]
+        convert_assignment(ctx, [K"=" ex[1] closure_val])
+        (::K"TOMBSTONE")
+    ]
 end
 
 # Map the children of `ex` through _convert_closures, lifting any toplevel
 # closure definition statements to occur before the other content of `ex`.
 function map_cl_convert(ctx::ClosureConversionCtx, ex, toplevel_preserving)
-    if ctx.is_toplevel_seq_point && !toplevel_preserving
+    if ctx.toplevel && !toplevel_preserving
         toplevel_stmts = SyntaxList(ctx)
-        ctx2 = ClosureConversionCtx(ctx.graph, ctx.bindings, ctx.mod,
-                                    ctx.closure_bindings, ctx.capture_rewriting, ctx.lambda_bindings,
-                                    false, ctx.toplevel_pure, toplevel_stmts, ctx.closure_infos)
+        ctx2 = ClosureConversionCtx(
+            ctx.graph, ctx.bindings, ctx.mod,
+            ctx.closure_bindings, ctx.capture_rewriting, ctx.lambda_bindings,
+            ctx.sp_typevars, false, ctx.lifted,
+            ctx.toplevel_pure, toplevel_stmts, ctx.closure_infos)
         res = mapchildren(e->_convert_closures(ctx2, e), ctx2, ex)
         if isempty(toplevel_stmts)
             res
         else
-            @ast ctx ex [K"block"
-                toplevel_stmts...
-                res
-            ]
+            @ast ctx ex [K"block" toplevel_stmts... res]
         end
     else
         mapchildren(e->_convert_closures(ctx, e), ctx, ex)
@@ -337,11 +398,12 @@ end
 function _convert_closures(ctx::ClosureConversionCtx, ex)
     k = kind(ex)
     if k == K"BindingId"
-        access = is_self_captured(ctx, ex) ? captured_var_access(ctx, ex) : ex
-        if is_boxed(ctx, ex)
-            get_box_contents(ctx, ex, access)
+        b = get_binding(ctx, ex)
+        if ctx.lifted && haskey(ctx.sp_typevars, b.id)
+            binding_ex(ctx, ctx.sp_typevars[b.id])
         else
-            access
+            access = is_self_captured(ctx, ex) ? captured_var_access(ctx, ex) : ex
+            is_boxed(ctx, ex) ? get_box_contents(ctx, ex, access) : access
         end
     elseif is_leaf(ex) || k == K"inert" || k == K"syntaxinert" || k == K"static_eval"
         ex
@@ -404,88 +466,65 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
             newleaf(ctx, ex, K"TOMBSTONE")
         end
     elseif k == K"lambda"
-        closure_convert_lambda(ctx, ex)
+        @jl_assert false (ex, "lambda should be at top level or in `method`")
     elseif k == K"function_decl"
         func_name = ex[1]
         @jl_assert kind(func_name) == K"BindingId" ex
-        func_name_id = func_name.var_id
-        if haskey(ctx.closure_bindings, func_name_id)
-            closure_info = get(ctx.closure_infos, func_name_id, nothing)
-            needs_def = isnothing(closure_info)
-            if needs_def
-                closure_binds = ctx.closure_bindings[func_name_id]
-                field_syms, field_orig_bindings, field_inds, field_is_box =
-                    closure_type_fields(ctx, ex, closure_binds, false)
-                name_str = reserve_module_binding_i(
-                    ctx.mod,
-                    string("#", join(closure_binds.name_stack, "#"), "##"))
-                closure_type_def, closure_type_ =
-                    type_for_closure(ctx, ex, name_str, field_syms, field_is_box)
-                if !ctx.is_toplevel_seq_point
-                    push!(ctx.toplevel_stmts, closure_type_def)
-                    push!(ctx.toplevel_stmts, @ast ctx ex (::K"latestworld_if_toplevel"))
-                    closure_type_def = nothing
-                end
-                closure_info = ClosureInfo(closure_type_, field_syms, field_inds)
-                ctx.closure_infos[func_name_id] = closure_info
-                type_params = SyntaxList(ctx)
-                init_closure_args = SyntaxList(ctx)
-                for (id, boxed) in zip(field_orig_bindings, field_is_box)
-                    field_val = binding_ex(ctx, id)
-                    if is_self_captured(ctx, field_val)
-                        # Access from outer closure if necessary but do not
-                        # unbox to feed into the inner nested closure.
-                        field_val = captured_var_access(ctx, field_val)
-                    end
-                    push!(init_closure_args, field_val)
-                    if !boxed
-                        push!(type_params, @ast ctx ex [K"call"
-                              "_typeof_captured_variable"::K"core"
-                              field_val])
-                    end
-                end
-                @ast ctx ex [K"block"
-                    closure_type_def
-                    (::K"latestworld_if_toplevel")
-                    closure_type := if isempty(type_params)
-                        closure_type_
-                    else
-                        [K"call" "apply_type"::K"core" closure_type_ type_params...]
-                    end
-                    closure_val := [K"new"
-                        closure_type
-                        init_closure_args...
-                    ]
-                    convert_assignment(ctx, [K"=" func_name closure_val])
-                    ::K"TOMBSTONE"
-                ]
-            else
-                @ast ctx ex (::K"TOMBSTONE")
-            end
+        if haskey(ctx.closure_bindings, func_name.var_id::IdTag)
+            convert_local_function_decl(ctx, ex)
         else
             # Single-arg K"method" has the side effect of creating a global
             # binding for `func_name` if it doesn't exist.
             @ast ctx ex [K"block"
                 [K"method" func_name]
-                ::K"TOMBSTONE" # <- function_decl should not be used in value position
+                (::K"TOMBSTONE") # <- function_decl should not be used in value position
             ]
         end
-    elseif k == K"method" && kind(ex[1]) === K"BindingId" &&
-            haskey(ctx.closure_bindings, ex[1].var_id)
+    elseif k == K"method"
+        @jl_assert ctx.lifted ex
+        # The method sp svec needs every sp the body and sig capture
+        cr = ctx.capture_rewriting
+        sp_ids = IdTag[c.var_id::IdTag for c in children(ex[3][2])]
+        if cr isa ClosureInfo
+            append!(sp_ids, sp.var_id::IdTag for sp in cr.capt_sp)
+        end
+        sort!(sp_ids)
+        sps = SyntaxList(ctx)
+        for id in sp_ids
+            push!(sps, binding_ex(ctx, id))
+        end
+        tvs = mapsyntax(c->binding_ex(ctx, ctx.sp_typevars[c.var_id::IdTag]), sps)
+
         # rm method table argument if it's a closure id, since it's unnecessary
         # and requires the `(= id (new ...))` call to be lifted above the
         # method.  flisp might be messing up overlays when it does this, since
         # it removes all locals, not just closure ids.
+        mtable = kind(ex[1]) === K"BindingId" &&
+            haskey(ctx.closure_bindings, ex[1].var_id) ?
+            @ast(ctx, ex[1], (::K"nothing")) : _convert_closures(ctx, ex[1])
         @ast ctx ex [K"method"
-            (::K"nothing"(ex[1]))
-            _convert_closures(ctx, ex[2])
-            _convert_closures(ctx, ex[3])]
+            mtable
+            [K"call" "svec"::K"core"
+                _convert_closures(ctx, ex[2])
+                [K"call" "svec"::K"core" tvs...]
+                (::K"SourceLocation")]
+            closure_convert_lambda(ctx, ex[3], sps)
+        ]
     elseif k == K"function_type"
         func_name = ex[1]
         if kind(func_name) == K"BindingId" && get_binding(ctx, func_name).kind === :local
             @jl_assert(haskey(ctx.closure_infos, func_name.var_id),
                        (ex, "function_type of local without known closure type"))
-            ctx.closure_infos[func_name.var_id].type_name
+            ci = ctx.closure_infos[func_name.var_id]
+            if isempty(ci.capt_sp) || ci !== ctx.capture_rewriting
+                ci.type_name
+            else
+                # flisp: fix-function-arg-type
+                tvs = mapsyntax(
+                    sp->binding_ex(ctx, ctx.sp_typevars[sp.var_id::IdTag]),
+                    ci.capt_sp)
+                @ast ctx ex [K"call" "apply_type"::K"core" ci.type_name tvs...]
+            end
         else
             @ast ctx ex [K"call" TypeEqOf::K"core" _convert_closures(ctx, func_name)]
         end
@@ -493,35 +532,39 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
         name = ex[1]
         is_closure = kind(name) == K"BindingId" && get_binding(ctx, name).kind === :local
         cap_rewrite = is_closure ? ctx.closure_infos[name.var_id] : nothing
-        ctx2 = ClosureConversionCtx(ctx.graph, ctx.bindings, ctx.mod,
-                                    ctx.closure_bindings, cap_rewrite, ex.lambda_bindings,
-                                    ctx.is_toplevel_seq_point, ctx.toplevel_pure, ctx.toplevel_stmts,
-                                    ctx.closure_infos)
-        body = map_cl_convert(ctx2, ex[2], false)
+        ctx2 = ClosureConversionCtx(
+            ctx.graph, ctx.bindings, ctx.mod,
+            ctx.closure_bindings, cap_rewrite, ex.lambda_bindings, ctx.sp_typevars,
+            ctx.toplevel, true, ctx.toplevel_pure, ctx.toplevel_stmts,
+            ctx.closure_infos)
+        tvs = map_cl_convert(ctx2, ex[2], true)
+        if !ctx.toplevel
+            push!(ctx2.toplevel_stmts, tvs)
+            tvs = @ast ctx ex[2] (::K"TOMBSTONE")
+        end
+        body = map_cl_convert(ctx2, ex[3], false)
         if is_closure
-            if ctx.is_toplevel_seq_point
-                body
+            if ctx.toplevel
+                @ast ctx ex [K"block" tvs body]
             else
-                # Move methods out to a top-level sequence point.
-                push!(ctx.toplevel_stmts, body)
+                push!(ctx2.toplevel_stmts, body)
                 @ast ctx ex (::K"TOMBSTONE")
             end
         else
-            @ast ctx ex [K"block"
-                body
-                ::K"TOMBSTONE"
-            ]
+            @ast ctx ex [K"block" tvs body (::K"TOMBSTONE")]
         end
     elseif k == K"_opaque_closure"
         closure_binds = ctx.closure_bindings[ex[1].var_id]
-        field_syms, field_orig_bindings, field_inds, _field_is_box =
+        field_syms, field_orig_bindings, field_inds, _field_is_box, capt_sp =
             closure_type_fields(ctx, ex, closure_binds, true)
 
-        capture_rewrites = ClosureInfo(ex #=unused=#, field_syms, field_inds)
+        capture_rewrites = ClosureInfo(ex #=unused=#, field_syms, field_inds, capt_sp)
 
-        ctx2 = ClosureConversionCtx(ctx.graph, ctx.bindings, ctx.mod,
-                                    ctx.closure_bindings, capture_rewrites, ctx.lambda_bindings,
-                                    false, ctx.toplevel_pure, ctx.toplevel_stmts, ctx.closure_infos)
+        ctx2 = ClosureConversionCtx(
+            ctx.graph, ctx.bindings, ctx.mod,
+            ctx.closure_bindings, capture_rewrites, ctx.lambda_bindings,
+            ctx.sp_typevars, false, false,
+            ctx.toplevel_pure, ctx.toplevel_stmts, ctx.closure_infos)
 
         argt = _convert_closures(ctx, ex[2])
         rt_lb = _convert_closures(ctx, ex[3])
@@ -545,21 +588,19 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
                 ex[6] # nargs
                 ex[7] # is_va
                 ex[8] # functionloc
-                closure_convert_lambda(ctx2, ex[9])
+                closure_convert_lambda(ctx2, ex[9], SyntaxList(ctx))
             ]
             init_closure_args...
         ]
     else
-        # A small number of kinds are toplevel-preserving in terms of closure
-        # closure definitions will be lifted out into `toplevel_stmts` if they
-        # occur inside `ex`.
-        toplevel_seq_preserving = k == K"if" || k == K"elseif" || k == K"block" ||
-                              k == K"tryfinally" || k == K"trycatchelse"
+        toplevel_seq_preserving =
+            k == K"if" || k == K"elseif" || k == K"block" ||
+            k == K"tryfinally" || k == K"trycatchelse"
         map_cl_convert(ctx, ex, toplevel_seq_preserving)
     end
 end
 
-function closure_convert_lambda(ctx, ex)
+function closure_convert_lambda(ctx, ex, sps)
     @jl_assert kind(ex) == K"lambda" ex
     lambda_bindings = ex.lambda_bindings
     interpolations = nothing
@@ -570,14 +611,16 @@ function closure_convert_lambda(ctx, ex)
     else
         cap_rewrite = ctx.capture_rewriting
     end
-    ctx2 = ClosureConversionCtx(ctx.graph, ctx.bindings, ctx.mod,
-                                ctx.closure_bindings, cap_rewrite, lambda_bindings,
-                                ex.is_toplevel_thunk, ctx.toplevel_pure && ex.toplevel_pure,
-                                ctx.toplevel_stmts, ctx.closure_infos)
+    ctx2 = ClosureConversionCtx(
+        ctx.graph, ctx.bindings, ctx.mod,
+        ctx.closure_bindings, cap_rewrite, lambda_bindings, ctx.sp_typevars,
+        ex.is_toplevel_thunk, ex.is_toplevel_thunk,
+        ctx.toplevel_pure && ex.toplevel_pure,
+        ctx.toplevel_stmts, ctx.closure_infos)
     lambda_children = SyntaxList(ctx)
     args = ex[1]
     push!(lambda_children, args)
-    push!(lambda_children, ex[2])
+    push!(lambda_children, @ast ctx ex[2] [K"block" sps...])
 
     # Add box initializations for arguments which are captured by an inner lambda
     body_stmts = SyntaxList(ctx)
@@ -640,10 +683,10 @@ Invariants:
     ctx_out = ClosureConversionCtx(ctx.graph, ctx.bindings,
                                    ctx.layer.mod,
                                    ctx.closure_bindings, nothing,
-                                   ex.lambda_bindings,
-                                   false, true, SyntaxList(ctx.graph),
+                                   ex.lambda_bindings, ctx.sp_typevars,
+                                   false, true, true, SyntaxList(ctx.graph),
                                    Dict{IdTag,ClosureInfo{Attrs}}())
-    ex_out = closure_convert_lambda(ctx_out, ex)
+    ex_out = closure_convert_lambda(ctx_out, ex, children(ex[2]))
     if !isempty(ctx_out.toplevel_stmts)
         throw(LoweringError(first(ctx_out.toplevel_stmts), "Top level code was found outside any top level context. `@generated` functions may not contain closures, including `do` syntax and generators/comprehension"))
     end

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -646,7 +646,7 @@ function closure_convert_lambda(ctx, ex, sps)
     lam = setattr!(mknode(ex, lambda_children), :lambda_bindings, lambda_bindings)
     if !isnothing(interpolations) && !isempty(interpolations)
         @ast ctx ex [K"call"
-            replace_captured_locals!::K"Value"
+            replace_captured_locals::K"Value"
             lam
             [K"call"
                 "svec"::K"core"

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -376,13 +376,13 @@ end
 
 # Map the children of `ex` through _convert_closures, lifting any toplevel
 # closure definition statements to occur before the other content of `ex`.
-function map_cl_convert(ctx::ClosureConversionCtx, ex, toplevel_preserving)
-    if ctx.toplevel && !toplevel_preserving
+function map_cl_convert(ctx::ClosureConversionCtx, ex)
+    if ctx.toplevel
         toplevel_stmts = SyntaxList(ctx)
         ctx2 = ClosureConversionCtx(
             ctx.graph, ctx.bindings, ctx.mod,
             ctx.closure_bindings, ctx.capture_rewriting, ctx.lambda_bindings,
-            ctx.sp_typevars, false, ctx.lifted,
+            ctx.sp_typevars, true, ctx.lifted,
             ctx.toplevel_pure, toplevel_stmts, ctx.closure_infos)
         res = mapchildren(e->_convert_closures(ctx2, e), ctx2, ex)
         if isempty(toplevel_stmts)
@@ -537,12 +537,12 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
             ctx.closure_bindings, cap_rewrite, ex.lambda_bindings, ctx.sp_typevars,
             ctx.toplevel, true, ctx.toplevel_pure, ctx.toplevel_stmts,
             ctx.closure_infos)
-        tvs = map_cl_convert(ctx2, ex[2], true)
+        tvs = map_cl_convert(ctx2, ex[2])
         if !ctx.toplevel
             push!(ctx2.toplevel_stmts, tvs)
             tvs = @ast ctx ex[2] (::K"TOMBSTONE")
         end
-        body = map_cl_convert(ctx2, ex[3], false)
+        body = map_cl_convert(ctx2, ex[3])
         if is_closure
             if ctx.toplevel
                 @ast ctx ex [K"block" tvs body]
@@ -593,10 +593,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
             init_closure_args...
         ]
     else
-        toplevel_seq_preserving =
-            k == K"if" || k == K"elseif" || k == K"block" ||
-            k == K"tryfinally" || k == K"trycatchelse"
-        map_cl_convert(ctx, ex, toplevel_seq_preserving)
+        map_cl_convert(ctx, ex)
     end
 end
 

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -375,6 +375,58 @@ function apply_arglist_meta(st, meta::Union{Nothing, Symbol, Dict{String, Symbol
     end
 end
 
+# flisp bug; underscore sparams are sometimes readable (see #60626).  Should
+# return `st` unchanged 99% of the time.
+function force_readable_sparams(st)
+    kind(st) === K"where" && is_flisp_compat(st) || return st
+    sig, wheres = let (sig0, wheres0) = flatten_wheres(st)
+        sig0, mapsyntax(typevar_bounds, wheres0)
+    end
+    any(w->is_flisp_compat(w) && is_writeonly_est_name(w[1].name_val::String),
+        wheres) || return st
+
+    g = st._graph
+    seen = Set{String}()
+    lt = @ast g st "<:"::K"Identifier"
+    for i in eachindex(wheres)
+        n = wheres[i][1]
+        n_str = n.name_val::String
+        lb = _mangle_writeonly(wheres[i][2], seen)
+        ub = _mangle_writeonly(wheres[i][3], seen)
+        is_flisp_compat(n) && is_writeonly_est_name(n_str) && push!(seen, n_str)
+        wheres[i] = @ast g st [K"comparison" lb lt _mangle_writeonly(n, seen) lt ub]
+    end
+    mangle = args->mapsyntax(a->_mangle_writeonly_argt(a, seen), args)
+    sig2 = @stm sig begin
+        [K"::" [K"call" as...] t] -> @ast g sig [K"::" [K"call" mangle(as)...] t]
+        [K"call" as...] -> @ast g sig [K"call" mangle(as)...]
+        [K"tuple" as...] -> @ast g sig [K"tuple" mangle(as)...]
+    end
+    @ast g st [K"where" sig2 wheres...]
+end
+_mangle_writeonly_argt(st, seen) = let g = st._graph; @stm st begin
+    [K"parameters" _...] -> mapchildren(c->_mangle_writeonly_argt(c, seen), g, st)
+    [K"kw" x v] -> @ast g st [K"kw" _mangle_writeonly_argt(x, seen) v]
+    [K"=" x v] -> @ast g st [K"=" _mangle_writeonly_argt(x, seen) v]
+    [K"..." x] -> @ast g st [K"..." _mangle_writeonly_argt(x, seen)]
+    [K"::" x t] -> @ast g st [K"::" x _mangle_writeonly(t, seen)]
+    [K"::" t] -> @ast g st [K"::" _mangle_writeonly(t, seen)]
+    [K"overlay" mt x] -> @ast g st [K"overlay" mt _mangle_writeonly(x, seen)]
+    _ -> st
+end; end
+function _mangle_writeonly(st, seen)
+    g = st._graph
+    k = kind(st)
+    if k === K"Identifier" && !hasattr(st, :mod) && is_flisp_compat(st)
+        n = st.name_val::String
+        !(n in seen) ? st : @ast g st (string(n, "FIXME#60626")::K"Identifier")
+    elseif is_leaf(st) || is_quoted(st) || k === K"->" || k === K"function"
+        st
+    else
+        mapchildren(c->_mangle_writeonly(c, seen), g, st)
+    end
+end
+
 # nothing if not found, or symbol if 0-arg [no]specialize, or dict arg->meta
 function collect_body_arg_meta(st)
     out = nothing
@@ -513,6 +565,7 @@ function est_to_dst(st::SyntaxTree)
         ([K"=" l r], when=(is_eventually_call(l))) -> let
             # no fix_arglist needed, since this func can't be anonymous
             l = apply_arglist_meta(l, collect_body_arg_meta(r))
+            l = force_readable_sparams(l)
             if has_if_generated(r)
                 gen, nongen = split_generated(r, true), split_generated(r, false)
                 r2 = @ast g st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]
@@ -523,6 +576,7 @@ function est_to_dst(st::SyntaxTree)
         end
         [K"function" l r] -> let
             l = apply_arglist_meta(_dst_fix_arglist(l), collect_body_arg_meta(r))
+            l = force_readable_sparams(l)
             if has_if_generated(r)
                 gen, nongen = split_generated(r, true), split_generated(r, false)
                 r2 = @ast g st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]
@@ -533,6 +587,7 @@ function est_to_dst(st::SyntaxTree)
         end
         [K"->" l r] -> let
             l = apply_arglist_meta(_dst_fix_arglist(l), collect_body_arg_meta(r))
+            l = force_readable_sparams(l)
             if has_if_generated(r)
                 gen, nongen = split_generated(r, true), split_generated(r, false)
                 r2 = @ast g st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2315,14 +2315,6 @@ end
 #-------------------------------------------------------------------------------
 # Expansion of function definitions
 
-# Expand `where` clause(s) of a function into (typevar_names, typevar_stmts) where
-# - `typevar_names` are the names of the type's type parameters
-# - `typevar_stmts` are a list of statements to define a `TypeVar` for each parameter
-#   name in `typevar_names`, with exactly one per `typevar_name`. Some of these
-#   may already have been emitted.
-# - `new_typevar_stmts` is the list of statements which needs to be emitted
-#   prior to uses of `typevar_names`.
-
 # (where (where x a b) c d) -> (x, [c d a b])
 function flatten_wheres(ex)
     tvs = SyntaxList(ex._graph)
@@ -2426,6 +2418,15 @@ function assign_sparams(ctx, tvs)
     out
 end
 
+function method_def_sparams(ctx, src, tvs)
+    out = SyntaxList(ctx)
+    for tv in tvs
+        @jl_assert kind(tv) === K"_typevar" tv
+        push!(out, @ast ctx tv [K"typevar" tv[1] bounds_to_typevar(ctx, tv)])
+    end
+    @ast ctx src [K"block" out...]
+end
+
 # Hack: Normally just (block ex body), but needs special handling due to
 # pre-quoted parts of generated function body, where we need to prepend
 # desugarable AST to macro AST.  Fortunately there are only two places (meta
@@ -2465,23 +2466,13 @@ function method_def_expr(ctx, src, mtable, sparams, argl, body,
     end
     # Needs to be done per method, not per function (may create ssavalues)
     arg_types = mapsyntax(a->expand_forms_2(ctx, a[2]), argl)
-    @ast ctx src [K"block"
-        # possible TODO: flisp assigns typevars to ssavalues and manually
-        # resolves them here instead of assigning to locals
-        assign_sparams(ctx, sparams)...
-        method_metadata := [K"call"(src) "svec"::K"core"
-            [K"call" "svec"::K"core" arg_types...]
-            [K"call" "svec"::K"core" mapindex(sparams, 1)...]
-            ::K"SourceLocation"(src[1])]
-        [K"method"
-            mtable
-            method_metadata
-            [K"lambda"(body, is_toplevel_thunk=false, toplevel_pure=false)
-                [K"block" mapindex(argl, 1)...]
-                [K"block" mapindex(sparams, 1)...]
-                expand_forms_2(ctx, body)
-                is_core_Any(rett) ? nothing : expand_forms_2(ctx, rett)]]
-        [K"removable" method_metadata]]
+    @ast ctx src [K"method" mtable
+        [K"call" "svec"::K"core" arg_types...]
+        [K"lambda"(body, is_toplevel_thunk=false, toplevel_pure=false)
+            [K"block" mapindex(argl, 1)...]
+            [K"block" mapindex(sparams, 1)...]
+            expand_forms_2(ctx, body)
+            is_core_Any(rett) ? nothing : expand_forms_2(ctx, rett)]]
 end
 
 function _untyped_arg(a)
@@ -2548,7 +2539,7 @@ function generated_method_defs(ctx, src, mtable, sparams, argl, body, rett)
     @ast ctx src [K"block"
         [K"global" gen_name]
         [K"function_decl" gen_name]
-        [K"method_defs" gen_name gen_mdef]
+        [K"method_defs" gen_name [K"block"] gen_mdef]
         nongen_mdef]
 end
 
@@ -2605,6 +2596,7 @@ function optional_positional_defs(ctx, src, mtable, sparams, argl, body, rett)
             @ast ctx src [K"block"
                 [K"call" mapindex(passed, 1)... opt_defaults[i]]]
         end
+        # this function and method_def_expr need sp bounds because of this
         push!(methods, method_def_expr(
             ctx, src, mtable, used_typevars(passed, sparams),
             passed, wrapper_body))
@@ -2670,7 +2662,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
     end
     (kw_decls, kw_names, kw_syms, kw_defaults, restkw) = expand_kw_args(ctx, kws)
     ordered_defaults = any(val->contains_identifier(val, kw_names), kw_defaults)
-    positional_sparams = used_typevars(pargl, sparams)
+    pos_sparams = used_typevars(pargl, sparams)
 
     m1_name = let n = kind(mtable) === K"nothing" ? "_" : mtable.name_val,
         mangled = string(startswith(n, '#') ? "" : "#kw_body#", n, "#")
@@ -2702,7 +2694,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
                 @ast ctx src [K"call" m1_name kw_names... rkw forward_pargl...])
         end
         method_def_expr(
-            ctx, src, mtable, positional_sparams, pargl,
+            ctx, src, mtable, pos_sparams, pargl,
             @ast(ctx, src, [K"block" [K"return" body2]]))
     end
     # (3) Core.kwcall(arg2::NamedTuple, pargl...) methods (one per optarg).
@@ -2791,16 +2783,16 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
             ]
             arg2 = @ast ctx arg2_name [K"::" arg2_name "NamedTuple"::K"core"]
             method_def_expr(
-                ctx, src, mtable, positional_sparams,
+                ctx, src, mtable, pos_sparams,
                 SyntaxList(arg1, arg2, pargl...), kwcall_body)
         end
     end
     @ast ctx src [K"block"
         [K"function_decl" m1_name]
         kind(mtable) === K"nothing" ? nothing : [K"function_decl" mtable]
-        [K"method_defs" m1_name mdefs1]
-        [K"method_defs" mtable mdefs2]
-        [K"method_defs" mtable mdefs3]
+        [K"method_defs" m1_name method_def_sparams(ctx, src, sparams) mdefs1]
+        [K"method_defs" mtable method_def_sparams(ctx, src, pos_sparams) mdefs2]
+        [K"method_defs" mtable method_def_sparams(ctx, src, pos_sparams) mdefs3]
         mtable
     ]
 end
@@ -2907,7 +2899,7 @@ function expand_function_def(ctx, src, raw_args, wheres, body, rett)
             end
         end
     end
-    sparams = mapsyntax(x->typevar_bounds(ctx, x), wheres)
+    sparams = mapsyntax(typevar_bounds, wheres)
     if has_kws
         pos_va = @stm raw_args[end-1] begin
             [K"kw" [K"..." _] _...] -> true
@@ -2918,8 +2910,9 @@ function expand_function_def(ctx, src, raw_args, wheres, body, rett)
     else
         @ast ctx src [K"block"
             (overlay || kind(mtable) === K"nothing") ? nothing : [K"function_decl" mtable]
-            [K"method_defs" mtable [K"block"
-                method_def_expr(ctx, src, mtable, sparams, argl, body, rett)]]
+            [K"method_defs" mtable
+                method_def_sparams(ctx, src, sparams)
+                [K"block" method_def_expr(ctx, src, mtable, sparams, argl, body, rett)]]
                 # TODO: overlay should return the method
                 [K"removable" mtable]]
     end
@@ -3044,8 +3037,8 @@ end
 
 # argument to where expression -> (_typevar name expanded_lb expanded_ub)
 # used, e.g. in all `sparams`, where flisp generally uses a list (name, lb, ub)
-function typevar_bounds(ctx, ex)
-    any = @ast ctx ex "Any"::K"core"
+function typevar_bounds(ex)
+    any = @ast ex._graph ex "Any"::K"core"
     (name, lb, ub) = bounds = @stm ex begin
         [K"Identifier"] -> (ex, any, any)
         [K"Placeholder"] -> (ex, any, any)
@@ -3054,7 +3047,7 @@ function typevar_bounds(ctx, ex)
         [K"<:" x ub] -> (x, any, ub)
         [K">:" x lb] -> (x, lb, any)
     end
-    @ast ctx ex [K"_typevar" name lb ub]
+    @ast ex._graph ex [K"_typevar" name lb ub]
 end
 
 function bounds_to_typevar(ctx, ex)
@@ -3119,7 +3112,7 @@ function expand_typevars(ctx, type_params)
     typevar_names = SyntaxList(ctx)
     typevar_stmts = SyntaxList(ctx)
     for param in type_params
-        bounds = typevar_bounds(ctx, param)
+        bounds = typevar_bounds(param)
         n = bounds[1]
         push!(typevar_names, n)
         push!(typevar_stmts, @ast ctx param [K"block"
@@ -3379,7 +3372,7 @@ function rewrite_ctor(ctx, ex, tname, global_tname, struct_typevars, field_types
                 rewrite_ctor_sig(ctx, sig, tname, global_tname, struct_typevars, wheres)
             body2 = _rewrite_ctor_new_calls(
                 ctx, body, global_tname,
-                mapsyntax(x->typevar_bounds(ctx, x), wheres),
+                mapsyntax(typevar_bounds, wheres),
                 struct_typevars, ctor_self, field_types)
             @ast ctx ex [K"function" call2 body2]
         end
@@ -3836,7 +3829,7 @@ function expand_struct_def(ctx, ex, docs)
             if !typevar_in_fields
                 typevar_in_bounds = any(type_params[i+1:end]) do param
                     # Check the bounds of subsequent type params
-                    (lb,ub) = let bounds = typevar_bounds(ctx, param)
+                    (lb,ub) = let bounds = typevar_bounds(param)
                         bounds[2], bounds[3]
                     end
                     # todo: flisp lowering tests `lb` here so we also do. But
@@ -3961,7 +3954,7 @@ end
 # Expand `where` syntax
 
 function expand_where(ctx, srcref, lhs, rhs)
-    bounds = typevar_bounds(ctx, rhs)
+    bounds = typevar_bounds(rhs)
     v = bounds[1]
     @ast ctx srcref [K"let"
         [K"block" [K"=" v bounds_to_typevar(ctx, bounds)]]

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -124,9 +124,18 @@ function _register_kinds()
             # [K"function_type" name]
             # Evaluates to the type of the function or closure with given `name`
             "function_type"
-            # [K"method_defs" name block]
-            # The code in `block` defines methods for generic function `name`
+            # [K"method_defs" name [K"block" typevars...] [K"block" body...]]
+            # The code in `body` defines methods for generic function `name`.
+            # If non-toplevel, all contained methods share a closure type.
+            # `typevars` are assigned-once top-level locals only referenced
+            # inside `K"method"`, but outside of `K"lambda"`, since any
+            # reference inside a lambda should resolve to the lambda's sparam
+            # shadowing it.
             "method_defs"
+            # [K"typevar" name rhs] appears only in method_defs and gets special
+            # scope resolution: a sequence of K"sparam"s are similar to nested
+            # let-blocks, but without introducing a local scope.
+            "typevar"
             "_opaque_closure"
             # The enclosed statements must be executed at top level
             "toplevel_butfirst"

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -1131,10 +1131,11 @@ function renumber_body(ctx, input_code, slot_rewrites)
     for ex in input_code
         k = kind(ex)
         ex_out = nothing
-        if k == K"=" && is_ssa(ctx, ex[1])
+        if k == K"=" && (b = get_binding(ctx, ex[1]); b.is_ssa || b.kind == :typevar)
             lhs_id = _binding_id(ex[1])
             @jl_assert(!haskey(ssa_rewrites, lhs_id),
                        (ex, "multiple assignments to ssavalue"))
+            @jl_assert ctx.is_toplevel_thunk || b.kind !== :typevar binding_ex(ctx, b)
             if is_ssa(ctx, ex[2])
                 # For SSA₁ = SSA₂, record that all uses of SSA₁ should be replaced by SSA₂
                 ssa_rewrites[lhs_id] = ssa_rewrites[_binding_id(ex[2])]

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -134,13 +134,14 @@ function eval_closure_type(mod::Module, closure_type_name::Symbol,
 end
 
 # Interpolate captured local variables into the CodeInfo for a global method
-function replace_captured_locals!(codeinfo::Core.CodeInfo, locals::Core.SimpleVector)
-    for (i, ex) in enumerate(codeinfo.code)
+function replace_captured_locals!(ci_in::Core.CodeInfo, locals::Core.SimpleVector)
+    ci = copy(ci_in)
+    for (i, ex) in enumerate(ci.code)
         if Meta.isexpr(ex, :captured_local)
-            codeinfo.code[i] = locals[ex.args[1]::Int]
+            ci.code[i] = locals[ex.args[1]::Int]
         end
     end
-    codeinfo
+    ci
 end
 
 #--------------------------------------------------

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -105,9 +105,13 @@ end
 
 #--------------------------------------------------
 # Functions called by closure conversion
-function eval_closure_type(mod::Module, closure_type_name::Symbol, field_names, field_is_box)
+function eval_closure_type(mod::Module, closure_type_name::Symbol,
+                           capt_sp, field_names, field_is_box)
     type_params = Core.TypeVar[]
     field_types = []
+    for name in capt_sp
+        push!(type_params, Core.TypeVar(name))
+    end
     for (name, isbox) in zip(field_names, field_is_box)
         if !isbox
             T = Core.TypeVar(Symbol(name, "_type"))

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -134,7 +134,7 @@ function eval_closure_type(mod::Module, closure_type_name::Symbol,
 end
 
 # Interpolate captured local variables into the CodeInfo for a global method
-function replace_captured_locals!(ci_in::Core.CodeInfo, locals::Core.SimpleVector)
+function replace_captured_locals(ci_in::Core.CodeInfo, locals::Core.SimpleVector)
     ci = copy(ci_in)
     for (i, ex) in enumerate(ci.code)
         if Meta.isexpr(ex, :captured_local)

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -78,6 +78,12 @@ struct ScopeResolutionContext{Attrs} <: AbstractLoweringContext
     # be assigned to without the `global` keyword in soft scopes due to being
     # assigned to at top level, or passing the defined-and-owned-global check.
     soft_assignable_globals::Set{NameKey}
+    # Every static parameter corresponds to some typevar (top-level local)
+    # required to create this method
+    sp_typevars::Dict{IdTag, IdTag}
+    # Typevars referenced in each typevar's bounds.  Closures capturing a static
+    # parameter must also capture the sparams of its typevar's dependencies
+    tv_deps::Dict{IdTag, Vector{IdTag}}
     enable_soft_scopes::Bool
     world::UInt
 end
@@ -100,6 +106,7 @@ _var_str(v) = v === :local ? "local variable" :
     v === :global ? "global variable" :
     v === :argument ? "argument" :
     v === :destructured_arg ? "destructured argument" :
+    v === :typevar ? "typevar" :
     v === :static_parameter ? "static parameter" : "unknown"
 
 # Declare `ex` in `scope`, unless a binding already exists with the same name in
@@ -167,6 +174,7 @@ function add_lambda_local!(ctx, scope::ScopeInfo, b)
         return
     end
     lam = scope.is_lifted ? top_scope(ctx) : enclosing_lambda(ctx, scope)
+    b.kind == :typevar && @jl_assert scope.is_lifted binding_ex(ctx, b)
     @jl_assert !haskey(lam.locals_capt, b.id) (
         binding_ex(ctx, b), "adding lambda local twice")
     lam.locals_capt[b.id] = false
@@ -175,11 +183,12 @@ function add_lambda_local!(ctx, scope::ScopeInfo, b)
 end
 
 function ensure_captured!(ctx, scope::ScopeInfo, b)
-    if b.kind === :global || b.is_ssa
+    if b.kind === :global || b.kind === :typevar || b.is_ssa
         return
     end
     lam = enclosing_lambda(ctx, scope)
     if !haskey(lam.locals_capt, b.id)
+        # assert is opaque closure, or b not static_parameter
         b.is_captured = true
         lam.locals_capt[b.id] = true
         s2 = parent(ctx, lam)
@@ -203,6 +212,9 @@ function resolve_name(ctx, ex; exclude_toplevel_globals=false)
         bid = get(ctx.scopes[sid].vars, nk, nothing)
         isnothing(bid) && continue
         b = get_binding(ctx, bid)
+        if b.kind === :typevar # only visible to lifted scopes
+            ctx.scopes[ctx.scope_stack[end]].is_lifted || continue
+        end
         if !exclude_toplevel_globals || sid !== top_scope(ctx).id || b.kind !== :global
             return b
         end
@@ -281,7 +293,6 @@ function enter_scope!(ctx, ex)
     parent_id = (is_toplevel_thunk || isempty(ctx.scope_stack)) ?
         0 : ctx.scopes[ctx.scope_stack[end]].id
     scope = ScopeInfo(ctx, parent_id, ex)
-    push!(ctx.scope_stack, scope.id)
 
     #---------------------------------------------------------------------------
     # Find explicit decls that may influence assignment assignment resolution
@@ -291,8 +302,13 @@ function enter_scope!(ctx, ex)
             explicit_declare_in_scope!(ctx, scope, c, :argument)
         end
         for c in children(ex[2])
-            @jl_assert kind(c) in KSet"Identifier BindingId Placeholder" c
-            explicit_declare_in_scope!(ctx, scope, c, :static_parameter)
+            kind(c) === K"Placeholder" && continue
+            @jl_assert kind(c) === K"Identifier" c
+            sp_id = explicit_declare_in_scope!(ctx, scope, c, :static_parameter)
+            p = parent(ctx, scope)
+            if !isnothing(p) # usually true, false for generated functions
+                ctx.sp_typevars[sp_id] = p.vars[NameKey(c)]
+            end
         end
         for c in children(ex)[3:end]
             _find_scope_decls!(ctx, scope, c)
@@ -302,6 +318,7 @@ function enter_scope!(ctx, ex)
             _find_scope_decls!(ctx, scope, c)
         end
     end
+    push!(ctx.scope_stack, scope.id) # influences resolution below
 
     #---------------------------------------------------------------------------
     # Find assignment targets, possibly introducing implicit locals and globals
@@ -424,9 +441,15 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         resolve_name(ctx, ex[1]).is_always_defined = true
         newleaf(ctx, ex, K"TOMBSTONE")
     elseif k == K"lambda"
+        # opaque closures are the exception
+        # scope isa ScopeInfo && @jl_assert scope.is_lifted ex
         newscope = enter_scope!(ctx, ex)
         arg_bindings = _resolve_scopes(ctx, ex[1], newscope)
-        sparam_bindings = _resolve_scopes(ctx, ex[2], newscope)
+        sparam_bindings = SyntaxList(ctx)
+        for sp in children(ex[2])
+            kind(sp) === K"Placeholder" && continue
+            push!(sparam_bindings, _resolve_scopes(ctx, sp, newscope))
+        end
         self_id = if numchildren(arg_bindings) === 0
             0
         elseif getmeta(ex[1][1], :is_kwcall_self, false)
@@ -451,10 +474,8 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
                                is_toplevel_thunk=ex.is_toplevel_thunk,
                                toplevel_pure=ex.toplevel_pure)
             arg_bindings
-            sparam_bindings
-            [K"block"
-                body_stmts...
-            ]
+            [K"block" sparam_bindings...]
+            [K"block" body_stmts...]
             ret_var
         ]
     elseif k == K"scope_block"
@@ -468,15 +489,25 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         @ast ctx ex [K"block" stmts...]
     elseif k == K"method_defs"
         newscope = enter_scope!(ctx, ex)
-        mname = _resolve_scopes(ctx, ex[1], newscope)
+        mname = _resolve_scopes(ctx, ex[1], scope)
+        tvs = SyntaxList(ctx.graph)
+        for tv in children(ex[2]) # hack. flisp: replace-vars
+            rhs = _resolve_scopes(ctx, tv[2], newscope)
+            if kind(tv[1]) === K"Placeholder"
+                @ast ctx tv [K"=" tv[1] rhs]
+            else
+                bid = declare_in_scope!(ctx, newscope, tv[1], :typevar)
+                get_binding(ctx, bid).is_always_defined = true
+                push!(tvs, @ast ctx tv [K"=" binding_ex(ctx, bid) rhs])
+            end
+        end
         stmts = SyntaxList(ctx)
         add_local_decls!(ctx, stmts, ex, newscope)
-        for e in children(ex[2])
-            push!(stmts, _resolve_scopes(ctx, e, newscope))
-        end
+        push!(stmts, _resolve_scopes(ctx, ex[3], newscope))
         pop!(ctx.scope_stack)
         lb = LambdaBindings(0, top_scope(ctx).id, top_scope(ctx).locals_capt::Dict)
-        @ast ctx ex [K"method_defs"(lambda_bindings=lb) mname [K"block" stmts...]]
+        @ast ctx ex [K"method_defs"(lambda_bindings=lb)
+            mname [K"block" tvs...] [K"block" stmts...]]
     elseif k == K"islocal"
         e1 = ex[1]
         islocal = kind(e1) == K"Identifier" &&
@@ -615,9 +646,11 @@ end
 struct ClosureBindings
     name_stack::Vector{String}      # Names of functions the closure is nested within
     lambdas::Vector{LambdaBindings} # Bindings for each method of the closure
+    capt_sp::Set{IdTag}
 end
 
-ClosureBindings(name_stack) = ClosureBindings(name_stack, Vector{LambdaBindings}())
+ClosureBindings(name_stack) =
+    ClosureBindings(name_stack, Vector{LambdaBindings}(), Set{IdTag}())
 
 struct VariableAnalysisContext{Attrs} <: AbstractLoweringContext
     graph::SyntaxGraph{Attrs}
@@ -625,11 +658,14 @@ struct VariableAnalysisContext{Attrs} <: AbstractLoweringContext
     bindings::Bindings
     scopes::Vector{ScopeInfo}
     lambda_bindings::LambdaBindings
+    lifted::Bool
     # Stack of method definitions for closure naming
     method_def_stack::SyntaxList{Attrs, Vector{NodeId}}
     # Collection of information about each closure, principally which methods
     # are part of the closure (and hence captures).
     closure_bindings::Dict{IdTag,ClosureBindings}
+    sp_typevars::Dict{IdTag, IdTag}
+    tv_deps::Dict{IdTag, Vector{IdTag}}
 end
 
 function init_closure_bindings!(ctx, fname)
@@ -670,6 +706,13 @@ function add_assign!(b::BindingInfo)
     b.is_assigned = true
 end
 
+function current_closure_bindings(ctx)
+    isempty(ctx.method_def_stack) && return nothing
+    mdef = ctx.method_def_stack[end]
+    kind(mdef) !== K"BindingId" && return nothing
+    get(ctx.closure_bindings, mdef.var_id::IdTag, nothing)
+end
+
 # Update ctx.bindings metadata based on binding usage
 function analyze_variables!(ctx, ex)
     k = kind(ex)
@@ -680,9 +723,13 @@ function analyze_variables!(ctx, ex)
         # but is filled in here.
         scope = ctx.scopes[ctx.lambda_bindings.scope_id]
         ensure_captured!(ctx, scope, b)
-        @jl_assert (b.kind === :global ||
-            b.is_ssa ||
+        # b.kind === :static_parameter && ensure_captured!(ctx, scope, b)
+        @jl_assert (b.kind === :global || b.kind === :typevar || b.is_ssa ||
             haskey(ctx.lambda_bindings.locals_capt, b.id)) ex binding_ex(ctx, b.id)
+        if b.kind === :static_parameter && ctx.lifted
+            cb = current_closure_bindings(ctx)
+            isnothing(cb) || push!(cb.capt_sp, b.id)
+        end
     elseif k == K"Identifier"
         @jl_assert false ex
     elseif k == K"break" && numchildren(ex) >= 2
@@ -744,7 +791,14 @@ function analyze_variables!(ctx, ex)
         foreach(e->analyze_variables!(ctx, e), children(ex))
     elseif k == K"method_defs"
         push!(ctx.method_def_stack, ex[1])
-        analyze_variables!(ctx, ex[2])
+        is_closure = kind(ex[1]) == K"BindingId" &&
+            get_binding(ctx, ex[1]).kind === :local
+        ctx2 = VariableAnalysisContext(
+            ctx.graph, ctx.layer, ctx.bindings, ctx.scopes,
+            ctx.lambda_bindings, true, ctx.method_def_stack,
+            ctx.closure_bindings, ctx.sp_typevars, ctx.tv_deps)
+        analyze_variables!(ctx2, ex[2])
+        analyze_variables!(ctx2, ex[3])
         pop!(ctx.method_def_stack)
     elseif k == K"_opaque_closure"
         name = ex[1]
@@ -756,7 +810,7 @@ function analyze_variables!(ctx, ex)
         analyze_variables!(ctx, ex[9])
         pop!(ctx.method_def_stack)
     elseif k == K"lambda"
-        lambda_bindings = ex.lambda_bindings
+        lambda_bindings = ex.lambda_bindings::LambdaBindings
         if !ex.is_toplevel_thunk && !isempty(ctx.method_def_stack)
             # Record all lambdas for the same closure type in one place
             func_name = last(ctx.method_def_stack)
@@ -767,10 +821,12 @@ function analyze_variables!(ctx, ex)
                 end
             end
         end
-        ctx2 = VariableAnalysisContext(
+        let ctx2 = VariableAnalysisContext(
             ctx.graph, ctx.layer, ctx.bindings, ctx.scopes,
-            lambda_bindings, ctx.method_def_stack, ctx.closure_bindings)
-        foreach(e->analyze_variables!(ctx2, e), ex[3:end]) # body & return type
+            lambda_bindings, false, ctx.method_def_stack, ctx.closure_bindings,
+            ctx.sp_typevars, ctx.tv_deps)
+            foreach(e->analyze_variables!(ctx2, e), ex[3:end])
+        end
     else
         foreach(e->analyze_variables!(ctx, e), children(ex))
     end
@@ -813,14 +869,16 @@ enclosing lambda form and information about variables captured by closures.
     ctx2 = ScopeResolutionContext(graph, ctx.layer, ctx.bindings,
                                   Dict{ScopeLayer, Int}(),
                                   Vector{ScopeInfo}(), Vector{ScopeId}(),
-                                  Set{NameKey}(),
+                                  Set{NameKey}(), Dict{IdTag, IdTag}(),
+                                  Dict{IdTag, Vector{IdTag}}(),
                                   enable_soft_scopes,
                                   world)
     ex2 = resolve_scopes(ctx2, ex)
     ctx3 = VariableAnalysisContext(graph, ctx2.layer, ctx2.bindings,
-                                   ctx2.scopes, ex2.lambda_bindings,
+                                   ctx2.scopes, ex2.lambda_bindings, true,
                                    SyntaxList(graph),
-                                   Dict{IdTag,ClosureBindings}())
+                                   Dict{IdTag,ClosureBindings}(),
+                                   ctx2.sp_typevars, ctx2.tv_deps)
     analyze_variables!(ctx3, ex2)
     analyze_def_and_use!(ctx3, ex2)
     ctx3, ex2

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -745,7 +745,9 @@ function expand_captured_sp_deps!(ctx, cb::ClosureBindings, scope)
                     break
                 end
             end
-            (isnothing(dep_sp) || dep_sp in sps) && continue
+            isnothing(dep_sp) && throw(LoweringError(
+                binding_ex(ctx, dep_tv), "unimplemented capture in sparam bounds"))
+            dep_sp in sps && continue
             push!(sps, dep_sp)
             push!(cb.capt_sp, dep_sp)
             ensure_captured!(ctx, scope, get_binding(ctx, dep_sp))

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -222,6 +222,17 @@ function resolve_name(ctx, ex; exclude_toplevel_globals=false)
     return nothing
 end
 
+# Collect typevar bindings referenced in `ex` (a resolved typevar bound)
+function _typevar_refs!(out, ctx, ex)
+    k = kind(ex)
+    if k == K"BindingId"
+        b = get_binding(ctx, ex)
+        b.kind === :typevar && !(b.id in out) && push!(out, b.id)
+    elseif !is_leaf(ex) && needs_resolution(ex)
+        foreach(e->_typevar_refs!(out, ctx, e), children(ex))
+    end
+end
+
 function _record_layer!(ctx, ex)
     !hasattr(ex, :context) && return
     sl = (ex.context::SyntaxContext).layer
@@ -498,6 +509,9 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
             else
                 bid = declare_in_scope!(ctx, newscope, tv[1], :typevar)
                 get_binding(ctx, bid).is_always_defined = true
+                deps = Vector{IdTag}()
+                _typevar_refs!(deps, ctx, rhs)
+                isempty(deps) || (ctx.tv_deps[bid] = deps)
                 push!(tvs, @ast ctx tv [K"=" binding_ex(ctx, bid) rhs])
             end
         end
@@ -706,6 +720,37 @@ function add_assign!(b::BindingInfo)
     b.is_assigned = true
 end
 
+# When a closure captures `T` and `T`'s typevar bound references `S`, it must
+# capture `S` too
+function expand_captured_sp_deps!(ctx, cb::ClosureBindings, scope)
+    sps = copy(cb.capt_sp)
+    for lb in cb.lambdas, (id, is_capt) in lb.locals_capt
+        is_capt && get_binding(ctx, id).kind === :static_parameter && push!(sps, id)
+    end
+    todo = collect(sps)
+    while !isempty(todo)
+        sp = pop!(todo)
+        owner = ctx.scopes[get_binding(ctx, sp).lambda_id]
+        for dep_tv in get(ctx.tv_deps, ctx.sp_typevars[sp], ())
+            # The sparam for dep_tv in the same lambda that owns `sp`
+            dep_sp = nothing
+            for id in keys(owner.locals_capt)
+                b = get_binding(ctx, id)
+                if b.kind === :static_parameter &&
+                        get(ctx.sp_typevars, b.id, IdTag(0)) == dep_tv
+                    dep_sp = id
+                    break
+                end
+            end
+            (isnothing(dep_sp) || dep_sp in sps) && continue
+            push!(sps, dep_sp)
+            push!(cb.capt_sp, dep_sp)
+            ensure_captured!(ctx, scope, get_binding(ctx, dep_sp))
+            push!(todo, dep_sp)
+        end
+    end
+end
+
 function current_closure_bindings(ctx)
     isempty(ctx.method_def_stack) && return nothing
     mdef = ctx.method_def_stack[end]
@@ -797,8 +842,16 @@ function analyze_variables!(ctx, ex)
             ctx.graph, ctx.layer, ctx.bindings, ctx.scopes,
             ctx.lambda_bindings, true, ctx.method_def_stack,
             ctx.closure_bindings, ctx.sp_typevars, ctx.tv_deps)
+        if is_closure
+            cb = init_closure_bindings!(ctx2, ex[1])
+            scope = ctx.scopes[ctx2.lambda_bindings.scope_id]
+        end
         analyze_variables!(ctx2, ex[2])
         analyze_variables!(ctx2, ex[3])
+        if is_closure
+            # All captures are known now; close them over typevar-bound deps
+            expand_captured_sp_deps!(ctx, cb, scope)
+        end
         pop!(ctx.method_def_stack)
     elseif k == K"_opaque_closure"
         name = ex[1]

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -212,8 +212,11 @@ function resolve_name(ctx, ex; exclude_toplevel_globals=false)
         bid = get(ctx.scopes[sid].vars, nk, nothing)
         isnothing(bid) && continue
         b = get_binding(ctx, bid)
-        if b.kind === :typevar # only visible to lifted scopes
-            ctx.scopes[ctx.scope_stack[end]].is_lifted || continue
+        if b.kind === :typevar
+            # only visible to lifted scopes in the same lambda (we should only
+            # hit this when we filter sparams with `used_typevars`)
+            s0 = ctx.scopes[ctx.scope_stack[end]]
+            s0.is_lifted && ctx.scopes[sid].lambda_id == s0.lambda_id || continue
         end
         if !exclude_toplevel_globals || sid !== top_scope(ctx).id || b.kind !== :global
             return b

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -81,9 +81,8 @@ Base.@kwdef struct Validation1Context <: ValidationContext
                             # syntax TODO: no return in finally? type decls?
     # assign_ok::Bool=true    # no in vect, curly, [typed_]h/v/ncat
 
-    # fixme: flisp happens to allow reading of underscore vars if they are
-    # introduced like `(function (where (call f (:: arg T)...) _) body)`, and
-    # the underscore is used in T.  See #60626.
+    # fixme: flisp happens to allow reading of underscore sparam names if they
+    # are used in function signature types or other sparam bounds.  See #60626.
     #
     # Mod._ is also readable
     readable_underscore::Bool=false
@@ -541,7 +540,8 @@ vst1_ident(vcx, st; lhs=false) = @stm st begin
     _ -> @fail(st, "expected identifier")
 end
 function _ident_str(vcx, st, s::String; lhs=false)
-    if !lhs && !vcx.readable_underscore && is_writeonly_est_name(s)
+    if !lhs && (!vcx.readable_underscore || !is_flisp_compat(st)) &&
+        is_writeonly_est_name(s)
         @fail(st, "all-underscore identifiers are write-only and their values cannot be used in expressions")
     elseif lhs && s in ("ccall", "cglobal")
         @fail(st, string(s, " is a reserved identifier"))
@@ -617,7 +617,8 @@ vst1_lam_lhs(vcx, st) = @stm st begin
     [K"tuple" ps...] ->
         _calldecl_positionals(vcx, ps, true)
     [K"where" ps tds...] ->
-        vst1_lam_lhs(vcx, ps) & all(vst1_typevar_decl, vcx, tds)
+        vst1_lam_lhs(vcx, ps) &
+        all(vst1_typevar_decl, with(vcx; readable_underscore=true), tds)
     # syntax TODO: This is handled badly in the parser
     [K"block"] -> pass()
     [K"block" x] -> _calldecl_positionals(vcx, SyntaxList(x), true)
@@ -659,10 +660,10 @@ end
 
 vst1_function_calldecl(vcx, st) = @stm st begin
     [K"where" callex tds...] ->
-        vst1_function_calldecl(vcx, callex) & all(vst1_typevar_decl, vcx, tds)
+        vst1_function_calldecl(vcx, callex) &
+        all(vst1_typevar_decl, with(vcx; readable_underscore=true), tds)
     [K"::" callex rt] ->
-        vst1_simple_calldecl(vcx, callex) &
-        vst1(with(vcx, readable_underscore=true), rt)
+        vst1_simple_calldecl(vcx, callex) & vst1(vcx, rt)
     _ -> vst1_simple_calldecl(vcx, st)
 end
 
@@ -711,7 +712,8 @@ vst1_calldecl_name(vcx, st) = @stm (st=strip_arg_meta(st)) begin
         vst1_calldecl_name(vcx, t) & all(vst1, vcx, tvs)
     [K"Value"] ->
         pass() # GlobalRef works. Function? Type?
-    # callable type
+    # ([K"::" _...], when=!vcx.toplevel) ->
+        # @fail(st, "adding methods to callable type only allowed at top level")
     [K"::" t] -> vst1(vcx, t)
     [K"::" x t] -> vst1_pparam_simple_tuple(vcx, x) & vst1(vcx, t)
     # TODO: @overlay broken in many cases, should be stricter
@@ -1271,13 +1273,14 @@ vst2(vcx::Validation2Context, st::SyntaxTree) = @stm st begin
     [K"lambda" _...] -> vst2_lam(vcx, st)
     [K"function_decl" x] -> vst2_ident(vcx, x)
     [K"function_type" x] -> vst2(vcx, x)
-    [K"method" name meta lam] -> !vcx.in_method_defs ?
+    # TODO: check that mtable is equal to the method_defs arg 1?
+    [K"method" mtable argtypes lam] -> !vcx.in_method_defs ?
         @fail(st, "method outside of method_defs") :
-        (kind(name) === K"nothing" ? pass() : vst2_ident_val(vcx, name)) &
-        vst2(vcx, meta) & vst2_lam(vcx, lam)
-    [K"method_defs" id body] ->
+        (kind(mtable) === K"nothing" ? pass() : vst2_ident_val(vcx, mtable)) &
+        vst2(vcx, argtypes) & vst2_lam(vcx, lam)
+    [K"method_defs" id [K"block" sps...] body] ->
         (kind(id) === K"nothing" ? pass() : vst2_ident_val(vcx, id)) &
-        vst2(with(vcx; in_method_defs=true), body)
+        all(vst2_typevar, vcx, sps) & vst2(with(vcx; in_method_defs=true), body)
     [K"new" t args...] -> vst2(vcx, t) & all(vst2, vcx, args)
     [K"splatnew" t arg] -> vst2(vcx, t) & vst2(vcx, arg)
     [K"softscope"] -> pass()
@@ -1363,4 +1366,9 @@ vst2_else(vcx, st) = @stm st begin
     [K"elseif" cond t] -> vst2(vcx, cond) & vst2(vcx, t)
     [K"elseif" cond t f] -> vst2(vcx, cond) & vst2(vcx, t) & vst2_else(vcx, f)
     _ -> vst2(vcx, st)
+end
+
+vst2_typevar(vcx, st) = @stm st begin
+    [K"typevar" tv val] -> vst2_ident_lhs(vcx, tv) & vst2(vcx, val)
+    _ -> @fail(st, "malformed sparam")
 end

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -1167,4 +1167,43 @@ func_in_own_sp(func_in_own_sp)
         f_value_pos_sp(42)()
     end
     """) == Int
+
+    # CC must not lift typevar T above assignment to x
+    @test JuliaLowering.include_string(test_mod, """
+    for x in (Int, Float64)
+        global f_local_in_tvbounds
+        f_local_in_tvbounds(y::T) where {T<:x} = T
+    end
+    """) == nothing
+    @test JuliaLowering.include_string(test_mod, """
+    f_local_in_tvbounds(1)
+    """) == Int
+    @test JuliaLowering.include_string(test_mod, """
+    f_local_in_tvbounds(1.0)
+    """) == Float64
+
+    @test JuliaLowering.include_string(test_mod, """
+    global g_tvbound = Int
+    for i in 1:2
+        global f_global_in_tvbounds, g_tvbound
+        f_global_in_tvbounds(y::T) where {T<:g_tvbound} = (i, T)
+        g_tvbound = Float64
+    end
+    f_global_in_tvbounds(1), f_global_in_tvbounds(1.5)
+    """) == ((1, Int), (2, Float64))
 end
+
+# questionable test: g_shadowed_by_sparam is not an sparam of the single-arg
+# version of `f`, so capture into the single-arg method's body resolves to the
+# outer typevar instead of an sparam, which scope resolution re-resolves in
+# global scope (typevars are only visible in the same lambda).  However, it
+# would probably make more sense to keep the sparam in both methods, and have
+# the inner lambda's sig refer to the sparam instead of the global.
+@test JuliaLowering.include_string(test_mod, """
+global g_shadowed_by_sparam = Int
+function f_sp_in_sig_in_lam_in_optarg(
+        x, y=((z::g_shadowed_by_sparam)->z)) where g_shadowed_by_sparam
+    y
+end
+f_sp_in_sig_in_lam_in_optarg(1.)(2)
+""") == 2

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -640,7 +640,7 @@ begin
 end
 """) == (1, Int)
 
-@test_broken JuliaLowering.include_string(test_mod, """
+@test JuliaLowering.include_string(test_mod, """
 begin
     function f_argcapt_sp(x::T) where T
         (inner_x::T)->(x, inner_x, T)
@@ -649,10 +649,10 @@ begin
 end
 """) == (1, 2, Int)
 
-# Inner method typevar `U` depending on a static parameter `T` so hoisting the
-# method def for `inner` out to top level would require detecting this and
-# making `inner` parametric on `T`.  Note this doesn't work in flisp either.
-@test_broken JuliaLowering.include_string(test_mod, """
+# Inner method typevar `U` depending on a static parameter `T`: the hoisted
+# method def for `inner` captures `T` as a closure type parameter, making
+# `inner` parametric on `T`.  This doesn't work in flisp (UndefVarError).
+@test JuliaLowering.include_string(test_mod, """
 begin
     function f_typevarcapt_sp(x::T) where T
         function inner(y::U) where {U<:T}
@@ -747,3 +747,18 @@ let (g, x) = test_mod.f_arg_reassign_with_label(42)
     @test g() == 1
     @test x == 1
 end
+
+@test JuliaLowering.include_string(test_mod, """
+func_in_own_sig(x::typeof(func_in_own_sig)) = (x, 1)
+""") isa Function
+@test JuliaLowering.include_string(test_mod, """
+func_in_own_sig(func_in_own_sig)
+""") == (test_mod.func_in_own_sig, 1)
+@test JuliaLowering.include_string(test_mod, """
+function func_in_own_sp(x::T) where {T<:typeof(func_in_own_sp)}
+(x, T)
+end
+""") isa Function
+@test JuliaLowering.include_string(test_mod, """
+func_in_own_sp(func_in_own_sp)
+""") == (test_mod.func_in_own_sp, typeof(test_mod.func_in_own_sp))

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -764,9 +764,9 @@ func_in_own_sp(func_in_own_sp)
 """) == (test_mod.func_in_own_sp, typeof(test_mod.func_in_own_sp))
 
 @testset "(AI) Captured static parameters" begin
-    # Captured static parameter used in a closure signature: dispatch must pin `T`
-    # to the value captured in the closure's type parameter, not re-derive it from
-    # the argument.
+    # Captured static parameter used in a closure signature: dispatch must pin
+    # `T` to the value captured in the closure's type parameter, not re-derive
+    # it from the argument.
     JuliaLowering.include_string(test_mod, """
     function f_sigcapt_sp(x::T) where T
         g_sigcapt(y::T) = (y, T)
@@ -776,8 +776,8 @@ func_in_own_sp(func_in_own_sp)
     @test test_mod.f_sigcapt_sp(1)(2) == (2, Int)
     @test_throws MethodError test_mod.f_sigcapt_sp(1)(2.5)
 
-    # All methods of a closure share its captured static parameters, even methods
-    # that don't reference them.
+    # All methods of a closure share its captured static parameters, even
+    # methods that don't reference them.
     @test JuliaLowering.include_string(test_mod, """
     begin
         function f_multimeth_sp(x::T) where T
@@ -789,8 +789,8 @@ func_in_own_sp(func_in_own_sp)
     end
     """) == (Float64, (2, Float64))
 
-    # (broken in flisp) Static parameter captured by an opaque closure (as a
-    # field, since opaque closures have no closure type to parameterize)
+    # Static parameter captured by an opaque closure (as a field, since opaque
+    # closures have no closure type to parameterize)
     @test JuliaLowering.include_string(test_mod, """
     begin
         function f_oc_sp(x::T) where T
@@ -835,7 +835,8 @@ func_in_own_sp(func_in_own_sp)
     """)
     @test test_mod.f_captsp_lb_dep(1, Any[1.0])("anything") == ("anything", Any)
 
-    # Typevar bound referencing a static parameter two closure levels up: `g` must
+    # (broken in flisp, JL may or may not have the desired behaviour) Typevar
+    # bound referencing a static parameter two closure levels up: `g` must
     # capture `T` in passing so its value reaches `h`'s creation site.
     @test JuliaLowering.include_string(test_mod, """
     begin

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -762,3 +762,408 @@ end
 @test JuliaLowering.include_string(test_mod, """
 func_in_own_sp(func_in_own_sp)
 """) == (test_mod.func_in_own_sp, typeof(test_mod.func_in_own_sp))
+
+@testset "(AI) Captured static parameters" begin
+    # Captured static parameter used in a closure signature: dispatch must pin `T`
+    # to the value captured in the closure's type parameter, not re-derive it from
+    # the argument.
+    JuliaLowering.include_string(test_mod, """
+    function f_sigcapt_sp(x::T) where T
+        g_sigcapt(y::T) = (y, T)
+        g_sigcapt
+    end
+    """)
+    @test test_mod.f_sigcapt_sp(1)(2) == (2, Int)
+    @test_throws MethodError test_mod.f_sigcapt_sp(1)(2.5)
+
+    # All methods of a closure share its captured static parameters, even methods
+    # that don't reference them.
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_multimeth_sp(x::T) where T
+            g() = T
+            g(y) = (y, T)
+            g
+        end
+        (f_multimeth_sp(1.5)(), f_multimeth_sp(1.5)(2))
+    end
+    """) == (Float64, (2, Float64))
+
+    # (broken in flisp) Static parameter captured by an opaque closure (as a
+    # field, since opaque closures have no closure type to parameterize)
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_oc_sp(x::T) where T
+            Base.Experimental.@opaque y -> (x, y, T)
+        end
+        f_oc_sp(1)(2)
+    end
+    """) == (1, 2, Int)
+
+    # A captured sparam's typevar bound may reference another sparam the closure
+    # doesn't mention at all: `S` must be captured transitively or the hoisted
+    # method signature contains a free TypeVar.  (flisp instead drops the bound.)
+    JuliaLowering.include_string(test_mod, """
+    function f_captsp_bound_dep(x::S, y::T) where {S, T<:AbstractVector{S}}
+        g_bound_dep(z::T) = (z, T)
+        g_bound_dep
+    end
+    """)
+    let g = test_mod.f_captsp_bound_dep(1, [1, 2])
+        @test g([3, 4]) == ([3, 4], Vector{Int})
+        @test_throws MethodError g("nope")
+        @test_throws MethodError g(Any[1, 2]) # T is pinned to Vector{Int}
+    end
+
+    # As above, but the dependency `S` is also captured normally by the body
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_captsp_bound_dep2(x::S, y::T) where {S, T<:AbstractVector{S}}
+            g_bound_dep2(z::T) = (z, T, S)
+            g_bound_dep2
+        end
+        f_captsp_bound_dep2(1, [1, 2])([3, 4])
+    end
+    """) == ([3, 4], Vector{Int}, Int)
+
+    # Same, via a lower bound
+    JuliaLowering.include_string(test_mod, """
+    function f_captsp_lb_dep(x::T, ys::Vector{S}) where {T, S>:T}
+        g_lb_dep(z::S) = (z, S)
+        g_lb_dep
+    end
+    """)
+    @test test_mod.f_captsp_lb_dep(1, Any[1.0])("anything") == ("anything", Any)
+
+    # Typevar bound referencing a static parameter two closure levels up: `g` must
+    # capture `T` in passing so its value reaches `h`'s creation site.
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_typevarcapt_sp_deep(::T) where T
+            function g_deep()
+                h_deep(y::U) where {U<:T} = (y, T, U)
+                h_deep
+            end
+            g_deep
+        end
+        f_typevarcapt_sp_deep(1.5)()(2.0)
+    end
+    """) == (2.0, Float64, Float64)
+
+    # Runtime state of enclosing functions can't be used in hoisted method
+    # signatures or typevar bounds (flisp errors identically).
+    @test_throws LoweringError JuliaLowering.include_string(test_mod, """
+    function f_local_in_closure_sig(x)
+        g(y::typeof(x)) = y
+        g
+    end
+    """)
+    @test_throws LoweringError JuliaLowering.include_string(test_mod, """
+    function f_local_in_closure_spbound(x)
+        g(y::T) where {T<:typeof(x)} = y
+        g
+    end
+    """)
+
+    # Global method definitions can't be nested inside functions (flisp errors
+    # identically).
+    @test_throws LoweringError JuliaLowering.include_string(test_mod, """
+    function f_nested_global_methdef()
+        global g_nested_global_methdef
+        g_nested_global_methdef(x::T) where T = x
+    end
+    """)
+
+    #-------------------------------------------------------------------------------
+    # Static parameter capture: combinations with other closure features
+
+    # do-block closure capturing a static parameter
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_do_sp(y::T) where T
+            call_it(3) do x
+                (x, y, T)
+            end
+        end
+        f_do_sp(1.5)
+    end
+    """) == (3, 1.5, Float64)
+
+    # comprehensions and generators capturing a static parameter
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_generator_sp(::T) where T
+            ([T for _ in 1:2], first(T for _ in 1:1))
+        end
+        f_generator_sp(1)
+    end
+    """) == ([Int, Int], Int)
+
+    # Closure defined inside an opaque closure, capturing a static parameter
+    # through it.  This is broken in flisp ("Found raw symbol T in code returned
+    # from lowering").
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_closure_in_oc_sp(x::T) where T
+            Base.Experimental.@opaque () -> begin
+                g() = (x, T)
+                g()
+            end
+        end
+        f_closure_in_oc_sp(1)()
+    end
+    """) == (1, Int)
+
+    # Opaque closure nested inside a regular closure, capturing a static parameter
+    # through it
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_oc_in_closure_sp(x::T) where T
+            function mid()
+                Base.Experimental.@opaque () -> (x, T)
+            end
+            mid
+        end
+        f_oc_in_closure_sp(2)()()
+    end
+    """) == (2, Int)
+
+    # Local function overloaded with keyword and plain methods; the captured
+    # static parameter appears only in a keyword default, which is evaluated in
+    # the kwcall method, while the body method's signature mentions the closure's
+    # type unparameterized.
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_kw_overload_sp(x::T) where T
+            g(y; k=T) = (:kw, y, k)
+            g(y::Int) = (:plain, y)
+            (g(1), g(1.5), g(1.5; k=2))
+        end
+        f_kw_overload_sp(1)
+    end
+    """) == ((:plain, 1), (:kw, 1.5, Int), (:kw, 1.5, 2))
+
+    # Keyword closure with the captured sparam in both signature and kw default:
+    # dispatch through the kw sorter still pins `T`.
+    JuliaLowering.include_string(test_mod, """
+    function f_kwsig_sp(x::T) where T
+        g_kwsig(y::T; k=T) = (y, k, T)
+        g_kwsig
+    end
+    """)
+    let g = test_mod.f_kwsig_sp(1)
+        @test g(2) == (2, Int, Int)
+        @test g(2; k=Int8) == (2, Int8, Int)
+        @test_throws MethodError g(2.5)
+    end
+
+    # Self-recursive closure capturing a static parameter
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_recursive_sp(x::T) where T
+            g(n) = n <= 0 ? T : g(n - 1)
+            g(3)
+        end
+        f_recursive_sp(1.5)
+    end
+    """) == Float64
+
+    # Boxed (assigned) captured local and captured static parameter in one closure
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_box_plus_sp(x::T) where T
+            c = 0
+            g() = (c += 1; (c, T))
+            (g(), g())
+        end
+        f_box_plus_sp(1im)
+    end
+    """) == ((1, Complex{Int}), (2, Complex{Int}))
+
+    # @isdefined of a captured static parameter inside a closure; an undefined
+    # sparam throws at closure creation (as in flisp), not at the @isdefined
+    JuliaLowering.include_string(test_mod, """
+    function f_isdefined_sp(x::Union{T,Nothing}) where T
+        g_isdefined_sp() = @isdefined(T)
+        g_isdefined_sp
+    end
+    """)
+    @test test_mod.f_isdefined_sp(1)()
+    @test_throws UndefVarError test_mod.f_isdefined_sp(nothing)
+
+    # Closure with an anonymous static parameter of its own plus a captured one
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_anon_sp_closure(x::T) where T
+            g(y) where _ = (y, T)
+            g(2)
+        end
+        f_anon_sp_closure(1)
+    end
+    """) == (2, Int)
+
+    # `let` inside a closure signature referencing a captured static parameter
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_let_sig_sp(::T) where T
+            g(x::(let v = T; Vector{v} end)) = x
+            g
+        end
+        f_let_sig_sp(1)([1, 2])
+    end
+    """) == [1, 2]
+
+    # Undetermined static parameter throws at closure creation (flisp parity)
+    @test_throws UndefVarError JuliaLowering.include_string(test_mod, """
+    begin
+        function f_undet_sp_creation(x::T, y::S) where {T, S>:T}
+            g(z::S) = z
+            g
+        end
+        f_undet_sp_creation(1, 2.5)
+    end
+    """)
+
+    # Signature capture through four levels of nested closures
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_sig_capture_depth4(x::T) where T
+            function a()
+                function b()
+                    function c()
+                        d(y::T) = (y, T)
+                        d(x)
+                    end
+                    c()
+                end
+                b()
+            end
+            a()
+        end
+        f_sig_capture_depth4(42)
+    end
+    """) == (42, Int)
+
+    # The closure's own sparam shadows the captured one, with the outer as bound
+    JuliaLowering.include_string(test_mod, """
+    function f_shadow_sp_bound(x::T) where T
+        g_shadow(y::T) where {T<:T} = (y, T)
+        g_shadow
+    end
+    """)
+    let g = test_mod.f_shadow_sp_bound(1)
+        @test g(2) == (2, Int)
+        @test_throws MethodError g(2.5) # inner T <: outer T == Int
+    end
+
+    # Vararg length pinned by a captured static parameter
+    JuliaLowering.include_string(test_mod, """
+    function f_vararg_n_sp(::Val{N}) where N
+        g_vararg_n(xs::Vararg{Int,N}) = xs
+        g_vararg_n
+    end
+    """)
+    let g = test_mod.f_vararg_n_sp(Val(2))
+        @test g(1, 2) == (1, 2)
+        @test_throws MethodError g(1, 2, 3) # N is pinned to 2
+    end
+
+    # Return-type annotation is the only use of the captured static parameter
+    JuliaLowering.include_string(test_mod, """
+    function f_rett_only_sp(x::T) where T
+        g_rett(y)::T = y
+        g_rett
+    end
+    """)
+    @test test_mod.f_rett_only_sp(1)(2) === 2
+    @test_throws MethodError test_mod.f_rett_only_sp(1)("s") # convert(Int, "s")
+
+    # Two sibling closures capturing the same static parameter (and sharing its
+    # typevar object in their hoisted method signatures)
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_two_closures_sp(x::T) where T
+            g(y::T) = (y, :g)
+            h(y::T) = (y, :h)
+            (g(x), h(x))
+        end
+        f_two_closures_sp(2)
+    end
+    """) == ((2, :g), (2, :h))
+
+    # A closure which captures nothing must be creatable even when the enclosing
+    # method's sparams are undetermined: closures must capture only the sparams
+    # they (transitively) reference, not all lexically enclosing ones.
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_nocapt_undet_sp(x::Union{T,Nothing}) where T
+            g_nocapt() = 1
+            g_nocapt
+        end
+        f_nocapt_undet_sp(nothing)()
+    end
+    """) == 1
+
+    # The static parameter's owner is itself a nested closure: its hoisted typevar
+    # assignments must be emitted before the inner closure's hoisted methods,
+    # which reference them (issue found as a segfault from a forward SSA ref).
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_nested_owner_body()
+            function g(x::T) where T
+                () -> T
+            end
+            g
+        end
+        f_nested_owner_body()(1)()
+    end
+    """) == Int
+
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_nested_owner_sig()
+            function g(x::T) where T
+                h(y::T) = (y, T)
+                h(x)
+            end
+            g
+        end
+        f_nested_owner_sig()(2.5)
+    end
+    """) == (2.5, Float64)
+
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_nested_owner_bound()
+            function g(x::T) where T
+                h(y::U) where {U<:T} = (y, T, U)
+                h(x)
+            end
+            g
+        end
+        f_nested_owner_bound()(3)
+    end
+    """) == (3, Int, Int)
+
+    # Sparams owned by two different nesting levels, captured together
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_two_level_sps(a::A) where A
+            function g(x::T) where T
+                () -> (A, T)
+            end
+            g
+        end
+        f_two_level_sps(1im)(2.5)()
+    end
+    """) == (Complex{Int}, Float64)
+
+    # method_defs in value position (not a top-level sequence point), with a
+    # nested closure capturing the sparam
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        x_value_pos_sp = (f_value_pos_sp(y::T) where T = () -> T)
+        f_value_pos_sp(42)()
+    end
+    """) == Int
+end

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -8,29 +8,30 @@ let
 end
 #---------------------
 1   (= slot₂/x 1)
-2   (call core.svec :x)
-3   (call core.svec false)
-4   (call JuliaLowering.eval_closure_type TestMod :#f##0 %₂ %₃)
-5   latestworld
-6   TestMod.#f##0
-7   (call core._typeof_captured_variable slot₂/x)
-8   (call core.apply_type %₆ %₇)
-9   (new %₈ slot₂/x)
-10  (= slot₁/f %₉)
-11  TestMod.#f##0
-12  (call core.svec %₁₁ core.Any)
-13  (call core.svec)
-14  SourceLocation::3:14
-15  (call core.svec %₁₂ %₁₃ %₁₄)
-16  --- method core.nothing %₁₅
+2   (call core.svec)
+3   (call core.svec :x)
+4   (call core.svec false)
+5   (call JuliaLowering.eval_closure_type TestMod :#f##0 %₂ %₃ %₄)
+6   latestworld
+7   TestMod.#f##0
+8   (call core._typeof_captured_variable slot₂/x)
+9   (call core.apply_type %₇ %₈)
+10  (new %₉ slot₂/x)
+11  (= slot₁/f %₁₀)
+12  TestMod.#f##0
+13  (call core.svec %₁₂ core.Any)
+14  (call core.svec)
+15  SourceLocation::3:5
+16  (call core.svec %₁₃ %₁₄ %₁₅)
+17  --- method core.nothing %₁₆
     slots: [slot₁/#self#(!read) slot₂/y]
     1   TestMod.+
     2   (call core.getfield slot₁/#self# :x)
     3   (call %₁ %₂ slot₂/y)
     4   (return %₃)
-17  latestworld
-18  slot₁/f
-19  (return %₁₈)
+18  latestworld
+19  slot₁/f
+20  (return %₁₉)
 
 ########################################
 # Closure declaration with no methods
@@ -42,13 +43,14 @@ end
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :#no_method_f##0 %₁ %₂)
-4   latestworld
-5   TestMod.#no_method_f##0
-6   (new %₅)
-7   (= slot₁/no_method_f %₆)
-8   slot₁/no_method_f
-9   (return %₈)
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :#no_method_f##0 %₁ %₂ %₃)
+5   latestworld
+6   TestMod.#no_method_f##0
+7   (new %₆)
+8   (= slot₁/no_method_f %₇)
+9   slot₁/no_method_f
+10  (return %₉)
 
 ########################################
 # Closure which sets the value of a captured variable
@@ -63,28 +65,29 @@ end
 2   1
 3   slot₂/x
 4   (call core.setfield! %₃ :contents %₂)
-5   (call core.svec :x)
-6   (call core.svec true)
-7   (call JuliaLowering.eval_closure_type TestMod :#f##1 %₅ %₆)
-8   latestworld
-9   TestMod.#f##1
-10  slot₂/x
-11  (new %₉ %₁₀)
-12  (= slot₁/f %₁₁)
-13  TestMod.#f##1
-14  (call core.svec %₁₃ core.Any)
-15  (call core.svec)
-16  SourceLocation::3:14
-17  (call core.svec %₁₄ %₁₅ %₁₆)
-18  --- method core.nothing %₁₇
+5   (call core.svec)
+6   (call core.svec :x)
+7   (call core.svec true)
+8   (call JuliaLowering.eval_closure_type TestMod :#f##1 %₅ %₆ %₇)
+9   latestworld
+10  TestMod.#f##1
+11  slot₂/x
+12  (new %₁₀ %₁₁)
+13  (= slot₁/f %₁₂)
+14  TestMod.#f##1
+15  (call core.svec %₁₄ core.Any)
+16  (call core.svec)
+17  SourceLocation::3:5
+18  (call core.svec %₁₅ %₁₆ %₁₇)
+19  --- method core.nothing %₁₈
     slots: [slot₁/#self#(!read) slot₂/y(!read)]
     1   2
     2   (call core.getfield slot₁/#self# :x)
     3   (call core.setfield! %₂ :contents %₁)
     4   (return %₁)
-19  latestworld
-20  slot₁/f
-21  (return %₂₀)
+20  latestworld
+21  slot₁/f
+22  (return %₂₁)
 
 ########################################
 # Function where arguments are captured into a closure and assigned
@@ -98,29 +101,30 @@ end
 #---------------------
 1   (method TestMod.f)
 2   latestworld
-3   (call core.svec :x)
-4   (call core.svec true)
-5   (call JuliaLowering.eval_closure_type TestMod :#f#g##0 %₃ %₄)
-6   latestworld
-7   TestMod.#f#g##0
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::2:14
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.svec)
+4   (call core.svec :x)
+5   (call core.svec true)
+6   (call JuliaLowering.eval_closure_type TestMod :#f#g##0 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.#f#g##0
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::2:5
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
     slots: [slot₁/#self#(!read)]
     1   10
     2   (call core.getfield slot₁/#self# :x)
     3   (call core.setfield! %₂ :contents %₁)
     4   (return %₁)
-13  latestworld
-14  TestMod.f
-15  (call core.TypeEqOf %₁₄)
-16  (call core.svec %₁₅ core.Any)
-17  (call core.svec)
-18  SourceLocation::1:10
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method TestMod.f %₁₉
+14  latestworld
+15  TestMod.f
+16  (call core.TypeEqOf %₁₅)
+17  (call core.svec %₁₆ core.Any)
+18  (call core.svec)
+19  SourceLocation::1:1
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method TestMod.f %₂₀
     slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/g(single_assign,called) slot₄/x(!read,maybe_undef) slot₅/x(!read)]
     1   (= slot₅/x slot₂/x)
     2   slot₅/x
@@ -139,9 +143,9 @@ end
     15  slot₄/x
     16  (call core.getfield %₁₀ :contents)
     17  (return %₁₆)
-21  latestworld
-22  TestMod.f
-23  (return %₂₂)
+22  latestworld
+23  TestMod.f
+24  (return %₂₃)
 
 ########################################
 # Argument reassigned in outer scope then captured - no Box needed
@@ -156,27 +160,28 @@ end
 #---------------------
 1   (method TestMod.foo)
 2   latestworld
-3   (call core.svec :x)
-4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#foo##->###0 %₃ %₄)
-6   latestworld
-7   TestMod.#foo##->###0
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::4:16
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.svec)
+4   (call core.svec :x)
+5   (call core.svec false)
+6   (call JuliaLowering.eval_closure_type TestMod :#foo##->###0 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.#foo##->###0
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::4:16
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
     slots: [slot₁/#self#(!read)]
     1   (call core.getfield slot₁/#self# :x)
     2   (return %₁)
-13  latestworld
-14  TestMod.foo
-15  (call core.TypeEqOf %₁₄)
-16  (call core.svec %₁₅ core.Any)
-17  (call core.svec)
-18  SourceLocation::1:10
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method TestMod.foo %₁₉
+14  latestworld
+15  TestMod.foo
+16  (call core.TypeEqOf %₁₅)
+17  (call core.svec %₁₆ core.Any)
+18  (call core.svec)
+19  SourceLocation::1:1
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method TestMod.foo %₂₀
     slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#->#(single_assign) slot₄/x(!read)]
     1   (= slot₄/x slot₂/x)
     2   (newvar slot₃/#->#)
@@ -196,9 +201,9 @@ end
     16  (return %₁₅)
     17  slot₄/x
     18  (return %₁₇)
-21  latestworld
-22  TestMod.foo
-23  (return %₂₂)
+22  latestworld
+23  TestMod.foo
+24  (return %₂₃)
 
 ########################################
 # Closure where a local `x` is captured but not boxed
@@ -211,28 +216,29 @@ end
 #---------------------
 1   (method TestMod.f)
 2   latestworld
-3   (call core.svec :x)
-4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f#g##1 %₃ %₄)
-6   latestworld
-7   TestMod.#f#g##1
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::2:14
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.svec)
+4   (call core.svec :x)
+5   (call core.svec false)
+6   (call JuliaLowering.eval_closure_type TestMod :#f#g##1 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.#f#g##1
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::2:5
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
     slots: [slot₁/#self#(!read) slot₂/y(!read,single_assign)]
     1   (call core.getfield slot₁/#self# :x)
     2   (= slot₂/y %₁)
     3   (return %₁)
-13  latestworld
-14  TestMod.f
-15  (call core.TypeEqOf %₁₄)
-16  (call core.svec %₁₅ core.Any)
-17  (call core.svec)
-18  SourceLocation::1:10
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method TestMod.f %₁₉
+14  latestworld
+15  TestMod.f
+16  (call core.TypeEqOf %₁₅)
+17  (call core.svec %₁₆ core.Any)
+18  (call core.svec)
+19  SourceLocation::1:1
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method TestMod.f %₂₀
     slots: [slot₁/#self#(!read) slot₂/x slot₃/g(single_assign) slot₄/z(!read,single_assign)]
     1   TestMod.#f#g##1
     2   (call core._typeof_captured_variable slot₂/x)
@@ -242,9 +248,9 @@ end
     6   slot₂/x
     7   (= slot₄/z %₆)
     8   (return %₆)
-21  latestworld
-22  TestMod.f
-23  (return %₂₂)
+22  latestworld
+23  TestMod.f
+24  (return %₂₃)
 
 ########################################
 # Closure where a static parameter of an outer function is captured
@@ -256,42 +262,40 @@ end
 #---------------------
 1   (method TestMod.f)
 2   latestworld
-3   (call core.svec :T)
-4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f#g##2 %₃ %₄)
-6   latestworld
-7   TestMod.#f#g##2
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::2:14
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.TypeVar :T)
+4   (call core.svec :T)
+5   (call core.svec)
+6   (call core.svec)
+7   (call JuliaLowering.eval_closure_type TestMod :#f#g##2 %₄ %₅ %₆)
+8   latestworld
+9   TestMod.#f#g##2
+10  (call core.apply_type %₉ %₃)
+11  (call core.svec %₁₀)
+12  (call core.svec %₃)
+13  SourceLocation::2:5
+14  (call core.svec %₁₁ %₁₂ %₁₃)
+15  --- method core.nothing %₁₄
     slots: [slot₁/#self#(!read)]
     1   TestMod.use
-    2   (call core.getfield slot₁/#self# :T)
+    2   static_parameter₁
     3   (call %₁ %₂)
     4   (return %₃)
-13  latestworld
-14  (= slot₁/T (call core.TypeVar :T))
-15  TestMod.f
-16  (call core.TypeEqOf %₁₅)
-17  slot₁/T
-18  (call core.svec %₁₆ %₁₇)
-19  slot₁/T
-20  (call core.svec %₁₉)
-21  SourceLocation::1:10
-22  (call core.svec %₁₈ %₂₀ %₂₁)
+16  latestworld
+17  TestMod.f
+18  (call core.TypeEqOf %₁₇)
+19  (call core.svec %₁₈ %₃)
+20  (call core.svec %₃)
+21  SourceLocation::1:1
+22  (call core.svec %₁₉ %₂₀ %₂₁)
 23  --- method TestMod.f %₂₂
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read) slot₃/g(single_assign)]
     1   TestMod.#f#g##2
     2   static_parameter₁
-    3   (call core._typeof_captured_variable %₂)
-    4   (call core.apply_type %₁ %₃)
-    5   static_parameter₁
-    6   (new %₄ %₅)
-    7   (= slot₃/g %₆)
-    8   slot₃/g
-    9   (return %₈)
+    3   (call core.apply_type %₁ %₂)
+    4   (new %₃)
+    5   (= slot₃/g %₄)
+    6   slot₃/g
+    7   (return %₆)
 24  latestworld
 25  TestMod.f
 26  (return %₂₅)
@@ -312,16 +316,17 @@ end
 #---------------------
 1   (method TestMod.f)
 2   latestworld
-3   (call core.svec :x :y)
-4   (call core.svec false true)
-5   (call JuliaLowering.eval_closure_type TestMod :#f#g##3 %₃ %₄)
-6   latestworld
-7   TestMod.#f#g##3
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::2:14
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.svec)
+4   (call core.svec :x :y)
+5   (call core.svec false true)
+6   (call JuliaLowering.eval_closure_type TestMod :#f#g##3 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.#f#g##3
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::2:5
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
     slots: [slot₁/#self#(!read) slot₂/z(single_assign)]
     1   (= slot₂/z 3)
     2   (call core.getfield slot₁/#self# :y)
@@ -329,14 +334,14 @@ end
     4   (isdefined slot₂/z)
     5   (call core.tuple true %₃ %₄)
     6   (return %₅)
-13  latestworld
-14  TestMod.f
-15  (call core.TypeEqOf %₁₄)
-16  (call core.svec %₁₅ core.Any)
-17  (call core.svec)
-18  SourceLocation::1:10
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method TestMod.f %₁₉
+14  latestworld
+15  TestMod.f
+16  (call core.TypeEqOf %₁₅)
+17  (call core.svec %₁₆ core.Any)
+18  (call core.svec)
+19  SourceLocation::1:1
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method TestMod.f %₂₀
     slots: [slot₁/#self#(!read) slot₂/x slot₃/g(single_assign) slot₄/y(single_assign)]
     1   (= slot₄/y (call core.Box))
     2   TestMod.#f#g##3
@@ -352,9 +357,9 @@ end
     12  (call core.isdefined %₁₁ :contents)
     13  (call core.tuple %₁₂ true)
     14  (return %₁₃)
-21  latestworld
-22  TestMod.f
-23  (return %₂₂)
+22  latestworld
+23  TestMod.f
+24  (return %₂₃)
 
 ########################################
 # Nested captures - here `g` captures `x` because it is needed to initialize
@@ -399,7 +404,7 @@ end
 8   (call core.TypeEqOf %₇)
 9   (call core.svec %₈)
 10  (call core.svec)
-11  SourceLocation::3:14
+11  SourceLocation::3:5
 12  (call core.svec %₉ %₁₀ %₁₁)
 13  --- code_info
     slots: [slot₁/#self#(!read) slot₂/x(!read,maybe_undef)]
@@ -429,24 +434,25 @@ x -> x*x
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###0 %₁ %₂)
-4   latestworld
-5   TestMod.##->###0
-6   (new %₅)
-7   (= slot₁/#-># %₆)
-8   TestMod.##->###0
-9   (call core.svec %₈ core.Any)
-10  (call core.svec)
-11  SourceLocation::1:1
-12  (call core.svec %₉ %₁₀ %₁₁)
-13  --- method core.nothing %₁₂
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :##->###0 %₁ %₂ %₃)
+5   latestworld
+6   TestMod.##->###0
+7   (new %₆)
+8   (= slot₁/#-># %₇)
+9   TestMod.##->###0
+10  (call core.svec %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::1:1
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method core.nothing %₁₃
     slots: [slot₁/#self#(!read) slot₂/x]
     1   TestMod.*
     2   (call %₁ slot₂/x slot₂/x)
     3   (return %₂)
-14  latestworld
-15  slot₁/#->#
-16  (return %₁₅)
+15  latestworld
+16  slot₁/#->#
+17  (return %₁₆)
 
 ########################################
 # Anonymous function syntax with `function`
@@ -456,24 +462,25 @@ end
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##anon###0 %₁ %₂)
-4   latestworld
-5   TestMod.##anon###0
-6   (new %₅)
-7   (= slot₁/#anon# %₆)
-8   TestMod.##anon###0
-9   (call core.svec %₈ core.Any)
-10  (call core.svec)
-11  SourceLocation::1:10
-12  (call core.svec %₉ %₁₀ %₁₁)
-13  --- method core.nothing %₁₂
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :##anon###0 %₁ %₂ %₃)
+5   latestworld
+6   TestMod.##anon###0
+7   (new %₆)
+8   (= slot₁/#anon# %₇)
+9   TestMod.##anon###0
+10  (call core.svec %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::1:1
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method core.nothing %₁₃
     slots: [slot₁/#self#(!read) slot₂/x]
     1   TestMod.*
     2   (call %₁ slot₂/x slot₂/x)
     3   (return %₂)
-14  latestworld
-15  slot₁/#anon#
-16  (return %₁₅)
+15  latestworld
+16  slot₁/#anon#
+17  (return %₁₆)
 
 ########################################
 # `do` blocks
@@ -488,26 +495,27 @@ end
 5   (call %₃ %₄)
 6   (call core.svec)
 7   (call core.svec)
-8   (call JuliaLowering.eval_closure_type TestMod :##->###1 %₆ %₇)
-9   latestworld
-10  TestMod.##->###1
-11  (call core.svec %₁₀ core.Any)
-12  (call core.svec)
-13  SourceLocation::1:13
-14  (call core.svec %₁₁ %₁₂ %₁₃)
-15  --- method core.nothing %₁₄
+8   (call core.svec)
+9   (call JuliaLowering.eval_closure_type TestMod :##->###1 %₆ %₇ %₈)
+10  latestworld
+11  TestMod.##->###1
+12  (call core.svec %₁₁ core.Any)
+13  (call core.svec)
+14  SourceLocation::1:10
+15  (call core.svec %₁₂ %₁₃ %₁₄)
+16  --- method core.nothing %₁₅
     slots: [slot₁/#self#(!read) slot₂/y]
     1   TestMod.+
     2   (call %₁ slot₂/y 2)
     3   (return %₂)
-16  latestworld
-17  TestMod.##->###1
-18  (new %₁₇)
-19  (= slot₁/#-># %₁₈)
-20  slot₁/#->#
-21  TestMod.x
-22  (call core.kwcall %₅ %₁ %₂₀ %₂₁)
-23  (return %₂₂)
+17  latestworld
+18  TestMod.##->###1
+19  (new %₁₈)
+20  (= slot₁/#-># %₁₉)
+21  slot₁/#->#
+22  TestMod.x
+23  (call core.kwcall %₅ %₁ %₂₁ %₂₂)
+24  (return %₂₃)
 
 ########################################
 # Error: Static parameter clashing with closure name
@@ -583,20 +591,21 @@ let
 end
 #---------------------
 1   (= slot₂/recursive_b (call core.Box))
-2   (call core.svec :recursive_b)
-3   (call core.svec true)
-4   (call JuliaLowering.eval_closure_type TestMod :#recursive_a##0 %₂ %₃)
-5   latestworld
-6   TestMod.#recursive_a##0
-7   slot₂/recursive_b
-8   (new %₆ %₇)
-9   (= slot₁/recursive_a %₈)
-10  TestMod.#recursive_a##0
-11  (call core.svec %₁₀)
-12  (call core.svec)
-13  SourceLocation::2:14
-14  (call core.svec %₁₁ %₁₂ %₁₃)
-15  --- method core.nothing %₁₄
+2   (call core.svec)
+3   (call core.svec :recursive_b)
+4   (call core.svec true)
+5   (call JuliaLowering.eval_closure_type TestMod :#recursive_a##0 %₂ %₃ %₄)
+6   latestworld
+7   TestMod.#recursive_a##0
+8   slot₂/recursive_b
+9   (new %₇ %₈)
+10  (= slot₁/recursive_a %₉)
+11  TestMod.#recursive_a##0
+12  (call core.svec %₁₁)
+13  (call core.svec)
+14  SourceLocation::2:5
+15  (call core.svec %₁₂ %₁₃ %₁₄)
+16  --- method core.nothing %₁₅
     slots: [slot₁/#self#(!read) slot₂/recursive_b(!read,maybe_undef)]
     1   (call core.getfield slot₁/#self# :recursive_b)
     2   (call core.isdefined %₁ :contents)
@@ -607,36 +616,37 @@ end
     7   (call core.getfield %₁ :contents)
     8   (call %₇)
     9   (return %₈)
-16  latestworld
-17  (call core.svec :recursive_a)
-18  (call core.svec false)
-19  (call JuliaLowering.eval_closure_type TestMod :#recursive_b##0 %₁₇ %₁₈)
-20  latestworld
-21  TestMod.#recursive_b##0
-22  (call core._typeof_captured_variable slot₁/recursive_a)
-23  (call core.apply_type %₂₁ %₂₂)
-24  (new %₂₃ slot₁/recursive_a)
-25  slot₂/recursive_b
-26  (call core.setfield! %₂₅ :contents %₂₄)
-27  TestMod.#recursive_b##0
-28  (call core.svec %₂₇)
-29  (call core.svec)
-30  SourceLocation::5:14
-31  (call core.svec %₂₈ %₂₉ %₃₀)
-32  --- method core.nothing %₃₁
+17  latestworld
+18  (call core.svec)
+19  (call core.svec :recursive_a)
+20  (call core.svec false)
+21  (call JuliaLowering.eval_closure_type TestMod :#recursive_b##0 %₁₈ %₁₉ %₂₀)
+22  latestworld
+23  TestMod.#recursive_b##0
+24  (call core._typeof_captured_variable slot₁/recursive_a)
+25  (call core.apply_type %₂₃ %₂₄)
+26  (new %₂₅ slot₁/recursive_a)
+27  slot₂/recursive_b
+28  (call core.setfield! %₂₇ :contents %₂₆)
+29  TestMod.#recursive_b##0
+30  (call core.svec %₂₉)
+31  (call core.svec)
+32  SourceLocation::5:5
+33  (call core.svec %₃₀ %₃₁ %₃₂)
+34  --- method core.nothing %₃₃
     slots: [slot₁/#self#(!read)]
     1   (call core.getfield slot₁/#self# :recursive_a)
     2   (call %₁)
     3   (return %₂)
-33  latestworld
-34  slot₂/recursive_b
-35  (call core.isdefined %₃₄ :contents)
-36  (gotoifnot %₃₅ label₃₈)
-37  (goto label₄₀)
-38  (newvar slot₃/recursive_b)
-39  slot₃/recursive_b
-40  (call core.getfield %₃₄ :contents)
-41  (return %₄₀)
+35  latestworld
+36  slot₂/recursive_b
+37  (call core.isdefined %₃₆ :contents)
+38  (gotoifnot %₃₇ label₄₀)
+39  (goto label₄₂)
+40  (newvar slot₃/recursive_b)
+41  slot₃/recursive_b
+42  (call core.getfield %₃₆ :contents)
+43  (return %₄₂)
 
 ########################################
 # Closure with keywords
@@ -648,58 +658,60 @@ end
 #---------------------
 1   TestMod.y_init
 2   (= slot₁/y %₁)
-3   (call core.svec :y)
-4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :##kw_body#f_kw_closure#0##0 %₃ %₄)
-6   latestworld
-7   TestMod.##kw_body#f_kw_closure#0##0
-8   (call core._typeof_captured_variable slot₁/y)
-9   (call core.apply_type %₇ %₈)
-10  (new %₉ slot₁/y)
-11  (= slot₂/#kw_body#f_kw_closure#0 %₁₀)
-12  (call core.svec :#kw_body#f_kw_closure#0)
-13  (call core.svec false)
-14  (call JuliaLowering.eval_closure_type TestMod :#f_kw_closure##0 %₁₂ %₁₃)
-15  latestworld
-16  TestMod.#f_kw_closure##0
-17  (call core._typeof_captured_variable slot₂/#kw_body#f_kw_closure#0)
-18  (call core.apply_type %₁₆ %₁₇)
-19  (new %₁₈ slot₂/#kw_body#f_kw_closure#0)
-20  (= slot₃/f_kw_closure %₁₉)
-21  TestMod.##kw_body#f_kw_closure#0##0
-22  TestMod.X
-23  TestMod.#f_kw_closure##0
-24  (call core.svec %₂₁ %₂₂ %₂₃)
-25  (call core.svec)
-26  SourceLocation::2:14
-27  (call core.svec %₂₄ %₂₅ %₂₆)
-28  --- method core.nothing %₂₇
+3   (call core.svec)
+4   (call core.svec :y)
+5   (call core.svec false)
+6   (call JuliaLowering.eval_closure_type TestMod :##kw_body#f_kw_closure#0##0 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.##kw_body#f_kw_closure#0##0
+9   (call core._typeof_captured_variable slot₁/y)
+10  (call core.apply_type %₈ %₉)
+11  (new %₁₀ slot₁/y)
+12  (= slot₂/#kw_body#f_kw_closure#0 %₁₁)
+13  (call core.svec)
+14  (call core.svec :#kw_body#f_kw_closure#0)
+15  (call core.svec false)
+16  (call JuliaLowering.eval_closure_type TestMod :#f_kw_closure##0 %₁₃ %₁₄ %₁₅)
+17  latestworld
+18  TestMod.#f_kw_closure##0
+19  (call core._typeof_captured_variable slot₂/#kw_body#f_kw_closure#0)
+20  (call core.apply_type %₁₈ %₁₉)
+21  (new %₂₀ slot₂/#kw_body#f_kw_closure#0)
+22  (= slot₃/f_kw_closure %₂₁)
+23  TestMod.##kw_body#f_kw_closure#0##0
+24  TestMod.X
+25  TestMod.#f_kw_closure##0
+26  (call core.svec %₂₃ %₂₄ %₂₅)
+27  (call core.svec)
+28  SourceLocation::2:5
+29  (call core.svec %₂₆ %₂₇ %₂₈)
+30  --- method core.nothing %₂₉
     slots: [slot₁/#kw_body#f_kw_closure#0(!read) slot₂/x slot₃/#self#(!read)]
     1   (meta :nkw 1)
     2   TestMod.+
     3   (call core.getfield slot₁/#kw_body#f_kw_closure#0 :y)
     4   (call %₂ slot₂/x %₃)
     5   (return %₄)
-29  latestworld
-30  TestMod.#f_kw_closure##0
-31  (call core.svec %₃₀)
-32  (call core.svec)
-33  SourceLocation::2:14
-34  (call core.svec %₃₁ %₃₂ %₃₃)
-35  --- method core.nothing %₃₄
+31  latestworld
+32  TestMod.#f_kw_closure##0
+33  (call core.svec %₃₂)
+34  (call core.svec)
+35  SourceLocation::2:5
+36  (call core.svec %₃₃ %₃₄ %₃₅)
+37  --- method core.nothing %₃₆
     slots: [slot₁/#self#]
     1   (call core.getfield slot₁/#self# :#kw_body#f_kw_closure#0)
     2   TestMod.x_default
     3   (call %₁ %₂ slot₁/#self#)
     4   (return %₃)
-36  latestworld
-37  (call core.typeof core.kwcall)
-38  TestMod.#f_kw_closure##0
-39  (call core.svec %₃₇ core.NamedTuple %₃₈)
-40  (call core.svec)
-41  SourceLocation::2:14
-42  (call core.svec %₃₉ %₄₀ %₄₁)
-43  --- method core.nothing %₄₂
+38  latestworld
+39  (call core.typeof core.kwcall)
+40  TestMod.#f_kw_closure##0
+41  (call core.svec %₃₉ core.NamedTuple %₄₀)
+42  (call core.svec)
+43  SourceLocation::2:5
+44  (call core.svec %₄₁ %₄₂ %₄₃)
+45  --- method core.nothing %₄₄
     slots: [slot₁/#unused#(!read) slot₂/kws slot₃/#self# slot₄/x(!read) slot₅/kwtmp]
     1   (newvar slot₄/x)
     2   (newvar slot₅/kwtmp)
@@ -728,9 +740,9 @@ end
     25  (call core.getfield slot₃/#self# :#kw_body#f_kw_closure#0)
     26  (call %₂₅ %₁₇ slot₃/#self#)
     27  (return %₂₆)
-44  latestworld
-45  slot₃/f_kw_closure
-46  (return %₄₅)
+46  latestworld
+47  slot₃/f_kw_closure
+48  (return %₄₇)
 
 ########################################
 # Closure capturing a typed local must also capture the type expression
@@ -770,27 +782,28 @@ end
 #---------------------
 1   (method TestMod.f_after_if)
 2   latestworld
-3   (call core.svec :y)
-4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_after_if##->###0 %₃ %₄)
-6   latestworld
-7   TestMod.#f_after_if##->###0
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::6:5
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.svec)
+4   (call core.svec :y)
+5   (call core.svec false)
+6   (call JuliaLowering.eval_closure_type TestMod :#f_after_if##->###0 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.#f_after_if##->###0
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::6:5
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
     slots: [slot₁/#self#(!read)]
     1   (call core.getfield slot₁/#self# :y)
     2   (return %₁)
-13  latestworld
-14  TestMod.f_after_if
-15  (call core.TypeEqOf %₁₄)
-16  (call core.svec %₁₅ core.Any)
-17  (call core.svec)
-18  SourceLocation::1:10
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method TestMod.f_after_if %₁₉
+14  latestworld
+15  TestMod.f_after_if
+16  (call core.TypeEqOf %₁₅)
+17  (call core.svec %₁₆ core.Any)
+18  (call core.svec)
+19  SourceLocation::1:1
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method TestMod.f_after_if %₂₀
     slots: [slot₁/#self#(!read) slot₂/cond slot₃/#->#(single_assign) slot₄/y(single_assign)]
     1   (newvar slot₃/#->#)
     2   (gotoifnot slot₂/cond label₅)
@@ -804,9 +817,9 @@ end
     10  (= slot₃/#-># %₉)
     11  slot₃/#->#
     12  (return %₁₁)
-21  latestworld
-22  TestMod.f_after_if
-23  (return %₂₂)
+22  latestworld
+23  TestMod.f_after_if
+24  (return %₂₃)
 
 ########################################
 # Ternary operator (if expression in value position) doesn't need Box
@@ -817,27 +830,28 @@ end
 #---------------------
 1   (method TestMod.f_ternary)
 2   latestworld
-3   (call core.svec :y)
-4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_ternary##->###0 %₃ %₄)
-6   latestworld
-7   TestMod.#f_ternary##->###0
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::3:5
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.svec)
+4   (call core.svec :y)
+5   (call core.svec false)
+6   (call JuliaLowering.eval_closure_type TestMod :#f_ternary##->###0 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.#f_ternary##->###0
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::3:5
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
     slots: [slot₁/#self#(!read)]
     1   (call core.getfield slot₁/#self# :y)
     2   (return %₁)
-13  latestworld
-14  TestMod.f_ternary
-15  (call core.TypeEqOf %₁₄)
-16  (call core.svec %₁₅ core.Any)
-17  (call core.svec)
-18  SourceLocation::1:10
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method TestMod.f_ternary %₁₉
+14  latestworld
+15  TestMod.f_ternary
+16  (call core.TypeEqOf %₁₅)
+17  (call core.svec %₁₆ core.Any)
+18  (call core.svec)
+19  SourceLocation::1:1
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method TestMod.f_ternary %₂₀
     slots: [slot₁/#self#(!read) slot₂/x slot₃/#->#(single_assign) slot₄/y(single_assign) slot₅/if_val(!read)]
     1   (newvar slot₃/#->#)
     2   TestMod.>
@@ -856,9 +870,9 @@ end
     15  (= slot₃/#-># %₁₄)
     16  slot₃/#->#
     17  (return %₁₆)
-21  latestworld
-22  TestMod.f_ternary
-23  (return %₂₂)
+22  latestworld
+23  TestMod.f_ternary
+24  (return %₂₃)
 
 ########################################
 # || guard pattern (value position with early exit) doesn't need Box
@@ -870,27 +884,28 @@ end
 #---------------------
 1   (method TestMod.f_or_guard)
 2   latestworld
-3   (call core.svec :y)
-4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_or_guard##->###0 %₃ %₄)
-6   latestworld
-7   TestMod.#f_or_guard##->###0
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::4:5
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.svec)
+4   (call core.svec :y)
+5   (call core.svec false)
+6   (call JuliaLowering.eval_closure_type TestMod :#f_or_guard##->###0 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.#f_or_guard##->###0
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::4:5
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
     slots: [slot₁/#self#(!read)]
     1   (call core.getfield slot₁/#self# :y)
     2   (return %₁)
-13  latestworld
-14  TestMod.f_or_guard
-15  (call core.TypeEqOf %₁₄)
-16  (call core.svec %₁₅ core.Any)
-17  (call core.svec)
-18  SourceLocation::1:10
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method TestMod.f_or_guard %₁₉
+14  latestworld
+15  TestMod.f_or_guard
+16  (call core.TypeEqOf %₁₅)
+17  (call core.svec %₁₆ core.Any)
+18  (call core.svec)
+19  SourceLocation::1:1
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method TestMod.f_or_guard %₂₀
     slots: [slot₁/#self#(!read) slot₂/x slot₃/#->#(single_assign) slot₄/y(single_assign) slot₅/if_val(!read)]
     1   (newvar slot₃/#->#)
     2   TestMod.===
@@ -916,9 +931,9 @@ end
     22  (= slot₃/#-># %₂₁)
     23  slot₃/#->#
     24  (return %₂₃)
-21  latestworld
-22  TestMod.f_or_guard
-23  (return %₂₂)
+22  latestworld
+23  TestMod.f_or_guard
+24  (return %₂₃)
 
 ########################################
 # Argument reassigned in outer scope - no Box needed
@@ -929,27 +944,28 @@ end
 #---------------------
 1   (method TestMod.f_arg_reassign)
 2   latestworld
-3   (call core.svec :x)
-4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_arg_reassign##->###0 %₃ %₄)
-6   latestworld
-7   TestMod.#f_arg_reassign##->###0
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::3:12
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.svec)
+4   (call core.svec :x)
+5   (call core.svec false)
+6   (call JuliaLowering.eval_closure_type TestMod :#f_arg_reassign##->###0 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.#f_arg_reassign##->###0
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::3:12
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
     slots: [slot₁/#self#(!read)]
     1   (call core.getfield slot₁/#self# :x)
     2   (return %₁)
-13  latestworld
-14  TestMod.f_arg_reassign
-15  (call core.TypeEqOf %₁₄)
-16  (call core.svec %₁₅ core.Any)
-17  (call core.svec)
-18  SourceLocation::1:10
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method TestMod.f_arg_reassign %₁₉
+14  latestworld
+15  TestMod.f_arg_reassign
+16  (call core.TypeEqOf %₁₅)
+17  (call core.svec %₁₆ core.Any)
+18  (call core.svec)
+19  SourceLocation::1:1
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method TestMod.f_arg_reassign %₂₀
     slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#->#(single_assign) slot₄/x(!read)]
     1   (= slot₄/x slot₂/x)
     2   (= slot₄/x 1)
@@ -962,9 +978,9 @@ end
     9   (= slot₃/#-># %₈)
     10  slot₃/#->#
     11  (return %₁₀)
-21  latestworld
-22  TestMod.f_arg_reassign
-23  (return %₂₂)
+22  latestworld
+23  TestMod.f_arg_reassign
+24  (return %₂₃)
 
 ########################################
 # Label can be jumped to, bypassing assignment - needs Box
@@ -981,20 +997,21 @@ end
 4   1
 5   slot₂/y
 6   (call core.setfield! %₅ :contents %₄)
-7   (call core.svec :y)
-8   (call core.svec true)
-9   (call JuliaLowering.eval_closure_type TestMod :##->###2 %₇ %₈)
-10  latestworld
-11  TestMod.##->###2
-12  slot₂/y
-13  (new %₁₁ %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  TestMod.##->###2
-16  (call core.svec %₁₅)
-17  (call core.svec)
-18  SourceLocation::5:5
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method core.nothing %₁₉
+7   (call core.svec)
+8   (call core.svec :y)
+9   (call core.svec true)
+10  (call JuliaLowering.eval_closure_type TestMod :##->###2 %₇ %₈ %₉)
+11  latestworld
+12  TestMod.##->###2
+13  slot₂/y
+14  (new %₁₂ %₁₃)
+15  (= slot₁/#-># %₁₄)
+16  TestMod.##->###2
+17  (call core.svec %₁₆)
+18  (call core.svec)
+19  SourceLocation::5:5
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method core.nothing %₂₀
     slots: [slot₁/#self#(!read) slot₂/y(!read,maybe_undef)]
     1   (call core.getfield slot₁/#self# :y)
     2   (call core.isdefined %₁ :contents)
@@ -1004,9 +1021,9 @@ end
     6   slot₂/y
     7   (call core.getfield %₁ :contents)
     8   (return %₇)
-21  latestworld
-22  slot₁/#->#
-23  (return %₂₂)
+22  latestworld
+23  slot₁/#->#
+24  (return %₂₃)
 
 ########################################
 # Local single-assigned after declaration - no Box needed
@@ -1018,27 +1035,28 @@ end
 #---------------------
 1   (method TestMod.f_local_no_box)
 2   latestworld
-3   (call core.svec :x)
-4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_local_no_box##->###0 %₃ %₄)
-6   latestworld
-7   TestMod.#f_local_no_box##->###0
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::4:5
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.svec)
+4   (call core.svec :x)
+5   (call core.svec false)
+6   (call JuliaLowering.eval_closure_type TestMod :#f_local_no_box##->###0 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.#f_local_no_box##->###0
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::4:5
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
     slots: [slot₁/#self#(!read)]
     1   (call core.getfield slot₁/#self# :x)
     2   (return %₁)
-13  latestworld
-14  TestMod.f_local_no_box
-15  (call core.TypeEqOf %₁₄)
-16  (call core.svec %₁₅)
-17  (call core.svec)
-18  SourceLocation::1:10
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method TestMod.f_local_no_box %₁₉
+14  latestworld
+15  TestMod.f_local_no_box
+16  (call core.TypeEqOf %₁₅)
+17  (call core.svec %₁₆)
+18  (call core.svec)
+19  SourceLocation::1:1
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method TestMod.f_local_no_box %₂₀
     slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#->#(single_assign)]
     1   (= slot₂/x 1)
     2   TestMod.#f_local_no_box##->###0
@@ -1048,9 +1066,9 @@ end
     6   (= slot₃/#-># %₅)
     7   slot₃/#->#
     8   (return %₇)
-21  latestworld
-22  TestMod.f_local_no_box
-23  (return %₂₂)
+22  latestworld
+23  TestMod.f_local_no_box
+24  (return %₂₃)
 
 ########################################
 # Typed local single-assigned after declaration - no Box needed
@@ -1062,27 +1080,28 @@ end
 #---------------------
 1   (method TestMod.f_typed_local_no_box)
 2   latestworld
-3   (call core.svec :x)
-4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_typed_local_no_box##->###0 %₃ %₄)
-6   latestworld
-7   TestMod.#f_typed_local_no_box##->###0
-8   (call core.svec %₇)
-9   (call core.svec)
-10  SourceLocation::4:5
-11  (call core.svec %₈ %₉ %₁₀)
-12  --- method core.nothing %₁₁
+3   (call core.svec)
+4   (call core.svec :x)
+5   (call core.svec false)
+6   (call JuliaLowering.eval_closure_type TestMod :#f_typed_local_no_box##->###0 %₃ %₄ %₅)
+7   latestworld
+8   TestMod.#f_typed_local_no_box##->###0
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::4:5
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
     slots: [slot₁/#self#(!read)]
     1   (call core.getfield slot₁/#self# :x)
     2   (return %₁)
-13  latestworld
-14  TestMod.f_typed_local_no_box
-15  (call core.TypeEqOf %₁₄)
-16  (call core.svec %₁₅)
-17  (call core.svec)
-18  SourceLocation::1:10
-19  (call core.svec %₁₆ %₁₇ %₁₈)
-20  --- method TestMod.f_typed_local_no_box %₁₉
+14  latestworld
+15  TestMod.f_typed_local_no_box
+16  (call core.TypeEqOf %₁₅)
+17  (call core.svec %₁₆)
+18  (call core.svec)
+19  SourceLocation::1:1
+20  (call core.svec %₁₇ %₁₈ %₁₉)
+21  --- method TestMod.f_typed_local_no_box %₂₀
     slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#->#(single_assign) slot₄/tmp(!read)]
     1   (newvar slot₃/#->#)
     2   1
@@ -1102,9 +1121,9 @@ end
     16  (= slot₃/#-># %₁₅)
     17  slot₃/#->#
     18  (return %₁₇)
-21  latestworld
-22  TestMod.f_typed_local_no_box
-23  (return %₂₂)
+22  latestworld
+23  TestMod.f_typed_local_no_box
+24  (return %₂₃)
 
 ########################################
 # Error: Closure outside any top level context
@@ -1119,6 +1138,6 @@ end
 LoweringError:
 #= line 1 =# - Top level code was found outside any top level context. `@generated` functions may not contain closures, including `do` syntax and generators/comprehension
 Expression:
-  (call JuliaLowering.eval_closure_type Main.TestMod :##->###3 (call core.svec) (call core.svec))
+  (call JuliaLowering.eval_closure_type Main.TestMod :##->###3 (call core.svec) (call core.svec) (call core.svec))
 Containing expressions:
-  (call JuliaLowering.eval_closure_type Main.TestMod :##->###3 (call core.svec) (call core.svec))
+  (call JuliaLowering.eval_closure_type Main.TestMod :##->###3 (call core.svec) (call core.svec) (call core.svec))

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -499,19 +499,19 @@ end
 9   (call JuliaLowering.eval_closure_type TestMod :##->###1 %₆ %₇ %₈)
 10  latestworld
 11  TestMod.##->###1
-12  (call core.svec %₁₁ core.Any)
-13  (call core.svec)
-14  SourceLocation::1:10
-15  (call core.svec %₁₂ %₁₃ %₁₄)
-16  --- method core.nothing %₁₅
+12  (new %₁₁)
+13  (= slot₁/#-># %₁₂)
+14  TestMod.##->###1
+15  (call core.svec %₁₄ core.Any)
+16  (call core.svec)
+17  SourceLocation::1:10
+18  (call core.svec %₁₅ %₁₆ %₁₇)
+19  --- method core.nothing %₁₈
     slots: [slot₁/#self#(!read) slot₂/y]
     1   TestMod.+
     2   (call %₁ slot₂/y 2)
     3   (return %₂)
-17  latestworld
-18  TestMod.##->###1
-19  (new %₁₈)
-20  (= slot₁/#-># %₁₉)
+20  latestworld
 21  slot₁/#->#
 22  TestMod.x
 23  (call core.kwcall %₅ %₁ %₂₁ %₂₂)

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -422,7 +422,7 @@ end
     12  (return %₉)
 14  slot₁/x
 15  (call core.svec %₁₄)
-16  (call JuliaLowering.replace_captured_locals! %₁₃ %₁₅)
+16  (call JuliaLowering.replace_captured_locals %₁₃ %₁₅)
 17  --- method TestMod.f %₁₂ %₁₆
 18  latestworld
 19  TestMod.f

--- a/JuliaLowering/test/decls_ir.jl
+++ b/JuliaLowering/test/decls_ir.jl
@@ -380,7 +380,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read) slot₂/x slot₃/tmp(!read) slot₄/tmp(!read) slot₅/x(!read)]

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -1365,6 +1365,28 @@ end
     @test xy(0,0) == (1,9,9,9,2,0,0)
 end
 
+@testset "sparam in keyword default" begin
+    # The keyword default is evaluated in the body method, which carries all
+    # of the function's static parameters
+    @test JL.include_string(test_mod,
+        "f_kwdef_sp(y::T; k=T) where T = (y, k); f_kwdef_sp(1)") == (1, Int)
+    # ... but an sparam unused in the signature is undetermined at dispatch
+    JL.include_string(test_mod, "f_kwdef_sp_undet(y; k=T) where T = (y, k)")
+    @test_throws UndefVarError test_mod.f_kwdef_sp_undet(1)
+end
+
+@testset "anonymous static parameters" begin
+    # `where _` declares a static parameter which can never be referenced
+    @test JL.include_string(test_mod, "f_anon_sp(x) where _ = x; f_anon_sp(42)") == 42
+    @test JL.include_string(
+        test_mod, "f_anon_sp2(x::T) where {T, _} = (x, T); f_anon_sp2(1.5)") == (1.5, Float64)
+    @test_throws LoweringError JL.include_string(
+        test_mod, "f_anon_sp3(x) where {_, _} = x"; expr_compat_mode=true)
+    # Currently allowed (like arguments).  Could error like flisp.
+    @test_throws LoweringError JL.include_string(
+        test_mod, "f_anon_sp3(x) where {_, _} = x") broken=true
+end
+
 @testset "first arg `where`" begin
     @eval test_mod struct A12238{T} end
     Core.@latestworld

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -425,7 +425,7 @@ end
     end
     """) == (Complex(1), Complex(2))
 
-    # Both JL and flisp will evaluate the sparam bound multiple times
+    # flisp will evaluate the sparam bound multiple times
     let res = JuliaLowering.include_string(test_mod, """
         let eval_spbounds_counter = 0
             global function f_optarg_eval_spbounds_counter(
@@ -436,8 +436,7 @@ end
             f_optarg_eval_spbounds_counter(Complex(1))
         end
         """)
-        @test res == (Complex(1), 4)
-        @test_broken res == (Complex(1), 1)
+        @test res == (Complex(1), 1)
     end
 end
 

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -20,7 +20,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read) slot₂/x slot₃/#unused#(!read) slot₄/y]
@@ -44,7 +44,7 @@ end
 5   TestMod.T
 6   (call core.svec %₄ %₅ core.Any)
 7   (call core.svec)
-8   SourceLocation::1:10
+8   SourceLocation::1:1
 9   (call core.svec %₆ %₇ %₈)
 10  --- method TestMod.f %₉
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read) slot₃/x]
@@ -67,7 +67,7 @@ end
 5   TestMod.T
 6   (call core.svec %₄ core.Any %₅)
 7   (call core.svec)
-8   SourceLocation::1:10
+8   SourceLocation::1:1
 9   (call core.svec %₆ %₇ %₈)
 10  --- method TestMod.f %₉
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/y(!read)]
@@ -90,7 +90,7 @@ end
 5   (call core.apply_type core.Vararg core.Any)
 6   (call core.svec %₄ core.Any %₅)
 7   (call core.svec)
-8   SourceLocation::1:10
+8   SourceLocation::1:1
 9   (call core.svec %₆ %₇ %₈)
 10  --- method TestMod.f %₉
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/ys(!read)]
@@ -114,7 +114,7 @@ end
 6   (call core.apply_type core.Vararg %₅)
 7   (call core.svec %₄ core.Any %₆)
 8   (call core.svec)
-9   SourceLocation::1:10
+9   SourceLocation::1:1
 10  (call core.svec %₇ %₈ %₉)
 11  --- method TestMod.f %₁₀
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/ys(!read)]
@@ -144,31 +144,25 @@ end
 #---------------------
 1   (method TestMod.f)
 2   latestworld
-3   (= slot₁/U (call core.TypeVar :U))
-4   (= slot₂/V (call core.TypeVar :V))
-5   (= slot₃/T (call core.TypeVar :T))
+3   (call core.TypeVar :U)
+4   (call core.TypeVar :V)
+5   (call core.TypeVar :T)
 6   TestMod.f
 7   (call core.TypeEqOf %₆)
-8   slot₃/T
-9   slot₁/U
-10  slot₂/V
-11  (call core.svec %₇ %₈ %₉ %₁₀)
-12  slot₁/U
-13  slot₂/V
-14  slot₃/T
-15  (call core.svec %₁₂ %₁₃ %₁₄)
-16  SourceLocation::1:10
-17  (call core.svec %₁₁ %₁₅ %₁₆)
-18  --- method TestMod.f %₁₇
+8   (call core.svec %₇ %₅ %₃ %₄)
+9   (call core.svec %₃ %₄ %₅)
+10  SourceLocation::1:1
+11  (call core.svec %₈ %₉ %₁₀)
+12  --- method TestMod.f %₁₁
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read) slot₃/#unused#(!read) slot₄/#unused#(!read)]
     1   static_parameter₃
     2   static_parameter₁
     3   static_parameter₂
     4   (call core.tuple %₁ %₂ %₃)
     5   (return %₄)
-19  latestworld
-20  TestMod.f
-21  (return %₂₀)
+13  latestworld
+14  TestMod.f
+15  (return %₁₄)
 
 ########################################
 # Static parameter with bounds and used with apply_type in argument
@@ -180,24 +174,22 @@ end
 2   latestworld
 3   TestMod.X
 4   TestMod.Y
-5   (= slot₁/T (call core.TypeVar :T %₃ %₄))
+5   (call core.TypeVar :T %₃ %₄)
 6   TestMod.f
 7   (call core.TypeEqOf %₆)
 8   TestMod.S
-9   slot₁/T
-10  (call core.apply_type %₈ %₉)
-11  (call core.svec %₇ %₁₀)
-12  slot₁/T
-13  (call core.svec %₁₂)
-14  SourceLocation::1:10
-15  (call core.svec %₁₁ %₁₃ %₁₄)
-16  --- method TestMod.f %₁₅
+9   (call core.apply_type %₈ %₅)
+10  (call core.svec %₇ %₉)
+11  (call core.svec %₅)
+12  SourceLocation::1:1
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method TestMod.f %₁₃
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read)]
     1   static_parameter₁
     2   (return %₁)
-17  latestworld
-18  TestMod.f
-19  (return %₁₈)
+15  latestworld
+16  TestMod.f
+17  (return %₁₆)
 
 ########################################
 # Static parameter with lower bound
@@ -208,24 +200,22 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   TestMod.X
-4   (= slot₁/T (call core.TypeVar :T %₃ core.Any))
+4   (call core.TypeVar :T %₃ core.Any)
 5   TestMod.f
 6   (call core.TypeEqOf %₅)
 7   TestMod.S
-8   slot₁/T
-9   (call core.apply_type %₇ %₈)
-10  (call core.svec %₆ %₉)
-11  slot₁/T
-12  (call core.svec %₁₁)
-13  SourceLocation::1:10
-14  (call core.svec %₁₀ %₁₂ %₁₃)
-15  --- method TestMod.f %₁₄
+8   (call core.apply_type %₇ %₄)
+9   (call core.svec %₆ %₈)
+10  (call core.svec %₄)
+11  SourceLocation::1:1
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method TestMod.f %₁₂
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read)]
     1   static_parameter₁
     2   (return %₁)
-16  latestworld
-17  TestMod.f
-18  (return %₁₇)
+14  latestworld
+15  TestMod.f
+16  (return %₁₅)
 
 ########################################
 # Static parameter which is used only in the bounds of another static parameter
@@ -236,29 +226,61 @@ end
 #---------------------
 1   (method TestMod.f)
 2   latestworld
-3   (= slot₁/T (call core.TypeVar :T))
+3   (call core.TypeVar :T)
 4   TestMod.AbstractVector
-5   slot₁/T
-6   (call core.apply_type %₄ %₅)
-7   (= slot₂/S (call core.TypeVar :S %₆))
-8   TestMod.f
-9   (call core.TypeEqOf %₈)
-10  slot₂/S
-11  (call core.svec %₉ core.Any %₁₀)
-12  slot₁/T
-13  slot₂/S
-14  (call core.svec %₁₂ %₁₃)
-15  SourceLocation::1:10
-16  (call core.svec %₁₁ %₁₄ %₁₅)
-17  --- method TestMod.f %₁₆
+5   (call core.apply_type %₄ %₃)
+6   (call core.TypeVar :S %₅)
+7   TestMod.f
+8   (call core.TypeEqOf %₇)
+9   (call core.svec %₈ core.Any %₆)
+10  (call core.svec %₃ %₆)
+11  SourceLocation::1:1
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method TestMod.f %₁₂
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/y(!read)]
     1   static_parameter₁
     2   static_parameter₂
     3   (call core.tuple %₁ %₂)
     4   (return %₃)
-18  latestworld
-19  TestMod.f
-20  (return %₁₉)
+14  latestworld
+15  TestMod.f
+16  (return %₁₅)
+
+########################################
+# Error: underscore sparam is not readable in the function body
+function f(x::_) where _
+    return _
+end
+#---------------------
+LoweringError:
+function f(x::_) where _
+#             ╙ ── all-underscore identifiers are write-only and their values cannot be used in expressions
+    return _
+end
+
+########################################
+# Error: underscore sparam is not readable in a default arg value
+f(x::_, y=_) where _ = x
+#---------------------
+LoweringError:
+f(x::_, y=_) where _ = x
+#    ╙ ── all-underscore identifiers are write-only and their values cannot be used in expressions
+
+########################################
+# Error: underscore sparam is not readable in a default kwarg value
+f(x::_; y=_) where _ = x
+#---------------------
+LoweringError:
+f(x::_; y=_) where _ = x
+#    ╙ ── all-underscore identifiers are write-only and their values cannot be used in expressions
+
+########################################
+# Error: underscore sparam is not readable in the return type
+(f(x)::_) where _ = x
+#---------------------
+LoweringError:
+(f(x)::_) where _ = x
+#      ╙ ── all-underscore identifiers are write-only and their values cannot be used in expressions
 
 ########################################
 # Return types
@@ -275,7 +297,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read) slot₂/x slot₃/tmp(!read)]
@@ -311,7 +333,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read) slot₂/c(!read) slot₃/b1 slot₄/b2 slot₅/tmp(!read) slot₆/tmp(!read) slot₇/tmp(!read)]
@@ -362,7 +384,7 @@ end
 1   TestMod.T
 2   (call core.svec %₁ core.Any)
 3   (call core.svec)
-4   SourceLocation::1:10
+4   SourceLocation::1:1
 5   (call core.svec %₂ %₃ %₄)
 6   --- method core.nothing %₅
     slots: [slot₁/#self#(!read) slot₂/x]
@@ -380,7 +402,7 @@ end
 1   TestMod.T
 2   (call core.svec %₁ core.Any)
 3   (call core.svec)
-4   SourceLocation::1:10
+4   SourceLocation::1:1
 5   (call core.svec %₂ %₃ %₄)
 6   --- method core.nothing %₅
     slots: [slot₁/y slot₂/x]
@@ -395,21 +417,19 @@ function (x::X1{T})() where T
     T
 end
 #---------------------
-1   (= slot₁/T (call core.TypeVar :T))
+1   (call core.TypeVar :T)
 2   TestMod.X1
-3   slot₁/T
-4   (call core.apply_type %₂ %₃)
-5   (call core.svec %₄)
-6   slot₁/T
-7   (call core.svec %₆)
-8   SourceLocation::1:10
-9   (call core.svec %₅ %₇ %₈)
-10  --- method core.nothing %₉
+3   (call core.apply_type %₂ %₁)
+4   (call core.svec %₃)
+5   (call core.svec %₁)
+6   SourceLocation::1:1
+7   (call core.svec %₄ %₅ %₆)
+8   --- method core.nothing %₇
     slots: [slot₁/x(!read)]
     1   static_parameter₁
     2   (return %₁)
-11  latestworld
-12  (return core.nothing)
+9   latestworld
+10  (return core.nothing)
 
 ########################################
 # Function with module ref in name
@@ -421,7 +441,7 @@ end
 3   (call core.TypeEqOf %₂)
 4   (call core.svec %₃)
 5   (call core.svec)
-6   SourceLocation::1:10
+6   SourceLocation::1:1
 7   (call core.svec %₄ %₅ %₆)
 8   --- method core.nothing %₇
     slots: [slot₁/#self#(!read)]
@@ -459,7 +479,7 @@ function var".f"(); end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod..f %₈
     slots: [slot₁/#self#(!read)]
@@ -491,7 +511,7 @@ end
 5   TestMod.T
 6   (call core.svec %₄ %₅)
 7   (call core.svec)
-8   SourceLocation::1:10
+8   SourceLocation::1:1
 9   (call core.svec %₆ %₇ %₈)
 10  --- method TestMod.f %₉
     slots: [slot₁/#self#(called) slot₂/x slot₃/y(single_assign)]
@@ -506,7 +526,7 @@ end
 15  TestMod.S
 16  (call core.svec %₁₃ %₁₄ %₁₅)
 17  (call core.svec)
-18  SourceLocation::1:10
+18  SourceLocation::1:1
 19  (call core.svec %₁₆ %₁₇ %₁₈)
 20  --- method TestMod.f %₁₉
     slots: [slot₁/#self#(called) slot₂/x slot₃/y]
@@ -520,7 +540,7 @@ end
 26  TestMod.U
 27  (call core.svec %₂₃ %₂₄ %₂₅ %₂₆)
 28  (call core.svec)
-29  SourceLocation::1:10
+29  SourceLocation::1:1
 30  (call core.svec %₂₇ %₂₈ %₂₉)
 31  --- method TestMod.f %₃₀
     slots: [slot₁/#self#(!read) slot₂/x slot₃/y slot₄/z(!read)]
@@ -542,7 +562,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(called) slot₂/x(single_assign)]
@@ -556,7 +576,7 @@ end
 12  (call core.TypeEqOf %₁₁)
 13  (call core.svec %₁₂ core.Any)
 14  (call core.svec)
-15  SourceLocation::1:10
+15  SourceLocation::1:1
 16  (call core.svec %₁₃ %₁₄ %₁₅)
 17  --- method TestMod.f %₁₆
     slots: [slot₁/#self#(called) slot₂/x]
@@ -567,7 +587,7 @@ end
 20  (call core.TypeEqOf %₁₉)
 21  (call core.svec %₂₀ core.Any core.Any)
 22  (call core.svec)
-23  SourceLocation::1:10
+23  SourceLocation::1:1
 24  (call core.svec %₂₁ %₂₂ %₂₃)
 25  --- method TestMod.f %₂₄
     slots: [slot₁/#self#(!read) slot₂/x slot₃/y]
@@ -590,7 +610,7 @@ end
 5   TestMod.Int
 6   (call core.svec %₄ %₅)
 7   (call core.svec)
-8   SourceLocation::1:10
+8   SourceLocation::1:1
 9   (call core.svec %₆ %₇ %₈)
 10  --- method TestMod.f %₉
     slots: [slot₁/#self#(called) slot₂/#arg# slot₃/y(single_assign)]
@@ -604,7 +624,7 @@ end
 14  TestMod.Int
 15  (call core.svec %₁₃ %₁₄ core.Any)
 16  (call core.svec)
-17  SourceLocation::1:10
+17  SourceLocation::1:1
 18  (call core.svec %₁₅ %₁₆ %₁₇)
 19  --- method TestMod.f %₁₈
     slots: [slot₁/#self#(called) slot₂/#arg# slot₃/y]
@@ -616,7 +636,7 @@ end
 23  TestMod.Int
 24  (call core.svec %₂₂ %₂₃ core.Any core.Any)
 25  (call core.svec)
-26  SourceLocation::1:10
+26  SourceLocation::1:1
 27  (call core.svec %₂₄ %₂₅ %₂₆)
 28  --- method TestMod.f %₂₇
     slots: [slot₁/#self#(!read) slot₂/#arg#(!read) slot₃/y slot₄/z]
@@ -639,7 +659,7 @@ end
 5   TestMod.Int
 6   (call core.svec %₄ %₅)
 7   (call core.svec)
-8   SourceLocation::1:10
+8   SourceLocation::1:1
 9   (call core.svec %₆ %₇ %₈)
 10  --- method TestMod.f %₉
     slots: [slot₁/#self#(called) slot₂/#arg#]
@@ -651,7 +671,7 @@ end
 14  TestMod.Int
 15  (call core.svec %₁₃ %₁₄ core.Any)
 16  (call core.svec)
-17  SourceLocation::1:10
+17  SourceLocation::1:1
 18  (call core.svec %₁₅ %₁₆ %₁₇)
 19  --- method TestMod.f %₁₈
     slots: [slot₁/#self#(!read) slot₂/#arg#(!read) slot₃/x]
@@ -669,15 +689,15 @@ end
 #---------------------
 1   (method TestMod.f)
 2   latestworld
-3   (= slot₁/T (call core.TypeVar :T))
-4   TestMod.f
-5   (call core.TypeEqOf %₄)
-6   slot₁/T
-7   (call core.svec %₅ %₆)
-8   slot₁/T
-9   (call core.svec %₈)
-10  SourceLocation::1:10
-11  (call core.svec %₇ %₉ %₁₀)
+3   (call core.TypeVar :T)
+4   (call core.TypeVar :S %₃)
+5   (call core.TypeVar :U %₄)
+6   TestMod.f
+7   (call core.TypeEqOf %₆)
+8   (call core.svec %₇ %₃)
+9   (call core.svec %₃)
+10  SourceLocation::1:1
+11  (call core.svec %₈ %₉ %₁₀)
 12  --- method TestMod.f %₁₁
     slots: [slot₁/#self#(called) slot₂/x slot₃/y(single_assign)]
     1   (= slot₃/y 1)
@@ -685,48 +705,30 @@ end
     3   (call slot₁/#self# slot₂/x %₂ 2)
     4   (return %₃)
 13  latestworld
-14  (= slot₁/T (call core.TypeVar :T))
-15  slot₁/T
-16  (= slot₂/S (call core.TypeVar :S %₁₅))
-17  TestMod.f
-18  (call core.TypeEqOf %₁₇)
-19  slot₁/T
-20  slot₂/S
-21  (call core.svec %₁₈ %₁₉ %₂₀)
-22  slot₁/T
-23  slot₂/S
-24  (call core.svec %₂₂ %₂₃)
-25  SourceLocation::1:10
-26  (call core.svec %₂₁ %₂₄ %₂₅)
-27  --- method TestMod.f %₂₆
+14  TestMod.f
+15  (call core.TypeEqOf %₁₄)
+16  (call core.svec %₁₅ %₃ %₄)
+17  (call core.svec %₃ %₄)
+18  SourceLocation::1:1
+19  (call core.svec %₁₆ %₁₇ %₁₈)
+20  --- method TestMod.f %₁₉
     slots: [slot₁/#self#(called) slot₂/x slot₃/y]
     1   (call slot₁/#self# slot₂/x slot₃/y 2)
     2   (return %₁)
-28  latestworld
-29  (= slot₁/T (call core.TypeVar :T))
-30  slot₁/T
-31  (= slot₂/S (call core.TypeVar :S %₃₀))
-32  slot₂/S
-33  (= slot₃/U (call core.TypeVar :U %₃₂))
-34  TestMod.f
-35  (call core.TypeEqOf %₃₄)
-36  slot₁/T
-37  slot₂/S
-38  slot₃/U
-39  (call core.svec %₃₅ %₃₆ %₃₇ %₃₈)
-40  slot₁/T
-41  slot₂/S
-42  slot₃/U
-43  (call core.svec %₄₀ %₄₁ %₄₂)
-44  SourceLocation::1:10
-45  (call core.svec %₃₉ %₄₃ %₄₄)
-46  --- method TestMod.f %₄₅
+21  latestworld
+22  TestMod.f
+23  (call core.TypeEqOf %₂₂)
+24  (call core.svec %₂₃ %₃ %₄ %₅)
+25  (call core.svec %₃ %₄ %₅)
+26  SourceLocation::1:1
+27  (call core.svec %₂₄ %₂₅ %₂₆)
+28  --- method TestMod.f %₂₇
     slots: [slot₁/#self#(!read) slot₂/x slot₃/y slot₄/z]
     1   (call core.tuple slot₂/x slot₃/y slot₄/z)
     2   (return %₁)
-47  latestworld
-48  TestMod.f
-49  (return %₄₈)
+29  latestworld
+30  TestMod.f
+31  (return %₃₀)
 
 ########################################
 # Positional args and type parameters with transitive dependencies
@@ -738,65 +740,51 @@ end
 #---------------------
 1   (method TestMod.f)
 2   latestworld
-3   TestMod.f
-4   (call core.TypeEqOf %₃)
-5   (call core.svec %₄ core.Any)
-6   (call core.svec)
-7   SourceLocation::1:10
-8   (call core.svec %₅ %₆ %₇)
-9   --- method TestMod.f %₈
+3   (call core.TypeVar :T)
+4   TestMod.AbstractVector
+5   (call core.apply_type %₄ %₃)
+6   (call core.TypeVar :S %₅)
+7   (call core.TypeVar :U)
+8   TestMod.f
+9   (call core.TypeEqOf %₈)
+10  (call core.svec %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::1:1
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method TestMod.f %₁₃
     slots: [slot₁/#self#(called) slot₂/x slot₃/y(single_assign)]
     1   (= slot₃/y (call top.vect 1))
     2   slot₃/y
     3   (call slot₁/#self# slot₂/x %₂ 2)
     4   (return %₃)
-10  latestworld
-11  (= slot₁/T (call core.TypeVar :T))
-12  TestMod.AbstractVector
-13  slot₁/T
-14  (call core.apply_type %₁₂ %₁₃)
-15  (= slot₂/S (call core.TypeVar :S %₁₄))
+15  latestworld
 16  TestMod.f
 17  (call core.TypeEqOf %₁₆)
-18  slot₂/S
-19  (call core.svec %₁₇ core.Any %₁₈)
-20  slot₁/T
-21  slot₂/S
-22  (call core.svec %₂₀ %₂₁)
-23  SourceLocation::1:10
-24  (call core.svec %₁₉ %₂₂ %₂₃)
-25  --- method TestMod.f %₂₄
+18  (call core.svec %₁₇ core.Any %₆)
+19  (call core.svec %₃ %₆)
+20  SourceLocation::1:1
+21  (call core.svec %₁₈ %₁₉ %₂₀)
+22  --- method TestMod.f %₂₁
     slots: [slot₁/#self#(called) slot₂/x slot₃/y]
     1   (call slot₁/#self# slot₂/x slot₃/y 2)
     2   (return %₁)
-26  latestworld
-27  (= slot₁/T (call core.TypeVar :T))
-28  TestMod.AbstractVector
-29  slot₁/T
-30  (call core.apply_type %₂₈ %₂₉)
-31  (= slot₂/S (call core.TypeVar :S %₃₀))
-32  (= slot₃/U (call core.TypeVar :U))
-33  TestMod.f
-34  (call core.TypeEqOf %₃₃)
-35  slot₂/S
-36  slot₃/U
-37  (call core.svec %₃₄ core.Any %₃₅ %₃₆)
-38  slot₁/T
-39  slot₂/S
-40  slot₃/U
-41  (call core.svec %₃₈ %₃₉ %₄₀)
-42  SourceLocation::1:10
-43  (call core.svec %₃₇ %₄₁ %₄₂)
-44  --- method TestMod.f %₄₃
+23  latestworld
+24  TestMod.f
+25  (call core.TypeEqOf %₂₄)
+26  (call core.svec %₂₅ core.Any %₆ %₇)
+27  (call core.svec %₃ %₆ %₇)
+28  SourceLocation::1:1
+29  (call core.svec %₂₆ %₂₇ %₂₈)
+30  --- method TestMod.f %₂₉
     slots: [slot₁/#self#(!read) slot₂/x slot₃/y slot₄/z]
     1   static_parameter₁
     2   static_parameter₂
     3   static_parameter₃
     4   (call core.tuple slot₂/x slot₃/y slot₄/z %₁ %₂ %₃)
     5   (return %₄)
-45  latestworld
-46  TestMod.f
-47  (return %₄₆)
+31  latestworld
+32  TestMod.f
+33  (return %₃₂)
 
 ########################################
 # Default positional args are allowed before trailing slurp with no default
@@ -810,7 +798,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(called)]
@@ -822,7 +810,7 @@ end
 13  (call core.apply_type core.Vararg core.Any)
 14  (call core.svec %₁₂ core.Any %₁₃)
 15  (call core.svec)
-16  SourceLocation::1:10
+16  SourceLocation::1:1
 17  (call core.svec %₁₄ %₁₅ %₁₆)
 18  --- method TestMod.f %₁₇
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/ys]
@@ -856,7 +844,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(called)]
@@ -868,7 +856,7 @@ end
 13  (call core.apply_type core.Vararg core.Any)
 14  (call core.svec %₁₂ %₁₃)
 15  (call core.svec)
-16  SourceLocation::1:10
+16  SourceLocation::1:1
 17  (call core.svec %₁₄ %₁₅ %₁₆)
 18  --- method TestMod.f %₁₇
     slots: [slot₁/#self#(!read) slot₂/xs]
@@ -890,7 +878,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#]
@@ -903,7 +891,7 @@ end
 13  (call core.apply_type core.Vararg core.Any)
 14  (call core.svec %₁₂ %₁₃)
 15  (call core.svec)
-16  SourceLocation::1:10
+16  SourceLocation::1:1
 17  (call core.svec %₁₄ %₁₅ %₁₆)
 18  --- method TestMod.f %₁₇
     slots: [slot₁/#self#(!read) slot₂/xs]
@@ -924,7 +912,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/destructured slot₄/w(!read) slot₅/iterstate(single_assign) slot₆/y(!read,single_assign) slot₇/z(!read,single_assign)]
@@ -950,7 +938,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(called)]
@@ -964,7 +952,7 @@ end
 14  (call core.apply_type core.Vararg %₁₃)
 15  (call core.svec %₁₂ %₁₄)
 16  (call core.svec)
-17  SourceLocation::1:10
+17  SourceLocation::1:1
 18  (call core.svec %₁₅ %₁₆ %₁₇)
 19  --- method TestMod.f %₁₈
     slots: [slot₁/#self#(!read) slot₂/destructured slot₃/x(!read,single_assign)]
@@ -1122,7 +1110,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(called)]
@@ -1134,7 +1122,7 @@ end
 12  (call core.TypeEqOf %₁₁)
 13  (call core.svec %₁₂ core.Any)
 14  (call core.svec)
-15  SourceLocation::1:10
+15  SourceLocation::1:1
 16  (call core.svec %₁₃ %₁₄ %₁₅)
 17  --- method TestMod.f %₁₆
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/tmp(!read)]
@@ -1161,7 +1149,7 @@ function f(_, _); end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read) slot₃/#unused#(!read)]
@@ -1181,7 +1169,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read) slot₂/destructured slot₃/destructured]
@@ -1206,7 +1194,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read) slot₂/x(nospecialize,!read) slot₃/g(called) slot₄/y]
@@ -1280,7 +1268,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read)]
@@ -1303,7 +1291,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read) slot₂/x(!read,single_assign)]
@@ -1413,7 +1401,7 @@ end
 12  TestMod.Float64
 13  (call core.svec %₆ %₇ %₈ %₁₀ %₁₁ %₁₂)
 14  (call core.svec)
-15  SourceLocation::1:10
+15  SourceLocation::1:1
 16  (call core.svec %₁₃ %₁₄ %₁₅)
 17  --- method TestMod.#kw_body#f_kw_simple#0 %₁₆
     slots: [slot₁/#kw_body#f_kw_simple#0(!read) slot₂/x slot₃/y slot₄/#self#(!read) slot₅/a slot₆/b]
@@ -1425,7 +1413,7 @@ end
 20  (call core.TypeEqOf %₁₉)
 21  (call core.svec %₂₀)
 22  (call core.svec)
-23  SourceLocation::1:10
+23  SourceLocation::1:1
 24  (call core.svec %₂₁ %₂₂ %₂₃)
 25  --- method TestMod.f_kw_simple %₂₄
     slots: [slot₁/#self#(called) slot₂/a(single_assign)]
@@ -1439,7 +1427,7 @@ end
 29  TestMod.Int
 30  (call core.svec %₂₈ %₂₉)
 31  (call core.svec)
-32  SourceLocation::1:10
+32  SourceLocation::1:1
 33  (call core.svec %₃₀ %₃₁ %₃₂)
 34  --- method TestMod.f_kw_simple %₃₃
     slots: [slot₁/#self#(called) slot₂/a]
@@ -1452,7 +1440,7 @@ end
 39  TestMod.Float64
 40  (call core.svec %₃₇ %₃₈ %₃₉)
 41  (call core.svec)
-42  SourceLocation::1:10
+42  SourceLocation::1:1
 43  (call core.svec %₄₀ %₄₁ %₄₂)
 44  --- method TestMod.f_kw_simple %₄₃
     slots: [slot₁/#self# slot₂/a slot₃/b]
@@ -1465,7 +1453,7 @@ end
 48  (call core.TypeEqOf %₄₇)
 49  (call core.svec %₄₆ core.NamedTuple %₄₈)
 50  (call core.svec)
-51  SourceLocation::1:10
+51  SourceLocation::1:1
 52  (call core.svec %₄₉ %₅₀ %₅₁)
 53  --- method TestMod.f_kw_simple %₅₂
     slots: [slot₁/#kwcall_self#(called) slot₂/kws slot₃/#self# slot₄/a(single_assign)]
@@ -1480,7 +1468,7 @@ end
 58  TestMod.Int
 59  (call core.svec %₅₅ core.NamedTuple %₅₇ %₅₈)
 60  (call core.svec)
-61  SourceLocation::1:10
+61  SourceLocation::1:1
 62  (call core.svec %₅₉ %₆₀ %₆₁)
 63  --- method TestMod.f_kw_simple %₆₂
     slots: [slot₁/#kwcall_self#(called) slot₂/kws slot₃/#self# slot₄/a]
@@ -1494,7 +1482,7 @@ end
 69  TestMod.Float64
 70  (call core.svec %₆₅ core.NamedTuple %₆₇ %₆₈ %₆₉)
 71  (call core.svec)
-72  SourceLocation::1:10
+72  SourceLocation::1:1
 73  (call core.svec %₇₀ %₇₁ %₇₂)
 74  --- method TestMod.f_kw_simple %₇₃
     slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/a slot₅/b slot₆/x(!read) slot₇/y(!read) slot₈/kwtmp]
@@ -1630,7 +1618,7 @@ end
 9   (call core.TypeEqOf %₈)
 10  (call core.svec %₆ %₇ %₉)
 11  (call core.svec)
-12  SourceLocation::1:10
+12  SourceLocation::1:1
 13  (call core.svec %₁₀ %₁₁ %₁₂)
 14  --- method TestMod.#kw_body#f_kw_slurp_simple#0 %₁₃
     slots: [slot₁/#kw_body#f_kw_slurp_simple#0(!read) slot₂/all_kws slot₃/#self#(!read)]
@@ -1642,7 +1630,7 @@ end
 17  (call core.TypeEqOf %₁₆)
 18  (call core.svec %₁₇)
 19  (call core.svec)
-20  SourceLocation::1:10
+20  SourceLocation::1:1
 21  (call core.svec %₁₈ %₁₉ %₂₀)
 22  --- method TestMod.f_kw_slurp_simple %₂₁
     slots: [slot₁/#self#]
@@ -1657,7 +1645,7 @@ end
 26  (call core.TypeEqOf %₂₅)
 27  (call core.svec %₂₄ core.NamedTuple %₂₆)
 28  (call core.svec)
-29  SourceLocation::1:10
+29  SourceLocation::1:1
 30  (call core.svec %₂₇ %₂₈ %₂₉)
 31  --- method TestMod.f_kw_slurp_simple %₃₀
     slots: [slot₁/#unused#(!read) slot₂/kws slot₃/#self#]
@@ -1686,7 +1674,7 @@ end
 9   (call core.TypeEqOf %₈)
 10  (call core.svec %₆ core.Any %₇ %₉)
 11  (call core.svec)
-12  SourceLocation::1:10
+12  SourceLocation::1:1
 13  (call core.svec %₁₀ %₁₁ %₁₂)
 14  --- method TestMod.#kw_body#f_kw_slurp#0 %₁₃
     slots: [slot₁/#kw_body#f_kw_slurp#0(!read) slot₂/x(!read) slot₃/non_x_kws(!read) slot₄/#self#(!read)]
@@ -1698,7 +1686,7 @@ end
 17  (call core.TypeEqOf %₁₆)
 18  (call core.svec %₁₇)
 19  (call core.svec)
-20  SourceLocation::1:10
+20  SourceLocation::1:1
 21  (call core.svec %₁₈ %₁₉ %₂₀)
 22  --- method TestMod.f_kw_slurp %₂₁
     slots: [slot₁/#self#]
@@ -1714,7 +1702,7 @@ end
 26  (call core.TypeEqOf %₂₅)
 27  (call core.svec %₂₄ core.NamedTuple %₂₆)
 28  (call core.svec)
-29  SourceLocation::1:10
+29  SourceLocation::1:1
 30  (call core.svec %₂₇ %₂₈ %₂₉)
 31  --- method TestMod.f_kw_slurp %₃₀
     slots: [slot₁/#unused#(!read) slot₂/kws slot₃/#self# slot₄/x(!read) slot₅/kwtmp]
@@ -1758,7 +1746,7 @@ end
 9   (call core.TypeEqOf %₈)
 10  (call core.svec %₆ core.Any core.Any %₇ %₉)
 11  (call core.svec)
-12  SourceLocation::1:10
+12  SourceLocation::1:1
 13  (call core.svec %₁₀ %₁₁ %₁₂)
 14  --- method TestMod.#kw_body#f_kw_slurp_dep#0 %₁₃
     slots: [slot₁/#kw_body#f_kw_slurp_dep#0(!read) slot₂/a slot₃/b slot₄/kws slot₅/#self#(!read)]
@@ -1770,7 +1758,7 @@ end
 17  (call core.TypeEqOf %₁₆)
 18  (call core.svec %₁₇)
 19  (call core.svec)
-20  SourceLocation::1:10
+20  SourceLocation::1:1
 21  (call core.svec %₁₈ %₁₉ %₂₀)
 22  --- method TestMod.f_kw_slurp_dep %₂₁
     slots: [slot₁/#self# slot₂/a(single_assign) slot₃/b(single_assign)]
@@ -1789,7 +1777,7 @@ end
 26  (call core.TypeEqOf %₂₅)
 27  (call core.svec %₂₄ core.NamedTuple %₂₆)
 28  (call core.svec)
-29  SourceLocation::1:10
+29  SourceLocation::1:1
 30  (call core.svec %₂₇ %₂₈ %₂₉)
 31  --- method TestMod.f_kw_slurp_dep %₃₀
     slots: [slot₁/#unused#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/a(single_assign) slot₆/b(single_assign)]
@@ -1834,57 +1822,48 @@ end
 2   latestworld
 3   (method TestMod.f_kw_sparams)
 4   latestworld
-5   (= slot₁/X (call core.TypeVar :X))
-6   (= slot₂/A (call core.TypeVar :A))
+5   (call core.TypeVar :X)
+6   (call core.TypeVar :A)
 7   TestMod.#kw_body#f_kw_sparams#0
 8   (call core.TypeEqOf %₇)
-9   slot₂/A
-10  slot₁/X
-11  TestMod.f_kw_sparams
-12  (call core.TypeEqOf %₁₁)
-13  slot₁/X
-14  (call core.svec %₈ %₉ %₁₀ %₁₂ %₁₃)
-15  slot₁/X
-16  slot₂/A
-17  (call core.svec %₁₅ %₁₆)
-18  SourceLocation::1:10
-19  (call core.svec %₁₄ %₁₇ %₁₈)
-20  --- method TestMod.#kw_body#f_kw_sparams#0 %₁₉
+9   TestMod.f_kw_sparams
+10  (call core.TypeEqOf %₉)
+11  (call core.svec %₈ %₆ %₅ %₁₀ %₅)
+12  (call core.svec %₅ %₆)
+13  SourceLocation::1:1
+14  (call core.svec %₁₁ %₁₂ %₁₃)
+15  --- method TestMod.#kw_body#f_kw_sparams#0 %₁₄
     slots: [slot₁/#kw_body#f_kw_sparams#0(!read) slot₂/a(!read) slot₃/b(!read) slot₄/#self#(!read) slot₅/x(!read)]
     1   (meta :nkw 2)
     2   static_parameter₁
     3   static_parameter₂
     4   (call core.tuple %₂ %₃)
     5   (return %₄)
-21  latestworld
-22  (= slot₃/X (call core.TypeVar :X))
-23  TestMod.f_kw_sparams
-24  (call core.TypeEqOf %₂₃)
-25  slot₃/X
-26  (call core.svec %₂₄ %₂₅)
-27  slot₃/X
-28  (call core.svec %₂₇)
-29  SourceLocation::1:10
-30  (call core.svec %₂₆ %₂₈ %₂₉)
-31  --- method TestMod.f_kw_sparams %₃₀
+16  latestworld
+17  (call core.TypeVar :X)
+18  TestMod.f_kw_sparams
+19  (call core.TypeEqOf %₁₈)
+20  (call core.svec %₁₉ %₁₇)
+21  (call core.svec %₁₇)
+22  SourceLocation::1:1
+23  (call core.svec %₂₀ %₂₁ %₂₂)
+24  --- method TestMod.f_kw_sparams %₂₃
     slots: [slot₁/#self# slot₂/x]
     1   TestMod.#kw_body#f_kw_sparams#0
     2   TestMod.a_def
     3   TestMod.b_def
     4   (call %₁ %₂ %₃ slot₁/#self# slot₂/x)
     5   (return %₄)
-32  latestworld
-33  (= slot₄/X (call core.TypeVar :X))
-34  (call core.typeof core.kwcall)
-35  TestMod.f_kw_sparams
-36  (call core.TypeEqOf %₃₅)
-37  slot₄/X
-38  (call core.svec %₃₄ core.NamedTuple %₃₆ %₃₇)
-39  slot₄/X
-40  (call core.svec %₃₉)
-41  SourceLocation::1:10
-42  (call core.svec %₃₈ %₄₀ %₄₁)
-43  --- method TestMod.f_kw_sparams %₄₂
+25  latestworld
+26  (call core.TypeVar :X)
+27  (call core.typeof core.kwcall)
+28  TestMod.f_kw_sparams
+29  (call core.TypeEqOf %₂₈)
+30  (call core.svec %₂₇ core.NamedTuple %₂₉ %₂₆)
+31  (call core.svec %₂₆)
+32  SourceLocation::1:1
+33  (call core.svec %₃₀ %₃₁ %₃₂)
+34  --- method TestMod.f_kw_sparams %₃₃
     slots: [slot₁/#unused#(!read) slot₂/kws slot₃/#self# slot₄/x slot₅/a(!read) slot₆/b(!read) slot₇/kwtmp]
     1   (newvar slot₅/a)
     2   (newvar slot₆/b)
@@ -1921,9 +1900,9 @@ end
     33  TestMod.#kw_body#f_kw_sparams#0
     34  (call %₃₃ %₁₀ %₂₅ slot₃/#self# slot₄/x)
     35  (return %₃₄)
-44  latestworld
-45  TestMod.f_kw_sparams
-46  (return %₄₅)
+35  latestworld
+36  TestMod.f_kw_sparams
+37  (return %₃₆)
 
 ########################################
 # Keyword @nospecialize
@@ -1942,7 +1921,7 @@ end
 9   (call core.TypeEqOf %₈)
 10  (call core.svec %₆ core.Any core.Any %₇ %₉ core.Any)
 11  (call core.svec)
-12  SourceLocation::1:10
+12  SourceLocation::1:1
 13  (call core.svec %₁₀ %₁₁ %₁₂)
 14  --- method TestMod.#kw_body#f_kw_slurp#1 %₁₃
     slots: [slot₁/#kw_body#f_kw_slurp#1(!read) slot₂/kw1(nospecialize,!read) slot₃/kw2(nospecialize,!read) slot₄/restkw(nospecialize,!read) slot₅/#self#(!read) slot₆/a(nospecialize,!read)]
@@ -1954,7 +1933,7 @@ end
 17  (call core.TypeEqOf %₁₆)
 18  (call core.svec %₁₇ core.Any)
 19  (call core.svec)
-20  SourceLocation::1:10
+20  SourceLocation::1:1
 21  (call core.svec %₁₈ %₁₉ %₂₀)
 22  --- method TestMod.f_kw_slurp %₂₁
     slots: [slot₁/#self# slot₂/a(nospecialize)]
@@ -1972,7 +1951,7 @@ end
 26  (call core.TypeEqOf %₂₅)
 27  (call core.svec %₂₄ core.NamedTuple %₂₆ core.Any)
 28  (call core.svec)
-29  SourceLocation::1:10
+29  SourceLocation::1:1
 30  (call core.svec %₂₇ %₂₈ %₂₉)
 31  --- method TestMod.f_kw_slurp %₃₀
     slots: [slot₁/#unused#(!read) slot₂/kws slot₃/#self# slot₄/a(nospecialize) slot₅/kw1(!read) slot₆/kw2(!read) slot₇/kwtmp]
@@ -2077,7 +2056,7 @@ end
 8   (call core.TypeEqOf %₇)
 9   (call core.svec %₈ JuliaSyntax.SyntaxContext core.Any core.Any core.Any)
 10  (call core.svec)
-11  SourceLocation::1:21
+11  SourceLocation::1:1
 12  (call core.svec %₉ %₁₀ %₁₁)
 13  --- method TestMod.#f_only_generated@generator#0 %₁₂
     slots: [slot₁/#self#(!read) slot₂/__context__(!read) slot₃/#self#(nospecialize,!read) slot₄/x(nospecialize) slot₅/y(nospecialize)]
@@ -2092,7 +2071,7 @@ end
 16  (call core.TypeEqOf %₁₅)
 17  (call core.svec %₁₆ core.Any core.Any)
 18  (call core.svec)
-19  SourceLocation::1:21
+19  SourceLocation::1:1
 20  (call core.svec %₁₇ %₁₈ %₁₉)
 21  --- method TestMod.f_only_generated %₂₀
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/y(!read)]
@@ -2127,7 +2106,7 @@ end
 8   (call core.TypeEqOf %₇)
 9   (call core.svec %₈ JuliaSyntax.SyntaxContext core.Any core.Any core.Any)
 10  (call core.svec)
-11  SourceLocation::1:10
+11  SourceLocation::1:1
 12  (call core.svec %₉ %₁₀ %₁₁)
 13  --- method TestMod.#f_partially_generated@generator#0 %₁₂
     slots: [slot₁/#self#(!read) slot₂/__context__(!read) slot₃/#self#(nospecialize,!read) slot₄/x(nospecialize,!read) slot₅/y(nospecialize,!read)]
@@ -2141,7 +2120,7 @@ end
 16  (call core.TypeEqOf %₁₅)
 17  (call core.svec %₁₆ core.Any core.Any)
 18  (call core.svec)
-19  SourceLocation::1:10
+19  SourceLocation::1:1
 20  (call core.svec %₁₇ %₁₈ %₁₉)
 21  --- method TestMod.f_partially_generated %₂₀
     slots: [slot₁/#self#(!read) slot₂/x slot₃/y slot₄/maybe_gen_stuff(single_assign) slot₅/nongen_stuff(single_assign)]

--- a/JuliaLowering/test/generators_ir.jl
+++ b/JuliaLowering/test/generators_ir.jl
@@ -8,19 +8,19 @@
 4   (call JuliaLowering.eval_closure_type TestMod :##->###0 %₁ %₂ %₃)
 5   latestworld
 6   TestMod.##->###0
-7   (call core.svec %₆ core.Any)
-8   (call core.svec)
-9   SourceLocation::1:2
-10  (call core.svec %₇ %₈ %₉)
-11  --- method core.nothing %₁₀
+7   (new %₆)
+8   (= slot₁/#-># %₇)
+9   TestMod.##->###0
+10  (call core.svec %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::1:2
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method core.nothing %₁₃
     slots: [slot₁/#self#(!read) slot₂/x]
     1   TestMod.+
     2   (call %₁ slot₂/x 1)
     3   (return %₂)
-12  latestworld
-13  TestMod.##->###0
-14  (new %₁₃)
-15  (= slot₁/#-># %₁₄)
+15  latestworld
 16  slot₁/#->#
 17  TestMod.xs
 18  (call top.Generator %₁₆ %₁₇)
@@ -36,11 +36,14 @@
 4   (call JuliaLowering.eval_closure_type TestMod :##->###1 %₁ %₂ %₃)
 5   latestworld
 6   TestMod.##->###1
-7   (call core.svec %₆ core.Any)
-8   (call core.svec)
-9   SourceLocation::1:2
-10  (call core.svec %₇ %₈ %₉)
-11  --- method core.nothing %₁₀
+7   (new %₆)
+8   (= slot₁/#-># %₇)
+9   TestMod.##->###1
+10  (call core.svec %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::1:2
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method core.nothing %₁₃
     slots: [slot₁/#self#(!read) slot₂/#generator# slot₃/iterstate(single_assign) slot₄/x(single_assign) slot₅/y(single_assign)]
     1   (call top.indexed_iterate slot₂/#generator# 1)
     2   (= slot₄/x (call core.getfield %₁ 1))
@@ -53,10 +56,7 @@
     9   slot₅/y
     10  (call %₇ %₈ %₉)
     11  (return %₁₀)
-12  latestworld
-13  TestMod.##->###1
-14  (new %₁₃)
-15  (= slot₁/#-># %₁₄)
+15  latestworld
 16  slot₁/#->#
 17  TestMod.xs
 18  TestMod.ys
@@ -74,11 +74,14 @@
 4   (call JuliaLowering.eval_closure_type TestMod :##->###2 %₁ %₂ %₃)
 5   latestworld
 6   TestMod.##->###2
-7   (call core.svec %₆ core.Any)
-8   (call core.svec)
-9   SourceLocation::1:2
-10  (call core.svec %₇ %₈ %₉)
-11  --- method core.nothing %₁₀
+7   (new %₆)
+8   (= slot₁/#-># %₇)
+9   TestMod.##->###2
+10  (call core.svec %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::1:2
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method core.nothing %₁₃
     slots: [slot₁/#self#(!read) slot₂/#generator# slot₃/iterstate(single_assign) slot₄/x(single_assign) slot₅/y(single_assign)]
     1   (call top.indexed_iterate slot₂/#generator# 1)
     2   (= slot₄/x (call core.getfield %₁ 1))
@@ -90,18 +93,22 @@
     8   slot₅/y
     9   (call core.tuple %₇ %₈)
     10  (return %₉)
-12  latestworld
-13  (call core.svec)
-14  (call core.svec)
-15  (call core.svec)
-16  (call JuliaLowering.eval_closure_type TestMod :##->###3 %₁₃ %₁₄ %₁₅)
-17  latestworld
-18  TestMod.##->###3
-19  (call core.svec %₁₈ core.Any)
-20  (call core.svec)
-21  SourceLocation::1:29
-22  (call core.svec %₁₉ %₂₀ %₂₁)
-23  --- method core.nothing %₂₂
+15  latestworld
+16  slot₁/#->#
+17  (call core.svec)
+18  (call core.svec)
+19  (call core.svec)
+20  (call JuliaLowering.eval_closure_type TestMod :##->###3 %₁₇ %₁₈ %₁₉)
+21  latestworld
+22  TestMod.##->###3
+23  (new %₂₂)
+24  (= slot₂/#-># %₂₃)
+25  TestMod.##->###3
+26  (call core.svec %₂₅ core.Any)
+27  (call core.svec)
+28  SourceLocation::1:29
+29  (call core.svec %₂₆ %₂₇ %₂₈)
+30  --- method core.nothing %₂₉
     slots: [slot₁/#self#(!read) slot₂/#generator# slot₃/iterstate(single_assign) slot₄/x(single_assign) slot₅/y(!read,single_assign)]
     1   (call top.indexed_iterate slot₂/#generator# 1)
     2   (= slot₄/x (call core.getfield %₁ 1))
@@ -113,20 +120,12 @@
     8   slot₄/x
     9   (call %₇ %₈)
     10  (return %₉)
-24  latestworld
-25  TestMod.##->###2
-26  (new %₂₅)
-27  (= slot₁/#-># %₂₆)
-28  slot₁/#->#
-29  latestworld
-30  TestMod.##->###3
-31  (new %₃₀)
-32  (= slot₂/#-># %₃₁)
-33  slot₂/#->#
-34  TestMod.iter
-35  (call top.Filter %₃₃ %₃₄)
-36  (call top.Generator %₂₈ %₃₅)
-37  (return %₃₆)
+31  latestworld
+32  slot₂/#->#
+33  TestMod.iter
+34  (call top.Filter %₃₂ %₃₃)
+35  (call top.Generator %₁₆ %₃₄)
+36  (return %₃₅)
 
 ########################################
 # Use of placeholders in iteration vars
@@ -138,17 +137,17 @@
 4   (call JuliaLowering.eval_closure_type TestMod :##->###4 %₁ %₂ %₃)
 5   latestworld
 6   TestMod.##->###4
-7   (call core.svec %₆ core.Any)
-8   (call core.svec)
-9   SourceLocation::1:2
-10  (call core.svec %₇ %₈ %₉)
-11  --- method core.nothing %₁₀
+7   (new %₆)
+8   (= slot₁/#-># %₇)
+9   TestMod.##->###4
+10  (call core.svec %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::1:2
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method core.nothing %₁₃
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read)]
     1   (return 1)
-12  latestworld
-13  TestMod.##->###4
-14  (new %₁₃)
-15  (= slot₁/#-># %₁₄)
+15  latestworld
 16  slot₁/#->#
 17  TestMod.xs
 18  (call top.Generator %₁₆ %₁₇)
@@ -172,11 +171,14 @@ LoweringError:
 4   (call JuliaLowering.eval_closure_type TestMod :##->###5 %₁ %₂ %₃)
 5   latestworld
 6   TestMod.##->###5
-7   (call core.svec %₆ core.Any)
-8   (call core.svec)
-9   SourceLocation::1:2
-10  (call core.svec %₇ %₈ %₉)
-11  --- method core.nothing %₁₀
+7   (new %₆)
+8   (= slot₁/#-># %₇)
+9   TestMod.##->###5
+10  (call core.svec %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::1:2
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method core.nothing %₁₃
     slots: [slot₁/#self#(!read) slot₂/#generator# slot₃/iterstate slot₄/x(!read,single_assign) slot₅/y(!read,single_assign)]
     1   (call top.indexed_iterate slot₂/#generator# 1)
     2   (= slot₄/x (call core.getfield %₁ 1))
@@ -190,10 +192,7 @@ LoweringError:
     10  (= slot₅/y (call core.getfield %₉ 1))
     11  TestMod.body
     12  (return %₁₁)
-12  latestworld
-13  TestMod.##->###5
-14  (new %₁₃)
-15  (= slot₁/#-># %₁₄)
+15  latestworld
 16  slot₁/#->#
 17  TestMod.iter
 18  (call top.Generator %₁₆ %₁₇)
@@ -209,18 +208,18 @@ LoweringError:
 4   (call JuliaLowering.eval_closure_type TestMod :##->###6 %₁ %₂ %₃)
 5   latestworld
 6   TestMod.##->###6
-7   (call core.svec %₆ core.Any)
-8   (call core.svec)
-9   SourceLocation::1:4
-10  (call core.svec %₇ %₈ %₉)
-11  --- method core.nothing %₁₀
+7   (new %₆)
+8   (= slot₁/#-># %₇)
+9   TestMod.##->###6
+10  (call core.svec %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::1:4
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method core.nothing %₁₃
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read)]
     1   (call JuliaLowering.interpolate_expr (inert (return x)))
     2   (return %₁)
-12  latestworld
-13  TestMod.##->###6
-14  (new %₁₃)
-15  (= slot₁/#-># %₁₄)
+15  latestworld
 16  slot₁/#->#
 17  TestMod.iter
 18  (call top.Generator %₁₆ %₁₇)
@@ -243,29 +242,32 @@ LoweringError:
 3   (call core.svec)
 4   (call JuliaLowering.eval_closure_type TestMod :##->###7 %₁ %₂ %₃)
 5   latestworld
-6   (call core.svec)
-7   (call core.svec)
-8   (call core.svec)
-9   (call JuliaLowering.eval_closure_type TestMod :##->###->###0 %₆ %₇ %₈)
-10  latestworld
-11  TestMod.##->###->###0
-12  (call core.svec %₁₁ core.Any)
-13  (call core.svec)
-14  SourceLocation::1:2
-15  (call core.svec %₁₂ %₁₃ %₁₄)
-16  --- method core.nothing %₁₅
+6   TestMod.##->###7
+7   (new %₆)
+8   (= slot₁/#-># %₇)
+9   (call core.svec)
+10  (call core.svec)
+11  (call core.svec)
+12  (call JuliaLowering.eval_closure_type TestMod :##->###->###0 %₉ %₁₀ %₁₁)
+13  latestworld
+14  TestMod.##->###->###0
+15  (call core.svec %₁₄ core.Any)
+16  (call core.svec)
+17  SourceLocation::1:2
+18  (call core.svec %₁₅ %₁₆ %₁₇)
+19  --- method core.nothing %₁₈
     slots: [slot₁/#self#(!read) slot₂/x slot₃/x(single_assign)]
     1   slot₂/x
     2   (= slot₃/x %₁)
     3   slot₃/x
     4   (return %₃)
-17  latestworld
-18  TestMod.##->###7
-19  (call core.svec %₁₈ core.Any)
-20  (call core.svec)
-21  SourceLocation::1:2
-22  (call core.svec %₁₉ %₂₀ %₂₁)
-23  --- method core.nothing %₂₂
+20  latestworld
+21  TestMod.##->###7
+22  (call core.svec %₂₁ core.Any)
+23  (call core.svec)
+24  SourceLocation::1:2
+25  (call core.svec %₂₂ %₂₃ %₂₄)
+26  --- method core.nothing %₂₅
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/#->#(single_assign)]
     1   TestMod.##->###->###0
     2   (new %₁)
@@ -275,10 +277,7 @@ LoweringError:
     6   (call %₅ 1 2)
     7   (call top.Generator %₄ %₆)
     8   (return %₇)
-24  latestworld
-25  TestMod.##->###7
-26  (new %₂₅)
-27  (= slot₁/#-># %₂₆)
+27  latestworld
 28  slot₁/#->#
 29  TestMod.:
 30  (call %₂₉ 1 3)

--- a/JuliaLowering/test/generators_ir.jl
+++ b/JuliaLowering/test/generators_ir.jl
@@ -4,26 +4,27 @@
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###0 %₁ %₂)
-4   latestworld
-5   TestMod.##->###0
-6   (call core.svec %₅ core.Any)
-7   (call core.svec)
-8   SourceLocation::1:2
-9   (call core.svec %₆ %₇ %₈)
-10  --- method core.nothing %₉
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :##->###0 %₁ %₂ %₃)
+5   latestworld
+6   TestMod.##->###0
+7   (call core.svec %₆ core.Any)
+8   (call core.svec)
+9   SourceLocation::1:2
+10  (call core.svec %₇ %₈ %₉)
+11  --- method core.nothing %₁₀
     slots: [slot₁/#self#(!read) slot₂/x]
     1   TestMod.+
     2   (call %₁ slot₂/x 1)
     3   (return %₂)
-11  latestworld
-12  TestMod.##->###0
-13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
-16  TestMod.xs
-17  (call top.Generator %₁₅ %₁₆)
-18  (return %₁₇)
+12  latestworld
+13  TestMod.##->###0
+14  (new %₁₃)
+15  (= slot₁/#-># %₁₄)
+16  slot₁/#->#
+17  TestMod.xs
+18  (call top.Generator %₁₆ %₁₇)
+19  (return %₁₈)
 
 ########################################
 # Product iteration
@@ -31,14 +32,15 @@
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###1 %₁ %₂)
-4   latestworld
-5   TestMod.##->###1
-6   (call core.svec %₅ core.Any)
-7   (call core.svec)
-8   SourceLocation::1:2
-9   (call core.svec %₆ %₇ %₈)
-10  --- method core.nothing %₉
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :##->###1 %₁ %₂ %₃)
+5   latestworld
+6   TestMod.##->###1
+7   (call core.svec %₆ core.Any)
+8   (call core.svec)
+9   SourceLocation::1:2
+10  (call core.svec %₇ %₈ %₉)
+11  --- method core.nothing %₁₀
     slots: [slot₁/#self#(!read) slot₂/#generator# slot₃/iterstate(single_assign) slot₄/x(single_assign) slot₅/y(single_assign)]
     1   (call top.indexed_iterate slot₂/#generator# 1)
     2   (= slot₄/x (call core.getfield %₁ 1))
@@ -51,16 +53,16 @@
     9   slot₅/y
     10  (call %₇ %₈ %₉)
     11  (return %₁₀)
-11  latestworld
-12  TestMod.##->###1
-13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
-16  TestMod.xs
-17  TestMod.ys
-18  (call top.product %₁₆ %₁₇)
-19  (call top.Generator %₁₅ %₁₈)
-20  (return %₁₉)
+12  latestworld
+13  TestMod.##->###1
+14  (new %₁₃)
+15  (= slot₁/#-># %₁₄)
+16  slot₁/#->#
+17  TestMod.xs
+18  TestMod.ys
+19  (call top.product %₁₇ %₁₈)
+20  (call top.Generator %₁₆ %₁₉)
+21  (return %₂₀)
 
 ########################################
 # Use `identity` as the Generator function when possible eg in filters
@@ -68,14 +70,15 @@
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###2 %₁ %₂)
-4   latestworld
-5   TestMod.##->###2
-6   (call core.svec %₅ core.Any)
-7   (call core.svec)
-8   SourceLocation::1:2
-9   (call core.svec %₆ %₇ %₈)
-10  --- method core.nothing %₉
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :##->###2 %₁ %₂ %₃)
+5   latestworld
+6   TestMod.##->###2
+7   (call core.svec %₆ core.Any)
+8   (call core.svec)
+9   SourceLocation::1:2
+10  (call core.svec %₇ %₈ %₉)
+11  --- method core.nothing %₁₀
     slots: [slot₁/#self#(!read) slot₂/#generator# slot₃/iterstate(single_assign) slot₄/x(single_assign) slot₅/y(single_assign)]
     1   (call top.indexed_iterate slot₂/#generator# 1)
     2   (= slot₄/x (call core.getfield %₁ 1))
@@ -87,17 +90,18 @@
     8   slot₅/y
     9   (call core.tuple %₇ %₈)
     10  (return %₉)
-11  latestworld
-12  (call core.svec)
+12  latestworld
 13  (call core.svec)
-14  (call JuliaLowering.eval_closure_type TestMod :##->###3 %₁₂ %₁₃)
-15  latestworld
-16  TestMod.##->###3
-17  (call core.svec %₁₆ core.Any)
-18  (call core.svec)
-19  SourceLocation::1:29
-20  (call core.svec %₁₇ %₁₈ %₁₉)
-21  --- method core.nothing %₂₀
+14  (call core.svec)
+15  (call core.svec)
+16  (call JuliaLowering.eval_closure_type TestMod :##->###3 %₁₃ %₁₄ %₁₅)
+17  latestworld
+18  TestMod.##->###3
+19  (call core.svec %₁₈ core.Any)
+20  (call core.svec)
+21  SourceLocation::1:29
+22  (call core.svec %₁₉ %₂₀ %₂₁)
+23  --- method core.nothing %₂₂
     slots: [slot₁/#self#(!read) slot₂/#generator# slot₃/iterstate(single_assign) slot₄/x(single_assign) slot₅/y(!read,single_assign)]
     1   (call top.indexed_iterate slot₂/#generator# 1)
     2   (= slot₄/x (call core.getfield %₁ 1))
@@ -109,20 +113,20 @@
     8   slot₄/x
     9   (call %₇ %₈)
     10  (return %₉)
-22  latestworld
-23  TestMod.##->###2
-24  (new %₂₃)
-25  (= slot₁/#-># %₂₄)
-26  slot₁/#->#
-27  latestworld
-28  TestMod.##->###3
-29  (new %₂₈)
-30  (= slot₂/#-># %₂₉)
-31  slot₂/#->#
-32  TestMod.iter
-33  (call top.Filter %₃₁ %₃₂)
-34  (call top.Generator %₂₆ %₃₃)
-35  (return %₃₄)
+24  latestworld
+25  TestMod.##->###2
+26  (new %₂₅)
+27  (= slot₁/#-># %₂₆)
+28  slot₁/#->#
+29  latestworld
+30  TestMod.##->###3
+31  (new %₃₀)
+32  (= slot₂/#-># %₃₁)
+33  slot₂/#->#
+34  TestMod.iter
+35  (call top.Filter %₃₃ %₃₄)
+36  (call top.Generator %₂₈ %₃₅)
+37  (return %₃₆)
 
 ########################################
 # Use of placeholders in iteration vars
@@ -130,24 +134,25 @@
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###4 %₁ %₂)
-4   latestworld
-5   TestMod.##->###4
-6   (call core.svec %₅ core.Any)
-7   (call core.svec)
-8   SourceLocation::1:2
-9   (call core.svec %₆ %₇ %₈)
-10  --- method core.nothing %₉
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :##->###4 %₁ %₂ %₃)
+5   latestworld
+6   TestMod.##->###4
+7   (call core.svec %₆ core.Any)
+8   (call core.svec)
+9   SourceLocation::1:2
+10  (call core.svec %₇ %₈ %₉)
+11  --- method core.nothing %₁₀
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read)]
     1   (return 1)
-11  latestworld
-12  TestMod.##->###4
-13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
-16  TestMod.xs
-17  (call top.Generator %₁₅ %₁₆)
-18  (return %₁₇)
+12  latestworld
+13  TestMod.##->###4
+14  (new %₁₃)
+15  (= slot₁/#-># %₁₄)
+16  slot₁/#->#
+17  TestMod.xs
+18  (call top.Generator %₁₆ %₁₇)
+19  (return %₁₈)
 
 ########################################
 # Error: Use of placeholders in body
@@ -163,14 +168,15 @@ LoweringError:
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###5 %₁ %₂)
-4   latestworld
-5   TestMod.##->###5
-6   (call core.svec %₅ core.Any)
-7   (call core.svec)
-8   SourceLocation::1:2
-9   (call core.svec %₆ %₇ %₈)
-10  --- method core.nothing %₉
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :##->###5 %₁ %₂ %₃)
+5   latestworld
+6   TestMod.##->###5
+7   (call core.svec %₆ core.Any)
+8   (call core.svec)
+9   SourceLocation::1:2
+10  (call core.svec %₇ %₈ %₉)
+11  --- method core.nothing %₁₀
     slots: [slot₁/#self#(!read) slot₂/#generator# slot₃/iterstate slot₄/x(!read,single_assign) slot₅/y(!read,single_assign)]
     1   (call top.indexed_iterate slot₂/#generator# 1)
     2   (= slot₄/x (call core.getfield %₁ 1))
@@ -184,14 +190,14 @@ LoweringError:
     10  (= slot₅/y (call core.getfield %₉ 1))
     11  TestMod.body
     12  (return %₁₁)
-11  latestworld
-12  TestMod.##->###5
-13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
-16  TestMod.iter
-17  (call top.Generator %₁₅ %₁₆)
-18  (return %₁₇)
+12  latestworld
+13  TestMod.##->###5
+14  (new %₁₃)
+15  (= slot₁/#-># %₁₄)
+16  slot₁/#->#
+17  TestMod.iter
+18  (call top.Generator %₁₆ %₁₇)
+19  (return %₁₈)
 
 ########################################
 # return permitted in quoted syntax in generator
@@ -199,25 +205,26 @@ LoweringError:
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###6 %₁ %₂)
-4   latestworld
-5   TestMod.##->###6
-6   (call core.svec %₅ core.Any)
-7   (call core.svec)
-8   SourceLocation::1:4
-9   (call core.svec %₆ %₇ %₈)
-10  --- method core.nothing %₉
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :##->###6 %₁ %₂ %₃)
+5   latestworld
+6   TestMod.##->###6
+7   (call core.svec %₆ core.Any)
+8   (call core.svec)
+9   SourceLocation::1:4
+10  (call core.svec %₇ %₈ %₉)
+11  --- method core.nothing %₁₀
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read)]
     1   (call JuliaLowering.interpolate_expr (inert (return x)))
     2   (return %₁)
-11  latestworld
-12  TestMod.##->###6
-13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
-16  TestMod.iter
-17  (call top.Generator %₁₅ %₁₆)
-18  (return %₁₇)
+12  latestworld
+13  TestMod.##->###6
+14  (new %₁₃)
+15  (= slot₁/#-># %₁₄)
+16  slot₁/#->#
+17  TestMod.iter
+18  (call top.Generator %₁₆ %₁₇)
+19  (return %₁₈)
 
 ########################################
 # Error: `return` not permitted in generator body
@@ -233,30 +240,32 @@ LoweringError:
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###7 %₁ %₂)
-4   latestworld
-5   (call core.svec)
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :##->###7 %₁ %₂ %₃)
+5   latestworld
 6   (call core.svec)
-7   (call JuliaLowering.eval_closure_type TestMod :##->###->###0 %₅ %₆)
-8   latestworld
-9   TestMod.##->###->###0
-10  (call core.svec %₉ core.Any)
-11  (call core.svec)
-12  SourceLocation::1:2
-13  (call core.svec %₁₀ %₁₁ %₁₂)
-14  --- method core.nothing %₁₃
+7   (call core.svec)
+8   (call core.svec)
+9   (call JuliaLowering.eval_closure_type TestMod :##->###->###0 %₆ %₇ %₈)
+10  latestworld
+11  TestMod.##->###->###0
+12  (call core.svec %₁₁ core.Any)
+13  (call core.svec)
+14  SourceLocation::1:2
+15  (call core.svec %₁₂ %₁₃ %₁₄)
+16  --- method core.nothing %₁₅
     slots: [slot₁/#self#(!read) slot₂/x slot₃/x(single_assign)]
     1   slot₂/x
     2   (= slot₃/x %₁)
     3   slot₃/x
     4   (return %₃)
-15  latestworld
-16  TestMod.##->###7
-17  (call core.svec %₁₆ core.Any)
-18  (call core.svec)
-19  SourceLocation::1:2
-20  (call core.svec %₁₇ %₁₈ %₁₉)
-21  --- method core.nothing %₂₀
+17  latestworld
+18  TestMod.##->###7
+19  (call core.svec %₁₈ core.Any)
+20  (call core.svec)
+21  SourceLocation::1:2
+22  (call core.svec %₁₉ %₂₀ %₂₁)
+23  --- method core.nothing %₂₂
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/#->#(single_assign)]
     1   TestMod.##->###->###0
     2   (new %₁)
@@ -266,16 +275,16 @@ LoweringError:
     6   (call %₅ 1 2)
     7   (call top.Generator %₄ %₆)
     8   (return %₇)
-22  latestworld
-23  TestMod.##->###7
-24  (new %₂₃)
-25  (= slot₁/#-># %₂₄)
-26  slot₁/#->#
-27  TestMod.:
-28  (call %₂₇ 1 3)
-29  (call top.Generator %₂₆ %₂₈)
-30  (call top.Flatten %₂₉)
-31  (return %₃₀)
+24  latestworld
+25  TestMod.##->###7
+26  (new %₂₅)
+27  (= slot₁/#-># %₂₆)
+28  slot₁/#->#
+29  TestMod.:
+30  (call %₂₉ 1 3)
+31  (call top.Generator %₂₈ %₃₀)
+32  (call top.Flatten %₃₁)
+33  (return %₃₂)
 
 ########################################
 # Comprehension lowers to generator with collect

--- a/JuliaLowering/test/macros_ir.jl
+++ b/JuliaLowering/test/macros_ir.jl
@@ -48,7 +48,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ JuliaLowering.MacroContext core.Any)
 6   (call core.svec)
-7   SourceLocation::1:7
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.@add_one %₈
     slots: [slot₁/#self#(!read) slot₂/__context__(!read) slot₃/ex]
@@ -71,7 +71,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ JuliaLowering.MacroContext core.Any)
 6   (call core.svec)
-7   SourceLocation::1:7
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.@foo %₈
     slots: [slot₁/#self#(!read) slot₂/__context__ slot₃/ex(!read) slot₄/ctx(!read,single_assign)]
@@ -211,7 +211,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.foo %₈
     slots: [slot₁/#self#(!read) slot₂/a(nospecialize,!read)]
@@ -234,7 +234,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.foo %₈
     slots: [slot₁/#self#(!read) slot₂/a(nospecialize) slot₃/b]
@@ -259,7 +259,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any core.Any core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.foo %₈
     slots: [slot₁/#self#(!read) slot₂/x(nospecialize) slot₃/y slot₄/z(nospecialize)]

--- a/JuliaLowering/test/misc_ir.jl
+++ b/JuliaLowering/test/misc_ir.jl
@@ -550,7 +550,7 @@ const f(x::Int)::Int = x+1
 5   TestMod.Int
 6   (call core.svec %₄ %₅)
 7   (call core.svec)
-8   SourceLocation::1:7
+8   SourceLocation::1:6
 9   (call core.svec %₆ %₇ %₈)
 10  --- method TestMod.f %₉
     slots: [slot₁/#self#(!read) slot₂/x slot₃/tmp(!read)]

--- a/JuliaLowering/test/quoting_ir.jl
+++ b/JuliaLowering/test/quoting_ir.jl
@@ -78,7 +78,7 @@ function Base.:(==)() end
 3   (call core.TypeEqOf %₂)
 4   (call core.svec %₃)
 5   (call core.svec)
-6   SourceLocation::1:10
+6   SourceLocation::1:1
 7   (call core.svec %₄ %₅ %₆)
 8   --- method core.nothing %₇
     slots: [slot₁/#self#(!read)]

--- a/JuliaLowering/test/scopes.jl
+++ b/JuliaLowering/test/scopes.jl
@@ -240,6 +240,16 @@ distraction_scope_end === "resolve me!"
 
 end
 
+@test JuliaLowering.include_string(test_mod, """
+global g_shadow_sp_bound = Number
+function f_g_shadow_sp_bound(x::g_shadow_sp_bound) where {
+        g_shadow_sp_bound<:g_shadow_sp_bound
+    }
+    (x, g_shadow_sp_bound)
+end
+f_g_shadow_sp_bound(1)
+""") == (1, Int)
+
 # For each distinct outer scope, declaration scope, and assignment scope, and
 # each kind of variable (lhs_names) in the declaration scope, set the same name
 # to true from the inner scope

--- a/JuliaLowering/test/scopes_ir.jl
+++ b/JuliaLowering/test/scopes_ir.jl
@@ -69,22 +69,23 @@ end
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :#f##0 %₁ %₂)
-4   latestworld
-5   TestMod.#f##0
-6   (new %₅)
-7   (= slot₁/f %₆)
-8   TestMod.#f##0
-9   (call core.svec %₈)
-10  (call core.svec)
-11  SourceLocation::1:5
-12  (call core.svec %₉ %₁₀ %₁₁)
-13  --- method core.nothing %₁₂
+3   (call core.svec)
+4   (call JuliaLowering.eval_closure_type TestMod :#f##0 %₁ %₂ %₃)
+5   latestworld
+6   TestMod.#f##0
+7   (new %₆)
+8   (= slot₁/f %₇)
+9   TestMod.#f##0
+10  (call core.svec %₉)
+11  (call core.svec)
+12  SourceLocation::1:4
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method core.nothing %₁₃
     slots: [slot₁/#self#(!read)]
     1   TestMod.body
     2   (return %₁)
-14  latestworld
-15  (return core.nothing)
+15  latestworld
+16  (return core.nothing)
 
 ########################################
 # Error: Invalid `let` var with K"::"
@@ -144,7 +145,7 @@ end
 5   (call core.TypeEqOf %₄)
 6   (call core.svec %₅ core.Any)
 7   (call core.svec)
-8   SourceLocation::3:14
+8   SourceLocation::3:5
 9   (call core.svec %₆ %₇ %₈)
 10  --- method TestMod.f %₉
     slots: [slot₁/#self#(!read) slot₂/x(!read)]
@@ -196,7 +197,7 @@ end
 4   (call core.TypeEqOf %₃)
 5   (call core.svec %₄ core.Any)
 6   (call core.svec)
-7   SourceLocation::1:10
+7   SourceLocation::1:1
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
     slots: [slot₁/#self#(!read) slot₂/z]
@@ -410,7 +411,7 @@ end
 9   (call core.TypeEqOf %₈)
 10  (call core.svec %₉ core.Any)
 11  (call core.svec)
-12  SourceLocation::2:12
+12  SourceLocation::2:11
 13  (call core.svec %₁₀ %₁₁ %₁₂)
 14  --- code_info
     slots: [slot₁/#self#(!read) slot₂/y]
@@ -430,7 +431,7 @@ end
 24  (call core.TypeEqOf %₂₃)
 25  (call core.svec %₂₄)
 26  (call core.svec)
-27  SourceLocation::3:12
+27  SourceLocation::3:11
 28  (call core.svec %₂₅ %₂₆ %₂₇)
 29  --- code_info
     slots: [slot₁/#self#(!read) slot₂/x(!read,maybe_undef)]
@@ -466,7 +467,7 @@ end
 9   (call core.TypeEqOf %₈)
 10  (call core.svec %₉)
 11  (call core.svec)
-12  SourceLocation::2:12
+12  SourceLocation::2:11
 13  (call core.svec %₁₀ %₁₁ %₁₂)
 14  --- code_info
     slots: [slot₁/#self#(!read) slot₂/x(!read,maybe_undef)]

--- a/JuliaLowering/test/scopes_ir.jl
+++ b/JuliaLowering/test/scopes_ir.jl
@@ -420,7 +420,7 @@ end
     3   (call core.setfield! %₂ :contents %₁)
     4   (return %₁)
 15  (call core.svec slot₁/x)
-16  (call JuliaLowering.replace_captured_locals! %₁₄ %₁₅)
+16  (call JuliaLowering.replace_captured_locals %₁₄ %₁₅)
 17  --- method TestMod.f %₁₃ %₁₆
 18  latestworld
 19  (call core.declare_global TestMod :g false)
@@ -444,7 +444,7 @@ end
     7   (call core.getfield %₁ :contents)
     8   (return %₇)
 30  (call core.svec slot₁/x)
-31  (call JuliaLowering.replace_captured_locals! %₂₉ %₃₀)
+31  (call JuliaLowering.replace_captured_locals %₂₉ %₃₀)
 32  --- method TestMod.g %₂₈ %₃₁
 33  latestworld
 34  TestMod.g
@@ -484,7 +484,7 @@ end
     11  (call core.setfield! %₁₀ :contents %₉)
     12  (return %₉)
 15  (call core.svec slot₁/x)
-16  (call JuliaLowering.replace_captured_locals! %₁₄ %₁₅)
+16  (call JuliaLowering.replace_captured_locals %₁₄ %₁₅)
 17  --- method TestMod.f %₁₃ %₁₆
 18  latestworld
 19  TestMod.f

--- a/JuliaLowering/test/typedefs_ir.jl
+++ b/JuliaLowering/test/typedefs_ir.jl
@@ -766,56 +766,57 @@ end
 26  latestworld
 27  (call core.svec)
 28  (call core.svec)
-29  (call JuliaLowering.eval_closure_type TestMod :#f##0 %₂₇ %₂₈)
-30  latestworld
-31  TestMod.#f##0
-32  (new %₃₁)
-33  (= slot₂/f %₃₂)
-34  TestMod.#f##0
-35  (call core.svec %₃₄)
-36  (call core.svec)
-37  SourceLocation::3:5
-38  (call core.svec %₃₅ %₃₆ %₃₇)
-39  --- method core.nothing %₃₈
+29  (call core.svec)
+30  (call JuliaLowering.eval_closure_type TestMod :#f##0 %₂₇ %₂₈ %₂₉)
+31  latestworld
+32  TestMod.#f##0
+33  (new %₃₂)
+34  (= slot₂/f %₃₃)
+35  TestMod.#f##0
+36  (call core.svec %₃₅)
+37  (call core.svec)
+38  SourceLocation::3:5
+39  (call core.svec %₃₆ %₃₇ %₃₈)
+40  --- method core.nothing %₃₉
     slots: [slot₁/#self#(!read)]
     1   TestMod.X
     2   (new %₁ 1)
     3   (return %₂)
-40  latestworld
-41  TestMod.X
-42  (call core.apply_type core.Type %₄₁)
-43  (call core.svec %₄₂)
-44  (call core.svec)
-45  SourceLocation::4:5
-46  (call core.svec %₄₃ %₄₄ %₄₅)
-47  --- code_info
+41  latestworld
+42  TestMod.X
+43  (call core.apply_type core.Type %₄₂)
+44  (call core.svec %₄₃)
+45  (call core.svec)
+46  SourceLocation::4:5
+47  (call core.svec %₄₄ %₄₅ %₄₆)
+48  --- code_info
     slots: [slot₁/#ctor-self#(!read)]
     1   (captured_local 1)
     2   (call %₁)
     3   (return %₂)
-48  (call core.svec slot₂/f)
-49  (call JuliaLowering.replace_captured_locals! %₄₇ %₄₈)
-50  --- method core.nothing %₄₆ %₄₉
-51  latestworld
-52  TestMod.X
-53  (call core.apply_type core.Type %₅₂)
-54  (call core.svec %₅₃ core.Any)
-55  (call core.svec)
-56  SourceLocation::5:5
-57  (call core.svec %₅₄ %₅₅ %₅₆)
-58  --- method core.nothing %₅₇
+49  (call core.svec slot₂/f)
+50  (call JuliaLowering.replace_captured_locals! %₄₈ %₄₉)
+51  --- method core.nothing %₄₇ %₅₀
+52  latestworld
+53  TestMod.X
+54  (call core.apply_type core.Type %₅₃)
+55  (call core.svec %₅₄ core.Any)
+56  (call core.svec)
+57  SourceLocation::5:5
+58  (call core.svec %₅₅ %₅₆ %₅₇)
+59  --- method core.nothing %₅₈
     slots: [slot₁/#ctor-self# slot₂/x]
     1   slot₁/#ctor-self#
     2   (new %₁ slot₂/x)
     3   (return %₂)
-59  latestworld
-60  TestMod.X
-61  (call core.apply_type core.Type %₆₀)
-62  (call core.svec %₆₁ core.Any core.Any)
-63  (call core.svec)
-64  SourceLocation::6:5
-65  (call core.svec %₆₂ %₆₃ %₆₄)
-66  --- method core.nothing %₆₅
+60  latestworld
+61  TestMod.X
+62  (call core.apply_type core.Type %₆₁)
+63  (call core.svec %₆₂ core.Any core.Any)
+64  (call core.svec)
+65  SourceLocation::6:5
+66  (call core.svec %₆₃ %₆₄ %₆₅)
+67  --- method core.nothing %₆₆
     slots: [slot₁/#ctor-self# slot₂/y slot₃/z slot₄/tmp(!read)]
     1   TestMod.ReallyXIPromise
     2   slot₁/#ctor-self#
@@ -829,20 +830,20 @@ end
     10  (= slot₄/tmp (call core.typeassert %₉ %₁))
     11  slot₄/tmp
     12  (return %₁₁)
-67  latestworld
-68  TestMod.X
-69  (call core.apply_type core.Type %₆₈)
-70  (call core.svec %₆₉ core.Any core.Any core.Any)
-71  (call core.svec)
-72  SourceLocation::10:5
-73  (call core.svec %₇₀ %₇₁ %₇₂)
-74  --- method core.nothing %₇₃
+68  latestworld
+69  TestMod.X
+70  (call core.apply_type core.Type %₆₉)
+71  (call core.svec %₇₀ core.Any core.Any core.Any)
+72  (call core.svec)
+73  SourceLocation::10:5
+74  (call core.svec %₇₁ %₇₂ %₇₃)
+75  --- method core.nothing %₇₄
     slots: [slot₁/#ctor-self# slot₂/a slot₃/b(!read) slot₄/c(!read)]
     1   slot₁/#ctor-self#
     2   (new %₁ slot₂/a)
     3   (return %₂)
-75  latestworld
-76  (return core.nothing)
+76  latestworld
+77  (return core.nothing)
 
 ########################################
 # User defined inner constructors and helper functions for structs with type params
@@ -868,16 +869,16 @@ end
 13  (call core.isdefinedglobal TestMod :X false)
 14  (gotoifnot %₁₃ label₁₈)
 15  TestMod.X
-16  (= slot₈/if_val (call core._equiv_typedef %₁₅ %₁₀))
+16  (= slot₆/if_val (call core._equiv_typedef %₁₅ %₁₀))
 17  (goto label₁₉)
-18  (= slot₈/if_val false)
-19  slot₈/if_val
+18  (= slot₆/if_val false)
+19  slot₆/if_val
 20  (gotoifnot %₁₉ label₂₄)
 21  TestMod.X
-22  (= slot₉/if_val %₂₁)
+22  (= slot₇/if_val %₂₁)
 23  (goto label₂₅)
-24  (= slot₉/if_val false)
-25  slot₉/if_val
+24  (= slot₇/if_val false)
+25  slot₇/if_val
 26  (gotoifnot %₁₉ label₃₇)
 27  TestMod.X
 28  (call top.getproperty %₂₇ :body)
@@ -908,38 +909,35 @@ end
     2   (new %₁ 1)
     3   (return %₂)
 51  latestworld
-52  (= slot₆/U (call core.TypeVar :U))
-53  (= slot₇/V (call core.TypeVar :V))
+52  (call core.TypeVar :U)
+53  (call core.TypeVar :V)
 54  TestMod.X
-55  slot₆/U
-56  slot₇/V
-57  (call core.apply_type %₅₄ %₅₅ %₅₆)
-58  (call core.apply_type core.Type %₅₇)
-59  (call core.svec %₅₈)
-60  slot₆/U
-61  slot₇/V
-62  (call core.svec %₆₀ %₆₁)
-63  SourceLocation::4:5
-64  (call core.svec %₅₉ %₆₂ %₆₃)
-65  --- method core.nothing %₆₄
+55  (call core.apply_type %₅₄ %₅₂ %₅₃)
+56  (call core.apply_type core.Type %₅₅)
+57  (call core.svec %₅₆)
+58  (call core.svec %₅₂ %₅₃)
+59  SourceLocation::4:5
+60  (call core.svec %₅₇ %₅₈ %₅₉)
+61  --- method core.nothing %₆₀
     slots: [slot₁/#ctor-self#]
     1   slot₁/#ctor-self#
     2   (new %₁ 1)
     3   (return %₂)
-66  latestworld
-67  (call core.svec)
-68  (call core.svec)
-69  (call JuliaLowering.eval_closure_type TestMod :#f##1 %₆₇ %₆₈)
-70  latestworld
+62  latestworld
+63  (call core.svec)
+64  (call core.svec)
+65  (call core.svec)
+66  (call JuliaLowering.eval_closure_type TestMod :#f##1 %₆₃ %₆₄ %₆₅)
+67  latestworld
+68  TestMod.#f##1
+69  (new %₆₈)
+70  (= slot₅/f %₆₉)
 71  TestMod.#f##1
-72  (new %₇₁)
-73  (= slot₅/f %₇₂)
-74  TestMod.#f##1
-75  (call core.svec %₇₄)
-76  (call core.svec)
-77  SourceLocation::5:5
-78  (call core.svec %₇₅ %₇₆ %₇₇)
-79  --- method core.nothing %₇₈
+72  (call core.svec %₇₁)
+73  (call core.svec)
+74  SourceLocation::5:5
+75  (call core.svec %₇₂ %₇₃ %₇₄)
+76  --- method core.nothing %₇₅
     slots: [slot₁/#self#(!read)]
     1   TestMod.X
     2   TestMod.A
@@ -947,8 +945,8 @@ end
     4   (call core.apply_type %₁ %₂ %₃)
     5   (new %₄ 1)
     6   (return %₅)
-80  latestworld
-81  (return core.nothing)
+77  latestworld
+78  (return core.nothing)
 
 ########################################
 # new() calls with splats; `Any` fields
@@ -1020,16 +1018,16 @@ end
 11  (call core.isdefinedglobal TestMod :X false)
 12  (gotoifnot %₁₁ label₁₆)
 13  TestMod.X
-14  (= slot₄/if_val (call core._equiv_typedef %₁₃ %₈))
+14  (= slot₃/if_val (call core._equiv_typedef %₁₃ %₈))
 15  (goto label₁₇)
-16  (= slot₄/if_val false)
-17  slot₄/if_val
+16  (= slot₃/if_val false)
+17  slot₃/if_val
 18  (gotoifnot %₁₇ label₂₂)
 19  TestMod.X
-20  (= slot₅/if_val %₁₉)
+20  (= slot₄/if_val %₁₉)
 21  (goto label₂₃)
-22  (= slot₅/if_val false)
-23  slot₅/if_val
+22  (= slot₄/if_val false)
+23  slot₄/if_val
 24  (gotoifnot %₁₇ label₃₀)
 25  TestMod.X
 26  (call top.getproperty %₂₅ :body)
@@ -1042,17 +1040,15 @@ end
 33  (call core._typebody! %₂₃ %₈ %₃₂)
 34  (call core.declare_const TestMod :X %₃₃)
 35  latestworld
-36  (= slot₃/T (call core.TypeVar :T))
+36  (call core.TypeVar :T)
 37  TestMod.X
-38  slot₃/T
-39  (call core.apply_type %₃₇ %₃₈)
-40  (call core.apply_type core.Type %₃₉)
-41  (call core.svec %₄₀ core.Any)
-42  slot₃/T
-43  (call core.svec %₄₂)
-44  SourceLocation::4:5
-45  (call core.svec %₄₁ %₄₃ %₄₄)
-46  --- method core.nothing %₄₅
+38  (call core.apply_type %₃₇ %₃₆)
+39  (call core.apply_type core.Type %₃₈)
+40  (call core.svec %₃₉ core.Any)
+41  (call core.svec %₃₆)
+42  SourceLocation::4:5
+43  (call core.svec %₄₀ %₄₁ %₄₂)
+44  --- method core.nothing %₄₃
     slots: [slot₁/#ctor-self# slot₂/xs slot₃/tmp slot₄/tmp]
     1   (call core._apply_iterate top.iterate core.tuple slot₂/xs)
     2   (call core.nfields %₁)
@@ -1081,8 +1077,8 @@ end
     25  slot₄/tmp
     26  (new %₁₁ %₁₈ %₂₅)
     27  (return %₂₆)
-47  latestworld
-48  (return core.nothing)
+45  latestworld
+46  (return core.nothing)
 
 ########################################
 # Error: new doesn't accept keywords
@@ -1231,7 +1227,7 @@ end
 36  (call core.apply_type core.Type %₃₅)
 37  (call core.svec %₃₆ core.Any)
 38  (call core.svec)
-39  SourceLocation::3:14
+39  SourceLocation::3:5
 40  (call core.svec %₃₇ %₃₈ %₃₉)
 41  --- method core.nothing %₄₀
     slots: [slot₁/#ctor-self#(!read) slot₂/x slot₃/tmp slot₄/T(single_assign)]

--- a/JuliaLowering/test/typedefs_ir.jl
+++ b/JuliaLowering/test/typedefs_ir.jl
@@ -795,7 +795,7 @@ end
     2   (call %₁)
     3   (return %₂)
 49  (call core.svec slot₂/f)
-50  (call JuliaLowering.replace_captured_locals! %₄₈ %₄₉)
+50  (call JuliaLowering.replace_captured_locals %₄₈ %₄₉)
 51  --- method core.nothing %₄₇ %₅₀
 52  latestworld
 53  TestMod.X

--- a/JuliaLowering/test/validation.jl
+++ b/JuliaLowering/test/validation.jl
@@ -3,6 +3,7 @@
 
 function vst1_ok(x::Expr)
     est = JuliaLowering.expr_to_est(x)
+    JuliaSyntax.fill_context!(est, JuliaSyntax.SyntaxContext(@__MODULE__, v"1.13"))
     JuliaLowering.valid_st1(est).ok
 end
 


### PR DESCRIPTION
Static parameter capture is (as far as I know) the last non-trivial, non-performance piece of
JuliaLowering that doesn't match flisp yet.  I kind of understand why it was
left unimplemented.  In flisp lowering:

- Scope resolution for static parameters in method signatures is more-or-less
  done in desugaring
  - This is buggy; see #60626
- We need two new variables for every sparam: the sparam usable in the lambda
  body, and the method-signature typevar at top level
- Capturing an sparam into an inner method signature means we need to add
  somthing to the method definition's typevar list
- Capturing an sparam into an inner lambda body means we need to add to both the
  inner lambda's sparams as well as the inner method definition's typevar list
- Defining and instantiating the closure type also requires knowing what static
  parameters to feed into the `apply_type` call
- Captures are only known after variable analysis but need to change
  desugaring's decisions, so:
  - The typevar list is constructed in desugaring, then the `core svec`
    expression is re-constructed to contain sparam captures in closure
    conversion
  - `analyze-vars-lambda` mutates the lambda's sparam list

Static param capture into the lambda body in JuliaLowering happens to work today
because it's treated the same as a never-boxed local, so it's just a struct
field. I assumed this might cause inference issues, but admittedly didn't check.
The main issue is that capture into signatures doesn't work
(https://github.com/JuliaLang/JuliaLowering.jl/issues/140).

This PR:
- Don't do the flisp renaming-sparams-early step, since it just makes the hard
  parts of this harder.
- Change the `method` form out of desugaring to be `(method argtype_svec
  lambda)` and fully construct the svec after its contents are known
- Change the `method_defs` form to be `(method_defs id typevar_list body)`,
  because typevar_list should always precede lifted stuff in closure conversion,
  and because special resolution needs to happen when each `(typevar a b)` gets
  resolved (resolve b first, then declare a).
  - This is kind of a hack, but I didn't want deeply-nested scope blocks.  These
    were previously declared as locals, which had the wrong scope resolution
    (they could all see each other), and this was a pkgeval problem.
- Add new binding kind `:typevar`.  This behaves like a local up until
  before linearization, and more like an ssavalue after that.
- In scope resolution, we collect the mapping from static parameter to typevar,
  so that inner method signatures may resolve successfully (and even re-use the
  original typevar)

This change also implements "underscore sparams are readable" #60626 and ports
#57928 (sparam capture in opaque closure is more like capture of locals).  It
does not fix the pkgeval bug @topolarity reported to me with same-named
functions that require different closure types.

I've also added a cleaned-up Claude fix for typevars that depend on each other
in their bounds.  Not sure if it's the best way of doing this.  There's an easy
way out if this approach doesn't work (flisp just creates typevars `<:Any` in
closures).

The real change isn't as big as the diff implies, it just changes the closure
type creation near the beginning of the IR in many tests, so ends up changing a
lot of IR numbering.
