### PR TITLE
stream: ignore errors from the zero-length write in flush

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1065,6 +1065,16 @@ uv_write(s::LibuvStream, p::Vector{UInt8}) = GC.@preserve p uv_write(s, pointer(
 # caller must have acquired the iolock
 function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
     uvw = uv_write_async(s, p, n)
+    status = uv_write_wait(uvw)
+    if status < 0
+        throw(_UVError("write", status))
+    end
+    return Int(n)
+end
+
+# wait for the write request to complete and return its status,
+# caller must have acquired the iolock, which is released before waiting
+function uv_write_wait(uvw::Ptr{Cvoid})
     ct = current_task()
     preserve_handle(ct)
     sigatomic_begin()
@@ -1094,10 +1104,7 @@ function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
         iolock_end()
         unpreserve_handle(ct)
     end
-    if status < 0
-        throw(_UVError("write", status))
-    end
-    return Int(n)
+    return status
 end
 
 # helper function for uv_write that returns the uv_write_t struct for the write
@@ -1162,7 +1169,20 @@ function flush(s::LibuvStream)
             return
         end
     end
-    uv_write(s, Ptr{UInt8}(Base.eventloop()), UInt(0)) # zero write from a random pointer to flush current queue
+    # zero write from a random pointer to flush current queue, ignoring any
+    # errors from it: previously queued writes have already reported their
+    # errors to their writers, and the peer closing the stream after a
+    # completed exchange must not make flush throw
+    local uvw
+    try
+        uvw = uv_write_async(s, Ptr{UInt8}(Base.eventloop()), UInt(0))
+    catch ex
+        # uv_write_async throws before it releases the iolock
+        ex isa IOError || rethrow()
+        iolock_end()
+        return
+    end
+    uv_write_wait(uvw) # discard the status
     return
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1177,7 +1177,6 @@ function flush(s::LibuvStream)
     try
         uvw = uv_write_async(s, Ptr{UInt8}(Base.eventloop()), UInt(0))
     catch ex
-        # uv_write_async throws before it releases the iolock
         ex isa IOError || rethrow()
         iolock_end()
         return

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -293,6 +293,40 @@ defaultport = rand(2000:4000)
     end
 end
 
+# flush() must not throw after the peer has received everything and closed.
+@testset "flush after peer close" begin
+    mktempdir() do tmpdir
+        for reply in (false, true)
+            socketname = Sys.iswindows() ? ("\\\\.\\pipe\\uv-test-" * randstring(6)) :
+                         joinpath(tmpdir, "socket-$(Int(reply))")
+            server = listen(socketname)
+            peer_closed = Channel{Nothing}(1)
+            server_task = @async begin
+                peer = accept(server)
+                try
+                    @test readline(peer) == "ping"
+                    reply && write(peer, "pong\n")
+                finally
+                    close(peer)
+                    close(server)
+                    put!(peer_closed, nothing)
+                end
+            end
+
+            client = connect(socketname)
+            try
+                @test write(client, "ping\n") == 5
+                take!(peer_closed)
+                reply && @test readline(client) == "pong"
+                @test flush(client) === nothing
+            finally
+                close(client)
+            end
+            wait(server_task)
+        end
+    end
+end
+
 @testset "getsockname errors" begin
     sock = TCPSocket()
     serv = Sockets.TCPServer()


### PR DESCRIPTION
👨 I had some trouble with some local daemon code and the robot MWEd it to:

```julia
# flush() on a socket throws after the peer closes the connection, even
# though every byte was already written successfully (and even answered).
#
# flush(s::LibuvStream) issues a zero-length uv_write just to drain the
# write queue (base/stream.jl ~1167); that write fails once the peer end
# is gone, so a fully successful one-shot exchange
#     write(request) -> peer replies -> peer closes -> flush()
# errors whenever anything delays the flush past the peer's close (busy
# event loop, many concurrent tasks, ...).
#
# Reproduces on 1.10.11, 1.12.6, 1.13.0-rc1 (macOS).
using Sockets

function serve_once(path; reply::Bool)
    server = listen(path)
    peer_closed = Channel{Nothing}(1)
    task = @async begin
        c = accept(server)
        try
            readline(c)
            reply && write(c, "pong\n")
        finally
            close(c)                # peer closes right after handling
            close(server)
            put!(peer_closed, nothing)
        end
    end
    return task, peer_closed
end

# Variant 1: flush after the peer closed -> spurious EPIPE.
path = tempname()
server_task, peer_closed = serve_once(path; reply=false)
conn = connect(path)
write(conn, "ping\n")               # delivered: the server read it
take!(peer_closed)                   # wait until the peer has read and closed
try
    flush(conn)                     # IOError: write: broken pipe (EPIPE)
    println("variant 1: flush ok")
catch e
    println("variant 1: flush threw: ", sprint(showerror, e))
end
close(conn)
wait(server_task)
rm(path; force=true)

# Variant 2: the complete reply arrives before flush. Depending on whether
# Julia has processed the peer's EOF by then, flush throws either EPIPE or
# "stream is closed or unusable". Both come from the extra zero-length write.
path = tempname()
server_task, peer_closed = serve_once(path; reply=true)
conn = connect(path)
write(conn, "ping\n")
take!(peer_closed)
println("variant 2: got ", repr(readline(conn)), " — full round trip worked")
try
    flush(conn)                     # IOError: EPIPE or closed/unusable
    println("variant 2: flush ok")
catch e
    println("variant 2: flush threw: ", sprint(showerror, e))
end
close(conn)
wait(server_task)
rm(path; force=true)
```

Running this gives:

```
variant 1: flush threw: IOError: write: broken pipe (EPIPE)
variant 2: got "pong" — full round trip worked
variant 2: flush threw: IOError: stream is closed or unusable
```

with the patched `flush` here it gives:

```
variant 1: flush ok
variant 2: got "pong" — full round trip worked
variant 2: flush ok
```

----

🤖
`flush(::LibuvStream)` submits a zero-length write to wait for the write queue to drain. If the peer closes the connection after a completed exchange, that write fails with EPIPE (or `check_open` throws once the peer's EOF has been processed), so `flush` threw even though every byte had already been delivered. Swallow errors from this flush-write: the queued writes report their failures to their own writers, so nothing is lost.

Written with the assistance of generative AI.

Co-authored-by: OpenAI Codex <codex@openai.com>
Co-authored-by: Claude Fable 5 <noreply@anthropic.com>
