### PR TITLE
Remove static base address logic for MMtk write-barrier

### DIFF
--- a/src/gc-mmtk/llvm-final-gc-lowering-mmtk.cpp
+++ b/src/gc-mmtk/llvm-final-gc-lowering-mmtk.cpp
@@ -136,26 +136,19 @@ void FinalLowerGC::lowerWriteBarrier(CallInst *target, Function &F) {
 
             // intptr_t addr = (intptr_t) (void*) src;
             // uint8_t* meta_addr = (uint8_t*) (SIDE_METADATA_BASE_ADDRESS + (addr >> 6));
-            Value *metadata_base_ptr;
-            if (jl_generating_output()) {
-                F.getParent()->getOrInsertGlobal("MMTK_SIDE_LOG_BIT_BASE_ADDRESS", i8_ptr_ty);
-                auto metadata_base_global = F.getParent()->getNamedGlobal("MMTK_SIDE_LOG_BIT_BASE_ADDRESS");
-                assert(metadata_base_global != nullptr);
-                auto metadata_base_load = builder.CreateAlignedLoad(
-                    i8_ptr_ty, metadata_base_global, Align(sizeof(void *)), "mmtk_side_log_bit_base");
-                metadata_base_load->setMetadata(llvm::LLVMContext::MD_tbaa, get_tbaa_const(F.getContext()));
-                metadata_base_load->setMetadata(llvm::LLVMContext::MD_invariant_load,
-                                                llvm::MDNode::get(F.getContext(), {}));
-                metadata_base_ptr = builder.CreateAlignedLoad(
-                    i8_ptr_ty,
-                    metadata_base_global,
-                    Align(sizeof(void *)),
-                    "mmtk_side_log_bit_base");
-            } else {
-                intptr_t metadata_base_address = reinterpret_cast<intptr_t>(MMTK_SIDE_LOG_BIT_BASE_ADDRESS);
-                auto metadata_base_val = ConstantInt::get(intptr_ty, metadata_base_address);
-                metadata_base_ptr = ConstantExpr::getIntToPtr(metadata_base_val, PointerType::getUnqual(F.getContext()));
-            }
+            // The metadata base address is dynamic (chosen by mmap at start-up), so it
+            // must always be loaded through the global rather than baked in as an
+            // immediate: JIT code may outlive the current process via the object cache,
+            // and AOT code is shared across processes by construction.
+            F.getParent()->getOrInsertGlobal("MMTK_SIDE_LOG_BIT_BASE_ADDRESS", i8_ptr_ty);
+            auto metadata_base_global = F.getParent()->getNamedGlobal("MMTK_SIDE_LOG_BIT_BASE_ADDRESS");
+            assert(metadata_base_global != nullptr);
+            auto metadata_base_load = builder.CreateAlignedLoad(
+                i8_ptr_ty, metadata_base_global, Align(sizeof(void *)), "mmtk_side_log_bit_base");
+            metadata_base_load->setMetadata(llvm::LLVMContext::MD_tbaa, get_tbaa_const(F.getContext()));
+            metadata_base_load->setMetadata(llvm::LLVMContext::MD_invariant_load,
+                                            llvm::MDNode::get(F.getContext(), {}));
+            Value *metadata_base_ptr = metadata_base_load;
 
             auto parent_val = builder.CreatePtrToInt(parent, intptr_ty);
             auto shr = builder.CreateLShr(parent_val, ConstantInt::get(intptr_ty, 6));


### PR DESCRIPTION
Caught by https://github.com/JuliaCI/julia-buildkite/pull/541

This is another case of a minor JIT optimization that is invalid now that we share JIT code across processes: https://github.com/JuliaLang/julia/pull/61527

This PR takes the same stance other optimizations modified in that PR: since we're willing to live without this optimization for AOT code (which is ideally the majority of code being executed by the user), we should be willing to live without it in JIT code too.

Diagnosed by Claude Fable 5 🤖 