### PR TITLE
jit: only use native-owned CIs in the cfunc abi-converter path

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -518,7 +518,7 @@ static void generate_cfunc_thunks(jl_codegen_output_t &out)
     DenseMap<jl_method_instance_t*, jl_code_instance_t*> compiled_mi;
     for (auto &[ci, _] : out.ci_funcs) {
         jl_method_instance_t *mi = jl_get_ci_mi(ci);
-        if ((ci->owner == jl_nothing || ci->owner == (jl_value_t*)jl_trim_sym) &&
+        if (jl_ci_owner_is_native(ci) &&
             jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0 && ci->def == (jl_value_t*)mi)
             compiled_mi[mi] = ci;
     }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -325,6 +325,11 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
     bool target_specsig = false;
     jl_callptr_t invoke = nullptr;
     if (codeinst != nullptr) {
+        // This path interprets the CI's invoke/specptr with native ABI
+        // conventions, so callers must only pass native-owned CIs
+        // (jl_get_abi_converter falls back to the unspecialized thunk for CIs
+        // owned by external interpreters).
+        assert(jl_ci_owner_is_native(codeinst));
         uint8_t specsigflags;
         jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
         void *specptr = nullptr;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2087,6 +2087,15 @@ JL_DLLEXPORT int jl_isabspath(const char *in) JL_NOTSAFEPOINT;
 JL_COMMON_SYMBOLS(XX)
 #undef XX
 
+// Whether this CodeInstance was produced by the native compilation pipeline
+// (owner `nothing`, or the `:trim` owner used during --trim AOT compilation),
+// as opposed to an external AbstractInterpreter. Only native-owned CIs have
+// invoke/specptr pointers that the runtime may use as direct call targets.
+STATIC_INLINE int jl_ci_owner_is_native(jl_code_instance_t *ci) JL_NOTSAFEPOINT
+{
+    return ci->owner == jl_nothing || ci->owner == (jl_value_t*)jl_trim_sym;
+}
+
 JL_DLLEXPORT enum jl_memory_order jl_get_atomic_order(jl_sym_t *order, char loading, char storing);
 JL_DLLEXPORT enum jl_memory_order jl_get_atomic_order_checked(jl_sym_t *order, char loading, char storing);
 

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -405,6 +405,11 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
                 }
             }
             else {
+                // only native-owned CIs can land in the cfunc cache: the image
+                // slot is filtered by generate_cfunc_thunks and the runtime path
+                // above falls back to the unspecialized thunk for non-native
+                // inference results
+                assert(jl_ci_owner_is_native(last_ci));
                 if ((jl_value_t*)jl_get_ci_mi(last_ci) == mi && jl_atomic_load_relaxed(&last_ci->max_world) >= world) { // same dispatch and source
                     jl_atomic_store_release(&cfuncdata->last_world, world);
                     JL_UNLOCK(&cfun_lock);
@@ -415,6 +420,13 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
         JL_UNLOCK(&cfun_lock);
         // next, try to figure out what the target should look like (outside of the lock since this is very slow)
         codeinst = mi != jl_nothing ? jl_type_infer((jl_method_instance_t*)mi, world, SOURCE_MODE_ABI, jl_options.trim) : NULL;
+        if (codeinst != NULL && !jl_ci_owner_is_native(codeinst)) {
+            // a CI owned by an external interpreter cannot be used as a direct
+            // call target (and we cannot consult that interpreter from here),
+            // so fall back to the unspecialized thunk, which performs a full
+            // dynamic dispatch
+            codeinst = NULL;
+        }
         // relock for the remainder of the function
         JL_LOCK(&cfun_lock);
     } while (jl_atomic_load_acquire(&jl_world_counter) != world); // restart entirely, since jl_world_counter changed thus jl_get_specialization1 might have changed

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -733,7 +733,7 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
                 }
                 else if (may_discard_trees &&
                          native_functions && // don't delete any code if making a ji file
-                         (ci->owner == jl_nothing || ci->owner == (jl_value_t*)jl_trim_sym) && // don't delete code for external interpreters
+                         jl_ci_owner_is_native(ci) && // don't delete code for external interpreters
                          !effects_foldable(jl_atomic_load_relaxed(&ci->ipo_purity_bits)) && // don't delete code we may want for irinterp
                          jl_ir_inlining_cost(inferred) == UINT16_MAX) { // don't delete inlineable code
                     // delete the code now: if we thought it was worth keeping, it would have been converted to object code


### PR DESCRIPTION
The cfunc abi-converter machinery interprets a code instance's
invoke/specptr with native ABI conventions and resolves targets with the
native interpreter. A CI owned by an external AbstractInterpreter cannot
be used as a direct call target there, and the owning interpreter cannot
be consulted from the runtime, so make `jl_get_abi_converter` fall back
to the unspecialized thunk (a full dynamic dispatch) when inference
returns a non-native CI, the same as when no inferred target is
available.

Introduce `jl_ci_owner_is_native` as the single definition of the
accepted owner set and use it for the new fallback, for asserts at
`jl_jit_abi_converter_impl` entry and in the `last_ci` fast-path
revalidation of `jl_get_abi_converter` (so a foreign-owned CI slipping
into these paths fails loudly instead of handing back a pointer with the
wrong ABI or semantics), and for the existing owner filters in
`generate_cfunc_thunks` and staticdata's code-discard logic.

This is intended to prevent situations like #62348: the abi-converter
path silently assuming per-session compilation state (there, the
caller's `gcstack_arg`; here, the CI's `owner`) instead of validating
it — the ownership assumption now degrades gracefully at runtime and
fails loudly in assert builds rather than producing a calling
convention mismatch and segfault.

This pull request was written with the assistance of generative AI
(Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)