### PR TITLE
task: Add missing write-barrier in `save_stack`

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -189,6 +189,7 @@ static void NOINLINE save_stack(jl_ptls_t ptls, jl_task_t *lastt, jl_task_t **pt
     if (lastt->ctx.bufsz < nb) {
         asan_free_copy_stack(lastt->ctx.stkbuf, lastt->ctx.bufsz);
         buf = (void*)jl_gc_alloc_buf(ptls, nb);
+        jl_gc_wb(lastt, buf);
         lastt->ctx.stkbuf = buf;
         lastt->ctx.bufsz = nb;
     }

--- a/src/task.c
+++ b/src/task.c
@@ -1594,7 +1594,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     if (always_copy_stacks) {
         // when this is set, we will attempt to corrupt the process stack to switch tasks,
         // although this is unreliable, and thus not recommended
-        ptls->stackbase = jl_get_frame_addr();
+        ptls->stackbase = (void*)((uintptr_t)jl_get_frame_addr() & ~(uintptr_t)15);
         ptls->stacksize =  (char*)ptls->stackbase - (char*)stack_lo;
     }
     else {

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -587,3 +587,21 @@ let once = OncePerTask{Int}(() -> error("expected"))
     @test_throws ErrorException("expected") once()
     @test_throws ErrorException("expected") once()
 end
+
+# Exercise `save_stack`/`restore_stack` under GC pressure: a missing write-barrier
+# when storing the freshly-allocated copy-stack buffer into `lastt->ctx.stkbuf`
+# let the GC collect the buffer while the (old) task still referenced it.
+let code = """
+    function f(x)
+        x in (0, 1) && return x
+        a = Threads.@spawn f(x - 2)
+        b = Threads.@spawn f(x - 1)
+        return fetch(a) + fetch(b)
+    end
+    print(@sync f(25))
+    """
+    cmd = addenv(`$(Base.julia_cmd()) --depwarn=error --startup-file=no -t4 -e $code`,
+                 "JULIA_COPY_STACKS" => "1")
+    # JULIA_COPY_STACKS is broken on Windows (#35147)
+    @test read(cmd, String) == "75025" skip=Sys.iswindows()
+end


### PR DESCRIPTION
Caught by https://github.com/JuliaCI/julia-buildkite/pull/541.

Reproduces readily with `JULIA_COPY_STACKS=1` in an `MMTK_PLAN=StickyImmix` build:

```julia
$ JULIA_COPY_STACKS=1 ./julia --startup-file=no -e "fib(x) = @sync begin; function f(x); x in (0, 1) && return x; a = Threads.@spawn f(x - 2); b = Threads.@spawn f(x - 1); fetch(a) + fetch(b); end; f(x); end; println(fib(25))"

[2035119] signal 11 (1): Segmentation fault
```

This doesn't affect the stock GC which has a persistent remset, but it does matter for MMTK. 

Investigated from core dump by Claude Fable 🤖 (w/ some human prodding)