### PR TITLE
scheduler: handle enqueuing tasks into threadpools with zero threads

### DIFF
--- a/base/partr.jl
+++ b/base/partr.jl
@@ -109,6 +109,12 @@ end
 
 function multiq_size(tpid::Int8)
     nt = UInt32(Threads._nthreads_in_pool(tpid))
+    if nt == 0
+        # A pool with no threads can still receive tasks (e.g. during
+        # sysimage bootstrap); size the heaps so insertion can park them
+        # instead of indexing an empty heap vector.
+        nt = UInt32(1)
+    end
     tp = tpid + 1
     tpheaps = heaps[tp]
     heap_c = UInt32(2)
@@ -124,6 +130,9 @@ function multiq_size(tpid::Int8)
         tpheaps = heaps[tp]
         heap_p = UInt32(length(tpheaps))
         nt = UInt32(Threads._nthreads_in_pool(tpid))
+        if nt == 0
+            nt = UInt32(1)
+        end
         if heap_c * nt <= heap_p
             return heap_p
         end

--- a/base/task.jl
+++ b/base/task.jl
@@ -977,6 +977,17 @@ function enq_work(t::Task)
     else
         @label not_sticky
         tp = Threads.threadpool(t)
+        if tp !== :foreign && Threads.threadpoolsize(tp) == 0
+            # The task's threadpool has no threads, so it can never run;
+            # fail it with a ConcurrencyViolationError rather than queueing
+            # it (the multiqueue heaps are unsized for empty pools, and a
+            # task queued during sysimage bootstrap would be serialized
+            # into the system image).
+            t.result = ConcurrencyViolationError("deadlock detected: cannot schedule task")
+            t._isexception = true
+            @atomic :release t._state = task_state_failed
+            return t
+        end
         if tp === :foreign || Threads.threadpoolsize(tp) == 1
             # There's only one thread in the task's assigned thread pool;
             # use its work queue.


### PR DESCRIPTION
A non-sticky task whose threadpool has no threads falls through
enq_work's single-thread check into Partr.multiq_insert. There
multiq_size finds length(heaps) == 0 and, computing
heap_c * nt <= heap_p with nt == 0, returns 0 without ever sizing the
heaps. cong(0) then yields index 1 (formerly `seed % 0`, which is
undefined behavior: SIGFPE on x86, converted into a spurious
DivideError; a silent garbage index on architectures like PowerPC
where integer division by zero does not trap), and indexing the empty
heap vector throws:

    fatal: error thrown and no exception handler available.
    BoundsError(a=Array{Base.Partr.taskheap, (0,)}[], i=(357873774,))

This is reachable during every sysimage build: _finish_julia_init
moves the bootstrap thread into the interactive pool, leaving the
default pool with zero threads, and the Downloads stdlib's precompile
workload (download("file://" * @__FILE__)) spawns an errormonitor
task into the default pool from Curl's socket_callback. On x86 the
resulting DivideError happens to be swallowed, so the task is silently
lost and the build proceeds; on FreeBSD/powerpc64le the garbage index
aborts the sysimage build. Found while porting Julia to
FreeBSD/powerpc64le.

Fix it in two places:

- enq_work: if the task's pool has no threads, leave the task
  unqueued. This makes the previously accidental behavior explicit
  and deterministic, and keeps unrunnable tasks from being reachable
  from Partr.heaps during sysimage serialization (a task queued there
  while bootstrapping ends up serialized into the image and aborts
  the subsequent load).

- multiq_size: treat nt == 0 as 1 at both reads so an insert into an
  empty pool can never index unsized heaps, should it be reached by
  another path (e.g. jl_set_task_threadpoolid users).
