### PR TITLE
deps: updates for gitexternal usage

### DIFF
--- a/deps/tools/git-external.mk
+++ b/deps/tools/git-external.mk
@@ -30,11 +30,14 @@ $2_SRC_DIR := $1
 $2_SRC_FILE := $$(SRCCACHE)/$1.git
 $$($2_SRC_FILE)/HEAD: | $$(SRCCACHE)
 	git clone -q --mirror --branch $$($2_BRANCH) $$($2_GIT_URL) $$(dir $$@)
-$5/$1/.git/HEAD: | $$($2_SRC_FILE)/HEAD
+$5/$1/.git: | $$($2_SRC_FILE)/HEAD
 	# try to update the cache, if that fails, attempt to continue anyways (the ref might already be local)
 	-cd $$($2_SRC_FILE) && git fetch -q $$($2_GIT_URL) $$($2_BRANCH):remotes/origin/$$($2_BRANCH)
-	git clone -q --depth=10 --branch $$($2_BRANCH) $$($2_SRC_FILE) $5/$1
-	cd $5/$1 && git remote set-url origin $$($2_GIT_URL)
+	# if a checkout is already present (e.g. an old-style local clone from a previous
+	# build), keep it and proceed as before; otherwise add a worktree sharing the bare
+	# cache's object store instead of making a full local clone
+	-git -C $$($2_SRC_FILE) worktree prune
+	[ -e $5/$1/.git ] || git -C $$($2_SRC_FILE) worktree add --detach $5/$1 $$($2_BRANCH)
 #ifneq ($3,)
 	touch -c $5/$1/$3 # old target
 #endif
@@ -44,14 +47,15 @@ $$(BUILDDIR)/$1:
 	mkdir -p $$@
 $5/$1/source-extracted: | $$(BUILDDIR)/$1
 endif
-$5/$1/source-extracted: $$(SRCDIR)/$1.version | $5/$1/.git/HEAD
+$5/$1/source-extracted: $$(SRCDIR)/$1.version | $5/$1/.git
 	# try to update the cache, if that fails, attempt to continue anyways (the ref might already be local)
 	-cd $$(SRCCACHE)/$1.git && git fetch -q $$($2_GIT_URL) $$($2_BRANCH):remotes/origin/$$($2_BRANCH)
-	cd $5/$1 && git fetch -q $$(SRCCACHE)/$1.git remotes/origin/$$($2_BRANCH):remotes/origin/$$($2_BRANCH)
+	# pull the branch into the checkout: harmless for a worktree (it already shares the
+	# cache's object store), and required to update an old-style local clone
+	-cd $5/$1 && git fetch -q $$(SRCCACHE)/$1.git remotes/origin/$$($2_BRANCH):remotes/origin/$$($2_BRANCH)
 	cd $5/$1 && git checkout -q --detach $$($2_SHA1)
 	@[ '$$($2_SHA1)' = "$$$$(cd $5/$1 && git show -s --format='%H' HEAD)" ] || echo $$(WARNCOLOR)'==> warning: SHA1 hash did not match $1.version file'$$(ENDCOLOR)
 	echo 1 > $$@
-$5/$1/source-compiled: $5/$1/.git/HEAD
 $$($2_SRC_FILE): | $$($2_SRC_FILE)/HEAD
 	touch -c $$@
 

--- a/deps/tools/git-external.mk
+++ b/deps/tools/git-external.mk
@@ -1,4 +1,8 @@
 ## A rule for making a git-external dependency ##
+# For a user-facing overview of building a dependency from a Git checkout (DEPS_GIT,
+# USE_BINARYBUILDER_<NAME>, the .version file, and editing the worktree in place), see
+# "Building a dependency from a Git checkout" in doc/src/devdocs/build/build.md
+#
 # call syntax:
 #   $(eval $(call git-external,dirname,VARNAME,file_from_download,file_from_compile,SRCDIR)
 # dirname is the folder name to create

--- a/doc/src/devdocs/build/build.md
+++ b/doc/src/devdocs/build/build.md
@@ -220,6 +220,53 @@ If you already have one or more of these packages installed on your system, you 
 
 Please be aware that this procedure is not officially supported, as it introduces additional variability into the installation and versioning of the dependencies, and is recommended only for system package maintainers. Unexpected compile errors may result, as the build system will do no further checking to ensure the proper packages are installed.
 
+### Building a dependency from a Git checkout
+
+Most dependencies are downloaded as prebuilt BinaryBuilder artifacts (`*_jll`), but many can instead be
+built from a Git checkout — useful for testing a patch or building against an unreleased upstream commit.
+This is driven by `git-external` in
+[`deps/tools/git-external.mk`](https://github.com/JuliaLang/julia/blob/master/deps/tools/git-external.mk).
+Set the following in `Make.user` (or on the `make` command line):
+
+```make
+# 1. prefer the source build over the prebuilt binary for this dep (or USE_BINARYBUILDER=0 for all)
+USE_BINARYBUILDER_LLVM = 0
+# 2. fetch the source with Git (DEPS_GIT=1 for all, or a space-separated list of names)
+DEPS_GIT = llvm
+# 3. optionally override the origin/branch/commit (defaults live in deps/<name>.version and .mk)
+LLVM_GIT_URL = https://github.com/JuliaLang/llvm-project.git
+LLVM_BRANCH = julia-release/18.x
+LLVM_SHA1 = $(LLVM_BRANCH)   # a branch name, tag, or explicit commit hash
+```
+
+`<NAME>` is the upper-cased dependency name (see `deps/*.mk`, e.g. `LLVM`, `LIBUV`). The branch and commit
+come from `<NAME>_BRANCH`/`<NAME>_SHA1` in `deps/<name>.version`. The checkout is a
+[`git worktree`](https://git-scm.com/docs/git-worktree) of a bare mirror cached at
+`deps/srccache/<name>.git` (so it shares that mirror's objects rather than being a full clone), living at
+`deps/srccache/<name>/` on a detached `HEAD` at `<NAME>_SHA1`.
+
+**Rebuilds** are keyed off `deps/<name>.version`: changing *or merely touching* it re-fetches and resets the
+checkout to `<NAME>_SHA1` and reinstalls the dependency. Each build step records progress in a marker file, so
+touching one (or a predecessor) forces that step and everything after it to rerun:
+
+ * `deps/<name>.version` — re-checkout to `<NAME>_SHA1` (`extract-<name>`) and reinstall (`install-<name>`)
+ * `deps/srccache/<name>/source-extracted` — reconfigure (`configure-<name>`)
+ * `deps/scratch/<name>/build-configured` — recompile (`compile-<name>`)
+ * `deps/scratch/<name>/build-compiled` — restage (`stage-<name>`)
+ * `usr/manifest/<name>` — the installed result (also `uninstall-<name>` / `reinstall-<name>`)
+
+`make version-check-<name>` runs on every build to warn when the checkout has local modifications or does not
+match `<NAME>_SHA1`, and `make distclean-<name>` removes the worktree and cached mirror. Not every dependency
+defines every step (e.g. header-only or install-only deps may have no `configure`/`compile` stage), so some of
+these markers and targets may be absent — check `deps/<name>.mk` for the ones a given dependency actually uses.
+
+**To edit in place**, treat `deps/srccache/<name>/` as an ordinary worktree: change files, commit, or `git
+checkout` another commit, then rebuild (`make compile-<name>` / `make install-<name>`). As long as you don't
+touch `deps/<name>.version`, the checkout is never reset to `<NAME>_SHA1`, so local edits survive rebuilds.
+Bumping `<NAME>_SHA1` to record a new commit triggers a fresh checkout on the next extract, but that checkout
+will fail if the worktree is dirty — this is intentional, so that uncommitted changes are never clobbered.
+Commit (or stash) your work first, then update `<NAME>_SHA1`.
+
 ### LLVM
 
 The most complicated dependency is LLVM, for which we require additional patches from upstream (LLVM is not backward compatible).


### PR DESCRIPTION
Change to use git worktrees instead of local clones for git-external deps, which were released a few months after I created this approximate version of them. And add some docs for gitexternal usage.