### PR TITLE
gf: record complete method interferences and fix ambiguity reporting

### DIFF
--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -441,20 +441,58 @@ const VERIFY_INTERF_CAP = 8
 # interference set, intersects the queried `sig` over the nonempty `ti`.
 # Decide whether the sort provably prunes it silently: acceptance implies the
 # full `ml_matches` lookup would return exactly the expected methods
-# `expecteds[i:i+n-1]` with no ambiguity flag.
-function newcomer_prunes_silently(meth::Method, interference_method::Method, @nospecialize(ti),
+# `expecteds[i:i+n-1]` with no ambiguity flag caused by the new method.
+# Returns `false` conservative when a full lookup is necessary to decide.
+function newcomer_prunes_silently(meth::Method, interference_method::Method, @nospecialize(ti), @nospecialize(sig),
                                   expecteds::Core.SimpleVector, i::Int, n::Int, world::UInt)
     if method_in_interferences(meth, interference_method)
         # Mutually ambiguous with the expected method whose set is being
-        # scanned: the fresh sort always flags this pair (both stay in the
-        # intersecting-match list), so only the full lookup can decide this
-        # edge.
-        return false
+        # scanned. This is the canonical `Type{Union{}}`-slurp recovery shape --
+        # f(::Type{<:A}) and f(::Type{<:B}) overlap only at the corner the
+        # slurp resolves -- so it must stay on the fast path. The fresh sort
+        # keeps the pair silent only through the minmax exemption: the sort
+        # pre-marks the minmax match finalized and never visits it, so its
+        # `check_fully_ambiguous` scan (which would flag any mutual partner
+        # still in the raw match list, dropped or not) never runs. Certify
+        # set-locally that `meth` is that minmax:
+        #  - `meth` must fully cover sig (a visited owner always flags the
+        #    pair, since the partner intersects sig and so sits in the raw
+        #    match list);
+        #  - the partner must NOT fully cover sig: minmax discovery runs over
+        #    the raw list before any drop, so a fully-covering mutual partner
+        #    disqualifies `meth` there even though it is later pruned;
+        #  - `meth` must recorded-beat every other fully-covering expected
+        #    (minmax is unique: recorded strict-beat is antisymmetric, and
+        #    this check also rejects the owner of any second mutual pair);
+        #  - a fully-covering newcomer that `meth` does not beat would steal
+        #    minmax, but needs no check here: it is itself a visible entry of
+        #    `meth`'s set, and its own certification fails -- as a mutual
+        #    entry by the partner-covers-sig condition above, and as a strict
+        #    beater because its empty-set cover would have to fully cover sig,
+        #    and an expected with those properties would have dropped `meth`
+        #    from the recorded result in the first place.
+        # The drop of the partner and its blocker-transfer obligations are
+        # then certified by the shared conditions below, exactly as for a
+        # strict beater: an empty-set cover's transfers are all automatic
+        # (nothing beats it, and it patches any transfer region inside its
+        # signature), and the beater scan keeps the partner off any
+        # specificity cycle.
+        sig <: meth.sig || return false
+        sig <: interference_method.sig && return false
+        for j = 1:n
+            meth2 = get_method_from_edge(expecteds[i+j-1])
+            meth2 === meth && continue
+            if sig <: meth2.sig
+                if !(method_in_interferences(meth, meth2) && !method_in_interferences(meth2, meth))
+                    return false
+                end
+            end
+        end
     end
-    # This method strictly beats the scanned set's owner. Look for a
-    # different expected method that covers it over this intersection
-    # and provably certifies the removal as silent: only an expected
-    # with an EMPTY interference set qualifies, since such a method
+    # Otherwise this method strictly beats the scanned set's owner. Either
+    # way, look for a different expected method that covers it over this
+    # intersection and provably certifies the removal as silent: only an
+    # expected with an empty interference set qualifies, since such a method
     # beats everything it intersects, so:
     #  - nothing beats or ties it, so it can never sit in a
     #    specificity cycle and always finalizes before the sort
@@ -614,7 +652,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                             # pruned result below would compare equal), it can make `ml_matches`
                             # flag an ambiguity -- a mutual pair or a specificity cycle with a
                             # reported match -- which must invalidate below.
-                            if !newcomer_prunes_silently(meth, interference_method, ti, expecteds, i, n, world)
+                            if !newcomer_prunes_silently(meth, interference_method, ti, sig, expecteds, i, n, world)
                                 interference_fast_path_success = false
                                 break
                             end

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -417,14 +417,8 @@ function method_in_interferences(method2::Method, method1::Method)
     return false
 end
 
-# Whether method1 is strictly more specific than method2, read directly from the
-# recorded interference relation: method1 is in method2's set (so
-# !morespecific(method2, method1)) and method2 is not in method1's set (so
-# morespecific(method1, method2)). Because recording is complete for
-# intersecting pairs this is exact for them; for disjoint pairs neither
-# membership is recorded and it returns false (a disjoint method dominates
-# nothing), which is what the caller wants.
-# slow check: @assert ms === morespecific(method1, method2) || typeintersect(method1.sig, method2.sig) === Union{} || typeintersect(method2.sig, method1.sig) === Union{}
+# Check if method1 is more specific than method2 via the interference graph
+# equivalent to: ms === morespecific(method1, method2) || typeintersect(method1.sig, method2.sig) === Union{}
 function method_morespecific_recorded(method1::Method, method2::Method)
     method1 === method2 && return false
     return method_in_interferences(method1, method2) && !method_in_interferences(method2, method1)
@@ -471,10 +465,8 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                         return minworld, maxworld
                     end
                 end
-                # Fast path is legal when fully_covers=true. An empty interference
-                # set means the method is strictly morespecific than every method
-                # it intersects, so it dominates its sig in every world it exists.
-                if fully_covers && isempty(meth.interferences)
+                # Fast path is legal when fully_covers=true
+                if fully_covers && !iszero(meth.dispatch_status & METHOD_SIG_LATEST_ONLY)
                     minworld = meth.primary_world
                     @assert minworld ≤ world "expected method not present in verification world"
                     maxworld = typemax(UInt)
@@ -602,11 +594,11 @@ end
 # fast-path dispatch_status bit definitions (false indicates unknown)
 # true indicates this method would be returned as the result from `which` when invoking `method.sig` in the current latest world
 const METHOD_SIG_LATEST_WHICH = 0x1
-# MethodInstance-level: true indicates dispatch of this mi's specTypes yields only this
-# result in the current latest world (the Method-level equivalent is `isempty(method.interferences)`)
+# true indicates this method would be returned as the only result from `methods` when calling `method_instance.specTypes` in the current latest world
+# it is equivalently tracked as `isempty(interferences)` on a `method`
 const METHOD_SIG_LATEST_ONLY = 0x2
-# Method-level: true indicates this method is not strictly morespecific than any method it
-# intersects, in any world (monotone-cleared at insertion of a method this one beats)
+# true indicates this method is not strictly morespecific than any method it intersects
+# (equivalently, that this method is not in the interference set of any other method without also being in this methods interference set too).
 const METHOD_SIG_NO_LOSERS = 0x4
 
 function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UInt, matches::Vector{Any})

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -605,6 +605,9 @@ const METHOD_SIG_LATEST_WHICH = 0x1
 # MethodInstance-level: true indicates dispatch of this mi's specTypes yields only this
 # result in the current latest world (the Method-level equivalent is `isempty(method.interferences)`)
 const METHOD_SIG_LATEST_ONLY = 0x2
+# Method-level: true indicates this method is not strictly morespecific than any method it
+# intersects, in any world (monotone-cleared at insertion of a method this one beats)
+const METHOD_SIG_NO_LOSERS = 0x4
 
 function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UInt, matches::Vector{Any})
     @assert invokesig isa Type "corrupt edges list"

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -403,24 +403,21 @@ function get_method_from_edge(@nospecialize t)
     end
 end
 
-# Iterate a method's `interferences` set. The set is an idset used append-only
-# (`jl_idset_pop` is never called on it), so its keys form a packed prefix --
-# no interior holes -- in insertion order, which is method-definition order,
-# making `primary_world` non-decreasing along the prefix (see
-# `jl_idset_put_key` in idset.c). Iteration therefore stops at the first
-# unassigned slot and, given a `world` cutoff, at the first entry defined in a
+# Iterate a method's `interferences` set. The set is an idset used append-only,
+# in method-definition order. Iteration therefore stops at the first
+# unassigned slot and, given a world cutoff, at the first entry defined in a
 # future world (which hides all later ones too).
 struct EachInterference
     interferences::Memory{Any}
-    world::UInt # typemax(UInt) means no world cutoff
+    cutoff::UInt # typemax(UInt) means no world cutoff
 end
-eachinterference(m::Method, world::UInt=typemax(UInt)) = EachInterference(m.interferences, world)
+eachinterference(m::Method, cutoff::UInt=typemax(UInt)) = EachInterference(m.interferences, cutoff)
 function Base.iterate(ei::EachInterference, k::Int=1)
     interferences = ei.interferences
     k > length(interferences) && return nothing
     isassigned(interferences, k) || return nothing # no more entries
     interference_method = interferences[k]::Method
-    ei.world < interference_method.primary_world && return nothing # this and later entries are for a future world
+    ei.cutoff < interference_method.primary_world && return nothing # this and later entries are for a future world
     return interference_method, k + 1
 end
 

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -500,9 +500,9 @@ method_is_latest_which(m::Method) = !iszero(m.dispatch_status & METHOD_SIG_LATES
 # pruned `ml_matches` lookup is cheaper (~8 is the empirical crossover).
 const VERIFY_INTERF_CAP = 8
 
-# The unexpected `interference_method` (the newcomer), recorded in expected method
+# The unexpected `interference_method` (the new method), recorded in expected method
 # `meth`'s interference set, intersects the queried `sig` over the nonempty `ti`. Decide
-# whether the sort provably prunes it silently: acceptance implies the full `ml_matches`
+# whether the sort provably removes it: acceptance implies the full `ml_matches`
 # lookup would return exactly the expected methods `expecteds[i:i+n-1]` with no ambiguity
 # flag caused by the new method. Returns `false` conservative when a full lookup is
 # necessary to decide.
@@ -511,32 +511,32 @@ const VERIFY_INTERF_CAP = 8
 # methods recorded in the expected methods' own sets, because that scan witnesses every
 # visible change:
 #  - fully_covers means every method intersecting sig intersects some expected pointwise;
-#  - methods invisible to it (strictly beaten by every expected they intersect, hence in no
-#    expected's set) always prune silently: the union of their intersecting expecteds
-#    covers them, and a failing blocker transfer would need a blocker that beats an
-#    expected cover -- which recording makes visible;
-#  - any cycle that could flag or change the result must thread an expected, entering
-#    through a visible strict beater of it -- an entry of that scan, which is either
-#    rejected by the conditions below or, by `beaters_cannot_cycle`, provably not on any
-#    cycle.
-function newcomer_prunes_silently(meth::Method, interference_method::Method, @nospecialize(ti), @nospecialize(sig),
+#  - methods invisible to it (strictly less-specific than every expected they intersect,
+#    hence in no expected's set) always removed silently: the union of their intersecting
+#    expecteds covers them, and a failing blocker transfer would need a blocker that beats
+#    an expected cover -- which recording makes visible;
+#  - any cycle that could flag or change the result must thread an expected, entering through
+#    a visible interference method strictly morespecific than it -- an entry of that scan,
+#    which is either rejected by the conditions below or by `morespecific_cannot_cycle`,
+#    are provably not on any cycle.
+function newmethod_removed_silently(meth::Method, interference_method::Method, @nospecialize(ti), @nospecialize(sig),
                                   expecteds::Core.SimpleVector, i::Int, n::Int, world::UInt)
     # the caller's scan supplies `interference_method ∈ meth`'s set, so this single probe
     # decides `method_morespecific_recorded(interference_method, meth)`: found means the
-    # two are mutually ambiguous, absent means the newcomer strictly beats `meth`
+    # two are mutually ambiguous, absent means the new method strictly beats `meth`
     if method_in_interferences(meth, interference_method)
         expected_is_minmax(meth, interference_method, sig, expecteds, i, n) || return false
     end
     # Either way, the drop needs a certifying cover. This cheap search is the common
-    # bail, so it runs before the beater scan (each probe of which is a linear set scan
-    # of its own).
+    # bail, so it runs before the morespecific list scan (each probe of which is a linear set
+    # scan of its own).
     has_empty_set_cover(interference_method, ti, expecteds, i, n) || return false
-    return beaters_cannot_cycle(interference_method, world)
+    return morespecific_cannot_cycle(interference_method, world)
 end
 
-# The mutually ambiguous case of `newcomer_prunes_silently`, where `meth` (the owner of
-# the interference set being scanned) neither beats nor is beaten by the newcomer, its
-# ambiguity partner. This is the canonical `Type{Union{}}`-slurp recovery shape --
+# The mutually ambiguous case of `newmethod_removed_silently`, where `meth` (the owner of
+# the interference set being scanned) is neither more nor less specific than the new method `interference_method`,
+# its ambiguity partner. This is the canonical `Type{Union{}}`-slurp recovery shape --
 # f(::Type{<:A}) and f(::Type{<:B}) overlap only at the corner the slurp resolves -- so it
 # must stay on the fast path. The fresh sort keeps the pair silent only through the minmax
 # exemption: the sort pre-marks the minmax match finalized and never visits it, so its
@@ -546,19 +546,20 @@ end
 #    intersects sig and so sits in the raw match list);
 #  - the partner must NOT fully cover sig: minmax discovery runs over the raw list before
 #    any drop, so a fully-covering mutual partner disqualifies `meth` there even though it
-#    is later pruned;
+#    is later removed;
 #  - `meth` must recorded-beat every other fully-covering expected (minmax is unique:
 #    recorded strict-beat is antisymmetric, and this check also rejects the owner of any
 #    second mutual pair);
-#  - a fully-covering newcomer that `meth` does not beat would steal minmax, but needs no
+#  - a fully-covering new method that `meth` does not beat would steal minmax, but needs no
 #    check here: it is itself a visible entry of `meth`'s set, and its own certification
 #    fails -- as a mutual entry by the partner-covers-sig condition above, and as a strict
-#    beater because its empty-set cover would have to fully cover sig, and an expected with
+#    morespecific choice because its empty-set cover would have to fully cover sig, and an expected with
 #    those properties would have dropped `meth` from the recorded result in the first place.
 # The drop of the partner and its blocker-transfer obligations are then certified by the
-# caller's two remaining conditions, exactly as for a strict beater: an empty-set cover's
-# transfers are all automatic (nothing beats it, and it patches any transfer region inside
-# its signature), and the beater scan keeps the partner off any specificity cycle.
+# caller's two remaining conditions, exactly as for a strictly morespecific method: an empty-set
+# cover's transfers are all automatic (nothing is morespecific than it, and it patches any transfer
+# region inside its signature), and the morespecific scan of expected ensures the partner is not
+# tangled in a specificity cycle.
 function expected_is_minmax(meth::Method, interference_method::Method, @nospecialize(sig),
                             expecteds::Core.SimpleVector, i::Int, n::Int)
     sig <: meth.sig || return false                 # `meth` fully covers sig
@@ -572,7 +573,7 @@ function expected_is_minmax(meth::Method, interference_method::Method, @nospecia
     return true
 end
 
-# Look for an expected method that covers the pruned `interference_method` over their
+# Look for an expected method that covers the removed `interference_method` over their
 # intersection `ti` and provably certifies the removal as silent: only an expected with an
 # empty interference set qualifies, since such a method beats everything it intersects, so:
 #  - nothing beats or ties it, so it can never sit in a specificity cycle and always
@@ -599,24 +600,24 @@ function has_empty_set_cover(interference_method::Method, @nospecialize(ti),
     return false
 end
 
-# Require every strict beater of the pruned `interference_method` to have an empty
-# interference set itself: like the cover found by `has_empty_set_cover`, such a beater
+# Require every strictly morespecific method of the removed `interference_method` to have an empty
+# interference set itself: like the cover found by `has_empty_set_cover`, such a method
 # cannot continue a specificity cycle. This is the condition the last bullet above
-# `newcomer_prunes_silently` relies on to keep an acceptance conservative.
+# `newmethod_removed_silently` relies on to keep an acceptance conservative.
 #
-# Without it, a cycle through invisible methods could re-enter the beaten expected behind
+# Without it, a cycle through invisible methods could encounter the less-specific expected behind
 # the caller's scan's back (dragging it into an SCC mid-sort, where it stops covering the
 # invisible members and they survive into the result): detecting that re-entry edge
 # directly would mean intersecting `interference_method`'s own set against sig -- the full
 # lookup's price.
-function beaters_cannot_cycle(interference_method::Method, world::UInt)
-    for beater in eachinterference(interference_method, world)
-        # the iteration supplies `beater ∈ interference_method`'s set, which is the first
-        # half of `method_morespecific_recorded(beater, interference_method)`, so this only
+function morespecific_cannot_cycle(interference_method::Method, world::UInt)
+    for msp in eachinterference(interference_method, world)
+        # the iteration supplies `msp ∈ interference_method`'s set, which is the first
+        # half of `method_morespecific_recorded(msp, interference_method)`, so this only
         # needs to now check the second half
-        if !isempty(beater.interferences) &&
-            !method_in_interferences(interference_method, beater)
-            # a strict beater that could itself sit on a cycle
+        if !isempty(msp.interferences) &&
+            !method_in_interferences(interference_method, msp)
+            # a strict morespecific method that could itself sit on a cycle
             return false
         end
     end
@@ -689,10 +690,10 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                         if !(ti === Union{})
                             # An unexpected method intersecting sig can change more than the
                             # match set: even when an expected method fully covers it (so the
-                            # pruned result below would compare equal), it can make `ml_matches`
+                            # sorted result below would compare equal), it can make `ml_matches`
                             # flag an ambiguity -- a mutual pair or a specificity cycle with a
                             # reported match -- which must invalidate below.
-                            if !newcomer_prunes_silently(meth, interference_method, ti, sig, expecteds, i, n, world)
+                            if !newmethod_removed_silently(meth, interference_method, ti, sig, expecteds, i, n, world)
                                 interference_fast_path_success = false
                                 break
                             end
@@ -721,8 +722,8 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         maxworld[] = 0
     else
         # A method added after this edge was recorded can be ambiguous with an expected
-        # match without changing this include_ambiguous=false result: the newcomer is
-        # pruned when an expected match fully covers their overlap, yet dispatch in the
+        # match without changing this include_ambiguous=false result: the new method is
+        # removed when an expected match fully covers their overlap, yet dispatch in the
         # contested region now throws a MethodError that inference never accounted for.
         # Until edges record that inference itself saw an ambiguity
         # (JuliaLang/julia#62322), any ambiguity over sig must invalidate.

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -390,6 +390,16 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
     end
 end
 
+# fast-path dispatch_status bit definitions (false indicates unknown)
+# true indicates this method would be returned as the result from `which` when invoking `method.sig` in the current latest world
+const METHOD_SIG_LATEST_WHICH = 0x1
+# true indicates this method would be returned as the only result from `methods` when calling `method_instance.specTypes` in the current latest world
+# it is equivalently tracked as `isempty(interferences)` on a `method`
+const METHOD_SIG_LATEST_ONLY = 0x2
+# true indicates this method is not strictly morespecific than any method it intersects
+# (equivalently, that this method is not in the interference set of any other method without also being in this methods interference set too).
+const METHOD_SIG_NO_LOSERS = 0x4
+
 function get_method_from_edge(@nospecialize t)
     if t isa Method
         return t
@@ -401,6 +411,47 @@ function get_method_from_edge(@nospecialize t)
         end
         return t.def::Method
     end
+end
+
+# The MethodInstance behind an edge, or `nothing` for a bare Method edge
+function get_mi_from_edge(@nospecialize t)
+    t isa Method && return nothing
+    t isa CodeInstance && return get_ci_mi(t)::MethodInstance
+    return t::MethodInstance
+end
+
+# The single expected match provably dominates the queried signature, so the result of
+# `ml_matches` is already known to be just this method (only valid when `fully_covers`)
+function expected_dominates_sig(meth::Method, mi::Union{Nothing,MethodInstance})
+    if mi !== nothing && !iszero(mi.dispatch_status & METHOD_SIG_LATEST_ONLY)
+        return true # the sole match for `mi.specTypes`
+    end
+    # an empty interference set is the Method-level equivalent of
+    # METHOD_SIG_LATEST_ONLY: the method beats everything it intersects
+    return isempty(meth.interferences)
+end
+
+# Iterate the methods of an expected-match run `expecteds[i:i+n-1]`, resolving each
+# edge (Method, MethodInstance or CodeInstance) to its Method.
+struct EachExpected
+    expecteds::Core.SimpleVector
+    i::Int
+    n::Int
+end
+eachexpected(expecteds::Core.SimpleVector, i::Int, n::Int) = EachExpected(expecteds, i, n)
+function Base.iterate(ee::EachExpected, j::Int=1)
+    j > ee.n && return nothing
+    return get_method_from_edge(ee.expecteds[ee.i+j-1]), j + 1
+end
+
+# Check if `m` is one of the expected methods of this run
+function method_in_expecteds(m::Method, expecteds::Core.SimpleVector, i::Int, n::Int)
+    for meth in eachexpected(expecteds, i, n)
+        if m === meth
+            return true
+        end
+    end
+    return false
 end
 
 # Iterate a method's `interferences` set. The set is an idset used append-only,
@@ -432,121 +483,137 @@ function method_in_interferences(method2::Method, method1::Method)
     return false
 end
 
+# Check if method1 is more specific than method2 via the interference graph
+# equivalent to: morespecific(method1, method2) && typeintersect(method1.sig, method2.sig) !== Union{}
+function method_morespecific_recorded(method1::Method, method2::Method)
+    method1 === method2 && return false
+    return method_in_interferences(method1, method2) && !method_in_interferences(method2, method1)
+end
+
+# The fast-path `dispatch_status` bit is set: `which` would return this method when
+# invoking `method.sig` in the current latest world. False indicates unknown, so callers
+# must treat a false result as conservatively as an actually deleted method.
+method_is_latest_which(m::Method) = !iszero(m.dispatch_status & METHOD_SIG_LATEST_WHICH)
+
 # Max interference-set size for which n==1 uses the interference fast path instead of
 # `ml_matches`: the scan probes every member with `typeintersect`, so above this size the
 # pruned `ml_matches` lookup is cheaper (~8 is the empirical crossover).
 const VERIFY_INTERF_CAP = 8
 
-# The unexpected `interference_method`, recorded in expected method `meth`'s
-# interference set, intersects the queried `sig` over the nonempty `ti`.
-# Decide whether the sort provably prunes it silently: acceptance implies the
-# full `ml_matches` lookup would return exactly the expected methods
-# `expecteds[i:i+n-1]` with no ambiguity flag caused by the new method.
-# Returns `false` conservative when a full lookup is necessary to decide.
+# The unexpected `interference_method` (the newcomer), recorded in expected method
+# `meth`'s interference set, intersects the queried `sig` over the nonempty `ti`. Decide
+# whether the sort provably prunes it silently: acceptance implies the full `ml_matches`
+# lookup would return exactly the expected methods `expecteds[i:i+n-1]` with no ambiguity
+# flag caused by the new method. Returns `false` conservative when a full lookup is
+# necessary to decide.
+#
+# Accepting stays conservative even though the caller only ever offers up the unexpected
+# methods recorded in the expected methods' own sets, because that scan witnesses every
+# visible change:
+#  - fully_covers means every method intersecting sig intersects some expected pointwise;
+#  - methods invisible to it (strictly beaten by every expected they intersect, hence in no
+#    expected's set) always prune silently: the union of their intersecting expecteds
+#    covers them, and a failing blocker transfer would need a blocker that beats an
+#    expected cover -- which recording makes visible;
+#  - any cycle that could flag or change the result must thread an expected, entering
+#    through a visible strict beater of it -- an entry of that scan, which is either
+#    rejected by the conditions below or, by `beaters_cannot_cycle`, provably not on any
+#    cycle.
 function newcomer_prunes_silently(meth::Method, interference_method::Method, @nospecialize(ti), @nospecialize(sig),
                                   expecteds::Core.SimpleVector, i::Int, n::Int, world::UInt)
+    # the caller's scan supplies `interference_method ∈ meth`'s set, so this single probe
+    # decides `method_morespecific_recorded(interference_method, meth)`: found means the
+    # two are mutually ambiguous, absent means the newcomer strictly beats `meth`
     if method_in_interferences(meth, interference_method)
-        # Mutually ambiguous with the expected method whose set is being
-        # scanned. This is the canonical `Type{Union{}}`-slurp recovery shape --
-        # f(::Type{<:A}) and f(::Type{<:B}) overlap only at the corner the
-        # slurp resolves -- so it must stay on the fast path. The fresh sort
-        # keeps the pair silent only through the minmax exemption: the sort
-        # pre-marks the minmax match finalized and never visits it, so its
-        # `check_fully_ambiguous` scan (which would flag any mutual partner
-        # still in the raw match list, dropped or not) never runs. Certify
-        # set-locally that `meth` is that minmax:
-        #  - `meth` must fully cover sig (a visited owner always flags the
-        #    pair, since the partner intersects sig and so sits in the raw
-        #    match list);
-        #  - the partner must NOT fully cover sig: minmax discovery runs over
-        #    the raw list before any drop, so a fully-covering mutual partner
-        #    disqualifies `meth` there even though it is later pruned;
-        #  - `meth` must recorded-beat every other fully-covering expected
-        #    (minmax is unique: recorded strict-beat is antisymmetric, and
-        #    this check also rejects the owner of any second mutual pair);
-        #  - a fully-covering newcomer that `meth` does not beat would steal
-        #    minmax, but needs no check here: it is itself a visible entry of
-        #    `meth`'s set, and its own certification fails -- as a mutual
-        #    entry by the partner-covers-sig condition above, and as a strict
-        #    beater because its empty-set cover would have to fully cover sig,
-        #    and an expected with those properties would have dropped `meth`
-        #    from the recorded result in the first place.
-        # The drop of the partner and its blocker-transfer obligations are
-        # then certified by the shared conditions below, exactly as for a
-        # strict beater: an empty-set cover's transfers are all automatic
-        # (nothing beats it, and it patches any transfer region inside its
-        # signature), and the beater scan keeps the partner off any
-        # specificity cycle.
-        sig <: meth.sig || return false
-        sig <: interference_method.sig && return false
-        for j = 1:n
-            meth2 = get_method_from_edge(expecteds[i+j-1])
-            meth2 === meth && continue
-            if sig <: meth2.sig
-                if !(method_in_interferences(meth, meth2) && !method_in_interferences(meth2, meth))
-                    return false
-                end
-            end
+        expected_is_minmax(meth, interference_method, sig, expecteds, i, n) || return false
+    end
+    # Either way, the drop needs a certifying cover. This cheap search is the common
+    # bail, so it runs before the beater scan (each probe of which is a linear set scan
+    # of its own).
+    has_empty_set_cover(interference_method, ti, expecteds, i, n) || return false
+    return beaters_cannot_cycle(interference_method, world)
+end
+
+# The mutually ambiguous case of `newcomer_prunes_silently`, where `meth` (the owner of
+# the interference set being scanned) neither beats nor is beaten by the newcomer, its
+# ambiguity partner. This is the canonical `Type{Union{}}`-slurp recovery shape --
+# f(::Type{<:A}) and f(::Type{<:B}) overlap only at the corner the slurp resolves -- so it
+# must stay on the fast path. The fresh sort keeps the pair silent only through the minmax
+# exemption: the sort pre-marks the minmax match finalized and never visits it, so its
+# `check_fully_ambiguous` scan (which would flag any mutual partner still in the raw match
+# list, dropped or not) never runs. Certify set-locally that `meth` is that minmax:
+#  - `meth` must fully cover sig (a visited owner always flags the pair, since the partner
+#    intersects sig and so sits in the raw match list);
+#  - the partner must NOT fully cover sig: minmax discovery runs over the raw list before
+#    any drop, so a fully-covering mutual partner disqualifies `meth` there even though it
+#    is later pruned;
+#  - `meth` must recorded-beat every other fully-covering expected (minmax is unique:
+#    recorded strict-beat is antisymmetric, and this check also rejects the owner of any
+#    second mutual pair);
+#  - a fully-covering newcomer that `meth` does not beat would steal minmax, but needs no
+#    check here: it is itself a visible entry of `meth`'s set, and its own certification
+#    fails -- as a mutual entry by the partner-covers-sig condition above, and as a strict
+#    beater because its empty-set cover would have to fully cover sig, and an expected with
+#    those properties would have dropped `meth` from the recorded result in the first place.
+# The drop of the partner and its blocker-transfer obligations are then certified by the
+# caller's two remaining conditions, exactly as for a strict beater: an empty-set cover's
+# transfers are all automatic (nothing beats it, and it patches any transfer region inside
+# its signature), and the beater scan keeps the partner off any specificity cycle.
+function expected_is_minmax(meth::Method, interference_method::Method, @nospecialize(sig),
+                            expecteds::Core.SimpleVector, i::Int, n::Int)
+    sig <: meth.sig || return false                 # `meth` fully covers sig
+    sig <: interference_method.sig && return false  # its partner does not
+    for meth2 in eachexpected(expecteds, i, n)      # and `meth` beats every other full cover
+        meth2 === meth && continue
+        if sig <: meth2.sig && !method_morespecific_recorded(meth, meth2)
+            return false
         end
     end
-    # Otherwise this method strictly beats the scanned set's owner. Either
-    # way, look for a different expected method that covers it over this
-    # intersection and provably certifies the removal as silent: only an
-    # expected with an empty interference set qualifies, since such a method
-    # beats everything it intersects, so:
-    #  - nothing beats or ties it, so it can never sit in a
-    #    specificity cycle and always finalizes before the sort
-    #    needs it as a cover;
-    #  - every blocker transfer through it passes automatically;
-    #  - being recorded in the set of every method it intersects, it
-    #    patches any blocker-transfer region inside its signature
-    #    for the other drops too.
-    # The `Union{}` bottom-slurp methods are exactly this shape,
-    # keeping verification fast when a later-added method intersects
-    # sig only at the `Type{Union{}}` corner they resolve. Any other
-    # unexpected entry is left to the full lookup (the sort's
-    # dominance-transfer protocol): anything weaker re-opens the
-    # cycle counterexamples, where a cover tangled in a specificity
-    # cycle certifies a drop it must not.
-    local cover_found = false
-    for j = 1:n
-        meth2 = get_method_from_edge(expecteds[i+j-1])
+    return true
+end
+
+# Look for an expected method that covers the pruned `interference_method` over their
+# intersection `ti` and provably certifies the removal as silent: only an expected with an
+# empty interference set qualifies, since such a method beats everything it intersects, so:
+#  - nothing beats or ties it, so it can never sit in a specificity cycle and always
+#    finalizes before the sort needs it as a cover;
+#  - every blocker transfer through it passes automatically;
+#  - being recorded in the set of every method it intersects, it patches any
+#    blocker-transfer region inside its signature for the other drops too.
+# The `Union{}` bottom-slurp methods are exactly this shape, keeping verification fast when
+# a later-added method intersects sig only at the `Type{Union{}}` corner they resolve. Any
+# other unexpected entry is left to the full lookup (the sort's dominance-transfer
+# protocol): anything weaker re-opens the cycle counterexamples, where a cover tangled in a
+# specificity cycle certifies a drop it must not.
+function has_empty_set_cover(interference_method::Method, @nospecialize(ti),
+                             expecteds::Core.SimpleVector, i::Int, n::Int)
+    for meth2 in eachexpected(expecteds, i, n)
+        # the emptiness test is the O(1) bail, and also makes the second half of
+        # `method_morespecific_recorded` a scan of the empty set
         if isempty(meth2.interferences) &&
-            method_in_interferences(meth2, interference_method) &&
+            method_morespecific_recorded(meth2, interference_method) &&
             ti <: meth2.sig
-            cover_found = true
-            break
+            return true
         end
     end
-    # This cheap search is the common bail, so it runs before the beater
-    # scan below (each probe of which is a linear set scan of its own).
-    cover_found || return false
-    # Additionally require every strict beater of this method to
-    # have an empty interference set itself (like the cover, such a
-    # beater cannot continue a specificity cycle). This is what
-    # makes accepting purely conservative -- an acceptance implies
-    # the full lookup would return exactly the expected methods with
-    # no ambiguity -- because scanning only the expected methods'
-    # sets then witnesses every dangerous change:
-    #  - fully_covers means every method intersecting sig intersects
-    #    some expected pointwise;
-    #  - methods invisible here (strictly beaten by every expected
-    #    they intersect, hence in no expected's set) always prune
-    #    silently: the union of their intersecting expecteds covers
-    #    them, and a failing blocker transfer would need a blocker
-    #    that beats an expected cover -- visible by recording;
-    #  - any cycle that could flag or change the result must thread
-    #    an expected, entering through a visible strict beater of
-    #    it -- an entry of this scan, which is either rejected here
-    #    or, by the beater condition, provably not on any cycle.
-    # Without the beater condition, a cycle through invisible
-    # methods could re-enter the beaten expected behind this scan's
-    # back (dragging it into an SCC mid-sort, where it stops
-    # covering the invisible members and they survive into the
-    # result): detecting that re-entry edge directly would mean
-    # intersecting this method's own set against sig -- the full
-    # lookup's price.
+    return false
+end
+
+# Require every strict beater of the pruned `interference_method` to have an empty
+# interference set itself: like the cover found by `has_empty_set_cover`, such a beater
+# cannot continue a specificity cycle. This is the condition the last bullet above
+# `newcomer_prunes_silently` relies on to keep an acceptance conservative.
+#
+# Without it, a cycle through invisible methods could re-enter the beaten expected behind
+# the caller's scan's back (dragging it into an SCC mid-sort, where it stops covering the
+# invisible members and they survive into the result): detecting that re-entry edge
+# directly would mean intersecting `interference_method`'s own set against sig -- the full
+# lookup's price.
+function beaters_cannot_cycle(interference_method::Method, world::UInt)
     for beater in eachinterference(interference_method, world)
+        # the iteration supplies `beater ∈ interference_method`'s set, which is the first
+        # half of `method_morespecific_recorded(beater, interference_method)`, so this only
+        # needs to now check the second half
         if !isempty(beater.interferences) &&
             !method_in_interferences(interference_method, beater)
             # a strict beater that could itself sit on a cycle
@@ -560,10 +627,8 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
     # verify that these edges intersect with the same methods as before
     mi = nothing
     expected_deleted = false
-    for j = 1:n
-        t = expecteds[i+j-1]
-        meth = get_method_from_edge(t)
-        if iszero(meth.dispatch_status & METHOD_SIG_LATEST_WHICH)
+    for meth in eachexpected(expecteds, i, n)
+        if !method_is_latest_which(meth)
             expected_deleted = true
             break
         end
@@ -576,30 +641,13 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         if n == 1
             # first, fast-path a check if the expected method simply dominates its sig anyways
             # so the result of ml_matches is already simply known
-            let t = expecteds[i], meth, minworld, maxworld
-                meth = get_method_from_edge(t)
-                if !(t isa Method)
-                    if t isa CodeInstance
-                        mi = get_ci_mi(t)::MethodInstance
-                    else
-                        mi = t::MethodInstance
-                    end
-                    # Fast path is legal when fully_covers=true
-                    if fully_covers && !iszero(mi.dispatch_status & METHOD_SIG_LATEST_ONLY)
-                        minworld = meth.primary_world
-                        @assert minworld ≤ world "expected method not present in verification world"
-                        maxworld = typemax(UInt)
-                        return minworld, maxworld
-                    end
-                end
+            let t = expecteds[i], meth = get_method_from_edge(t), minworld
+                mi = get_mi_from_edge(t) # also recorded for `jl_promote_mi_to_current` below
                 # Fast path is legal when fully_covers=true
-                # (an empty interference set is the Method-level equivalent of
-                # METHOD_SIG_LATEST_ONLY: the method beats everything it intersects)
-                if fully_covers && isempty(meth.interferences)
+                if fully_covers && expected_dominates_sig(meth, mi)
                     minworld = meth.primary_world
                     @assert minworld ≤ world "expected method not present in verification world"
-                    maxworld = typemax(UInt)
-                    return minworld, maxworld
+                    return minworld, typemax(UInt)
                 end
             end
         end
@@ -619,8 +667,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         # If it didn't fail yet, then check that all interference methods are either expected, or not applicable.
         if interference_fast_path_success
             local interference_minworld::UInt = 1
-            for j = 1:n
-                meth = get_method_from_edge(expecteds[i+j-1])
+            for meth in eachexpected(expecteds, i, n)
                 if interference_minworld < meth.primary_world
                     interference_minworld = meth.primary_world
                 end
@@ -631,20 +678,13 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                 for k = 1:length(interferences)
                     isassigned(interferences, k) || break # no more entries
                     interference_method = interferences[k]::Method
-                    if iszero(interference_method.dispatch_status & METHOD_SIG_LATEST_WHICH)
+                    if !method_is_latest_which(interference_method)
                         # detected a deleted interference_method, so need the full lookup to compute minworld
                         interference_fast_path_success = false
                         break
                     end
                     world < interference_method.primary_world && break # this and later entries are for a future world
-                    local found_in_expecteds = false
-                    for j = 1:n
-                        if interference_method === get_method_from_edge(expecteds[i+j-1])
-                            found_in_expecteds = true
-                            break
-                        end
-                    end
-                    if !found_in_expecteds
+                    if !method_in_expecteds(interference_method, expecteds, i, n)
                         ti = typeintersect(sig, interference_method.sig)
                         if !(ti === Union{})
                             # An unexpected method intersecting sig can change more than the
@@ -666,8 +706,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
             if interference_fast_path_success
                 # All interference sets are covered by expecteds, can return success
                 @assert interference_minworld ≤ world "expected method not present in verification world"
-                maxworld = typemax(UInt)
-                return interference_minworld, maxworld
+                return interference_minworld, typemax(UInt)
             end
         end
    end
@@ -697,15 +736,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         ins = 0
         for k = 1:length(result)
             match = result[k]::Core.MethodMatch
-            local found = false
-            for j = 1:n
-                t = expecteds[i+j-1]
-                if match.method == get_method_from_edge(t)
-                    found = true
-                    break
-                end
-            end
-            if !found
+            if !method_in_expecteds(match.method, expecteds, i, n)
                 # intersection has a new method or a method was
                 # deleted--this is now probably no good, just invalidate
                 # everything about it now
@@ -728,21 +759,11 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
     return minworld[], maxworld[]
 end
 
-# fast-path dispatch_status bit definitions (false indicates unknown)
-# true indicates this method would be returned as the result from `which` when invoking `method.sig` in the current latest world
-const METHOD_SIG_LATEST_WHICH = 0x1
-# true indicates this method would be returned as the only result from `methods` when calling `method_instance.specTypes` in the current latest world
-# it is equivalently tracked as `isempty(interferences)` on a `method`
-const METHOD_SIG_LATEST_ONLY = 0x2
-# true indicates this method is not strictly morespecific than any method it intersects
-# (equivalently, that this method is not in the interference set of any other method without also being in this methods interference set too).
-const METHOD_SIG_NO_LOSERS = 0x4
-
 function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UInt, matches::Vector{Any})
     @assert invokesig isa Type "corrupt edges list"
     local minworld::UInt, maxworld::UInt
     empty!(matches)
-    if invokesig === expected.sig && !iszero(expected.dispatch_status & METHOD_SIG_LATEST_WHICH)
+    if invokesig === expected.sig && method_is_latest_which(expected)
         # the invoke match is `expected` for `expected->sig`, unless `expected` is replaced
         minworld = expected.primary_world
         @assert minworld ≤ world "expected method not present in verification world"

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -471,8 +471,10 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                         return minworld, maxworld
                     end
                 end
-                # Fast path is legal when fully_covers=true
-                if fully_covers && !iszero(meth.dispatch_status & METHOD_SIG_LATEST_ONLY)
+                # Fast path is legal when fully_covers=true. An empty interference
+                # set means the method is strictly morespecific than every method
+                # it intersects, so it dominates its sig in every world it exists.
+                if fully_covers && isempty(meth.interferences)
                     minworld = meth.primary_world
                     @assert minworld ≤ world "expected method not present in verification world"
                     maxworld = typemax(UInt)
@@ -600,7 +602,8 @@ end
 # fast-path dispatch_status bit definitions (false indicates unknown)
 # true indicates this method would be returned as the result from `which` when invoking `method.sig` in the current latest world
 const METHOD_SIG_LATEST_WHICH = 0x1
-# true indicates this method would be returned as the only result from `methods` when calling `method.sig` in the current latest world
+# MethodInstance-level: true indicates dispatch of this mi's specTypes yields only this
+# result in the current latest world (the Method-level equivalent is `isempty(method.interferences)`)
 const METHOD_SIG_LATEST_ONLY = 0x2
 
 function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UInt, matches::Vector{Any})

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -466,7 +466,9 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                     end
                 end
                 # Fast path is legal when fully_covers=true
-                if fully_covers && !iszero(meth.dispatch_status & METHOD_SIG_LATEST_ONLY)
+                # (an empty interference set is the Method-level equivalent of
+                # METHOD_SIG_LATEST_ONLY: the method beats everything it intersects)
+                if fully_covers && isempty(meth.interferences)
                     minworld = meth.primary_world
                     @assert minworld ≤ world "expected method not present in verification world"
                     maxworld = typemax(UInt)

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -403,13 +403,31 @@ function get_method_from_edge(@nospecialize t)
     end
 end
 
+# Iterate a method's `interferences` set. The set is an idset used append-only
+# (`jl_idset_pop` is never called on it), so its keys form a packed prefix --
+# no interior holes -- in insertion order, which is method-definition order,
+# making `primary_world` non-decreasing along the prefix (see
+# `jl_idset_put_key` in idset.c). Iteration therefore stops at the first
+# unassigned slot and, given a `world` cutoff, at the first entry defined in a
+# future world (which hides all later ones too).
+struct EachInterference
+    interferences::Memory{Any}
+    world::UInt # typemax(UInt) means no world cutoff
+end
+eachinterference(m::Method, world::UInt=typemax(UInt)) = EachInterference(m.interferences, world)
+function Base.iterate(ei::EachInterference, k::Int=1)
+    interferences = ei.interferences
+    k > length(interferences) && return nothing
+    isassigned(interferences, k) || return nothing # no more entries
+    interference_method = interferences[k]::Method
+    ei.world < interference_method.primary_world && return nothing # this and later entries are for a future world
+    return interference_method, k + 1
+end
+
 # Check if method2 is in method1's interferences set
 # Returns true if method2 is found (meaning !morespecific(method1, method2))
 function method_in_interferences(method2::Method, method1::Method)
-    interferences = method1.interferences
-    for k = 1:length(interferences)
-        isassigned(interferences, k) || break
-        interference_method = interferences[k]::Method
+    for interference_method in eachinterference(method1)
         if interference_method === method2
             return true
         end
@@ -421,6 +439,87 @@ end
 # `ml_matches`: the scan probes every member with `typeintersect`, so above this size the
 # pruned `ml_matches` lookup is cheaper (~8 is the empirical crossover).
 const VERIFY_INTERF_CAP = 8
+
+# The unexpected `interference_method`, recorded in expected method `meth`'s
+# interference set, intersects the queried `sig` over the nonempty `ti`.
+# Decide whether the sort provably prunes it silently: acceptance implies the
+# full `ml_matches` lookup would return exactly the expected methods
+# `expecteds[i:i+n-1]` with no ambiguity flag.
+function newcomer_prunes_silently(meth::Method, interference_method::Method, @nospecialize(ti),
+                                  expecteds::Core.SimpleVector, i::Int, n::Int, world::UInt)
+    if method_in_interferences(meth, interference_method)
+        # Mutually ambiguous with the expected method whose set is being
+        # scanned: the fresh sort always flags this pair (both stay in the
+        # intersecting-match list), so only the full lookup can decide this
+        # edge.
+        return false
+    end
+    # This method strictly beats the scanned set's owner. Look for a
+    # different expected method that covers it over this intersection
+    # and provably certifies the removal as silent: only an expected
+    # with an EMPTY interference set qualifies, since such a method
+    # beats everything it intersects, so:
+    #  - nothing beats or ties it, so it can never sit in a
+    #    specificity cycle and always finalizes before the sort
+    #    needs it as a cover;
+    #  - every blocker transfer through it passes automatically;
+    #  - being recorded in the set of every method it intersects, it
+    #    patches any blocker-transfer region inside its signature
+    #    for the other drops too.
+    # The `Union{}` bottom-slurp methods are exactly this shape,
+    # keeping verification fast when a later-added method intersects
+    # sig only at the `Type{Union{}}` corner they resolve. Any other
+    # unexpected entry is left to the full lookup (the sort's
+    # dominance-transfer protocol): anything weaker re-opens the
+    # cycle counterexamples, where a cover tangled in a specificity
+    # cycle certifies a drop it must not.
+    local cover_found = false
+    for j = 1:n
+        meth2 = get_method_from_edge(expecteds[i+j-1])
+        if isempty(meth2.interferences) &&
+            method_in_interferences(meth2, interference_method) &&
+            ti <: meth2.sig
+            cover_found = true
+            break
+        end
+    end
+    # This cheap search is the common bail, so it runs before the beater
+    # scan below (each probe of which is a linear set scan of its own).
+    cover_found || return false
+    # Additionally require every strict beater of this method to
+    # have an empty interference set itself (like the cover, such a
+    # beater cannot continue a specificity cycle). This is what
+    # makes accepting purely conservative -- an acceptance implies
+    # the full lookup would return exactly the expected methods with
+    # no ambiguity -- because scanning only the expected methods'
+    # sets then witnesses every dangerous change:
+    #  - fully_covers means every method intersecting sig intersects
+    #    some expected pointwise;
+    #  - methods invisible here (strictly beaten by every expected
+    #    they intersect, hence in no expected's set) always prune
+    #    silently: the union of their intersecting expecteds covers
+    #    them, and a failing blocker transfer would need a blocker
+    #    that beats an expected cover -- visible by recording;
+    #  - any cycle that could flag or change the result must thread
+    #    an expected, entering through a visible strict beater of
+    #    it -- an entry of this scan, which is either rejected here
+    #    or, by the beater condition, provably not on any cycle.
+    # Without the beater condition, a cycle through invisible
+    # methods could re-enter the beaten expected behind this scan's
+    # back (dragging it into an SCC mid-sort, where it stops
+    # covering the invisible members and they survive into the
+    # result): detecting that re-entry edge directly would mean
+    # intersecting this method's own set against sig -- the full
+    # lookup's price.
+    for beater in eachinterference(interference_method, world)
+        if !isempty(beater.interferences) &&
+            !method_in_interferences(interference_method, beater)
+            # a strict beater that could itself sit on a cycle
+            return false
+        end
+    end
+    return true
+end
 
 function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n::Int, world::UInt, fully_covers::Bool, matches::Vector{Any})
     # verify that these edges intersect with the same methods as before
@@ -490,6 +589,9 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                 if interference_minworld < meth.primary_world
                     interference_minworld = meth.primary_world
                 end
+                # manual `eachinterference(meth, world)`: the deleted-entry check
+                # below runs before the world cutoff, so a deleted future-world
+                # entry conservatively fails the fast path instead of being hidden
                 interferences = meth.interferences
                 for k = 1:length(interferences)
                     isassigned(interferences, k) || break # no more entries
@@ -515,85 +617,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                             # pruned result below would compare equal), it can make `ml_matches`
                             # flag an ambiguity -- a mutual pair or a specificity cycle with a
                             # reported match -- which must invalidate below.
-                            if method_in_interferences(meth, interference_method)
-                                # Mutually ambiguous with the expected method whose set is
-                                # being scanned: the fresh sort always flags this pair (both
-                                # stay in the intersecting-match list), so only the full
-                                # lookup can decide this edge.
-                                interference_fast_path_success = false
-                                break
-                            end
-                            # This method strictly beats the scanned set's owner. Look for a
-                            # different expected method that covers it over this intersection
-                            # and provably certifies the removal as silent: only an expected
-                            # with an EMPTY interference set qualifies, since such a method
-                            # beats everything it intersects, so:
-                            #  - nothing beats or ties it, so it can never sit in a
-                            #    specificity cycle and always finalizes before the sort
-                            #    needs it as a cover;
-                            #  - every blocker transfer through it passes automatically;
-                            #  - being recorded in the set of every method it intersects, it
-                            #    patches any blocker-transfer region inside its signature
-                            #    for the other drops too.
-                            # The `Union{}` bottom-slurp methods are exactly this shape,
-                            # keeping verification fast when a later-added method intersects
-                            # sig only at the `Type{Union{}}` corner they resolve. Any other
-                            # unexpected entry is left to the full lookup (the sort's
-                            # dominance-transfer protocol): anything weaker re-opens the
-                            # cycle counterexamples, where a cover tangled in a specificity
-                            # cycle certifies a drop it must not.
-                            #
-                            # Additionally require every strict beater of this method to
-                            # have an empty interference set itself (like the cover, such a
-                            # beater cannot continue a specificity cycle). This is what
-                            # makes accepting purely conservative -- an acceptance implies
-                            # the full lookup would return exactly the expected methods with
-                            # no ambiguity -- because scanning only the expected methods'
-                            # sets then witnesses every dangerous change:
-                            #  - fully_covers means every method intersecting sig intersects
-                            #    some expected pointwise;
-                            #  - methods invisible here (strictly beaten by every expected
-                            #    they intersect, hence in no expected's set) always prune
-                            #    silently: the union of their intersecting expecteds covers
-                            #    them, and a failing blocker transfer would need a blocker
-                            #    that beats an expected cover -- visible by recording;
-                            #  - any cycle that could flag or change the result must thread
-                            #    an expected, entering through a visible strict beater of
-                            #    it -- an entry of this scan, which is either rejected here
-                            #    or, by the beater condition, provably not on any cycle.
-                            # Without the beater condition, a cycle through invisible
-                            # methods could re-enter the beaten expected behind this scan's
-                            # back (dragging it into an SCC mid-sort, where it stops
-                            # covering the invisible members and they survive into the
-                            # result): detecting that re-entry edge directly would mean
-                            # intersecting this method's own set against sig -- the full
-                            # lookup's price.
-                            local beaters_safe = true
-                            let interferences2 = interference_method.interferences
-                                for k2 = 1:length(interferences2)
-                                    isassigned(interferences2, k2) || break # no more entries
-                                    beater = interferences2[k2]::Method
-                                    world < beater.primary_world && break # this and later entries are for a future world
-                                    if !isempty(beater.interferences) &&
-                                        !method_in_interferences(interference_method, beater)
-                                        # a strict beater that could itself sit on a cycle
-                                        beaters_safe = false
-                                        break
-                                    end
-                                end
-                            end
-                            if beaters_safe
-                                for j2 = 1:n
-                                    meth2 = get_method_from_edge(expecteds[i+j2-1])
-                                    if isempty(meth2.interferences) &&
-                                        method_in_interferences(meth2, interference_method) &&
-                                        ti <: meth2.sig
-                                        found_in_expecteds = true
-                                        break
-                                    end
-                                end
-                            end
-                            if !found_in_expecteds
+                            if !newcomer_prunes_silently(meth, interference_method, ti, expecteds, i, n, world)
                                 interference_fast_path_success = false
                                 break
                             end

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -417,53 +417,17 @@ function method_in_interferences(method2::Method, method1::Method)
     return false
 end
 
-# Check if method1 is more specific than method2 via the interference graph
-function method_morespecific_via_interferences(method1::Method, method2::Method)
-    if method1 === method2
-        return false
-    end
-
-    # Check direct interferences first
-    if method_in_interferences(method2, method1)
-        return false
-    end
-    if method_in_interferences(method1, method2)
-        return true
-    end
-
-    visited = Method[]
-    push!(visited, method2)
-
-    workqueue = Method[method2]
-    while !isempty(workqueue)
-        current = pop!(workqueue)
-        interferences = current.interferences
-        for k = 1:length(interferences)
-            isassigned(interferences, k) || break
-            method3 = interferences[k]::Method
-
-            # Check if we're already visiting this interference method (cycle prevention and memoization)
-            method3 in visited && continue
-            push!(visited, method3)
-
-            if method_in_interferences(current, method3)
-                continue # only follow edges to morespecific methods in search of the morespecific target (skip ambiguities)
-            end
-
-            # Check direct interferences for this interference method
-            if method_in_interferences(method3, method1)
-                continue # return false for this path
-            end
-            if method_in_interferences(method1, method3)
-                return true # found method1 in the interference graph
-            end
-
-            push!(workqueue, method3)
-        end
-    end
-
-    # slow check: @assert ms === morespecific(method1, method2) || typeintersect(method1.sig, method2.sig) === Union{} || typeintersect(method2.sig, method1.sig) === Union{}
-    return false
+# Whether method1 is strictly more specific than method2, read directly from the
+# recorded interference relation: method1 is in method2's set (so
+# !morespecific(method2, method1)) and method2 is not in method1's set (so
+# morespecific(method1, method2)). Because recording is complete for
+# intersecting pairs this is exact for them; for disjoint pairs neither
+# membership is recorded and it returns false (a disjoint method dominates
+# nothing), which is what the caller wants.
+# slow check: @assert ms === morespecific(method1, method2) || typeintersect(method1.sig, method2.sig) === Union{} || typeintersect(method2.sig, method1.sig) === Union{}
+function method_morespecific_recorded(method1::Method, method2::Method)
+    method1 === method2 && return false
+    return method_in_interferences(method1, method2) && !method_in_interferences(method2, method1)
 end
 
 # Max interference-set size for which n==1 uses the interference fast path instead of
@@ -560,7 +524,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                             # try looking for a different expected method that fully covers this interference_method anyways over their intersection
                             for j = 1:n
                                 meth2 = get_method_from_edge(expecteds[i+j-1])
-                                if method_morespecific_via_interferences(meth2, interference_method) && ti <: meth2.sig
+                                if method_morespecific_recorded(meth2, interference_method) && ti <: meth2.sig
                                     found_in_expecteds = true
                                     break
                                 end

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -417,13 +417,6 @@ function method_in_interferences(method2::Method, method1::Method)
     return false
 end
 
-# Check if method1 is more specific than method2 via the interference graph
-# equivalent to: ms === morespecific(method1, method2) || typeintersect(method1.sig, method2.sig) === Union{}
-function method_morespecific_recorded(method1::Method, method2::Method)
-    method1 === method2 && return false
-    return method_in_interferences(method1, method2) && !method_in_interferences(method2, method1)
-end
-
 # Max interference-set size for which n==1 uses the interference fast path instead of
 # `ml_matches`: the scan probes every member with `typeintersect`, so above this size the
 # pruned `ml_matches` lookup is cheaper (~8 is the empirical crossover).
@@ -517,16 +510,90 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                     if !found_in_expecteds
                         ti = typeintersect(sig, interference_method.sig)
                         if !(ti === Union{})
-                            # try looking for a different expected method that fully covers this interference_method anyways over their intersection
-                            for j = 1:n
-                                meth2 = get_method_from_edge(expecteds[i+j-1])
-                                if method_morespecific_recorded(meth2, interference_method) && ti <: meth2.sig
-                                    found_in_expecteds = true
-                                    break
+                            # An unexpected method intersecting sig can change more than the
+                            # match set: even when an expected method fully covers it (so the
+                            # pruned result below would compare equal), it can make `ml_matches`
+                            # flag an ambiguity -- a mutual pair or a specificity cycle with a
+                            # reported match -- which must invalidate below.
+                            if method_in_interferences(meth, interference_method)
+                                # Mutually ambiguous with the expected method whose set is
+                                # being scanned: the fresh sort always flags this pair (both
+                                # stay in the intersecting-match list), so only the full
+                                # lookup can decide this edge.
+                                interference_fast_path_success = false
+                                break
+                            end
+                            # This method strictly beats the scanned set's owner. Look for a
+                            # different expected method that covers it over this intersection
+                            # and provably certifies the removal as silent: only an expected
+                            # with an EMPTY interference set qualifies, since such a method
+                            # beats everything it intersects, so:
+                            #  - nothing beats or ties it, so it can never sit in a
+                            #    specificity cycle and always finalizes before the sort
+                            #    needs it as a cover;
+                            #  - every blocker transfer through it passes automatically;
+                            #  - being recorded in the set of every method it intersects, it
+                            #    patches any blocker-transfer region inside its signature
+                            #    for the other drops too.
+                            # The `Union{}` bottom-slurp methods are exactly this shape,
+                            # keeping verification fast when a later-added method intersects
+                            # sig only at the `Type{Union{}}` corner they resolve. Any other
+                            # unexpected entry is left to the full lookup (the sort's
+                            # dominance-transfer protocol): anything weaker re-opens the
+                            # cycle counterexamples, where a cover tangled in a specificity
+                            # cycle certifies a drop it must not.
+                            #
+                            # Additionally require every strict beater of this method to
+                            # have an empty interference set itself (like the cover, such a
+                            # beater cannot continue a specificity cycle). This is what
+                            # makes accepting purely conservative -- an acceptance implies
+                            # the full lookup would return exactly the expected methods with
+                            # no ambiguity -- because scanning only the expected methods'
+                            # sets then witnesses every dangerous change:
+                            #  - fully_covers means every method intersecting sig intersects
+                            #    some expected pointwise;
+                            #  - methods invisible here (strictly beaten by every expected
+                            #    they intersect, hence in no expected's set) always prune
+                            #    silently: the union of their intersecting expecteds covers
+                            #    them, and a failing blocker transfer would need a blocker
+                            #    that beats an expected cover -- visible by recording;
+                            #  - any cycle that could flag or change the result must thread
+                            #    an expected, entering through a visible strict beater of
+                            #    it -- an entry of this scan, which is either rejected here
+                            #    or, by the beater condition, provably not on any cycle.
+                            # Without the beater condition, a cycle through invisible
+                            # methods could re-enter the beaten expected behind this scan's
+                            # back (dragging it into an SCC mid-sort, where it stops
+                            # covering the invisible members and they survive into the
+                            # result): detecting that re-entry edge directly would mean
+                            # intersecting this method's own set against sig -- the full
+                            # lookup's price.
+                            local beaters_safe = true
+                            let interferences2 = interference_method.interferences
+                                for k2 = 1:length(interferences2)
+                                    isassigned(interferences2, k2) || break # no more entries
+                                    beater = interferences2[k2]::Method
+                                    world < beater.primary_world && break # this and later entries are for a future world
+                                    if !isempty(beater.interferences) &&
+                                        !method_in_interferences(interference_method, beater)
+                                        # a strict beater that could itself sit on a cycle
+                                        beaters_safe = false
+                                        break
+                                    end
+                                end
+                            end
+                            if beaters_safe
+                                for j2 = 1:n
+                                    meth2 = get_method_from_edge(expecteds[i+j2-1])
+                                    if isempty(meth2.interferences) &&
+                                        method_in_interferences(meth2, interference_method) &&
+                                        ti <: meth2.sig
+                                        found_in_expecteds = true
+                                        break
+                                    end
                                 end
                             end
                             if !found_in_expecteds
-                                meth2 = get_method_from_edge(expecteds[i])
                                 interference_fast_path_success = false
                                 break
                             end
@@ -555,6 +622,15 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         empty!(matches)
         maxworld[] = 0
     else
+        # A method added after this edge was recorded can be ambiguous with an expected
+        # match without changing this include_ambiguous=false result: the newcomer is
+        # pruned when an expected match fully covers their overlap, yet dispatch in the
+        # contested region now throws a MethodError that inference never accounted for.
+        # Until edges record that inference itself saw an ambiguity
+        # (JuliaLang/julia#62322), any ambiguity over sig must invalidate.
+        if has_ambig[] != 0
+            maxworld[] = 0
+        end
         # setdiff!(result, expected)
         if length(result) ≠ n
             maxworld[] = 0

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1246,31 +1246,56 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
             return false
         end
         if !ambiguous_bottom
-            # since we're intentionally ignoring certain ambiguities (via the
-            # filter call above), see if we can now declare the intersection fully
-            # covered even though it is partially ambiguous over Union{} as a type
-            # parameter somewhere
-            minmax = nothing
+            # Since we're intentionally ignoring certain ambiguities (via the
+            # filter call above), see if the intersection is nevertheless fully
+            # resolved by other methods. There need not be a single method that
+            # covers all of `ti`: several methods may each be more specific than
+            # both `m1` and `m2`, and together cover the whole intersection, in
+            # which case dispatch is never actually ambiguous between `m1` and
+            # `m2`.
+            #
+            # `morespecific` is not transitive, so being more specific than both
+            # `m1` and `m2` does not by itself guarantee that a method actually
+            # wins dispatch over its portion of the intersection: a specificity
+            # cycle may lead back to `m1` or `m2` (e.g. some `m4` more specific
+            # than the candidate resolver `m3`, while `m1` is more specific than
+            # `m4`), keeping the ambiguity real over the part of the
+            # intersection shared with `m4`. So first (transitively) reject
+            # every method that loses to `m1` or `m2` through such a chain, then
+            # check whether the union of the signatures of the remaining methods
+            # that are more specific than both `m1` and `m2` covers the whole
+            # intersection.
+            losers = IdSet{Method}()
+            worklist = Method[]
             for match in ms
                 m = match.method
-                match.fully_covers || continue
-                if minmax === nothing || morespecific(m, minmax)
-                    minmax = m
+                (m === m1 || m === m2) && continue
+                if morespecific(m1, m) || morespecific(m2, m)
+                    push!(losers, m)
+                    push!(worklist, m)
                 end
             end
-            if minmax === nothing || minmax == m1 || minmax == m2
-                return true
-            end
-            for match in ms
-                m = match.method
-                m === minmax && continue
-                if !morespecific(minmax, m)
-                    if match.fully_covers || !morespecific(m, minmax)
-                        return true
+            while !isempty(worklist)
+                u = pop!(worklist)
+                for match in ms
+                    m = match.method
+                    (m === m1 || m === m2 || m in losers) && continue
+                    if morespecific(u, m)
+                        push!(losers, m)
+                        push!(worklist, m)
                     end
                 end
             end
-            return false
+            resolvers = nothing
+            for match in ms
+                m = match.method
+                (m === m1 || m === m2 || m in losers) && continue
+                if morespecific(m, m1) && morespecific(m, m2)
+                    resolvers = resolvers === nothing ? match.spec_types : Union{resolvers, match.spec_types}
+                end
+            end
+            resolvers === nothing && return true
+            return !(ti <: resolvers)
         end
         return true
     end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1248,12 +1248,10 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
         # ml-matches did not need both methods to expose the reported ambiguity
         involves_both(ms) || return false
         if length(ms) != nms
-            # Since we intentionally removed certain ambiguities (via the
+            # If we intentionally removed certain ambiguities (via the
             # filter call above), re-run the runtime's match sort on the
             # remaining matches and see if the solution is still holding an ambiguity
-            # and m1 and m2 are both still reported in the solution. When the filter
-            # removed nothing, `ms` is exactly the sorted result from above and the
-            # re-sort could only recompute the same answer.
+            # and m1 and m2 are both still reported in the solution.
             if ccall(:jl_sort_method_matches, Cint, (Any, Cint), ms, true) == 0
                 return false
             end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1233,7 +1233,7 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
         end
         # if ml-matches reported the existence of an ambiguity over their
         # intersection, see if both m1 and m2 seem to be involved in it
-        # (if one was fully dominated by a different method, we want to will
+        # (if one was fully dominated by a different method, we want to
         # report the other ambiguous pair)
         have_m1 = have_m2 = false
         for match in ms
@@ -1248,12 +1248,11 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
         if !ambiguous_bottom
             # Since we're intentionally ignoring certain ambiguities (via the
             # filter call above), re-run the runtime's match sort on the
-            # remaining matches: without the Union{}-parameter matches, the
-            # apparent ambiguity may now be resolved by the other more specific
-            # methods (possibly only by a union of several of them together).
-            # This prunes every match that can no longer be a dispatch target
-            # from `ms` and recomputes whether any ambiguity remains.
-            ccall(:jl_sort_method_matches, Cint, (Any, Cint), ms, true) == 0 && return false
+            # remaining matches and see if the solution is still holding an ambiguity
+            # and m1 and m2 are both still reported in the solution
+            if ccall(:jl_sort_method_matches, Cint, (Any, Cint), ms, true) == 0
+                return false
+            end
             have_m1 = have_m2 = false
             for match in ms
                 m = (match::Core.MethodMatch).method
@@ -1261,8 +1260,6 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
                 m === m2 && (have_m2 = true)
             end
             if !have_m1 || !have_m2
-                # the remaining ambiguity is not between m1 and m2 (at least one
-                # of them can never be the dispatch target over `ti`)
                 return false
             end
         end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1226,42 +1226,38 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
         has_ambig = Ref{Int32}(0)
         ms = _methods_by_ftype(ti, nothing, -1, world, true, min, max, has_ambig)::Vector{Any}
         has_ambig[] == 0 && return false
-        if !ambiguous_bottom
-            filter!(ms) do m
-                return !has_bottom_parameter((m::Core.MethodMatch).spec_types)
-            end
-        end
         # if ml-matches reported the existence of an ambiguity over their
         # intersection, see if both m1 and m2 seem to be involved in it
         # (if one was fully dominated by a different method, we want to
         # report the other ambiguous pair)
-        have_m1 = have_m2 = false
-        for match in ms
-            m = (match::Core.MethodMatch).method
-            m === m1 && (have_m1 = true)
-            m === m2 && (have_m2 = true)
-        end
-        if !have_m1 || !have_m2
-            # ml-matches did not need both methods to expose the reported ambiguity
-            return false
-        end
-        if !ambiguous_bottom
-            # Since we're intentionally ignoring certain ambiguities (via the
-            # filter call above), re-run the runtime's match sort on the
-            # remaining matches and see if the solution is still holding an ambiguity
-            # and m1 and m2 are both still reported in the solution
-            if ccall(:jl_sort_method_matches, Cint, (Any, Cint), ms, true) == 0
-                return false
-            end
+        function involves_both(ms)
             have_m1 = have_m2 = false
             for match in ms
                 m = (match::Core.MethodMatch).method
                 m === m1 && (have_m1 = true)
                 m === m2 && (have_m2 = true)
             end
-            if !have_m1 || !have_m2
+            return have_m1 && have_m2
+        end
+        nms = length(ms)
+        if !ambiguous_bottom
+            filter!(ms) do m
+                return !has_bottom_parameter((m::Core.MethodMatch).spec_types)
+            end
+        end
+        # ml-matches did not need both methods to expose the reported ambiguity
+        involves_both(ms) || return false
+        if length(ms) != nms
+            # Since we intentionally removed certain ambiguities (via the
+            # filter call above), re-run the runtime's match sort on the
+            # remaining matches and see if the solution is still holding an ambiguity
+            # and m1 and m2 are both still reported in the solution. When the filter
+            # removed nothing, `ms` is exactly the sorted result from above and the
+            # re-sort could only recompute the same answer.
+            if ccall(:jl_sort_method_matches, Cint, (Any, Cint), ms, true) == 0
                 return false
             end
+            involves_both(ms) || return false
         end
         return true
     end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1224,11 +1224,11 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
         min = Ref{UInt}(typemin(UInt))
         max = Ref{UInt}(typemax(UInt))
         has_ambig = Ref{Int32}(0)
-        ms = collect(Core.MethodMatch, _methods_by_ftype(ti, nothing, -1, world, true, min, max, has_ambig)::Vector)
+        ms = _methods_by_ftype(ti, nothing, -1, world, true, min, max, has_ambig)::Vector{Any}
         has_ambig[] == 0 && return false
         if !ambiguous_bottom
-            filter!(ms) do m::Core.MethodMatch
-                return !has_bottom_parameter(m.spec_types)
+            filter!(ms) do m
+                return !has_bottom_parameter((m::Core.MethodMatch).spec_types)
             end
         end
         # if ml-matches reported the existence of an ambiguity over their
@@ -1237,7 +1237,7 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
         # report the other ambiguous pair)
         have_m1 = have_m2 = false
         for match in ms
-            m = match.method
+            m = (match::Core.MethodMatch).method
             m === m1 && (have_m1 = true)
             m === m2 && (have_m2 = true)
         end
@@ -1247,55 +1247,24 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
         end
         if !ambiguous_bottom
             # Since we're intentionally ignoring certain ambiguities (via the
-            # filter call above), see if the intersection is nevertheless fully
-            # resolved by other methods. There need not be a single method that
-            # covers all of `ti`: several methods may each be more specific than
-            # both `m1` and `m2`, and together cover the whole intersection, in
-            # which case dispatch is never actually ambiguous between `m1` and
-            # `m2`.
-            #
-            # `morespecific` is not transitive, so being more specific than both
-            # `m1` and `m2` does not by itself guarantee that a method actually
-            # wins dispatch over its portion of the intersection: a specificity
-            # cycle may lead back to `m1` or `m2` (e.g. some `m4` more specific
-            # than the candidate resolver `m3`, while `m1` is more specific than
-            # `m4`), keeping the ambiguity real over the part of the
-            # intersection shared with `m4`. So first (transitively) reject
-            # every method that loses to `m1` or `m2` through such a chain, then
-            # check whether the union of the signatures of the remaining methods
-            # that are more specific than both `m1` and `m2` covers the whole
-            # intersection.
-            losers = IdSet{Method}()
-            worklist = Method[]
+            # filter call above), re-run the runtime's match sort on the
+            # remaining matches: without the Union{}-parameter matches, the
+            # apparent ambiguity may now be resolved by the other more specific
+            # methods (possibly only by a union of several of them together).
+            # This prunes every match that can no longer be a dispatch target
+            # from `ms` and recomputes whether any ambiguity remains.
+            ccall(:jl_sort_method_matches, Cint, (Any, Cint), ms, true) == 0 && return false
+            have_m1 = have_m2 = false
             for match in ms
-                m = match.method
-                (m === m1 || m === m2) && continue
-                if morespecific(m1, m) || morespecific(m2, m)
-                    push!(losers, m)
-                    push!(worklist, m)
-                end
+                m = (match::Core.MethodMatch).method
+                m === m1 && (have_m1 = true)
+                m === m2 && (have_m2 = true)
             end
-            while !isempty(worklist)
-                u = pop!(worklist)
-                for match in ms
-                    m = match.method
-                    (m === m1 || m === m2 || m in losers) && continue
-                    if morespecific(u, m)
-                        push!(losers, m)
-                        push!(worklist, m)
-                    end
-                end
+            if !have_m1 || !have_m2
+                # the remaining ambiguity is not between m1 and m2 (at least one
+                # of them can never be the dispatch target over `ti`)
+                return false
             end
-            resolvers = nothing
-            for match in ms
-                m = match.method
-                (m === m1 || m === m2 || m in losers) && continue
-                if morespecific(m, m1) && morespecific(m, m2)
-                    resolvers = resolvers === nothing ? match.spec_types : Union{resolvers, match.spec_types}
-                end
-            end
-            resolvers === nothing && return true
-            return !(ti <: resolvers)
         end
         return true
     end

--- a/src/gf.c
+++ b/src/gf.c
@@ -352,7 +352,7 @@ jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *sname, jl_fptr_args
     m->isva = 1;
     m->nargs = 2;
     jl_atomic_store_relaxed(&m->primary_world, 1);
-    jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_LATEST_WHICH);
+    jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_LATEST_WHICH | METHOD_SIG_NO_LOSERS);
     m->sig = (jl_value_t*)tuptyp;
     m->slot_syms = jl_an_empty_string;
     m->nospecialize = 0;
@@ -3082,10 +3082,20 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
 // pass), which the caller must record as an ambiguity.
 static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t)
 {
+    // If D is not strictly morespecific than anything it intersects
+    // (METHOD_SIG_NO_LOSERS), it was beating nobody and there is nothing to
+    // transfer: the removal is unconditionally silent.
+    if (jl_atomic_load_relaxed(&D->dispatch_status) & METHOD_SIG_NO_LOSERS)
+        return 1;
     size_t len = jl_array_nrows(t);
     for (size_t i = 0; i < len; i++) {
         jl_method_t *S = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
         if (S == D)
+            continue;
+        // An S that beats nothing can never strictly beat a cover, so it can
+        // never close a directed cycle: whether the covers dominate it is then
+        // irrelevant (the unordered case falls through to safety below anyway).
+        if (jl_atomic_load_relaxed(&S->dispatch_status) & METHOD_SIG_NO_LOSERS)
             continue;
         // only consider S that D is strictly morespecific than
         if (!method_morespecific_recorded(D, S))
@@ -3228,6 +3238,8 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
     assert(result == jl_method_morespecific(target_method, start_method) ||
            jl_has_empty_intersection(target_method->sig, start_method->sig) ||
            jl_has_empty_intersection(start_method->sig, target_method->sig));
+    // a method recorded as strictly beating something must not carry NO_LOSERS
+    assert(!result || !(jl_atomic_load_relaxed(&target_method->dispatch_status) & METHOD_SIG_NO_LOSERS));
     return result;
 }
 
@@ -3273,6 +3285,13 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     }
 
     int invalidated = 0;
+    // Tentatively assume the new method is not strictly morespecific than
+    // anything it intersects (METHOD_SIG_NO_LOSERS); the scan below clears it
+    // on the first method this one beats. Conversely, an old method that this
+    // one is beaten by keeps its state, and an old method that is beaten
+    // (morespec[j], conservatively including both-ways-morespecific pairs)
+    // loses its bit.
+    int dispatch_bits = METHOD_SIG_LATEST_WHICH | METHOD_SIG_NO_LOSERS;
     // Holds the set of all intersecting methods not more specific than this one.
     // The insertion scan below visits every intersecting method (the
     // LATEST_ONLY early-out was removed), so the recorded relation is complete:
@@ -3289,6 +3308,10 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             method_overwrite(newentry, m);
             // This is an optimized version of below, given we know the type-intersection is exact
             jl_method_table_invalidate(m, max_world);
+            // The replacement has the same signature, so it inherits the
+            // replaced method's specificity relations, including NO_LOSERS
+            if (!(jl_atomic_load_relaxed(&m->dispatch_status) & METHOD_SIG_NO_LOSERS))
+                dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
             // Clear METHOD_SIG_LATEST_WHICH bit
             jl_atomic_store_relaxed(&m->dispatch_status, 0);
             // Take over the interference list from the replaced method
@@ -3354,6 +3377,16 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                     ssize_t idx;
                     if (!has_key(interferences, (jl_value_t*)m))
                         interferences = jl_idset_put_key(interferences, (jl_value_t*)m, &idx);
+                }
+                if (morespec[j]) {
+                    // morespecific(old, new): the old method gained a strict loser
+                    int m_dispatch = jl_atomic_load_relaxed(&m->dispatch_status);
+                    if (m_dispatch & METHOD_SIG_NO_LOSERS)
+                        jl_atomic_store_relaxed(&m->dispatch_status, m_dispatch & ~METHOD_SIG_NO_LOSERS);
+                }
+                else if (!ambig) {
+                    // morespecific(new, old): the new method beats something
+                    dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
                 }
                 if (!morespec[j]) {
                     // !morespecific(old, new): add the new method to its interference set
@@ -3472,7 +3505,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         jl_array_ptr_1d_push(_jl_debug_method_invalidation, loctag);
     }
     jl_atomic_store_relaxed(&newentry->max_world, ~(size_t)0);
-    jl_atomic_store_relaxed(&method->dispatch_status, METHOD_SIG_LATEST_WHICH); // TODO: this should be sequenced fully after the world counter store
+    jl_atomic_store_relaxed(&method->dispatch_status, dispatch_bits); // TODO: this should be sequenced fully after the world counter store
     jl_gc_write_atomic(method, method->interferences, jl_genericmemory_t, interferences, release);
     JL_GC_POP();
 }

--- a/src/gf.c
+++ b/src/gf.c
@@ -3324,8 +3324,6 @@ static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, 
     if (include_ambiguous && *has_ambiguity)
         return 0; // this can only compute *has_ambiguity, which is already known
     int result = 0;
-    // Root the snapshot across the `jl_subtype` safepoints (see
-    // `check_dominance_transfer`).
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
     JL_GC_PUSH1(&interferences);
     for (size_t i = 0; i < interferences->length; i++) {
@@ -3414,10 +3412,8 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             // Take over the interference list from the replaced method.
             // (TODO: we should consider recomputing it instead, since type-equal
             // doesn't imply more-specific-equal: an inherited edge may misstate
-            // this method's specificity against a third method, silently making
-            // the interference records diverge from ground truth. When debugging
-            // a suspected missed ambiguity, re-enable the expensive cross-check
-            // in `method_morespecific_recorded` to detect such divergence.)
+            // this method's specificity against a third method, making the
+            // interference records incorrect.
             jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
             if (interferences->length == 0) {
                 interferences = jl_genericmemory_copy(m_interferences);
@@ -5371,13 +5367,6 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                 }
 
                 // Process interferences iteratively.
-                // The set is reloaded on every iteration rather than cached in
-                // the frame: the frame lives in malloc'd memory that no GC scan
-                // can see, and a concurrent method definition may swap in a
-                // grown copy of the set, leaving a cached snapshot unreachable
-                // across the safepoints below. The entries already present are
-                // a stable prefix of any replacement, so the cached count and
-                // cursor stay valid.
                 while (current->interference_index < current->interference_count) {
                     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&current->m->interferences);
                     jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, current->interference_index);
@@ -5435,13 +5424,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
             case STATE_CHECK_COVERS: {
                 // There is some probability that this method is already fully covered
                 // now, and we can delete this vertex now without anyone noticing.
-                // A match dominated by the minmax method needs no special case
-                // here: minmax is pre-marked visited (it is unconditionally
-                // reported), so `check_interferences_covers` can use it as a
-                // cover like any other finalized match -- together with the
-                // other covers and their union, which a lone minmax transfer
-                // could not consult (test `AmbigMinmaxUnion`).
-                if (check_interferences_covers(current->m, current->ti, t, visited, minmaxm, include_ambiguous, has_ambiguity)) {
+               if (check_interferences_covers(current->m, current->ti, t, visited, minmaxm, include_ambiguous, has_ambiguity)) {
                     visited->items[current->idx] = (void*)1;
                 }
                 else if (check_fully_ambiguous(current->m, current->ti, t, include_ambiguous, has_ambiguity)) {
@@ -5667,9 +5650,6 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         jl_method_t *minmaxm = NULL;
         if (minmax != NULL) {
             minmaxm = minmax->method;
-            // `t` is unchanged since `minmax_idx` was recorded: the only
-            // reorder above (the all-subtypes fast path) leaves len == 1,
-            // which skips this block.
             assert((jl_method_match_t*)jl_array_ptr_ref(t, minmax_idx) == minmax);
             visited.items[minmax_idx] = (void*)1;
         }

--- a/src/gf.c
+++ b/src/gf.c
@@ -3266,7 +3266,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
 
     int invalidated = 0;
     int precompiled_status = jl_atomic_load_relaxed(&method->dispatch_status);
-    // Always set LATEST_WHICH and carry over NO_LOSERS from initialization and accross precompilation
+    // Always set LATEST_WHICH and carry over NO_LOSERS from initialization and across precompilation
     int dispatch_bits = METHOD_SIG_LATEST_WHICH | (precompiled_status & METHOD_SIG_NO_LOSERS);
     // Holds the set of all intersecting methods not more specific than this one.
     interferences = (jl_genericmemory_t*)jl_atomic_load_relaxed(&method->interferences);

--- a/src/gf.c
+++ b/src/gf.c
@@ -5128,7 +5128,17 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     if (closure->match.max_valid > max_world)
         closure->match.max_valid = max_world;
     jl_method_t *meth = ml->func.method;
-    int only = jl_atomic_load_relaxed(&meth->dispatch_status) & METHOD_SIG_LATEST_ONLY;
+    // Whether this method dominates (is strictly morespecific than) every
+    // method it intersects, and hence every other candidate for this query:
+    // either its LATEST_ONLY bit is set, or its interference set is empty (the
+    // ground-truth relation, which the bit tracks in lockstep except that the
+    // bit can be suppressed by PRECOMPILE_MANY). Such a method always survives
+    // into the final result (nothing can cover a method that beats every
+    // intersecting method), and when it also fully covers the query it is the
+    // unique result, so the rest of the search can be skipped. Interference
+    // sets only grow, so emptiness now implies emptiness in the query's world.
+    int only = (jl_atomic_load_relaxed(&meth->dispatch_status) & METHOD_SIG_LATEST_ONLY) ||
+               jl_atomic_load_relaxed(&meth->interferences)->length == 0;
     if (closure->lim >= 0 && only) {
         if (closure->lim == 0) {
             closure->t = jl_an_empty_vec_any;
@@ -5475,6 +5485,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
     // more-specific than any other fully-covering method (but if !all_subtypes, there are
     // non-fully-covering methods to which it is _likely_ not more specific)
     jl_method_match_t *minmax = NULL;
+    int minmax_dominates = 0;
     int any_subtypes = 0;
     if (len > 1) {
         // first try to pre-process the results to find the most specific option
@@ -5486,6 +5497,21 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             if (matc->fully_covers == FULLY_COVERS) {
                 any_subtypes = 1;
                 jl_method_t *m = matc->method;
+                // A fully-covering match with an empty interference set is
+                // strictly morespecific than every method it intersects
+                // (recording is complete), and every other match intersects it
+                // (through the query type it covers): it is the unique
+                // dispatch winner over the whole query, every other match can
+                // be dropped with `m` itself as the dominating cover, and no
+                // ambiguity can involve it. Since interference sets only ever
+                // grow, emptiness now implies emptiness in the query's world.
+                // (Two such matches cannot coexist: they would intersect, so
+                // one of the two memberships would be recorded.)
+                if (jl_atomic_load_relaxed(&m->interferences)->length == 0) {
+                    minmax = matc;
+                    minmax_dominates = 1;
+                    break;
+                }
                 for (j = 0; j < len; j++) {
                     if (i == j)
                         continue;
@@ -5513,7 +5539,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         //     (we will look for this later, when we compute ambig_groupid, for
         //     correctness)
         int all_subtypes = any_subtypes;
-        if (any_subtypes) {
+        if (any_subtypes && !minmax_dominates) {
             jl_method_t *minmaxm = NULL;
             if (minmax != NULL)
                 minmaxm = minmax->method;

--- a/src/gf.c
+++ b/src/gf.c
@@ -2304,15 +2304,6 @@ static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_in
     if (closure->shadowed == NULL)
         closure->shadowed = (jl_value_t*)jl_alloc_vec_any(0);
     // Record every intersecting method so the interference relation is complete.
-    // We must NOT early-out when the new method is a strict subtype of an
-    // `oldmethod` that dominates its dispatch (empty interference set): stopping
-    // the scan there would omit the new method's other intersecting pairs, and
-    // `morespecific` is not monotone under subtyping (strict-subtype implies
-    // morespecific, but the supertype's specificity relations do not transfer to
-    // the subtype and can even reverse), so a dominated-looking supertype can
-    // still hide intersections that must be recorded. `typemap_slurp_search`
-    // below is only the shared `Type{Union{}}` (exclude_typeofbottom) traversal
-    // hint used on the query path too; it does not drop intersecting entries.
     jl_array_ptr_1d_push((jl_array_t*)closure->shadowed, (jl_value_t*)oldmethod);
     typemap_slurp_search(oldentry, &closure->match);
     return 1;
@@ -3049,21 +3040,8 @@ static int has_key(jl_genericmemory_t *keys, jl_value_t *key)
 }
 
 // Check if m2 is in m1's interferences set, which means !morespecific(m1, m2)
-//
-// Completeness contract: for any two currently-live methods with intersecting
-// signatures, at least one of `method_in_interferences(a, b)` /
-// `method_in_interferences(b, a)` is recorded (both, when they are mutually
-// non-morespecific, i.e. ambiguous), and each present membership implies its
-// `!morespecific` fact. This holds because `jl_method_table_activate` visits
-// every intersecting method when recording (no LATEST_ONLY / dominance
-// early-out). For disjoint pairs neither membership is present.
-//
-// Tolerated staleness: a set may still name methods that have since been
-// deleted, or methods not yet visible in the querying world (a set is populated
-// at insertion and not pruned on deletion). Consumers must filter by world
-// (reinfer.jl checks METHOD_SIG_LATEST_WHICH / primary_world; gf.c filters
-// through find_method_in_matches, which only keeps methods present in the
-// current query's match array).
+// for two methods that were at any point live in the same table at the same time
+// over some type-intersection
 static int method_in_interferences(jl_method_t *m2, jl_method_t *m1)
 {
     return has_key(jl_atomic_load_relaxed(&m1->interferences), (jl_value_t*)m2);
@@ -3081,13 +3059,7 @@ static int find_method_in_matches(jl_array_t *t, jl_method_t *method)
     return -1;
 }
 
-// Whether `target_method` is strictly morespecific than `start_method`, read
-// directly from the recorded interference relation (which is complete for
-// intersecting pairs, see `method_in_interferences`). Exact for intersecting
-// pairs; returns 0 for disjoint pairs (neither membership is recorded), which
-// is the answer the covering/dominance callers want (a disjoint method cannot
-// dominate another).
-static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method);
+static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method) JL_CANSAFEPOINT;
 
 // About to remove match `D` from the possible dispatch targets, since it is
 // fully covered by the strictly-morespecific cover(s) `covers` and thus can
@@ -3098,7 +3070,7 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
 // removal is safe, or 0 when such a method exists, meaning the sorted order is
 // not exact over this query (removing `D` would hide the cycle from the SCC
 // pass), which the caller must record as an ambiguity.
-static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t)
+static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t) JL_CANSAFEPOINT
 {
     // If D is not strictly morespecific than anything it intersects
     // (METHOD_SIG_NO_LOSERS), it was beating nobody and there is nothing to
@@ -3112,10 +3084,9 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
             continue;
         // An S that beats nothing can never strictly beat a cover, so it can
         // never close a directed cycle: whether the covers dominate it is then
-        // irrelevant (the unordered case falls through to safety below anyway).
+        // irrelevant (as a fast-path)
         if (jl_atomic_load_relaxed(&S->dispatch_status) & METHOD_SIG_NO_LOSERS)
             continue;
-        // only consider S that D is strictly morespecific than
         if (!method_morespecific_recorded(D, S))
             continue;
         size_t j;
@@ -3124,12 +3095,12 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
                 break;
         }
         if (j == ncovers) {
-            // No cover dominates S. That is only dangerous when S strictly
-            // beats one of the covers (a directed specificity cycle through
-            // D); if S is merely mutually ambiguous with (or unordered
-            // against) the covers, that ambiguity is recorded on their own
-            // interference edges and remains visible to check_fully_ambiguous
-            // independent of D's removal.
+            // No cover dominates S. Now check if S strictly beats one of the
+            // covers (detecting a directed specificity cycle through D); if
+            // S is merely mutually ambiguous with (or unordered against) the
+            // covers, that ambiguity is recorded on their own interference
+            // edges and remains visible to check_fully_ambiguous independent
+            // of D's removal.
             for (j = 0; j < ncovers; j++) {
                 if (method_morespecific_recorded(S, covers[j]))
                     return 0;
@@ -3149,10 +3120,7 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
 {
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
     // First: is `m` fully covered (dominated over the whole query region `ti`)
-    // by a single recorded strictly-morespecific method? Because recording is
-    // complete, any such method intersects `m` and is morespecific than it, so
-    // `!morespecific(m, it)` was recorded and it is a *direct* member of `m`'s
-    // interference set: a single pass suffices, with no transitive chase.
+    // by a single recorded strictly-morespecific method?
     for (size_t i = 0; i < interferences->length; i++) {
         jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
         if (m2 == NULL)
@@ -3161,7 +3129,7 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
         if (idx < 0)
             continue;
         if (method_in_interferences(m, m2))
-            continue; // mutual interference (ambiguous), not a strict cover
+            continue; // ambiguous
         if (visited->items[idx] != (void*)1)
             continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
         if (jl_subtype(ti, m2->sig)) {
@@ -3196,7 +3164,7 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
             continue;
         if (visited->items[idx] != (void*)1 || tainted[idx])
             continue;
-        if (method_in_interferences(m, m2)) // mutual interference (ambiguous)
+        if (method_in_interferences(m, m2)) // ambiguous
             continue;
         covers[ncovers++] = m2;
     }
@@ -3240,25 +3208,17 @@ static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, 
     return 0;
 }
 
-// Whether target_method is strictly morespecific than start_method, read
-// directly from the recorded interference relation: target is in start's set
-// (so !morespecific(start, target)) but start is not in target's set (so
-// morespecific(target, start)). Because recording is complete for intersecting
-// pairs, this is exact for them; for disjoint pairs neither membership is
-// present and the result is 0 (a disjoint method dominates nothing), which is
-// what the covering/dominance callers want. The assert documents that contract.
-static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method)
+// Whether `target_method` is morespecific than `start_method`, and has an type-intersection
+static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method) JL_CANSAFEPOINT
 {
     if (target_method == start_method)
         return 0;
     int result = method_in_interferences(target_method, start_method) &&
                  !method_in_interferences(start_method, target_method);
-    assert(result == jl_method_morespecific(target_method, start_method) ||
-           jl_has_empty_intersection(target_method->sig, start_method->sig) ||
-           jl_has_empty_intersection(start_method->sig, target_method->sig));
-    // a method recorded as strictly beating something must not carry NO_LOSERS
-    // (the replacement path clears the bit for the recency-tiebreak win it
-    // records over the type-equal method it replaces)
+    //// Expensive cross-check:
+    //assert(result == jl_method_morespecific(target_method, start_method) ||
+    //       jl_has_empty_intersection(target_method->sig, start_method->sig) ||
+    //       jl_has_empty_intersection(start_method->sig, target_method->sig));
     assert(!result || !(jl_atomic_load_relaxed(&target_method->dispatch_status) & METHOD_SIG_NO_LOSERS));
     return result;
 }
@@ -3305,23 +3265,10 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     }
 
     int invalidated = 0;
-    // METHOD_SIG_NO_LOSERS is carried in from the method's current state, not
-    // re-derived: it is set at method creation and monotone-cleared. The scan
-    // below clears it on the first method this one beats; conversely an old
-    // method that is beaten (morespec[j], conservatively including
-    // both-ways-morespecific pairs) loses its bit. The bit must survive
-    // serialization (like the interference sets, and unlike LATEST_WHICH)
-    // because a cache-image batch shares one world: this scan runs against the
-    // prior world and cannot see same-image methods, so their pairs are never
-    // re-derived at load and only the precompile-time state is correct.
     int precompiled_status = jl_atomic_load_relaxed(&method->dispatch_status);
+    // Always set LATEST_WHICH and carry over NO_LOSERS from initialization and accross precompilation
     int dispatch_bits = METHOD_SIG_LATEST_WHICH | (precompiled_status & METHOD_SIG_NO_LOSERS);
     // Holds the set of all intersecting methods not more specific than this one.
-    // The insertion scan below visits every intersecting method (the
-    // LATEST_ONLY early-out was removed), so the recorded relation is complete:
-    // for any two currently-live methods with intersecting signatures, at least
-    // one of the two memberships is present (see the contract on
-    // `method_in_interferences`).
     interferences = (jl_genericmemory_t*)jl_atomic_load_relaxed(&method->interferences);
     if (oldvalue) {
         assert(n > 0);
@@ -3333,15 +3280,12 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             // This is an optimized version of below, given we know the type-intersection is exact
             jl_method_table_invalidate(m, max_world);
             // The replacement strictly beats the replaced method (the recency
-            // tiebreak in `jl_method_morespecific` for type-equal signatures,
-            // recorded below), so it always has at least that one strict loser.
-            // NO_LOSERS cannot be inherited: type-equal does not imply
-            // morespecific-equal, so the predecessor's relations do not
-            // transfer.
+            // tiebreak in `jl_method_morespecific` for type-equal signatures).
             dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
             // Clear METHOD_SIG_LATEST_WHICH bit
             jl_atomic_store_relaxed(&m->dispatch_status, 0);
             // Take over the interference list from the replaced method
+            // (TODO: we should consider recomputing it instead, since type-equal doesn't imply more-specific-equal)
             jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
             if (interferences->length == 0) {
                 interferences = jl_genericmemory_copy(m_interferences);
@@ -3360,20 +3304,13 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             jl_gc_write_atomic(m, m->interferences, jl_genericmemory_t, m_interferences, release);
             for (j = 0; j < n; j++) {
                 jl_method_t *m2 = d[j];
-                if (m2 && method_in_interferences(m, m2)) {
+                if (!m2 || m == m2)
+                    continue;
+                if (method_in_interferences(m, m2)) {
                     jl_genericmemory_t *m2_interferences = jl_atomic_load_relaxed(&m2->interferences);
                     ssize_t idx;
                     m2_interferences = jl_idset_put_key(m2_interferences, (jl_value_t*)method, &idx);
                     jl_gc_write_atomic(m2, m2->interferences, jl_genericmemory_t, m2_interferences, release);
-                }
-                if (m2 && m2 != m) {
-                    // Recompute the partner's NO_LOSERS against the
-                    // replacement's own signature: type-equal does not imply
-                    // morespecific-equal, so `morespecific(m2, method)` may
-                    // hold where `morespecific(m2, m)` did not.
-                    int m2_dispatch = jl_atomic_load_relaxed(&m2->dispatch_status);
-                    if ((m2_dispatch & METHOD_SIG_NO_LOSERS) && jl_type_morespecific(m2->sig, type))
-                        jl_atomic_store_relaxed(&m2->dispatch_status, m2_dispatch & ~METHOD_SIG_NO_LOSERS);
                 }
             }
             loctag = jl_atomic_load_relaxed(&m->specializations); // use loctag for a gcroot
@@ -5162,13 +5099,6 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     if (closure->match.max_valid > max_world)
         closure->match.max_valid = max_world;
     jl_method_t *meth = ml->func.method;
-    // An empty interference set means this method is strictly morespecific
-    // than every method it intersects, and hence than every other candidate
-    // for this query. Such a method always survives into the final result
-    // (nothing can cover a method that beats every intersecting method), and
-    // when it also fully covers the query it is the unique result, so the rest
-    // of the search can be skipped. Interference sets only grow, so emptiness
-    // now implies emptiness in the query's world.
     int only = jl_atomic_load_relaxed(&meth->interferences)->length == 0;
     if (closure->lim >= 0 && only) {
         if (closure->lim == 0) {
@@ -5210,6 +5140,7 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
 //  * `t`: the array of vertexes (method matches)
 //  * `idx`: the next vertex to add to the output
 //  * `visited`: the state of the algorithm for each vertex in `t`: either 1 if we visited it already or 1+depth if we are visiting it now
+//  * `tainted`: TBD
 //  * `stack`: the state of the algorithm for the current vertex (up to length equal to `t`): the list of all vertexes currently in the depth-first path or in the current SCC
 //  * `result`: the output of the algorithm, a sorted list of vertexes (up to length `lim`)
 //  * `lim`: either -1 for unlimited matches, or the maximum length for `result` before returning failure (return -1).
@@ -5500,9 +5431,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
 // Sort the intersecting matches in `t` (a Vector{Any} of MethodMatch, as
 // collected for a single query type) into dispatch order, removing every match
 // that can never be the dispatch target over its intersection with the query
-// (being fully covered by more specific methods), and setting *has_ambiguity
-// if the sorted order of the remaining matches is not exact (some of them are
-// ambiguous with each other over part of the query). When `approximate_ambig`
+// (being fully covered by more specific methods). When `approximate_ambig`
 // is set, the caller does not need *has_ambiguity computed accurately and it
 // is pessimistically set to 1 without attempting to prove otherwise.
 // Returns the new length of `t`, or -1 if `lim` was exceeded (in which case
@@ -5530,14 +5459,8 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 jl_method_t *m = matc->method;
                 // A fully-covering match with an empty interference set is
                 // strictly morespecific than every method it intersects
-                // (recording is complete), and every other match intersects it
-                // (through the query type it covers): it is the unique
-                // dispatch winner over the whole query, every other match can
-                // be dropped with `m` itself as the dominating cover, and no
-                // ambiguity can involve it. Since interference sets only ever
-                // grow, emptiness now implies emptiness in the query's world.
-                // (Two such matches cannot coexist: they would intersect, so
-                // one of the two memberships would be recorded.)
+                // meaning it is already proven to be the `minmax` choice
+                // without exploring the list any further
                 if (jl_atomic_load_relaxed(&m->interferences)->length == 0) {
                     minmax = matc;
                     minmax_dominates = 1;

--- a/src/gf.c
+++ b/src/gf.c
@@ -3248,7 +3248,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
 
     int invalidated = 0;
     int precompiled_status = jl_atomic_load_relaxed(&method->dispatch_status);
-    // Always set LATEST_WHICH and carry over NO_LOSERS from initialization and accross precompilation
+    // Always set LATEST_WHICH and carry over NO_LOSERS from initialization and across precompilation
     int dispatch_bits = METHOD_SIG_LATEST_WHICH | (precompiled_status & METHOD_SIG_NO_LOSERS);
     // Holds the set of all intersecting methods not more specific than this one.
     interferences = (jl_genericmemory_t*)jl_atomic_load_relaxed(&method->interferences);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3186,9 +3186,6 @@ static int check_dominance_transfer(jl_method_t *D, jl_value_t *ti, jl_method_t 
     // exempt from that scan -- notably when S is the minmax method, which the
     // sort never visits -- leaving this check as the only witness of the pair
     // when D's only cover is a match that S beats (test `AmbigMinmaxPartner`))
-    // Root the interference-set snapshot: a concurrent method definition may
-    // swap in a grown copy, leaving this one unreachable across the safepoints
-    // in `check_blocker_transfer`.
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&D->interferences);
     JL_GC_PUSH1(&interferences);
     for (size_t i = 0; i < interferences->length; i++) {
@@ -3241,51 +3238,50 @@ static int check_dominance_transfer(jl_method_t *D, jl_value_t *ti, jl_method_t 
 // match was blocking another match, sets *has_ambiguity; in that case the match
 // is only reported as covered when `include_ambiguous` is false, so that
 // ambiguity-reporting consumers still see it.
+//
+// The return value certifies whether to drop m from the reported matches.
 static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, jl_method_t *minmaxm, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
-    int transfer_failed = 0;
+    // Outcome of the cover analysis for one match `m` over its region `ti`, in
+    // increasing strength -- each step of the analysis only ever raises it:
+    enum {
+        COVER_NONE = 0,      // no strictly-morespecific cover contains ti: m may still be selectable
+        COVER_AMBIGUOUS = 1, // covers contain ti (so m can never win) but could not take over the
+                             // roles m had in the sort, so the apparent ambiguity is real
+        COVER_CERTIFIED = 2, // covers contain ti and took over m's roles: dropping m is silent
+    } status = COVER_NONE;
+
+    // Optimization: when ambiguity is already known and the caller does not want ambiguous
+    // matches reported, m is dropped either way, so skip the transfer proofs.
+    int prove_transfer = include_ambiguous || !*has_ambiguity;
+
+    // The minmax method contains every match's region, is reported unconditionally,
+    // and is pre-finalized, so whenever it strictly beats `m` it is an admissible cover:
+    // probe it directly before scanning the interference set in storage order.
     int probed_minmax = 0;
-    // The minmax method contains every match's region (it fully covers the
-    // query, and `ti` normally is contained in the query -- though an imprecise
-    // intersection still requires the explicit subtype check), is reported
-    // unconditionally, and is pre-finalized, so whenever it strictly beats `m`
-    // it is an admissible cover: probe it directly before scanning the
-    // interference set in storage order.
     if (minmaxm != NULL && method_morespecific_recorded(minmaxm, m) &&
         jl_subtype(ti, (jl_value_t*)minmaxm->sig)) {
         probed_minmax = 1;
-        // minmaxm is strictly morespecific than m (a one-directional recorded
-        // edge) and fully covers ti, so m can never win dispatch here. Dropping
-        // m is only safe if minmaxm also takes over the roles m had in the
-        // sort: a specificity cycle may lead back from a cover to a method only
+        // m can never win dispatch here.
+        // Drop m if minmaxm also takes over the roles m had in the sort:
+        // a specificity cycle may lead back from a cover to a method that only
         // m beat, or m may be the last match blocking another one, and either
-        // way the apparent ambiguity is real. When `!include_ambiguous` we drop
-        // `m` here either way, so this only computes *has_ambiguity and can be
-        // skipped once that is already known.
-        if ((include_ambiguous || !*has_ambiguity) && !check_dominance_transfer(m, ti, &minmaxm, 1, t)) {
-            // Do not latch *has_ambiguity yet: another cover (or the union of
-            // covers below) may still certify the removal cleanly, in which
-            // case this failure was moot.
-            transfer_failed = 1;
-        }
-        else {
-            return 1;
-        }
+        // way the apparent ambiguity is real.
+        if (prove_transfer && !check_dominance_transfer(m, ti, &minmaxm, 1, t))
+            status = COVER_AMBIGUOUS;
+        else
+            return 1; // COVER_CERTIFIED
     }
-    // Scan the interference set once: each admissible cover (recorded
+    // Scan the interference set: each admissible cover (recorded
     // strictly-morespecific interference the sort has already finalized) is
     // both attempted as a single cover of ti and collected for the union check
-    // below -- neither `t` nor `visited` changes here, so one pass serves
-    // both. (The transfer obligations are the same as for the minmax probe
+    // below. (The transfer obligations are the same as for the minmax probe
     // above.)
-    int result = 0;
     arraylist_t covers;
     arraylist_new(&covers, 0);
-    // Root the interference-set snapshot across the safepoints below (see
-    // `check_dominance_transfer`).
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
     JL_GC_PUSH1(&interferences);
-    for (size_t i = 0; !result && i < interferences->length; i++) {
+    for (size_t i = 0; status != COVER_CERTIFIED && i < interferences->length; i++) {
         jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
         if (!admissible_cover(m, m2, t, visited))
             continue;
@@ -3294,11 +3290,8 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
             continue; // its transfer already failed above
         if (!jl_subtype(ti, (jl_value_t*)m2->sig))
             continue;
-        if ((include_ambiguous || !*has_ambiguity) && !check_dominance_transfer(m, ti, &m2, 1, t)) {
-            transfer_failed = 1;
-            continue;
-        }
-        result = 1;
+        status = (prove_transfer && !check_dominance_transfer(m, ti, &m2, 1, t)) ?
+                 COVER_AMBIGUOUS : COVER_CERTIFIED;
     }
     JL_GC_POP();
     // No single morespecific method certified covering ti, but a union of them
@@ -3307,26 +3300,23 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
     // `check_dominance_transfer` again: a cover may be tangled in a specificity
     // cycle that leads back to `m`, or may fail to block what `m` was blocking
     // (test `AmbigUnionCycle`).
-    if (!result && covers.len > 1 && union_of_sigs_covers(ti, (jl_method_t**)covers.items, covers.len)) {
-        result = 1;
-        if ((include_ambiguous || !*has_ambiguity) &&
-            !check_dominance_transfer(m, ti, (jl_method_t**)covers.items, covers.len, t)) {
-            *has_ambiguity = 1;
-            if (include_ambiguous)
-                result = 0;
-        }
+    if (status != COVER_CERTIFIED && covers.len > 1 &&
+        union_of_sigs_covers(ti, (jl_method_t**)covers.items, covers.len)) {
+        status = (prove_transfer &&
+                  !check_dominance_transfer(m, ti, (jl_method_t**)covers.items, covers.len, t)) ?
+                 COVER_AMBIGUOUS : COVER_CERTIFIED;
     }
     arraylist_free(&covers);
-    if (!result && transfer_failed) {
-        // Some single cover dominated m over all of ti, but neither it, any
-        // other cover, nor their union could take over the roles m had in the
-        // sort: the apparent ambiguity is real. Per the contract above, the
-        // dominated m is still dropped when `!include_ambiguous`, but kept as
-        // a witness when ambiguity-reporting consumers need to see it.
+    if (status == COVER_AMBIGUOUS) {
+        // Some cover, or the union of the covers, dominated m over all of ti,
+        // but none of them could take over the roles m had in the sort: the
+        // apparent ambiguity is real. Per the contract above, the dominated m
+        // is still dropped when `!include_ambiguous`, but kept as a witness
+        // when ambiguity-reporting consumers need to see it.
         *has_ambiguity = 1;
-        result = !include_ambiguous;
+        return !include_ambiguous;
     }
-    return result;
+    return status == COVER_CERTIFIED;
 }
 
 static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT

--- a/src/gf.c
+++ b/src/gf.c
@@ -3061,15 +3061,53 @@ static int find_method_in_matches(jl_array_t *t, jl_method_t *method)
 
 static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method) JL_CANSAFEPOINT;
 
-// About to remove match `D` from the possible dispatch targets, since it is
-// fully covered by the strictly-morespecific cover(s) `covers` and thus can
-// never be the dispatch winner. That removal is unobservable only if every
-// other match that `D` is morespecific than is also dominated by one of the
-// covers: `morespecific` is not transitive, so a specificity cycle may lead
-// from a cover back to a method that only `D` was beating. Returns 1 when the
-// removal is safe, or 0 when such a method exists, meaning the sorted order is
-// not exact over this query (removing `D` would hide the cycle from the SCC
-// pass), which the caller must record as an ambiguity.
+#ifndef NDEBUG
+// A match may only be removed from the output when it can never be selected over
+// `ti`: every point of `ti` must be covered by some match that is strictly
+// morespecific than `m`. Note this is a statement about *applicable* methods, so
+// it does not care whether the dominating matches survive the sort themselves
+// (chains of drops are fine). It is necessary but not sufficient -- a match that
+// cannot be selected may still block another match from being selected, which is
+// what the ambiguity witness accounting in `sort_method_matches` preserves.
+static void assert_dominated_over(jl_method_t *m, jl_value_t *ti, jl_array_t *t) JL_CANSAFEPOINT
+{
+    size_t len = jl_array_nrows(t), n = 0;
+    jl_value_t **sigs = (jl_value_t**)malloc_s(len * sizeof(jl_value_t*));
+    for (size_t i = 0; i < len; i++) {
+        jl_method_t *Q = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
+        if (Q != m && method_morespecific_recorded(Q, m))
+            sigs[n++] = (jl_value_t*)Q->sig;
+    }
+    jl_value_t *u = n == 0 ? jl_bottom_type : (n == 1 ? sigs[0] : jl_type_union(sigs, n));
+    JL_GC_PUSH1(&u);
+    assert(jl_subtype(ti, u) && "dropped a match that could still be selected");
+    JL_GC_POP();
+    free(sigs);
+}
+#else
+#define assert_dominated_over(m, ti, t) ((void)0)
+#endif
+
+// Dispatch selects a match only when it is morespecific than *every* other
+// applicable match, so a call is ambiguous whenever no match beats all the
+// others. That has two shapes, which the two checks here correspond to: a pair
+// that is unordered (a mutual ambiguity, `check_fully_ambiguous`) or a
+// specificity cycle, where every match is beaten by another one (the SCC pass in
+// `sort_mlmatches`). A match is reportable when it can be selected somewhere in
+// its region, and also when it blocks another match from being selected there --
+// dominance alone therefore justifies removing it from the *selection* answer,
+// while `sort_method_matches` separately keeps enough blockers to witness each
+// ambiguity it reports.
+//
+// About to remove match `D`, which the strictly-morespecific `covers` dominate
+// over all of its region, so `D` can never be selected there.
+// Dominance alone is not enough to remove it, because every member of a
+// specificity cycle is dominated by another member: removing them all on that
+// basis would delete the cycle and report the call as unambiguous (test
+// `AmbigCycle3` fails if this check is skipped). So the removal is silent only
+// if the covers also dominate everything `D` beat -- otherwise a cycle leads
+// from a cover back to a method only `D` was beating, and the caller must
+// record an ambiguity. Returns 1 when the removal is silent, 0 otherwise.
 static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t) JL_CANSAFEPOINT
 {
     // If D is not strictly morespecific than anything it intersects
@@ -3110,6 +3148,38 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
     return 1;
 }
 
+// Find a match that is strictly morespecific than `m` and applies over all of
+// `ti`: a witness that `m` is dominated at every point of `ti`, and so can never
+// be selected there. `visited`, if given, restricts the witness to matches the
+// sort has already finalized, so that a method still tangled in the cycle being
+// resolved cannot serve as one; pass NULL to accept any applicable match. `pos`
+// carries an index into the interference set so a caller can resume the scan for
+// a further witness.
+static jl_method_t *find_dominating_match(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, size_t *pos) JL_CANSAFEPOINT
+{
+    jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
+    for (size_t i = pos == NULL ? 0 : *pos; i < interferences->length; i++) {
+        jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
+        if (m2 == NULL)
+            continue;
+        int idx = find_method_in_matches(t, m2);
+        if (idx < 0)
+            continue;
+        if (method_in_interferences(m, m2))
+            continue; // mutually ambiguous, so not a dominator
+        if (visited != NULL && visited->items[idx] != (void*)1)
+            continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
+        if (jl_subtype(ti, (jl_value_t*)m2->sig)) {
+            if (pos != NULL)
+                *pos = i + 1;
+            return m2;
+        }
+    }
+    if (pos != NULL)
+        *pos = interferences->length;
+    return NULL;
+}
+
 // Check if some morespecific method (or a union of them) covers the given
 // type intersection, meaning this match can never be the dispatch winner and
 // can be removed from the returned matches without anyone noticing. When the
@@ -3121,37 +3191,32 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
     // First: is `m` fully covered (dominated over the whole query region `ti`)
     // by a single recorded strictly-morespecific method?
-    for (size_t i = 0; i < interferences->length; i++) {
-        jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
+    size_t pos = 0;
+    while (1) {
+        jl_method_t *m2 = find_dominating_match(m, ti, t, visited, &pos);
         if (m2 == NULL)
-            continue;
-        int idx = find_method_in_matches(t, m2);
-        if (idx < 0)
-            continue;
-        if (method_in_interferences(m, m2))
-            continue; // ambiguous
-        if (visited->items[idx] != (void*)1)
-            continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
-        if (jl_subtype(ti, m2->sig)) {
-            // m2 is strictly morespecific than m (a one-directional recorded
-            // edge) and fully covers ti, so m can never win dispatch here.
-            // Dropping m is only safe if m2 also dominates everything m was
-            // beating; otherwise a specificity cycle leads back from a cover to
-            // a method only m beat, and the apparent ambiguity is real.
-            if (!check_dominance_transfer(m, &m2, 1, t)) {
-                *has_ambiguity = 1;
-                if (include_ambiguous)
-                    continue;
-            }
-            return 1;
+            break;
+        // m2 is strictly morespecific than m (a one-directional recorded edge)
+        // and fully covers ti, so m can never win dispatch here. Dropping m is
+        // only safe if m2 also dominates everything m was beating; otherwise a
+        // specificity cycle leads back from a cover to a method only m beat, and
+        // the apparent ambiguity is real.
+        if (!check_dominance_transfer(m, &m2, 1, t)) {
+            *has_ambiguity = 1;
+            if (include_ambiguous)
+                continue; // another cover may still certify the removal
         }
+        assert_dominated_over(m, ti, t);
+        return 1;
     }
     // No single morespecific method covers ti, but a union of them may (e.g.
     // several methods each covering one component of a Union-typed argument).
     // Collect the recorded strictly-morespecific interferences that were already
     // finalized cleanly (not part of an ambiguity group, which could mean they
     // lose dispatch back to `m` through a specificity cycle) and check whether
-    // ti is covered by their union.
+    // ti is covered by their union. Both filters are load-bearing: dropping them
+    // lets a cycle member serve as a cover and wrongly resolves the pair (test
+    // `AmbigUnionCycle`).
     int result = 0;
     size_t ncovers = 0;
     jl_method_t **covers = (jl_method_t**)malloc_s(interferences->length * sizeof(jl_method_t*));
@@ -3182,6 +3247,8 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
                 if (include_ambiguous)
                     result = 0;
             }
+            if (result)
+                assert_dominated_over(m, ti, t);
         }
         JL_GC_POP();
     }
@@ -3215,7 +3282,10 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
         return 0;
     int result = method_in_interferences(target_method, start_method) &&
                  !method_in_interferences(start_method, target_method);
-    //// Expensive cross-check:
+    //// Expensive cross-check: the recorded relation must agree with ground truth
+    //// for every intersecting pair. Too costly to leave armed (it makes every
+    //// recorded query cost two type queries), but it has been run over the
+    //// ambiguity, specificity, worlds, reflection and core suites without firing.
     //assert(result == jl_method_morespecific(target_method, start_method) ||
     //       jl_has_empty_intersection(target_method->sig, start_method->sig) ||
     //       jl_has_empty_intersection(start_method->sig, target_method->sig));
@@ -5313,6 +5383,8 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
                                 visited->items[current->idx] = (void*)1;
                         }
                         else {
+                            if (current->m != minmaxm && minmaxm != NULL)
+                                assert_dominated_over(current->m, current->ti, t);
                             visited->items[current->idx] = (void*)1;
                         }
                     }
@@ -5380,6 +5452,8 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
                                 visited->items[childidx] = (void*)1;
                         }
                         else {
+                            if (visited->items[childidx] != (void*)1 && matc->method != minmaxm && minmaxm != NULL)
+                                assert_dominated_over(matc->method, (jl_value_t*)matc->spec_types, t);
                             visited->items[childidx] = (void*)1;
                         }
                     }
@@ -5440,10 +5514,16 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
 {
     int has_ambiguity = 0;
     size_t i, j, len = jl_array_nrows(t);
+    size_t len_in = len;
 
     // the 'minmax' method is a method that (1) fully-covers the queried type, and (2) is
     // more-specific than any other fully-covering method (but if !all_subtypes, there are
-    // non-fully-covering methods to which it is _likely_ not more specific)
+    // non-fully-covering methods to which it is _likely_ not more specific).
+    // n.b. its absence does not mean the query is unresolvable, and in particular
+    // must not be short-circuited into an empty result: the sort below still has to
+    // run to compute `has_ambiguity` and to keep the matches that witness the
+    // ambiguity, or an ambiguous call is reported as having no applicable method
+    // at all (test `AmbigNoBeatAll`).
     jl_method_match_t *minmax = NULL;
     int minmax_dominates = 0;
     int any_subtypes = 0;
@@ -5519,16 +5599,15 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         //      we've already processed all of the possible outputs
         if (all_subtypes) {
             if (minmax == NULL) {
-                // all intersecting methods are fully-covering, but there is no unique most-specific method
-                if (!include_ambiguous) {
-                    // there no unambiguous choice of method
-                    jl_array_del_end(t, len);
-                    len = 0;
-                }
-                else if (lim == 1) {
-                    // we'd have to return >1 method due to the ambiguity, so bail early
-                    return -1;
-                }
+                // All intersecting methods are fully-covering, but none of them
+                // is more specific than every other one. Since `morespecific` is
+                // not transitive, that does not make the call unresolvable: the
+                // comparison may be blocked by a method that is itself dominated
+                // (m1 ≻ m2, m2 ≻ m3, m3 unordered with m1 leaves no
+                // beat-everything winner even though removing m2 and m3 leaves
+                // m1 alone). Fall through to the coverage and SCC pass below,
+                // which removes the dominated matches and reports an ambiguity
+                // only if one actually remains.
             }
             else {
                 // `minmax` is more-specific than all other matches and is fully-covering
@@ -5558,8 +5637,13 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             found_minmax = 1;
         else if (minmax != NULL)
             found_minmax = 2;
-        else if (any_subtypes && !include_ambiguous)
-            found_minmax = 1;
+        // n.b. we cannot shortcut `any_subtypes && !include_ambiguous` to
+        // found_minmax = 1 here: that assumes the absence of a `minmax` method
+        // means no fully-covering method can win, which is false when the
+        // beat-everything comparison was merely blocked by a match that is
+        // itself dominated (see AmbigTransferRegion in test/ambiguous.jl). It
+        // also loses *has_ambiguity, reporting an ambiguous call as having no
+        // applicable method at all.
         has_ambiguity = 0;
         if (approximate_ambig) // if we don't care about the result, set it now so we won't bother attempting to compute it accurately later
             has_ambiguity = 1;
@@ -5586,6 +5670,30 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         free(tainted);
         arraylist_free(&visited);
         arraylist_free(&stack);
+        // A method is only selected when it is morespecific than every applicable
+        // method, so an ambiguity has to be witnessed by at least two reported
+        // methods: with only one left, the caller would read the result as a
+        // resolved call (and an error would come out as `no method matching`).
+        // Dominated matches are dropped above because some other match witnesses
+        // the same ambiguity, but the last blocker of the survivor is not
+        // redundant -- restore the matches it is unordered with.
+        if (include_ambiguous && has_ambiguity && result.len == 1 && minmax == NULL) {
+            size_t survivor = (size_t)result.items[0];
+            jl_method_t *m = ((jl_method_match_t*)jl_array_ptr_ref(t, survivor))->method;
+            for (i = 0; i < len; i++) {
+                if (i == survivor)
+                    continue;
+                jl_method_t *m2 = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
+                if (!method_in_interferences(m2, m) || !method_in_interferences(m, m2))
+                    continue; // not an unordered pair, so not a blocker
+                if (lim != -1 && (int)result.len >= lim) {
+                    // n.b. `tainted`, `visited` and `stack` were already released above
+                    arraylist_free(&result);
+                    return -1;
+                }
+                arraylist_push(&result, (void*)i);
+            }
+        }
         for (j = 0; j < result.len; j++) {
             i = (size_t)result.items[j];
             jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
@@ -5604,6 +5712,15 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             jl_array_del_end(t, len - j);
         len = j;
     }
+    // Every match can only be removed by being dominated or by being part of an
+    // ambiguity, and a chain of dominated matches has to bottom out somewhere
+    // unless it closes a cycle (which is an ambiguity). So emptying a non-empty
+    // match list means the query is ambiguous, never that no method applies --
+    // reporting the latter would turn an ambiguous call into a `no method
+    // matching` error (test `AmbigNoBeatAll`).
+    assert((len > 0 || len_in == 0 || has_ambiguity) &&
+           "dropped every applicable method without recording an ambiguity");
+    (void)len_in;
     *has_ambiguity_out = has_ambiguity;
     return len;
 }

--- a/src/gf.c
+++ b/src/gf.c
@@ -3067,8 +3067,66 @@ static int find_method_in_matches(jl_array_t *t, jl_method_t *method)
     return -1;
 }
 
-// Recursively check if any method in interferences covers the given type signature
-static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, arraylist_t *seen) JL_CANSAFEPOINT
+// Check whether `m2` is (visibly) strictly morespecific than `m`, using the
+// recorded interference edges when the pair was recorded (both directions are
+// decided together at method definition time), and falling back to the direct
+// specificity query for unrecorded pairs.
+static int method_strictly_morespecific(jl_method_t *m2, jl_method_t *m)
+{
+    if (method_in_interferences(m2, m)) // !morespecific(m, m2) recorded
+        return !method_in_interferences(m, m2); // and not mutual (ambiguous)
+    // either morespecific(m, m2), or the pair was never recorded (its
+    // intersection was shadowed at definition time): ask the type system
+    return jl_type_morespecific(m2->sig, m->sig);
+}
+
+// About to remove match `D` from the possible dispatch targets, since it is
+// fully covered by the strictly-morespecific cover(s) `covers` and thus can
+// never be the dispatch winner. That removal is unobservable only if every
+// other match that `D` is morespecific than is also dominated by one of the
+// covers: `morespecific` is not transitive, so a specificity cycle may lead
+// from a cover back to a method that only `D` was beating. Returns 1 when the
+// removal is safe, or 0 when such a method exists, meaning the sorted order is
+// not exact over this query (removing `D` would hide the cycle from the SCC
+// pass), which the caller must record as an ambiguity.
+static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t)
+{
+    size_t len = jl_array_nrows(t);
+    for (size_t i = 0; i < len; i++) {
+        jl_method_t *S = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
+        if (S == D)
+            continue;
+        // only consider S that D is (visibly) strictly morespecific than
+        if (!method_in_interferences(D, S) || method_in_interferences(S, D))
+            continue;
+        size_t j;
+        for (j = 0; j < ncovers; j++) {
+            if (S == covers[j] || method_strictly_morespecific(covers[j], S))
+                break;
+        }
+        if (j == ncovers) {
+            // No cover dominates S. That is only dangerous when S strictly
+            // beats one of the covers (a directed specificity cycle through
+            // D); if S is merely mutually ambiguous with (or unordered
+            // against) the covers, that ambiguity is recorded on their own
+            // interference edges and remains visible to check_fully_ambiguous
+            // independent of D's removal.
+            for (j = 0; j < ncovers; j++) {
+                if (method_strictly_morespecific(S, covers[j]))
+                    return 0;
+            }
+        }
+    }
+    return 1;
+}
+
+// Check if some morespecific method (or a union of them) covers the given
+// type intersection, meaning this match can never be the dispatch winner and
+// can be removed from the returned matches without anyone noticing. When the
+// covering relation is entangled in a specificity cycle, sets *has_ambiguity;
+// in that case the match is only reported as covered when `include_ambiguous`
+// is false, so that ambiguity-reporting consumers still see it.
+static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, char *tainted, arraylist_t *seen, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
     arraylist_t workqueue;
     arraylist_new(&workqueue, 0);
@@ -3099,15 +3157,79 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
                 continue;
             if (method_in_interferences(current_m, m2))
                 continue; // ambiguous
-            assert(visited->items[idx] != (void*)0);
             if (visited->items[idx] != (void*)1)
-                continue; // part of the same SCC cycle (handled by ambiguity later)
+                continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
             if (jl_subtype(ti, m2->sig)) {
+                // The chain of interference edges only suggests transitively
+                // that m2 is morespecific than m; that inference is wrong if a
+                // specificity cycle leads back from m to m2, in which case the
+                // covering method does not actually win dispatch from m over
+                // (all of) their intersection and the apparent ambiguity is
+                // real (conservatively, since the methods witnessing the
+                // non-transitivity may intersect elsewhere in the query).
+                if (!method_strictly_morespecific(m2, m)) {
+                    // if m actually beats m2, the chain from m back to m2 is
+                    // a directed specificity cycle (a genuine ambiguity); if
+                    // they are merely mutually ambiguous, that is recorded on
+                    // their own interference edge and handled by
+                    // check_fully_ambiguous
+                    if (method_strictly_morespecific(m, m2)) {
+                        *has_ambiguity = 1;
+                    }
+                    continue;
+                }
+                if (!check_dominance_transfer(m, &m2, 1, t)) {
+                    *has_ambiguity = 1;
+                    if (include_ambiguous)
+                        continue;
+                }
                 result = 1;
                 goto cleanup;
             }
             arraylist_push(&workqueue, m2);
         }
+    }
+    if (!result) {
+        // No single morespecific method covers ti, but a union of them may
+        // (e.g. several methods each covering one component of a Union-typed
+        // argument). Collect the recorded strictly-morespecific interferences
+        // that were already finalized cleanly (not part of an ambiguity
+        // group, which could mean they lose dispatch back to `m` through a
+        // specificity cycle) and check whether ti is covered by their union.
+        jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
+        size_t ncovers = 0;
+        jl_method_t **covers = (jl_method_t**)malloc_s(interferences->length * sizeof(jl_method_t*));
+        for (size_t i = 0; i < interferences->length; i++) {
+            jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
+            if (m2 == NULL)
+                continue;
+            int idx = find_method_in_matches(t, m2);
+            if (idx < 0)
+                continue;
+            if (visited->items[idx] != (void*)1 || tainted[idx])
+                continue;
+            if (method_in_interferences(m, m2)) // mutual interference (ambiguous)
+                continue;
+            covers[ncovers++] = m2;
+        }
+        if (ncovers > 1) {
+            jl_value_t **sigs = (jl_value_t**)malloc_s(ncovers * sizeof(jl_value_t*));
+            for (size_t i = 0; i < ncovers; i++)
+                sigs[i] = (jl_value_t*)covers[i]->sig;
+            jl_value_t *u = jl_type_union(sigs, ncovers);
+            free(sigs);
+            JL_GC_PUSH1(&u);
+            if (jl_subtype(ti, u)) {
+                result = 1;
+                if (!check_dominance_transfer(m, covers, ncovers, t)) {
+                    *has_ambiguity = 1;
+                    if (include_ambiguous)
+                        result = 0;
+                }
+            }
+            JL_GC_POP();
+        }
+        free(covers);
     }
 cleanup:
     seen->len = 0;
@@ -5145,7 +5267,7 @@ typedef struct {
 //  * -1: too many matches for lim, other outputs are undefined
 //  *  0: the child(ren) have been added to the output
 //  * 1+: the children are part of this SCC (up to this depth)
-static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, arraylist_t *stack, arraylist_t *result, arraylist_t *recursion_stack, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax) JL_CANSAFEPOINT
+static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char *tainted, arraylist_t *stack, arraylist_t *result, arraylist_t *recursion_stack, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax, jl_method_t *minmaxm) JL_CANSAFEPOINT
 {
     // Use arraylist_t for explicit stack of processing frames
     arraylist_t frame_stack;
@@ -5272,10 +5394,21 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                 // There is some probability that this method is already fully covered
                 // now, and we can delete this vertex now without anyone noticing.
                 if (current->subt && *found_minmax) {
-                    if (*found_minmax == 2)
-                        visited->items[current->idx] = (void*)1;
+                    if (*found_minmax == 2) {
+                        // minmax dominates all fully-covering methods, but this
+                        // dropped method may have been beating a partial match
+                        // that minmax does not dominate (a specificity cycle)
+                        if (current->m != minmaxm && !check_dominance_transfer(current->m, &minmaxm, minmaxm == NULL ? 0 : 1, t)) {
+                            *has_ambiguity = 1;
+                            if (!include_ambiguous)
+                                visited->items[current->idx] = (void*)1;
+                        }
+                        else {
+                            visited->items[current->idx] = (void*)1;
+                        }
+                    }
                 }
-                else if (check_interferences_covers(current->m, current->ti, t, visited, recursion_stack)) {
+                else if (check_interferences_covers(current->m, current->ti, t, visited, tainted, recursion_stack, include_ambiguous, has_ambiguity)) {
                     visited->items[current->idx] = (void*)1;
                 }
                 else if (check_fully_ambiguous(current->m, current->ti, t, include_ambiguous, has_ambiguity)) {
@@ -5304,6 +5437,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
 
             case STATE_FINALIZE_SCC: {
                 // If this is in an SCC group, do some additional checks before returning or setting has_ambiguity
+                int scc_ambiguous = 0;
                 if (current->depth != stack->len) {
                     int scc_count = 0;
                     for (size_t i = current->depth - 1; i < stack->len; i++) {
@@ -5312,8 +5446,10 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                             continue;
                         scc_count++;
                     }
-                    if (scc_count > 1)
+                    if (scc_count > 1) {
                         *has_ambiguity = 1;
+                        scc_ambiguous = 1;
+                    }
                 }
 
                 // copy this cycle into the results
@@ -5321,8 +5457,23 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                     size_t childidx = (size_t)stack->items[i];
                     jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, childidx);
                     int subt = matc->fully_covers != NOT_FULLY_COVERS;
-                    if (subt && *found_minmax)
-                        visited->items[childidx] = (void*)1;
+                    if (scc_ambiguous && visited->items[childidx] != (void*)1)
+                        // mark members of an ambiguity group: they cannot be
+                        // trusted to resolve (cover) other apparent
+                        // ambiguities, since they may sit in a specificity
+                        // cycle leading back to the method they would resolve
+                        tainted[childidx] = 1;
+                    if (subt && *found_minmax) {
+                        if (visited->items[childidx] != (void*)1 && matc->method != minmaxm &&
+                            !check_dominance_transfer(matc->method, &minmaxm, minmaxm == NULL ? 0 : 1, t)) {
+                            *has_ambiguity = 1;
+                            if (!include_ambiguous)
+                                visited->items[childidx] = (void*)1;
+                        }
+                        else {
+                            visited->items[childidx] = (void*)1;
+                        }
+                    }
                     if ((size_t)visited->items[childidx] == 1)
                         continue;
                     assert(visited->items[childidx] == (void*)(2 + i));
@@ -5624,6 +5775,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
         arraylist_new(&recursion_stack, len);
         arraylist_grow(&visited, len);
         memset(visited.items, 0, len * sizeof(size_t));
+        char *tainted = (char*)calloc_s(len);
         // if we had a minmax method (any subtypes), now may now be able to
         // quickly cleanup some of methods
         int found_minmax = 0;
@@ -5644,8 +5796,9 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                 // by visiting it and it might be a bit costly
                 continue;
             }
-            int child_cycle = sort_mlmatches((jl_array_t*)env.t, i, &visited, &stack, &result, &recursion_stack, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax);
+            int child_cycle = sort_mlmatches((jl_array_t*)env.t, i, &visited, tainted, &stack, &result, &recursion_stack, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
             if (child_cycle == -1) {
+                free(tainted);
                 arraylist_free(&recursion_stack);
                 arraylist_free(&visited);
                 arraylist_free(&stack);
@@ -5657,6 +5810,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
             assert(stack.len == 0);
             assert(visited.items[i] == (void*)1);
         }
+        free(tainted);
         arraylist_free(&recursion_stack);
         arraylist_free(&visited);
         arraylist_free(&stack);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3075,6 +3075,44 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
     return result;
 }
 
+// Whether `m2` is admissible as a cover of `m`: reported in the match list and
+// strictly morespecific than `m` (a one-directional recorded edge). `visited`,
+// if given, additionally restricts covers to matches the sort has already
+// finalized, so that a method still tangled in the cycle being resolved cannot
+// serve as a cover; pass NULL to accept any applicable match.
+static int admissible_cover(jl_method_t *m, jl_method_t *m2, jl_array_t *t, arraylist_t *visited)
+{
+    if (m2 == NULL)
+        return 0;
+    int idx = find_method_in_matches(t, m2);
+    if (idx < 0)
+        return 0;
+    if (method_in_interferences(m, m2))
+        return 0; // mutually ambiguous, so not a dominator
+    if (visited != NULL && visited->items[idx] != (void*)1)
+        return 0; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
+    return 1;
+}
+
+// Whether `ti` is contained in the union of the signatures of the `n` methods
+// in `ms` (trivially false for an empty list).
+static int union_of_sigs_covers(jl_value_t *ti, jl_method_t **ms, size_t n) JL_CANSAFEPOINT
+{
+    if (n == 0)
+        return 0;
+    arraylist_t sigs;
+    arraylist_new(&sigs, n);
+    for (size_t i = 0; i < n; i++)
+        arraylist_push(&sigs, (void*)ms[i]->sig);
+    jl_value_t *u = NULL;
+    JL_GC_PUSH1(&u);
+    u = jl_type_union((jl_value_t**)sigs.items, sigs.len);
+    arraylist_free(&sigs);
+    int result = jl_subtype(ti, u);
+    JL_GC_POP();
+    return result;
+}
+
 // About to remove match `D` (matching the query over `ti`), which the
 // strictly-morespecific `covers` jointly contain, so `D` can never be selected
 // there. But removing `D` also removes it as evidence against `S` being selected:
@@ -3106,27 +3144,23 @@ static int check_blocker_transfer(jl_value_t *ti, jl_value_t *ti_S, jl_method_t 
         return 1;
     int result = 0;
     jl_value_t *region = NULL;
-    jl_value_t *u = NULL;
-    JL_GC_PUSH2(&region, &u);
+    JL_GC_PUSH1(&region);
     region = jl_type_intersection(ti, ti_S);
     if (region == jl_bottom_type) {
         // D was never a witness of S within the query, so S doesn't block its removal
         result = 1;
     }
     else {
-        arraylist_t sigs;
-        arraylist_new(&sigs, 0);
+        arraylist_t blockers;
+        arraylist_new(&blockers, 0);
         for (j = 0; j < ncovers; j++) {
             // a cover that S does not beat blocks S, whether it is strictly
             // morespecific than S or merely unordered with it
             if (method_in_interferences(covers[j], S))
-                arraylist_push(&sigs, (void*)covers[j]->sig);
+                arraylist_push(&blockers, (void*)covers[j]);
         }
-        if (sigs.len > 0) {
-            u = jl_type_union((jl_value_t**)sigs.items, sigs.len);
-            result = jl_subtype(region, u);
-        }
-        arraylist_free(&sigs);
+        result = union_of_sigs_covers(region, (jl_method_t**)blockers.items, blockers.len);
+        arraylist_free(&blockers);
     }
     JL_GC_POP();
     return result;
@@ -3147,9 +3181,12 @@ static int check_dominance_transfer(jl_method_t *D, jl_value_t *ti, jl_method_t 
     // First, the matches D was unordered with. Both members of such a pair
     // record each other, so D's own interference set is enough to enumerate
     // them.
-    // (n.b. this scan is not required with `!include_ambiguous`, where D is
-    // dropped either way and S reports the same pair from `check_fully_ambiguous`,
-    // unlike the cycle detection below)
+    // (n.b. even with `!include_ambiguous`, where D is dropped either way, this
+    // scan is still needed to compute *has_ambiguity: usually a surviving S
+    // re-reports the same pair from `check_fully_ambiguous`, but S can be
+    // exempt from that scan -- notably when S is the minmax method, which the
+    // sort never visits -- leaving this check as the only witness of the pair
+    // when D's only cover is a match that S beats (test `AmbigMinmaxPartner`))
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&D->interferences);
     for (size_t i = 0; i < interferences->length; i++) {
         jl_method_t *S = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
@@ -3201,15 +3238,8 @@ static jl_method_t *find_dominating_match(jl_method_t *m, jl_value_t *ti, jl_arr
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
     for (size_t i = pos == NULL ? 0 : *pos; i < interferences->length; i++) {
         jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
-        if (m2 == NULL)
+        if (!admissible_cover(m, m2, t, visited))
             continue;
-        int idx = find_method_in_matches(t, m2);
-        if (idx < 0)
-            continue;
-        if (method_in_interferences(m, m2))
-            continue; // mutually ambiguous, so not a dominator
-        if (visited != NULL && visited->items[idx] != (void*)1)
-            continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
         if (jl_subtype(ti, (jl_value_t*)m2->sig)) {
             if (pos != NULL)
                 *pos = i + 1;
@@ -3235,6 +3265,7 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
     // First: is `m` fully covered (dominated over the whole query region `ti`)
     // by a single recorded strictly-morespecific method?
     size_t pos = 0;
+    int transfer_failed = 0;
     while (1) {
         jl_method_t *m2 = find_dominating_match(m, ti, t, visited, &pos);
         if (m2 == NULL)
@@ -3248,17 +3279,19 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
         // either way, so this only computes *has_ambiguity and can be skipped
         // once that is already known.
         if ((include_ambiguous || !*has_ambiguity) && !check_dominance_transfer(m, ti, &m2, 1, t)) {
-            *has_ambiguity = 1;
-            if (include_ambiguous)
-                continue; // another cover may still certify the removal
+            // Do not latch *has_ambiguity yet: another cover (or the union of
+            // covers below) may still certify the removal cleanly, in which
+            // case this failure was moot.
+            transfer_failed = 1;
+            continue;
         }
         return 1;
     }
-    // No single morespecific method covers ti, but a union of them may (e.g.
-    // several methods each covering one component of a Union-typed argument).
-    // Collect the recorded strictly-morespecific interferences that the sort has
-    // already finalized and check whether ti is covered by their union. Whether
-    // such a union really certifies the removal is left to
+    // No single morespecific method certified covering ti, but a union of them
+    // may (e.g. several methods each covering one component of a Union-typed
+    // argument). Collect the recorded strictly-morespecific interferences that
+    // the sort has already finalized and check whether ti is covered by their
+    // union. Whether such a union really certifies the removal is left to
     // `check_dominance_transfer` below: a cover may be tangled in a specificity
     // cycle that leads back to `m`, or may fail to block what `m` was blocking
     // (test `AmbigUnionCycle`).
@@ -3267,37 +3300,28 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
     arraylist_new(&covers, 0);
     for (size_t i = 0; i < interferences->length; i++) {
         jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
-        if (m2 == NULL)
-            continue;
-        int idx = find_method_in_matches(t, m2);
-        if (idx < 0)
-            continue;
-        if (visited->items[idx] != (void*)1)
-            continue;
-        if (method_in_interferences(m, m2)) // ambiguous
-            continue;
-        arraylist_push(&covers, (void*)m2);
+        if (admissible_cover(m, m2, t, visited))
+            arraylist_push(&covers, (void*)m2);
     }
-    if (covers.len > 1) {
-        arraylist_t sigs;
-        arraylist_new(&sigs, covers.len);
-        for (size_t i = 0; i < covers.len; i++)
-            arraylist_push(&sigs, (void*)((jl_method_t*)covers.items[i])->sig);
-        jl_value_t *u = jl_type_union((jl_value_t**)sigs.items, sigs.len);
-        arraylist_free(&sigs);
-        JL_GC_PUSH1(&u);
-        if (jl_subtype(ti, u)) {
-            result = 1;
-            if ((include_ambiguous || !*has_ambiguity) &&
-                !check_dominance_transfer(m, ti, (jl_method_t**)covers.items, covers.len, t)) {
-                *has_ambiguity = 1;
-                if (include_ambiguous)
-                    result = 0;
-            }
+    if (covers.len > 1 && union_of_sigs_covers(ti, (jl_method_t**)covers.items, covers.len)) {
+        result = 1;
+        if ((include_ambiguous || !*has_ambiguity) &&
+            !check_dominance_transfer(m, ti, (jl_method_t**)covers.items, covers.len, t)) {
+            *has_ambiguity = 1;
+            if (include_ambiguous)
+                result = 0;
         }
-        JL_GC_POP();
     }
     arraylist_free(&covers);
+    if (!result && transfer_failed) {
+        // Some single cover dominated m over all of ti, but neither it, any
+        // other cover, nor their union could take over the roles m had in the
+        // sort: the apparent ambiguity is real. Per the contract above, the
+        // dominated m is still dropped when `!include_ambiguous`, but kept as
+        // a witness when ambiguity-reporting consumers need to see it.
+        *has_ambiguity = 1;
+        result = !include_ambiguous;
+    }
     return result;
 }
 
@@ -3443,6 +3467,11 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             // Compute all morespec values upfront
             for (j = 0; j < n; j++)
                 morespec[j] = (char)jl_type_morespecific(d[j]->sig, type);
+            // `d` has no duplicates, so a duplicate key can only be one of the
+            // entries already present at loop entry (a precompile re-activation);
+            // for a freshly defined method the set starts empty and the probe
+            // would be a guaranteed-miss linear scan of the growing set.
+            int check_dup_key = interferences->length > 0;
             for (j = 0; j < n; j++) {
                 jl_method_t *m = d[j];
                 // Compute ambig state: is there an ambiguity between new method and old m?
@@ -3450,7 +3479,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                 if (morespec[j] || ambig) {
                     // !morespecific(new, old): add the old method to this interference set
                     ssize_t idx;
-                    if (!has_key(interferences, (jl_value_t*)m))
+                    if (!check_dup_key || !has_key(interferences, (jl_value_t*)m))
                         interferences = jl_idset_put_key(interferences, (jl_value_t*)m, &idx);
                 }
                 if (morespec[j]) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -3257,6 +3257,8 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
            jl_has_empty_intersection(target_method->sig, start_method->sig) ||
            jl_has_empty_intersection(start_method->sig, target_method->sig));
     // a method recorded as strictly beating something must not carry NO_LOSERS
+    // (the replacement path clears the bit for the recency-tiebreak win it
+    // records over the type-equal method it replaces)
     assert(!result || !(jl_atomic_load_relaxed(&target_method->dispatch_status) & METHOD_SIG_NO_LOSERS));
     return result;
 }
@@ -3303,13 +3305,17 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     }
 
     int invalidated = 0;
-    // Tentatively assume the new method is not strictly morespecific than
-    // anything it intersects (METHOD_SIG_NO_LOSERS); the scan below clears it
-    // on the first method this one beats. Conversely, an old method that this
-    // one is beaten by keeps its state, and an old method that is beaten
-    // (morespec[j], conservatively including both-ways-morespecific pairs)
-    // loses its bit.
-    int dispatch_bits = METHOD_SIG_LATEST_WHICH | METHOD_SIG_NO_LOSERS;
+    // METHOD_SIG_NO_LOSERS is carried in from the method's current state, not
+    // re-derived: it is set at method creation and monotone-cleared. The scan
+    // below clears it on the first method this one beats; conversely an old
+    // method that is beaten (morespec[j], conservatively including
+    // both-ways-morespecific pairs) loses its bit. The bit must survive
+    // serialization (like the interference sets, and unlike LATEST_WHICH)
+    // because a cache-image batch shares one world: this scan runs against the
+    // prior world and cannot see same-image methods, so their pairs are never
+    // re-derived at load and only the precompile-time state is correct.
+    int precompiled_status = jl_atomic_load_relaxed(&method->dispatch_status);
+    int dispatch_bits = METHOD_SIG_LATEST_WHICH | (precompiled_status & METHOD_SIG_NO_LOSERS);
     // Holds the set of all intersecting methods not more specific than this one.
     // The insertion scan below visits every intersecting method (the
     // LATEST_ONLY early-out was removed), so the recorded relation is complete:
@@ -3326,10 +3332,13 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             method_overwrite(newentry, m);
             // This is an optimized version of below, given we know the type-intersection is exact
             jl_method_table_invalidate(m, max_world);
-            // The replacement has the same signature, so it inherits the
-            // replaced method's specificity relations, including NO_LOSERS
-            if (!(jl_atomic_load_relaxed(&m->dispatch_status) & METHOD_SIG_NO_LOSERS))
-                dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
+            // The replacement strictly beats the replaced method (the recency
+            // tiebreak in `jl_method_morespecific` for type-equal signatures,
+            // recorded below), so it always has at least that one strict loser.
+            // NO_LOSERS cannot be inherited: type-equal does not imply
+            // morespecific-equal, so the predecessor's relations do not
+            // transfer.
+            dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
             // Clear METHOD_SIG_LATEST_WHICH bit
             jl_atomic_store_relaxed(&m->dispatch_status, 0);
             // Take over the interference list from the replaced method
@@ -3356,6 +3365,15 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                     ssize_t idx;
                     m2_interferences = jl_idset_put_key(m2_interferences, (jl_value_t*)method, &idx);
                     jl_gc_write_atomic(m2, m2->interferences, jl_genericmemory_t, m2_interferences, release);
+                }
+                if (m2 && m2 != m) {
+                    // Recompute the partner's NO_LOSERS against the
+                    // replacement's own signature: type-equal does not imply
+                    // morespecific-equal, so `morespecific(m2, method)` may
+                    // hold where `morespecific(m2, m)` did not.
+                    int m2_dispatch = jl_atomic_load_relaxed(&m2->dispatch_status);
+                    if ((m2_dispatch & METHOD_SIG_NO_LOSERS) && jl_type_morespecific(m2->sig, type))
+                        jl_atomic_store_relaxed(&m2->dispatch_status, m2_dispatch & ~METHOD_SIG_NO_LOSERS);
                 }
             }
             loctag = jl_atomic_load_relaxed(&m->specializations); // use loctag for a gcroot

--- a/src/gf.c
+++ b/src/gf.c
@@ -5519,6 +5519,196 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
 }
 
 
+// Sort the intersecting matches in `t` (a Vector{Any} of MethodMatch, as
+// collected for a single query type) into dispatch order, removing every match
+// that can never be the dispatch target over its intersection with the query
+// (being fully covered by more specific methods), and setting *has_ambiguity
+// if the sorted order of the remaining matches is not exact (some of them are
+// ambiguous with each other over part of the query). When `approximate_ambig`
+// is set, the caller does not need *has_ambiguity computed accurately and it
+// is pessimistically set to 1 without attempting to prove otherwise.
+// Returns the new length of `t`, or -1 if `lim` was exceeded (in which case
+// the contents of `t` are left in an unspecified state).
+static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous, int approximate_ambig, int *has_ambiguity_out) JL_CANSAFEPOINT
+{
+    int has_ambiguity = 0;
+    size_t i, j, len = jl_array_nrows(t);
+
+    // the 'minmax' method is a method that (1) fully-covers the queried type, and (2) is
+    // more-specific than any other fully-covering method (but if !all_subtypes, there are
+    // non-fully-covering methods to which it is _likely_ not more specific)
+    jl_method_match_t *minmax = NULL;
+    int any_subtypes = 0;
+    if (len > 1) {
+        // first try to pre-process the results to find the most specific option
+        // among the fully-covering methods, since we can do this in O(n^2)
+        // time, and the rest is O(n^3)
+        //   - first find a candidate for the best of these method results
+        for (i = 0; i < len; i++) {
+            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
+            if (matc->fully_covers == FULLY_COVERS) {
+                any_subtypes = 1;
+                jl_method_t *m = matc->method;
+                for (j = 0; j < len; j++) {
+                    if (i == j)
+                        continue;
+                    jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(t, j);
+                    if (matc2->fully_covers == FULLY_COVERS) {
+                        jl_method_t *m2 = matc2->method;
+                        if (!method_morespecific_via_interferences(m, m2))
+                            break;
+                    }
+                }
+                if (j == len) {
+                    // Found the minmax method
+                    minmax = matc;
+                    break;
+                }
+            }
+        }
+        //   - it may even dominate (be more specific than) some choices that are not fully-covering!
+        //     move those into the subtype group, where we'll filter them out shortly after
+        //     (potentially avoiding reporting these as an ambiguity, and
+        //     potentially allowing us to hit the next fast path)
+        //   - we could always check here if *any* FULLY_COVERS method is
+        //     more-specific (instead of just considering minmax), but that may
+        //     cost much extra and is less likely to help us hit a fast path
+        //     (we will look for this later, when we compute ambig_groupid, for
+        //     correctness)
+        int all_subtypes = any_subtypes;
+        if (any_subtypes) {
+            jl_method_t *minmaxm = NULL;
+            if (minmax != NULL)
+                minmaxm = minmax->method;
+            // scan through all the non-fully-matching methods and count them as "fully-covering" (ish)
+            // (i.e. in the 'subtype' group) if `minmax` is more-specific
+            for (i = 0; i < len; i++) {
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
+                if (matc->fully_covers != FULLY_COVERS) {
+                    jl_method_t *m = matc->method;
+                    if (minmaxm) {
+                        if (method_morespecific_via_interferences(minmaxm, m)) {
+                            matc->fully_covers = SENTINEL; // put a sentinel value here for sorting
+                            continue;
+                        }
+                        if (method_in_interferences(minmaxm, m)) // !morespecific(m, minmaxm)
+                            has_ambiguity = 1;
+                    }
+                    all_subtypes = 0;
+                }
+            }
+        }
+        //    - now we might have a fast-return here, if we see that
+        //      we've already processed all of the possible outputs
+        if (all_subtypes) {
+            if (minmax == NULL) {
+                // all intersecting methods are fully-covering, but there is no unique most-specific method
+                if (!include_ambiguous) {
+                    // there no unambiguous choice of method
+                    jl_array_del_end(t, len);
+                    len = 0;
+                }
+                else if (lim == 1) {
+                    // we'd have to return >1 method due to the ambiguity, so bail early
+                    return -1;
+                }
+            }
+            else {
+                // `minmax` is more-specific than all other matches and is fully-covering
+                // we can return it as our only result
+                jl_array_ptr_set(t, 0, minmax);
+                jl_array_del_end(t, len - 1);
+                len = 1;
+            }
+        }
+        if (minmax && lim == 0) {
+            // protect some later algorithms from underflow
+            return -1;
+        }
+    }
+    if (len > 1) {
+        arraylist_t stack, visited, result, recursion_stack;
+        arraylist_new(&result, lim != -1 && lim < len ? lim : len);
+        arraylist_new(&stack, 0);
+        arraylist_new(&visited, len);
+        arraylist_new(&recursion_stack, len);
+        arraylist_grow(&visited, len);
+        memset(visited.items, 0, len * sizeof(size_t));
+        char *tainted = (char*)calloc_s(len);
+        // if we had a minmax method (any subtypes), now may now be able to
+        // quickly cleanup some of methods
+        int found_minmax = 0;
+        if (has_ambiguity)
+            found_minmax = 1;
+        else if (minmax != NULL)
+            found_minmax = 2;
+        else if (any_subtypes && !include_ambiguous)
+            found_minmax = 1;
+        has_ambiguity = 0;
+        if (approximate_ambig) // if we don't care about the result, set it now so we won't bother attempting to compute it accurately later
+            has_ambiguity = 1;
+        for (i = 0; i < len; i++) {
+            assert(visited.items[i] == (void*)0 || visited.items[i] == (void*)1);
+            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
+            if (matc->fully_covers != NOT_FULLY_COVERS && found_minmax) {
+                // this was already handled above and below, so we won't learn anything new
+                // by visiting it and it might be a bit costly
+                continue;
+            }
+            int child_cycle = sort_mlmatches(t, i, &visited, tainted, &stack, &result, &recursion_stack, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
+            if (child_cycle == -1) {
+                free(tainted);
+                arraylist_free(&recursion_stack);
+                arraylist_free(&visited);
+                arraylist_free(&stack);
+                arraylist_free(&result);
+                return -1;
+            }
+            assert(child_cycle == 0); (void)child_cycle;
+            assert(stack.len == 0);
+            assert(visited.items[i] == (void*)1);
+        }
+        free(tainted);
+        arraylist_free(&recursion_stack);
+        arraylist_free(&visited);
+        arraylist_free(&stack);
+        for (j = 0; j < result.len; j++) {
+            i = (size_t)result.items[j];
+            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
+            // remove our sentinel entry markers
+            if (matc->fully_covers == SENTINEL)
+                matc->fully_covers = NOT_FULLY_COVERS;
+            result.items[j] = (void*)matc;
+        }
+        if (minmax) {
+            arraylist_push(&result, minmax);
+            j++;
+        }
+        memcpy(jl_array_data(t, jl_method_match_t*), result.items, j * sizeof(jl_method_match_t*));
+        arraylist_free(&result);
+        if (j != len)
+            jl_array_del_end(t, len - j);
+        len = j;
+    }
+    *has_ambiguity_out = has_ambiguity;
+    return len;
+}
+
+// Re-sort a (possibly filtered) vector of MethodMatch objects, as collected by
+// jl_matching_methods for a single query type, removing matches that can no
+// longer be the dispatch target, and return whether any dispatch ambiguity
+// remains between the remaining matches. Used by `Base.isambiguous` to decide
+// whether an ambiguity remains after filtering out matches whose intersection
+// has a Union{} type parameter.
+JL_DLLEXPORT int jl_sort_method_matches(jl_array_t *t, int include_ambiguous) JL_CANSAFEPOINT
+{
+    JL_TYPECHK(sort_method_matches, array_any, (jl_value_t*)t);
+    int has_ambiguity = 0;
+    ssize_t sorted = sort_method_matches(t, -1, include_ambiguous, 0, &has_ambiguity);
+    assert(sorted != -1); (void)sorted; // lim == -1 cannot be exceeded
+    return has_ambiguity;
+}
+
 // This is the collect form of calling jl_typemap_intersection_visitor
 // with optimizations to skip fully shadowed methods.
 //
@@ -5671,166 +5861,14 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
 
     // all intersecting methods have been collected now. the remaining work is to sort
     // these and apply specificity to determine a list of dispatch-possible call targets
-    size_t i, j, len = jl_array_nrows(env.t);
-
-    // the 'minmax' method is a method that (1) fully-covers the queried type, and (2) is
-    // more-specific than any other fully-covering method (but if !all_subtypes, there are
-    // non-fully-covering methods to which it is _likely_ not more specific)
-    jl_method_match_t *minmax = NULL;
-    int any_subtypes = 0;
-    if (len > 1) {
-        // first try to pre-process the results to find the most specific option
-        // among the fully-covering methods, since we can do this in O(n^2)
-        // time, and the rest is O(n^3)
-        //   - first find a candidate for the best of these method results
-        for (i = 0; i < len; i++) {
-            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
-            if (matc->fully_covers == FULLY_COVERS) {
-                any_subtypes = 1;
-                jl_method_t *m = matc->method;
-                for (j = 0; j < len; j++) {
-                    if (i == j)
-                        continue;
-                    jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(env.t, j);
-                    if (matc2->fully_covers == FULLY_COVERS) {
-                        jl_method_t *m2 = matc2->method;
-                        if (!method_morespecific_via_interferences(m, m2))
-                            break;
-                    }
-                }
-                if (j == len) {
-                    // Found the minmax method
-                    minmax = matc;
-                    break;
-                }
-            }
-        }
-        //   - it may even dominate (be more specific than) some choices that are not fully-covering!
-        //     move those into the subtype group, where we'll filter them out shortly after
-        //     (potentially avoiding reporting these as an ambiguity, and
-        //     potentially allowing us to hit the next fast path)
-        //   - we could always check here if *any* FULLY_COVERS method is
-        //     more-specific (instead of just considering minmax), but that may
-        //     cost much extra and is less likely to help us hit a fast path
-        //     (we will look for this later, when we compute ambig_groupid, for
-        //     correctness)
-        int all_subtypes = any_subtypes;
-        if (any_subtypes) {
-            jl_method_t *minmaxm = NULL;
-            if (minmax != NULL)
-                minmaxm = minmax->method;
-            // scan through all the non-fully-matching methods and count them as "fully-covering" (ish)
-            // (i.e. in the 'subtype' group) if `minmax` is more-specific
-            for (i = 0; i < len; i++) {
-                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
-                if (matc->fully_covers != FULLY_COVERS) {
-                    jl_method_t *m = matc->method;
-                    if (minmaxm) {
-                        if (method_morespecific_via_interferences(minmaxm, m)) {
-                            matc->fully_covers = SENTINEL; // put a sentinel value here for sorting
-                            continue;
-                        }
-                        if (method_in_interferences(minmaxm, m)) // !morespecific(m, minmaxm)
-                            has_ambiguity = 1;
-                    }
-                    all_subtypes = 0;
-                }
-            }
-        }
-        //    - now we might have a fast-return here, if we see that
-        //      we've already processed all of the possible outputs
-        if (all_subtypes) {
-            if (minmax == NULL) {
-                // all intersecting methods are fully-covering, but there is no unique most-specific method
-                if (!include_ambiguous) {
-                    // there no unambiguous choice of method
-                    len = 0;
-                    env.t = jl_an_empty_vec_any;
-                }
-                else if (lim == 1) {
-                    // we'd have to return >1 method due to the ambiguity, so bail early
-                    JL_GC_POP();
-                    return jl_nothing;
-                }
-            }
-            else {
-                // `minmax` is more-specific than all other matches and is fully-covering
-                // we can return it as our only result
-                jl_array_ptr_set(env.t, 0, minmax);
-                jl_array_del_end((jl_array_t*)env.t, len - 1);
-                len = 1;
-            }
-        }
-        if (minmax && lim == 0) {
-            // protect some later algorithms from underflow
+    size_t j, len;
+    {
+        ssize_t sorted = sort_method_matches((jl_array_t*)env.t, lim, include_ambiguous, ambig == NULL, &has_ambiguity);
+        if (sorted == -1) {
             JL_GC_POP();
             return jl_nothing;
         }
-    }
-    if (len > 1) {
-        arraylist_t stack, visited, result, recursion_stack;
-        arraylist_new(&result, lim != -1 && lim < len ? lim : len);
-        arraylist_new(&stack, 0);
-        arraylist_new(&visited, len);
-        arraylist_new(&recursion_stack, len);
-        arraylist_grow(&visited, len);
-        memset(visited.items, 0, len * sizeof(size_t));
-        char *tainted = (char*)calloc_s(len);
-        // if we had a minmax method (any subtypes), now may now be able to
-        // quickly cleanup some of methods
-        int found_minmax = 0;
-        if (has_ambiguity)
-            found_minmax = 1;
-        else if (minmax != NULL)
-            found_minmax = 2;
-        else if (any_subtypes && !include_ambiguous)
-            found_minmax = 1;
-        has_ambiguity = 0;
-        if (ambig == NULL) // if we don't care about the result, set it now so we won't bother attempting to compute it accurately later
-            has_ambiguity = 1;
-        for (i = 0; i < len; i++) {
-            assert(visited.items[i] == (void*)0 || visited.items[i] == (void*)1);
-            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
-            if (matc->fully_covers != NOT_FULLY_COVERS && found_minmax) {
-                // this was already handled above and below, so we won't learn anything new
-                // by visiting it and it might be a bit costly
-                continue;
-            }
-            int child_cycle = sort_mlmatches((jl_array_t*)env.t, i, &visited, tainted, &stack, &result, &recursion_stack, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
-            if (child_cycle == -1) {
-                free(tainted);
-                arraylist_free(&recursion_stack);
-                arraylist_free(&visited);
-                arraylist_free(&stack);
-                arraylist_free(&result);
-                JL_GC_POP();
-                return jl_nothing;
-            }
-            assert(child_cycle == 0); (void)child_cycle;
-            assert(stack.len == 0);
-            assert(visited.items[i] == (void*)1);
-        }
-        free(tainted);
-        arraylist_free(&recursion_stack);
-        arraylist_free(&visited);
-        arraylist_free(&stack);
-        for (j = 0; j < result.len; j++) {
-            i = (size_t)result.items[j];
-            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
-            // remove our sentinel entry markers
-            if (matc->fully_covers == SENTINEL)
-                matc->fully_covers = NOT_FULLY_COVERS;
-            result.items[j] = (void*)matc;
-        }
-        if (minmax) {
-            arraylist_push(&result, minmax);
-            j++;
-        }
-        memcpy(jl_array_data(env.t, jl_method_match_t*), result.items, j * sizeof(jl_method_match_t*));
-        arraylist_free(&result);
-        if (j != len)
-            jl_array_del_end((jl_array_t*)env.t, len - j);
-        len = j;
+        len = (size_t)sorted;
     }
     for (j = 0; j < len; j++) {
         jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, j);

--- a/src/gf.c
+++ b/src/gf.c
@@ -352,7 +352,7 @@ jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *sname, jl_fptr_args
     m->isva = 1;
     m->nargs = 2;
     jl_atomic_store_relaxed(&m->primary_world, 1);
-    jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_LATEST_ONLY | METHOD_SIG_LATEST_WHICH);
+    jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_LATEST_WHICH);
     m->sig = (jl_value_t*)tuptyp;
     m->slot_syms = jl_an_empty_string;
     m->nospecialize = 0;
@@ -1883,8 +1883,10 @@ static void cache_insert(
         jl_method_cache_inserted();
         JL_UNLOCK(&mc->writelock); // before acquiring world_counter_lock
 
-        // Only set METHOD_SIG_LATEST_ONLY on method instance if method does NOT have the bit, no guards required, and min_valid == primary_world
-        int should_set_dispatch_status = !(jl_atomic_load_relaxed(&definition->dispatch_status) & METHOD_SIG_LATEST_ONLY) &&
+        // Only set METHOD_SIG_LATEST_ONLY on method instance if the method-level fact
+        // (an empty interference set) does not already cover it, no guards required,
+        // and min_valid == primary_world
+        int should_set_dispatch_status = jl_atomic_load_relaxed(&definition->interferences)->length != 0 &&
             (jl_value_t*)cachett == newmeth->specTypes && jl_svec_len(guardsigs) == 0 &&
             min_valid == jl_atomic_load_relaxed(&definition->primary_world) &&
             !(jl_atomic_load_relaxed(&newmeth->dispatch_status) & METHOD_SIG_LATEST_ONLY);
@@ -2208,9 +2210,10 @@ JL_DLLEXPORT void jl_promote_mi_to_current(jl_method_instance_t *mi, size_t min_
     // No need to acquire the lock if we've been invalidated anyway
     if (current_world > validated_world)
         return;
-    // Only set METHOD_SIG_LATEST_ONLY on method instance if method does NOT have the bit and min_valid == primary_world
+    // Only set METHOD_SIG_LATEST_ONLY on method instance if the method-level fact
+    // (an empty interference set) does not already cover it and min_valid == primary_world
     jl_method_t *definition = mi->def.method;
-    if ((jl_atomic_load_relaxed(&definition->dispatch_status) & METHOD_SIG_LATEST_ONLY) ||
+    if (jl_atomic_load_relaxed(&definition->interferences)->length == 0 ||
         min_world != jl_atomic_load_relaxed(&definition->primary_world) ||
         (jl_atomic_load_relaxed(&mi->dispatch_status) & METHOD_SIG_LATEST_ONLY))
         return;
@@ -2290,7 +2293,7 @@ static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_in
         closure->shadowed = (jl_value_t*)jl_alloc_vec_any(0);
     // Record every intersecting method so the interference relation is complete.
     // We must NOT early-out when the new method is a strict subtype of an
-    // `oldmethod` that dominates its dispatch (METHOD_SIG_LATEST_ONLY): stopping
+    // `oldmethod` that dominates its dispatch (empty interference set): stopping
     // the scan there would omit the new method's other intersecting pairs, and
     // `morespecific` is not monotone under subtyping (strict-subtype implies
     // morespecific, but the supertype's specificity relations do not transfer to
@@ -3004,7 +3007,6 @@ jl_typemap_entry_t *jl_method_table_add(jl_methtable_t *mt, jl_method_t *method,
     // add our new entry
     assert(jl_atomic_load_relaxed(&method->primary_world) == ~(size_t)0); // min-world
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_WHICH) == 0);
-    assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     JL_LOCK(&mt->cache->writelock);
     newentry = jl_typemap_alloc((jl_tupletype_t*)method->sig, simpletype, jl_emptysvec, (jl_value_t*)method, ~(size_t)0, 1);
     jl_typemap_insert(&mt->defs, (jl_value_t*)mt, newentry, 0);
@@ -3244,7 +3246,6 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     size_t world = jl_atomic_load_relaxed(&method->primary_world);
     assert(world == jl_atomic_load_relaxed(&jl_world_counter) + 1); // min-world
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_WHICH) == 0);
-    assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     assert(jl_atomic_load_relaxed(&newentry->min_world) == ~(size_t)0);
     assert(jl_atomic_load_relaxed(&newentry->max_world) == 1);
     jl_atomic_store_relaxed(&newentry->min_world, world);
@@ -3271,14 +3272,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         oldmi = jl_alloc_vec_any(0);
     }
 
-    // These get updated from their state stored in the caches files, since content in cache files gets added "all at once".
     int invalidated = 0;
-    int dispatch_bits = METHOD_SIG_LATEST_WHICH; // Always set LATEST_WHICH
-    // Check precompiled dispatch status bits
-    int precompiled_status = jl_atomic_load_relaxed(&method->dispatch_status);
-    if (!(precompiled_status & METHOD_SIG_PRECOMPILE_MANY))
-        // This will store if this method will be currently the only result that would returned from `ml_matches` given `sig`.
-        dispatch_bits |= METHOD_SIG_LATEST_ONLY; // Tentatively set, will be cleared if not applicable
     // Holds the set of all intersecting methods not more specific than this one.
     // The insertion scan below visits every intersecting method (the
     // LATEST_ONLY early-out was removed), so the recorded relation is complete:
@@ -3295,11 +3289,8 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             method_overwrite(newentry, m);
             // This is an optimized version of below, given we know the type-intersection is exact
             jl_method_table_invalidate(m, max_world);
-            int m_dispatch = jl_atomic_load_relaxed(&m->dispatch_status);
-            // Clear METHOD_SIG_LATEST_ONLY and METHOD_SIG_LATEST_WHICH bits
+            // Clear METHOD_SIG_LATEST_WHICH bit
             jl_atomic_store_relaxed(&m->dispatch_status, 0);
-            if (!(m_dispatch & METHOD_SIG_LATEST_ONLY))
-                dispatch_bits &= ~METHOD_SIG_LATEST_ONLY;
             // Take over the interference list from the replaced method
             jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
             if (interferences->length == 0) {
@@ -3358,27 +3349,19 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                 jl_method_t *m = d[j];
                 // Compute ambig state: is there an ambiguity between new method and old m?
                 char ambig = !morespec[j] && !jl_type_morespecific(type, m->sig);
-                // Compute updates to the dispatch state bits
-                int m_dispatch = jl_atomic_load_relaxed(&m->dispatch_status);
                 if (morespec[j] || ambig) {
-                    // !morespecific(new, old)
-                    dispatch_bits &= ~METHOD_SIG_LATEST_ONLY;
-                    // Add the old method to this interference set
+                    // !morespecific(new, old): add the old method to this interference set
                     ssize_t idx;
                     if (!has_key(interferences, (jl_value_t*)m))
                         interferences = jl_idset_put_key(interferences, (jl_value_t*)m, &idx);
                 }
                 if (!morespec[j]) {
-                    // !morespecific(old, new)
-                    m_dispatch &= ~METHOD_SIG_LATEST_ONLY;
-                    // Add the new method to its interference set
+                    // !morespecific(old, new): add the new method to its interference set
                     jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
                     ssize_t idx;
                     m_interferences = jl_idset_put_key(m_interferences, (jl_value_t*)method, &idx);
                     jl_gc_write_atomic(m, m->interferences, jl_genericmemory_t, m_interferences, release);
                 }
-                // Add methods that intersect but are not more specific to interference list
-                jl_atomic_store_relaxed(&m->dispatch_status, m_dispatch);
                 if (morespec[j])
                     continue;
 
@@ -3489,7 +3472,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         jl_array_ptr_1d_push(_jl_debug_method_invalidation, loctag);
     }
     jl_atomic_store_relaxed(&newentry->max_world, ~(size_t)0);
-    jl_atomic_store_relaxed(&method->dispatch_status, dispatch_bits); // TODO: this should be sequenced fully after the world counter store
+    jl_atomic_store_relaxed(&method->dispatch_status, METHOD_SIG_LATEST_WHICH); // TODO: this should be sequenced fully after the world counter store
     jl_gc_write_atomic(method, method->interferences, jl_genericmemory_t, interferences, release);
     JL_GC_POP();
 }
@@ -5110,17 +5093,14 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     if (closure->match.max_valid > max_world)
         closure->match.max_valid = max_world;
     jl_method_t *meth = ml->func.method;
-    // Whether this method dominates (is strictly morespecific than) every
-    // method it intersects, and hence every other candidate for this query:
-    // either its LATEST_ONLY bit is set, or its interference set is empty (the
-    // ground-truth relation, which the bit tracks in lockstep except that the
-    // bit can be suppressed by PRECOMPILE_MANY). Such a method always survives
-    // into the final result (nothing can cover a method that beats every
-    // intersecting method), and when it also fully covers the query it is the
-    // unique result, so the rest of the search can be skipped. Interference
-    // sets only grow, so emptiness now implies emptiness in the query's world.
-    int only = (jl_atomic_load_relaxed(&meth->dispatch_status) & METHOD_SIG_LATEST_ONLY) ||
-               jl_atomic_load_relaxed(&meth->interferences)->length == 0;
+    // An empty interference set means this method is strictly morespecific
+    // than every method it intersects, and hence than every other candidate
+    // for this query. Such a method always survives into the final result
+    // (nothing can cover a method that beats every intersecting method), and
+    // when it also fully covers the query it is the unique result, so the rest
+    // of the search can be skipped. Interference sets only grow, so emptiness
+    // now implies emptiness in the query's world.
+    int only = jl_atomic_load_relaxed(&meth->interferences)->length == 0;
     if (closure->lim >= 0 && only) {
         if (closure->lim == 0) {
             closure->t = jl_an_empty_vec_any;

--- a/src/gf.c
+++ b/src/gf.c
@@ -3239,6 +3239,8 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
            jl_has_empty_intersection(target_method->sig, start_method->sig) ||
            jl_has_empty_intersection(start_method->sig, target_method->sig));
     // a method recorded as strictly beating something must not carry NO_LOSERS
+    // (the replacement path clears the bit for the recency-tiebreak win it
+    // records over the type-equal method it replaces)
     assert(!result || !(jl_atomic_load_relaxed(&target_method->dispatch_status) & METHOD_SIG_NO_LOSERS));
     return result;
 }
@@ -3285,13 +3287,17 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     }
 
     int invalidated = 0;
-    // Tentatively assume the new method is not strictly morespecific than
-    // anything it intersects (METHOD_SIG_NO_LOSERS); the scan below clears it
-    // on the first method this one beats. Conversely, an old method that this
-    // one is beaten by keeps its state, and an old method that is beaten
-    // (morespec[j], conservatively including both-ways-morespecific pairs)
-    // loses its bit.
-    int dispatch_bits = METHOD_SIG_LATEST_WHICH | METHOD_SIG_NO_LOSERS;
+    // METHOD_SIG_NO_LOSERS is carried in from the method's current state, not
+    // re-derived: it is set at method creation and monotone-cleared. The scan
+    // below clears it on the first method this one beats; conversely an old
+    // method that is beaten (morespec[j], conservatively including
+    // both-ways-morespecific pairs) loses its bit. The bit must survive
+    // serialization (like the interference sets, and unlike LATEST_WHICH)
+    // because a cache-image batch shares one world: this scan runs against the
+    // prior world and cannot see same-image methods, so their pairs are never
+    // re-derived at load and only the precompile-time state is correct.
+    int precompiled_status = jl_atomic_load_relaxed(&method->dispatch_status);
+    int dispatch_bits = METHOD_SIG_LATEST_WHICH | (precompiled_status & METHOD_SIG_NO_LOSERS);
     // Holds the set of all intersecting methods not more specific than this one.
     // The insertion scan below visits every intersecting method (the
     // LATEST_ONLY early-out was removed), so the recorded relation is complete:
@@ -3308,10 +3314,13 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             method_overwrite(newentry, m);
             // This is an optimized version of below, given we know the type-intersection is exact
             jl_method_table_invalidate(m, max_world);
-            // The replacement has the same signature, so it inherits the
-            // replaced method's specificity relations, including NO_LOSERS
-            if (!(jl_atomic_load_relaxed(&m->dispatch_status) & METHOD_SIG_NO_LOSERS))
-                dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
+            // The replacement strictly beats the replaced method (the recency
+            // tiebreak in `jl_method_morespecific` for type-equal signatures,
+            // recorded below), so it always has at least that one strict loser.
+            // NO_LOSERS cannot be inherited: type-equal does not imply
+            // morespecific-equal, so the predecessor's relations do not
+            // transfer.
+            dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
             // Clear METHOD_SIG_LATEST_WHICH bit
             jl_atomic_store_relaxed(&m->dispatch_status, 0);
             // Take over the interference list from the replaced method
@@ -3338,6 +3347,15 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                     ssize_t idx;
                     m2_interferences = jl_idset_put_key(m2_interferences, (jl_value_t*)method, &idx);
                     jl_gc_write_atomic(m2, m2->interferences, jl_genericmemory_t, m2_interferences, release);
+                }
+                if (m2 && m2 != m) {
+                    // Recompute the partner's NO_LOSERS against the
+                    // replacement's own signature: type-equal does not imply
+                    // morespecific-equal, so `morespecific(m2, method)` may
+                    // hold where `morespecific(m2, m)` did not.
+                    int m2_dispatch = jl_atomic_load_relaxed(&m2->dispatch_status);
+                    if ((m2_dispatch & METHOD_SIG_NO_LOSERS) && jl_type_morespecific(m2->sig, type))
+                        jl_atomic_store_relaxed(&m2->dispatch_status, m2_dispatch & ~METHOD_SIG_NO_LOSERS);
                 }
             }
             loctag = jl_atomic_load_relaxed(&m->specializations); // use loctag for a gcroot

--- a/src/gf.c
+++ b/src/gf.c
@@ -3075,11 +3075,10 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
     return result;
 }
 
-// Whether `m2` is admissible as a cover of `m`: reported in the match list and
-// strictly morespecific than `m` (a one-directional recorded edge). `visited`,
-// if given, additionally restricts covers to matches the sort has already
-// finalized, so that a method still tangled in the cycle being resolved cannot
-// serve as a cover; pass NULL to accept any applicable match.
+// Whether `m2` is admissible as a cover of `m`: reported in the match list,
+// strictly morespecific than `m` (a one-directional recorded edge), and
+// already finalized by the sort, so that a method still tangled in the cycle
+// being resolved cannot serve as a cover.
 static int admissible_cover(jl_method_t *m, jl_method_t *m2, jl_array_t *t, arraylist_t *visited)
 {
     if (m2 == NULL)
@@ -3089,8 +3088,8 @@ static int admissible_cover(jl_method_t *m, jl_method_t *m2, jl_array_t *t, arra
         return 0;
     if (method_in_interferences(m, m2))
         return 0; // mutually ambiguous, so not a dominator
-    if (visited != NULL && visited->items[idx] != (void*)1)
-        return 0; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
+    if (visited->items[idx] != (void*)1)
+        return 0; // not finalized yet (part of the same SCC cycle, handled by ambiguity later)
     return 1;
 }
 
@@ -3187,7 +3186,11 @@ static int check_dominance_transfer(jl_method_t *D, jl_value_t *ti, jl_method_t 
     // exempt from that scan -- notably when S is the minmax method, which the
     // sort never visits -- leaving this check as the only witness of the pair
     // when D's only cover is a match that S beats (test `AmbigMinmaxPartner`))
+    // Root the interference-set snapshot: a concurrent method definition may
+    // swap in a grown copy, leaving this one unreachable across the safepoints
+    // in `check_blocker_transfer`.
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&D->interferences);
+    JL_GC_PUSH1(&interferences);
     for (size_t i = 0; i < interferences->length; i++) {
         jl_method_t *S = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
         if (S == NULL)
@@ -3198,9 +3201,12 @@ static int check_dominance_transfer(jl_method_t *D, jl_value_t *ti, jl_method_t 
         if (idx < 0)
             continue;
         jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, idx);
-        if (!check_blocker_transfer(ti, (jl_value_t*)matc->spec_types, S, covers, ncovers))
+        if (!check_blocker_transfer(ti, (jl_value_t*)matc->spec_types, S, covers, ncovers)) {
+            JL_GC_POP();
             return 0;
+        }
     }
+    JL_GC_POP();
     // Next, the methods `D` was beating: those stay unselectable through the
     // covers by the same rule.
     //
@@ -3227,30 +3233,6 @@ static int check_dominance_transfer(jl_method_t *D, jl_value_t *ti, jl_method_t 
     return 1;
 }
 
-// Find a match `S` that is strictly morespecific than `m` and applies over all of `ti`.
-// `visited`, if given, restricts the witness to matches the
-// sort has already finalized, so that a method still tangled in the cycle being
-// resolved cannot serve as a cover; pass NULL to accept any applicable match. `pos`
-// carries an index into the interference set so a caller can resume the scan for
-// a further witness.
-static jl_method_t *find_dominating_match(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, size_t *pos) JL_CANSAFEPOINT
-{
-    jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
-    for (size_t i = pos == NULL ? 0 : *pos; i < interferences->length; i++) {
-        jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
-        if (!admissible_cover(m, m2, t, visited))
-            continue;
-        if (jl_subtype(ti, (jl_value_t*)m2->sig)) {
-            if (pos != NULL)
-                *pos = i + 1;
-            return m2;
-        }
-    }
-    if (pos != NULL)
-        *pos = interferences->length;
-    return NULL;
-}
-
 // Check if some morespecific method (or a union of them) covers the given
 // type intersection, meaning this match can never be the dispatch winner and
 // can be removed from the returned matches without any dispatch noticing. When the
@@ -3259,51 +3241,73 @@ static jl_method_t *find_dominating_match(jl_method_t *m, jl_value_t *ti, jl_arr
 // match was blocking another match, sets *has_ambiguity; in that case the match
 // is only reported as covered when `include_ambiguous` is false, so that
 // ambiguity-reporting consumers still see it.
-static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
+static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, jl_method_t *minmaxm, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
-    jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
-    // First: is `m` fully covered (dominated over the whole query region `ti`)
-    // by a single recorded strictly-morespecific method?
-    size_t pos = 0;
     int transfer_failed = 0;
-    while (1) {
-        jl_method_t *m2 = find_dominating_match(m, ti, t, visited, &pos);
-        if (m2 == NULL)
-            break;
-        // m2 is strictly morespecific than m (a one-directional recorded edge)
-        // and fully covers ti, so m can never win dispatch here. Dropping m is
-        // only safe if m2 also takes over the roles m had in the sort: a
-        // specificity cycle may lead back from a cover to a method only m beat,
-        // or m may be the last match blocking another one, and either way the
-        // apparent ambiguity is real. When `!include_ambiguous` we drop `m` here
-        // either way, so this only computes *has_ambiguity and can be skipped
-        // once that is already known.
-        if ((include_ambiguous || !*has_ambiguity) && !check_dominance_transfer(m, ti, &m2, 1, t)) {
+    int probed_minmax = 0;
+    // The minmax method contains every match's region (it fully covers the
+    // query, and `ti` normally is contained in the query -- though an imprecise
+    // intersection still requires the explicit subtype check), is reported
+    // unconditionally, and is pre-finalized, so whenever it strictly beats `m`
+    // it is an admissible cover: probe it directly before scanning the
+    // interference set in storage order.
+    if (minmaxm != NULL && method_morespecific_recorded(minmaxm, m) &&
+        jl_subtype(ti, (jl_value_t*)minmaxm->sig)) {
+        probed_minmax = 1;
+        // minmaxm is strictly morespecific than m (a one-directional recorded
+        // edge) and fully covers ti, so m can never win dispatch here. Dropping
+        // m is only safe if minmaxm also takes over the roles m had in the
+        // sort: a specificity cycle may lead back from a cover to a method only
+        // m beat, or m may be the last match blocking another one, and either
+        // way the apparent ambiguity is real. When `!include_ambiguous` we drop
+        // `m` here either way, so this only computes *has_ambiguity and can be
+        // skipped once that is already known.
+        if ((include_ambiguous || !*has_ambiguity) && !check_dominance_transfer(m, ti, &minmaxm, 1, t)) {
             // Do not latch *has_ambiguity yet: another cover (or the union of
             // covers below) may still certify the removal cleanly, in which
             // case this failure was moot.
             transfer_failed = 1;
-            continue;
         }
-        return 1;
+        else {
+            return 1;
+        }
     }
-    // No single morespecific method certified covering ti, but a union of them
-    // may (e.g. several methods each covering one component of a Union-typed
-    // argument). Collect the recorded strictly-morespecific interferences that
-    // the sort has already finalized and check whether ti is covered by their
-    // union. Whether such a union really certifies the removal is left to
-    // `check_dominance_transfer` below: a cover may be tangled in a specificity
-    // cycle that leads back to `m`, or may fail to block what `m` was blocking
-    // (test `AmbigUnionCycle`).
+    // Scan the interference set once: each admissible cover (recorded
+    // strictly-morespecific interference the sort has already finalized) is
+    // both attempted as a single cover of ti and collected for the union check
+    // below -- neither `t` nor `visited` changes here, so one pass serves
+    // both. (The transfer obligations are the same as for the minmax probe
+    // above.)
     int result = 0;
     arraylist_t covers;
     arraylist_new(&covers, 0);
-    for (size_t i = 0; i < interferences->length; i++) {
+    // Root the interference-set snapshot across the safepoints below (see
+    // `check_dominance_transfer`).
+    jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
+    JL_GC_PUSH1(&interferences);
+    for (size_t i = 0; !result && i < interferences->length; i++) {
         jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
-        if (admissible_cover(m, m2, t, visited))
-            arraylist_push(&covers, (void*)m2);
+        if (!admissible_cover(m, m2, t, visited))
+            continue;
+        arraylist_push(&covers, (void*)m2);
+        if (probed_minmax && m2 == minmaxm)
+            continue; // its transfer already failed above
+        if (!jl_subtype(ti, (jl_value_t*)m2->sig))
+            continue;
+        if ((include_ambiguous || !*has_ambiguity) && !check_dominance_transfer(m, ti, &m2, 1, t)) {
+            transfer_failed = 1;
+            continue;
+        }
+        result = 1;
     }
-    if (covers.len > 1 && union_of_sigs_covers(ti, (jl_method_t**)covers.items, covers.len)) {
+    JL_GC_POP();
+    // No single morespecific method certified covering ti, but a union of them
+    // may (e.g. several methods each covering one component of a Union-typed
+    // argument). Whether such a union really certifies the removal is left to
+    // `check_dominance_transfer` again: a cover may be tangled in a specificity
+    // cycle that leads back to `m`, or may fail to block what `m` was blocking
+    // (test `AmbigUnionCycle`).
+    if (!result && covers.len > 1 && union_of_sigs_covers(ti, (jl_method_t**)covers.items, covers.len)) {
         result = 1;
         if ((include_ambiguous || !*has_ambiguity) &&
             !check_dominance_transfer(m, ti, (jl_method_t**)covers.items, covers.len, t)) {
@@ -3329,7 +3333,11 @@ static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, 
 {
     if (include_ambiguous && *has_ambiguity)
         return 0; // this can only compute *has_ambiguity, which is already known
+    int result = 0;
+    // Root the snapshot across the `jl_subtype` safepoints (see
+    // `check_dominance_transfer`).
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
+    JL_GC_PUSH1(&interferences);
     for (size_t i = 0; i < interferences->length; i++) {
         jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
         if (m2 == NULL)
@@ -3341,11 +3349,14 @@ static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, 
             continue;
         *has_ambiguity = 1;
         if (include_ambiguous)
-            return 0; // the rest of the scan could only set *has_ambiguity again
-        if (jl_subtype(ti, m2->sig))
-            return 1;
+            break; // the rest of the scan could only set *has_ambiguity again
+        if (jl_subtype(ti, m2->sig)) {
+            result = 1;
+            break;
+        }
     }
-    return 0;
+    JL_GC_POP();
+    return result;
 }
 
 
@@ -3493,7 +3504,12 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                     dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
                 }
                 if (!morespec[j]) {
-                    // !morespecific(old, new): add the new method to its interference set
+                    // !morespecific(old, new): add the new method to its interference set.
+                    // No duplicate-key probe is needed here: `d` was collected against the
+                    // prior world, and the methods of a loaded image activate together in a
+                    // single world bump, so a same-image method -- the only kind whose
+                    // serialized interference set could already contain `method` -- never
+                    // appears in `d`.
                     jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
                     ssize_t idx;
                     m_interferences = jl_idset_put_key(m_interferences, (jl_value_t*)method, &idx);
@@ -5181,20 +5197,14 @@ struct ml_matches_env {
     jl_method_match_t *matc; // current working method match
 };
 
-enum SIGNATURE_FULLY_COVERS {
-    NOT_FULLY_COVERS = 0,
-    FULLY_COVERS = 1,
-    SENTINEL    = 2,
-};
-
-static jl_method_match_t *make_method_match(jl_tupletype_t *spec_types, jl_svec_t *sparams, jl_method_t *method, enum SIGNATURE_FULLY_COVERS fully_covers) JL_CANSAFEPOINT
+static jl_method_match_t *make_method_match(jl_tupletype_t *spec_types, jl_svec_t *sparams, jl_method_t *method, int fully_covers) JL_CANSAFEPOINT
 {
     jl_task_t *ct = jl_current_task;
     jl_method_match_t *match = (jl_method_match_t*)jl_gc_alloc(ct->ptls, sizeof(jl_method_match_t), jl_method_match_type);
     match->spec_types = spec_types;
     match->sparams = sparams;
     match->method = method;
-    match->fully_covers = fully_covers;
+    match->fully_covers = fully_covers != 0;
     return match;
 }
 
@@ -5240,7 +5250,7 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     }
     closure->matc = make_method_match((jl_tupletype_t*)closure->match.ti,
         closure->match.env, meth,
-        closure->match.issubty ? FULLY_COVERS : NOT_FULLY_COVERS);
+        closure->match.issubty);
     size_t len = jl_array_nrows(closure->t);
     if (closure->match.issubty && only) {
         if (len == 0)
@@ -5289,13 +5299,12 @@ enum sort_state {
 typedef struct {
     size_t idx;                    // Current method match index
     size_t interference_index;     // Current position in interferences loop
-    size_t interference_count;     // Total interferences count
+    size_t interference_count;     // Interferences count when the frame was created
     size_t depth;                  // Stack depth when frame created
     size_t cycle;                  // Cycle depth tracking
     jl_method_match_t *matc;       // Current method match
     jl_method_t *m;                // Current method
     jl_value_t *ti;                // Type intersection
-    jl_genericmemory_t *interferences; // Method interferences
     int child_result;              // Result from child recursive call
     enum sort_state state;
 } sort_stack_frame_t;
@@ -5304,7 +5313,7 @@ typedef struct {
 //  * -1: too many matches for lim, other outputs are undefined
 //  *  0: the child(ren) have been added to the output
 //  * 1+: the children are part of this SCC (up to this depth)
-static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, arraylist_t *stack, arraylist_t *result, int lim, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
+static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, arraylist_t *stack, arraylist_t *result, int lim, int include_ambiguous, jl_method_t *minmaxm, int *has_ambiguity) JL_CANSAFEPOINT
 {
     // Use arraylist_t for explicit stack of processing frames
     arraylist_t frame_stack;
@@ -5320,7 +5329,6 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
         .matc = NULL,
         .m = NULL,
         .ti = NULL,
-        .interferences = NULL,
         .child_result = 0,
         .state = STATE_VISITING
     };
@@ -5331,7 +5339,6 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
     while (1) {
         sort_stack_frame_t *current = (sort_stack_frame_t*)frame_stack.items[frame_stack.len - 1];
         JL_GC_PROMISE_ROOTED(current->m);
-        JL_GC_PROMISE_ROOTED(current->interferences);
         JL_GC_PROMISE_ROOTED(current->ti);
 
         switch (current->state) {
@@ -5348,9 +5355,8 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                 current->matc = (jl_method_match_t*)jl_array_ptr_ref(t, current->idx);
                 current->m = current->matc->method;
                 current->ti = (jl_value_t*)current->matc->spec_types;
-                current->interferences = jl_atomic_load_relaxed(&current->m->interferences);
                 current->cycle = current->depth;
-                current->interference_count = current->interferences->length;
+                current->interference_count = jl_atomic_load_relaxed(&current->m->interferences)->length;
                 current->interference_index = 0;
                 current->state = STATE_PROCESSING_INTERFERENCES;
                 break;
@@ -5369,9 +5375,17 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                     current->child_result = 0; // Clear after processing
                 }
 
-                // Process interferences iteratively
+                // Process interferences iteratively.
+                // The set is reloaded on every iteration rather than cached in
+                // the frame: the frame lives in malloc'd memory that no GC scan
+                // can see, and a concurrent method definition may swap in a
+                // grown copy of the set, leaving a cached snapshot unreachable
+                // across the safepoints below. The entries already present are
+                // a stable prefix of any replacement, so the cached count and
+                // cursor stay valid.
                 while (current->interference_index < current->interference_count) {
-                    jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(current->interferences, current->interference_index);
+                    jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&current->m->interferences);
+                    jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, current->interference_index);
                     current->interference_index++;
 
                     if (m2 == NULL)
@@ -5411,7 +5425,6 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                             .matc = NULL,
                             .m = NULL,
                             .ti = NULL,
-                                            .interferences = NULL,
                             .child_result = 0,
                             .state = STATE_VISITING
                         };
@@ -5433,7 +5446,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                 // cover like any other finalized match -- together with the
                 // other covers and their union, which a lone minmax transfer
                 // could not consult (test `AmbigMinmaxUnion`).
-                if (check_interferences_covers(current->m, current->ti, t, visited, include_ambiguous, has_ambiguity)) {
+                if (check_interferences_covers(current->m, current->ti, t, visited, minmaxm, include_ambiguous, has_ambiguity)) {
                     visited->items[current->idx] = (void*)1;
                 }
                 else if (check_fully_ambiguous(current->m, current->ti, t, include_ambiguous, has_ambiguity)) {
@@ -5560,7 +5573,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         //   - First, find a candidate for the best of these method results.
         for (i = 0; i < len; i++) {
             jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
-            if (matc->fully_covers == FULLY_COVERS) {
+            if (matc->fully_covers) {
                 any_subtypes = 1;
                 jl_method_t *m = matc->method;
                 // A fully-covering match with an empty interference set is
@@ -5576,7 +5589,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                     if (i == j)
                         continue;
                     jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(t, j);
-                    if (matc2->fully_covers == FULLY_COVERS) {
+                    if (matc2->fully_covers) {
                         jl_method_t *m2 = matc2->method;
                         if (!method_morespecific_recorded(m, m2))
                             break;
@@ -5590,10 +5603,10 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             }
         }
         //   - It may even dominate (be more specific than) some choices that are not fully-covering!
-        //     move those into the subtype group, where we'll filter them out shortly after
-        //     (potentially avoiding reporting these as an ambiguity, and
-        //     potentially allowing us to hit the next fast path).
-        //   - We could always check here if *any* FULLY_COVERS method is
+        //     If it dominates all of them, the fast-return below applies; otherwise
+        //     the sort rediscovers minmax as the certifying cover for each match it
+        //     dominates (`check_interferences_covers` probes it first).
+        //   - We could always check here if *any* fully-covering method is
         //     more-specific (instead of just considering minmax), but that may
         //     cost much extra and is less likely to help us hit a fast path
         //     (we will look for this later, when we compute the full sort).
@@ -5602,21 +5615,14 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             jl_method_t *minmaxm = NULL;
             if (minmax != NULL)
                 minmaxm = minmax->method;
-            // scan through all the non-fully-matching methods and count them as "fully-covering" (ish)
-            // (i.e. in the 'subtype' group) if `minmax` is more-specific
             for (i = 0; i < len; i++) {
                 jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
-                if (matc->fully_covers != FULLY_COVERS) {
+                if (!matc->fully_covers) {
                     jl_method_t *m = matc->method;
-                    if (minmaxm) {
-                        if (method_morespecific_recorded(minmaxm, m)) {
-                            matc->fully_covers = SENTINEL; // put a sentinel value here for sorting
-                            continue;
-                        }
-                        if (method_in_interferences(minmaxm, m)) // !morespecific(m, minmaxm)
-                            has_ambiguity = 1;
-                    }
+                    if (minmaxm != NULL && method_morespecific_recorded(minmaxm, m))
+                        continue; // minmax dominates this match too
                     all_subtypes = 0;
+                    break;
                 }
             }
         }
@@ -5659,11 +5665,10 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         // admissible as a cover for every dominance check, so a match it
         // dominates is certified against it together with the other finalized
         // covers and their union -- a lone minmax transfer could consult
-        // neither (tests `AmbigMinmaxSkip`, `AmbigMinmaxUnion`). n.b. the
-        // pre-scan's `has_ambiguity` was only a hint for choosing minmax: the
-        // sort recomputes the flag, rediscovering any real, uncertified
-        // ambiguity through `check_dominance_transfer`/`check_fully_ambiguous`.
+        // neither (tests `AmbigMinmaxSkip`, `AmbigMinmaxUnion`).
+        jl_method_t *minmaxm = NULL;
         if (minmax != NULL) {
+            minmaxm = minmax->method;
             for (i = 0; i < len; i++) {
                 if ((jl_method_match_t*)jl_array_ptr_ref(t, i) == minmax) {
                     visited.items[i] = (void*)1;
@@ -5672,12 +5677,11 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             }
             assert(i < len);
         }
-        has_ambiguity = 0;
         if (approximate_ambig) // if we don't care about the result, set it now so we won't bother attempting to compute it accurately later
             has_ambiguity = 1;
         for (i = 0; i < len; i++) {
             assert(visited.items[i] == (void*)0 || visited.items[i] == (void*)1);
-            int child_cycle = sort_mlmatches(t, i, &visited, &stack, &result, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity);
+            int child_cycle = sort_mlmatches(t, i, &visited, &stack, &result, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, minmaxm, &has_ambiguity);
             if (child_cycle == -1) {
                 arraylist_free(&visited);
                 arraylist_free(&stack);
@@ -5692,11 +5696,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         arraylist_free(&stack);
         for (j = 0; j < result.len; j++) {
             i = (size_t)result.items[j];
-            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
-            // remove our sentinel entry markers
-            if (matc->fully_covers == SENTINEL)
-                matc->fully_covers = NOT_FULLY_COVERS;
-            result.items[j] = (void*)matc;
+            result.items[j] = (void*)jl_array_ptr_ref(t, i);
         }
         if (minmax) {
             arraylist_push(&result, minmax);
@@ -5834,7 +5834,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                     env.match.ti = jl_type_intersection_env((jl_value_t*)type, (jl_value_t*)meth->sig, &env.match.env);
                 }
                 env.matc = make_method_match((jl_tupletype_t*)env.match.ti,
-                    env.match.env, meth, FULLY_COVERS);
+                    env.match.env, meth, 1);
                 env.t = (jl_value_t*)jl_alloc_vec_any(1);
                 jl_array_ptr_set(env.t, 0, env.matc);
                 size_t min_world = jl_atomic_load_relaxed(&entry->min_world);
@@ -5869,7 +5869,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                         env.match.ti = jl_type_intersection_env((jl_value_t*)type, (jl_value_t*)meth->sig, &env.match.env);
                     }
                     env.matc = make_method_match((jl_tupletype_t*)env.match.ti,
-                        env.match.env, meth, FULLY_COVERS);
+                        env.match.env, meth, 1);
                     env.t = (jl_value_t*)jl_alloc_vec_any(1);
                     jl_array_ptr_set(env.t, 0, env.matc);
                     if (*min_valid < min_world)

--- a/src/gf.c
+++ b/src/gf.c
@@ -5276,7 +5276,6 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
 //  * `lim`: either -1 for unlimited matches, or the maximum length for `result` before returning failure (return -1).
 //  * `include_ambiguous`: whether to filter out fully ambiguous matches from `result`
 //  * `*has_ambiguity`: whether the algorithm does not need to compute if there is an unresolved ambiguity
-//  * `*found_minmax`: whether there is a minmax method already found, so future fully_covers matches should be ignored
 // Outputs:
 //  * `*has_ambiguity`: whether there are any ambiguities that mean the sort order is not exact
 // Stack frame for iterative sort_mlmatches implementation
@@ -5296,7 +5295,6 @@ typedef struct {
     jl_method_match_t *matc;       // Current method match
     jl_method_t *m;                // Current method
     jl_value_t *ti;                // Type intersection
-    int subt;                      // Subtype flag
     jl_genericmemory_t *interferences; // Method interferences
     int child_result;              // Result from child recursive call
     enum sort_state state;
@@ -5306,7 +5304,7 @@ typedef struct {
 //  * -1: too many matches for lim, other outputs are undefined
 //  *  0: the child(ren) have been added to the output
 //  * 1+: the children are part of this SCC (up to this depth)
-static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, arraylist_t *stack, arraylist_t *result, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax, jl_method_t *minmaxm) JL_CANSAFEPOINT
+static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, arraylist_t *stack, arraylist_t *result, int lim, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
     // Use arraylist_t for explicit stack of processing frames
     arraylist_t frame_stack;
@@ -5322,7 +5320,6 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
         .matc = NULL,
         .m = NULL,
         .ti = NULL,
-        .subt = 0,
         .interferences = NULL,
         .child_result = 0,
         .state = STATE_VISITING
@@ -5351,7 +5348,6 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                 current->matc = (jl_method_match_t*)jl_array_ptr_ref(t, current->idx);
                 current->m = current->matc->method;
                 current->ti = (jl_value_t*)current->matc->spec_types;
-                current->subt = current->matc->fully_covers != NOT_FULLY_COVERS;
                 current->interferences = jl_atomic_load_relaxed(&current->m->interferences);
                 current->cycle = current->depth;
                 current->interference_count = current->interferences->length;
@@ -5415,8 +5411,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                             .matc = NULL,
                             .m = NULL,
                             .ti = NULL,
-                            .subt = 0,
-                            .interferences = NULL,
+                                            .interferences = NULL,
                             .child_result = 0,
                             .state = STATE_VISITING
                         };
@@ -5432,24 +5427,13 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
             case STATE_CHECK_COVERS: {
                 // There is some probability that this method is already fully covered
                 // now, and we can delete this vertex now without anyone noticing.
-                if (current->subt && *found_minmax) {
-                    assert(minmaxm != NULL);
-                    if (*found_minmax == 2) {
-                        // minmax dominates all fully-covering methods, but this
-                        // dropped method may have been beating a partial match
-                        // that minmax does not dominate (a specificity cycle)
-                        if (current->m != minmaxm && (include_ambiguous || !*has_ambiguity) &&
-                            !check_dominance_transfer(current->m, current->ti, &minmaxm, 1, t)) {
-                            *has_ambiguity = 1;
-                            if (!include_ambiguous)
-                                visited->items[current->idx] = (void*)1;
-                        }
-                        else {
-                            visited->items[current->idx] = (void*)1;
-                        }
-                    }
-                }
-                else if (check_interferences_covers(current->m, current->ti, t, visited, include_ambiguous, has_ambiguity)) {
+                // A match dominated by the minmax method needs no special case
+                // here: minmax is pre-marked visited (it is unconditionally
+                // reported), so `check_interferences_covers` can use it as a
+                // cover like any other finalized match -- together with the
+                // other covers and their union, which a lone minmax transfer
+                // could not consult (test `AmbigMinmaxUnion`).
+                if (check_interferences_covers(current->m, current->ti, t, visited, include_ambiguous, has_ambiguity)) {
                     visited->items[current->idx] = (void*)1;
                 }
                 else if (check_fully_ambiguous(current->m, current->ti, t, include_ambiguous, has_ambiguity)) {
@@ -5493,21 +5477,6 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                 // copy this cycle into the results
                 for (size_t i = current->depth - 1; i < stack->len; i++) {
                     size_t childidx = (size_t)stack->items[i];
-                    jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, childidx);
-                    int subt = matc->fully_covers != NOT_FULLY_COVERS;
-                    if (subt && *found_minmax) {
-                        assert(minmaxm != NULL);
-                        if (visited->items[childidx] != (void*)1 && matc->method != minmaxm &&
-                            (include_ambiguous || !*has_ambiguity) &&
-                            !check_dominance_transfer(matc->method, (jl_value_t*)matc->spec_types, &minmaxm, 1, t)) {
-                            *has_ambiguity = 1;
-                            if (!include_ambiguous)
-                                visited->items[childidx] = (void*)1;
-                        }
-                        else {
-                            visited->items[childidx] = (void*)1;
-                        }
-                    }
                     if ((size_t)visited->items[childidx] == 1)
                         continue;
                     assert(visited->items[childidx] == (void*)(2 + i));
@@ -5523,12 +5492,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                 // now finally cleanup the stack
                 while (stack->len >= current->depth) {
                     size_t childidx = (size_t)arraylist_pop(stack);
-                    // always remove fully_covers matches after the first minmax ambiguity group is handled
-                    jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, childidx);
-                    int subt = matc->fully_covers == FULLY_COVERS;
-                    if (subt && *found_minmax == 1)
-                        *found_minmax = 2;
-                    assert(visited->items[childidx] == (void*)1);
+                    assert(visited->items[childidx] == (void*)1); (void)childidx;
                 }
 
                 final_result = 0;
@@ -5690,49 +5654,30 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         arraylist_new(&visited, len);
         arraylist_grow(&visited, len);
         memset(visited.items, 0, len * sizeof(size_t));
-        // if we had a minmax method (any subtypes), now may now be able to
-        // quickly cleanup some of methods
-        int found_minmax = 0;
-        if (has_ambiguity)
-            found_minmax = 1;
-        else if (minmax != NULL)
-            found_minmax = 2;
-        // n.b. we cannot shortcut `any_subtypes && !include_ambiguous` to
-        // found_minmax = 1 here: that assumes the absence of a `minmax` method
-        // means no fully-covering method can win, which is false when the
-        // beat-everything comparison was merely blocked by a match that is
-        // itself dominated (see AmbigTransferRegion in test/ambiguous.jl). It
-        // also loses *has_ambiguity, reporting an ambiguous call as having no
-        // applicable method at all.
+        // minmax is reported unconditionally (appended after the sort below),
+        // so pre-mark it as finalized: the sort then never visits it, and it is
+        // admissible as a cover for every dominance check, so a match it
+        // dominates is certified against it together with the other finalized
+        // covers and their union -- a lone minmax transfer could consult
+        // neither (tests `AmbigMinmaxSkip`, `AmbigMinmaxUnion`). n.b. the
+        // pre-scan's `has_ambiguity` was only a hint for choosing minmax: the
+        // sort recomputes the flag, rediscovering any real, uncertified
+        // ambiguity through `check_dominance_transfer`/`check_fully_ambiguous`.
+        if (minmax != NULL) {
+            for (i = 0; i < len; i++) {
+                if ((jl_method_match_t*)jl_array_ptr_ref(t, i) == minmax) {
+                    visited.items[i] = (void*)1;
+                    break;
+                }
+            }
+            assert(i < len);
+        }
         has_ambiguity = 0;
         if (approximate_ambig) // if we don't care about the result, set it now so we won't bother attempting to compute it accurately later
             has_ambiguity = 1;
         for (i = 0; i < len; i++) {
             assert(visited.items[i] == (void*)0 || visited.items[i] == (void*)1);
-            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
-            if (matc->fully_covers != NOT_FULLY_COVERS && found_minmax) {
-                // minmax (or a match it dominates) was already handled above and
-                // below, so visiting it would not usually learn anything new and
-                // might be a bit costly. But a match the DFS never reaches (one
-                // that strictly beats nothing is never anyone's child) would
-                // otherwise be dropped without the dominance-transfer check,
-                // losing the ambiguities only it witnesses (test `AmbigMinmaxSkip`).
-                assert(minmax != NULL);
-                if (visited.items[i] == (void*)1 || matc == minmax)
-                    continue;
-                jl_method_t *minmaxm = minmax->method;
-                if ((include_ambiguous || !has_ambiguity) &&
-                    !check_dominance_transfer(matc->method, (jl_value_t*)matc->spec_types, &minmaxm, 1, t)) {
-                    has_ambiguity = 1;
-                    if (!include_ambiguous)
-                        continue;
-                    // fall through to sort_mlmatches
-                }
-                else {
-                    continue;
-                }
-            }
-            int child_cycle = sort_mlmatches(t, i, &visited, &stack, &result, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
+            int child_cycle = sort_mlmatches(t, i, &visited, &stack, &result, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity);
             if (child_cycle == -1) {
                 arraylist_free(&visited);
                 arraylist_free(&stack);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1889,7 +1889,7 @@ static void cache_insert(
         JL_UNLOCK(&mc->writelock); // before acquiring world_counter_lock
 
         // Only set METHOD_SIG_LATEST_ONLY on method instance if the method-level fact
-        // (an empty interference set) does not already cover it, no guards required,
+        // (an empty interference set) does not already cover it, no guards are required,
         // and min_valid == primary_world
         int should_set_dispatch_status = jl_atomic_load_relaxed(&definition->interferences)->length != 0 &&
             (jl_value_t*)cachett == newmeth->specTypes && jl_svec_len(guardsigs) == 0 &&
@@ -3059,43 +3059,30 @@ static int find_method_in_matches(jl_array_t *t, jl_method_t *method)
     return -1;
 }
 
-static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method) JL_CANSAFEPOINT;
-
-#ifndef NDEBUG
-// A match may only be removed from the output when it can never be selected over
-// `ti`: every point of `ti` must be covered by some match that is strictly
-// morespecific than `m`. Note this is a statement about *applicable* methods, so
-// it does not care whether the dominating matches survive the sort themselves
-// (chains of drops are fine). It is necessary but not sufficient -- a match that
-// cannot be selected may still block another match from being selected, which is
-// what the ambiguity witness accounting in `sort_method_matches` preserves.
-static void assert_dominated_over(jl_method_t *m, jl_value_t *ti, jl_array_t *t) JL_CANSAFEPOINT
+// Whether `target_method` is morespecific than `start_method`, and has an type-intersection
+static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method) JL_CANSAFEPOINT
 {
-    size_t len = jl_array_nrows(t), n = 0;
-    jl_value_t **sigs = (jl_value_t**)malloc_s(len * sizeof(jl_value_t*));
-    for (size_t i = 0; i < len; i++) {
-        jl_method_t *Q = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
-        if (Q != m && method_morespecific_recorded(Q, m))
-            sigs[n++] = (jl_value_t*)Q->sig;
-    }
-    jl_value_t *u = n == 0 ? jl_bottom_type : (n == 1 ? sigs[0] : jl_type_union(sigs, n));
-    JL_GC_PUSH1(&u);
-    assert(jl_subtype(ti, u) && "dropped a match that could still be selected");
-    JL_GC_POP();
-    free(sigs);
+    if (target_method == start_method)
+        return 0;
+    int result = method_in_interferences(target_method, start_method) &&
+                 !method_in_interferences(start_method, target_method);
+    //// Expensive cross-check: the recorded relation must agree with ground truth
+    //// for every intersecting pair.
+    //assert(result == jl_method_morespecific(target_method, start_method) ||
+    //       jl_has_empty_intersection(target_method->sig, start_method->sig) ||
+    //       jl_has_empty_intersection(start_method->sig, target_method->sig));
+    assert(!result || !(jl_atomic_load_relaxed(&target_method->dispatch_status) & METHOD_SIG_NO_LOSERS));
+    return result;
 }
-#else
-#define assert_dominated_over(m, ti, t) ((void)0)
-#endif
 
-// Dispatch selects a match only when it is morespecific than *every* other
+// Dispatch selects a match only when it is morespecific than every other
 // applicable match, so a call is ambiguous whenever no match beats all the
 // others. That has two shapes, which the two checks here correspond to: a pair
 // that is unordered (a mutual ambiguity, `check_fully_ambiguous`) or a
 // specificity cycle, where every match is beaten by another one (the SCC pass in
 // `sort_mlmatches`). A match is reportable when it can be selected somewhere in
 // its region, and also when it blocks another match from being selected there --
-// dominance alone therefore justifies removing it from the *selection* answer,
+// dominance alone therefore justifies removing it from the selection answer,
 // while `sort_method_matches` separately keeps enough blockers to witness each
 // ambiguity it reports.
 //
@@ -3112,7 +3099,7 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
 {
     // If D is not strictly morespecific than anything it intersects
     // (METHOD_SIG_NO_LOSERS), it was beating nobody and there is nothing to
-    // transfer: the removal is unconditionally silent.
+    // transfer: the removal is unconditionally silent (as a fast-path).
     if (jl_atomic_load_relaxed(&D->dispatch_status) & METHOD_SIG_NO_LOSERS)
         return 1;
     size_t len = jl_array_nrows(t);
@@ -3121,8 +3108,8 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
         if (S == D)
             continue;
         // An S that beats nothing can never strictly beat a cover, so it can
-        // never close a directed cycle: whether the covers dominate it is then
-        // irrelevant (as a fast-path)
+        // never be part of a directed cycle: whether the covers dominate it is
+        // then irrelevant (as a fast-path)
         if (jl_atomic_load_relaxed(&S->dispatch_status) & METHOD_SIG_NO_LOSERS)
             continue;
         if (!method_morespecific_recorded(D, S))
@@ -3206,7 +3193,6 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
             if (include_ambiguous)
                 continue; // another cover may still certify the removal
         }
-        assert_dominated_over(m, ti, t);
         return 1;
     }
     // No single morespecific method covers ti, but a union of them may (e.g.
@@ -3214,7 +3200,7 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
     // Collect the recorded strictly-morespecific interferences that were already
     // finalized cleanly (not part of an ambiguity group, which could mean they
     // lose dispatch back to `m` through a specificity cycle) and check whether
-    // ti is covered by their union. Both filters are load-bearing: dropping them
+    // ti is covered by their union. Both filters are relevant: dropping eiter
     // lets a cycle member serve as a cover and wrongly resolves the pair (test
     // `AmbigUnionCycle`).
     int result = 0;
@@ -3247,8 +3233,6 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
                 if (include_ambiguous)
                     result = 0;
             }
-            if (result)
-                assert_dominated_over(m, ti, t);
         }
         JL_GC_POP();
     }
@@ -3275,23 +3259,6 @@ static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, 
     return 0;
 }
 
-// Whether `target_method` is morespecific than `start_method`, and has an type-intersection
-static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method) JL_CANSAFEPOINT
-{
-    if (target_method == start_method)
-        return 0;
-    int result = method_in_interferences(target_method, start_method) &&
-                 !method_in_interferences(start_method, target_method);
-    //// Expensive cross-check: the recorded relation must agree with ground truth
-    //// for every intersecting pair. Too costly to leave armed (it makes every
-    //// recorded query cost two type queries), but it has been run over the
-    //// ambiguity, specificity, worlds, reflection and core suites without firing.
-    //assert(result == jl_method_morespecific(target_method, start_method) ||
-    //       jl_has_empty_intersection(target_method->sig, start_method->sig) ||
-    //       jl_has_empty_intersection(start_method->sig, target_method->sig));
-    assert(!result || !(jl_atomic_load_relaxed(&target_method->dispatch_status) & METHOD_SIG_NO_LOSERS));
-    return result;
-}
 
 
 void jl_method_table_activate(jl_typemap_entry_t *newentry)
@@ -5210,7 +5177,7 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
 //  * `t`: the array of vertexes (method matches)
 //  * `idx`: the next vertex to add to the output
 //  * `visited`: the state of the algorithm for each vertex in `t`: either 1 if we visited it already or 1+depth if we are visiting it now
-//  * `tainted`: TBD
+//  * `tainted`: record if `visited==1` still can't rely on this method to have covered up an ambiguity
 //  * `stack`: the state of the algorithm for the current vertex (up to length equal to `t`): the list of all vertexes currently in the depth-first path or in the current SCC
 //  * `result`: the output of the algorithm, a sorted list of vertexes (up to length `lim`)
 //  * `lim`: either -1 for unlimited matches, or the maximum length for `result` before returning failure (return -1).
@@ -5383,8 +5350,6 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
                                 visited->items[current->idx] = (void*)1;
                         }
                         else {
-                            if (current->m != minmaxm && minmaxm != NULL)
-                                assert_dominated_over(current->m, current->ti, t);
                             visited->items[current->idx] = (void*)1;
                         }
                     }
@@ -5445,15 +5410,13 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
                         // cycle leading back to the method they would resolve
                         tainted[childidx] = 1;
                     if (subt && *found_minmax) {
-                        if (visited->items[childidx] != (void*)1 && matc->method != minmaxm &&
-                            !check_dominance_transfer(matc->method, &minmaxm, minmaxm == NULL ? 0 : 1, t)) {
+                        if (minmaxm && visited->items[childidx] != (void*)1 && matc->method != minmaxm &&
+                            !check_dominance_transfer(matc->method, &minmaxm, 1, t)) {
                             *has_ambiguity = 1;
                             if (!include_ambiguous)
                                 visited->items[childidx] = (void*)1;
                         }
                         else {
-                            if (visited->items[childidx] != (void*)1 && matc->method != minmaxm && minmaxm != NULL)
-                                assert_dominated_over(matc->method, (jl_value_t*)matc->spec_types, t);
                             visited->items[childidx] = (void*)1;
                         }
                     }
@@ -5522,16 +5485,16 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
     // n.b. its absence does not mean the query is unresolvable, and in particular
     // must not be short-circuited into an empty result: the sort below still has to
     // run to compute `has_ambiguity` and to keep the matches that witness the
-    // ambiguity, or an ambiguous call is reported as having no applicable method
-    // at all (test `AmbigNoBeatAll`).
+    // ambiguity, else an ambiguous call would be reported as having no applicable
+    // method (see test `AmbigNoBeatAll`).
     jl_method_match_t *minmax = NULL;
     int minmax_dominates = 0;
     int any_subtypes = 0;
     if (len > 1) {
-        // first try to pre-process the results to find the most specific option
+        // First try to pre-process the results to find the most specific option
         // among the fully-covering methods, since we can do this in O(n^2)
-        // time, and the rest is O(n^3)
-        //   - first find a candidate for the best of these method results
+        // time, and the rest is O(n^3).
+        //   - First, find a candidate for the best of these method results.
         for (i = 0; i < len; i++) {
             jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
             if (matc->fully_covers == FULLY_COVERS) {
@@ -5540,7 +5503,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 // A fully-covering match with an empty interference set is
                 // strictly morespecific than every method it intersects
                 // meaning it is already proven to be the `minmax` choice
-                // without exploring the list any further
+                // without exploring the list any further.
                 if (jl_atomic_load_relaxed(&m->interferences)->length == 0) {
                     minmax = matc;
                     minmax_dominates = 1;
@@ -5557,21 +5520,20 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                     }
                 }
                 if (j == len) {
-                    // Found the minmax method
+                    // Found the minmax method.
                     minmax = matc;
                     break;
                 }
             }
         }
-        //   - it may even dominate (be more specific than) some choices that are not fully-covering!
+        //   - It may even dominate (be more specific than) some choices that are not fully-covering!
         //     move those into the subtype group, where we'll filter them out shortly after
         //     (potentially avoiding reporting these as an ambiguity, and
-        //     potentially allowing us to hit the next fast path)
-        //   - we could always check here if *any* FULLY_COVERS method is
+        //     potentially allowing us to hit the next fast path).
+        //   - We could always check here if *any* FULLY_COVERS method is
         //     more-specific (instead of just considering minmax), but that may
         //     cost much extra and is less likely to help us hit a fast path
-        //     (we will look for this later, when we compute ambig_groupid, for
-        //     correctness)
+        //     (we will look for this later, when we compute the full sort).
         int all_subtypes = any_subtypes;
         if (any_subtypes && !minmax_dominates) {
             jl_method_t *minmaxm = NULL;
@@ -5595,8 +5557,8 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 }
             }
         }
-        //    - now we might have a fast-return here, if we see that
-        //      we've already processed all of the possible outputs
+        //    - Now we might have a fast-return here, if we see that
+        //      we've already processed all of the possible outputs.
         if (all_subtypes) {
             if (minmax == NULL) {
                 // All intersecting methods are fully-covering, but none of them
@@ -5678,6 +5640,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         // the same ambiguity, but the last blocker of the survivor is not
         // redundant -- restore the matches it is unordered with.
         if (include_ambiguous && has_ambiguity && result.len == 1 && minmax == NULL) {
+            abort();
             size_t survivor = (size_t)result.items[0];
             jl_method_t *m = ((jl_method_match_t*)jl_array_ptr_ref(t, survivor))->method;
             for (i = 0; i < len; i++) {
@@ -5687,7 +5650,6 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 if (!method_in_interferences(m2, m) || !method_in_interferences(m, m2))
                     continue; // not an unordered pair, so not a blocker
                 if (lim != -1 && (int)result.len >= lim) {
-                    // n.b. `tainted`, `visited` and `stack` were already released above
                     arraylist_free(&result);
                     return -1;
                 }
@@ -5714,7 +5676,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
     }
     // Every match can only be removed by being dominated or by being part of an
     // ambiguity, and a chain of dominated matches has to bottom out somewhere
-    // unless it closes a cycle (which is an ambiguity). So emptying a non-empty
+    // unless it makes a cycle (which is an ambiguity). So emptying a non-empty
     // match list means the query is ambiguous, never that no method applies --
     // reporting the latter would turn an ambiguous call into a `no method
     // matching` error (test `AmbigNoBeatAll`).

--- a/src/gf.c
+++ b/src/gf.c
@@ -5684,9 +5684,29 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             assert(visited.items[i] == (void*)0 || visited.items[i] == (void*)1);
             jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
             if (matc->fully_covers != NOT_FULLY_COVERS && found_minmax) {
-                // this was already handled above and below, so we won't learn anything new
-                // by visiting it and it might be a bit costly
-                continue;
+                // minmax (or a match it dominates) was already handled above and
+                // below, so visiting it would not usually learn anything new and
+                // might be a bit costly. But a match the DFS never reaches (one
+                // that strictly beats nothing is never anyone's child) would
+                // otherwise be dropped without the dominance-transfer check that
+                // every other removal runs, losing the ambiguities only it
+                // witnesses (test `AmbigMinmaxSkip`): run that check here, and
+                // sort the match normally when its blocking duties do not
+                // transfer to minmax, so it stays in the result.
+                assert(minmax != NULL);
+                if (visited.items[i] == (void*)1 || matc == minmax)
+                    continue;
+                jl_method_t *minmaxm = minmax->method;
+                if ((include_ambiguous || !has_ambiguity) &&
+                    !check_dominance_transfer(matc->method, (jl_value_t*)matc->spec_types, &minmaxm, 1, t)) {
+                    has_ambiguity = 1;
+                    if (!include_ambiguous)
+                        continue;
+                    // fall through to sort_mlmatches
+                }
+                else {
+                    continue;
+                }
             }
             int child_cycle = sort_mlmatches(t, i, &visited, &stack, &result, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
             if (child_cycle == -1) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -354,7 +354,7 @@ jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *sname, jl_fptr_args
     m->isva = 1;
     m->nargs = 2;
     jl_atomic_store_relaxed(&m->primary_world, 1);
-    jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_LATEST_ONLY | METHOD_SIG_LATEST_WHICH);
+    jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_LATEST_WHICH);
     m->sig = (jl_value_t*)tuptyp;
     m->slot_syms = jl_an_empty_string;
     m->nospecialize = 0;
@@ -1888,8 +1888,10 @@ static void cache_insert(
         jl_method_cache_inserted();
         JL_UNLOCK(&mc->writelock); // before acquiring world_counter_lock
 
-        // Only set METHOD_SIG_LATEST_ONLY on method instance if method does NOT have the bit, no guards required, and min_valid == primary_world
-        int should_set_dispatch_status = !(jl_atomic_load_relaxed(&definition->dispatch_status) & METHOD_SIG_LATEST_ONLY) &&
+        // Only set METHOD_SIG_LATEST_ONLY on method instance if the method-level fact
+        // (an empty interference set) does not already cover it, no guards required,
+        // and min_valid == primary_world
+        int should_set_dispatch_status = jl_atomic_load_relaxed(&definition->interferences)->length != 0 &&
             (jl_value_t*)cachett == newmeth->specTypes && jl_svec_len(guardsigs) == 0 &&
             min_valid == jl_atomic_load_relaxed(&definition->primary_world) &&
             !(jl_atomic_load_relaxed(&newmeth->dispatch_status) & METHOD_SIG_LATEST_ONLY);
@@ -2220,9 +2222,10 @@ JL_DLLEXPORT void jl_promote_mi_to_current(jl_method_instance_t *mi, size_t min_
     // No need to acquire the lock if we've been invalidated anyway
     if (current_world > validated_world)
         return;
-    // Only set METHOD_SIG_LATEST_ONLY on method instance if method does NOT have the bit and min_valid == primary_world
+    // Only set METHOD_SIG_LATEST_ONLY on method instance if the method-level fact
+    // (an empty interference set) does not already cover it and min_valid == primary_world
     jl_method_t *definition = mi->def.method;
-    if ((jl_atomic_load_relaxed(&definition->dispatch_status) & METHOD_SIG_LATEST_ONLY) ||
+    if (jl_atomic_load_relaxed(&definition->interferences)->length == 0 ||
         min_world != jl_atomic_load_relaxed(&definition->primary_world) ||
         (jl_atomic_load_relaxed(&mi->dispatch_status) & METHOD_SIG_LATEST_ONLY))
         return;
@@ -2302,7 +2305,7 @@ static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_in
         closure->shadowed = (jl_value_t*)jl_alloc_vec_any(0);
     // Record every intersecting method so the interference relation is complete.
     // We must NOT early-out when the new method is a strict subtype of an
-    // `oldmethod` that dominates its dispatch (METHOD_SIG_LATEST_ONLY): stopping
+    // `oldmethod` that dominates its dispatch (empty interference set): stopping
     // the scan there would omit the new method's other intersecting pairs, and
     // `morespecific` is not monotone under subtyping (strict-subtype implies
     // morespecific, but the supertype's specificity relations do not transfer to
@@ -3022,7 +3025,6 @@ jl_typemap_entry_t *jl_method_table_add(jl_methtable_t *mt, jl_method_t *method,
     // add our new entry
     assert(jl_atomic_load_relaxed(&method->primary_world) == ~(size_t)0); // min-world
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_WHICH) == 0);
-    assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     JL_LOCK(&mt->cache->writelock);
     newentry = jl_typemap_alloc((jl_tupletype_t*)method->sig, simpletype, jl_emptysvec, (jl_value_t*)method, ~(size_t)0, 1);
     jl_typemap_insert(&mt->defs, (jl_value_t*)mt, newentry, 0);
@@ -3262,7 +3264,6 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     size_t world = jl_atomic_load_relaxed(&method->primary_world);
     assert(world == jl_atomic_load_relaxed(&jl_world_counter) + 1); // min-world
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_WHICH) == 0);
-    assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     assert(jl_atomic_load_relaxed(&newentry->min_world) == ~(size_t)0);
     assert(jl_atomic_load_relaxed(&newentry->max_world) == 1);
     jl_atomic_store_relaxed(&newentry->min_world, world);
@@ -3289,14 +3290,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         oldmi = jl_alloc_vec_any(0);
     }
 
-    // These get updated from their state stored in the caches files, since content in cache files gets added "all at once".
     int invalidated = 0;
-    int dispatch_bits = METHOD_SIG_LATEST_WHICH; // Always set LATEST_WHICH
-    // Check precompiled dispatch status bits
-    int precompiled_status = jl_atomic_load_relaxed(&method->dispatch_status);
-    if (!(precompiled_status & METHOD_SIG_PRECOMPILE_MANY))
-        // This will store if this method will be currently the only result that would returned from `ml_matches` given `sig`.
-        dispatch_bits |= METHOD_SIG_LATEST_ONLY; // Tentatively set, will be cleared if not applicable
     // Holds the set of all intersecting methods not more specific than this one.
     // The insertion scan below visits every intersecting method (the
     // LATEST_ONLY early-out was removed), so the recorded relation is complete:
@@ -3313,11 +3307,8 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             method_overwrite(newentry, m);
             // This is an optimized version of below, given we know the type-intersection is exact
             jl_method_table_invalidate(m, max_world);
-            int m_dispatch = jl_atomic_load_relaxed(&m->dispatch_status);
-            // Clear METHOD_SIG_LATEST_ONLY and METHOD_SIG_LATEST_WHICH bits
+            // Clear METHOD_SIG_LATEST_WHICH bit
             jl_atomic_store_relaxed(&m->dispatch_status, 0);
-            if (!(m_dispatch & METHOD_SIG_LATEST_ONLY))
-                dispatch_bits &= ~METHOD_SIG_LATEST_ONLY;
             // Take over the interference list from the replaced method
             jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
             if (interferences->length == 0) {
@@ -3376,27 +3367,19 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                 jl_method_t *m = d[j];
                 // Compute ambig state: is there an ambiguity between new method and old m?
                 char ambig = !morespec[j] && !jl_type_morespecific(type, m->sig);
-                // Compute updates to the dispatch state bits
-                int m_dispatch = jl_atomic_load_relaxed(&m->dispatch_status);
                 if (morespec[j] || ambig) {
-                    // !morespecific(new, old)
-                    dispatch_bits &= ~METHOD_SIG_LATEST_ONLY;
-                    // Add the old method to this interference set
+                    // !morespecific(new, old): add the old method to this interference set
                     ssize_t idx;
                     if (!has_key(interferences, (jl_value_t*)m))
                         interferences = jl_idset_put_key(interferences, (jl_value_t*)m, &idx);
                 }
                 if (!morespec[j]) {
-                    // !morespecific(old, new)
-                    m_dispatch &= ~METHOD_SIG_LATEST_ONLY;
-                    // Add the new method to its interference set
+                    // !morespecific(old, new): add the new method to its interference set
                     jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
                     ssize_t idx;
                     m_interferences = jl_idset_put_key(m_interferences, (jl_value_t*)method, &idx);
                     jl_gc_write_atomic(m, m->interferences, jl_genericmemory_t, m_interferences, release);
                 }
-                // Add methods that intersect but are not more specific to interference list
-                jl_atomic_store_relaxed(&m->dispatch_status, m_dispatch);
                 if (morespec[j])
                     continue;
 
@@ -3507,7 +3490,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         jl_array_ptr_1d_push(_jl_debug_method_invalidation, loctag);
     }
     jl_atomic_store_relaxed(&newentry->max_world, ~(size_t)0);
-    jl_atomic_store_relaxed(&method->dispatch_status, dispatch_bits); // TODO: this should be sequenced fully after the world counter store
+    jl_atomic_store_relaxed(&method->dispatch_status, METHOD_SIG_LATEST_WHICH); // TODO: this should be sequenced fully after the world counter store
     jl_gc_write_atomic(method, method->interferences, jl_genericmemory_t, interferences, release);
     JL_GC_POP();
 }
@@ -5128,17 +5111,14 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     if (closure->match.max_valid > max_world)
         closure->match.max_valid = max_world;
     jl_method_t *meth = ml->func.method;
-    // Whether this method dominates (is strictly morespecific than) every
-    // method it intersects, and hence every other candidate for this query:
-    // either its LATEST_ONLY bit is set, or its interference set is empty (the
-    // ground-truth relation, which the bit tracks in lockstep except that the
-    // bit can be suppressed by PRECOMPILE_MANY). Such a method always survives
-    // into the final result (nothing can cover a method that beats every
-    // intersecting method), and when it also fully covers the query it is the
-    // unique result, so the rest of the search can be skipped. Interference
-    // sets only grow, so emptiness now implies emptiness in the query's world.
-    int only = (jl_atomic_load_relaxed(&meth->dispatch_status) & METHOD_SIG_LATEST_ONLY) ||
-               jl_atomic_load_relaxed(&meth->interferences)->length == 0;
+    // An empty interference set means this method is strictly morespecific
+    // than every method it intersects, and hence than every other candidate
+    // for this query. Such a method always survives into the final result
+    // (nothing can cover a method that beats every intersecting method), and
+    // when it also fully covers the query it is the unique result, so the rest
+    // of the search can be skipped. Interference sets only grow, so emptiness
+    // now implies emptiness in the query's world.
+    int only = jl_atomic_load_relaxed(&meth->interferences)->length == 0;
     if (closure->lim >= 0 && only) {
         if (closure->lim == 0) {
             closure->t = jl_an_empty_vec_any;

--- a/src/gf.c
+++ b/src/gf.c
@@ -3049,8 +3049,66 @@ static int find_method_in_matches(jl_array_t *t, jl_method_t *method)
     return -1;
 }
 
-// Recursively check if any method in interferences covers the given type signature
-static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, arraylist_t *seen) JL_CANSAFEPOINT
+// Check whether `m2` is (visibly) strictly morespecific than `m`, using the
+// recorded interference edges when the pair was recorded (both directions are
+// decided together at method definition time), and falling back to the direct
+// specificity query for unrecorded pairs.
+static int method_strictly_morespecific(jl_method_t *m2, jl_method_t *m)
+{
+    if (method_in_interferences(m2, m)) // !morespecific(m, m2) recorded
+        return !method_in_interferences(m, m2); // and not mutual (ambiguous)
+    // either morespecific(m, m2), or the pair was never recorded (its
+    // intersection was shadowed at definition time): ask the type system
+    return jl_type_morespecific(m2->sig, m->sig);
+}
+
+// About to remove match `D` from the possible dispatch targets, since it is
+// fully covered by the strictly-morespecific cover(s) `covers` and thus can
+// never be the dispatch winner. That removal is unobservable only if every
+// other match that `D` is morespecific than is also dominated by one of the
+// covers: `morespecific` is not transitive, so a specificity cycle may lead
+// from a cover back to a method that only `D` was beating. Returns 1 when the
+// removal is safe, or 0 when such a method exists, meaning the sorted order is
+// not exact over this query (removing `D` would hide the cycle from the SCC
+// pass), which the caller must record as an ambiguity.
+static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t)
+{
+    size_t len = jl_array_nrows(t);
+    for (size_t i = 0; i < len; i++) {
+        jl_method_t *S = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
+        if (S == D)
+            continue;
+        // only consider S that D is (visibly) strictly morespecific than
+        if (!method_in_interferences(D, S) || method_in_interferences(S, D))
+            continue;
+        size_t j;
+        for (j = 0; j < ncovers; j++) {
+            if (S == covers[j] || method_strictly_morespecific(covers[j], S))
+                break;
+        }
+        if (j == ncovers) {
+            // No cover dominates S. That is only dangerous when S strictly
+            // beats one of the covers (a directed specificity cycle through
+            // D); if S is merely mutually ambiguous with (or unordered
+            // against) the covers, that ambiguity is recorded on their own
+            // interference edges and remains visible to check_fully_ambiguous
+            // independent of D's removal.
+            for (j = 0; j < ncovers; j++) {
+                if (method_strictly_morespecific(S, covers[j]))
+                    return 0;
+            }
+        }
+    }
+    return 1;
+}
+
+// Check if some morespecific method (or a union of them) covers the given
+// type intersection, meaning this match can never be the dispatch winner and
+// can be removed from the returned matches without anyone noticing. When the
+// covering relation is entangled in a specificity cycle, sets *has_ambiguity;
+// in that case the match is only reported as covered when `include_ambiguous`
+// is false, so that ambiguity-reporting consumers still see it.
+static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, char *tainted, arraylist_t *seen, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
     arraylist_t workqueue;
     arraylist_new(&workqueue, 0);
@@ -3081,15 +3139,79 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
                 continue;
             if (method_in_interferences(current_m, m2))
                 continue; // ambiguous
-            assert(visited->items[idx] != (void*)0);
             if (visited->items[idx] != (void*)1)
-                continue; // part of the same SCC cycle (handled by ambiguity later)
+                continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
             if (jl_subtype(ti, m2->sig)) {
+                // The chain of interference edges only suggests transitively
+                // that m2 is morespecific than m; that inference is wrong if a
+                // specificity cycle leads back from m to m2, in which case the
+                // covering method does not actually win dispatch from m over
+                // (all of) their intersection and the apparent ambiguity is
+                // real (conservatively, since the methods witnessing the
+                // non-transitivity may intersect elsewhere in the query).
+                if (!method_strictly_morespecific(m2, m)) {
+                    // if m actually beats m2, the chain from m back to m2 is
+                    // a directed specificity cycle (a genuine ambiguity); if
+                    // they are merely mutually ambiguous, that is recorded on
+                    // their own interference edge and handled by
+                    // check_fully_ambiguous
+                    if (method_strictly_morespecific(m, m2)) {
+                        *has_ambiguity = 1;
+                    }
+                    continue;
+                }
+                if (!check_dominance_transfer(m, &m2, 1, t)) {
+                    *has_ambiguity = 1;
+                    if (include_ambiguous)
+                        continue;
+                }
                 result = 1;
                 goto cleanup;
             }
             arraylist_push(&workqueue, m2);
         }
+    }
+    if (!result) {
+        // No single morespecific method covers ti, but a union of them may
+        // (e.g. several methods each covering one component of a Union-typed
+        // argument). Collect the recorded strictly-morespecific interferences
+        // that were already finalized cleanly (not part of an ambiguity
+        // group, which could mean they lose dispatch back to `m` through a
+        // specificity cycle) and check whether ti is covered by their union.
+        jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
+        size_t ncovers = 0;
+        jl_method_t **covers = (jl_method_t**)malloc_s(interferences->length * sizeof(jl_method_t*));
+        for (size_t i = 0; i < interferences->length; i++) {
+            jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
+            if (m2 == NULL)
+                continue;
+            int idx = find_method_in_matches(t, m2);
+            if (idx < 0)
+                continue;
+            if (visited->items[idx] != (void*)1 || tainted[idx])
+                continue;
+            if (method_in_interferences(m, m2)) // mutual interference (ambiguous)
+                continue;
+            covers[ncovers++] = m2;
+        }
+        if (ncovers > 1) {
+            jl_value_t **sigs = (jl_value_t**)malloc_s(ncovers * sizeof(jl_value_t*));
+            for (size_t i = 0; i < ncovers; i++)
+                sigs[i] = (jl_value_t*)covers[i]->sig;
+            jl_value_t *u = jl_type_union(sigs, ncovers);
+            free(sigs);
+            JL_GC_PUSH1(&u);
+            if (jl_subtype(ti, u)) {
+                result = 1;
+                if (!check_dominance_transfer(m, covers, ncovers, t)) {
+                    *has_ambiguity = 1;
+                    if (include_ambiguous)
+                        result = 0;
+                }
+            }
+            JL_GC_POP();
+        }
+        free(covers);
     }
 cleanup:
     seen->len = 0;
@@ -5127,7 +5249,7 @@ typedef struct {
 //  * -1: too many matches for lim, other outputs are undefined
 //  *  0: the child(ren) have been added to the output
 //  * 1+: the children are part of this SCC (up to this depth)
-static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, arraylist_t *stack, arraylist_t *result, arraylist_t *recursion_stack, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax) JL_CANSAFEPOINT
+static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char *tainted, arraylist_t *stack, arraylist_t *result, arraylist_t *recursion_stack, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax, jl_method_t *minmaxm) JL_CANSAFEPOINT
 {
     // Use arraylist_t for explicit stack of processing frames
     arraylist_t frame_stack;
@@ -5254,10 +5376,21 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                 // There is some probability that this method is already fully covered
                 // now, and we can delete this vertex now without anyone noticing.
                 if (current->subt && *found_minmax) {
-                    if (*found_minmax == 2)
-                        visited->items[current->idx] = (void*)1;
+                    if (*found_minmax == 2) {
+                        // minmax dominates all fully-covering methods, but this
+                        // dropped method may have been beating a partial match
+                        // that minmax does not dominate (a specificity cycle)
+                        if (current->m != minmaxm && !check_dominance_transfer(current->m, &minmaxm, minmaxm == NULL ? 0 : 1, t)) {
+                            *has_ambiguity = 1;
+                            if (!include_ambiguous)
+                                visited->items[current->idx] = (void*)1;
+                        }
+                        else {
+                            visited->items[current->idx] = (void*)1;
+                        }
+                    }
                 }
-                else if (check_interferences_covers(current->m, current->ti, t, visited, recursion_stack)) {
+                else if (check_interferences_covers(current->m, current->ti, t, visited, tainted, recursion_stack, include_ambiguous, has_ambiguity)) {
                     visited->items[current->idx] = (void*)1;
                 }
                 else if (check_fully_ambiguous(current->m, current->ti, t, include_ambiguous, has_ambiguity)) {
@@ -5286,6 +5419,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
 
             case STATE_FINALIZE_SCC: {
                 // If this is in an SCC group, do some additional checks before returning or setting has_ambiguity
+                int scc_ambiguous = 0;
                 if (current->depth != stack->len) {
                     int scc_count = 0;
                     for (size_t i = current->depth - 1; i < stack->len; i++) {
@@ -5294,8 +5428,10 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                             continue;
                         scc_count++;
                     }
-                    if (scc_count > 1)
+                    if (scc_count > 1) {
                         *has_ambiguity = 1;
+                        scc_ambiguous = 1;
+                    }
                 }
 
                 // copy this cycle into the results
@@ -5303,8 +5439,23 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                     size_t childidx = (size_t)stack->items[i];
                     jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, childidx);
                     int subt = matc->fully_covers != NOT_FULLY_COVERS;
-                    if (subt && *found_minmax)
-                        visited->items[childidx] = (void*)1;
+                    if (scc_ambiguous && visited->items[childidx] != (void*)1)
+                        // mark members of an ambiguity group: they cannot be
+                        // trusted to resolve (cover) other apparent
+                        // ambiguities, since they may sit in a specificity
+                        // cycle leading back to the method they would resolve
+                        tainted[childidx] = 1;
+                    if (subt && *found_minmax) {
+                        if (visited->items[childidx] != (void*)1 && matc->method != minmaxm &&
+                            !check_dominance_transfer(matc->method, &minmaxm, minmaxm == NULL ? 0 : 1, t)) {
+                            *has_ambiguity = 1;
+                            if (!include_ambiguous)
+                                visited->items[childidx] = (void*)1;
+                        }
+                        else {
+                            visited->items[childidx] = (void*)1;
+                        }
+                    }
                     if ((size_t)visited->items[childidx] == 1)
                         continue;
                     assert(visited->items[childidx] == (void*)(2 + i));
@@ -5606,6 +5757,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
         arraylist_new(&recursion_stack, len);
         arraylist_grow(&visited, len);
         memset(visited.items, 0, len * sizeof(size_t));
+        char *tainted = (char*)calloc_s(len);
         // if we had a minmax method (any subtypes), now may now be able to
         // quickly cleanup some of methods
         int found_minmax = 0;
@@ -5626,8 +5778,9 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                 // by visiting it and it might be a bit costly
                 continue;
             }
-            int child_cycle = sort_mlmatches((jl_array_t*)env.t, i, &visited, &stack, &result, &recursion_stack, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax);
+            int child_cycle = sort_mlmatches((jl_array_t*)env.t, i, &visited, tainted, &stack, &result, &recursion_stack, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
             if (child_cycle == -1) {
+                free(tainted);
                 arraylist_free(&recursion_stack);
                 arraylist_free(&visited);
                 arraylist_free(&stack);
@@ -5639,6 +5792,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
             assert(stack.len == 0);
             assert(visited.items[i] == (void*)1);
         }
+        free(tainted);
         arraylist_free(&recursion_stack);
         arraylist_free(&visited);
         arraylist_free(&stack);

--- a/src/gf.c
+++ b/src/gf.c
@@ -2292,15 +2292,6 @@ static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_in
     if (closure->shadowed == NULL)
         closure->shadowed = (jl_value_t*)jl_alloc_vec_any(0);
     // Record every intersecting method so the interference relation is complete.
-    // We must NOT early-out when the new method is a strict subtype of an
-    // `oldmethod` that dominates its dispatch (empty interference set): stopping
-    // the scan there would omit the new method's other intersecting pairs, and
-    // `morespecific` is not monotone under subtyping (strict-subtype implies
-    // morespecific, but the supertype's specificity relations do not transfer to
-    // the subtype and can even reverse), so a dominated-looking supertype can
-    // still hide intersections that must be recorded. `typemap_slurp_search`
-    // below is only the shared `Type{Union{}}` (exclude_typeofbottom) traversal
-    // hint used on the query path too; it does not drop intersecting entries.
     jl_array_ptr_1d_push((jl_array_t*)closure->shadowed, (jl_value_t*)oldmethod);
     typemap_slurp_search(oldentry, &closure->match);
     return 1;
@@ -3031,21 +3022,8 @@ static int has_key(jl_genericmemory_t *keys, jl_value_t *key)
 }
 
 // Check if m2 is in m1's interferences set, which means !morespecific(m1, m2)
-//
-// Completeness contract: for any two currently-live methods with intersecting
-// signatures, at least one of `method_in_interferences(a, b)` /
-// `method_in_interferences(b, a)` is recorded (both, when they are mutually
-// non-morespecific, i.e. ambiguous), and each present membership implies its
-// `!morespecific` fact. This holds because `jl_method_table_activate` visits
-// every intersecting method when recording (no LATEST_ONLY / dominance
-// early-out). For disjoint pairs neither membership is present.
-//
-// Tolerated staleness: a set may still name methods that have since been
-// deleted, or methods not yet visible in the querying world (a set is populated
-// at insertion and not pruned on deletion). Consumers must filter by world
-// (reinfer.jl checks METHOD_SIG_LATEST_WHICH / primary_world; gf.c filters
-// through find_method_in_matches, which only keeps methods present in the
-// current query's match array).
+// for two methods that were at any point live in the same table at the same time
+// over some type-intersection
 static int method_in_interferences(jl_method_t *m2, jl_method_t *m1)
 {
     return has_key(jl_atomic_load_relaxed(&m1->interferences), (jl_value_t*)m2);
@@ -3063,13 +3041,7 @@ static int find_method_in_matches(jl_array_t *t, jl_method_t *method)
     return -1;
 }
 
-// Whether `target_method` is strictly morespecific than `start_method`, read
-// directly from the recorded interference relation (which is complete for
-// intersecting pairs, see `method_in_interferences`). Exact for intersecting
-// pairs; returns 0 for disjoint pairs (neither membership is recorded), which
-// is the answer the covering/dominance callers want (a disjoint method cannot
-// dominate another).
-static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method);
+static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method) JL_CANSAFEPOINT;
 
 // About to remove match `D` from the possible dispatch targets, since it is
 // fully covered by the strictly-morespecific cover(s) `covers` and thus can
@@ -3080,7 +3052,7 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
 // removal is safe, or 0 when such a method exists, meaning the sorted order is
 // not exact over this query (removing `D` would hide the cycle from the SCC
 // pass), which the caller must record as an ambiguity.
-static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t)
+static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t) JL_CANSAFEPOINT
 {
     // If D is not strictly morespecific than anything it intersects
     // (METHOD_SIG_NO_LOSERS), it was beating nobody and there is nothing to
@@ -3094,10 +3066,9 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
             continue;
         // An S that beats nothing can never strictly beat a cover, so it can
         // never close a directed cycle: whether the covers dominate it is then
-        // irrelevant (the unordered case falls through to safety below anyway).
+        // irrelevant (as a fast-path)
         if (jl_atomic_load_relaxed(&S->dispatch_status) & METHOD_SIG_NO_LOSERS)
             continue;
-        // only consider S that D is strictly morespecific than
         if (!method_morespecific_recorded(D, S))
             continue;
         size_t j;
@@ -3106,12 +3077,12 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
                 break;
         }
         if (j == ncovers) {
-            // No cover dominates S. That is only dangerous when S strictly
-            // beats one of the covers (a directed specificity cycle through
-            // D); if S is merely mutually ambiguous with (or unordered
-            // against) the covers, that ambiguity is recorded on their own
-            // interference edges and remains visible to check_fully_ambiguous
-            // independent of D's removal.
+            // No cover dominates S. Now check if S strictly beats one of the
+            // covers (detecting a directed specificity cycle through D); if
+            // S is merely mutually ambiguous with (or unordered against) the
+            // covers, that ambiguity is recorded on their own interference
+            // edges and remains visible to check_fully_ambiguous independent
+            // of D's removal.
             for (j = 0; j < ncovers; j++) {
                 if (method_morespecific_recorded(S, covers[j]))
                     return 0;
@@ -3131,10 +3102,7 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
 {
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
     // First: is `m` fully covered (dominated over the whole query region `ti`)
-    // by a single recorded strictly-morespecific method? Because recording is
-    // complete, any such method intersects `m` and is morespecific than it, so
-    // `!morespecific(m, it)` was recorded and it is a *direct* member of `m`'s
-    // interference set: a single pass suffices, with no transitive chase.
+    // by a single recorded strictly-morespecific method?
     for (size_t i = 0; i < interferences->length; i++) {
         jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
         if (m2 == NULL)
@@ -3143,7 +3111,7 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
         if (idx < 0)
             continue;
         if (method_in_interferences(m, m2))
-            continue; // mutual interference (ambiguous), not a strict cover
+            continue; // ambiguous
         if (visited->items[idx] != (void*)1)
             continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
         if (jl_subtype(ti, m2->sig)) {
@@ -3178,7 +3146,7 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
             continue;
         if (visited->items[idx] != (void*)1 || tainted[idx])
             continue;
-        if (method_in_interferences(m, m2)) // mutual interference (ambiguous)
+        if (method_in_interferences(m, m2)) // ambiguous
             continue;
         covers[ncovers++] = m2;
     }
@@ -3222,25 +3190,17 @@ static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, 
     return 0;
 }
 
-// Whether target_method is strictly morespecific than start_method, read
-// directly from the recorded interference relation: target is in start's set
-// (so !morespecific(start, target)) but start is not in target's set (so
-// morespecific(target, start)). Because recording is complete for intersecting
-// pairs, this is exact for them; for disjoint pairs neither membership is
-// present and the result is 0 (a disjoint method dominates nothing), which is
-// what the covering/dominance callers want. The assert documents that contract.
-static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method)
+// Whether `target_method` is morespecific than `start_method`, and has an type-intersection
+static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method) JL_CANSAFEPOINT
 {
     if (target_method == start_method)
         return 0;
     int result = method_in_interferences(target_method, start_method) &&
                  !method_in_interferences(start_method, target_method);
-    assert(result == jl_method_morespecific(target_method, start_method) ||
-           jl_has_empty_intersection(target_method->sig, start_method->sig) ||
-           jl_has_empty_intersection(start_method->sig, target_method->sig));
-    // a method recorded as strictly beating something must not carry NO_LOSERS
-    // (the replacement path clears the bit for the recency-tiebreak win it
-    // records over the type-equal method it replaces)
+    //// Expensive cross-check:
+    //assert(result == jl_method_morespecific(target_method, start_method) ||
+    //       jl_has_empty_intersection(target_method->sig, start_method->sig) ||
+    //       jl_has_empty_intersection(start_method->sig, target_method->sig));
     assert(!result || !(jl_atomic_load_relaxed(&target_method->dispatch_status) & METHOD_SIG_NO_LOSERS));
     return result;
 }
@@ -3287,23 +3247,10 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     }
 
     int invalidated = 0;
-    // METHOD_SIG_NO_LOSERS is carried in from the method's current state, not
-    // re-derived: it is set at method creation and monotone-cleared. The scan
-    // below clears it on the first method this one beats; conversely an old
-    // method that is beaten (morespec[j], conservatively including
-    // both-ways-morespecific pairs) loses its bit. The bit must survive
-    // serialization (like the interference sets, and unlike LATEST_WHICH)
-    // because a cache-image batch shares one world: this scan runs against the
-    // prior world and cannot see same-image methods, so their pairs are never
-    // re-derived at load and only the precompile-time state is correct.
     int precompiled_status = jl_atomic_load_relaxed(&method->dispatch_status);
+    // Always set LATEST_WHICH and carry over NO_LOSERS from initialization and accross precompilation
     int dispatch_bits = METHOD_SIG_LATEST_WHICH | (precompiled_status & METHOD_SIG_NO_LOSERS);
     // Holds the set of all intersecting methods not more specific than this one.
-    // The insertion scan below visits every intersecting method (the
-    // LATEST_ONLY early-out was removed), so the recorded relation is complete:
-    // for any two currently-live methods with intersecting signatures, at least
-    // one of the two memberships is present (see the contract on
-    // `method_in_interferences`).
     interferences = (jl_genericmemory_t*)jl_atomic_load_relaxed(&method->interferences);
     if (oldvalue) {
         assert(n > 0);
@@ -3315,15 +3262,12 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             // This is an optimized version of below, given we know the type-intersection is exact
             jl_method_table_invalidate(m, max_world);
             // The replacement strictly beats the replaced method (the recency
-            // tiebreak in `jl_method_morespecific` for type-equal signatures,
-            // recorded below), so it always has at least that one strict loser.
-            // NO_LOSERS cannot be inherited: type-equal does not imply
-            // morespecific-equal, so the predecessor's relations do not
-            // transfer.
+            // tiebreak in `jl_method_morespecific` for type-equal signatures).
             dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
             // Clear METHOD_SIG_LATEST_WHICH bit
             jl_atomic_store_relaxed(&m->dispatch_status, 0);
             // Take over the interference list from the replaced method
+            // (TODO: we should consider recomputing it instead, since type-equal doesn't imply more-specific-equal)
             jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
             if (interferences->length == 0) {
                 interferences = jl_genericmemory_copy(m_interferences);
@@ -3342,20 +3286,13 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             jl_gc_write_atomic(m, m->interferences, jl_genericmemory_t, m_interferences, release);
             for (j = 0; j < n; j++) {
                 jl_method_t *m2 = d[j];
-                if (m2 && method_in_interferences(m, m2)) {
+                if (!m2 || m == m2)
+                    continue;
+                if (method_in_interferences(m, m2)) {
                     jl_genericmemory_t *m2_interferences = jl_atomic_load_relaxed(&m2->interferences);
                     ssize_t idx;
                     m2_interferences = jl_idset_put_key(m2_interferences, (jl_value_t*)method, &idx);
                     jl_gc_write_atomic(m2, m2->interferences, jl_genericmemory_t, m2_interferences, release);
-                }
-                if (m2 && m2 != m) {
-                    // Recompute the partner's NO_LOSERS against the
-                    // replacement's own signature: type-equal does not imply
-                    // morespecific-equal, so `morespecific(m2, method)` may
-                    // hold where `morespecific(m2, m)` did not.
-                    int m2_dispatch = jl_atomic_load_relaxed(&m2->dispatch_status);
-                    if ((m2_dispatch & METHOD_SIG_NO_LOSERS) && jl_type_morespecific(m2->sig, type))
-                        jl_atomic_store_relaxed(&m2->dispatch_status, m2_dispatch & ~METHOD_SIG_NO_LOSERS);
                 }
             }
             loctag = jl_atomic_load_relaxed(&m->specializations); // use loctag for a gcroot
@@ -5144,13 +5081,6 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     if (closure->match.max_valid > max_world)
         closure->match.max_valid = max_world;
     jl_method_t *meth = ml->func.method;
-    // An empty interference set means this method is strictly morespecific
-    // than every method it intersects, and hence than every other candidate
-    // for this query. Such a method always survives into the final result
-    // (nothing can cover a method that beats every intersecting method), and
-    // when it also fully covers the query it is the unique result, so the rest
-    // of the search can be skipped. Interference sets only grow, so emptiness
-    // now implies emptiness in the query's world.
     int only = jl_atomic_load_relaxed(&meth->interferences)->length == 0;
     if (closure->lim >= 0 && only) {
         if (closure->lim == 0) {
@@ -5192,6 +5122,7 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
 //  * `t`: the array of vertexes (method matches)
 //  * `idx`: the next vertex to add to the output
 //  * `visited`: the state of the algorithm for each vertex in `t`: either 1 if we visited it already or 1+depth if we are visiting it now
+//  * `tainted`: TBD
 //  * `stack`: the state of the algorithm for the current vertex (up to length equal to `t`): the list of all vertexes currently in the depth-first path or in the current SCC
 //  * `result`: the output of the algorithm, a sorted list of vertexes (up to length `lim`)
 //  * `lim`: either -1 for unlimited matches, or the maximum length for `result` before returning failure (return -1).
@@ -5482,9 +5413,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
 // Sort the intersecting matches in `t` (a Vector{Any} of MethodMatch, as
 // collected for a single query type) into dispatch order, removing every match
 // that can never be the dispatch target over its intersection with the query
-// (being fully covered by more specific methods), and setting *has_ambiguity
-// if the sorted order of the remaining matches is not exact (some of them are
-// ambiguous with each other over part of the query). When `approximate_ambig`
+// (being fully covered by more specific methods). When `approximate_ambig`
 // is set, the caller does not need *has_ambiguity computed accurately and it
 // is pessimistically set to 1 without attempting to prove otherwise.
 // Returns the new length of `t`, or -1 if `lim` was exceeded (in which case
@@ -5512,14 +5441,8 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 jl_method_t *m = matc->method;
                 // A fully-covering match with an empty interference set is
                 // strictly morespecific than every method it intersects
-                // (recording is complete), and every other match intersects it
-                // (through the query type it covers): it is the unique
-                // dispatch winner over the whole query, every other match can
-                // be dropped with `m` itself as the dominating cover, and no
-                // ambiguity can involve it. Since interference sets only ever
-                // grow, emptiness now implies emptiness in the query's world.
-                // (Two such matches cannot coexist: they would intersect, so
-                // one of the two memberships would be recorded.)
+                // meaning it is already proven to be the `minmax` choice
+                // without exploring the list any further
                 if (jl_atomic_load_relaxed(&m->interferences)->length == 0) {
                     minmax = matc;
                     minmax_dominates = 1;

--- a/src/gf.c
+++ b/src/gf.c
@@ -3421,8 +3421,13 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
             // Clear METHOD_SIG_LATEST_WHICH bit
             jl_atomic_store_relaxed(&m->dispatch_status, 0);
-            // Take over the interference list from the replaced method
-            // (TODO: we should consider recomputing it instead, since type-equal doesn't imply more-specific-equal)
+            // Take over the interference list from the replaced method.
+            // (TODO: we should consider recomputing it instead, since type-equal
+            // doesn't imply more-specific-equal: an inherited edge may misstate
+            // this method's specificity against a third method, silently making
+            // the interference records diverge from ground truth. When debugging
+            // a suspected missed ambiguity, re-enable the expensive cross-check
+            // in `method_morespecific_recorded` to detect such divergence.)
             jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
             if (interferences->length == 0) {
                 interferences = jl_genericmemory_copy(m_interferences);
@@ -5564,6 +5569,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
     // ambiguity, else an ambiguous call would be reported as having no applicable
     // method (see test `AmbigNoBeatAll`).
     jl_method_match_t *minmax = NULL;
+    size_t minmax_idx = 0;
     int minmax_dominates = 0;
     int any_subtypes = 0;
     if (len > 1) {
@@ -5582,6 +5588,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 // without exploring the list any further.
                 if (jl_atomic_load_relaxed(&m->interferences)->length == 0) {
                     minmax = matc;
+                    minmax_idx = i;
                     minmax_dominates = 1;
                     break;
                 }
@@ -5598,6 +5605,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 if (j == len) {
                     // Found the minmax method.
                     minmax = matc;
+                    minmax_idx = i;
                     break;
                 }
             }
@@ -5669,13 +5677,11 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         jl_method_t *minmaxm = NULL;
         if (minmax != NULL) {
             minmaxm = minmax->method;
-            for (i = 0; i < len; i++) {
-                if ((jl_method_match_t*)jl_array_ptr_ref(t, i) == minmax) {
-                    visited.items[i] = (void*)1;
-                    break;
-                }
-            }
-            assert(i < len);
+            // `t` is unchanged since `minmax_idx` was recorded: the only
+            // reorder above (the all-subtypes fast path) leaves len == 1,
+            // which skips this block.
+            assert((jl_method_match_t*)jl_array_ptr_ref(t, minmax_idx) == minmax);
+            visited.items[minmax_idx] = (void*)1;
         }
         if (approximate_ambig) // if we don't care about the result, set it now so we won't bother attempting to compute it accurately later
             has_ambiguity = 1;
@@ -5754,9 +5760,8 @@ JL_DLLEXPORT int jl_sort_method_matches(jl_array_t *t, int include_ambiguous) JL
 //
 // See below for the meaning of lim.
 //
-// fully-covers is a Bool indicating subtyping, though temporarily it may be
-// tri-values, with `nothing` indicating a match that is not a subtype, but
-// which is dominated by one which is (and thus should be excluded unless ambiguous)
+// fully-covers is a Bool indicating whether the queried type is a subtype of
+// the method signature.
 static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                               jl_tupletype_t *type, int lim, int include_ambiguous,
                               int intersections, size_t world, int cache_result_recursion,

--- a/src/gf.c
+++ b/src/gf.c
@@ -3086,26 +3086,79 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
 // while `sort_method_matches` separately keeps enough blockers to witness each
 // ambiguity it reports.
 //
+// About to remove match `D` (matching the query over `ti`), which the
+// strictly-morespecific `covers` jointly contain, so `D` can never be selected
+// there. Removing `D` also removes it as evidence against `S` being selected:
+// `S` stays visibly unselectable at a point only while some *reported* match
+// that `S` does not beat still applies there, whether `D` was strictly beating
+// `S` or merely unordered with it. Check that this holds at every point of
+// `ti` ∩ `S` for the given `S`.
+//
+// Since the covers jointly contain `ti`, some cover applies at any such point,
+// and a cover applying at a point of `S`'s region intersects `S` there. So if
+// `S` beats none of the covers, whichever cover applies also blocks `S`, and
+// the transfer is automatic. Only when `S` strictly beats some cover -- a
+// directed specificity cycle through `D` -- can a point be left where every
+// applicable cover is beaten by `S`: then require the union of the covers that
+// `S` does not beat to contain the region where `D` was the evidence (test
+// `AmbigTransferRegion` requires the region check; `AmbigCycle3` fails if the
+// cycle is ignored altogether). A cover need not survive into the report
+// itself: its own removal was subject to this same check against covers
+// finalized before it, so by induction a reported blocker exists at every
+// point it took over. Returns 1 when the transfer holds, 0 otherwise.
+static int check_blocker_transfer(jl_value_t *ti, jl_value_t *ti_S, jl_method_t *S, jl_method_t **covers, size_t ncovers) JL_CANSAFEPOINT
+{
+    size_t j;
+    for (j = 0; j < ncovers; j++) {
+        if (method_morespecific_recorded(S, covers[j]))
+            break;
+    }
+    if (j == ncovers)
+        return 1;
+    int result = 0;
+    jl_value_t *region = NULL;
+    jl_value_t *u = NULL;
+    JL_GC_PUSH2(&region, &u);
+    region = jl_type_intersection(ti, ti_S);
+    if (region == jl_bottom_type) {
+        result = 1; // D was never evidence against S within the query
+    }
+    else {
+        arraylist_t sigs;
+        arraylist_new(&sigs, 0);
+        for (j = 0; j < ncovers; j++) {
+            // a cover that S does not beat blocks S, whether it is strictly
+            // morespecific than S or merely unordered with it
+            if (method_in_interferences(covers[j], S))
+                arraylist_push(&sigs, (void*)covers[j]->sig);
+        }
+        if (sigs.len > 0) {
+            u = jl_type_union((jl_value_t**)sigs.items, sigs.len);
+            result = jl_subtype(region, u);
+        }
+        arraylist_free(&sigs);
+    }
+    JL_GC_POP();
+    return result;
+}
+
 // About to remove match `D`, which the strictly-morespecific `covers` dominate
-// over all of its region, so `D` can never be selected there.
+// over all of its region `ti`, so `D` can never be selected there.
 // Dominance alone is not enough to remove it, because every member of a
 // specificity cycle is dominated by another member: removing them all on that
 // basis would delete the cycle and report the call as unambiguous (test
-// `AmbigCycle3` fails if this check is skipped). So the removal is silent only
-// if the covers also dominate everything `D` beat -- otherwise a cycle leads
-// from a cover back to a method only `D` was beating, and the caller must
-// record an ambiguity. Returns 1 when the removal is silent, 0 otherwise.
-//
-// Removing `D` also removes it as a blocker: a match `S` that `D` was unordered
-// with needs `D` present to stay unselectable, since selection requires beating
-// every applicable match. So the covers must block everything `D` blocked too, or
-// the removal turns an ambiguous call into a resolved one (test `AmbigNoBeatAll`).
-static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t) JL_CANSAFEPOINT
+// `AmbigCycle3` fails if this check is skipped). And removing `D` also removes
+// it as a blocker: a match `S` that `D` was unordered with needs `D` present to
+// stay unselectable, since selection requires beating every applicable match,
+// so the removal can turn an ambiguous call into a resolved one (test
+// `AmbigNoBeatAll`). Both obligations transfer to the covers under the same
+// pointwise rule (`check_blocker_transfer`). Returns 1 when the removal is
+// silent, 0 when the caller must record an ambiguity.
+static int check_dominance_transfer(jl_method_t *D, jl_value_t *ti, jl_method_t **covers, size_t ncovers, jl_array_t *t) JL_CANSAFEPOINT
 {
-    // First, only an unordered pair is at stake here: if D beats S then S was already
-    // unselectable for a stronger reason (handled by the loop below), and if S
-    // beats D then D was never blocking S. Both members of such a pair record
-    // each other, so D's own interference set is enough to enumerate them.
+    // First, the matches D was unordered with. Both members of such a pair
+    // record each other, so D's own interference set is enough to enumerate
+    // them.
     // (n.b. this scan is not required with `!include_ambiguous`, where D is
     // dropped either way and S reports the same pair from `check_fully_ambiguous`,
     // unlike the cycle detection below)
@@ -3116,21 +3169,15 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
             continue;
         if (!method_in_interferences(D, S))
             continue; // S is morespecific than D, so D was not blocking it
-        if (find_method_in_matches(t, S) < 0)
+        int idx = find_method_in_matches(t, S);
+        if (idx < 0)
             continue;
-        size_t j;
-        for (j = 0; j < ncovers; j++) {
-            // a cover that S does not beat still blocks S, whether it is
-            // strictly morespecific than S or merely unordered with it
-            if (method_in_interferences(covers[j], S))
-                break;
-        }
-        if (j == ncovers)
+        jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, idx);
+        if (!check_blocker_transfer(ti, (jl_value_t*)matc->spec_types, S, covers, ncovers))
             return 0;
     }
-    // Next, check that the `covers` take over the methods `D` was beating: any
-    // such method that the covers do not dominate must form a directed
-    // specificity cycle through them.
+    // Next, the methods `D` was beating: those stay unselectable through the
+    // covers by the same rule.
     //
     // If D is not strictly morespecific than anything it intersects
     // (METHOD_SIG_NO_LOSERS), it was beating nobody and there is nothing more to
@@ -3139,33 +3186,18 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
         return 1;
     size_t len = jl_array_nrows(t);
     for (size_t i = 0; i < len; i++) {
-        jl_method_t *S = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
+        jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
+        jl_method_t *S = matc->method;
         if (S == D)
             continue;
-        // An S that beats nothing can never strictly beat a cover, so it can
-        // never be part of a directed cycle: whether the covers dominate it is
-        // then irrelevant (as a fast-path)
+        // An S that beats nothing can never strictly beat a cover, so its
+        // blocking transfers automatically (as a fast-path)
         if (jl_atomic_load_relaxed(&S->dispatch_status) & METHOD_SIG_NO_LOSERS)
             continue;
         if (!method_morespecific_recorded(D, S))
             continue;
-        size_t j;
-        for (j = 0; j < ncovers; j++) {
-            if (S == covers[j] || method_morespecific_recorded(covers[j], S))
-                break;
-        }
-        if (j == ncovers) {
-            // No cover dominates S. Now check if S strictly beats one of the
-            // covers (detecting a directed specificity cycle through D); if
-            // S is merely mutually ambiguous with (or unordered against) the
-            // covers, that ambiguity is recorded on their own interference
-            // edges and remains visible to check_fully_ambiguous independent
-            // of D's removal.
-            for (j = 0; j < ncovers; j++) {
-                if (method_morespecific_recorded(S, covers[j]))
-                    return 0;
-            }
-        }
+        if (!check_blocker_transfer(ti, (jl_value_t*)matc->spec_types, S, covers, ncovers))
+            return 0;
     }
     return 1;
 }
@@ -3228,7 +3260,7 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
         // apparent ambiguity is real. When `!include_ambiguous` we drop `m` here
         // either way, so this only computes *has_ambiguity and can be skipped
         // once that is already known.
-        if ((include_ambiguous || !*has_ambiguity) && !check_dominance_transfer(m, &m2, 1, t)) {
+        if ((include_ambiguous || !*has_ambiguity) && !check_dominance_transfer(m, ti, &m2, 1, t)) {
             *has_ambiguity = 1;
             if (include_ambiguous)
                 continue; // another cover may still certify the removal
@@ -3270,7 +3302,7 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
         if (jl_subtype(ti, u)) {
             result = 1;
             if ((include_ambiguous || !*has_ambiguity) &&
-                !check_dominance_transfer(m, (jl_method_t**)covers.items, covers.len, t)) {
+                !check_dominance_transfer(m, ti, (jl_method_t**)covers.items, covers.len, t)) {
                 *has_ambiguity = 1;
                 if (include_ambiguous)
                     result = 0;
@@ -5391,7 +5423,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                         // dropped method may have been beating a partial match
                         // that minmax does not dominate (a specificity cycle)
                         if (current->m != minmaxm && (include_ambiguous || !*has_ambiguity) &&
-                            !check_dominance_transfer(current->m, &minmaxm, 1, t)) {
+                            !check_dominance_transfer(current->m, current->ti, &minmaxm, 1, t)) {
                             *has_ambiguity = 1;
                             if (!include_ambiguous)
                                 visited->items[current->idx] = (void*)1;
@@ -5451,7 +5483,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                         assert(minmaxm != NULL);
                         if (visited->items[childidx] != (void*)1 && matc->method != minmaxm &&
                             (include_ambiguous || !*has_ambiguity) &&
-                            !check_dominance_transfer(matc->method, &minmaxm, 1, t)) {
+                            !check_dominance_transfer(matc->method, (jl_value_t*)matc->spec_types, &minmaxm, 1, t)) {
                             *has_ambiguity = 1;
                             if (!include_ambiguous)
                                 visited->items[childidx] = (void*)1;

--- a/src/gf.c
+++ b/src/gf.c
@@ -5501,6 +5501,196 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
 }
 
 
+// Sort the intersecting matches in `t` (a Vector{Any} of MethodMatch, as
+// collected for a single query type) into dispatch order, removing every match
+// that can never be the dispatch target over its intersection with the query
+// (being fully covered by more specific methods), and setting *has_ambiguity
+// if the sorted order of the remaining matches is not exact (some of them are
+// ambiguous with each other over part of the query). When `approximate_ambig`
+// is set, the caller does not need *has_ambiguity computed accurately and it
+// is pessimistically set to 1 without attempting to prove otherwise.
+// Returns the new length of `t`, or -1 if `lim` was exceeded (in which case
+// the contents of `t` are left in an unspecified state).
+static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous, int approximate_ambig, int *has_ambiguity_out) JL_CANSAFEPOINT
+{
+    int has_ambiguity = 0;
+    size_t i, j, len = jl_array_nrows(t);
+
+    // the 'minmax' method is a method that (1) fully-covers the queried type, and (2) is
+    // more-specific than any other fully-covering method (but if !all_subtypes, there are
+    // non-fully-covering methods to which it is _likely_ not more specific)
+    jl_method_match_t *minmax = NULL;
+    int any_subtypes = 0;
+    if (len > 1) {
+        // first try to pre-process the results to find the most specific option
+        // among the fully-covering methods, since we can do this in O(n^2)
+        // time, and the rest is O(n^3)
+        //   - first find a candidate for the best of these method results
+        for (i = 0; i < len; i++) {
+            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
+            if (matc->fully_covers == FULLY_COVERS) {
+                any_subtypes = 1;
+                jl_method_t *m = matc->method;
+                for (j = 0; j < len; j++) {
+                    if (i == j)
+                        continue;
+                    jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(t, j);
+                    if (matc2->fully_covers == FULLY_COVERS) {
+                        jl_method_t *m2 = matc2->method;
+                        if (!method_morespecific_via_interferences(m, m2))
+                            break;
+                    }
+                }
+                if (j == len) {
+                    // Found the minmax method
+                    minmax = matc;
+                    break;
+                }
+            }
+        }
+        //   - it may even dominate (be more specific than) some choices that are not fully-covering!
+        //     move those into the subtype group, where we'll filter them out shortly after
+        //     (potentially avoiding reporting these as an ambiguity, and
+        //     potentially allowing us to hit the next fast path)
+        //   - we could always check here if *any* FULLY_COVERS method is
+        //     more-specific (instead of just considering minmax), but that may
+        //     cost much extra and is less likely to help us hit a fast path
+        //     (we will look for this later, when we compute ambig_groupid, for
+        //     correctness)
+        int all_subtypes = any_subtypes;
+        if (any_subtypes) {
+            jl_method_t *minmaxm = NULL;
+            if (minmax != NULL)
+                minmaxm = minmax->method;
+            // scan through all the non-fully-matching methods and count them as "fully-covering" (ish)
+            // (i.e. in the 'subtype' group) if `minmax` is more-specific
+            for (i = 0; i < len; i++) {
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
+                if (matc->fully_covers != FULLY_COVERS) {
+                    jl_method_t *m = matc->method;
+                    if (minmaxm) {
+                        if (method_morespecific_via_interferences(minmaxm, m)) {
+                            matc->fully_covers = SENTINEL; // put a sentinel value here for sorting
+                            continue;
+                        }
+                        if (method_in_interferences(minmaxm, m)) // !morespecific(m, minmaxm)
+                            has_ambiguity = 1;
+                    }
+                    all_subtypes = 0;
+                }
+            }
+        }
+        //    - now we might have a fast-return here, if we see that
+        //      we've already processed all of the possible outputs
+        if (all_subtypes) {
+            if (minmax == NULL) {
+                // all intersecting methods are fully-covering, but there is no unique most-specific method
+                if (!include_ambiguous) {
+                    // there no unambiguous choice of method
+                    jl_array_del_end(t, len);
+                    len = 0;
+                }
+                else if (lim == 1) {
+                    // we'd have to return >1 method due to the ambiguity, so bail early
+                    return -1;
+                }
+            }
+            else {
+                // `minmax` is more-specific than all other matches and is fully-covering
+                // we can return it as our only result
+                jl_array_ptr_set(t, 0, minmax);
+                jl_array_del_end(t, len - 1);
+                len = 1;
+            }
+        }
+        if (minmax && lim == 0) {
+            // protect some later algorithms from underflow
+            return -1;
+        }
+    }
+    if (len > 1) {
+        arraylist_t stack, visited, result, recursion_stack;
+        arraylist_new(&result, lim != -1 && lim < len ? lim : len);
+        arraylist_new(&stack, 0);
+        arraylist_new(&visited, len);
+        arraylist_new(&recursion_stack, len);
+        arraylist_grow(&visited, len);
+        memset(visited.items, 0, len * sizeof(size_t));
+        char *tainted = (char*)calloc_s(len);
+        // if we had a minmax method (any subtypes), now may now be able to
+        // quickly cleanup some of methods
+        int found_minmax = 0;
+        if (has_ambiguity)
+            found_minmax = 1;
+        else if (minmax != NULL)
+            found_minmax = 2;
+        else if (any_subtypes && !include_ambiguous)
+            found_minmax = 1;
+        has_ambiguity = 0;
+        if (approximate_ambig) // if we don't care about the result, set it now so we won't bother attempting to compute it accurately later
+            has_ambiguity = 1;
+        for (i = 0; i < len; i++) {
+            assert(visited.items[i] == (void*)0 || visited.items[i] == (void*)1);
+            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
+            if (matc->fully_covers != NOT_FULLY_COVERS && found_minmax) {
+                // this was already handled above and below, so we won't learn anything new
+                // by visiting it and it might be a bit costly
+                continue;
+            }
+            int child_cycle = sort_mlmatches(t, i, &visited, tainted, &stack, &result, &recursion_stack, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
+            if (child_cycle == -1) {
+                free(tainted);
+                arraylist_free(&recursion_stack);
+                arraylist_free(&visited);
+                arraylist_free(&stack);
+                arraylist_free(&result);
+                return -1;
+            }
+            assert(child_cycle == 0); (void)child_cycle;
+            assert(stack.len == 0);
+            assert(visited.items[i] == (void*)1);
+        }
+        free(tainted);
+        arraylist_free(&recursion_stack);
+        arraylist_free(&visited);
+        arraylist_free(&stack);
+        for (j = 0; j < result.len; j++) {
+            i = (size_t)result.items[j];
+            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
+            // remove our sentinel entry markers
+            if (matc->fully_covers == SENTINEL)
+                matc->fully_covers = NOT_FULLY_COVERS;
+            result.items[j] = (void*)matc;
+        }
+        if (minmax) {
+            arraylist_push(&result, minmax);
+            j++;
+        }
+        memcpy(jl_array_data(t, jl_method_match_t*), result.items, j * sizeof(jl_method_match_t*));
+        arraylist_free(&result);
+        if (j != len)
+            jl_array_del_end(t, len - j);
+        len = j;
+    }
+    *has_ambiguity_out = has_ambiguity;
+    return len;
+}
+
+// Re-sort a (possibly filtered) vector of MethodMatch objects, as collected by
+// jl_matching_methods for a single query type, removing matches that can no
+// longer be the dispatch target, and return whether any dispatch ambiguity
+// remains between the remaining matches. Used by `Base.isambiguous` to decide
+// whether an ambiguity remains after filtering out matches whose intersection
+// has a Union{} type parameter.
+JL_DLLEXPORT int jl_sort_method_matches(jl_array_t *t, int include_ambiguous) JL_CANSAFEPOINT
+{
+    JL_TYPECHK(sort_method_matches, array_any, (jl_value_t*)t);
+    int has_ambiguity = 0;
+    ssize_t sorted = sort_method_matches(t, -1, include_ambiguous, 0, &has_ambiguity);
+    assert(sorted != -1); (void)sorted; // lim == -1 cannot be exceeded
+    return has_ambiguity;
+}
+
 // This is the collect form of calling jl_typemap_intersection_visitor
 // with optimizations to skip fully shadowed methods.
 //
@@ -5653,166 +5843,14 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
 
     // all intersecting methods have been collected now. the remaining work is to sort
     // these and apply specificity to determine a list of dispatch-possible call targets
-    size_t i, j, len = jl_array_nrows(env.t);
-
-    // the 'minmax' method is a method that (1) fully-covers the queried type, and (2) is
-    // more-specific than any other fully-covering method (but if !all_subtypes, there are
-    // non-fully-covering methods to which it is _likely_ not more specific)
-    jl_method_match_t *minmax = NULL;
-    int any_subtypes = 0;
-    if (len > 1) {
-        // first try to pre-process the results to find the most specific option
-        // among the fully-covering methods, since we can do this in O(n^2)
-        // time, and the rest is O(n^3)
-        //   - first find a candidate for the best of these method results
-        for (i = 0; i < len; i++) {
-            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
-            if (matc->fully_covers == FULLY_COVERS) {
-                any_subtypes = 1;
-                jl_method_t *m = matc->method;
-                for (j = 0; j < len; j++) {
-                    if (i == j)
-                        continue;
-                    jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(env.t, j);
-                    if (matc2->fully_covers == FULLY_COVERS) {
-                        jl_method_t *m2 = matc2->method;
-                        if (!method_morespecific_via_interferences(m, m2))
-                            break;
-                    }
-                }
-                if (j == len) {
-                    // Found the minmax method
-                    minmax = matc;
-                    break;
-                }
-            }
-        }
-        //   - it may even dominate (be more specific than) some choices that are not fully-covering!
-        //     move those into the subtype group, where we'll filter them out shortly after
-        //     (potentially avoiding reporting these as an ambiguity, and
-        //     potentially allowing us to hit the next fast path)
-        //   - we could always check here if *any* FULLY_COVERS method is
-        //     more-specific (instead of just considering minmax), but that may
-        //     cost much extra and is less likely to help us hit a fast path
-        //     (we will look for this later, when we compute ambig_groupid, for
-        //     correctness)
-        int all_subtypes = any_subtypes;
-        if (any_subtypes) {
-            jl_method_t *minmaxm = NULL;
-            if (minmax != NULL)
-                minmaxm = minmax->method;
-            // scan through all the non-fully-matching methods and count them as "fully-covering" (ish)
-            // (i.e. in the 'subtype' group) if `minmax` is more-specific
-            for (i = 0; i < len; i++) {
-                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
-                if (matc->fully_covers != FULLY_COVERS) {
-                    jl_method_t *m = matc->method;
-                    if (minmaxm) {
-                        if (method_morespecific_via_interferences(minmaxm, m)) {
-                            matc->fully_covers = SENTINEL; // put a sentinel value here for sorting
-                            continue;
-                        }
-                        if (method_in_interferences(minmaxm, m)) // !morespecific(m, minmaxm)
-                            has_ambiguity = 1;
-                    }
-                    all_subtypes = 0;
-                }
-            }
-        }
-        //    - now we might have a fast-return here, if we see that
-        //      we've already processed all of the possible outputs
-        if (all_subtypes) {
-            if (minmax == NULL) {
-                // all intersecting methods are fully-covering, but there is no unique most-specific method
-                if (!include_ambiguous) {
-                    // there no unambiguous choice of method
-                    len = 0;
-                    env.t = jl_an_empty_vec_any;
-                }
-                else if (lim == 1) {
-                    // we'd have to return >1 method due to the ambiguity, so bail early
-                    JL_GC_POP();
-                    return jl_nothing;
-                }
-            }
-            else {
-                // `minmax` is more-specific than all other matches and is fully-covering
-                // we can return it as our only result
-                jl_array_ptr_set(env.t, 0, minmax);
-                jl_array_del_end((jl_array_t*)env.t, len - 1);
-                len = 1;
-            }
-        }
-        if (minmax && lim == 0) {
-            // protect some later algorithms from underflow
+    size_t j, len;
+    {
+        ssize_t sorted = sort_method_matches((jl_array_t*)env.t, lim, include_ambiguous, ambig == NULL, &has_ambiguity);
+        if (sorted == -1) {
             JL_GC_POP();
             return jl_nothing;
         }
-    }
-    if (len > 1) {
-        arraylist_t stack, visited, result, recursion_stack;
-        arraylist_new(&result, lim != -1 && lim < len ? lim : len);
-        arraylist_new(&stack, 0);
-        arraylist_new(&visited, len);
-        arraylist_new(&recursion_stack, len);
-        arraylist_grow(&visited, len);
-        memset(visited.items, 0, len * sizeof(size_t));
-        char *tainted = (char*)calloc_s(len);
-        // if we had a minmax method (any subtypes), now may now be able to
-        // quickly cleanup some of methods
-        int found_minmax = 0;
-        if (has_ambiguity)
-            found_minmax = 1;
-        else if (minmax != NULL)
-            found_minmax = 2;
-        else if (any_subtypes && !include_ambiguous)
-            found_minmax = 1;
-        has_ambiguity = 0;
-        if (ambig == NULL) // if we don't care about the result, set it now so we won't bother attempting to compute it accurately later
-            has_ambiguity = 1;
-        for (i = 0; i < len; i++) {
-            assert(visited.items[i] == (void*)0 || visited.items[i] == (void*)1);
-            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
-            if (matc->fully_covers != NOT_FULLY_COVERS && found_minmax) {
-                // this was already handled above and below, so we won't learn anything new
-                // by visiting it and it might be a bit costly
-                continue;
-            }
-            int child_cycle = sort_mlmatches((jl_array_t*)env.t, i, &visited, tainted, &stack, &result, &recursion_stack, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
-            if (child_cycle == -1) {
-                free(tainted);
-                arraylist_free(&recursion_stack);
-                arraylist_free(&visited);
-                arraylist_free(&stack);
-                arraylist_free(&result);
-                JL_GC_POP();
-                return jl_nothing;
-            }
-            assert(child_cycle == 0); (void)child_cycle;
-            assert(stack.len == 0);
-            assert(visited.items[i] == (void*)1);
-        }
-        free(tainted);
-        arraylist_free(&recursion_stack);
-        arraylist_free(&visited);
-        arraylist_free(&stack);
-        for (j = 0; j < result.len; j++) {
-            i = (size_t)result.items[j];
-            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
-            // remove our sentinel entry markers
-            if (matc->fully_covers == SENTINEL)
-                matc->fully_covers = NOT_FULLY_COVERS;
-            result.items[j] = (void*)matc;
-        }
-        if (minmax) {
-            arraylist_push(&result, minmax);
-            j++;
-        }
-        memcpy(jl_array_data(env.t, jl_method_match_t*), result.items, j * sizeof(jl_method_match_t*));
-        arraylist_free(&result);
-        if (j != len)
-            jl_array_del_end((jl_array_t*)env.t, len - j);
-        len = j;
+        len = (size_t)sorted;
     }
     for (j = 0; j < len; j++) {
         jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, j);

--- a/src/gf.c
+++ b/src/gf.c
@@ -2300,19 +2300,16 @@ static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_in
     }
     if (closure->shadowed == NULL)
         closure->shadowed = (jl_value_t*)jl_alloc_vec_any(0);
-    // This should be rarely true (in fact, get_intersect_visitor should be
-    // rarely true), but might as well skip the rest of the scan fast anyways
-    // since we can.
-    if (closure->match.issubty) {
-        int only = jl_atomic_load_relaxed(&oldmethod->dispatch_status) & METHOD_SIG_LATEST_ONLY;
-        if (only) {
-            size_t len = jl_array_nrows(closure->shadowed);
-            if (len > 0)
-                jl_array_del_end((jl_array_t*)closure->shadowed, len);
-            jl_array_ptr_1d_push((jl_array_t*)closure->shadowed, (jl_value_t*)oldmethod);
-            return 0;
-        }
-    }
+    // Record every intersecting method so the interference relation is complete.
+    // We must NOT early-out when the new method is a strict subtype of an
+    // `oldmethod` that dominates its dispatch (METHOD_SIG_LATEST_ONLY): stopping
+    // the scan there would omit the new method's other intersecting pairs, and
+    // `morespecific` is not monotone under subtyping (strict-subtype implies
+    // morespecific, but the supertype's specificity relations do not transfer to
+    // the subtype and can even reverse), so a dominated-looking supertype can
+    // still hide intersections that must be recorded. `typemap_slurp_search`
+    // below is only the shared `Type{Union{}}` (exclude_typeofbottom) traversal
+    // hint used on the query path too; it does not drop intersecting entries.
     jl_array_ptr_1d_push((jl_array_t*)closure->shadowed, (jl_value_t*)oldmethod);
     typemap_slurp_search(oldentry, &closure->match);
     return 1;
@@ -3050,6 +3047,21 @@ static int has_key(jl_genericmemory_t *keys, jl_value_t *key)
 }
 
 // Check if m2 is in m1's interferences set, which means !morespecific(m1, m2)
+//
+// Completeness contract: for any two currently-live methods with intersecting
+// signatures, at least one of `method_in_interferences(a, b)` /
+// `method_in_interferences(b, a)` is recorded (both, when they are mutually
+// non-morespecific, i.e. ambiguous), and each present membership implies its
+// `!morespecific` fact. This holds because `jl_method_table_activate` visits
+// every intersecting method when recording (no LATEST_ONLY / dominance
+// early-out). For disjoint pairs neither membership is present.
+//
+// Tolerated staleness: a set may still name methods that have since been
+// deleted, or methods not yet visible in the querying world (a set is populated
+// at insertion and not pruned on deletion). Consumers must filter by world
+// (reinfer.jl checks METHOD_SIG_LATEST_WHICH / primary_world; gf.c filters
+// through find_method_in_matches, which only keeps methods present in the
+// current query's match array).
 static int method_in_interferences(jl_method_t *m2, jl_method_t *m1)
 {
     return has_key(jl_atomic_load_relaxed(&m1->interferences), (jl_value_t*)m2);
@@ -3067,18 +3079,13 @@ static int find_method_in_matches(jl_array_t *t, jl_method_t *method)
     return -1;
 }
 
-// Check whether `m2` is (visibly) strictly morespecific than `m`, using the
-// recorded interference edges when the pair was recorded (both directions are
-// decided together at method definition time), and falling back to the direct
-// specificity query for unrecorded pairs.
-static int method_strictly_morespecific(jl_method_t *m2, jl_method_t *m)
-{
-    if (method_in_interferences(m2, m)) // !morespecific(m, m2) recorded
-        return !method_in_interferences(m, m2); // and not mutual (ambiguous)
-    // either morespecific(m, m2), or the pair was never recorded (its
-    // intersection was shadowed at definition time): ask the type system
-    return jl_type_morespecific(m2->sig, m->sig);
-}
+// Whether `target_method` is strictly morespecific than `start_method`, read
+// directly from the recorded interference relation (which is complete for
+// intersecting pairs, see `method_in_interferences`). Exact for intersecting
+// pairs; returns 0 for disjoint pairs (neither membership is recorded), which
+// is the answer the covering/dominance callers want (a disjoint method cannot
+// dominate another).
+static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method);
 
 // About to remove match `D` from the possible dispatch targets, since it is
 // fully covered by the strictly-morespecific cover(s) `covers` and thus can
@@ -3096,12 +3103,12 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
         jl_method_t *S = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
         if (S == D)
             continue;
-        // only consider S that D is (visibly) strictly morespecific than
-        if (!method_in_interferences(D, S) || method_in_interferences(S, D))
+        // only consider S that D is strictly morespecific than
+        if (!method_morespecific_recorded(D, S))
             continue;
         size_t j;
         for (j = 0; j < ncovers; j++) {
-            if (S == covers[j] || method_strictly_morespecific(covers[j], S))
+            if (S == covers[j] || method_morespecific_recorded(covers[j], S))
                 break;
         }
         if (j == ncovers) {
@@ -3112,7 +3119,7 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
             // interference edges and remains visible to check_fully_ambiguous
             // independent of D's removal.
             for (j = 0; j < ncovers; j++) {
-                if (method_strictly_morespecific(S, covers[j]))
+                if (method_morespecific_recorded(S, covers[j]))
                     return 0;
             }
         }
@@ -3126,114 +3133,79 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
 // covering relation is entangled in a specificity cycle, sets *has_ambiguity;
 // in that case the match is only reported as covered when `include_ambiguous`
 // is false, so that ambiguity-reporting consumers still see it.
-static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, char *tainted, arraylist_t *seen, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
+static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, char *tainted, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
-    arraylist_t workqueue;
-    arraylist_new(&workqueue, 0);
-    arraylist_push(&workqueue, m);
-    arraylist_push(seen, (void*)m);
-    int result = 0;
-    while (workqueue.len > 0) {
-        jl_method_t *current_m = (jl_method_t*)arraylist_pop(&workqueue);
-        JL_GC_PROMISE_ROOTED(current_m);
-        jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&current_m->interferences);
-        for (size_t i = 0; i < interferences->length; i++) {
-            jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
-            if (m2 == NULL)
-                continue;
-            // Check if we already visited this method
-            int in_seen = 0;
-            for (size_t i = 0; i < seen->len; i++) {
-                if (seen->items[i] == (void*)m2) {
-                    in_seen = 1;
-                    break;
-                }
-            }
-            if (in_seen)
-                continue;
-            arraylist_push(seen, (void*)m2);
-            int idx = find_method_in_matches(t, m2);
-            if (idx < 0)
-                continue;
-            if (method_in_interferences(current_m, m2))
-                continue; // ambiguous
-            if (visited->items[idx] != (void*)1)
-                continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
-            if (jl_subtype(ti, m2->sig)) {
-                // The chain of interference edges only suggests transitively
-                // that m2 is morespecific than m; that inference is wrong if a
-                // specificity cycle leads back from m to m2, in which case the
-                // covering method does not actually win dispatch from m over
-                // (all of) their intersection and the apparent ambiguity is
-                // real (conservatively, since the methods witnessing the
-                // non-transitivity may intersect elsewhere in the query).
-                if (!method_strictly_morespecific(m2, m)) {
-                    // if m actually beats m2, the chain from m back to m2 is
-                    // a directed specificity cycle (a genuine ambiguity); if
-                    // they are merely mutually ambiguous, that is recorded on
-                    // their own interference edge and handled by
-                    // check_fully_ambiguous
-                    if (method_strictly_morespecific(m, m2)) {
-                        *has_ambiguity = 1;
-                    }
+    jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
+    // First: is `m` fully covered (dominated over the whole query region `ti`)
+    // by a single recorded strictly-morespecific method? Because recording is
+    // complete, any such method intersects `m` and is morespecific than it, so
+    // `!morespecific(m, it)` was recorded and it is a *direct* member of `m`'s
+    // interference set: a single pass suffices, with no transitive chase.
+    for (size_t i = 0; i < interferences->length; i++) {
+        jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
+        if (m2 == NULL)
+            continue;
+        int idx = find_method_in_matches(t, m2);
+        if (idx < 0)
+            continue;
+        if (method_in_interferences(m, m2))
+            continue; // mutual interference (ambiguous), not a strict cover
+        if (visited->items[idx] != (void*)1)
+            continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
+        if (jl_subtype(ti, m2->sig)) {
+            // m2 is strictly morespecific than m (a one-directional recorded
+            // edge) and fully covers ti, so m can never win dispatch here.
+            // Dropping m is only safe if m2 also dominates everything m was
+            // beating; otherwise a specificity cycle leads back from a cover to
+            // a method only m beat, and the apparent ambiguity is real.
+            if (!check_dominance_transfer(m, &m2, 1, t)) {
+                *has_ambiguity = 1;
+                if (include_ambiguous)
                     continue;
-                }
-                if (!check_dominance_transfer(m, &m2, 1, t)) {
-                    *has_ambiguity = 1;
-                    if (include_ambiguous)
-                        continue;
-                }
-                result = 1;
-                goto cleanup;
             }
-            arraylist_push(&workqueue, m2);
+            return 1;
         }
     }
-    if (!result) {
-        // No single morespecific method covers ti, but a union of them may
-        // (e.g. several methods each covering one component of a Union-typed
-        // argument). Collect the recorded strictly-morespecific interferences
-        // that were already finalized cleanly (not part of an ambiguity
-        // group, which could mean they lose dispatch back to `m` through a
-        // specificity cycle) and check whether ti is covered by their union.
-        jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
-        size_t ncovers = 0;
-        jl_method_t **covers = (jl_method_t**)malloc_s(interferences->length * sizeof(jl_method_t*));
-        for (size_t i = 0; i < interferences->length; i++) {
-            jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
-            if (m2 == NULL)
-                continue;
-            int idx = find_method_in_matches(t, m2);
-            if (idx < 0)
-                continue;
-            if (visited->items[idx] != (void*)1 || tainted[idx])
-                continue;
-            if (method_in_interferences(m, m2)) // mutual interference (ambiguous)
-                continue;
-            covers[ncovers++] = m2;
-        }
-        if (ncovers > 1) {
-            jl_value_t **sigs = (jl_value_t**)malloc_s(ncovers * sizeof(jl_value_t*));
-            for (size_t i = 0; i < ncovers; i++)
-                sigs[i] = (jl_value_t*)covers[i]->sig;
-            jl_value_t *u = jl_type_union(sigs, ncovers);
-            free(sigs);
-            JL_GC_PUSH1(&u);
-            if (jl_subtype(ti, u)) {
-                result = 1;
-                if (!check_dominance_transfer(m, covers, ncovers, t)) {
-                    *has_ambiguity = 1;
-                    if (include_ambiguous)
-                        result = 0;
-                }
-            }
-            JL_GC_POP();
-        }
-        free(covers);
+    // No single morespecific method covers ti, but a union of them may (e.g.
+    // several methods each covering one component of a Union-typed argument).
+    // Collect the recorded strictly-morespecific interferences that were already
+    // finalized cleanly (not part of an ambiguity group, which could mean they
+    // lose dispatch back to `m` through a specificity cycle) and check whether
+    // ti is covered by their union.
+    int result = 0;
+    size_t ncovers = 0;
+    jl_method_t **covers = (jl_method_t**)malloc_s(interferences->length * sizeof(jl_method_t*));
+    for (size_t i = 0; i < interferences->length; i++) {
+        jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
+        if (m2 == NULL)
+            continue;
+        int idx = find_method_in_matches(t, m2);
+        if (idx < 0)
+            continue;
+        if (visited->items[idx] != (void*)1 || tainted[idx])
+            continue;
+        if (method_in_interferences(m, m2)) // mutual interference (ambiguous)
+            continue;
+        covers[ncovers++] = m2;
     }
-cleanup:
-    seen->len = 0;
-    arraylist_free(&workqueue);
+    if (ncovers > 1) {
+        jl_value_t **sigs = (jl_value_t**)malloc_s(ncovers * sizeof(jl_value_t*));
+        for (size_t i = 0; i < ncovers; i++)
+            sigs[i] = (jl_value_t*)covers[i]->sig;
+        jl_value_t *u = jl_type_union(sigs, ncovers);
+        free(sigs);
+        JL_GC_PUSH1(&u);
+        if (jl_subtype(ti, u)) {
+            result = 1;
+            if (!check_dominance_transfer(m, covers, ncovers, t)) {
+                *has_ambiguity = 1;
+                if (include_ambiguous)
+                    result = 0;
+            }
+        }
+        JL_GC_POP();
+    }
+    free(covers);
     return result;
 }
 
@@ -3256,58 +3228,22 @@ static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, 
     return 0;
 }
 
-// Recursively check if target_method is in the interferences of (morespecific than) start_method, but not the reverse
-static int method_morespecific_via_interferences(jl_method_t *target_method, jl_method_t *start_method)
+// Whether target_method is strictly morespecific than start_method, read
+// directly from the recorded interference relation: target is in start's set
+// (so !morespecific(start, target)) but start is not in target's set (so
+// morespecific(target, start)). Because recording is complete for intersecting
+// pairs, this is exact for them; for disjoint pairs neither membership is
+// present and the result is 0 (a disjoint method dominates nothing), which is
+// what the covering/dominance callers want. The assert documents that contract.
+static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method)
 {
     if (target_method == start_method)
         return 0;
-    // Check direct interferences first
-    if (method_in_interferences(start_method, target_method))
-        return 0;
-    if (method_in_interferences(target_method, start_method))
-        return 1;
-    arraylist_t seen;
-    arraylist_t workqueue;
-    arraylist_new(&seen, 0);
-    arraylist_push(&seen, (void*)start_method);
-    arraylist_new(&workqueue, 0);
-    arraylist_push(&workqueue, start_method);
-    int result = 0;
-    while (workqueue.len > 0) {
-        jl_method_t *current = (jl_method_t*)arraylist_pop(&workqueue);
-        JL_GC_PROMISE_ROOTED(current);
-        jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&current->interferences);
-        for (size_t i = 0; i < interferences->length; i++) {
-            jl_method_t *interference_method = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
-            if (interference_method == NULL)
-                continue;
-            // Check if we're already visiting this interference method (cycle prevention)
-            int already_seen = 0;
-            for (size_t j = 0; j < seen.len; j++) {
-                if (seen.items[j] == (void*)interference_method) {
-                    already_seen = 1;
-                    break;
-                }
-            }
-            if (already_seen)
-                continue;
-            arraylist_push(&seen, interference_method);
-            if (method_in_interferences(current, interference_method))
-                continue; // only follow edges to morespecific methods in search of morespecific target (skip ambiguities)
-            // Check direct interferences for this interference method
-            if (method_in_interferences(interference_method, target_method))
-                continue; // return 0 for this path
-            if (method_in_interferences(target_method, interference_method)) {
-                result = 1;
-                goto cleanup;
-            }
-            arraylist_push(&workqueue, interference_method);
-        }
-    }
-cleanup:
-    arraylist_free(&workqueue);
-    arraylist_free(&seen);
-    //assert(result == jl_method_morespecific(target_method, start_method) || jl_has_empty_intersection(target_method->sig, start_method->sig) || jl_has_empty_intersection(start_method->sig, target_method->sig));
+    int result = method_in_interferences(target_method, start_method) &&
+                 !method_in_interferences(start_method, target_method);
+    assert(result == jl_method_morespecific(target_method, start_method) ||
+           jl_has_empty_intersection(target_method->sig, start_method->sig) ||
+           jl_has_empty_intersection(start_method->sig, target_method->sig));
     return result;
 }
 
@@ -3362,9 +3298,11 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         // This will store if this method will be currently the only result that would returned from `ml_matches` given `sig`.
         dispatch_bits |= METHOD_SIG_LATEST_ONLY; // Tentatively set, will be cleared if not applicable
     // Holds the set of all intersecting methods not more specific than this one.
-    // Note: this set may be incomplete (may exclude methods whose intersection
-    // is covered by another method that is morespecific than both, causing them
-    // to have no relevant type intersection for sorting).
+    // The insertion scan below visits every intersecting method (the
+    // LATEST_ONLY early-out was removed), so the recorded relation is complete:
+    // for any two currently-live methods with intersecting signatures, at least
+    // one of the two memberships is present (see the contract on
+    // `method_in_interferences`).
     interferences = (jl_genericmemory_t*)jl_atomic_load_relaxed(&method->interferences);
     if (oldvalue) {
         assert(n > 0);
@@ -5233,7 +5171,6 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
 //  * `visited`: the state of the algorithm for each vertex in `t`: either 1 if we visited it already or 1+depth if we are visiting it now
 //  * `stack`: the state of the algorithm for the current vertex (up to length equal to `t`): the list of all vertexes currently in the depth-first path or in the current SCC
 //  * `result`: the output of the algorithm, a sorted list of vertexes (up to length `lim`)
-//  * `recursion_stack`: an array for temporary use
 //  * `lim`: either -1 for unlimited matches, or the maximum length for `result` before returning failure (return -1).
 //  * `include_ambiguous`: whether to filter out fully ambiguous matches from `result`
 //  * `*has_ambiguity`: whether the algorithm does not need to compute if there is an unresolved ambiguity
@@ -5267,7 +5204,7 @@ typedef struct {
 //  * -1: too many matches for lim, other outputs are undefined
 //  *  0: the child(ren) have been added to the output
 //  * 1+: the children are part of this SCC (up to this depth)
-static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char *tainted, arraylist_t *stack, arraylist_t *result, arraylist_t *recursion_stack, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax, jl_method_t *minmaxm) JL_CANSAFEPOINT
+static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char *tainted, arraylist_t *stack, arraylist_t *result, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax, jl_method_t *minmaxm) JL_CANSAFEPOINT
 {
     // Use arraylist_t for explicit stack of processing frames
     arraylist_t frame_stack;
@@ -5408,7 +5345,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
                         }
                     }
                 }
-                else if (check_interferences_covers(current->m, current->ti, t, visited, tainted, recursion_stack, include_ambiguous, has_ambiguity)) {
+                else if (check_interferences_covers(current->m, current->ti, t, visited, tainted, include_ambiguous, has_ambiguity)) {
                     visited->items[current->idx] = (void*)1;
                 }
                 else if (check_fully_ambiguous(current->m, current->ti, t, include_ambiguous, has_ambiguity)) {
@@ -5555,7 +5492,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                     jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(t, j);
                     if (matc2->fully_covers == FULLY_COVERS) {
                         jl_method_t *m2 = matc2->method;
-                        if (!method_morespecific_via_interferences(m, m2))
+                        if (!method_morespecific_recorded(m, m2))
                             break;
                     }
                 }
@@ -5587,7 +5524,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 if (matc->fully_covers != FULLY_COVERS) {
                     jl_method_t *m = matc->method;
                     if (minmaxm) {
-                        if (method_morespecific_via_interferences(minmaxm, m)) {
+                        if (method_morespecific_recorded(minmaxm, m)) {
                             matc->fully_covers = SENTINEL; // put a sentinel value here for sorting
                             continue;
                         }
@@ -5627,11 +5564,10 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         }
     }
     if (len > 1) {
-        arraylist_t stack, visited, result, recursion_stack;
+        arraylist_t stack, visited, result;
         arraylist_new(&result, lim != -1 && lim < len ? lim : len);
         arraylist_new(&stack, 0);
         arraylist_new(&visited, len);
-        arraylist_new(&recursion_stack, len);
         arraylist_grow(&visited, len);
         memset(visited.items, 0, len * sizeof(size_t));
         char *tainted = (char*)calloc_s(len);
@@ -5655,10 +5591,9 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 // by visiting it and it might be a bit costly
                 continue;
             }
-            int child_cycle = sort_mlmatches(t, i, &visited, tainted, &stack, &result, &recursion_stack, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
+            int child_cycle = sort_mlmatches(t, i, &visited, tainted, &stack, &result, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
             if (child_cycle == -1) {
                 free(tainted);
-                arraylist_free(&recursion_stack);
                 arraylist_free(&visited);
                 arraylist_free(&stack);
                 arraylist_free(&result);
@@ -5669,7 +5604,6 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             assert(visited.items[i] == (void*)1);
         }
         free(tainted);
-        arraylist_free(&recursion_stack);
         arraylist_free(&visited);
         arraylist_free(&stack);
         for (j = 0; j < result.len; j++) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -5110,7 +5110,17 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     if (closure->match.max_valid > max_world)
         closure->match.max_valid = max_world;
     jl_method_t *meth = ml->func.method;
-    int only = jl_atomic_load_relaxed(&meth->dispatch_status) & METHOD_SIG_LATEST_ONLY;
+    // Whether this method dominates (is strictly morespecific than) every
+    // method it intersects, and hence every other candidate for this query:
+    // either its LATEST_ONLY bit is set, or its interference set is empty (the
+    // ground-truth relation, which the bit tracks in lockstep except that the
+    // bit can be suppressed by PRECOMPILE_MANY). Such a method always survives
+    // into the final result (nothing can cover a method that beats every
+    // intersecting method), and when it also fully covers the query it is the
+    // unique result, so the rest of the search can be skipped. Interference
+    // sets only grow, so emptiness now implies emptiness in the query's world.
+    int only = (jl_atomic_load_relaxed(&meth->dispatch_status) & METHOD_SIG_LATEST_ONLY) ||
+               jl_atomic_load_relaxed(&meth->interferences)->length == 0;
     if (closure->lim >= 0 && only) {
         if (closure->lim == 0) {
             closure->t = jl_an_empty_vec_any;
@@ -5457,6 +5467,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
     // more-specific than any other fully-covering method (but if !all_subtypes, there are
     // non-fully-covering methods to which it is _likely_ not more specific)
     jl_method_match_t *minmax = NULL;
+    int minmax_dominates = 0;
     int any_subtypes = 0;
     if (len > 1) {
         // first try to pre-process the results to find the most specific option
@@ -5468,6 +5479,21 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             if (matc->fully_covers == FULLY_COVERS) {
                 any_subtypes = 1;
                 jl_method_t *m = matc->method;
+                // A fully-covering match with an empty interference set is
+                // strictly morespecific than every method it intersects
+                // (recording is complete), and every other match intersects it
+                // (through the query type it covers): it is the unique
+                // dispatch winner over the whole query, every other match can
+                // be dropped with `m` itself as the dominating cover, and no
+                // ambiguity can involve it. Since interference sets only ever
+                // grow, emptiness now implies emptiness in the query's world.
+                // (Two such matches cannot coexist: they would intersect, so
+                // one of the two memberships would be recorded.)
+                if (jl_atomic_load_relaxed(&m->interferences)->length == 0) {
+                    minmax = matc;
+                    minmax_dominates = 1;
+                    break;
+                }
                 for (j = 0; j < len; j++) {
                     if (i == j)
                         continue;
@@ -5495,7 +5521,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         //     (we will look for this later, when we compute ambig_groupid, for
         //     correctness)
         int all_subtypes = any_subtypes;
-        if (any_subtypes) {
+        if (any_subtypes && !minmax_dominates) {
             jl_method_t *minmaxm = NULL;
             if (minmax != NULL)
                 minmaxm = minmax->method;

--- a/src/gf.c
+++ b/src/gf.c
@@ -2288,19 +2288,16 @@ static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_in
     }
     if (closure->shadowed == NULL)
         closure->shadowed = (jl_value_t*)jl_alloc_vec_any(0);
-    // This should be rarely true (in fact, get_intersect_visitor should be
-    // rarely true), but might as well skip the rest of the scan fast anyways
-    // since we can.
-    if (closure->match.issubty) {
-        int only = jl_atomic_load_relaxed(&oldmethod->dispatch_status) & METHOD_SIG_LATEST_ONLY;
-        if (only) {
-            size_t len = jl_array_nrows(closure->shadowed);
-            if (len > 0)
-                jl_array_del_end((jl_array_t*)closure->shadowed, len);
-            jl_array_ptr_1d_push((jl_array_t*)closure->shadowed, (jl_value_t*)oldmethod);
-            return 0;
-        }
-    }
+    // Record every intersecting method so the interference relation is complete.
+    // We must NOT early-out when the new method is a strict subtype of an
+    // `oldmethod` that dominates its dispatch (METHOD_SIG_LATEST_ONLY): stopping
+    // the scan there would omit the new method's other intersecting pairs, and
+    // `morespecific` is not monotone under subtyping (strict-subtype implies
+    // morespecific, but the supertype's specificity relations do not transfer to
+    // the subtype and can even reverse), so a dominated-looking supertype can
+    // still hide intersections that must be recorded. `typemap_slurp_search`
+    // below is only the shared `Type{Union{}}` (exclude_typeofbottom) traversal
+    // hint used on the query path too; it does not drop intersecting entries.
     jl_array_ptr_1d_push((jl_array_t*)closure->shadowed, (jl_value_t*)oldmethod);
     typemap_slurp_search(oldentry, &closure->match);
     return 1;
@@ -3032,6 +3029,21 @@ static int has_key(jl_genericmemory_t *keys, jl_value_t *key)
 }
 
 // Check if m2 is in m1's interferences set, which means !morespecific(m1, m2)
+//
+// Completeness contract: for any two currently-live methods with intersecting
+// signatures, at least one of `method_in_interferences(a, b)` /
+// `method_in_interferences(b, a)` is recorded (both, when they are mutually
+// non-morespecific, i.e. ambiguous), and each present membership implies its
+// `!morespecific` fact. This holds because `jl_method_table_activate` visits
+// every intersecting method when recording (no LATEST_ONLY / dominance
+// early-out). For disjoint pairs neither membership is present.
+//
+// Tolerated staleness: a set may still name methods that have since been
+// deleted, or methods not yet visible in the querying world (a set is populated
+// at insertion and not pruned on deletion). Consumers must filter by world
+// (reinfer.jl checks METHOD_SIG_LATEST_WHICH / primary_world; gf.c filters
+// through find_method_in_matches, which only keeps methods present in the
+// current query's match array).
 static int method_in_interferences(jl_method_t *m2, jl_method_t *m1)
 {
     return has_key(jl_atomic_load_relaxed(&m1->interferences), (jl_value_t*)m2);
@@ -3049,18 +3061,13 @@ static int find_method_in_matches(jl_array_t *t, jl_method_t *method)
     return -1;
 }
 
-// Check whether `m2` is (visibly) strictly morespecific than `m`, using the
-// recorded interference edges when the pair was recorded (both directions are
-// decided together at method definition time), and falling back to the direct
-// specificity query for unrecorded pairs.
-static int method_strictly_morespecific(jl_method_t *m2, jl_method_t *m)
-{
-    if (method_in_interferences(m2, m)) // !morespecific(m, m2) recorded
-        return !method_in_interferences(m, m2); // and not mutual (ambiguous)
-    // either morespecific(m, m2), or the pair was never recorded (its
-    // intersection was shadowed at definition time): ask the type system
-    return jl_type_morespecific(m2->sig, m->sig);
-}
+// Whether `target_method` is strictly morespecific than `start_method`, read
+// directly from the recorded interference relation (which is complete for
+// intersecting pairs, see `method_in_interferences`). Exact for intersecting
+// pairs; returns 0 for disjoint pairs (neither membership is recorded), which
+// is the answer the covering/dominance callers want (a disjoint method cannot
+// dominate another).
+static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method);
 
 // About to remove match `D` from the possible dispatch targets, since it is
 // fully covered by the strictly-morespecific cover(s) `covers` and thus can
@@ -3078,12 +3085,12 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
         jl_method_t *S = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
         if (S == D)
             continue;
-        // only consider S that D is (visibly) strictly morespecific than
-        if (!method_in_interferences(D, S) || method_in_interferences(S, D))
+        // only consider S that D is strictly morespecific than
+        if (!method_morespecific_recorded(D, S))
             continue;
         size_t j;
         for (j = 0; j < ncovers; j++) {
-            if (S == covers[j] || method_strictly_morespecific(covers[j], S))
+            if (S == covers[j] || method_morespecific_recorded(covers[j], S))
                 break;
         }
         if (j == ncovers) {
@@ -3094,7 +3101,7 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
             // interference edges and remains visible to check_fully_ambiguous
             // independent of D's removal.
             for (j = 0; j < ncovers; j++) {
-                if (method_strictly_morespecific(S, covers[j]))
+                if (method_morespecific_recorded(S, covers[j]))
                     return 0;
             }
         }
@@ -3108,114 +3115,79 @@ static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t
 // covering relation is entangled in a specificity cycle, sets *has_ambiguity;
 // in that case the match is only reported as covered when `include_ambiguous`
 // is false, so that ambiguity-reporting consumers still see it.
-static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, char *tainted, arraylist_t *seen, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
+static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, char *tainted, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
-    arraylist_t workqueue;
-    arraylist_new(&workqueue, 0);
-    arraylist_push(&workqueue, m);
-    arraylist_push(seen, (void*)m);
-    int result = 0;
-    while (workqueue.len > 0) {
-        jl_method_t *current_m = (jl_method_t*)arraylist_pop(&workqueue);
-        JL_GC_PROMISE_ROOTED(current_m);
-        jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&current_m->interferences);
-        for (size_t i = 0; i < interferences->length; i++) {
-            jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
-            if (m2 == NULL)
-                continue;
-            // Check if we already visited this method
-            int in_seen = 0;
-            for (size_t i = 0; i < seen->len; i++) {
-                if (seen->items[i] == (void*)m2) {
-                    in_seen = 1;
-                    break;
-                }
-            }
-            if (in_seen)
-                continue;
-            arraylist_push(seen, (void*)m2);
-            int idx = find_method_in_matches(t, m2);
-            if (idx < 0)
-                continue;
-            if (method_in_interferences(current_m, m2))
-                continue; // ambiguous
-            if (visited->items[idx] != (void*)1)
-                continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
-            if (jl_subtype(ti, m2->sig)) {
-                // The chain of interference edges only suggests transitively
-                // that m2 is morespecific than m; that inference is wrong if a
-                // specificity cycle leads back from m to m2, in which case the
-                // covering method does not actually win dispatch from m over
-                // (all of) their intersection and the apparent ambiguity is
-                // real (conservatively, since the methods witnessing the
-                // non-transitivity may intersect elsewhere in the query).
-                if (!method_strictly_morespecific(m2, m)) {
-                    // if m actually beats m2, the chain from m back to m2 is
-                    // a directed specificity cycle (a genuine ambiguity); if
-                    // they are merely mutually ambiguous, that is recorded on
-                    // their own interference edge and handled by
-                    // check_fully_ambiguous
-                    if (method_strictly_morespecific(m, m2)) {
-                        *has_ambiguity = 1;
-                    }
+    jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
+    // First: is `m` fully covered (dominated over the whole query region `ti`)
+    // by a single recorded strictly-morespecific method? Because recording is
+    // complete, any such method intersects `m` and is morespecific than it, so
+    // `!morespecific(m, it)` was recorded and it is a *direct* member of `m`'s
+    // interference set: a single pass suffices, with no transitive chase.
+    for (size_t i = 0; i < interferences->length; i++) {
+        jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
+        if (m2 == NULL)
+            continue;
+        int idx = find_method_in_matches(t, m2);
+        if (idx < 0)
+            continue;
+        if (method_in_interferences(m, m2))
+            continue; // mutual interference (ambiguous), not a strict cover
+        if (visited->items[idx] != (void*)1)
+            continue; // not finalized yet (part of the same SCC cycle, handled by ambiguity later, or skipped as part of the minmax group)
+        if (jl_subtype(ti, m2->sig)) {
+            // m2 is strictly morespecific than m (a one-directional recorded
+            // edge) and fully covers ti, so m can never win dispatch here.
+            // Dropping m is only safe if m2 also dominates everything m was
+            // beating; otherwise a specificity cycle leads back from a cover to
+            // a method only m beat, and the apparent ambiguity is real.
+            if (!check_dominance_transfer(m, &m2, 1, t)) {
+                *has_ambiguity = 1;
+                if (include_ambiguous)
                     continue;
-                }
-                if (!check_dominance_transfer(m, &m2, 1, t)) {
-                    *has_ambiguity = 1;
-                    if (include_ambiguous)
-                        continue;
-                }
-                result = 1;
-                goto cleanup;
             }
-            arraylist_push(&workqueue, m2);
+            return 1;
         }
     }
-    if (!result) {
-        // No single morespecific method covers ti, but a union of them may
-        // (e.g. several methods each covering one component of a Union-typed
-        // argument). Collect the recorded strictly-morespecific interferences
-        // that were already finalized cleanly (not part of an ambiguity
-        // group, which could mean they lose dispatch back to `m` through a
-        // specificity cycle) and check whether ti is covered by their union.
-        jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
-        size_t ncovers = 0;
-        jl_method_t **covers = (jl_method_t**)malloc_s(interferences->length * sizeof(jl_method_t*));
-        for (size_t i = 0; i < interferences->length; i++) {
-            jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
-            if (m2 == NULL)
-                continue;
-            int idx = find_method_in_matches(t, m2);
-            if (idx < 0)
-                continue;
-            if (visited->items[idx] != (void*)1 || tainted[idx])
-                continue;
-            if (method_in_interferences(m, m2)) // mutual interference (ambiguous)
-                continue;
-            covers[ncovers++] = m2;
-        }
-        if (ncovers > 1) {
-            jl_value_t **sigs = (jl_value_t**)malloc_s(ncovers * sizeof(jl_value_t*));
-            for (size_t i = 0; i < ncovers; i++)
-                sigs[i] = (jl_value_t*)covers[i]->sig;
-            jl_value_t *u = jl_type_union(sigs, ncovers);
-            free(sigs);
-            JL_GC_PUSH1(&u);
-            if (jl_subtype(ti, u)) {
-                result = 1;
-                if (!check_dominance_transfer(m, covers, ncovers, t)) {
-                    *has_ambiguity = 1;
-                    if (include_ambiguous)
-                        result = 0;
-                }
-            }
-            JL_GC_POP();
-        }
-        free(covers);
+    // No single morespecific method covers ti, but a union of them may (e.g.
+    // several methods each covering one component of a Union-typed argument).
+    // Collect the recorded strictly-morespecific interferences that were already
+    // finalized cleanly (not part of an ambiguity group, which could mean they
+    // lose dispatch back to `m` through a specificity cycle) and check whether
+    // ti is covered by their union.
+    int result = 0;
+    size_t ncovers = 0;
+    jl_method_t **covers = (jl_method_t**)malloc_s(interferences->length * sizeof(jl_method_t*));
+    for (size_t i = 0; i < interferences->length; i++) {
+        jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
+        if (m2 == NULL)
+            continue;
+        int idx = find_method_in_matches(t, m2);
+        if (idx < 0)
+            continue;
+        if (visited->items[idx] != (void*)1 || tainted[idx])
+            continue;
+        if (method_in_interferences(m, m2)) // mutual interference (ambiguous)
+            continue;
+        covers[ncovers++] = m2;
     }
-cleanup:
-    seen->len = 0;
-    arraylist_free(&workqueue);
+    if (ncovers > 1) {
+        jl_value_t **sigs = (jl_value_t**)malloc_s(ncovers * sizeof(jl_value_t*));
+        for (size_t i = 0; i < ncovers; i++)
+            sigs[i] = (jl_value_t*)covers[i]->sig;
+        jl_value_t *u = jl_type_union(sigs, ncovers);
+        free(sigs);
+        JL_GC_PUSH1(&u);
+        if (jl_subtype(ti, u)) {
+            result = 1;
+            if (!check_dominance_transfer(m, covers, ncovers, t)) {
+                *has_ambiguity = 1;
+                if (include_ambiguous)
+                    result = 0;
+            }
+        }
+        JL_GC_POP();
+    }
+    free(covers);
     return result;
 }
 
@@ -3238,58 +3210,22 @@ static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, 
     return 0;
 }
 
-// Recursively check if target_method is in the interferences of (morespecific than) start_method, but not the reverse
-static int method_morespecific_via_interferences(jl_method_t *target_method, jl_method_t *start_method)
+// Whether target_method is strictly morespecific than start_method, read
+// directly from the recorded interference relation: target is in start's set
+// (so !morespecific(start, target)) but start is not in target's set (so
+// morespecific(target, start)). Because recording is complete for intersecting
+// pairs, this is exact for them; for disjoint pairs neither membership is
+// present and the result is 0 (a disjoint method dominates nothing), which is
+// what the covering/dominance callers want. The assert documents that contract.
+static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t *start_method)
 {
     if (target_method == start_method)
         return 0;
-    // Check direct interferences first
-    if (method_in_interferences(start_method, target_method))
-        return 0;
-    if (method_in_interferences(target_method, start_method))
-        return 1;
-    arraylist_t seen;
-    arraylist_t workqueue;
-    arraylist_new(&seen, 0);
-    arraylist_push(&seen, (void*)start_method);
-    arraylist_new(&workqueue, 0);
-    arraylist_push(&workqueue, start_method);
-    int result = 0;
-    while (workqueue.len > 0) {
-        jl_method_t *current = (jl_method_t*)arraylist_pop(&workqueue);
-        JL_GC_PROMISE_ROOTED(current);
-        jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&current->interferences);
-        for (size_t i = 0; i < interferences->length; i++) {
-            jl_method_t *interference_method = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
-            if (interference_method == NULL)
-                continue;
-            // Check if we're already visiting this interference method (cycle prevention)
-            int already_seen = 0;
-            for (size_t j = 0; j < seen.len; j++) {
-                if (seen.items[j] == (void*)interference_method) {
-                    already_seen = 1;
-                    break;
-                }
-            }
-            if (already_seen)
-                continue;
-            arraylist_push(&seen, interference_method);
-            if (method_in_interferences(current, interference_method))
-                continue; // only follow edges to morespecific methods in search of morespecific target (skip ambiguities)
-            // Check direct interferences for this interference method
-            if (method_in_interferences(interference_method, target_method))
-                continue; // return 0 for this path
-            if (method_in_interferences(target_method, interference_method)) {
-                result = 1;
-                goto cleanup;
-            }
-            arraylist_push(&workqueue, interference_method);
-        }
-    }
-cleanup:
-    arraylist_free(&workqueue);
-    arraylist_free(&seen);
-    //assert(result == jl_method_morespecific(target_method, start_method) || jl_has_empty_intersection(target_method->sig, start_method->sig) || jl_has_empty_intersection(start_method->sig, target_method->sig));
+    int result = method_in_interferences(target_method, start_method) &&
+                 !method_in_interferences(start_method, target_method);
+    assert(result == jl_method_morespecific(target_method, start_method) ||
+           jl_has_empty_intersection(target_method->sig, start_method->sig) ||
+           jl_has_empty_intersection(start_method->sig, target_method->sig));
     return result;
 }
 
@@ -3344,9 +3280,11 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         // This will store if this method will be currently the only result that would returned from `ml_matches` given `sig`.
         dispatch_bits |= METHOD_SIG_LATEST_ONLY; // Tentatively set, will be cleared if not applicable
     // Holds the set of all intersecting methods not more specific than this one.
-    // Note: this set may be incomplete (may exclude methods whose intersection
-    // is covered by another method that is morespecific than both, causing them
-    // to have no relevant type intersection for sorting).
+    // The insertion scan below visits every intersecting method (the
+    // LATEST_ONLY early-out was removed), so the recorded relation is complete:
+    // for any two currently-live methods with intersecting signatures, at least
+    // one of the two memberships is present (see the contract on
+    // `method_in_interferences`).
     interferences = (jl_genericmemory_t*)jl_atomic_load_relaxed(&method->interferences);
     if (oldvalue) {
         assert(n > 0);
@@ -5215,7 +5153,6 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
 //  * `visited`: the state of the algorithm for each vertex in `t`: either 1 if we visited it already or 1+depth if we are visiting it now
 //  * `stack`: the state of the algorithm for the current vertex (up to length equal to `t`): the list of all vertexes currently in the depth-first path or in the current SCC
 //  * `result`: the output of the algorithm, a sorted list of vertexes (up to length `lim`)
-//  * `recursion_stack`: an array for temporary use
 //  * `lim`: either -1 for unlimited matches, or the maximum length for `result` before returning failure (return -1).
 //  * `include_ambiguous`: whether to filter out fully ambiguous matches from `result`
 //  * `*has_ambiguity`: whether the algorithm does not need to compute if there is an unresolved ambiguity
@@ -5249,7 +5186,7 @@ typedef struct {
 //  * -1: too many matches for lim, other outputs are undefined
 //  *  0: the child(ren) have been added to the output
 //  * 1+: the children are part of this SCC (up to this depth)
-static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char *tainted, arraylist_t *stack, arraylist_t *result, arraylist_t *recursion_stack, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax, jl_method_t *minmaxm) JL_CANSAFEPOINT
+static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char *tainted, arraylist_t *stack, arraylist_t *result, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax, jl_method_t *minmaxm) JL_CANSAFEPOINT
 {
     // Use arraylist_t for explicit stack of processing frames
     arraylist_t frame_stack;
@@ -5390,7 +5327,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
                         }
                     }
                 }
-                else if (check_interferences_covers(current->m, current->ti, t, visited, tainted, recursion_stack, include_ambiguous, has_ambiguity)) {
+                else if (check_interferences_covers(current->m, current->ti, t, visited, tainted, include_ambiguous, has_ambiguity)) {
                     visited->items[current->idx] = (void*)1;
                 }
                 else if (check_fully_ambiguous(current->m, current->ti, t, include_ambiguous, has_ambiguity)) {
@@ -5537,7 +5474,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                     jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(t, j);
                     if (matc2->fully_covers == FULLY_COVERS) {
                         jl_method_t *m2 = matc2->method;
-                        if (!method_morespecific_via_interferences(m, m2))
+                        if (!method_morespecific_recorded(m, m2))
                             break;
                     }
                 }
@@ -5569,7 +5506,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 if (matc->fully_covers != FULLY_COVERS) {
                     jl_method_t *m = matc->method;
                     if (minmaxm) {
-                        if (method_morespecific_via_interferences(minmaxm, m)) {
+                        if (method_morespecific_recorded(minmaxm, m)) {
                             matc->fully_covers = SENTINEL; // put a sentinel value here for sorting
                             continue;
                         }
@@ -5609,11 +5546,10 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         }
     }
     if (len > 1) {
-        arraylist_t stack, visited, result, recursion_stack;
+        arraylist_t stack, visited, result;
         arraylist_new(&result, lim != -1 && lim < len ? lim : len);
         arraylist_new(&stack, 0);
         arraylist_new(&visited, len);
-        arraylist_new(&recursion_stack, len);
         arraylist_grow(&visited, len);
         memset(visited.items, 0, len * sizeof(size_t));
         char *tainted = (char*)calloc_s(len);
@@ -5637,10 +5573,9 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 // by visiting it and it might be a bit costly
                 continue;
             }
-            int child_cycle = sort_mlmatches(t, i, &visited, tainted, &stack, &result, &recursion_stack, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
+            int child_cycle = sort_mlmatches(t, i, &visited, tainted, &stack, &result, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
             if (child_cycle == -1) {
                 free(tainted);
-                arraylist_free(&recursion_stack);
                 arraylist_free(&visited);
                 arraylist_free(&stack);
                 arraylist_free(&result);
@@ -5651,7 +5586,6 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             assert(visited.items[i] == (void*)1);
         }
         free(tainted);
-        arraylist_free(&recursion_stack);
         arraylist_free(&visited);
         arraylist_free(&stack);
         for (j = 0; j < result.len; j++) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -3095,11 +3095,46 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
 // if the covers also dominate everything `D` beat -- otherwise a cycle leads
 // from a cover back to a method only `D` was beating, and the caller must
 // record an ambiguity. Returns 1 when the removal is silent, 0 otherwise.
+//
+// Removing `D` also removes it as a blocker: a match `S` that `D` was unordered
+// with needs `D` present to stay unselectable, since selection requires beating
+// every applicable match. So the covers must block everything `D` blocked too, or
+// the removal turns an ambiguous call into a resolved one (test `AmbigNoBeatAll`).
 static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t) JL_CANSAFEPOINT
 {
+    // First, only an unordered pair is at stake here: if D beats S then S was already
+    // unselectable for a stronger reason (handled by the loop below), and if S
+    // beats D then D was never blocking S. Both members of such a pair record
+    // each other, so D's own interference set is enough to enumerate them.
+    // (n.b. this scan is not required with `!include_ambiguous`, where D is
+    // dropped either way and S reports the same pair from `check_fully_ambiguous`,
+    // unlike the cycle detection below)
+    jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&D->interferences);
+    for (size_t i = 0; i < interferences->length; i++) {
+        jl_method_t *S = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
+        if (S == NULL)
+            continue;
+        if (!method_in_interferences(D, S))
+            continue; // S is morespecific than D, so D was not blocking it
+        if (find_method_in_matches(t, S) < 0)
+            continue;
+        size_t j;
+        for (j = 0; j < ncovers; j++) {
+            // a cover that S does not beat still blocks S, whether it is
+            // strictly morespecific than S or merely unordered with it
+            if (method_in_interferences(covers[j], S))
+                break;
+        }
+        if (j == ncovers)
+            return 0;
+    }
+    // Next, check that the `covers` take over the methods `D` was beating: any
+    // such method that the covers do not dominate must form a directed
+    // specificity cycle through them.
+    //
     // If D is not strictly morespecific than anything it intersects
-    // (METHOD_SIG_NO_LOSERS), it was beating nobody and there is nothing to
-    // transfer: the removal is unconditionally silent (as a fast-path).
+    // (METHOD_SIG_NO_LOSERS), it was beating nobody and there is nothing more to
+    // transfer: the removal is silent (as a fast-path).
     if (jl_atomic_load_relaxed(&D->dispatch_status) & METHOD_SIG_NO_LOSERS)
         return 1;
     size_t len = jl_array_nrows(t);
@@ -3170,10 +3205,12 @@ static jl_method_t *find_dominating_match(jl_method_t *m, jl_value_t *ti, jl_arr
 // Check if some morespecific method (or a union of them) covers the given
 // type intersection, meaning this match can never be the dispatch winner and
 // can be removed from the returned matches without anyone noticing. When the
-// covering relation is entangled in a specificity cycle, sets *has_ambiguity;
+// removal would not go unnoticed after all (`check_dominance_transfer`), because
+// the covering relation is entangled in a specificity cycle or because this
+// match was the last one blocking another match, sets *has_ambiguity;
 // in that case the match is only reported as covered when `include_ambiguous`
 // is false, so that ambiguity-reporting consumers still see it.
-static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, char *tainted, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
+static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
     // First: is `m` fully covered (dominated over the whole query region `ti`)
@@ -3185,10 +3222,13 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
             break;
         // m2 is strictly morespecific than m (a one-directional recorded edge)
         // and fully covers ti, so m can never win dispatch here. Dropping m is
-        // only safe if m2 also dominates everything m was beating; otherwise a
-        // specificity cycle leads back from a cover to a method only m beat, and
-        // the apparent ambiguity is real.
-        if (!check_dominance_transfer(m, &m2, 1, t)) {
+        // only safe if m2 also takes over the roles m had in the sort: a
+        // specificity cycle may lead back from a cover to a method only m beat,
+        // or m may be the last match blocking another one, and either way the
+        // apparent ambiguity is real. When `!include_ambiguous` we drop `m` here
+        // either way, so this only computes *has_ambiguity and can be skipped
+        // once that is already known.
+        if ((include_ambiguous || !*has_ambiguity) && !check_dominance_transfer(m, &m2, 1, t)) {
             *has_ambiguity = 1;
             if (include_ambiguous)
                 continue; // another cover may still certify the removal
@@ -3197,15 +3237,15 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
     }
     // No single morespecific method covers ti, but a union of them may (e.g.
     // several methods each covering one component of a Union-typed argument).
-    // Collect the recorded strictly-morespecific interferences that were already
-    // finalized cleanly (not part of an ambiguity group, which could mean they
-    // lose dispatch back to `m` through a specificity cycle) and check whether
-    // ti is covered by their union. Both filters are relevant: dropping eiter
-    // lets a cycle member serve as a cover and wrongly resolves the pair (test
-    // `AmbigUnionCycle`).
+    // Collect the recorded strictly-morespecific interferences that the sort has
+    // already finalized and check whether ti is covered by their union. Whether
+    // such a union really certifies the removal is left to
+    // `check_dominance_transfer` below: a cover may be tangled in a specificity
+    // cycle that leads back to `m`, or may fail to block what `m` was blocking
+    // (test `AmbigUnionCycle`).
     int result = 0;
-    size_t ncovers = 0;
-    jl_method_t **covers = (jl_method_t**)malloc_s(interferences->length * sizeof(jl_method_t*));
+    arraylist_t covers;
+    arraylist_new(&covers, 0);
     for (size_t i = 0; i < interferences->length; i++) {
         jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
         if (m2 == NULL)
@@ -3213,22 +3253,24 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
         int idx = find_method_in_matches(t, m2);
         if (idx < 0)
             continue;
-        if (visited->items[idx] != (void*)1 || tainted[idx])
+        if (visited->items[idx] != (void*)1)
             continue;
         if (method_in_interferences(m, m2)) // ambiguous
             continue;
-        covers[ncovers++] = m2;
+        arraylist_push(&covers, (void*)m2);
     }
-    if (ncovers > 1) {
-        jl_value_t **sigs = (jl_value_t**)malloc_s(ncovers * sizeof(jl_value_t*));
-        for (size_t i = 0; i < ncovers; i++)
-            sigs[i] = (jl_value_t*)covers[i]->sig;
-        jl_value_t *u = jl_type_union(sigs, ncovers);
-        free(sigs);
+    if (covers.len > 1) {
+        arraylist_t sigs;
+        arraylist_new(&sigs, covers.len);
+        for (size_t i = 0; i < covers.len; i++)
+            arraylist_push(&sigs, (void*)((jl_method_t*)covers.items[i])->sig);
+        jl_value_t *u = jl_type_union((jl_value_t**)sigs.items, sigs.len);
+        arraylist_free(&sigs);
         JL_GC_PUSH1(&u);
         if (jl_subtype(ti, u)) {
             result = 1;
-            if (!check_dominance_transfer(m, covers, ncovers, t)) {
+            if ((include_ambiguous || !*has_ambiguity) &&
+                !check_dominance_transfer(m, (jl_method_t**)covers.items, covers.len, t)) {
                 *has_ambiguity = 1;
                 if (include_ambiguous)
                     result = 0;
@@ -3236,12 +3278,14 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
         }
         JL_GC_POP();
     }
-    free(covers);
+    arraylist_free(&covers);
     return result;
 }
 
 static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
+    if (include_ambiguous && *has_ambiguity)
+        return 0; // this can only compute *has_ambiguity, which is already known
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
     for (size_t i = 0; i < interferences->length; i++) {
         jl_method_t *m2 = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
@@ -3253,7 +3297,9 @@ static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, 
         if (!method_in_interferences(m, m2))
             continue;
         *has_ambiguity = 1;
-        if (!include_ambiguous && jl_subtype(ti, m2->sig))
+        if (include_ambiguous)
+            return 0; // the rest of the scan could only set *has_ambiguity again
+        if (jl_subtype(ti, m2->sig))
             return 1;
     }
     return 0;
@@ -5177,7 +5223,6 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
 //  * `t`: the array of vertexes (method matches)
 //  * `idx`: the next vertex to add to the output
 //  * `visited`: the state of the algorithm for each vertex in `t`: either 1 if we visited it already or 1+depth if we are visiting it now
-//  * `tainted`: record if `visited==1` still can't rely on this method to have covered up an ambiguity
 //  * `stack`: the state of the algorithm for the current vertex (up to length equal to `t`): the list of all vertexes currently in the depth-first path or in the current SCC
 //  * `result`: the output of the algorithm, a sorted list of vertexes (up to length `lim`)
 //  * `lim`: either -1 for unlimited matches, or the maximum length for `result` before returning failure (return -1).
@@ -5213,7 +5258,7 @@ typedef struct {
 //  * -1: too many matches for lim, other outputs are undefined
 //  *  0: the child(ren) have been added to the output
 //  * 1+: the children are part of this SCC (up to this depth)
-static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char *tainted, arraylist_t *stack, arraylist_t *result, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax, jl_method_t *minmaxm) JL_CANSAFEPOINT
+static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, arraylist_t *stack, arraylist_t *result, int lim, int include_ambiguous, int *has_ambiguity, int *found_minmax, jl_method_t *minmaxm) JL_CANSAFEPOINT
 {
     // Use arraylist_t for explicit stack of processing frames
     arraylist_t frame_stack;
@@ -5340,11 +5385,13 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
                 // There is some probability that this method is already fully covered
                 // now, and we can delete this vertex now without anyone noticing.
                 if (current->subt && *found_minmax) {
+                    assert(minmaxm != NULL);
                     if (*found_minmax == 2) {
                         // minmax dominates all fully-covering methods, but this
                         // dropped method may have been beating a partial match
                         // that minmax does not dominate (a specificity cycle)
-                        if (current->m != minmaxm && !check_dominance_transfer(current->m, &minmaxm, minmaxm == NULL ? 0 : 1, t)) {
+                        if (current->m != minmaxm && (include_ambiguous || !*has_ambiguity) &&
+                            !check_dominance_transfer(current->m, &minmaxm, 1, t)) {
                             *has_ambiguity = 1;
                             if (!include_ambiguous)
                                 visited->items[current->idx] = (void*)1;
@@ -5354,7 +5401,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
                         }
                     }
                 }
-                else if (check_interferences_covers(current->m, current->ti, t, visited, tainted, include_ambiguous, has_ambiguity)) {
+                else if (check_interferences_covers(current->m, current->ti, t, visited, include_ambiguous, has_ambiguity)) {
                     visited->items[current->idx] = (void*)1;
                 }
                 else if (check_fully_ambiguous(current->m, current->ti, t, include_ambiguous, has_ambiguity)) {
@@ -5383,7 +5430,6 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
 
             case STATE_FINALIZE_SCC: {
                 // If this is in an SCC group, do some additional checks before returning or setting has_ambiguity
-                int scc_ambiguous = 0;
                 if (current->depth != stack->len) {
                     int scc_count = 0;
                     for (size_t i = current->depth - 1; i < stack->len; i++) {
@@ -5392,10 +5438,8 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
                             continue;
                         scc_count++;
                     }
-                    if (scc_count > 1) {
+                    if (scc_count > 1)
                         *has_ambiguity = 1;
-                        scc_ambiguous = 1;
-                    }
                 }
 
                 // copy this cycle into the results
@@ -5403,14 +5447,10 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, char 
                     size_t childidx = (size_t)stack->items[i];
                     jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, childidx);
                     int subt = matc->fully_covers != NOT_FULLY_COVERS;
-                    if (scc_ambiguous && visited->items[childidx] != (void*)1)
-                        // mark members of an ambiguity group: they cannot be
-                        // trusted to resolve (cover) other apparent
-                        // ambiguities, since they may sit in a specificity
-                        // cycle leading back to the method they would resolve
-                        tainted[childidx] = 1;
                     if (subt && *found_minmax) {
-                        if (minmaxm && visited->items[childidx] != (void*)1 && matc->method != minmaxm &&
+                        assert(minmaxm != NULL);
+                        if (visited->items[childidx] != (void*)1 && matc->method != minmaxm &&
+                            (include_ambiguous || !*has_ambiguity) &&
                             !check_dominance_transfer(matc->method, &minmaxm, 1, t)) {
                             *has_ambiguity = 1;
                             if (!include_ambiguous)
@@ -5591,7 +5631,6 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         arraylist_new(&visited, len);
         arraylist_grow(&visited, len);
         memset(visited.items, 0, len * sizeof(size_t));
-        char *tainted = (char*)calloc_s(len);
         // if we had a minmax method (any subtypes), now may now be able to
         // quickly cleanup some of methods
         int found_minmax = 0;
@@ -5617,9 +5656,8 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 // by visiting it and it might be a bit costly
                 continue;
             }
-            int child_cycle = sort_mlmatches(t, i, &visited, tainted, &stack, &result, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
+            int child_cycle = sort_mlmatches(t, i, &visited, &stack, &result, lim == -1 || minmax == NULL ? lim : lim - 1, include_ambiguous, &has_ambiguity, &found_minmax, minmax == NULL ? NULL : minmax->method);
             if (child_cycle == -1) {
-                free(tainted);
                 arraylist_free(&visited);
                 arraylist_free(&stack);
                 arraylist_free(&result);
@@ -5629,33 +5667,8 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             assert(stack.len == 0);
             assert(visited.items[i] == (void*)1);
         }
-        free(tainted);
         arraylist_free(&visited);
         arraylist_free(&stack);
-        // A method is only selected when it is morespecific than every applicable
-        // method, so an ambiguity has to be witnessed by at least two reported
-        // methods: with only one left, the caller would read the result as a
-        // resolved call (and an error would come out as `no method matching`).
-        // Dominated matches are dropped above because some other match witnesses
-        // the same ambiguity, but the last blocker of the survivor is not
-        // redundant -- restore the matches it is unordered with.
-        if (include_ambiguous && has_ambiguity && result.len == 1 && minmax == NULL) {
-            abort();
-            size_t survivor = (size_t)result.items[0];
-            jl_method_t *m = ((jl_method_match_t*)jl_array_ptr_ref(t, survivor))->method;
-            for (i = 0; i < len; i++) {
-                if (i == survivor)
-                    continue;
-                jl_method_t *m2 = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
-                if (!method_in_interferences(m2, m) || !method_in_interferences(m, m2))
-                    continue; // not an unordered pair, so not a blocker
-                if (lim != -1 && (int)result.len >= lim) {
-                    arraylist_free(&result);
-                    return -1;
-                }
-                arraylist_push(&result, (void*)i);
-            }
-        }
         for (j = 0; j < result.len; j++) {
             i = (size_t)result.items[j];
             jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(t, i);
@@ -5668,6 +5681,17 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
             arraylist_push(&result, minmax);
             j++;
         }
+        // A method is only selected when it is morespecific than every applicable
+        // method, so an ambiguity has to be witnessed by at least two reported
+        // methods: with only one left, the caller would read the result as a
+        // resolved call (and an error would come out as `no method matching`).
+        // Since a dominated match may only be dropped above when the matches that
+        // certified the removal also block everything it was blocking
+        // (`check_dominance_transfer`), the last blocker of the survivor
+        // should not have been removed silently.
+        // (n.b. `approximate_ambig` sets `has_ambiguity` without computing it)
+        assert(!(include_ambiguous && !approximate_ambig && has_ambiguity && result.len == 1) &&
+               "dropped the last witness of an ambiguity");
         memcpy(jl_array_data(t, jl_method_match_t*), result.items, j * sizeof(jl_method_match_t*));
         arraylist_free(&result);
         if (j != len)

--- a/src/gf.c
+++ b/src/gf.c
@@ -5685,7 +5685,7 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
         // Since a dominated match may only be dropped above when the matches that
         // certified the removal also block everything it was blocking
         // (`check_dominance_transfer`), the last blocker of the survivor
-        // should not have been removed silently.
+        // should not have been removed.
         // (n.b. `approximate_ambig` sets `has_ambiguity` without computing it)
         assert(!(include_ambiguous && !approximate_ambig && has_ambiguity && result.len == 1) &&
                "dropped the last witness of an ambiguity");

--- a/src/gf.c
+++ b/src/gf.c
@@ -3075,24 +3075,13 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
     return result;
 }
 
-// Dispatch selects a match only when it is morespecific than every other
-// applicable match, so a call is ambiguous whenever no match beats all the
-// others. That has two shapes, which the two checks here correspond to: a pair
-// that is unordered (a mutual ambiguity, `check_fully_ambiguous`) or a
-// specificity cycle, where every match is beaten by another one (the SCC pass in
-// `sort_mlmatches`). A match is reportable when it can be selected somewhere in
-// its region, and also when it blocks another match from being selected there --
-// dominance alone therefore justifies removing it from the selection answer,
-// while `sort_method_matches` separately keeps enough blockers to witness each
-// ambiguity it reports.
-//
 // About to remove match `D` (matching the query over `ti`), which the
 // strictly-morespecific `covers` jointly contain, so `D` can never be selected
-// there. Removing `D` also removes it as evidence against `S` being selected:
-// `S` stays visibly unselectable at a point only while some *reported* match
+// there. But removing `D` also removes it as evidence against `S` being selected:
+// `S` stays visibly unselectable at a point only while some reported match
 // that `S` does not beat still applies there, whether `D` was strictly beating
 // `S` or merely unordered with it. Check that this holds at every point of
-// `ti` ∩ `S` for the given `S`.
+// `ti` ∩ `S` for the given `S` (using the query ∩ `S` in place of `S`).
 //
 // Since the covers jointly contain `ti`, some cover applies at any such point,
 // and a cover applying at a point of `S`'s region intersects `S` there. So if
@@ -3100,12 +3089,12 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
 // the transfer is automatic. Only when `S` strictly beats some cover -- a
 // directed specificity cycle through `D` -- can a point be left where every
 // applicable cover is beaten by `S`: then require the union of the covers that
-// `S` does not beat to contain the region where `D` was the evidence (test
+// `S` does not beat to contain the region where `D` was the witness (test
 // `AmbigTransferRegion` requires the region check; `AmbigCycle3` fails if the
 // cycle is ignored altogether). A cover need not survive into the report
 // itself: its own removal was subject to this same check against covers
 // finalized before it, so by induction a reported blocker exists at every
-// point it took over. Returns 1 when the transfer holds, 0 otherwise.
+// point it took over.
 static int check_blocker_transfer(jl_value_t *ti, jl_value_t *ti_S, jl_method_t *S, jl_method_t **covers, size_t ncovers) JL_CANSAFEPOINT
 {
     size_t j;
@@ -3121,7 +3110,8 @@ static int check_blocker_transfer(jl_value_t *ti, jl_value_t *ti_S, jl_method_t 
     JL_GC_PUSH2(&region, &u);
     region = jl_type_intersection(ti, ti_S);
     if (region == jl_bottom_type) {
-        result = 1; // D was never evidence against S within the query
+        // D was never a witness of S within the query, so S doesn't block its removal
+        result = 1;
     }
     else {
         arraylist_t sigs;
@@ -3144,16 +3134,14 @@ static int check_blocker_transfer(jl_value_t *ti, jl_value_t *ti_S, jl_method_t 
 
 // About to remove match `D`, which the strictly-morespecific `covers` dominate
 // over all of its region `ti`, so `D` can never be selected there.
-// Dominance alone is not enough to remove it, because every member of a
+// But dominance alone is not enough to remove it, because every member of a
 // specificity cycle is dominated by another member: removing them all on that
 // basis would delete the cycle and report the call as unambiguous (test
-// `AmbigCycle3` fails if this check is skipped). And removing `D` also removes
-// it as a blocker: a match `S` that `D` was unordered with needs `D` present to
-// stay unselectable, since selection requires beating every applicable match,
-// so the removal can turn an ambiguous call into a resolved one (test
-// `AmbigNoBeatAll`). Both obligations transfer to the covers under the same
-// pointwise rule (`check_blocker_transfer`). Returns 1 when the removal is
-// silent, 0 when the caller must record an ambiguity.
+// `AmbigCycle3`). And removing `D` also removes it as a witness: a match `S`
+// that `D` was unordered with needs `D` present to stay unselectable. Since
+// selection requires beating every applicable match, the removal would turn
+// an ambiguous call into apparently a resolved one (test `AmbigNoBeatAll`).
+// Both obligations transfer to the covers under the same pointwise rule.
 static int check_dominance_transfer(jl_method_t *D, jl_value_t *ti, jl_method_t **covers, size_t ncovers, jl_array_t *t) JL_CANSAFEPOINT
 {
     // First, the matches D was unordered with. Both members of such a pair
@@ -3202,11 +3190,10 @@ static int check_dominance_transfer(jl_method_t *D, jl_value_t *ti, jl_method_t 
     return 1;
 }
 
-// Find a match that is strictly morespecific than `m` and applies over all of
-// `ti`: a witness that `m` is dominated at every point of `ti`, and so can never
-// be selected there. `visited`, if given, restricts the witness to matches the
+// Find a match `S` that is strictly morespecific than `m` and applies over all of `ti`.
+// `visited`, if given, restricts the witness to matches the
 // sort has already finalized, so that a method still tangled in the cycle being
-// resolved cannot serve as one; pass NULL to accept any applicable match. `pos`
+// resolved cannot serve as a cover; pass NULL to accept any applicable match. `pos`
 // carries an index into the interference set so a caller can resume the scan for
 // a further witness.
 static jl_method_t *find_dominating_match(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, size_t *pos) JL_CANSAFEPOINT
@@ -3236,12 +3223,12 @@ static jl_method_t *find_dominating_match(jl_method_t *m, jl_value_t *ti, jl_arr
 
 // Check if some morespecific method (or a union of them) covers the given
 // type intersection, meaning this match can never be the dispatch winner and
-// can be removed from the returned matches without anyone noticing. When the
-// removal would not go unnoticed after all (`check_dominance_transfer`), because
+// can be removed from the returned matches without any dispatch noticing. When the
+// removal would not go unnoticed after all (`check_dominance_transfer` fails), because
 // the covering relation is entangled in a specificity cycle or because this
-// match was the last one blocking another match, sets *has_ambiguity;
-// in that case the match is only reported as covered when `include_ambiguous`
-// is false, so that ambiguity-reporting consumers still see it.
+// match was blocking another match, sets *has_ambiguity; in that case the match
+// is only reported as covered when `include_ambiguous` is false, so that
+// ambiguity-reporting consumers still see it.
 static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t *t, arraylist_t *visited, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
     jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
@@ -5545,6 +5532,17 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
 // is pessimistically set to 1 without attempting to prove otherwise.
 // Returns the new length of `t`, or -1 if `lim` was exceeded (in which case
 // the contents of `t` are left in an unspecified state).
+//
+// Dispatch selects a match only when it is morespecific than every other
+// applicable match, so a call is ambiguous whenever no match beats all the
+// others. That has two shapes, which the two checks will correspond to: a pair
+// that is unordered (a mutual ambiguity, `check_fully_ambiguous`) or a
+// specificity cycle, where every match is beaten by another one (the SCC pass in
+// `sort_mlmatches`). A match is reportable when it can be selected somewhere in
+// its region, and also when it blocks another match from being selected there
+// and include_ambiguous is set -- dominance alone therefore justifies removing
+// it from the selection answer, while `sort_method_matches` separately keeps
+// enough blockers to witness each ambiguity it reports.
 static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous, int approximate_ambig, int *has_ambiguity_out) JL_CANSAFEPOINT
 {
     int has_ambiguity = 0;
@@ -5688,11 +5686,8 @@ static ssize_t sort_method_matches(jl_array_t *t, int lim, int include_ambiguous
                 // below, so visiting it would not usually learn anything new and
                 // might be a bit costly. But a match the DFS never reaches (one
                 // that strictly beats nothing is never anyone's child) would
-                // otherwise be dropped without the dominance-transfer check that
-                // every other removal runs, losing the ambiguities only it
-                // witnesses (test `AmbigMinmaxSkip`): run that check here, and
-                // sort the match normally when its blocking duties do not
-                // transfer to minmax, so it stays in the result.
+                // otherwise be dropped without the dominance-transfer check,
+                // losing the ambiguities only it witnesses (test `AmbigMinmaxSkip`).
                 assert(minmax != NULL);
                 if (visited.items[i] == (void*)1 || matc == minmax)
                     continue;

--- a/src/gf.c
+++ b/src/gf.c
@@ -354,7 +354,7 @@ jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *sname, jl_fptr_args
     m->isva = 1;
     m->nargs = 2;
     jl_atomic_store_relaxed(&m->primary_world, 1);
-    jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_LATEST_WHICH);
+    jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_LATEST_WHICH | METHOD_SIG_NO_LOSERS);
     m->sig = (jl_value_t*)tuptyp;
     m->slot_syms = jl_an_empty_string;
     m->nospecialize = 0;
@@ -3100,10 +3100,20 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
 // pass), which the caller must record as an ambiguity.
 static int check_dominance_transfer(jl_method_t *D, jl_method_t **covers, size_t ncovers, jl_array_t *t)
 {
+    // If D is not strictly morespecific than anything it intersects
+    // (METHOD_SIG_NO_LOSERS), it was beating nobody and there is nothing to
+    // transfer: the removal is unconditionally silent.
+    if (jl_atomic_load_relaxed(&D->dispatch_status) & METHOD_SIG_NO_LOSERS)
+        return 1;
     size_t len = jl_array_nrows(t);
     for (size_t i = 0; i < len; i++) {
         jl_method_t *S = ((jl_method_match_t*)jl_array_ptr_ref(t, i))->method;
         if (S == D)
+            continue;
+        // An S that beats nothing can never strictly beat a cover, so it can
+        // never close a directed cycle: whether the covers dominate it is then
+        // irrelevant (the unordered case falls through to safety below anyway).
+        if (jl_atomic_load_relaxed(&S->dispatch_status) & METHOD_SIG_NO_LOSERS)
             continue;
         // only consider S that D is strictly morespecific than
         if (!method_morespecific_recorded(D, S))
@@ -3246,6 +3256,8 @@ static int method_morespecific_recorded(jl_method_t *target_method, jl_method_t 
     assert(result == jl_method_morespecific(target_method, start_method) ||
            jl_has_empty_intersection(target_method->sig, start_method->sig) ||
            jl_has_empty_intersection(start_method->sig, target_method->sig));
+    // a method recorded as strictly beating something must not carry NO_LOSERS
+    assert(!result || !(jl_atomic_load_relaxed(&target_method->dispatch_status) & METHOD_SIG_NO_LOSERS));
     return result;
 }
 
@@ -3291,6 +3303,13 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     }
 
     int invalidated = 0;
+    // Tentatively assume the new method is not strictly morespecific than
+    // anything it intersects (METHOD_SIG_NO_LOSERS); the scan below clears it
+    // on the first method this one beats. Conversely, an old method that this
+    // one is beaten by keeps its state, and an old method that is beaten
+    // (morespec[j], conservatively including both-ways-morespecific pairs)
+    // loses its bit.
+    int dispatch_bits = METHOD_SIG_LATEST_WHICH | METHOD_SIG_NO_LOSERS;
     // Holds the set of all intersecting methods not more specific than this one.
     // The insertion scan below visits every intersecting method (the
     // LATEST_ONLY early-out was removed), so the recorded relation is complete:
@@ -3307,6 +3326,10 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             method_overwrite(newentry, m);
             // This is an optimized version of below, given we know the type-intersection is exact
             jl_method_table_invalidate(m, max_world);
+            // The replacement has the same signature, so it inherits the
+            // replaced method's specificity relations, including NO_LOSERS
+            if (!(jl_atomic_load_relaxed(&m->dispatch_status) & METHOD_SIG_NO_LOSERS))
+                dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
             // Clear METHOD_SIG_LATEST_WHICH bit
             jl_atomic_store_relaxed(&m->dispatch_status, 0);
             // Take over the interference list from the replaced method
@@ -3372,6 +3395,16 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                     ssize_t idx;
                     if (!has_key(interferences, (jl_value_t*)m))
                         interferences = jl_idset_put_key(interferences, (jl_value_t*)m, &idx);
+                }
+                if (morespec[j]) {
+                    // morespecific(old, new): the old method gained a strict loser
+                    int m_dispatch = jl_atomic_load_relaxed(&m->dispatch_status);
+                    if (m_dispatch & METHOD_SIG_NO_LOSERS)
+                        jl_atomic_store_relaxed(&m->dispatch_status, m_dispatch & ~METHOD_SIG_NO_LOSERS);
+                }
+                else if (!ambig) {
+                    // morespecific(new, old): the new method beats something
+                    dispatch_bits &= ~METHOD_SIG_NO_LOSERS;
                 }
                 if (!morespec[j]) {
                     // !morespecific(old, new): add the new method to its interference set
@@ -3490,7 +3523,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         jl_array_ptr_1d_push(_jl_debug_method_invalidation, loctag);
     }
     jl_atomic_store_relaxed(&newentry->max_world, ~(size_t)0);
-    jl_atomic_store_relaxed(&method->dispatch_status, METHOD_SIG_LATEST_WHICH); // TODO: this should be sequenced fully after the world counter store
+    jl_atomic_store_relaxed(&method->dispatch_status, dispatch_bits); // TODO: this should be sequenced fully after the world counter store
     jl_gc_write_atomic(method, method->interferences, jl_genericmemory_t, interferences, release);
     JL_GC_POP();
 }

--- a/src/idset.c
+++ b/src/idset.c
@@ -67,14 +67,8 @@ static ssize_t idset_compact(jl_genericmemory_t *keys)
     return rehash ? -j : j;
 }
 
-// Insert `key` into the first free slot at the end of the packed prefix of
-// `keys` (growing, and compacting order-preservingly, if there is none). On a
-// set that never sees `jl_idset_pop`, the keys therefore form a packed prefix
-// -- no interior holes -- in insertion order. `Method.interferences` consumers
-// rely on exactly that: iteration may stop at the first empty slot, and
-// entries appear in method-definition (world) order (see the stable-prefix
-// reload in `sort_mlmatches` in gf.c and `eachinterference` in
-// Compiler/src/reinfer.jl).
+// Insert `key` into the first free slot at the end of the ordered set
+// `keys` (growing and compacting are insertion-order-preserving).
 jl_genericmemory_t *jl_idset_put_key(jl_genericmemory_t *keys, jl_value_t *key, ssize_t *newidx)
 {
     ssize_t l = keys->length;
@@ -119,11 +113,11 @@ jl_genericmemory_t *jl_idset_put_idx(jl_genericmemory_t *keys, jl_genericmemory_
     return jl_atomic_load_relaxed(&newidxs);
 }
 
-/* returns idx if key is in hash, otherwise -1 */
 // Removal NULLs the key's slot in place, leaving an interior hole until a
-// later insertion happens to compact the prefix. That breaks the packed-prefix
-// guarantee documented at `jl_idset_put_key`, so this must not be used on
-// sets whose consumers rely on it (notably `Method.interferences`).
+// later insertion compacts the list. That breaks the packed-prefix guarantee
+// of the ordered-set insertion, so this must not be used on sets whose
+// consumers rely on that property for lock-free iteration (such as `Method.interferences`).
+// Returns idx if key is in hash, otherwise -1.
 ssize_t jl_idset_pop(jl_genericmemory_t *keys, jl_genericmemory_t *idxs, jl_value_t *key) JL_NOTSAFEPOINT
 {
     uintptr_t hv = jl_object_id(key);

--- a/src/idset.c
+++ b/src/idset.c
@@ -67,6 +67,14 @@ static ssize_t idset_compact(jl_genericmemory_t *keys)
     return rehash ? -j : j;
 }
 
+// Insert `key` into the first free slot at the end of the packed prefix of
+// `keys` (growing, and compacting order-preservingly, if there is none). On a
+// set that never sees `jl_idset_pop`, the keys therefore form a packed prefix
+// -- no interior holes -- in insertion order. `Method.interferences` consumers
+// rely on exactly that: iteration may stop at the first empty slot, and
+// entries appear in method-definition (world) order (see the stable-prefix
+// reload in `sort_mlmatches` in gf.c and `eachinterference` in
+// Compiler/src/reinfer.jl).
 jl_genericmemory_t *jl_idset_put_key(jl_genericmemory_t *keys, jl_value_t *key, ssize_t *newidx)
 {
     ssize_t l = keys->length;
@@ -112,6 +120,10 @@ jl_genericmemory_t *jl_idset_put_idx(jl_genericmemory_t *keys, jl_genericmemory_
 }
 
 /* returns idx if key is in hash, otherwise -1 */
+// Removal NULLs the key's slot in place, leaving an interior hole until a
+// later insertion happens to compact the prefix. That breaks the packed-prefix
+// guarantee documented at `jl_idset_put_key`, so this must not be used on
+// sets whose consumers rely on it (notably `Method.interferences`).
 ssize_t jl_idset_pop(jl_genericmemory_t *keys, jl_genericmemory_t *idxs, jl_value_t *key) JL_NOTSAFEPOINT
 {
     uintptr_t hv = jl_object_id(key);

--- a/src/julia.h
+++ b/src/julia.h
@@ -416,7 +416,7 @@ typedef struct _jl_method_t {
     struct _jl_module_t *module;
     jl_sym_t *file;
     int32_t line;
-    _Atomic(uint8_t) dispatch_status; // METHOD_SIG_LATEST_WHICH bit, see julia_internal.h
+    _Atomic(uint8_t) dispatch_status; // bits defined in julia_internal.h or staticdata.jl
     _Atomic(jl_genericmemory_t*) interferences; // set of intersecting methods not more specific
     _Atomic(size_t) primary_world;
 
@@ -508,7 +508,7 @@ struct _jl_method_instance_t {
     //   bit 2: The ->backedges field is currently being walked higher up the stack - entries may be deleted, but not moved
     //   bit 3: The ->backedges field was modified and should be compacted when clearing bit 2
     _Atomic(uint8_t) flags;
-    _Atomic(uint8_t) dispatch_status; // METHOD_SIG_LATEST_ONLY bit, see julia_internal.h
+    _Atomic(uint8_t) dispatch_status; // bits defined in julia_internal.h or staticdata.jl
     _Atomic(uint8_t) precompile; // if set, this will be added to the output system image
 };
 #define JL_MI_FLAGS_MASK_PRECOMPILED    0x01

--- a/src/julia.h
+++ b/src/julia.h
@@ -416,7 +416,7 @@ typedef struct _jl_method_t {
     struct _jl_module_t *module;
     jl_sym_t *file;
     int32_t line;
-    _Atomic(uint8_t) dispatch_status; // bits defined in staticdata.jl
+    _Atomic(uint8_t) dispatch_status; // METHOD_SIG_LATEST_WHICH bit, see julia_internal.h
     _Atomic(jl_genericmemory_t*) interferences; // set of intersecting methods not more specific
     _Atomic(size_t) primary_world;
 
@@ -508,7 +508,7 @@ struct _jl_method_instance_t {
     //   bit 2: The ->backedges field is currently being walked higher up the stack - entries may be deleted, but not moved
     //   bit 3: The ->backedges field was modified and should be compacted when clearing bit 2
     _Atomic(uint8_t) flags;
-    _Atomic(uint8_t) dispatch_status; // bits defined in staticdata.jl
+    _Atomic(uint8_t) dispatch_status; // METHOD_SIG_LATEST_ONLY bit, see julia_internal.h
     _Atomic(uint8_t) precompile; // if set, this will be added to the output system image
 };
 #define JL_MI_FLAGS_MASK_PRECOMPILED    0x01

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -818,12 +818,20 @@ typedef union {
 #define SOURCE_MODE_NOT_REQUIRED            0x0
 #define SOURCE_MODE_ABI                     0x1
 
-// dispatch_status bits. LATEST_WHICH is used on Method. LATEST_ONLY is used
-// only on MethodInstance (dispatch of this mi's exact specTypes yields only
-// this result); the corresponding Method-level fact is the method's
-// `interferences` set being empty, which needs no separate bit.
+// dispatch_status bits. LATEST_WHICH and NO_LOSERS are used on Method.
+// LATEST_ONLY is used only on MethodInstance (dispatch of this mi's exact
+// specTypes yields only this result); the corresponding Method-level fact is
+// the method's `interferences` set being empty, which needs no separate bit.
+// NO_LOSERS: this method is not strictly morespecific than any method it
+// intersects (its strict out-neighborhood is empty, the opposite pole from an
+// empty interference set, which means it beats everything it intersects).
+// Set when the method is inserted and cleared - never re-set - when a later
+// insertion finds this method beats it, so a set bit is valid for a query at
+// any world. It cannot be read from the method's own interference set, which
+// records only the methods it does NOT beat.
 #define METHOD_SIG_LATEST_WHICH             0b0001
 #define METHOD_SIG_LATEST_ONLY              0b0010
+#define METHOD_SIG_NO_LOSERS                0b0100
 
 void jl_init_engine(void) JL_NOTSAFEPOINT;
 void jl_engine_sweep(jl_ptls_t *gc_all_tls_states) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -818,23 +818,13 @@ typedef union {
 #define SOURCE_MODE_NOT_REQUIRED            0x0
 #define SOURCE_MODE_ABI                     0x1
 
-// dispatch_status bits. LATEST_WHICH and NO_LOSERS are used on Method.
-// LATEST_ONLY is used only on MethodInstance (dispatch of this mi's exact
-// specTypes yields only this result); the corresponding Method-level fact is
-// the method's `interferences` set being empty, which needs no separate bit.
-// NO_LOSERS: this method is not strictly morespecific than any method it
-// intersects (its strict out-neighborhood is empty, the opposite pole from an
-// empty interference set, which means it beats everything it intersects).
-// Set when the method is created and cleared - never re-set - when an
-// insertion scan finds a method it beats, so a set bit is valid for a query
-// at any world. It cannot be read from the method's own interference set,
-// which records only the methods it does NOT beat, and (like that set, but
-// unlike LATEST_WHICH) it survives incremental serialization, because the
-// activation scan at load cannot see same-image methods and so cannot
-// re-derive it. A type-equal replacement does not inherit the bit: it records
-// a recency-tiebreak win over the method it replaces (so it always has that
-// strict loser), and type-equal does not imply morespecific-equal, so the
-// predecessor's relations do not transfer.
+// dispatch_status bits.
+// - LATEST_WHICH: invoke of this mi's exact specTypes yields exactly this result.
+// - LATEST_ONLY: dispatch of this mi's exact specTypes yields only this result);
+//   the corresponding Method-level fact is the method's `interferences` set being empty.
+// - NO_LOSERS: this method is not strictly morespecific than any method it
+//   intersects (its strict out-neighborhood is empty, the opposite pole from an
+//   empty interference set, which means it beats everything it intersects).
 #define METHOD_SIG_LATEST_WHICH             0b0001
 #define METHOD_SIG_LATEST_ONLY              0b0010
 #define METHOD_SIG_NO_LOSERS                0b0100

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -818,9 +818,12 @@ typedef union {
 #define SOURCE_MODE_NOT_REQUIRED            0x0
 #define SOURCE_MODE_ABI                     0x1
 
+// dispatch_status bits. LATEST_WHICH is used on Method. LATEST_ONLY is used
+// only on MethodInstance (dispatch of this mi's exact specTypes yields only
+// this result); the corresponding Method-level fact is the method's
+// `interferences` set being empty, which needs no separate bit.
 #define METHOD_SIG_LATEST_WHICH             0b0001
 #define METHOD_SIG_LATEST_ONLY              0b0010
-#define METHOD_SIG_PRECOMPILE_MANY          0b0100
 
 void jl_init_engine(void) JL_NOTSAFEPOINT;
 void jl_engine_sweep(jl_ptls_t *gc_all_tls_states) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -825,10 +825,16 @@ typedef union {
 // NO_LOSERS: this method is not strictly morespecific than any method it
 // intersects (its strict out-neighborhood is empty, the opposite pole from an
 // empty interference set, which means it beats everything it intersects).
-// Set when the method is inserted and cleared - never re-set - when a later
-// insertion finds this method beats it, so a set bit is valid for a query at
-// any world. It cannot be read from the method's own interference set, which
-// records only the methods it does NOT beat.
+// Set when the method is created and cleared - never re-set - when an
+// insertion scan finds a method it beats, so a set bit is valid for a query
+// at any world. It cannot be read from the method's own interference set,
+// which records only the methods it does NOT beat, and (like that set, but
+// unlike LATEST_WHICH) it survives incremental serialization, because the
+// activation scan at load cannot see same-image methods and so cannot
+// re-derive it. A type-equal replacement does not inherit the bit: it records
+// a recency-tiebreak win over the method it replaces (so it always has that
+// strict loser), and type-equal does not imply morespecific-equal, so the
+// predecessor's relations do not transfer.
 #define METHOD_SIG_LATEST_WHICH             0b0001
 #define METHOD_SIG_LATEST_ONLY              0b0010
 #define METHOD_SIG_NO_LOSERS                0b0100

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -801,9 +801,12 @@ typedef union {
 #define SOURCE_MODE_NOT_REQUIRED            0x0
 #define SOURCE_MODE_ABI                     0x1
 
+// dispatch_status bits. LATEST_WHICH is used on Method. LATEST_ONLY is used
+// only on MethodInstance (dispatch of this mi's exact specTypes yields only
+// this result); the corresponding Method-level fact is the method's
+// `interferences` set being empty, which needs no separate bit.
 #define METHOD_SIG_LATEST_WHICH             0b0001
 #define METHOD_SIG_LATEST_ONLY              0b0010
-#define METHOD_SIG_PRECOMPILE_MANY          0b0100
 
 void jl_init_engine(void) JL_NOTSAFEPOINT;
 void jl_engine_sweep(jl_ptls_t *gc_all_tls_states) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -801,12 +801,20 @@ typedef union {
 #define SOURCE_MODE_NOT_REQUIRED            0x0
 #define SOURCE_MODE_ABI                     0x1
 
-// dispatch_status bits. LATEST_WHICH is used on Method. LATEST_ONLY is used
-// only on MethodInstance (dispatch of this mi's exact specTypes yields only
-// this result); the corresponding Method-level fact is the method's
-// `interferences` set being empty, which needs no separate bit.
+// dispatch_status bits. LATEST_WHICH and NO_LOSERS are used on Method.
+// LATEST_ONLY is used only on MethodInstance (dispatch of this mi's exact
+// specTypes yields only this result); the corresponding Method-level fact is
+// the method's `interferences` set being empty, which needs no separate bit.
+// NO_LOSERS: this method is not strictly morespecific than any method it
+// intersects (its strict out-neighborhood is empty, the opposite pole from an
+// empty interference set, which means it beats everything it intersects).
+// Set when the method is inserted and cleared - never re-set - when a later
+// insertion finds this method beats it, so a set bit is valid for a query at
+// any world. It cannot be read from the method's own interference set, which
+// records only the methods it does NOT beat.
 #define METHOD_SIG_LATEST_WHICH             0b0001
 #define METHOD_SIG_LATEST_ONLY              0b0010
+#define METHOD_SIG_NO_LOSERS                0b0100
 
 void jl_init_engine(void) JL_NOTSAFEPOINT;
 void jl_engine_sweep(jl_ptls_t *gc_all_tls_states) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -801,23 +801,13 @@ typedef union {
 #define SOURCE_MODE_NOT_REQUIRED            0x0
 #define SOURCE_MODE_ABI                     0x1
 
-// dispatch_status bits. LATEST_WHICH and NO_LOSERS are used on Method.
-// LATEST_ONLY is used only on MethodInstance (dispatch of this mi's exact
-// specTypes yields only this result); the corresponding Method-level fact is
-// the method's `interferences` set being empty, which needs no separate bit.
-// NO_LOSERS: this method is not strictly morespecific than any method it
-// intersects (its strict out-neighborhood is empty, the opposite pole from an
-// empty interference set, which means it beats everything it intersects).
-// Set when the method is created and cleared - never re-set - when an
-// insertion scan finds a method it beats, so a set bit is valid for a query
-// at any world. It cannot be read from the method's own interference set,
-// which records only the methods it does NOT beat, and (like that set, but
-// unlike LATEST_WHICH) it survives incremental serialization, because the
-// activation scan at load cannot see same-image methods and so cannot
-// re-derive it. A type-equal replacement does not inherit the bit: it records
-// a recency-tiebreak win over the method it replaces (so it always has that
-// strict loser), and type-equal does not imply morespecific-equal, so the
-// predecessor's relations do not transfer.
+// dispatch_status bits.
+// - LATEST_WHICH: invoke of this mi's exact specTypes yields exactly this result.
+// - LATEST_ONLY: dispatch of this mi's exact specTypes yields only this result);
+//   the corresponding Method-level fact is the method's `interferences` set being empty.
+// - NO_LOSERS: this method is not strictly morespecific than any method it
+//   intersects (its strict out-neighborhood is empty, the opposite pole from an
+//   empty interference set, which means it beats everything it intersects).
 #define METHOD_SIG_LATEST_WHICH             0b0001
 #define METHOD_SIG_LATEST_ONLY              0b0010
 #define METHOD_SIG_NO_LOSERS                0b0100

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -808,10 +808,16 @@ typedef union {
 // NO_LOSERS: this method is not strictly morespecific than any method it
 // intersects (its strict out-neighborhood is empty, the opposite pole from an
 // empty interference set, which means it beats everything it intersects).
-// Set when the method is inserted and cleared - never re-set - when a later
-// insertion finds this method beats it, so a set bit is valid for a query at
-// any world. It cannot be read from the method's own interference set, which
-// records only the methods it does NOT beat.
+// Set when the method is created and cleared - never re-set - when an
+// insertion scan finds a method it beats, so a set bit is valid for a query
+// at any world. It cannot be read from the method's own interference set,
+// which records only the methods it does NOT beat, and (like that set, but
+// unlike LATEST_WHICH) it survives incremental serialization, because the
+// activation scan at load cannot see same-image methods and so cannot
+// re-derive it. A type-equal replacement does not inherit the bit: it records
+// a recency-tiebreak win over the method it replaces (so it always has that
+// strict loser), and type-equal does not imply morespecific-equal, so the
+// predecessor's relations do not transfer.
 #define METHOD_SIG_LATEST_WHICH             0b0001
 #define METHOD_SIG_LATEST_ONLY              0b0010
 #define METHOD_SIG_NO_LOSERS                0b0100

--- a/src/method.c
+++ b/src/method.c
@@ -1082,8 +1082,6 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     m->isva = 0;
     m->nargs = 0;
     jl_atomic_store_relaxed(&m->primary_world, ~(size_t)0);
-    // a method is born beating nothing; METHOD_SIG_NO_LOSERS is monotone-cleared
-    // from here (by activation scans and later insertions), never re-derived
     jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_NO_LOSERS);
     jl_atomic_store_relaxed(&m->interferences, (jl_genericmemory_t*)jl_an_empty_memory_any);
     m->is_for_opaque_closure = 0;

--- a/src/method.c
+++ b/src/method.c
@@ -1082,7 +1082,9 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     m->isva = 0;
     m->nargs = 0;
     jl_atomic_store_relaxed(&m->primary_world, ~(size_t)0);
-    jl_atomic_store_relaxed(&m->dispatch_status, 0);
+    // a method is born beating nothing; METHOD_SIG_NO_LOSERS is monotone-cleared
+    // from here (by activation scans and later insertions), never re-derived
+    jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_NO_LOSERS);
     jl_atomic_store_relaxed(&m->interferences, (jl_genericmemory_t*)jl_an_empty_memory_any);
     m->is_for_opaque_closure = 0;
     m->nospecializeinfer = 0;

--- a/src/method.c
+++ b/src/method.c
@@ -1086,7 +1086,9 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     m->isva = 0;
     m->nargs = 0;
     jl_atomic_store_relaxed(&m->primary_world, ~(size_t)0);
-    jl_atomic_store_relaxed(&m->dispatch_status, 0);
+    // a method is born beating nothing; METHOD_SIG_NO_LOSERS is monotone-cleared
+    // from here (by activation scans and later insertions), never re-derived
+    jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_NO_LOSERS);
     jl_atomic_store_relaxed(&m->interferences, (jl_genericmemory_t*)jl_an_empty_memory_any);
     m->is_for_opaque_closure = 0;
     m->nospecializeinfer = 0;

--- a/src/method.c
+++ b/src/method.c
@@ -1086,8 +1086,6 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     m->isva = 0;
     m->nargs = 0;
     jl_atomic_store_relaxed(&m->primary_world, ~(size_t)0);
-    // a method is born beating nothing; METHOD_SIG_NO_LOSERS is monotone-cleared
-    // from here (by activation scans and later insertions), never re-derived
     jl_atomic_store_relaxed(&m->dispatch_status, METHOD_SIG_NO_LOSERS);
     jl_atomic_store_relaxed(&m->interferences, (jl_genericmemory_t*)jl_an_empty_memory_any);
     m->is_for_opaque_closure = 0;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1823,10 +1823,7 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 if (s->incremental) {
                     if (jl_atomic_load_relaxed(&newm->primary_world) > 1) {
                         jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
-                        // Keep METHOD_SIG_NO_LOSERS across serialization: the
-                        // activation scan at load runs against the prior world
-                        // and cannot see same-image methods, so this bit (like
-                        // the interference sets) cannot be re-derived there.
+                        // Keep METHOD_SIG_NO_LOSERS across serialization, but re-derive other bits on activation
                         int dispatch_status = jl_atomic_load_relaxed(&newm->dispatch_status);
                         jl_atomic_store_relaxed(&newm->dispatch_status, dispatch_status & METHOD_SIG_NO_LOSERS);
                         arraylist_push(&s->fixup_objs, (void*)reloc_offset);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1717,7 +1717,12 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 if (s->incremental) {
                     if (jl_atomic_load_relaxed(&newm->primary_world) > 1) {
                         jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
-                        jl_atomic_store_relaxed(&newm->dispatch_status, 0);
+                        // Keep METHOD_SIG_NO_LOSERS across serialization: the
+                        // activation scan at load runs against the prior world
+                        // and cannot see same-image methods, so this bit (like
+                        // the interference sets) cannot be re-derived there.
+                        int dispatch_status = jl_atomic_load_relaxed(&newm->dispatch_status);
+                        jl_atomic_store_relaxed(&newm->dispatch_status, dispatch_status & METHOD_SIG_NO_LOSERS);
                         arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                     }
                 }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1717,10 +1717,7 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 if (s->incremental) {
                     if (jl_atomic_load_relaxed(&newm->primary_world) > 1) {
                         jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
-                        // Keep METHOD_SIG_NO_LOSERS across serialization: the
-                        // activation scan at load runs against the prior world
-                        // and cannot see same-image methods, so this bit (like
-                        // the interference sets) cannot be re-derived there.
+                        // Keep METHOD_SIG_NO_LOSERS across serialization, but re-derive other bits on activation
                         int dispatch_status = jl_atomic_load_relaxed(&newm->dispatch_status);
                         jl_atomic_store_relaxed(&newm->dispatch_status, dispatch_status & METHOD_SIG_NO_LOSERS);
                         arraylist_push(&s->fixup_objs, (void*)reloc_offset);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1823,11 +1823,7 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 if (s->incremental) {
                     if (jl_atomic_load_relaxed(&newm->primary_world) > 1) {
                         jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
-                        int dispatch_status = jl_atomic_load_relaxed(&newm->dispatch_status);
-                        int new_dispatch_status = 0;
-                        if (!(dispatch_status & METHOD_SIG_LATEST_ONLY))
-                            new_dispatch_status |= METHOD_SIG_PRECOMPILE_MANY;
-                        jl_atomic_store_relaxed(&newm->dispatch_status, new_dispatch_status);
+                        jl_atomic_store_relaxed(&newm->dispatch_status, 0);
                         arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                     }
                 }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1823,7 +1823,12 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 if (s->incremental) {
                     if (jl_atomic_load_relaxed(&newm->primary_world) > 1) {
                         jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
-                        jl_atomic_store_relaxed(&newm->dispatch_status, 0);
+                        // Keep METHOD_SIG_NO_LOSERS across serialization: the
+                        // activation scan at load runs against the prior world
+                        // and cannot see same-image methods, so this bit (like
+                        // the interference sets) cannot be re-derived there.
+                        int dispatch_status = jl_atomic_load_relaxed(&newm->dispatch_status);
+                        jl_atomic_store_relaxed(&newm->dispatch_status, dispatch_status & METHOD_SIG_NO_LOSERS);
                         arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                     }
                 }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1717,11 +1717,7 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 if (s->incremental) {
                     if (jl_atomic_load_relaxed(&newm->primary_world) > 1) {
                         jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
-                        int dispatch_status = jl_atomic_load_relaxed(&newm->dispatch_status);
-                        int new_dispatch_status = 0;
-                        if (!(dispatch_status & METHOD_SIG_LATEST_ONLY))
-                            new_dispatch_status |= METHOD_SIG_PRECOMPILE_MANY;
-                        jl_atomic_store_relaxed(&newm->dispatch_status, new_dispatch_status);
+                        jl_atomic_store_relaxed(&newm->dispatch_status, 0);
                         arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                     }
                 }

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -941,11 +941,6 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
         for (i = 0; i < l; i++) {
             jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_array_ptr_ref(external, i);
             //uint64_t t0 = uv_hrtime();
-            // Re-runs the full intersection scan against the live table, so the
-            // interference relation stays complete across package boundaries:
-            // this method's set and every intersecting partner's set are updated
-            // here. (Internal methods keep the complete sets serialized at
-            // precompile time.)
             jl_method_table_activate(entry);
             //jl_printf(JL_STDERR, "%f ", (double)(uv_hrtime() - t0) / 1e6);
             //jl_static_show(JL_STDERR, entry->func.value);

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -941,6 +941,11 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
         for (i = 0; i < l; i++) {
             jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_array_ptr_ref(external, i);
             //uint64_t t0 = uv_hrtime();
+            // Re-runs the full intersection scan against the live table, so the
+            // interference relation stays complete across package boundaries:
+            // this method's set and every intersecting partner's set are updated
+            // here. (Internal methods keep the complete sets serialized at
+            // precompile time.)
             jl_method_table_activate(entry);
             //jl_printf(JL_STDERR, "%f ", (double)(uv_hrtime() - t0) / 1e6);
             //jl_static_show(JL_STDERR, entry->func.value);

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -956,11 +956,6 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
         for (i = 0; i < l; i++) {
             jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_array_ptr_ref(external, i);
             //uint64_t t0 = uv_hrtime();
-            // Re-runs the full intersection scan against the live table, so the
-            // interference relation stays complete across package boundaries:
-            // this method's set and every intersecting partner's set are updated
-            // here. (Internal methods keep the complete sets serialized at
-            // precompile time.)
             jl_method_table_activate(entry);
             //jl_printf(JL_STDERR, "%f ", (double)(uv_hrtime() - t0) / 1e6);
             //jl_static_show(JL_STDERR, entry->func.value);

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -956,6 +956,11 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
         for (i = 0; i < l; i++) {
             jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_array_ptr_ref(external, i);
             //uint64_t t0 = uv_hrtime();
+            // Re-runs the full intersection scan against the live table, so the
+            // interference relation stays complete across package boundaries:
+            // this method's set and every intersecting partner's set are updated
+            // here. (Internal methods keep the complete sets serialized at
+            // precompile time.)
             jl_method_table_activate(entry);
             //jl_printf(JL_STDERR, "%f ", (double)(uv_hrtime() - t0) / 1e6);
             //jl_static_show(JL_STDERR, entry->func.value);

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -638,4 +638,26 @@ let ambig = Ref{Int32}(0)
 end
 @test !isempty(detect_ambiguities(AmbigCycle3Reorder))
 
+# the `METHOD_SIG_NO_LOSERS` dispatch_status bit records that a method is not
+# strictly morespecific than anything it intersects (so removing it from a
+# match list can never free another method from suppression); it is set at
+# insertion and monotone-cleared when a later method is beaten by it
+module NoLosersBit
+f(::Any) = 1
+end
+let NO_LOSERS = Base.ReinferUtils.METHOD_SIG_NO_LOSERS
+    @test !iszero(only(methods(NoLosersBit.f)).dispatch_status & NO_LOSERS)
+    # a specialization beats the fallback: it never gets the bit, while the
+    # fallback (which still beats nothing) keeps it
+    @eval NoLosersBit f(::Int) = 2
+    @test !iszero(which(NoLosersBit.f, Tuple{Any}).dispatch_status & NO_LOSERS)
+    @test iszero(which(NoLosersBit.f, Tuple{Int}).dispatch_status & NO_LOSERS)
+    # every member of a specificity cycle beats another member, so none may
+    # carry the bit (otherwise the check_dominance_transfer fast path would
+    # mask the cycle); this covers both insertion orders used above
+    for mod in (AmbigCycle3, AmbigCycle3Reorder), m in methods(mod.f)
+        @test iszero(m.dispatch_status & NO_LOSERS)
+    end
+end
+
 nothing

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -820,4 +820,26 @@ let ambig = Ref{Int32}(0)
 end
 @test !isempty(detect_ambiguities(AmbigCycle3Reorder))
 
+# the `METHOD_SIG_NO_LOSERS` dispatch_status bit records that a method is not
+# strictly morespecific than anything it intersects (so removing it from a
+# match list can never free another method from suppression); it is set at
+# insertion and monotone-cleared when a later method is beaten by it
+module NoLosersBit
+f(::Any) = 1
+end
+let NO_LOSERS = Base.ReinferUtils.METHOD_SIG_NO_LOSERS
+    @test !iszero(only(methods(NoLosersBit.f)).dispatch_status & NO_LOSERS)
+    # a specialization beats the fallback: it never gets the bit, while the
+    # fallback (which still beats nothing) keeps it
+    @eval NoLosersBit f(::Int) = 2
+    @test !iszero(which(NoLosersBit.f, Tuple{Any}).dispatch_status & NO_LOSERS)
+    @test iszero(which(NoLosersBit.f, Tuple{Int}).dispatch_status & NO_LOSERS)
+    # every member of a specificity cycle beats another member, so none may
+    # carry the bit (otherwise the check_dominance_transfer fast path would
+    # mask the cycle); this covers both insertion orders used above
+    for mod in (AmbigCycle3, AmbigCycle3Reorder), m in methods(mod.f)
+        @test iszero(m.dispatch_status & NO_LOSERS)
+    end
+end
+
 nothing

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -791,4 +791,33 @@ end
 # ambiguity
 @test !isempty(detect_ambiguities(AmbigCycle3))
 
+# same 3-way cycle, but defined in the order that used to trigger the
+# `LATEST_ONLY` slurp early-out in `get_intersect_visitor`: `mU` is inserted
+# before `mStr`, so when `mStr` (a strict subtype of `mU`, which dominates `mT`
+# and is thus `METHOD_SIG_LATEST_ONLY`) is added, the scan used to stop after
+# recording only the `(mStr, mU)` pair and never record that `mT` is
+# morespecific than `mStr`. That omission left `mStr`'s interference set empty,
+# so the cycle was invisible and `f(1)` silently dispatched to `mStr` instead of
+# raising an ambiguity. Insertion order must not change the observed relation.
+module AmbigCycle3Reorder
+f(::T, ::Vararg{T}) where {T<:Integer} = 1    # mT
+f(::Integer, ::Vararg{Union{Int,String}}) = 3 # mU  (inserted before mStr; dominates mT)
+f(::Integer, ::Vararg{String}) = 2            # mStr (⊊ mU)
+end
+let mT   = which(AmbigCycle3Reorder.f, Tuple{T, Vararg{T}} where T<:Integer),
+    mStr = which(AmbigCycle3Reorder.f, Tuple{Integer, Vararg{String}}),
+    mU   = which(AmbigCycle3Reorder.f, Tuple{Integer, Vararg{Union{Int,String}}})
+    @test Base.morespecific(mT, mStr) && Base.morespecific(mStr, mU) && Base.morespecific(mU, mT)
+    @test !(Base.morespecific(mStr, mT) || Base.morespecific(mU, mStr) || Base.morespecific(mT, mU))
+    @test Base.isambiguous(mT, mStr)
+    @test Base.isambiguous(mStr, mU)
+    @test Base.isambiguous(mU, mT)
+end
+@test_throws MethodError AmbigCycle3Reorder.f(1) # genuinely ambiguous in dispatch
+let ambig = Ref{Int32}(0)
+    Base._methods_by_ftype(Tuple{typeof(AmbigCycle3Reorder.f), Int}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    @test ambig[] == 1
+end
+@test !isempty(detect_ambiguities(AmbigCycle3Reorder))
+
 nothing

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -807,7 +807,7 @@ let ambig = Ref{Int32}(0)
 end
 @test !isempty(detect_ambiguities(AmbigCycle3Reorder))
 
-# A method is selected only when it is more specific than *every* other
+# A method is selected only when it is more specific than every other
 # applicable method, so a match that is itself dominated can still make a call
 # ambiguous by blocking the would-be winner. Here 3 ≻ 2, 2 ≻ 1 and 3 is unordered
 # with 1: nothing beats both others, so the call is ambiguous, and method 1 has to
@@ -850,7 +850,7 @@ end
 # method, and the new method is one more thing to beat. That is what lets the
 # method table backedges skip invalidation here, so a caller compiled while the
 # call was ambiguous (and therefore inferred to always throw) stays valid. n.b.
-# the converse direction is not covered: a new method can turn a *resolved* call
+# the converse direction is not covered: a new method can turn a resolved call
 # ambiguous without `is_replacing` noticing, which is a pre-existing hole.
 module AmbigResolveByExclusion
 abstract type Top end

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -1001,6 +1001,78 @@ let verify_call = Base.Compiler.ReinferUtils.verify_call,
     end
 end
 
+# The mutual-pair shape: the canonical `Type{Union{}}`-slurp recovery.
+# Where the newcomer is mutually ambiguous with the fully-covering expected owner
+# (their only overlap is the corner the slurp resolves), and the fresh sort
+# keeps the pair silent through the owner's minmax exemption; the fast path
+# must certify exactly that and accept without the full lookup.
+module VerifyCallSlurp
+abstract type QA end
+abstract type QB end
+q(::Type{<:QA}) = 1        # qA: the recorded owner, fully covers the edge below
+q(::Type{Union{}}) = 0     # qS: the slurp, with an empty interference set
+# the control family: same shape, but no slurp to resolve the corner
+abstract type UA end
+abstract type UB end
+u(::Type{<:UA}) = 1        # uA
+end
+let verify_call = Base.Compiler.ReinferUtils.verify_call,
+    method_in_interferences = Base.Compiler.ReinferUtils.method_in_interferences,
+    q = VerifyCallSlurp.q,
+    mA = which(q, Tuple{Type{VerifyCallSlurp.QA}}),
+    mS = which(q, Tuple{Type{Union{}}}),
+    sig = Tuple{typeof(q), Type{T}} where T<:VerifyCallSlurp.QA,
+    expecteds = Core.svec(mS, mA)
+    # the unchanged recorded state revalidates
+    let (minw, maxw) = verify_call(sig, expecteds, 1, 2, Base.get_world_counter(), true, Any[])
+        @test maxw == typemax(UInt)
+    end
+    VerifyCallSlurp.eval(:(q(::Type{<:QB}) = 2))
+    mB = which(q, Tuple{Type{VerifyCallSlurp.QB}})
+    # the mutual pair is recorded on both edges; the slurp beats both
+    @test method_in_interferences(mA, mB) && method_in_interferences(mB, mA)
+    @test isempty(mS.interferences) && method_in_interferences(mS, mB)
+    # ground truth: the fresh sort prunes the newcomer silently (the owner's
+    # minmax exemption is what keeps the mutual pair from being flagged)
+    let ambig = Ref{Int32}(0)
+        ms = Base._methods_by_ftype(sig, nothing, -1, Base.get_world_counter(), false,
+                                    Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        @test length(ms) == 2 && ambig[] == 0
+    end
+    let (minw, maxw) = verify_call(sig, expecteds, 1, 2, Base.get_world_counter(), true, Any[])
+        @test maxw == typemax(UInt)
+    end
+    # the fallback would also revalidate this edge (the pruned match set is
+    # unchanged), so additionally pin that the fast-path predicate itself
+    # accepts, and that it rejects when the owner does not fully cover the query
+    let newcomer_prunes_silently = Base.Compiler.ReinferUtils.newcomer_prunes_silently,
+        ti = typeintersect(sig, mB.sig)
+        @test newcomer_prunes_silently(mA, mB, ti, sig, expecteds, 1, 2, Base.get_world_counter())
+        let sig2 = Tuple{typeof(q), Type{T}} where T, ti2 = typeintersect(sig2, mB.sig)
+            @test !newcomer_prunes_silently(mA, mB, ti2, sig2, Core.svec(mS, mA, mB), 1, 3, Base.get_world_counter())
+        end
+    end
+end
+# The control: the same mutual corner pair with no slurp cover must invalidate due to the added ambiguity.
+let verify_call = Base.Compiler.ReinferUtils.verify_call,
+    u = VerifyCallSlurp.u,
+    uA = which(u, Tuple{Type{VerifyCallSlurp.UA}}),
+    sig = Tuple{typeof(u), Type{T}} where T<:VerifyCallSlurp.UA,
+    expecteds = Core.svec(uA)
+    let (minw, maxw) = verify_call(sig, expecteds, 1, 1, Base.get_world_counter(), true, Any[])
+        @test maxw == typemax(UInt)
+    end
+    VerifyCallSlurp.eval(:(u(::Type{<:UB}) = 2))
+    let ambig = Ref{Int32}(0)
+        ms = Base._methods_by_ftype(sig, nothing, -1, Base.get_world_counter(), false,
+                                    Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        @test length(ms) == 1 && ambig[] == 1
+    end
+    let (minw, maxw) = verify_call(sig, expecteds, 1, 1, Base.get_world_counter(), true, Any[])
+        @test maxw == 0
+    end
+end
+
 # A method is selected only when it is more specific than every other
 # applicable method, so a match that is itself dominated can still make a call
 # ambiguous by blocking the would-be winner. Here 3 ≻ 2, 2 ≻ 1 and 3 is unordered

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -280,7 +280,11 @@ end
 for f in (Ambig8.f, Ambig8.g)
     @test length(methods(f, (Integer,))) == 2 # 3 is also acceptable
     @test length(methods(f, (Signed,))) == 1 # 2 is also acceptable
-    @test length(Base.methods_including_ambiguous(f, (Signed,))) == 2
+    # all three matches are required: `Union{AbstractIrrational, Int}` is
+    # morespecific than `Signed`, so without `Union{typeof(pi), Integer}`
+    # (unordered with it) the report would read as resolved at `(Int,)`,
+    # where the call is really ambiguous
+    @test length(Base.methods_including_ambiguous(f, (Signed,))) == 3
     @test f(0x00) == 1
     @test f(Ambig8.Irrational2()) == 2
     @test f(MathConstants.γ) == 3
@@ -938,6 +942,45 @@ let A1 = AmbigTransferRegion.A1, B1 = AmbigTransferRegion.B1,
         @test m1 in [m.method for m in matches]
     end
     @test_throws MethodError AmbigTransferRegion.f(A1(), A1())
+end
+
+# A fully-covering match that strictly beats nothing is never reached by the
+# result sort's DFS (which only descends to strictly-morespecific matches), so
+# when a minmax method exists it used to be skipped -- and dropped -- without the
+# dominance-transfer check that every other removal runs. The specificity
+# triangle here (3 ≻ 1 ≻ 2, with 2 and 3 unordered) makes the skipped method 2
+# the only match blocking method 3 at `(P,)`: method 3 beats the minmax method 1,
+# so dropping method 2 leaves the report with no witness of the ambiguity at all,
+# only a strictly ordered pair reading as resolved to method 3.
+module AmbigMinmaxSkip
+abstract type Top end
+struct P <: Top end
+struct Q <: Top end
+struct R <: Top end
+f(::T, ::Vararg{T}) where {T<:Union{P,Q}} = 1  # minmax over the query below: beats 2, beaten by 3
+f(::Union{P,Q}, ::Vararg{R}) = 2               # fully covers, beats nothing, unordered with 3
+f(::P, ::Vararg{P}) = 3                        # partial, beats 1, unordered with 2
+end
+let ms = sort(collect(methods(AmbigMinmaxSkip.f)), by = m -> m.line),
+    (m1, m2, m3) = (ms[1], ms[2], ms[3]),
+    P = AmbigMinmaxSkip.P, Q = AmbigMinmaxSkip.Q
+    # the intransitive specificity triangle
+    @test Base.morespecific(m3, m1) && Base.morespecific(m1, m2)
+    @test !Base.morespecific(m2, m3) && !Base.morespecific(m3, m2)
+    let ambig = Ref{Int32}(0)
+        matches = Base._methods_by_ftype(
+            Tuple{typeof(AmbigMinmaxSkip.f), T} where T<:Union{P,Q},
+            nothing, -1, Base.get_world_counter(), true,
+            Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        @test ambig[] == 1
+        @test Set(m.method for m in matches) == Set([m1, m2, m3])
+        # the ambiguity at `(P,)` stays witnessed by the reported matches
+        # applicable there
+        applicable_at = [m.method for m in matches if Tuple{typeof(AmbigMinmaxSkip.f), P} <: m.method.sig]
+        @test m2 in applicable_at && m3 in applicable_at
+    end
+    @test_throws MethodError AmbigMinmaxSkip.f(P())
+    @test AmbigMinmaxSkip.f(Q()) == 1
 end
 
 module NoLosersBit

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -480,4 +480,94 @@ let ambig = Ref{Int32}(0)
     @test ms[4].method === which(ambig10, (Vararg{Number},))
 end
 
+# issue #62262: an ambiguity can be resolved by the *union* of several more
+# specific methods, without any single method covering the intersection
+module Ambig62262
+abstract type MyAbstractMat end
+struct MatA <: MyAbstractMat end
+struct MatB <: MyAbstractMat end
+struct SpecialMat <: MyAbstractMat end
+h(::MyAbstractMat, ::SpecialMat) = 1
+h(::Union{MatA,MatB}, ::MyAbstractMat) = 2
+h(::MatA, ::SpecialMat) = 3
+h(::MatB, ::SpecialMat) = 4
+end
+@test Ambig62262.h(Ambig62262.MatA(), Ambig62262.SpecialMat()) == 3
+@test Ambig62262.h(Ambig62262.MatB(), Ambig62262.SpecialMat()) == 4
+@test isempty(detect_ambiguities(Ambig62262))
+
+# ... but since `morespecific` is not transitive, a method that is more specific
+# than both ambiguous methods does not resolve them if it loses back to one of
+# them through a specificity cycle (here two steps long)
+module AmbigUnionCycle
+abstract type LikeSigned end
+struct LikeInt <: LikeSigned end
+abstract type LikeString end
+struct LikeStr <: LikeString end
+struct LikeMissing end
+s(x::Union{LikeSigned,LikeMissing}, y::LikeInt...) = 1            # m1
+s(x::Union{LikeInt,LikeString,LikeMissing}, y::LikeSigned...) = 2 # m2
+s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3         # covers the LikeInt part, but loses to method 5 (below)
+s(x::LikeMissing, y::LikeInt...) = 4                              # genuinely covers the LikeMissing part
+s(x::Union{LikeSigned,LikeStr}, y::LikeStr...) = 5               # more specific than method 3
+s(x::LikeSigned, y::LikeStr...) = 6                              # more specific than 5; method 2 is more specific than this
+end
+let ms = collect(methods(AmbigUnionCycle.s)),
+    m1 = only(filter(m -> m.sig == Tuple{typeof(AmbigUnionCycle.s), Union{AmbigUnionCycle.LikeSigned,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeInt}}, ms)),
+    m2 = only(filter(m -> m.sig == Tuple{typeof(AmbigUnionCycle.s), Union{AmbigUnionCycle.LikeInt,AmbigUnionCycle.LikeString,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeSigned}}, ms))
+    # method 3 "covers" the LikeInt part but is in a specificity cycle (2 ≻ 6 ≻ 5 ≻ 3 ≻ 2)
+    @test Base.isambiguous(m1, m2)
+end
+@test_throws MethodError AmbigUnionCycle.s(AmbigUnionCycle.LikeInt()) # genuinely ambiguous
+@test AmbigUnionCycle.s(AmbigUnionCycle.LikeMissing()) == 4
+@test AmbigUnionCycle.s(AmbigUnionCycle.LikeInt(), AmbigUnionCycle.LikeInt()) == 3
+
+# complement of #62262: if the more specific methods only cover *part* of the
+# intersection, the uncovered part is still a genuine ambiguity (so the union
+# check must not over-resolve)
+module Ambig62262Partial
+abstract type MyAbstractMat end
+struct MatA <: MyAbstractMat end
+struct MatB <: MyAbstractMat end
+struct SpecialMat <: MyAbstractMat end
+h(::MyAbstractMat, ::SpecialMat) = 1
+h(::Union{MatA,MatB}, ::MyAbstractMat) = 2
+h(::MatA, ::SpecialMat) = 3  # covers only the MatA part of the intersection
+end
+@test length(detect_ambiguities(Ambig62262Partial)) == 1
+@test Ambig62262Partial.h(Ambig62262Partial.MatA(), Ambig62262Partial.SpecialMat()) == 3          # covered -> resolved
+@test_throws MethodError Ambig62262Partial.h(Ambig62262Partial.MatB(), Ambig62262Partial.SpecialMat()) # uncovered -> ambiguous
+
+# a 3-way (non-transitive) specificity cycle is a real dispatch ambiguity that
+# `_methods_by_ftype` reports via `has_ambig`, even though every *pair* of the
+# three methods has a clear winner
+module AmbigCycle3
+f(::T, ::Vararg{T}) where {T<:Integer} = 1    # mT
+f(::Integer, ::Vararg{String}) = 2            # mStr
+f(::Integer, ::Vararg{Union{Int,String}}) = 3 # mU
+end
+let tf = typeof(AmbigCycle3.f),
+    ms = collect(methods(AmbigCycle3.f)),
+    bysig = s -> only(filter(m -> m.sig == s, ms)),
+    mT   = bysig(Tuple{tf, T, Vararg{T}} where T<:Integer),
+    mStr = bysig(Tuple{tf, Integer, Vararg{String}}),
+    mU   = bysig(Tuple{tf, Integer, Vararg{Union{Int,String}}})
+    # specificity cycle mT ≻ mStr ≻ mU ≻ mT: no unique most specific method
+    @test Base.morespecific(mT, mStr) && Base.morespecific(mStr, mU) && Base.morespecific(mU, mT)
+    @test !(Base.morespecific(mStr, mT) || Base.morespecific(mU, mStr) || Base.morespecific(mT, mU))
+    # `isambiguous` still detects the ambiguity present in the mT/mStr region
+    @test Base.isambiguous(mT, mStr)
+    @test !Base.isambiguous(mStr, mU)
+    @test !Base.isambiguous(mU, mT)
+end
+@test_throws MethodError AmbigCycle3.f(3) # genuinely ambiguous in dispatch
+let ambig = Ref{Int32}(0)
+    Base._methods_by_ftype(Tuple{typeof(AmbigCycle3.f), Int}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    @test ambig[] == 1
+end
+# `detect_ambiguities` queries each method signature on its own, where the cycle
+# does not surface (`has_ambig == 0` for each), so pairwise detection misses the
+# 3-way ambiguity entirely
+@test_broken !isempty(detect_ambiguities(AmbigCycle3))
+
 nothing

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -280,7 +280,7 @@ end
 for f in (Ambig8.f, Ambig8.g)
     @test length(methods(f, (Integer,))) == 2 # 3 is also acceptable
     @test length(methods(f, (Signed,))) == 1 # 2 is also acceptable
-    # all three matches are required: `Union{AbstractIrrational, Int}` is
+    # all three matches are required as witnesses: `Union{AbstractIrrational, Int}` is
     # morespecific than `Signed`, so without `Union{typeof(pi), Integer}`
     # (unordered with it) the report would read as resolved at `(Int,)`,
     # where the call is really ambiguous
@@ -711,7 +711,7 @@ end
 # resolver may be rejected because a loser is `morespecific` than it globally,
 # even when the loser's overlap with it inside the intersection is itself
 # resolved by other methods. Here dispatch resolves every point of the
-# intersection of methods 1 and 2 (methods 7 and 8 rescue the only points where
+# intersection of methods 1 and 2 (methods 7 and 8 cover the only points where
 # the loser chain 2 ≻ 6 ≻ 5 ≻ 3 overlaps method 3). The region-aware
 # union-coverage resolution computes that the cycle members are fully covered
 # over this query before they can disqualify method 3, so the pair is correctly
@@ -882,9 +882,9 @@ ambig_exclusion_caller() = AmbigResolveByExclusion.g(AmbigResolveByExclusion.A1(
 # `(A1, B1)`: method 3, the cover applying there, is itself beaten by method 4,
 # so it blocks nothing. A region-blind transfer check accepts method 5 (which
 # blocks method 4, but only where it applies) and drops method 1, leaving the
-# reported subset at `(A1, B1)` reading as resolved to method 4. Method 3 also
-# sits in a specificity cycle with methods 1 and 2 (1 ≻ 2 ≻ 3 ≻ 1), which is
-# where a transfer check that ignores cycles would additionally lose the
+# reported subset at `(A1, B1)` appearing to have resolved that to method 4.
+# Method 3 also sits in a specificity cycle with methods 1 and 2 (1 ≻ 2 ≻ 3 ≻ 1),
+# which is where a transfer check that ignores cycles would additionally lose the
 # ambiguity flag.
 module AmbigTransferRegion
 abstract type Top end
@@ -902,7 +902,7 @@ f(::MidA, ::A1) = 5                              # beats 1 and 2
 end
 let A1 = AmbigTransferRegion.A1, B1 = AmbigTransferRegion.B1,
     ms = sort(collect(methods(AmbigTransferRegion.f)), by = m -> m.line),
-    (m1, m2, m3, m4, m5) = (ms[1], ms[2], ms[3], ms[4], ms[5])
+    (m1, m2, m3, m4, m5) = ms
     # the specificity cycle that makes the dominance-transfer check necessary
     @test Base.morespecific(m1, m2) && Base.morespecific(m2, m3) && Base.morespecific(m3, m1)
     # method 1 is dominated at every point of its region (by method 5 at
@@ -917,7 +917,7 @@ let A1 = AmbigTransferRegion.A1, B1 = AmbigTransferRegion.B1,
             nothing, -1, Base.get_world_counter(), true,
             Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
         @test ambig[] == 1
-        # methods 4 and 5 witness the ambiguity at `(A1, A1)`. Method 1 is
+        # Methods 4 and 5 witness the ambiguity at `(A1, A1)`. Method 1 is
         # covered over this whole region by the union of 5 and 3, so it can
         # never be selected -- but it must stay reported anyway, because it is
         # the only match blocking method 4 at `(A1, B1)`: dropping it would make
@@ -962,8 +962,9 @@ f(::Union{P,Q}, ::Vararg{R}) = 2               # fully covers, beats nothing, un
 f(::P, ::Vararg{P}) = 3                        # partial, beats 1, unordered with 2
 end
 let ms = sort(collect(methods(AmbigMinmaxSkip.f)), by = m -> m.line),
-    (m1, m2, m3) = (ms[1], ms[2], ms[3]),
-    P = AmbigMinmaxSkip.P, Q = AmbigMinmaxSkip.Q
+    (m1, m2, m3) = ms,
+    P = AmbigMinmaxSkip.P,
+    Q = AmbigMinmaxSkip.Q
     # the intransitive specificity triangle
     @test Base.morespecific(m3, m1) && Base.morespecific(m1, m2)
     @test !Base.morespecific(m2, m3) && !Base.morespecific(m3, m2)

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -480,7 +480,7 @@ let ambig = Ref{Int32}(0)
     @test ms[4].method === which(ambig10, (Vararg{Number},))
 end
 
-# issue #62262: an ambiguity can be resolved by the *union* of several more
+# issue #62262: an ambiguity can be resolved by the union of several more
 # specific methods, without any single method covering the intersection
 module Ambig62262
 abstract type MyAbstractMat end
@@ -507,17 +507,17 @@ struct LikeStr <: LikeString end
 struct LikeMissing end
 s(x::Union{LikeSigned,LikeMissing}, y::LikeInt...) = 1            # m1
 s(x::Union{LikeInt,LikeString,LikeMissing}, y::LikeSigned...) = 2 # m2
-s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3         # covers the LikeInt part, but loses to method 5 (below)
-s(x::LikeMissing, y::LikeInt...) = 4                              # genuinely covers the LikeMissing part
-s(x::Union{LikeSigned,LikeStr}, y::LikeStr...) = 5               # more specific than method 3
-s(x::LikeSigned, y::LikeStr...) = 6                              # more specific than 5; method 2 is more specific than this
+s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3         # m3 covers the LikeInt part, but loses to method 5 (below)
+s(x::LikeMissing, y::LikeInt...) = 4                              # m4 covers the LikeMissing part
+s(x::Union{LikeSigned,LikeStr}, y::LikeStr...) = 5                # m5 more specific than method 3
+s(x::LikeSigned, y::LikeStr...) = 6                               # m6 more specific than 5; method 2 is more specific than this
 end
 let m1 = which(AmbigUnionCycle.s, Tuple{Union{AmbigUnionCycle.LikeSigned,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeInt}}),
     m2 = which(AmbigUnionCycle.s, Tuple{Union{AmbigUnionCycle.LikeInt,AmbigUnionCycle.LikeString,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeSigned}})
     # method 3 "covers" the LikeInt part but is in a specificity cycle (2 ≻ 6 ≻ 5 ≻ 3 ≻ 2)
     @test Base.isambiguous(m1, m2)
 end
-@test_throws MethodError AmbigUnionCycle.s(AmbigUnionCycle.LikeInt()) # genuinely ambiguous
+@test_throws MethodError AmbigUnionCycle.s(AmbigUnionCycle.LikeInt())
 @test AmbigUnionCycle.s(AmbigUnionCycle.LikeMissing()) == 4
 @test AmbigUnionCycle.s(AmbigUnionCycle.LikeInt(), AmbigUnionCycle.LikeInt()) == 3
 
@@ -527,9 +527,9 @@ end
 # resolved by other methods. Here dispatch resolves every point of the
 # intersection of methods 1 and 2 (methods 7 and 8 rescue the only points where
 # the loser chain 2 ≻ 6 ≻ 5 ≻ 3 overlaps method 3). The region-aware
-# union-coverage resolution in `ml_matches` (gf.c) sees that the cycle members
-# are fully covered over this query before they can disqualify method 3, so the
-# pair is correctly reported as resolved.
+# union-coverage resolution computes that the cycle members are fully covered
+# over this query before they can disqualify method 3, so the pair is correctly
+# reported as resolved.
 module AmbigLoserRegion
 abstract type LikeSigned end
 struct LikeInt <: LikeSigned end
@@ -538,14 +538,14 @@ struct LikeStr <: LikeString end
 struct LikeMissing end
 s(x::Union{LikeSigned,LikeMissing}, y::LikeInt...) = 1             # m1
 s(x::Union{LikeInt,LikeString,LikeMissing}, y::LikeSigned...) = 2  # m2
-s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3          # resolves the (LikeInt, LikeInt...) region
-s(x::LikeMissing, y::LikeInt...) = 4                               # resolves the LikeMissing region
-s(x::Union{LikeSigned,LikeStr,LikeMissing}, y::LikeStr...) = 5     # more specific than method 3
-s(x::Union{LikeSigned,LikeMissing}, y::LikeStr...) = 6             # more specific than 5; method 2 is more specific than this
-s(x::LikeInt) = 7                                                  # resolves the arity-1 LikeInt point
-s(x::LikeMissing) = 8                                              # resolves the arity-1 LikeMissing point
+s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3          # m3 resolves the (LikeInt, LikeInt...) region
+s(x::LikeMissing, y::LikeInt...) = 4                               # m4 resolves the LikeMissing region
+s(x::Union{LikeSigned,LikeStr,LikeMissing}, y::LikeStr...) = 5     # m5 more specific than method 3
+s(x::Union{LikeSigned,LikeMissing}, y::LikeStr...) = 6             # m6 more specific than 5; method 2 is more specific than this
+s(x::LikeInt) = 7                                                  # m7 resolves the arity-1 LikeInt point
+s(x::LikeMissing) = 8                                              # m8 resolves the arity-1 LikeMissing point
 end
-# dispatch is fully resolved over the intersection of methods 1 and 2 ...
+# dispatch is fully resolved over the intersection of methods 1 and 2
 @test AmbigLoserRegion.s(AmbigLoserRegion.LikeInt()) == 7
 @test AmbigLoserRegion.s(AmbigLoserRegion.LikeMissing()) == 8
 @test AmbigLoserRegion.s(AmbigLoserRegion.LikeInt(), AmbigLoserRegion.LikeInt()) == 3
@@ -555,7 +555,7 @@ let m1 = which(AmbigLoserRegion.s, Tuple{Union{AmbigLoserRegion.LikeSigned,Ambig
     @test !Base.isambiguous(m1, m2)
 end
 
-# complement of #62262: if the more specific methods only cover *part* of the
+# complement of #62262: if the more specific methods only cover part of the
 # intersection, the uncovered part is still a genuine ambiguity (so the union
 # check must not over-resolve)
 module Ambig62262Partial
@@ -568,11 +568,11 @@ h(::Union{MatA,MatB}, ::MyAbstractMat) = 2
 h(::MatA, ::SpecialMat) = 3  # covers only the MatA part of the intersection
 end
 @test length(detect_ambiguities(Ambig62262Partial)) == 1
-@test Ambig62262Partial.h(Ambig62262Partial.MatA(), Ambig62262Partial.SpecialMat()) == 3          # covered -> resolved
-@test_throws MethodError Ambig62262Partial.h(Ambig62262Partial.MatB(), Ambig62262Partial.SpecialMat()) # uncovered -> ambiguous
+@test Ambig62262Partial.h(Ambig62262Partial.MatA(), Ambig62262Partial.SpecialMat()) == 3
+@test_throws MethodError Ambig62262Partial.h(Ambig62262Partial.MatB(), Ambig62262Partial.SpecialMat())
 
 # a 3-way (non-transitive) specificity cycle is a real dispatch ambiguity that
-# `_methods_by_ftype` reports via `has_ambig`, even though every *pair* of the
+# `_methods_by_ftype` reports via `has_ambig`, even though every pair of the
 # three methods has a clear winner
 module AmbigCycle3
 f(::T, ::Vararg{T}) where {T<:Integer} = 1    # mT
@@ -582,7 +582,7 @@ end
 let mT   = which(AmbigCycle3.f, Tuple{T, Vararg{T}} where T<:Integer),
     mStr = which(AmbigCycle3.f, Tuple{Integer, Vararg{String}}),
     mU   = which(AmbigCycle3.f, Tuple{Integer, Vararg{Union{Int,String}}})
-    # specificity cycle mT ≻ mStr ≻ mU ≻ mT: no unique most specific method
+    # specificity cycle mT ≻ mStr ≻ mU ≻ mT
     @test Base.morespecific(mT, mStr) && Base.morespecific(mStr, mU) && Base.morespecific(mU, mT)
     @test !(Base.morespecific(mStr, mT) || Base.morespecific(mU, mStr) || Base.morespecific(mT, mU))
     # every pair is pairwise ordered, but each pair still participates in the
@@ -591,32 +591,19 @@ let mT   = which(AmbigCycle3.f, Tuple{T, Vararg{T}} where T<:Integer),
     @test Base.isambiguous(mStr, mU)
     @test Base.isambiguous(mU, mT)
 end
-@test_throws MethodError AmbigCycle3.f(3) # genuinely ambiguous in dispatch
+@test_throws MethodError AmbigCycle3.f(3)
 let ambig = Ref{Int32}(0)
     Base._methods_by_ftype(Tuple{typeof(AmbigCycle3.f), Int}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ambig[] == 1
 end
-# querying a single method signature must also report the cycle (`has_ambig`):
-# inference consumes that result, and effects for a signature covering the
-# throwing call `f(3)` above must not be inferred `:nothrow`
 @test !Base.infer_effects(AmbigCycle3.f, Tuple{Integer, Vararg{Union{Int,String}}}).nothrow
 let ambig = Ref{Int32}(0)
     Base._methods_by_ftype(Tuple{typeof(AmbigCycle3.f), Integer, Vararg{Union{Int,String}}}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ambig[] == 1
 end
-# `detect_ambiguities` queries each method signature on its own, where the
-# cycle now surfaces via `has_ambig`, so pairwise detection reports the 3-way
-# ambiguity
 @test !isempty(detect_ambiguities(AmbigCycle3))
 
-# same 3-way cycle, but defined in the order that used to trigger the
-# `LATEST_ONLY` slurp early-out in `get_intersect_visitor`: `mU` is inserted
-# before `mStr`, so when `mStr` (a strict subtype of `mU`, which dominates `mT`
-# and is thus `METHOD_SIG_LATEST_ONLY`) is added, the scan used to stop after
-# recording only the `(mStr, mU)` pair and never record that `mT` is
-# morespecific than `mStr`. That omission left `mStr`'s interference set empty,
-# so the cycle was invisible and `f(1)` silently dispatched to `mStr` instead of
-# raising an ambiguity. Insertion order must not change the observed relation.
+# same 3-way cycle, but defined in reverse order
 module AmbigCycle3Reorder
 f(::T, ::Vararg{T}) where {T<:Integer} = 1    # mT
 f(::Integer, ::Vararg{Union{Int,String}}) = 3 # mU  (inserted before mStr; dominates mT)
@@ -638,10 +625,6 @@ let ambig = Ref{Int32}(0)
 end
 @test !isempty(detect_ambiguities(AmbigCycle3Reorder))
 
-# the `METHOD_SIG_NO_LOSERS` dispatch_status bit records that a method is not
-# strictly morespecific than anything it intersects (so removing it from a
-# match list can never free another method from suppression); it is set at
-# insertion and monotone-cleared when a later method is beaten by it
 module NoLosersBit
 f(::Any) = 1
 end
@@ -652,11 +635,13 @@ let NO_LOSERS = Base.ReinferUtils.METHOD_SIG_NO_LOSERS
     @eval NoLosersBit f(::Int) = 2
     @test !iszero(which(NoLosersBit.f, Tuple{Any}).dispatch_status & NO_LOSERS)
     @test iszero(which(NoLosersBit.f, Tuple{Int}).dispatch_status & NO_LOSERS)
-    # every member of a specificity cycle beats another member, so none may
-    # carry the bit (otherwise the check_dominance_transfer fast path would
-    # mask the cycle); this covers both insertion orders used above
+    # every member of a specificity cycle beats another member (which loses to it)
     for mod in (AmbigCycle3, AmbigCycle3Reorder), m in methods(mod.f)
         @test iszero(m.dispatch_status & NO_LOSERS)
+    end
+    # every member of a ambiguity still sets the bit
+    for m in methods(amb_2)
+        @test !iszero(m.dispatch_status & NO_LOSERS)
     end
     # a type-equal replacement records a recency-tiebreak win over the method
     # it replaces, so it must not inherit the predecessor's bit

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -1045,11 +1045,11 @@ let verify_call = Base.Compiler.ReinferUtils.verify_call,
     # the fallback would also revalidate this edge (the pruned match set is
     # unchanged), so additionally pin that the fast-path predicate itself
     # accepts, and that it rejects when the owner does not fully cover the query
-    let newcomer_prunes_silently = Base.Compiler.ReinferUtils.newcomer_prunes_silently,
+    let newmethod_removed_silently = Base.Compiler.ReinferUtils.newmethod_removed_silently,
         ti = typeintersect(sig, mB.sig)
-        @test newcomer_prunes_silently(mA, mB, ti, sig, expecteds, 1, 2, Base.get_world_counter())
+        @test newmethod_removed_silently(mA, mB, ti, sig, expecteds, 1, 2, Base.get_world_counter())
         let sig2 = Tuple{typeof(q), Type{T}} where T, ti2 = typeintersect(sig2, mB.sig)
-            @test !newcomer_prunes_silently(mA, mB, ti2, sig2, Core.svec(mS, mA, mB), 1, 3, Base.get_world_counter())
+            @test !newmethod_removed_silently(mA, mB, ti2, sig2, Core.svec(mS, mA, mB), 1, 3, Base.get_world_counter())
         end
     end
 end

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -694,15 +694,48 @@ s(x::LikeMissing, y::LikeInt...) = 4                              # genuinely co
 s(x::Union{LikeSigned,LikeStr}, y::LikeStr...) = 5               # more specific than method 3
 s(x::LikeSigned, y::LikeStr...) = 6                              # more specific than 5; method 2 is more specific than this
 end
-let ms = collect(methods(AmbigUnionCycle.s)),
-    m1 = only(filter(m -> m.sig == Tuple{typeof(AmbigUnionCycle.s), Union{AmbigUnionCycle.LikeSigned,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeInt}}, ms)),
-    m2 = only(filter(m -> m.sig == Tuple{typeof(AmbigUnionCycle.s), Union{AmbigUnionCycle.LikeInt,AmbigUnionCycle.LikeString,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeSigned}}, ms))
+let m1 = which(AmbigUnionCycle.s, Tuple{Union{AmbigUnionCycle.LikeSigned,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeInt}}),
+    m2 = which(AmbigUnionCycle.s, Tuple{Union{AmbigUnionCycle.LikeInt,AmbigUnionCycle.LikeString,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeSigned}})
     # method 3 "covers" the LikeInt part but is in a specificity cycle (2 ≻ 6 ≻ 5 ≻ 3 ≻ 2)
     @test Base.isambiguous(m1, m2)
 end
 @test_throws MethodError AmbigUnionCycle.s(AmbigUnionCycle.LikeInt()) # genuinely ambiguous
 @test AmbigUnionCycle.s(AmbigUnionCycle.LikeMissing()) == 4
 @test AmbigUnionCycle.s(AmbigUnionCycle.LikeInt(), AmbigUnionCycle.LikeInt()) == 3
+
+# the transitive loser rejection in `isambiguous` is region-blind: a candidate
+# resolver may be rejected because a loser is `morespecific` than it globally,
+# even when the loser's overlap with it inside the intersection is itself
+# resolved by other methods. Here dispatch resolves every point of the
+# intersection of methods 1 and 2 (methods 7 and 8 rescue the only points where
+# the loser chain 2 ≻ 6 ≻ 5 ≻ 3 overlaps method 3). The region-aware
+# union-coverage resolution in `ml_matches` (gf.c) sees that the cycle members
+# are fully covered over this query before they can disqualify method 3, so the
+# pair is correctly reported as resolved.
+module AmbigLoserRegion
+abstract type LikeSigned end
+struct LikeInt <: LikeSigned end
+abstract type LikeString end
+struct LikeStr <: LikeString end
+struct LikeMissing end
+s(x::Union{LikeSigned,LikeMissing}, y::LikeInt...) = 1             # m1
+s(x::Union{LikeInt,LikeString,LikeMissing}, y::LikeSigned...) = 2  # m2
+s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3          # resolves the (LikeInt, LikeInt...) region
+s(x::LikeMissing, y::LikeInt...) = 4                               # resolves the LikeMissing region
+s(x::Union{LikeSigned,LikeStr,LikeMissing}, y::LikeStr...) = 5     # more specific than method 3
+s(x::Union{LikeSigned,LikeMissing}, y::LikeStr...) = 6             # more specific than 5; method 2 is more specific than this
+s(x::LikeInt) = 7                                                  # resolves the arity-1 LikeInt point
+s(x::LikeMissing) = 8                                              # resolves the arity-1 LikeMissing point
+end
+# dispatch is fully resolved over the intersection of methods 1 and 2 ...
+@test AmbigLoserRegion.s(AmbigLoserRegion.LikeInt()) == 7
+@test AmbigLoserRegion.s(AmbigLoserRegion.LikeMissing()) == 8
+@test AmbigLoserRegion.s(AmbigLoserRegion.LikeInt(), AmbigLoserRegion.LikeInt()) == 3
+@test AmbigLoserRegion.s(AmbigLoserRegion.LikeMissing(), AmbigLoserRegion.LikeInt()) == 4
+let m1 = which(AmbigLoserRegion.s, Tuple{Union{AmbigLoserRegion.LikeSigned,AmbigLoserRegion.LikeMissing}, Vararg{AmbigLoserRegion.LikeInt}}),
+    m2 = which(AmbigLoserRegion.s, Tuple{Union{AmbigLoserRegion.LikeInt,AmbigLoserRegion.LikeString,AmbigLoserRegion.LikeMissing}, Vararg{AmbigLoserRegion.LikeSigned}})
+    @test !Base.isambiguous(m1, m2)
+end
 
 # complement of #62262: if the more specific methods only cover *part* of the
 # intersection, the uncovered part is still a genuine ambiguity (so the union
@@ -728,28 +761,34 @@ f(::T, ::Vararg{T}) where {T<:Integer} = 1    # mT
 f(::Integer, ::Vararg{String}) = 2            # mStr
 f(::Integer, ::Vararg{Union{Int,String}}) = 3 # mU
 end
-let tf = typeof(AmbigCycle3.f),
-    ms = collect(methods(AmbigCycle3.f)),
-    bysig = s -> only(filter(m -> m.sig == s, ms)),
-    mT   = bysig(Tuple{tf, T, Vararg{T}} where T<:Integer),
-    mStr = bysig(Tuple{tf, Integer, Vararg{String}}),
-    mU   = bysig(Tuple{tf, Integer, Vararg{Union{Int,String}}})
+let mT   = which(AmbigCycle3.f, Tuple{T, Vararg{T}} where T<:Integer),
+    mStr = which(AmbigCycle3.f, Tuple{Integer, Vararg{String}}),
+    mU   = which(AmbigCycle3.f, Tuple{Integer, Vararg{Union{Int,String}}})
     # specificity cycle mT ≻ mStr ≻ mU ≻ mT: no unique most specific method
     @test Base.morespecific(mT, mStr) && Base.morespecific(mStr, mU) && Base.morespecific(mU, mT)
     @test !(Base.morespecific(mStr, mT) || Base.morespecific(mU, mStr) || Base.morespecific(mT, mU))
-    # `isambiguous` still detects the ambiguity present in the mT/mStr region
+    # every pair is pairwise ordered, but each pair still participates in the
+    # unresolved cycle over their shared region, so all are ambiguous in context
     @test Base.isambiguous(mT, mStr)
-    @test !Base.isambiguous(mStr, mU)
-    @test !Base.isambiguous(mU, mT)
+    @test Base.isambiguous(mStr, mU)
+    @test Base.isambiguous(mU, mT)
 end
 @test_throws MethodError AmbigCycle3.f(3) # genuinely ambiguous in dispatch
 let ambig = Ref{Int32}(0)
     Base._methods_by_ftype(Tuple{typeof(AmbigCycle3.f), Int}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ambig[] == 1
 end
-# `detect_ambiguities` queries each method signature on its own, where the cycle
-# does not surface (`has_ambig == 0` for each), so pairwise detection misses the
-# 3-way ambiguity entirely
-@test_broken !isempty(detect_ambiguities(AmbigCycle3))
+# querying a single method signature must also report the cycle (`has_ambig`):
+# inference consumes that result, and effects for a signature covering the
+# throwing call `f(3)` above must not be inferred `:nothrow`
+@test !Base.infer_effects(AmbigCycle3.f, Tuple{Integer, Vararg{Union{Int,String}}}).nothrow
+let ambig = Ref{Int32}(0)
+    Base._methods_by_ftype(Tuple{typeof(AmbigCycle3.f), Integer, Vararg{Union{Int,String}}}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    @test ambig[] == 1
+end
+# `detect_ambiguities` queries each method signature on its own, where the
+# cycle now surfaces via `has_ambig`, so pairwise detection reports the 3-way
+# ambiguity
+@test !isempty(detect_ambiguities(AmbigCycle3))
 
 nothing

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -741,6 +741,87 @@ let m1 = which(AmbigLoserRegion.s, Tuple{Union{AmbigLoserRegion.LikeSigned,Ambig
     @test !Base.isambiguous(m1, m2)
 end
 
+# the order the dominating covers are consulted in must not affect the answer:
+# here the first recorded cover of method 1 (method 2) fails the dominance
+# transfer because the mutual partner (method 3) beats it, but the later cover
+# (method 4) certifies every removal, so the query is resolved and no ambiguity
+# may be reported
+module AmbigCoverRetry
+abstract type LikeSigned end
+struct LikeInt <: LikeSigned end
+abstract type LikeString end
+struct LikeStr <: LikeString end
+struct LikeMissing end
+struct Unrelated end
+s(x::Union{LikeSigned,LikeMissing}, y::LikeInt...) = 1         # m1: mutual with m3
+s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 2      # m2: first cover of m1, loses to m3
+s(x::Union{LikeSigned,LikeStr,LikeMissing}, y::LikeStr...) = 3 # m3: mutual with m1, beats m2
+s(x::LikeInt) = 4                                              # m4: beats m1, m2 and m3, certifying their removal
+s(x::Unrelated) = 5                                            # keeps the query below from being fully covered
+end
+@test AmbigCoverRetry.s(AmbigCoverRetry.LikeInt()) == 4
+@test AmbigCoverRetry.s(AmbigCoverRetry.Unrelated()) == 5
+@test_throws MethodError AmbigCoverRetry.s(AmbigCoverRetry.LikeMissing()) # m1~m3 is genuinely ambiguous outside the query below
+for include_ambiguous in (false, true)
+    ambig = Ref{Int32}(0)
+    matches = Base._methods_by_ftype(
+        Tuple{typeof(AmbigCoverRetry.s), Union{AmbigCoverRetry.LikeInt, AmbigCoverRetry.Unrelated}},
+        nothing, -1, Base.get_world_counter(), include_ambiguous,
+        Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    @test ambig[] == 0
+    @test length(matches) == 2
+    @test Set(m.method for m in matches) ==
+        Set([which(AmbigCoverRetry.s, Tuple{AmbigCoverRetry.LikeInt}), which(AmbigCoverRetry.s, Tuple{AmbigCoverRetry.Unrelated})])
+end
+
+# a dominance-dropped match must still report the mutual pairs it witnesses even
+# when the partner is the minmax method, which the sort never visits (so
+# `check_fully_ambiguous` never runs for it): here method 2 is mutually
+# ambiguous with method 1 (the minmax) and is dropped because method 3 covers
+# it, but method 1 beats method 3, so removing method 2 leaves nothing blocking
+# method 1 over the contested region -- the unordered-blockers scan in
+# `check_dominance_transfer` is the only witness of this genuine ambiguity
+module AmbigMinmaxPartner
+abstract type LikeSigned end
+struct LikeInt <: LikeSigned end
+abstract type LikeString end
+struct LikeStr <: LikeString end
+struct LikeMissing end
+s(x::LikeInt, y::LikeInt...) = 1                               # m1: minmax
+s(x::Union{LikeInt,LikeMissing,LikeString}, y::LikeStr...) = 2 # m2: partial, mutual with m1
+s(x::Union{LikeInt,LikeStr}, y::LikeInt...) = 3                # m3: m1 ≻ m3 ≻ m2 (non-transitive)
+end
+module AmbigMinmaxPartnerReorder # same set, m3 inserted before m2
+abstract type LikeSigned end
+struct LikeInt <: LikeSigned end
+abstract type LikeString end
+struct LikeStr <: LikeString end
+struct LikeMissing end
+s(x::LikeInt, y::LikeInt...) = 1                               # m1
+s(x::Union{LikeInt,LikeStr}, y::LikeInt...) = 3                # m3
+s(x::Union{LikeInt,LikeMissing,LikeString}, y::LikeStr...) = 2 # m2
+end
+for M in (AmbigMinmaxPartner, AmbigMinmaxPartnerReorder)
+    m1 = which(M.s, Tuple{M.LikeInt, Vararg{M.LikeInt}})
+    m2 = which(M.s, Tuple{Union{M.LikeInt,M.LikeMissing,M.LikeString}, Vararg{M.LikeStr}})
+    m3 = which(M.s, Tuple{Union{M.LikeInt,M.LikeStr}, Vararg{M.LikeInt}})
+    @test Base.morespecific(m1, m3) && Base.morespecific(m3, m2)
+    @test !Base.morespecific(m3, m1) && !Base.morespecific(m2, m3)
+    @test !Base.morespecific(m1, m2) && !Base.morespecific(m2, m1) # unordered
+    @test_throws MethodError M.s(M.LikeInt())
+    @test Base.isambiguous(m1, m2)
+    for include_ambiguous in (false, true)
+        ambig = Ref{Int32}(0)
+        matches = Base._methods_by_ftype(
+            Tuple{typeof(M.s), M.LikeInt, Vararg{M.LikeInt}}, nothing, -1,
+            Base.get_world_counter(), include_ambiguous,
+            Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        @test ambig[] == 1
+        # under include_ambiguous the dropped method 2 is kept to witness the pair
+        @test Set(m.method for m in matches) == (include_ambiguous ? Set([m1, m2]) : Set([m1]))
+    end
+end
+
 # complement of #62262: if the more specific methods only cover part of the
 # intersection, the uncovered part is still a genuine ambiguity (so the union
 # check must not over-resolve)

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -662,7 +662,7 @@ let ambig = Ref{Int32}(0)
     @test ms[4].method === which(ambig10, (Vararg{Number},))
 end
 
-# issue #62262: an ambiguity can be resolved by the *union* of several more
+# issue #62262: an ambiguity can be resolved by the union of several more
 # specific methods, without any single method covering the intersection
 module Ambig62262
 abstract type MyAbstractMat end
@@ -689,17 +689,17 @@ struct LikeStr <: LikeString end
 struct LikeMissing end
 s(x::Union{LikeSigned,LikeMissing}, y::LikeInt...) = 1            # m1
 s(x::Union{LikeInt,LikeString,LikeMissing}, y::LikeSigned...) = 2 # m2
-s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3         # covers the LikeInt part, but loses to method 5 (below)
-s(x::LikeMissing, y::LikeInt...) = 4                              # genuinely covers the LikeMissing part
-s(x::Union{LikeSigned,LikeStr}, y::LikeStr...) = 5               # more specific than method 3
-s(x::LikeSigned, y::LikeStr...) = 6                              # more specific than 5; method 2 is more specific than this
+s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3         # m3 covers the LikeInt part, but loses to method 5 (below)
+s(x::LikeMissing, y::LikeInt...) = 4                              # m4 covers the LikeMissing part
+s(x::Union{LikeSigned,LikeStr}, y::LikeStr...) = 5                # m5 more specific than method 3
+s(x::LikeSigned, y::LikeStr...) = 6                               # m6 more specific than 5; method 2 is more specific than this
 end
 let m1 = which(AmbigUnionCycle.s, Tuple{Union{AmbigUnionCycle.LikeSigned,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeInt}}),
     m2 = which(AmbigUnionCycle.s, Tuple{Union{AmbigUnionCycle.LikeInt,AmbigUnionCycle.LikeString,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeSigned}})
     # method 3 "covers" the LikeInt part but is in a specificity cycle (2 ≻ 6 ≻ 5 ≻ 3 ≻ 2)
     @test Base.isambiguous(m1, m2)
 end
-@test_throws MethodError AmbigUnionCycle.s(AmbigUnionCycle.LikeInt()) # genuinely ambiguous
+@test_throws MethodError AmbigUnionCycle.s(AmbigUnionCycle.LikeInt())
 @test AmbigUnionCycle.s(AmbigUnionCycle.LikeMissing()) == 4
 @test AmbigUnionCycle.s(AmbigUnionCycle.LikeInt(), AmbigUnionCycle.LikeInt()) == 3
 
@@ -709,9 +709,9 @@ end
 # resolved by other methods. Here dispatch resolves every point of the
 # intersection of methods 1 and 2 (methods 7 and 8 rescue the only points where
 # the loser chain 2 ≻ 6 ≻ 5 ≻ 3 overlaps method 3). The region-aware
-# union-coverage resolution in `ml_matches` (gf.c) sees that the cycle members
-# are fully covered over this query before they can disqualify method 3, so the
-# pair is correctly reported as resolved.
+# union-coverage resolution computes that the cycle members are fully covered
+# over this query before they can disqualify method 3, so the pair is correctly
+# reported as resolved.
 module AmbigLoserRegion
 abstract type LikeSigned end
 struct LikeInt <: LikeSigned end
@@ -720,14 +720,14 @@ struct LikeStr <: LikeString end
 struct LikeMissing end
 s(x::Union{LikeSigned,LikeMissing}, y::LikeInt...) = 1             # m1
 s(x::Union{LikeInt,LikeString,LikeMissing}, y::LikeSigned...) = 2  # m2
-s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3          # resolves the (LikeInt, LikeInt...) region
-s(x::LikeMissing, y::LikeInt...) = 4                               # resolves the LikeMissing region
-s(x::Union{LikeSigned,LikeStr,LikeMissing}, y::LikeStr...) = 5     # more specific than method 3
-s(x::Union{LikeSigned,LikeMissing}, y::LikeStr...) = 6             # more specific than 5; method 2 is more specific than this
-s(x::LikeInt) = 7                                                  # resolves the arity-1 LikeInt point
-s(x::LikeMissing) = 8                                              # resolves the arity-1 LikeMissing point
+s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3          # m3 resolves the (LikeInt, LikeInt...) region
+s(x::LikeMissing, y::LikeInt...) = 4                               # m4 resolves the LikeMissing region
+s(x::Union{LikeSigned,LikeStr,LikeMissing}, y::LikeStr...) = 5     # m5 more specific than method 3
+s(x::Union{LikeSigned,LikeMissing}, y::LikeStr...) = 6             # m6 more specific than 5; method 2 is more specific than this
+s(x::LikeInt) = 7                                                  # m7 resolves the arity-1 LikeInt point
+s(x::LikeMissing) = 8                                              # m8 resolves the arity-1 LikeMissing point
 end
-# dispatch is fully resolved over the intersection of methods 1 and 2 ...
+# dispatch is fully resolved over the intersection of methods 1 and 2
 @test AmbigLoserRegion.s(AmbigLoserRegion.LikeInt()) == 7
 @test AmbigLoserRegion.s(AmbigLoserRegion.LikeMissing()) == 8
 @test AmbigLoserRegion.s(AmbigLoserRegion.LikeInt(), AmbigLoserRegion.LikeInt()) == 3
@@ -737,7 +737,7 @@ let m1 = which(AmbigLoserRegion.s, Tuple{Union{AmbigLoserRegion.LikeSigned,Ambig
     @test !Base.isambiguous(m1, m2)
 end
 
-# complement of #62262: if the more specific methods only cover *part* of the
+# complement of #62262: if the more specific methods only cover part of the
 # intersection, the uncovered part is still a genuine ambiguity (so the union
 # check must not over-resolve)
 module Ambig62262Partial
@@ -750,11 +750,11 @@ h(::Union{MatA,MatB}, ::MyAbstractMat) = 2
 h(::MatA, ::SpecialMat) = 3  # covers only the MatA part of the intersection
 end
 @test length(detect_ambiguities(Ambig62262Partial)) == 1
-@test Ambig62262Partial.h(Ambig62262Partial.MatA(), Ambig62262Partial.SpecialMat()) == 3          # covered -> resolved
-@test_throws MethodError Ambig62262Partial.h(Ambig62262Partial.MatB(), Ambig62262Partial.SpecialMat()) # uncovered -> ambiguous
+@test Ambig62262Partial.h(Ambig62262Partial.MatA(), Ambig62262Partial.SpecialMat()) == 3
+@test_throws MethodError Ambig62262Partial.h(Ambig62262Partial.MatB(), Ambig62262Partial.SpecialMat())
 
 # a 3-way (non-transitive) specificity cycle is a real dispatch ambiguity that
-# `_methods_by_ftype` reports via `has_ambig`, even though every *pair* of the
+# `_methods_by_ftype` reports via `has_ambig`, even though every pair of the
 # three methods has a clear winner
 module AmbigCycle3
 f(::T, ::Vararg{T}) where {T<:Integer} = 1    # mT
@@ -764,7 +764,7 @@ end
 let mT   = which(AmbigCycle3.f, Tuple{T, Vararg{T}} where T<:Integer),
     mStr = which(AmbigCycle3.f, Tuple{Integer, Vararg{String}}),
     mU   = which(AmbigCycle3.f, Tuple{Integer, Vararg{Union{Int,String}}})
-    # specificity cycle mT ≻ mStr ≻ mU ≻ mT: no unique most specific method
+    # specificity cycle mT ≻ mStr ≻ mU ≻ mT
     @test Base.morespecific(mT, mStr) && Base.morespecific(mStr, mU) && Base.morespecific(mU, mT)
     @test !(Base.morespecific(mStr, mT) || Base.morespecific(mU, mStr) || Base.morespecific(mT, mU))
     # every pair is pairwise ordered, but each pair still participates in the
@@ -773,32 +773,19 @@ let mT   = which(AmbigCycle3.f, Tuple{T, Vararg{T}} where T<:Integer),
     @test Base.isambiguous(mStr, mU)
     @test Base.isambiguous(mU, mT)
 end
-@test_throws MethodError AmbigCycle3.f(3) # genuinely ambiguous in dispatch
+@test_throws MethodError AmbigCycle3.f(3)
 let ambig = Ref{Int32}(0)
     Base._methods_by_ftype(Tuple{typeof(AmbigCycle3.f), Int}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ambig[] == 1
 end
-# querying a single method signature must also report the cycle (`has_ambig`):
-# inference consumes that result, and effects for a signature covering the
-# throwing call `f(3)` above must not be inferred `:nothrow`
 @test !Base.infer_effects(AmbigCycle3.f, Tuple{Integer, Vararg{Union{Int,String}}}).nothrow
 let ambig = Ref{Int32}(0)
     Base._methods_by_ftype(Tuple{typeof(AmbigCycle3.f), Integer, Vararg{Union{Int,String}}}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ambig[] == 1
 end
-# `detect_ambiguities` queries each method signature on its own, where the
-# cycle now surfaces via `has_ambig`, so pairwise detection reports the 3-way
-# ambiguity
 @test !isempty(detect_ambiguities(AmbigCycle3))
 
-# same 3-way cycle, but defined in the order that used to trigger the
-# `LATEST_ONLY` slurp early-out in `get_intersect_visitor`: `mU` is inserted
-# before `mStr`, so when `mStr` (a strict subtype of `mU`, which dominates `mT`
-# and is thus `METHOD_SIG_LATEST_ONLY`) is added, the scan used to stop after
-# recording only the `(mStr, mU)` pair and never record that `mT` is
-# morespecific than `mStr`. That omission left `mStr`'s interference set empty,
-# so the cycle was invisible and `f(1)` silently dispatched to `mStr` instead of
-# raising an ambiguity. Insertion order must not change the observed relation.
+# same 3-way cycle, but defined in reverse order
 module AmbigCycle3Reorder
 f(::T, ::Vararg{T}) where {T<:Integer} = 1    # mT
 f(::Integer, ::Vararg{Union{Int,String}}) = 3 # mU  (inserted before mStr; dominates mT)
@@ -820,10 +807,6 @@ let ambig = Ref{Int32}(0)
 end
 @test !isempty(detect_ambiguities(AmbigCycle3Reorder))
 
-# the `METHOD_SIG_NO_LOSERS` dispatch_status bit records that a method is not
-# strictly morespecific than anything it intersects (so removing it from a
-# match list can never free another method from suppression); it is set at
-# insertion and monotone-cleared when a later method is beaten by it
 module NoLosersBit
 f(::Any) = 1
 end
@@ -834,11 +817,13 @@ let NO_LOSERS = Base.ReinferUtils.METHOD_SIG_NO_LOSERS
     @eval NoLosersBit f(::Int) = 2
     @test !iszero(which(NoLosersBit.f, Tuple{Any}).dispatch_status & NO_LOSERS)
     @test iszero(which(NoLosersBit.f, Tuple{Int}).dispatch_status & NO_LOSERS)
-    # every member of a specificity cycle beats another member, so none may
-    # carry the bit (otherwise the check_dominance_transfer fast path would
-    # mask the cycle); this covers both insertion orders used above
+    # every member of a specificity cycle beats another member (which loses to it)
     for mod in (AmbigCycle3, AmbigCycle3Reorder), m in methods(mod.f)
         @test iszero(m.dispatch_status & NO_LOSERS)
+    end
+    # every member of a ambiguity still sets the bit
+    for m in methods(amb_2)
+        @test !iszero(m.dispatch_status & NO_LOSERS)
     end
     # a type-equal replacement records a recency-tiebreak win over the method
     # it replaces, so it must not inherit the predecessor's bit

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -1065,6 +1065,42 @@ let ms = sort(collect(methods(AmbigMinmaxSkip.f)), by = m -> m.line),
     @test AmbigMinmaxSkip.f(Q()) == 1
 end
 
+# the same triangle plus a method 4 resolving the contested region: certifying
+# the removal of method 2 needs the union of the minmax method 1 (blocked over
+# `(P,)` where method 3 beats it) and method 4 (which blocks method 3 there), so
+# a dominance transfer consulting only the minmax method would report a spurious
+# ambiguity for a query dispatch fully resolves
+module AmbigMinmaxUnion
+abstract type Top end
+struct P <: Top end
+struct Q <: Top end
+struct R <: Top end
+f(::T, ::Vararg{T}) where {T<:Union{P,Q}} = 1  # minmax over the query below: beats 2, beaten by 3 and 4
+f(::Union{P,Q}, ::Vararg{R}) = 2               # fully covers, beats nothing, unordered with 3
+f(::P, ::Vararg{P}) = 3                        # partial, beats 1, unordered with 2, beaten by 4
+f(::P) = 4                                     # beats 1, 2 and 3; covers the contested region `(P,)`
+end
+let ms = sort(collect(methods(AmbigMinmaxUnion.f)), by = m -> m.line),
+    (m1, m2, m3, m4) = ms,
+    P = AmbigMinmaxUnion.P,
+    Q = AmbigMinmaxUnion.Q
+    @test Base.morespecific(m3, m1) && Base.morespecific(m1, m2)
+    @test !Base.morespecific(m2, m3) && !Base.morespecific(m3, m2)
+    @test Base.morespecific(m4, m1) && Base.morespecific(m4, m2) && Base.morespecific(m4, m3)
+    # dispatch resolves every point of the query
+    @test AmbigMinmaxUnion.f(P()) == 4
+    @test AmbigMinmaxUnion.f(Q()) == 1
+    for include_ambiguous in (false, true)
+        ambig = Ref{Int32}(0)
+        matches = Base._methods_by_ftype(
+            Tuple{typeof(AmbigMinmaxUnion.f), T} where T<:Union{P,Q},
+            nothing, -1, Base.get_world_counter(), include_ambiguous,
+            Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        @test ambig[] == 0
+        @test Set(m.method for m in matches) == Set([m1, m4])
+    end
+end
+
 module NoLosersBit
 f(::Any) = 1
 end

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -662,4 +662,94 @@ let ambig = Ref{Int32}(0)
     @test ms[4].method === which(ambig10, (Vararg{Number},))
 end
 
+# issue #62262: an ambiguity can be resolved by the *union* of several more
+# specific methods, without any single method covering the intersection
+module Ambig62262
+abstract type MyAbstractMat end
+struct MatA <: MyAbstractMat end
+struct MatB <: MyAbstractMat end
+struct SpecialMat <: MyAbstractMat end
+h(::MyAbstractMat, ::SpecialMat) = 1
+h(::Union{MatA,MatB}, ::MyAbstractMat) = 2
+h(::MatA, ::SpecialMat) = 3
+h(::MatB, ::SpecialMat) = 4
+end
+@test Ambig62262.h(Ambig62262.MatA(), Ambig62262.SpecialMat()) == 3
+@test Ambig62262.h(Ambig62262.MatB(), Ambig62262.SpecialMat()) == 4
+@test isempty(detect_ambiguities(Ambig62262))
+
+# ... but since `morespecific` is not transitive, a method that is more specific
+# than both ambiguous methods does not resolve them if it loses back to one of
+# them through a specificity cycle (here two steps long)
+module AmbigUnionCycle
+abstract type LikeSigned end
+struct LikeInt <: LikeSigned end
+abstract type LikeString end
+struct LikeStr <: LikeString end
+struct LikeMissing end
+s(x::Union{LikeSigned,LikeMissing}, y::LikeInt...) = 1            # m1
+s(x::Union{LikeInt,LikeString,LikeMissing}, y::LikeSigned...) = 2 # m2
+s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3         # covers the LikeInt part, but loses to method 5 (below)
+s(x::LikeMissing, y::LikeInt...) = 4                              # genuinely covers the LikeMissing part
+s(x::Union{LikeSigned,LikeStr}, y::LikeStr...) = 5               # more specific than method 3
+s(x::LikeSigned, y::LikeStr...) = 6                              # more specific than 5; method 2 is more specific than this
+end
+let ms = collect(methods(AmbigUnionCycle.s)),
+    m1 = only(filter(m -> m.sig == Tuple{typeof(AmbigUnionCycle.s), Union{AmbigUnionCycle.LikeSigned,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeInt}}, ms)),
+    m2 = only(filter(m -> m.sig == Tuple{typeof(AmbigUnionCycle.s), Union{AmbigUnionCycle.LikeInt,AmbigUnionCycle.LikeString,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeSigned}}, ms))
+    # method 3 "covers" the LikeInt part but is in a specificity cycle (2 ≻ 6 ≻ 5 ≻ 3 ≻ 2)
+    @test Base.isambiguous(m1, m2)
+end
+@test_throws MethodError AmbigUnionCycle.s(AmbigUnionCycle.LikeInt()) # genuinely ambiguous
+@test AmbigUnionCycle.s(AmbigUnionCycle.LikeMissing()) == 4
+@test AmbigUnionCycle.s(AmbigUnionCycle.LikeInt(), AmbigUnionCycle.LikeInt()) == 3
+
+# complement of #62262: if the more specific methods only cover *part* of the
+# intersection, the uncovered part is still a genuine ambiguity (so the union
+# check must not over-resolve)
+module Ambig62262Partial
+abstract type MyAbstractMat end
+struct MatA <: MyAbstractMat end
+struct MatB <: MyAbstractMat end
+struct SpecialMat <: MyAbstractMat end
+h(::MyAbstractMat, ::SpecialMat) = 1
+h(::Union{MatA,MatB}, ::MyAbstractMat) = 2
+h(::MatA, ::SpecialMat) = 3  # covers only the MatA part of the intersection
+end
+@test length(detect_ambiguities(Ambig62262Partial)) == 1
+@test Ambig62262Partial.h(Ambig62262Partial.MatA(), Ambig62262Partial.SpecialMat()) == 3          # covered -> resolved
+@test_throws MethodError Ambig62262Partial.h(Ambig62262Partial.MatB(), Ambig62262Partial.SpecialMat()) # uncovered -> ambiguous
+
+# a 3-way (non-transitive) specificity cycle is a real dispatch ambiguity that
+# `_methods_by_ftype` reports via `has_ambig`, even though every *pair* of the
+# three methods has a clear winner
+module AmbigCycle3
+f(::T, ::Vararg{T}) where {T<:Integer} = 1    # mT
+f(::Integer, ::Vararg{String}) = 2            # mStr
+f(::Integer, ::Vararg{Union{Int,String}}) = 3 # mU
+end
+let tf = typeof(AmbigCycle3.f),
+    ms = collect(methods(AmbigCycle3.f)),
+    bysig = s -> only(filter(m -> m.sig == s, ms)),
+    mT   = bysig(Tuple{tf, T, Vararg{T}} where T<:Integer),
+    mStr = bysig(Tuple{tf, Integer, Vararg{String}}),
+    mU   = bysig(Tuple{tf, Integer, Vararg{Union{Int,String}}})
+    # specificity cycle mT ≻ mStr ≻ mU ≻ mT: no unique most specific method
+    @test Base.morespecific(mT, mStr) && Base.morespecific(mStr, mU) && Base.morespecific(mU, mT)
+    @test !(Base.morespecific(mStr, mT) || Base.morespecific(mU, mStr) || Base.morespecific(mT, mU))
+    # `isambiguous` still detects the ambiguity present in the mT/mStr region
+    @test Base.isambiguous(mT, mStr)
+    @test !Base.isambiguous(mStr, mU)
+    @test !Base.isambiguous(mU, mT)
+end
+@test_throws MethodError AmbigCycle3.f(3) # genuinely ambiguous in dispatch
+let ambig = Ref{Int32}(0)
+    Base._methods_by_ftype(Tuple{typeof(AmbigCycle3.f), Int}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    @test ambig[] == 1
+end
+# `detect_ambiguities` queries each method signature on its own, where the cycle
+# does not surface (`has_ambig == 0` for each), so pairwise detection misses the
+# 3-way ambiguity entirely
+@test_broken !isempty(detect_ambiguities(AmbigCycle3))
+
 nothing

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -658,6 +658,10 @@ let NO_LOSERS = Base.ReinferUtils.METHOD_SIG_NO_LOSERS
     for mod in (AmbigCycle3, AmbigCycle3Reorder), m in methods(mod.f)
         @test iszero(m.dispatch_status & NO_LOSERS)
     end
+    # a type-equal replacement records a recency-tiebreak win over the method
+    # it replaces, so it must not inherit the predecessor's bit
+    @eval NoLosersBit f(::Any) = 3
+    @test iszero(which(NoLosersBit.f, Tuple{Any}).dispatch_status & NO_LOSERS)
 end
 
 nothing

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -609,4 +609,33 @@ end
 # ambiguity
 @test !isempty(detect_ambiguities(AmbigCycle3))
 
+# same 3-way cycle, but defined in the order that used to trigger the
+# `LATEST_ONLY` slurp early-out in `get_intersect_visitor`: `mU` is inserted
+# before `mStr`, so when `mStr` (a strict subtype of `mU`, which dominates `mT`
+# and is thus `METHOD_SIG_LATEST_ONLY`) is added, the scan used to stop after
+# recording only the `(mStr, mU)` pair and never record that `mT` is
+# morespecific than `mStr`. That omission left `mStr`'s interference set empty,
+# so the cycle was invisible and `f(1)` silently dispatched to `mStr` instead of
+# raising an ambiguity. Insertion order must not change the observed relation.
+module AmbigCycle3Reorder
+f(::T, ::Vararg{T}) where {T<:Integer} = 1    # mT
+f(::Integer, ::Vararg{Union{Int,String}}) = 3 # mU  (inserted before mStr; dominates mT)
+f(::Integer, ::Vararg{String}) = 2            # mStr (⊊ mU)
+end
+let mT   = which(AmbigCycle3Reorder.f, Tuple{T, Vararg{T}} where T<:Integer),
+    mStr = which(AmbigCycle3Reorder.f, Tuple{Integer, Vararg{String}}),
+    mU   = which(AmbigCycle3Reorder.f, Tuple{Integer, Vararg{Union{Int,String}}})
+    @test Base.morespecific(mT, mStr) && Base.morespecific(mStr, mU) && Base.morespecific(mU, mT)
+    @test !(Base.morespecific(mStr, mT) || Base.morespecific(mU, mStr) || Base.morespecific(mT, mU))
+    @test Base.isambiguous(mT, mStr)
+    @test Base.isambiguous(mStr, mU)
+    @test Base.isambiguous(mU, mT)
+end
+@test_throws MethodError AmbigCycle3Reorder.f(1) # genuinely ambiguous in dispatch
+let ambig = Ref{Int32}(0)
+    Base._methods_by_ftype(Tuple{typeof(AmbigCycle3Reorder.f), Int}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    @test ambig[] == 1
+end
+@test !isempty(detect_ambiguities(AmbigCycle3Reorder))
+
 nothing

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -512,15 +512,48 @@ s(x::LikeMissing, y::LikeInt...) = 4                              # genuinely co
 s(x::Union{LikeSigned,LikeStr}, y::LikeStr...) = 5               # more specific than method 3
 s(x::LikeSigned, y::LikeStr...) = 6                              # more specific than 5; method 2 is more specific than this
 end
-let ms = collect(methods(AmbigUnionCycle.s)),
-    m1 = only(filter(m -> m.sig == Tuple{typeof(AmbigUnionCycle.s), Union{AmbigUnionCycle.LikeSigned,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeInt}}, ms)),
-    m2 = only(filter(m -> m.sig == Tuple{typeof(AmbigUnionCycle.s), Union{AmbigUnionCycle.LikeInt,AmbigUnionCycle.LikeString,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeSigned}}, ms))
+let m1 = which(AmbigUnionCycle.s, Tuple{Union{AmbigUnionCycle.LikeSigned,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeInt}}),
+    m2 = which(AmbigUnionCycle.s, Tuple{Union{AmbigUnionCycle.LikeInt,AmbigUnionCycle.LikeString,AmbigUnionCycle.LikeMissing}, Vararg{AmbigUnionCycle.LikeSigned}})
     # method 3 "covers" the LikeInt part but is in a specificity cycle (2 ≻ 6 ≻ 5 ≻ 3 ≻ 2)
     @test Base.isambiguous(m1, m2)
 end
 @test_throws MethodError AmbigUnionCycle.s(AmbigUnionCycle.LikeInt()) # genuinely ambiguous
 @test AmbigUnionCycle.s(AmbigUnionCycle.LikeMissing()) == 4
 @test AmbigUnionCycle.s(AmbigUnionCycle.LikeInt(), AmbigUnionCycle.LikeInt()) == 3
+
+# the transitive loser rejection in `isambiguous` is region-blind: a candidate
+# resolver may be rejected because a loser is `morespecific` than it globally,
+# even when the loser's overlap with it inside the intersection is itself
+# resolved by other methods. Here dispatch resolves every point of the
+# intersection of methods 1 and 2 (methods 7 and 8 rescue the only points where
+# the loser chain 2 ≻ 6 ≻ 5 ≻ 3 overlaps method 3). The region-aware
+# union-coverage resolution in `ml_matches` (gf.c) sees that the cycle members
+# are fully covered over this query before they can disqualify method 3, so the
+# pair is correctly reported as resolved.
+module AmbigLoserRegion
+abstract type LikeSigned end
+struct LikeInt <: LikeSigned end
+abstract type LikeString end
+struct LikeStr <: LikeString end
+struct LikeMissing end
+s(x::Union{LikeSigned,LikeMissing}, y::LikeInt...) = 1             # m1
+s(x::Union{LikeInt,LikeString,LikeMissing}, y::LikeSigned...) = 2  # m2
+s(x::T, y::T...) where {T<:Union{LikeInt,LikeString}} = 3          # resolves the (LikeInt, LikeInt...) region
+s(x::LikeMissing, y::LikeInt...) = 4                               # resolves the LikeMissing region
+s(x::Union{LikeSigned,LikeStr,LikeMissing}, y::LikeStr...) = 5     # more specific than method 3
+s(x::Union{LikeSigned,LikeMissing}, y::LikeStr...) = 6             # more specific than 5; method 2 is more specific than this
+s(x::LikeInt) = 7                                                  # resolves the arity-1 LikeInt point
+s(x::LikeMissing) = 8                                              # resolves the arity-1 LikeMissing point
+end
+# dispatch is fully resolved over the intersection of methods 1 and 2 ...
+@test AmbigLoserRegion.s(AmbigLoserRegion.LikeInt()) == 7
+@test AmbigLoserRegion.s(AmbigLoserRegion.LikeMissing()) == 8
+@test AmbigLoserRegion.s(AmbigLoserRegion.LikeInt(), AmbigLoserRegion.LikeInt()) == 3
+@test AmbigLoserRegion.s(AmbigLoserRegion.LikeMissing(), AmbigLoserRegion.LikeInt()) == 4
+let m1 = which(AmbigLoserRegion.s, Tuple{Union{AmbigLoserRegion.LikeSigned,AmbigLoserRegion.LikeMissing}, Vararg{AmbigLoserRegion.LikeInt}}),
+    m2 = which(AmbigLoserRegion.s, Tuple{Union{AmbigLoserRegion.LikeInt,AmbigLoserRegion.LikeString,AmbigLoserRegion.LikeMissing}, Vararg{AmbigLoserRegion.LikeSigned}})
+    @test !Base.isambiguous(m1, m2)
+end
 
 # complement of #62262: if the more specific methods only cover *part* of the
 # intersection, the uncovered part is still a genuine ambiguity (so the union
@@ -546,28 +579,34 @@ f(::T, ::Vararg{T}) where {T<:Integer} = 1    # mT
 f(::Integer, ::Vararg{String}) = 2            # mStr
 f(::Integer, ::Vararg{Union{Int,String}}) = 3 # mU
 end
-let tf = typeof(AmbigCycle3.f),
-    ms = collect(methods(AmbigCycle3.f)),
-    bysig = s -> only(filter(m -> m.sig == s, ms)),
-    mT   = bysig(Tuple{tf, T, Vararg{T}} where T<:Integer),
-    mStr = bysig(Tuple{tf, Integer, Vararg{String}}),
-    mU   = bysig(Tuple{tf, Integer, Vararg{Union{Int,String}}})
+let mT   = which(AmbigCycle3.f, Tuple{T, Vararg{T}} where T<:Integer),
+    mStr = which(AmbigCycle3.f, Tuple{Integer, Vararg{String}}),
+    mU   = which(AmbigCycle3.f, Tuple{Integer, Vararg{Union{Int,String}}})
     # specificity cycle mT ≻ mStr ≻ mU ≻ mT: no unique most specific method
     @test Base.morespecific(mT, mStr) && Base.morespecific(mStr, mU) && Base.morespecific(mU, mT)
     @test !(Base.morespecific(mStr, mT) || Base.morespecific(mU, mStr) || Base.morespecific(mT, mU))
-    # `isambiguous` still detects the ambiguity present in the mT/mStr region
+    # every pair is pairwise ordered, but each pair still participates in the
+    # unresolved cycle over their shared region, so all are ambiguous in context
     @test Base.isambiguous(mT, mStr)
-    @test !Base.isambiguous(mStr, mU)
-    @test !Base.isambiguous(mU, mT)
+    @test Base.isambiguous(mStr, mU)
+    @test Base.isambiguous(mU, mT)
 end
 @test_throws MethodError AmbigCycle3.f(3) # genuinely ambiguous in dispatch
 let ambig = Ref{Int32}(0)
     Base._methods_by_ftype(Tuple{typeof(AmbigCycle3.f), Int}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ambig[] == 1
 end
-# `detect_ambiguities` queries each method signature on its own, where the cycle
-# does not surface (`has_ambig == 0` for each), so pairwise detection misses the
-# 3-way ambiguity entirely
-@test_broken !isempty(detect_ambiguities(AmbigCycle3))
+# querying a single method signature must also report the cycle (`has_ambig`):
+# inference consumes that result, and effects for a signature covering the
+# throwing call `f(3)` above must not be inferred `:nothrow`
+@test !Base.infer_effects(AmbigCycle3.f, Tuple{Integer, Vararg{Union{Int,String}}}).nothrow
+let ambig = Ref{Int32}(0)
+    Base._methods_by_ftype(Tuple{typeof(AmbigCycle3.f), Integer, Vararg{Union{Int,String}}}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    @test ambig[] == 1
+end
+# `detect_ambiguities` queries each method signature on its own, where the
+# cycle now surfaces via `has_ambig`, so pairwise detection reports the 3-way
+# ambiguity
+@test !isempty(detect_ambiguities(AmbigCycle3))
 
 nothing

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -840,6 +840,10 @@ let NO_LOSERS = Base.ReinferUtils.METHOD_SIG_NO_LOSERS
     for mod in (AmbigCycle3, AmbigCycle3Reorder), m in methods(mod.f)
         @test iszero(m.dispatch_status & NO_LOSERS)
     end
+    # a type-equal replacement records a recency-tiebreak win over the method
+    # it replaces, so it must not inherit the predecessor's bit
+    @eval NoLosersBit f(::Any) = 3
+    @test iszero(which(NoLosersBit.f, Tuple{Any}).dispatch_status & NO_LOSERS)
 end
 
 nothing

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -807,6 +807,129 @@ let ambig = Ref{Int32}(0)
 end
 @test !isempty(detect_ambiguities(AmbigCycle3Reorder))
 
+# A method is selected only when it is more specific than *every* other
+# applicable method, so a match that is itself dominated can still make a call
+# ambiguous by blocking the would-be winner. Here 3 ≻ 2, 2 ≻ 1 and 3 is unordered
+# with 1: nothing beats both others, so the call is ambiguous, and method 1 has to
+# be reported for the error to name the blocking pair (reporting method 3 alone
+# would come out as `no method matching`).
+module AmbigNoBeatAll
+abstract type Top end
+abstract type MidA <: Top end
+abstract type MidB <: Top end
+struct A1 <: MidA end
+struct B1 <: MidB end
+g(::MidA, ::Union{A1,MidB}) = 1
+g(::MidA, ::Vararg{B1}) = 2
+g(::Union{A1,B1}, ::Vararg{Union{B1,MidA}}) = 3
+end
+let A1 = AmbigNoBeatAll.A1, B1 = AmbigNoBeatAll.B1,
+    ms = sort(collect(methods(AmbigNoBeatAll.g)), by = m -> m.line),
+    (m1, m2, m3) = (ms[1], ms[2], ms[3])
+    @test Base.morespecific(m3, m2) && Base.morespecific(m2, m1)
+    @test !Base.morespecific(m3, m1) && !Base.morespecific(m1, m3) # unordered
+    @test_throws MethodError AmbigNoBeatAll.g(A1(), B1())
+    let ambig = Ref{Int32}(0)
+        matches = Base._methods_by_ftype(
+            Tuple{typeof(AmbigNoBeatAll.g), A1, B1}, nothing, -1,
+            Base.get_world_counter(), true,
+            Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        @test ambig[] == 1
+        # method 2 is dominated by 3 and blocks nothing, so it need not be listed
+        @test Set(m.method for m in matches) == Set([m1, m3])
+    end
+    let err = try AmbigNoBeatAll.g(A1(), B1()) catch e; e end
+        errstr = sprint(showerror, err)
+        @test occursin("is ambiguous", errstr)
+        @test occursin("::Union{$A1, $(AmbigNoBeatAll.MidB)}", errstr) # method 1
+    end
+end
+
+# Adding a method that some existing method is more specific than cannot turn an
+# ambiguous call into a resolved one: selection requires beating every applicable
+# method, and the new method is one more thing to beat. That is what lets the
+# method table backedges skip invalidation here, so a caller compiled while the
+# call was ambiguous (and therefore inferred to always throw) stays valid. n.b.
+# the converse direction is not covered: a new method can turn a *resolved* call
+# ambiguous without `is_replacing` noticing, which is a pre-existing hole.
+module AmbigResolveByExclusion
+abstract type Top end
+abstract type MidA <: Top end
+abstract type MidB <: Top end
+struct A1 <: MidA end
+struct B1 <: MidB end
+g(::MidA, ::Union{A1,MidB}) = 1                  # unordered with method 2 below
+g(::Union{A1,B1}, ::Vararg{Union{B1,MidA}}) = 2  # more specific than method 3 below
+end
+ambig_exclusion_caller() = AmbigResolveByExclusion.g(AmbigResolveByExclusion.A1(),
+                                                    AmbigResolveByExclusion.B1())
+@test_throws MethodError ambig_exclusion_caller() # also compiles the caller
+@eval AmbigResolveByExclusion g(::MidA, ::Vararg{B1}) = 3 # loses to 2, beats 1
+@test_throws MethodError ambig_exclusion_caller() # still blocked by method 1
+@test_throws MethodError AmbigResolveByExclusion.g(AmbigResolveByExclusion.A1(),
+                                                  AmbigResolveByExclusion.B1())
+
+# A match that is dominated over its whole region can be dropped from the report,
+# since it can never be selected -- but only as long as the ambiguities it takes
+# part in stay witnessed by the matches that remain. Here method 1 is covered over
+# the query region by the union of methods 5 (the `(A1, A1)` part) and 3 (the
+# `(A1, B1)` part), which each strictly beat it. Method 3 reaches that cover role
+# only by being dropped itself (method 4 covers it) while sitting in a specificity
+# cycle with methods 1 and 2 (1 ≻ 2 ≻ 3 ≻ 1), which is where a region-blind
+# transfer check would lose the cycle.
+module AmbigTransferRegion
+abstract type Top end
+abstract type MidA <: Top end
+abstract type MidB <: Top end
+struct A1 <: MidA end
+struct A2 <: MidA end
+struct B1 <: MidB end
+struct B2 <: MidB end
+f(::MidA, ::Union{A1,MidB}) = 1                  # covered by the union of 5 and 3
+f(::T, ::Vararg{T}) where {T<:MidA} = 2          # beaten by 1, beats 3
+f(::MidA, ::Vararg{B1}) = 3                      # beats 1, beaten by 2 (the cycle)
+f(::Union{A1,B1}, ::Vararg{Union{B1,MidA}}) = 4  # covers 3, unordered with 1 and 5
+f(::MidA, ::A1) = 5                              # beats 1 and 2
+end
+let A1 = AmbigTransferRegion.A1, B1 = AmbigTransferRegion.B1,
+    ms = sort(collect(methods(AmbigTransferRegion.f)), by = m -> m.line),
+    (m1, m2, m3, m4, m5) = (ms[1], ms[2], ms[3], ms[4], ms[5])
+    # the specificity cycle that makes the dominance-transfer check necessary
+    @test Base.morespecific(m1, m2) && Base.morespecific(m2, m3) && Base.morespecific(m3, m1)
+    # method 1 is dominated at every point of its region (by method 5 at
+    # `(A1, A1)`, by method 3 at `(A1, B1)`) yet unordered with method 4, which
+    # neither of those covers beats
+    @test !Base.morespecific(m1, m4) && !Base.morespecific(m4, m1)
+    @test Base.morespecific(m5, m1) && Base.morespecific(m3, m1)
+    @test !Base.morespecific(m5, m4) && !Base.morespecific(m3, m4)
+    let ambig = Ref{Int32}(0)
+        matches = Base._methods_by_ftype(
+            Tuple{typeof(AmbigTransferRegion.f), Union{A1,B1}, Vararg{Union{A1,B1}}},
+            nothing, -1, Base.get_world_counter(), true,
+            Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        @test ambig[] == 1
+        # methods 4 and 5 witness the ambiguity at `(A1, A1)`. Method 1 blocks
+        # method 4 at `(A1, B1)`, but over this whole region it is covered by the
+        # union of 5 and 3, so it is dropped: the region-wide report guarantees a
+        # witness pair for the query, not one for every point in it. The `1`/`4`
+        # pair is still reported over its own intersection (below).
+        @test Set(m.method for m in matches) == Set([m4, m5])
+    end
+    @test Base.isambiguous(m1, m4) # visible over the pair's own intersection
+    # `(A1, B1)` applies methods 1, 3 and 4, and nothing beats all of them, so it
+    # is ambiguous and method 1 must be reported as one of the blocking pair
+    @test_throws MethodError AmbigTransferRegion.f(A1(), B1())
+    let ambig = Ref{Int32}(0)
+        matches = Base._methods_by_ftype(
+            Tuple{typeof(AmbigTransferRegion.f), A1, B1}, nothing, -1,
+            Base.get_world_counter(), true,
+            Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        @test ambig[] == 1
+        @test m1 in [m.method for m in matches]
+    end
+    @test_throws MethodError AmbigTransferRegion.f(A1(), A1())
+end
+
 module NoLosersBit
 f(::Any) = 1
 end

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -892,6 +892,115 @@ let ambig = Ref{Int32}(0)
 end
 @test !isempty(detect_ambiguities(AmbigCycle3Reorder))
 
+# Unit tests for the pkgimage edge verifier `Compiler.ReinferUtils.verify_call`,
+# driven directly with `Method` edges: methods defined after the "recorded"
+# expected set play the role of methods loaded between image build and image
+# load, and the verifier must agree with what a fresh `ml_matches` would report.
+module VerifyCallEdge
+# The recorded state: sig below is union-split so that no single method fully
+# covers it (no minmax match shields the sort), jointly covered by fE2 and fD.
+f(::Integer, ::Vararg{Union{Int,String}}) = 1  # fE2: the Integer half
+f(::Int, ::Vararg{String}) = 2                 # fC: concrete cover with an empty interference set
+f(::Char, ::Vararg{Union{Int,String}}) = 3     # fD: the Char half, interferes with nothing
+end
+let verify_call = Base.Compiler.ReinferUtils.verify_call,
+    method_in_interferences = Base.Compiler.ReinferUtils.method_in_interferences,
+    f = VerifyCallEdge.f,
+    mE2 = which(f, Tuple{Integer, Vararg{Union{Int,String}}}),
+    mC = which(f, Tuple{Int, Vararg{String}}),
+    mD = which(f, Tuple{Char, Vararg{Union{Int,String}}}),
+    sig = Tuple{typeof(f), Union{Int,Char}, Vararg{Union{Int,String}}},
+    expecteds = Core.svec(mE2, mC, mD)
+    # the unchanged recorded state revalidates
+    let (minw, maxw) = verify_call(sig, expecteds, 1, 3, Base.get_world_counter(), true, Any[])
+        @test maxw == typemax(UInt)
+    end
+    # A newcomer that strictly beats an expected method but is resolved by the
+    # empty-interference-set cover mC keeps the edge valid: the fresh sort prunes
+    # it silently, and the interference fast path may accept it directly (the
+    # `Union{}` bottom-slurp shape).
+    VerifyCallEdge.eval(:(f(::Integer, ::Vararg{String}) = 4)) # N: mC ≻ N ≻ mE2
+    mN = which(f, Tuple{Integer, Vararg{String}})
+    @test Base.morespecific(mC, mN) && Base.morespecific(mN, mE2)
+    @test isempty(mC.interferences) && typeintersect(sig, mN.sig) <: mC.sig
+    let (minw, maxw) = verify_call(sig, expecteds, 1, 3, Base.get_world_counter(), true, Any[])
+        @test maxw == typemax(UInt)
+    end
+end
+
+# Same recorded shape, but the newcomers close a specificity cycle
+# mE2 ≻ X ≻ N ≻ mE2 through X -- invisible to the scanned interference sets,
+# since every expected method it intersects strictly beats it -- which must
+# invalidate: the fresh sort drags mE2 into the SCC (where it stops being an
+# admissible cover for X), reporting an extra match and an ambiguity. The fast
+# path cannot see X itself; it has to notice that N gained a strict beater that
+# could sit on a cycle and leave the decision to the full lookup.
+module VerifyCallCycle
+h(::Integer, ::Vararg{Union{Int,String}}) = 1  # hE2: the Integer half
+h(::Int, ::Vararg{String}) = 2                 # hC: concrete cover with an empty interference set
+h(::Char, ::Vararg{Union{Int,String}}) = 3     # hD: the Char half, interferes with nothing
+end
+let verify_call = Base.Compiler.ReinferUtils.verify_call,
+    method_in_interferences = Base.Compiler.ReinferUtils.method_in_interferences,
+    h = VerifyCallCycle.h,
+    mE2 = which(h, Tuple{Integer, Vararg{Union{Int,String}}}),
+    mC = which(h, Tuple{Int, Vararg{String}}),
+    mD = which(h, Tuple{Char, Vararg{Union{Int,String}}}),
+    sig = Tuple{typeof(h), Union{Int,Char}, Vararg{Union{Int,String}}},
+    expecteds = Core.svec(mE2, mC, mD)
+    VerifyCallCycle.eval(:(h(::T, ::Vararg{T}) where {T<:Integer} = 5)) # X
+    VerifyCallCycle.eval(:(h(::Integer, ::Vararg{String}) = 4))         # N
+    mX = which(h, Tuple{T, Vararg{T}} where T<:Integer)
+    mN = which(h, Tuple{Integer, Vararg{String}})
+    @test Base.morespecific(mC, mN) && Base.morespecific(mN, mE2)
+    @test Base.morespecific(mE2, mX) && Base.morespecific(mX, mN)
+    @test isempty(mC.interferences) && isempty(mD.interferences)
+    @test !method_in_interferences(mX, mE2) # X is invisible to the scan
+    @test typeintersect(sig, mN.sig) <: mC.sig
+    # The ground truth the verifier must agree with. Note the fresh sort's
+    # treatment of the cycle is sensitive to the match-list order, hence to the
+    # definition order of the newcomers: defined the other way around, it
+    # happens to prune the cycle cleanly. If a sort change makes this assertion
+    # fail, the construction needs re-arming, not the verifier weakening.
+    let ambig = Ref{Int32}(0)
+        ms = Base._methods_by_ftype(sig, nothing, -1, Base.get_world_counter(), false,
+                                    Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        @test length(ms) == 4 && ambig[] == 1
+    end
+    let (minw, maxw) = verify_call(sig, expecteds, 1, 3, Base.get_world_counter(), true, Any[])
+        @test maxw == 0
+    end
+end
+
+# A new method that is ambiguous with the expected one must invalidate even when
+# the include_ambiguous=false match set is unchanged (the newcomer is pruned
+# because the expected method covers their overlap, yet dispatch in the contested
+# region now throws a MethodError the compiled code never accounted for): the
+# fast path bails on the mutual pair and the fallback rejects on has_ambig.
+module VerifyCallAmbig
+g(x::Integer, y) = 1
+end
+let verify_call = Base.Compiler.ReinferUtils.verify_call,
+    g = VerifyCallAmbig.g,
+    mS = which(g, Tuple{Integer, Any}),
+    sig = Tuple{typeof(g), Int, Any},
+    expecteds = Core.svec(mS)
+    let (minw, maxw) = verify_call(sig, expecteds, 1, 1, Base.get_world_counter(), true, Any[])
+        @test maxw == typemax(UInt)
+    end
+    VerifyCallAmbig.eval(:(g(x, y::String) = 2))
+    mN = which(g, Tuple{Any, String})
+    @test Base.isambiguous(mS, mN)
+    let ambig = Ref{Int32}(0) # match set unchanged, only the flag reports the change
+        ms = Base._methods_by_ftype(sig, nothing, -1, Base.get_world_counter(), false,
+                                    Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        @test length(ms) == 1 && (ms[1]::Core.MethodMatch).method === mS && ambig[] == 1
+    end
+    let (minw, maxw) = verify_call(sig, expecteds, 1, 1, Base.get_world_counter(), true, Any[])
+        @test maxw == 0
+    end
+end
+
 # A method is selected only when it is more specific than every other
 # applicable method, so a match that is itself dominated can still make a call
 # ambiguous by blocking the would-be winner. Here 3 ≻ 2, 2 ≻ 1 and 3 is unordered

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -870,13 +870,18 @@ ambig_exclusion_caller() = AmbigResolveByExclusion.g(AmbigResolveByExclusion.A1(
                                                   AmbigResolveByExclusion.B1())
 
 # A match that is dominated over its whole region can be dropped from the report,
-# since it can never be selected -- but only as long as the ambiguities it takes
-# part in stay witnessed by the matches that remain. Here method 1 is covered over
-# the query region by the union of methods 5 (the `(A1, A1)` part) and 3 (the
-# `(A1, B1)` part), which each strictly beat it. Method 3 reaches that cover role
-# only by being dropped itself (method 4 covers it) while sitting in a specificity
-# cycle with methods 1 and 2 (1 ≻ 2 ≻ 3 ≻ 1), which is where a region-blind
-# transfer check would lose the cycle.
+# since it can never be selected -- but only as long as, at every point of the
+# region, the ambiguities it takes part in stay witnessed by the matches that
+# remain applicable there. Here method 1 is covered over the query region by the
+# union of methods 5 (the `(A1, A1)` part) and 3 (the `(A1, B1)` part), which
+# each strictly beat it. But method 1 is the only match blocking method 4 at
+# `(A1, B1)`: method 3, the cover applying there, is itself beaten by method 4,
+# so it blocks nothing. A region-blind transfer check accepts method 5 (which
+# blocks method 4, but only where it applies) and drops method 1, leaving the
+# reported subset at `(A1, B1)` reading as resolved to method 4. Method 3 also
+# sits in a specificity cycle with methods 1 and 2 (1 ≻ 2 ≻ 3 ≻ 1), which is
+# where a transfer check that ignores cycles would additionally lose the
+# ambiguity flag.
 module AmbigTransferRegion
 abstract type Top end
 abstract type MidA <: Top end
@@ -908,12 +913,17 @@ let A1 = AmbigTransferRegion.A1, B1 = AmbigTransferRegion.B1,
             nothing, -1, Base.get_world_counter(), true,
             Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
         @test ambig[] == 1
-        # methods 4 and 5 witness the ambiguity at `(A1, A1)`. Method 1 blocks
-        # method 4 at `(A1, B1)`, but over this whole region it is covered by the
-        # union of 5 and 3, so it is dropped: the region-wide report guarantees a
-        # witness pair for the query, not one for every point in it. The `1`/`4`
-        # pair is still reported over its own intersection (below).
-        @test Set(m.method for m in matches) == Set([m4, m5])
+        # methods 4 and 5 witness the ambiguity at `(A1, A1)`. Method 1 is
+        # covered over this whole region by the union of 5 and 3, so it can
+        # never be selected -- but it must stay reported anyway, because it is
+        # the only match blocking method 4 at `(A1, B1)`: dropping it would make
+        # the reported subset applicable at that point read as resolved to
+        # method 4, while the call is really ambiguous (below).
+        @test Set(m.method for m in matches) == Set([m1, m4, m5])
+        # every point of the region keeps its ambiguity witnessed by the
+        # reported matches applicable there
+        applicable_at = [m.method for m in matches if Tuple{typeof(AmbigTransferRegion.f), A1, B1} <: m.method.sig]
+        @test m1 in applicable_at && m4 in applicable_at
     end
     @test Base.isambiguous(m1, m4) # visible over the pair's own intersection
     # `(A1, B1)` applies methods 1, 3 and 4, and nothing beats all of them, so it

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2112,7 +2112,7 @@ precompile_test_harness("custom MethodTable dispatch status") do load_path
         method = only(ms).method
         @test method.module === M
         @test !iszero(method.dispatch_status & Base.ReinferUtils.METHOD_SIG_LATEST_WHICH)
-        @test !iszero(method.dispatch_status & Base.ReinferUtils.METHOD_SIG_LATEST_ONLY)
+        @test isempty(method.interferences)
     end
     Base.compilecache(Base.PkgId("OverlayDispatchStatusUser"))
     @eval using OverlayDispatchStatusUser

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2048,7 +2048,7 @@ precompile_test_harness("custom MethodTable dispatch status") do load_path
         method = only(ms).method
         @test method.module === M
         @test !iszero(method.dispatch_status & Base.ReinferUtils.METHOD_SIG_LATEST_WHICH)
-        @test !iszero(method.dispatch_status & Base.ReinferUtils.METHOD_SIG_LATEST_ONLY)
+        @test isempty(method.interferences)
     end
     Base.compilecache(Base.PkgId("OverlayDispatchStatusUser"))
     @eval using OverlayDispatchStatusUser

--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -208,6 +208,21 @@ let A = Tuple{Vector, AbstractVector},
     @test args_morespecific(A, C)
 end
 
+# `morespecific` is a partial order but is deliberately NOT transitive: genuine
+# specificity cycles exist. This is a rock-paper-scissors cycle A ≻ B ≻ C ≻ A
+# (which is what allows a 3-way method ambiguity even when every pair of the
+# three methods has a clear winner).
+let A = Tuple{T, Vararg{T}} where T<:Integer,
+    B = Tuple{Integer, Vararg{String}},
+    C = Tuple{Integer, Vararg{Union{Int,String}}}
+    @test args_morespecific(A, B)
+    @test args_morespecific(B, C)
+    @test args_morespecific(C, A)  # not transitive: A ≻ B and B ≻ C, yet C ≻ A
+    @test !args_morespecific(B, A)
+    @test !args_morespecific(C, B)
+    @test !args_morespecific(A, C)
+end
+
 # issue #27361
 f27361(::M) where M <: Tuple{2} = nothing
 f27361(::M) where M <: Tuple{3} = nothing

--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -208,10 +208,7 @@ let A = Tuple{Vector, AbstractVector},
     @test args_morespecific(A, C)
 end
 
-# `morespecific` is a partial order but is deliberately NOT transitive: genuine
-# specificity cycles exist. This is a rock-paper-scissors cycle A ≻ B ≻ C ≻ A
-# (which is what allows a 3-way method ambiguity even when every pair of the
-# three methods has a clear winner).
+# exemplify that `morespecific` is a non-transitive relation
 let A = Tuple{T, Vararg{T}} where T<:Integer,
     B = Tuple{Integer, Vararg{String}},
     C = Tuple{Integer, Vararg{Union{Int,String}}}


### PR DESCRIPTION
:robot: summary of our long conversation below

`Method.interferences` was an incomplete record of the pairwise
intersecting-but-not-morespecific relation: `get_intersect_visitor` stopped the
insertion scan early once the new method was a strict subtype of an existing
method that dominates its dispatch. The implicit justification was monotonicity
of `morespecific` under subtyping, which is false -- `morespecific`
short-circuits on subtyping, but a supertype's structural specificity relations
do not transfer to a subtype and can even reverse. A dominated-looking supertype
could therefore hide intersections that were never recorded, making dispatch
order-dependent and silently wrong:

    f(::T, ::Vararg{T}) where T<:Integer = "A"
    f(::Integer, ::Vararg{Union{Int,String}}) = "C"
    f(::Integer, ::Vararg{String}) = "B"
    f(1)   # silently returned "B"; these three form a specificity cycle
           # and the call is ambiguous, as it is in the A,B,C order

Record every intersecting method instead. With the relation complete,
`morespecific(target, start)` is exactly `target in interferences(start) &&
start not in interferences(target)`, so the transitive interference-graph walk
is replaced by that two-membership test in both the runtime and the Compiler --
the walk was itself a liability, returning false positives on disjoint pairs and
inverted answers on the omitted ones, including on the `verify_call`
invalidation fast path.

On that foundation, make the match sort's ambiguity reporting exact. A match may
be dropped from the sort only when strictly-morespecific covers take over both
of its roles: what it was beating, and what it was *blocking* -- selection
requires beating every applicable match, so a match that can never win can still
be the only reason another does not. Both obligations become one pointwise rule:
a cover only blocks where it is applicable, so when the blocked match beats some
cover, the union of the covers it does not beat must contain the region where
the dropped match was blocking it. Ambiguity certification is likewise no longer
single-cover: an apparent ambiguity is resolved when the intersection is a
subtype of the union of the more-specific methods' signatures, with methods
excluded whose specificity cycles back through the pair, which also fixes the
spurious `Test.detect_ambiguities` reports on `Union`-typed arguments. The
minmax match now flows through that same cover protocol rather than three
drifted hand-rolled kernels, fully-covering matches the sort never visits get
the same transfer check before being skipped, and an ambiguous call with no
beat-everything winner is no longer reported as having no applicable method.

The Method-level `METHOD_SIG_LATEST_ONLY` bit is exactly the fact that the
interference set is empty, so it is read from the set directly and
`METHOD_SIG_PRECOMPILE_MANY`, which existed only to suppress it at load, is
removed. The opposite pole -- a method strictly morespecific than nothing it
intersects -- cannot be read from the method's own set and gets a new
`METHOD_SIG_NO_LOSERS` bit, maintained for free by the activation scan and
carried through incremental images rather than re-derived, since that scan
cannot see same-image methods. Both facts gate fast paths: an empty set marks
the unique dispatch winner, and `NO_LOSERS` skips the dominance-transfer scan.

`Core.MethodMatch.fully_covers` is a plain `Bool` again (the out-of-range
`SENTINEL` marker is gone, and with it the tri-valued enum), the match sort is
exposed as `jl_sort_method_matches` so `Base.isambiguous` reuses the runtime
algorithm instead of reimplementing it, and interference-set snapshots held
across safepoints in the sort are rooted or reloaded.

Removing the early-out means insertion records dominated intersectors it used to
skip, so a fully pairwise-intersecting clique of methods under a dominating
umbrella now costs O(n^2) in total (~2.4/4.6/9.5 ms per method at n=500/1000/
2000); tables without such cliques are unaffected, as disjoint entries are still
pruned by the typemap.

Fixes #62262

Assisted-by: Claude Code (Opus 4.8, Opus 5, Fable 5)