### PR TITLE
agents: Move test coordination guidance to skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,12 +53,6 @@ make sure to take them into account.
 - Do not `ccall` runtime C functions directly if there are existing wrappers for the function.
 - Do not explicitly add a module prefix if the code you're adding is in the same module. E.g. do not use `Base.` for code in Base unless required.
 
-## Tests
-
-- Do not coordinate with fixed `sleep`s — loaded CI machines break any fixed
-  delay. Synchronize on observable state (readiness markers, round-trips), or
-  retry.
-
 ## Task-specific skills
 
 Detailed, situational procedures are provided as Agent Skills following the

--- a/doc/src/devdocs/agents/skills/test-changes/SKILL.md
+++ b/doc/src/devdocs/agents/skills/test-changes/SKILL.md
@@ -14,3 +14,6 @@ Use this when you change or add a Julia test.
 - Write one comment at the top of the test to explain what is being tested.
   Otherwise keep comments minimal.
 - Use the environment variable `JULIA_TEST_FAILFAST=1` to make tests fail fast.
+- Do not coordinate with fixed `sleep`s — loaded CI machines break any fixed
+  delay. Synchronize on observable state (readiness markers, round-trips), or
+  retry.


### PR DESCRIPTION
Keep situational test-writing guidance in the dedicated test-changes skill so it is loaded when relevant rather than occupying the global agent context.

Follows up JuliaLang/julia#62386