### PR TITLE
Use malloc to allocate excstack for memory error

### DIFF
--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -592,6 +592,15 @@ void jl_gc_track_malloced_genericmemory(jl_ptls_t ptls, jl_genericmemory_t *m, i
     small_arraylist_push(&ptls->gc_tls_common.heap.mallocarrays, a);
 }
 
+// tracking tasks whose exception stack buffer is malloc'd (see `jl_reserve_excstack`).
+// The entry is tagged with bit 1 to distinguish it from a genericmemory entry.
+void jl_gc_track_malloced_excstack(jl_task_t *ct) JL_NOTSAFEPOINT
+{
+    // This is **NOT** a GC safe point.
+    void *a = (void*)((uintptr_t)ct | 2);
+    small_arraylist_push(&ct->ptls->gc_tls_common.heap.mallocarrays, a);
+}
+
 // =========================================================================== //
 // GC Debug
 // =========================================================================== //

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -595,10 +595,13 @@ JL_DLLEXPORT void jl_gc_scan_julia_exc_obj(void* obj_raw, void* closure, Process
 
     if (ta->excstack) { // inlining label `excstack` from mark_loop
 
-        // the excstack should always be a heap object
-        assert(mmtk_object_is_managed_by_mmtk(ta->excstack));
-
-        process_slot(closure, &ta->excstack);
+        if (!ta->excstack->malloced) {
+            // the excstack is a heap object: trace (and possibly move) the buffer itself.
+            // Malloc'd buffers are not GC objects: they are freed by
+            // the malloced-memory sweep and must not be traced.
+            assert(mmtk_object_is_managed_by_mmtk(ta->excstack));
+            process_slot(closure, &ta->excstack);
+        }
         jl_excstack_t *excstack = ta->excstack;
         size_t itr = ta->excstack->top;
         size_t bt_index = 0;
@@ -661,6 +664,33 @@ JL_DLLEXPORT void jl_gc_mmtk_sweep_malloced_memory(void) JL_NOTSAFEPOINT
         void **lst = ptls2->gc_tls_common.heap.mallocarrays.items;
         // filter without preserving order
         while (n < l) {
+            if ((uintptr_t)lst[n] & 2) {
+                // A task with a malloc'd exception stack buffer
+                // (see `jl_gc_track_malloced_excstack`).
+                jl_task_t *t = (jl_task_t*)((uintptr_t)lst[n] & ~3);
+                if (mmtk_is_live_object(t)) {
+                    t = (jl_task_t*)mmtk_get_possibly_forwarded(t);
+                    // Keep the entry only while the task still owns a malloc'd buffer
+                    // (it may have been replaced by a GC-allocated one).
+                    if (t->excstack && t->excstack->malloced) {
+                        lst[n] = (void*)((uintptr_t)t | 2);
+                        n++;
+                        continue;
+                    }
+                }
+                else {
+                    jl_excstack_t *s = t->excstack;
+                    if (s && s->malloced) {
+                        // NULL the field so that a duplicate entry for this task
+                        // does not free the buffer again.
+                        t->excstack = NULL;
+                        free(s);
+                    }
+                }
+                l--;
+                lst[n] = lst[l];
+                continue;
+            }
             jl_genericmemory_t *m = (jl_genericmemory_t*)((uintptr_t)lst[n] & ~1);
             if (mmtk_is_live_object(m)) {
                 n++;

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -660,6 +660,31 @@ static void sweep_malloced_memory(void) JL_NOTSAFEPOINT
         void **lst = ptls2->gc_tls_common.heap.mallocarrays.items;
         // filter without preserving order
         while (n < l) {
+            if ((uintptr_t)lst[n] & 2) {
+                // A task with a malloc'd exception stack buffer
+                // (see `jl_gc_track_malloced_excstack`).
+                jl_task_t *t = (jl_task_t*)((uintptr_t)lst[n] & ~3);
+                if (gc_marked(jl_astaggedvalue(t)->bits.gc)) {
+                    // Keep the entry only while the task still owns a malloc'd buffer
+                    // (it may have been replaced by a GC-allocated one).
+                    if (t->excstack && t->excstack->malloced) {
+                        n++;
+                        continue;
+                    }
+                }
+                else {
+                    jl_excstack_t *s = t->excstack;
+                    if (s && s->malloced) {
+                        // NULL the field so that a duplicate entry for this task
+                        // does not free the buffer again.
+                        t->excstack = NULL;
+                        free(s);
+                    }
+                }
+                l--;
+                lst[n] = lst[l];
+                continue;
+            }
             jl_genericmemory_t *m = (jl_genericmemory_t*)((uintptr_t)lst[n] & ~1);
             if (gc_marked(jl_astaggedvalue(m)->bits.gc)) {
                 n++;
@@ -2375,9 +2400,12 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     jl_excstack_t *excstack = ta->excstack;
                     gc_heap_snapshot_record_task_to_frame_edge(ta, excstack);
                     size_t itr = ta->excstack->top;
-                    gc_setmark_buf(ptls, excstack, bits,
-                                    sizeof(jl_excstack_t) +
-                                        sizeof(uintptr_t) * excstack->reserved_size);
+                    // Malloc'd buffers are not GC objects: they are freed by
+                    // the malloced-memory sweep and must not be marked.
+                    if (!excstack->malloced)
+                        gc_setmark_buf(ptls, excstack, bits,
+                                        sizeof(jl_excstack_t) +
+                                            sizeof(uintptr_t) * excstack->reserved_size);
                     gc_mark_excstack(ptls, excstack, itr);
                 }
                 const jl_datatype_layout_t *layout = jl_task_type->layout;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -744,6 +744,7 @@ jl_svec_t *jl_perm_symsvec(size_t n, ...);
 #endif
 
 void jl_gc_track_malloced_genericmemory(jl_ptls_t ptls, jl_genericmemory_t *m, int isaligned) JL_NOTSAFEPOINT;
+void jl_gc_track_malloced_excstack(jl_task_t *ct) JL_NOTSAFEPOINT;
 size_t jl_genericmemory_nbytes(jl_genericmemory_t *a) JL_NOTSAFEPOINT;
 size_t memory_block_usable_size(void *mem, int isaligned) JL_NOTSAFEPOINT;
 void jl_gc_count_allocd(size_t sz) JL_NOTSAFEPOINT;
@@ -1636,6 +1637,10 @@ JL_DLLEXPORT size_t jl_capture_interp_frame(jl_bt_element_t *bt_data,
 struct _jl_excstack_t { // typedef in julia.h
     size_t top;
     size_t reserved_size;
+    // 1 if the buffer was allocated with malloc (used when throwing OutOfMemoryError;
+    // freed by the GC's malloced-memory sweep once the owning task dies), 0 if it
+    // was allocated with the GC (reclaimed by tracing).
+    size_t malloced;
     // Pack all stack entries into a growable buffer to amortize allocation
     // across repeated exception handling.
     // Layout: [bt_data1... bt_size1 exc1  bt_data2... bt_size2 exc2  ..]

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -386,25 +386,53 @@ static void jl_copy_excstack(jl_excstack_t *dest, jl_excstack_t *src) JL_NOTSAFE
 }
 
 static void jl_reserve_excstack(jl_task_t *ct, jl_excstack_t **stack JL_REQUIRE_ROOTED_SLOT,
-                                size_t reserved_size) JL_CANSAFEPOINT
+                                size_t reserved_size, int use_malloc) JL_CANSAFEPOINT
 {
     jl_excstack_t *s = *stack;
     if (s && s->reserved_size >= reserved_size)
         return;
     size_t bufsz = sizeof(jl_excstack_t) + sizeof(uintptr_t)*reserved_size;
-    jl_excstack_t *new_s = (jl_excstack_t*)jl_gc_alloc_buf(ct->ptls, bufsz);
+    jl_excstack_t *new_s;
+    if (use_malloc)
+        // We are throwing an OutOfMemoryError: a GC allocation here could fail
+        // and recursively throw, so allocate the buffer with malloc. The owning
+        // task is tracked in `mallocarrays` (see `jl_gc_track_malloced_excstack`)
+        // and the buffer is freed when the GC sweeps the dead task.
+        new_s = (jl_excstack_t*)malloc_s(bufsz);
+    else
+        new_s = (jl_excstack_t*)jl_gc_alloc_buf(ct->ptls, bufsz);
     new_s->top = 0;
     new_s->reserved_size = reserved_size;
+    new_s->malloced = use_malloc;
     if (s)
         jl_copy_excstack(new_s, s);
-    jl_gc_write(ct, *stack, jl_excstack_t, new_s);
+    if (use_malloc) {
+        // Track the task when it transitions from a GC-allocated (or no) buffer
+        // to a malloc'd one. If the old buffer was already malloc'd, the task is
+        // already tracked; re-tracking it would accumulate duplicate entries.
+        if (!s || !s->malloced)
+            jl_gc_track_malloced_excstack(ct);
+        // No write barrier needed: the buffer is not a GC object.
+        *stack = new_s;
+    }
+    else {
+        jl_gc_write(ct, *stack, jl_excstack_t, new_s);
+    }
+    // Free a replaced malloc'd buffer only after `*stack` points to the new one,
+    // so that a signal handler on this thread (e.g. `jlbacktrace`) never sees a
+    // freed buffer through `ct->excstack`.
+    if (s && s->malloced)
+        free(s);
 }
 
 void jl_push_excstack(jl_task_t *ct, jl_excstack_t **stack JL_REQUIRE_ROOTED_SLOT,
                       jl_value_t *exception JL_ROOTED_BY_ARG(1),
                       jl_bt_element_t *bt_data, size_t bt_size)
 {
-    jl_reserve_excstack(ct, stack, (*stack ? (*stack)->top : 0) + bt_size + 2);
+    // Throwing OutOfMemoryError must not allocate GC memory, or the allocation
+    // could fail and throw recursively.
+    int use_malloc = (exception == jl_memory_exception);
+    jl_reserve_excstack(ct, stack, (*stack ? (*stack)->top : 0) + bt_size + 2, use_malloc);
     jl_excstack_t *s = *stack;
     jl_bt_element_t *rawstack = jl_excstack_raw(s);
     memcpy(rawstack + s->top, bt_data, sizeof(jl_bt_element_t)*bt_size);


### PR DESCRIPTION
This fixes https://github.com/JuliaLang/julia/issues/38666. `jl_memory_exception` is used for out of memory. When handling `jl_memory_exception`, we should avoid allocating with GC. Otherwise, we may trigger an infinite loop: out of memory -> handling out of memory -> allocate with GC -> out of memory.

Mostly done by Claude.