### PR TITLE
derive detect_unbound_args from subtyping's updated parameter-assignment rule

### DIFF
--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -712,66 +712,252 @@ function convert_cache_mode(cache_mode::Symbol)
 end
 
 """
-    constrains_param(var::TypeVar, sig, covariant::Bool, type_constrains::Bool)
+    constrains_var(var::TypeVar, t, covariant::Bool, nonempty_vararg::Bool=false)
 
-Check if `var` will be constrained to have a definite value
-in any concrete leaftype subtype of `sig`.
+Check whether every call matching a method signature pins the static parameter
+`var` to a definite value; `t` is the signature body under `var`'s binder.
+`true` means every matching call pins `var`; `false` means some call may leave
+it unbound, so reading it in the method body would throw `UndefVarError`.
 
-It is used as a helper to determine whether type intersection is guaranteed to be able to
-find a value for a particular type parameter.
-A necessary condition for type intersection to not assign a parameter is that it only
-appears in a `Union[All]` and during subtyping some other union component (that does not
-constrain the type parameter) is selected.
+When a call matches a method, type intersection computes a value for each
+static parameter (`subtype_unionall` in `src/subtype.c`). Subtyping pins a
+variable through two channels (`eff_constrained` in `src/subtype.c`):
 
-The `type_constrains` flag determines whether Type{T} is considered to be constraining
-`T`. This is not true in general, because of the existence of types with free type
-parameters, however, some callers would like to ignore this corner case.
+ * an invariant occurrence: the corresponding position of the call
+   signature must be *equal* to the instantiated method parameter, so any
+   successful match determines the variable. This fails to be definite
+   only where distinct assignments can spell equal types: a `Union` arm
+   can be absorbed by the other arm (`Union{T,Int}` matched against `Int`),
+   a `Vararg` can be respelled (`Tuple{Vararg{T}}` matched against
+   `Tuple`), and the bound of an inner variable can be widened away
+   (`Vector{<:T}` matched against `Vector`), so none of those count.
+
+ * a covariant occurrence: the position is filled with `typeof` of an
+   argument, which contributes a lower bound, and the least solution is
+   taken as the parameter value. This is definite only if the declared
+   lower bound of the variable is `Union{}` (otherwise other types union
+   into the solution: `f(x::T) where {T>:Int}` is unbound for `f(2.0)`),
+   and only for occurrences guaranteed to contribute in every call:
+   present in all `Union` arms, not under a `Vararg` tail (which may match
+   zero arguments), and not merely in the declared bounds of another
+   variable — unless that variable is itself pinned to a `typeof`-produced
+   argument type in every call, since a variable ranging over an invariant
+   position or over a `Type` argument can take the value `Union{}`,
+   satisfying its bounds without constraining them (`f(::Type{<:T})` is
+   unbound for `f(Union{})`, and `f(::Vector{<:T})` for a
+   `Vector{Union{}}` argument).
+
+`constrains_var` is a conservative static approximation of that dynamic
+rule. `nonempty_vararg` credits the signature's own trailing `Vararg` as if
+it matched at least one argument (it is not propagated into nested
+positions, where an empty tuple can always occur); it is an assumption the
+caller must justify (see `Test.detect_unbound_args`).
 """
-function constrains_param(var::TypeVar, @nospecialize(typ), covariant::Bool, type_constrains::Bool=false)
-    typ === var && return true
-    while typ isa UnionAll
-        covariant && constrains_param(var, typ.var.ub, covariant, type_constrains) && return true
-        # typ.var.lb doesn't constrain var
-        typ = typ.body
+function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempty_vararg::Bool=false)
+    if t === var
+        return !covariant || var.lb === Union{}
     end
-    if typ isa Union
-        # for unions, verify that both options would constrain var
-        ba = constrains_param(var, typ.a, covariant, type_constrains)
-        bb = constrains_param(var, typ.b, covariant, type_constrains)
-        (ba && bb) && return true
-    elseif isType(typ)
-        p = type_parameter(typ)
-        if p === var && var.ub === Any
-            # Types with free type parameters are <: Type cause the typevar
-            # to be unconstrained because Type{T} with free typevars is illegal
-            return type_constrains
-        end
-        constrains_param(var, p, false, type_constrains) && return true
-    elseif typ isa DataType
-        # return true if any param constrains var
-        fc = length(typ.parameters)
-        if fc > 0
-            if typ.name === Tuple.name
-                # vararg tuple needs special handling
-                for i in 1:(fc - 1)
-                    p = typ.parameters[i]
-                    constrains_param(var, p, covariant, type_constrains) && return true
-                end
-                lastp = typ.parameters[fc]
-                vararg = unwrap_unionall(lastp)
-                if vararg isa Core.TypeofVararg && isdefined(vararg, :N)
-                    constrains_param(var, vararg.N, covariant, type_constrains) && return true
-                    # T = vararg.parameters[1] doesn't constrain var
-                else
-                    constrains_param(var, lastp, covariant, type_constrains) && return true
-                end
-            else
-                for i in 1:fc
-                    p = typ.parameters[i]
-                    constrains_param(var, p, false, type_constrains) && return true
-                end
+    while t isa UnionAll
+        if covariant && t.var.lb === Union{}
+            pin = pin_grade(t.var, t.body, nonempty_vararg)
+            if pin == PIN_TYPEOF && constrains_var(var, t.var.ub, true)
+                return true
+            elseif pin == PIN_INHABITED && constrains_type_value(var, t.var.ub)
+                return true
             end
         end
+        # other occurrences in the bounds of `t.var` do not reliably pin `var`
+        if t.var === var
+            # `var` is rebound: occurrences below belong to the inner
+            # variable (a constructor signature reuses the struct's own
+            # variable objects in `Type{TheStruct}`, issue #54893)
+            return false
+        end
+        t = t.body
+    end
+    if t isa Union
+        if covariant
+            # each arm is individually reachable by some argument, so every
+            # arm must pin `var`
+            return constrains_var(var, t.a, true) &&
+                   constrains_var(var, t.b, true)
+        end
+        # matched by type equality: pinned if every arm pins `var`, or
+        # through any arm that the matched value must expose because no
+        # instantiation of it can be absorbed into the other arms
+        # (issues #58427, #59023)
+        constrains_var(var, t.a, false) && constrains_var(var, t.b, false) &&
+            return true
+        arms = uniontypes(t)
+        for (i, arm) in enumerate(arms)
+            # the cheap occurrence tests first; only arms that pass them
+            # need the `Union` reassembly and `typeintersect` query below
+            if arm === var
+                # absorbing a bare `var` arm forces `var = Union{}`, which
+                # pins it, provided `Union{}` is its only value inside the
+                # other arms
+                var.lb === Union{} || continue
+            else
+                constrains_var(var, arm, false) || continue
+            end
+            others = Union{}
+            for j in eachindex(arms)
+                j == i && continue
+                others = Union{others, arms[j]}
+            end
+            others = UnionAll(var, others)
+            if union_disjoint(arm === var ? var.ub : UnionAll(var, arm), others)
+                return true
+            end
+        end
+        return false
+    end
+    if isType(t)
+        # the parameter is matched exactly by the argument (covariant) or by
+        # type equality (invariant)
+        return constrains_var(var, type_parameter(t), false)
+    end
+    t isa DataType || return false
+    if t.name === Tuple.name
+        for p in t.parameters
+            if p isa Core.TypeofVararg
+                # the argument count pins `N` exactly (including zero)
+                isdefined(p, :N) && constrains_var(var, p.N, covariant) && return true
+                if covariant && nonempty_vararg && isdefined(p, :T)
+                    constrains_var(var, p.T, covariant) && return true
+                end
+            else
+                constrains_var(var, p, covariant) && return true
+            end
+        end
+    else
+        for p in t.parameters
+            constrains_var(var, p, false) && return true
+        end
+    end
+    return false
+end
+
+# Whether no instantiation of `a` overlaps `b`, so that no part of a matched
+# value can satisfy both. `false` when undecidable (free typevars remain).
+function union_disjoint(@nospecialize(a), @nospecialize(b))
+    (has_free_typevars(a) || has_free_typevars(b)) && return false
+    return !hasintersect(a, b)
+end
+
+# Whether matching any specific type value `X <: P` other than `Union{}`
+# necessarily pins `var` (or fails to match): `var` must occur where the
+# subtyping query is forced to constrain it — as `P` itself (`X` becomes its
+# lower bound, which pins any non-`Union{}` value up to type equality,
+# provided `var`'s declared lower bound is `Union{}` and does not union into
+# the solution), invariantly below a non-Tuple constructor, or as a `Vararg`
+# length — in every `Union` arm. Fixed `Tuple` slots of `P` correspond to
+# non-`Union{}` positions of `X` (a tuple type with a `Union{}` field cannot
+# be constructed) and are descended into; `Vararg` tails and ranges inside
+# `P` can be spelled away by `X` and never count.
+function constrains_type_value(var::TypeVar, @nospecialize(P))
+    P === var && return var.lb === Union{}
+    while P isa UnionAll
+        # ranges inside `P` can be widened away by the spelling of `X`
+        P.var === var && return false # `var` is rebound below
+        P = P.body
+    end
+    if P isa Union
+        return constrains_type_value(var, P.a) &&
+               constrains_type_value(var, P.b)
+    end
+    if isType(P)
+        # X <: Type{q} pins the parameter of X by equality with q
+        return constrains_var(var, type_parameter(P), false)
+    end
+    P isa DataType || return false
+    if P.name === Tuple.name
+        for p in P.parameters
+            if p isa Core.TypeofVararg
+                # the length of X pins `N` exactly (or the match fails)
+                isdefined(p, :N) && constrains_var(var, p.N, false) && return true
+            else
+                constrains_type_value(var, p) && return true
+            end
+        end
+        return false
+    end
+    for p in P.parameters
+        constrains_var(var, p, false) && return true
+    end
+    return false
+end
+
+# How strongly the position(s) of `v` in `t` pin its value, for every call:
+#  * `PIN_TYPEOF`: `v` takes a `typeof`-produced argument type — a concrete
+#    type, in particular not `Union{}` and without free type variables. This
+#    holds for a required covariant argument slot (directly, under nested
+#    `Tuple`s, or in all arms of a `Union`), or as the sole upper bound of
+#    another variable in such a slot.
+#  * `PIN_INHABITED`: `v` takes an *inhabited* type (not `Union{}`), though
+#    possibly an abstract one: `v` is an invariant parameter of a constructor
+#    in a required covariant slot, and that constructor declares a field of
+#    exactly that parameter's type which every inner constructor initializes,
+#    so a value of the parameter type must exist inside the argument.
+#  * `PIN_NONE`: neither is guaranteed; `v` may be `Union{}` (e.g. `Type{v}`
+#    positions matched by the argument `Union{}`, or invariant parameters
+#    without such a field), leaving its bounds unconstraining.
+const PIN_NONE = 0
+const PIN_INHABITED = 1
+const PIN_TYPEOF = 2
+
+function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
+    t === v && return PIN_TYPEOF
+    while t isa UnionAll
+        if t.var.ub === v && t.var.lb === Union{} &&
+            pin_grade(t.var, t.body, nonempty_vararg) == PIN_TYPEOF
+            # the least solution for `v` is the other variable's value
+            return PIN_TYPEOF
+        end
+        t.var === v && return PIN_NONE # `v` is rebound below
+        t = t.body
+    end
+    if t isa Union
+        return min(pin_grade(v, t.a), pin_grade(v, t.b))
+    end
+    t isa DataType || return PIN_NONE
+    if t.name === Tuple.name
+        grade = PIN_NONE
+        for p in t.parameters
+            if p isa Core.TypeofVararg
+                if nonempty_vararg && isdefined(p, :T)
+                    grade = max(grade, pin_grade(v, p.T))
+                end
+            else
+                grade = max(grade, pin_grade(v, p))
+            end
+            grade == PIN_TYPEOF && break
+        end
+        return grade
+    end
+    isType(t) && return PIN_NONE
+    for (i, p) in enumerate(t.parameters)
+        if p === v && param_has_field(t, i)
+            return PIN_INHABITED
+        end
+    end
+    return PIN_NONE
+end
+
+# Whether the `i`-th type parameter of `t`'s constructor is also the declared
+# type of one of its always-initialized fields, so that instances are
+# guaranteed to contain a value of it. Fields beyond
+# `datatype_min_ninitialized` can be left `#undef` by an incomplete `new`
+# inner constructor (`Base.RefValue{Union{}}()` is constructible), so they
+# prove nothing.
+function param_has_field(t::DataType, i::Int)
+    base = unwrap_unionall(t.name.wrapper)
+    base isa DataType || return false
+    tv = base.parameters[i]
+    tv isa TypeVar || return false
+    ftypes = datatype_fieldtypes(base)
+    for j in 1:datatype_min_ninitialized(base)
+        ftypes[j] === tv && return true
     end
     return false
 end
@@ -902,7 +1088,7 @@ function sptypes_from_meth_instance(mi::MethodInstance)
     sig = def.sig
     # mi is unspecialized: no subtyping has run, so we don't have the
     # `svec(tvar, constrained)` markers that specialized env entries carry.
-    # Use the static `constrains_param` check directly.
+    # Use the static `constrains_var` check directly.
     isempty(mi.sparam_vals) && return sptypes_from_unspecialized(sig)
     spvals = mi.sparam_vals
     nvals = length(spvals)
@@ -917,7 +1103,7 @@ function sptypes_from_meth_instance(mi::MethodInstance)
         # typevars (when the var got pinned to a value that still contains
         # call-site tvars). `constrained` is true iff every concrete subtype
         # of the call site will pin this var to a definite value.
-        # `src/subtype.c` folds in the static `constrains_param` semantics
+        # `src/subtype.c` folds in static `constrains_var`-style semantics
         # via `constrains_param_static`, so `v_constrained` is authoritative.
         v_tvar = nothing
         v_constrained = false
@@ -974,7 +1160,7 @@ end
 # Separate path for unspecialized MIs (empty `sparam_vals`): no subtyping has
 # run, so we can't rely on the svec-wrapped env entries produced by
 # intersection. Every sparam is represented by its raw method-sig TypeVar, and
-# `undef` is determined by the static `constrains_param` check.
+# `undef` is determined by the static `constrains_var` check.
 function sptypes_from_unspecialized(@nospecialize sig)
     isa(sig, UnionAll) || return EMPTY_SPTYPES
     nvals = 0
@@ -991,10 +1177,7 @@ function sptypes_from_unspecialized(@nospecialize sig)
         ty = sptype_for_tvar(vᵢ, vᵢ,
                              (unwrap_unionall(temp)::DataType).parameters,
                              sig)
-        undef = !(let sig=sig
-            @assert !has_free_typevars(sig)
-            vᵢ.lb === Bottom && constrains_param(vᵢ, sig, #=covariant=#true)
-        end)
+        undef = !constrains_var(vᵢ, (temp::UnionAll).body, #=covariant=#true)
         sptypes[i] = VarState(ty, typemin(Int), undef)
         temp = (temp::UnionAll).body
     end

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -758,7 +758,9 @@ function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempt
         return !covariant || var.lb === Union{}
     end
     while t isa UnionAll
-        if covariant && t.var.lb === Union{}
+        # the cheap occurs-check gates the `pin_grade` body traversal: both
+        # consumers below can only succeed when `var` occurs in the bound
+        if covariant && t.var.lb === Union{} && has_typevar(t.var.ub, var)
             pin = pin_grade(t.var, t.body, nonempty_vararg)
             if pin == PIN_TYPEOF && constrains_var(var, t.var.ub, true)
                 return true

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -711,157 +711,105 @@ function convert_cache_mode(cache_mode::Symbol)
     error("unexpected `cache_mode` is given")
 end
 
+# How the type filling a position is compared against the method parameter,
+# which determines when an occurrence of a static parameter there pins it:
+#  * `MATCH_EGAL`: the position must be equal to the instantiated parameter
+#    (an invariant slot), so any successful match determines the variable.
+#  * `MATCH_INHABITED`: the position is filled by an inhabited type `X`
+#    (possibly abstract), which contributes only a lower bound: it pins the
+#     variable up to type equality, but only when the variable's declared
+#    lower bound is `Union{}`.
+#  * `MATCH_TYPEOF`: the position is filled by `typeof` of an argument — a
+#    concrete inhabited type.
+const MATCH_EGAL      = 0
+const MATCH_INHABITED = 1
+const MATCH_TYPEOF    = 2
+
 """
-    constrains_var(var::TypeVar, t, covariant::Bool, nonempty_vararg::Bool=false)
+    constrains_var(var::TypeVar, t, match::Int, nonempty_vararg::Bool=false)
 
-Check whether every call matching a method signature pins the static parameter
-`var` to a definite value; `t` is the signature body under `var`'s binder.
-`true` means every matching call pins `var`; `false` means some call may leave
-it unbound, so reading it in the method body would throw `UndefVarError`.
+Check if `var` will be constrained to have a definite value when the position
+`t` (a signature body under `var`'s binder) is filled according to `match`
+(`MATCH_EGAL`, `MATCH_INHABITED`, or `MATCH_TYPEOF`); see the `MATCH_*`
+constants for what each match kind means.
 
-When a call matches a method, type intersection computes a value for each
-static parameter (`subtype_unionall` in `src/subtype.c`). Subtyping pins a
-variable through two channels (`eff_constrained` in `src/subtype.c`):
+Subtyping pins a variable through two channels (`eff_constrained` in
+`subtype.c`): an invariant occurrence (`MATCH_EGAL`, matched by type equality)
+and a covariant occurrence (`MATCH_TYPEOF`, filled with a `typeof`-produced
+argument type).
 
- * an invariant occurrence: the corresponding position of the call
-   signature must be *equal* to the instantiated method parameter, so any
-   successful match determines the variable. This fails to be definite
-   only where distinct assignments can spell equal types: a `Union` arm
-   can be absorbed by the other arm (`Union{T,Int}` matched against `Int`),
-   a `Vararg` can be respelled (`Tuple{Vararg{T}}` matched against
-   `Tuple`), and the bound of an inner variable can be widened away
-   (`Vector{<:T}` matched against `Vector`), so none of those count.
+`MATCH_INHABITED` is a refinement based on filtering out non-inhabited types
+(notably `Union{}`) when the field must be inhabited (because the constructor
+inhabits it).
 
- * a covariant occurrence: the position is filled with `typeof` of an
-   argument, which contributes a lower bound, and the least solution is
-   taken as the parameter value. This is definite only if the declared
-   lower bound of the variable is `Union{}` (otherwise other types union
-   into the solution: `f(x::T) where {T>:Int}` is unbound for `f(2.0)`),
-   and only for occurrences guaranteed to contribute in every call:
-   present in all `Union` arms, not under a `Vararg` tail (which may match
-   zero arguments), and not merely in the declared bounds of another
-   variable — unless that variable is itself pinned to a `typeof`-produced
-   argument type in every call, since a variable ranging over an invariant
-   position or over a `Type` argument can take the value `Union{}`,
-   satisfying its bounds without constraining them (`f(::Type{<:T})` is
-   unbound for `f(Union{})`, and `f(::Vector{<:T})` for a
-   `Vector{Union{}}` argument).
+`constrains_var` is a conservative static approximation of that dynamic rule.
+In particular an invariant (`MATCH_EGAL`) `Union` arm is always treated as
+absorbable (`Union{T,Int}` matched against `Int` does not pin `T`), even when
+it is disjoint from the other arms so that every match either exposes it or
+pins `var = Union{}` by absorbing it. Per issues #58427 and #59023: a parameter
+that some match pins only as `Union{}` is still worth reporting since it may be
+reachable with `invoke` and is consistent with the covariant occurrence rule.
 
-`constrains_var` is a conservative static approximation of that dynamic
-rule. In particular an invariant `Union` arm is always treated as
-absorbable, even when it is disjoint from the other arms so that every
-match either exposes it or pins `var = Union{}` by absorbing it
-(issues #58427, #59023): a parameter that some match pins only as
-`Union{}` is still worth reporting, and the arm-must-be-exposed
-refinement would need `typeintersect`-based disjointness proofs whose
-answers depend on union normalization order.
-`nonempty_vararg` credits the signature's own trailing `Vararg` as if
-it matched at least one argument (it is not propagated into nested
-positions, where an empty tuple can always occur); it is an assumption the
-caller must justify (see `Test.detect_unbound_args`).
+`nonempty_vararg` credits the signature's own trailing `Vararg` as if it
+matched at least one argument (it is not propagated into nested positions,
+where an empty tuple can always occur); it is an assumption the caller must
+justify (see `Test.detect_unbound_args`).
 """
-function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempty_vararg::Bool=false)
+function constrains_var(var::TypeVar, @nospecialize(t), match::Int, nonempty_vararg::Bool=false)
     if t === var
-        return !covariant || var.lb === Union{}
+        # equality pins unconditionally; a lower-bound contribution pins only
+        # when nothing else can union into the least solution
+        return match === MATCH_EGAL || var.lb === Union{}
     end
     while t isa UnionAll
-        # the cheap occurs-check gates the `pin_grade` body traversal: both
-        # consumers below can only succeed when `var` occurs in the bound
-        if covariant && t.var.lb === Union{} && has_typevar(t.var.ub, var)
+        # only a concrete `typeof` argument can carry the pin through an inner
+        # variable's range; the cheap occurs-check gates the `pin_grade` body
+        # traversal just for performance since constrains_var would be false
+        if match === MATCH_TYPEOF && t.var.lb === Union{} && has_typevar(t.var.ub, var)
             pin = pin_grade(t.var, t.body, nonempty_vararg)
-            if pin == PIN_TYPEOF && constrains_var(var, t.var.ub, true)
+            if pin == PIN_TYPEOF && constrains_var(var, t.var.ub, MATCH_TYPEOF)
                 return true
-            elseif pin == PIN_INHABITED && constrains_type_value(var, t.var.ub)
+            elseif pin == PIN_INHABITED && constrains_var(var, t.var.ub, MATCH_INHABITED)
                 return true
             end
         end
-        # other occurrences in the bounds of `t.var` do not reliably pin `var`
         if t.var === var
-            # `var` is rebound: occurrences below belong to the inner
-            # variable (a constructor signature reuses the struct's own
-            # variable objects in `Type{TheStruct}`, issue #54893)
+            # `var` is rebound: occurrences below belong to the inner variable
             return false
         end
+        # other occurrences in the bounds of `t.var` do not reliably pin `var`
         t = t.body
     end
     if t isa Union
-        # covariant: each arm is individually reachable by some argument, so
-        # every arm must pin `var`. invariant (matched by type equality): an
-        # arm that the other arms can absorb (`Union{T,Int}` matched against
-        # `Int`) pins nothing; when absorption is impossible (the arm is
-        # disjoint from the others) the assignments it does admit pin `var`,
-        # but possibly only as `var = Union{}` (issue #58427), which we
-        # deliberately still report as a problem — so in both cases require
-        # every arm to pin `var`, accepting the false positive for arms that
-        # every match must genuinely expose (issue #59023)
-        return constrains_var(var, t.a, covariant) &&
-               constrains_var(var, t.b, covariant)
+        # each arm is individually reachable, so every arm must pin `var`; an
+        # `MATCH_EGAL` arm the other arms can absorb pins nothing, but when
+        # absorption is impossible the assignments it admits pin `var`, possibly
+        # only as `var = Union{}` (issue #58427), which we deliberately still
+        # report — so in both cases require every arm to pin `var`, accepting
+        # the false positive for arms every match must expose (issue #59023)
+        return constrains_var(var, t.a, match) &&
+               constrains_var(var, t.b, match)
     end
-    if isType(t)
-        # the parameter is matched exactly by the argument (covariant) or by
-        # type equality (invariant)
-        return constrains_var(var, type_parameter(t), false)
+    if isTypeEq(t) # TypeEgal cannot constrain (or contain) a parameter
+        return constrains_var(var, type_parameter(t), MATCH_EGAL)
     end
     t isa DataType || return false
     if t.name === Tuple.name
         for p in t.parameters
             if p isa Core.TypeofVararg
                 # the argument count pins `N` exactly (including zero)
-                isdefined(p, :N) && constrains_var(var, p.N, covariant) && return true
-                if covariant && nonempty_vararg && isdefined(p, :T)
-                    constrains_var(var, p.T, covariant) && return true
+                isdefined(p, :N) && constrains_var(var, p.N, match) && return true
+                if match === MATCH_TYPEOF && nonempty_vararg && isdefined(p, :T)
+                    constrains_var(var, p.T, MATCH_TYPEOF) && return true
                 end
             else
-                constrains_var(var, p, covariant) && return true
+                constrains_var(var, p, match) && return true
             end
         end
     else
         for p in t.parameters
-            constrains_var(var, p, false) && return true
+            constrains_var(var, p, MATCH_EGAL) && return true
         end
-    end
-    return false
-end
-
-# Whether matching any specific type value `X <: P` other than `Union{}`
-# necessarily pins `var` (or fails to match): `var` must occur where the
-# subtyping query is forced to constrain it — as `P` itself (`X` becomes its
-# lower bound, which pins any non-`Union{}` value up to type equality,
-# provided `var`'s declared lower bound is `Union{}` and does not union into
-# the solution), invariantly below a non-Tuple constructor, or as a `Vararg`
-# length — in every `Union` arm. Fixed `Tuple` slots of `P` correspond to
-# non-`Union{}` positions of `X` (a tuple type with a `Union{}` field cannot
-# be constructed) and are descended into; `Vararg` tails and ranges inside
-# `P` can be spelled away by `X` and never count.
-function constrains_type_value(var::TypeVar, @nospecialize(P))
-    P === var && return var.lb === Union{}
-    while P isa UnionAll
-        # ranges inside `P` can be widened away by the spelling of `X`
-        P.var === var && return false # `var` is rebound below
-        P = P.body
-    end
-    if P isa Union
-        return constrains_type_value(var, P.a) &&
-               constrains_type_value(var, P.b)
-    end
-    if isType(P)
-        # X <: Type{q} pins the parameter of X by equality with q
-        return constrains_var(var, type_parameter(P), false)
-    end
-    P isa DataType || return false
-    if P.name === Tuple.name
-        for p in P.parameters
-            if p isa Core.TypeofVararg
-                # the length of X pins `N` exactly (or the match fails)
-                isdefined(p, :N) && constrains_var(var, p.N, false) && return true
-            else
-                constrains_type_value(var, p) && return true
-            end
-        end
-        return false
-    end
-    for p in P.parameters
-        constrains_var(var, p, false) && return true
     end
     return false
 end
@@ -885,22 +833,43 @@ const PIN_INHABITED = 1
 const PIN_TYPEOF = 2
 
 function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
+    # Implementation note: a covariant occurrence of `v` reports `PIN_TYPEOF`
+    # (concrete typeof value) computed in isolation. Strictly this over-reports
+    # when `v` also occurs elsewhere. We don't take the minimum (that would
+    # need a non-local scan of all of `v`'s occurrences), because the
+    # over-grade never changes a `constrains_var` result: `PIN_TYPEOF` vs
+    # `PIN_INHABITED` is consumed only by the triangular descent that pins an
+    # outer variable `W` appearing in `v`'s upper bound, and either (1) `v.ub`
+    # is a structured type mentioning `W` (`v<:Vector{W}`, `v<:Type{W}`) — the
+    # only place concreteness is load-bearing; or (2) `v.ub` is `W` or a
+    # `Union`, where concreteness is not needed (`v<:W` gives `W = v`, defined;
+    # `v<:Union{...W...}` is handled by the union-arm rule regardless of grade).
     t === v && return PIN_TYPEOF
+    grade = PIN_NONE
     while t isa UnionAll
-        if t.var.ub === v && t.var.lb === Union{} &&
-            pin_grade(t.var, t.body, nonempty_vararg) == PIN_TYPEOF
-            # the least solution for `v` is the other variable's value
-            return PIN_TYPEOF
+        if t.var.ub === v && t.var.lb === Union{}
+            # `v` is exactly the sole upper bound of `t.var`, so the least
+            # solution for `v` is `t.var`'s value, pinned at the same grade: a
+            # concrete `t.var` (`PIN_TYPEOF`) makes `v` concrete, an
+            # inhabited-but-abstract one (`PIN_INHABITED`) makes `v` inhabited
+            # (mirroring the two-grade handling in `constrains_var`)
+            g = pin_grade(t.var, t.body, nonempty_vararg)
+            g == PIN_TYPEOF && return PIN_TYPEOF
+            grade = max(grade, g)
         end
-        t.var === v && return PIN_NONE # `v` is rebound below
+        # `v` is rebound below: deeper occurrences belong to the inner variable,
+        # but the where-clauses peeled so far still count
+        t.var === v && return grade
         t = t.body
     end
     if t isa Union
-        return min(pin_grade(v, t.a), pin_grade(v, t.b))
+        # a where-clause position (`grade`) pins on its own; the union itself
+        # pins only if every arm does
+        return max(grade, min(pin_grade(v, t.a), pin_grade(v, t.b)))
     end
-    t isa DataType || return PIN_NONE
+    t isa DataType || return grade
+    isabstracttype(t) && return grade
     if t.name === Tuple.name
-        grade = PIN_NONE
         for p in t.parameters
             if p isa Core.TypeofVararg
                 if nonempty_vararg && isdefined(p, :T)
@@ -913,24 +882,20 @@ function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
         end
         return grade
     end
-    isType(t) && return PIN_NONE
-    for (i, p) in enumerate(t.parameters)
-        if p === v && param_has_field(t, i)
-            return PIN_INHABITED
+    for i in 1:length(t.parameters)
+        p = t.parameters[i]
+        if p === v && some_field_requires_inhabited_param(t, i)
+            return max(grade, PIN_INHABITED)
         end
     end
-    return PIN_NONE
+    return grade
 end
 
-# Whether the `i`-th type parameter of `t`'s constructor is also the declared
-# type of one of its always-initialized fields, so that instances are
-# guaranteed to contain a value of it. Fields beyond
-# `datatype_min_ninitialized` can be left `#undef` by an incomplete `new`
-# inner constructor (`Base.RefValue{Union{}}()` is constructible), so they
-# prove nothing.
-function param_has_field(t::DataType, i::Int)
-    base = unwrap_unionall(t.name.wrapper)
-    base isa DataType || return false
+# Whether the `i`-th type parameter of `t`'s is constrained to be inhabited
+# by being the declared type of one of its always-initialized fields, such
+# that instances are guaranteed to contain a value of it.
+function some_field_requires_inhabited_param(t::DataType, i::Int)
+    base = unwrap_unionall(t.name.wrapper)::DataType
     tv = base.parameters[i]
     tv isa TypeVar || return false
     ftypes = datatype_fieldtypes(base)
@@ -1066,8 +1031,8 @@ function sptypes_from_meth_instance(mi::MethodInstance)
     sig = def.sig
     # mi is unspecialized: no subtyping has run, so we don't have the
     # `svec(tvar, constrained)` markers that specialized env entries carry.
-    # Use the static `constrains_var` check directly.
     isempty(mi.sparam_vals) && return sptypes_from_unspecialized(sig)
+    sigtypes = (unwrap_unionall(sig)::DataType).parameters
     spvals = mi.sparam_vals
     nvals = length(spvals)
     sptypes = Vector{VarState}(undef, nvals)
@@ -1081,8 +1046,6 @@ function sptypes_from_meth_instance(mi::MethodInstance)
         # typevars (when the var got pinned to a value that still contains
         # call-site tvars). `constrained` is true iff every concrete subtype
         # of the call site will pin this var to a definite value.
-        # `src/subtype.c` folds in static `constrains_var`-style semantics
-        # via `constrains_param_static`, so `v_constrained` is authoritative.
         v_tvar = nothing
         v_constrained = false
         if isa(v, SimpleVector)
@@ -1106,7 +1069,6 @@ function sptypes_from_meth_instance(mi::MethodInstance)
             v_egal = false
         elseif v_tvar !== nothing || has_free_typevars(v)
             vᵢ = (temp::UnionAll).var
-            sigtypes = (unwrap_unionall(temp)::DataType).parameters
             if v_tvar !== nothing
                 v_egal = sparam_definitely_egal_from_spec(vᵢ, sigtypes, mi.specTypes)
                 ty = sptype_for_tvar(vᵢ, v_tvar, sigtypes, mi.specTypes, v_egal)
@@ -1114,7 +1076,7 @@ function sptypes_from_meth_instance(mi::MethodInstance)
                 ty = rewrap_free_typevars(TypeEq{v}, find_free_typevars(mi.specTypes))
                 v_egal = false
             end
-            undef = !v_constrained
+            undef = !v_constrained && !constrains_var(vᵢ, temp.body, MATCH_TYPEOF)
         elseif isvarargtype(v)
             # this parameter came from `func(..., ::Vararg{T,v})`,
             # so the type is known to be `Int`
@@ -1136,26 +1098,17 @@ function sptypes_from_meth_instance(mi::MethodInstance)
 end
 
 # Separate path for unspecialized MIs (empty `sparam_vals`): no subtyping has
-# run, so we can't rely on the svec-wrapped env entries produced by
-# intersection. Every sparam is represented by its raw method-sig TypeVar, and
-# `undef` is determined by the static `constrains_var` check.
+# run, so we can't use the svec-wrapped env entries produced by intersection.
 function sptypes_from_unspecialized(@nospecialize sig)
     isa(sig, UnionAll) || return EMPTY_SPTYPES
-    nvals = 0
-    let sig′ = sig
-        while isa(sig′, UnionAll)
-            nvals += 1
-            sig′ = sig′.body
-        end
-    end
+    nvals = unionall_depth(sig)
     sptypes = Vector{VarState}(undef, nvals)
+    params = (unwrap_unionall(sig)::DataType).parameters
     temp = sig
     for i = 1:nvals
         vᵢ = (temp::UnionAll).var
-        ty = sptype_for_tvar(vᵢ, vᵢ,
-                             (unwrap_unionall(temp)::DataType).parameters,
-                             sig)
-        undef = !constrains_var(vᵢ, (temp::UnionAll).body, #=covariant=#true)
+        ty = sptype_for_tvar(vᵢ, vᵢ, params, sig)
+        undef = !constrains_var(vᵢ, (temp::UnionAll).body, MATCH_TYPEOF)
         sptypes[i] = VarState(ty, typemin(Int), undef)
         temp = (temp::UnionAll).body
     end

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -748,7 +748,14 @@ variable through two channels (`eff_constrained` in `src/subtype.c`):
    `Vector{Union{}}` argument).
 
 `constrains_var` is a conservative static approximation of that dynamic
-rule. `nonempty_vararg` credits the signature's own trailing `Vararg` as if
+rule. In particular an invariant `Union` arm is always treated as
+absorbable, even when it is disjoint from the other arms so that every
+match either exposes it or pins `var = Union{}` by absorbing it
+(issues #58427, #59023): a parameter that some match pins only as
+`Union{}` is still worth reporting, and the arm-must-be-exposed
+refinement would need `typeintersect`-based disjointness proofs whose
+answers depend on union normalization order.
+`nonempty_vararg` credits the signature's own trailing `Vararg` as if
 it matched at least one argument (it is not propagated into nested
 positions, where an empty tuple can always occur); it is an assumption the
 caller must justify (see `Test.detect_unbound_args`).
@@ -778,41 +785,17 @@ function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempt
         t = t.body
     end
     if t isa Union
-        if covariant
-            # each arm is individually reachable by some argument, so every
-            # arm must pin `var`
-            return constrains_var(var, t.a, true) &&
-                   constrains_var(var, t.b, true)
-        end
-        # matched by type equality: pinned if every arm pins `var`, or
-        # through any arm that the matched value must expose because no
-        # instantiation of it can be absorbed into the other arms
-        # (issues #58427, #59023)
-        constrains_var(var, t.a, false) && constrains_var(var, t.b, false) &&
-            return true
-        arms = uniontypes(t)
-        for (i, arm) in enumerate(arms)
-            # the cheap occurrence tests first; only arms that pass them
-            # need the `Union` reassembly and `typeintersect` query below
-            if arm === var
-                # absorbing a bare `var` arm forces `var = Union{}`, which
-                # pins it, provided `Union{}` is its only value inside the
-                # other arms
-                var.lb === Union{} || continue
-            else
-                constrains_var(var, arm, false) || continue
-            end
-            others = Union{}
-            for j in eachindex(arms)
-                j == i && continue
-                others = Union{others, arms[j]}
-            end
-            others = UnionAll(var, others)
-            if union_disjoint(arm === var ? var.ub : UnionAll(var, arm), others)
-                return true
-            end
-        end
-        return false
+        # covariant: each arm is individually reachable by some argument, so
+        # every arm must pin `var`. invariant (matched by type equality): an
+        # arm that the other arms can absorb (`Union{T,Int}` matched against
+        # `Int`) pins nothing; when absorption is impossible (the arm is
+        # disjoint from the others) the assignments it does admit pin `var`,
+        # but possibly only as `var = Union{}` (issue #58427), which we
+        # deliberately still report as a problem — so in both cases require
+        # every arm to pin `var`, accepting the false positive for arms that
+        # every match must genuinely expose (issue #59023)
+        return constrains_var(var, t.a, covariant) &&
+               constrains_var(var, t.b, covariant)
     end
     if isType(t)
         # the parameter is matched exactly by the argument (covariant) or by
@@ -838,13 +821,6 @@ function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempt
         end
     end
     return false
-end
-
-# Whether no instantiation of `a` overlaps `b`, so that no part of a matched
-# value can satisfy both. `false` when undecidable (free typevars remain).
-function union_disjoint(@nospecialize(a), @nospecialize(b))
-    (has_free_typevars(a) || has_free_typevars(b)) && return false
-    return !hasintersect(a, b)
 end
 
 # Whether matching any specific type value `X <: P` other than `Union{}`

--- a/NEWS.md
+++ b/NEWS.md
@@ -210,7 +210,9 @@ Standard library changes
   `Vector{Union{}}` argument), and no longer reports methods whose problematic calls are
   all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback), or
   whose lowered bodies never read the possibly-unbound parameters (other than by
-  querying them with `@isdefined`).
+  querying them with `@isdefined`). A parameter that some calls can pin only as
+  `T == Union{}` by absorbing a `Union` arm (such as `f(::Vector{Union{Nothing, T}})
+  where {T<:Real}` called with a `Vector{Nothing}`) is deliberately still reported.
 
 #### Dates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -160,6 +160,13 @@ Standard library changes
   allocate `Core.Box` in their lowered code, which can indicate performance issues from
   captured variables in closures.
 
+* `detect_unbound_args` now uses a static rule derived from how subtyping assigns values
+  to static parameters, instead of a heuristic. It detects previously missed
+  possibly-unbound parameters (such as `f(::Type{<:T}) where {T}`, which leaves `T`
+  unbound when called with `Union{}`, or `f(::Vector{<:T}) where {T}` with a
+  `Vector{Union{}}` argument), and no longer reports methods whose problematic calls are
+  all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback).
+
 #### Dates
 
 * `unix2datetime` now accepts a keyword argument `localtime=true` to use the host system's local time zone instead of UTC ([#50296]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -203,16 +203,13 @@ Standard library changes
 * New functions `detect_closure_boxes` and `detect_closure_boxes_all` find methods that allocate `Core.Box`
   in their lowered code, which can indicate performance issues from captured variables in closures ([#60478]).
 
-* `detect_unbound_args` now uses a static rule derived from how subtyping assigns values
-  to static parameters, instead of a heuristic. It detects previously missed
+* `detect_unbound_args` now uses a conservative rule derived from how subtyping assigns values
+  to static parameters, instead of older heuristics. It detects previously missed
   possibly-unbound parameters (such as `f(::Type{<:T}) where {T}`, which leaves `T`
   unbound when called with `Union{}`, or `f(::Vector{<:T}) where {T}` with a
   `Vector{Union{}}` argument), and no longer reports methods whose problematic calls are
   all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback), or
-  whose lowered bodies never read the possibly-unbound parameters (other than by
-  querying them with `@isdefined`). A parameter that some calls can pin only as
-  `T == Union{}` by absorbing a `Union` arm (such as `f(::Vector{Union{Nothing, T}})
-  where {T<:Real}` called with a `Vector{Nothing}`) is deliberately still reported.
+  whose lowered bodies never read the possibly-unbound parameters.
 
 #### Dates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -165,7 +165,9 @@ Standard library changes
   possibly-unbound parameters (such as `f(::Type{<:T}) where {T}`, which leaves `T`
   unbound when called with `Union{}`, or `f(::Vector{<:T}) where {T}` with a
   `Vector{Union{}}` argument), and no longer reports methods whose problematic calls are
-  all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback).
+  all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback), or
+  whose lowered bodies never read the possibly-unbound parameters (other than by
+  querying them with `@isdefined`).
 
 #### Dates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -203,6 +203,13 @@ Standard library changes
 * New functions `detect_closure_boxes` and `detect_closure_boxes_all` find methods that allocate `Core.Box`
   in their lowered code, which can indicate performance issues from captured variables in closures ([#60478]).
 
+* `detect_unbound_args` now uses a static rule derived from how subtyping assigns values
+  to static parameters, instead of a heuristic. It detects previously missed
+  possibly-unbound parameters (such as `f(::Type{<:T}) where {T}`, which leaves `T`
+  unbound when called with `Union{}`, or `f(::Vector{<:T}) where {T}` with a
+  `Vector{Union{}}` argument), and no longer reports methods whose problematic calls are
+  all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback).
+
 #### Dates
 
 * `unix2datetime` now accepts a keyword argument `localtime=true` to use the host system's local time zone instead of UTC ([#50296]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -167,7 +167,9 @@ Standard library changes
   `Vector{Union{}}` argument), and no longer reports methods whose problematic calls are
   all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback), or
   whose lowered bodies never read the possibly-unbound parameters (other than by
-  querying them with `@isdefined`).
+  querying them with `@isdefined`). A parameter that some calls can pin only as
+  `T == Union{}` by absorbing a `Union` arm (such as `f(::Vector{Union{Nothing, T}})
+  where {T<:Real}` called with a `Vector{Nothing}`) is deliberately still reported.
 
 #### Dates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -160,16 +160,13 @@ Standard library changes
   allocate `Core.Box` in their lowered code, which can indicate performance issues from
   captured variables in closures.
 
-* `detect_unbound_args` now uses a static rule derived from how subtyping assigns values
-  to static parameters, instead of a heuristic. It detects previously missed
+* `detect_unbound_args` now uses a conservative rule derived from how subtyping assigns values
+  to static parameters, instead of older heuristics. It detects previously missed
   possibly-unbound parameters (such as `f(::Type{<:T}) where {T}`, which leaves `T`
   unbound when called with `Union{}`, or `f(::Vector{<:T}) where {T}` with a
   `Vector{Union{}}` argument), and no longer reports methods whose problematic calls are
   all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback), or
-  whose lowered bodies never read the possibly-unbound parameters (other than by
-  querying them with `@isdefined`). A parameter that some calls can pin only as
-  `T == Union{}` by absorbing a `Union` arm (such as `f(::Vector{Union{Nothing, T}})
-  where {T<:Real}` called with a `Vector{Nothing}`) is deliberately still reported.
+  whose lowered bodies never read the possibly-unbound parameters.
 
 #### Dates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -208,7 +208,9 @@ Standard library changes
   possibly-unbound parameters (such as `f(::Type{<:T}) where {T}`, which leaves `T`
   unbound when called with `Union{}`, or `f(::Vector{<:T}) where {T}` with a
   `Vector{Union{}}` argument), and no longer reports methods whose problematic calls are
-  all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback).
+  all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback), or
+  whose lowered bodies never read the possibly-unbound parameters (other than by
+  querying them with `@isdefined`).
 
 #### Dates
 

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1432,10 +1432,11 @@ static int unionall_is_Type_range(jl_unionall_t *ua) JL_NOTSAFEPOINT
     return jl_is_some_Type(ua->body) && jl_some_Type_T(ua->body) == (jl_value_t*)ua->var;
 }
 
-// Static check mirroring Core.Compiler.constrains_param: is `var` guaranteed
-// to be pinned by any concrete leaftype subtype of `typ`? Conservative: a
-// false return is always safe. Used only on fast paths where we don't have
-// dynamic varbinding state to draw from.
+// Static check approximating Core.Compiler.constrains_var (a coarser,
+// allocation-free subset of that rule): is `var` guaranteed to be pinned by
+// any concrete leaftype subtype of `typ`? Conservative: a false return is
+// always safe. Used only on fast paths where we don't have dynamic
+// varbinding state to draw from.
 static int constrains_param_static(jl_tvar_t *var, jl_value_t *typ, int covariant) JL_NOTSAFEPOINT
 {
     if (typ == (jl_value_t*)var)

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1427,28 +1427,77 @@ static jl_value_t *wrap_tvar_env(jl_value_t *tvar, int constrained) JL_CANSAFEPO
     return (jl_value_t*)jl_svec2(tvar, constrained ? jl_true : jl_false);
 }
 
-static int unionall_is_Type_range(jl_unionall_t *ua) JL_NOTSAFEPOINT
+// Allocation-free mirror of the `PIN_TYPEOF` grade of
+// `Core.Compiler.pin_grade`: is `v` pinned to a `typeof`-produced argument
+// type (concrete, in particular not `Union{}`) by every call matching `t`?
+// True for a required covariant argument slot (directly, under nested
+// `Tuple`s, or in all arms of a `Union`), or as the sole upper bound of
+// another variable in such a slot. A false return is always safe.
+static int pins_typeof_static(jl_tvar_t *v, jl_value_t *t) JL_NOTSAFEPOINT
 {
-    return jl_is_some_Type(ua->body) && jl_some_Type_T(ua->body) == (jl_value_t*)ua->var;
+    if (t == (jl_value_t*)v)
+        return 1;
+    while (jl_is_unionall(t)) {
+        jl_unionall_t *ua = (jl_unionall_t*)t;
+        if (ua->var->ub == (jl_value_t*)v && ua->var->lb == jl_bottom_type &&
+            pins_typeof_static(ua->var, ua->body))
+            // the least solution for `v` is the other variable's value
+            return 1;
+        if (ua->var == v)
+            return 0; // `v` is rebound below
+        t = ua->body;
+    }
+    if (jl_is_uniontype(t)) {
+        return pins_typeof_static(v, ((jl_uniontype_t*)t)->a) &&
+               pins_typeof_static(v, ((jl_uniontype_t*)t)->b);
+    }
+    if (!jl_is_datatype(t))
+        return 0;
+    jl_datatype_t *dt = (jl_datatype_t*)t;
+    if (dt->name == jl_tuple_typename) {
+        size_t fc = jl_nparams(dt);
+        for (size_t i = 0; i < fc; i++) {
+            jl_value_t *p = jl_tparam(dt, i);
+            // a `Vararg` tail may match zero arguments
+            if (!jl_is_vararg(p) && pins_typeof_static(v, p))
+                return 1;
+        }
+    }
+    // `Type{v}` can be matched by the argument `Union{}`, and invariant
+    // occurrences guarantee at most an inhabited value (the `PIN_INHABITED`
+    // grade, not mirrored here)
+    return 0;
 }
 
-// Static check approximating Core.Compiler.constrains_var (a coarser,
-// allocation-free subset of that rule): is `var` guaranteed to be pinned by
-// any concrete leaftype subtype of `typ`? Conservative: a false return is
-// always safe. Used only on fast paths where we don't have dynamic
-// varbinding state to draw from.
+// Static check mirroring a conservative subset of
+// Core.Compiler.constrains_var: is `var` guaranteed to be pinned by any
+// concrete leaftype subtype of `typ`? A false return is always safe; a true
+// return must also hold under `constrains_var`. Used only on fast paths
+// where we don't have dynamic varbinding state to draw from.
 static int constrains_param_static(jl_tvar_t *var, jl_value_t *typ, int covariant) JL_NOTSAFEPOINT
 {
     if (typ == (jl_value_t*)var)
-        return 1;
+        // a covariant occurrence contributes `typeof` of an argument as a
+        // lower bound, which determines the least solution only when the
+        // declared lower bound does not also union into it
+        return !covariant || var->lb == jl_bottom_type;
     while (jl_is_unionall(typ)) {
         jl_unionall_t *ua = (jl_unionall_t*)typ;
-        // A Type{<:...} range can be inhabited by Union{}, which does not
-        // expose the structure of the range bound to static parameters.
-        if (covariant && !unionall_is_Type_range(ua) &&
-            constrains_param_static(var, ua->var->ub, covariant))
+        // occurrences in the inner variable's declared bound pin `var` only
+        // when every call pins that variable to a `typeof`-produced argument
+        // type; otherwise it can take the value `Union{}` (e.g. a
+        // `Type{<:...}` range matched by `Union{}`), satisfying its bounds
+        // without constraining them (the `jl_has_typevar` occurs-check gates
+        // the `pins_typeof_static` body traversal)
+        if (covariant && ua->var->lb == jl_bottom_type &&
+            jl_has_typevar(ua->var->ub, var) &&
+            pins_typeof_static(ua->var, ua->body) &&
+            constrains_param_static(var, ua->var->ub, 1))
             return 1;
-        // ua->var->lb doesn't constrain var
+        if (ua->var == var)
+            // `var` is rebound: occurrences below belong to the inner
+            // variable (issue #54893)
+            return 0;
         typ = ua->body;
     }
     if (jl_is_uniontype(typ)) {

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1420,19 +1420,18 @@ static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want
 
 // wrap a TypeVar env entry as svec(tvar, constrained): preserves TypeVar
 // identity while carrying the "constrained by any concrete subtype" bit.
-// `tvar` is the uncertain value (typically a TypeVar); `constrained` is 1
-// iff any concrete subtype of the LHS will pin this var to a definite value.
+// `tvar` is the uncertain value (something with has_free_typevars)
+// `constrained` is 1 if all concrete subtypes of the LHS will pin this var to a definite value.
 static jl_value_t *wrap_tvar_env(jl_value_t *tvar, int constrained) JL_CANSAFEPOINT
 {
     return (jl_value_t*)jl_svec2(tvar, constrained ? jl_true : jl_false);
 }
 
-// Allocation-free mirror of the `PIN_TYPEOF` grade of
-// `Core.Compiler.pin_grade`: is `v` pinned to a `typeof`-produced argument
+// See `Core.Compiler.pin_grade`: is `v` pinned to a `typeof`-produced argument
 // type (concrete, in particular not `Union{}`) by every call matching `t`?
 // True for a required covariant argument slot (directly, under nested
 // `Tuple`s, or in all arms of a `Union`), or as the sole upper bound of
-// another variable in such a slot. A false return is always safe.
+// another variable in such a slot. A false return is always conservative.
 static int pins_typeof_static(jl_tvar_t *v, jl_value_t *t) JL_NOTSAFEPOINT
 {
     if (t == (jl_value_t*)v)
@@ -1444,14 +1443,14 @@ static int pins_typeof_static(jl_tvar_t *v, jl_value_t *t) JL_NOTSAFEPOINT
             // the least solution for `v` is the other variable's value
             return 1;
         if (ua->var == v)
-            return 0; // `v` is rebound below
+            return 0; // `v` is rebound
         t = ua->body;
     }
     if (jl_is_uniontype(t)) {
         return pins_typeof_static(v, ((jl_uniontype_t*)t)->a) &&
                pins_typeof_static(v, ((jl_uniontype_t*)t)->b);
     }
-    if (!jl_is_datatype(t))
+    if (!jl_is_datatype(t) || jl_is_abstracttype(t))
         return 0;
     jl_datatype_t *dt = (jl_datatype_t*)t;
     if (dt->name == jl_tuple_typename) {
@@ -1463,17 +1462,17 @@ static int pins_typeof_static(jl_tvar_t *v, jl_value_t *t) JL_NOTSAFEPOINT
                 return 1;
         }
     }
-    // `Type{v}` can be matched by the argument `Union{}`, and invariant
-    // occurrences guarantee at most an inhabited value (the `PIN_INHABITED`
-    // grade, not mirrored here)
     return 0;
 }
 
 // Static check mirroring a conservative subset of
 // Core.Compiler.constrains_var: is `var` guaranteed to be pinned by any
 // concrete leaftype subtype of `typ`? A false return is always safe; a true
-// return must also hold under `constrains_var`. Used only on fast paths
-// where we don't have dynamic varbinding state to draw from.
+// return must also hold under `constrains_var`. Used where a path-independent
+// answer is wanted: the env-copy fast paths in `jl_subtype_env`/`intersect`,
+// which have no dynamic varbinding state to draw from, and
+// `mark_required_tuple_element`, whose answer must not depend on the
+// in-progress dynamic bounds even though `e->vars` is available there.
 static int constrains_param_static(jl_tvar_t *var, jl_value_t *typ, int covariant) JL_NOTSAFEPOINT
 {
     if (typ == (jl_value_t*)var)
@@ -1485,32 +1484,23 @@ static int constrains_param_static(jl_tvar_t *var, jl_value_t *typ, int covarian
         jl_unionall_t *ua = (jl_unionall_t*)typ;
         // occurrences in the inner variable's declared bound pin `var` only
         // when every call pins that variable to a `typeof`-produced argument
-        // type; otherwise it can take the value `Union{}` (e.g. a
-        // `Type{<:...}` range matched by `Union{}`), satisfying its bounds
-        // without constraining them (the `jl_has_typevar` occurs-check gates
-        // the `pins_typeof_static` body traversal)
+        // type, satisfying its bounds without constraining them.
         if (covariant && ua->var->lb == jl_bottom_type &&
             jl_has_typevar(ua->var->ub, var) &&
             pins_typeof_static(ua->var, ua->body) &&
             constrains_param_static(var, ua->var->ub, 1))
             return 1;
-        if (ua->var == var)
-            // `var` is rebound: occurrences below belong to the inner
-            // variable (issue #54893)
+        if (ua->var == var) // `var` is rebound
             return 0;
         typ = ua->body;
     }
     if (jl_is_uniontype(typ)) {
-        // both alternatives must constrain var
+        // conservatively, both alternatives must constrain var
         return constrains_param_static(var, ((jl_uniontype_t*)typ)->a, covariant) &&
                constrains_param_static(var, ((jl_uniontype_t*)typ)->b, covariant);
     }
-    else if (jl_is_some_Type(typ)) {
-        jl_value_t *T = jl_some_Type_T(typ);
-        if (T == (jl_value_t*)var && var->ub == (jl_value_t*)jl_any_type) {
-            return 0;
-        }
-        return constrains_param_static(var, T, 0);
+    else if (jl_is_typeeq(typ)) {
+        return constrains_param_static(var, jl_typeeq_T(typ), 0);
     }
     else if (jl_is_datatype(typ)) {
         jl_datatype_t *dt = (jl_datatype_t*)typ;
@@ -1680,7 +1670,7 @@ static int var_occurs_covariant_only(jl_value_t *t, jl_tvar_t *var, int covarian
 
 // A (closed) type value bound only through equality (`Type{X}`) positions is
 // only known up to `==` (#61323); record it as a pinned (lb == ub) typevar
-// marker. A BOUND_EQ channel still marks it *defined* (constrained) for every
+// marker. A BOUND_EQ channel still marks it defined (constrained) for every
 // `==`-equal call. Returns NULL for other values: free-typevar values keep the
 // legacy plain binding (#61242), egality-certain values stay unwrapped.
 static jl_value_t *eq_pinned_envout_marker(jl_unionall_t *u, jl_varbinding_t *vb, jl_value_t *lb,

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2876,6 +2876,12 @@ function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempt
             end
         end
         # other occurrences in the bounds of `t.var` do not reliably pin `var`
+        if t.var === var
+            # `var` is rebound: occurrences below belong to the inner
+            # variable (a constructor signature reuses the struct's own
+            # variable objects in `Type{TheStruct}`, issue #54893)
+            return false
+        end
         t = t.body
     end
     if t isa Union
@@ -2955,6 +2961,7 @@ function constrains_type_value(var::TypeVar, @nospecialize(P))
     P === var && return true
     while P isa UnionAll
         # ranges inside `P` can be widened away by the spelling of `X`
+        P.var === var && return false # `var` is rebound below
         P = P.body
     end
     if P isa Union
@@ -3010,6 +3017,7 @@ function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
             # the least solution for `v` is the other variable's value
             return PIN_TYPEOF
         end
+        t.var === v && return PIN_NONE # `v` is rebound below
         t = t.body
     end
     if t isa Union

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2789,7 +2789,8 @@ function detect_unbound_args(mods...;
     function examine(mt::Core.MethodTable)
         for m in Base.MethodList(mt)
             is_in_mods(parentmodule(m), recursive, mods) || continue
-            has_unbound_vars(m.sig) || continue
+            idxs = unbound_sparams(m.sig)
+            isempty(idxs) && continue
             tuple_sig = Base.unwrap_unionall(m.sig)::DataType
             params = tuple_sig.parameters
             # The calls that leave a parameter unbound may all dispatch to
@@ -2806,13 +2807,31 @@ function detect_unbound_args(mods...;
                     nonempty_vararg = true
                 end
             end
+            # the where-chain binders, aligned with the `static_parameter`
+            # numbering used in `idxs`
+            sig_vars = TypeVar[]
+            let body = m.sig
+                while body isa UnionAll
+                    push!(sig_vars, body.var)
+                    body = body.body
+                end
+            end
             shadowed_slots = Int[]
             for i in eachindex(params)
                 # a `Type{S}` argument (with `S` a slot-local range or a
                 # method parameter) binds `S = Union{}` — which constrains
                 # nothing in the bounds of `S` — only when the argument is
                 # `Union{}` itself
-                type_slot_var(params[i]) === nothing && continue
+                v = type_slot_var(params[i])
+                v === nothing && continue
+                # the re-check consumes a shadowed slot only through
+                # `constrains_type_value` on the slot variable's bound, so a
+                # slot that cannot pin any possibly-unbound parameter that
+                # way needs no method-table probe (`idxs` is a superset of
+                # the parameters still unbound under `nonempty_vararg`)
+                any(idx -> (var = sig_vars[idx];
+                            v !== var && Core.Compiler.constrains_type_value(var, v.ub)),
+                    idxs) || continue
                 bot_params = Any[params...]
                 bot_params[i] = Type{Union{}}
                 bot_sig = Base.rewrap_unionall(Tuple{bot_params...}, m.sig)
@@ -2828,9 +2847,12 @@ function detect_unbound_args(mods...;
                 end
             end
             # re-check unboundness under the verified assumptions, keeping
-            # the parameter indices for the body query below
-            idxs = unbound_sparams(m.sig, nonempty_vararg, shadowed_slots)
-            isempty(idxs) && continue
+            # the parameter indices for the body query below; without any
+            # assumption the first scan already answered
+            if nonempty_vararg || !isempty(shadowed_slots)
+                idxs = unbound_sparams(m.sig, nonempty_vararg, shadowed_slots)
+                isempty(idxs) && continue
+            end
             # unboundness only matters if the body actually reads one of the
             # possibly-unbound parameters
             reads_sparams(m, idxs) || continue
@@ -2894,8 +2916,6 @@ function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
     end
     return idxs
 end
-
-has_unbound_vars(@nospecialize sig) = !isempty(unbound_sparams(sig))
 
 # Whether the lowered body of `m` reads any of the static parameters whose
 # indices are in `idxs`. An `Expr(:isdefined, ...)` query does not count as a

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2760,6 +2760,9 @@ are provably shadowed by a more specific method: a definition like
 `f(::Type{Union{}})` covers the `Union{}` argument that would leave `T`
 unbound in `f(::Type{<:T}) where {T}`, and a zero-argument fallback covers
 the empty call that would leave `T` unbound in `f(x::T...) where {T}`.
+Methods are also not reported when none of the possibly-unbound parameters
+is read in the method's lowered body (querying a parameter with
+`@isdefined` does not count as a read, since it cannot throw).
 
 By default, any undefined symbols trigger a warning. This warning can
 be suppressed by supplying a collection of `GlobalRef`s for which
@@ -2824,10 +2827,13 @@ function detect_unbound_args(mods...;
                     push!(shadowed_slots, i)
                 end
             end
-            if nonempty_vararg || !isempty(shadowed_slots)
-                # re-check unboundness under the verified assumptions
-                has_unbound_vars(m.sig, nonempty_vararg, shadowed_slots) || continue
-            end
+            # re-check unboundness under the verified assumptions, keeping
+            # the parameter indices for the body query below
+            idxs = unbound_sparams(m.sig, nonempty_vararg, shadowed_slots)
+            isempty(idxs) && continue
+            # unboundness only matters if the body actually reads one of the
+            # possibly-unbound parameters
+            reads_sparams(m, idxs) || continue
             push!(ambs, m)
         end
     end
@@ -2855,32 +2861,67 @@ function type_slot_var(@nospecialize(p))
     return nothing
 end
 
-# `nonempty_vararg` assumes the signature's trailing `Vararg` matches at
-# least one argument; `shadowed_slots` lists `Type{S}` argument positions
-# whose `Union{}` member never reaches this method. Both are assumptions the
-# caller must justify (see `detect_unbound_args`).
-function has_unbound_vars(@nospecialize(sig), nonempty_vararg::Bool=false,
-                          shadowed_slots::Vector{Int}=Int[])
+# The 1-based positions in the signature's `where` chain — which is also the
+# `static_parameter` numbering used by the lowered body — of parameters that
+# some matching call may leave unbound. `nonempty_vararg` assumes the
+# signature's trailing `Vararg` matches at least one argument;
+# `shadowed_slots` lists `Type{S}` argument positions whose `Union{}` member
+# never reaches this method. Both are assumptions the caller must justify
+# (see `detect_unbound_args`).
+function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
+                         shadowed_slots::Vector{Int}=Int[])
+    idxs = Int[]
     params = isempty(shadowed_slots) ? Core.svec() :
         (Base.unwrap_unionall(sig)::DataType).parameters
     body = sig
+    i = 0
     while body isa UnionAll
+        i += 1
         var = body.var
         body = body.body
         Core.Compiler.constrains_var(var, body, #=covariant=#true, nonempty_vararg) && continue
         pinned = false
-        for i in shadowed_slots
+        for j in shadowed_slots
             # any non-`Union{}` value of this slot's `Type` parameter pins
             # `var` if it occurs invariantly below a constructor of its bound
-            v = type_slot_var(params[i])::TypeVar
+            v = type_slot_var(params[j])::TypeVar
             if v !== var && Core.Compiler.constrains_type_value(var, v.ub)
                 pinned = true
                 break
             end
         end
-        pinned || return true
+        pinned || push!(idxs, i)
     end
-    return false
+    return idxs
+end
+
+has_unbound_vars(@nospecialize sig) = !isempty(unbound_sparams(sig))
+
+# Whether the lowered body of `m` reads any of the static parameters whose
+# indices are in `idxs`. An `Expr(:isdefined, ...)` query does not count as a
+# read (it cannot throw), but a raw read is counted even when an `@isdefined`
+# guard exists elsewhere in the body: verifying that the guard dominates the
+# read would require dataflow over typed code. Conservatively `true` when no
+# lowered code is available to inspect (e.g. generated functions).
+function reads_sparams(m::Method, idxs::Vector{Int})
+    isdefined(m, :source) || return true
+    src = Base.uncompressed_ir(m)
+    read = BitSet()
+    function scan(@nospecialize ex)
+        ex isa Expr || return
+        if ex.head === :static_parameter
+            push!(read, ex.args[1]::Int)
+        elseif ex.head !== :isdefined
+            for a in ex.args
+                scan(a)
+            end
+        end
+        return
+    end
+    for stmt in src.code
+        scan(stmt)
+    end
+    return any(in(read), idxs)
 end
 
 

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2755,7 +2755,10 @@ a definite value, so reading such a parameter in the method body throws an
 
 The check is a conservative static approximation of how subtyping assigns
 static parameters, so a reported method may in practice never see the calls
-that leave the parameter unbound. Methods are not reported when those calls
+that leave the parameter unbound. A parameter that some matching call can
+pin only as `T == Union{}`, by absorbing a `Union` arm (such as
+`f(::Vector{Union{Nothing, T}}) where {T<:Real}` called with a
+`Vector{Nothing}`), is deliberately reported as well. Methods are not reported when those calls
 are provably shadowed by a more specific method: a definition like
 `f(::Type{Union{}})` covers the `Union{}` argument that would leave `T`
 unbound in `f(::Type{<:T}) where {T}`, and a zero-argument fallback covers

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2761,6 +2761,9 @@ are provably shadowed by a more specific method: a definition like
 `f(::Type{Union{}})` covers the `Union{}` argument that would leave `T`
 unbound in `f(::Type{<:T}) where {T}`, and a zero-argument fallback covers
 the empty call that would leave `T` unbound in `f(x::T...) where {T}`.
+Methods are also not reported when none of the possibly-unbound parameters
+is read in the method's lowered body (querying a parameter with
+`@isdefined` does not count as a read, since it cannot throw).
 
 By default, any undefined symbols trigger a warning. This warning can
 be suppressed by supplying a collection of `GlobalRef`s for which
@@ -2825,10 +2828,13 @@ function detect_unbound_args(mods...;
                     push!(shadowed_slots, i)
                 end
             end
-            if nonempty_vararg || !isempty(shadowed_slots)
-                # re-check unboundness under the verified assumptions
-                has_unbound_vars(m.sig, nonempty_vararg, shadowed_slots) || continue
-            end
+            # re-check unboundness under the verified assumptions, keeping
+            # the parameter indices for the body query below
+            idxs = unbound_sparams(m.sig, nonempty_vararg, shadowed_slots)
+            isempty(idxs) && continue
+            # unboundness only matters if the body actually reads one of the
+            # possibly-unbound parameters
+            reads_sparams(m, idxs) || continue
             push!(ambs, m)
         end
     end
@@ -2856,32 +2862,67 @@ function type_slot_var(@nospecialize(p))
     return nothing
 end
 
-# `nonempty_vararg` assumes the signature's trailing `Vararg` matches at
-# least one argument; `shadowed_slots` lists `Type{S}` argument positions
-# whose `Union{}` member never reaches this method. Both are assumptions the
-# caller must justify (see `detect_unbound_args`).
-function has_unbound_vars(@nospecialize(sig), nonempty_vararg::Bool=false,
-                          shadowed_slots::Vector{Int}=Int[])
+# The 1-based positions in the signature's `where` chain — which is also the
+# `static_parameter` numbering used by the lowered body — of parameters that
+# some matching call may leave unbound. `nonempty_vararg` assumes the
+# signature's trailing `Vararg` matches at least one argument;
+# `shadowed_slots` lists `Type{S}` argument positions whose `Union{}` member
+# never reaches this method. Both are assumptions the caller must justify
+# (see `detect_unbound_args`).
+function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
+                         shadowed_slots::Vector{Int}=Int[])
+    idxs = Int[]
     params = isempty(shadowed_slots) ? Core.svec() :
         (Base.unwrap_unionall(sig)::DataType).parameters
     body = sig
+    i = 0
     while body isa UnionAll
+        i += 1
         var = body.var
         body = body.body
         Core.Compiler.constrains_var(var, body, #=covariant=#true, nonempty_vararg) && continue
         pinned = false
-        for i in shadowed_slots
+        for j in shadowed_slots
             # any non-`Union{}` value of this slot's `Type` parameter pins
             # `var` if it occurs invariantly below a constructor of its bound
-            v = type_slot_var(params[i])::TypeVar
+            v = type_slot_var(params[j])::TypeVar
             if v !== var && Core.Compiler.constrains_type_value(var, v.ub)
                 pinned = true
                 break
             end
         end
-        pinned || return true
+        pinned || push!(idxs, i)
     end
-    return false
+    return idxs
+end
+
+has_unbound_vars(@nospecialize sig) = !isempty(unbound_sparams(sig))
+
+# Whether the lowered body of `m` reads any of the static parameters whose
+# indices are in `idxs`. An `Expr(:isdefined, ...)` query does not count as a
+# read (it cannot throw), but a raw read is counted even when an `@isdefined`
+# guard exists elsewhere in the body: verifying that the guard dominates the
+# read would require dataflow over typed code. Conservatively `true` when no
+# lowered code is available to inspect (e.g. generated functions).
+function reads_sparams(m::Method, idxs::Vector{Int})
+    isdefined(m, :source) || return true
+    src = Base.uncompressed_ir(m)
+    read = BitSet()
+    function scan(@nospecialize ex)
+        ex isa Expr || return
+        if ex.head === :static_parameter
+            push!(read, ex.args[1]::Int)
+        elseif ex.head !== :isdefined
+            for a in ex.args
+                scan(a)
+            end
+        end
+        return
+    end
+    for stmt in src.code
+        scan(stmt)
+    end
+    return any(in(read), idxs)
 end
 
 

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2877,6 +2877,12 @@ function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempt
             end
         end
         # other occurrences in the bounds of `t.var` do not reliably pin `var`
+        if t.var === var
+            # `var` is rebound: occurrences below belong to the inner
+            # variable (a constructor signature reuses the struct's own
+            # variable objects in `Type{TheStruct}`, issue #54893)
+            return false
+        end
         t = t.body
     end
     if t isa Union
@@ -2956,6 +2962,7 @@ function constrains_type_value(var::TypeVar, @nospecialize(P))
     P === var && return true
     while P isa UnionAll
         # ranges inside `P` can be widened away by the spelling of `X`
+        P.var === var && return false # `var` is rebound below
         P = P.body
     end
     if P isa Union
@@ -3011,6 +3018,7 @@ function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
             # the least solution for `v` is the other variable's value
             return PIN_TYPEOF
         end
+        t.var === v && return PIN_NONE # `v` is rebound below
         t = t.body
     end
     if t isa Union

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2782,13 +2782,13 @@ function detect_unbound_args(mods...;
     @nospecialize mods
     ambs = Set{Method}()
     mods = Module[mods...]
+    world = Base.get_world_counter()
     function examine(mt::Core.MethodTable)
         for m in Base.MethodList(mt)
             is_in_mods(parentmodule(m), recursive, mods) || continue
             has_unbound_vars(m.sig) || continue
             tuple_sig = Base.unwrap_unionall(m.sig)::DataType
             params = tuple_sig.parameters
-            world = Base.get_world_counter()
             # The calls that leave a parameter unbound may all dispatch to
             # more specific methods, making the unboundness unreachable.
             # Verify which of the two shadowable call classes are covered,
@@ -2813,12 +2813,21 @@ function detect_unbound_args(mods...;
                 bot_params = Any[params...]
                 bot_params[i] = Type{Union{}}
                 bot_sig = Base.rewrap_unionall(Tuple{bot_params...}, m.sig)
+                # the rescue argument requires `m` itself to cover the probe
+                # signature: only then does a different lookup result prove
+                # that every `Union{}` call dispatches away from `m` (rather
+                # than the probe merely escaping to a broad fallback while
+                # `m` still wins the concrete calls)
+                bot_sig <: m.sig || continue
                 mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), bot_sig, nothing, world)
                 if mf !== nothing && mf !== m
                     push!(shadowed_slots, i)
                 end
             end
-            has_unbound_vars(m.sig, nonempty_vararg, shadowed_slots) || continue
+            if nonempty_vararg || !isempty(shadowed_slots)
+                # re-check unboundness under the verified assumptions
+                has_unbound_vars(m.sig, nonempty_vararg, shadowed_slots) || continue
+            end
             push!(ambs, m)
         end
     end
@@ -2826,239 +2835,11 @@ function detect_unbound_args(mods...;
     return collect(ambs)
 end
 
-# When a call matches a method, type intersection computes a value for each
-# static parameter (`subtype_unionall` in `src/subtype.c`). A parameter that
-# the match does not pin to a definite value is left unbound, and reading it
-# in the method body throws `UndefVarError`. Subtyping pins a variable
-# through two channels (`eff_constrained` in `src/subtype.c`):
-#
-#  * an invariant occurrence: the corresponding position of the call
-#    signature must be *equal* to the instantiated method parameter, so any
-#    successful match determines the variable. This fails to be definite
-#    only where distinct assignments can spell equal types: a `Union` arm
-#    can be absorbed by the other arm (`Union{T,Int}` matched against `Int`),
-#    a `Vararg` can be respelled (`Tuple{Vararg{T}}` matched against
-#    `Tuple`), and the bound of an inner variable can be widened away
-#    (`Vector{<:T}` matched against `Vector`), so none of those count.
-#
-#  * a covariant occurrence: the position is filled with `typeof` of an
-#    argument, which contributes a lower bound, and the least solution is
-#    taken as the parameter value. This is definite only if the declared
-#    lower bound of the variable is `Union{}` (otherwise other types union
-#    into the solution: `f(x::T) where {T>:Int}` is unbound for `f(2.0)`),
-#    and only for occurrences guaranteed to contribute in every call:
-#    present in all `Union` arms, not under a `Vararg` tail (which may match
-#    zero arguments), and not merely in the declared bounds of another
-#    variable — unless that variable is itself pinned to a `typeof`-produced
-#    argument type in every call, since a variable ranging over an invariant
-#    position or over a `Type` argument can take the value `Union{}`,
-#    satisfying its bounds without constraining them (`f(::Type{<:T})` is
-#    unbound for `f(Union{})`, and `f(::Vector{<:T})` for a
-#    `Vector{Union{}}` argument).
-#
-# `constrains_var` is a conservative static approximation of that dynamic
-# rule: `true` means every matching call pins `var`; `false` means some call
-# may leave it unbound. `nonempty_vararg` credits the signature's own
-# trailing `Vararg` as if it matched at least one argument (it is not
-# propagated into nested positions, where an empty tuple can always occur).
-
-function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempty_vararg::Bool=false)
-    if t === var
-        return !covariant || var.lb === Union{}
-    end
-    while t isa UnionAll
-        if covariant && t.var.lb === Union{}
-            pin = pin_grade(t.var, t.body, nonempty_vararg)
-            if pin == PIN_TYPEOF && constrains_var(var, t.var.ub, true)
-                return true
-            elseif pin == PIN_INHABITED && constrains_type_value(var, t.var.ub)
-                return true
-            end
-        end
-        # other occurrences in the bounds of `t.var` do not reliably pin `var`
-        if t.var === var
-            # `var` is rebound: occurrences below belong to the inner
-            # variable (a constructor signature reuses the struct's own
-            # variable objects in `Type{TheStruct}`, issue #54893)
-            return false
-        end
-        t = t.body
-    end
-    if t isa Union
-        if covariant
-            # each arm is individually reachable by some argument, so every
-            # arm must pin `var`
-            return constrains_var(var, t.a, true) &&
-                   constrains_var(var, t.b, true)
-        end
-        # matched by type equality: pinned if every arm pins `var`, or
-        # through any arm that the matched value must expose because no
-        # instantiation of it can be absorbed into the other arms
-        # (issues #58427, #59023)
-        constrains_var(var, t.a, false) && constrains_var(var, t.b, false) &&
-            return true
-        arms = Base.uniontypes(t)
-        for (i, arm) in enumerate(arms)
-            others = mapreduce(j -> arms[j], (a, b) -> Union{a, b},
-                               filter(!=(i), eachindex(arms)))
-            others = UnionAll(var, others)
-            if arm === var
-                # absorbing a bare `var` arm forces `var = Union{}`, which
-                # pins it, provided `Union{}` is its only value inside the
-                # other arms
-                var.lb === Union{} && union_disjoint(var.ub, others) &&
-                    return true
-            elseif union_disjoint(UnionAll(var, arm), others) &&
-                constrains_var(var, arm, false)
-                return true
-            end
-        end
-        return false
-    end
-    if Base.isType(t)
-        # the parameter is matched exactly by the argument (covariant) or by
-        # type equality (invariant)
-        return constrains_var(var, Base.type_parameter(t), false)
-    end
-    t isa DataType || return false
-    if t.name === Tuple.name
-        for p in t.parameters
-            if p isa Core.TypeofVararg
-                # the argument count pins `N` exactly (including zero)
-                isdefined(p, :N) && constrains_var(var, p.N, covariant) && return true
-                if covariant && nonempty_vararg && isdefined(p, :T)
-                    constrains_var(var, p.T, covariant) && return true
-                end
-            else
-                constrains_var(var, p, covariant) && return true
-            end
-        end
-    else
-        for p in t.parameters
-            constrains_var(var, p, false) && return true
-        end
-    end
-    return false
-end
-
-# Whether no instantiation of `a` overlaps `b`, so that no part of a matched
-# value can satisfy both. `false` when undecidable (free typevars remain).
-function union_disjoint(@nospecialize(a), @nospecialize(b))
-    (Base.has_free_typevars(a) || Base.has_free_typevars(b)) && return false
-    return Base.typeintersect(a, b) === Union{}
-end
-
-# Whether matching any specific type value `X <: P` other than `Union{}`
-# necessarily pins `var` (or fails to match): `var` must occur where the
-# subtyping query is forced to constrain it — as `P` itself (`X` becomes its
-# lower bound, which pins any non-`Union{}` value up to type equality),
-# invariantly below a non-Tuple constructor, or as a `Vararg` length — in
-# every `Union` arm. Fixed `Tuple` slots of `P` correspond to non-`Union{}`
-# positions of `X` (a tuple type with a `Union{}` field cannot be
-# constructed) and are descended into; `Vararg` tails and ranges inside `P`
-# can be spelled away by `X` and never count.
-function constrains_type_value(var::TypeVar, @nospecialize(P))
-    P === var && return true
-    while P isa UnionAll
-        # ranges inside `P` can be widened away by the spelling of `X`
-        P.var === var && return false # `var` is rebound below
-        P = P.body
-    end
-    if P isa Union
-        return constrains_type_value(var, P.a) &&
-               constrains_type_value(var, P.b)
-    end
-    if Base.isType(P)
-        # X <: Type{q} pins the parameter of X by equality with q
-        return constrains_var(var, Base.type_parameter(P), false)
-    end
-    P isa DataType || return false
-    if P.name === Tuple.name
-        for p in P.parameters
-            if p isa Core.TypeofVararg
-                # the length of X pins `N` exactly (or the match fails)
-                isdefined(p, :N) && constrains_var(var, p.N, false) && return true
-            else
-                constrains_type_value(var, p) && return true
-            end
-        end
-        return false
-    end
-    for p in P.parameters
-        constrains_var(var, p, false) && return true
-    end
-    return false
-end
-
-# How strongly the position(s) of `v` in `t` pin its value, for every call:
-#  * `PIN_TYPEOF`: `v` takes a `typeof`-produced argument type — a concrete
-#    type, in particular not `Union{}` and without free type variables. This
-#    holds for a required covariant argument slot (directly, under nested
-#    `Tuple`s, or in all arms of a `Union`), or as the sole upper bound of
-#    another variable in such a slot.
-#  * `PIN_INHABITED`: `v` takes an *inhabited* type (not `Union{}`), though
-#    possibly an abstract one: `v` is an invariant parameter of a constructor
-#    in a required covariant slot, and that constructor declares a field of
-#    exactly that parameter's type, so a value of the parameter type must
-#    exist inside the argument. (This assumes the field can not be left
-#    undefined by an incomplete `new` inner constructor.)
-#  * `PIN_NONE`: neither is guaranteed; `v` may be `Union{}` (e.g. `Type{v}`
-#    positions matched by the argument `Union{}`, or invariant parameters
-#    without such a field), leaving its bounds unconstraining.
-const PIN_NONE = 0
-const PIN_INHABITED = 1
-const PIN_TYPEOF = 2
-
-function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
-    t === v && return PIN_TYPEOF
-    while t isa UnionAll
-        if t.var.ub === v && t.var.lb === Union{} &&
-            pin_grade(t.var, t.body) == PIN_TYPEOF
-            # the least solution for `v` is the other variable's value
-            return PIN_TYPEOF
-        end
-        t.var === v && return PIN_NONE # `v` is rebound below
-        t = t.body
-    end
-    if t isa Union
-        return min(pin_grade(v, t.a), pin_grade(v, t.b))
-    end
-    t isa DataType || return PIN_NONE
-    if t.name === Tuple.name
-        grade = PIN_NONE
-        for p in t.parameters
-            if p isa Core.TypeofVararg
-                if nonempty_vararg && isdefined(p, :T)
-                    grade = max(grade, pin_grade(v, p.T))
-                end
-            else
-                grade = max(grade, pin_grade(v, p))
-            end
-            grade == PIN_TYPEOF && break
-        end
-        return grade
-    end
-    Base.isType(t) && return PIN_NONE
-    for (i, p) in enumerate(t.parameters)
-        if p === v && param_has_field(t, i)
-            return PIN_INHABITED
-        end
-    end
-    return PIN_NONE
-end
-
-# Whether the `i`-th type parameter of `t`'s constructor is also the declared
-# type of one of its fields, so that instances contain a value of it.
-function param_has_field(t::DataType, i::Int)
-    base = Base.unwrap_unionall(t.name.wrapper)
-    base isa DataType || return false
-    tv = base.parameters[i]
-    tv isa TypeVar || return false
-    for ft in Base.datatype_fieldtypes(base)
-        ft === tv && return true
-    end
-    return false
-end
+# The static rule for whether every call matching a signature pins a static
+# parameter to a definite value is `Core.Compiler.constrains_var` (see
+# `Compiler/src/inferencestate.jl` for its derivation from subtyping's
+# parameter-assignment semantics); inference uses the same predicate to
+# compute the maybe-undef bit of static parameters.
 
 # The `Type{S}`-valued argument slots recognized by the `Union{}`-shadowing
 # rescue in `detect_unbound_args`: either a slot-local range
@@ -3086,13 +2867,13 @@ function has_unbound_vars(@nospecialize(sig), nonempty_vararg::Bool=false,
     while body isa UnionAll
         var = body.var
         body = body.body
-        constrains_var(var, body, #=covariant=#true, nonempty_vararg) && continue
+        Core.Compiler.constrains_var(var, body, #=covariant=#true, nonempty_vararg) && continue
         pinned = false
         for i in shadowed_slots
             # any non-`Union{}` value of this slot's `Type` parameter pins
             # `var` if it occurs invariantly below a constructor of its bound
             v = type_slot_var(params[i])::TypeVar
-            if v !== var && constrains_type_value(var, v.ub)
+            if v !== var && Core.Compiler.constrains_type_value(var, v.ub)
                 pinned = true
                 break
             end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2756,7 +2756,10 @@ a definite value, so reading such a parameter in the method body throws an
 
 The check is a conservative static approximation of how subtyping assigns
 static parameters, so a reported method may in practice never see the calls
-that leave the parameter unbound. Methods are not reported when those calls
+that leave the parameter unbound. A parameter that some matching call can
+pin only as `T == Union{}`, by absorbing a `Union` arm (such as
+`f(::Vector{Union{Nothing, T}}) where {T<:Real}` called with a
+`Vector{Nothing}`), is deliberately reported as well. Methods are not reported when those calls
 are provably shadowed by a more specific method: a definition like
 `f(::Type{Union{}})` covers the `Union{}` argument that would leave `T`
 unbound in `f(::Type{<:T}) where {T}`, and a zero-argument fallback covers

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2790,7 +2790,8 @@ function detect_unbound_args(mods...;
     function examine(mt::Core.MethodTable)
         for m in Base.MethodList(mt)
             is_in_mods(parentmodule(m), recursive, mods) || continue
-            has_unbound_vars(m.sig) || continue
+            idxs = unbound_sparams(m.sig)
+            isempty(idxs) && continue
             tuple_sig = Base.unwrap_unionall(m.sig)::DataType
             params = tuple_sig.parameters
             # The calls that leave a parameter unbound may all dispatch to
@@ -2807,13 +2808,31 @@ function detect_unbound_args(mods...;
                     nonempty_vararg = true
                 end
             end
+            # the where-chain binders, aligned with the `static_parameter`
+            # numbering used in `idxs`
+            sig_vars = TypeVar[]
+            let body = m.sig
+                while body isa UnionAll
+                    push!(sig_vars, body.var)
+                    body = body.body
+                end
+            end
             shadowed_slots = Int[]
             for i in eachindex(params)
                 # a `Type{S}` argument (with `S` a slot-local range or a
                 # method parameter) binds `S = Union{}` — which constrains
                 # nothing in the bounds of `S` — only when the argument is
                 # `Union{}` itself
-                type_slot_var(params[i]) === nothing && continue
+                v = type_slot_var(params[i])
+                v === nothing && continue
+                # the re-check consumes a shadowed slot only through
+                # `constrains_type_value` on the slot variable's bound, so a
+                # slot that cannot pin any possibly-unbound parameter that
+                # way needs no method-table probe (`idxs` is a superset of
+                # the parameters still unbound under `nonempty_vararg`)
+                any(idx -> (var = sig_vars[idx];
+                            v !== var && Core.Compiler.constrains_type_value(var, v.ub)),
+                    idxs) || continue
                 bot_params = Any[params...]
                 bot_params[i] = Type{Union{}}
                 bot_sig = Base.rewrap_unionall(Tuple{bot_params...}, m.sig)
@@ -2829,9 +2848,12 @@ function detect_unbound_args(mods...;
                 end
             end
             # re-check unboundness under the verified assumptions, keeping
-            # the parameter indices for the body query below
-            idxs = unbound_sparams(m.sig, nonempty_vararg, shadowed_slots)
-            isempty(idxs) && continue
+            # the parameter indices for the body query below; without any
+            # assumption the first scan already answered
+            if nonempty_vararg || !isempty(shadowed_slots)
+                idxs = unbound_sparams(m.sig, nonempty_vararg, shadowed_slots)
+                isempty(idxs) && continue
+            end
             # unboundness only matters if the body actually reads one of the
             # possibly-unbound parameters
             reads_sparams(m, idxs) || continue
@@ -2895,8 +2917,6 @@ function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
     end
     return idxs
 end
-
-has_unbound_vars(@nospecialize sig) = !isempty(unbound_sparams(sig))
 
 # Whether the lowered body of `m` reads any of the static parameters whose
 # indices are in `idxs`. An `Expr(:isdefined, ...)` query does not count as a

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2749,8 +2749,18 @@ detect_closure_boxes_all_modules() = detect_closure_boxes(Base.loaded_modules_ar
 """
     detect_unbound_args(mod1, mod2...; recursive=false, allowed_undefineds=nothing)
 
-Return a vector of `Method`s which may have unbound type parameters.
-Use `recursive=true` to test in all submodules.
+Return a vector of `Method`s which may have unbound type parameters: some
+call matching the method's signature does not pin every static parameter to
+a definite value, so reading such a parameter in the method body throws an
+`UndefVarError`. Use `recursive=true` to test in all submodules.
+
+The check is a conservative static approximation of how subtyping assigns
+static parameters, so a reported method may in practice never see the calls
+that leave the parameter unbound. Methods are not reported when those calls
+are provably shadowed by a more specific method: a definition like
+`f(::Type{Union{}})` covers the `Union{}` argument that would leave `T`
+unbound in `f(::Type{<:T}) where {T}`, and a zero-argument fallback covers
+the empty call that would leave `T` unbound in `f(x::T...) where {T}`.
 
 By default, any undefined symbols trigger a warning. This warning can
 be suppressed by supplying a collection of `GlobalRef`s for which
@@ -2778,15 +2788,38 @@ function detect_unbound_args(mods...;
             is_in_mods(parentmodule(m), recursive, mods) || continue
             has_unbound_vars(m.sig) || continue
             tuple_sig = Base.unwrap_unionall(m.sig)::DataType
+            params = tuple_sig.parameters
+            world = Base.get_world_counter()
+            # The calls that leave a parameter unbound may all dispatch to
+            # more specific methods, making the unboundness unreachable.
+            # Verify which of the two shadowable call classes are covered,
+            # then re-check unboundness under those assumptions.
+            nonempty_vararg = false
             if Base.isvatuple(tuple_sig)
-                params = tuple_sig.parameters[1:(end - 1)]
-                tuple_sig = Base.rewrap_unionall(Tuple{params...}, m.sig)
-                world = Base.get_world_counter()
-                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), tuple_sig, nothing, world)
-                if mf !== nothing && mf !== m && mf.sig <: tuple_sig
-                    continue
+                # a trailing Vararg leaves its element variables unbound only
+                # for zero-length matches
+                short_sig = Base.rewrap_unionall(Tuple{params[1:(end - 1)]...}, m.sig)
+                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), short_sig, nothing, world)
+                if mf !== nothing && mf !== m && mf.sig <: short_sig
+                    nonempty_vararg = true
                 end
             end
+            shadowed_slots = Int[]
+            for i in eachindex(params)
+                # a `Type{S}` argument (with `S` a slot-local range or a
+                # method parameter) binds `S = Union{}` — which constrains
+                # nothing in the bounds of `S` — only when the argument is
+                # `Union{}` itself
+                type_slot_var(params[i]) === nothing && continue
+                bot_params = Any[params...]
+                bot_params[i] = Type{Union{}}
+                bot_sig = Base.rewrap_unionall(Tuple{bot_params...}, m.sig)
+                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), bot_sig, nothing, world)
+                if mf !== nothing && mf !== m
+                    push!(shadowed_slots, i)
+                end
+            end
+            has_unbound_vars(m.sig, nonempty_vararg, shadowed_slots) || continue
             push!(ambs, m)
         end
     end
@@ -2794,13 +2827,270 @@ function detect_unbound_args(mods...;
     return collect(ambs)
 end
 
-function has_unbound_vars(@nospecialize sig)
-    while sig isa UnionAll
-        var = sig.var
-        sig = sig.body
-        if !Core.Compiler.constrains_param(var, sig, #=covariant=#true, #=type_constrains=#true)
-            return true
+# When a call matches a method, type intersection computes a value for each
+# static parameter (`subtype_unionall` in `src/subtype.c`). A parameter that
+# the match does not pin to a definite value is left unbound, and reading it
+# in the method body throws `UndefVarError`. Subtyping pins a variable
+# through two channels (`eff_constrained` in `src/subtype.c`):
+#
+#  * an invariant occurrence: the corresponding position of the call
+#    signature must be *equal* to the instantiated method parameter, so any
+#    successful match determines the variable. This fails to be definite
+#    only where distinct assignments can spell equal types: a `Union` arm
+#    can be absorbed by the other arm (`Union{T,Int}` matched against `Int`),
+#    a `Vararg` can be respelled (`Tuple{Vararg{T}}` matched against
+#    `Tuple`), and the bound of an inner variable can be widened away
+#    (`Vector{<:T}` matched against `Vector`), so none of those count.
+#
+#  * a covariant occurrence: the position is filled with `typeof` of an
+#    argument, which contributes a lower bound, and the least solution is
+#    taken as the parameter value. This is definite only if the declared
+#    lower bound of the variable is `Union{}` (otherwise other types union
+#    into the solution: `f(x::T) where {T>:Int}` is unbound for `f(2.0)`),
+#    and only for occurrences guaranteed to contribute in every call:
+#    present in all `Union` arms, not under a `Vararg` tail (which may match
+#    zero arguments), and not merely in the declared bounds of another
+#    variable — unless that variable is itself pinned to a `typeof`-produced
+#    argument type in every call, since a variable ranging over an invariant
+#    position or over a `Type` argument can take the value `Union{}`,
+#    satisfying its bounds without constraining them (`f(::Type{<:T})` is
+#    unbound for `f(Union{})`, and `f(::Vector{<:T})` for a
+#    `Vector{Union{}}` argument).
+#
+# `constrains_var` is a conservative static approximation of that dynamic
+# rule: `true` means every matching call pins `var`; `false` means some call
+# may leave it unbound. `nonempty_vararg` credits the signature's own
+# trailing `Vararg` as if it matched at least one argument (it is not
+# propagated into nested positions, where an empty tuple can always occur).
+
+function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempty_vararg::Bool=false)
+    if t === var
+        return !covariant || var.lb === Union{}
+    end
+    while t isa UnionAll
+        if covariant && t.var.lb === Union{}
+            pin = pin_grade(t.var, t.body, nonempty_vararg)
+            if pin == PIN_TYPEOF && constrains_var(var, t.var.ub, true)
+                return true
+            elseif pin == PIN_INHABITED && constrains_type_value(var, t.var.ub)
+                return true
+            end
         end
+        # other occurrences in the bounds of `t.var` do not reliably pin `var`
+        t = t.body
+    end
+    if t isa Union
+        if covariant
+            # each arm is individually reachable by some argument, so every
+            # arm must pin `var`
+            return constrains_var(var, t.a, true) &&
+                   constrains_var(var, t.b, true)
+        end
+        # matched by type equality: pinned if every arm pins `var`, or
+        # through any arm that the matched value must expose because no
+        # instantiation of it can be absorbed into the other arms
+        # (issues #58427, #59023)
+        constrains_var(var, t.a, false) && constrains_var(var, t.b, false) &&
+            return true
+        arms = Base.uniontypes(t)
+        for (i, arm) in enumerate(arms)
+            others = mapreduce(j -> arms[j], (a, b) -> Union{a, b},
+                               filter(!=(i), eachindex(arms)))
+            others = UnionAll(var, others)
+            if arm === var
+                # absorbing a bare `var` arm forces `var = Union{}`, which
+                # pins it, provided `Union{}` is its only value inside the
+                # other arms
+                var.lb === Union{} && union_disjoint(var.ub, others) &&
+                    return true
+            elseif union_disjoint(UnionAll(var, arm), others) &&
+                constrains_var(var, arm, false)
+                return true
+            end
+        end
+        return false
+    end
+    if Base.isType(t)
+        # the parameter is matched exactly by the argument (covariant) or by
+        # type equality (invariant)
+        return constrains_var(var, Base.type_parameter(t), false)
+    end
+    t isa DataType || return false
+    if t.name === Tuple.name
+        for p in t.parameters
+            if p isa Core.TypeofVararg
+                # the argument count pins `N` exactly (including zero)
+                isdefined(p, :N) && constrains_var(var, p.N, covariant) && return true
+                if covariant && nonempty_vararg && isdefined(p, :T)
+                    constrains_var(var, p.T, covariant) && return true
+                end
+            else
+                constrains_var(var, p, covariant) && return true
+            end
+        end
+    else
+        for p in t.parameters
+            constrains_var(var, p, false) && return true
+        end
+    end
+    return false
+end
+
+# Whether no instantiation of `a` overlaps `b`, so that no part of a matched
+# value can satisfy both. `false` when undecidable (free typevars remain).
+function union_disjoint(@nospecialize(a), @nospecialize(b))
+    (Base.has_free_typevars(a) || Base.has_free_typevars(b)) && return false
+    return Base.typeintersect(a, b) === Union{}
+end
+
+# Whether matching any specific type value `X <: P` other than `Union{}`
+# necessarily pins `var` (or fails to match): `var` must occur where the
+# subtyping query is forced to constrain it — as `P` itself (`X` becomes its
+# lower bound, which pins any non-`Union{}` value up to type equality),
+# invariantly below a non-Tuple constructor, or as a `Vararg` length — in
+# every `Union` arm. Fixed `Tuple` slots of `P` correspond to non-`Union{}`
+# positions of `X` (a tuple type with a `Union{}` field cannot be
+# constructed) and are descended into; `Vararg` tails and ranges inside `P`
+# can be spelled away by `X` and never count.
+function constrains_type_value(var::TypeVar, @nospecialize(P))
+    P === var && return true
+    while P isa UnionAll
+        # ranges inside `P` can be widened away by the spelling of `X`
+        P = P.body
+    end
+    if P isa Union
+        return constrains_type_value(var, P.a) &&
+               constrains_type_value(var, P.b)
+    end
+    if Base.isType(P)
+        # X <: Type{q} pins the parameter of X by equality with q
+        return constrains_var(var, Base.type_parameter(P), false)
+    end
+    P isa DataType || return false
+    if P.name === Tuple.name
+        for p in P.parameters
+            if p isa Core.TypeofVararg
+                # the length of X pins `N` exactly (or the match fails)
+                isdefined(p, :N) && constrains_var(var, p.N, false) && return true
+            else
+                constrains_type_value(var, p) && return true
+            end
+        end
+        return false
+    end
+    for p in P.parameters
+        constrains_var(var, p, false) && return true
+    end
+    return false
+end
+
+# How strongly the position(s) of `v` in `t` pin its value, for every call:
+#  * `PIN_TYPEOF`: `v` takes a `typeof`-produced argument type — a concrete
+#    type, in particular not `Union{}` and without free type variables. This
+#    holds for a required covariant argument slot (directly, under nested
+#    `Tuple`s, or in all arms of a `Union`), or as the sole upper bound of
+#    another variable in such a slot.
+#  * `PIN_INHABITED`: `v` takes an *inhabited* type (not `Union{}`), though
+#    possibly an abstract one: `v` is an invariant parameter of a constructor
+#    in a required covariant slot, and that constructor declares a field of
+#    exactly that parameter's type, so a value of the parameter type must
+#    exist inside the argument. (This assumes the field can not be left
+#    undefined by an incomplete `new` inner constructor.)
+#  * `PIN_NONE`: neither is guaranteed; `v` may be `Union{}` (e.g. `Type{v}`
+#    positions matched by the argument `Union{}`, or invariant parameters
+#    without such a field), leaving its bounds unconstraining.
+const PIN_NONE = 0
+const PIN_INHABITED = 1
+const PIN_TYPEOF = 2
+
+function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
+    t === v && return PIN_TYPEOF
+    while t isa UnionAll
+        if t.var.ub === v && t.var.lb === Union{} &&
+            pin_grade(t.var, t.body) == PIN_TYPEOF
+            # the least solution for `v` is the other variable's value
+            return PIN_TYPEOF
+        end
+        t = t.body
+    end
+    if t isa Union
+        return min(pin_grade(v, t.a), pin_grade(v, t.b))
+    end
+    t isa DataType || return PIN_NONE
+    if t.name === Tuple.name
+        grade = PIN_NONE
+        for p in t.parameters
+            if p isa Core.TypeofVararg
+                if nonempty_vararg && isdefined(p, :T)
+                    grade = max(grade, pin_grade(v, p.T))
+                end
+            else
+                grade = max(grade, pin_grade(v, p))
+            end
+            grade == PIN_TYPEOF && break
+        end
+        return grade
+    end
+    Base.isType(t) && return PIN_NONE
+    for (i, p) in enumerate(t.parameters)
+        if p === v && param_has_field(t, i)
+            return PIN_INHABITED
+        end
+    end
+    return PIN_NONE
+end
+
+# Whether the `i`-th type parameter of `t`'s constructor is also the declared
+# type of one of its fields, so that instances contain a value of it.
+function param_has_field(t::DataType, i::Int)
+    base = Base.unwrap_unionall(t.name.wrapper)
+    base isa DataType || return false
+    tv = base.parameters[i]
+    tv isa TypeVar || return false
+    for ft in Base.datatype_fieldtypes(base)
+        ft === tv && return true
+    end
+    return false
+end
+
+# The `Type{S}`-valued argument slots recognized by the `Union{}`-shadowing
+# rescue in `detect_unbound_args`: either a slot-local range
+# (`Type{S} where S<:UB`) or a plain method parameter (`Type{S}` with `S`
+# bound in the signature's `where` chain). Returns `S`, or `nothing`.
+function type_slot_var(@nospecialize(p))
+    if p isa UnionAll && Base.isType(p.body) && Base.type_parameter(p.body) === p.var
+        return p.var
+    elseif Base.isType(p)
+        q = Base.type_parameter(p)
+        q isa TypeVar && return q
+    end
+    return nothing
+end
+
+# `nonempty_vararg` assumes the signature's trailing `Vararg` matches at
+# least one argument; `shadowed_slots` lists `Type{S}` argument positions
+# whose `Union{}` member never reaches this method. Both are assumptions the
+# caller must justify (see `detect_unbound_args`).
+function has_unbound_vars(@nospecialize(sig), nonempty_vararg::Bool=false,
+                          shadowed_slots::Vector{Int}=Int[])
+    params = isempty(shadowed_slots) ? Core.svec() :
+        (Base.unwrap_unionall(sig)::DataType).parameters
+    body = sig
+    while body isa UnionAll
+        var = body.var
+        body = body.body
+        constrains_var(var, body, #=covariant=#true, nonempty_vararg) && continue
+        pinned = false
+        for i in shadowed_slots
+            # any non-`Union{}` value of this slot's `Type` parameter pins
+            # `var` if it occurs invariantly below a constructor of its bound
+            v = type_slot_var(params[i])::TypeVar
+            if v !== var && constrains_type_value(var, v.ub)
+                pinned = true
+                break
+            end
+        end
+        pinned || return true
     end
     return false
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2750,8 +2750,9 @@ detect_closure_boxes_all_modules() = detect_closure_boxes(Base.loaded_modules_ar
 
 Return a vector of `Method`s which may have unbound type parameters: some
 call matching the method's signature does not pin every static parameter to
-a definite value, so reading such a parameter in the method body throws an
-`UndefVarError`. Use `recursive=true` to test in all submodules.
+a definite value, so reading such a parameter in the method body may throw an
+`UndefVarError`.
+Use `recursive=true` to test in all submodules.
 
 The check is a conservative static approximation of how subtyping assigns
 static parameters, so a reported method may in practice never see the calls
@@ -2803,15 +2804,15 @@ function detect_unbound_args(mods...;
             nonempty_vararg = false
             if Base.isvatuple(tuple_sig)
                 # a trailing Vararg leaves its element variables unbound only
-                # for zero-length matches
+                # for zero-length matches; remove Vararg and compute dispatch.
+                # compute type-intersect of sig with `NTuple{Any, nparams - 1}`:
                 short_sig = Base.rewrap_unionall(Tuple{params[1:(end - 1)]...}, m.sig)
-                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), short_sig, nothing, world)
-                if mf !== nothing && mf !== m && mf.sig <: short_sig
+                mf = Base._which(short_sig; world, raise=false)
+                if mf !== nothing && mf.method !== m && Base.morespecific(mf.method, m)
                     nonempty_vararg = true
                 end
             end
-            # the where-chain binders, aligned with the `static_parameter`
-            # numbering used in `idxs`
+            # the where-chain binders, aligned with the `static_parameter` numbering used in `idxs`
             sig_vars = TypeVar[]
             let body = m.sig
                 while body isa UnionAll
@@ -2821,37 +2822,27 @@ function detect_unbound_args(mods...;
             end
             shadowed_slots = Int[]
             for i in eachindex(params)
-                # a `Type{S}` argument (with `S` a slot-local range or a
-                # method parameter) binds `S = Union{}` — which constrains
-                # nothing in the bounds of `S` — only when the argument is
-                # `Union{}` itself
+                # a `Type{S}` argument (with type `S`) may bind `S = Union{}` — which does not constrain
+                # TypeVar internal to `S`, unless we later identify a covering method for that dispatch
                 v = type_slot_var(params[i])
                 v === nothing && continue
-                # the re-check consumes a shadowed slot only through
-                # `constrains_type_value` on the slot variable's bound, so a
+                # the re-check consumes a shadowed slot only through a
+                # `MATCH_INHABITED` `constrains_var` on the slot variable's bound, so a
                 # slot that cannot pin any possibly-unbound parameter that
                 # way needs no method-table probe (`idxs` is a superset of
                 # the parameters still unbound under `nonempty_vararg`)
                 any(idx -> (var = sig_vars[idx];
-                            v !== var && Core.Compiler.constrains_type_value(var, v.ub)),
+                            v !== var && Base.Compiler.constrains_var(var, v.ub, Core.Compiler.MATCH_INHABITED)),
                     idxs) || continue
                 bot_params = Any[params...]
                 bot_params[i] = Type{Union{}}
                 bot_sig = Base.rewrap_unionall(Tuple{bot_params...}, m.sig)
-                # the rescue argument requires `m` itself to cover the probe
-                # signature: only then does a different lookup result prove
-                # that every `Union{}` call dispatches away from `m` (rather
-                # than the probe merely escaping to a broad fallback while
-                # `m` still wins the concrete calls)
-                bot_sig <: m.sig || continue
-                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), bot_sig, nothing, world)
-                if mf !== nothing && mf !== m
+                mf = Base._which(bot_sig; world, raise=false)
+                if mf !== nothing && mf.method !== m && Base.morespecific(mf.method, m)
                     push!(shadowed_slots, i)
                 end
             end
-            # re-check unboundness under the verified assumptions, keeping
-            # the parameter indices for the body query below; without any
-            # assumption the first scan already answered
+            # re-check unboundness under the verified assumptions
             if nonempty_vararg || !isempty(shadowed_slots)
                 idxs = unbound_sparams(m.sig, nonempty_vararg, shadowed_slots)
                 isempty(idxs) && continue
@@ -2866,33 +2857,24 @@ function detect_unbound_args(mods...;
     return collect(ambs)
 end
 
-# The static rule for whether every call matching a signature pins a static
-# parameter to a definite value is `Core.Compiler.constrains_var` (see
-# `Compiler/src/inferencestate.jl` for its derivation from subtyping's
-# parameter-assignment semantics); inference uses the same predicate to
-# compute the maybe-undef bit of static parameters.
-
 # The `Type{S}`-valued argument slots recognized by the `Union{}`-shadowing
 # rescue in `detect_unbound_args`: either a slot-local range
 # (`Type{S} where S<:UB`) or a plain method parameter (`Type{S}` with `S`
 # bound in the signature's `where` chain). Returns `S`, or `nothing`.
 function type_slot_var(@nospecialize(p))
-    if p isa UnionAll && Base.isType(p.body) && Base.type_parameter(p.body) === p.var
+    if p isa UnionAll && Base.isTypeEq(p.body) && Base.type_parameter(p.body) === p.var
         return p.var
-    elseif Base.isType(p)
+    elseif Base.isTypeEq(p)
         q = Base.type_parameter(p)
         q isa TypeVar && return q
     end
     return nothing
 end
 
-# The 1-based positions in the signature's `where` chain — which is also the
-# `static_parameter` numbering used by the lowered body — of parameters that
-# some matching call may leave unbound. `nonempty_vararg` assumes the
-# signature's trailing `Vararg` matches at least one argument;
-# `shadowed_slots` lists `Type{S}` argument positions whose `Union{}` member
-# never reaches this method. Both are assumptions the caller must justify
-# (see `detect_unbound_args`).
+# The 1-based positions in the signature's `where` chain of parameters that
+# some matching call may leave unbound.
+# - `nonempty_vararg` assumes the signature's trailing `Vararg` matches at least one argument;
+# - `shadowed_slots` lists `Type{S}` argument positions whose `Union{}` member never reaches this method.
 function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
                          shadowed_slots::Vector{Int}=Int[])
     idxs = Int[]
@@ -2904,13 +2886,13 @@ function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
         i += 1
         var = body.var
         body = body.body
-        Core.Compiler.constrains_var(var, body, #=covariant=#true, nonempty_vararg) && continue
+        Base.Compiler.constrains_var(var, body, Core.Compiler.MATCH_TYPEOF, nonempty_vararg) && continue
         pinned = false
         for j in shadowed_slots
             # any non-`Union{}` value of this slot's `Type` parameter pins
             # `var` if it occurs invariantly below a constructor of its bound
             v = type_slot_var(params[j])::TypeVar
-            if v !== var && Core.Compiler.constrains_type_value(var, v.ub)
+            if v !== var && Base.Compiler.constrains_var(var, v.ub, Core.Compiler.MATCH_INHABITED)
                 pinned = true
                 break
             end
@@ -2921,30 +2903,20 @@ function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
 end
 
 # Whether the lowered body of `m` reads any of the static parameters whose
-# indices are in `idxs`. An `Expr(:isdefined, ...)` query does not count as a
-# read (it cannot throw), but a raw read is counted even when an `@isdefined`
-# guard exists elsewhere in the body: verifying that the guard dominates the
-# read would require dataflow over typed code. Conservatively `true` when no
-# lowered code is available to inspect (e.g. generated functions).
+# indices are in `idxs`.
 function reads_sparams(m::Method, idxs::Vector{Int})
     isdefined(m, :source) || return true
     src = Base.uncompressed_ir(m)
-    read = BitSet()
-    function scan(@nospecialize ex)
-        ex isa Expr || return
-        if ex.head === :static_parameter
-            push!(read, ex.args[1]::Int)
-        elseif ex.head !== :isdefined
-            for a in ex.args
-                scan(a)
+    maybeundef = BitSet(idxs)
+    for stmt in src.code
+        if Meta.isexpr(stmt, :static_parameter)
+            read = stmt.args[1]::Int
+            if read in maybeundef
+                return true
             end
         end
-        return
     end
-    for stmt in src.code
-        scan(stmt)
-    end
-    return any(in(read), idxs)
+    return false
 end
 
 

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2748,8 +2748,18 @@ detect_closure_boxes_all_modules() = detect_closure_boxes(Base.loaded_modules_ar
 """
     detect_unbound_args(mod1, mod2...; recursive=false, allowed_undefineds=nothing)
 
-Return a vector of `Method`s which may have unbound type parameters.
-Use `recursive=true` to test in all submodules.
+Return a vector of `Method`s which may have unbound type parameters: some
+call matching the method's signature does not pin every static parameter to
+a definite value, so reading such a parameter in the method body throws an
+`UndefVarError`. Use `recursive=true` to test in all submodules.
+
+The check is a conservative static approximation of how subtyping assigns
+static parameters, so a reported method may in practice never see the calls
+that leave the parameter unbound. Methods are not reported when those calls
+are provably shadowed by a more specific method: a definition like
+`f(::Type{Union{}})` covers the `Union{}` argument that would leave `T`
+unbound in `f(::Type{<:T}) where {T}`, and a zero-argument fallback covers
+the empty call that would leave `T` unbound in `f(x::T...) where {T}`.
 
 By default, any undefined symbols trigger a warning. This warning can
 be suppressed by supplying a collection of `GlobalRef`s for which
@@ -2777,15 +2787,38 @@ function detect_unbound_args(mods...;
             is_in_mods(parentmodule(m), recursive, mods) || continue
             has_unbound_vars(m.sig) || continue
             tuple_sig = Base.unwrap_unionall(m.sig)::DataType
+            params = tuple_sig.parameters
+            world = Base.get_world_counter()
+            # The calls that leave a parameter unbound may all dispatch to
+            # more specific methods, making the unboundness unreachable.
+            # Verify which of the two shadowable call classes are covered,
+            # then re-check unboundness under those assumptions.
+            nonempty_vararg = false
             if Base.isvatuple(tuple_sig)
-                params = tuple_sig.parameters[1:(end - 1)]
-                tuple_sig = Base.rewrap_unionall(Tuple{params...}, m.sig)
-                world = Base.get_world_counter()
-                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), tuple_sig, nothing, world)
-                if mf !== nothing && mf !== m && mf.sig <: tuple_sig
-                    continue
+                # a trailing Vararg leaves its element variables unbound only
+                # for zero-length matches
+                short_sig = Base.rewrap_unionall(Tuple{params[1:(end - 1)]...}, m.sig)
+                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), short_sig, nothing, world)
+                if mf !== nothing && mf !== m && mf.sig <: short_sig
+                    nonempty_vararg = true
                 end
             end
+            shadowed_slots = Int[]
+            for i in eachindex(params)
+                # a `Type{S}` argument (with `S` a slot-local range or a
+                # method parameter) binds `S = Union{}` — which constrains
+                # nothing in the bounds of `S` — only when the argument is
+                # `Union{}` itself
+                type_slot_var(params[i]) === nothing && continue
+                bot_params = Any[params...]
+                bot_params[i] = Type{Union{}}
+                bot_sig = Base.rewrap_unionall(Tuple{bot_params...}, m.sig)
+                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), bot_sig, nothing, world)
+                if mf !== nothing && mf !== m
+                    push!(shadowed_slots, i)
+                end
+            end
+            has_unbound_vars(m.sig, nonempty_vararg, shadowed_slots) || continue
             push!(ambs, m)
         end
     end
@@ -2793,13 +2826,270 @@ function detect_unbound_args(mods...;
     return collect(ambs)
 end
 
-function has_unbound_vars(@nospecialize sig)
-    while sig isa UnionAll
-        var = sig.var
-        sig = sig.body
-        if !Core.Compiler.constrains_param(var, sig, #=covariant=#true, #=type_constrains=#true)
-            return true
+# When a call matches a method, type intersection computes a value for each
+# static parameter (`subtype_unionall` in `src/subtype.c`). A parameter that
+# the match does not pin to a definite value is left unbound, and reading it
+# in the method body throws `UndefVarError`. Subtyping pins a variable
+# through two channels (`eff_constrained` in `src/subtype.c`):
+#
+#  * an invariant occurrence: the corresponding position of the call
+#    signature must be *equal* to the instantiated method parameter, so any
+#    successful match determines the variable. This fails to be definite
+#    only where distinct assignments can spell equal types: a `Union` arm
+#    can be absorbed by the other arm (`Union{T,Int}` matched against `Int`),
+#    a `Vararg` can be respelled (`Tuple{Vararg{T}}` matched against
+#    `Tuple`), and the bound of an inner variable can be widened away
+#    (`Vector{<:T}` matched against `Vector`), so none of those count.
+#
+#  * a covariant occurrence: the position is filled with `typeof` of an
+#    argument, which contributes a lower bound, and the least solution is
+#    taken as the parameter value. This is definite only if the declared
+#    lower bound of the variable is `Union{}` (otherwise other types union
+#    into the solution: `f(x::T) where {T>:Int}` is unbound for `f(2.0)`),
+#    and only for occurrences guaranteed to contribute in every call:
+#    present in all `Union` arms, not under a `Vararg` tail (which may match
+#    zero arguments), and not merely in the declared bounds of another
+#    variable — unless that variable is itself pinned to a `typeof`-produced
+#    argument type in every call, since a variable ranging over an invariant
+#    position or over a `Type` argument can take the value `Union{}`,
+#    satisfying its bounds without constraining them (`f(::Type{<:T})` is
+#    unbound for `f(Union{})`, and `f(::Vector{<:T})` for a
+#    `Vector{Union{}}` argument).
+#
+# `constrains_var` is a conservative static approximation of that dynamic
+# rule: `true` means every matching call pins `var`; `false` means some call
+# may leave it unbound. `nonempty_vararg` credits the signature's own
+# trailing `Vararg` as if it matched at least one argument (it is not
+# propagated into nested positions, where an empty tuple can always occur).
+
+function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempty_vararg::Bool=false)
+    if t === var
+        return !covariant || var.lb === Union{}
+    end
+    while t isa UnionAll
+        if covariant && t.var.lb === Union{}
+            pin = pin_grade(t.var, t.body, nonempty_vararg)
+            if pin == PIN_TYPEOF && constrains_var(var, t.var.ub, true)
+                return true
+            elseif pin == PIN_INHABITED && constrains_type_value(var, t.var.ub)
+                return true
+            end
         end
+        # other occurrences in the bounds of `t.var` do not reliably pin `var`
+        t = t.body
+    end
+    if t isa Union
+        if covariant
+            # each arm is individually reachable by some argument, so every
+            # arm must pin `var`
+            return constrains_var(var, t.a, true) &&
+                   constrains_var(var, t.b, true)
+        end
+        # matched by type equality: pinned if every arm pins `var`, or
+        # through any arm that the matched value must expose because no
+        # instantiation of it can be absorbed into the other arms
+        # (issues #58427, #59023)
+        constrains_var(var, t.a, false) && constrains_var(var, t.b, false) &&
+            return true
+        arms = Base.uniontypes(t)
+        for (i, arm) in enumerate(arms)
+            others = mapreduce(j -> arms[j], (a, b) -> Union{a, b},
+                               filter(!=(i), eachindex(arms)))
+            others = UnionAll(var, others)
+            if arm === var
+                # absorbing a bare `var` arm forces `var = Union{}`, which
+                # pins it, provided `Union{}` is its only value inside the
+                # other arms
+                var.lb === Union{} && union_disjoint(var.ub, others) &&
+                    return true
+            elseif union_disjoint(UnionAll(var, arm), others) &&
+                constrains_var(var, arm, false)
+                return true
+            end
+        end
+        return false
+    end
+    if Base.isType(t)
+        # the parameter is matched exactly by the argument (covariant) or by
+        # type equality (invariant)
+        return constrains_var(var, Base.type_parameter(t), false)
+    end
+    t isa DataType || return false
+    if t.name === Tuple.name
+        for p in t.parameters
+            if p isa Core.TypeofVararg
+                # the argument count pins `N` exactly (including zero)
+                isdefined(p, :N) && constrains_var(var, p.N, covariant) && return true
+                if covariant && nonempty_vararg && isdefined(p, :T)
+                    constrains_var(var, p.T, covariant) && return true
+                end
+            else
+                constrains_var(var, p, covariant) && return true
+            end
+        end
+    else
+        for p in t.parameters
+            constrains_var(var, p, false) && return true
+        end
+    end
+    return false
+end
+
+# Whether no instantiation of `a` overlaps `b`, so that no part of a matched
+# value can satisfy both. `false` when undecidable (free typevars remain).
+function union_disjoint(@nospecialize(a), @nospecialize(b))
+    (Base.has_free_typevars(a) || Base.has_free_typevars(b)) && return false
+    return Base.typeintersect(a, b) === Union{}
+end
+
+# Whether matching any specific type value `X <: P` other than `Union{}`
+# necessarily pins `var` (or fails to match): `var` must occur where the
+# subtyping query is forced to constrain it — as `P` itself (`X` becomes its
+# lower bound, which pins any non-`Union{}` value up to type equality),
+# invariantly below a non-Tuple constructor, or as a `Vararg` length — in
+# every `Union` arm. Fixed `Tuple` slots of `P` correspond to non-`Union{}`
+# positions of `X` (a tuple type with a `Union{}` field cannot be
+# constructed) and are descended into; `Vararg` tails and ranges inside `P`
+# can be spelled away by `X` and never count.
+function constrains_type_value(var::TypeVar, @nospecialize(P))
+    P === var && return true
+    while P isa UnionAll
+        # ranges inside `P` can be widened away by the spelling of `X`
+        P = P.body
+    end
+    if P isa Union
+        return constrains_type_value(var, P.a) &&
+               constrains_type_value(var, P.b)
+    end
+    if Base.isType(P)
+        # X <: Type{q} pins the parameter of X by equality with q
+        return constrains_var(var, Base.type_parameter(P), false)
+    end
+    P isa DataType || return false
+    if P.name === Tuple.name
+        for p in P.parameters
+            if p isa Core.TypeofVararg
+                # the length of X pins `N` exactly (or the match fails)
+                isdefined(p, :N) && constrains_var(var, p.N, false) && return true
+            else
+                constrains_type_value(var, p) && return true
+            end
+        end
+        return false
+    end
+    for p in P.parameters
+        constrains_var(var, p, false) && return true
+    end
+    return false
+end
+
+# How strongly the position(s) of `v` in `t` pin its value, for every call:
+#  * `PIN_TYPEOF`: `v` takes a `typeof`-produced argument type — a concrete
+#    type, in particular not `Union{}` and without free type variables. This
+#    holds for a required covariant argument slot (directly, under nested
+#    `Tuple`s, or in all arms of a `Union`), or as the sole upper bound of
+#    another variable in such a slot.
+#  * `PIN_INHABITED`: `v` takes an *inhabited* type (not `Union{}`), though
+#    possibly an abstract one: `v` is an invariant parameter of a constructor
+#    in a required covariant slot, and that constructor declares a field of
+#    exactly that parameter's type, so a value of the parameter type must
+#    exist inside the argument. (This assumes the field can not be left
+#    undefined by an incomplete `new` inner constructor.)
+#  * `PIN_NONE`: neither is guaranteed; `v` may be `Union{}` (e.g. `Type{v}`
+#    positions matched by the argument `Union{}`, or invariant parameters
+#    without such a field), leaving its bounds unconstraining.
+const PIN_NONE = 0
+const PIN_INHABITED = 1
+const PIN_TYPEOF = 2
+
+function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
+    t === v && return PIN_TYPEOF
+    while t isa UnionAll
+        if t.var.ub === v && t.var.lb === Union{} &&
+            pin_grade(t.var, t.body) == PIN_TYPEOF
+            # the least solution for `v` is the other variable's value
+            return PIN_TYPEOF
+        end
+        t = t.body
+    end
+    if t isa Union
+        return min(pin_grade(v, t.a), pin_grade(v, t.b))
+    end
+    t isa DataType || return PIN_NONE
+    if t.name === Tuple.name
+        grade = PIN_NONE
+        for p in t.parameters
+            if p isa Core.TypeofVararg
+                if nonempty_vararg && isdefined(p, :T)
+                    grade = max(grade, pin_grade(v, p.T))
+                end
+            else
+                grade = max(grade, pin_grade(v, p))
+            end
+            grade == PIN_TYPEOF && break
+        end
+        return grade
+    end
+    Base.isType(t) && return PIN_NONE
+    for (i, p) in enumerate(t.parameters)
+        if p === v && param_has_field(t, i)
+            return PIN_INHABITED
+        end
+    end
+    return PIN_NONE
+end
+
+# Whether the `i`-th type parameter of `t`'s constructor is also the declared
+# type of one of its fields, so that instances contain a value of it.
+function param_has_field(t::DataType, i::Int)
+    base = Base.unwrap_unionall(t.name.wrapper)
+    base isa DataType || return false
+    tv = base.parameters[i]
+    tv isa TypeVar || return false
+    for ft in Base.datatype_fieldtypes(base)
+        ft === tv && return true
+    end
+    return false
+end
+
+# The `Type{S}`-valued argument slots recognized by the `Union{}`-shadowing
+# rescue in `detect_unbound_args`: either a slot-local range
+# (`Type{S} where S<:UB`) or a plain method parameter (`Type{S}` with `S`
+# bound in the signature's `where` chain). Returns `S`, or `nothing`.
+function type_slot_var(@nospecialize(p))
+    if p isa UnionAll && Base.isType(p.body) && Base.type_parameter(p.body) === p.var
+        return p.var
+    elseif Base.isType(p)
+        q = Base.type_parameter(p)
+        q isa TypeVar && return q
+    end
+    return nothing
+end
+
+# `nonempty_vararg` assumes the signature's trailing `Vararg` matches at
+# least one argument; `shadowed_slots` lists `Type{S}` argument positions
+# whose `Union{}` member never reaches this method. Both are assumptions the
+# caller must justify (see `detect_unbound_args`).
+function has_unbound_vars(@nospecialize(sig), nonempty_vararg::Bool=false,
+                          shadowed_slots::Vector{Int}=Int[])
+    params = isempty(shadowed_slots) ? Core.svec() :
+        (Base.unwrap_unionall(sig)::DataType).parameters
+    body = sig
+    while body isa UnionAll
+        var = body.var
+        body = body.body
+        constrains_var(var, body, #=covariant=#true, nonempty_vararg) && continue
+        pinned = false
+        for i in shadowed_slots
+            # any non-`Union{}` value of this slot's `Type` parameter pins
+            # `var` if it occurs invariantly below a constructor of its bound
+            v = type_slot_var(params[i])::TypeVar
+            if v !== var && constrains_type_value(var, v.ub)
+                pinned = true
+                break
+            end
+        end
+        pinned || return true
     end
     return false
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2751,8 +2751,9 @@ detect_closure_boxes_all_modules() = detect_closure_boxes(Base.loaded_modules_ar
 
 Return a vector of `Method`s which may have unbound type parameters: some
 call matching the method's signature does not pin every static parameter to
-a definite value, so reading such a parameter in the method body throws an
-`UndefVarError`. Use `recursive=true` to test in all submodules.
+a definite value, so reading such a parameter in the method body may throw an
+`UndefVarError`.
+Use `recursive=true` to test in all submodules.
 
 The check is a conservative static approximation of how subtyping assigns
 static parameters, so a reported method may in practice never see the calls
@@ -2804,15 +2805,15 @@ function detect_unbound_args(mods...;
             nonempty_vararg = false
             if Base.isvatuple(tuple_sig)
                 # a trailing Vararg leaves its element variables unbound only
-                # for zero-length matches
+                # for zero-length matches; remove Vararg and compute dispatch.
+                # compute type-intersect of sig with `NTuple{Any, nparams - 1}`:
                 short_sig = Base.rewrap_unionall(Tuple{params[1:(end - 1)]...}, m.sig)
-                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), short_sig, nothing, world)
-                if mf !== nothing && mf !== m && mf.sig <: short_sig
+                mf = Base._which(short_sig; world, raise=false)
+                if mf !== nothing && mf.method !== m && Base.morespecific(mf.method, m)
                     nonempty_vararg = true
                 end
             end
-            # the where-chain binders, aligned with the `static_parameter`
-            # numbering used in `idxs`
+            # the where-chain binders, aligned with the `static_parameter` numbering used in `idxs`
             sig_vars = TypeVar[]
             let body = m.sig
                 while body isa UnionAll
@@ -2822,37 +2823,27 @@ function detect_unbound_args(mods...;
             end
             shadowed_slots = Int[]
             for i in eachindex(params)
-                # a `Type{S}` argument (with `S` a slot-local range or a
-                # method parameter) binds `S = Union{}` — which constrains
-                # nothing in the bounds of `S` — only when the argument is
-                # `Union{}` itself
+                # a `Type{S}` argument (with type `S`) may bind `S = Union{}` — which does not constrain
+                # TypeVar internal to `S`, unless we later identify a covering method for that dispatch
                 v = type_slot_var(params[i])
                 v === nothing && continue
-                # the re-check consumes a shadowed slot only through
-                # `constrains_type_value` on the slot variable's bound, so a
+                # the re-check consumes a shadowed slot only through a
+                # `MATCH_INHABITED` `constrains_var` on the slot variable's bound, so a
                 # slot that cannot pin any possibly-unbound parameter that
                 # way needs no method-table probe (`idxs` is a superset of
                 # the parameters still unbound under `nonempty_vararg`)
                 any(idx -> (var = sig_vars[idx];
-                            v !== var && Core.Compiler.constrains_type_value(var, v.ub)),
+                            v !== var && Base.Compiler.constrains_var(var, v.ub, Core.Compiler.MATCH_INHABITED)),
                     idxs) || continue
                 bot_params = Any[params...]
                 bot_params[i] = Type{Union{}}
                 bot_sig = Base.rewrap_unionall(Tuple{bot_params...}, m.sig)
-                # the rescue argument requires `m` itself to cover the probe
-                # signature: only then does a different lookup result prove
-                # that every `Union{}` call dispatches away from `m` (rather
-                # than the probe merely escaping to a broad fallback while
-                # `m` still wins the concrete calls)
-                bot_sig <: m.sig || continue
-                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), bot_sig, nothing, world)
-                if mf !== nothing && mf !== m
+                mf = Base._which(bot_sig; world, raise=false)
+                if mf !== nothing && mf.method !== m && Base.morespecific(mf.method, m)
                     push!(shadowed_slots, i)
                 end
             end
-            # re-check unboundness under the verified assumptions, keeping
-            # the parameter indices for the body query below; without any
-            # assumption the first scan already answered
+            # re-check unboundness under the verified assumptions
             if nonempty_vararg || !isempty(shadowed_slots)
                 idxs = unbound_sparams(m.sig, nonempty_vararg, shadowed_slots)
                 isempty(idxs) && continue
@@ -2867,33 +2858,24 @@ function detect_unbound_args(mods...;
     return collect(ambs)
 end
 
-# The static rule for whether every call matching a signature pins a static
-# parameter to a definite value is `Core.Compiler.constrains_var` (see
-# `Compiler/src/inferencestate.jl` for its derivation from subtyping's
-# parameter-assignment semantics); inference uses the same predicate to
-# compute the maybe-undef bit of static parameters.
-
 # The `Type{S}`-valued argument slots recognized by the `Union{}`-shadowing
 # rescue in `detect_unbound_args`: either a slot-local range
 # (`Type{S} where S<:UB`) or a plain method parameter (`Type{S}` with `S`
 # bound in the signature's `where` chain). Returns `S`, or `nothing`.
 function type_slot_var(@nospecialize(p))
-    if p isa UnionAll && Base.isType(p.body) && Base.type_parameter(p.body) === p.var
+    if p isa UnionAll && Base.isTypeEq(p.body) && Base.type_parameter(p.body) === p.var
         return p.var
-    elseif Base.isType(p)
+    elseif Base.isTypeEq(p)
         q = Base.type_parameter(p)
         q isa TypeVar && return q
     end
     return nothing
 end
 
-# The 1-based positions in the signature's `where` chain — which is also the
-# `static_parameter` numbering used by the lowered body — of parameters that
-# some matching call may leave unbound. `nonempty_vararg` assumes the
-# signature's trailing `Vararg` matches at least one argument;
-# `shadowed_slots` lists `Type{S}` argument positions whose `Union{}` member
-# never reaches this method. Both are assumptions the caller must justify
-# (see `detect_unbound_args`).
+# The 1-based positions in the signature's `where` chain of parameters that
+# some matching call may leave unbound.
+# - `nonempty_vararg` assumes the signature's trailing `Vararg` matches at least one argument;
+# - `shadowed_slots` lists `Type{S}` argument positions whose `Union{}` member never reaches this method.
 function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
                          shadowed_slots::Vector{Int}=Int[])
     idxs = Int[]
@@ -2905,13 +2887,13 @@ function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
         i += 1
         var = body.var
         body = body.body
-        Core.Compiler.constrains_var(var, body, #=covariant=#true, nonempty_vararg) && continue
+        Base.Compiler.constrains_var(var, body, Core.Compiler.MATCH_TYPEOF, nonempty_vararg) && continue
         pinned = false
         for j in shadowed_slots
             # any non-`Union{}` value of this slot's `Type` parameter pins
             # `var` if it occurs invariantly below a constructor of its bound
             v = type_slot_var(params[j])::TypeVar
-            if v !== var && Core.Compiler.constrains_type_value(var, v.ub)
+            if v !== var && Base.Compiler.constrains_var(var, v.ub, Core.Compiler.MATCH_INHABITED)
                 pinned = true
                 break
             end
@@ -2922,30 +2904,20 @@ function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
 end
 
 # Whether the lowered body of `m` reads any of the static parameters whose
-# indices are in `idxs`. An `Expr(:isdefined, ...)` query does not count as a
-# read (it cannot throw), but a raw read is counted even when an `@isdefined`
-# guard exists elsewhere in the body: verifying that the guard dominates the
-# read would require dataflow over typed code. Conservatively `true` when no
-# lowered code is available to inspect (e.g. generated functions).
+# indices are in `idxs`.
 function reads_sparams(m::Method, idxs::Vector{Int})
     isdefined(m, :source) || return true
     src = Base.uncompressed_ir(m)
-    read = BitSet()
-    function scan(@nospecialize ex)
-        ex isa Expr || return
-        if ex.head === :static_parameter
-            push!(read, ex.args[1]::Int)
-        elseif ex.head !== :isdefined
-            for a in ex.args
-                scan(a)
+    maybeundef = BitSet(idxs)
+    for stmt in src.code
+        if Meta.isexpr(stmt, :static_parameter)
+            read = stmt.args[1]::Int
+            if read in maybeundef
+                return true
             end
         end
-        return
     end
-    for stmt in src.code
-        scan(stmt)
-    end
-    return any(in(read), idxs)
+    return false
 end
 
 

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2783,13 +2783,13 @@ function detect_unbound_args(mods...;
     @nospecialize mods
     ambs = Set{Method}()
     mods = Module[mods...]
+    world = Base.get_world_counter()
     function examine(mt::Core.MethodTable)
         for m in Base.MethodList(mt)
             is_in_mods(parentmodule(m), recursive, mods) || continue
             has_unbound_vars(m.sig) || continue
             tuple_sig = Base.unwrap_unionall(m.sig)::DataType
             params = tuple_sig.parameters
-            world = Base.get_world_counter()
             # The calls that leave a parameter unbound may all dispatch to
             # more specific methods, making the unboundness unreachable.
             # Verify which of the two shadowable call classes are covered,
@@ -2814,12 +2814,21 @@ function detect_unbound_args(mods...;
                 bot_params = Any[params...]
                 bot_params[i] = Type{Union{}}
                 bot_sig = Base.rewrap_unionall(Tuple{bot_params...}, m.sig)
+                # the rescue argument requires `m` itself to cover the probe
+                # signature: only then does a different lookup result prove
+                # that every `Union{}` call dispatches away from `m` (rather
+                # than the probe merely escaping to a broad fallback while
+                # `m` still wins the concrete calls)
+                bot_sig <: m.sig || continue
                 mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), bot_sig, nothing, world)
                 if mf !== nothing && mf !== m
                     push!(shadowed_slots, i)
                 end
             end
-            has_unbound_vars(m.sig, nonempty_vararg, shadowed_slots) || continue
+            if nonempty_vararg || !isempty(shadowed_slots)
+                # re-check unboundness under the verified assumptions
+                has_unbound_vars(m.sig, nonempty_vararg, shadowed_slots) || continue
+            end
             push!(ambs, m)
         end
     end
@@ -2827,239 +2836,11 @@ function detect_unbound_args(mods...;
     return collect(ambs)
 end
 
-# When a call matches a method, type intersection computes a value for each
-# static parameter (`subtype_unionall` in `src/subtype.c`). A parameter that
-# the match does not pin to a definite value is left unbound, and reading it
-# in the method body throws `UndefVarError`. Subtyping pins a variable
-# through two channels (`eff_constrained` in `src/subtype.c`):
-#
-#  * an invariant occurrence: the corresponding position of the call
-#    signature must be *equal* to the instantiated method parameter, so any
-#    successful match determines the variable. This fails to be definite
-#    only where distinct assignments can spell equal types: a `Union` arm
-#    can be absorbed by the other arm (`Union{T,Int}` matched against `Int`),
-#    a `Vararg` can be respelled (`Tuple{Vararg{T}}` matched against
-#    `Tuple`), and the bound of an inner variable can be widened away
-#    (`Vector{<:T}` matched against `Vector`), so none of those count.
-#
-#  * a covariant occurrence: the position is filled with `typeof` of an
-#    argument, which contributes a lower bound, and the least solution is
-#    taken as the parameter value. This is definite only if the declared
-#    lower bound of the variable is `Union{}` (otherwise other types union
-#    into the solution: `f(x::T) where {T>:Int}` is unbound for `f(2.0)`),
-#    and only for occurrences guaranteed to contribute in every call:
-#    present in all `Union` arms, not under a `Vararg` tail (which may match
-#    zero arguments), and not merely in the declared bounds of another
-#    variable — unless that variable is itself pinned to a `typeof`-produced
-#    argument type in every call, since a variable ranging over an invariant
-#    position or over a `Type` argument can take the value `Union{}`,
-#    satisfying its bounds without constraining them (`f(::Type{<:T})` is
-#    unbound for `f(Union{})`, and `f(::Vector{<:T})` for a
-#    `Vector{Union{}}` argument).
-#
-# `constrains_var` is a conservative static approximation of that dynamic
-# rule: `true` means every matching call pins `var`; `false` means some call
-# may leave it unbound. `nonempty_vararg` credits the signature's own
-# trailing `Vararg` as if it matched at least one argument (it is not
-# propagated into nested positions, where an empty tuple can always occur).
-
-function constrains_var(var::TypeVar, @nospecialize(t), covariant::Bool, nonempty_vararg::Bool=false)
-    if t === var
-        return !covariant || var.lb === Union{}
-    end
-    while t isa UnionAll
-        if covariant && t.var.lb === Union{}
-            pin = pin_grade(t.var, t.body, nonempty_vararg)
-            if pin == PIN_TYPEOF && constrains_var(var, t.var.ub, true)
-                return true
-            elseif pin == PIN_INHABITED && constrains_type_value(var, t.var.ub)
-                return true
-            end
-        end
-        # other occurrences in the bounds of `t.var` do not reliably pin `var`
-        if t.var === var
-            # `var` is rebound: occurrences below belong to the inner
-            # variable (a constructor signature reuses the struct's own
-            # variable objects in `Type{TheStruct}`, issue #54893)
-            return false
-        end
-        t = t.body
-    end
-    if t isa Union
-        if covariant
-            # each arm is individually reachable by some argument, so every
-            # arm must pin `var`
-            return constrains_var(var, t.a, true) &&
-                   constrains_var(var, t.b, true)
-        end
-        # matched by type equality: pinned if every arm pins `var`, or
-        # through any arm that the matched value must expose because no
-        # instantiation of it can be absorbed into the other arms
-        # (issues #58427, #59023)
-        constrains_var(var, t.a, false) && constrains_var(var, t.b, false) &&
-            return true
-        arms = Base.uniontypes(t)
-        for (i, arm) in enumerate(arms)
-            others = mapreduce(j -> arms[j], (a, b) -> Union{a, b},
-                               filter(!=(i), eachindex(arms)))
-            others = UnionAll(var, others)
-            if arm === var
-                # absorbing a bare `var` arm forces `var = Union{}`, which
-                # pins it, provided `Union{}` is its only value inside the
-                # other arms
-                var.lb === Union{} && union_disjoint(var.ub, others) &&
-                    return true
-            elseif union_disjoint(UnionAll(var, arm), others) &&
-                constrains_var(var, arm, false)
-                return true
-            end
-        end
-        return false
-    end
-    if Base.isType(t)
-        # the parameter is matched exactly by the argument (covariant) or by
-        # type equality (invariant)
-        return constrains_var(var, Base.type_parameter(t), false)
-    end
-    t isa DataType || return false
-    if t.name === Tuple.name
-        for p in t.parameters
-            if p isa Core.TypeofVararg
-                # the argument count pins `N` exactly (including zero)
-                isdefined(p, :N) && constrains_var(var, p.N, covariant) && return true
-                if covariant && nonempty_vararg && isdefined(p, :T)
-                    constrains_var(var, p.T, covariant) && return true
-                end
-            else
-                constrains_var(var, p, covariant) && return true
-            end
-        end
-    else
-        for p in t.parameters
-            constrains_var(var, p, false) && return true
-        end
-    end
-    return false
-end
-
-# Whether no instantiation of `a` overlaps `b`, so that no part of a matched
-# value can satisfy both. `false` when undecidable (free typevars remain).
-function union_disjoint(@nospecialize(a), @nospecialize(b))
-    (Base.has_free_typevars(a) || Base.has_free_typevars(b)) && return false
-    return Base.typeintersect(a, b) === Union{}
-end
-
-# Whether matching any specific type value `X <: P` other than `Union{}`
-# necessarily pins `var` (or fails to match): `var` must occur where the
-# subtyping query is forced to constrain it — as `P` itself (`X` becomes its
-# lower bound, which pins any non-`Union{}` value up to type equality),
-# invariantly below a non-Tuple constructor, or as a `Vararg` length — in
-# every `Union` arm. Fixed `Tuple` slots of `P` correspond to non-`Union{}`
-# positions of `X` (a tuple type with a `Union{}` field cannot be
-# constructed) and are descended into; `Vararg` tails and ranges inside `P`
-# can be spelled away by `X` and never count.
-function constrains_type_value(var::TypeVar, @nospecialize(P))
-    P === var && return true
-    while P isa UnionAll
-        # ranges inside `P` can be widened away by the spelling of `X`
-        P.var === var && return false # `var` is rebound below
-        P = P.body
-    end
-    if P isa Union
-        return constrains_type_value(var, P.a) &&
-               constrains_type_value(var, P.b)
-    end
-    if Base.isType(P)
-        # X <: Type{q} pins the parameter of X by equality with q
-        return constrains_var(var, Base.type_parameter(P), false)
-    end
-    P isa DataType || return false
-    if P.name === Tuple.name
-        for p in P.parameters
-            if p isa Core.TypeofVararg
-                # the length of X pins `N` exactly (or the match fails)
-                isdefined(p, :N) && constrains_var(var, p.N, false) && return true
-            else
-                constrains_type_value(var, p) && return true
-            end
-        end
-        return false
-    end
-    for p in P.parameters
-        constrains_var(var, p, false) && return true
-    end
-    return false
-end
-
-# How strongly the position(s) of `v` in `t` pin its value, for every call:
-#  * `PIN_TYPEOF`: `v` takes a `typeof`-produced argument type — a concrete
-#    type, in particular not `Union{}` and without free type variables. This
-#    holds for a required covariant argument slot (directly, under nested
-#    `Tuple`s, or in all arms of a `Union`), or as the sole upper bound of
-#    another variable in such a slot.
-#  * `PIN_INHABITED`: `v` takes an *inhabited* type (not `Union{}`), though
-#    possibly an abstract one: `v` is an invariant parameter of a constructor
-#    in a required covariant slot, and that constructor declares a field of
-#    exactly that parameter's type, so a value of the parameter type must
-#    exist inside the argument. (This assumes the field can not be left
-#    undefined by an incomplete `new` inner constructor.)
-#  * `PIN_NONE`: neither is guaranteed; `v` may be `Union{}` (e.g. `Type{v}`
-#    positions matched by the argument `Union{}`, or invariant parameters
-#    without such a field), leaving its bounds unconstraining.
-const PIN_NONE = 0
-const PIN_INHABITED = 1
-const PIN_TYPEOF = 2
-
-function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
-    t === v && return PIN_TYPEOF
-    while t isa UnionAll
-        if t.var.ub === v && t.var.lb === Union{} &&
-            pin_grade(t.var, t.body) == PIN_TYPEOF
-            # the least solution for `v` is the other variable's value
-            return PIN_TYPEOF
-        end
-        t.var === v && return PIN_NONE # `v` is rebound below
-        t = t.body
-    end
-    if t isa Union
-        return min(pin_grade(v, t.a), pin_grade(v, t.b))
-    end
-    t isa DataType || return PIN_NONE
-    if t.name === Tuple.name
-        grade = PIN_NONE
-        for p in t.parameters
-            if p isa Core.TypeofVararg
-                if nonempty_vararg && isdefined(p, :T)
-                    grade = max(grade, pin_grade(v, p.T))
-                end
-            else
-                grade = max(grade, pin_grade(v, p))
-            end
-            grade == PIN_TYPEOF && break
-        end
-        return grade
-    end
-    Base.isType(t) && return PIN_NONE
-    for (i, p) in enumerate(t.parameters)
-        if p === v && param_has_field(t, i)
-            return PIN_INHABITED
-        end
-    end
-    return PIN_NONE
-end
-
-# Whether the `i`-th type parameter of `t`'s constructor is also the declared
-# type of one of its fields, so that instances contain a value of it.
-function param_has_field(t::DataType, i::Int)
-    base = Base.unwrap_unionall(t.name.wrapper)
-    base isa DataType || return false
-    tv = base.parameters[i]
-    tv isa TypeVar || return false
-    for ft in Base.datatype_fieldtypes(base)
-        ft === tv && return true
-    end
-    return false
-end
+# The static rule for whether every call matching a signature pins a static
+# parameter to a definite value is `Core.Compiler.constrains_var` (see
+# `Compiler/src/inferencestate.jl` for its derivation from subtyping's
+# parameter-assignment semantics); inference uses the same predicate to
+# compute the maybe-undef bit of static parameters.
 
 # The `Type{S}`-valued argument slots recognized by the `Union{}`-shadowing
 # rescue in `detect_unbound_args`: either a slot-local range
@@ -3087,13 +2868,13 @@ function has_unbound_vars(@nospecialize(sig), nonempty_vararg::Bool=false,
     while body isa UnionAll
         var = body.var
         body = body.body
-        constrains_var(var, body, #=covariant=#true, nonempty_vararg) && continue
+        Core.Compiler.constrains_var(var, body, #=covariant=#true, nonempty_vararg) && continue
         pinned = false
         for i in shadowed_slots
             # any non-`Union{}` value of this slot's `Type` parameter pins
             # `var` if it occurs invariantly below a constructor of its bound
             v = type_slot_var(params[i])::TypeVar
-            if v !== var && constrains_type_value(var, v.ub)
+            if v !== var && Core.Compiler.constrains_type_value(var, v.ub)
                 pinned = true
                 break
             end

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -330,10 +330,8 @@ _totuple(::Type{Tuple{Vararg{E}}}, itr, s...) where {E} = E
 end
 @test length(detect_unbound_args(M25341; recursive=true)) == 1
 
-# detect_unbound_args uses a static rule derived from how subtyping assigns
-# static parameters (see `Core.Compiler.constrains_var`)
 module UnboundDetect
-    # some matching call leaves the parameter unbound
+    # some matching calls leave the parameter unbound (with example given)
     unbound1(x::Type{<:T}) where {T} = T                       # f(Union{})
     unbound2(x::Vector{<:T}) where {T} = T                     # f(Vector{Union{}}())
     unbound3(x::T) where {T>:Int} = T                          # f(2.0)
@@ -344,11 +342,7 @@ module UnboundDetect
     unbound8(x::Type{Union{T,Missing}}) where {T} = T          # f(Missing)
     unbound9(x::Ref{Vector{<:T}}) where {T} = T                # f(Ref{Vector}(...))
     unbound10(x::Type{<:T}, y::Type{<:S}) where {T, S} = T     # f(Union{}, Int): S is never read, but T is
-    # a raw read is reported even when an `@isdefined` guard exists elsewhere
-    # in the body: proving the guard dominates the read would need dataflow
     unbound13(x::Type{<:T}) where {T} = @isdefined(T) ? T : 0
-    # a possibly-unbound parameter is only reported when the lowered body
-    # actually reads it; an `@isdefined` query alone cannot throw
     unused1(x::Type{<:T}) where {T} = 0
     unused2(x::Type{<:T}) where {T} = @isdefined(T)
     # every matching call pins the parameter
@@ -362,8 +356,7 @@ module UnboundDetect
     bound8(x::Ref{Vector{T}}) where {T} = T
     bound9(x::Tuple{<:T}) where {T} = T
     # issue #58427: every match pins `T`, but a `Vector{Missing}` argument
-    # does so only by absorbing the `T` arm as `T = Union{}` — deliberately
-    # still reported, since `T == Union{}` is a real problem for the body
+    # does so only by absorbing the `T` arm as `T = Union{}`
     unbound14(x::Vector{Union{Missing, T}}) where {T<:Real} = T
     # issue #59023: the `Vector{T}` arm cannot be absorbed into `Nothing`,
     # so every match genuinely pins `T` — an accepted false positive: the

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -385,6 +385,12 @@ module UnboundDetect
     struct WithoutField{S, A<:Tuple} end
     fieldpins(x::WithField{<:Any, <:Tuple{Ref{Type{T}}, Vararg{Any}}}) where {T} = T
     nofieldpins(x::WithoutField{<:Any, <:Tuple{Ref{Type{T}}, Vararg{Any}}}) where {T} = T
+    # issue #54893: `Foo54893(1.0)` leaves `T` unbound; the constructor
+    # signature spells `Type{Foo54893}` with the struct's own variable
+    # object, which must not be mistaken for an occurrence of `T`
+    struct Foo54893{T>:Int}
+        x::T
+    end
 end
 let unbound = Set{Method}(detect_unbound_args(UnboundDetect))
     tested = 0
@@ -402,6 +408,9 @@ let unbound = Set{Method}(detect_unbound_args(UnboundDetect))
         tested += 1
     end
     @test tested == 28
+    let ms = filter(m -> m.sig isa UnionAll, collect(methods(UnboundDetect.Foo54893)))
+        @test only(ms) in unbound
+    end
 end
 
 # Test that Core and Base are free of UndefVarErrors

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -361,12 +361,14 @@ module UnboundDetect
     bound7(x::Union{Vector{T}, Ref{T}}) where {T} = T
     bound8(x::Ref{Vector{T}}) where {T} = T
     bound9(x::Tuple{<:T}) where {T} = T
-    # issue #58427: absorbing `T` into `Missing` forces `T = Union{}` (its
-    # bound `Real` is disjoint from `Missing`), so every match pins it
-    bound10(x::Vector{Union{Missing, T}}) where {T<:Real} = T
+    # issue #58427: every match pins `T`, but a `Vector{Missing}` argument
+    # does so only by absorbing the `T` arm as `T = Union{}` — deliberately
+    # still reported, since `T == Union{}` is a real problem for the body
+    unbound14(x::Vector{Union{Missing, T}}) where {T<:Real} = T
     # issue #59023: the `Vector{T}` arm cannot be absorbed into `Nothing`,
-    # so every match must expose it
-    bound11(x::Type{Union{Nothing, Vector{T}}}) where {T} = T
+    # so every match genuinely pins `T` — an accepted false positive: the
+    # arm-must-be-exposed refinement is deliberately not implemented
+    unbound15(x::Type{Union{Nothing, Vector{T}}}) where {T} = T
     # the calls that would leave the parameter unbound all dispatch to a more
     # specific method
     shadowed1(x::Type{<:AbstractArray{T}}) where {T} = T

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -330,22 +330,141 @@ _totuple(::Type{Tuple{Vararg{E}}}, itr, s...) where {E} = E
 end
 @test length(detect_unbound_args(M25341; recursive=true)) == 1
 
+# detect_unbound_args uses a static rule derived from how subtyping assigns
+# static parameters (see `constrains_var` in Test.jl)
+module UnboundDetect
+    # some matching call leaves the parameter unbound
+    unbound1(x::Type{<:T}) where {T} = T                       # f(Union{})
+    unbound2(x::Vector{<:T}) where {T} = T                     # f(Vector{Union{}}())
+    unbound3(x::T) where {T>:Int} = T                          # f(2.0)
+    unbound4(x::Vector{Union{T,Int}}) where {T} = T            # f(Int[])
+    unbound5(x::S) where {T, S<:Union{T,Int}} = T              # f(1)
+    unbound6(x::S) where {T, S<:Tuple{Vararg{T}}} = T          # f(())
+    unbound7(x::Vector{S}) where {T, S<:AbstractVector{T}} = T # f(Union{}[])
+    unbound8(x::Type{Union{T,Missing}}) where {T} = T          # f(Missing)
+    unbound9(x::Ref{Vector{<:T}}) where {T} = T                # f(Ref{Vector}(...))
+    unbound10(x) where {T} = 0                                 # unused parameter
+    # every matching call pins the parameter
+    bound1(x::T) where {T} = T
+    bound2(x::Type{T}) where {T} = T
+    bound3(x::S) where {T, S<:AbstractVector{T}} = T
+    bound4(x::Vector{T}) where {T>:Int} = T
+    bound5(x::T, y::T) where {T} = T
+    bound6(x::Tuple{Vararg{Int,N}}) where {N} = N
+    bound7(x::Union{Vector{T}, Ref{T}}) where {T} = T
+    bound8(x::Ref{Vector{T}}) where {T} = T
+    bound9(x::Tuple{<:T}) where {T} = T
+    # issue #58427: absorbing `T` into `Missing` forces `T = Union{}` (its
+    # bound `Real` is disjoint from `Missing`), so every match pins it
+    bound10(x::Vector{Union{Missing, T}}) where {T<:Real} = T
+    # issue #59023: the `Vector{T}` arm cannot be absorbed into `Nothing`,
+    # so every match must expose it
+    bound11(x::Type{Union{Nothing, Vector{T}}}) where {T} = T
+    # the calls that would leave the parameter unbound all dispatch to a more
+    # specific method
+    shadowed1(x::Type{<:AbstractArray{T}}) where {T} = T
+    shadowed1(x::Type{Union{}}) = 0
+    shadowed2(x::Int, y::T...) where {T} = T
+    shadowed2(x::Int) = 0
+    shadowed3(x::Type{A}) where {T, A<:AbstractArray{T}} = T
+    shadowed3(x::Type{Union{}}) = 0
+    # with the `Union{}` member shadowed, any other value of the range
+    # variable pins `T` through its bound (even an abstract one)
+    shadowed4(x::Type{<:T}) where {T} = T
+    shadowed4(x::Type{Union{}}) = 0
+    # a `Union{}` shadow does not help when other calls also leave the
+    # parameter unbound (here: `f(Int)` never touches `T`)
+    notshadowed1(x::Type{<:Union{T,Int}}) where {T} = T
+    notshadowed1(x::Type{Union{}}) = 0
+    # a parameter of an argument's constructor that is also the declared type
+    # of one of its fields cannot be `Union{}` (no instance would exist), so
+    # its bound pins T; without such a field it can, and T may be unbound
+    struct WithField{S, A<:Tuple}
+        x::A
+    end
+    struct WithoutField{S, A<:Tuple} end
+    fieldpins(x::WithField{<:Any, <:Tuple{Ref{Type{T}}, Vararg{Any}}}) where {T} = T
+    nofieldpins(x::WithoutField{<:Any, <:Tuple{Ref{Type{T}}, Vararg{Any}}}) where {T} = T
+end
+let unbound = Set{Method}(detect_unbound_args(UnboundDetect))
+    tested = 0
+    for name in names(UnboundDetect; all=true)
+        startswith(String(name), '#') && continue
+        f = getglobal(UnboundDetect, name)
+        f isa Function || continue
+        ms = [m for m in methods(f, UnboundDetect) if m.sig isa UnionAll]
+        isempty(ms) && continue
+        m = only(ms)
+        should_flag = startswith(String(name), "unbound") ||
+                      startswith(String(name), "notshadowed") ||
+                      name === :nofieldpins
+        @test (m in unbound) == should_flag context=name
+        tested += 1
+    end
+    @test tested == 28
+end
+
 # Test that Core and Base are free of UndefVarErrors
 @testset "detect_unbound_args in Base and Core" begin
-    # TODO: review this list and remove everything between test_broken and test
     let need_to_handle_undef_sparam =
             Set{Method}(detect_unbound_args(Core; recursive=true))
         @test isempty(need_to_handle_undef_sparam)
     end
     let need_to_handle_undef_sparam =
             Set{Method}(detect_unbound_args(Base; recursive=true, allowed_undefineds))
-        pop!(need_to_handle_undef_sparam, which(Base._totuple, (Type{Tuple{Vararg{E}}} where E, Any, Any)))
-        pop!(need_to_handle_undef_sparam, which(Base._eltype_ntuple, Tuple{Type{Tuple{Any}}}))
-        pop!(need_to_handle_undef_sparam, which(Base.reduce_empty_iter, (Any, Tuple{Vararg{T}} where T, Base.HasEltype)))
-        pop!(need_to_handle_undef_sparam, first(methods(Base.same_names)))
+        # reviewed and expected
+        expected_undef_sparam = Any[
+            Tuple{typeof(Base._totuple), Type{Tuple{Vararg{E}}}, Any, Vararg{Any}} where E,
+            Tuple{typeof(Base._eltype_ntuple), Type{<:Tuple{Vararg{E}}}} where E,
+            Tuple{typeof(Base.reduce_empty_iter), Any, Tuple{Vararg{T}}, Base.HasEltype} where T,
+            Tuple{typeof(Base.same_names), Vararg{NamedTuple{names}}} where names,
+            # the body does not read the maybe-unbound sparams
+            Tuple{typeof(Base.el_same), Type{T}, Type{<:AbstractArray{T, n}}, Type{<:AbstractArray{T, n}}} where {T, n},
+            # `T` is unbound only for element type `Missing`, whose calls dispatch to the more specific `float(::AbstractArray{Missing})`
+            Tuple{typeof(float), AbstractArray{Union{Missing, T}}} where T,
+            # `N` is unbound only for element type `Union{}`, whose calls are dispatch-ambiguous with the `<:ScalarIndex` and `<:AbstractCartesianIndex{0}` methods, erroring before the body
+            Tuple{typeof(Base._trimmedindex), AbstractArray{<:Base.AbstractCartesianIndex{N}}} where N,
+            Tuple{typeof(Base._trimmedshape), AbstractArray{<:Base.AbstractCartesianIndex{N}}, Vararg{Any}} where N,
+            # `N` is unbound only for `Flatten{Union{}}`, whose calls are dispatch-ambiguous with the `I<:NamedTuple` method
+            Tuple{typeof(eltype), Type{Base.Iterators.Flatten{I}}} where {N, I<:NTuple{N, Any}},
+            # the sparams are unbound only for the argument `Union{}`, whose calls are dispatch-ambiguous among these four methods
+            Tuple{typeof(similar), Type{<:Base.CodeUnits{T}}, NTuple{N, Int} where N} where T,
+            Tuple{typeof(similar), Type{TA}, NTuple{N, Int} where N} where {T, N, O, P, TA<:Base.ReinterpretArray{T, N, O, P}},
+            Tuple{typeof(similar), Type{TA}, NTuple{N, Int} where N} where {T, N, P, TA<:Base.ReshapedArray{T, N, P}},
+            Tuple{typeof(similar), Type{TA}, NTuple{N, Int} where N} where {T, N, P, TA<:SubArray{T, N, P}},
+        ]
+        for sig in expected_undef_sparam
+            m = which(sig)
+            @test m in need_to_handle_undef_sparam context=sig
+            delete!(need_to_handle_undef_sparam, m)
+        end
         @test_broken isempty(need_to_handle_undef_sparam)
-        pop!(need_to_handle_undef_sparam, which(Base._cat, Tuple{Any, AbstractArray}))
-        pop!(need_to_handle_undef_sparam, which(Base.float, Tuple{AbstractArray{Union{Missing, T},N} where {T, N}}))
+        # TODO: not yet investigated or fixed — review this list and empty
+        # it, e.g. by adding a `::Type{Union{}}` method that shadows the
+        # problematic calls, or guarding parameter uses with `@isdefined`
+        todo_undef_sparam = Any[
+            # each entry notes an example call that throws UndefVarError from the body
+            Tuple{Type{Base.IteratorEltype}, Type{Base.Iterators.ProductIterator{T}}} where {N, T<:NTuple{N, Any}}, # IteratorEltype(ProductIterator{Union{}})
+            Tuple{Type{Base.IteratorEltype}, Type{Base.Iterators.Zip{Is}}} where {N, Is<:NTuple{N, Any}}, # IteratorEltype(Zip{Union{}})
+            Tuple{Type{Base.IteratorSize}, Type{Base.Iterators.ProductIterator{T}}} where {N, T<:NTuple{N, Any}}, # IteratorSize(ProductIterator{Union{}})
+            Tuple{Type{Base.IteratorSize}, Type{Base.Iterators.Zip{Is}}} where {N, Is<:NTuple{N, Any}}, # IteratorSize(Zip{Union{}})
+            Tuple{typeof(Base._cat), Any, Vararg{AbstractArray{T}}} where T, # cat(dims=Val(1)): only the `catdim::Int` zero-array case is shadowed
+            Tuple{typeof(Base._counttuple), Type{<:NTuple{N, Any}}} where N, # _counttuple(Union{})
+            Tuple{typeof(Base.Broadcast._maxndims), Type{<:Tuple{T, Vararg}}} where T, # _maxndims(Union{})
+            Tuple{typeof(Base._nt_names), Type{T}} where {names, T<:NamedTuple{names}}, # _nt_names(Union{})
+            Tuple{typeof(Base.Iterators._prod_eltype), Type{I}} where {N, I<:NTuple{N, Any}}, # eltype(ProductIterator{Union{}})
+            Tuple{typeof(Base.Enums.basetype), Type{<:Enum{T}}} where T<:Integer, # basetype(Union{})
+            Tuple{typeof(eltype), Type{<:Base.RSplitIterator{<:SubString{T}}}} where T, # eltype(RSplitIterator{Union{}})
+            Tuple{typeof(eltype), Type{<:Base.SplitIterator{<:SubString{T}}}} where T, # eltype(SplitIterator{Union{}})
+            Tuple{typeof(eltype), Type{Base.Iterators.Zip{Is}}} where {N, Is<:NTuple{N, Any}}, # eltype(Zip{Union{}})
+            Tuple{typeof(ndims), Type{<:Base.Broadcast.Broadcasted{<:Any, <:NTuple{N, Any}}}} where N, # ndims(Broadcasted{DefaultArrayStyle{1}, Union{}})
+            Tuple{typeof(ndims), Type{<:Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle{N}, Nothing}}} where N, # ndims(Broadcasted{Union{}, Nothing})
+        ]
+        for sig in todo_undef_sparam
+            m = which(sig)
+            @test m in need_to_handle_undef_sparam context=sig
+            delete!(need_to_handle_undef_sparam, m)
+        end
         @test isempty(need_to_handle_undef_sparam)
     end
 end

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -331,7 +331,7 @@ end
 @test length(detect_unbound_args(M25341; recursive=true)) == 1
 
 # detect_unbound_args uses a static rule derived from how subtyping assigns
-# static parameters (see `constrains_var` in Test.jl)
+# static parameters (see `Core.Compiler.constrains_var`)
 module UnboundDetect
     # some matching call leaves the parameter unbound
     unbound1(x::Type{<:T}) where {T} = T                       # f(Union{})
@@ -376,15 +376,43 @@ module UnboundDetect
     # parameter unbound (here: `f(Int)` never touches `T`)
     notshadowed1(x::Type{<:Union{T,Int}}) where {T} = T
     notshadowed1(x::Type{Union{}}) = 0
+    # when the range variable occurs in another slot, the `Type{Union{}}`
+    # probe signature is not covered by the method itself, so the lookup
+    # finding the broad fallback proves nothing: `f(Union{}, Ref{Union{}}())`
+    # still dispatches to the `where`-method and leaves `T` unbound
+    notshadowed2(x::Type{A}, y::Ref{A}) where {T, A<:AbstractArray{T}} = T
+    notshadowed2(x::Type, y::Any) = 0
+    # a shadowed slot pins `T` only through a bare lower-bound occurrence,
+    # which is indefinite when `T`'s declared lower bound is not `Union{}`
+    # (`f(Float64)` leaves `T` unbound: the least solution unions in `Int`)
+    notshadowed3(x::Type{<:T}) where {T>:Int} = T
+    notshadowed3(x::Type{Union{}}) = 0
+    # a zero-length-vararg shadow rescues chained bounds too, but not when a
+    # nonempty call can still leave the chain unpinned (`f(1, Ref{Union{}}())`)
+    shadowed5(x::Int, y::S...) where {T, U<:T, S<:U} = T
+    shadowed5(x::Int) = 0
+    notshadowed4(x::Int, y::Ref{S}...) where {T, U<:T, S<:U} = T
+    notshadowed4(x::Int) = 0
     # a parameter of an argument's constructor that is also the declared type
-    # of one of its fields cannot be `Union{}` (no instance would exist), so
-    # its bound pins T; without such a field it can, and T may be unbound
+    # of one of its always-initialized fields cannot be `Union{}` (no
+    # instance would exist), so its bound pins T; without such a field it
+    # can, and T may be unbound
     struct WithField{S, A<:Tuple}
         x::A
     end
     struct WithoutField{S, A<:Tuple} end
     fieldpins(x::WithField{<:Any, <:Tuple{Ref{Type{T}}, Vararg{Any}}}) where {T} = T
     nofieldpins(x::WithoutField{<:Any, <:Tuple{Ref{Type{T}}, Vararg{Any}}}) where {T} = T
+    # an incomplete `new` inner constructor can leave the field `#undef`, so
+    # `Incomplete{Union{}}()` is constructible and `T` may be unbound
+    mutable struct Incomplete{A}
+        x::A
+        Incomplete{A}() where {A} = new()
+    end
+    unbound11(x::Incomplete{<:T}) where {T} = T                # f(Incomplete{Union{}}())
+    # a field-pinned constructor parameter contributes only a lower bound,
+    # indefinite when `T`'s declared lower bound is not `Union{}`
+    unbound12(x::WithField{<:Any, <:T}) where {T>:Tuple{}} = T # f(WithField{1,Tuple{Int}}((1,)))
     # issue #54893: `Foo54893(1.0)` leaves `T` unbound; the constructor
     # signature spells `Type{Foo54893}` with the struct's own variable
     # object, which must not be mistaken for an occurrence of `T`
@@ -407,7 +435,7 @@ let unbound = Set{Method}(detect_unbound_args(UnboundDetect))
         @test (m in unbound) == should_flag context=name
         tested += 1
     end
-    @test tested == 28
+    @test tested == 34
     let ms = filter(m -> m.sig isa UnionAll, collect(methods(UnboundDetect.Foo54893)))
         @test only(ms) in unbound
     end

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -343,7 +343,14 @@ module UnboundDetect
     unbound7(x::Vector{S}) where {T, S<:AbstractVector{T}} = T # f(Union{}[])
     unbound8(x::Type{Union{T,Missing}}) where {T} = T          # f(Missing)
     unbound9(x::Ref{Vector{<:T}}) where {T} = T                # f(Ref{Vector}(...))
-    unbound10(x) where {T} = 0                                 # unused parameter
+    unbound10(x::Type{<:T}, y::Type{<:S}) where {T, S} = T     # f(Union{}, Int): S is never read, but T is
+    # a raw read is reported even when an `@isdefined` guard exists elsewhere
+    # in the body: proving the guard dominates the read would need dataflow
+    unbound13(x::Type{<:T}) where {T} = @isdefined(T) ? T : 0
+    # a possibly-unbound parameter is only reported when the lowered body
+    # actually reads it; an `@isdefined` query alone cannot throw
+    unused1(x::Type{<:T}) where {T} = 0
+    unused2(x::Type{<:T}) where {T} = @isdefined(T)
     # every matching call pins the parameter
     bound1(x::T) where {T} = T
     bound2(x::Type{T}) where {T} = T
@@ -435,7 +442,7 @@ let unbound = Set{Method}(detect_unbound_args(UnboundDetect))
         @test (m in unbound) == should_flag context=name
         tested += 1
     end
-    @test tested == 34
+    @test tested == 37
     let ms = filter(m -> m.sig isa UnionAll, collect(methods(UnboundDetect.Foo54893)))
         @test only(ms) in unbound
     end
@@ -452,11 +459,10 @@ end
         # reviewed and expected
         expected_undef_sparam = Any[
             Tuple{typeof(Base._totuple), Type{Tuple{Vararg{E}}}, Any, Vararg{Any}} where E,
+            # the raw reads are `@isdefined`-guarded and safe at runtime, but
+            # verifying that the guard dominates the read would need dataflow
             Tuple{typeof(Base._eltype_ntuple), Type{<:Tuple{Vararg{E}}}} where E,
             Tuple{typeof(Base.reduce_empty_iter), Any, Tuple{Vararg{T}}, Base.HasEltype} where T,
-            Tuple{typeof(Base.same_names), Vararg{NamedTuple{names}}} where names,
-            # the body does not read the maybe-unbound sparams
-            Tuple{typeof(Base.el_same), Type{T}, Type{<:AbstractArray{T, n}}, Type{<:AbstractArray{T, n}}} where {T, n},
             # `T` is unbound only for element type `Missing`, whose calls dispatch to the more specific `float(::AbstractArray{Missing})`
             Tuple{typeof(float), AbstractArray{Union{Missing, T}}} where T,
             # `N` is unbound only for element type `Union{}`, whose calls are dispatch-ambiguous with the `<:ScalarIndex` and `<:AbstractCartesianIndex{0}` methods, erroring before the body
@@ -478,7 +484,7 @@ end
         @test_broken isempty(need_to_handle_undef_sparam)
         # TODO: not yet investigated or fixed — review this list and empty
         # it, e.g. by adding a `::Type{Union{}}` method that shadows the
-        # problematic calls, or guarding parameter uses with `@isdefined`
+        # problematic calls
         todo_undef_sparam = Any[
             # each entry notes an example call that throws UndefVarError from the body
             Tuple{Type{Base.IteratorEltype}, Type{Base.Iterators.ProductIterator{T}}} where {N, T<:NTuple{N, Any}}, # IteratorEltype(ProductIterator{Union{}})

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -3120,6 +3120,24 @@ let rhs = Tuple{typeof(intersection_env), Type{<:Tuple{Vararg{E}}}} where E
     @test fixed_range isa Core.SimpleVector && fixed_range[1] isa TypeVar && !fixed_range[2]
 end
 
+# `Type{T}` pins `T` invariantly: the only dispatch types under `Type`
+# are the `Type{X}` singletons, each fixing `T = X` (the `DataType`/`Union`/
+# `UnionAll` kinds never appear as a dispatch-type tuple element). So even the
+# reflexive `Type` intersection must report `T` as bound, matching every
+# `Type{X}` case and `Base.Compiler.constrains_var(T, Type{T}, MATCH_TYPEOF)`.
+let e = only(intersection_env(Type, Type)[2])
+    @test e isa Core.SimpleVector && e[1] isa TypeVar && e[2]
+end
+let e = only(intersection_env(Type{Int}, Type)[2])
+    @test e isa Core.SimpleVector && e[1] isa TypeVar && e[2]
+end
+let e = only(intersection_env(Type{Integer}, Type)[2])
+    @test e isa Core.SimpleVector && e[1] isa TypeVar && e[2]
+end
+let e = only(intersection_env(Type{Union{}}, Type)[2])
+    @test e === Union{}
+end
+
 # Env entries must not introduce a fresh `newvar<:vb.lb` wrapper when `vb.lb`
 # is already a TypeVar. The doubled `where T<:T_outer where T_outer` pattern
 # that wrapper would produce accumulates across nested intersections and


### PR DESCRIPTION
Replace the `Core.Compiler.constrains_param` heuristic with a conservative
static approximation of how subtyping actually assigns static parameter values
(`subtype_unionall` / `eff_constrained` in `src/subtype.c`), fixing
inaccuracies in both directions, and share that one rule between its three
consumers: `Test.detect_unbound_args`, inference's
`sptypes_from_unspecialized`, and the `constrains_param_static` mirror in
`src/subtype.c`.

---

# :robot: Opus 5

## The rule

`Core.Compiler.constrains_var(var, t, match)` in
`Compiler/src/inferencestate.jl` answers whether every call matching a
signature pins the static parameter `var`, where `match` says how the position
`t` gets filled: `MATCH_EGAL` (an invariant slot, matched by type equality),
`MATCH_TYPEOF` (a covariant argument slot, filled with `typeof` of an
argument), or `MATCH_INHABITED` (filled with some inhabited — possibly
abstract — type). A parameter is guaranteed a definite value through one of
two channels:

- An invariant (`MATCH_EGAL`) occurrence pins it by type equality. This is not
  definite in a `Union` arm (the other arms may absorb it), in a `Vararg`
  element (respellable, e.g. `Tuple` vs `Tuple{Vararg{T}}`), or in the bounds
  of an inner range (`Vector{<:T}` matched by `Vector`).
- A covariant (`MATCH_TYPEOF`) occurrence contributes a lower bound and the
  least solution is taken. This is definite only if the declared lower bound
  is `Union{}` (`f(x::T) where {T>:Int}` is unbound for `f(2.0)`), and only
  for occurrences that contribute in every call: present in all `Union` arms,
  not under a `Vararg` tail, and reached through another variable's upper
  bound only when that variable is itself guaranteed a non-`Union{}` value
  (`pin_grade`) — either a `typeof`-produced argument slot (`PIN_TYPEOF`), or
  an invariant constructor parameter that is also the declared type of an
  always-initialized field, so that a `Union{}` value would make the argument
  uninhabited (`PIN_INHABITED`, counted only within
  `datatype_min_ninitialized`, so an incomplete `new()` inner constructor does
  not qualify).

Occurrences below a rebinding of the variable are not credited: a default
constructor signature spells `Type{TheStruct}` using the struct's own type
variable objects, so the method's variable appears rebound inside its own
signature. For `struct Foo{T>:Int}; x::T; end`, `Foo(1.0)` throws
`UndefVarError`, but the constructor went unreported because the bound `T`
inside `Type{Foo}` was mistaken for a constraining occurrence (#54893).

Invariant `Union` arms are deliberately coarsened: every arm must pin `var`,
with no disjointness escape. A parameter that some matching call pins only as
`var = Union{}`, by absorbing an arm, is still reported — it is reachable with
`invoke`, and it is consistent with the covariant-occurrence rule. Adding the
escape would need a suffix-scoped `typeintersect` disjointness proof, which
makes the answer depend on union normalization order
(`Union{Ref{Vector{T}}, Ref{T}, String}` pinned but the analogous
`Union{Ref{Vector{T}}, Ref{T}, Vector{Int}}` not, purely from arm sorting).
Consequently both of the false positives filed against the old
implementation are, deliberately, still reported:
`f(::Vector{Union{Missing,T}}) where {T<:Real}` (#58427) and
`f(::Type{Union{Nothing,Vector{T}}}) where {T}` (#59023, closed as a duplicate
of #58427).

## `Test.detect_unbound_args`

`has_unbound_vars` is replaced by `unbound_sparams(sig, ...)`, which returns
the 1-based `where`-chain positions of the possibly-unbound parameters — the
same numbering `Expr(:static_parameter, i)` uses in the lowered body — so the
rescues below apply per parameter instead of clearing the whole method.

Methods are no longer reported when the calls that would leave a parameter
unbound provably dispatch elsewhere. The existing zero-length-`Vararg` lookup
is joined by a `Type{Union{}}` argument-slot probe, which recognizes the
`f(::Type{Union{}}, ...)` fallbacks Base defines for this purpose. Both
require the method found to be `morespecific` than the candidate, so a broad
fallback can no longer fake a shadow; the `Type{Union{}}` probe additionally
runs only for slots that could rescue an unbound parameter, and unboundness is
re-checked only when an assumption was actually established.

Finally, a method is reported only if a surviving possibly-unbound parameter
is really read: `reads_sparams` walks `Base.uncompressed_ir(m).code` for
`Expr(:static_parameter, i)`. An `Expr(:isdefined, static_parameter)` query
does not count as a read (it cannot throw), but a raw read counts even when a
guard exists elsewhere in the body — proving the guard dominates the read
would need dataflow over typed code. Methods without `:source` (generated
functions) are conservatively treated as reading. Fixes #56698.

## Inference

`sptypes_from_unspecialized` uses the shared predicate too, which both fixes
the unsound `Const(true)` `isdefined` folding for `f(::Type{<:S})` shapes and
gains precision: the old `lb === Bottom` pre-guard wrongly forced maybe-undef
for invariant occurrences such as `Vector{T} where T>:Int`, and a plain
`Type{T}` was never credited. The stale `type_constrains` flag died with
`constrains_param`.

## `src/subtype.c`

`constrains_param_static` is now a provable conservative subset of
`constrains_var`: a bare covariant occurrence requires declared
`lb == Union{}`; descent into an inner variable's declared bound is gated on
`jl_has_typevar` plus a new allocation-free `pins_typeof_static` (mirroring
only `PIN_TYPEOF` — `PIN_INHABITED` is intentionally not mirrored, since
`false` is always safe); rebound occurrences are not credited. The safe
direction holds for both consumers: the `envout` constrained markers and
`mark_required_tuple_element`'s `lb_required` both read `false` as "maybe
undef". `unionall_is_Type_range` became dead and was removed, so a `Type{T}`
position now reports its parameter constrained — new `intersection_env` tests
in `test/subtype.jl` pin down that even the reflexive `Type` intersection
reports `T` bound, since the only dispatch types under `Type` are the
`Type{X}` singletons.
