### PR TITLE
typemap: store method caches as insertion-ordered dicts

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1982,11 +1982,13 @@ function visit(f, mt::Core.MethodTable)
 end
 function visit(f, mc::Core.TypeMapLevel)
     function avisit(f, e::Memory{Any})
-        for i in 2:2:length(e)
+        # slot 1 holds the smallintset index; key/value pairs follow, so values
+        # live on the odd slots starting at 3 (see mtcache layout in src/typemap.c)
+        for i in 3:2:length(e)
             isassigned(e, i) || continue
             ei = e[i]
             if ei isa Memory{Any}
-                for j in 2:2:length(ei)
+                for j in 3:2:length(ei)
                     isassigned(ei, j) || continue
                     visit(f, ei[j])
                 end

--- a/src/gf.c
+++ b/src/gf.c
@@ -1059,7 +1059,7 @@ static void drop_all_methcache(jl_methcache_t *mc) JL_CANSAFEPOINT
     jl_typemap_visitor(jl_atomic_load_relaxed(&mc->cache), invalidate_all_entries, NULL);
     jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
     size_t i, l = leafcache->length;
-    for (i = 1; i < l; i += 2) {
+    for (i = 1; i < l; i++) { // entries are dense from slot 1 (slot 0 is the index)
         jl_typemap_entry_t *oldentry = (jl_typemap_entry_t*)jl_genericmemory_ptr_ref(leafcache, i);
         if (oldentry) {
             while ((jl_value_t*)oldentry != jl_nothing) {
@@ -1677,10 +1677,55 @@ static int concretesig_equal(jl_value_t *tt, jl_value_t *simplesig) JL_NOTSAFEPO
     return 1;
 }
 
+// The leafcache is an insertion-ordered dictionary stored inline in a Memory{Any}:
+// slot [0] holds a `smallintset` mapping each key's hash to its logical entry
+// index, and entry `p` (0-based) is stored densely at slot `1 + p`. The key of
+// each entry is derivable from its value (`entry->sig == tt`), so no separate key
+// column is needed.
+static uint_t leafcache_hash(size_t p, jl_value_t *data) JL_NOTSAFEPOINT
+{
+    jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_genericmemory_ptr_ref(data, 1 + p);
+    // entry should not be NULL, unless there was concurrent corruption
+    return entry == NULL ? 0 : (uint_t)jl_object_id((jl_value_t*)entry->sig);
+}
+
+static int leafcache_eq(size_t p, const void *tt, jl_value_t *data, uint_t hv) JL_NOTSAFEPOINT
+{
+    size_t i = 1 + p;
+    if (i >= ((jl_genericmemory_t*)data)->length)
+        return 0; // OOB access, probably due to a data race
+    jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_genericmemory_ptr_ref(data, i);
+    return entry != NULL && jl_egal((jl_value_t*)entry->sig, (jl_value_t*)tt);
+}
+
+// find the logical index of the chain whose entries have `entry->sig == tt`, or -1
+static ssize_t leafcache_peek(jl_genericmemory_t *leafcache JL_PROPAGATES_ROOT, jl_value_t *tt) JL_NOTSAFEPOINT
+{
+    if (leafcache == (jl_genericmemory_t*)jl_an_empty_memory_any)
+        return -1;
+    jl_genericmemory_t *idxs = (jl_genericmemory_t*)jl_genericmemory_ptr_ref(leafcache, 0); // acquire
+    JL_GC_PROMISE_ROOTED(idxs);
+    // leafcache_eq does not safepoint, so declare this lookup is safe from JL_NOTSAFEPOINT callers
+    ssize_t jl_smallintset_lookup(jl_genericmemory_t *cache, smallintset_eq eq JL_NOTSAFEPOINT, const void *key, jl_value_t *data, uint_t hv, int pop) JL_NOTSAFEPOINT;
+    return jl_smallintset_lookup(idxs, leafcache_eq, tt, (jl_value_t*)leafcache, (uint_t)jl_object_id(tt), 0);
+}
+
+// append `entry` as a new chain and publish it in the index (caller holds the write lock)
+static void leafcache_insert(_Atomic(jl_genericmemory_t*) *pcache, jl_value_t *parent, jl_typemap_entry_t *entry) JL_CANSAFEPOINT
+{
+    size_t p = jl_ordereddict_reserve(pcache, parent, 1); // reserve one entry
+    jl_genericmemory_t *a = jl_atomic_load_relaxed(pcache);
+    jl_genericmemory_ptr_set(a, 1 + p, (jl_value_t*)entry); // release
+    // publish the entry last, so a concurrent lookup that observes it in the
+    // index also observes the entry written above
+    jl_smallintset_insert((_Atomic(jl_genericmemory_t*)*)a->ptr, (jl_value_t*)a, leafcache_hash, p, (jl_value_t*)a);
+}
+
 // if available, returns a TypeMapEntry in the "leafcache" that matches `tt` (by type-equality) and is valid during `world`
 static inline jl_typemap_entry_t *lookup_leafcache(jl_genericmemory_t *leafcache JL_PROPAGATES_ROOT, jl_value_t *tt, size_t world) JL_NOTSAFEPOINT
 {
-    jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_eqtable_get(leafcache, (jl_value_t*)tt, NULL);
+    ssize_t p = leafcache_peek(leafcache, tt);
+    jl_typemap_entry_t *entry = p == -1 ? NULL : (jl_typemap_entry_t*)jl_genericmemory_ptr_ref(leafcache, 1 + p);
     if (entry) {
         // search tail of the linked-list (including the returned entry) for an entry intersecting world
         //
@@ -1784,11 +1829,17 @@ static void cache_insert(
             JL_UNLOCK(&typecache_lock); // Might GC
         }
         jl_genericmemory_t *oldcache = jl_atomic_load_relaxed(&mc->leafcache);
-        jl_typemap_entry_t *old = (jl_typemap_entry_t*)jl_eqtable_get(oldcache, (jl_value_t*)tt, jl_nothing);
+        ssize_t p = leafcache_peek(oldcache, (jl_value_t*)tt);
+        jl_typemap_entry_t *old = p == -1 ? (jl_typemap_entry_t*)jl_nothing
+                                          : (jl_typemap_entry_t*)jl_genericmemory_ptr_ref(oldcache, 1 + p);
         jl_gc_write_atomic(newentry, newentry->next, jl_typemap_entry_t, old, relaxed);
-        jl_genericmemory_t *newcache = jl_eqtable_put(jl_atomic_load_relaxed(&mc->leafcache), (jl_value_t*)tt, (jl_value_t*)newentry, NULL);
-        if (newcache != oldcache) {
-            jl_gc_write_atomic(mc, mc->leafcache, jl_genericmemory_t, newcache, release);
+        if (p != -1) {
+            // prepend to the existing chain by replacing its head in place (release,
+            // so a concurrent lookup sees a consistent, world-versioned chain)
+            jl_genericmemory_ptr_set(oldcache, 1 + p, (jl_value_t*)newentry);
+        }
+        else {
+            leafcache_insert(&mc->leafcache, (jl_value_t*)mc, newentry);
         }
     }
     else {
@@ -2801,7 +2852,7 @@ static void _method_table_invalidate(jl_methcache_t *mc, void *env0) JL_CANSAFEP
     jl_typemap_visitor(jl_atomic_load_relaxed(&mc->cache), disable_mt_cache, env0);
     jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
     size_t i, l = leafcache->length;
-    for (i = 1; i < l; i += 2) {
+    for (i = 1; i < l; i++) { // entries are dense from slot 1 (slot 0 is the index)
         jl_typemap_entry_t *oldentry = (jl_typemap_entry_t*)jl_genericmemory_ptr_ref(leafcache, i);
         if (oldentry) {
             while ((jl_value_t*)oldentry != jl_nothing) {
@@ -3334,7 +3385,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         jl_typemap_visitor(jl_atomic_load_relaxed(&mc->cache), invalidate_mt_cache, (void*)&mt_cache_env);
         jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
         size_t i, l = leafcache->length;
-        for (i = 1; i < l; i += 2) {
+        for (i = 1; i < l; i++) { // entries are dense from slot 1 (slot 0 is the index)
             jl_value_t *entry = jl_genericmemory_ptr_ref(leafcache, i);
             if (entry) {
                 while (entry != jl_nothing) {
@@ -3758,7 +3809,7 @@ JL_DLLEXPORT void jl_add_codeinsts_to_jit(jl_array_t *codeinsts, jl_array_t *src
         jl_typemap_visitor(jl_atomic_load_relaxed(&mc->cache), invalidate_mt_cache, (void*)&mt_cache_env);
         jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
         size_t i, l = leafcache->length;
-        for (i = 1; i < l; i += 2) {
+        for (i = 1; i < l; i++) { // entries are dense from slot 1 (slot 0 is the index)
             jl_value_t *entry = jl_genericmemory_ptr_ref(leafcache, i);
             if (entry) {
                 while (entry != jl_nothing) {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1871,6 +1871,7 @@ typedef uint_t (*smallintset_hash)(size_t val, jl_value_t *data);
 typedef int (*smallintset_eq)(size_t val, const void *key, jl_value_t *data, uint_t hv);
 ssize_t jl_smallintset_lookup(jl_genericmemory_t *cache, smallintset_eq eq, const void *key, jl_value_t *data, uint_t hv, int pop);
 void jl_smallintset_insert(_Atomic(jl_genericmemory_t*) *pcache, jl_value_t *parent, smallintset_hash hash, size_t val, jl_value_t *data) JL_CANSAFEPOINT;
+size_t jl_ordereddict_reserve(_Atomic(jl_genericmemory_t*) *pcache, jl_value_t *parent, size_t stride) JL_CANSAFEPOINT;
 jl_genericmemory_t* smallintset_rehash(jl_genericmemory_t* a, smallintset_hash hash, jl_value_t *data, size_t newsz, size_t np) JL_CANSAFEPOINT;
 void smallintset_empty(const jl_genericmemory_t *a) JL_NOTSAFEPOINT;
 

--- a/src/smallintset.c
+++ b/src/smallintset.c
@@ -200,6 +200,47 @@ void jl_smallintset_insert(_Atomic(jl_genericmemory_t*) *pcache, jl_value_t *par
     }
 }
 
+// Support for insertion-ordered dictionaries backed by a Memory{Any} that stores
+// its `jl_smallintset` index inline at slot [0], followed by fixed-size entries
+// of `stride` slots each (entry `i` occupies slots `[1 + stride*i, 1 + stride*(i+1))`).
+// Entries are only appended (never removed), so the occupied entries are contiguous
+// and the free region is at the end. Reserve space for one more entry, growing
+// `*pcache` if needed (with release ordering and a write barrier on `parent`), and
+// return the new entry's index. The caller fills the entry's slots and then
+// publishes it with `jl_smallintset_insert` on the inline index at slot [0].
+size_t jl_ordereddict_reserve(_Atomic(jl_genericmemory_t*) *pcache, jl_value_t *parent, size_t stride)
+{
+    jl_genericmemory_t *a = jl_atomic_load_relaxed(pcache);
+    // scan back from the end for the append position (entries are contiguous)
+    size_t idx = a->length < 1 + stride ? 0 : (a->length - 1) / stride;
+    while (idx > 0 && jl_genericmemory_ptr_ref(a, 1 + stride * (idx - 1)) == NULL)
+        idx--;
+    size_t need = 1 + stride * (idx + 1);
+    if (need > a->length) {
+        size_t newlen = a->length < 8 ? 8 : (a->length * 3) >> 1;
+        if (newlen < need)
+            newlen = need;
+        jl_genericmemory_t *na = NULL;
+        JL_GC_PUSH2(&na, &a);
+        na = jl_alloc_memory_any(newlen);
+        if (a == (jl_genericmemory_t*)jl_an_empty_memory_any) {
+            jl_genericmemory_ptr_set(na, 0, (jl_value_t*)jl_an_empty_memory_any); // empty index
+        }
+        else {
+            for (size_t i = 0; i < a->length; i++) {
+                jl_value_t *v = jl_genericmemory_ptr_ref(a, i);
+                if (v != NULL)
+                    jl_genericmemory_ptr_set(na, i, v);
+            }
+        }
+        if (parent)
+            jl_gc_wb(parent, na);
+        jl_atomic_store_release(pcache, na);
+        JL_GC_POP();
+    }
+    return idx;
+}
+
 jl_genericmemory_t* smallintset_rehash(jl_genericmemory_t* a, smallintset_hash hash, jl_value_t *data, size_t newsz, size_t np)
 {
     size_t sz = a->length;

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -316,40 +316,71 @@ static int is_cache_leaf(jl_value_t *ty, int tparam)
     return (jl_is_concrete_type(ty) && (tparam || !jl_is_kind(ty)));
 }
 
-static _Atomic(jl_value_t*) *mtcache_hash_lookup_bp(jl_genericmemory_t *cache JL_PROPAGATES_ROOT, jl_value_t *ty) JL_NOTSAFEPOINT
+// A `mtcache` is an insertion-ordered dictionary stored inline in a Memory{Any},
+// so that iteration is deterministic (for repeatable builds) and table scans are
+// a simple linear walk. Slot [0] holds a `smallintset` mapping the hash of each
+// key to its logical pair index; pair `p` (0-based) then stores its key at slot
+// `1 + 2*p` and its value at slot `2 + 2*p`. Empty tables are the shared
+// `jl_an_empty_memory_any` (length 0), which grows on first insertion.
+// This mirrors the module `bindings`/`idset` pattern (see src/module.c, src/idset.c).
+#define MTCACHE_KEY_SLOT(p) (1 + 2 * (p))
+#define MTCACHE_VAL_SLOT(p) (2 + 2 * (p))
+
+static uint_t mtcache_hash(size_t p, jl_value_t *data) JL_NOTSAFEPOINT
+{
+    jl_value_t *key = jl_genericmemory_ptr_ref(data, MTCACHE_KEY_SLOT(p));
+    // key should not be NULL, unless there was concurrent corruption
+    return key == NULL ? 0 : (uint_t)jl_object_id(key);
+}
+
+static int mtcache_eq(size_t p, const void *key, jl_value_t *data, uint_t hv) JL_NOTSAFEPOINT
+{
+    size_t ki = MTCACHE_KEY_SLOT(p);
+    if (ki >= ((jl_genericmemory_t*)data)->length)
+        return 0; // OOB access, probably due to a data race
+    jl_value_t *k = jl_genericmemory_ptr_ref(data, ki);
+    return k != NULL && jl_egal(k, (jl_value_t*)key);
+}
+
+static ssize_t mtcache_hash_peek(jl_genericmemory_t *cache JL_PROPAGATES_ROOT, jl_value_t *ty) JL_NOTSAFEPOINT
 {
     if (cache == (jl_genericmemory_t*)jl_an_empty_memory_any)
+        return -1;
+    jl_genericmemory_t *idxs = (jl_genericmemory_t*)jl_genericmemory_ptr_ref(cache, 0); // acquire
+    JL_GC_PROMISE_ROOTED(idxs);
+    // mtcache_eq does not safepoint, so this lookup is safe from JL_NOTSAFEPOINT callers
+    ssize_t jl_smallintset_lookup(jl_genericmemory_t *cache, smallintset_eq eq JL_NOTSAFEPOINT, const void *key, jl_value_t *data, uint_t hv, int pop) JL_NOTSAFEPOINT;
+    return jl_smallintset_lookup(idxs, mtcache_eq, ty, (jl_value_t*)cache, (uint_t)jl_object_id(ty), 0);
+}
+
+static _Atomic(jl_value_t*) *mtcache_hash_lookup_bp(jl_genericmemory_t *cache JL_PROPAGATES_ROOT, jl_value_t *ty) JL_NOTSAFEPOINT
+{
+    ssize_t p = mtcache_hash_peek(cache, ty);
+    if (p == -1)
         return NULL;
-    _Atomic(jl_value_t*) *pml = jl_table_peek_bp(cache, ty);
+    _Atomic(jl_value_t*) *pml = &((_Atomic(jl_value_t*)*)cache->ptr)[MTCACHE_VAL_SLOT(p)];
     JL_GC_PROMISE_ROOTED(pml); // clang-sa doesn't trust our JL_PROPAGATES_ROOT claim
     return pml;
 }
 
 static void mtcache_hash_insert(_Atomic(jl_genericmemory_t*) *pcache, jl_value_t *parent, jl_value_t *key, jl_typemap_t *val) JL_CANSAFEPOINT
 {
-    int inserted = 0;
+    size_t p = jl_ordereddict_reserve(pcache, parent, 2); // reserve one key/value pair
     jl_genericmemory_t *a = jl_atomic_load_relaxed(pcache);
-    if (a == (jl_genericmemory_t*)jl_an_empty_memory_any) {
-        a = jl_alloc_memory_any(16);
-        if (parent)
-            jl_gc_wb(parent, a);
-        jl_atomic_store_release(pcache, a);
-    }
-    a = jl_eqtable_put(a, key, val, &inserted);
-    assert(inserted);
-    if (a != jl_atomic_load_relaxed(pcache)) {
-        if (parent)
-            jl_gc_wb(parent, a);
-        jl_atomic_store_release(pcache, a);
-    }
+    jl_genericmemory_ptr_set(a, MTCACHE_KEY_SLOT(p), key); // release
+    jl_genericmemory_ptr_set(a, MTCACHE_VAL_SLOT(p), (jl_value_t*)val); // release
+    // publish the entry last, so a concurrent lookup that observes it in the
+    // index also observes the key and value written above
+    jl_smallintset_insert((_Atomic(jl_genericmemory_t*)*)a->ptr, (jl_value_t*)a, mtcache_hash, p, (jl_value_t*)a);
 }
 
 static jl_typemap_t *mtcache_hash_lookup(jl_genericmemory_t *cache JL_PROPAGATES_ROOT, jl_value_t *ty) JL_NOTSAFEPOINT
 {
-    if (cache == (jl_genericmemory_t*)jl_an_empty_memory_any)
+    ssize_t p = mtcache_hash_peek(cache, ty);
+    if (p == -1)
         return (jl_typemap_t*)jl_nothing;
-    jl_typemap_t *ml = (jl_typemap_t*)jl_eqtable_get(cache, ty, jl_nothing);
-    return ml;
+    jl_typemap_t *ml = (jl_typemap_t*)jl_genericmemory_ptr_ref(cache, MTCACHE_VAL_SLOT(p));
+    return ml == NULL ? (jl_typemap_t*)jl_nothing : ml;
 }
 
 // ----- Sorted Type Signature Lookup Matching ----- //
@@ -358,7 +389,7 @@ static int jl_typemap_memory_visitor(jl_genericmemory_t *a, jl_typemap_visitor_f
 {
     size_t i, l = a->length;
     _Atomic(jl_typemap_t*) *data = (_Atomic(jl_typemap_t*)*) a->ptr;
-    for (i = 1; i < l; i += 2) {
+    for (i = 2; i < l; i += 2) { // values live on even slots >= 2 (slot 0 is the index)
         jl_value_t *d = jl_atomic_load_relaxed(&data[i]);
         JL_GC_PROMISE_ROOTED(d);
         if (d == NULL)
@@ -523,7 +554,7 @@ static int jl_typemap_intersection_memory_visitor(jl_genericmemory_t *a, jl_valu
         else
             height = jl_supertype_height(tydt);
     }
-    for (i = 0; i < l; i += 2) {
+    for (i = 1; i < l; i += 2) { // key on odd slot i, value on even slot i+1 (slot 0 is the index)
         jl_value_t *t = jl_atomic_load_relaxed(&data[i]);
         JL_GC_PROMISE_ROOTED(t);
         if (t == jl_nothing || t == NULL)
@@ -531,6 +562,10 @@ static int jl_typemap_intersection_memory_visitor(jl_genericmemory_t *a, jl_valu
         if (tparam & 2) {
             jl_typemap_t *ml = jl_atomic_load_relaxed(&data[i + 1]);
             JL_GC_PROMISE_ROOTED(ml);
+            // the value is published (release) after its key, so ml may be NULL if
+            // we're racing with the thread inserting this entry; skip incomplete entries
+            if (ml == NULL)
+                continue;
             if (tydt == jl_any_type ?
                     tname_intersection(ty, (jl_typename_t*)t, tparam & 1) :
                     tname_intersection_dt(tydt, (jl_typename_t*)t, height)) {
@@ -1073,7 +1108,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
                         size_t i, l = tname->length;
                         _Atomic(jl_typemap_t*) *data = (_Atomic(jl_typemap_t*)*) jl_genericmemory_ptr_data(tname);
                         JL_GC_PUSH1(&tname);
-                        for (i = 1; i < l; i += 2) {
+                        for (i = 2; i < l; i += 2) { // values live on even slots >= 2 (slot 0 is the index)
                             jl_typemap_t *ml = jl_atomic_load_relaxed(&data[i]);
                             if (ml == NULL || ml == jl_nothing)
                                 continue;
@@ -1112,7 +1147,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
                     size_t i, l = name1->length;
                     _Atomic(jl_typemap_t*) *data = (_Atomic(jl_typemap_t*)*) jl_genericmemory_ptr_data(name1);
                     JL_GC_PUSH1(&name1);
-                    for (i = 1; i < l; i += 2) {
+                    for (i = 2; i < l; i += 2) { // values live on even slots >= 2 (slot 0 is the index)
                         jl_typemap_t *ml = jl_atomic_load_relaxed(&data[i]);
                         if (ml == NULL || ml == jl_nothing)
                             continue;
@@ -1268,7 +1303,7 @@ jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_v
                 size_t i, l = tname->length;
                 _Atomic(jl_typemap_t*) *data = (_Atomic(jl_typemap_t*)*) jl_genericmemory_ptr_data(tname);
                 JL_GC_PUSH1(&tname);
-                for (i = 1; i < l; i += 2) {
+                for (i = 2; i < l; i += 2) { // values live on even slots >= 2 (slot 0 is the index)
                     jl_typemap_t *ml_or_cache = jl_atomic_load_relaxed(&data[i]);
                     if (ml_or_cache == NULL || ml_or_cache == jl_nothing)
                         continue;


### PR DESCRIPTION
The per-level subcaches of a TypeMapLevel (arg1/targ/name1/tname), the nested "doublesplit" tables they spawn, and the MethodCache leafcache were open-addressing hash tables (jl_eqtable). Rehashing reorders their entries by hash, so the contents serialized into the system image were dependent on hash-table layout rather than definition order, and every table walk had to skip empty hash slots in an arbitrary order.

Replace them with insertion-ordered dictionaries built from a list plus a smallintset index, following the pattern already used for module bindings and IdSet. The index lives inline in slot [0] of each Memory, so the payload (interleaved key/value pairs for the subcaches, dense entries for the leafcache) follows in append order and no object layouts change. Iteration is now deterministic, which makes builds more repeatable, and table scans become a straight linear walk.

Entries are only appended, never removed (the leafcache is instead reset wholesale), so no compaction is needed. Lock-free readers stay correct: the value slot is written last and acts as the completion sentinel, the smallintset lookup path is fenced by the release in jl_smallintset_insert and bounds-checked in its eq callback, and the intersection visitor skips entries whose value is not yet published.

This may save about a MB from the sysimage also (165 -> 164 MB), but that isn't confirmed extensively.