### PR TITLE
MMTK: Fix race condition in STW + collect coredumps from hung `runtests` workers

### DIFF
--- a/src/gc-mmtk/mmtk_julia/src/collection.rs
+++ b/src/gc-mmtk/mmtk_julia/src/collection.rs
@@ -80,11 +80,15 @@ impl Collection<JuliaVM> for VMCollection {
             )
         }
 
+        // Holding the mutex here guarantees that any mutator that observed
+        // `BLOCK_FOR_GC == true` is already enqueued in `wait()` by the time
+        // we call `notify_all`.
+        let (lock, cvar) = &*STW_COND.clone();
+        let count = lock.lock().unwrap();
         AtomicBool::store(&BLOCK_FOR_GC, false, Ordering::SeqCst);
         AtomicBool::store(&WORLD_HAS_STOPPED, false, Ordering::SeqCst);
-
-        let (_, cvar) = &*STW_COND.clone();
         cvar.notify_all();
+        drop(count);
 
         info!(
             "Live bytes = {}, total bytes = {}",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,6 +235,35 @@ cd(@__DIR__) do
         # Track timeout timers for each test
         test_timers = Dict{String, Timer}()
 
+        # Which worker each in-flight test is running on
+        running_on = Dict{String, Int}()
+
+        Sys.iswindows() || atexit() do
+            # This `atexit()` is a desperate attempt to collect .core dumps from
+            # any hung workers, if the CI test infrastructure decides to tear us
+            # down due to a timeout
+            isempty(running_on) && return
+            stuck = Int[]
+            # Send a `SIGQUIT` signal to any stuck workers so they produce
+            # a .core file and a stacktrace.
+            for (test, wrkr) in running_on
+                ospid = get(worker_ospids, wrkr, nothing)
+                ospid === nothing && continue
+                println(stderr, "Test $test is still running on worker $wrkr (pid $ospid) at teardown; sending SIGQUIT for a core dump.")
+                if ccall(:kill, Cint, (Cint, Cint), ospid, Base.SIGQUIT) == 0
+                    push!(stuck, ospid)
+                end
+            end
+            alive(pid) = ccall(:kill, Cint, (Cint, Cint), pid, 0) == 0
+            # This must stay comfortably below the watchdog's post-SIGTERM
+            # escalation timeout (JL_KILL_TIMEOUT) so that we exit before it
+            # escalates.
+            deadline = time() + 300
+            while time() < deadline && any(alive, stuck)
+                sleep(1)
+            end
+        end
+
         if !Sys.iswindows() && isa(stdin, Base.TTY)
             t = current_task()
             stdin_monitor = @async begin
@@ -272,6 +301,7 @@ cd(@__DIR__) do
                         test = popfirst!(tests)
                         running_tests[test] = now()
                         wrkr = p
+                        running_on[test] = wrkr
 
                         # Create a timer for this test to report long-running status
                         test_timers[test] = Timer(longrunning_delay, interval=longrunning_interval) do timer
@@ -308,6 +338,7 @@ cd(@__DIR__) do
                                 Any[CapturedException(e, catch_backtrace())], time() - before
                             end
                         delete!(running_tests, test)
+                        delete!(running_on, test)
                         if haskey(test_timers, test)
                             close(test_timers[test])
                             delete!(test_timers, test)
@@ -321,7 +352,7 @@ cd(@__DIR__) do
                             elseif n > 1
                                 # the worker encountered some failure, recycle it
                                 # so future tests get a fresh environment
-                                rmprocs(wrkr, waitfor=rmwait_timeout)
+                                rmprocs_with_testenv(wrkr, waitfor=rmwait_timeout)
                                 p = addprocs_with_testenv(1)[1]
                                 remotecall_fetch(include, p, "testdefs.jl")
                                 if use_revise
@@ -334,7 +365,7 @@ cd(@__DIR__) do
                                 # the worker has reached the max-rss limit, recycle it
                                 # so future tests start with a smaller working set
                                 if n > 1
-                                    rmprocs(wrkr, waitfor=rmwait_timeout)
+                                    rmprocs_with_testenv(wrkr, waitfor=rmwait_timeout)
                                     p = addprocs_with_testenv(1)[1]
                                     remotecall_fetch(include, p, "testdefs.jl")
                                     if use_revise
@@ -348,7 +379,7 @@ cd(@__DIR__) do
                     end
                     if p != 1
                         # Free up memory =)
-                        rmprocs(p, waitfor=rmwait_timeout)
+                        rmprocs_with_testenv(p, waitfor=rmwait_timeout)
                     end
                 end
             end

--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -37,13 +37,30 @@ if !@isdefined(testenv_defined)
 
     const test_relocated_depot = haskey(ENV, "RELOCATEDEPOT")
 
+    # OS pids of the workers spawned by `addprocs_with_testenv`, recorded at
+    # spawn time (while the worker is guaranteed healthy) so that the teardown
+    # hook in runtests.jl can signal workers that have hung in the meantime.
+    const worker_ospids = Dict{Int, Int}()
+
     function addprocs_with_testenv(X; rr_allowed=true, kwargs...)
         exename = rr_allowed ? `$rr_exename $test_exename` : test_exename
         if X isa Integer
             heap_size=round(Int,(Sys.total_memory()/(1024^2)/(X+1)))
             push!(test_exeflags.exec, "--heap-size-hint=$(heap_size)M")
         end
-        addprocs(X; exename=exename, exeflags=test_exeflags, kwargs...)
+        procs = addprocs(X; exename=exename, exeflags=test_exeflags, kwargs...)
+        for w in procs
+            worker_ospids[w] = remotecall_fetch(getpid, w)
+        end
+        return procs
+    end
+
+    function rmprocs_with_testenv(pids...; kwargs...)
+        result = rmprocs(pids...; kwargs...)
+        for p in pids, q in (p isa Integer ? (p,) : p)
+            delete!(worker_ospids, q)
+        end
+        return result
     end
 
     const curmod = @__MODULE__


### PR DESCRIPTION
This race condition was identified while I was looking into https://buildkite.com/julialang/julia-ci/builds/78#019f6065-958b-4b3c-b32e-5ecc786b73bf/L1580 . The window here is pretty small. I don't expect this will fix the problem, but it's good to fix up anyway.

As a related drive-by, also add  logic to `test/runtests.jl` to try to collect `.core` dumps from hung workers. As is, the `SIGQUIT` from CI only makes it to the test driver not any of its workers, so the `.core` files are pretty useless for timeouts (in this case almost certainly due to a GC hang)

Written up by Claude Fable 5 🤖 after investigating several coredumps