### PR TITLE
Don't ship the objcache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,6 +503,7 @@ endif
 	-rm -f $(DESTDIR)$(datarootdir)/julia/stdlib/$(VERSDIR)/*/build-configured
 	-rm -f $(DESTDIR)$(datarootdir)/julia/stdlib/$(VERSDIR)/*/build-compiled
 	-rm -f $(DESTDIR)$(datarootdir)/julia/stdlib/$(VERSDIR)/*/build-checked
+	-rm -rf $(DESTDIR)$(datarootdir)/julia/cache
 	# Copy in beautiful new man page
 	$(INSTALL_F) $(build_man1dir)/julia.1 $(DESTDIR)$(man1dir)/
 	# Copy .desktop file


### PR DESCRIPTION
While I can see the logic in pre-populating the objcache with some useful things, it doesn't make much sense to keep it around from bootstrapping.  Shipping it was an oversight.  Fixes #62394.

Assisted-by: Codex:gpt-5.6-sol