### PR TITLE
test: compile only `--check-bounds=yes` for JuliaLowering_stdlibs test

### DIFF
--- a/test/JuliaLowering_stdlibs.jl
+++ b/test/JuliaLowering_stdlibs.jl
@@ -46,7 +46,7 @@ stdlibs_to_test = filter(name -> !in(name, INCOMPATIBLE_STDLIBS), readdir(Sys.ST
 push!(stdlibs_to_test, "Compiler")
 
 configs = [
-    ``=>Base.CacheFlags(check_bounds=0, debug_level=2, opt_level=3),
+    # ``=>Base.CacheFlags(check_bounds=0, debug_level=2, opt_level=3),
     ``=>Base.CacheFlags(check_bounds=1, debug_level=2, opt_level=3),
 ]
 


### PR DESCRIPTION
@maleadt

This leaves the "sysimage w/ JL" + "stdlib pre-compilation" at about equal time (previously they were 1:2), so hopefully this will cut down on ~30% of the `JuliaLowering_stdlibs` time with minimal impact to coverage.