### PR TITLE
Fix Dates.week returning non-ISO week numbers for dates on or before 0000-12-31

### DIFF
--- a/stdlib/Dates/src/accessors.jl
+++ b/stdlib/Dates/src/accessors.jl
@@ -37,7 +37,7 @@ end
 # https://en.wikipedia.org/wiki/Talk:ISO_week_date#Algorithms
 const WEEK_INDEX = (15, 23, 3, 11)
 function week(days)
-    w = div(abs(days - 1), 7) % 20871
+    w = days >= 1 ? div(days - 1, 7) % 20871 : mod(fld(days - 1, 7), 20871)
     c, w = divrem((w + (w >= 10435)), 5218)
     w = (w * 28 + WEEK_INDEX[c + 1]) % 1461
     return div(w, 28) + 1

--- a/stdlib/Dates/test/accessors.jl
+++ b/stdlib/Dates/test/accessors.jl
@@ -191,6 +191,16 @@ end
         dt = dt + Dates.Day(1)
         dt1 = dt1 + Dates.Day(1)
     end
+    # Tests for dates before day 1 (0001-01-01)
+    dt = Dates.DateTime(0, 12, 20)
+    dt1 = Dates.Date(0, 12, 20)
+    check = (51, 51, 51, 51, 51, 52, 52, 52, 52, 52, 52, 52, 1, 1, 1, 1, 1, 1, 1, 2, 2)
+    for i = 1:21
+        @test Dates.week(dt) == check[i]
+        @test Dates.week(dt1) == check[i]
+        dt = dt + Dates.Day(1)
+        dt1 = dt1 + Dates.Day(1)
+    end
 end
 @testset "ISO year utils" begin
     # Tests from https://www.epochconverter.com/weeks


### PR DESCRIPTION
`Dates.week` gives incorrect week numbers before 0000-12-31. It returns a mirrored valued because `abs(days - 1)` reflects dates before the epoch onto dates after it rather than correctly continuing the 400-year (20871-week) cycle backward.

```julia
julia> week(Date(2000, 12, 1)) # expected
48

julia> week(Date(1000, 12, 1) # expected
49

julia> week(Date(0, 12, 1)) # surprise!
5
```

The fix adds a branch checking if `days >= 1`. If so use the old logic sans `abs`. If `days < 1`, then use the `mod` and `fld` logic which properly keeps the cycle without reflecting.

Seems to help performance for the typical case of positive days, guessing because we're avoiding the `abs` call? Though we are adding an extra branch. Also the `mod` and `fld` hurt performance for negative days, but that wasn't correct before anyway.

Before:
```julia
julia> x = today();

julia> @benchmark week($x)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  6.352 ns … 36.990 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.453 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.578 ns ±  0.866 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▆                                                         ▁
  ██▅▅▅█▆▅▅▅▇▆▇██▇▇▅▅▆▅▄▅▆▅▄▄▅▅▄▅▅▄▄▃▄▃▄▄▃▁▃▁▁▁▁▄▁▃▁▁▃▁▁▁▃▁▅ █
  6.35 ns      Histogram: log(frequency) by time     12.8 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

After:
```julia
julia> @benchmark week($x)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  5.451 ns … 12.113 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.540 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.570 ns ±  0.196 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

         ▆█                                                   
  ▂▂▄▅▃▅▇██▄▂▂▂▂▂▃▂▂▂▃▆▆▃▂▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▂▂▂ ▃
  5.45 ns        Histogram: frequency by time        6.05 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Pre 0000-12-31, after the fix:

```julia
julia> @benchmark week($x)
BenchmarkTools.Trial: 10000 samples with 999 evaluations per sample.
 Range (min … max):  7.822 ns … 69.672 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.933 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.968 ns ±  0.894 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

      █                                                       
  ▃▃▅▅██▂▂▂▁▂▁▁▁▁▂▁▂▂▁▁▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▂▁▁▂▁▁▁▁▁▁▂▂▁▁▂▁▁▁▂▂▁▂ ▂
  7.82 ns        Histogram: frequency by time        9.27 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Added tests for this as well.

Found by Claude Fable 5.

PS - claude suggested this solution:
```julia
const WEEK_SHIFT = 146097 * div(typemax(Int64) ÷ 2, 146097)
function week(days::Int64)
    u = (days - 1 + WEEK_SHIFT) % UInt64
    w = Int((u ÷ 0x7) % 0x5187)
    c, w = divrem((w + (w >= 10435)), 5218)
    w = (w * 28 + WEEK_INDEX[c + 1]) % 1461
    return div(w, 28) + 1
end
```
Which IIUC, will shift the days up by the largest possible positive Int64 ÷ 2, that's also divisible by 20871 * 7 so that we're in the same part of the cycle. That way you don't have to deal with the negative case, it'll always be positive. Finally, it converts to an unsigned integer because unsigned division uses cheaper magic-constant codegen than signed division. Performance is better and seems to produce the correct expected results, just slightly more complicated code.

Feel free to use this alternate solution instead, or let me know and I can update this PR. Thanks!