### PR TITLE
[JuliaLowering] Preserve `is_internal` metadata for keyword body helpers

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2694,9 +2694,9 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett)
             ctx.layer.mod,
             string(startswith(n, '#') ? "" : "#kw_body#", n, "#"))
         # probably not desirable, but fixes eval-into-closed-module
-        name = setattr!(newsym(ctx, mtable, mangled),
-                        :context, escape_layer(mtable.context::SyntaxContext, true))
-        setmeta!(name, :is_internal, true)
+        m1_sc = escape_layer(mtable.context::SyntaxContext, true)
+        setattr!(newsym(ctx, mtable, mangled), :context,
+                 SyntaxContext(m1_sc.layer, m1_sc.unexpanded, m1_sc.version, true))
     end
     # (1) Body method.  This contains the actual function body, and requires
     # every possible default to be filled.  `rett` is only passed here since it

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2694,8 +2694,9 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett)
             ctx.layer.mod,
             string(startswith(n, '#') ? "" : "#kw_body#", n, "#"))
         # probably not desirable, but fixes eval-into-closed-module
-        setattr!(newsym(ctx, mtable, mangled),
-                 :context, escape_layer(mtable.context::SyntaxContext, true))
+        name = setattr!(newsym(ctx, mtable, mangled),
+                        :context, escape_layer(mtable.context::SyntaxContext, true))
+        setmeta!(name, :is_internal, true)
     end
     # (1) Body method.  This contains the actual function body, and requires
     # every possible default to be filled.  `rett` is only passed here since it

--- a/JuliaLowering/test/scopes.jl
+++ b/JuliaLowering/test/scopes.jl
@@ -435,6 +435,13 @@ function resolve_and_get_bindings(
     return ctx3.bindings.info
 end
 
+@testset "internal keyword body bindings" begin
+    bindings = resolve_and_get_bindings(Module(), :(f(; x=1) = x))
+    kw_body_bindings = filter(b -> startswith(b.name, "#kw_body#"), bindings)
+    @test !isempty(kw_body_bindings)
+    @test all(b -> b.is_internal, kw_body_bindings)
+end
+
 @testset "is_ambiguous_local" begin
     # Assignment in for loop within begin block after toplevel assignment
     let bindings = resolve_and_get_bindings(ambiguous_local, :(for _ = 1:10; x = 1; end))


### PR DESCRIPTION
JuliaLang/julia#62412 changed keyword-body helper relayering so the escaped user context is installed after `newsym`. This preserves module placement but overwrites the `is_internal` context, causing generated `#kw_body#...` bindings to be exposed as user bindings.

Mark the helper name with `:is_internal` after relayering. Scope resolution already combines context and metadata flags, so this retains the fixed module selection while restoring generated-binding classification.