### PR TITLE
cancellation: Add basic CancellationToken[Source] APIs

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -527,6 +527,10 @@ end
 function _const_sizeof(@nospecialize(x))
     # Constant GenericMemory does not have constant size
     isa(x, GenericMemory) && return Int
+    # CancellationTokenSource instances are variable-sized (the datatype
+    # size covers only the fixed fields), so their type gives no constant
+    # size; a *constant instance* still folds fine below.
+    x === Core.CancellationTokenSource && return Int
     size = try
             Core.sizeof(x)
         catch ex

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -505,6 +505,8 @@ function sizeof_nothrow(@nospecialize(x))
     xw = widenconst(x)
     isType(xw) && !isconstType(xw) && return false
     x = unwrap_unionall(t)
+    # instances are variable-sized, so the type itself has no definite size
+    x === Core.CancellationTokenSource && return false
     if isconcrete
         if isa(x, DataType) && x.layout != C_NULL
             # there's just a few concrete types with an opaque layout

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -527,10 +527,6 @@ end
 function _const_sizeof(@nospecialize(x))
     # Constant GenericMemory does not have constant size
     isa(x, GenericMemory) && return Int
-    # CancellationTokenSource instances are variable-sized (the datatype
-    # size covers only the fixed fields), so their type gives no constant
-    # size; a *constant instance* still folds fine below.
-    x === Core.CancellationTokenSource && return Int
     size = try
             Core.sizeof(x)
         catch ex

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -100,6 +100,9 @@ include("set.jl")
 include("io.jl")
 include("iobuffer.jl")
 
+# Dynamic scopes (types only; the ScopedValues API is included much later)
+include("scope.jl")
+
 # Concurrency (part 1)
 include("linked_list.jl")
 include("condition.jl")

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -104,6 +104,7 @@ include("iobuffer.jl")
 include("scope.jl")
 
 # Concurrency (part 1)
+include("cancellation.jl")
 include("linked_list.jl")
 include("condition.jl")
 include("threads.jl")

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -1,0 +1,502 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+## Cancellation tokens
+#
+# Cancellation is organized around *cancellation token sources*
+# (`Core.CancellationTokenSource`): level-triggered condition nodes arranged
+# in a tree. Cancelling a source cancels its whole subtree; the cancelled
+# state is monotonic (severities only escalate, never reset). Following the
+# .NET split, a `CancellationToken` is the observe view handed to code that
+# may only *react* to cancellation; the source is the capability to *request*
+# it.
+#
+# The token governing a piece of code is carried dynamically as a scoped
+# value (see `CANCEL_TOKEN`), which `@cancel_check` resolves at every check.
+# Tasks inherit their creating task's scope, so cancellation scopes propagate
+# to child tasks without explicit plumbing.
+#
+# This file provides the data model and the cooperative (polling) checks.
+# Delivery — waking tasks parked in blocking operations, interrupting
+# running computations, `cancel` keyword arguments on the blocking APIs, and
+# the ^C machinery — builds on top of it separately.
+#
+# TODO(compiler): a scoped-value lookup is a `Core.current_scope()` read plus
+# a persistent-dict (HAMT) lookup. The optimizer currently only folds
+# `current_scope()` when the enclosing `@with` is visible in the same
+# (post-inlining) frame; for inherited scopes the lookup stays in hot loops.
+# Teaching the compiler to CSE/hoist `current_scope()` + `KeyValue.get` for
+# inherited scopes (sound: the scope is enter/leave-balanced and
+# task-private) would make per-iteration `@cancel_check` in tight loops
+# cheap. Until then, hot loops can hoist manually via the
+# `@cancel_check tok` form.
+
+const CancellationTokenSource = Core.CancellationTokenSource
+
+"""
+    CancellationToken(src::CancellationTokenSource)
+
+The observe side of a [`CancellationTokenSource`](@ref): code holding a
+token can be interrupted by - and can query ([`iscancelled`](@ref)) -
+cancellation of the associated source, but cannot request cancellation
+itself. Only the holder of the *source* can call [`cancel!`](@ref).
+
+A token takes effect by scoping it over a computation via the
+[`CANCEL_TOKEN`](@ref) scoped value (spawned tasks inherit it): once the
+source is cancelled, the computation's cancellation points (see
+[`@cancel_check`](@ref)) throw a [`CancellationRequest`](@ref).
+"""
+struct CancellationToken
+    source::CancellationTokenSource
+end
+
+"""
+    CancellationRequest
+
+The exception thrown by cancellation points whose governing cancellation
+token has been cancelled. The `request` field records the severity
+([`CANCEL_REQUEST_SAFE`](@ref), [`CANCEL_REQUEST_ABANDON_EXTERNAL`](@ref) or
+[`CANCEL_REQUEST_ABANDON_ALL`](@ref)) as observed at delivery time; the
+source may escalate afterwards.
+"""
+struct CancellationRequest
+    request::UInt8
+end
+
+"""
+    CANCEL_REQUEST_SAFE
+
+Request safe cancellation. Code observing the cancellation will request safe
+cancellation of any resources it is waiting for and wait for the cancellation
+of such resources to be completed.
+
+As a result, if either the cancelled code or any of its dependent resources
+are currently unable to process cancellation, the request may hang and a more
+aggressive cancellation severity may be required. However, in general _SAFE
+should be tried first.
+"""
+const CANCEL_REQUEST_SAFE = CancellationRequest(0x0)
+
+"""
+    CANCEL_REQUEST_ABANDON_EXTERNAL
+
+Request a cancellation that will cease waiting for any external resources
+(e.g. I/O objects) without going through a safe cancellation procedure for
+such resources. However, internal computational tasks are still awaited.
+
+This is a middleground between CANCEL_REQUEST_SAFE and
+CANCEL_REQUEST_ABANDON_ALL, as external I/O is often engineered for
+robustness in case of sudden disappearance of peers.
+"""
+const CANCEL_REQUEST_ABANDON_EXTERNAL = CancellationRequest(0x3)
+
+"""
+    CANCEL_REQUEST_ABANDON_ALL
+
+Request a cancellation that will cease waiting for all external resources,
+and give up on tasks that have not responded to the cancellation: they are
+frozen in place and never scheduled again.
+
+!!! warning
+    If any cancelled task has acquired locks or other resources that are
+    contested, this method of cancellation may leak such resources and create
+    deadlocks in future code. It is intended as a last-resort method to
+    recover a system, but the necessity of this operation should in general
+    be considered a bug (e.g. due to insufficient cancellation points in
+    computationally-heavy code).
+"""
+const CANCEL_REQUEST_ABANDON_ALL = CancellationRequest(0x4)
+
+# The state byte of a cancelled source is (STATE_CANCELLED_BIT | severity).
+# The 0x40 bit is reserved (status bytes of compiled cancellation points use
+# it to report a pending cooperative-yield request).
+const STATE_CANCELLED_BIT = 0x80
+const STATUS_PREEMPT_BIT = 0x40
+const SEVERITY_MASK = 0x3f
+
+severity(cr::CancellationRequest) = cr.request & SEVERITY_MASK
+
+"""
+    cancel_severity(src::CancellationTokenSource) -> Union{Nothing, CancellationRequest}
+    cancel_severity(tok::CancellationToken)
+
+Return `nothing` if the source has not been cancelled, or a
+`CancellationRequest` recording the current (monotonically escalating)
+severity if it has.
+"""
+function cancel_severity(src::CancellationTokenSource)
+    st = @atomic :acquire src.state
+    st == 0x00 && return nothing
+    return CancellationRequest(st & SEVERITY_MASK)
+end
+cancel_severity(tok::CancellationToken) = cancel_severity(tok.source)
+
+"""
+    iscancelled(src::CancellationTokenSource)::Bool
+    iscancelled(tok::CancellationToken)::Bool
+
+Whether the source has been cancelled (level-triggered: once cancelled, a
+source stays cancelled).
+"""
+iscancelled(src::CancellationTokenSource) = (@atomic :monotonic src.state) != 0x00
+iscancelled(tok::CancellationToken) = iscancelled(tok.source)
+
+## Source construction and tree linkage
+
+@eval function _new_cancel_source(parents::Union{Nothing, CancellationTokenSource, Core.SimpleVector})
+    return $(Expr(:new, :CancellationTokenSource,
+                  :parents, nothing, 0x00, 0x00, 0x00))
+end
+
+"""
+    CancellationTokenSource() -> CancellationTokenSource
+    CancellationTokenSource(parents::CancellationToken...)
+
+Create a new cancellation token source. With no arguments the source is a
+standalone root; given one or more parent tokens, the new source is linked
+underneath each of them, so that cancellation of *any* parent (or any of its
+ancestors) also cancels the new source - at the highest severity requested
+among them. Sources therefore form a directed acyclic graph; a source
+created under an already-cancelled parent is born cancelled. Linking one
+source under several parents is how an operation respects two independent
+lifetimes at once (say, a request scope and the connection it arrived on).
+
+A child source stays linked to its parents for exactly as long as it is
+reachable - a held token, or work governed by it, keeps it alive. Once
+nothing can observe it any more, it is garbage collected and thereby drops
+out of the graph; there is no explicit detach operation.
+
+Use [`CancellationToken`](@ref)`(src)` for the observe view, and
+[`cancel!`](@ref)`(src)` to request cancellation.
+"""
+function CancellationTokenSource(parent::CancellationToken)
+    src = _new_cancel_source(parent.source)
+    attach_child!(parent.source, src)
+    return src
+end
+function CancellationTokenSource(parent::CancellationToken, rest::CancellationToken...)
+    srcs = CancellationTokenSource[parent.source]
+    for tok in rest
+        any(s -> s === tok.source, srcs) || push!(srcs, tok.source)
+    end
+    length(srcs) == 1 && return CancellationTokenSource(parent)
+    child = _new_cancel_source(Core.svec(srcs...))
+    for p in srcs
+        attach_child!(p, child)
+    end
+    return child
+end
+CancellationTokenSource(::Nothing) = _new_cancel_source(nothing)
+CancellationTokenSource() = _new_cancel_source(nothing)
+
+# Spinlock on a source's `_lock` byte. These are leaf locks: no code may
+# block, allocate unboundedly, or take another source's lock while holding
+# one, except for the parent->child order used by the cancellation walk.
+function _lock_source(src::CancellationTokenSource)
+    while true
+        (@atomicreplace :acquire :monotonic src._lock 0x00 => 0x01).success && return
+        while (@atomic :monotonic src._lock) != 0x00
+            ccall(:jl_cpu_suspend, Cvoid, ())
+            ccall(:jl_gc_safepoint, Cvoid, ())
+        end
+    end
+end
+_unlock_source(src::CancellationTokenSource) = (@atomic :release src._lock = 0x00; nothing)
+
+# Link `child` under `parent`. The child inherits the parent's cancellation
+# state at link time (a node attached under an already-cancelled parent is
+# born cancelled) - together with `cancel!` marking each node *before*
+# draining it, this makes registration level-triggered under concurrent
+# cancellation.
+function attach_child!(parent::CancellationTokenSource, child::CancellationTokenSource)
+    wr = WeakRef(child) # allocated outside the spinlock
+    _lock_source(parent)
+    pst = @atomic :monotonic parent.state
+    if pst != 0x00
+        _raise_state!(child, pst & SEVERITY_MASK)
+    end
+    kids = parent.children
+    if kids === nothing
+        kids = WeakRef[]
+        parent.children = kids
+    else
+        kids = kids::Vector{WeakRef}
+        # Amortized pruning: whenever the list length reaches a power of two,
+        # drop entries whose child has been garbage collected. This bounds
+        # the list at roughly twice the live-child count with O(1) amortized
+        # attach cost, without any explicit detach operation.
+        n = length(kids)
+        if n >= 8 && (n & (n - 1)) == 0
+            filter!(w -> w.value !== nothing, kids)
+        end
+    end
+    push!(kids, wr)
+    _unlock_source(parent)
+    return child
+end
+
+# CAS-max the source's state to (STATE_CANCELLED_BIT | sev). Returns true if
+# the state was raised, false if it was already at (or above) the severity.
+function _raise_state!(src::CancellationTokenSource, sev::UInt8)
+    old = @atomic :monotonic src.state
+    while true
+        if old != 0x00 && (old & SEVERITY_MASK) >= sev
+            return false
+        end
+        old, success = @atomicreplace :acquire_release :monotonic src.state old => (STATE_CANCELLED_BIT | sev)
+        success && return true
+    end
+end
+
+## Delivery bookkeeping
+#
+# Cancellation is uniformly level-triggered: while the governing token is
+# cancelled, every cancellation point throws the `CancellationRequest`.
+# There is no per-task acknowledgement state; code that must keep running
+# under a cancelled scope shields itself by scoping `CANCEL_TOKEN => nothing`
+# over the block.
+
+# Record that a cancellation of `src` at severity `sev` was delivered to
+# (observed by) some task, i.e. thrown at one of its cancellation points.
+# Feeds the (upcoming) ^C episode state machine ("was the request ever
+# seen?"), so the bits are propagated to every ancestor: a delivery against a
+# nested scope's source acknowledges the episode source too - otherwise the
+# SIGINT classifier would misread a successfully delivered cancellation as
+# unacknowledged and escalate a repeat ^C to abandonment.
+function _mark_delivered!(src::CancellationTokenSource, sev::UInt8)
+    bit = 0x01 << sev
+    # fast path: no parents (the common episode-source case)
+    @atomic :monotonic src.delivered |= bit
+    p = src.parents
+    p === nothing && return nothing
+    # Iterative ancestor walk (a Vector worklist - deep chains must not
+    # recurse - deduplicated so a reconverging linked graph is marked once
+    # per node). Delivery is rare; the allocation is fine.
+    pending = CancellationTokenSource[]
+    seen = IdSet{CancellationTokenSource}()
+    push!(seen, src)
+    _push_parents!(pending, seen, p)
+    while !isempty(pending)
+        node = pop!(pending)
+        @atomic :monotonic node.delivered |= bit
+        np = node.parents
+        np === nothing || _push_parents!(pending, seen, np)
+    end
+    return nothing
+end
+
+function _push_parents!(pending::Vector{CancellationTokenSource},
+                        seen::IdSet{CancellationTokenSource}, @nospecialize(p))
+    if p isa CancellationTokenSource
+        if !(p in seen)
+            push!(seen, p)
+            push!(pending, p)
+        end
+    elseif p isa Core.SimpleVector
+        for i in 1:length(p)
+            c = p[i]
+            c isa CancellationTokenSource || continue
+            if !(c in seen)
+                push!(seen, c)
+                push!(pending, c)
+            end
+        end
+    end
+    return nothing
+end
+
+## Cancellation
+
+"""
+    cancel!(src::CancellationTokenSource,
+            request::CancellationRequest=CANCEL_REQUEST_SAFE)::Bool
+
+Cancel `src` and its whole subtree at the given severity. Level-triggered
+and monotonic: observers (including future registrants) see the cancellation
+until the source is discarded, and repeated calls only have an effect when
+they *escalate* the severity ([`CANCEL_REQUEST_SAFE`](@ref) ->
+[`CANCEL_REQUEST_ABANDON_EXTERNAL`](@ref) ->
+[`CANCEL_REQUEST_ABANDON_ALL`](@ref)). Returns whether the call changed the
+state.
+
+Computations governed by a token of the subtree observe the cancellation at
+their cancellation points (see [`@cancel_check`](@ref)), which throw a
+[`CancellationRequest`](@ref).
+"""
+function cancel!(src::CancellationTokenSource,
+                 request::CancellationRequest=CANCEL_REQUEST_SAFE)
+    sev = request.request
+    if !(sev == 0x0 || sev == 0x3 || sev == 0x4)
+        throw(ArgumentError("invalid cancellation severity $(repr(request.request))"))
+    end
+    _raise_state!(src, sev) || return false
+    # Pairs with the compiler-order-only publication of per-task token
+    # bindings at compiled cancellation points (upcoming): after this fence,
+    # either the canceller observes the binding of a running task, or the
+    # task's next cancellation point observes our state write.
+    Threads.atomic_fence_heavy()
+    # Mark the subtree: each node is marked before its children so a
+    # concurrent attach_child! is level-triggered.
+    _cancel_walk!(src, sev)
+    return true
+end
+
+function _cancel_walk!(src::CancellationTokenSource, sev::UInt8)
+    # Iterative worklist (no recursion): a deep source chain must not
+    # overflow the canceller's stack, and a reconverging ("linked") graph
+    # must visit each node once, not once per path.
+    pending = CancellationTokenSource[src]
+    while !isempty(pending)
+        _cancel_walk_node!(pop!(pending), sev, pending)
+    end
+    return nothing
+end
+
+function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
+                            pending::Vector{CancellationTokenSource})
+    children = nothing
+    _lock_source(node)
+    # Advance at least to the node's current severity: a concurrent higher-
+    # severity cancel! may have raised the state after this walk's own
+    # transition; its walk skips children this one already advanced, so this
+    # walk must carry the escalated severity onward.
+    st = @atomic :acquire node.state
+    stsev = st & SEVERITY_MASK
+    sev < stsev && (sev = stsev)
+    # Snapshot the live children (compacting away collected ones) and queue
+    # the ones whose state this walk advanced; a child whose state was
+    # already at (or above) this severity has been walked - or is being
+    # walked - by whoever advanced it, so revisiting it would make a
+    # reconverging graph exponential.
+    kids = node.children
+    if kids !== nothing
+        kids = kids::Vector{WeakRef}
+        n = length(kids)
+        i = 1
+        for j in 1:n
+            c = kids[j].value
+            c === nothing && continue
+            kids[i] = kids[j]
+            i += 1
+            c = c::CancellationTokenSource
+            if _raise_state!(c, sev)
+                children = (c, children)
+            end
+        end
+        i <= n && resize!(kids, i - 1)
+    end
+    _unlock_source(node)
+    while children !== nothing
+        (c, children) = children::Tuple{CancellationTokenSource, Any}
+        push!(pending, c)
+    end
+    return nothing
+end
+
+## Cancellation points
+
+# The slow path of `@cancel_check`: `st` is the (non-zero) state byte of the
+# governing source.
+@noinline function handle_cancellation!(src::CancellationTokenSource, st::UInt8)
+    # re-read: deliver the severity current at throw time, not the one the
+    # fast path happened to observe
+    st = @atomic :acquire src.state
+    sev = st & SEVERITY_MASK
+    _mark_delivered!(src, sev)
+    throw(CancellationRequest(sev))
+end
+
+"""
+    @cancel_check
+    @cancel_check token
+
+Explicit cancellation point: checks whether the cancellation token governing
+the current computation has been cancelled and, if so, throws the
+corresponding [`CancellationRequest`](@ref). Long-running computational code
+should place these in its hot loops so that it can be cancelled.
+
+The one-argument form checks an explicitly provided
+`Union{Nothing, CancellationToken}` instead of resolving the scoped default
+token; use it to hoist the token lookup out of a tight loop.
+"""
+macro cancel_check()
+    quote
+        # also a GC safepoint, so that a tight polling loop cannot starve a
+        # concurrent stop-the-world (compiled cancellation points will emit
+        # one as well)
+        ccall(:jl_gc_safepoint, Cvoid, ())
+        checkcancel(default_cancel_source())
+        nothing
+    end
+end
+
+macro cancel_check(tok)
+    quote
+        local t = $(esc(tok))
+        ccall(:jl_gc_safepoint, Cvoid, ())
+        checkcancel(t === nothing ? nothing : (t::CancellationToken).source)
+        nothing
+    end
+end
+
+# Throw the `CancellationRequest` if `src` is cancelled (level-triggered:
+# no per-task state is consulted).
+@inline function checkcancel(src::CancellationTokenSource)
+    st = @atomic :monotonic src.state
+    st == 0x00 && return nothing
+    handle_cancellation!(src, st)
+    return nothing
+end
+checkcancel(::Nothing) = nothing
+checkcancel(tok::CancellationToken) = checkcancel(tok.source)
+
+## The scoped default token
+
+# The scoped-value key under which the governing cancellation token is
+# carried. `AbstractScopedValue` so the ScopedValues API (`@with
+# Base.CANCEL_TOKEN => tok ...`) works on it; the accessors below avoid the
+# ScopedValues module so they are usable during early bootstrap.
+struct CancelTokenKey <: AbstractScopedValue{Union{Nothing, CancellationToken}} end
+
+"""
+    CANCEL_TOKEN
+
+The scoped value carrying the [`CancellationToken`](@ref) that governs the
+current dynamic extent, or `nothing` if there is none. [`@cancel_check`](@ref)
+checks it, and tasks spawned within a scope inherit it.
+
+Establish a governing token with the standard scoped-value API
+([`ScopedValues.@with`](@ref) / [`ScopedValues.with`](@ref)):
+
+```julia
+using Base.ScopedValues
+
+src = Base.CancellationTokenSource()
+with(Base.CANCEL_TOKEN => Base.CancellationToken(src)) do
+    ...   # cancellation points in here observe `cancel!(src)`
+end
+```
+
+Scoping `Base.CANCEL_TOKEN => nothing` instead *shields* the enclosed code
+from an outer (possibly cancelled) token; use this for cleanup that must
+complete while the surrounding computation is being cancelled.
+
+The current value can be read with `Base.CANCEL_TOKEN[]`, for example to
+hand the governing token across a boundary that does not preserve dynamic
+scope (a `ccall` callback, a queue consumed by unrelated tasks, another
+process).
+"""
+const CANCEL_TOKEN = CancelTokenKey()
+
+@inline function default_cancel_token()
+    scope = Core.current_scope()::Union{Scope, Nothing}
+    scope === nothing && return nothing
+    v = KeyValue.get(scope.values, CANCEL_TOKEN)
+    v === nothing && return nothing
+    return something(v)::Union{Nothing, CancellationToken}
+end
+
+@inline function default_cancel_source()
+    tok = default_cancel_token()
+    tok === nothing && return nothing
+    return (tok::CancellationToken).source
+end

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -251,6 +251,12 @@ state.
 Computations governed by a token of the subtree observe the cancellation at
 their cancellation points (see [`@cancel_check`](@ref)), which throw a
 [`CancellationRequest`](@ref).
+
+When `cancel!` returns, every source currently in the subtree has been
+advanced to (at least) the requested severity by this very call - even a
+call that returns `false` performs the full walk, so that a repeated
+`cancel!` also repairs a subtree whose earlier cancellation was cut short
+(say, by the cancelling task itself being torn down mid-walk).
 """
 function cancel!(src::CancellationTokenSource,
                  request::CancellationRequest=CANCEL_REQUEST_SAFE)
@@ -258,53 +264,64 @@ function cancel!(src::CancellationTokenSource,
     if !(sev == 0x0 || sev == 0x3 || sev == 0x4)
         throw(ArgumentError("invalid cancellation severity $(repr(request.request))"))
     end
-    _raise_state!(src, sev) || return false
+    raised = _raise_state!(src, sev)
     # Pairs with the compiler-order-only publication of per-task token
     # bindings at compiled cancellation points (upcoming): after this fence,
     # either the canceller observes the binding of a running task, or the
     # task's next cancellation point observes our state write.
     Threads.atomic_fence_heavy()
     # Mark the subtree: each node is marked before its children so a
-    # concurrent construction of a child source is level-triggered.
+    # concurrent construction of a child source is level-triggered. The walk
+    # does not depend on `raised`: when a concurrent equal-severity cancel!
+    # wins the state transition, its walk may still be in flight (or may
+    # never finish), so the loser must provide the on-return guarantee with
+    # its own traversal.
     _cancel_walk!(src, sev)
-    return true
+    return raised
 end
 
 function _cancel_walk!(src::CancellationTokenSource, sev::UInt8)
     # Iterative worklist (no recursion): a deep source chain must not
-    # overflow the canceller's stack, and a reconverging ("linked") graph
-    # must visit each node once, not once per path.
+    # overflow the canceller's stack. The visited set - rather than pruning
+    # on nodes whose state some walk already advanced - makes a reconverging
+    # ("linked") graph linear in edges while keeping the walk self-contained:
+    # this call visits every reachable node itself instead of trusting
+    # another (possibly interrupted) walk to have done so.
+    visited = IdSet{CancellationTokenSource}()
+    push!(visited, src)
     pending = CancellationTokenSource[src]
     while !isempty(pending)
-        _cancel_walk_node!(pop!(pending), sev, pending)
+        _cancel_walk_node!(pop!(pending), sev, pending, visited)
     end
     return nothing
 end
 
 function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
-                            pending::Vector{CancellationTokenSource})
+                            pending::Vector{CancellationTokenSource},
+                            visited::IdSet{CancellationTokenSource})
     # Advance at least to the node's current severity: a concurrent higher-
     # severity cancel! may have raised the state after this walk's own
-    # transition; its walk skips children this one already advanced, so this
-    # walk must carry the escalated severity onward.
+    # transition, and this walk may reach parts of the subtree before that
+    # one does, so it carries the escalated severity onward (best effort;
+    # the escalator's own walk is what guarantees its severity).
     st = @atomic :acquire node.state
     stsev = st & SEVERITY_MASK
     sev < stsev && (sev = stsev)
-    # Walk the node's (weak, intrusive) child list, queueing the children
-    # whose state this walk advanced; a child whose state was already at (or
-    # above) this severity has been walked - or is being walked - by whoever
-    # advanced it, so revisiting it would make a reconverging graph
-    # exponential. The seq_cst `child_head` read below (paired with the
-    # seq_cst state write that queued `node`) closes the race against a
-    # concurrent attach: a child that this read misses was published after
-    # our state write, so its constructor observes that write and the child
-    # is born at (at least) this severity. Children attached concurrently
-    # *during* the walk are prepended before the list positions already
-    # traversed and are likewise born cancelled.
+    # Walk the node's (weak, intrusive) child list. The seq_cst `child_head`
+    # read below (paired with the seq_cst state CAS in `cancel!` - the read
+    # it performs is seq_cst even when the transition was lost) closes the
+    # race against a concurrent attach: a child that this read misses was
+    # published after the state write that made this walk reach `node`, so
+    # its constructor observes a cancelled parent and the child is born at
+    # (at least) this severity. Children attached concurrently *during* the
+    # walk are prepended before the list positions already traversed and are
+    # likewise born cancelled.
     c = @atomic node.child_head
     while c !== nothing
         c = c::CancellationTokenSource
-        if _raise_state!(c, sev)
+        _raise_state!(c, sev)
+        if !(c in visited)
+            push!(visited, c)
             push!(pending, c)
         end
         c = _cancel_next_child(node, c)

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -4,8 +4,9 @@
 #
 # Cancellation is organized around *cancellation token sources*
 # (`Core.CancellationTokenSource`): level-triggered condition nodes arranged
-# in a tree. Cancelling a source cancels its whole subtree; the cancelled
-# state is monotonic (severities only escalate, never reset). Following the
+# in a DAG (a source may have several parents). Cancelling a source cancels
+# all of its descendants; the cancelled state is monotonic (severities only
+# escalate, never reset). Following the
 # .NET split, a `CancellationToken` is the observe view handed to code that
 # may only *react* to cancellation; the source is the capability to *request*
 # it.
@@ -16,19 +17,12 @@
 # to child tasks without explicit plumbing.
 #
 # This file provides the data model and the cooperative (polling) checks.
-# Delivery — waking tasks parked in blocking operations, interrupting
-# running computations, `cancel` keyword arguments on the blocking APIs, and
-# the ^C machinery — builds on top of it separately.
 #
-# TODO(compiler): a scoped-value lookup is a `Core.current_scope()` read plus
-# a persistent-dict (HAMT) lookup. The optimizer currently only folds
+# A scoped-value lookup is a `Core.current_scope()` read plus a
+# persistent-dict (HAMT) lookup, and the optimizer only folds
 # `current_scope()` when the enclosing `@with` is visible in the same
-# (post-inlining) frame; for inherited scopes the lookup stays in hot loops.
-# Teaching the compiler to CSE/hoist `current_scope()` + `KeyValue.get` for
-# inherited scopes (sound: the scope is enter/leave-balanced and
-# task-private) would make per-iteration `@cancel_check` in tight loops
-# cheap. Until then, hot loops can hoist manually via the
-# `@cancel_check tok` form.
+# (post-inlining) frame - for inherited scopes the lookup stays in hot
+# loops. Hot loops can hoist it manually via the `@cancel_check tok` form.
 
 const CancellationTokenSource = Core.CancellationTokenSource
 
@@ -74,7 +68,7 @@ are currently unable to process cancellation, the request may hang and a more
 aggressive cancellation severity may be required. However, in general _SAFE
 should be tried first.
 """
-const CANCEL_REQUEST_SAFE = CancellationRequest(0x0)
+const CANCEL_REQUEST_SAFE = CancellationRequest(0x1)
 
 """
     CANCEL_REQUEST_ABANDON_EXTERNAL
@@ -106,14 +100,9 @@ frozen in place and never scheduled again.
 """
 const CANCEL_REQUEST_ABANDON_ALL = CancellationRequest(0x4)
 
-# The state byte of a cancelled source is (STATE_CANCELLED_BIT | severity).
-# The 0x40 bit is reserved (status bytes of compiled cancellation points use
-# it to report a pending cooperative-yield request).
-const STATE_CANCELLED_BIT = 0x80
-const STATUS_PREEMPT_BIT = 0x40
-const SEVERITY_MASK = 0x3f
-
-severity(cr::CancellationRequest) = cr.request & SEVERITY_MASK
+# The state byte of a source is 0x00 while uncancelled, and the (nonzero)
+# severity once cancelled - severities start at 0x1 precisely so that the
+# two cases cannot collide.
 
 """
     cancel_severity(src::CancellationTokenSource) -> Union{Nothing, CancellationRequest}
@@ -126,7 +115,7 @@ severity if it has.
 function cancel_severity(src::CancellationTokenSource)
     st = @atomic :acquire src.state
     st == 0x00 && return nothing
-    return CancellationRequest(st & SEVERITY_MASK)
+    return CancellationRequest(st)
 end
 cancel_severity(tok::CancellationToken) = cancel_severity(tok.source)
 
@@ -140,7 +129,7 @@ source stays cancelled).
 iscancelled(src::CancellationTokenSource) = (@atomic :monotonic src.state) != 0x00
 iscancelled(tok::CancellationToken) = iscancelled(tok.source)
 
-## Source construction and tree linkage
+## Source construction and graph linkage
 #
 # A source is a variable-sized object: its fixed fields (`child_head`,
 # `state`, `nparents`) are followed by `nparents` {parent,
@@ -213,17 +202,18 @@ _cancel_parent(src::CancellationTokenSource, i::Int) =
 _cancel_next_child(parent::CancellationTokenSource, child::CancellationTokenSource) =
     ccall(:jl_cancel_source_next_child, Any, (Any, Any), parent, child)::Union{Nothing, CancellationTokenSource}
 
-# CAS-max the source's state to (STATE_CANCELLED_BIT | sev). Returns true if
-# the state was raised, false if it was already at (or above) the severity.
+# CAS-max the source's state to `sev` (a valid, nonzero severity). Returns
+# true if the state was raised, false if it was already at (or above) the
+# severity.
 # seq_cst: pairs with the (child-list publication; state read) sequence in
 # `jl_new_cancel_source` - see the walk in `_cancel_walk_node!`.
 function _raise_state!(src::CancellationTokenSource, sev::UInt8)
     old = @atomic :monotonic src.state
     while true
-        if old != 0x00 && (old & SEVERITY_MASK) >= sev
+        if old >= sev
             return false
         end
-        old, success = @atomicreplace :sequentially_consistent :monotonic src.state old => (STATE_CANCELLED_BIT | sev)
+        old, success = @atomicreplace :sequentially_consistent :monotonic src.state old => sev
         success && return true
     end
 end
@@ -240,7 +230,7 @@ end
     cancel!(src::CancellationTokenSource,
             request::CancellationRequest=CANCEL_REQUEST_SAFE)::Bool
 
-Cancel `src` and its whole subtree at the given severity. Level-triggered
+Cancel `src` and all of its descendants at the given severity. Level-triggered
 and monotonic: observers (including future registrants) see the cancellation
 until the source is discarded, and repeated calls only have an effect when
 they *escalate* the severity ([`CANCEL_REQUEST_SAFE`](@ref) ->
@@ -248,35 +238,35 @@ they *escalate* the severity ([`CANCEL_REQUEST_SAFE`](@ref) ->
 [`CANCEL_REQUEST_ABANDON_ALL`](@ref)). Returns whether the call changed the
 state.
 
-Computations governed by a token of the subtree observe the cancellation at
+Computations governed by a token of `src` or a descendant observe the cancellation at
 their cancellation points (see [`@cancel_check`](@ref)), which throw a
 [`CancellationRequest`](@ref).
 
-When `cancel!` returns, every source currently in the subtree has been
-advanced to (at least) the requested severity by this very call - even a
-call that returns `false` performs the full walk, so that a repeated
-`cancel!` also repairs a subtree whose earlier cancellation was cut short
+When `cancel!` returns, every source currently reachable from `src` has
+been advanced to (at least) the requested severity by this very call - even
+a call that returns `false` performs the full walk, so that a repeated
+`cancel!` also repairs a subgraph whose earlier cancellation was cut short
 (say, by the cancelling task itself being torn down mid-walk).
 """
 function cancel!(src::CancellationTokenSource,
                  request::CancellationRequest=CANCEL_REQUEST_SAFE)
     sev = request.request
-    if !(sev == 0x0 || sev == 0x3 || sev == 0x4)
+    if !(sev == 0x1 || sev == 0x3 || sev == 0x4)
         throw(ArgumentError("invalid cancellation severity $(repr(request.request))"))
     end
     raised = _raise_state!(src, sev)
-    # Pairs with the compiler-order-only publication of per-task token
-    # bindings at compiled cancellation points (upcoming): after this fence,
-    # either the canceller observes the binding of a running task, or the
-    # task's next cancellation point observes our state write.
-    Threads.atomic_fence_heavy()
-    # Mark the subtree: each node is marked before its children so a
+    # Mark the descendants: each node is marked before its children so a
     # concurrent construction of a child source is level-triggered. The walk
     # does not depend on `raised`: when a concurrent equal-severity cancel!
     # wins the state transition, its walk may still be in flight (or may
     # never finish), so the loser must provide the on-return guarantee with
     # its own traversal.
     _cancel_walk!(src, sev)
+    # Heavy fence, after every state write of the walk: lets a delivery
+    # mechanism publish per-task token bindings with compiler ordering only
+    # - either the canceller observes the binding of a running task, or the
+    # task's next cancellation point observes the walk's state writes.
+    Threads.atomic_fence_heavy()
     return raised
 end
 
@@ -301,7 +291,7 @@ function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
                             visited::IdSet{CancellationTokenSource})
     # Advance at least to the node's current severity: a concurrent higher-
     # severity cancel! may have raised the state after this walk's own
-    # transition, and this walk may reach parts of the subtree before that
+    # transition, and this walk may reach parts of the graph before that
     # one does, so it carries the escalated severity onward (best effort;
     # the escalator's own walk is what guarantees its severity).
     # seq_cst, not acquire: when this walk's `_raise_state!` on `node` was
@@ -309,8 +299,7 @@ function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
     # walk's one seq_cst operation on `node.state` before the `child_head`
     # read below - the pairing depends on it.
     st = @atomic :sequentially_consistent node.state
-    stsev = st & SEVERITY_MASK
-    sev < stsev && (sev = stsev)
+    sev < st && (sev = st)
     # Walk the node's (weak, intrusive) child list. The level-trigger
     # guarantee is a store-buffering pairing: the constructor publishes the
     # child (seq_cst CAS on `child_head`), then reads the parent's state
@@ -344,8 +333,7 @@ end
     # re-read: deliver the severity current at throw time, not the one the
     # fast path happened to observe
     st = @atomic :acquire src.state
-    sev = st & SEVERITY_MASK
-    throw(CancellationRequest(sev))
+    throw(CancellationRequest(st))
 end
 
 """
@@ -364,8 +352,7 @@ token; use it to hoist the token lookup out of a tight loop.
 macro cancel_check()
     quote
         # also a GC safepoint, so that a tight polling loop cannot starve a
-        # concurrent stop-the-world (compiled cancellation points will emit
-        # one as well)
+        # concurrent stop-the-world
         ccall(:jl_gc_safepoint, Cvoid, ())
         checkcancel(default_cancel_source())
         nothing

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -11,18 +11,8 @@
 # may only *react* to cancellation; the source is the capability to *request*
 # it.
 #
-# The token governing a piece of code is carried dynamically as a scoped
-# value (see `CANCEL_TOKEN`), which `@cancel_check` resolves at every check.
-# Tasks inherit their creating task's scope, so cancellation scopes propagate
-# to child tasks without explicit plumbing.
-#
-# This file provides the data model and the cooperative (polling) checks.
-#
-# A scoped-value lookup is a `Core.current_scope()` read plus a
-# persistent-dict (HAMT) lookup, and the optimizer only folds
-# `current_scope()` when the enclosing `@with` is visible in the same
-# (post-inlining) frame - for inherited scopes the lookup stays in hot
-# loops. Hot loops can hoist it manually via the `@cancel_check tok` form.
+# For convenience, the scoped value `CANCEL_TOKEN` carries the governing token
+# carries the default cancellation token.
 
 const CancellationTokenSource = Core.CancellationTokenSource
 
@@ -35,8 +25,8 @@ cancellation of the associated source, but cannot request cancellation
 itself. Only the holder of the *source* can call [`cancel!`](@ref).
 
 A token takes effect by scoping it over a computation via the
-[`CANCEL_TOKEN`](@ref) scoped value (spawned tasks inherit it): once the
-source is cancelled, the computation's cancellation points (see
+[`CANCEL_TOKEN`](@ref) scoped value or by explicit token passing.
+Once the associated source is cancelled, the computation's cancellation points (see
 [`@cancel_check`](@ref)) throw a [`CancellationRequest`](@ref).
 """
 struct CancellationToken
@@ -100,10 +90,6 @@ frozen in place and never scheduled again.
 """
 const CANCEL_REQUEST_ABANDON_ALL = CancellationRequest(0x4)
 
-# The state byte of a source is 0x00 while uncancelled, and the (nonzero)
-# severity once cancelled - severities start at 0x1 precisely so that the
-# two cases cannot collide.
-
 """
     cancel_severity(src::CancellationTokenSource) -> Union{Nothing, CancellationRequest}
     cancel_severity(tok::CancellationToken)
@@ -130,31 +116,6 @@ iscancelled(src::CancellationTokenSource) = (@atomic :monotonic src.state) != 0x
 iscancelled(tok::CancellationToken) = iscancelled(tok.source)
 
 ## Source construction and graph linkage
-#
-# A source is a variable-sized object: its fixed fields (`child_head`,
-# `state`, `nparents`) are followed by `nparents` {parent,
-# next, pprev} link entries (see `jl_cancel_source_t` in julia_threads.h).
-# The `parent` slots are strong, const references - a child keeps its
-# parents alive - while `child_head` and the `next`/`pprev` slots form
-# intrusive per-parent sibling lists of *weak* references: when a source is
-# collected, the sweep - which visits every dead object anyway - detects it
-# and unlinks it from its parents' lists in O(1) via the `pprev`
-# back-pointer, so there is no explicit detach operation, the collector's
-# work is proportional to the number of sources that actually died, and, at
-# any point the mutator can observe, the lists contain only live sources.
-#
-# The lists are lock-free: mutators only ever prepend (in the C constructor
-# `jl_new_cancel_source`, via CAS on `child_head`); removal happens only
-# inside the collector with the world stopped. Construction and cancellation
-# synchronize with seq_cst operations so that attachment is level-triggered:
-# either the canceller's walk observes the new child, or the constructor
-# observes the cancelled state (and the child is born cancelled).
-
-# Construction is the builtin `Core._new_cancel_source(parents...)`
-# (jl_new_cancel_source): it allocates the object with one link entry per
-# argument and performs the linking and state inheritance in C, where the
-# absence of safepoints between publishing a link and reading the parent's
-# state can be guaranteed.
 
 """
     CancellationTokenSource() -> CancellationTokenSource
@@ -222,9 +183,6 @@ end
 #
 # Cancellation is uniformly level-triggered: while the governing token is
 # cancelled, every cancellation point throws the `CancellationRequest`.
-# There is no per-task acknowledgement state; code that must keep running
-# under a cancelled scope shields itself by scoping `CANCEL_TOKEN => nothing`
-# over the block.
 
 """
     cancel!(src::CancellationTokenSource,
@@ -243,10 +201,7 @@ their cancellation points (see [`@cancel_check`](@ref)), which throw a
 [`CancellationRequest`](@ref).
 
 When `cancel!` returns, every source currently reachable from `src` has
-been advanced to (at least) the requested severity by this very call - even
-a call that returns `false` performs the full walk, so that a repeated
-`cancel!` also repairs a subgraph whose earlier cancellation was cut short
-(say, by the cancelling task itself being torn down mid-walk).
+been advanced to (at least) the requested severity by this very call.
 """
 function cancel!(src::CancellationTokenSource,
                  request::CancellationRequest=CANCEL_REQUEST_SAFE)
@@ -255,28 +210,12 @@ function cancel!(src::CancellationTokenSource,
         throw(ArgumentError("invalid cancellation severity $(repr(request.request))"))
     end
     raised = _raise_state!(src, sev)
-    # Mark the descendants: each node is marked before its children so a
-    # concurrent construction of a child source is level-triggered. The walk
-    # does not depend on `raised`: when a concurrent equal-severity cancel!
-    # wins the state transition, its walk may still be in flight (or may
-    # never finish), so the loser must provide the on-return guarantee with
-    # its own traversal.
     _cancel_walk!(src, sev)
-    # Heavy fence, after every state write of the walk: lets a delivery
-    # mechanism publish per-task token bindings with compiler ordering only
-    # - either the canceller observes the binding of a running task, or the
-    # task's next cancellation point observes the walk's state writes.
     Threads.atomic_fence_heavy()
     return raised
 end
 
 function _cancel_walk!(src::CancellationTokenSource, sev::UInt8)
-    # Iterative worklist (no recursion): a deep source chain must not
-    # overflow the canceller's stack. The visited set - rather than pruning
-    # on nodes whose state some walk already advanced - makes a reconverging
-    # ("linked") graph linear in edges while keeping the walk self-contained:
-    # this call visits every reachable node itself instead of trusting
-    # another (possibly interrupted) walk to have done so.
     visited = IdSet{CancellationTokenSource}()
     push!(visited, src)
     pending = CancellationTokenSource[src]
@@ -289,29 +228,8 @@ end
 function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
                             pending::Vector{CancellationTokenSource},
                             visited::IdSet{CancellationTokenSource})
-    # Advance at least to the node's current severity: a concurrent higher-
-    # severity cancel! may have raised the state after this walk's own
-    # transition, and this walk may reach parts of the graph before that
-    # one does, so it carries the escalated severity onward (best effort;
-    # the escalator's own walk is what guarantees its severity).
-    # seq_cst, not acquire: when this walk's `_raise_state!` on `node` was
-    # lost, that call performed only monotonic reads, so this load is the
-    # walk's one seq_cst operation on `node.state` before the `child_head`
-    # read below - the pairing depends on it.
     st = @atomic :sequentially_consistent node.state
     sev < st && (sev = st)
-    # Walk the node's (weak, intrusive) child list. The level-trigger
-    # guarantee is a store-buffering pairing: the constructor publishes the
-    # child (seq_cst CAS on `child_head`), then reads the parent's state
-    # (seq_cst); the walk performs a seq_cst access of `node.state` - the
-    # winning CAS in `_raise_state!`, or the load above when the raise was
-    # lost (it re-reads the cancelled state, pinning the winner's write into
-    # the seq_cst order) - before the seq_cst `child_head` read below. Thus
-    # a child this read misses was published after the cancelled state
-    # became seq_cst-visible, so its constructor observes a cancelled parent
-    # and the child is born at (at least) this severity. Children attached
-    # concurrently *during* the walk are prepended before the list positions
-    # already traversed and are likewise born cancelled.
     c = @atomic node.child_head
     while c !== nothing
         c = c::CancellationTokenSource
@@ -379,12 +297,7 @@ end
 checkcancel(::Nothing) = nothing
 checkcancel(tok::CancellationToken) = checkcancel(tok.source)
 
-## The scoped default token
-
-# The scoped-value key under which the governing cancellation token is
-# carried. `AbstractScopedValue` so the ScopedValues API (`@with
-# Base.CANCEL_TOKEN => tok ...`) works on it; the accessors below avoid the
-# ScopedValues module so they are usable during early bootstrap.
+## CANCEL_TOKEN
 struct CancelTokenKey <: AbstractScopedValue{Union{Nothing, CancellationToken}} end
 
 """
@@ -410,13 +323,7 @@ Scoping `Base.CANCEL_TOKEN => nothing` instead *shields* the enclosed code
 from an outer (possibly cancelled) token; use this for cleanup that must
 complete while the surrounding computation is being cancelled.
 
-The current value can be read with `Base.CANCEL_TOKEN[]`, for example to
-hand the governing token across a boundary that does not preserve dynamic
-scope (a `ccall` callback, a queue consumed by unrelated tasks). Note that
-this only connects code within the same process: *serializing* a token
-(e.g. shipping it to a worker process) copies its source graph - the copy
-reflects the cancellation state as of serialization, and is independent
-thereafter, so cancelling the original does not cancel the copy.
+The current value can be read with `Base.CANCEL_TOKEN[]`.
 """
 const CANCEL_TOKEN = CancelTokenKey()
 

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -141,11 +141,31 @@ iscancelled(src::CancellationTokenSource) = (@atomic :monotonic src.state) != 0x
 iscancelled(tok::CancellationToken) = iscancelled(tok.source)
 
 ## Source construction and tree linkage
+#
+# A source is a variable-sized object: its fixed fields (`child_head`,
+# `state`, `delivered`, `nparents`) are followed by `nparents` {parent,
+# next, pprev} link entries (see `jl_cancel_source_t` in julia_threads.h).
+# The `parent` slots are strong, const references - a child keeps its
+# parents alive - while `child_head` and the `next`/`pprev` slots form
+# intrusive per-parent sibling lists of *weak* references: when a source is
+# collected, the sweep - which visits every dead object anyway - detects it
+# and unlinks it from its parents' lists in O(1) via the `pprev`
+# back-pointer, so there is no explicit detach operation, the collector's
+# work is proportional to the number of sources that actually died, and, at
+# any point the mutator can observe, the lists contain only live sources.
+#
+# The lists are lock-free: mutators only ever prepend (in the C constructor
+# `jl_new_cancel_source`, via CAS on `child_head`); removal happens only
+# inside the collector with the world stopped. Construction and cancellation
+# synchronize with seq_cst operations so that attachment is level-triggered:
+# either the canceller's walk observes the new child, or the constructor
+# observes the cancelled state (and the child is born cancelled).
 
-@eval function _new_cancel_source(parents::Union{Nothing, CancellationTokenSource, Core.SimpleVector})
-    return $(Expr(:new, :CancellationTokenSource,
-                  :parents, nothing, 0x00, 0x00, 0x00))
-end
+# Construction is the builtin `Core._new_cancel_source(parents...)`
+# (jl_new_cancel_source): it allocates the object with one link entry per
+# argument and performs the linking and state inheritance in C, where the
+# absence of safepoints between publishing a link and reading the parent's
+# state can be guaranteed.
 
 """
     CancellationTokenSource() -> CancellationTokenSource
@@ -168,81 +188,42 @@ out of the graph; there is no explicit detach operation.
 Use [`CancellationToken`](@ref)`(src)` for the observe view, and
 [`cancel!`](@ref)`(src)` to request cancellation.
 """
-function CancellationTokenSource(parent::CancellationToken)
-    src = _new_cancel_source(parent.source)
-    attach_child!(parent.source, src)
-    return src
-end
+CancellationTokenSource(parent::CancellationToken) =
+    Core._new_cancel_source(parent.source)::CancellationTokenSource
 function CancellationTokenSource(parent::CancellationToken, rest::CancellationToken...)
     srcs = CancellationTokenSource[parent.source]
     for tok in rest
         any(s -> s === tok.source, srcs) || push!(srcs, tok.source)
     end
-    length(srcs) == 1 && return CancellationTokenSource(parent)
-    child = _new_cancel_source(Core.svec(srcs...))
-    for p in srcs
-        attach_child!(p, child)
-    end
-    return child
+    return Core._new_cancel_source(srcs...)::CancellationTokenSource
 end
-CancellationTokenSource(::Nothing) = _new_cancel_source(nothing)
-CancellationTokenSource() = _new_cancel_source(nothing)
+CancellationTokenSource(::Nothing) = Core._new_cancel_source()::CancellationTokenSource
+CancellationTokenSource() = Core._new_cancel_source()::CancellationTokenSource
 
-# Spinlock on a source's `_lock` byte. These are leaf locks: no code may
-# block, allocate unboundedly, or take another source's lock while holding
-# one, except for the parent->child order used by the cancellation walk.
-function _lock_source(src::CancellationTokenSource)
-    while true
-        (@atomicreplace :acquire :monotonic src._lock 0x00 => 0x01).success && return
-        while (@atomic :monotonic src._lock) != 0x00
-            ccall(:jl_cpu_suspend, Cvoid, ())
-            ccall(:jl_gc_safepoint, Cvoid, ())
-        end
-    end
-end
-_unlock_source(src::CancellationTokenSource) = (@atomic :release src._lock = 0x00; nothing)
+# The i-th (1-based) parent of `src`. Parent links are strong and const, so
+# these reads need no synchronization.
+_cancel_parent(src::CancellationTokenSource, i::Int) =
+    ccall(:jl_cancel_source_parent, Any, (Any, Csize_t), src, i - 1)::CancellationTokenSource
 
-# Link `child` under `parent`. The child inherits the parent's cancellation
-# state at link time (a node attached under an already-cancelled parent is
-# born cancelled) - together with `cancel!` marking each node *before*
-# draining it, this makes registration level-triggered under concurrent
-# cancellation.
-function attach_child!(parent::CancellationTokenSource, child::CancellationTokenSource)
-    wr = WeakRef(child) # allocated outside the spinlock
-    _lock_source(parent)
-    pst = @atomic :monotonic parent.state
-    if pst != 0x00
-        _raise_state!(child, pst & SEVERITY_MASK)
-    end
-    kids = parent.children
-    if kids === nothing
-        kids = WeakRef[]
-        parent.children = kids
-    else
-        kids = kids::Vector{WeakRef}
-        # Amortized pruning: whenever the list length reaches a power of two,
-        # drop entries whose child has been garbage collected. This bounds
-        # the list at roughly twice the live-child count with O(1) amortized
-        # attach cost, without any explicit detach operation.
-        n = length(kids)
-        if n >= 8 && (n & (n - 1)) == 0
-            filter!(w -> w.value !== nothing, kids)
-        end
-    end
-    push!(kids, wr)
-    _unlock_source(parent)
-    return child
-end
+# The sibling after `child` on `parent`'s child list (`nothing` at its end).
+# Weak, but safe to traverse from Julia: the returned reference is rooted the
+# moment the ccall returns, and the GC's splice pass keeps the lists free of
+# collected entries at every safepoint, so a traversal (re-)started from a
+# rooted node only ever sees live sources.
+_cancel_next_child(parent::CancellationTokenSource, child::CancellationTokenSource) =
+    ccall(:jl_cancel_source_next_child, Any, (Any, Any), parent, child)::Union{Nothing, CancellationTokenSource}
 
 # CAS-max the source's state to (STATE_CANCELLED_BIT | sev). Returns true if
 # the state was raised, false if it was already at (or above) the severity.
+# seq_cst: pairs with the (child-list publication; state read) sequence in
+# `jl_new_cancel_source` - see the walk in `_cancel_walk_node!`.
 function _raise_state!(src::CancellationTokenSource, sev::UInt8)
     old = @atomic :monotonic src.state
     while true
         if old != 0x00 && (old & SEVERITY_MASK) >= sev
             return false
         end
-        old, success = @atomicreplace :acquire_release :monotonic src.state old => (STATE_CANCELLED_BIT | sev)
+        old, success = @atomicreplace :sequentially_consistent :monotonic src.state old => (STATE_CANCELLED_BIT | sev)
         success && return true
     end
 end
@@ -266,39 +247,29 @@ function _mark_delivered!(src::CancellationTokenSource, sev::UInt8)
     bit = 0x01 << sev
     # fast path: no parents (the common episode-source case)
     @atomic :monotonic src.delivered |= bit
-    p = src.parents
-    p === nothing && return nothing
+    src.nparents == 0x0000 && return nothing
     # Iterative ancestor walk (a Vector worklist - deep chains must not
     # recurse - deduplicated so a reconverging linked graph is marked once
     # per node). Delivery is rare; the allocation is fine.
     pending = CancellationTokenSource[]
     seen = IdSet{CancellationTokenSource}()
     push!(seen, src)
-    _push_parents!(pending, seen, p)
+    _push_parents!(pending, seen, src)
     while !isempty(pending)
         node = pop!(pending)
         @atomic :monotonic node.delivered |= bit
-        np = node.parents
-        np === nothing || _push_parents!(pending, seen, np)
+        _push_parents!(pending, seen, node)
     end
     return nothing
 end
 
 function _push_parents!(pending::Vector{CancellationTokenSource},
-                        seen::IdSet{CancellationTokenSource}, @nospecialize(p))
-    if p isa CancellationTokenSource
+                        seen::IdSet{CancellationTokenSource}, src::CancellationTokenSource)
+    for i in 1:Int(src.nparents)
+        p = _cancel_parent(src, i)
         if !(p in seen)
             push!(seen, p)
             push!(pending, p)
-        end
-    elseif p isa Core.SimpleVector
-        for i in 1:length(p)
-            c = p[i]
-            c isa CancellationTokenSource || continue
-            if !(c in seen)
-                push!(seen, c)
-                push!(pending, c)
-            end
         end
     end
     return nothing
@@ -335,7 +306,7 @@ function cancel!(src::CancellationTokenSource,
     # task's next cancellation point observes our state write.
     Threads.atomic_fence_heavy()
     # Mark the subtree: each node is marked before its children so a
-    # concurrent attach_child! is level-triggered.
+    # concurrent construction of a child source is level-triggered.
     _cancel_walk!(src, sev)
     return true
 end
@@ -353,8 +324,6 @@ end
 
 function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
                             pending::Vector{CancellationTokenSource})
-    children = nothing
-    _lock_source(node)
     # Advance at least to the node's current severity: a concurrent higher-
     # severity cancel! may have raised the state after this walk's own
     # transition; its walk skips children this one already advanced, so this
@@ -362,32 +331,24 @@ function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
     st = @atomic :acquire node.state
     stsev = st & SEVERITY_MASK
     sev < stsev && (sev = stsev)
-    # Snapshot the live children (compacting away collected ones) and queue
-    # the ones whose state this walk advanced; a child whose state was
-    # already at (or above) this severity has been walked - or is being
-    # walked - by whoever advanced it, so revisiting it would make a
-    # reconverging graph exponential.
-    kids = node.children
-    if kids !== nothing
-        kids = kids::Vector{WeakRef}
-        n = length(kids)
-        i = 1
-        for j in 1:n
-            c = kids[j].value
-            c === nothing && continue
-            kids[i] = kids[j]
-            i += 1
-            c = c::CancellationTokenSource
-            if _raise_state!(c, sev)
-                children = (c, children)
-            end
+    # Walk the node's (weak, intrusive) child list, queueing the children
+    # whose state this walk advanced; a child whose state was already at (or
+    # above) this severity has been walked - or is being walked - by whoever
+    # advanced it, so revisiting it would make a reconverging graph
+    # exponential. The seq_cst `child_head` read below (paired with the
+    # seq_cst state write that queued `node`) closes the race against a
+    # concurrent attach: a child that this read misses was published after
+    # our state write, so its constructor observes that write and the child
+    # is born at (at least) this severity. Children attached concurrently
+    # *during* the walk are prepended before the list positions already
+    # traversed and are likewise born cancelled.
+    c = @atomic node.child_head
+    while c !== nothing
+        c = c::CancellationTokenSource
+        if _raise_state!(c, sev)
+            push!(pending, c)
         end
-        i <= n && resize!(kids, i - 1)
-    end
-    _unlock_source(node)
-    while children !== nothing
-        (c, children) = children::Tuple{CancellationTokenSource, Any}
-        push!(pending, c)
+        c = _cancel_next_child(node, c)
     end
     return nothing
 end

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -143,7 +143,7 @@ iscancelled(tok::CancellationToken) = iscancelled(tok.source)
 ## Source construction and tree linkage
 #
 # A source is a variable-sized object: its fixed fields (`child_head`,
-# `state`, `delivered`, `nparents`) are followed by `nparents` {parent,
+# `state`, `nparents`) are followed by `nparents` {parent,
 # next, pprev} link entries (see `jl_cancel_source_t` in julia_threads.h).
 # The `parent` slots are strong, const references - a child keeps its
 # parents alive - while `child_head` and the `next`/`pprev` slots form
@@ -228,54 +228,13 @@ function _raise_state!(src::CancellationTokenSource, sev::UInt8)
     end
 end
 
-## Delivery bookkeeping
+## Cancellation
 #
 # Cancellation is uniformly level-triggered: while the governing token is
 # cancelled, every cancellation point throws the `CancellationRequest`.
 # There is no per-task acknowledgement state; code that must keep running
 # under a cancelled scope shields itself by scoping `CANCEL_TOKEN => nothing`
 # over the block.
-
-# Record that a cancellation of `src` at severity `sev` was delivered to
-# (observed by) some task, i.e. thrown at one of its cancellation points.
-# Feeds the (upcoming) ^C episode state machine ("was the request ever
-# seen?"), so the bits are propagated to every ancestor: a delivery against a
-# nested scope's source acknowledges the episode source too - otherwise the
-# SIGINT classifier would misread a successfully delivered cancellation as
-# unacknowledged and escalate a repeat ^C to abandonment.
-function _mark_delivered!(src::CancellationTokenSource, sev::UInt8)
-    bit = 0x01 << sev
-    # fast path: no parents (the common episode-source case)
-    @atomic :monotonic src.delivered |= bit
-    src.nparents == 0x0000 && return nothing
-    # Iterative ancestor walk (a Vector worklist - deep chains must not
-    # recurse - deduplicated so a reconverging linked graph is marked once
-    # per node). Delivery is rare; the allocation is fine.
-    pending = CancellationTokenSource[]
-    seen = IdSet{CancellationTokenSource}()
-    push!(seen, src)
-    _push_parents!(pending, seen, src)
-    while !isempty(pending)
-        node = pop!(pending)
-        @atomic :monotonic node.delivered |= bit
-        _push_parents!(pending, seen, node)
-    end
-    return nothing
-end
-
-function _push_parents!(pending::Vector{CancellationTokenSource},
-                        seen::IdSet{CancellationTokenSource}, src::CancellationTokenSource)
-    for i in 1:Int(src.nparents)
-        p = _cancel_parent(src, i)
-        if !(p in seen)
-            push!(seen, p)
-            push!(pending, p)
-        end
-    end
-    return nothing
-end
-
-## Cancellation
 
 """
     cancel!(src::CancellationTokenSource,
@@ -362,7 +321,6 @@ end
     # fast path happened to observe
     st = @atomic :acquire src.state
     sev = st & SEVERITY_MASK
-    _mark_delivered!(src, sev)
     throw(CancellationRequest(sev))
 end
 

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -58,7 +58,7 @@ token has been cancelled. The `request` field records the severity
 [`CANCEL_REQUEST_ABANDON_ALL`](@ref)) as observed at delivery time; the
 source may escalate afterwards.
 """
-struct CancellationRequest
+struct CancellationRequest <: Exception
     request::UInt8
 end
 
@@ -304,18 +304,25 @@ function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
     # transition, and this walk may reach parts of the subtree before that
     # one does, so it carries the escalated severity onward (best effort;
     # the escalator's own walk is what guarantees its severity).
-    st = @atomic :acquire node.state
+    # seq_cst, not acquire: when this walk's `_raise_state!` on `node` was
+    # lost, that call performed only monotonic reads, so this load is the
+    # walk's one seq_cst operation on `node.state` before the `child_head`
+    # read below - the pairing depends on it.
+    st = @atomic :sequentially_consistent node.state
     stsev = st & SEVERITY_MASK
     sev < stsev && (sev = stsev)
-    # Walk the node's (weak, intrusive) child list. The seq_cst `child_head`
-    # read below (paired with the seq_cst state CAS in `cancel!` - the read
-    # it performs is seq_cst even when the transition was lost) closes the
-    # race against a concurrent attach: a child that this read misses was
-    # published after the state write that made this walk reach `node`, so
-    # its constructor observes a cancelled parent and the child is born at
-    # (at least) this severity. Children attached concurrently *during* the
-    # walk are prepended before the list positions already traversed and are
-    # likewise born cancelled.
+    # Walk the node's (weak, intrusive) child list. The level-trigger
+    # guarantee is a store-buffering pairing: the constructor publishes the
+    # child (seq_cst CAS on `child_head`), then reads the parent's state
+    # (seq_cst); the walk performs a seq_cst access of `node.state` - the
+    # winning CAS in `_raise_state!`, or the load above when the raise was
+    # lost (it re-reads the cancelled state, pinning the winner's write into
+    # the seq_cst order) - before the seq_cst `child_head` read below. Thus
+    # a child this read misses was published after the cancelled state
+    # became seq_cst-visible, so its constructor observes a cancelled parent
+    # and the child is born at (at least) this severity. Children attached
+    # concurrently *during* the walk are prepended before the list positions
+    # already traversed and are likewise born cancelled.
     c = @atomic node.child_head
     while c !== nothing
         c = c::CancellationTokenSource

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -418,8 +418,11 @@ complete while the surrounding computation is being cancelled.
 
 The current value can be read with `Base.CANCEL_TOKEN[]`, for example to
 hand the governing token across a boundary that does not preserve dynamic
-scope (a `ccall` callback, a queue consumed by unrelated tasks, another
-process).
+scope (a `ccall` callback, a queue consumed by unrelated tasks). Note that
+this only connects code within the same process: *serializing* a token
+(e.g. shipping it to a worker process) copies its source graph - the copy
+reflects the cancellation state as of serialization, and is independent
+thereafter, so cancelling the original does not cancel the copy.
 """
 const CANCEL_TOKEN = CancelTokenKey()
 

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -34,7 +34,8 @@ function deepcopy(@nospecialize x)
     return deepcopy_internal(x, IdDict())::typeof(x)
 end
 
-deepcopy_internal(x::Union{Symbol,Core.MethodInstance,Method,GlobalRef,DataType,Union,UnionAll,Task,Regex},
+deepcopy_internal(x::Union{Symbol,Core.MethodInstance,Method,GlobalRef,DataType,Union,UnionAll,Task,Regex,
+                           Core.CancellationTokenSource},
                   stackdict::IdDict) = x
 deepcopy_internal(x::Tuple, stackdict::IdDict) =
     ntuple(i->deepcopy_internal(x[i], stackdict), length(x))

--- a/base/scope.jl
+++ b/base/scope.jl
@@ -1,0 +1,47 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Early definitions of the dynamic-scope types used by `Core.current_scope()`.
+# The user-facing API lives in the `ScopedValues` module (scopedvalues.jl, included
+# much later in bootstrap); the types live here so that early Base code — in
+# particular the cancellation machinery (`cancellation.jl`) — can resolve
+# scoped state during bootstrap.
+
+"""
+    AbstractScopedValue{T}
+
+Abstract base type for scoped values that propagate values across
+dynamic scopes. All scoped value types must extend this abstract type.
+
+See also: [`ScopedValues.ScopedValue`](@ref), [`ScopedValues.LazyScopedValue`](@ref)
+
+!!! compat "Julia 1.13"
+    AbstractScopedValue requires Julia 1.13+.
+"""
+abstract type AbstractScopedValue{T} end
+
+const ScopeStorage = PersistentDict{AbstractScopedValue, Any}
+
+struct Scope
+    values::ScopeStorage
+end
+
+Scope(scope::Scope) = scope
+
+function Scope(parent::Union{Nothing, Scope}, key::AbstractScopedValue{T}, value) where T
+    val = convert(T, value)
+    if parent === nothing
+        return Scope(ScopeStorage(key=>val))
+    end
+    return Scope(ScopeStorage(parent.values, key=>val))
+end
+
+function Scope(scope, pair::Pair{<:AbstractScopedValue})
+    return Scope(scope, pair...)
+end
+
+function Scope(scope, pair1::Pair{<:AbstractScopedValue}, pair2::Pair{<:AbstractScopedValue}, pairs::Pair{<:AbstractScopedValue}...)
+    # Unroll this loop through recursion to make sure that
+    # our compiler optimization support works
+    return Scope(Scope(scope, pair1...), pair2, pairs...)
+end
+Scope(::Nothing) = nothing

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -4,10 +4,6 @@ module ScopedValues
 
 export ScopedValue, LazyScopedValue, with, @with, ScopedThunk
 public get
-
-# The `Scope`/`AbstractScopedValue` types are defined early in bootstrap
-# (base/scope.jl) so that early Base code can resolve scoped state; this
-# module provides the user-facing API on top of them.
 using Base: AbstractScopedValue, Scope, ScopeStorage
 
 

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -94,9 +94,11 @@ Base.eltype(::AbstractScopedValue{T}) where {T} = T
 
 hasdefault(val::ScopedValue) = val.hasdefault
 hasdefault(val::LazyScopedValue) = true
+hasdefault(val::Base.CancelTokenKey) = true
 
 getdefault(val::ScopedValue) = val.hasdefault ? val.default : throw(KeyError(val))
 getdefault(val::LazyScopedValue) = val.getdefault()
+getdefault(val::Base.CancelTokenKey) = nothing
 
 """
     isassigned(val::ScopedValue)

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -5,18 +5,10 @@ module ScopedValues
 export ScopedValue, LazyScopedValue, with, @with, ScopedThunk
 public get
 
-"""
-    AbstractScopedValue{T}
-
-Abstract base type for scoped values that propagate values across
-dynamic scopes. All scoped value types must extend this abstract type.
-
-See also: [`ScopedValue`](@ref), [`LazyScopedValue`](@ref)
-
-!!! compat "Julia 1.13"
-    AbstractScopedValue requires Julia 1.13+.
-"""
-abstract type AbstractScopedValue{T} end
+# The `Scope`/`AbstractScopedValue` types are defined early in bootstrap
+# (base/scope.jl) so that early Base code can resolve scoped state; this
+# module provides the user-facing API on top of them.
+using Base: AbstractScopedValue, Scope, ScopeStorage
 
 
 """
@@ -132,33 +124,6 @@ function Base.isassigned(val::AbstractScopedValue)
     scope === nothing && return false
     return haskey((scope::Scope).values, val)
 end
-
-const ScopeStorage = Base.PersistentDict{AbstractScopedValue, Any}
-
-struct Scope
-    values::ScopeStorage
-end
-
-Scope(scope::Scope) = scope
-
-function Scope(parent::Union{Nothing, Scope}, key::AbstractScopedValue{T}, value) where T
-    val = convert(T, value)
-    if parent === nothing
-        return Scope(ScopeStorage(key=>val))
-    end
-    return Scope(ScopeStorage(parent.values, key=>val))
-end
-
-function Scope(scope, pair::Pair{<:AbstractScopedValue})
-    return Scope(scope, pair...)
-end
-
-function Scope(scope, pair1::Pair{<:AbstractScopedValue}, pair2::Pair{<:AbstractScopedValue}, pairs::Pair{<:AbstractScopedValue}...)
-    # Unroll this loop through recursion to make sure that
-    # our compiler optimization support works
-    return Scope(Scope(scope, pair1...), pair2, pairs...)
-end
-Scope(::Nothing) = nothing
 
 function Base.show(io::IO, scope::Scope)
     print(io, Scope, "(")

--- a/base/show.jl
+++ b/base/show.jl
@@ -294,6 +294,25 @@ function show(io::IO, ::MIME"text/plain", t::Task)
     end
 end
 
+# Compact summary: the default field-recursive show would descend the
+# intrusive child list (unbounded, possibly very deep) via `child_head`.
+function show(io::IO, src::Core.CancellationTokenSource)
+    print(io, "CancellationTokenSource(")
+    sev = cancel_severity(src)
+    if sev === nothing
+        print(io, "active")
+    else
+        r = sev.request
+        print(io, r == 0x0 ? "cancelled" :
+                  r == 0x3 ? "cancelled, abandon external" :
+                  r == 0x4 ? "cancelled, abandon all" :
+                  "cancelled, severity $(repr(r))")
+    end
+    np = Int(src.nparents)
+    np > 0 && print(io, ", ", np, np == 1 ? " parent" : " parents")
+    print(io, ")")
+end
+
 
 print(io::IO, s::Symbol) = (write(io,s); nothing)
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -303,7 +303,7 @@ function show(io::IO, src::Core.CancellationTokenSource)
         print(io, "active")
     else
         r = sev.request
-        print(io, r == 0x0 ? "cancelled" :
+        print(io, r == 0x1 ? "cancelled" :
                   r == 0x3 ? "cancelled, abandon external" :
                   r == 0x4 ? "cancelled, abandon all" :
                   "cancelled, severity $(repr(r))")

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -60,6 +60,11 @@ function summarysize(obj;
             if isassigned(x, i)
                 val = x[i]
             end
+        elseif isa(x, Core.CancellationTokenSource)
+            # the strong references of a source are its (hidden, trailing)
+            # parent links, enumerated here rather than via the layout
+            nf = Int(x.nparents)
+            val = _cancel_parent(x, i)
         elseif isa(x, GenericMemory)
             T = eltype(x)
             if allocatedinline(T)
@@ -206,14 +211,15 @@ function (ss::SummarySize)(obj::Core.CancellationTokenSource)
     key = pointer_from_objref(obj)
     haskey(ss.seen, key) ? (return 0) : (ss.seen[key] = true)
     # Variable-sized: Core.sizeof includes the trailing parent link entries.
-    # Traverse the (strong) parent references; the child list is weak - a
-    # source does not keep its children alive - so it is deliberately not
-    # followed.
-    size::Int = ss.count ? 1 : Core.sizeof(obj)
-    for i in 1:Int(obj.nparents)
-        size += ss(_cancel_parent(obj, i))::Int
+    # The (strong) parent references are traversed through the iterative
+    # frontier (see the branch in `summarysize`), which keeps deep chains
+    # off the stack and honors `exclude`; the child list is weak - a source
+    # does not keep its children alive - so it is deliberately not followed.
+    if Int(obj.nparents) > 0
+        push!(ss.frontier_x, obj)
+        push!(ss.frontier_i, 1)
     end
-    return size
+    return ss.count ? 1 : Core.sizeof(obj)
 end
 
 function (ss::SummarySize)(obj::Task)

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -202,6 +202,20 @@ function (ss::SummarySize)(obj::Module)
     return size
 end
 
+function (ss::SummarySize)(obj::Core.CancellationTokenSource)
+    key = pointer_from_objref(obj)
+    haskey(ss.seen, key) ? (return 0) : (ss.seen[key] = true)
+    # Variable-sized: Core.sizeof includes the trailing parent link entries.
+    # Traverse the (strong) parent references; the child list is weak - a
+    # source does not keep its children alive - so it is deliberately not
+    # followed.
+    size::Int = ss.count ? 1 : Core.sizeof(obj)
+    for i in 1:Int(obj.nparents)
+        size += ss(_cancel_parent(obj, i))::Int
+    end
+    return size
+end
+
 function (ss::SummarySize)(obj::Task)
     haskey(ss.seen, obj) ? (return 0) : (ss.seen[obj] = true)
     size::Int = (ss.count ? 1 : Core.sizeof(obj))

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -16,6 +16,7 @@ extern "C" {
     XX(_equiv_typedef,"_equiv_typedef") \
     XX(_expr,"_expr") \
     XX(_import, "_import") \
+    XX(_new_cancel_source,"_new_cancel_source") \
     XX(_primitivetype,"_primitivetype") \
     XX(_setsuper,"_setsuper!") \
     XX(_structtype,"_structtype") \

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -614,6 +614,12 @@ JL_CALLABLE(jl_f_sizeof)
         return jl_box_long(strlen(jl_symbol_name((jl_sym_t*)x)));
     if (jl_is_svec(x))
         return jl_box_long((1+jl_svec_len(x))*sizeof(void*));
+    if (jl_is_cancel_source(x)) {
+        // variable-sized: one link entry per parent follows the fixed fields
+        jl_cancel_source_t *cs = (jl_cancel_source_t*)x;
+        return jl_box_long(sizeof(jl_cancel_source_t) +
+                           cs->nparents * sizeof(jl_cancel_parent_link_t));
+    }
     jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(x);
     assert(jl_is_datatype(dt));
     assert(!dt->name->abstract);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2729,6 +2729,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("CodeInfo", (jl_value_t*)jl_code_info_type);
     add_builtin("LLVMPtr", (jl_value_t*)jl_llvmpointer_type);
     add_builtin("Task", (jl_value_t*)jl_task_type);
+    add_builtin("CancellationTokenSource", (jl_value_t*)jl_cancel_source_type);
 
     add_builtin("AddrSpace", (jl_value_t*)jl_addrspace_type);
     add_builtin("Ref", (jl_value_t*)jl_ref_type);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -675,6 +675,14 @@ JL_CALLABLE(jl_f_current_scope)
     return jl_current_task->scope;
 }
 
+JL_CALLABLE(jl_f__new_cancel_source)
+{
+    // each argument is a parent CancellationTokenSource (checked, along
+    // with distinctness, by jl_new_cancel_source); no arguments makes a
+    // root source
+    return jl_new_cancel_source(args, nargs);
+}
+
 // apply ----------------------------------------------------------------------
 
 static NOINLINE jl_svec_t *_copy_to(size_t newalloc, jl_value_t **oldargs, size_t oldalloc) JL_CANSAFEPOINT

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -309,6 +309,7 @@ JL_DLLEXPORT int jl_egal__bitstag(const jl_value_t *a JL_MAYBE_UNROOTED, const j
         case jl_module_tag:
         case jl_bool_tag:
         case jl_nothing_tag:
+        case jl_cancel_source_tag: // mutable: identity (a == b checked above)
             return 0;
         case jl_simplevector_tag:
             return compare_svec((jl_svec_t*)a, (jl_svec_t*)b);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -602,7 +602,8 @@ JL_CALLABLE(jl_f_sizeof)
             else
                 jl_errorf("Argument is an incomplete %s type and does not have a definite size.", jl_symbol_name(dx->name->name));
         }
-        if (jl_is_layout_opaque(dx->layout)) // includes all GenericMemory{kind,T}
+        if (jl_is_layout_opaque(dx->layout) || // includes all GenericMemory{kind,T}
+            dx == jl_cancel_source_type)       // variable-sized (layout covers only the fixed fields)
             jl_errorf("Type %s does not have a definite size.", jl_symbol_name(dx->name->name));
         return jl_box_long(jl_datatype_size(x));
     }

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -628,6 +628,15 @@ int gc_slot_to_arrayidx(void *obj, void *_slot) JL_NOTSAFEPOINT
         start = (char*)mem->ptr;
         len = mem->length;
     }
+    else if (vt == jl_cancel_source_type) {
+        // the (strong) `parent` slots of the trailing link entries are the
+        // only slots marked as an array (see the objarray mark with stride
+        // sizeof(jl_cancel_parent_link_t) in gc-stock.c)
+        jl_cancel_source_t *s = (jl_cancel_source_t*)obj;
+        start = (char*)jl_cancel_source_links(s);
+        len = s->nparents;
+        elsize = sizeof(jl_cancel_parent_link_t);
+    }
     if (slot < start || slot >= start + elsize * len)
         return -1;
     return (slot - start) / elsize;

--- a/src/gc-heap-snapshot.c
+++ b/src/gc-heap-snapshot.c
@@ -407,6 +407,13 @@ static size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
         name = "Task";
         self_size = sizeof(jl_task_t);
     }
+    else if (jl_is_cancel_source(a)) {
+        // variable-sized: one link entry per parent follows the fixed fields
+        node_type = "jl_cancel_source_t";
+        name = "CancellationTokenSource";
+        self_size = sizeof(jl_cancel_source_t) +
+                    ((jl_cancel_source_t*)a)->nparents * sizeof(jl_cancel_parent_link_t);
+    }
     else if (jl_is_datatype(a)) {
         ios_need_close = 1;
         ios_mem(&str_, 0);

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -64,12 +64,21 @@ JL_DLLEXPORT void* MMTK_SIDE_VO_BIT_BASE_ADDRESS;
 // GC Initialization and Control
 // ========================================================================= //
 
+// Registry entries (see jl_gc_set_needs_weak_processing) of threads that
+// have exited: their thread-local list is spliced in here so the entries
+// survive mutator destruction. Guarded by orphaned_weak_processing_lock
+// (thread exits may race each other; the sweep runs while no mutator does).
+static small_arraylist_t orphaned_weak_processing_list;
+static uv_mutex_t orphaned_weak_processing_lock;
+
 void jl_gc_init(void) {
     // TODO: use jl_options.heap_size_hint to set MMTk's fixed heap size? (see issue: https://github.com/mmtk/mmtk-julia/issues/167)
     JL_MUTEX_INIT(&finalizers_lock, "finalizers_lock");
 
     arraylist_new(&to_finalize, 0);
     arraylist_new(&finalizer_list_marked, 0);
+    small_arraylist_new(&orphaned_weak_processing_list, 0);
+    uv_mutex_init(&orphaned_weak_processing_lock);
     gc_num.interval = default_collect_interval;
     gc_num.allocd = 0;
     gc_num.max_pause = 0;
@@ -217,6 +226,19 @@ void jl_init_thread_heap(struct _jl_tls_states_t *ptls) JL_NOTSAFEPOINT {
 }
 
 void jl_free_thread_gc_state(struct _jl_tls_states_t *ptls) {
+    // The weak-processing registry entries of this thread may outlive it (a
+    // linked cancellation source can escape the thread that allocated it);
+    // the sweep only enumerates active mutators, so move them to the global
+    // orphan list. Runs GC-unsafe, so it cannot race the sweep.
+    small_arraylist_t *lst = &ptls->gc_tls_common.heap.weak_processing_list;
+    if (lst->len > 0) {
+        uv_mutex_lock(&orphaned_weak_processing_lock);
+        for (size_t i = 0; i < lst->len; i++)
+            small_arraylist_push(&orphaned_weak_processing_list, lst->items[i]);
+        uv_mutex_unlock(&orphaned_weak_processing_lock);
+        lst->len = 0;
+    }
+    small_arraylist_free(lst);
     mmtk_destroy_mutator(&ptls->gc_tls.mmtk_mutator);
 }
 
@@ -660,6 +682,47 @@ void jl_gc_set_needs_weak_processing(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPO
     small_arraylist_push(&ptls->gc_tls_common.heap.weak_processing_list, v);
 }
 
+void jl_gc_set_weak_processing_target(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPOINT
+{
+    // Nothing to do: MMTk reclaims memory only after the SweepVMSpecific
+    // work packet (which runs jl_gc_sweep_weak_processing) has completed,
+    // so the memory of every object that died this cycle is still intact
+    // when the unlink pass writes into it.
+    (void)ptls;
+    (void)v;
+}
+
+// Filter one weak-processing registry: unlink the dead entries and keep
+// the live ones (see jl_gc_sweep_weak_processing).
+static void sweep_weak_processing_list(small_arraylist_t *reg) JL_NOTSAFEPOINT
+{
+    size_t n = 0;
+    size_t l = reg->len;
+    void **lst = reg->items;
+    for (size_t i = 0; i < l; i++) {
+        // dispatch on the object's type once more kinds of
+        // weakly-processed objects exist
+        jl_cancel_source_t *s = (jl_cancel_source_t*)lst[i];
+        if (mmtk_is_live_object(s)) {
+            lst[n++] = s;
+            continue;
+        }
+        jl_cancel_parent_link_t *links = jl_cancel_source_links(s);
+        for (size_t j = 0; j < s->nparents; j++) {
+            jl_value_t *next = jl_atomic_load_relaxed(&links[j].next);
+            _Atomic(jl_value_t*) *pprev = links[j].pprev;
+            jl_atomic_store_relaxed(pprev, next);
+            if (next != (jl_value_t*)jl_nothing) {
+                jl_cancel_parent_link_t *nl =
+                    jl_cancel_source_link((jl_cancel_source_t*)next, links[j].parent);
+                assert(nl != NULL);
+                nl->pprev = pprev;
+            }
+        }
+    }
+    reg->len = n;
+}
+
 // Process the dead entries of the weak_processing_list registries -
 // currently: unlink collected cancellation sources from their parents'
 // (weak, intrusive, doubly-linked) child lists, with O(1) hlist unlinks
@@ -667,40 +730,20 @@ void jl_gc_set_needs_weak_processing(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPO
 // the stock GC's sweep_weak_processing for the invariants). Runs from the
 // SweepVMSpecific work packet, after the mark closure (including finalizer
 // resurrection) and before the memory of dead objects is reused, so dead
-// entries' links are still intact.
+// entries' links are still intact. Covers both the active mutators'
+// registries and the entries orphaned by exited threads.
 JL_DLLEXPORT void jl_gc_sweep_weak_processing(void) JL_NOTSAFEPOINT
 {
     void *iter = mmtk_new_mutator_iterator();
     jl_ptls_t ptls2 = (jl_ptls_t)mmtk_get_next_mutator_tls(iter);
     while (ptls2 != NULL) {
-        size_t n = 0;
-        size_t l = ptls2->gc_tls_common.heap.weak_processing_list.len;
-        void **lst = ptls2->gc_tls_common.heap.weak_processing_list.items;
-        for (size_t i = 0; i < l; i++) {
-            // dispatch on the object's type once more kinds of
-            // weakly-processed objects exist
-            jl_cancel_source_t *s = (jl_cancel_source_t*)lst[i];
-            if (mmtk_is_live_object(s)) {
-                lst[n++] = s;
-                continue;
-            }
-            jl_cancel_parent_link_t *links = jl_cancel_source_links(s);
-            for (size_t j = 0; j < s->nparents; j++) {
-                jl_value_t *next = jl_atomic_load_relaxed(&links[j].next);
-                _Atomic(jl_value_t*) *pprev = links[j].pprev;
-                jl_atomic_store_relaxed(pprev, next);
-                if (next != (jl_value_t*)jl_nothing) {
-                    jl_cancel_parent_link_t *nl =
-                        jl_cancel_source_link((jl_cancel_source_t*)next, links[j].parent);
-                    assert(nl != NULL);
-                    nl->pprev = pprev;
-                }
-            }
-        }
-        ptls2->gc_tls_common.heap.weak_processing_list.len = n;
+        sweep_weak_processing_list(&ptls2->gc_tls_common.heap.weak_processing_list);
         ptls2 = (jl_ptls_t)mmtk_get_next_mutator_tls(iter);
     }
     mmtk_close_mutator_iterator(iter);
+    uv_mutex_lock(&orphaned_weak_processing_lock);
+    sweep_weak_processing_list(&orphaned_weak_processing_list);
+    uv_mutex_unlock(&orphaned_weak_processing_lock);
 }
 
 JL_DLLEXPORT void jl_gc_mmtk_sweep_malloced_memory(void) JL_NOTSAFEPOINT

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -68,6 +68,9 @@ JL_DLLEXPORT void* MMTK_SIDE_VO_BIT_BASE_ADDRESS;
 // have exited: their thread-local list is spliced in here so the entries
 // survive mutator destruction. Guarded by orphaned_weak_processing_lock
 // (thread exits may race each other; the sweep runs while no mutator does).
+// The registry stores raw object pointers (and, transitively, the interior
+// `pprev` pointers of the intrusive lists) that are never updated on object
+// movement - sound only while the binding is non-moving.
 static small_arraylist_t orphaned_weak_processing_list;
 static uv_mutex_t orphaned_weak_processing_lock;
 

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -197,6 +197,7 @@ void jl_start_gc_threads(void) {
 void jl_init_thread_heap(struct _jl_tls_states_t *ptls) JL_NOTSAFEPOINT {
     jl_thread_heap_common_t *heap = &ptls->gc_tls_common.heap;
     small_arraylist_new(&heap->weak_refs, 0);
+    small_arraylist_new(&heap->weak_processing_list, 0);
     small_arraylist_new(&heap->live_tasks, 0);
     for (int i = 0; i < JL_N_STACK_POOLS; i++)
         small_arraylist_new(&heap->free_stacks[i], 0);
@@ -649,6 +650,57 @@ static void jl_gc_free_memory(jl_genericmemory_t *m, int isaligned) JL_NOTSAFEPO
         free(d);
     gc_num.freed += freed_bytes;
     gc_num.freecall++;
+}
+
+void jl_gc_set_needs_weak_processing(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPOINT
+{
+    // MMTk never visits individual dead objects (lines/blocks are
+    // reclaimed wholesale), so dead objects requiring weak processing are
+    // found by scanning this registry instead.
+    small_arraylist_push(&ptls->gc_tls_common.heap.weak_processing_list, v);
+}
+
+// Process the dead entries of the weak_processing_list registries -
+// currently: unlink collected cancellation sources from their parents'
+// (weak, intrusive, doubly-linked) child lists, with O(1) hlist unlinks
+// whose fix-up writes land only in live or dying-this-cycle memory (see
+// the stock GC's sweep_weak_processing for the invariants). Runs from the
+// SweepVMSpecific work packet, after the mark closure (including finalizer
+// resurrection) and before the memory of dead objects is reused, so dead
+// entries' links are still intact.
+JL_DLLEXPORT void jl_gc_sweep_weak_processing(void) JL_NOTSAFEPOINT
+{
+    void *iter = mmtk_new_mutator_iterator();
+    jl_ptls_t ptls2 = (jl_ptls_t)mmtk_get_next_mutator_tls(iter);
+    while (ptls2 != NULL) {
+        size_t n = 0;
+        size_t l = ptls2->gc_tls_common.heap.weak_processing_list.len;
+        void **lst = ptls2->gc_tls_common.heap.weak_processing_list.items;
+        for (size_t i = 0; i < l; i++) {
+            // dispatch on the object's type once more kinds of
+            // weakly-processed objects exist
+            jl_cancel_source_t *s = (jl_cancel_source_t*)lst[i];
+            if (mmtk_is_live_object(s)) {
+                lst[n++] = s;
+                continue;
+            }
+            jl_cancel_parent_link_t *links = jl_cancel_source_links(s);
+            for (size_t j = 0; j < s->nparents; j++) {
+                jl_value_t *next = jl_atomic_load_relaxed(&links[j].next);
+                _Atomic(jl_value_t*) *pprev = links[j].pprev;
+                jl_atomic_store_relaxed(pprev, next);
+                if (next != (jl_value_t*)jl_nothing) {
+                    jl_cancel_parent_link_t *nl =
+                        jl_cancel_source_link((jl_cancel_source_t*)next, links[j].parent);
+                    assert(nl != NULL);
+                    nl->pprev = pprev;
+                }
+            }
+        }
+        ptls2->gc_tls_common.heap.weak_processing_list.len = n;
+        ptls2 = (jl_ptls_t)mmtk_get_next_mutator_tls(iter);
+    }
+    mmtk_close_mutator_iterator(iter);
 }
 
 JL_DLLEXPORT void jl_gc_mmtk_sweep_malloced_memory(void) JL_NOTSAFEPOINT

--- a/src/gc-mmtk/mmtk_julia/build.rs
+++ b/src/gc-mmtk/mmtk_julia/build.rs
@@ -128,6 +128,8 @@ fn main() {
         .allowlist_item("jl_task_t")
         .allowlist_item("jl_datatype_t")
         .allowlist_item("jl_weakref_t")
+        .allowlist_item("jl_cancel_source_t")
+        .allowlist_item("jl_cancel_parent_link_t")
         .allowlist_item("jl_binding_partition_t")
         .allowlist_item("jl_bt_element_t")
         .allowlist_item("jl_taggedvalue_t")

--- a/src/gc-mmtk/mmtk_julia/src/julia_scanning.rs
+++ b/src/gc-mmtk/mmtk_julia/src/julia_scanning.rs
@@ -184,6 +184,20 @@ pub unsafe fn scan_julia_object<SV: SlotVisitor<JuliaVMSlot>>(obj: Address, clos
                 process_slot(closure, slot);
                 obj8_begin = obj8_begin.shift::<u8>(1);
             }
+        } else if vtag_usize == ((jl_small_typeof_tags_jl_cancel_source_tag as usize) << 4) {
+            // Variable-sized cancellation token source: `nparents` {parent,
+            // next, pprev} link entries follow the fixed fields. Only the
+            // (strong) `parent` slot of each entry is traced; `child_head`
+            // and the `next`/`pprev` slots are weak references with
+            // unlink-on-death semantics (see jl_gc_sweep_weak_processing)
+            // and must not be traced.
+            let cs = obj.to_ptr::<jl_cancel_source_t>();
+            let np = (*cs).nparents as usize;
+            let mut slot = obj + std::mem::size_of::<jl_cancel_source_t>();
+            for _ in 0..np {
+                process_slot(closure, slot);
+                slot = slot + std::mem::size_of::<jl_cancel_parent_link_t>();
+            }
         } else if vtag_usize == ((jl_small_typeof_tags_jl_string_tag as usize) << 4)
             && PRINT_OBJ_TYPE
         {

--- a/src/gc-mmtk/mmtk_julia/src/lib.rs
+++ b/src/gc-mmtk/mmtk_julia/src/lib.rs
@@ -106,6 +106,7 @@ extern "C" {
     pub fn jl_throw_out_of_memory_error();
     pub fn jl_get_gc_disable_counter() -> u32;
     pub fn jl_gc_mmtk_sweep_malloced_memory();
+    pub fn jl_gc_sweep_weak_processing();
     pub fn jl_gc_sweep_stack_pools_and_mtarraylist_buffers();
     pub fn jl_hrtime() -> u64;
     pub fn jl_gc_update_stats(t: u64, mmtk_live_bytes: usize, is_nursery: bool);

--- a/src/gc-mmtk/mmtk_julia/src/object_model.rs
+++ b/src/gc-mmtk/mmtk_julia/src/object_model.rs
@@ -221,6 +221,20 @@ pub unsafe fn get_so_object_size(object: ObjectReference) -> usize {
             );
 
             return llt_align(dtsz + JULIA_HEADER_SIZE, 16);
+        } else if vtag_usize == ((jl_small_typeof_tags_jl_cancel_source_tag as usize) << 4) {
+            // Variable-sized: `nparents` {parent, next, pprev} link entries
+            // follow the fixed fields.
+            let cs = obj_address.to_ptr::<jl_cancel_source_t>();
+            let np = (*cs).nparents as usize;
+            let dtsz = std::mem::size_of::<jl_cancel_source_t>()
+                + np * std::mem::size_of::<jl_cancel_parent_link_t>();
+            debug_assert!(
+                dtsz + JULIA_HEADER_SIZE <= 2032,
+                "size {} greater than minimum!",
+                dtsz + JULIA_HEADER_SIZE
+            );
+
+            return llt_align(dtsz + JULIA_HEADER_SIZE, 16);
         } else if vtag_usize == ((jl_small_typeof_tags_jl_string_tag as usize) << 4) {
             let length = object.to_raw_address().load::<usize>();
             let dtsz = length + std::mem::size_of::<usize>() + 1;

--- a/src/gc-mmtk/mmtk_julia/src/scanning.rs
+++ b/src/gc-mmtk/mmtk_julia/src/scanning.rs
@@ -229,8 +229,9 @@ impl Default for SweepVMSpecific {
 
 impl<VM: VMBinding> GCWork<VM> for SweepVMSpecific {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
-        // call sweep malloced arrays and sweep stack pools
+        // call sweep malloced arrays, cancellation-source child lists, and sweep stack pools
         unsafe { jl_gc_mmtk_sweep_malloced_memory() }
+        unsafe { crate::jl_gc_sweep_weak_processing() }
         unsafe { jl_gc_sweep_stack_pools_and_mtarraylist_buffers() }
         self.swept = true;
     }

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -988,6 +988,118 @@ STATIC_INLINE void gc_compute_utilization_data_for_size_classes(void) JL_NOTSAFE
     }
 }
 
+// The cell-by-cell scan of gc_sweep_page: rebuilds the page's free list and
+// recomputes its metadata. Force-inlined into two instantiations specialized
+// on the compile-time-constant `has_weakproc` (see the call sites in
+// gc_sweep_page), so the weak-processing checks vanish entirely from the
+// common (unflagged) sweep loop. Returns whether every cell turned out dead.
+FORCE_INLINE int gc_sweep_page_cells(gc_page_profiler_serializer_t *s, jl_gc_pagemeta_t *pg,
+                                     jl_taggedvalue_t *v0, char *lim, char *lim_newpages,
+                                     int osize, int page_profile_enabled, jl_ptls_t ptls,
+                                     const int has_weakproc) JL_NOTSAFEPOINT
+{
+    char *data = pg->data;
+    int freedall = 1;
+    int has_marked = 0;
+    int has_young = 0;
+    // recomputed from the page's live contents: a page keeps its
+    // has_weak_processing flag only while it still holds a live source
+    // that future sweeps must detect (one with parents) or retain (one
+    // with children, whose dying children write into it) - so pages
+    // whose sources are gone return to the wholesale-free fast path
+    // instead of being scanned (and kept) forever
+    int keep_weakproc = 0;
+    int16_t prev_nold = 0;
+    int pg_nfree = 0;
+    jl_taggedvalue_t *fl = NULL;
+    jl_taggedvalue_t **pfl = &fl;
+    jl_taggedvalue_t **pfl_begin = NULL;
+    // collect page profile
+    jl_taggedvalue_t *v = v0;
+    if (page_profile_enabled) {
+        while ((char*)v <= lim) {
+            int bits = v->bits.gc;
+            if (!gc_marked(bits) || (char*)v >= lim_newpages) {
+                gc_page_profile_write_garbage(s, page_profile_enabled);
+            }
+            else {
+                gc_page_profile_write_live_obj(s, v, page_profile_enabled);
+            }
+            v = (jl_taggedvalue_t*)((char*)v + osize);
+        }
+        v = v0;
+    }
+    // sweep the page
+    while ((char*)v <= lim) {
+        int bits = v->bits.gc;
+        // if an object is past `lim_newpages` then we can guarantee it's garbage
+        if (!gc_marked(bits) || (char*)v >= lim_newpages) {
+            // A dead cancellation source that is still linked into its
+            // parents' child lists is kept for this cycle and queued
+            // for the post-sweep unlink pass; the cleared back-pointers
+            // let the next sweep that visits it free it normally. Cells
+            // past `lim_newpages` were never allocated - their headers
+            // are garbage and must not be inspected.
+            if (has_weakproc && __unlikely((char*)v < lim_newpages &&
+                                           gc_is_dead_linked_cancel_source(v))) {
+                small_arraylist_push(&ptls->gc_tls.weak_processing_objs, jl_valueof(v));
+                // treat as young so a quick sweep revisits (and frees)
+                // the corpse promptly
+                has_young = 1;
+                freedall = 0;
+            }
+            else {
+                *pfl = v;
+                pfl = &v->next;
+                pfl_begin = (pfl_begin != NULL) ? pfl_begin : pfl;
+                pg_nfree++;
+            }
+        }
+        else { // marked young or old
+            if (current_sweep_full || bits == GC_MARKED) { // old enough
+                bits = v->bits.gc = GC_OLD; // promote
+            }
+            prev_nold++;
+            has_marked |= gc_marked(bits);
+            freedall = 0;
+            if (has_weakproc && !keep_weakproc && gc_is_cancel_source(v)) {
+                jl_cancel_source_t *src = (jl_cancel_source_t*)jl_valueof(v);
+                if (src->nparents > 0 ||
+                    jl_atomic_load_relaxed(&src->child_head) != (jl_value_t*)jl_nothing)
+                    keep_weakproc = 1;
+            }
+        }
+        v = (jl_taggedvalue_t*)((char*)v + osize);
+    }
+    // gc_scrub_range (active under WITH_GC_DEBUG_ENV) conservatively marks any
+    // pool object found on a task stack, including slots past lim_newpages on the
+    // currently-active bump-pointer page. Those slots are unconditionally treated
+    // as garbage by the sweep (line above: `(char*)v >= lim_newpages`), so
+    // freedall=1 is valid when this is the active newpages page. A page whose
+    // has_weak_processing flag skipped the wholesale-free fast path can also
+    // legitimately turn out fully dead here (it is retained for this cycle -
+    // unlink writes may target it - and freed by the next sweep).
+    assert(!freedall || lim_newpages < data + GC_PAGE_SZ || has_weakproc);
+    pg->has_marked = has_marked;
+    pg->has_young = has_young;
+    pg->has_weak_processing = keep_weakproc;
+    if (pfl_begin) {
+        pg->fl_begin_offset = (char*)pfl_begin - data;
+        pg->fl_end_offset = (char*)pfl - data;
+    }
+    else {
+        pg->fl_begin_offset = UINT16_MAX;
+        pg->fl_end_offset = UINT16_MAX;
+    }
+
+    pg->nfree = pg_nfree;
+    if (current_sweep_full) {
+        pg->nold = 0;
+        pg->prev_nold = prev_nold;
+    }
+    return freedall;
+}
+
 // Walks over a page, reconstruting the free lists if the page contains at least one live object. If not,
 // queues up the page for later decommit (i.e. through `madvise` on Unix).
 static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_gc_page_stack_t *allocd, jl_gc_pagemeta_t *pg, int osize) JL_NOTSAFEPOINT
@@ -1032,107 +1144,15 @@ static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_
     }
 
     pg_skpd = 0;
-    {   // scope to avoid clang goto errors
-        int has_marked = 0;
-        int has_young = 0;
-        int has_weakproc = pg->has_weak_processing;
-        // recomputed from the page's live contents: a page keeps its
-        // has_weak_processing flag only while it still holds a live source
-        // that future sweeps must detect (one with parents) or retain (one
-        // with children, whose dying children write into it) - so pages
-        // whose sources are gone return to the wholesale-free fast path
-        // instead of being scanned (and kept) forever
-        int keep_weakproc = 0;
-        int16_t prev_nold = 0;
-        int pg_nfree = 0;
-        jl_taggedvalue_t *fl = NULL;
-        jl_taggedvalue_t **pfl = &fl;
-        jl_taggedvalue_t **pfl_begin = NULL;
-        // collect page profile
-        jl_taggedvalue_t *v = v0;
-        if (page_profile_enabled) {
-            while ((char*)v <= lim) {
-                int bits = v->bits.gc;
-                if (!gc_marked(bits) || (char*)v >= lim_newpages) {
-                    gc_page_profile_write_garbage(s, page_profile_enabled);
-                }
-                else {
-                    gc_page_profile_write_live_obj(s, v, page_profile_enabled);
-                }
-                v = (jl_taggedvalue_t*)((char*)v + osize);
-            }
-            v = v0;
-        }
-        // sweep the page
-        while ((char*)v <= lim) {
-            int bits = v->bits.gc;
-            // if an object is past `lim_newpages` then we can guarantee it's garbage
-            if (!gc_marked(bits) || (char*)v >= lim_newpages) {
-                // A dead cancellation source that is still linked into its
-                // parents' child lists is kept for this cycle and queued
-                // for the post-sweep unlink pass; the cleared back-pointers
-                // let the next sweep that visits it free it normally. Cells
-                // past `lim_newpages` were never allocated - their headers
-                // are garbage and must not be inspected.
-                if (__unlikely(has_weakproc && (char*)v < lim_newpages &&
-                               gc_is_dead_linked_cancel_source(v))) {
-                    small_arraylist_push(&ptls->gc_tls.weak_processing_objs, jl_valueof(v));
-                    // treat as young so a quick sweep revisits (and frees)
-                    // the corpse promptly
-                    has_young = 1;
-                    freedall = 0;
-                }
-                else {
-                    *pfl = v;
-                    pfl = &v->next;
-                    pfl_begin = (pfl_begin != NULL) ? pfl_begin : pfl;
-                    pg_nfree++;
-                }
-            }
-            else { // marked young or old
-                if (current_sweep_full || bits == GC_MARKED) { // old enough
-                    bits = v->bits.gc = GC_OLD; // promote
-                }
-                prev_nold++;
-                has_marked |= gc_marked(bits);
-                freedall = 0;
-                if (__unlikely(has_weakproc) && !keep_weakproc &&
-                    gc_is_cancel_source(v)) {
-                    jl_cancel_source_t *s = (jl_cancel_source_t*)jl_valueof(v);
-                    if (s->nparents > 0 ||
-                        jl_atomic_load_relaxed(&s->child_head) != (jl_value_t*)jl_nothing)
-                        keep_weakproc = 1;
-                }
-            }
-            v = (jl_taggedvalue_t*)((char*)v + osize);
-        }
-        // gc_scrub_range (active under WITH_GC_DEBUG_ENV) conservatively marks any
-        // pool object found on a task stack, including slots past lim_newpages on the
-        // currently-active bump-pointer page. Those slots are unconditionally treated
-        // as garbage by the sweep (line above: `(char*)v >= lim_newpages`), so
-        // freedall=1 is valid when this is the active newpages page. A page whose
-        // has_weak_processing flag skipped the wholesale-free fast path can also
-        // legitimately turn out fully dead here (it is retained for this cycle -
-        // unlink writes may target it - and freed by the next sweep).
-        assert(!freedall || lim_newpages < data + GC_PAGE_SZ || has_weakproc);
-        pg->has_marked = has_marked;
-        pg->has_young = has_young;
-        pg->has_weak_processing = keep_weakproc;
-        if (pfl_begin) {
-            pg->fl_begin_offset = (char*)pfl_begin - data;
-            pg->fl_end_offset = (char*)pfl - data;
-        }
-        else {
-            pg->fl_begin_offset = UINT16_MAX;
-            pg->fl_end_offset = UINT16_MAX;
-        }
-
-        pg->nfree = pg_nfree;
-        if (current_sweep_full) {
-            pg->nold = 0;
-            pg->prev_nold = prev_nold;
-        }
-    }
+    // unswitched on the page's has_weak_processing flag (constant-folded in
+    // each instantiation of gc_sweep_page_cells): flagged pages are rare,
+    // and the common sweep loop stays free of the weak-processing checks
+    if (__unlikely(pg->has_weak_processing))
+        freedall = gc_sweep_page_cells(s, pg, v0, lim, lim_newpages, osize,
+                                       page_profile_enabled, ptls, 1);
+    else
+        freedall = gc_sweep_page_cells(s, pg, v0, lim, lim_newpages, osize,
+                                       page_profile_enabled, ptls, 0);
     nfree = pg->nfree;
 
 done:

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -384,51 +384,20 @@ static void clear_weak_refs(void) JL_NOTSAFEPOINT
     }
 }
 
-// weak processing (currently: cancellation token source child lists)
+// Accelerated weak processing
 //
-// A collected cancellation source must leave its parents' (weak,
-// intrusive, doubly-linked) child lists. There is no registry to scan:
-// the sweep - which visits every dead cell's header anyway - detects dead
-// sources that are still linked (`gc_is_dead_linked_cancel_source`, gated
-// by the page's has_weak_processing flag), *keeps* their cells for this
-// cycle instead of freeing them, and queues them on the sweeping thread's
-// `weak_processing_objs` list. After all sweeping, still inside the
-// stop-the-world window,
-// sweep_weak_processing() performs the O(1) hlist unlinks: every slot
-// it writes lives either in an object that survived this cycle (a correct
-// fix-up) or in an object that died *this* cycle whose memory the sweep
-// kept around (see below) - sibling lists only ever contain cancellation
-// sources, and a parent strongly referenced by its children can never die
-// before them - so unlinks of adjacent dead nodes compose in any order.
-// The cleared back-pointers (`pprev == NULL`) make the next sweep that
-// visits a kept corpse free it normally. Total cost is strictly
-// proportional to the number of sources that died.
-//
-// Memory validity of the unlink writes:
-//  - pool pages holding any cancellation source that unlink writes may
-//    target carry the has_weak_processing flag (set when a source with
-//    parents is allocated on the page, and on every parent's page - see
-//    jl_gc_set_weak_processing_target). A flagged page is never freed
-//    wholesale by the `!has_marked` fast path; the cell-by-cell scan it
-//    takes instead always retains the page for the cycle, so writes into
-//    cells that died this cycle land in mapped, still-owned memory. The
-//    scan recomputes the flag from the page's *live* contents, so a page
-//    whose sources are gone stops being scanned - and gets reclaimed -
-//    by the following sweep.
-//  - big-object cancellation sources are not freed by sweep_big when they
-//    die; they are pushed onto `big_weak_corpses` (still linked into the
-//    bigval list) and freed at the end of sweep_weak_processing, after
-//    every unlink has been performed.
+// This code supports O(dead object) processing of weak object links.
+// Currently this is only used for cancellation sources. Pages
+// containing objects that need weak processing are flagged during allocation.
+// The sweep phase of the GC then collects all such objects into a per-thread
+// list. After the sweep phase, the GC calls `sweep_weak_processing` to
+// perform the necessary processing.
 
 // Dead big-object cancellation sources whose free is deferred until after
 // the unlink pass. Only touched by the serial parts of the sweep.
 static arraylist_t big_weak_corpses;
 
 // Does this (live or dead-this-cycle) cell hold a cancellation source?
-// Constant compare: cancellation sources carry a small type tag. Cells
-// freed by a previous sweep cannot false-positive: their header holds
-// either a freelist pointer (a valid heap address) or a newly allocated
-// object's type tag.
 STATIC_INLINE int gc_is_cancel_source(jl_taggedvalue_t *v) JL_NOTSAFEPOINT
 {
     return (v->header & ~(uintptr_t)0xf) == (jl_cancel_source_tag << 4);
@@ -3465,11 +3434,6 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
         gc_scrub();
         gc_verify_tags();
         gc_sweep_pool();
-        // Process the dead weakly-processed objects found (and kept) by the
-        // big-object and pool sweeps above - i.e. unlink dead cancellation
-        // sources from their parents' child lists. Must run before the
-        // world restarts, while the memory of every dead list neighbor is
-        // still intact.
         sweep_weak_processing();
     }
 

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -448,8 +448,10 @@ void jl_gc_set_needs_weak_processing(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPO
 {
     (void)ptls;
     jl_gc_pagemeta_t *pg = page_metadata(v);
+    // relaxed: two mutators may set the flag concurrently for a shared
+    // page (both write 1; the GC only reads it inside the STW sweep)
     if (pg != NULL)
-        pg->has_weak_processing = 1;
+        jl_atomic_store_relaxed(&pg->has_weak_processing, 1);
     // big objects are always swept per-object; no flag needed
 }
 
@@ -818,7 +820,7 @@ STATIC_INLINE jl_taggedvalue_t *gc_reset_page(jl_ptls_t ptls2, const jl_gc_pool_
     jl_taggedvalue_t *beg = (jl_taggedvalue_t*)(pg->data + GC_PAGE_OFFSET);
     pg->has_young = 0;
     pg->has_marked = 0;
-    pg->has_weak_processing = 0;
+    jl_atomic_store_relaxed(&pg->has_weak_processing, 0);
     pg->prev_nold = 0;
     pg->nold = 0;
     pg->fl_begin_offset = UINT16_MAX;
@@ -1082,7 +1084,7 @@ FORCE_INLINE int gc_sweep_page_cells(gc_page_profiler_serializer_t *s, jl_gc_pag
     assert(!freedall || lim_newpages < data + GC_PAGE_SZ || has_weakproc);
     pg->has_marked = has_marked;
     pg->has_young = has_young;
-    pg->has_weak_processing = keep_weakproc;
+    jl_atomic_store_relaxed(&pg->has_weak_processing, keep_weakproc);
     if (pfl_begin) {
         pg->fl_begin_offset = (char*)pfl_begin - data;
         pg->fl_end_offset = (char*)pfl - data;
@@ -1125,7 +1127,7 @@ static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_
     // cannot be freed wholesale: its cells must be visited so that those
     // dead objects get their processing (e.g. a still-linked cancellation
     // source being kept and queued for unlinking).
-    if (!pg->has_marked && !pg->has_weak_processing) {
+    if (!pg->has_marked && !jl_atomic_load_relaxed(&pg->has_weak_processing)) {
         re_use_page = 0;
         nfree = (GC_PAGE_SZ - GC_PAGE_OFFSET) / osize;
         gc_page_profile_write_empty_page(s, page_profile_enabled);
@@ -1147,7 +1149,7 @@ static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_
     // unswitched on the page's has_weak_processing flag (constant-folded in
     // each instantiation of gc_sweep_page_cells): flagged pages are rare,
     // and the common sweep loop stays free of the weak-processing checks
-    if (__unlikely(pg->has_weak_processing))
+    if (__unlikely(jl_atomic_load_relaxed(&pg->has_weak_processing)))
         freedall = gc_sweep_page_cells(s, pg, v0, lim, lim_newpages, osize,
                                        page_profile_enabled, ptls, 1);
     else

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -384,6 +384,77 @@ static void clear_weak_refs(void) JL_NOTSAFEPOINT
     }
 }
 
+// weak processing (currently: cancellation token source child lists)
+//
+// A collected cancellation source must leave its parents' (weak,
+// intrusive, doubly-linked) child lists. There is no registry to scan:
+// the sweep - which visits every dead cell's header anyway - detects dead
+// sources that are still linked (`gc_is_dead_linked_cancel_source`, gated
+// by the page's has_weak_processing flag), *keeps* their cells for this
+// cycle instead of freeing them, and queues them on the sweeping thread's
+// `weak_processing_objs` list. After all sweeping, still inside the
+// stop-the-world window,
+// sweep_weak_processing() performs the O(1) hlist unlinks: every slot
+// it writes lives either in an object that survived this cycle (a correct
+// fix-up) or in a fellow kept corpse (intact, harmlessly stale) - sibling
+// lists only ever contain cancellation sources, and every dead one was
+// kept - so unlinks of adjacent dead nodes compose in any order. The
+// cleared back-pointers (`pprev == NULL`) make the next sweep that visits
+// the corpse free it normally. Total cost is strictly proportional to the
+// number of sources that died.
+
+// Is `v` (a dead cell whose header is known valid) a cancellation source
+// that is still linked into some parent's child list?
+STATIC_INLINE int gc_is_dead_linked_cancel_source(jl_taggedvalue_t *v) JL_NOTSAFEPOINT
+{
+    // constant compare: cancellation sources carry a small type tag
+    if (__likely((v->header & ~(uintptr_t)0xf) != (jl_cancel_source_tag << 4)))
+        return 0;
+    jl_cancel_source_t *s = (jl_cancel_source_t*)jl_valueof(v);
+    return s->nparents > 0 && jl_cancel_source_links(s)[0].pprev != NULL;
+}
+
+void jl_gc_set_needs_weak_processing(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPOINT
+{
+    (void)ptls;
+    jl_gc_pagemeta_t *pg = page_metadata(v);
+    if (pg != NULL)
+        pg->has_weak_processing = 1;
+    // big objects are always swept per-object; no flag needed
+}
+
+static void sweep_weak_processing(void) JL_NOTSAFEPOINT
+{
+    assert(gc_n_threads != 0);
+    for (int t_i = 0; t_i < gc_n_threads; t_i++) {
+        jl_ptls_t ptls2 = gc_all_tls_states[t_i];
+        if (ptls2 == NULL)
+            continue;
+        small_arraylist_t *lst = &ptls2->gc_tls.weak_processing_objs;
+        for (size_t i = 0; i < lst->len; i++) {
+            // dispatch on the object's type once more kinds of
+            // weakly-processed objects exist; today these are all
+            // cancellation token sources
+            jl_cancel_source_t *s = (jl_cancel_source_t*)lst->items[i];
+            jl_cancel_parent_link_t *links = jl_cancel_source_links(s);
+            for (size_t j = 0; j < s->nparents; j++) {
+                jl_value_t *next = jl_atomic_load_relaxed(&links[j].next);
+                _Atomic(jl_value_t*) *pprev = links[j].pprev;
+                assert(pprev != NULL);
+                jl_atomic_store_relaxed(pprev, next);
+                if (next != (jl_value_t*)jl_nothing) {
+                    jl_cancel_parent_link_t *nl =
+                        jl_cancel_source_link((jl_cancel_source_t*)next, links[j].parent);
+                    assert(nl != NULL);
+                    nl->pprev = pprev;
+                }
+                links[j].pprev = NULL;
+            }
+        }
+        lst->len = 0;
+    }
+}
+
 static void sweep_weak_refs(void) JL_NOTSAFEPOINT
 {
     assert(gc_n_threads != 0);
@@ -509,6 +580,14 @@ static bigval_t *sweep_list_of_young_bigvals(bigval_t *young) JL_NOTSAFEPOINT
                 gc_big_object_link(old, v);
             }
             v->bits.gc = bits;
+        }
+        else if (__unlikely(gc_is_dead_linked_cancel_source((jl_taggedvalue_t*)&v->header))) {
+            // keep the corpse on the list for this cycle; it is queued for
+            // the post-sweep unlink pass and freed by the next sweep (see
+            // sweep_weak_processing)
+            small_arraylist_push(&jl_current_task->ptls->gc_tls.weak_processing_objs,
+                                 jl_valueof((jl_taggedvalue_t*)&v->header));
+            last_node = v;
         }
         else {
             sweep_unlink_and_free(v);
@@ -685,6 +764,7 @@ STATIC_INLINE jl_taggedvalue_t *gc_reset_page(jl_ptls_t ptls2, const jl_gc_pool_
     jl_taggedvalue_t *beg = (jl_taggedvalue_t*)(pg->data + GC_PAGE_OFFSET);
     pg->has_young = 0;
     pg->has_marked = 0;
+    pg->has_weak_processing = 0;
     pg->prev_nold = 0;
     pg->nold = 0;
     pg->fl_begin_offset = UINT16_MAX;
@@ -870,11 +950,16 @@ static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_
     // avoid loading a global variable in the hot path
     int page_profile_enabled = gc_page_profile_is_enabled();
     gc_page_serializer_init(s, pg);
+    jl_ptls_t ptls = jl_current_task->ptls;
 
     int re_use_page = 1;
     int freedall = 1;
     int pg_skpd = 1;
-    if (!pg->has_marked) {
+    // A fully-dead page that may hold objects requiring weak processing
+    // cannot be freed wholesale: its cells must be visited so that those
+    // dead objects get their processing (e.g. a still-linked cancellation
+    // source being kept and queued for unlinking).
+    if (!pg->has_marked && !pg->has_weak_processing) {
         re_use_page = 0;
         nfree = (GC_PAGE_SZ - GC_PAGE_OFFSET) / osize;
         gc_page_profile_write_empty_page(s, page_profile_enabled);
@@ -896,6 +981,7 @@ static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_
     {   // scope to avoid clang goto errors
         int has_marked = 0;
         int has_young = 0;
+        int has_weakproc = pg->has_weak_processing;
         int16_t prev_nold = 0;
         int pg_nfree = 0;
         jl_taggedvalue_t *fl = NULL;
@@ -921,10 +1007,26 @@ static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_
             int bits = v->bits.gc;
             // if an object is past `lim_newpages` then we can guarantee it's garbage
             if (!gc_marked(bits) || (char*)v >= lim_newpages) {
-                *pfl = v;
-                pfl = &v->next;
-                pfl_begin = (pfl_begin != NULL) ? pfl_begin : pfl;
-                pg_nfree++;
+                // A dead cancellation source that is still linked into its
+                // parents' child lists is kept for this cycle and queued
+                // for the post-sweep unlink pass; the cleared back-pointers
+                // let the next sweep that visits it free it normally. Cells
+                // past `lim_newpages` were never allocated - their headers
+                // are garbage and must not be inspected.
+                if (__unlikely(has_weakproc && (char*)v < lim_newpages &&
+                               gc_is_dead_linked_cancel_source(v))) {
+                    small_arraylist_push(&ptls->gc_tls.weak_processing_objs, jl_valueof(v));
+                    // treat as young so a quick sweep revisits (and frees)
+                    // the corpse promptly
+                    has_young = 1;
+                    freedall = 0;
+                }
+                else {
+                    *pfl = v;
+                    pfl = &v->next;
+                    pfl_begin = (pfl_begin != NULL) ? pfl_begin : pfl;
+                    pg_nfree++;
+                }
             }
             else { // marked young or old
                 if (current_sweep_full || bits == GC_MARKED) { // old enough
@@ -973,7 +1075,6 @@ done:
     }
     gc_page_profile_write_to_file(s);
     gc_time_count_page(freedall, pg_skpd);
-    jl_ptls_t ptls = jl_current_task->ptls;
     // Note that we aggregate the `pool_live_bytes` over all threads before returning this
     // value to the user. It doesn't matter how the `pool_live_bytes` are partitioned among
     // the threads as long as the sum is correct. Let's add the `pool_live_bytes` to the current thread
@@ -2397,6 +2498,27 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                         gc_ptr_queue_push(mq, new_obj);
                 }
             }
+            else if (vtag == jl_cancel_source_tag << 4) {
+                // Variable-sized: `nparents` link entries follow the fixed
+                // fields. The `parent` slot of each entry is a strong
+                // reference; `child_head` and the `next`/`pprev` slots are
+                // weak (unlinked on death by sweep_weak_processing) and
+                // must not be traced.
+                jl_cancel_source_t *cs = (jl_cancel_source_t*)new_obj;
+                size_t np = cs->nparents;
+                size_t dtsz = sizeof(jl_cancel_source_t) + np * sizeof(jl_cancel_parent_link_t);
+                if (update_meta)
+                    gc_setmark(ptls, o, bits, dtsz);
+                if (np > 0) {
+                    jl_value_t **objary_begin = (jl_value_t**)jl_cancel_source_links(cs);
+                    // stride over the link entries, visiting only the
+                    // (strong) `parent` slot of each
+                    uint32_t step = sizeof(jl_cancel_parent_link_t) / sizeof(jl_value_t*);
+                    jl_value_t **objary_end = objary_begin + step * np;
+                    uintptr_t nptr = (np << 2) | (bits & GC_OLD);
+                    gc_mark_objarray(ptls, new_obj, objary_begin, objary_end, step, nptr);
+                }
+            }
             else if (vtag == jl_string_tag << 4) {
                 size_t dtsz = jl_string_len(new_obj) + sizeof(size_t) + 1;
                 if (update_meta)
@@ -3249,6 +3371,12 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
         gc_scrub();
         gc_verify_tags();
         gc_sweep_pool();
+        // Process the dead weakly-processed objects found (and kept) by the
+        // big-object and pool sweeps above - i.e. unlink dead cancellation
+        // sources from their parents' child lists. Must run before the
+        // world restarts, while the memory of every dead list neighbor is
+        // still intact.
+        sweep_weak_processing();
     }
 
     JL_PROBE_GC_SWEEP_END();
@@ -3430,6 +3558,8 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
             jl_thread_heap_t *heap = &ptls2->gc_tls.heap;
             if (common_heap->weak_refs.len == 0)
                 small_arraylist_free(&common_heap->weak_refs);
+            if (common_heap->weak_processing_list.len == 0)
+                small_arraylist_free(&common_heap->weak_processing_list);
             if (common_heap->live_tasks.len == 0)
                 small_arraylist_free(&common_heap->live_tasks);
             if (heap->remset.len == 0)
@@ -3438,6 +3568,8 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
                 arraylist_free(&ptls2->finalizers);
             if (ptls2->gc_tls.sweep_objs.len == 0)
                 arraylist_free(&ptls2->gc_tls.sweep_objs);
+            if (ptls2->gc_tls.weak_processing_objs.len == 0)
+                small_arraylist_free(&ptls2->gc_tls.weak_processing_objs);
         }
     }
 
@@ -3613,6 +3745,7 @@ void jl_init_thread_heap(jl_ptls_t ptls)
         p[i].newpages = NULL;
     }
     small_arraylist_new(&common_heap->weak_refs, 0);
+    small_arraylist_new(&common_heap->weak_processing_list, 0);
     small_arraylist_new(&common_heap->live_tasks, 0);
     for (int i = 0; i < JL_N_STACK_POOLS; i++)
         small_arraylist_new(&common_heap->free_stacks[i], 0);
@@ -3623,6 +3756,7 @@ void jl_init_thread_heap(jl_ptls_t ptls)
     arraylist_new(&heap->remset, 0);
     arraylist_new(&ptls->finalizers, 0);
     arraylist_new(&ptls->gc_tls.sweep_objs, 0);
+    small_arraylist_new(&ptls->gc_tls.weak_processing_objs, 0);
 
     jl_gc_mark_cache_t *gc_cache = &ptls->gc_tls.gc_cache;
     gc_cache->perm_scanned_bytes = 0;

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -396,19 +396,49 @@ static void clear_weak_refs(void) JL_NOTSAFEPOINT
 // stop-the-world window,
 // sweep_weak_processing() performs the O(1) hlist unlinks: every slot
 // it writes lives either in an object that survived this cycle (a correct
-// fix-up) or in a fellow kept corpse (intact, harmlessly stale) - sibling
-// lists only ever contain cancellation sources, and every dead one was
-// kept - so unlinks of adjacent dead nodes compose in any order. The
-// cleared back-pointers (`pprev == NULL`) make the next sweep that visits
-// the corpse free it normally. Total cost is strictly proportional to the
-// number of sources that died.
+// fix-up) or in an object that died *this* cycle whose memory the sweep
+// kept around (see below) - sibling lists only ever contain cancellation
+// sources, and a parent strongly referenced by its children can never die
+// before them - so unlinks of adjacent dead nodes compose in any order.
+// The cleared back-pointers (`pprev == NULL`) make the next sweep that
+// visits a kept corpse free it normally. Total cost is strictly
+// proportional to the number of sources that died.
+//
+// Memory validity of the unlink writes:
+//  - pool pages holding any cancellation source that unlink writes may
+//    target carry the has_weak_processing flag (set when a source with
+//    parents is allocated on the page, and on every parent's page - see
+//    jl_gc_set_weak_processing_target). A flagged page is never freed
+//    wholesale by the `!has_marked` fast path; the cell-by-cell scan it
+//    takes instead always retains the page for the cycle, so writes into
+//    cells that died this cycle land in mapped, still-owned memory. The
+//    scan recomputes the flag from the page's *live* contents, so a page
+//    whose sources are gone stops being scanned - and gets reclaimed -
+//    by the following sweep.
+//  - big-object cancellation sources are not freed by sweep_big when they
+//    die; they are pushed onto `big_weak_corpses` (still linked into the
+//    bigval list) and freed at the end of sweep_weak_processing, after
+//    every unlink has been performed.
+
+// Dead big-object cancellation sources whose free is deferred until after
+// the unlink pass. Only touched by the serial parts of the sweep.
+static arraylist_t big_weak_corpses;
+
+// Does this (live or dead-this-cycle) cell hold a cancellation source?
+// Constant compare: cancellation sources carry a small type tag. Cells
+// freed by a previous sweep cannot false-positive: their header holds
+// either a freelist pointer (a valid heap address) or a newly allocated
+// object's type tag.
+STATIC_INLINE int gc_is_cancel_source(jl_taggedvalue_t *v) JL_NOTSAFEPOINT
+{
+    return (v->header & ~(uintptr_t)0xf) == (jl_cancel_source_tag << 4);
+}
 
 // Is `v` (a dead cell whose header is known valid) a cancellation source
 // that is still linked into some parent's child list?
 STATIC_INLINE int gc_is_dead_linked_cancel_source(jl_taggedvalue_t *v) JL_NOTSAFEPOINT
 {
-    // constant compare: cancellation sources carry a small type tag
-    if (__likely((v->header & ~(uintptr_t)0xf) != (jl_cancel_source_tag << 4)))
+    if (__likely(!gc_is_cancel_source(v)))
         return 0;
     jl_cancel_source_t *s = (jl_cancel_source_t*)jl_valueof(v);
     return s->nparents > 0 && jl_cancel_source_links(s)[0].pprev != NULL;
@@ -422,6 +452,19 @@ void jl_gc_set_needs_weak_processing(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPO
         pg->has_weak_processing = 1;
     // big objects are always swept per-object; no flag needed
 }
+
+void jl_gc_set_weak_processing_target(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPOINT
+{
+    // `v` may be written by the weak-processing pass after it dies (e.g. a
+    // parent's `child_head`, spliced when a dead child is unlinked), so its
+    // memory must stay valid through the cycle in which it dies: flag its
+    // page so the sweep never frees it wholesale. Big objects need nothing
+    // (sweep_big defers freeing every dead cancellation source until after
+    // the unlink pass) and image objects are never freed at all.
+    jl_gc_set_needs_weak_processing(ptls, v);
+}
+
+FORCE_INLINE void sweep_unlink_and_free(bigval_t *v) JL_NOTSAFEPOINT;
 
 static void sweep_weak_processing(void) JL_NOTSAFEPOINT
 {
@@ -453,6 +496,13 @@ static void sweep_weak_processing(void) JL_NOTSAFEPOINT
         }
         lst->len = 0;
     }
+    // Every dead source is now unlinked; the big-object corpses kept by
+    // sweep_big can finally be freed. (Pool corpses instead stay for one
+    // cycle and are freed by the next sweep that visits their - retained -
+    // page.)
+    for (size_t i = 0; i < big_weak_corpses.len; i++)
+        sweep_unlink_and_free((bigval_t*)big_weak_corpses.items[i]);
+    big_weak_corpses.len = 0;
 }
 
 static void sweep_weak_refs(void) JL_NOTSAFEPOINT
@@ -581,12 +631,16 @@ static bigval_t *sweep_list_of_young_bigvals(bigval_t *young) JL_NOTSAFEPOINT
             }
             v->bits.gc = bits;
         }
-        else if (__unlikely(gc_is_dead_linked_cancel_source((jl_taggedvalue_t*)&v->header))) {
-            // keep the corpse on the list for this cycle; it is queued for
-            // the post-sweep unlink pass and freed by the next sweep (see
-            // sweep_weak_processing)
-            small_arraylist_push(&jl_current_task->ptls->gc_tls.weak_processing_objs,
-                                 jl_valueof((jl_taggedvalue_t*)&v->header));
+        else if (__unlikely(gc_is_cancel_source((jl_taggedvalue_t*)&v->header))) {
+            // Defer the free until after the unlink pass: a dead *linked*
+            // source's link entries are read by it, and a dead *parent*'s
+            // `child_head` slot may be written by it (its dying children
+            // splice themselves out). Keep the corpse on the bigval list;
+            // sweep_weak_processing frees it once every unlink is done.
+            if (gc_is_dead_linked_cancel_source((jl_taggedvalue_t*)&v->header))
+                small_arraylist_push(&jl_current_task->ptls->gc_tls.weak_processing_objs,
+                                     jl_valueof((jl_taggedvalue_t*)&v->header));
+            arraylist_push(&big_weak_corpses, v);
             last_node = v;
         }
         else {
@@ -982,6 +1036,13 @@ static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_
         int has_marked = 0;
         int has_young = 0;
         int has_weakproc = pg->has_weak_processing;
+        // recomputed from the page's live contents: a page keeps its
+        // has_weak_processing flag only while it still holds a live source
+        // that future sweeps must detect (one with parents) or retain (one
+        // with children, whose dying children write into it) - so pages
+        // whose sources are gone return to the wholesale-free fast path
+        // instead of being scanned (and kept) forever
+        int keep_weakproc = 0;
         int16_t prev_nold = 0;
         int pg_nfree = 0;
         jl_taggedvalue_t *fl = NULL;
@@ -1035,6 +1096,13 @@ static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_
                 prev_nold++;
                 has_marked |= gc_marked(bits);
                 freedall = 0;
+                if (__unlikely(has_weakproc) && !keep_weakproc &&
+                    gc_is_cancel_source(v)) {
+                    jl_cancel_source_t *s = (jl_cancel_source_t*)jl_valueof(v);
+                    if (s->nparents > 0 ||
+                        jl_atomic_load_relaxed(&s->child_head) != (jl_value_t*)jl_nothing)
+                        keep_weakproc = 1;
+                }
             }
             v = (jl_taggedvalue_t*)((char*)v + osize);
         }
@@ -1042,10 +1110,14 @@ static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_
         // pool object found on a task stack, including slots past lim_newpages on the
         // currently-active bump-pointer page. Those slots are unconditionally treated
         // as garbage by the sweep (line above: `(char*)v >= lim_newpages`), so
-        // freedall=1 is valid when this is the active newpages page.
-        assert(!freedall || lim_newpages < data + GC_PAGE_SZ);
+        // freedall=1 is valid when this is the active newpages page. A page whose
+        // has_weak_processing flag skipped the wholesale-free fast path can also
+        // legitimately turn out fully dead here (it is retained for this cycle -
+        // unlink writes may target it - and freed by the next sweep).
+        assert(!freedall || lim_newpages < data + GC_PAGE_SZ || has_weakproc);
         pg->has_marked = has_marked;
         pg->has_young = has_young;
+        pg->has_weak_processing = keep_weakproc;
         if (pfl_begin) {
             pg->fl_begin_offset = (char*)pfl_begin - data;
             pg->fl_end_offset = (char*)pfl - data;
@@ -3923,6 +3995,7 @@ void jl_gc_init(void)
 
     arraylist_new(&finalizer_list_marked, 0);
     arraylist_new(&to_finalize, 0);
+    arraylist_new(&big_weak_corpses, 0);
     jl_atomic_store_relaxed(&gc_heap_stats.heap_target, default_collect_interval);
     if (jl_options.hard_heap_limit != 0) {
         jl_atomic_store_relaxed(&gc_heap_stats.heap_target, jl_options.hard_heap_limit);

--- a/src/gc-stock.h
+++ b/src/gc-stock.h
@@ -119,6 +119,13 @@ typedef struct _jl_gc_pagemeta_t {
     // still be old dead objects in the page and `nold` and `prev_nold`
     // should be used to determine if the page needs to be swept
     uint8_t has_young;
+    // Whether any object requiring weak processing on death (see
+    // jl_gc_set_needs_weak_processing) was ever allocated in this page:
+    // such pages must not be freed wholesale when fully dead, and their
+    // dead cells must be inspected by the sweep so those objects get their
+    // processing (currently: linked cancellation token sources, see
+    // gc_is_dead_linked_cancel_source)
+    uint8_t has_weak_processing;
     // Number of old objects in the page
     uint16_t nold;
     // Number of old objects in the page at the end of the previous full sweep

--- a/src/gc-stock.h
+++ b/src/gc-stock.h
@@ -124,8 +124,11 @@ typedef struct _jl_gc_pagemeta_t {
     // such pages must not be freed wholesale when fully dead, and their
     // dead cells must be inspected by the sweep so those objects get their
     // processing (currently: linked cancellation token sources, see
-    // gc_is_dead_linked_cancel_source)
-    uint8_t has_weak_processing;
+    // gc_is_dead_linked_cancel_source). Atomic: mutators may set it
+    // concurrently for a shared parent's page; all other accesses happen
+    // inside the collection (relaxed suffices - the flag-setter's object
+    // publication, not the flag, carries the ordering)
+    _Atomic(uint8_t) has_weak_processing;
     // Number of old objects in the page
     uint16_t nold;
     // Number of old objects in the page at the end of the previous full sweep

--- a/src/gc-tls-common.h
+++ b/src/gc-tls-common.h
@@ -17,6 +17,15 @@ extern "C" {
 typedef struct {
     // variable for tracking weak references
     small_arraylist_t weak_refs;
+    // Only used by MMTk builds: registry of objects requiring weak
+    // processing on death (see jl_gc_set_needs_weak_processing) -
+    // currently cancellation token sources sitting on some parent's (weak,
+    // intrusive) child list. MMTk never visits individual dead objects, so
+    // it detects dead ones by scanning this flat registry after marking
+    // (see jl_gc_sweep_weak_processing). The stock GC needs no registry:
+    // its sweep visits every dead object's header anyway and detects them
+    // there, gated by a per-page flag.
+    small_arraylist_t weak_processing_list;
     // live tasks started on this thread
     // that are holding onto a stack from the pool
     small_arraylist_t live_tasks;

--- a/src/gc-tls-stock.h
+++ b/src/gc-tls-stock.h
@@ -59,6 +59,11 @@ typedef struct {
     _Atomic(size_t) gc_sweeps_requested;
     _Atomic(size_t) gc_stack_sweep_requested;
     arraylist_t sweep_objs;
+    // dead objects requiring weak processing (currently:
+    // dead-but-still-linked cancellation sources) found by this thread
+    // during the current sweep; processed (and the list drained) by
+    // sweep_weak_processing before the world restarts
+    small_arraylist_t weak_processing_objs;
 } jl_gc_tls_states_t;
 
 #ifdef __cplusplus

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -30,6 +30,7 @@
     XX(bottom_type, jl_value_t*) \
     XX(boundserror_type, jl_datatype_t*) \
     XX(builtin_type, jl_datatype_t*) \
+    XX(cancel_source_type, jl_datatype_t*) \
     XX(char_type, jl_datatype_t*) \
     XX(code_info_type, jl_datatype_t*) \
     XX(code_instance_type, jl_datatype_t*) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4161,28 +4161,35 @@ void jl_init_types(void) JL_GC_DISABLED
     ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_namedtuple_type))->layout = NULL;
     jl_namedtuple_typename = ntt->name;
 
+    // Variable-sized (see jl_cancel_source_t): the declared fields cover only
+    // the fixed part; `nparents` parent links follow them. The GCs
+    // special-case both the size and the scanning of this layout (the
+    // declared fields contain no boxed values as far as the field system is
+    // concerned - `child_head` is a weak reference the marker must not
+    // trace).
     jl_cancel_source_type = (jl_datatype_t*)
         jl_new_datatype(jl_symbol("CancellationTokenSource"), core, jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(5,
-                                        "parents",
-                                        "children",
+                        jl_perm_symsvec(4,
+                                        "child_head",
                                         "state",
-                                        "_lock",
-                                        "delivered"),
-                        jl_svec(5,
-                                jl_any_type,
-                                jl_any_type,
+                                        "delivered",
+                                        "nparents"),
+                        jl_svec(4,
+                                jl_any_type, // Union{Nothing, CancellationTokenSource}, weak
                                 jl_uint8_type,
                                 jl_uint8_type,
-                                jl_uint8_type),
+                                jl_uint16_type),
                         jl_emptysvec,
-                        0, 1, 5);
-    // Field 1 (parents) is const; fields 3-5 (state, _lock, delivered) are atomic
-    const static uint32_t cancel_source_constfields[1]  = { 0b00001 };
-    const static uint32_t cancel_source_atomicfields[1] = { 0b11100 };
+                        0, 1, 4);
+    // Field 4 (nparents) is const; fields 1-3 (child_head, state, delivered)
+    // are atomic
+    const static uint32_t cancel_source_constfields[1]  = { 0b1000 };
+    const static uint32_t cancel_source_atomicfields[1] = { 0b0111 };
     jl_cancel_source_type->name->constfields = cancel_source_constfields;
     jl_cancel_source_type->name->atomicfields = cancel_source_atomicfields;
+    XX(cancel_source);
+    assert(jl_datatype_size(jl_cancel_source_type) == sizeof(jl_cancel_source_t));
 
     jl_task_type = (jl_datatype_t*)
         jl_new_datatype(jl_symbol("Task"),

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4161,6 +4161,29 @@ void jl_init_types(void) JL_GC_DISABLED
     ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_namedtuple_type))->layout = NULL;
     jl_namedtuple_typename = ntt->name;
 
+    jl_cancel_source_type = (jl_datatype_t*)
+        jl_new_datatype(jl_symbol("CancellationTokenSource"), core, jl_any_type,
+                        jl_emptysvec,
+                        jl_perm_symsvec(5,
+                                        "parents",
+                                        "children",
+                                        "state",
+                                        "_lock",
+                                        "delivered"),
+                        jl_svec(5,
+                                jl_any_type,
+                                jl_any_type,
+                                jl_uint8_type,
+                                jl_uint8_type,
+                                jl_uint8_type),
+                        jl_emptysvec,
+                        0, 1, 5);
+    // Field 1 (parents) is const; fields 3-5 (state, _lock, delivered) are atomic
+    const static uint32_t cancel_source_constfields[1]  = { 0b00001 };
+    const static uint32_t cancel_source_atomicfields[1] = { 0b11100 };
+    jl_cancel_source_type->name->constfields = cancel_source_constfields;
+    jl_cancel_source_type->name->atomicfields = cancel_source_atomicfields;
+
     jl_task_type = (jl_datatype_t*)
         jl_new_datatype(jl_symbol("Task"),
                         NULL,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4170,22 +4170,19 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_cancel_source_type = (jl_datatype_t*)
         jl_new_datatype(jl_symbol("CancellationTokenSource"), core, jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(4,
+                        jl_perm_symsvec(3,
                                         "child_head",
                                         "state",
-                                        "delivered",
                                         "nparents"),
-                        jl_svec(4,
+                        jl_svec(3,
                                 jl_any_type, // Union{Nothing, CancellationTokenSource}, weak
-                                jl_uint8_type,
                                 jl_uint8_type,
                                 jl_uint16_type),
                         jl_emptysvec,
-                        0, 1, 4);
-    // Field 4 (nparents) is const; fields 1-3 (child_head, state, delivered)
-    // are atomic
-    const static uint32_t cancel_source_constfields[1]  = { 0b1000 };
-    const static uint32_t cancel_source_atomicfields[1] = { 0b0111 };
+                        0, 1, 3);
+    // Field 3 (nparents) is const; fields 1-2 (child_head, state) are atomic
+    const static uint32_t cancel_source_constfields[1]  = { 0b100 };
+    const static uint32_t cancel_source_atomicfields[1] = { 0b011 };
     jl_cancel_source_type->name->constfields = cancel_source_constfields;
     jl_cancel_source_type->name->atomicfields = cancel_source_atomicfields;
     XX(cancel_source);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4161,12 +4161,8 @@ void jl_init_types(void) JL_GC_DISABLED
     ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_namedtuple_type))->layout = NULL;
     jl_namedtuple_typename = ntt->name;
 
-    // Variable-sized (see jl_cancel_source_t): the declared fields cover only
-    // the fixed part; `nparents` parent links follow them. The GCs
-    // special-case both the size and the scanning of this layout (the
-    // declared fields contain no boxed values as far as the field system is
-    // concerned - `child_head` is a weak reference the marker must not
-    // trace).
+    // Variable-sized (see jl_cancel_source_t) - only the fixed fields are exposed to
+    // julia.
     jl_cancel_source_type = (jl_datatype_t*)
         jl_new_datatype(jl_symbol("CancellationTokenSource"), core, jl_any_type,
                         jl_emptysvec,

--- a/src/julia.h
+++ b/src/julia.h
@@ -1757,6 +1757,7 @@ static inline int jl_field_isconst(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 #define jl_is_mtable(v)      jl_typetagis(v,jl_methtable_type)
 #define jl_is_mcache(v)      jl_typetagis(v,jl_methcache_type)
 #define jl_is_task(v)        jl_typetagis(v,jl_task_tag<<4)
+#define jl_is_cancel_source(v) jl_typetagis(v,jl_cancel_source_type)
 #define jl_is_string(v)      jl_typetagis(v,jl_string_tag<<4)
 #define jl_is_cpointer(v)    jl_is_cpointer_type(jl_typeof(v))
 #define jl_is_pointer(v)     jl_is_cpointer_type(jl_typeof(v))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1116,6 +1116,7 @@ typedef struct {
     XX(quotenode) \
     XX(typeeq) \
     XX(typeegal) \
+    XX(cancel_source) \
     /* Add new tags here to keep existing builds ABI stable - we don't guarantee ABI \
        stability, but it'll help PkgEval to not break it unnecessarily */ \
     /* end of JL_SMALL_TYPEOF */
@@ -1757,7 +1758,7 @@ static inline int jl_field_isconst(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 #define jl_is_mtable(v)      jl_typetagis(v,jl_methtable_type)
 #define jl_is_mcache(v)      jl_typetagis(v,jl_methcache_type)
 #define jl_is_task(v)        jl_typetagis(v,jl_task_tag<<4)
-#define jl_is_cancel_source(v) jl_typetagis(v,jl_cancel_source_type)
+#define jl_is_cancel_source(v) jl_typetagis(v,jl_cancel_source_tag<<4)
 #define jl_is_string(v)      jl_typetagis(v,jl_string_tag<<4)
 #define jl_is_cpointer(v)    jl_is_cpointer_type(jl_typeof(v))
 #define jl_is_pointer(v)     jl_is_cpointer_type(jl_typeof(v))
@@ -2535,6 +2536,9 @@ struct _jl_handler_t {
 #define JL_TASK_STATE_FAILED   2
 
 JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t*, jl_value_t*, size_t) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t nparents) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_cancel_source_parent(jl_cancel_source_t *src, size_t i);
+JL_DLLEXPORT jl_value_t *jl_cancel_source_next_child(jl_cancel_source_t *parent, jl_cancel_source_t *child) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_switchto(jl_task_t **pt) JL_CANSAFEPOINT_ENTER_LEAVE;
 JL_DLLEXPORT int jl_set_task_tid(jl_task_t *task, int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_set_task_threadpoolid(jl_task_t *task, int8_t tpid) JL_NOTSAFEPOINT;

--- a/src/julia.h
+++ b/src/julia.h
@@ -2539,6 +2539,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t*, jl_value_t*, size_t) JL_CANSAFE
 JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t nparents) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_cancel_source_parent(jl_cancel_source_t *src, size_t i);
 JL_DLLEXPORT jl_value_t *jl_cancel_source_next_child(jl_cancel_source_t *parent, jl_cancel_source_t *child) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_cancel_source_relink(jl_cancel_source_t *src) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_switchto(jl_task_t **pt) JL_CANSAFEPOINT_ENTER_LEAVE;
 JL_DLLEXPORT int jl_set_task_tid(jl_task_t *task, int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_set_task_threadpoolid(jl_task_t *task, int8_t tpid) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -688,10 +688,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_alloc(jl_ptls_t ptls, size_t sz, void *ty) JL_CAN
 // Informs the collector that `v` (freshly allocated) requires weak
 // processing when it dies - collector-side bookkeeping beyond freeing the
 // memory, dispatched on the object's type (currently: unlinking a
-// cancellation token source from its parents' child lists). How the
-// collector finds such dead objects is implementation-defined: the stock GC
-// flags the page so its sweep inspects dead cells there; MMTk registers the
-// object for a post-mark registry scan.
+// cancellation token source from its parents' child lists).
 void jl_gc_set_needs_weak_processing(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPOINT;
 // Declare that `v` may be *written* by the GC's weak-processing pass in the
 // cycle in which it dies (e.g. a parent whose intrusive child list dead

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -693,6 +693,11 @@ JL_DLLEXPORT jl_value_t *jl_gc_alloc(jl_ptls_t ptls, size_t sz, void *ty) JL_CAN
 // flags the page so its sweep inspects dead cells there; MMTk registers the
 // object for a post-mark registry scan.
 void jl_gc_set_needs_weak_processing(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPOINT;
+// Declare that `v` may be *written* by the GC's weak-processing pass in the
+// cycle in which it dies (e.g. a parent whose intrusive child list dead
+// children splice themselves out of), so its memory must not be reclaimed
+// before that pass has run.
+void jl_gc_set_weak_processing_target(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPOINT;
 // On GCC, only inline when sz is constant
 #ifdef __GNUC__
 #  define jl_gc_alloc(ptls, sz, ty)  \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -685,6 +685,14 @@ static_assert(ARRAY_CACHE_ALIGN_THRESHOLD > GC_MAX_SZCLASS, "");
  * safepoints will be caught by the GC analyzer.
  */
 JL_DLLEXPORT jl_value_t *jl_gc_alloc(jl_ptls_t ptls, size_t sz, void *ty) JL_CANSAFEPOINT;
+// Informs the collector that `v` (freshly allocated) requires weak
+// processing when it dies - collector-side bookkeeping beyond freeing the
+// memory, dispatched on the object's type (currently: unlinking a
+// cancellation token source from its parents' child lists). How the
+// collector finds such dead objects is implementation-defined: the stock GC
+// flags the page so its sweep inspects dead cells there; MMTk registers the
+// object for a post-mark registry scan.
+void jl_gc_set_needs_weak_processing(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPOINT;
 // On GCC, only inline when sz is constant
 #ifdef __GNUC__
 #  define jl_gc_alloc(ptls, sz, ty)  \

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -232,29 +232,97 @@ typedef struct _jl_handler_t jl_handler_t;
 
 // Cancellation token source: a node in the level-triggered cancellation tree
 // (`Core.CancellationTokenSource`). Cancelling a node cancels its whole
-// subtree; the state is monotonic and never de-escalates. The layout must be
-// kept in sync with the registration in jltypes.c.
-typedef struct _jl_cancel_source_t {
+// subtree; the state is monotonic and never de-escalates.
+//
+// The object is variable-sized: the fixed fields below are followed by
+// `nparents` parent links (`jl_cancel_parent_link_t`). Together with the
+// per-node `child_head` field these links arrange the sources in a DAG,
+// with each node's children kept on intrusive singly-linked sibling lists:
+// node C is a child of P iff C has a link entry whose `parent` is P, and
+// that entry's `next` points to P's next child (the one attached before C).
+// Iterating P's children therefore starts at `P->child_head` and, at each
+// node, scans that node's link entries for the one belonging to P - a
+// linear scan, but child iteration only happens on the (slow) cancellation
+// path.
+//
+// GC treatment (the layout is special-cased in the collectors): the
+// `parent` half of each link is a strong reference - a child keeps its
+// parents alive, so that cancellation of a still-reachable ancestor always
+// reaches the whole subtree - and is const after construction, so lock-free
+// ancestor walks are safe. The child-list links (`child_head` and the
+// `next`/`pprev` fields of each link) are *weak*, with unlink-on-death
+// semantics rather than WeakRef's clear-on-death: a child stays linked for
+// exactly as long as it is reachable, and when it is collected the GC
+// unlinks it from each parent's sibling list before the world restarts
+// (stock GC: detected per-dead-object by the sweep, which reads every dead
+// cell's header anyway, and unlinked by sweep_weak_processing; MMTk:
+// detected by scanning a registry, see jl_gc_sweep_weak_processing). At any
+// mutator-observable point the lists therefore contain only live objects.
+// The lists are doubly linked in the hlist style - `pprev` points at
+// whichever slot currently points at this node (the parent's `child_head`
+// or the previous sibling's `next`) - so unlinking a dead source is O(1)
+// and the stock collector's total work is proportional to the number of
+// sources that actually died.
+//
+// Concurrency: the lists are lock-free. Mutators only ever *prepend* (at
+// construction, via CAS on `child_head`); removal happens only inside the
+// collector with the world stopped. `pprev` is written by the constructor
+// (its own entry, and the fix-up of the previous head's entry immediately
+// after the publishing CAS, with no intervening safepoint - so the
+// collector never observes a half-updated list) and read only by the
+// collector; cancellation walks follow `next` alone. The seq_cst ordering
+// dance between attaching (publish link, then read the parent's state) and
+// cancelling (write the state, then walk the links) is what makes
+// attachment level-triggered; see jl_new_cancel_source and `cancel!`.
+typedef struct _jl_cancel_source_t jl_cancel_source_t;
+
+typedef struct {
+    // Strong, const after construction.
+    jl_cancel_source_t *parent;
+    // Weak (unlinked by the GC): next sibling under `parent`;
+    // `jl_nothing`-terminated. Union{Nothing, CancellationTokenSource}.
+    _Atomic(jl_value_t*) next;
+    // Weak back-pointer: the slot through which this node is reachable on
+    // `parent`'s child list. Collector- and constructor-private.
+    _Atomic(jl_value_t*) *pprev;
+} jl_cancel_parent_link_t;
+
+struct _jl_cancel_source_t {
     JL_DATA_TYPE
-    // Graph links. `parents` - `nothing` (a root), a single parent source,
-    // or a SimpleVector of parent sources (a "linked" source, making the
-    // structure a DAG) - is const after construction, so lock-free ancestor
-    // walks (e.g. subtree-membership tests on the cancellation path) are
-    // safe. `children` - `nothing`, or a `Vector{WeakRef}` of child
-    // sources, guarded by this node's `_lock` - holds children *weakly*: a
-    // child stays linked for exactly as long as it is reachable (a token or
-    // a registered observer keeps it alive), and is pruned after it has
-    // been garbage collected.
-    jl_value_t *parents;     // Union{Nothing, CancellationTokenSource, SimpleVector}
-    jl_value_t *children;    // Union{Nothing, Vector{WeakRef}}
+    // Weak (spliced by the GC): most recently attached live child;
+    // `jl_nothing`-terminated. Union{Nothing, CancellationTokenSource}.
+    _Atomic(jl_value_t*) child_head;
     // 0x00 = live; (0x80 | sev) = cancelled at severity sev (0x0 SAFE,
     // 0x3 ABANDON_EXTERNAL, 0x4 ABANDON_ALL). Monotonic (CAS-max).
     _Atomic(uint8_t) state;
-    _Atomic(uint8_t) _lock;  // spinlock guarding `children`
     // Bitmask (1 << sev) of severities whose delivery some task observed;
     // feeds the ^C episode state machine.
     _Atomic(uint8_t) delivered;
-} jl_cancel_source_t;
+    // Number of parent links following the fixed fields. Const.
+    uint16_t nparents;
+    // jl_cancel_parent_link_t links[nparents];  (see jl_cancel_source_links)
+};
+
+// The fixed-field layout above must be kept in sync with the registration
+// in jltypes.c; the trailing links are invisible to the field system.
+static inline jl_cancel_parent_link_t *jl_cancel_source_links(jl_cancel_source_t *src) JL_NOTSAFEPOINT
+{
+    // The struct size is already pointer-aligned on all supported platforms.
+    return (jl_cancel_parent_link_t*)((char*)src + sizeof(jl_cancel_source_t));
+}
+
+// The link entry connecting `child` to `parent` (which must be one of its
+// parents).
+static inline jl_cancel_parent_link_t *jl_cancel_source_link(jl_cancel_source_t *child,
+                                                             jl_cancel_source_t *parent) JL_NOTSAFEPOINT
+{
+    jl_cancel_parent_link_t *links = jl_cancel_source_links(child);
+    for (size_t i = 0; i < child->nparents; i++) {
+        if (links[i].parent == parent)
+            return &links[i];
+    }
+    return NULL;
+}
 
 
 typedef struct _jl_task_t {

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -253,16 +253,7 @@ typedef struct _jl_handler_t jl_handler_t;
 // `next`/`pprev` fields of each link) are *weak*, with unlink-on-death
 // semantics rather than WeakRef's clear-on-death: a child stays linked for
 // exactly as long as it is reachable, and when it is collected the GC
-// unlinks it from each parent's sibling list before the world restarts
-// (stock GC: detected per-dead-object by the sweep, which reads every dead
-// cell's header anyway, and unlinked by sweep_weak_processing; MMTk:
-// detected by scanning a registry, see jl_gc_sweep_weak_processing). At any
-// mutator-observable point the lists therefore contain only live objects.
-// The lists are doubly linked in the hlist style - `pprev` points at
-// whichever slot currently points at this node (the parent's `child_head`
-// or the previous sibling's `next`) - so unlinking a dead source is O(1)
-// and the stock collector's total work is proportional to the number of
-// sources that actually died.
+// unlinks it from each parent's sibling list before the world restarts.
 //
 // Concurrency: the lists are lock-free. Mutators only ever *prepend* (at
 // construction, via CAS on `child_head`); removal happens only inside the

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -230,9 +230,9 @@ typedef struct _jl_excstack_t jl_excstack_t;
 
 typedef struct _jl_handler_t jl_handler_t;
 
-// Cancellation token source: a node in the level-triggered cancellation tree
-// (`Core.CancellationTokenSource`). Cancelling a node cancels its whole
-// subtree; the state is monotonic and never de-escalates.
+// Cancellation token source: a node in the level-triggered cancellation
+// DAG (`Core.CancellationTokenSource`). Cancelling a node cancels all of
+// its descendants; the state is monotonic and never de-escalates.
 //
 // The object is variable-sized: the fixed fields below are followed by
 // `nparents` parent links (`jl_cancel_parent_link_t`). Together with the
@@ -248,7 +248,7 @@ typedef struct _jl_handler_t jl_handler_t;
 // GC treatment (the layout is special-cased in the collectors): the
 // `parent` half of each link is a strong reference - a child keeps its
 // parents alive, so that cancellation of a still-reachable ancestor always
-// reaches the whole subtree - and is const after construction, so lock-free
+// reaches all its descendants - and is const after construction, so lock-free
 // ancestor walks are safe. The child-list links (`child_head` and the
 // `next`/`pprev` fields of each link) are *weak*, with unlink-on-death
 // semantics rather than WeakRef's clear-on-death: a child stays linked for
@@ -292,8 +292,9 @@ struct _jl_cancel_source_t {
     // Weak (spliced by the GC): most recently attached live child;
     // `jl_nothing`-terminated. Union{Nothing, CancellationTokenSource}.
     _Atomic(jl_value_t*) child_head;
-    // 0x00 = live; (0x80 | sev) = cancelled at severity sev (0x0 SAFE,
-    // 0x3 ABANDON_EXTERNAL, 0x4 ABANDON_ALL). Monotonic (CAS-max).
+    // 0x00 = uncancelled; otherwise the (nonzero) severity at which the
+    // source is cancelled (0x1 SAFE, 0x3 ABANDON_EXTERNAL, 0x4 ABANDON_ALL).
+    // Monotonic (CAS-max).
     _Atomic(uint8_t) state;
     // Number of parent links following the fixed fields. Const.
     uint16_t nparents;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -230,6 +230,33 @@ typedef struct _jl_excstack_t jl_excstack_t;
 
 typedef struct _jl_handler_t jl_handler_t;
 
+// Cancellation token source: a node in the level-triggered cancellation tree
+// (`Core.CancellationTokenSource`). Cancelling a node cancels its whole
+// subtree; the state is monotonic and never de-escalates. The layout must be
+// kept in sync with the registration in jltypes.c.
+typedef struct _jl_cancel_source_t {
+    JL_DATA_TYPE
+    // Graph links. `parents` - `nothing` (a root), a single parent source,
+    // or a SimpleVector of parent sources (a "linked" source, making the
+    // structure a DAG) - is const after construction, so lock-free ancestor
+    // walks (e.g. subtree-membership tests on the cancellation path) are
+    // safe. `children` - `nothing`, or a `Vector{WeakRef}` of child
+    // sources, guarded by this node's `_lock` - holds children *weakly*: a
+    // child stays linked for exactly as long as it is reachable (a token or
+    // a registered observer keeps it alive), and is pruned after it has
+    // been garbage collected.
+    jl_value_t *parents;     // Union{Nothing, CancellationTokenSource, SimpleVector}
+    jl_value_t *children;    // Union{Nothing, Vector{WeakRef}}
+    // 0x00 = live; (0x80 | sev) = cancelled at severity sev (0x0 SAFE,
+    // 0x3 ABANDON_EXTERNAL, 0x4 ABANDON_ALL). Monotonic (CAS-max).
+    _Atomic(uint8_t) state;
+    _Atomic(uint8_t) _lock;  // spinlock guarding `children`
+    // Bitmask (1 << sev) of severities whose delivery some task observed;
+    // feeds the ^C episode state machine.
+    _Atomic(uint8_t) delivered;
+} jl_cancel_source_t;
+
+
 typedef struct _jl_task_t {
     JL_DATA_TYPE
     jl_value_t *next; // invasive linked list for scheduler

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -295,9 +295,6 @@ struct _jl_cancel_source_t {
     // 0x00 = live; (0x80 | sev) = cancelled at severity sev (0x0 SAFE,
     // 0x3 ABANDON_EXTERNAL, 0x4 ABANDON_ALL). Monotonic (CAS-max).
     _Atomic(uint8_t) state;
-    // Bitmask (1 << sev) of severities whose delivery some task observed;
-    // feeds the ^C episode state machine.
-    _Atomic(uint8_t) delivered;
     // Number of parent links following the fixed fields. Const.
     uint16_t nparents;
     // jl_cancel_parent_link_t links[nparents];  (see jl_cancel_source_links)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -976,6 +976,11 @@ static void jl_queue_for_serialization_(jl_serializer_state *s, jl_value_t *v, i
     if (t == jl_task_type) {
         jl_error("Task cannot be serialized");
     }
+    if (t == jl_cancel_source_type) {
+        // Variable-sized, with weak intrusive child lists the serializer
+        // does not know how to relink on load.
+        jl_error("CancellationTokenSource cannot be serialized");
+    }
     if (s->incremental && needs_uniquing(v, s->query_cache) && t == jl_binding_type) {
         jl_binding_t *b = (jl_binding_t*)v;
         if (b->globalref == NULL)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -885,10 +885,7 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
         jl_queue_module_for_serialization(s, (jl_module_t*)v);
     }
     else if (jl_is_cancel_source(v)) {
-        // Only the (strong) parent links are serialized; the weak child
-        // lists (`child_head` and the link entries' `next`/`pprev`) are
-        // dropped and rebuilt on load by relinking each source under its
-        // parents as if newly allocated (see jl_cancel_source_relink).
+        // Write parents - child lists are reconstruct at load time.
         jl_cancel_source_t *cs = (jl_cancel_source_t*)v;
         jl_cancel_parent_link_t *links = jl_cancel_source_links(cs);
         for (size_t i = 0; i < cs->nparents; i++)
@@ -1600,12 +1597,7 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
             write_uint8(f, '\0'); // null-terminated strings for easier C-compatibility
         }
         else if (jl_is_cancel_source(v)) {
-            // Variable-sized: the fixed fields are followed by `nparents`
-            // {parent, next, pprev} link entries. The weak child links
-            // (`child_head` and the `next`/`pprev` slots) are reset rather
-            // than serialized: on load the source is relinked under its
-            // parents as if newly allocated (see the fixup below), which
-            // also re-inherits their current cancellation state.
+            // Variable-sized. Store parents, reset children (reconstructed on load).
             assert(f == s->s);
             jl_cancel_source_t *cs = (jl_cancel_source_t*)v;
             write_pointerfield(s, jl_nothing); // child_head (weak; reset)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1610,9 +1610,9 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
             jl_cancel_source_t *cs = (jl_cancel_source_t*)v;
             write_pointerfield(s, jl_nothing); // child_head (weak; reset)
             write_uint8(f, jl_atomic_load_relaxed(&cs->state));
-            write_uint8(f, jl_atomic_load_relaxed(&cs->delivered));
+            write_padding(f, offsetof(jl_cancel_source_t, nparents) - sizeof(void*) - sizeof(uint8_t));
             ios_write(f, (char*)&cs->nparents, sizeof(uint16_t));
-            write_padding(f, sizeof(jl_cancel_source_t) - sizeof(void*) - 2 * sizeof(uint8_t) - sizeof(uint16_t));
+            write_padding(f, sizeof(jl_cancel_source_t) - offsetof(jl_cancel_source_t, nparents) - sizeof(uint16_t));
             jl_cancel_parent_link_t *links = jl_cancel_source_links(cs);
             for (size_t i = 0; i < cs->nparents; i++) {
                 write_pointerfield(s, (jl_value_t*)links[i].parent);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -884,6 +884,16 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
     else if (jl_is_module(v)) {
         jl_queue_module_for_serialization(s, (jl_module_t*)v);
     }
+    else if (jl_is_cancel_source(v)) {
+        // Only the (strong) parent links are serialized; the weak child
+        // lists (`child_head` and the link entries' `next`/`pprev`) are
+        // dropped and rebuilt on load by relinking each source under its
+        // parents as if newly allocated (see jl_cancel_source_relink).
+        jl_cancel_source_t *cs = (jl_cancel_source_t*)v;
+        jl_cancel_parent_link_t *links = jl_cancel_source_links(cs);
+        for (size_t i = 0; i < cs->nparents; i++)
+            jl_queue_for_serialization_(s, (jl_value_t*)links[i].parent, 1, immediate);
+    }
     else if (layout->nfields > 0) {
         if (jl_options.trim) {
             if (jl_is_method(v)) {
@@ -975,11 +985,6 @@ static void jl_queue_for_serialization_(jl_serializer_state *s, jl_value_t *v, i
     // check early from errors, so we have a little bit of contextual state for debugging them
     if (t == jl_task_type) {
         jl_error("Task cannot be serialized");
-    }
-    if (t == jl_cancel_source_type) {
-        // Variable-sized, with weak intrusive child lists the serializer
-        // does not know how to relink on load.
-        jl_error("CancellationTokenSource cannot be serialized");
     }
     if (s->incremental && needs_uniquing(v, s->query_cache) && t == jl_binding_type) {
         jl_binding_t *b = (jl_binding_t*)v;
@@ -1593,6 +1598,29 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
         else if (jl_is_string(v)) {
             ios_write(f, (char*)v, sizeof(void*) + jl_string_len(v));
             write_uint8(f, '\0'); // null-terminated strings for easier C-compatibility
+        }
+        else if (jl_is_cancel_source(v)) {
+            // Variable-sized: the fixed fields are followed by `nparents`
+            // {parent, next, pprev} link entries. The weak child links
+            // (`child_head` and the `next`/`pprev` slots) are reset rather
+            // than serialized: on load the source is relinked under its
+            // parents as if newly allocated (see the fixup below), which
+            // also re-inherits their current cancellation state.
+            assert(f == s->s);
+            jl_cancel_source_t *cs = (jl_cancel_source_t*)v;
+            write_pointerfield(s, jl_nothing); // child_head (weak; reset)
+            write_uint8(f, jl_atomic_load_relaxed(&cs->state));
+            write_uint8(f, jl_atomic_load_relaxed(&cs->delivered));
+            ios_write(f, (char*)&cs->nparents, sizeof(uint16_t));
+            write_padding(f, sizeof(jl_cancel_source_t) - sizeof(void*) - 2 * sizeof(uint8_t) - sizeof(uint16_t));
+            jl_cancel_parent_link_t *links = jl_cancel_source_links(cs);
+            for (size_t i = 0; i < cs->nparents; i++) {
+                write_pointerfield(s, (jl_value_t*)links[i].parent);
+                write_pointerfield(s, jl_nothing); // next (weak; reset)
+                write_pointer(f);                  // pprev (reset; set by relink)
+            }
+            // relink under the parents on load
+            arraylist_push(&s->fixup_objs, (void*)reloc_offset);
         }
         else if (jl_is_foreign_type(t) == 1) {
             abort(); // unreachable
@@ -4222,6 +4250,11 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                     }
                 }
             }
+        }
+        else if (jl_is_cancel_source(obj)) {
+            // relink under its parents, as if newly allocated (the weak
+            // child links were dropped at serialization)
+            jl_cancel_source_relink((jl_cancel_source_t*)obj);
         }
         else {
             abort();

--- a/src/task.c
+++ b/src/task.c
@@ -1634,15 +1634,15 @@ JL_DLLEXPORT int8_t jl_get_task_threadpoolid(jl_task_t *t)
 
 // cancellation token sources -----------------------------------------------
 
-// CAS-max the source's state to (0x80 | sev); returns whether the state was
-// raised. Mirrors `Base._raise_state!`.
+// CAS-max the source's state to `sev` (a nonzero severity); returns whether
+// the state was raised. Mirrors `Base._raise_state!`.
 static int cancel_source_raise_state(jl_cancel_source_t *src, uint8_t sev) JL_NOTSAFEPOINT
 {
     uint8_t old = jl_atomic_load_relaxed(&src->state);
     while (1) {
-        if (old != 0 && (old & 0x3f) >= sev)
+        if (old >= sev)
             return 0;
-        if (jl_atomic_cmpswap(&src->state, &old, (uint8_t)(0x80 | sev)))
+        if (jl_atomic_cmpswap(&src->state, &old, sev))
             return 1;
     }
 }
@@ -1678,18 +1678,14 @@ static void cancel_source_attach(jl_cancel_source_t *src) JL_NOTSAFEPOINT
             hl->pprev = &links[i].next;
         }
         // Level-triggered attachment: the seq_cst publication above and the
-        // seq_cst load below pair with `cancel!`'s (state write; fence;
-        // child_head read) so that either the canceller's walk observes this
-        // node, or this load observes the cancelled state.
+        // seq_cst load below pair with the walk's (seq_cst state access;
+        // child_head read) so that either the canceller's walk observes
+        // this node, or this load observes the cancelled state.
         uint8_t pst = jl_atomic_load(&p->state);
-        if (pst != 0) {
-            cancelled = 1;
-            uint8_t psev = pst & 0x3f;
-            if (psev > sev)
-                sev = psev;
-        }
+        if (pst > sev)
+            sev = pst;
     }
-    if (cancelled)
+    if (sev != 0)
         cancel_source_raise_state(src, sev);
 }
 
@@ -1773,7 +1769,7 @@ static void cancel_source_propagate_state(jl_cancel_source_t *src) JL_NOTSAFEPOI
     ptrhash_put(&visited, src, (void*)1);
     while (wl.len > 0) {
         jl_cancel_source_t *n = (jl_cancel_source_t*)wl.items[--wl.len];
-        uint8_t sev = jl_atomic_load(&n->state) & 0x3f;
+        uint8_t sev = jl_atomic_load(&n->state);
         jl_value_t *c = jl_atomic_load(&n->child_head);
         while (c != (jl_value_t*)jl_nothing) {
             jl_cancel_source_t *cs = (jl_cancel_source_t*)c;

--- a/src/task.c
+++ b/src/task.c
@@ -1647,6 +1647,52 @@ static int cancel_source_raise_state(jl_cancel_source_t *src, uint8_t sev) JL_NO
     }
 }
 
+// Link `src` - whose link entries have `parent` filled in and `next`/`pprev`
+// reset - into each parent's (intrusive, weak) child list and inherit the
+// parents' cancellation state: a node attached under an already-cancelled
+// parent is born cancelled, at the highest severity among its parents.
+// Shared between construction and image reload.
+static void cancel_source_attach(jl_cancel_source_t *src) JL_NOTSAFEPOINT
+{
+    jl_cancel_parent_link_t *links = jl_cancel_source_links(src);
+    size_t np = src->nparents;
+    int cancelled = 0;
+    uint8_t sev = 0;
+    for (size_t i = 0; i < np; i++) {
+        jl_cancel_source_t *p = links[i].parent;
+        // Prepend to p's child list. No write barrier: the edge is weak and
+        // never traced.
+        links[i].pprev = &p->child_head;
+        jl_value_t *head = jl_atomic_load_relaxed(&p->child_head);
+        while (1) {
+            jl_atomic_store_relaxed(&links[i].next, head);
+            if (jl_atomic_cmpswap(&p->child_head, &head, (jl_value_t*)src))
+                break;
+        }
+        if (head != jl_nothing) {
+            // Fix the displaced head's back-pointer. Only this attacher may
+            // write it (the CAS made us the unique predecessor), and no
+            // safepoint separates the CAS from this store.
+            jl_cancel_parent_link_t *hl = jl_cancel_source_link((jl_cancel_source_t*)head, p);
+            assert(hl != NULL);
+            hl->pprev = &links[i].next;
+        }
+        // Level-triggered attachment: the seq_cst publication above and the
+        // seq_cst load below pair with `cancel!`'s (state write; fence;
+        // child_head read) so that either the canceller's walk observes this
+        // node, or this load observes the cancelled state.
+        uint8_t pst = jl_atomic_load(&p->state);
+        if (pst != 0) {
+            cancelled = 1;
+            uint8_t psev = pst & 0x3f;
+            if (psev > sev)
+                sev = psev;
+        }
+    }
+    if (cancelled)
+        cancel_source_raise_state(src, sev);
+}
+
 // Create a new cancellation token source underneath the given (distinct)
 // parent sources - none makes a root - and link it into each parent's
 // (intrusive, weak) child list. The child inherits the parents'
@@ -1694,44 +1740,23 @@ JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
     // No safepoint is permitted from here to the return: the collector's
     // unlink pass must never observe a registered-but-unpublished (or
     // published-but-unregistered) node or a half-updated (`pprev` not yet
-    // fixed up) list, and the `next` values staged by the CAS loop below
-    // are weak references that a collection could invalidate.
-    int cancelled = 0;
-    uint8_t sev = 0;
-    for (size_t i = 0; i < np; i++) {
-        jl_cancel_source_t *p = links[i].parent;
-        // Prepend to p's child list. No write barrier: the edge is weak and
-        // never traced.
-        links[i].pprev = &p->child_head;
-        jl_value_t *head = jl_atomic_load_relaxed(&p->child_head);
-        while (1) {
-            jl_atomic_store_relaxed(&links[i].next, head);
-            if (jl_atomic_cmpswap(&p->child_head, &head, (jl_value_t*)src))
-                break;
-        }
-        if (head != jl_nothing) {
-            // Fix the displaced head's back-pointer. Only this constructor
-            // may write it (the CAS made us the unique predecessor), and no
-            // safepoint separates the CAS from this store.
-            jl_cancel_parent_link_t *hl = jl_cancel_source_link((jl_cancel_source_t*)head, p);
-            assert(hl != NULL);
-            hl->pprev = &links[i].next;
-        }
-        // Level-triggered attachment: the seq_cst publication above and the
-        // seq_cst load below pair with `cancel!`'s (state write; fence;
-        // child_head read) so that either the canceller's walk observes this
-        // node, or this load observes the cancelled state.
-        uint8_t pst = jl_atomic_load(&p->state);
-        if (pst != 0) {
-            cancelled = 1;
-            uint8_t psev = pst & 0x3f;
-            if (psev > sev)
-                sev = psev;
-        }
-    }
-    if (cancelled)
-        cancel_source_raise_state(src, sev);
+    // fixed up) list, and the `next` values staged by the CAS loops in
+    // cancel_source_attach are weak references that a collection could
+    // invalidate.
+    cancel_source_attach(src);
     return (jl_value_t*)src;
+}
+
+// Re-attach a deserialized (image-resident) cancellation source to its
+// parents, exactly as if it had just been constructed: its serialized
+// child links were dropped by the serializer, and its parents' *current*
+// cancellation state must be (re)inherited - a parent may have been
+// cancelled between serialization and load. Image objects are never
+// collected, so unlike jl_new_cancel_source there is no sweep-support
+// registration.
+JL_DLLEXPORT void jl_cancel_source_relink(jl_cancel_source_t *src)
+{
+    cancel_source_attach(src);
 }
 
 // The i-th (0-based) parent of `src` (a strong, const link).

--- a/src/task.c
+++ b/src/task.c
@@ -1756,30 +1756,39 @@ JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
 // may re-attach to `src` *before* `src` itself is relinked - and thereby
 // miss a cancelled state that `src` only inherits during its own relink
 // (from an already-cancelled parent). Mirrors `Base._cancel_walk!`: each
-// node's children are advanced to (at least) the node's own severity,
-// recursing only where a state was actually raised (which bounds the walk
-// on reconverging graphs).
+// node's children are advanced to (at least) the node's own severity, and
+// the traversal is bounded by a visited set rather than by who won the
+// state transition - a concurrent cancel! that raised a node may never
+// finish visiting that node's descendants, so a lost CAS must not prune
+// the walk.
 static void cancel_source_propagate_state(jl_cancel_source_t *src) JL_NOTSAFEPOINT
 {
     if (jl_atomic_load_relaxed(&src->state) == 0)
         return;
+    htable_t visited;
+    htable_new(&visited, 0);
     arraylist_t wl;
     arraylist_new(&wl, 0);
     arraylist_push(&wl, src);
+    ptrhash_put(&visited, src, (void*)1);
     while (wl.len > 0) {
         jl_cancel_source_t *n = (jl_cancel_source_t*)wl.items[--wl.len];
         uint8_t sev = jl_atomic_load(&n->state) & 0x3f;
         jl_value_t *c = jl_atomic_load(&n->child_head);
         while (c != (jl_value_t*)jl_nothing) {
             jl_cancel_source_t *cs = (jl_cancel_source_t*)c;
-            if (cancel_source_raise_state(cs, sev))
+            cancel_source_raise_state(cs, sev);
+            if (ptrhash_get(&visited, cs) == HT_NOTFOUND) {
+                ptrhash_put(&visited, cs, (void*)1);
                 arraylist_push(&wl, cs);
+            }
             jl_cancel_parent_link_t *link = jl_cancel_source_link(cs, n);
             assert(link != NULL);
             c = jl_atomic_load(&link->next);
         }
     }
     arraylist_free(&wl);
+    htable_free(&visited);
 }
 
 // Re-attach a deserialized (image-resident) cancellation source to its

--- a/src/task.c
+++ b/src/task.c
@@ -1726,7 +1726,6 @@ JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
     }
     jl_atomic_store_relaxed(&src->child_head, jl_nothing);
     jl_atomic_store_relaxed(&src->state, 0);
-    jl_atomic_store_relaxed(&src->delivered, 0);
     src->nparents = (uint16_t)np;
     // Initialize every link entry before publishing the node under *any*
     // parent: a concurrent cancellation walk that reaches the node through

--- a/src/task.c
+++ b/src/task.c
@@ -1656,7 +1656,6 @@ static void cancel_source_attach(jl_cancel_source_t *src) JL_NOTSAFEPOINT
 {
     jl_cancel_parent_link_t *links = jl_cancel_source_links(src);
     size_t np = src->nparents;
-    int cancelled = 0;
     uint8_t sev = 0;
     for (size_t i = 0; i < np; i++) {
         jl_cancel_source_t *p = links[i].parent;

--- a/src/task.c
+++ b/src/task.c
@@ -1649,8 +1649,7 @@ static int cancel_source_raise_state(jl_cancel_source_t *src, uint8_t sev) JL_NO
 
 // Link `src` - whose link entries have `parent` filled in and `next`/`pprev`
 // reset - into each parent's (intrusive, weak) child list and inherit the
-// parents' cancellation state: a node attached under an already-cancelled
-// parent is born cancelled, at the highest severity among its parents.
+// parents' cancellation state.
 // Shared between construction and image reload.
 static void cancel_source_attach(jl_cancel_source_t *src) JL_NOTSAFEPOINT
 {
@@ -1689,10 +1688,7 @@ static void cancel_source_attach(jl_cancel_source_t *src) JL_NOTSAFEPOINT
 }
 
 // Create a new cancellation token source underneath the given (distinct)
-// parent sources - none makes a root - and link it into each parent's
-// (intrusive, weak) child list. The child inherits the parents'
-// cancellation state: a node attached under an already-cancelled parent is
-// born cancelled, at the highest severity among its parents.
+// parent sources - none makes a root.
 JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
 {
     jl_task_t *ct = jl_current_task;
@@ -1730,32 +1726,20 @@ JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
     // Initialize every link entry before publishing the node under *any*
     // parent: a concurrent cancellation walk that reaches the node through
     // one parent scans all of its entries.
+    // N.B.: No safepoints from this point until return - the source is an inconsistent
+    // state.
     jl_cancel_parent_link_t *links = jl_cancel_source_links(src);
     for (size_t i = 0; i < np; i++) {
         links[i].parent = (jl_cancel_source_t*)parents[i];
         jl_atomic_store_relaxed(&links[i].next, jl_nothing);
         links[i].pprev = NULL;
     }
-    // No safepoint is permitted from here to the return: the collector's
-    // unlink pass must never observe a registered-but-unpublished (or
-    // published-but-unregistered) node or a half-updated (`pprev` not yet
-    // fixed up) list, and the `next` values staged by the CAS loops in
-    // cancel_source_attach are weak references that a collection could
-    // invalidate.
     cancel_source_attach(src);
     return (jl_value_t*)src;
 }
 
 // Push a (re)inherited cancelled state down `src`'s already-attached
-// children. Image fixups relink sources in no particular order, so a child
-// may re-attach to `src` *before* `src` itself is relinked - and thereby
-// miss a cancelled state that `src` only inherits during its own relink
-// (from an already-cancelled parent). Mirrors `Base._cancel_walk!`: each
-// node's children are advanced to (at least) the node's own severity, and
-// the traversal is bounded by a visited set rather than by who won the
-// state transition - a concurrent cancel! that raised a node may never
-// finish visiting that node's descendants, so a lost CAS must not prune
-// the walk.
+// children.
 static void cancel_source_propagate_state(jl_cancel_source_t *src) JL_NOTSAFEPOINT
 {
     if (jl_atomic_load_relaxed(&src->state) == 0)
@@ -1786,14 +1770,6 @@ static void cancel_source_propagate_state(jl_cancel_source_t *src) JL_NOTSAFEPOI
     htable_free(&visited);
 }
 
-// Re-attach a deserialized (image-resident) cancellation source to its
-// parents, exactly as if it had just been constructed: its serialized
-// child links were dropped by the serializer, and its parents' *current*
-// cancellation state must be (re)inherited - a parent may have been
-// cancelled between serialization and load. A state raised this way is
-// propagated down any children that re-attached before us (fixup order is
-// arbitrary). Image objects are never collected, so unlike
-// jl_new_cancel_source there is no sweep-support registration.
 JL_DLLEXPORT void jl_cancel_source_relink(jl_cancel_source_t *src) JL_NOTSAFEPOINT
 {
     cancel_source_attach(src);

--- a/src/task.c
+++ b/src/task.c
@@ -1632,6 +1632,127 @@ JL_DLLEXPORT int8_t jl_get_task_threadpoolid(jl_task_t *t)
 }
 
 
+// cancellation token sources -----------------------------------------------
+
+// CAS-max the source's state to (0x80 | sev); returns whether the state was
+// raised. Mirrors `Base._raise_state!`.
+static int cancel_source_raise_state(jl_cancel_source_t *src, uint8_t sev) JL_NOTSAFEPOINT
+{
+    uint8_t old = jl_atomic_load_relaxed(&src->state);
+    while (1) {
+        if (old != 0 && (old & 0x3f) >= sev)
+            return 0;
+        if (jl_atomic_cmpswap(&src->state, &old, (uint8_t)(0x80 | sev)))
+            return 1;
+    }
+}
+
+// Create a new cancellation token source underneath the given (distinct)
+// parent sources - none makes a root - and link it into each parent's
+// (intrusive, weak) child list. The child inherits the parents'
+// cancellation state: a node attached under an already-cancelled parent is
+// born cancelled, at the highest severity among its parents.
+JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
+{
+    jl_task_t *ct = jl_current_task;
+    if (np > UINT16_MAX)
+        jl_error("CancellationTokenSource: too many parents");
+    for (size_t i = 0; i < np; i++) {
+        jl_value_t *p = parents[i];
+        if (!jl_is_cancel_source(p))
+            jl_type_error("CancellationTokenSource", (jl_value_t*)jl_cancel_source_type, p);
+        // Duplicate parents would create two link entries whose `parent`
+        // halves are identical, breaking the sibling-list traversal (which
+        // locates the entry by scanning for the parent).
+        for (size_t j = 0; j < i; j++) {
+            if (parents[j] == p)
+                jl_error("CancellationTokenSource: duplicate parent");
+        }
+    }
+    jl_cancel_source_t *src = (jl_cancel_source_t*)jl_gc_alloc(
+        ct->ptls, sizeof(jl_cancel_source_t) + np * sizeof(jl_cancel_parent_link_t),
+        jl_cancel_source_type);
+    jl_set_typetagof(src, jl_cancel_source_tag, 0);
+    if (np > 0) {
+        // a linked source must be unlinked from its parents' sibling lists
+        // when it dies (a root is never on any list and needs nothing)
+        jl_gc_set_needs_weak_processing(ct->ptls, (jl_value_t*)src);
+    }
+    jl_atomic_store_relaxed(&src->child_head, jl_nothing);
+    jl_atomic_store_relaxed(&src->state, 0);
+    jl_atomic_store_relaxed(&src->delivered, 0);
+    src->nparents = (uint16_t)np;
+    // Initialize every link entry before publishing the node under *any*
+    // parent: a concurrent cancellation walk that reaches the node through
+    // one parent scans all of its entries.
+    jl_cancel_parent_link_t *links = jl_cancel_source_links(src);
+    for (size_t i = 0; i < np; i++) {
+        links[i].parent = (jl_cancel_source_t*)parents[i];
+        jl_atomic_store_relaxed(&links[i].next, jl_nothing);
+        links[i].pprev = NULL;
+    }
+    // No safepoint is permitted from here to the return: the collector's
+    // unlink pass must never observe a registered-but-unpublished (or
+    // published-but-unregistered) node or a half-updated (`pprev` not yet
+    // fixed up) list, and the `next` values staged by the CAS loop below
+    // are weak references that a collection could invalidate.
+    int cancelled = 0;
+    uint8_t sev = 0;
+    for (size_t i = 0; i < np; i++) {
+        jl_cancel_source_t *p = links[i].parent;
+        // Prepend to p's child list. No write barrier: the edge is weak and
+        // never traced.
+        links[i].pprev = &p->child_head;
+        jl_value_t *head = jl_atomic_load_relaxed(&p->child_head);
+        while (1) {
+            jl_atomic_store_relaxed(&links[i].next, head);
+            if (jl_atomic_cmpswap(&p->child_head, &head, (jl_value_t*)src))
+                break;
+        }
+        if (head != jl_nothing) {
+            // Fix the displaced head's back-pointer. Only this constructor
+            // may write it (the CAS made us the unique predecessor), and no
+            // safepoint separates the CAS from this store.
+            jl_cancel_parent_link_t *hl = jl_cancel_source_link((jl_cancel_source_t*)head, p);
+            assert(hl != NULL);
+            hl->pprev = &links[i].next;
+        }
+        // Level-triggered attachment: the seq_cst publication above and the
+        // seq_cst load below pair with `cancel!`'s (state write; fence;
+        // child_head read) so that either the canceller's walk observes this
+        // node, or this load observes the cancelled state.
+        uint8_t pst = jl_atomic_load(&p->state);
+        if (pst != 0) {
+            cancelled = 1;
+            uint8_t psev = pst & 0x3f;
+            if (psev > sev)
+                sev = psev;
+        }
+    }
+    if (cancelled)
+        cancel_source_raise_state(src, sev);
+    return (jl_value_t*)src;
+}
+
+// The i-th (0-based) parent of `src` (a strong, const link).
+JL_DLLEXPORT jl_value_t *jl_cancel_source_parent(jl_cancel_source_t *src, size_t i)
+{
+    if (i >= src->nparents)
+        jl_bounds_error_int((jl_value_t*)src, i + 1);
+    return (jl_value_t*)jl_cancel_source_links(src)[i].parent;
+}
+
+// The sibling after `child` on `parent`'s child list (`nothing` at the
+// end). `child` must currently be a child of `parent`.
+JL_DLLEXPORT jl_value_t *jl_cancel_source_next_child(jl_cancel_source_t *parent, jl_cancel_source_t *child)
+{
+    jl_cancel_parent_link_t *link = jl_cancel_source_link(child, parent);
+    if (link == NULL)
+        jl_error("CancellationTokenSource: not a child of the given parent");
+    return jl_atomic_load(&link->next);
+}
+
+
 #ifdef _OS_WINDOWS_
 #if defined(_CPU_X86_)
 extern DWORD32 __readgsdword(int);

--- a/src/task.c
+++ b/src/task.c
@@ -1723,6 +1723,11 @@ JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
         // a linked source must be unlinked from its parents' sibling lists
         // when it dies (a root is never on any list and needs nothing)
         jl_gc_set_needs_weak_processing(ct->ptls, (jl_value_t*)src);
+        // and the unlink writes into each parent's `child_head`/sibling
+        // slots, so a parent that dies in the same cycle as its children
+        // must keep its memory until the unlink pass has run
+        for (size_t i = 0; i < np; i++)
+            jl_gc_set_weak_processing_target(ct->ptls, parents[i]);
     }
     jl_atomic_store_relaxed(&src->child_head, jl_nothing);
     jl_atomic_store_relaxed(&src->state, 0);
@@ -1746,16 +1751,49 @@ JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
     return (jl_value_t*)src;
 }
 
+// Push a (re)inherited cancelled state down `src`'s already-attached
+// children. Image fixups relink sources in no particular order, so a child
+// may re-attach to `src` *before* `src` itself is relinked - and thereby
+// miss a cancelled state that `src` only inherits during its own relink
+// (from an already-cancelled parent). Mirrors `Base._cancel_walk!`: each
+// node's children are advanced to (at least) the node's own severity,
+// recursing only where a state was actually raised (which bounds the walk
+// on reconverging graphs).
+static void cancel_source_propagate_state(jl_cancel_source_t *src) JL_NOTSAFEPOINT
+{
+    if (jl_atomic_load_relaxed(&src->state) == 0)
+        return;
+    arraylist_t wl;
+    arraylist_new(&wl, 0);
+    arraylist_push(&wl, src);
+    while (wl.len > 0) {
+        jl_cancel_source_t *n = (jl_cancel_source_t*)wl.items[--wl.len];
+        uint8_t sev = jl_atomic_load(&n->state) & 0x3f;
+        jl_value_t *c = jl_atomic_load(&n->child_head);
+        while (c != (jl_value_t*)jl_nothing) {
+            jl_cancel_source_t *cs = (jl_cancel_source_t*)c;
+            if (cancel_source_raise_state(cs, sev))
+                arraylist_push(&wl, cs);
+            jl_cancel_parent_link_t *link = jl_cancel_source_link(cs, n);
+            assert(link != NULL);
+            c = jl_atomic_load(&link->next);
+        }
+    }
+    arraylist_free(&wl);
+}
+
 // Re-attach a deserialized (image-resident) cancellation source to its
 // parents, exactly as if it had just been constructed: its serialized
 // child links were dropped by the serializer, and its parents' *current*
 // cancellation state must be (re)inherited - a parent may have been
-// cancelled between serialization and load. Image objects are never
-// collected, so unlike jl_new_cancel_source there is no sweep-support
-// registration.
-JL_DLLEXPORT void jl_cancel_source_relink(jl_cancel_source_t *src)
+// cancelled between serialization and load. A state raised this way is
+// propagated down any children that re-attached before us (fixup order is
+// arbitrary). Image objects are never collected, so unlike
+// jl_new_cancel_source there is no sweep-support registration.
+JL_DLLEXPORT void jl_cancel_source_relink(jl_cancel_source_t *src) JL_NOTSAFEPOINT
 {
     cancel_source_attach(src);
+    cancel_source_propagate_state(src);
 }
 
 // The i-th (0-based) parent of `src` (a strong, const link).

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -572,10 +572,37 @@ function serialize(s::AbstractSerializer, mc::Core.MethodCache)
     error("cannot serialize MethodCache objects")
 end
 
+# Only the (strong) parent links and the state bytes are serialized; the
+# weak intrusive child lists are rebuilt on deserialization by relinking
+# the source under its parents as if it were newly constructed (which also
+# re-inherits the parents' current cancellation state).
 function serialize(s::AbstractSerializer, src::Core.CancellationTokenSource)
-    # variable-sized, with intrusive weak child lists the generic
-    # field-by-field path would corrupt
-    error("cannot serialize CancellationTokenSource objects")
+    serialize_cycle_header(s, src) && return
+    np = Int(src.nparents)
+    serialize(s, np)
+    for i in 1:np
+        serialize(s, Base._cancel_parent(src, i))
+    end
+    serialize(s, @atomic src.state)
+    serialize(s, @atomic src.delivered)
+    nothing
+end
+
+function deserialize(s::AbstractSerializer, ::Type{Core.CancellationTokenSource})
+    np = deserialize(s)::Int
+    parents = Vector{Any}(undef, np)
+    for i in 1:np
+        parents[i] = deserialize(s)::Core.CancellationTokenSource
+    end
+    src = Core._new_cancel_source(parents...)::Core.CancellationTokenSource
+    deserialize_cycle(s, src)
+    state = deserialize(s)::UInt8
+    delivered = deserialize(s)::UInt8
+    # CAS-max with whatever the relinking inherited from the parents;
+    # severities only ever escalate
+    state != 0x00 && Base._raise_state!(src, state & Base.SEVERITY_MASK)
+    delivered != 0x00 && (@atomic :monotonic src.delivered |= delivered)
+    return src
 end
 
 

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -572,6 +572,12 @@ function serialize(s::AbstractSerializer, mc::Core.MethodCache)
     error("cannot serialize MethodCache objects")
 end
 
+function serialize(s::AbstractSerializer, src::Core.CancellationTokenSource)
+    # variable-sized, with intrusive weak child lists the generic
+    # field-by-field path would corrupt
+    error("cannot serialize CancellationTokenSource objects")
+end
+
 
 function serialize(s::AbstractSerializer, linfo::Core.MethodInstance)
     serialize_cycle(s, linfo) && return

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -579,7 +579,7 @@ end
 function serialize(s::AbstractSerializer, src::Core.CancellationTokenSource)
     serialize_cycle_header(s, src) && return
     np = Int(src.nparents)
-    serialize(s, np)
+    serialize(s, np % Int64)  # fixed width: streams are word-size independent
     for i in 1:np
         serialize(s, Base._cancel_parent(src, i))
     end
@@ -588,7 +588,7 @@ function serialize(s::AbstractSerializer, src::Core.CancellationTokenSource)
 end
 
 function deserialize(s::AbstractSerializer, ::Type{Core.CancellationTokenSource})
-    np = deserialize(s)::Int
+    np = Int(deserialize(s)::Int64)
     parents = Vector{Any}(undef, np)
     for i in 1:np
         parents[i] = deserialize(s)::Core.CancellationTokenSource
@@ -596,9 +596,17 @@ function deserialize(s::AbstractSerializer, ::Type{Core.CancellationTokenSource}
     src = Core._new_cancel_source(parents...)::Core.CancellationTokenSource
     deserialize_cycle(s, src)
     state = deserialize(s)::UInt8
-    # CAS-max with whatever the relinking inherited from the parents;
-    # severities only ever escalate
-    state != 0x00 && Base._raise_state!(src, state & Base.SEVERITY_MASK)
+    if state != 0x00
+        sev = state & Base.SEVERITY_MASK
+        # reject severities the API cannot produce rather than letting a
+        # corrupt stream inject an unescalatable bogus level
+        if !(sev == 0x0 || sev == 0x3 || sev == 0x4)
+            throw(ArgumentError("invalid cancellation severity $(repr(sev)) in serialized CancellationTokenSource"))
+        end
+        # CAS-max with whatever the relinking inherited from the parents;
+        # severities only ever escalate
+        Base._raise_state!(src, sev)
+    end
     return src
 end
 

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -584,7 +584,6 @@ function serialize(s::AbstractSerializer, src::Core.CancellationTokenSource)
         serialize(s, Base._cancel_parent(src, i))
     end
     serialize(s, @atomic src.state)
-    serialize(s, @atomic src.delivered)
     nothing
 end
 
@@ -597,11 +596,9 @@ function deserialize(s::AbstractSerializer, ::Type{Core.CancellationTokenSource}
     src = Core._new_cancel_source(parents...)::Core.CancellationTokenSource
     deserialize_cycle(s, src)
     state = deserialize(s)::UInt8
-    delivered = deserialize(s)::UInt8
     # CAS-max with whatever the relinking inherited from the parents;
     # severities only ever escalate
     state != 0x00 && Base._raise_state!(src, state & Base.SEVERITY_MASK)
-    delivered != 0x00 && (@atomic :monotonic src.delivered |= delivered)
     return src
 end
 

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -597,15 +597,14 @@ function deserialize(s::AbstractSerializer, ::Type{Core.CancellationTokenSource}
     deserialize_cycle(s, src)
     state = deserialize(s)::UInt8
     if state != 0x00
-        sev = state & Base.SEVERITY_MASK
         # reject severities the API cannot produce rather than letting a
         # corrupt stream inject an unescalatable bogus level
-        if !(sev == 0x0 || sev == 0x3 || sev == 0x4)
-            throw(ArgumentError("invalid cancellation severity $(repr(sev)) in serialized CancellationTokenSource"))
+        if !(state == 0x1 || state == 0x3 || state == 0x4)
+            throw(ArgumentError("invalid cancellation severity $(repr(state)) in serialized CancellationTokenSource"))
         end
         # CAS-max with whatever the relinking inherited from the parents;
         # severities only ever escalate
-        Base._raise_state!(src, sev)
+        Base._raise_state!(src, state)
     end
     return src
 end

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -781,7 +781,7 @@ end
     # child inherits the state when it relinks under the parent
     p = CancellationTokenSource()
     c = CancellationTokenSource(CancellationToken(p))
-    Base._raise_state!(p, 0x00) # cancel p without walking to c
+    Base._raise_state!(p, 0x01) # cancel p without walking to c
     @test !Base.iscancelled(c)
     buf = IOBuffer()
     serialize(buf, c) # parents serialize first, with their state
@@ -795,6 +795,6 @@ end
     buf = IOBuffer()
     serialize(buf, src)
     data = take!(buf)
-    data[end] = 0xbf # state byte: cancelled at (invalid) severity 0x3f
+    data[end] = 0xbf # state byte: invalid severity 0xbf
     @test_throws ArgumentError deserialize(IOBuffer(data))
 end

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -764,7 +764,8 @@ end
     s2 = deserialize(buf)
     @test Base.cancel_severity(s2) === Base.CANCEL_REQUEST_ABANDON_EXTERNAL
 
-    # deserializing under an already-cancelled parent is born cancelled
+    # the copy is independent: cancelling the original after serialization
+    # does not affect the deserialized graph
     p = CancellationTokenSource()
     c = CancellationTokenSource(CancellationToken(p))
     buf = IOBuffer()
@@ -773,4 +774,27 @@ end
     cancel!(p) # does not affect the serialized bytes
     p3, c3 = deserialize(buf)
     @test !Base.iscancelled(c3) # p3 was not cancelled at relink time
+
+    # deserializing under an already-cancelled parent is born cancelled:
+    # a stream may legally record a cancelled parent with an uncancelled
+    # child (e.g. the serializer raced an in-flight cancel! walk); the
+    # child inherits the state when it relinks under the parent
+    p = CancellationTokenSource()
+    c = CancellationTokenSource(CancellationToken(p))
+    Base._raise_state!(p, 0x00) # cancel p without walking to c
+    @test !Base.iscancelled(c)
+    buf = IOBuffer()
+    serialize(buf, c) # parents serialize first, with their state
+    seekstart(buf)
+    c4 = deserialize(buf)
+    @test Base.iscancelled(Base._cancel_parent(c4, 1))
+    @test Base.iscancelled(c4)
+
+    # a corrupt stream cannot inject an out-of-range severity
+    src = CancellationTokenSource()
+    buf = IOBuffer()
+    serialize(buf, src)
+    data = take!(buf)
+    data[end] = 0xbf # state byte: cancelled at (invalid) severity 0x3f
+    @test_throws ArgumentError deserialize(IOBuffer(data))
 end

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -755,16 +755,14 @@ end
     # ...without affecting the original graph
     @test !Base.iscancelled(root) && !Base.iscancelled(child)
 
-    # cancellation state and delivered bits round-trip
+    # cancellation state round-trips
     src = CancellationTokenSource()
     cancel!(src, Base.CANCEL_REQUEST_ABANDON_EXTERNAL)
-    @atomic src.delivered |= 0x08
     buf = IOBuffer()
     serialize(buf, src)
     seekstart(buf)
     s2 = deserialize(buf)
     @test Base.cancel_severity(s2) === Base.CANCEL_REQUEST_ABANDON_EXTERNAL
-    @test (@atomic s2.delivered) & 0x08 != 0x00
 
     # deserializing under an already-cancelled parent is born cancelled
     p = CancellationTokenSource()

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -733,3 +733,46 @@ end
     @test new_d[:m] isa Memory
     @test new_d[:m][5] == 125
 end
+
+@testset "CancellationTokenSource" begin
+    using Base: cancel!, CancellationToken, CancellationTokenSource
+    # a diamond: identity sharing of parents must survive the round-trip
+    root = CancellationTokenSource()
+    left = CancellationTokenSource(CancellationToken(root))
+    right = CancellationTokenSource(CancellationToken(root))
+    child = CancellationTokenSource(CancellationToken(left), CancellationToken(right))
+    buf = IOBuffer()
+    serialize(buf, (root, left, right, child))
+    seekstart(buf)
+    r2, l2, rt2, c2 = deserialize(buf)
+    @test r2 isa CancellationTokenSource && c2.nparents == 2
+    @test Base._cancel_parent(c2, 1) === l2 && Base._cancel_parent(c2, 2) === rt2
+    @test Base._cancel_parent(l2, 1) === r2 && Base._cancel_parent(rt2, 1) === r2
+    @test !Base.iscancelled(c2)
+    # the deserialized graph is relinked: cancelling its root reaches the leaf
+    cancel!(r2)
+    @test Base.iscancelled(c2) && Base.iscancelled(l2) && Base.iscancelled(rt2)
+    # ...without affecting the original graph
+    @test !Base.iscancelled(root) && !Base.iscancelled(child)
+
+    # cancellation state and delivered bits round-trip
+    src = CancellationTokenSource()
+    cancel!(src, Base.CANCEL_REQUEST_ABANDON_EXTERNAL)
+    @atomic src.delivered |= 0x08
+    buf = IOBuffer()
+    serialize(buf, src)
+    seekstart(buf)
+    s2 = deserialize(buf)
+    @test Base.cancel_severity(s2) === Base.CANCEL_REQUEST_ABANDON_EXTERNAL
+    @test (@atomic s2.delivered) & 0x08 != 0x00
+
+    # deserializing under an already-cancelled parent is born cancelled
+    p = CancellationTokenSource()
+    c = CancellationTokenSource(CancellationToken(p))
+    buf = IOBuffer()
+    serialize(buf, (p, c))
+    seekstart(buf)
+    cancel!(p) # does not affect the serialized bytes
+    p3, c3 = deserialize(buf)
+    @test !Base.iscancelled(c3) # p3 was not cancelled at relink time
+end

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -40,9 +40,22 @@ end
     @test_throws ArgumentError cancel!(CancellationTokenSource(), CancellationRequest(0x1))
     @test_throws ArgumentError cancel!(CancellationTokenSource(), CancellationRequest(0x7f))
 
-    # children are held weakly: a child that becomes unreachable simply
-    # drops out of the tree, while an escaped token keeps its source
-    # attached (cancellation still reaches whoever can observe it)
+    # walk a source's (weak, intrusive) child list
+    function live_children(src::CancellationTokenSource)
+        kids = CancellationTokenSource[]
+        c = @atomic src.child_head
+        while c !== nothing
+            c = c::CancellationTokenSource
+            push!(kids, c)
+            c = Base._cancel_next_child(src, c)
+        end
+        return kids
+    end
+
+    # children are held weakly: a child that becomes unreachable is spliced
+    # out of its parents' child lists by the GC, while an escaped token
+    # keeps its source attached (cancellation still reaches whoever can
+    # observe it)
     @noinline function make_children(root)
         CancellationTokenSource(CancellationToken(root)) # unreachable after return
         c = CancellationTokenSource(CancellationToken(root))
@@ -51,19 +64,21 @@ end
     root2 = CancellationTokenSource()
     kept = CancellationTokenSource(CancellationToken(root2))
     escaped_tok = make_children(root2)
-    GC.gc()
-    cancel!(root2) # the walk prunes the collected child
+    GC.gc() # splices the collected child out of root2's list
+    cancel!(root2)
     @test Base.iscancelled(kept)
     @test Base.iscancelled(escaped_tok)
-    kids = root2.children::Vector{WeakRef}
-    @test length(kids) == 2 # kept + escaped; the dead child was pruned
-    @test all(w -> w.value !== nothing, kids)
+    kids = live_children(root2)
+    @test length(kids) == 2 # kept + escaped; the dead child was spliced out
+    @test kept in kids && escaped_tok.source in kids
 
     # linked sources: a source with several parents is cancelled by any of
     # them (the graph is a DAG, not just a tree)
     la = CancellationTokenSource()
     lb = CancellationTokenSource()
     linked = CancellationTokenSource(CancellationToken(la), CancellationToken(lb))
+    @test linked.nparents == 2
+    @test Base._cancel_parent(linked, 1) === la && Base._cancel_parent(linked, 2) === lb
     @test !Base.iscancelled(CancellationToken(linked))
     @test cancel!(lb)
     @test Base.iscancelled(CancellationToken(linked))
@@ -91,8 +106,23 @@ end
 
     # duplicate parents collapse to the single-parent form
     dup = CancellationTokenSource(CancellationToken(droot), CancellationToken(droot))
-    @test dup.parents === droot
+    @test dup.nparents == 1
+    @test Base._cancel_parent(dup, 1) === droot
     @test Base.iscancelled(CancellationToken(dup)) # born under the cancelled root
+
+    # attachment and GC splicing keep the sibling lists consistent across
+    # many children coming and going
+    sroot = CancellationTokenSource()
+    skeep = CancellationTokenSource[]
+    for i in 1:1000
+        c = CancellationTokenSource(CancellationToken(sroot))
+        i % 7 == 0 && push!(skeep, c)
+        i % 250 == 0 && GC.gc(false)
+    end
+    GC.gc()
+    @test length(live_children(sroot)) >= length(skeep)
+    cancel!(sroot)
+    @test all(Base.iscancelled, skeep)
 
     # deep chains cancel without recursion depth issues
     deep_root = CancellationTokenSource()

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -14,8 +14,8 @@ function cancellable_spawn(f)
     return t, src
 end
 
-@testset "cancellation token tree semantics" begin
-    # cancel! marks the whole subtree, level-triggered
+@testset "cancellation token graph semantics" begin
+    # cancel! marks all descendants, level-triggered
     root = CancellationTokenSource()
     child = CancellationTokenSource(CancellationToken(root))
     grandchild = CancellationTokenSource(CancellationToken(child))
@@ -37,7 +37,7 @@ end
     @test Base.cancel_severity(grandchild) === CANCEL_REQUEST_ABANDON_EXTERNAL
 
     # invalid severities are rejected
-    @test_throws ArgumentError cancel!(CancellationTokenSource(), CancellationRequest(0x1))
+    @test_throws ArgumentError cancel!(CancellationTokenSource(), CancellationRequest(0x2))
     @test_throws ArgumentError cancel!(CancellationTokenSource(), CancellationRequest(0x7f))
 
     # walk a source's (weak, intrusive) child list
@@ -146,15 +146,15 @@ end
     @test inherited === tok
 end
 
-@testset "cancel! repairs partially-cancelled subtrees" begin
-    # Simulate a cancel! whose subtree walk never ran (e.g. the cancelling
+@testset "cancel! repairs partially-cancelled subgraphs" begin
+    # Simulate a cancel! whose descendant walk never ran (e.g. the cancelling
     # task torn down mid-walk): the state is raised, but no child is.
     root = CancellationTokenSource()
     child = CancellationTokenSource(CancellationToken(root))
-    @test Base._raise_state!(root, 0x0)
+    @test Base._raise_state!(root, 0x1)
     @test !Base.iscancelled(child)
     # A repeated cancel! loses the state transition (returns false) but
-    # must still perform the subtree walk itself.
+    # must still perform the full walk itself.
     @test !cancel!(root)
     @test Base.iscancelled(child)
 end
@@ -264,7 +264,7 @@ end
         end
     end
     @test err isa CancellationRequest
-    @test Base.severity(err) == Base.severity(CANCEL_REQUEST_ABANDON_EXTERNAL)
+    @test err == CANCEL_REQUEST_ABANDON_EXTERNAL
 
     # the explicit-token form checks the given token, ignoring the scope
     live = CancellationToken(CancellationTokenSource())
@@ -352,5 +352,5 @@ end
     cancel!(src3, CANCEL_REQUEST_ABANDON_EXTERNAL)
     @test timedwait(() -> istaskdone(t3), 30.0) == :ok
     @test t3.result isa CancellationRequest
-    @test Base.severity(t3.result) == Base.severity(CANCEL_REQUEST_ABANDON_EXTERNAL)
+    @test t3.result == CANCEL_REQUEST_ABANDON_EXTERNAL
 end

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -208,6 +208,16 @@ end
     @test Base.summarysize(c2) == base + 2 * linksz + 2 * base
     @test Base.summarysize(c2; count=true) == 3
     @test Base.summarysize(a) == base # a's children are weak: c2 not charged
+    # the hidden parent references go through the regular traversal policy
+    one = CancellationTokenSource(CancellationToken(a))
+    @test Base.summarysize(one; exclude=CancellationTokenSource) == base + linksz
+    @test Base.summarysize(one; exclude=CancellationTokenSource, count=true) == 1
+    # deep parent chains are traversed iteratively, not by recursion
+    node = CancellationTokenSource()
+    for _ in 1:100_000
+        node = CancellationTokenSource(CancellationToken(node))
+    end
+    @test Base.summarysize(node) >= 100_001 * base + 100_000 * linksz
 end
 
 @testset "cancellation points" begin

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -1,0 +1,236 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Base: cancel!, CancellationRequest, CancellationToken, CancellationTokenSource,
+    CANCEL_REQUEST_SAFE, CANCEL_REQUEST_ABANDON_EXTERNAL, CANCEL_REQUEST_ABANDON_ALL,
+    CANCEL_TOKEN
+using Base.ScopedValues: with, ScopedValue
+
+# Threads.@spawn-style cancellable task (non-sticky, explicitly on the
+# default pool - a compute-bound victim must not land on the interactive/io
+# thread); returns (task, source).
+function cancellable_spawn(f)
+    src = CancellationTokenSource()
+    t = with(() -> Threads.@spawn(f()), CANCEL_TOKEN => CancellationToken(src))
+    return t, src
+end
+
+@testset "cancellation token tree semantics" begin
+    # cancel! marks the whole subtree, level-triggered
+    root = CancellationTokenSource()
+    child = CancellationTokenSource(CancellationToken(root))
+    grandchild = CancellationTokenSource(CancellationToken(child))
+    @test !Base.iscancelled(grandchild)
+    @test Base.cancel_severity(grandchild) === nothing
+    @test cancel!(root)
+    @test Base.iscancelled(root) && Base.iscancelled(child) && Base.iscancelled(grandchild)
+    @test !cancel!(root) # idempotent at the same severity
+
+    # a source attached under an already-cancelled parent is born cancelled
+    late = CancellationTokenSource(CancellationToken(child))
+    @test Base.iscancelled(late)
+    @test Base.cancel_severity(late) === CANCEL_REQUEST_SAFE
+
+    # escalation is monotonic and propagates down
+    @test cancel!(root, CANCEL_REQUEST_ABANDON_EXTERNAL)
+    @test Base.cancel_severity(grandchild) === CANCEL_REQUEST_ABANDON_EXTERNAL
+    @test !cancel!(grandchild, CANCEL_REQUEST_SAFE) # never de-escalates
+    @test Base.cancel_severity(grandchild) === CANCEL_REQUEST_ABANDON_EXTERNAL
+
+    # invalid severities are rejected
+    @test_throws ArgumentError cancel!(CancellationTokenSource(), CancellationRequest(0x1))
+    @test_throws ArgumentError cancel!(CancellationTokenSource(), CancellationRequest(0x7f))
+
+    # children are held weakly: a child that becomes unreachable simply
+    # drops out of the tree, while an escaped token keeps its source
+    # attached (cancellation still reaches whoever can observe it)
+    @noinline function make_children(root)
+        CancellationTokenSource(CancellationToken(root)) # unreachable after return
+        c = CancellationTokenSource(CancellationToken(root))
+        return CancellationToken(c) # only the token escapes
+    end
+    root2 = CancellationTokenSource()
+    kept = CancellationTokenSource(CancellationToken(root2))
+    escaped_tok = make_children(root2)
+    GC.gc()
+    cancel!(root2) # the walk prunes the collected child
+    @test Base.iscancelled(kept)
+    @test Base.iscancelled(escaped_tok)
+    kids = root2.children::Vector{WeakRef}
+    @test length(kids) == 2 # kept + escaped; the dead child was pruned
+    @test all(w -> w.value !== nothing, kids)
+
+    # linked sources: a source with several parents is cancelled by any of
+    # them (the graph is a DAG, not just a tree)
+    la = CancellationTokenSource()
+    lb = CancellationTokenSource()
+    linked = CancellationTokenSource(CancellationToken(la), CancellationToken(lb))
+    @test !Base.iscancelled(CancellationToken(linked))
+    @test cancel!(lb)
+    @test Base.iscancelled(CancellationToken(linked))
+    @test !Base.iscancelled(CancellationToken(la))
+    # escalation propagates through the other parent too
+    @test cancel!(la, CANCEL_REQUEST_ABANDON_EXTERNAL)
+    @test Base.cancel_severity(linked) === CANCEL_REQUEST_ABANDON_EXTERNAL
+
+    # born cancelled at the highest severity among the parents
+    lc = CancellationTokenSource()
+    ld = CancellationTokenSource()
+    cancel!(ld, CANCEL_REQUEST_ABANDON_EXTERNAL)
+    born = CancellationTokenSource(CancellationToken(lc), CancellationToken(ld))
+    @test Base.cancel_severity(born) === CANCEL_REQUEST_ABANDON_EXTERNAL
+
+    # a diamond converges: the shared descendant is cancelled exactly once
+    # from the root
+    droot = CancellationTokenSource()
+    dl = CancellationTokenSource(CancellationToken(droot))
+    dr = CancellationTokenSource(CancellationToken(droot))
+    dd = CancellationTokenSource(CancellationToken(dl), CancellationToken(dr))
+    cancel!(droot)
+    @test Base.iscancelled(dd)
+    @test Base.cancel_severity(dd) === CANCEL_REQUEST_SAFE
+
+    # duplicate parents collapse to the single-parent form
+    dup = CancellationTokenSource(CancellationToken(droot), CancellationToken(droot))
+    @test dup.parents === droot
+    @test Base.iscancelled(CancellationToken(dup)) # born under the cancelled root
+
+    # deep chains cancel without recursion depth issues
+    deep_root = CancellationTokenSource()
+    node = deep_root
+    chain = CancellationTokenSource[]
+    for _ in 1:50_000
+        node = CancellationTokenSource(CancellationToken(node))
+        push!(chain, node) # keep them alive
+    end
+    cancel!(deep_root)
+    @test Base.iscancelled(chain[end])
+
+    # the current scoped token is discoverable, and `=> nothing` scopes it out
+    tok = CancellationToken(CancellationTokenSource())
+    @test with(() -> CANCEL_TOKEN[], CANCEL_TOKEN => tok) === tok
+    @test with(() -> CANCEL_TOKEN[], CANCEL_TOKEN => nothing) === nothing
+    # an unrelated nested scope inherits the governing token
+    inherited = with(CANCEL_TOKEN => tok) do
+        with(() -> CANCEL_TOKEN[], ScopedValue(0) => 1)
+    end
+    @test inherited === tok
+end
+
+@testset "cancellation points" begin
+    # @cancel_check with no scoped token is a no-op
+    @test with(() -> (Base.@cancel_check; :ran), CANCEL_TOKEN => nothing) === :ran
+    @test (Base.@cancel_check; :ran) === :ran
+
+    # a cancellation point under a cancelled scope throws the request
+    src = CancellationTokenSource()
+    cancel!(src, CANCEL_REQUEST_ABANDON_EXTERNAL)
+    err = with(CANCEL_TOKEN => CancellationToken(src)) do
+        try
+            Base.@cancel_check
+            nothing
+        catch e
+            e
+        end
+    end
+    @test err isa CancellationRequest
+    @test Base.severity(err) == Base.severity(CANCEL_REQUEST_ABANDON_EXTERNAL)
+
+    # the explicit-token form checks the given token, ignoring the scope
+    live = CancellationToken(CancellationTokenSource())
+    dead = CancellationToken(src)
+    with(CANCEL_TOKEN => dead) do
+        @test (Base.@cancel_check(live); :ran) === :ran
+    end
+    @test_throws CancellationRequest Base.@cancel_check(dead)
+    @test (Base.@cancel_check(nothing); :ran) === :ran
+
+    # level-triggered: after catching one request, the next point throws again
+    with(CANCEL_TOKEN => dead) do
+        caught = 0
+        for _ in 1:2
+            try
+                Base.@cancel_check
+            catch e
+                e isa CancellationRequest || rethrow()
+                caught += 1
+            end
+        end
+        @test caught == 2
+        # shielding scopes the token out
+        with(CANCEL_TOKEN => nothing) do
+            @test (Base.@cancel_check; :ran) === :ran
+        end
+    end
+
+    # a delivered cancellation is recorded on the source and its ancestors
+    proot = CancellationTokenSource()
+    pchild = CancellationTokenSource(CancellationToken(proot))
+    cancel!(pchild)
+    @test_throws CancellationRequest with(() -> Base.@cancel_check,
+                                          CANCEL_TOKEN => CancellationToken(pchild))
+    @test (@atomic pchild.delivered) != 0x00
+    # ancestors are acknowledged unconditionally (the ^C episode machinery
+    # reads the bit on the episode source even when the delivery hit a
+    # nested scope's source)
+    @test (@atomic proot.delivered) != 0x00
+    # ...and against a nested source it propagates to the cancelled ancestors
+    qroot = CancellationTokenSource()
+    qchild = CancellationTokenSource(CancellationToken(qroot))
+    cancel!(qroot)
+    @test_throws CancellationRequest with(() -> Base.@cancel_check,
+                                          CANCEL_TOKEN => CancellationToken(qchild))
+    @test (@atomic qroot.delivered) != 0x00
+end
+
+@testset "cooperative cancellation of running tasks" begin
+    # a @cancel_check polling loop is stopped cross-thread by cancel!
+    started = Threads.Atomic{Bool}(false)
+    t, src = cancellable_spawn() do
+        started[] = true
+        while true
+            Base.@cancel_check
+            yield() # let the canceller run when there is only one thread
+        end
+    end
+    @test timedwait(() -> started[], 30.0) == :ok
+    cancel!(src)
+    @test timedwait(() -> istaskdone(t), 30.0) == :ok
+    @test istaskfailed(t)
+    @test t.result isa CancellationRequest
+
+    # the scoped token is inherited through nested task spawns
+    inner_result = Ref{Any}(nothing)
+    t2, src2 = cancellable_spawn() do
+        inner = Threads.@spawn begin
+            while true
+                Base.@cancel_check
+                yield()
+            end
+        end
+        try
+            wait(inner)
+        catch
+        end
+        inner_result[] = inner.result
+    end
+    spin_started = timedwait(() -> istaskstarted(t2), 30.0)
+    @test spin_started == :ok
+    cancel!(src2)
+    @test timedwait(() -> istaskdone(t2), 30.0) == :ok
+    @test inner_result[] isa CancellationRequest
+
+    # the hoisted-token form polls the explicit token
+    src3 = CancellationTokenSource()
+    tok3 = CancellationToken(src3)
+    t3 = Threads.@spawn begin
+        while true
+            Base.@cancel_check tok3
+            yield()
+        end
+    end
+    @test timedwait(() -> istaskstarted(t3), 30.0) == :ok
+    cancel!(src3, CANCEL_REQUEST_ABANDON_EXTERNAL)
+    @test timedwait(() -> istaskdone(t3), 30.0) == :ok
+    @test t3.result isa CancellationRequest
+    @test Base.severity(t3.result) == Base.severity(CANCEL_REQUEST_ABANDON_EXTERNAL)
+end

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -146,6 +146,70 @@ end
     @test inherited === tok
 end
 
+@testset "cancel! repairs partially-cancelled subtrees" begin
+    # Simulate a cancel! whose subtree walk never ran (e.g. the cancelling
+    # task torn down mid-walk): the state is raised, but no child is.
+    root = CancellationTokenSource()
+    child = CancellationTokenSource(CancellationToken(root))
+    @test Base._raise_state!(root, 0x0)
+    @test !Base.iscancelled(child)
+    # A repeated cancel! loses the state transition (returns false) but
+    # must still perform the subtree walk itself.
+    @test !cancel!(root)
+    @test Base.iscancelled(child)
+end
+
+@testset "cancellation source GC with dying parents" begin
+    # Parents dying in the same cycle as their children: the unlink pass
+    # writes into the dead parents' memory, which the sweep must keep
+    # valid through the cycle.
+    for _ in 1:5
+        for _ in 1:1000
+            r = CancellationTokenSource()
+            m = CancellationTokenSource(CancellationToken(r))
+            CancellationTokenSource(CancellationToken(m))
+        end
+        GC.gc()
+    end
+    GC.gc()
+    GC.gc() # pages now hold no sources: the sweep flag must clear, not pin them
+    # big-object sources (many parents) take the deferred-free path
+    let
+        parents = [CancellationTokenSource() for _ in 1:100]
+        cancel!(parents[1])
+        big = CancellationTokenSource(map(CancellationToken, parents)...)
+        @test Base.iscancelled(big)
+        parents = nothing
+        big = nothing
+    end
+    GC.gc()
+    GC.gc()
+    # a survivor amid heavy churn stays correctly linked throughout
+    root = CancellationTokenSource()
+    keep = CancellationTokenSource(CancellationToken(root))
+    for _ in 1:10_000
+        CancellationTokenSource(CancellationToken(root))
+    end
+    GC.gc()
+    GC.gc()
+    cancel!(root)
+    @test Base.iscancelled(keep)
+end
+
+@testset "cancellation source memory accounting" begin
+    a = CancellationTokenSource()
+    b = CancellationTokenSource()
+    base = Core.sizeof(a)
+    linksz = 3 * sizeof(Ptr{Cvoid})
+    c2 = CancellationTokenSource(CancellationToken(a), CancellationToken(b))
+    @test Core.sizeof(c2) == base + 2 * linksz
+    # summarysize charges the link tail and the (strong) parents, but not
+    # the (weak) children
+    @test Base.summarysize(c2) == base + 2 * linksz + 2 * base
+    @test Base.summarysize(c2; count=true) == 3
+    @test Base.summarysize(a) == base # a's children are weak: c2 not charged
+end
+
 @testset "cancellation points" begin
     # @cancel_check with no scoped token is a no-op
     @test with(() -> (Base.@cancel_check; :ran), CANCEL_TOKEN => nothing) === :ran

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -192,24 +192,13 @@ end
         end
     end
 
-    # a delivered cancellation is recorded on the source and its ancestors
-    proot = CancellationTokenSource()
-    pchild = CancellationTokenSource(CancellationToken(proot))
-    cancel!(pchild)
-    @test_throws CancellationRequest with(() -> Base.@cancel_check,
-                                          CANCEL_TOKEN => CancellationToken(pchild))
-    @test (@atomic pchild.delivered) != 0x00
-    # ancestors are acknowledged unconditionally (the ^C episode machinery
-    # reads the bit on the episode source even when the delivery hit a
-    # nested scope's source)
-    @test (@atomic proot.delivered) != 0x00
-    # ...and against a nested source it propagates to the cancelled ancestors
+    # a cancellation against a nested source also throws from the nested
+    # scope's cancellation points
     qroot = CancellationTokenSource()
     qchild = CancellationTokenSource(CancellationToken(qroot))
     cancel!(qroot)
     @test_throws CancellationRequest with(() -> Base.@cancel_check,
                                           CANCEL_TOKEN => CancellationToken(qchild))
-    @test (@atomic qroot.delivered) != 0x00
 end
 
 @testset "cooperative cancellation of running tasks" begin

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -159,6 +159,33 @@ end
     @test Base.iscancelled(child)
 end
 
+@testset "concurrent child construction is level-triggered" begin
+    # A child constructed concurrently with cancel! must end up cancelled,
+    # whichever side wins the race: either the walk sees it in the child
+    # list, or its constructor observes the already-cancelled parent.
+    nspawners = max(Threads.nthreads() - 1, 1)
+    for trial in 1:20
+        root = CancellationTokenSource()
+        tok = CancellationToken(root)
+        go = Threads.Event()
+        tasks = map(1:nspawners) do _
+            Threads.@spawn begin
+                wait(go)
+                kids = CancellationTokenSource[]
+                for _ in 1:500
+                    push!(kids, CancellationTokenSource(tok))
+                end
+                kids
+            end
+        end
+        notify(go)
+        cancel!(root)
+        for t in tasks
+            @test all(Base.iscancelled, fetch(t))
+        end
+    end
+end
+
 @testset "cancellation source GC with dying parents" begin
     # Parents dying in the same cycle as their children: the unlink pass
     # writes into the dead parents' memory, which the sweep must keep

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -226,6 +226,10 @@ end
 @testset "cancellation source memory accounting" begin
     a = CancellationTokenSource()
     b = CancellationTokenSource()
+    # instances are variable-sized, so (like String or Memory) the type has
+    # no definite size and inference must not fold an instance's sizeof
+    @test_throws ErrorException Core.sizeof(CancellationTokenSource)
+    @test Base.infer_return_type(Core.sizeof, Tuple{CancellationTokenSource}) == Int
     base = Core.sizeof(a)
     linksz = 3 * sizeof(Ptr{Cvoid})
     c2 = CancellationTokenSource(CancellationToken(a), CancellationToken(b))

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -26,7 +26,7 @@ const TESTNAMES = [
         "enums", "cmdlineargs", "int", "interpreter",
         "checked", "bitset", "floatfuncs", "precompile", "relocatedepot",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
-        "channels", "iostream", "secretbuffer", "specificity",
+        "channels", "cancellation", "iostream", "secretbuffer", "specificity",
         "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",
         "smallarrayshrink", "opaque_closure", "filesystem", "download",
         "scopedvalues", "compileall", "rebinding",

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3647,6 +3647,11 @@ precompile_test_harness("cancellation relink under cancelled external parent") d
               using Base: CancellationToken, CancellationTokenSource
               const B_MID = CancellationTokenSource(CancellationToken(CancelExtA.A_ROOT))
               const B_CHILD = CancellationTokenSource(CancellationToken(B_MID))
+              const B_GRAND = CancellationTokenSource(CancellationToken(B_CHILD))
+              # a cancel! interrupted mid-walk (state raised, children not
+              # visited) captured in the image: load-time propagation must
+              # not treat the already-raised state as having been walked
+              Base._raise_state!(B_CHILD, 0x00)
           end
           """)
     Base.compilecache(Base.PkgId("CancelExtA"))
@@ -3659,10 +3664,13 @@ precompile_test_harness("cancellation relink under cancelled external parent") d
     invokelatest() do
         # CancelExtB's sources re-attached at load time under the already-
         # cancelled A_ROOT: B_MID is born cancelled during its relink, and
-        # that state must reach B_CHILD regardless of the order in which
-        # the image's fixups relinked the two
+        # that state must reach every descendant regardless of the order in
+        # which the image's fixups relinked them - including through
+        # B_CHILD, whose already-cancelled (but never walked) state must
+        # not prune the propagation
         @test Base.iscancelled(CancelExtB.B_MID)
         @test Base.iscancelled(CancelExtB.B_CHILD)
+        @test Base.iscancelled(CancelExtB.B_GRAND)
     end
 end
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3605,4 +3605,31 @@ precompile_test_harness("include mapexpr persistence") do dir
     @test length(mapexprs) == 3
 end
 
+precompile_test_harness("cancellation source relinking") do dir
+    write(joinpath(dir, "CancelRelink.jl"),
+          """
+          module CancelRelink
+              using Base: CancellationToken, CancellationTokenSource
+              const ROOT = CancellationTokenSource()
+              const LEFT = CancellationTokenSource(CancellationToken(ROOT))
+              const RIGHT = CancellationTokenSource(CancellationToken(ROOT))
+              const CHILD = CancellationTokenSource(CancellationToken(LEFT), CancellationToken(RIGHT))
+          end
+          """)
+    Base.compilecache(Base.PkgId("CancelRelink"))
+    @eval using CancelRelink
+    invokelatest() do
+        # the sources were serialized into the package image with their weak
+        # child lists dropped; loading must have relinked them under their
+        # parents so that cancellation still propagates through the diamond
+        @test CancelRelink.CHILD.nparents == 2
+        @test Base._cancel_parent(CancelRelink.CHILD, 1) === CancelRelink.LEFT
+        @test !Base.iscancelled(CancelRelink.CHILD)
+        Base.cancel!(CancelRelink.ROOT)
+        @test Base.iscancelled(CancelRelink.LEFT)
+        @test Base.iscancelled(CancelRelink.RIGHT)
+        @test Base.iscancelled(CancelRelink.CHILD)
+    end
+end
+
 finish_precompile_test!()

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3632,4 +3632,38 @@ precompile_test_harness("cancellation source relinking") do dir
     end
 end
 
+precompile_test_harness("cancellation relink under cancelled external parent") do dir
+    write(joinpath(dir, "CancelExtA.jl"),
+          """
+          module CancelExtA
+              using Base: CancellationTokenSource
+              const A_ROOT = CancellationTokenSource()
+          end
+          """)
+    write(joinpath(dir, "CancelExtB.jl"),
+          """
+          module CancelExtB
+              using CancelExtA
+              using Base: CancellationToken, CancellationTokenSource
+              const B_MID = CancellationTokenSource(CancellationToken(CancelExtA.A_ROOT))
+              const B_CHILD = CancellationTokenSource(CancellationToken(B_MID))
+          end
+          """)
+    Base.compilecache(Base.PkgId("CancelExtA"))
+    Base.compilecache(Base.PkgId("CancelExtB"))
+    @eval using CancelExtA
+    invokelatest() do
+        Base.cancel!(CancelExtA.A_ROOT)
+    end
+    @eval using CancelExtB
+    invokelatest() do
+        # CancelExtB's sources re-attached at load time under the already-
+        # cancelled A_ROOT: B_MID is born cancelled during its relink, and
+        # that state must reach B_CHILD regardless of the order in which
+        # the image's fixups relinked the two
+        @test Base.iscancelled(CancelExtB.B_MID)
+        @test Base.iscancelled(CancelExtB.B_CHILD)
+    end
+end
+
 finish_precompile_test!()

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3651,7 +3651,7 @@ precompile_test_harness("cancellation relink under cancelled external parent") d
               # a cancel! interrupted mid-walk (state raised, children not
               # visited) captured in the image: load-time propagation must
               # not treat the already-raised state as having been walked
-              Base._raise_state!(B_CHILD, 0x00)
+              Base._raise_state!(B_CHILD, 0x01)
           end
           """)
     Base.compilecache(Base.PkgId("CancelExtA"))

--- a/test/scopedvalues.jl
+++ b/test/scopedvalues.jl
@@ -86,7 +86,7 @@ end
         @test sprint(show, sval, context=(:module=>Core,)) == "Base.ScopedValues.ScopedValue{$Int}(2)"
         objid = sprint(show, Base.objectid(sval))
         let str = sprint(show, Core.current_scope(), context=(:module=>Core,))
-            @test startswith(str, "Base.ScopedValues.Scope")
+            @test startswith(str, "Base.Scope")
             @test contains(str, "Base.ScopedValues.ScopedValue{$Int}@$objid => 2")
         end
     end


### PR DESCRIPTION
Split out from #60281. Cancellation sources are a level-triggered, non-resettable, DAG of cancellation conditions. Additionally, there is a notion of a cancellation token as an opaque wrapper around a cancellation source, but that by itself cannot be canceled, thus providing separate object for the cancelling side and the cancelee side. This distinction is inherited from .NET. Of course we don't quite have the same type-level enforcement, but it does make sense to me that this is a useful distinction.

Cancellation sources/tokens semantically encapsulate cancellable units of work. To facilitate the common case that every operation running on a given Task is part of the same unit of work, there is a new AbstractScopedValue that is the default token for all cancelable operations. Ordinary ScopedValue inheritance rules govern the propagation of cancellation scope.

This is not the only possible design (e.g. one might want a `wait(t)` to automatically propagate cancellation to `t`, which was the original design in #60281), but I think it's a clean and easily explainable design since it builds on an already extant mechanism. If other cancellation propagation is needed it can be easily built out of the primitives.

This PR only defines the type and the `@cancel_check` macro to check whether a cancellation has occurred. It does not yet wire up cancellation to ^C on the input or any I/O libraries or computation libraries nor the compiler-supported cancellation mechanism.