### PR TITLE
cancellation: Split wait and lock wait queues

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -212,6 +212,8 @@
 #    @atomic last_started_running_at::UInt64
 #    @atomic running_time_ns::UInt64
 #    @atomic finished_at::UInt64
+#    @atomic waiting_on::Any
+#    cached_wait_entry::Any
 #end
 
 export

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -437,14 +437,25 @@ function put_unbuffered(c::Channel, v)
     lock(c)
     taker = try
         _increment_n_avail(c, 1)
-        while isempty(c.cond_take.waitq)
+        local taker
+        while true
+            while isempty(c.cond_take.waitq)
+                check_channel_state(c)
+                notify(c.cond_wait)
+                wait(c.cond_put)
+            end
             check_channel_state(c)
-            notify(c.cond_wait)
-            wait(c.cond_put)
+            # unfair scheduled version of: notify(c.cond_take, v, false, false); yield()
+            w = popfirst!(waitqueue(c.cond_take))
+            t = w.task
+            if t isa Task && claim_wait(t, w)
+                taker = t
+                break
+            end
+            # stale registration: this waiter's wake was already claimed
+            # by an interrupter - drop it and look for the next taker
         end
-        check_channel_state(c)
-        # unfair scheduled version of: notify(c.cond_take, v, false, false); yield()
-        popfirst!(c.cond_take.waitq)
+        taker
     finally
         _increment_n_avail(c, -1)
         unlock(c)

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -54,6 +54,66 @@ islocked(::AlwaysLockedST) = true
 
 ## condition variables
 
+# A task's registration on a wait queue. All fields are plain: `next` and
+# `queue` are protected by the waitee's lock (`queue` holds the queue's
+# identity - see `waitqueue` - while the entry is enqueued, acting as the
+# "am I registered, and on what" witness, and `nothing` otherwise); `task`
+# is written by the owning task before enqueueing, so it is ordered by the
+# same lock for lock-holding readers.
+#
+# The wake-claim protocol: a parked task `t` points to its current
+# registration through the atomic field `t.waiting_on`. Whoever wants to wake
+# it must first claim the wake by atomically clearing that field:
+#
+#   - `notify` (holding the waitee's lock) pops an entry `w` and claims via
+#     CAS(t.waiting_on, w => nothing). The expected-value CAS makes stale
+#     entries harmless: if `t` was interrupted and has since registered
+#     elsewhere, the CAS fails and the popped corpse is simply dropped.
+#   - an interrupter (`schedule(t, exc, error=true)`) claims via an
+#     unconditional swap: it is directed at the *task*, not at any particular
+#     wait, so claiming whatever `t` is currently registered on is correct.
+#     The claimed entry stays linked - the interrupter may not touch the queue
+#     without its lock - and is unlinked lazily, either by the interrupted
+#     task's own wait cleanup or by the `notify` that pops and drops it.
+#   - wake sources directed at one *specific* wait (e.g. the timeout task of
+#     `Experimental.wait_with_timeout`) must register the wait with a fresh,
+#     single-use entry: single-use-ness is what guarantees their
+#     expected-value CAS cannot mistakenly claim a later, unrelated wait.
+#
+# Entries are heap objects (rather than links folded into the Task) so that a
+# task whose interrupted wait left a stale registration behind can immediately
+# register anew - e.g. park on a lock during its cleanup - with a fresh entry.
+# To keep the common park allocation-free, each task caches one entry
+# (`t.cached_wait_entry`) and reuses it whenever it is free, i.e. not still
+# linked into some queue (`w.queue === nothing`, always a synchronized read
+# for the owning task since the unlinker either is the task itself or
+# subsequently scheduled it).
+mutable struct WaitEntry
+    task::Union{Task, Nothing}
+    next::Union{WaitEntry, Nothing}
+    queue::Any
+    WaitEntry(task::Union{Task, Nothing}) = new(task, nothing, nothing)
+end
+
+# Return the cached entry of `waiter` if it is free, else a fresh (and newly
+# cached) one.
+function _cached_wait_entry(waiter::Task)
+    w = waiter.cached_wait_entry
+    if w isa WaitEntry && w.queue === nothing
+        w.task = waiter
+    else
+        w = WaitEntry(waiter)
+        waiter.cached_wait_entry = w
+    end
+    return w
+end
+
+# Claim the wake of the wait that `w` was registered for (returns whether the
+# claim succeeded). `w` must be an entry armed for `t` by `_wait2`.
+function claim_wait(t::Task, w::WaitEntry)
+    return (@atomicreplace t.waiting_on w => nothing).success
+end
+
 """
     GenericCondition
 
@@ -61,13 +121,21 @@ Abstract implementation of a condition object
 for synchronizing task objects with a given lock.
 """
 struct GenericCondition{L<:AbstractLock}
-    waitq::IntrusiveLinkedList{Task}
+    waitq::IntrusiveLinkedList{WaitEntry}
     lock::L
 
-    GenericCondition{L}() where {L<:AbstractLock} = new{L}(IntrusiveLinkedList{Task}(), L())
-    GenericCondition{L}(l::L) where {L<:AbstractLock} = new{L}(IntrusiveLinkedList{Task}(), l)
-    GenericCondition(l::AbstractLock) = new{typeof(l)}(IntrusiveLinkedList{Task}(), l)
+    GenericCondition{L}() where {L<:AbstractLock} = new{L}(IntrusiveLinkedList{WaitEntry}(), L())
+    GenericCondition{L}(l::L) where {L<:AbstractLock} = new{L}(IntrusiveLinkedList{WaitEntry}(), l)
+    GenericCondition(l::AbstractLock) = new{typeof(l)}(IntrusiveLinkedList{WaitEntry}(), l)
 end
+
+# The queue identity recorded in entries (the membership witness) must be a
+# mutable, identity-stable object: an immutable waitee would be re-boxed on
+# every park, allocating in the steady state. Plain condition waits therefore
+# use the waitq list itself as the identity; waits on behalf of a richer
+# (mutable) waitee - e.g. waiting on a Task via its donenotify - record that
+# waitee instead (see `waitqueue(::Task)`).
+waitqueue(c::GenericCondition) = ILLRef(c.waitq, c.waitq)
 
 show(io::IO, c::GenericCondition) = print(io, GenericCondition, "(", c.lock, ")")
 
@@ -79,14 +147,19 @@ islocked(c::GenericCondition) = islocked(c.lock)
 
 lock(f, c::GenericCondition) = lock(f, c.lock)
 
-# have waiter wait for c
-function _wait2(c::GenericCondition, waiter::Task, first::Bool=false)
+# have waiter wait for c: register `waiter` on c's wait queue (with `waitee`
+# recorded as the queue identity) and arm the registration for a wake.
+# Returns the registration entry.
+function _wait2(c::GenericCondition, waiter::Task, first::Bool=false;
+                waitee=c.waitq, entry::Union{WaitEntry, Nothing}=nothing)
     ct = current_task()
     assert_havelock(c)
+    w = entry === nothing ? _cached_wait_entry(waiter) : entry
+    @atomic :release waiter.waiting_on = w
     if first
-        pushfirst!(c.waitq, waiter)
+        pushfirst!(ILLRef(c.waitq, waitee), w)
     else
-        push!(c.waitq, waiter)
+        push!(ILLRef(c.waitq, waitee), w)
     end
     # since _wait2 is similar to schedule, we should observe the sticky bit now
     if waiter.sticky && Threads.threadid(waiter) == 0 && !GC.in_finalizer()
@@ -99,7 +172,7 @@ function _wait2(c::GenericCondition, waiter::Task, first::Bool=false)
         tid = Threads.threadid()
         ccall(:jl_set_task_tid, Cint, (Any, Cint), waiter, tid-1)
     end
-    return
+    return w
 end
 
 """
@@ -133,18 +206,28 @@ Wait for [`notify`](@ref) on `c` and return the `val` parameter passed to `notif
 If the keyword `first` is set to `true`, the waiter will be put _first_
 in line to wake up on `notify`. Otherwise, `wait` has first-in-first-out (FIFO) behavior.
 """
-function wait(c::GenericCondition; first::Bool=false)
+function wait(c::GenericCondition; first::Bool=false, waitee=c.waitq)
     ct = current_task()
-    _wait2(c, ct, first)
+    assert_havelock(c)
+    w = _wait2(c, ct, first; waitee)
     token = unlockall(c.lock)
-    try
-        return wait()
+    ret = try
+        wait()
     catch
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::IntrusiveLinkedList{Task}, ct)
-        rethrow()
-    finally
+        # We were resumed without a wake having been delivered through our
+        # registration: either an interrupter claimed it (leaving the entry
+        # linked for us to clean up), or we got a raw `throwto`. Disarm the
+        # registration first - before the relock below can register a new
+        # wait - then unlink our entry (a no-op if a `notify` already popped
+        # and dropped it).
+        @atomicreplace ct.waiting_on w => nothing
         relockall(c.lock, token)
+        list_deletefirst!(ILLRef(c.waitq, waitee), w)
+        rethrow()
     end
+    # a normal wake implies our claim was won and our entry already unlinked
+    relockall(c.lock, token)
+    return ret
 end
 
 """
@@ -161,7 +244,15 @@ function notify(c::GenericCondition, @nospecialize(arg), all, error)
     assert_havelock(c)
     cnt = 0
     while !isempty(c.waitq)
-        t = popfirst!(c.waitq)
+        w = popfirst!(waitqueue(c))
+        # An entry whose wake was already claimed by an interrupter does not
+        # count as woken: drop it and continue to the next waiter (the
+        # interrupted task resumes via whatever its claimer scheduled and
+        # will find its entry already unlinked).
+        t = w.task
+        if !(t isa Task && claim_wait(t, w))
+            continue
+        end
         schedule(t, arg, error=error)
         cnt += 1
         all || break

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -85,9 +85,11 @@ islocked(::AlwaysLockedST) = true
 # register anew - e.g. park on a lock during its cleanup - with a fresh entry.
 # To keep the common park allocation-free, each task caches one entry
 # (`t.cached_wait_entry`) and reuses it whenever it is free, i.e. not still
-# linked into some queue (`w.queue === nothing`, always a synchronized read
-# for the owning task since the unlinker either is the task itself or
-# subsequently scheduled it).
+# linked into some queue (`w.queue === nothing`). Reuse requires the owning
+# task to be synchronized with the unlinker: either the task unlinked the entry
+# itself, or the unlinker subsequently scheduled it. Interrupted-wait cleanup
+# temporarily removes its entry from the cache before relocking, since another
+# task may unlink that stale entry without being the task that scheduled us.
 mutable struct WaitEntry
     task::Union{Task, Nothing}
     next::Union{WaitEntry, Nothing}
@@ -105,6 +107,17 @@ function _cached_wait_entry(waiter::Task)
         w = WaitEntry(waiter)
         waiter.cached_wait_entry = w
     end
+    return w
+end
+
+@noinline function _wait_registration_error()
+    throw(ConcurrencyViolationError("Task is already registered on a wait queue"))
+end
+
+# Publish `w` as `waiter`'s only armed wait registration.
+function _arm_wait(waiter::Task, w::WaitEntry)
+    armed = @atomicreplace :release :monotonic waiter.waiting_on nothing => w
+    armed.success || _wait_registration_error()
     return w
 end
 
@@ -155,7 +168,7 @@ function _wait2(c::GenericCondition, waiter::Task, first::Bool=false;
     ct = current_task()
     assert_havelock(c)
     w = entry === nothing ? _cached_wait_entry(waiter) : entry
-    @atomic :release waiter.waiting_on = w
+    _arm_wait(waiter, w)
     if first
         pushfirst!(ILLRef(c.waitq, waitee), w)
     else
@@ -221,8 +234,18 @@ function wait(c::GenericCondition; first::Bool=false, waitee=c.waitq)
         # wait - then unlink our entry (a no-op if a `notify` already popped
         # and dropped it).
         @atomicreplace ct.waiting_on w => nothing
+        # Do not reuse `w` while relocking: a notifier may have popped this
+        # stale entry without scheduling us and may still retain its identity
+        # for the wake-claim CAS. If relocking does not need to park and cache
+        # a replacement, restore `w` once cleanup under the old lock makes it
+        # safe to reuse again.
+        was_cached = ct.cached_wait_entry === w
+        was_cached && (ct.cached_wait_entry = nothing)
         relockall(c.lock, token)
         list_deletefirst!(ILLRef(c.waitq, waitee), w)
+        if was_cached && ct.cached_wait_entry === nothing
+            ct.cached_wait_entry = w
+        end
         rethrow()
     end
     # a normal wake implies our claim was won and our entry already unlinked
@@ -267,7 +290,13 @@ notify_error(c::GenericCondition, err) = notify(c, err, true, true)
 
 Return `true` if no tasks are waiting on the condition, `false` otherwise.
 """
-isempty(c::GenericCondition) = isempty(c.waitq)
+function isempty(c::GenericCondition)
+    for w in c.waitq
+        t = w.task
+        t isa Task && (@atomic t.waiting_on) === w && return false
+    end
+    return true
+end
 
 
 # default (Julia v1.0) is currently single-threaded

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -65,33 +65,12 @@ islocked(::AlwaysLockedST) = true
 # registration through the atomic field `t.waiting_on`. Whoever wants to wake
 # it must first claim the wake by atomically clearing that field:
 #
-#   - `notify` (holding the waitee's lock) pops an entry `w` and claims via
-#     CAS(t.waiting_on, w => nothing). The expected-value CAS makes stale
-#     entries harmless: if `t` was interrupted and has since registered
-#     elsewhere, the CAS fails and the popped corpse is simply dropped.
-#   - an interrupter (`schedule(t, exc, error=true)`) claims via an
-#     unconditional swap: it is directed at the *task*, not at any particular
-#     wait, so claiming whatever `t` is currently registered on is correct.
-#     It then opportunistically unlinks the claimed entry under the waitee's
-#     lock via `trylock` (see `try_unlink_claimed!`); if the lock is
-#     unavailable the entry stays linked and is collected lazily, either by
-#     the interrupted task's own wait cleanup or by the `notify` that pops
-#     and drops it.
-#   - wake sources directed at one *specific* wait (e.g. the timeout task of
-#     `Experimental.wait_with_timeout`) must register the wait with a fresh,
-#     single-use entry: single-use-ness is what guarantees their
-#     expected-value CAS cannot mistakenly claim a later, unrelated wait.
+# CAS(w => nothing) succeeds: the claim is won, and the owner may schedule
+# N.B.: Interrupters currently claim unconditionally, normal waiters claim
+# a specific entry. In the future this will be managed by the cancellation system.
 #
-# Entries are heap objects (rather than links folded into the Task) so that a
-# task whose interrupted wait left a stale registration behind can immediately
-# register anew - e.g. park on a lock during its cleanup - with a fresh entry.
-# To keep the common park allocation-free, each task caches one entry
-# (`t.cached_wait_entry`) and reuses it whenever it is free, i.e. not still
-# linked into some queue (`w.queue === nothing`). Reuse requires the owning
-# task to be synchronized with the unlinker: either the task unlinked the entry
-# itself, or the unlinker subsequently scheduled it. Interrupted-wait cleanup
-# temporarily removes its entry from the cache before relocking, since another
-# task may unlink that stale entry without being the task that scheduled us.
+# Entries are heap objects. A task whose interrupted wait left a stale registration
+# behind can immediately register anew - e.g. park on a lock during its cleanup - with a fresh entry.
 mutable struct WaitEntry
     task::Union{Task, Nothing}
     next::Union{WaitEntry, Nothing}
@@ -135,12 +114,8 @@ end
 Abstract implementation of a condition object
 for synchronizing task objects with a given lock.
 """
-# Mutable so that it can serve as the queue identity recorded in entries (the
-# membership witness): the witness must be an identity-stable heap object (an
-# immutable waitee would be re-boxed on every park, allocating in the steady
-# state), and the interrupt path must be able to find the queue's lock from
-# the witness alone (see `try_unlink_claimed!`).
 mutable struct GenericCondition{L<:AbstractLock}
+    # mutable for identity only
     const waitq::IntrusiveLinkedList{WaitEntry}
     const lock::L
 
@@ -151,30 +126,17 @@ end
 
 waitqueue(c::GenericCondition) = ILLRef(c.waitq, c)
 
-# Opportunistically unlink a *claimed* entry from whatever queue it is still
-# linked on, so interrupted waits do not accumulate corpses on the queue (and
-# the owner's cached entry becomes reusable right away). Precondition: the
-# caller holds the entry's claim and has not yet rescheduled the owner.
-# Every mutation of `w.queue` happens under the owning queue's lock, so the
-# racy read below is only a hint for locating that lock: `list_deletefirst!`
-# revalidates it (via the witness check) once the lock is held. The claim's
-# acquire edge on `waiting_on` guarantees the read sees the current queue or
-# `nothing`, never a stale previous waitee. Reading `nothing` can also mean
-# the claim landed mid-park, before the (still running) owner linked the
-# entry it had already armed; skipping the unlink is fine then - the entry
-# is collected lazily, exactly as on `trylock` failure (by the owner's own
-# wait cleanup or by a later notify popping and dropping it). Uses `trylock`
-# because the interrupt path must never block. The return value is a
-# best-effort "no linked corpse remains" indication (currently unused).
-#
-# The waitee kinds are matched explicitly, rather than through dynamic
-# dispatch on `trylock`/`unlock`: this path is reachable from `schedule`, so
-# it must be statically resolvable for trimmed binaries (juliac). A waitee
-# kind not matched here (a GenericCondition over a user-defined lock type)
-# just reports failure and relies on lazy collection.
+"""
+    try_unlink_claimed!(w::WaitEntry)
+
+Opportunistically attempt to unlink a wait entry from its queue. This is a memory pressure
+optimization. If the queue is locked by another task, the entry will remain linked and will
+be unlinked upon the next wakeup attempt.
+"""
 function try_unlink_claimed!(w::WaitEntry)
     q = w.queue
     q === nothing && return true
+    # Manual split for --trim
     if q isa Task
         dn = q.donenotify
         dn isa GenericCondition{Threads.SpinLock} || return false
@@ -276,18 +238,12 @@ function wait(c::GenericCondition; first::Bool=false, waitee=c)
     ret = try
         wait()
     catch
-        # We were resumed without a wake having been delivered through our
-        # registration: either an interrupter claimed it (leaving the entry
-        # linked for us to clean up), or we got a raw `throwto`. Disarm the
-        # registration first - before the relock below can register a new
-        # wait - then unlink our entry (a no-op if a `notify` already popped
-        # and dropped it).
+        # Error path - this could have come from an interrupt or other error.
+        # Clean up our wait condition.
+        # TODO: Replace this with the proper cancellation protocol.
         @atomicreplace ct.waiting_on w => nothing
-        # Do not reuse `w` while relocking: a notifier may have popped this
-        # stale entry without scheduling us and may still retain its identity
-        # for the wake-claim CAS. If relocking does not need to park and cache
-        # a replacement, restore `w` once cleanup under the old lock makes it
-        # safe to reuse again.
+        # WARNING: Do not use `w` for establish a wait on any tokens - otherwise
+        # we risk ABA issues by attempting to use the cached token for the lock wait.
         was_cached = ct.cached_wait_entry === w
         was_cached && (ct.cached_wait_entry = nothing)
         relockall(c.lock, token)
@@ -317,10 +273,6 @@ function notify(c::GenericCondition, @nospecialize(arg), all, error)
     cnt = 0
     while !isempty(c.waitq)
         w = popfirst!(waitqueue(c))
-        # An entry whose wake was already claimed by an interrupter does not
-        # count as woken: drop it and continue to the next waiter (the
-        # interrupted task resumes via whatever its claimer scheduled and
-        # will find its entry already unlinked).
         t = w.task
         if !(t isa Task && claim_wait(t, w))
             continue

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -72,9 +72,11 @@ islocked(::AlwaysLockedST) = true
 #   - an interrupter (`schedule(t, exc, error=true)`) claims via an
 #     unconditional swap: it is directed at the *task*, not at any particular
 #     wait, so claiming whatever `t` is currently registered on is correct.
-#     The claimed entry stays linked - the interrupter may not touch the queue
-#     without its lock - and is unlinked lazily, either by the interrupted
-#     task's own wait cleanup or by the `notify` that pops and drops it.
+#     It then opportunistically unlinks the claimed entry under the waitee's
+#     lock via `trylock` (see `try_unlink_claimed!`); if the lock is
+#     unavailable the entry stays linked and is collected lazily, either by
+#     the interrupted task's own wait cleanup or by the `notify` that pops
+#     and drops it.
 #   - wake sources directed at one *specific* wait (e.g. the timeout task of
 #     `Experimental.wait_with_timeout`) must register the wait with a fresh,
 #     single-use entry: single-use-ness is what guarantees their
@@ -133,22 +135,69 @@ end
 Abstract implementation of a condition object
 for synchronizing task objects with a given lock.
 """
-struct GenericCondition{L<:AbstractLock}
-    waitq::IntrusiveLinkedList{WaitEntry}
-    lock::L
+# Mutable so that it can serve as the queue identity recorded in entries (the
+# membership witness): the witness must be an identity-stable heap object (an
+# immutable waitee would be re-boxed on every park, allocating in the steady
+# state), and the interrupt path must be able to find the queue's lock from
+# the witness alone (see `try_unlink_claimed!`).
+mutable struct GenericCondition{L<:AbstractLock}
+    const waitq::IntrusiveLinkedList{WaitEntry}
+    const lock::L
 
     GenericCondition{L}() where {L<:AbstractLock} = new{L}(IntrusiveLinkedList{WaitEntry}(), L())
     GenericCondition{L}(l::L) where {L<:AbstractLock} = new{L}(IntrusiveLinkedList{WaitEntry}(), l)
     GenericCondition(l::AbstractLock) = new{typeof(l)}(IntrusiveLinkedList{WaitEntry}(), l)
 end
 
-# The queue identity recorded in entries (the membership witness) must be a
-# mutable, identity-stable object: an immutable waitee would be re-boxed on
-# every park, allocating in the steady state. Plain condition waits therefore
-# use the waitq list itself as the identity; waits on behalf of a richer
-# (mutable) waitee - e.g. waiting on a Task via its donenotify - record that
-# waitee instead (see `waitqueue(::Task)`).
-waitqueue(c::GenericCondition) = ILLRef(c.waitq, c.waitq)
+waitqueue(c::GenericCondition) = ILLRef(c.waitq, c)
+
+# Opportunistically unlink a *claimed* entry from whatever queue it is still
+# linked on, so interrupted waits do not accumulate corpses on the queue (and
+# the owner's cached entry becomes reusable right away). Precondition: the
+# caller holds the entry's claim and has not yet rescheduled the owner.
+# Every mutation of `w.queue` happens under the owning queue's lock, so the
+# racy read below is only a hint for locating that lock: `list_deletefirst!`
+# revalidates it (via the witness check) once the lock is held. The claim's
+# acquire edge on `waiting_on` guarantees the read sees the current queue or
+# `nothing`, never a stale previous waitee. Reading `nothing` can also mean
+# the claim landed mid-park, before the (still running) owner linked the
+# entry it had already armed; skipping the unlink is fine then - the entry
+# is collected lazily, exactly as on `trylock` failure (by the owner's own
+# wait cleanup or by a later notify popping and dropping it). Uses `trylock`
+# because the interrupt path must never block. The return value is a
+# best-effort "no linked corpse remains" indication (currently unused).
+#
+# The waitee kinds are matched explicitly, rather than through dynamic
+# dispatch on `trylock`/`unlock`: this path is reachable from `schedule`, so
+# it must be statically resolvable for trimmed binaries (juliac). A waitee
+# kind not matched here (a GenericCondition over a user-defined lock type)
+# just reports failure and relies on lazy collection.
+function try_unlink_claimed!(w::WaitEntry)
+    q = w.queue
+    q === nothing && return true
+    if q isa Task
+        dn = q.donenotify
+        dn isa GenericCondition{Threads.SpinLock} || return false
+        return _try_unlink_from!(dn, q, w)
+    elseif q isa GenericCondition{Threads.SpinLock}
+        return _try_unlink_from!(q, q, w)
+    elseif q isa GenericCondition{ReentrantLock}
+        return _try_unlink_from!(q, q, w)
+    elseif q isa GenericCondition{AlwaysLockedST}
+        return _try_unlink_from!(q, q, w)
+    end
+    return false
+end
+
+function _try_unlink_from!(c::GenericCondition, @nospecialize(waitee), w::WaitEntry)
+    trylock(c.lock) || return false
+    try
+        list_deletefirst!(ILLRef(c.waitq, waitee), w)
+    finally
+        unlock(c.lock)
+    end
+    return true
+end
 
 show(io::IO, c::GenericCondition) = print(io, GenericCondition, "(", c.lock, ")")
 
@@ -164,7 +213,7 @@ lock(f, c::GenericCondition) = lock(f, c.lock)
 # recorded as the queue identity) and arm the registration for a wake.
 # Returns the registration entry.
 function _wait2(c::GenericCondition, waiter::Task, first::Bool=false;
-                waitee=c.waitq, entry::Union{WaitEntry, Nothing}=nothing)
+                waitee=c, entry::Union{WaitEntry, Nothing}=nothing)
     ct = current_task()
     assert_havelock(c)
     w = entry === nothing ? _cached_wait_entry(waiter) : entry
@@ -219,7 +268,7 @@ Wait for [`notify`](@ref) on `c` and return the `val` parameter passed to `notif
 If the keyword `first` is set to `true`, the waiter will be put _first_
 in line to wake up on `notify`. Otherwise, `wait` has first-in-first-out (FIFO) behavior.
 """
-function wait(c::GenericCondition; first::Bool=false, waitee=c.waitq)
+function wait(c::GenericCondition; first::Bool=false, waitee=c)
     ct = current_task()
     assert_havelock(c)
     w = _wait2(c, ct, first; waitee)

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -242,6 +242,11 @@ function wait(c::GenericCondition; first::Bool=false, waitee=c)
         # Clean up our wait condition.
         # TODO: Replace this with the proper cancellation protocol.
         @atomicreplace ct.waiting_on w => nothing
+        # Our wake may already have been claimed and turned into a workqueue
+        # enqueue that this unwind will never consume - drop that too, so a
+        # later `schedule` of this task does not find it spuriously queued.
+        q = ct.queue
+        q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
         # WARNING: Do not use `w` for establish a wait on any tokens - otherwise
         # we risk ABA issues by attempting to use the cached token for the lock wait.
         was_cached = ct.cached_wait_entry === w

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -685,6 +685,8 @@ function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real
         # resumed without a wake through our registration (interrupter or raw
         # throwto): disarm it, then unlink our entry under the lock
         @atomicreplace ct.waiting_on w => nothing
+        q = ct.queue
+        q === nothing || Base.list_deletefirst!(q::Base.StickyWorkqueue, ct)
         Base.relockall(c.lock, token)
         timer !== nothing && close(timer)
         Base.list_deletefirst!(Base.waitqueue(c), w)

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -623,37 +623,29 @@ end
 # 3. Task N: the task that notifies the Condition being waited on.
 #
 # Typical flow:
-# - W enters the Condition's wait queue.
+# - W registers on the Condition's wait queue with a fresh, single-use
+#   WaitEntry `w` (see the wake-claim protocol in condition.jl).
 # - W creates T and stops running (calls wait()).
 # - T, when scheduled, waits on a Timer.
 # - Two common outcomes:
-#   - N notifies the Condition.
-#     - W starts running, closes the Timer, sets waiter_left and returns
-#       the notify'ed value.
-#     - The closed Timer throws an EOFError to T which simply ends.
+#   - N notifies the Condition: N claims W's wake (clearing W's
+#     `waiting_on`) and pops `w`. W starts running, closes the Timer and
+#     returns the notify'ed value. The closed Timer throws an EOFError
+#     to T which simply ends.
 #   - The Timer expires.
-#     - T starts running and locks the Condition.
-#     - T confirms that waiter_left is unset and that W is still in the
-#       Condition's wait queue; it then removes W from the wait queue,
-#       sets dosched to true and unlocks the Condition.
-#     - If dosched is true, T schedules W with the special :timed_out
-#       value.
-#     - T ends.
+#     - T starts running, locks the Condition, and tries to claim W's
+#       wake via CAS(W.waiting_on, w => nothing). Because `w` is
+#       single-use, the claim can only succeed while W is still parked
+#       in *this* wait - never in a later wait of W, even one on the
+#       same Condition.
+#     - If the claim succeeds, T removes `w` from the wait queue,
+#       unlocks the Condition and schedules W with the special
+#       :timed_out value.
 #     - W runs and returns :timed_out.
 #
-# Some possible interleavings:
-# - N notifies the Condition but the Timer expires and T starts running
-#   before W:
-#   - W closing the expired Timer is benign.
-#   - T will find that W is no longer in the Condition's wait queue
-#     (which is protected by a lock) and will not schedule W.
-# - N notifies the Condition; W runs and calls wait on the Condition
-#   again before the Timer expires:
-#   - W sets waiter_left before leaving. When T runs, it will find that
-#     waiter_left is set and will not schedule W.
-#
-# The lock on the Condition's wait queue and waiter_left together
-# ensure proper synchronization and behavior of the tasks involved.
+# The single CAS on W's `waiting_on` arbitrates every race between N, T
+# and any interrupter: whoever wins the claim (and only that entity)
+# schedules W.
 
 """
     wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real=0.0)
@@ -669,38 +661,42 @@ millisecond.
 """
 function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real=0.0)
     ct = current_task()
-    Base._wait2(c, ct, first)
+    # This wait has a wake source directed at it specifically (the timeout
+    # task below), so it must register with a fresh, single-use entry: only
+    # single-use-ness guarantees that the timeout task's expected-entry CAS
+    # cannot claim a later, unrelated wait of `ct`.
+    w = Base._wait2(c, ct, first; entry=Base.WaitEntry(ct))
     token = Base.unlockall(c.lock)
 
     timer::Union{Timer, Nothing} = nothing
-    waiter_left::Union{Threads.Atomic{Bool}, Nothing} = nothing
     if timeout > 0.0
         timer = Timer(timeout)
-        waiter_left = Threads.Atomic{Bool}(false)
         # start a task to wait on the timer
-        t = _wait_with_timeout_task(c, ct, timer, waiter_left)
+        t = _wait_with_timeout_task(c, ct, w, timer)
         t.sticky = false
         Threads._spawn_set_thrpool(t, :interactive)
         schedule(t)
     end
 
+    local res
     try
         res = wait()
-        if timer !== nothing
-            close(timer)
-            @atomic waiter_left[] = true
-        end
-        return res
     catch
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.IntrusiveLinkedList{Task}, ct)
-        rethrow()
-    finally
+        # resumed without a wake through our registration (interrupter or raw
+        # throwto): disarm it, then unlink our entry under the lock
+        @atomicreplace ct.waiting_on w => nothing
         Base.relockall(c.lock, token)
+        timer !== nothing && close(timer)
+        Base.list_deletefirst!(Base.waitqueue(c), w)
+        rethrow()
     end
+    # a normal wake (notify or timeout) claimed and unlinked our registration
+    Base.relockall(c.lock, token)
+    timer !== nothing && close(timer)
+    return res
 end
 
-function _wait_with_timeout_task(c::GenericCondition, ct::Task, timer::Timer,
-    waiter_left::Threads.Atomic{Bool})
+function _wait_with_timeout_task(c::GenericCondition, ct::Task, w::Base.WaitEntry, timer::Timer)
     return Task() do
         try
             wait(timer)
@@ -710,12 +706,13 @@ function _wait_with_timeout_task(c::GenericCondition, ct::Task, timer::Timer,
         end
         dosched = false
         lock(c.lock)
-        # Confirm that the waiting task is still in the wait queue and remove it. If
-        # the task is not in the wait queue, it must have been notified already so we
-        # don't do anything here.
-        if !waiter_left[] && ct.queue === c.waitq
+        # Claim the wake of the specific wait `w` was registered for; `w` is
+        # single-use, so a successful claim means `ct` is still parked in
+        # that wait. If the claim fails (already notified or interrupted),
+        # do nothing.
+        if Base.claim_wait(ct, w)
             dosched = true
-            Base.list_deletefirst!(c.waitq, ct)
+            Base.list_deletefirst!(Base.waitqueue(c), w)
         end
         unlock(c.lock)
         # send the waiting task a timeout

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -514,7 +514,7 @@ function _atexit(exitcode::Cint)
     # this exit came from a signal for example), then try to clear that state
     # to minimize scheduler issues later
     ct = current_task()
-    q = ct.queue; q === nothing || list_deletefirst!(q::IntrusiveLinkedList{Task}, ct)
+    q = ct.queue; q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
     # Don't hold the lock around the iteration, just in case any other thread executing in
     # parallel tries to register a new atexit hook while this is running. We don't want to
     # block that thread from proceeding, and we can allow it to register its hook which we

--- a/base/linked_list.jl
+++ b/base/linked_list.jl
@@ -7,13 +7,6 @@ mutable struct IntrusiveLinkedList{T}
     IntrusiveLinkedList{T}() where {T} = new{T}(nothing, nothing)
 end
 
-# A reference to an intrusive list together with the identity recorded in the
-# elements' `queue` field while they are enqueued (the element's "which queue am
-# I on" witness). Plain lists use the list object itself as the identity; lists
-# that are owned by some other object (a synchronized workqueue wrapper, a
-# condition, a waited-on object) record that owner instead, so that code
-# holding only the element can identify the owner - and thus the lock
-# protecting the list - from the element alone.
 struct ILLRef{T}
     list::IntrusiveLinkedList{T}
     waitee::Any # Invariant: waitqueue(waitee).list === list

--- a/base/linked_list.jl
+++ b/base/linked_list.jl
@@ -1,11 +1,27 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 mutable struct IntrusiveLinkedList{T}
-    # Invasive list requires that T have a field `.next >: U{T, Nothing}` and `.queue >: U{ILL{T}, Nothing}`
+    # Invasive list requires that T have a field `.next >: U{T, Nothing}` and `.queue::Any`
     head::Union{T, Nothing}
     tail::Union{T, Nothing}
     IntrusiveLinkedList{T}() where {T} = new{T}(nothing, nothing)
 end
+
+# A reference to an intrusive list together with the identity recorded in the
+# elements' `queue` field while they are enqueued (the element's "which queue am
+# I on" witness). Plain lists use the list object itself as the identity; lists
+# that are owned by some other object (a synchronized workqueue wrapper, a
+# condition, a waited-on object) record that owner instead, so that code
+# holding only the element can identify the owner - and thus the lock
+# protecting the list - from the element alone.
+struct ILLRef{T}
+    list::IntrusiveLinkedList{T}
+    waitee::Any # Invariant: waitqueue(waitee).list === list
+end
+
+# waitqueue(x) returns the ILLRef for the queue of waiters registered on `x`.
+# Methods are added for each waitee type (conditions, tasks, workqueues, ...).
+function waitqueue end
 
 #const list_append!! = append!
 #const list_deletefirst! = delete!
@@ -49,9 +65,13 @@ function list_append!!(q::IntrusiveLinkedList{T}, q2::IntrusiveLinkedList{T}) wh
     return q
 end
 
-function push!(q::IntrusiveLinkedList{T}, val::T) where T
+isempty(qr::ILLRef) = isempty(qr.list)
+length(qr::ILLRef) = length(qr.list)
+
+function push!(qr::ILLRef{T}, val::T) where T
     val.queue === nothing || error("val already in a list")
-    val.queue = q
+    val.queue = qr.waitee
+    q = qr.list
     tail = q.tail
     if tail === nothing
         q.head = q.tail = val
@@ -62,9 +82,10 @@ function push!(q::IntrusiveLinkedList{T}, val::T) where T
     return q
 end
 
-function pushfirst!(q::IntrusiveLinkedList{T}, val::T) where T
+function pushfirst!(qr::ILLRef{T}, val::T) where T
     val.queue === nothing || error("val already in a list")
-    val.queue = q
+    val.queue = qr.waitee
+    q = qr.list
     head = q.head
     if head === nothing
         q.head = q.tail = val
@@ -75,21 +96,34 @@ function pushfirst!(q::IntrusiveLinkedList{T}, val::T) where T
     return q
 end
 
-function pop!(q::IntrusiveLinkedList{T}) where {T}
-    val = q.tail::T
-    list_deletefirst!(q, val) # expensive!
+function pop!(qr::ILLRef{T}) where {T}
+    val = qr.list.tail::T
+    _list_deletefirst!(qr.list, val) # expensive!
     return val
 end
 
-function popfirst!(q::IntrusiveLinkedList{T}) where {T}
-    val = q.head::T
-    list_deletefirst!(q, val) # cheap
+function popfirst!(qr::ILLRef{T}) where {T}
+    val = qr.list.head::T
+    _list_deletefirst!(qr.list, val) # cheap
     return val
 end
+
+# Delete `val` from the list, but only if it is actually in it, as witnessed by
+# `val.queue` holding the ILLRef's waitee. This makes deletion a no-op if `val`
+# was concurrently popped, which various cleanup paths rely upon.
+function list_deletefirst!(qr::ILLRef{T}, val::T) where T
+    val.queue === qr.waitee || return qr.list
+    return _list_deletefirst!(qr.list, val)
+end
+
+push!(q::IntrusiveLinkedList{T}, val::T) where T = push!(ILLRef(q, q), val)
+pushfirst!(q::IntrusiveLinkedList{T}, val::T) where T = pushfirst!(ILLRef(q, q), val)
+pop!(q::IntrusiveLinkedList{T}) where T = pop!(ILLRef(q, q))
+popfirst!(q::IntrusiveLinkedList{T}) where T = popfirst!(ILLRef(q, q))
+list_deletefirst!(q::IntrusiveLinkedList{T}, val::T) where T = list_deletefirst!(ILLRef(q, q), val)
 
 # this function assumes `val` is found in `q`
-function list_deletefirst!(q::IntrusiveLinkedList{T}, val::T) where T
-    val.queue === q || return
+function _list_deletefirst!(q::IntrusiveLinkedList{T}, val::T) where T
     head = q.head::T
     if head === val
         if q.tail::T === val

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2340,7 +2340,9 @@ function canstart_loading(modkey::PkgId, build_id::UInt128, stalecheck::Bool)
         for each in package_locks
             cond2 = each[2][2]
             assert_havelock(cond2.lock)
-            for waiting in cond2.waitq
+            for w in cond2.waitq
+                waiting = w.task
+                waiting isa Task || continue
                 push!(waiters, waiting => (each[2][1] => each[1]))
             end
         end

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -247,12 +247,19 @@ end
 
 function wait_no_relock(c::GenericCondition)
     ct = current_task()
-    _wait2(c, ct)
-    unlockall(c.lock)
+    w = _wait2(c, ct)
+    token = unlockall(c.lock)
     try
         return wait()
     catch
-        ct.queue === nothing || list_deletefirst!(ct.queue::IntrusiveLinkedList{Task}, ct)
+        # We were resumed without a wake having been delivered through our
+        # registration (an interrupter claimed it, or a raw `throwto`).
+        # Disarm it, then unlink our entry, which requires the waitee lock -
+        # for lock parking this is a leaf spinlock, so no re-parking here.
+        @atomicreplace ct.waiting_on w => nothing
+        lock(c.lock)
+        list_deletefirst!(waitqueue(c), w)
+        unlock(c.lock)
         rethrow()
     end
 end

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -254,6 +254,8 @@ function wait_no_relock(c::GenericCondition)
     catch
         # See disarm protocol in condition.jl
         @atomicreplace ct.waiting_on w => nothing
+        q = ct.queue
+        q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
         was_cached = ct.cached_wait_entry === w
         was_cached && (ct.cached_wait_entry = nothing)
         lock(c.lock)

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -252,13 +252,15 @@ function wait_no_relock(c::GenericCondition)
     try
         return wait()
     catch
-        # We were resumed without a wake having been delivered through our
-        # registration (an interrupter claimed it, or a raw `throwto`).
-        # Disarm it, then unlink our entry, which requires the waitee lock -
-        # for lock parking this is a leaf spinlock, so no re-parking here.
+        # See disarm protocol in condition.jl
         @atomicreplace ct.waiting_on w => nothing
+        was_cached = ct.cached_wait_entry === w
+        was_cached && (ct.cached_wait_entry = nothing)
         lock(c.lock)
         list_deletefirst!(waitqueue(c), w)
+        if was_cached && ct.cached_wait_entry === nothing
+            ct.cached_wait_entry = w
+        end
         unlock(c.lock)
         rethrow()
     end

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -74,11 +74,11 @@ mutable struct ReentrantLock <: AbstractLock
     #            |            | potentially never getting woken up).
     @atomic havelock::UInt8
     # offset32 = 28, offset64 = 32
-    cond_wait::ThreadSynchronizer # 2 words
-    # offset32 = 36, offset64 = 48
-    # sizeof32 = 20, sizeof64 = 32
+    cond_wait::ThreadSynchronizer # 1 word (mutable, held by reference)
+    # offset32 = 32, offset64 = 40
+    # sizeof32 = 16, sizeof64 = 24
     # now add padding to make this a full cache line to minimize false sharing between objects
-    _::NTuple{Int === Int32 ? 2 : 3, Int}
+    _::NTuple{Int === Int32 ? 3 : 4, Int}
     # offset32 = 44, offset64 = 72 == sizeof+offset
     # sizeof32 = 28, sizeof64 = 56
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -459,7 +459,7 @@ function closewrite(s::LibuvStream)
         # try-finally unwinds the sigatomic level, so need to repeat sigatomic_end
         sigatomic_end()
         iolock_begin()
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::IntrusiveLinkedList{Task}, ct)
+        q = ct.queue; q === nothing || Base.list_deletefirst!(q::StickyWorkqueue, ct)
         if uv_req_data(req) != C_NULL
             # req is still alive,
             # so make sure we won't get spurious notifications later
@@ -1092,7 +1092,7 @@ function uv_write_wait(uvw::Ptr{Cvoid})
         # try-finally unwinds the sigatomic level, so need to repeat sigatomic_end
         sigatomic_end()
         iolock_begin()
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::IntrusiveLinkedList{Task}, ct)
+        q = ct.queue; q === nothing || Base.list_deletefirst!(q::StickyWorkqueue, ct)
         if uv_req_data(uvw) != C_NULL
             # uvw is still alive,
             # so make sure we won't get spurious notifications later

--- a/base/task.jl
+++ b/base/task.jl
@@ -911,10 +911,6 @@ mutable struct IntrusiveLinkedListSynchronized{T}
     lock::Threads.SpinLock
     IntrusiveLinkedListSynchronized{T}() where {T} = new(IntrusiveLinkedList{T}(), Threads.SpinLock())
 end
-# The elements record this synchronized wrapper (not the inner list) as their
-# `queue` identity, so that an asynchronous deletion (e.g. `schedule(t, exc,
-# error=true)` yanking a task out of a sticky workqueue) dispatches back here
-# and takes the lock instead of mutating the inner list unsynchronized.
 waitqueue(W::IntrusiveLinkedListSynchronized) = ILLRef(W.queue, W)
 isempty(W::IntrusiveLinkedListSynchronized) = isempty(W.queue)
 length(W::IntrusiveLinkedListSynchronized) = length(W.queue)
@@ -970,11 +966,6 @@ workqueue_for(tid::Int) = Workqueues[tid]
 
 function enq_work(t::Task)
     (t._state === task_state_runnable && t.queue === nothing) || error("schedule: Task not runnable")
-    # A task with an armed wait registration is parked, not runnable: whoever
-    # wants to wake it must claim the registration first (see the wake-claim
-    # protocol in condition.jl). Every internal wake path does; catching the
-    # misuse here keeps a stray `schedule(t)` from racing the queue's `notify`
-    # into waking `t` twice.
     (@atomic :monotonic t.waiting_on) === nothing ||
         throw(ConcurrencyViolationError("schedule: Task is registered on a wait queue"))
 
@@ -1096,16 +1087,10 @@ function schedule(t::Task, @nospecialize(arg); error=false)
     # schedule a task to be (re)started with the given value or exception
     t._state === task_state_runnable || Base.error("schedule: Task not runnable")
     if error
-        # If `t` is registered on a wait queue, claim its wake so that a
-        # concurrent or later `notify` skips its registration, then
-        # opportunistically unlink the claimed entry: until `enq_work` below,
-        # `t` cannot run, so the entry cannot be reused and the unlink is
-        # safe. If the waitee's lock is unavailable the entry is left for
-        # lazy collection instead (this path must never block).
+        # Interrupt path: Unconditionally remove the wait (if any)
+        # TODO: This should use the proper cancellation system instead
         w = @atomicswap t.waiting_on = nothing
         w isa WaitEntry && try_unlink_claimed!(w)
-        # A parked task is never in a workqueue and wait registrations do not
-        # go through `t.queue`, so any queue here is a sticky workqueue.
         q = t.queue
         q === nothing || list_deletefirst!(q::StickyWorkqueue, t)
         setfield!(t, :result, arg)

--- a/base/task.jl
+++ b/base/task.jl
@@ -309,7 +309,7 @@ function _wait(t::Task)
         lock(donenotify)
         try
             while !istaskdone(t)
-                wait(donenotify)
+                wait(donenotify; waitee=t)
             end
         finally
             unlock(donenotify)
@@ -317,6 +317,8 @@ function _wait(t::Task)
     end
     nothing
 end
+
+waitqueue(t::Task) = ILLRef((t.donenotify::ThreadSynchronizer).waitq, t)
 
 # have `waiter` wait for `t`
 function _wait2(t::Task, waiter::Task)
@@ -336,7 +338,9 @@ function _wait2(t::Task, waiter::Task)
         donenotify = t.donenotify::ThreadSynchronizer
         lock(donenotify)
         if !istaskdone(t)
-            push!(donenotify.waitq, waiter)
+            w = _cached_wait_entry(waiter)
+            @atomic :release waiter.waiting_on = w
+            push!(waitqueue(t), w)
             unlock(donenotify)
             return nothing
         else
@@ -524,7 +528,13 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
             waiter = waiter_tasks[i]
             waiter === sentinel && continue
             donenotify = tasks[i].donenotify::ThreadSynchronizer
-            @lock donenotify list_deletefirst!(donenotify.waitq, waiter)
+            lock(donenotify)
+            # Claim the never-started waiter's wake so that a concurrent
+            # completion notify skips it, then unlink its registration (a
+            # no-op if a notify already popped it).
+            w = @atomicswap waiter.waiting_on = nothing
+            w isa WaitEntry && list_deletefirst!(waitqueue(tasks[i]), w)
+            unlock(donenotify)
         end
         done_tasks = tasks[done_mask]
         if throwexc && exception
@@ -856,8 +866,9 @@ function task_done_hook(t::Task)
         lock(donenotify)
         try
             if !isempty(donenotify.waitq)
-                handled = true
-                notify(donenotify)
+                # only wakes whose claim was won count as having consumed the
+                # result (a stale, already-claimed registration does not)
+                handled = notify(donenotify) > 0
             end
         finally
             unlock(donenotify)
@@ -899,12 +910,17 @@ mutable struct IntrusiveLinkedListSynchronized{T}
     lock::Threads.SpinLock
     IntrusiveLinkedListSynchronized{T}() where {T} = new(IntrusiveLinkedList{T}(), Threads.SpinLock())
 end
+# The elements record this synchronized wrapper (not the inner list) as their
+# `queue` identity, so that an asynchronous deletion (e.g. `schedule(t, exc,
+# error=true)` yanking a task out of a sticky workqueue) dispatches back here
+# and takes the lock instead of mutating the inner list unsynchronized.
+waitqueue(W::IntrusiveLinkedListSynchronized) = ILLRef(W.queue, W)
 isempty(W::IntrusiveLinkedListSynchronized) = isempty(W.queue)
 length(W::IntrusiveLinkedListSynchronized) = length(W.queue)
 function push!(W::IntrusiveLinkedListSynchronized{T}, t::T) where T
     lock(W.lock)
     try
-        push!(W.queue, t)
+        push!(waitqueue(W), t)
     finally
         unlock(W.lock)
     end
@@ -913,7 +929,7 @@ end
 function pushfirst!(W::IntrusiveLinkedListSynchronized{T}, t::T) where T
     lock(W.lock)
     try
-        pushfirst!(W.queue, t)
+        pushfirst!(waitqueue(W), t)
     finally
         unlock(W.lock)
     end
@@ -922,7 +938,7 @@ end
 function pop!(W::IntrusiveLinkedListSynchronized)
     lock(W.lock)
     try
-        return pop!(W.queue)
+        return pop!(waitqueue(W))
     finally
         unlock(W.lock)
     end
@@ -930,7 +946,7 @@ end
 function popfirst!(W::IntrusiveLinkedListSynchronized)
     lock(W.lock)
     try
-        return popfirst!(W.queue)
+        return popfirst!(waitqueue(W))
     finally
         unlock(W.lock)
     end
@@ -938,7 +954,7 @@ end
 function list_deletefirst!(W::IntrusiveLinkedListSynchronized{T}, t::T) where T
     lock(W.lock)
     try
-        list_deletefirst!(W.queue, t)
+        list_deletefirst!(waitqueue(W), t)
     finally
         unlock(W.lock)
     end
@@ -1072,7 +1088,14 @@ function schedule(t::Task, @nospecialize(arg); error=false)
     # schedule a task to be (re)started with the given value or exception
     t._state === task_state_runnable || Base.error("schedule: Task not runnable")
     if error
-        q = t.queue; q === nothing || list_deletefirst!(q::IntrusiveLinkedList{Task}, t)
+        # If `t` is registered on a wait queue, claim its wake so that a
+        # concurrent or later `notify` skips its registration (the entry
+        # itself stays linked; the resumed task's wait cleanup unlinks it).
+        @atomicswap t.waiting_on = nothing
+        # A parked task is never in a workqueue and wait registrations do not
+        # go through `t.queue`, so any queue here is a sticky workqueue.
+        q = t.queue
+        q === nothing || list_deletefirst!(q::StickyWorkqueue, t)
         setfield!(t, :result, arg)
         setfield!(t, :_isexception, true)
     else
@@ -1098,7 +1121,7 @@ function yield()
     try
         wait()
     catch
-        q = ct.queue; q === nothing || list_deletefirst!(q::IntrusiveLinkedList{Task}, ct)
+        q = ct.queue; q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
         rethrow()
     end
 end

--- a/base/task.jl
+++ b/base/task.jl
@@ -1090,9 +1090,13 @@ function schedule(t::Task, @nospecialize(arg); error=false)
     t._state === task_state_runnable || Base.error("schedule: Task not runnable")
     if error
         # If `t` is registered on a wait queue, claim its wake so that a
-        # concurrent or later `notify` skips its registration (the entry
-        # itself stays linked; the resumed task's wait cleanup unlinks it).
-        @atomicswap t.waiting_on = nothing
+        # concurrent or later `notify` skips its registration, then
+        # opportunistically unlink the claimed entry: until `enq_work` below,
+        # `t` cannot run, so the entry cannot be reused and the unlink is
+        # safe. If the waitee's lock is unavailable the entry is left for
+        # lazy collection instead (this path must never block).
+        w = @atomicswap t.waiting_on = nothing
+        w isa WaitEntry && try_unlink_claimed!(w)
         # A parked task is never in a workqueue and wait registrations do not
         # go through `t.queue`, so any queue here is a sticky workqueue.
         q = t.queue

--- a/base/task.jl
+++ b/base/task.jl
@@ -337,13 +337,14 @@ function _wait2(t::Task, waiter::Task)
         end
         donenotify = t.donenotify::ThreadSynchronizer
         lock(donenotify)
-        if !istaskdone(t)
-            w = _cached_wait_entry(waiter)
-            @atomic :release waiter.waiting_on = w
-            push!(waitqueue(t), w)
-            unlock(donenotify)
-            return nothing
-        else
+        try
+            if !istaskdone(t)
+                w = _cached_wait_entry(waiter)
+                _arm_wait(waiter, w)
+                push!(waitqueue(t), w)
+                return nothing
+            end
+        finally
             unlock(donenotify)
         end
     end

--- a/base/task.jl
+++ b/base/task.jl
@@ -970,6 +970,13 @@ workqueue_for(tid::Int) = Workqueues[tid]
 
 function enq_work(t::Task)
     (t._state === task_state_runnable && t.queue === nothing) || error("schedule: Task not runnable")
+    # A task with an armed wait registration is parked, not runnable: whoever
+    # wants to wake it must claim the registration first (see the wake-claim
+    # protocol in condition.jl). Every internal wake path does; catching the
+    # misuse here keeps a stray `schedule(t)` from racing the queue's `notify`
+    # into waking `t` twice.
+    (@atomic :monotonic t.waiting_on) === nothing ||
+        throw(ConcurrencyViolationError("schedule: Task is registered on a wait queue"))
 
     # Sticky tasks go into their thread's work queue.
     if t.sticky
@@ -1144,7 +1151,8 @@ Throws a `ConcurrencyViolationError` if `t` is the currently running task.
 function yield(t::Task, @nospecialize(x=nothing))
     ct = current_task()
     t === ct && throw(ConcurrencyViolationError("Cannot yield to currently running task!"))
-    (t._state === task_state_runnable && t.queue === nothing) || throw(ConcurrencyViolationError("yield: Task not runnable"))
+    (t._state === task_state_runnable && t.queue === nothing &&
+     (@atomic :monotonic t.waiting_on) === nothing) || throw(ConcurrencyViolationError("yield: Task not runnable"))
     # [task] user_time -yield-> wait_time
     record_running_time!(ct)
     # [task] created -scheduled-> wait_time

--- a/src/Makefile
+++ b/src/Makefile
@@ -101,6 +101,7 @@ CODEGEN_SRCS_HASH := codegen.cpp jitlayers.cpp aotcompile.cpp debuginfo.cpp disa
 	debug-registry.h debuginfo.h intrinsics.h jitlayers.h julia-task-dispatcher.h \
 	llvm-alloc-helpers.h llvm-codegen-shared.h llvm-gc-interface-passes.h llvm-pass-helpers.h \
 	llvm-version.h passes.h \
+	julia.h julia_threads.h julia_internal.h julia_fasttls.h \
 	$(GC_CODEGEN_SRCS_HASH)
 CODEGEN_SRCS := codegen jitlayers aotcompile debuginfo disasm llvm-simdloop \
 	llvm-pass-helpers llvm-ptls llvm-propagate-addrspaces \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4335,7 +4335,7 @@ void jl_init_types(void) JL_GC_DISABLED
                         NULL,
                         jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(27,
+                        jl_perm_symsvec(29,
                                         "next",
                                         "queue",
                                         "storage",
@@ -4362,8 +4362,10 @@ void jl_init_types(void) JL_GC_DISABLED
                                         "first_enqueued_at",
                                         "last_started_running_at",
                                         "running_time_ns",
-                                        "finished_at"),
-                        jl_svec(27,
+                                        "finished_at",
+                                        "waiting_on",
+                                        "cached_wait_entry"),
+                        jl_svec(29,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
@@ -4390,16 +4392,18 @@ void jl_init_types(void) JL_GC_DISABLED
                                 jl_uint64_type,
                                 jl_uint64_type,
                                 jl_uint64_type,
-                                jl_uint64_type),
+                                jl_uint64_type,
+                                jl_any_type,
+                                jl_any_type),
                         jl_emptysvec,
                         0, 1, 6);
     XX(task);
     jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);
     // Set field 20 (metrics_enabled) as const
-    // Set fields 8 (_state) and 24-27 (metric counters) as atomic
+    // Set fields 8 (_state), 24-27 (metric counters) and 28 (waiting_on) as atomic
     const static uint32_t task_constfields[1]  = { 0b00000000000010000000000000000000 };
-    const static uint32_t task_atomicfields[1] = { 0b00000111100000000000000010000000 };
+    const static uint32_t task_atomicfields[1] = { 0b00001111100000000000000010000000 };
     jl_task_type->name->constfields = task_constfields;
     jl_task_type->name->atomicfields = task_atomicfields;
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -343,6 +343,15 @@ typedef struct _jl_task_t {
     // timestamp this task finished (i.e. entered state DONE or FAILED).
     _Atomic(uint64_t) finished_at;
 
+    // This task's current registration on a wait queue (a `Base.WaitEntry`),
+    // or `nothing`. Doubles as the wake-claim word: whoever atomically clears
+    // it (notify via CAS against the specific entry, an interrupter via swap)
+    // owns waking the task. See the wake-claim protocol in base/condition.jl.
+    _Atomic(jl_value_t*) waiting_on;
+    // A `Base.WaitEntry` cached for reuse across parks (or `nothing`), so the
+    // common single-registration park does not allocate. Owned by this task.
+    jl_value_t *cached_wait_entry;
+
 // hidden state:
 
     // id of owning thread - does not need to be defined until the task runs

--- a/src/task.c
+++ b/src/task.c
@@ -1092,6 +1092,8 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_fu
     }
     t->next = jl_nothing;
     t->queue = jl_nothing;
+    jl_atomic_store_relaxed(&t->waiting_on, jl_nothing);
+    t->cached_wait_entry = jl_nothing;
     t->tls = jl_nothing;
     jl_atomic_store_relaxed(&t->_state, JL_TASK_STATE_RUNNABLE);
     t->start = start;
@@ -1543,6 +1545,8 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     ct->ctx.started = 1;
     ct->next = jl_nothing;
     ct->queue = jl_nothing;
+    jl_atomic_store_relaxed(&ct->waiting_on, jl_nothing);
+    ct->cached_wait_entry = jl_nothing;
     ct->tls = jl_nothing;
     jl_atomic_store_relaxed(&ct->_state, JL_TASK_STATE_RUNNABLE);
     ct->start = NULL;

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -32,7 +32,6 @@ function kill_timer(delay)
         # **DON'T COPY ME.**
         # The correct way to handle timeouts is to close the handle:
         # e.g. `close(stdout_read); close(stdin_write)`
-        test_task.queue === nothing || Base.list_deletefirst!(test_task.queue::Base.IntrusiveLinkedList{Task}, test_task)
         schedule(test_task, "hard kill repl test"; error=true)
         print(stderr, "WARNING: attempting hard kill of repl test after exceeding timeout\n")
     end

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -456,7 +456,7 @@ function send(sock::UDPSocket, ipaddr::IPAddr, port::Integer, msg)
     finally
         Base.sigatomic_end()
         iolock_begin()
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.IntrusiveLinkedList{Task}, ct)
+        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.StickyWorkqueue, ct)
         if uv_req_data(uvw) != C_NULL
             # uvw is still alive,
             # so make sure we won't get spurious notifications later

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -90,7 +90,7 @@ function getalladdrinfo(host::String)
     finally
         Base.sigatomic_end()
         iolock_begin()
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.IntrusiveLinkedList{Task}, ct)
+        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.StickyWorkqueue, ct)
         if uv_req_data(req) != C_NULL
             # req is still alive,
             # so make sure we don't get spurious notifications later
@@ -223,7 +223,7 @@ function getnameinfo(address::Union{IPv4, IPv6})
     finally
         Base.sigatomic_end()
         iolock_begin()
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.IntrusiveLinkedList{Task}, ct)
+        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.StickyWorkqueue, ct)
         if uv_req_data(req) != C_NULL
             # req is still alive,
             # so make sure we don't get spurious notifications later

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -431,7 +431,7 @@ end
         t = Timer(0) do t
             tc[] += 1
         end
-        cb = first(t.cond.waitq)
+        cb = first(t.cond.waitq).task::Task
         Libc.systemsleep(0.005)
         @test isopen(t)
         Base.process_events()
@@ -446,7 +446,7 @@ end
         t = Timer(0) do t
             tc[] += 1
         end
-        cb = first(t.cond.waitq)
+        cb = first(t.cond.waitq).task::Task
         Libc.systemsleep(0.005)
         @test isopen(t)
         close(t)
@@ -460,7 +460,7 @@ end
         async = Base.AsyncCondition() do async
             tc[] += 1
         end
-        cb = first(async.cond.waitq)
+        cb = first(async.cond.waitq).task::Task
         @test isopen(async)
         ccall(:uv_async_send, Cvoid, (Ptr{Cvoid},), async)
         Base.process_events() # schedule event
@@ -496,7 +496,7 @@ end
         async = Base.AsyncCondition() do async
             tc[] += 1
         end
-        cb = first(async.cond.waitq)
+        cb = first(async.cond.waitq).task::Task
         @test isopen(async)
         ccall(:uv_async_send, Cvoid, (Ptr{Cvoid},), async)
         Base.process_events() # schedule event

--- a/test/core.jl
+++ b/test/core.jl
@@ -48,7 +48,7 @@ for (T, c) in (
         (DataType, [:types, :layout]),
         (Core.Memory, []),
         (Core.GenericMemoryRef, []),
-        (Task, [:_state, :running_time_ns, :finished_at, :first_enqueued_at, :last_started_running_at]),
+        (Task, [:_state, :running_time_ns, :finished_at, :first_enqueued_at, :last_started_running_at, :waiting_on]),
         (Core.BindingPartition, [:min_world, :max_world, :next]),
     )
     @test Set((fieldname(T, i) for i in 1:fieldcount(T) if Base.isfieldatomic(T, i))) == Set(c)

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -247,6 +247,18 @@ end
         notify(e)
         @test timedwait(() -> istaskdone(target), 10.0) == :ok
     end
+    # scheduling (or yielding to) a task with an armed wait registration is a
+    # concurrency violation: it must be woken through its registration's queue
+    # (or by claiming, as `schedule(t, exc, error=true)` does)
+    let cond = Threads.Condition()
+        t = @async @lock cond wait(cond)
+        @test timedwait(() -> parked_on(t, cond), 10.0) == :ok
+        @test_throws ConcurrencyViolationError schedule(t)
+        @test_throws ConcurrencyViolationError schedule(t, :wrong)
+        @test_throws ConcurrencyViolationError yield(t)
+        @lock cond notify(cond, :legit)
+        @test fetch(t) === :legit
+    end
 end
 
 # the cached WaitEntry makes the steady-state park/wake cycle allocation-free:

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -6,13 +6,10 @@ using Base.Threads
 
 include("print_process_affinity.jl") # import `uv_thread_getaffinity`
 
-# whether `t` currently has an armed wait registration on `waitee` (plain
-# condition waits record the condition's waitq list as the queue identity)
+# whether `t` currently has an armed wait registration on `waitee`
 function parked_on(t::Task, @nospecialize(waitee))
     w = @atomic t.waiting_on
-    w isa Base.WaitEntry || return false
-    id = waitee isa Base.GenericCondition ? waitee.waitq : waitee
-    return w.queue === id
+    return w isa Base.WaitEntry && w.queue === waitee
 end
 
 # simple sanity tests for locks under cooperative concurrent access
@@ -108,8 +105,9 @@ end
             unlock(cond)
         end
     end
-    # interrupting a parked waiter claims its wake, so a later notify skips
-    # the stale entry instead of double-waking the task
+    # interrupting a parked waiter claims its wake and (when the waitee's
+    # lock is free) eagerly unlinks its entry, so nothing stale remains and
+    # its cached entry stays reusable
     let cond = Threads.Condition()
         t = @async begin
             lock(cond)
@@ -122,17 +120,21 @@ end
         yield() # let t park
         @test parked_on(t, cond)
         @test !isempty(cond.waitq)
+        w = @atomic t.waiting_on
         schedule(t, ErrorException("interrupt"), error=true)
-        # t has not run yet: its (claimed) entry is still linked
+        # eager unlink: entry gone before t even runs
         @test !parked_on(t, cond)
+        @test isempty(cond.waitq)
+        @test (w::Base.WaitEntry).queue === nothing # freed for reuse
         lock(cond)
-        @test notify(cond) == 0 # stale entry skipped, not woken twice
+        @test notify(cond) == 0
         unlock(cond)
         yield() # let t run its cleanup
         @test istaskfailed(t)
-        @test isempty(cond.waitq)
     end
-    # same, but the interrupted task cleans up its own entry first
+    # if the interrupter cannot take the waitee's lock, the claimed entry is
+    # left linked and collected lazily: a notify skips (and pops) it instead
+    # of double-waking the task
     let cond = Threads.Condition()
         t = @async begin
             lock(cond)
@@ -144,20 +146,28 @@ end
         end
         yield()
         @test parked_on(t, cond)
+        # the lock must be held by a *different* task: a reentrant trylock by
+        # the interrupter itself would succeed and unlink eagerly
+        holder_go = Event()
+        holder = @async (lock(cond); wait(holder_go); unlock(cond))
+        yield() # holder takes cond's lock, parks on holder_go
         schedule(t, ErrorException("interrupt"), error=true)
-        yield()
-        @test istaskfailed(t)
-        @test isempty(cond.waitq)
+        @test !parked_on(t, cond)
+        @test !isempty(cond.waitq) # stale entry awaiting lazy collection
+        notify(holder_go)
+        wait(holder)
         lock(cond)
-        @test notify(cond) == 0
+        @test notify(cond) == 0 # skipped (and popped), not woken twice
+        @test isempty(cond.waitq)
         unlock(cond)
+        yield() # let t finish its cleanup
+        @test istaskfailed(t)
     end
     # a task interrupted while waiting on a Threads.Condition must be able to
     # park on the condition's (contended) lock during its cleanup, while its
     # stale registration is still linked: the busy cached entry forces a
     # fresh registration
     let cond = Threads.Condition()
-        lock(cond) # hold the condition's lock so t's cleanup relock parks
         t = @async begin
             lock(cond)
             try
@@ -166,16 +176,23 @@ end
                 unlock(cond)
             end
         end
-        # let t park on the condition (we must release the lock for that)
-        unlock(cond)
-        @test timedwait(() -> parked_on(t, cond), 10.0) == :ok
-        lock(cond)
+        yield() # let t park on the condition
+        @test parked_on(t, cond)
+        w1 = @atomic t.waiting_on
+        # a different task must hold cond's lock so the interrupter's trylock
+        # unlink fails (leaving the corpse) and t's cleanup relock must park
+        holder_go = Event()
+        holder = @async (lock(cond); wait(holder_go); unlock(cond))
+        yield() # holder takes cond's lock, parks on holder_go
         schedule(t, ErrorException("interrupt"), error=true)
-        # t resumes and parks on the ReentrantLock we hold, with a fresh
-        # entry, while its stale claimed registration is still on cond
+        @test !isempty(cond.waitq) # corpse remains: trylock unlink failed
+        # t resumes and its cleanup relock parks on the ReentrantLock (it may
+        # spin-yield in slowlock first, so poll for the parked state)
         @test timedwait(() -> parked_on(t, cond.lock.cond_wait), 10.0) == :ok
-        @test !isempty(cond.waitq) # the stale entry
-        unlock(cond)
+        @test (@atomic t.waiting_on) !== w1 # cached entry busy -> fresh one
+        @test !isempty(cond.waitq) # corpse still linked while t is reparked
+        notify(holder_go)
+        wait(holder)
         @test timedwait(() -> istaskdone(t), 10.0) == :ok
         @test istaskfailed(t)
         @test isempty(cond.waitq) # collected by t's cleanup
@@ -197,9 +214,12 @@ end
         @test parked_on(t, cond)
         w = @atomic t.waiting_on
         @test w isa Base.WaitEntry
-        schedule(t, ErrorException("interrupt"), error=true)
         lock(cond)
         try
+            # interrupt from a helper task while we hold the lock, so the
+            # interrupter's opportunistic trylock unlink fails and the corpse
+            # stays linked for us (the "notifier") to pop
+            wait(@async schedule(t, ErrorException("interrupt"), error=true))
             @test popfirst!(Base.waitqueue(cond)) === w
             @test (w::Base.WaitEntry).queue === nothing
             for _ in 1:1000

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -42,6 +42,72 @@ end
 # skipped by notify and collected lazily; a task whose interrupted wait
 # left a stale registration behind can immediately park elsewhere
 @testset "wait registration claim protocol" begin
+    # A task can have only one armed wait registration at a time.
+    let
+        c1 = Threads.Condition()
+        c2 = Threads.Condition()
+        t = @task :done
+        lock(c1)
+        lock(c2)
+        try
+            w = Base._wait2(c1, t)
+            @test_throws ConcurrencyViolationError Base._wait2(c2, t)
+            @test (@atomic t.waiting_on) === w
+            @test length(c1.waitq) == 1
+            @test isempty(c2.waitq)
+            @test notify(c1) == 1
+            @test notify(c2) == 0
+        finally
+            unlock(c2)
+            unlock(c1)
+        end
+        @test fetch(t) === :done
+    end
+    let
+        target1 = @task nothing
+        target2 = @task nothing
+        waiter = @task nothing
+        Base._wait2(target1, waiter)
+        w = @atomic waiter.waiting_on
+        @test_throws ConcurrencyViolationError Base._wait2(target2, waiter)
+        @test (@atomic waiter.waiting_on) === w
+        @test length((target1.donenotify::Base.ThreadSynchronizer).waitq) == 1
+        donenotify2 = target2.donenotify::Base.ThreadSynchronizer
+        @test isempty(donenotify2.waitq)
+        gotlock = trylock(donenotify2)
+        # Release either our probe or the lock leaked by a regression.
+        unlock(donenotify2)
+        @test gotlock
+        schedule(target1)
+        schedule(target2)
+        wait(target1)
+        wait(target2)
+        wait(waiter)
+    end
+    # Claimed entries do not count as waiters while awaiting lazy removal.
+    let
+        cond = Threads.Condition()
+        stale = @task nothing
+        live = @task nothing
+        lock(cond)
+        try
+            w_stale = Base._wait2(cond, stale)
+            @test !isempty(cond)
+            @test Base.claim_wait(stale, w_stale)
+            @test !isempty(cond.waitq)
+            @test isempty(cond)
+            w_live = Base._wait2(cond, live)
+            @test !isempty(cond)
+            @test Base.claim_wait(live, w_live)
+            @test isempty(cond)
+            notified = notify(cond)
+            @test notified == 0
+            @test isempty(cond.waitq)
+        finally
+            notify(cond)
+            unlock(cond)
+        end
+    end
     # interrupting a parked waiter claims its wake, so a later notify skips
     # the stale entry instead of double-waking the task
     let cond = Threads.Condition()
@@ -113,6 +179,40 @@ end
         @test timedwait(() -> istaskdone(t), 10.0) == :ok
         @test istaskfailed(t)
         @test isempty(cond.waitq) # collected by t's cleanup
+    end
+    # A stale entry popped before interrupted-wait cleanup must not be reused
+    # while its old notifier could still retain its identity for a wake claim.
+    let cond = Threads.Condition()
+        ready = Event()
+        t = @async begin
+            lock(cond)
+            try
+                notify(ready)
+                wait(cond)
+            finally
+                unlock(cond)
+            end
+        end
+        wait(ready)
+        @test parked_on(t, cond)
+        w = @atomic t.waiting_on
+        @test w isa Base.WaitEntry
+        schedule(t, ErrorException("interrupt"), error=true)
+        lock(cond)
+        try
+            @test popfirst!(Base.waitqueue(cond)) === w
+            @test (w::Base.WaitEntry).queue === nothing
+            for _ in 1:1000
+                parked_on(t, cond.lock.cond_wait) && break
+                yield()
+            end
+            @test parked_on(t, cond.lock.cond_wait)
+            @test (@atomic t.waiting_on) !== w
+        finally
+            unlock(cond)
+        end
+        wait(t; throw=false)
+        @test istaskfailed(t)
     end
     # a task waiting on another task can be interrupted, and the waited-on
     # task's completion then does not count the stale registration as handled

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -6,6 +6,15 @@ using Base.Threads
 
 include("print_process_affinity.jl") # import `uv_thread_getaffinity`
 
+# whether `t` currently has an armed wait registration on `waitee` (plain
+# condition waits record the condition's waitq list as the queue identity)
+function parked_on(t::Task, @nospecialize(waitee))
+    w = @atomic t.waiting_on
+    w isa Base.WaitEntry || return false
+    id = waitee isa Base.GenericCondition ? waitee.waitq : waitee
+    return w.queue === id
+end
+
 # simple sanity tests for locks under cooperative concurrent access
 let lk = ReentrantLock()
     c1 = Event()
@@ -17,15 +26,154 @@ let lk = ReentrantLock()
     wait(c1)
     wait(c2)
     # wait for the task to park in the queue (it may be spinning)
-    @test timedwait(() -> t1.queue === lk.cond_wait.waitq, 1.0) == :ok
-    @test t2.queue !== lk.cond_wait.waitq
+    @test timedwait(() -> parked_on(t1, lk.cond_wait), 10.0) == :ok
+    @test !parked_on(t2, lk.cond_wait)
     @test istaskdone(t2)
     @test !fetch(t2)
     unlock(lk)
-    @test t1.queue === lk.cond_wait.waitq
+    @test parked_on(t1, lk.cond_wait)
     unlock(lk)
-    @test t1.queue !== lk.cond_wait.waitq
+    @test timedwait(() -> istaskdone(t1), 10.0) == :ok
+    @test !parked_on(t1, lk.cond_wait)
     @test fetch(t1)
+end
+
+# the wake-claim protocol: an interrupted waiter's stale registration is
+# skipped by notify and collected lazily; a task whose interrupted wait
+# left a stale registration behind can immediately park elsewhere
+@testset "wait registration claim protocol" begin
+    # interrupting a parked waiter claims its wake, so a later notify skips
+    # the stale entry instead of double-waking the task
+    let cond = Threads.Condition()
+        t = @async begin
+            lock(cond)
+            try
+                wait(cond)
+            finally
+                unlock(cond)
+            end
+        end
+        yield() # let t park
+        @test parked_on(t, cond)
+        @test !isempty(cond.waitq)
+        schedule(t, ErrorException("interrupt"), error=true)
+        # t has not run yet: its (claimed) entry is still linked
+        @test !parked_on(t, cond)
+        lock(cond)
+        @test notify(cond) == 0 # stale entry skipped, not woken twice
+        unlock(cond)
+        yield() # let t run its cleanup
+        @test istaskfailed(t)
+        @test isempty(cond.waitq)
+    end
+    # same, but the interrupted task cleans up its own entry first
+    let cond = Threads.Condition()
+        t = @async begin
+            lock(cond)
+            try
+                wait(cond)
+            finally
+                unlock(cond)
+            end
+        end
+        yield()
+        @test parked_on(t, cond)
+        schedule(t, ErrorException("interrupt"), error=true)
+        yield()
+        @test istaskfailed(t)
+        @test isempty(cond.waitq)
+        lock(cond)
+        @test notify(cond) == 0
+        unlock(cond)
+    end
+    # a task interrupted while waiting on a Threads.Condition must be able to
+    # park on the condition's (contended) lock during its cleanup, while its
+    # stale registration is still linked: the busy cached entry forces a
+    # fresh registration
+    let cond = Threads.Condition()
+        lock(cond) # hold the condition's lock so t's cleanup relock parks
+        t = @async begin
+            lock(cond)
+            try
+                wait(cond)
+            finally
+                unlock(cond)
+            end
+        end
+        # let t park on the condition (we must release the lock for that)
+        unlock(cond)
+        @test timedwait(() -> parked_on(t, cond), 10.0) == :ok
+        lock(cond)
+        schedule(t, ErrorException("interrupt"), error=true)
+        # t resumes and parks on the ReentrantLock we hold, with a fresh
+        # entry, while its stale claimed registration is still on cond
+        @test timedwait(() -> parked_on(t, cond.lock.cond_wait), 10.0) == :ok
+        @test !isempty(cond.waitq) # the stale entry
+        unlock(cond)
+        @test timedwait(() -> istaskdone(t), 10.0) == :ok
+        @test istaskfailed(t)
+        @test isempty(cond.waitq) # collected by t's cleanup
+    end
+    # a task waiting on another task can be interrupted, and the waited-on
+    # task's completion then does not count the stale registration as handled
+    let e = Event()
+        target = @async wait(e)
+        t = @async wait(target)
+        yield()
+        @test parked_on(t, target)
+        schedule(t, ErrorException("interrupt"), error=true)
+        yield()
+        @test istaskfailed(t)
+        notify(e)
+        @test timedwait(() -> istaskdone(target), 10.0) == :ok
+    end
+end
+
+# the cached WaitEntry makes the steady-state park/wake cycle allocation-free:
+# the same entry object is recycled across parks, and nothing on the park or
+# notify path allocates (in particular, the queue-identity witness must be a
+# mutable object - storing an immutable waitee would re-box it every park)
+@testset "wait registration recycling is allocation-free" begin
+    ping = Event(true)
+    pong = Event(true)
+    n = 500
+    t = Threads.@spawn for i in 1:(n + 20)
+        wait(ping)
+        notify(pong)
+    end
+    driver() = (notify(ping); wait(pong))
+    for i in 1:20 # warmup: compile and populate both tasks' cached entries
+        driver()
+    end
+    w_spawned = t.cached_wait_entry
+    w_driver = current_task().cached_wait_entry
+    @test w_spawned isa Base.WaitEntry
+    @test w_driver isa Base.WaitEntry
+    measure() = @allocated for i in 1:n
+        driver()
+    end
+    allocated = measure()
+    wait(t)
+    # the cached entries were recycled, not replaced
+    @test t.cached_wait_entry === w_spawned
+    @test current_task().cached_wait_entry === w_driver
+    @test (w_driver::Base.WaitEntry).queue === nothing # free between parks
+    if Base.JLOptions().code_coverage == 0
+        @test allocated == 0
+    end
+end
+
+@testset "unbuffered channel: interrupted taker is skipped" begin
+    ch = Channel{Int}(0)
+    t1 = @async take!(ch)
+    yield() # t1 parks as a taker
+    @test parked_on(t1, ch.cond_take)
+    schedule(t1, ErrorException("interrupt"), error=true)
+    t2 = @async take!(ch)
+    yield() # t2 parks as a taker, behind t1's stale entry
+    put!(ch, 42) # must skip t1's claimed entry and hand off to t2
+    @test fetch(t2) == 42
+    @test istaskfailed(t1)
 end
 
 let e = Event(), started1 = Event(false), started2 = Event(false)


### PR DESCRIPTION
This is split out from #60281. The fundamental problem is the following: When an operation is cancelled it starts running again, and some bookkeeping may be required for remove that waiting task from its waitqueue. However, that operation may need to acquire locks, including potentially sleeping again. This is a pre-existing problem. E.g. https://github.com/JuliaLang/julia/blob/2f35a920f04cfe7a3c9948c5f919159b17e75df4/base/task.jl#L1064 performs an unsynchronized waitq operation on a foreign task, which I don't believe is legal.