### PR TITLE
loading: point to the stale manifest when a dev-dep is missing

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2633,11 +2633,15 @@ function __require(into::Module, mod::Symbol)
 
                 throw(ArgumentError("Package $mod not found in current path$hint_message.$install_message"))
             else
+                stale_hint = stale_manifest_dep_hint(where, mod)
                 manifest_warnings = collect_manifest_warnings()
+                # If we can pinpoint a stale developed-package manifest, lead with
+                # that specific fix rather than the generic checklist below.
+                extra = stale_hint === nothing ? "" : stale_hint
                 throw(ArgumentError("""
                 Cannot load (`using/import`) module $mod into module $into in package $(where.name)
                 because package $(where.name) does not have $mod in its dependencies:
-                $manifest_warnings- You may have a partially installed environment. Try `Pkg.instantiate()`
+                $extra$manifest_warnings- You may have a partially installed environment. Try `Pkg.instantiate()`
                   to ensure all packages in the environment are installed.
                 - Or, if you have $(where.name) checked out for development and have
                   added $mod as a dependency but haven't updated your primary
@@ -2706,6 +2710,68 @@ function collect_manifest_warnings()
         """
     end
     return msg
+end
+
+# When `where` fails to load `mod`, the most common cause for a developed
+# package is a stale manifest: `where`'s Project.toml declares `mod`, but the
+# manifest entry for `where` in the active environment was resolved before that
+# dependency was added, so the loader does not see it. Detect exactly that case
+# and return a targeted hint naming the offending manifest, or `nothing` if this
+# specific situation does not apply (in which case the generic message is used).
+# This is best-effort diagnostics: any failure here must never mask the original
+# load error, so the whole body is guarded.
+function stale_manifest_dep_hint(where::PkgId, mod::Symbol)
+    where.uuid === nothing && return nothing
+    modname = String(mod)
+    try
+        for env in load_path()
+            project_file = env_project_file(env)
+            project_file isa String || continue
+            manifest_file = project_file_manifest_path(project_file)
+            manifest_file isa String || continue
+            d = get_deps(parsed_toml(manifest_file))
+            entries = get(d, where.name, nothing)::Union{Nothing, Vector{Any}}
+            entries === nothing && continue
+            for entry in entries
+                entry = entry::Dict{String, Any}
+                uuid = get(entry, "uuid", nothing)::Union{String, Nothing}
+                (uuid === nothing || UUID(uuid) !== where.uuid) && continue
+                # `where` is present in this manifest. If it already lists `mod`
+                # as a dependency the problem lies elsewhere; leave it alone.
+                deps = get(entry, "deps", nothing)::Union{Vector{String}, Dict{String, Any}, Nothing}
+                dep_stanza_get(deps, modname) === nothing || return nothing
+                # Only developed (path-referenced) packages can be repaired by a
+                # plain `Pkg.resolve()`; registered ones would need `Pkg.instantiate`.
+                path = get(entry, "path", nothing)::Union{String, Nothing}
+                path === nothing && return nothing
+                pkgdir = normpath(abspath(dirname(manifest_file), path))
+                # Confirm the developed package's Project.toml actually declares
+                # `mod`; otherwise the fix really is to add the dependency there.
+                for proj in project_names
+                    dev_project = joinpath(pkgdir, proj)
+                    isfile_casesensitive(dev_project) || continue
+                    pd = parsed_toml(dev_project)
+                    projdeps = get(pd, "deps", nothing)::Union{Dict{String, Any}, Nothing}
+                    if projdeps !== nothing && haskey(projdeps, modname)
+                        return """
+                        - The developed package $(where.name) (at $(pkgdir)) declares $mod in its
+                          Project.toml, but the manifest at
+                            $(manifest_file)
+                          is out of date and does not list it. Run `Pkg.resolve()` with that
+                          environment active to update the manifest:
+                            julia --project=$(dirname(manifest_file)) -e 'using Pkg; Pkg.resolve()'
+                        """
+                    end
+                    return nothing
+                end
+                return nothing
+            end
+        end
+    catch
+        # Diagnostics must never replace the real error with a new one.
+        return nothing
+    end
+    return nothing
 end
 
 function require(uuidkey::PkgId)

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -2165,3 +2165,79 @@ end
         rm(tmpdir; recursive=true, force=true)
     end
 end
+
+@testset "stale developed-package manifest dependency hint" begin
+    devuuid = "22222222-2222-2222-2222-222222222222"
+    depuuid = "11111111-1111-1111-1111-111111111111"
+
+    # Build an environment whose manifest lists a developed package `DevPkg`
+    # (referenced by `path`) whose deps stanza omits `DepPkg`, while `DevPkg`'s
+    # own Project.toml declares `DepPkg`. This is the stale-manifest situation.
+    function make_env(tmp; manifest_deps::String, project_deps::String)
+        devdir = joinpath(tmp, "DevPkg")
+        mkpath(joinpath(devdir, "src"))
+        write(joinpath(devdir, "Project.toml"), """
+            name = "DevPkg"
+            uuid = "$devuuid"
+
+            [deps]
+            $project_deps
+            """)
+        write(joinpath(devdir, "src", "DevPkg.jl"), "module DevPkg end")
+
+        env = joinpath(tmp, "env")
+        mkpath(env)
+        write(joinpath(env, "Project.toml"), """
+            [deps]
+            DevPkg = "$devuuid"
+            """)
+        write(joinpath(env, "Manifest.toml"), """
+            julia_version = "$(VERSION)"
+            manifest_format = "2.0"
+
+            [[deps.DevPkg]]
+            $manifest_deps
+            uuid = "$devuuid"
+            path = "../DevPkg"
+            """)
+        return env, devdir
+    end
+
+    where = Base.PkgId(Base.UUID(devuuid), "DevPkg")
+    old_load_path = copy(LOAD_PATH)
+    try
+        # Positive: manifest resolved before `DepPkg` was added; Project.toml has it.
+        mktempdir() do tmp
+            env, devdir = make_env(tmp;
+                manifest_deps = "deps = [\"Dates\"]",
+                project_deps  = "DepPkg = \"$depuuid\"")
+            copy!(LOAD_PATH, [env])
+            hint = Base.stale_manifest_dep_hint(where, :DepPkg)
+            @test hint !== nothing
+            @test occursin("Pkg.resolve()", hint)
+            @test occursin(joinpath(env, "Manifest.toml"), hint)
+            @test occursin(devdir, hint)
+        end
+
+        # Negative: the manifest already lists `DepPkg`, so nothing is stale.
+        mktempdir() do tmp
+            env, _ = make_env(tmp;
+                manifest_deps = "deps = [\"DepPkg\"]",
+                project_deps  = "DepPkg = \"$depuuid\"")
+            copy!(LOAD_PATH, [env])
+            @test Base.stale_manifest_dep_hint(where, :DepPkg) === nothing
+        end
+
+        # Negative: the dependency is not declared in DevPkg's Project.toml either,
+        # so `Pkg.resolve()` would not help and the generic message is right.
+        mktempdir() do tmp
+            env, _ = make_env(tmp;
+                manifest_deps = "deps = [\"Dates\"]",
+                project_deps  = "DepPkg = \"$depuuid\"")
+            copy!(LOAD_PATH, [env])
+            @test Base.stale_manifest_dep_hint(where, :NotADep) === nothing
+        end
+    finally
+        copy!(LOAD_PATH, old_load_path)
+    end
+end


### PR DESCRIPTION
### Motivation

When a developed (path-referenced) package declares a dependency in its `Project.toml` but the active environment's manifest was resolved *before* that dependency was added, `using`/`import` fails with:

```
Package X does not have Y in its dependencies:
- You may have a partially installed environment. Try `Pkg.instantiate()` ...
- Or, if you have X checked out for development and have added Y as a dependency
  but haven't updated your primary environment's manifest file, try `Pkg.resolve()`.
- Otherwise you may need to report an issue with X
```

The message reads as though `Y` is missing from `X`'s `Project.toml` (it usually is not — the user just added it), and it names neither the stale manifest nor the environment in which to run `Pkg.resolve()`. This is especially confusing when the failing package runs under a *different* shared environment (e.g. a launcher that forces `--project=@Foo`), so users routinely run `resolve` in the wrong project and nothing changes. See #45166 for the same class of complaint.

### Change

Add `stale_manifest_dep_hint(where, mod)`, called just before the generic checklist. It detects exactly this situation:

- `where` appears in a load-path manifest as a `path`-referenced (developed) entry,
- whose `deps` stanza omits `mod`,
- while `where`'s own `Project.toml` **does** declare `mod`.

When that holds, it prepends a targeted hint naming the offending manifest and the exact command:

```
- The developed package X (at /path/to/X) declares Y in its
  Project.toml, but the manifest at
    /path/to/env/Manifest.toml
  is out of date and does not list it. Run `Pkg.resolve()` with that
  environment active to update the manifest:
    julia --project=/path/to/env -e 'using Pkg; Pkg.resolve()'
```

Detection is entirely best-effort and wrapped in `try`/`catch`, so it can never replace the original load error; when it does not apply, the existing message is unchanged.

### Tests

`test/loading.jl` gains a testset covering the positive case and two negatives (dependency already in the manifest; dependency not declared in the developed `Project.toml` either).

Assisted by AI.