### PR TITLE
Suppress "objcache error: Operation not permitted" print

### DIFF
--- a/src/objcache.cpp
+++ b/src/objcache.cpp
@@ -174,7 +174,7 @@ void ObjCache::initDB()
     checkMDB(mdb_env_set_mapsize(Env, OBJCACHE_CAPACITY * 2));
     llvm::sys::fs::create_directories(*CachePath);
     if (int Err = mdb_env_open(Env, CachePath->c_str(), MDB_NOSYNC | MDB_NOTLS, 0640)) {
-        if (Err != ENOENT)
+        if (Err != ENOENT && Err != EACCES)
             checkMDB(Err);
         mdb_env_close(Env);
         goto cleanup;


### PR DESCRIPTION
Failing to open the objcache because we can't access the directory shouldn't print a nuisance message.  This is especially common when launching Julia from a coding agent, where the sandbox typically allows read-only access to the depot.