### PR TITLE
mac/app: make the bundle main executable notarizable

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -33,6 +33,15 @@ LOADER_EXE_LDFLAGS := $(LOADER_LDFLAGS)
 
 ifeq ($(OS),Darwin)
 LOADER_EXE_LDFLAGS += -Wl,-export_dynamic
+# The macOS app bundle (contrib/mac/app) uses a plain copy of this loader at
+# Contents/MacOS/julia-terminal as its main executable (Apple's notary requires
+# a real Mach-O there, not a symlink into the sealed Resources tree). From that
+# location @executable_path/../lib misses the bundled julia tree, so also carry
+# an rpath to the bundle's lib dir. In any other layout the path simply doesn't
+# exist and dyld ignores it. Baking it in at link time keeps the .app assembly
+# a pure repackage of the binary dist, needing no Mach-O tools (it runs on
+# Linux CI hosts).
+LOADER_EXE_LDFLAGS += -Wl,-rpath,'@executable_path/../Resources/julia/lib'
 endif
 
 # Build list of dependent libraries that must be opened

--- a/cli/loader_exe.c
+++ b/cli/loader_exe.c
@@ -16,24 +16,22 @@ JULIA_DEFINE_FAST_TLS
 
 #ifdef _OS_DARWIN_
 // The macOS application bundle (contrib/mac/app) uses `julia-terminal` as its
-// double-clickable entry point (CFBundleExecutable). `julia-terminal` is a hardlink
-// to the julia binary sitting next to it in `bin/`. When the loader is invoked under
-// that name, we don't start the REPL in-process (a Finder-launched bundle has no
-// controlling terminal); instead we relaunch the sibling `julia` binary inside a new
-// Terminal.app window so the user gets an interactive session.
-//
-// A hardlink (rather than a symlink) is what makes this work: LaunchServices resolves
-// a symlinked CFBundleExecutable down to its target, discarding the `julia-terminal`
-// name, whereas a hardlink keeps its own name. That distinct name is also how we avoid
-// hijacking ordinary `julia` invocations (e.g. non-interactive `julia script.jl`).
+// double-clickable entry point (CFBundleExecutable): a copy of this loader placed
+// directly in Contents/MacOS/ (a real Mach-O, as Apple's notary requires of a bundle's
+// main executable -- a symlink, or a binary living under Contents/Resources/ where it is
+// also sealed as a resource, is rejected as an invalid signature). When the loader is
+// invoked under that name, we don't start the REPL in-process (a Finder-launched bundle
+// has no controlling terminal); instead we relaunch the REPL binary from the bundled
+// tree inside a new Terminal.app window so the user gets an interactive session. Keying
+// off the `julia-terminal` name is also how we avoid hijacking ordinary `julia`
+// invocations (e.g. non-interactive `julia script.jl`).
 static void maybe_launch_terminal(void)
 {
     char exe_path[JL_PATH_MAX];
     uint32_t bufsize = sizeof(exe_path);
     if (_NSGetExecutablePath(exe_path, &bufsize) != 0)
         return;
-    // Resolve any intermediate symlinks (the bundle's Contents/MacOS/julia-terminal
-    // is a symlink into bin/) to land on the real `julia-terminal` hardlink.
+    // Resolve any symlinks to get this executable's canonical path.
     char self_path[JL_PATH_MAX];
     if (realpath(exe_path, self_path) == NULL)
         return;
@@ -46,9 +44,25 @@ static void maybe_launch_terminal(void)
     if (strcmp(base, "julia-terminal") != 0)
         return;
 
-    // The real julia binary is the sibling `julia`. Hand it to Terminal.app, which
-    // opens a window and runs the REPL there.
-    strcpy(base, "julia");
+    // Locate the REPL binary to hand to Terminal.app. In the app bundle the main
+    // executable is Contents/MacOS/julia-terminal and the REPL lives in the bundled tree
+    // at ../Resources/julia/bin/julia -- it must run from there so it finds its sysimage,
+    // stdlibs and share/ via its own ../lib and ../share. Rewrite self_path to that path
+    // in place, falling back to a sibling `julia` for any other (non-bundle) layout.
+    base[-1] = '\0';                             // strip "/julia-terminal" -> "...MacOS"
+    char * dir = strrchr(self_path, '/');
+    if (dir != NULL && strcmp(dir + 1, "MacOS") == 0) {
+        static const char rel[] = "/Resources/julia/bin/julia";
+        if ((size_t)(dir - self_path) + sizeof(rel) > sizeof(self_path))
+            return;
+        strcpy(dir, rel);                        // ".../Contents" + "/Resources/julia/bin/julia"
+    }
+    else {
+        static const char rel[] = "/julia";
+        if (strlen(self_path) + sizeof(rel) > sizeof(self_path))
+            return;
+        strcat(self_path, rel);
+    }
     execl("/usr/bin/open", "open", "-a", "Terminal", self_path, (char *)NULL);
     jl_loader_print_stderr("ERROR: Failed to launch Terminal.app!\n");
     exit(1);

--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -46,15 +46,19 @@ dmg/$(APP_NAME): Info.plist.in julia.icns
 	cp julia.icns $@/Contents/Resources/
 	$(MAKE) -C $(JULIAHOME) binary-dist
 	$(TAR) -xzf $(JULIAHOME)/$(JULIA_BINARYDIST_FILENAME).tar.gz -C $@/Contents/Resources/julia --strip-components 1
-	# The app's double-clickable entry point is `julia-terminal`. It is a hardlink to
-	# the bundled julia binary (NOT a symlink: LaunchServices resolves a symlinked
-	# CFBundleExecutable down to its target, discarding the name the loader keys off).
-	# When the loader is invoked under this name it relaunches julia inside Terminal.app
+	# The app's double-clickable entry point is `julia-terminal` (CFBundleExecutable):
+	# a real copy of the julia loader placed directly in Contents/MacOS/. Apple's notary
+	# requires the bundle's main executable to be a regular Mach-O in Contents/MacOS/ --
+	# a symlink, or a binary living under Contents/Resources/ (where it is also sealed as
+	# a resource), is rejected as an invalid signature. When the loader is invoked under
+	# this name it relaunches the REPL from the bundled tree in a new Terminal.app window
 	# (see cli/loader_exe.c) instead of starting the REPL in the windowless bundle
-	# process. Contents/MacOS/julia-terminal is a symlink to that hardlink, so the real
-	# executable keeps its bin/ location and thus its relative rpath to the libraries.
-	ln -f $@/Contents/Resources/julia/bin/julia $@/Contents/Resources/julia/bin/julia-terminal
-	ln -fs ../Resources/julia/bin/julia-terminal $@/Contents/MacOS/julia-terminal
+	# process; the distinct name is also how it avoids hijacking ordinary `julia` runs.
+	# A plain `cp` suffices: the loader is linked with an extra rpath into the bundled
+	# tree (@executable_path/../Resources/julia/lib, see cli/Makefile) precisely so this
+	# copy can resolve @rpath/libjulia from Contents/MacOS/ -- keeping this rule free of
+	# Mach-O tooling so it can run on any host (CI assembles the .app on Linux).
+	cp $@/Contents/Resources/julia/bin/julia $@/Contents/MacOS/julia-terminal
 	find $@/Contents/Resources/julia -type f -exec chmod -w {} \;
 	# Even though the tarball may already be signed, we re-sign here to make it easier to add
 	# unsigned executables (like the app launcher) and whatnot, without needing to maintain lists

--- a/contrib/mac/app/README.md
+++ b/contrib/mac/app/README.md
@@ -7,14 +7,20 @@ This builds the Julia OS X application bundle (.app folder), and stores it in a 
 The application bundle opens Terminal.app and executes the julia binary (which opens
 the REPL). All the Julia binary files and their dependencies are bundled inside this.
 
-Its double-clickable entry point is `julia-terminal`, a hardlink to the bundled julia
-binary (`Contents/Resources/julia/bin/julia-terminal`, reached via a
-`Contents/MacOS/julia-terminal` symlink). When the loader is invoked under the name
-`julia-terminal` it relaunches julia inside a new Terminal.app window rather than starting
-the REPL directly in the (windowless) bundle process. See `cli/loader_exe.c` for that
-logic. A hardlink is used rather than a symlink because LaunchServices resolves a
-symlinked `CFBundleExecutable` down to its target, discarding the `julia-terminal` name
-that the loader keys off.
+Its double-clickable entry point is `julia-terminal` (the bundle's `CFBundleExecutable`):
+a real copy of the julia loader placed directly at `Contents/MacOS/julia-terminal`. When
+the loader is invoked under that name it relaunches the REPL binary from the bundled tree
+(`Contents/Resources/julia/bin/julia`) inside a new Terminal.app window rather than
+starting the REPL directly in the (windowless) bundle process. See `cli/loader_exe.c` for
+that logic.
+
+The main executable is a real file in `Contents/MacOS/` -- not a symlink, and not inside
+`Contents/Resources/` -- because Apple's notary rejects a bundle main executable that is a
+symlink or that lives among the sealed resources. Because this copy runs from
+`Contents/MacOS/` rather than the tree's `bin/`, the loader is linked with an extra rpath
+into the bundled tree so dyld can resolve `libjulia` from there (see `cli/Makefile`);
+assembling the bundle is then a plain `cp` needing no Mach-O tools, so it runs on any
+host (CI assembles the .app on Linux).
 
 Run `make` to build.
 


### PR DESCRIPTION
The .app's main executable (`CFBundleExecutable = julia-terminal`) was a `Contents/MacOS/julia-terminal` symlink pointing at a `julia` hardlink under `Contents/Resources/julia/bin/`. Apple's notary rejects that: a bundle's main executable must be a real Mach-O in `Contents/MacOS/`, not a symlink and not a file under `Contents/Resources/` (where it is also sealed as a resource). The notarization log fails with, for both the hardlinked pair:

    "The signature of the binary is invalid."
      Julia-X.Y.app/Contents/Resources/julia/bin/julia
      Julia-X.Y.app/Contents/Resources/julia/bin/julia-terminal

Make `Contents/MacOS/julia-terminal` a real copy of the loader instead. Since it then runs from `Contents/MacOS/` rather than the tree's `bin/`, its stock rpath (`@executable_path/../lib`) would no longer point at the bundled libraries, so link the Darwin loader with one extra rpath into the bundle tree (`@executable_path/../Resources/julia/lib`) -- enough for dyld to resolve `@rpath/libjulia` at load time and reach `main`, where the loader immediately relaunches the REPL in Terminal and never actually uses libjulia itself. For every other layout the path simply doesn't exist and dyld ignores it. Baking the rpath in at link time (rather than patching the copy with `install_name_tool` during .app assembly) keeps the assembly a pure repackage of the binary dist needing no Mach-O tooling, so it can run on Linux CI hosts -- which carry no cctools/llvm binutils.

`maybe_launch_terminal()` no longer relaunches a sibling `julia` (there is none next to the copy); it relaunches the REPL from the bundled tree at `../Resources/julia/bin/julia`, which must run from there so it finds its sysimage, stdlibs and `share/` via its own `../lib` and `../share`. A non-bundle `julia-terminal` still falls back to the sibling `julia`. The `Resources/julia/bin/julia-terminal` hardlink is dropped.