### PR TITLE
loading: Make package cache loading robust to malformed caches and fix pkgimage restore crashes

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1390,22 +1390,22 @@ function find_all_in_cache_path(pkg::PkgId, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT
     if length(paths) > 1
         function sort_by(path)
             # when using pkgimages, consider those cache files first
-            pkgimage = if JLOptions().use_pkgimages != 0
-                io = open(path, "r")
-                try
-                    if isvalid_cache_header(io) === nothing
-                        false
-                    else
-                        _, _, _, _, _, _, flags = parse_cache_header(io, path)
-                        CacheFlags(flags).use_pkgimages
+            pkgimage = false
+            path_mtime = 0.0
+            try
+                if JLOptions().use_pkgimages != 0
+                    open(path, "r") do io
+                        if isvalid_cache_header(io) !== nothing
+                            pkgimage = CacheFlags(read_cache_header_flags(io)).use_pkgimages
+                        end
                     end
-                finally
-                    close(io)
                 end
-            else
-                false
+                path_mtime = mtime(path)
+            catch ex
+                # stale_cachefile will reject this candidate later
+                ex isa InterruptException && rethrow()
             end
-            (; pkgimage, mtime=mtime(path))
+            (; pkgimage, mtime=path_mtime)
         end
         function sort_lt(a, b)
             if a.pkgimage != b.pkgimage
@@ -2007,6 +2007,8 @@ function parse_image_target(io::IO)
 end
 
 function parse_image_targets(targets::Vector{UInt8})
+    # no native code
+    isempty(targets) && return ImageTarget[]
     io = IOBuffer(targets)
     ntargets = read(io, Int32)
     targets = Vector{ImageTarget}(undef, ntargets)
@@ -2143,7 +2145,7 @@ function isrelocatable(pkg::PkgId)
         _, (includes, includes_srcfiles, _), _... = _parse_cache_header(io, path)
         for inc in includes
             !startswith(inc.filename, "@depot") && return false
-            if inc ∉ includes_srcfiles
+            if inc.filename ∉ includes_srcfiles
                 # its an include_dependency
                 track_content = inc.mtime == -1.0
                 track_content || return false
@@ -2160,8 +2162,8 @@ function parse_cache_buildid(cachepath::String)
     try
         checksum = isvalid_cache_header(f)
         checksum === nothing && throw(ArgumentError("Incompatible header in cache file $cachepath."))
-        read(f, UInt8) # flags
-        read(f, UInt8) # syntax_version
+        read_cache_header_flags(f) # skip flags
+        skip(f, 1) # skip syntax_version
         n = read(f, Int32)
         n == 0 && error("no module defined in $cachepath")
         skip(f, n) # module name
@@ -3723,14 +3725,18 @@ function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stder
                     idx = findmin(mtime.(joinpath.(cachepath, cachefiles)))[2]
                     evicted_cachefile = joinpath(cachepath, cachefiles[idx])
                     @debug "Evicting file from cache" evicted_cachefile
-                    rm(evicted_cachefile; force=true)
-                    try
-                        rm(ocachefile_from_cachefile(evicted_cachefile); force=true)
-                        @static if Sys.isapple()
-                            rm(ocachefile_from_cachefile(evicted_cachefile) * ".dSYM"; force=true, recursive=true)
+                    evicted_files = [evicted_cachefile, ocachefile_from_cachefile(evicted_cachefile)]
+                    @static if Sys.isapple()
+                        push!(evicted_files, ocachefile_from_cachefile(evicted_cachefile) * ".dSYM")
+                    end
+                    for evicted in evicted_files
+                        try
+                            rm(evicted; force=true, recursive=true)
+                        catch e
+                            # Keep the successful compile.
+                            e isa IOError || rethrow()
+                            @warn "Failed to evict file from cache" evicted exception=e
                         end
-                    catch e
-                        e isa IOError || rethrow()
                     end
                 end
             end
@@ -3869,12 +3875,31 @@ function resolve_depot(inc::AbstractString)
     return :no_depot_found
 end
 
+# `read(f, n)` returns a short vector when the file ends early instead of throwing, which
+# lets a truncated cache file parse into a valid-looking header.
+function read_cache_bytes(f::IO, n::Integer)
+    bytes = read(f, n)
+    length(bytes) == n || throw(EOFError())
+    return bytes
+end
+
+# Names recorded in a cache file end up in filesystem paths and identifiers, where an
+# embedded NUL throws from `ispath` or `joinpath`. That happens outside the malformed-cache
+# handling in `stale_cachefile`, so reject such a name while parsing the file instead.
+function check_cache_name(name::String)
+    '\0' in name && error("cache file records a name containing an embedded NUL")
+    return name
+end
+check_cache_name(pkg::PkgId) = (check_cache_name(pkg.name); pkg)
+
+read_cache_name(f::IO, n::Integer) = check_cache_name(String(read_cache_bytes(f, n)))
+
 function read_module_list(f::IO, has_buildid_hi::Bool)
     modules = Vector{Pair{PkgId, UInt128}}()
     while true
         n = read(f, Int32)
         n == 0 && break
-        sym = String(read(f, n)) # module name
+        sym = read_cache_name(f, n) # module name
         uuid = UUID((read(f, UInt64), read(f, UInt64))) # pkg UUID
         build_id_hi = UInt128(has_buildid_hi ? read(f, UInt64) : UInt64(0)) << 64
         build_id = (build_id_hi | read(f, UInt64)) # build id (checksum + time - not a UUID)
@@ -3883,8 +3908,11 @@ function read_module_list(f::IO, has_buildid_hi::Bool)
     return modules
 end
 
+# Read flags after the version header.
+read_cache_header_flags(f::IO) = read(f, UInt8)
+
 function _parse_cache_header(f::IO, cachefile::AbstractString)
-    flags = read(f, UInt8)
+    flags = read_cache_header_flags(f)
     syntax_version = read(f, UInt8)
     modules = read_module_list(f, false)
     totbytes = Int64(read(f, UInt64)) # total bytes for file dependencies + preferences
@@ -3898,7 +3926,7 @@ function _parse_cache_header(f::IO, cachefile::AbstractString)
         if n2 == 0
             break
         end
-        depname = String(read(f, n2))
+        depname = String(read_cache_bytes(f, n2))
         totbytes -= n2
         fsize = read(f, UInt64)
         totbytes -= 8
@@ -3919,19 +3947,19 @@ function _parse_cache_header(f::IO, cachefile::AbstractString)
                 if n1 == 0
                     break
                 end
-                push!(modpath, String(read(f, n1)))
+                push!(modpath, read_cache_name(f, n1))
                 totbytes -= n1
             end
         end
         if depname[1] == '\0'
-            push!(requires, modkey => binunpack(depname))
+            push!(requires, modkey => check_cache_name(binunpack(depname)))
         else
-            push!(includes, CacheHeaderIncludes(modkey, depname, fsize, hash, mtime, modpath))
+            push!(includes, CacheHeaderIncludes(modkey, check_cache_name(depname), fsize, hash, mtime, modpath))
         end
     end
     n2 = read(f, Int32)
     totbytes -= 4
-    prefs_blob = String(read(f, n2))
+    prefs_blob = String(read_cache_bytes(f, n2))
     totbytes -= n2
     srctextpos = read(f, Int64)
     totbytes -= 8
@@ -3939,7 +3967,7 @@ function _parse_cache_header(f::IO, cachefile::AbstractString)
     # read the list of modules that are required to be present during loading
     required_modules = read_module_list(f, true)
     l = read(f, Int32)
-    clone_targets = read(f, l)
+    clone_targets = read_cache_bytes(f, l)
 
     srcfiles = srctext_files(f, srctextpos, includes)
 
@@ -3949,7 +3977,12 @@ end
 function parse_cache_header(f::IO, cachefile::AbstractString)
     modules, (includes, srcfiles, requires), required_modules,
         srctextpos, prefs_blob, clone_targets, flags, syntax_version = _parse_cache_header(f, cachefile)
+    includes_srcfiles, _ = resolve_depot_includes!(includes, srcfiles, cachefile)
+    return modules, (includes, includes_srcfiles, requires), required_modules, srctextpos, prefs_blob, clone_targets, flags, syntax_version
+end
 
+# Resolve `@depot` include paths in place.
+function resolve_depot_includes!(includes::Vector{CacheHeaderIncludes}, srcfiles::Set{String}, cachefile::AbstractString)
     includes_srcfiles = CacheHeaderIncludes[]
     includes_depfiles = CacheHeaderIncludes[]
     for inc in includes
@@ -4022,7 +4055,7 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
         end
     end
 
-    return modules, (includes, includes_srcfiles, requires), required_modules, srctextpos, prefs_blob, clone_targets, flags, syntax_version
+    return includes_srcfiles, includes_depfiles
 end
 
 function parse_cache_header(cachefile::String)
@@ -4111,7 +4144,7 @@ function srctext_files(f::IO, srctextpos::Int64, includes::Vector{CacheHeaderInc
     while !eof(f)
         filenamelen = read(f, Int32)
         filenamelen == 0 && break
-        filename = String(read(f, filenamelen))
+        filename = read_cache_name(f, filenamelen)
         len = read(f, UInt64)
         push!(files, filename)
         seek(f, position(f) + len)
@@ -4385,6 +4418,7 @@ const CACHE_REJECT_REASONS = Dict{Symbol,Pair{Symbol,String}}(
     :source_path_changed     => :actionable  => "different source file path",
     :dep_identity_changed    => :actionable  => "dependency identifier changed",
     :checksum_invalid        => :actionable  => "cache file checksum is invalid",
+    :malformed_cache         => :actionable  => "cache file contents are malformed or truncated",
     :ocache_checksum_invalid => :actionable  => "native code cache checksum is invalid",
     :preferences_changed     => :actionable  => "package preferences changed",
     :incompatible_header     => :wrong_julia => "incompatible cache header",
@@ -4510,27 +4544,46 @@ function toml_egal(A::AbstractDict, B::AbstractDict)
     return true
 end
 
-function stale_prefs(prefs_blob::String)
-    # ensure any preferences observed match their precompile-time values
-    prefs_blob == "" && return false # no observed preferences (fast-path)
+# Parse the preferences recorded in a cache file into the observed and unset preferences
+# of each package, or `nothing` if none were recorded. Separate from `stale_prefs` so that
+# a caller can attribute a failure here to the cache file, while the environment lookups
+# the comparison performs are not the cache file's fault.
+function parse_prefs_blob(prefs_blob::String)
+    prefs_blob == "" && return nothing # no observed preferences (fast-path)
     prefs_data = TOML.parse(TOML.Parser{nothing}(prefs_blob))
+    observed = Dict{UUID,Dict{String,Any}}()
+    unset = Dict{UUID,Vector{String}}()
+    for (uuid, prefs) in prefs_data
+        if uuid == "unset"
+            for (unset_uuid, pref_keys) in prefs::Dict{String,Any}
+                unset[UUID(unset_uuid)] = pref_keys::Vector{String}
+            end
+        else
+            observed[UUID(uuid)] = prefs::Dict{String,Any}
+        end
+    end
+    return observed, unset
+end
 
-    for (uuid, observed) in prefs_data
-        uuid == "unset" && continue
-        curr = get_preferences(UUID(uuid))
-        for (key, val) in observed::Dict{String,Any}
+stale_prefs(prefs_blob::String) = stale_prefs(parse_prefs_blob(prefs_blob))
+stale_prefs(::Nothing) = false
+
+# ensure any preferences observed match their precompile-time values
+function stale_prefs(prefs::Tuple{Dict{UUID,Dict{String,Any}},Dict{UUID,Vector{String}}})
+    observed, unset = prefs
+    for (uuid, set_prefs) in observed
+        curr = get_preferences(uuid)
+        for (key, val) in set_prefs
             # any set preferences should have the same value
             !haskey(curr, key) && return true
             !toml_egal(curr[key], val) && return true
         end
     end
-    if haskey(prefs_data, "unset")
-        for (uuid, observed) in prefs_data["unset"]::Dict{String,Any}
-            curr = get_preferences(UUID(uuid))
-            for key in observed::Vector{String}
-                # any unset preferences should still be unset
-                haskey(curr, key) && return true
-            end
+    for (uuid, pref_keys) in unset
+        curr = get_preferences(uuid)
+        for key in pref_keys
+            # any unset preferences should still be unset
+            haskey(curr, key) && return true
         end
     end
     return false
@@ -4556,14 +4609,28 @@ end
         @debug "Rejecting cache file $cachefile for $modkey because it could not be opened" isfile(cachefile)
         return true
     end
+    # Treat malformed cache contents as stale.
+    @noinline function reject_malformed_cachefile(ex)
+        @debug "Rejecting cache file $cachefile due to malformed or truncated contents" exception=(ex, catch_backtrace())
+        record_reason(reasons, :malformed_cache)
+        return true
+    end
     try
-        checksum = isvalid_cache_header(io)
-        if checksum === nothing
-            @debug "Rejecting cache file $cachefile due to it containing an incompatible cache header"
-            record_reason(reasons, :incompatible_header)
-            return true # incompatible cache file
+        local checksum, modules, includes, srcfiles, requires, required_modules, prefs_blob, clone_targets, actual_flags, syntax_version
+        try
+            checksum = isvalid_cache_header(io)
+            if checksum === nothing
+                @debug "Rejecting cache file $cachefile due to it containing an incompatible cache header"
+                record_reason(reasons, :incompatible_header)
+                return true # incompatible cache file
+            end
+            modules, (includes, srcfiles, requires), required_modules, _, prefs_blob, clone_targets, actual_flags, syntax_version = _parse_cache_header(io, cachefile)
+        catch ex
+            ex isa InterruptException && rethrow()
+            return reject_malformed_cachefile(ex)
         end
-        modules, (includes, _, requires), required_modules, srctextpos, prefs_blob, clone_targets, actual_flags, syntax_version = parse_cache_header(io, cachefile)
+        # Keep filesystem queries outside the malformed-cache guard.
+        resolve_depot_includes!(includes, srcfiles, cachefile)
         if isempty(modules)
             return true # ignore empty file
         end
@@ -4590,7 +4657,12 @@ end
                 record_reason(reasons, :pkgimages_disabled)
                 return true
             end
-            rejection_reasons = check_clone_targets(clone_targets)
+            rejection_reasons = try
+                check_clone_targets(clone_targets)
+            catch ex
+                ex isa InterruptException && rethrow()
+                return reject_malformed_cachefile(ex)
+            end
             if !isnothing(rejection_reasons)
                 @debug("Rejecting cache file $cachefile for $modkey:",
                     Reasons=rejection_reasons,
@@ -4684,6 +4756,12 @@ end
 
         # now check if this file's content hash has changed relative to its source files
         if stalecheck
+            if isempty(includes)
+                # Packages record at least their entry source file.
+                @debug "Rejecting cache file $cachefile because it records no source files"
+                record_reason(reasons, :malformed_cache)
+                return true
+            end
             if !samefile(includes[1].filename, modspec.path)
                 # In certain cases the path rewritten by `fixup_stdlib_path` may
                 # point to an unreadable directory, make sure we can `stat` the
@@ -4710,22 +4788,35 @@ end
         end
 
         if verify_checksums
-            if !isvalid_file_crc(io)
-                @debug "Rejecting cache file $cachefile because it has an invalid checksum"
-                record_reason(reasons, :checksum_invalid)
-                return true
-            end
-
-            if pkgimage
-                if !isvalid_pkgimage_crc(io, ocachefile::String)
-                    @debug "Rejecting cache file $cachefile because $ocachefile has an invalid checksum"
-                    record_reason(reasons, :ocache_checksum_invalid)
+            try
+                if !isvalid_file_crc(io)
+                    @debug "Rejecting cache file $cachefile because it has an invalid checksum"
+                    record_reason(reasons, :checksum_invalid)
                     return true
                 end
+
+                if pkgimage
+                    if !isvalid_pkgimage_crc(io, ocachefile::String)
+                        @debug "Rejecting cache file $cachefile because $ocachefile has an invalid checksum"
+                        record_reason(reasons, :ocache_checksum_invalid)
+                        return true
+                    end
+                end
+            catch ex
+                ex isa InterruptException && rethrow()
+                return reject_malformed_cachefile(ex)
             end
         end
 
-        if stale_prefs(prefs_blob)
+        # only the blob itself comes from the cache file; the comparison against the
+        # active environment can fail for reasons that do not implicate the cache
+        prefs = try
+            parse_prefs_blob(prefs_blob)
+        catch ex
+            ex isa InterruptException && rethrow()
+            return reject_malformed_cachefile(ex)
+        end
+        if stale_prefs(prefs)
             @debug "Rejecting cache file $cachefile because preferences have changed"
             record_reason(reasons, :preferences_changed)
             return true

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1390,20 +1390,20 @@ function find_all_in_cache_path(pkg::PkgId, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT
     if length(paths) > 1
         function sort_by(path)
             # when using pkgimages, consider those cache files first
-            pkgimage = if JLOptions().use_pkgimages != 0
-                io = open(path, "r")
+            pkgimage = false
+            if JLOptions().use_pkgimages != 0
                 try
-                    if iszero(isvalid_cache_header(io))
-                        false
-                    else
-                        _, _, _, _, _, _, flags = parse_cache_header(io, path)
-                        CacheFlags(flags).use_pkgimages
+                    open(path, "r") do io
+                        if !iszero(isvalid_cache_header(io))
+                            # the flags byte immediately follows the cache header
+                            pkgimage = CacheFlags(read(io, UInt8)).use_pkgimages
+                        end
                     end
-                finally
-                    close(io)
+                catch ex
+                    # an unreadable or truncated candidate must not abort the search over
+                    # the other candidates; stale_cachefile will reject it later
+                    ex isa InterruptException && rethrow()
                 end
-            else
-                false
             end
             (; pkgimage, mtime=mtime(path))
         end
@@ -1958,6 +1958,8 @@ function parse_image_target(io::IO)
 end
 
 function parse_image_targets(targets::Vector{UInt8})
+    # caches built without native code record an empty clone-targets blob
+    isempty(targets) && return ImageTarget[]
     io = IOBuffer(targets)
     ntargets = read(io, Int32)
     targets = Vector{ImageTarget}(undef, ntargets)
@@ -2075,11 +2077,11 @@ function isrelocatable(pkg::PkgId)
     isnothing(path) && return false
     io = open(path, "r")
     try
-        iszero(isvalid_cache_header(io)) && throw(ArgumentError("Incompatible header in cache file $cachefile."))
+        iszero(isvalid_cache_header(io)) && throw(ArgumentError("Incompatible header in cache file $path."))
         _, (includes, includes_srcfiles, _), _... = _parse_cache_header(io, path)
         for inc in includes
             !startswith(inc.filename, "@depot") && return false
-            if inc ∉ includes_srcfiles
+            if inc.filename ∉ includes_srcfiles
                 # its an include_dependency
                 track_content = inc.mtime == -1.0
                 track_content || return false
@@ -2095,11 +2097,11 @@ function parse_cache_buildid(cachepath::String)
     f = open(cachepath, "r")
     try
         checksum = isvalid_cache_header(f)
-        iszero(checksum) && throw(ArgumentError("Incompatible header in cache file $cachefile."))
+        iszero(checksum) && throw(ArgumentError("Incompatible header in cache file $cachepath."))
         flags = read(f, UInt8)
         syntax_version = read(f, UInt8)
         n = read(f, Int32)
-        n == 0 && error("no module defined in $cachefile")
+        n == 0 && error("no module defined in $cachepath")
         skip(f, n) # module name
         uuid = UUID((read(f, UInt64), read(f, UInt64))) # pkg UUID
         build_id = (UInt128(checksum) << 64) | read(f, UInt64)
@@ -3653,8 +3655,8 @@ function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stder
                     idx = findmin(mtime.(joinpath.(cachepath, cachefiles)))[2]
                     evicted_cachefile = joinpath(cachepath, cachefiles[idx])
                     @debug "Evicting file from cache" evicted_cachefile
-                    rm(evicted_cachefile; force=true)
                     try
+                        rm(evicted_cachefile; force=true)
                         rm(ocachefile_from_cachefile(evicted_cachefile); force=true)
                         @static if Sys.isapple()
                             rm(ocachefile_from_cachefile(evicted_cachefile) * ".dSYM"; force=true, recursive=true)
@@ -4311,6 +4313,7 @@ const CACHE_REJECT_REASONS = Dict{Symbol,Pair{Symbol,String}}(
     :source_path_changed     => :actionable  => "different source file path",
     :dep_identity_changed    => :actionable  => "dependency identifier changed",
     :checksum_invalid        => :actionable  => "cache file checksum is invalid",
+    :malformed_cache         => :actionable  => "cache file contents are malformed or truncated",
     :ocache_checksum_invalid => :actionable  => "native code cache checksum is invalid",
     :preferences_changed     => :actionable  => "package preferences changed",
     :incompatible_header     => :wrong_julia => "incompatible cache header",
@@ -4641,6 +4644,15 @@ end
         end
 
         return depmods, ocachefile, id_build # fresh cachefile
+    catch ex
+        # a cache file with a valid header but truncated or otherwise malformed contents
+        # (e.g. from a process killed mid-write) can throw from anywhere in the validation
+        # above; it must be treated as stale so that recompilation replaces it, rather than
+        # the exception escaping and making the package unloadable
+        ex isa InterruptException && rethrow()
+        @debug "Rejecting cache file $cachefile due to malformed or truncated contents" exception=(ex, catch_backtrace())
+        record_reason(reasons, :malformed_cache)
+        return true
     finally
         close(io)
     end

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1118,8 +1118,11 @@ static void ios_ensureroom(ios_t *s, size_t newsize) JL_NOTSAFEPOINT
 {
     size_t prevsize = s->size;
     if (prevsize < newsize) {
-        ios_trunc(s, newsize);
-        assert(s->size == newsize);
+        if (ios_trunc(s, newsize) != 0 || s->size != newsize) {
+            // Avoid writing past the buffer.
+            jl_safe_printf("FATAL ERROR: failed to allocate memory for image serialization\n");
+            abort();
+        }
         memset(&s->buf[prevsize], 0, newsize - prevsize);
     }
 }
@@ -4591,6 +4594,17 @@ static jl_value_t *jl_validate_cache_file(ios_t *f, jl_array_t *depmods, uint32_
     return NULL;
 }
 
+// Reject an already-relocated pkgimage mapping. Image ranges are start-exclusive, so probe
+// a word into the payload: the range start itself always tests as out of range.
+static jl_value_t *jl_check_pkgimage_already_restored(const char *datastart, const char *pkgname) JL_CANSAFEPOINT
+{
+    if (eyt_tree_is_in_range(&image_tree, (uintptr_t)datastart + sizeof(uintptr_t))) {
+        return jl_get_exceptionf(jl_errorexception_type,
+            "Package image for %s has already been loaded in this session; it cannot be restored again.", pkgname);
+    }
+    return NULL;
+}
+
 // TODO?: refactor to make it easier to create the "package inspector"
 static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *image, jl_array_t *depmods, int completeinfo, const char *pkgname, int needs_permalloc) JL_CANSAFEPOINT
 {
@@ -4606,8 +4620,26 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
     if (verify_fail)
         return verify_fail;
 
-    assert(datastartpos > 0 && datastartpos < dataendpos);
+    if (!(datastartpos > 0 && datastartpos < dataendpos)) {
+        // Header-only pkgimage stub.
+        return jl_get_exceptionf(jl_errorexception_type,
+            "Cache file for %s contains no serialized data.", pkgname);
+    }
     needs_permalloc = jl_options.permalloc_pkgimg || needs_permalloc;
+
+    if (!needs_permalloc && (uint64_t)dataendpos > f->size) {
+        // The in-place payload must fit in the buffer.
+        return jl_get_exceptionf(jl_errorexception_type,
+            "Cache file for %s is truncated: serialized data extends past the end of the file.", pkgname);
+    }
+    // An image already relocated in place cannot be restored again, whether in place or
+    // copied, so this does not depend on `needs_permalloc`. Only a memory stream can alias
+    // such a mapping, and only within its own bounds.
+    if (f->bm == bm_mem && (uint64_t)dataendpos <= f->size) {
+        jl_value_t *reload_fail = jl_check_pkgimage_already_restored(f->buf + datastartpos, pkgname);
+        if (reload_fail)
+            return reload_fail;
+    }
 
     jl_value_t *restored = NULL;
     jl_array_t *init_order = NULL, *extext_methods = NULL, *internal_methods = NULL, *method_roots_list = NULL;
@@ -4758,6 +4790,23 @@ JL_DLLEXPORT jl_value_t *jl_restore_package_image_from_file(const char *fname, j
 {
     void *pkgimg_handle = jl_dlopen_e(fname, JL_RTLD_LAZY);
     jl_image_buf_t buf = get_image_buf(pkgimg_handle, /* is_pkgimage */ 1);
+
+    // Reject an already-restored mapping before loading metadata, so that the rejected load
+    // does not allocate (and leak) any. `jl_restore_package_image_from_stream` repeats the
+    // check for callers that arrive with a buffer.
+    {
+        ios_t header_io;
+        ios_static_buffer(&header_io, (char*)buf.data, buf.size);
+        uint32_t flags = 0, checksum = 0;
+        int64_t dataendpos = 0, datastartpos = 0;
+        int header_ok = jl_read_verify_header(&header_io, &flags, &checksum, &dataendpos, &datastartpos) == 0;
+        ios_close(&header_io);
+        if (header_ok && datastartpos > 0 && datastartpos < dataendpos && (uint64_t)dataendpos <= buf.size) {
+            jl_value_t *reload_fail = jl_check_pkgimage_already_restored((const char*)buf.data + datastartpos, pkgname);
+            if (reload_fail)
+                return reload_fail;
+        }
+    }
 
     jl_gc_notify_image_load(buf.data, buf.size);
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1052,8 +1052,11 @@ static void ios_ensureroom(ios_t *s, size_t newsize) JL_NOTSAFEPOINT
 {
     size_t prevsize = s->size;
     if (prevsize < newsize) {
-        ios_trunc(s, newsize);
-        assert(s->size == newsize);
+        if (ios_trunc(s, newsize) != 0 || s->size != newsize) {
+            // writing past the un-grown buffer would silently corrupt the image
+            jl_safe_printf("FATAL ERROR: failed to allocate memory for image serialization\n");
+            abort();
+        }
         memset(&s->buf[prevsize], 0, newsize - prevsize);
     }
 }
@@ -4526,6 +4529,25 @@ JL_DLLEXPORT jl_value_t *jl_restore_package_image_from_file(const char *fname, j
 {
     void *pkgimg_handle = jl_dlopen_e(fname, JL_RTLD_LAZY);
     jl_image_buf_t buf = get_image_buf(pkgimg_handle, /* is_pkgimage */ 1);
+
+    // If this exact mapping was already restored in this session (dlopen of an
+    // already-loaded pkgimage returns the existing mapping, whose serialized data has
+    // already been relocated in place), reject it up front, before jl_load_pkgimg
+    // allocates image metadata that would be leaked and before deserialization would
+    // misread the relocated pointers as relocation ids and crash.
+    {
+        ios_t header_io;
+        ios_static_buffer(&header_io, (char*)buf.data, buf.size);
+        uint8_t pkgimage = 0;
+        int64_t dataendpos = 0, datastartpos = 0;
+        jl_read_verify_header(&header_io, &pkgimage, &dataendpos, &datastartpos);
+        ios_close(&header_io);
+        if (datastartpos > 0 && (size_t)datastartpos < buf.size &&
+            eyt_tree_is_in_range(&image_tree, (uintptr_t)buf.data + (size_t)datastartpos)) {
+            return jl_get_exceptionf(jl_errorexception_type,
+                "Package image for %s has already been loaded in this session; it cannot be restored again.", pkgname);
+        }
+    }
 
     jl_gc_notify_image_load(buf.data, buf.size);
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -4370,8 +4370,22 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
     if (verify_fail)
         return verify_fail;
 
-    assert(datastartpos > 0 && datastartpos < dataendpos);
+    if (!(datastartpos > 0 && datastartpos < dataendpos)) {
+        // e.g. a header-only pkgimage stub `.ji`, whose serialized data lives only in the
+        // corresponding shared library
+        return jl_get_exceptionf(jl_errorexception_type,
+            "Cache file for %s contains no serialized data.", pkgname);
+    }
     needs_permalloc = jl_options.permalloc_pkgimg || needs_permalloc;
+
+    // If this exact buffer was already restored in this session (e.g. dlopen of an
+    // already-loaded pkgimage returns the existing mapping), its serialized data has
+    // already been relocated in place; deserializing it again would misread the
+    // relocated pointers as relocation ids and crash.
+    if (!needs_permalloc && eyt_tree_is_in_range(&image_tree, (uintptr_t)(f->buf + datastartpos))) {
+        return jl_get_exceptionf(jl_errorexception_type,
+            "Package image for %s has already been loaded in this session; it cannot be restored again.", pkgname);
+    }
 
     jl_value_t *restored = NULL;
     jl_array_t *init_order = NULL, *extext_methods = NULL, *internal_methods = NULL, *method_roots_list = NULL;

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -544,10 +544,12 @@ static jl_array_t *queue_used(jl_array_t *list, jl_query_cache *query_cache)
             jl_code_instance_t *ci = (jl_code_instance_t*)v;
             jl_method_instance_t *mi = jl_get_ci_mi(ci);
             jl_method_t *m = mi->def.method;
+            if (!jl_is_method(m))
+                continue; // toplevel code: mi->def is a module
             int dispatch_status = jl_atomic_load_relaxed(&m->dispatch_status);
             if (!(dispatch_status & METHOD_SIG_LATEST_WHICH))
                 continue; // ignore replaced methods
-            if (jl_atomic_load_relaxed(&ci->inferred) && jl_is_method(m)) {
+            if (jl_atomic_load_relaxed(&ci->inferred)) {
                 int found = jl_object_in_image((jl_value_t*)m->module) ? has_backedge_to_worklist(mi, &visited, &stack, query_cache) : 1;
                 assert(found == 0 || found == 1 || found == 2);
                 assert(stack.len == 0);

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -577,7 +577,7 @@ int ios_trunc(ios_t *s, size_t size)
         }
         else {
             if (_buf_realloc(s, size)==NULL)
-                return 0;
+                return 1;
         }
         s->size = size;
         return 0;


### PR DESCRIPTION
Fixes found while auditing the pkgimage/cache pipeline with PkgCacheInspector https://github.com/timholy/PkgCacheInspector.jl/pull/44

Claude:

---

- **loading.jl**:
  - A cache file with a valid header but truncated/malformed contents (e.g. process killed mid-write) threw uncaught from `stale_cachefile` (`EOFError` from `parse_cache_header`, or e.g. `BoundsError` from later validation of structurally invalid contents), so `using` the package hard-errored forever and the broken file was never replaced. Any validation failure in `stale_cachefile` is now treated as stale (new `:malformed_cache` rejection reason) so recompilation self-heals.
  - fixed `UndefVarError`s in several error paths that interpolated an undefined `cachefile`
  - fixed `isrelocatable` comparing `CacheHeaderIncludes` against a set of filename strings (every include was misclassified as an `include_dependency`)
  - `find_all_in_cache_path` now reads only the flags byte per candidate instead of parsing the full header, and tolerates unreadable candidates
  - `parse_image_targets` returns an empty list for the empty clone-targets blob written with `--pkgimages=no`
  - cache-eviction `rm` calls can no longer abort an otherwise-successful compile.
- **staticdata.c**:
  - Two segfaults become catchable errors: restoring a pkgimage whose buffer was already restored (and relocated in place) this session — e.g. inspector tools calling `jl_restore_package_image_from_file` on an already-loaded package — and passing a header-only pkgimage stub `.ji` to `jl_restore_incremental`. The duplicate check runs before `jl_load_pkgimg`, so no image metadata is allocated (and leaked) for the rejected load.
  - hoisted the `jl_is_method` check in `queue_used` above the `dispatch_status` load, which read garbage bits inside a `jl_module_t` for toplevel-thunk CodeInstances.
- **ios.c / staticdata.c**:
  - `ios_trunc` reported success when `_buf_realloc` failed, and `ios_ensureroom` ignored the failure and memset past the un-grown buffer, which could silently produce a corrupt cache under allocation failure. `ios_trunc` now reports the failure and `ios_ensureroom` aborts on it rather than writing out of bounds.