### PR TITLE
Don't inline `AssertionError()`

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -495,9 +495,9 @@ MethodError(@nospecialize(f), @nospecialize(args)) = MethodError(f, args, typema
 
 struct AssertionError <: Exception
     msg::AbstractString
-    AssertionError(msg::AbstractString) = new(msg)
+    AssertionError(msg::AbstractString) = (@noinline; new(msg))
 end
-AssertionError() = AssertionError("")
+AssertionError() = (@noinline; AssertionError(""))
 
 struct FieldError <: Exception
     type::DataType

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -240,7 +240,7 @@ function ht_keyindex(h::Dict{K,V}, key) where V where K
     sz = length(h.keys)
     iter = 0
     maxprobe = h.maxprobe
-    maxprobe < sz || throw(AssertionError()) # This error will never trigger, but is needed for terminates_locally to be valid
+    maxprobe < sz || throw(h) # This error will never trigger, but is needed for terminates_locally to be valid
     index, sh = hashindex(key, sz)
     keys = h.keys
 


### PR DESCRIPTION
Matches other more common error constructors.

`ht_keyindex` is inlined into JuliaLowering a billion times, so having a
     never-reached `AssertionError()` and its `gc_small_alloc` inlined into that
     was producing a lot of noise in the disassembly, which is a minor nuisance
     when tracking down actual allocations.