### PR TITLE
builtins: accept the 4-argument (order) form of isdefinedglobal

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1471,18 +1471,18 @@ JL_CALLABLE(jl_f_isdefinedglobal)
 {
     jl_module_t *m = NULL;
     jl_sym_t *s = NULL;
-    JL_NARGS(isdefined, 2, 3);
+    JL_NARGS(isdefined, 2, 4);
     int allow_import = 1;
     enum jl_memory_order order = jl_memory_order_unspecified;
     JL_TYPECHK(isdefined, module, args[0]);
     JL_TYPECHK(isdefined, symbol, args[1]);
-    if (nargs == 3) {
+    if (nargs >= 3) {
         JL_TYPECHK(isdefined, bool, args[2]);
         allow_import = jl_unbox_bool(args[2]);
     }
     if (nargs == 4) {
         JL_TYPECHK(isdefined, symbol, args[3]);
-        order = jl_get_atomic_order_checked((jl_sym_t*)args[2], 1, 0);
+        order = jl_get_atomic_order_checked((jl_sym_t*)args[3], 1, 0);
     }
     m = (jl_module_t*)args[0];
     s = (jl_sym_t*)args[1];

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -4129,6 +4129,11 @@ module ExtendedIsDefined
         @test !Core.isdefinedglobal(@__MODULE__, :x2, false)
         @test !Core.isdefinedglobal(@__MODULE__, :x3, false)
         @test !Core.isdefinedglobal(@__MODULE__, :x4, false)
+
+        @test Core.isdefinedglobal(@__MODULE__, :x1, true, :monotonic)
+        @test Core.isdefinedglobal(@__MODULE__, :x1, false, :acquire)
+        @test !Core.isdefinedglobal(@__MODULE__, :x2, false, :sequentially_consistent)
+        @test_throws ConcurrencyViolationError Core.isdefinedglobal(@__MODULE__, :x1, true, :not_atomic)
     end
 end
 


### PR DESCRIPTION
`jl_f_isdefinedglobal` declared `JL_NARGS(isdefined, 2, 3)`, so its 4-argument `isdefinedglobal(m, s, allow_import, order)` branch was unreachable and a dynamic call passing an order threw "too many arguments" -- contradicting the builtin's own documented signature and the abstract model. Accept up to 4 arguments and read the order from `args[3]` (it had read `args[2]`, the `allow_import` slot). With this, `isdefinedglobal_partition` can just delegate the order through to `isdefinedglobal` rather than re-validating it itself.

Bug introduced by #56985