### PR TITLE
EscapeAnalysis: correct annotation of setfield into object

### DIFF
--- a/Compiler/src/ssair/EscapeAnalysis.jl
+++ b/Compiler/src/ssair/EscapeAnalysis.jl
@@ -1326,8 +1326,11 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
     if isa(obj, SSAValue) || isa(obj, Argument)
         objinfo = estate[obj]
     else
-        # unanalyzable object (e.g. obj::GlobalRef): escape field value conservatively
-        add_escape_change!(astate, val, ⊤)
+        # unanalyzable object (e.g. obj::GlobalRef):
+        # escape field value conservatively. Force the change so it applies even to an
+        # identity-free value (e.g. a `String` stored into a global): the value genuinely
+        # escapes to global scope, matching the aliasing path taken when `obj` is an SSA value.
+        add_escape_change!(astate, val, ⊤, #=force=#true)
         @goto add_thrown_escapes
     end
     AliasInfo = objinfo.AliasInfo

--- a/Compiler/test/EscapeAnalysis.jl
+++ b/Compiler/test/EscapeAnalysis.jl
@@ -682,6 +682,13 @@ end
             end
         end
         @test has_all_escape(result.state[Argument(2)])
+        result = @eval M begin
+            $code_escapes((String,)) do s
+                $(M.___xxx___.Rx)[] = s
+                nothing
+            end
+        end
+        @test has_all_escape(result.state[Argument(2)])
     end
 
     # field escape


### PR DESCRIPTION
When s is a String (identity-free) stored into a global const SafeRef (`___xxx___.Rx` at 684), the escape info has an EA gap:

- If `getfield(___xxx___, :Rx)` folds inline, so setfield!'s object is a constant instead of an SSAValue, that routes escape_builtin!(setfield!) into its unanalyzable-object else-branch instead of the SSAValue/aliasing path.
- That branch called add_escape_change!(astate, val, ⊤) without force, and add_escape_change! skips identity-free values (!is_identity_free_argtype(...)). Since s::String is identity-free, the all-escape was silently dropped.
- Test 670 passed because it uses RefValue{String} (mutable → not identity-free), and at 684 passed because obj was an SSAValue (the aliasing path, which doesn't skip identity-free).

Fix: the else-branch now forces the change (add_escape_change!(astate, val, ⊤, #=force=#true)), matching its own "escape conservatively" intent and the SSAValue/aliasing path — a value stored into global scope escapes regardless of identity-freeness.