### PR TITLE
Profile: fix a batch of bugs found in a review of the whole stdlib

### DIFF
--- a/src/gc-alloc-profiler.c
+++ b/src/gc-alloc-profiler.c
@@ -168,6 +168,29 @@ JL_DLLEXPORT void jl_free_alloc_profile(void)
     alloc_array_clear(&g_combined_allocs);
 }
 
+// == GC root marking ==
+
+static void foreach_type_in_array(alloc_array_t *a, void (*f)(jl_value_t*, void*), void *env) JL_NOTSAFEPOINT
+{
+    for (size_t i = 0; i < a->len; i++) {
+        jl_datatype_t *type = a->data[i].type_address;
+        // skip the sentinel values that are not object pointers
+        if ((uintptr_t)type < 4096 || (uintptr_t)type == jl_buff_tag ||
+            type == jl_gc_unknown_type_tag)
+            continue;
+        f((jl_value_t*)type, env);
+    }
+}
+
+// Called during GC root marking (with the world stopped, so the arrays are
+// stable); keeps the recorded types alive until `jl_free_alloc_profile`.
+void jl_gc_foreach_alloc_profile_root(void (*f)(jl_value_t*, void*), void *env) JL_NOTSAFEPOINT
+{
+    for (size_t i = 0; i < g_alloc_profile.num_profiles; i++)
+        foreach_type_in_array(&g_alloc_profile.per_thread_profiles[i].allocs, f, env);
+    foreach_type_in_array(&g_combined_allocs, f, env);
+}
+
 // == callback called into by the outside ==
 
 void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t *type) JL_NOTSAFEPOINT

--- a/src/gc-alloc-profiler.c
+++ b/src/gc-alloc-profiler.c
@@ -51,8 +51,19 @@ typedef struct {
 // == Global variables manipulated by callbacks ==
 
 static jl_alloc_profile_t g_alloc_profile;
-int g_alloc_profile_enabled = 0;
+_Atomic(int) g_alloc_profile_enabled = 0;
+// number of threads currently inside `_maybe_record_alloc_to_profile`
+static _Atomic(int) g_recording_threads = 0;
 static alloc_array_t g_combined_allocs; // Will live forever.
+
+// Wait for every in-flight recorder to finish. Must only be called while
+// `g_alloc_profile_enabled` is 0, so that once the count reaches zero no new
+// recorder can start touching the profile arrays.
+static void wait_for_recorders(void) JL_NOTSAFEPOINT
+{
+    while (jl_atomic_load(&g_recording_threads) != 0)
+        jl_cpu_pause();
+}
 
 // === stack stuff ===
 
@@ -86,6 +97,10 @@ static jl_raw_backtrace_t get_raw_backtrace(void) JL_NOTSAFEPOINT
 
 JL_DLLEXPORT void jl_start_alloc_profile(double sample_rate)
 {
+    // stop any already-running profile and wait for in-flight recorders, since
+    // they read the per-thread profile array we may be about to reallocate
+    jl_stop_alloc_profile();
+
     size_t nthreads = jl_atomic_load_acquire(&jl_n_threads);
     size_t num_profiles = g_alloc_profile.num_profiles;
     if (num_profiles < nthreads) {
@@ -99,7 +114,7 @@ JL_DLLEXPORT void jl_start_alloc_profile(double sample_rate)
     }
 
     g_alloc_profile.sample_rate = sample_rate;
-    g_alloc_profile_enabled = 1;
+    jl_atomic_store_release(&g_alloc_profile_enabled, 1);
 }
 
 JL_DLLEXPORT jl_profile_allocs_raw_results_t jl_fetch_alloc_profile(void)
@@ -122,7 +137,15 @@ JL_DLLEXPORT jl_profile_allocs_raw_results_t jl_fetch_alloc_profile(void)
 
 JL_DLLEXPORT void jl_stop_alloc_profile(void)
 {
-    g_alloc_profile_enabled = 0;
+    jl_atomic_store(&g_alloc_profile_enabled, 0);
+    // after this returns, no thread is mid-record and none can start recording,
+    // so the profile arrays are safe to read and free
+    wait_for_recorders();
+}
+
+JL_DLLEXPORT int jl_alloc_profile_is_running(void)
+{
+    return jl_atomic_load_acquire(&g_alloc_profile_enabled);
 }
 
 JL_DLLEXPORT void jl_free_alloc_profile(void)
@@ -149,22 +172,34 @@ JL_DLLEXPORT void jl_free_alloc_profile(void)
 
 void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t *type) JL_NOTSAFEPOINT
 {
-    size_t thread_id = jl_atomic_load_relaxed(&jl_current_task->tid);
-    if (thread_id >= g_alloc_profile.num_profiles)
-        return; // ignore allocations on threads started after the alloc-profile started
+    jl_atomic_fetch_add(&g_recording_threads, 1);
+    // re-check the flag under the recorder count: either we see the stop and
+    // leave, or the stopping thread waits for us to finish (Dekker-style
+    // synchronization; both sides use sequentially consistent operations)
+    if (!jl_atomic_load(&g_alloc_profile_enabled))
+        goto done;
 
-    alloc_array_t *allocs = &g_alloc_profile.per_thread_profiles[thread_id].allocs;
+    {
+        size_t thread_id = jl_atomic_load_relaxed(&jl_current_task->tid);
+        if (thread_id >= g_alloc_profile.num_profiles)
+            goto done; // ignore allocations on threads started after the alloc-profile started
 
-    jl_ptls_t ptls = jl_current_task->ptls;
-    double sample_val = (double)cong(UINT64_MAX, &ptls->rngseed) / (double)UINT64_MAX;
-    if (sample_val > g_alloc_profile.sample_rate)
-        return;
+        alloc_array_t *allocs = &g_alloc_profile.per_thread_profiles[thread_id].allocs;
 
-    jl_raw_alloc_t alloc;
-    alloc.type_address = type;
-    alloc.backtrace = get_raw_backtrace();
-    alloc.size = size;
-    alloc.task = (void *)jl_current_task;
-    alloc.timestamp = cycleclock();
-    alloc_array_push(allocs, alloc);
+        jl_ptls_t ptls = jl_current_task->ptls;
+        double sample_val = (double)cong(UINT64_MAX, &ptls->rngseed) / (double)UINT64_MAX;
+        if (sample_val > g_alloc_profile.sample_rate)
+            goto done;
+
+        jl_raw_alloc_t alloc;
+        alloc.type_address = type;
+        alloc.backtrace = get_raw_backtrace();
+        alloc.size = size;
+        alloc.task = (void *)jl_current_task;
+        alloc.timestamp = cycleclock();
+        alloc_array_push(allocs, alloc);
+    }
+
+done:
+    jl_atomic_fetch_add(&g_recording_threads, -1);
 }

--- a/src/gc-alloc-profiler.c
+++ b/src/gc-alloc-profiler.c
@@ -36,9 +36,31 @@ static void alloc_array_push(alloc_array_t *a, jl_raw_alloc_t val) JL_NOTSAFEPOI
 
 static void alloc_array_clear(alloc_array_t *a) JL_NOTSAFEPOINT { a->len = 0; }
 
-// Per-thread profile: a growable array of alloc records.
+typedef struct {
+    jl_datatype_t **data;
+    size_t len;
+    size_t cap;
+} type_array_t;
+
+static void type_array_push(type_array_t *a, jl_datatype_t *val) JL_NOTSAFEPOINT
+{
+    if (a->len >= a->cap) {
+        a->cap = a->cap ? a->cap * 2 : 8;
+        a->data = (jl_datatype_t **)realloc_s(a->data, a->cap * sizeof(a->data[0]));
+    }
+    a->data[a->len++] = val;
+}
+
+#define TYPE_FILTER_SIZE 256 // must be a power of two
+
+// Per-thread profile: a growable array of alloc records, plus the types they
+// refer to, which have to be reported to the GC as roots.
 typedef struct {
     alloc_array_t allocs;
+    type_array_t type_roots;
+    // direct-mapped filter over `type_roots`, so that it doesn't grow with every
+    // sample. Owning thread only; a collision just lets a duplicate through.
+    jl_datatype_t *type_filter[TYPE_FILTER_SIZE];
 } jl_per_thread_alloc_profile_t;
 
 // Global profile state.
@@ -60,8 +82,48 @@ static alloc_array_t g_combined_allocs; // Will live forever.
 // count reaches zero no new recorder can start touching the profile arrays.
 static void wait_for_recorders(void) JL_NOTSAFEPOINT
 {
-    while (jl_atomic_load(&g_recording_threads) != 0)
-        jl_cpu_pause();
+    // a recorder can take a while (unwinding takes locks and mallocs), so back off
+    for (int spins = 0; jl_atomic_load(&g_recording_threads) != 0; spins++) {
+        if (spins < 128)
+            jl_cpu_pause();
+        else
+            jl_cpu_suspend();
+    }
+}
+
+// Disable recording and wait for in-flight recorders to leave, so that the profile
+// arrays can be read, reallocated or freed. Returns the state for `resume_recording`.
+static int suspend_recording(void) JL_NOTSAFEPOINT
+{
+    int was_enabled = jl_atomic_exchange(&g_alloc_profile_enabled, 0);
+    wait_for_recorders();
+    return was_enabled;
+}
+
+static void resume_recording(int was_enabled) JL_NOTSAFEPOINT
+{
+    if (was_enabled)
+        jl_atomic_store_release(&g_alloc_profile_enabled, 1);
+}
+
+// the recorded "type" is sometimes a sentinel rather than an object pointer;
+// keep in sync with `load_type` in stdlib/Profile/src/Allocs.jl
+static int is_object_type(jl_datatype_t *type) JL_NOTSAFEPOINT
+{
+    return !((uintptr_t)type < 4096 || (uintptr_t)type == jl_buff_tag ||
+             type == jl_gc_unknown_type_tag);
+}
+
+// keep `type` alive for as long as an alloc record refers to it
+static void record_type_root(jl_per_thread_alloc_profile_t *p, jl_datatype_t *type) JL_NOTSAFEPOINT
+{
+    if (!is_object_type(type))
+        return;
+    size_t slot = ((uintptr_t)type >> 4) & (TYPE_FILTER_SIZE - 1);
+    if (p->type_filter[slot] == type)
+        return;
+    p->type_filter[slot] = type;
+    type_array_push(&p->type_roots, type);
 }
 
 // === stack stuff ===
@@ -117,6 +179,10 @@ JL_DLLEXPORT void jl_start_alloc_profile(double sample_rate)
 
 JL_DLLEXPORT jl_profile_allocs_raw_results_t jl_fetch_alloc_profile(void)
 {
+    // in-flight recorders may be pushing onto (and thus reallocating) the
+    // per-thread arrays we are about to drain
+    int was_enabled = suspend_recording();
+
     // combine allocs
     // TODO: interleave to preserve ordering
     for (size_t i = 0; i < g_alloc_profile.num_profiles; i++) {
@@ -130,15 +196,18 @@ JL_DLLEXPORT jl_profile_allocs_raw_results_t jl_fetch_alloc_profile(void)
     jl_profile_allocs_raw_results_t result;
     result.allocs = g_combined_allocs.data;
     result.num_allocs = g_combined_allocs.len;
+
+    // recorders only ever push onto the per-thread arrays, never onto
+    // `g_combined_allocs`, so the result stays valid while recording resumes
+    resume_recording(was_enabled);
     return result;
 }
 
 JL_DLLEXPORT void jl_stop_alloc_profile(void)
 {
-    jl_atomic_store(&g_alloc_profile_enabled, 0);
     // after this returns, no thread is mid-record and none can start recording,
     // so the profile arrays are safe to read and free
-    wait_for_recorders();
+    suspend_recording();
 }
 
 JL_DLLEXPORT int jl_alloc_profile_is_running(void)
@@ -148,14 +217,20 @@ JL_DLLEXPORT int jl_alloc_profile_is_running(void)
 
 JL_DLLEXPORT void jl_free_alloc_profile(void)
 {
+    // in-flight recorders may be pushing onto the arrays we are about to free
+    int was_enabled = suspend_recording();
+
     // Free any allocs that remain in the per-thread profiles, that haven't
     // been combined yet (which happens in jl_fetch_alloc_profile()).
     for (size_t i = 0; i < g_alloc_profile.num_profiles; i++) {
-        alloc_array_t *allocs = &g_alloc_profile.per_thread_profiles[i].allocs;
-        for (size_t j = 0; j < allocs->len; j++) {
-            free(allocs->data[j].backtrace.data);
+        jl_per_thread_alloc_profile_t *p = &g_alloc_profile.per_thread_profiles[i];
+        for (size_t j = 0; j < p->allocs.len; j++) {
+            free(p->allocs.data[j].backtrace.data);
         }
-        alloc_array_clear(allocs);
+        alloc_array_clear(&p->allocs);
+        // no alloc record refers to these types any more
+        p->type_roots.len = 0;
+        memset(p->type_filter, 0, sizeof(p->type_filter));
     }
 
     // Free the allocs that have been already combined into the combined results object.
@@ -164,29 +239,21 @@ JL_DLLEXPORT void jl_free_alloc_profile(void)
     }
 
     alloc_array_clear(&g_combined_allocs);
+    resume_recording(was_enabled);
 }
 
 // == GC root marking ==
 
-static void foreach_type_in_array(alloc_array_t *a, jl_alloc_profile_root_cb_t f, void *env) JL_NOTSAFEPOINT
-{
-    for (size_t i = 0; i < a->len; i++) {
-        jl_datatype_t *type = a->data[i].type_address;
-        // skip the sentinel values that are not object pointers
-        if ((uintptr_t)type < 4096 || (uintptr_t)type == jl_buff_tag ||
-            type == jl_gc_unknown_type_tag)
-            continue;
-        f((jl_value_t*)type, env);
-    }
-}
-
-// Called during GC root marking (with the world stopped, so the arrays are
-// stable); keeps the recorded types alive until `jl_free_alloc_profile`.
+// Called during GC root marking (world stopped, so no recorder can be appending to
+// `type_roots`); keeps the recorded types alive until `jl_free_alloc_profile`. Walks
+// the distinct types seen, not every record, so the mark work is bounded.
 void jl_gc_foreach_alloc_profile_root(jl_alloc_profile_root_cb_t f, void *env) JL_NOTSAFEPOINT
 {
-    for (size_t i = 0; i < g_alloc_profile.num_profiles; i++)
-        foreach_type_in_array(&g_alloc_profile.per_thread_profiles[i].allocs, f, env);
-    foreach_type_in_array(&g_combined_allocs, f, env);
+    for (size_t i = 0; i < g_alloc_profile.num_profiles; i++) {
+        type_array_t *roots = &g_alloc_profile.per_thread_profiles[i].type_roots;
+        for (size_t j = 0; j < roots->len; j++)
+            f((jl_value_t*)roots->data[j], env);
+    }
 }
 
 // == callback called into by the outside ==
@@ -205,7 +272,7 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t 
         if (thread_id >= g_alloc_profile.num_profiles)
             goto done; // ignore allocations on threads started after the alloc-profile started
 
-        alloc_array_t *allocs = &g_alloc_profile.per_thread_profiles[thread_id].allocs;
+        jl_per_thread_alloc_profile_t *p = &g_alloc_profile.per_thread_profiles[thread_id];
 
         jl_ptls_t ptls = jl_current_task->ptls;
         double sample_val = (double)cong(UINT64_MAX, &ptls->rngseed) / (double)UINT64_MAX;
@@ -218,7 +285,8 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t 
         alloc.size = size;
         alloc.task = (void *)jl_current_task;
         alloc.timestamp = cycleclock();
-        alloc_array_push(allocs, alloc);
+        alloc_array_push(&p->allocs, alloc);
+        record_type_root(p, type);
     }
 
 done:

--- a/src/gc-alloc-profiler.c
+++ b/src/gc-alloc-profiler.c
@@ -56,9 +56,8 @@ _Atomic(int) g_alloc_profile_enabled = 0;
 static _Atomic(int) g_recording_threads = 0;
 static alloc_array_t g_combined_allocs; // Will live forever.
 
-// Wait for every in-flight recorder to finish. Must only be called while
-// `g_alloc_profile_enabled` is 0, so that once the count reaches zero no new
-// recorder can start touching the profile arrays.
+// Must only be called while `g_alloc_profile_enabled` is 0, so that once the
+// count reaches zero no new recorder can start touching the profile arrays.
 static void wait_for_recorders(void) JL_NOTSAFEPOINT
 {
     while (jl_atomic_load(&g_recording_threads) != 0)
@@ -97,8 +96,7 @@ static jl_raw_backtrace_t get_raw_backtrace(void) JL_NOTSAFEPOINT
 
 JL_DLLEXPORT void jl_start_alloc_profile(double sample_rate)
 {
-    // stop any already-running profile and wait for in-flight recorders, since
-    // they read the per-thread profile array we may be about to reallocate
+    // in-flight recorders read the per-thread arrays we may be about to reallocate
     jl_stop_alloc_profile();
 
     size_t nthreads = jl_atomic_load_acquire(&jl_n_threads);

--- a/src/gc-alloc-profiler.c
+++ b/src/gc-alloc-profiler.c
@@ -170,7 +170,7 @@ JL_DLLEXPORT void jl_free_alloc_profile(void)
 
 // == GC root marking ==
 
-static void foreach_type_in_array(alloc_array_t *a, void (*f)(jl_value_t*, void*), void *env) JL_NOTSAFEPOINT
+static void foreach_type_in_array(alloc_array_t *a, jl_alloc_profile_root_cb_t f, void *env) JL_NOTSAFEPOINT
 {
     for (size_t i = 0; i < a->len; i++) {
         jl_datatype_t *type = a->data[i].type_address;
@@ -184,7 +184,7 @@ static void foreach_type_in_array(alloc_array_t *a, void (*f)(jl_value_t*, void*
 
 // Called during GC root marking (with the world stopped, so the arrays are
 // stable); keeps the recorded types alive until `jl_free_alloc_profile`.
-void jl_gc_foreach_alloc_profile_root(void (*f)(jl_value_t*, void*), void *env) JL_NOTSAFEPOINT
+void jl_gc_foreach_alloc_profile_root(jl_alloc_profile_root_cb_t f, void *env) JL_NOTSAFEPOINT
 {
     for (size_t i = 0; i < g_alloc_profile.num_profiles; i++)
         foreach_type_in_array(&g_alloc_profile.per_thread_profiles[i].allocs, f, env);

--- a/src/gc-alloc-profiler.h
+++ b/src/gc-alloc-profiler.h
@@ -30,7 +30,8 @@ JL_DLLEXPORT void jl_free_alloc_profile(void);
 
 // Report every recorded type pointer to `f`, for GC root marking, so that the
 // types referenced by recorded allocations stay valid until the profile is freed.
-void jl_gc_foreach_alloc_profile_root(void (*f)(jl_value_t*, void*), void *env) JL_NOTSAFEPOINT;
+typedef void (*jl_alloc_profile_root_cb_t)(jl_value_t*, void*) JL_NOTSAFEPOINT;
+void jl_gc_foreach_alloc_profile_root(jl_alloc_profile_root_cb_t f, void *env) JL_NOTSAFEPOINT;
 
 // ---------------------------------------------------------------------
 // Functions to call from GC when alloc profiling is enabled

--- a/src/gc-alloc-profiler.h
+++ b/src/gc-alloc-profiler.h
@@ -25,6 +25,7 @@ typedef struct {
 JL_DLLEXPORT void jl_start_alloc_profile(double sample_rate);
 JL_DLLEXPORT jl_profile_allocs_raw_results_t jl_fetch_alloc_profile(void);
 JL_DLLEXPORT void jl_stop_alloc_profile(void);
+JL_DLLEXPORT int jl_alloc_profile_is_running(void);
 JL_DLLEXPORT void jl_free_alloc_profile(void);
 
 // ---------------------------------------------------------------------
@@ -33,13 +34,15 @@ JL_DLLEXPORT void jl_free_alloc_profile(void);
 
 void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t *typ) JL_NOTSAFEPOINT;
 
-extern int g_alloc_profile_enabled;
+extern _Atomic(int) g_alloc_profile_enabled;
 
 // This should only be used from _deprecated_ code paths. We shouldn't see UNKNOWN anymore.
 #define jl_gc_unknown_type_tag ((jl_datatype_t*)0xdeadaa03)
 
 static inline void maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t *typ) JL_NOTSAFEPOINT {
-    if (__unlikely(g_alloc_profile_enabled)) {
+    // relaxed: the slow path re-checks the flag with the ordering needed to
+    // synchronize with `jl_stop_alloc_profile`
+    if (__unlikely(jl_atomic_load_relaxed(&g_alloc_profile_enabled))) {
         _maybe_record_alloc_to_profile(val, size, typ);
     }
 }

--- a/src/gc-alloc-profiler.h
+++ b/src/gc-alloc-profiler.h
@@ -28,6 +28,10 @@ JL_DLLEXPORT void jl_stop_alloc_profile(void);
 JL_DLLEXPORT int jl_alloc_profile_is_running(void);
 JL_DLLEXPORT void jl_free_alloc_profile(void);
 
+// Report every recorded type pointer to `f`, for GC root marking, so that the
+// types referenced by recorded allocations stay valid until the profile is freed.
+void jl_gc_foreach_alloc_profile_root(void (*f)(jl_value_t*, void*), void *env) JL_NOTSAFEPOINT;
+
 // ---------------------------------------------------------------------
 // Functions to call from GC when alloc profiling is enabled
 // ---------------------------------------------------------------------

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -545,6 +545,20 @@ static void add_node_to_tpinned_roots_buffer(RootsWorkClosure* closure, RootsWor
     }
 }
 
+// tpinned: the alloc profile holds raw pointers that `Profile.Allocs.load_type`
+// dereferences later, so the recorded types must not move
+typedef struct {
+    RootsWorkClosure *closure;
+    RootsWorkBuffer *buf;
+    size_t *len;
+} alloc_profile_root_env_t;
+
+static void add_alloc_profile_root(jl_value_t *v, void *env) JL_NOTSAFEPOINT
+{
+    alloc_profile_root_env_t *e = (alloc_profile_root_env_t*)env;
+    add_node_to_tpinned_roots_buffer(e->closure, e->buf, e->len, v);
+}
+
 JL_DLLEXPORT void jl_gc_scan_vm_specific_roots(RootsWorkClosure* closure)
 {
     // Create a new buf
@@ -584,6 +598,10 @@ JL_DLLEXPORT void jl_gc_scan_vm_specific_roots(RootsWorkClosure* closure)
 
     // FIXME: transitively pinning for now, should be removed after we add moving Immix
     add_node_to_tpinned_roots_buffer(closure, &tpinned_buf, &tpinned_len, precompile_field_replace);
+
+    // types recorded by the allocation profiler
+    alloc_profile_root_env_t alloc_profile_env = {closure, &tpinned_buf, &tpinned_len};
+    jl_gc_foreach_alloc_profile_root(add_alloc_profile_root, &alloc_profile_env);
 
     // Push the result of the work.
     (closure->report_nodes_func)(buf.ptr, len, buf.cap, closure->data, false);

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -2917,7 +2917,6 @@ static void gc_mark_roots(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
     gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_global_roots_keyset, "global_roots_keyset");
     gc_try_claim_and_push(mq, precompile_field_replace, NULL);
     gc_heap_snapshot_record_gc_roots((jl_value_t*)precompile_field_replace, "precompile_field_replace");
-    // types recorded by the allocation profiler
     jl_gc_foreach_alloc_profile_root(gc_mark_alloc_profile_root, mq);
 }
 

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -2873,6 +2873,12 @@ extern jl_value_t *cmpswap_names JL_GLOBALLY_ROOTED;
 extern jl_task_t *wait_empty JL_GLOBALLY_ROOTED;
 
 // mark the initial root set
+static void gc_mark_alloc_profile_root(jl_value_t *v, void *mq) JL_NOTSAFEPOINT
+{
+    gc_try_claim_and_push((jl_gc_markqueue_t*)mq, v, NULL);
+    gc_heap_snapshot_record_gc_roots(v, "alloc_profile");
+}
+
 static void gc_mark_roots(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
 {
     // modules
@@ -2911,6 +2917,8 @@ static void gc_mark_roots(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
     gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_global_roots_keyset, "global_roots_keyset");
     gc_try_claim_and_push(mq, precompile_field_replace, NULL);
     gc_heap_snapshot_record_gc_roots((jl_value_t*)precompile_field_replace, "precompile_field_replace");
+    // types recorded by the allocation profiler
+    jl_gc_foreach_alloc_profile_root(gc_mark_alloc_profile_root, mq);
 }
 
 // find unmarked objects that need to be finalized from the finalizer list "list".

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -38,7 +38,10 @@ JL_DLLEXPORT int jl_profile_init(size_t maxsize, uint64_t delay_nsec)
 {
     uv_mutex_lock(&bt_data_prof_lock);
     if (profile_running) {
-        // the sampler may be writing into the buffer we are about to free
+        // the sampler may be writing into the buffer we are about to free. Note this
+        // only rules out re-initializing while running: `jl_profile_stop_timer` doesn't
+        // wait for a sampler iteration already under way, and the thread samplers write
+        // without taking this lock.
         uv_mutex_unlock(&bt_data_prof_lock);
         return -2;
     }

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -36,14 +36,23 @@ JL_DLLEXPORT int jl_profile_start_timer(uint8_t) JL_NOTSAFEPOINT;
 ///////////////////////
 JL_DLLEXPORT int jl_profile_init(size_t maxsize, uint64_t delay_nsec)
 {
+    uv_mutex_lock(&bt_data_prof_lock);
+    if (profile_running) {
+        // the sampler may be writing into the buffer we are about to free
+        uv_mutex_unlock(&bt_data_prof_lock);
+        return -2;
+    }
     profile_bt_size_max = maxsize;
     nsecprof = delay_nsec;
     if (profile_bt_data_prof != NULL)
         free((void*)profile_bt_data_prof);
     profile_bt_data_prof = (jl_bt_element_t*) calloc(maxsize, sizeof(jl_bt_element_t));
-    if (profile_bt_data_prof == NULL && maxsize > 0)
+    if (profile_bt_data_prof == NULL && maxsize > 0) {
+        uv_mutex_unlock(&bt_data_prof_lock);
         return -1;
+    }
     profile_bt_size_cur = 0;
+    uv_mutex_unlock(&bt_data_prof_lock);
     return 0;
 }
 

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -928,8 +928,11 @@ JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
     timerprof.tv_sec = nsecprof/GIGA;
     timerprof.tv_nsec = nsecprof%GIGA;
 
+    // hold the lock so that `jl_profile_init` cannot free the buffer while we transition to running
+    uv_mutex_lock(&bt_data_prof_lock);
     profile_running = 1;
     profile_all_tasks = all_tasks;
+    uv_mutex_unlock(&bt_data_prof_lock);
     // ensure the alarm is running
     ret = clock_alarm(clk, TIME_RELATIVE, timerprof, profile_port);
     HANDLE_MACH_ERROR("clock_alarm", ret);

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -792,7 +792,10 @@ JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
     sigprof.sigev_notify = SIGEV_SIGNAL;
     sigprof.sigev_signo = SIGUSR1;
     sigprof.sigev_value.sival_ptr = &timerprof;
-    // hold the lock so that `jl_profile_init` cannot free the buffer while we transition to running
+    // hold the lock so that `jl_profile_init` cannot free the buffer while we transition to running.
+    // Safe to hold across `timer_settime`: SIGUSR1 is blocked in every thread and consumed by the
+    // dedicated `signal_listener` thread via `sigwait`, so no in-thread handler can run here and
+    // deadlock trying to take this same lock.
     uv_mutex_lock(&bt_data_prof_lock);
     // Because SIGUSR1 is multipurpose, set `profile_running` before so that we know that the first SIGUSR1 came from the timer
     profile_running = 1;

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -792,12 +792,15 @@ JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
     sigprof.sigev_notify = SIGEV_SIGNAL;
     sigprof.sigev_signo = SIGUSR1;
     sigprof.sigev_value.sival_ptr = &timerprof;
+    // hold the lock so that `jl_profile_init` cannot free the buffer while we transition to running
+    uv_mutex_lock(&bt_data_prof_lock);
     // Because SIGUSR1 is multipurpose, set `profile_running` before so that we know that the first SIGUSR1 came from the timer
     profile_running = 1;
     profile_all_tasks = all_tasks;
     if (timer_create(CLOCK_REALTIME, &sigprof, &timerprof) == -1) {
         profile_running = 0;
         profile_all_tasks = 0;
+        uv_mutex_unlock(&bt_data_prof_lock);
         return -2;
     }
 
@@ -809,8 +812,10 @@ JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
     if (timer_settime(timerprof, 0, &itsprof, NULL) == -1) {
         profile_running = 0;
         profile_all_tasks = 0;
+        uv_mutex_unlock(&bt_data_prof_lock);
         return -3;
     }
+    uv_mutex_unlock(&bt_data_prof_lock);
     return 0;
 }
 

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -175,6 +175,8 @@ struct CorruptType end
 struct BufferType end
 struct UnknownType end
 
+# N.B. the pointer is unrooted on the C side, so like `Alloc.task` it may be
+# stale by the time it is fetched if the type is not otherwise reachable
 function load_type(ptr::Ptr{Type})
     if UInt(ptr) < UInt(4096)
         return CorruptType

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -318,7 +318,7 @@ function parse_flat(::Type{T}, data::Vector{Alloc}, C::Bool) where T
 end
 
 function flat(io::IO, data::Vector{Alloc}, cols::Int, fmt::ProfileFormat)
-    fmt.combine || error(ArgumentError("combine=false"))
+    fmt.combine || throw(ArgumentError("combine=false is not supported for allocation profiles"))
     lilist, n, m, totalbytes = parse_flat(fmt.combine ? StackFrame : UInt64, data, fmt.C)
     filenamemap = Profile.FileNameMap()
     if isempty(lilist)
@@ -402,7 +402,7 @@ function tree!(root::StackFrameTree{T}, all::Vector{Alloc}, C::Bool, recur::Symb
 end
 
 function tree(io::IO, data::Vector{Alloc}, cols::Int, fmt::ProfileFormat)
-    fmt.combine || error(ArgumentError("combine=false"))
+    fmt.combine || throw(ArgumentError("combine=false is not supported for allocation profiles"))
     if fmt.combine
         root = tree!(StackFrameTree{StackFrame}(), data, fmt.C, fmt.recur)
     else

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -192,8 +192,21 @@ end
 
 function load_backtrace(trace::RawBacktrace)::Vector{BTElement}
     out = Vector{BTElement}()
-    for i in 1:trace.size
-        push!(out, unsafe_load(trace.data, i))
+    i = 1
+    while i <= trace.size
+        e = unsafe_load(trace.data, i)
+        if e == typemax(BTElement) # JL_BT_NON_PTR_ENTRY: start of an extended entry
+            # Extended entries (e.g. interpreter frames) hold unrooted object
+            # pointers, not native instruction pointers, so they cannot be
+            # decoded here; skip over them (size is encoded in the descriptor).
+            descriptor = unsafe_load(trace.data, i + 1)
+            ngc = descriptor & 0x7
+            nptr = (descriptor >> 3) & 0x7
+            i += 2 + ngc + nptr
+            continue
+        end
+        push!(out, e)
+        i += 1
     end
 
     return out

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -86,17 +86,17 @@ function _prof_expr(expr, opts)
     end
 end
 
+# The C-side buffers are not safe to mutate/free while another task is reading
+# them (e.g. `clear` frees the backtrace buffers that `fetch` reads), so
+# serialize all API entry points.
+const allocs_lock = Base.ReentrantLock()
+
 """
     Profile.Allocs.start(; sample_rate::Real)
 
 Begin recording allocations with the given sample rate
 A sample rate of 1.0 will record everything; 0.0 will record nothing.
 """
-# The C-side buffers are not safe to mutate/free while another task is reading
-# them (e.g. `clear` frees the backtrace buffers that `fetch` reads), so
-# serialize all API entry points.
-const allocs_lock = Base.ReentrantLock()
-
 function start(; sample_rate::Real)
     @lock allocs_lock begin
         ccall(:jl_start_alloc_profile, Cvoid, (Cdouble,), Float64(sample_rate))

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -207,16 +207,19 @@ end
 
 function load_backtrace(trace::RawBacktrace)::Vector{BTElement}
     out = Vector{BTElement}()
+    n = Int(trace.size)
     i = 1
-    while i <= trace.size
+    while i <= n
         e = unsafe_load(trace.data, i)
         if e == typemax(BTElement) # JL_BT_NON_PTR_ENTRY: start of an extended entry
             # Extended entries (e.g. interpreter frames) hold unrooted object
             # pointers, not native instruction pointers, so they cannot be
             # decoded here; skip over them (size is encoded in the descriptor).
+            # Those frames are therefore missing from the reported stack.
+            i + 1 <= n || break # truncated entry; nothing more to decode
             descriptor = unsafe_load(trace.data, i + 1)
-            ngc = descriptor & 0x7
-            nptr = (descriptor >> 3) & 0x7
+            ngc = Int(descriptor & 0x7)
+            nptr = Int((descriptor >> 3) & 0x7)
             i += 2 + ngc + nptr
             continue
         end

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -92,8 +92,15 @@ end
 Begin recording allocations with the given sample rate
 A sample rate of 1.0 will record everything; 0.0 will record nothing.
 """
+# The C-side buffers are not safe to mutate/free while another task is reading
+# them (e.g. `clear` frees the backtrace buffers that `fetch` reads), so
+# serialize all API entry points.
+const allocs_lock = Base.ReentrantLock()
+
 function start(; sample_rate::Real)
-    ccall(:jl_start_alloc_profile, Cvoid, (Cdouble,), Float64(sample_rate))
+    @lock allocs_lock begin
+        ccall(:jl_start_alloc_profile, Cvoid, (Cdouble,), Float64(sample_rate))
+    end
 end
 
 """
@@ -102,7 +109,9 @@ end
 Stop recording allocations.
 """
 function stop()
-    ccall(:jl_stop_alloc_profile, Cvoid, ())
+    @lock allocs_lock begin
+        ccall(:jl_stop_alloc_profile, Cvoid, ())
+    end
 end
 
 """
@@ -111,7 +120,9 @@ end
 Clear all previously profiled allocation information from memory.
 """
 function clear()
-    ccall(:jl_free_alloc_profile, Cvoid, ())
+    @lock allocs_lock begin
+        ccall(:jl_free_alloc_profile, Cvoid, ())
+    end
     return nothing
 end
 
@@ -122,8 +133,12 @@ Retrieve the recorded allocations, and decode them into Julia
 objects which can be analyzed.
 """
 function fetch()
-    raw_results = ccall(:jl_fetch_alloc_profile, RawResults, ())
-    return decode(raw_results)
+    # hold the lock through `decode`, which reads the C-side buffers that a
+    # concurrent `clear` would free
+    @lock allocs_lock begin
+        raw_results = ccall(:jl_fetch_alloc_profile, RawResults, ())
+        return decode(raw_results)
+    end
 end
 
 # decoded results

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -237,7 +237,9 @@ Prints profiling results to `io` (by default, `stdout`). If you do not
 supply a `data` argument, the internal buffer of accumulated backtraces
 will be used.
 
-See `Profile.print` for an explanation of the valid keyword arguments.
+See `Profile.print` for an explanation of the valid keyword arguments; of those,
+`format`, `C`, `maxdepth`, `mincount`, `noisefloor`, `sortedby` and `recur` are
+supported here.
 """
 print(; kwargs...) =
     Profile.print(stdout, fetch(); kwargs...)
@@ -258,7 +260,6 @@ function Profile.print(io::IO,
         mincount::Int = 0,
         noisefloor = 0,
         sortedby::Symbol = :filefuncline,
-        groupby::Union{Symbol,AbstractVector{Symbol}} = :none,
         recur::Symbol = :off,
         )
     pf = ProfileFormat(;C, maxdepth, mincount, noisefloor, sortedby, recur)

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -87,7 +87,7 @@ function _prof_expr(expr, opts)
 end
 
 """
-    Profile.Allocs.start(sample_rate::Real)
+    Profile.Allocs.start(; sample_rate::Real)
 
 Begin recording allocations with the given sample rate
 A sample rate of 1.0 will record everything; 0.0 will record nothing.

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -175,8 +175,8 @@ struct CorruptType end
 struct BufferType end
 struct UnknownType end
 
-# N.B. the pointer is unrooted on the C side, so like `Alloc.task` it may be
-# stale by the time it is fetched if the type is not otherwise reachable
+# recorded type pointers are marked as GC roots while stored in the profile
+# (see `jl_gc_foreach_alloc_profile_root`), so the pointer is safe to load here
 function load_type(ptr::Ptr{Type})
     if UInt(ptr) < UInt(4096)
         return CorruptType

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -86,9 +86,8 @@ function _prof_expr(expr, opts)
     end
 end
 
-# The C-side buffers are not safe to mutate/free while another task is reading
-# them (e.g. `clear` frees the backtrace buffers that `fetch` reads), so
-# serialize all API entry points.
+# serializes the API entry points: e.g. `clear` frees the C-side buffers that a
+# concurrent `fetch` would be reading
 const allocs_lock = Base.ReentrantLock()
 
 """
@@ -133,8 +132,7 @@ Retrieve the recorded allocations, and decode them into Julia
 objects which can be analyzed.
 """
 function fetch()
-    # hold the lock through `decode`, which reads the C-side buffers that a
-    # concurrent `clear` would free
+    # hold the lock through `decode`, which reads the C-side buffers
     @lock allocs_lock begin
         raw_results = ccall(:jl_fetch_alloc_profile, RawResults, ())
         return decode(raw_results)

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -297,7 +297,7 @@ function parse_flat(::Type{T}, data::Vector{Alloc}, C::Bool) where T
         totalbytes += nb
         for frame in r.stacktrace
             !C && frame.from_c && continue
-            key = (T === UInt64 ? ip : frame)
+            key = (T === UInt64 ? frame.pointer : frame)
             idx = get!(lilist_idx, key, length(lilist) + 1)
             if idx > length(lilist)
                 push!(recursive, key)
@@ -343,7 +343,7 @@ function tree!(root::StackFrameTree{T}, all::Vector{Alloc}, C::Bool, recur::Symb
         parent = root
         for i in reverse(eachindex(r.stacktrace))
             frame = r.stacktrace[i]
-            key = (T === UInt64 ? ip : frame)
+            key = (T === UInt64 ? frame.pointer : frame)
             if (recur === :flat && !frame.from_c) || recur === :flatc
                 # see if this frame already has a parent
                 this = get!(build, frame, parent)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1164,7 +1164,7 @@ function tree!(root::StackFrameTree{T}, all::Vector{UInt64}, lidict::Union{LineI
             builder_key = parent.builder_key
             builder_value = parent.builder_value
             fastkey = searchsortedfirst(builder_key, ip)
-            if fastkey < length(builder_key) && builder_key[fastkey] === ip
+            if fastkey <= length(builder_key) && builder_key[fastkey] === ip
                 # jump forward to the end of the inlining chain
                 # avoiding an extra (slow) lookup of `ip` in `lidict`
                 # and an extra chain of them in `down`

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -692,6 +692,9 @@ function fetch(;include_meta = true, limitwarn = true)
     if maxlen == 0
         error("The profiling data buffer is not initialized. A profile has not been requested this session.")
     end
+    if is_running()
+        @warn "Profiling is still running; the resulting data may be incomplete. Call `Profile.stop_timer()` before fetching."
+    end
     len = len_data()
     if limitwarn && is_buffer_full()
         @warn """The profile data buffer is full; profiling probably terminated

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -654,7 +654,7 @@ function start_timer(all_tasks::Bool=false)
     check_init() # if the profile buffer hasn't been initialized, initialize with default size
     status = ccall(:jl_profile_start_timer, Cint, (Bool,), all_tasks)
     if status < 0
-        error(error_codes[status])
+        error(get(error_codes, status, "cannot start the profiling timer (error $status)"))
     end
 end
 
@@ -671,11 +671,10 @@ len_data() = convert(Int, ccall(:jl_profile_len_data, Csize_t, ()))
 
 maxlen_data() = convert(Int, ccall(:jl_profile_maxlen_data, Csize_t, ()))
 
-error_codes = Dict(
-    -1=>"cannot specify signal action for profiling",
+const error_codes = Dict(
+    -1=> Sys.iswindows() ? "cannot create the profiling thread" : "profiling is not supported on this platform",
     -2=>"cannot create the timer for profiling",
-    -3=>"cannot start the timer for profiling",
-    -4=>"cannot unblock SIGUSR1")
+    -3=>"cannot start the timer for profiling")
 
 
 """

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -622,8 +622,11 @@ function callers(funcname::String, bt::Vector, lidict::LineInfoFlatDict; filenam
     end
 end
 
-callers(funcname::String, bt::Vector, lidict::LineInfoDict; kwargs...) =
-    callers(funcname, flatten(bt, lidict)...; kwargs...)
+function callers(funcname::String, bt::Vector, lidict::LineInfoDict; kwargs...)
+    # metadata is not part of the lookup dict, so it must be stripped before flattening
+    bt = has_meta(bt) ? strip_meta(bt) : bt
+    return callers(funcname, flatten(bt, lidict)...; kwargs...)
+end
 callers(funcname::String; kwargs...) = callers(funcname, retrieve()...; kwargs...)
 callers(func::Function, bt::Vector, lidict::LineInfoFlatDict; kwargs...) =
     callers(string(func), bt, lidict; kwargs...)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -461,12 +461,12 @@ function retrieve(; kwargs...)
     return (data, getdict(data))
 end
 
-function getdict(data::Vector{UInt})
+function getdict(data::Vector{<:Unsigned})
     dict = LineInfoDict()
     return getdict!(dict, data)
 end
 
-function getdict!(dict::LineInfoDict, data::Vector{UInt})
+function getdict!(dict::LineInfoDict, data::Vector{<:Unsigned})
     # we don't want metadata here as we're just looking up ips
     unique_ips = unique(has_meta(data) ? strip_meta(data) : data)
     n_unique_ips = length(unique_ips)
@@ -486,7 +486,7 @@ function getdict!(dict::LineInfoDict, data::Vector{UInt})
     return dict
 end
 
-function _lookup_corrected(ip::UInt)
+function _lookup_corrected(ip::Unsigned)
     st = lookup(convert(Ptr{Cvoid}, ip))
     # To correct line numbers for moving code, put it in the form expected by
     # Base.update_stackframes_callback[]

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1379,10 +1379,11 @@ end
 
 
 """
-    Profile.take_heap_snapshot(filepath::String, all_one::Bool=false;
+    Profile.take_heap_snapshot(filepath::AbstractString, all_one::Bool=false;
                                redact_data::Bool=true, streaming::Bool=false)
-    Profile.take_heap_snapshot(all_one::Bool=false; redact_data:Bool=true,
-                               dir::String=nothing, streaming::Bool=false)
+    Profile.take_heap_snapshot(io::IO, all_one::Bool=false; redact_data::Bool=true)
+    Profile.take_heap_snapshot(all_one::Bool=false; redact_data::Bool=true,
+                               dir::Union{Nothing,AbstractString}=nothing, streaming::Bool=false)
 
 Write a snapshot of the heap, in the JSON format expected by the Chrome
 Devtools Heap Snapshot viewer (.heapsnapshot extension) to a file

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -142,6 +142,9 @@ function init(; n::Union{Nothing,Integer} = nothing, delay::Union{Nothing,Real} 
 end
 
 function init(n::Integer, delay::Real; limitwarn::Bool = true)
+    # jl_profile_init frees and reallocates the sample buffer, which the sampler
+    # thread may be concurrently writing into
+    is_running() && error("profiling is running; call `Profile.stop_timer()` before calling `Profile.init()`")
     sample_size_bytes = sizeof(Ptr) # == Sys.WORD_SIZE / 8
     buffer_samples = n
     buffer_size_bytes = buffer_samples * sample_size_bytes

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -831,7 +831,7 @@ function flat(io::IO, data::Vector{UInt64}, lidict::Union{LineInfoDict, LineInfo
         n = n[keep]
         m = m[keep]
     end
-    util_perc = (1 - (nsleeping / totalshots)) * 100
+    util_perc = totalshots == 0 ? 0.0 : (1 - (nsleeping / totalshots)) * 100
     filenamemap = FileNameMap()
     if isempty(lilist)
         if is_subsection
@@ -1292,7 +1292,7 @@ function tree(io::IO, data::Vector{UInt64}, lidict::Union{LineInfoFlatDict, Line
     else
         root, nsleeping, is_task_profile = tree!(StackFrameTree{UInt64}(), data, lidict, fmt.C, fmt.recur, threads, tasks)
     end
-    util_perc = (1 - (nsleeping / root.count)) * 100
+    util_perc = root.count == 0 ? 0.0 : (1 - (nsleeping / root.count)) * 100
     is_subsection || print_tree(io, root, cols, fmt, is_subsection)
     if isempty(root.down)
         if is_subsection

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -338,7 +338,6 @@ function print(io::IO,
                 end
             end
         elseif groupby === :task
-            threads = 1:typemax(Int)
             taskids = intersect(get_task_ids(data), tasks)
             isempty(taskids) && (any_nosamples = true)
             for taskid in taskids
@@ -348,7 +347,6 @@ function print(io::IO,
                 println(io)
             end
         elseif groupby === :thread
-            tasks = 1:typemax(UInt)
             threadids = intersect(get_thread_ids(data), threads)
             isempty(threadids) && (any_nosamples = true)
             for threadid in threadids

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1465,9 +1465,10 @@ function take_heap_snapshot(all_one::Bool=false; dir::Union{Nothing,S}=nothing, 
     if isnothing(dir)
         wd = pwd()
         fpath = joinpath(wd, fname)
+        fpath_test = fpath * ".test" # use a different test file as windows can fail to save immediately after rm-ing a file
         try
-            touch(fpath)
-            rm(fpath; force=true)
+            touch(fpath_test)
+            rm(fpath_test; force=true)
         catch
             @warn "Cannot write to current directory `$(pwd())` so saving heap snapshot to `$(tempdir())`" maxlog=1 _id=Symbol(wd)
             fpath = joinpath(tempdir(), fname)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -489,7 +489,8 @@ function getdict!(dict::LineInfoDict, data::Vector{<:Unsigned})
 end
 
 function _lookup_corrected(ip::Unsigned)
-    st = lookup(convert(Ptr{Cvoid}, ip))
+    # convert through UInt: only word-size integers convert directly to Ptr
+    st = lookup(convert(Ptr{Cvoid}, UInt(ip)))
     # To correct line numbers for moving code, put it in the form expected by
     # Base.update_stackframes_callback[]
     stn = map(x->(x, 1), st)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1430,10 +1430,11 @@ function take_heap_snapshot(io::IO, all_one::Bool=false; redact_data::Bool=true)
     # Support the legacy, non-streaming mode, by first streaming the parts to a tempdir,
     # then reassembling it after we're done.
     prefix = tempname()
-    _stream_heap_snapshot(prefix, all_one, redact_data)
     try
+        _stream_heap_snapshot(prefix, all_one, redact_data)
         Profile.HeapSnapshot.assemble_snapshot(prefix, io)
     finally
+        # a failure while streaming may have created only some of the parts
         Profile.HeapSnapshot.cleanup_streamed_files(prefix)
     end
 end

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -142,8 +142,8 @@ function init(; n::Union{Nothing,Integer} = nothing, delay::Union{Nothing,Real} 
 end
 
 function init(n::Integer, delay::Real; limitwarn::Bool = true)
-    # jl_profile_init frees and reallocates the sample buffer, which the sampler
-    # thread may be concurrently writing into
+    # fast-path check; jl_profile_init also refuses (-2) under its lock, since the
+    # sampler may be concurrently writing into the buffer it would free
     is_running() && error("profiling is running; call `Profile.stop_timer()` before calling `Profile.init()`")
     sample_size_bytes = sizeof(Ptr) # == Sys.WORD_SIZE / 8
     buffer_samples = n
@@ -156,6 +156,8 @@ function init(n::Integer, delay::Real; limitwarn::Bool = true)
     status = ccall(:jl_profile_init, Cint, (Csize_t, UInt64), buffer_samples, round(UInt64, 10^9*delay))
     if status == -1
         error("could not allocate space for ", n, " instruction pointers ($(Base.format_bytes(buffer_size_bytes)))")
+    elseif status == -2
+        error("profiling is running; call `Profile.stop_timer()` before calling `Profile.init()`")
     end
 end
 

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -292,7 +292,7 @@ function print(io::IO,
         print_group(io, data, lidict, pf, format, threads, tasks, false)
     else
         if !in(groupby, [:thread, :task, [:task, :thread], [:thread, :task]])
-            error(ArgumentError("Unrecognized groupby option: $groupby. Options are :none (default), :task, :thread, [:task, :thread], or [:thread, :task]"))
+            throw(ArgumentError("Unrecognized groupby option: $groupby. Options are :none (default), :task, :thread, [:task, :thread], or [:thread, :task]"))
         elseif Sys.iswindows() && in(groupby, [:thread, [:task, :thread], [:thread, :task]])
             @warn "Profiling on windows is limited to the main thread. Other threads have not been sampled and will not show in the report"
         end

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1424,10 +1424,13 @@ end
 function take_heap_snapshot(io::IO, all_one::Bool=false; redact_data::Bool=true)
     # Support the legacy, non-streaming mode, by first streaming the parts to a tempdir,
     # then reassembling it after we're done.
-    dir = tempdir()
-    prefix = joinpath(dir, "snapshot")
+    prefix = tempname()
     _stream_heap_snapshot(prefix, all_one, redact_data)
-    Profile.HeapSnapshot.assemble_snapshot(prefix, io)
+    try
+        Profile.HeapSnapshot.assemble_snapshot(prefix, io)
+    finally
+        Profile.HeapSnapshot.cleanup_streamed_files(prefix)
+    end
 end
 function _stream_heap_snapshot(prefix::AbstractString, all_one::Bool, redact_data::Bool)
     # Nodes and edges are binary files

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -675,7 +675,7 @@ len_data() = convert(Int, ccall(:jl_profile_len_data, Csize_t, ()))
 maxlen_data() = convert(Int, ccall(:jl_profile_maxlen_data, Csize_t, ()))
 
 const error_codes = Dict(
-    -1=> Sys.iswindows() ? "cannot create the profiling thread" : "profiling is not supported on this platform",
+    -1=>Sys.iswindows() ? "cannot create the profiling thread" : "profiling is not supported on this platform",
     -2=>"cannot create the timer for profiling",
     -3=>"cannot start the timer for profiling")
 
@@ -688,13 +688,14 @@ values in `data` have meaning only on this machine in the current session, becau
 depends on the exact memory addresses used in JIT-compiling. This function is primarily for
 internal use; [`retrieve`](@ref) may be a better choice for most users.
 By default metadata such as threadid and taskid is included. Set `include_meta` to `false` to strip metadata.
+Set `limitwarn` to `false` to suppress the warnings about a full buffer or a still-running profiler.
 """
 function fetch(;include_meta = true, limitwarn = true)
     maxlen = maxlen_data()
     if maxlen == 0
         error("The profiling data buffer is not initialized. A profile has not been requested this session.")
     end
-    if is_running()
+    if limitwarn && is_running()
         @warn "Profiling is still running; the resulting data may be incomplete. Call `Profile.stop_timer()` before fetching."
     end
     len = len_data()

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -293,7 +293,7 @@ function print(io::IO,
         elseif Sys.iswindows() && in(groupby, [:thread, [:task, :thread], [:thread, :task]])
             @warn "Profiling on windows is limited to the main thread. Other threads have not been sampled and will not show in the report"
         end
-        any_nosamples = true
+        any_nosamples = false
         if format === :tree
             Base.print(io, "Overhead ╎ [+additional indent] Count File:Line  Function\n")
             Base.print(io, "=========================================================\n")

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -112,8 +112,12 @@ function assemble_snapshot(in_prefix, io::IO)
             node_name_idx = read(nodes_file, UInt)
             id = read(nodes_file, UInt)
             self_size = read(nodes_file, Int)
-            @assert read(nodes_file, Int) == 0 # trace_node_id
-            @assert read(nodes_file, Int8) == 0 # detachedness
+            trace_node_id = read(nodes_file, Int) # always 0 in snapshots Julia produces
+            trace_node_id == 0 ||
+                error("malformed nodes file `$(in_prefix).nodes`: nonzero trace_node_id $(trace_node_id) for node $(i)")
+            detachedness = read(nodes_file, Int8) # always 0 in snapshots Julia produces
+            detachedness == 0 ||
+                error("malformed nodes file `$(in_prefix).nodes`: nonzero detachedness $(detachedness) for node $(i)")
 
             nodes.type[i] = node_type
             nodes.name_idx[i] = node_name_idx
@@ -150,7 +154,8 @@ function assemble_snapshot(in_prefix, io::IO)
         delete!(orphans, 0)
     end
 
-    @assert isempty(orphans) "Orphaned nodes: $(orphans), node count: $(length(nodes)), orphan node count: $(length(orphans))"
+    isempty(orphans) ||
+        error("malformed snapshot `$(in_prefix)`: $(length(orphans)) of $(length(nodes)) nodes have no incoming edges: $(orphans)")
 
     _digits_buf = zeros(UInt8, ndigits(typemax(UInt)))
     println(io, @view(preamble[1:end-1]), ",") # remove trailing "}" to reopen the object

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -85,7 +85,8 @@ function assemble_snapshot(in_prefix, out_file::AbstractString = in_prefix)
         open(tmp_file, "w") do io
             assemble_snapshot(in_prefix, io)
         end
-        mv(tmp_file, out_file; force=true)
+        # `rename` replaces atomically, unlike `mv(...; force=true)` which unlinks first
+        Base.Filesystem.rename(tmp_file, out_file)
     finally
         rm(tmp_file; force=true)
     end
@@ -151,13 +152,11 @@ function assemble_snapshot(in_prefix, io::IO)
         end
     end
 
-    # remove the uber node from the orphans
-    if 0 in orphans
-        delete!(orphans, 0)
-    end
+    delete!(orphans, 0) # the uber node has no incoming edges by construction
 
     isempty(orphans) ||
-        error("malformed snapshot `$(in_prefix)`: $(length(orphans)) of $(length(nodes)) nodes have no incoming edges: $(orphans)")
+        error("malformed snapshot `$(in_prefix)`: $(length(orphans)) of $(length(nodes)) nodes have no incoming edges: ",
+              join(Iterators.take(orphans, 10), ", "), length(orphans) > 10 ? ", ..." : "")
 
     _digits_buf = zeros(UInt8, ndigits(typemax(UInt)))
     println(io, @view(preamble[1:end-1]), ",") # remove trailing "}" to reopen the object

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -78,9 +78,16 @@ Assemble a `.heapsnapshot` file from the four files produced by
 `Profile.take_heap_snapshot(...; streaming=true)` with prefix `in_prefix`.
 """
 function assemble_snapshot(in_prefix, out_file::AbstractString = in_prefix)
-    open(out_file, "w") do io
-        assemble_snapshot(in_prefix, io)
+    try
+        open(out_file, "w") do io
+            assemble_snapshot(in_prefix, io)
+        end
+    catch
+        # don't leave a partial (or truncated pre-existing) snapshot behind
+        rm(out_file; force=true)
+        rethrow()
     end
+    return nothing
 end
 
 # Manually parse and write the .json files, given that we don't have JSON import/export in
@@ -137,6 +144,13 @@ function assemble_snapshot(in_prefix, io::IO)
             end
         end
     end
+
+    # remove the uber node from the orphans
+    if 0 in orphans
+        delete!(orphans, 0)
+    end
+
+    @assert isempty(orphans) "Orphaned nodes: $(orphans), node count: $(length(nodes)), orphan node count: $(length(orphans))"
 
     _digits_buf = zeros(UInt8, ndigits(typemax(UInt)))
     println(io, @view(preamble[1:end-1]), ",") # remove trailing "}" to reopen the object
@@ -203,13 +217,6 @@ function assemble_snapshot(in_prefix, io::IO)
         end
     end
     print(io, "]}")
-
-    # remove the uber node from the orphans
-    if 0 in orphans
-        delete!(orphans, 0)
-    end
-
-    @assert isempty(orphans) "Orphaned nodes: $(orphans), node count: $(length(nodes)), orphan node count: $(length(orphans))"
 
     return nothing
 end

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -191,6 +191,8 @@ function assemble_snapshot(in_prefix, io::IO)
         while !eof(strings_io)
             str_size = read(strings_io, UInt)
             str_bytes = read(strings_io, str_size)
+            length(str_bytes) == str_size ||
+                error("truncated strings file: `$(in_prefix).strings` (expected $(str_size) bytes, got $(length(str_bytes)))")
             str = String(str_bytes)
             if first
                 first = false

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -2,12 +2,6 @@
 
 module HeapSnapshot
 
-"""
-    assemble_snapshot(filepath::AbstractString, out_file::AbstractString)
-
-Assemble a .heapsnapshot file from the .json files produced by `Profile.take_heap_snapshot`.
-"""
-
 # SoA layout to reduce padding
 struct Edges
     type::Vector{UInt32}       # index into `snapshot.meta.edge_types`
@@ -77,6 +71,12 @@ let _dec_d100 = UInt16[(0x30 + i % 10) << 0x8 + (0x30 + i ÷ 10) for i = 0:99]
     end
 end
 
+"""
+    assemble_snapshot(in_prefix::AbstractString, out_file::AbstractString = in_prefix)
+
+Assemble a `.heapsnapshot` file from the four files produced by
+`Profile.take_heap_snapshot(...; streaming=true)` with prefix `in_prefix`.
+"""
 function assemble_snapshot(in_prefix, out_file::AbstractString = in_prefix)
     open(out_file, "w") do io
         assemble_snapshot(in_prefix, io)

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -78,14 +78,16 @@ Assemble a `.heapsnapshot` file from the four files produced by
 `Profile.take_heap_snapshot(...; streaming=true)` with prefix `in_prefix`.
 """
 function assemble_snapshot(in_prefix, out_file::AbstractString = in_prefix)
+    # assemble into a temporary sibling and only replace `out_file` on success, so
+    # that a failure doesn't leave a partial snapshot or destroy a pre-existing one
+    tmp_file = tempname(dirname(abspath(out_file)); cleanup=false)
     try
-        open(out_file, "w") do io
+        open(tmp_file, "w") do io
             assemble_snapshot(in_prefix, io)
         end
-    catch
-        # don't leave a partial (or truncated pre-existing) snapshot behind
-        rm(out_file; force=true)
-        rethrow()
+        mv(tmp_file, out_file; force=true)
+    finally
+        rm(tmp_file; force=true)
     end
     return nothing
 end
@@ -232,10 +234,11 @@ end
 Remove files streamed during `take_heap_snapshot` in streaming mode.
 """
 function cleanup_streamed_files(prefix::AbstractString)
-    rm(string(prefix, ".metadata.json"))
-    rm(string(prefix, ".nodes"))
-    rm(string(prefix, ".edges"))
-    rm(string(prefix, ".strings"))
+    # tolerate missing files, e.g. from a failure partway through streaming
+    rm(string(prefix, ".metadata.json"); force=true)
+    rm(string(prefix, ".nodes"); force=true)
+    rm(string(prefix, ".edges"); force=true)
+    rm(string(prefix, ".strings"); force=true)
     return nothing
 end
 

--- a/stdlib/Profile/src/precompile.jl
+++ b/stdlib/Profile/src/precompile.jl
@@ -5,7 +5,7 @@ if Base.generating_output()
     precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, UnitRange{Int}, UnitRange{UInt}})
     precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, Vector{Int}, Vector{UInt}})
     precompile(Tuple{typeof(Profile._peek_report)})
-    precompile(Tuple{typeof(Profile.Allocs.start)})
+    precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:sample_rate,), Tuple{Float64}}, typeof(Profile.Allocs.start)})
     precompile(Tuple{typeof(Profile.Allocs.stop)})
     precompile(Tuple{typeof(Profile.Allocs.fetch)})
 end

--- a/stdlib/Profile/test/allocs.jl
+++ b/stdlib/Profile/test/allocs.jl
@@ -6,6 +6,8 @@ let iobuf = IOBuffer()
     for format in (:tree, :flat)
         Test.@test_logs (:warn, r"^There were no samples collected\.") Allocs.print(iobuf; format, C=true)
     end
+    # kwargs that allocation profiles don't support must error rather than be silently ignored
+    @test_throws MethodError Allocs.print(iobuf; groupby = :task)
 end
 
 # Issue #57103: This test does not work with MMTk because of fastpath

--- a/stdlib/Profile/test/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/test/heapsnapshot_reassemble.jl
@@ -79,12 +79,6 @@ end
         end
     end
 
-    array_section(s, key) = begin
-        start = last(findfirst("\"$key\":[", s)) + 1
-        s[start:findnext(==(']'), s, start)-1]
-    end
-    n_elems(section) = isempty(strip(section)) ? 0 : count(==(','), section) + 1
-
     mktempdir() do tmpdir
         prefix = joinpath(tmpdir, "syn")
         out_file = joinpath(tmpdir, "syn.heapsnapshot")
@@ -92,12 +86,11 @@ end
         write_parts(prefix)
         Profile.HeapSnapshot.assemble_snapshot(prefix, out_file)
         sshot = read(out_file, String)
-        @test n_elems(array_section(sshot, "nodes")) == 7 * 2
-        @test n_elems(array_section(sshot, "edges")) == 3 * 1
+        @test length(snapshot_array(sshot, "nodes")) == 7 * 2
         @test contains(sshot, "\"node_a\"")
         @test contains(sshot, "\"node_b\"")
-        # to_node is emitted as an offset into the flat nodes array
-        @test contains(array_section(sshot, "edges"), "7")
+        # type, name_or_index, and to_node as an offset into the flat nodes array
+        @test snapshot_array(sshot, "edges") == [0, 0, 7]
         rm(out_file)
 
         # a node with no incoming edges is an error, and must not leave output behind

--- a/stdlib/Profile/test/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/test/heapsnapshot_reassemble.jl
@@ -110,9 +110,14 @@ end
         @test_throws "truncated strings file" Profile.HeapSnapshot.assemble_snapshot(prefix, out_file)
         @test !isfile(out_file)
 
-        # missing part files must not leave (or destroy) the output file
+        # a failed assembly must preserve a pre-existing output file
         write(out_file, "pre-existing")
         @test_throws SystemError Profile.HeapSnapshot.assemble_snapshot(joinpath(tmpdir, "nonexistent"), out_file)
-        @test !isfile(out_file)
+        @test read(out_file, String) == "pre-existing"
+        rm(out_file)
+
+        # cleanup_streamed_files tolerates missing part files
+        Profile.HeapSnapshot.cleanup_streamed_files(prefix)
+        @test Profile.HeapSnapshot.cleanup_streamed_files(prefix) === nothing
     end
 end

--- a/stdlib/Profile/test/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/test/heapsnapshot_reassemble.jl
@@ -51,4 +51,68 @@ end
 
     # Test handling of empty string
     test_print_str_escape_json("", "\"\"")
+
+    # Invalid unicode is replaced (vscode's viewer chokes on the replacement char)
+    test_print_str_escape_json(String(UInt8[0xff]), "\"[invalid unicode character]\"")
+end
+
+# assemble_snapshot on hand-written part files, checking the assembled JSON
+# structure and the error paths for malformed inputs
+@testset "assemble_snapshot from synthetic parts" begin
+    # node layout: type, name_idx, id, self_size, trace_node_id, detachedness
+    # edge layout: type, name_or_index, from_node, to_node (node indices)
+    function write_parts(prefix; to_node = 1, strings_short_by = 0)
+        write(string(prefix, ".metadata.json"),
+            """{"snapshot":{"node_count":2,"edge_count":1,"trace_function_count":0}}""")
+        open(string(prefix, ".nodes"), "w") do io
+            for i in 0:1
+                write(io, UInt32(0), UInt(i), UInt(0x1000 + i), Int(16), Int(0), Int8(0))
+            end
+        end
+        open(string(prefix, ".edges"), "w") do io
+            write(io, UInt32(0), UInt(0), UInt(0), UInt(to_node))
+        end
+        open(string(prefix, ".strings"), "w") do io
+            write(io, UInt(sizeof("node_a")), codeunits("node_a"))
+            # optionally declare the final string longer than the bytes present
+            write(io, UInt(sizeof("node_b") + strings_short_by), codeunits("node_b"))
+        end
+    end
+
+    array_section(s, key) = begin
+        start = last(findfirst("\"$key\":[", s)) + 1
+        s[start:findnext(==(']'), s, start)-1]
+    end
+    n_elems(section) = isempty(strip(section)) ? 0 : count(==(','), section) + 1
+
+    mktempdir() do tmpdir
+        prefix = joinpath(tmpdir, "syn")
+        out_file = joinpath(tmpdir, "syn.heapsnapshot")
+
+        write_parts(prefix)
+        Profile.HeapSnapshot.assemble_snapshot(prefix, out_file)
+        sshot = read(out_file, String)
+        @test n_elems(array_section(sshot, "nodes")) == 7 * 2
+        @test n_elems(array_section(sshot, "edges")) == 3 * 1
+        @test contains(sshot, "\"node_a\"")
+        @test contains(sshot, "\"node_b\"")
+        # to_node is emitted as an offset into the flat nodes array
+        @test contains(array_section(sshot, "edges"), "7")
+        rm(out_file)
+
+        # a node with no incoming edges is an error, and must not leave output behind
+        write_parts(prefix; to_node = 0) # node 1 becomes an orphan
+        @test_throws "no incoming edges" Profile.HeapSnapshot.assemble_snapshot(prefix, out_file)
+        @test !isfile(out_file)
+
+        # a truncated strings file is an error, and must not leave output behind
+        write_parts(prefix; strings_short_by = 5)
+        @test_throws "truncated strings file" Profile.HeapSnapshot.assemble_snapshot(prefix, out_file)
+        @test !isfile(out_file)
+
+        # missing part files must not leave (or destroy) the output file
+        write(out_file, "pre-existing")
+        @test_throws SystemError Profile.HeapSnapshot.assemble_snapshot(joinpath(tmpdir, "nonexistent"), out_file)
+        @test !isfile(out_file)
+    end
 end

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -427,6 +427,15 @@ end
     @test only(node.down).first == lidict[8]
 end
 
+# the elements of the flat `"<key>":[...]` array of a .heapsnapshot. Every field is
+# emitted as an unsigned decimal, and e.g. an edge's `name_or_index` can be typemax(UInt).
+# Also used by heapsnapshot_reassemble.jl, which runs under MMTk too.
+function snapshot_array(sshot::AbstractString, key::AbstractString)
+    start = last(findfirst("\"$key\":[", sshot)) + 1
+    section = strip(sshot[start:findnext(==(']'), sshot, start)-1])
+    return isempty(section) ? UInt[] : parse.(UInt, split(section, ','))
+end
+
 # FIXME: Issue #57103: heap snapshots are currently not supported in MMTk
 @static if Base.USING_STOCK_GC
 @testset "HeapSnapshot" begin
@@ -493,13 +502,6 @@ end
             end
         end
     end
-end
-
-# the elements of the flat `"<key>":[...]` array of a .heapsnapshot, as integers
-function snapshot_array(sshot::AbstractString, key::AbstractString)
-    start = last(findfirst("\"$key\":[", sshot)) + 1
-    section = strip(sshot[start:findnext(==(']'), sshot, start)-1])
-    return isempty(section) ? Int[] : parse.(Int, split(section, ','))
 end
 
 # the documented streaming workflow: stream the parts, assemble offline, clean up

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -116,6 +116,41 @@ end
     end
 end
 
+# regression tests: spurious group warning, discarded filters in flat groupby,
+# `callers` on metadata-bearing data, groupby error type, non-UInt data, and
+# reconfiguring the buffer while profiling is running
+@testset "printing and callers regressions" begin
+    iobuf = IOBuffer()
+    # synthetic single-sample profile on thread 1, so group contents are deterministic
+    fake_data = Profile.add_fake_meta(UInt64[1, 0])
+    fake_lidict = Dict{UInt64,Vector{StackFrame}}(UInt64(1) => [StackFrame(:f1, :file1, 1, nothing, false, false, 0)])
+    if !Sys.iswindows() # avoid the multi-thread-profiling-unsupported warning
+        # no "no samples" warning when every group has samples
+        @test_logs Profile.print(iobuf, fake_data, fake_lidict, groupby = :thread)
+    end
+    # a threads filter that matches no samples must be honored under groupby=:task
+    @test_logs (:warn, r"There were no samples collected in one or more groups") match_mode=:any begin
+        Profile.print(iobuf, fake_data, fake_lidict, groupby = :task, threads = 999:1000)
+    end
+    @test_throws ArgumentError Profile.print(iobuf, groupby = :bogus)
+    # callers must accept default (metadata-bearing) profile data
+    @test Profile.callers("busywait") isa Vector
+    let (data, lidict) = Profile.retrieve()
+        @test Profile.callers("busywait", data, lidict) isa Vector
+    end
+    # data saved as a different unsigned type is accepted by the default lidict path
+    @test Profile.getdict(UInt64.(Profile.fetch(include_meta = false))) isa Profile.LineInfoDict
+end
+
+@testset "init while profiling errors" begin
+    Profile.start_timer()
+    try
+        @test_throws "profiling is running" Profile.init(n = 10^6, delay = 0.01)
+    finally
+        Profile.stop_timer()
+    end
+end
+
 @testset "Profile.fetch() with and without meta" begin
     data_without = Profile.fetch(include_meta = false)
     data_with = Profile.fetch()
@@ -396,34 +431,73 @@ end
 # FIXME: Issue #57103: heap snapshots are currently not supported in MMTk
 @static if Base.USING_STOCK_GC
 @testset "HeapSnapshot" begin
-    tmpdir = mktempdir()
+    mktempdir() do tmpdir
+        # ensure that we can prevent redacting data
+        fname = cd(tmpdir) do
+            read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; const x = \"redact_this\"; print(Profile.take_heap_snapshot(; redact_data=false))"`, String)
+        end
 
-    # ensure that we can prevent redacting data
-    fname = cd(tmpdir) do
-        read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; const x = \"redact_this\"; print(Profile.take_heap_snapshot(; redact_data=false))"`, String)
+        @test isfile(fname)
+
+        sshot = read(fname, String)
+        @test sshot != ""
+        @test contains(sshot, "redact_this")
+
+        rm(fname)
+
+        # ensure that string data is redacted by default
+        fname = cd(tmpdir) do
+            read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; const x = \"redact_this\"; print(Profile.take_heap_snapshot())"`, String)
+        end
+
+        @test isfile(fname)
+
+        sshot = read(fname, String)
+        @test sshot != ""
+        @test !contains(sshot, "redact_this")
+
+        rm(fname)
     end
+end
 
-    @test isfile(fname)
+# the documented streaming workflow: stream the parts, assemble offline, clean up
+@testset "HeapSnapshot streaming workflow" begin
+    mktempdir() do tmpdir
+        prefix = joinpath(tmpdir, "streamed")
+        run(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; Profile.take_heap_snapshot(ARGS[1]; streaming=true)" $prefix`)
+        part_files = [string(prefix, ext) for ext in (".metadata.json", ".nodes", ".edges", ".strings")]
+        @test all(isfile, part_files)
 
-    sshot = read(fname, String)
-    @test sshot != ""
-    @test contains(sshot, "redact_this")
+        out_file = string(prefix, ".heapsnapshot")
+        Profile.HeapSnapshot.assemble_snapshot(prefix, out_file)
+        sshot = read(out_file, String)
+        @test sshot != ""
 
-    rm(fname)
+        # structural check: the node/edge arrays must have the expected number of fields
+        node_count = parse(Int, match(r"\"node_count\":(\d+)", sshot).captures[1])
+        edge_count = parse(Int, match(r"\"edge_count\":(\d+)", sshot).captures[1])
+        function array_length(key)
+            start = last(findfirst("\"$key\":[", sshot)) + 1
+            stop = findnext(==(']'), sshot, start) - 1
+            section = strip(sshot[start:stop])
+            return isempty(section) ? 0 : count(==(','), section) + 1
+        end
+        @test node_count > 0
+        @test edge_count > 0
+        @test array_length("nodes") == 7 * node_count
+        @test array_length("edges") == 3 * edge_count
 
-    # ensure that string data is redacted by default
-    fname = cd(tmpdir) do
-        read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; const x = \"redact_this\"; print(Profile.take_heap_snapshot())"`, String)
+        Profile.HeapSnapshot.cleanup_streamed_files(prefix)
+        @test !any(isfile, part_files)
     end
+end
 
-    @test isfile(fname)
-
-    sshot = read(fname, String)
-    @test sshot != ""
-    @test !contains(sshot, "redact_this")
-
-    rm(fname)
-    rm(tmpdir, force = true, recursive = true)
+@testset "take_heap_snapshot to an IO stream" begin
+    mktempdir() do tmpdir
+        out_file = joinpath(tmpdir, "io_method.heapsnapshot")
+        run(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; open(io -> Profile.take_heap_snapshot(io, true), ARGS[1], \"w\")" $out_file`)
+        @test filesize(out_file) > 0
+    end
 end
 end
 

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -458,6 +458,42 @@ end
 
         rm(fname)
     end
+
+    # a readonly current directory should fall back to saving in tempdir
+    # (the readonly bit on a directory doesn't prevent file creation on windows, and root bypasses it)
+    @static if !Sys.iswindows()
+        if ccall(:geteuid, Cuint, ()) != 0
+            @testset "default save when current directory is readonly" begin
+                mktempdir() do tmpdir
+                    fname = cd(tmpdir) do
+                        chmod(tmpdir, 0o555)
+                        try
+                            read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; print(Profile.take_heap_snapshot())"`, String)
+                        finally
+                            chmod(tmpdir, 0o777)
+                        end
+                    end
+                    @test !occursin(tmpdir, fname) # should not be in the readonly dir
+                    @test isfile(fname)
+                    open(fname) do fs
+                        @test readline(fs) != ""
+                    end
+                    rm(fname)
+                end
+            end
+        end
+    end
+
+    @testset "save with custom dir" begin
+        mktempdir() do tmpdir
+            fname = read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; print(Profile.take_heap_snapshot(dir=ARGS[1]))" $tmpdir`, String)
+            @test occursin(tmpdir, fname)
+            @test isfile(fname)
+            open(fname) do fs
+                @test readline(fs) != ""
+            end
+        end
+    end
 end
 
 # the documented streaming workflow: stream the parts, assemble offline, clean up

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -123,7 +123,7 @@ end
     fake_lidict = Dict{UInt64,Vector{StackFrame}}(UInt64(1) => [StackFrame(:f1, :file1, 1, nothing, false, false, 0)])
     if !Sys.iswindows() # avoid the multi-thread-profiling-unsupported warning
         # no "no samples" warning when every group has samples
-        @test_logs Profile.print(iobuf, fake_data, fake_lidict, groupby = :thread)
+        @test_logs min_level=Logging.Warn Profile.print(iobuf, fake_data, fake_lidict, groupby = :thread)
     end
     # a threads filter that matches no samples must be honored under groupby=:task
     @test_logs (:warn, r"There were no samples collected in one or more groups") match_mode=:any begin
@@ -135,8 +135,10 @@ end
     let (data, lidict) = Profile.retrieve()
         @test Profile.callers("busywait", data, lidict) isa Vector
     end
-    # data saved as a different unsigned type is accepted by the default lidict path
-    @test Profile.getdict(UInt64.(Profile.fetch(include_meta = false))) isa Profile.LineInfoDict
+    # data saved on a host with a different word size is accepted (`UInt` there may
+    # not be `UInt` here), rather than hitting a MethodError
+    @test Profile.getdict(UInt32[1, 0]) isa Profile.LineInfoDict
+    @test Profile.getdict(UInt64[1, 0]) isa Profile.LineInfoDict
 end
 
 @testset "init while profiling errors" begin
@@ -493,6 +495,13 @@ end
     end
 end
 
+# the elements of the flat `"<key>":[...]` array of a .heapsnapshot, as integers
+function snapshot_array(sshot::AbstractString, key::AbstractString)
+    start = last(findfirst("\"$key\":[", sshot)) + 1
+    section = strip(sshot[start:findnext(==(']'), sshot, start)-1])
+    return isempty(section) ? Int[] : parse.(Int, split(section, ','))
+end
+
 # the documented streaming workflow: stream the parts, assemble offline, clean up
 @testset "HeapSnapshot streaming workflow" begin
     mktempdir() do tmpdir
@@ -509,16 +518,10 @@ end
         # structural check: the node/edge arrays must have the expected number of fields
         node_count = parse(Int, match(r"\"node_count\":(\d+)", sshot).captures[1])
         edge_count = parse(Int, match(r"\"edge_count\":(\d+)", sshot).captures[1])
-        function array_length(key)
-            start = last(findfirst("\"$key\":[", sshot)) + 1
-            stop = findnext(==(']'), sshot, start) - 1
-            section = strip(sshot[start:stop])
-            return isempty(section) ? 0 : count(==(','), section) + 1
-        end
         @test node_count > 0
         @test edge_count > 0
-        @test array_length("nodes") == 7 * node_count
-        @test array_length("edges") == 3 * edge_count
+        @test length(snapshot_array(sshot, "nodes")) == 7 * node_count
+        @test length(snapshot_array(sshot, "edges")) == 3 * edge_count
 
         Profile.HeapSnapshot.cleanup_streamed_files(prefix)
         @test !any(isfile, part_files)

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -116,9 +116,6 @@ end
     end
 end
 
-# regression tests: spurious group warning, discarded filters in flat groupby,
-# `callers` on metadata-bearing data, groupby error type, non-UInt data, and
-# reconfiguring the buffer while profiling is running
 @testset "printing and callers regressions" begin
     iobuf = IOBuffer()
     # synthetic single-sample profile on thread 1, so group contents are deterministic


### PR DESCRIPTION
I pointed Claude Fable at Profile, then got gpt5.6-sol to review, then got Opus 5 to tidy up...

Closes #50513

Claude:

---

## Summary

A review of the whole `Profile` stdlib — the Julia code, the runtime C that backs it, and the heap snapshot assembler — turned up a batch of bugs, fixed here with one commit per issue.

**What this buys:**

- **Four memory-safety bugs in the runtime are closed.** The allocation profiler recorded `jl_datatype_t*` pointers that nothing kept alive, so a type could be collected out from under `fetch`; its enabled flag was a plain `int` written and read from multiple threads; `start`/`stop`/`fetch`/`clear` could tear down or reallocate the per-thread buffers while other threads were still recording into them; and `Profile.init` while profiling let the sampler write into freed memory.
- **`Profile.callers` works at all.** It threw `KeyError` on any default profile data, i.e. on everything except hand-stripped `fetch(include_meta=false)` output.
- **`print` filters and warnings tell the truth.** `groupby=:task` silently discarded `threads=`, `groupby=:thread` silently discarded `tasks=`, and grouped printing warned about missing samples unconditionally.
- **`take_heap_snapshot` and `assemble_snapshot` stop destroying data.** Concurrent `take_heap_snapshot(io)` calls corrupted each other through a shared fixed temp prefix and leaked their (potentially multi-GB) part files; `assemble_snapshot` truncated its output file before reading any input, so with the default `out_file = in_prefix` a failure destroyed a previously assembled snapshot.
- **Retaining an allocation profile no longer makes every GC slower in proportion to its length.**
- **Test coverage for paths that had none**, including the documented streaming snapshot workflow end to end.

## Bug fixes

**Profile**

- `Profile.callers(funcname)` threw `KeyError` on any default (metadata-bearing) profile data, making the API unusable without manually passing `fetch(include_meta=false)` data; metadata is now stripped before flattening
- Grouped `print` always emitted the "no samples were collected in one or more groups" warning (`any_nosamples` was initialized `true` and never cleared)
- `Profile.init` while profiling is running let the sampler write into freed memory: `jl_profile_init` frees and reallocates the sample buffer unconditionally. `jl_profile_init` now refuses (`-2`) under `bt_data_prof_lock` when `profile_running` is set, with a friendlier fast-path error on the Julia side, and the unix/mach `jl_profile_start_timer` implementations take the same lock around the `profile_running` transition (Windows already did). Note this rules out re-initializing *while* the profiler is running, which is the reported bug; it is not full mutual exclusion with the sampler, since `jl_profile_stop_timer` doesn't wait for a sampler iteration already under way and the thread samplers write without taking this lock — the comments say so
- `print(groupby=:task, threads=...)` silently discarded the `threads` filter (and `groupby=:thread` discarded `tasks`); the flat groupings now honor both filters like the nested ones do
- Fixing the above exposed a latent `InexactError: Int64(NaN)` when printing an empty group (utilization computed as `nsleeping/totalshots` with zero snapshots); empty groups now report 0%
- `take_heap_snapshot(io::IO)` streamed parts to the fixed prefix `tempdir()/snapshot`, so concurrent snapshots corrupted each other, and the part files (potentially GBs) were never removed; it now uses `tempname()`, streams inside a protected scope, and cleans up even on failure partway through streaming
- Off-by-one in `tree!`'s fast-path lookup meant the largest ip never hit the cache and was re-`insert!`ed on every occurrence
- `fetch` now warns when the profiler is still running (the trailing sample block can be truncated and misparsed). The warning honors the existing `limitwarn` keyword, so inspecting a profile mid-run can silence it
- `start_timer` error messages now match what the C implementations actually return (`-1` is thread-creation failure on Windows / unsupported on OpenBSD; `-4` was dead), and `error_codes` is `const`
- `getdict` accepts `Vector{<:Unsigned}` like `print`/`retrieve`, so cross-word-size data doesn't hit `MethodError`
- `error(ArgumentError(...))` → `throw(ArgumentError(...))` so callers can catch by type
- Fixed `take_heap_snapshot` docstring signatures

**Profile.Allocs**

- `g_alloc_profile_enabled` was a plain int (a C data race), and `stop`/`fetch`r reallocate per-thread buffers while other threads were still recording intothem. The flag is now atomic (relaxed load on the allocation fast path), threads inside the recorder are counted, and every entry point that reads, reallocates or frees the profile    arrays first disables the flag and waits for in-flight recorders (Dekker-style before restoring the previous state. That covers `start` (which reallocates theper-thread array), `stop`, `fetch` (which drains the per-thread arrays) and `clear` (which frees the backtrace buffers). The wait backs off rather than spinning at full tilt, since a  recorder unwinds the stack and can hold locks and allocate. `jl_alloc_profile_i
- Recorded `jl_datatype_t*` pointers were unrooted, so a type not otherwise reachable could be collected between recording and `fetch`, and `load_type` dereferenced freed memory.      Recorded types are now reported as GC roots (via `jl_gc_foreach_alloc_profile_r` freed — during stock-GC root marking, where they are also recorded asheap-snapshot roots, and under MMTk as transitively pinned roots, since `load_type` dereferences the recorded pointer after the fact and it must not move. To keep this from making everGC scale with the length of the profile, each per-thread profile tracks the *dibehind a small direct-mapped filter, so the added mark work is proportional tothe number of types rather than the number of samples
- `start`/`stop`/`clear`/`fetch` are additionally serialized with a Julia-side ulia-level state the C-side quiescing doesn't cover: `clear` freed the C-sidebacktrace buffers while a concurrent `fetch` was `unsafe_load`ing them, and two concurrent `fetch` calls raced on a realloc
- Extended (`JL_BT_NON_PTR_ENTRY`) backtrace entries from interpreted frames we native instruction pointers, producing bogus frames. They are now skipped —their object pointers are unrooted and cannot be decoded safely after the fact — so those frames are absent from the reported stack rather than garbage. Reading the entry's descriptor is bounds-checked, and the skip arithmetic no longer promotes the loop index to
- Removed the accepted-but-ignored `groupby` kwarg from `Profile.print(::IO, ::AllocResults)` and documented which kwargs apply
- Fixed an undefined variable `ip` in the (currently unreachable) `combine=fals
- Fixed the `Allocs.start` docstring showing a positional signature for a keyword-only method                                                                                      - The precompile statement for `Allocs.start` only compiled the zero-keyword eres the real `kwcall` path

**Heap snapshot assembly**

- A truncated `.strings` part file silently produced a garbled string table (mie snapshot); it now errors like the other part readers
- `assemble_snapshot` truncated `out_file` before reading any input — with the default `out_file = in_prefix` it destroyed a previously assembled snapshot before erroring. It now assembles into a temporary sibling and swaps it into place with `rename` only oeserves any pre-existing snapshot, and the orphaned-node validation runs beforewriting
- Input-validation `@assert`s replaced with errors that name the offending file
- The `assemble_snapshot` docstring was a bare string literal attached to nothing

## Tests

Regression tests for the fixes above (using synthetic `add_fake_meta` data so group contents are deterministic), plus coverage of previously untested paths: the documented streaming
snapshot workflow (`take_heap_snapshot(streaming=true)` → `assemble_snapshot` →, the `take_heap_snapshot(io::IO)` method, structural validation of theassembled JSON (node/edge array field counts), unit tests of `assemble_snapshot` on hand-written part files including the malformed-input error paths and preserve-on-failure semantics,
and the invalid-unicode branch of `print_str_escape_json`.

## Absorbed PR

This PR also folds in and supersedes #50513: `take_heap_snapshot` now probes di separate `.test` file (Windows can fail to save immediately after rm-ing a file of the same name), and adds its tests for the readonly-current-directory fallback and saving with a custom `dir`.

## Notes for reviewers

- The runtime changes (`src/gc-alloc-profiler.c`, `src/gc-stock.c`, `src/gc-mmtk/gc-mmtk.c`, `src/signal*.c`) touch the GC root set and thread synchronization, and would benefit from a GC-side review independent of the stdlib fixes.
- Interpreted frames are currently dropped from allocation backtraces rather than rendered as a placeholder; rooting the objects they reference, the way recorded types now are, would let them be decoded properly. Left as a follow-up.