### PR TITLE
module: warn consistently on deprecated bindings imported via `using`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -319,6 +319,31 @@ end
 
 deprecate(m::Module, s::Symbol, flag=1) = ccall(:jl_deprecate_binding, Cvoid, (Any, Any, Cint), m, s, flag)
 
+"""
+    @deprecate_binding old new [export_old=true] [dep_message] [constant=true]
+
+Deprecate the binding `old`, making it an alias for `new` and printing a deprecation warning
+on access to `old` (when `julia` is run with `--depwarn=yes`). This is for deprecating a
+renamed or relocated global/constant, whereas [`@deprecate`](@ref) is for deprecating methods.
+
+`old` must be a symbol and `new` the replacement it forwards to. By default `old` is defined
+as a `const`; pass `false` for `constant` to define it as a non-constant global instead.
+
+To prevent `old` from being exported, set `export_old` to `false`. A custom `dep_message`
+string (printed after "<module>.old is deprecated") may be given.
+
+See also [`@deprecate`](@ref) and [`Base.depwarn`](@ref).
+
+# Examples
+```jldoctest
+julia> const dep_new = 42;
+
+julia> Base.@deprecate_binding dep_old dep_new false;
+
+julia> dep_old
+42
+```
+"""
 macro deprecate_binding(old, new, export_old=true, dep_message=:nothing, constant=true)
     dep_message === :nothing && (dep_message = ", use $new instead.")
     return Expr(:toplevel,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1113,6 +1113,7 @@ export
     @gensym,
     @eval,
     @deprecate,
+    @deprecate_binding,
 
     # performance annotations
     @boundscheck,

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -221,8 +221,9 @@ macro __FUNCTION__()
     Expr(:thisfunction)
 end
 
-# TODO: this is vaguely broken because it only works for explicit calls to
-# `Base.deprecate`, not the @deprecated macro:
+# Reflects binding-partition deprecation (as set by `Base.deprecate` / `Base.@deprecate_binding`),
+# including a binding reached through an implicit `using`, transparently through reexports.
+# `@deprecate` deprecates a method rather than the binding, so it is intentionally not reported here.
 isdeprecated(m::Module, s::Symbol) = ccall(:jl_is_binding_deprecated, Cint, (Any, Any), m, s) != 0
 
 function binding_module(m::Module, s::Symbol)

--- a/src/module.c
+++ b/src/module.c
@@ -125,11 +125,7 @@ static void update_implicit_resolution(struct implicit_search_resolution *to_upd
         same = 0;
     }
     else if (resolution.ultimate_kind == PARTITION_KIND_IMPLICIT_CONST) {
-        // Unify constants by value with `jl_egal`, so the same constant defined in two
-        // modules -- including distinct boxes of an equal immutable, such as an integer --
-        // is not spuriously ambiguous. (A deprecated constant is an IMPLICIT_CONST here too,
-        // carrying its deprecation in `deprecation_flags`, so two deprecated constants that
-        // name an egal value unify just like non-deprecated ones.)
+        // Unify constants by `egal`
         same = jl_egal(resolution.binding_or_const, to_update->binding_or_const);
     }
     else {
@@ -449,8 +445,7 @@ static void jl_walk_binding_inplace(jl_binding_t **bnd, jl_binding_partition_t *
 // Walk imports to the leaf while reporting whether any partition along the way carries a
 // deprecation `flag` (`PARTITION_FLAG_DEPWARN` for the access warning, or
 // `PARTITION_FLAG_DEPRECATED` for `isdeprecated`), suppressed once an explicit import is
-// passed (the `import`/`using: x` site is what should be fixed). Keeping the single walk
-// used by both the access-warning and `isdeprecated` paths ensures they agree.
+// passed (the `import`/`using: x` site is what should be fixed).
 static void jl_walk_binding_inplace_depwarn(jl_binding_t **bnd, jl_binding_partition_t **pbpart, size_t world, size_t flag, int *found) JL_CANSAFEPOINT
 {
     int passed_explicit = 0;
@@ -1272,6 +1267,59 @@ extern _Atomic(int) jl_lineno;
 
 static char const dep_message_prefix[] = "_dep_message_";
 
+static void jl_print_dep_message_value(jl_value_t *dep_message) JL_CANSAFEPOINT
+{
+    if (jl_is_string(dep_message))
+        jl_uv_puts(JL_STDERR, jl_string_data(dep_message), jl_string_len(dep_message));
+    else
+        jl_static_show(JL_STDERR, dep_message);
+}
+
+// A binding deprecated only through `using` imports likely has no `_dep_message_<name>` in
+// its own module: the message(s) live on the source module(s) (which do not export them).
+// Walk `m`'s usings to each exported source of `name`, resolve reexports to the defining
+// leaf, and print every deprecated source's message -- so importing the same deprecated
+// constant from several modules reports each one's guidance. Returns 1 if any message was
+// printed. `msgsym` is the `_dep_message_<name>` symbol.
+static int jl_print_using_dep_messages(jl_module_t *m, jl_sym_t *name, jl_sym_t *msgsym) JL_CANSAFEPOINT
+{
+    size_t world = jl_current_task->world_age;
+    int printed = 0;
+    JL_LOCK(&m->lock);
+    size_t usings_len = module_usings_length(m);
+    JL_UNLOCK(&m->lock);
+    for (size_t i = 0; i < usings_len; i++) {
+        JL_LOCK(&m->lock);
+        struct _jl_module_using data = *module_usings_getidx(m, i);
+        JL_UNLOCK(&m->lock);
+        if (data.min_world > world || data.max_world < world)
+            continue;
+        jl_module_t *imp = data.mod;
+        JL_GC_PROMISE_ROOTED(imp); // rooted via `m->usings`
+        jl_binding_t *tempb = jl_get_module_binding(imp, name, 0);
+        if (!tempb)
+            continue;
+        jl_binding_partition_t *tempbpart = jl_get_binding_partition(tempb, world);
+        if (!jl_bpart_is_exported(tempbpart->kind))
+            continue;
+        // Resolve reexports to the module that defines the binding (and holds the message).
+        jl_walk_binding_inplace(&tempb, &tempbpart, world);
+        if (!(tempbpart->kind & PARTITION_FLAG_DEPRECATED))
+            continue;
+        jl_binding_t *msgb = jl_get_module_binding(tempb->globalref->mod, msgsym, 0);
+        if (!msgb)
+            continue;
+        jl_value_t *msg = jl_get_binding_value(msgb);
+        if (!msg)
+            continue;
+        JL_GC_PUSH1(&msg);
+        jl_print_dep_message_value(msg);
+        JL_GC_POP();
+        printed = 1;
+    }
+    return printed;
+}
+
 static void jl_binding_dep_message(jl_binding_t *b)
 {
     jl_module_t *m = b->globalref->mod;
@@ -1282,20 +1330,18 @@ static void jl_binding_dep_message(jl_binding_t *b)
     memcpy(dep_binding_name, dep_message_prefix, prefix_len);
     memcpy(dep_binding_name + prefix_len, jl_symbol_name(name), name_len);
     dep_binding_name[prefix_len+name_len] = '\0';
-    jl_binding_t *dep_message_binding = jl_get_binding(m, jl_symbol(dep_binding_name));
+    jl_sym_t *msgsym = jl_symbol(dep_binding_name);
+    jl_binding_t *dep_message_binding = jl_get_binding(m, msgsym);
     jl_value_t *dep_message = NULL;
     if (dep_message_binding != NULL)
         dep_message = jl_get_binding_value(dep_message_binding);
     JL_GC_PUSH1(&dep_message);
     if (dep_message != NULL) {
-        if (jl_is_string(dep_message)) {
-            jl_uv_puts(JL_STDERR, jl_string_data(dep_message), jl_string_len(dep_message));
-        }
-        else {
-            jl_static_show(JL_STDERR, dep_message);
-        }
+        jl_print_dep_message_value(dep_message);
     }
-    else {
+    // No message on `m` itself: the deprecation may come through `using`, so gather the
+    // source module(s)' messages before falling back to describing the value.
+    else if (!jl_print_using_dep_messages(m, name, msgsym)) {
         jl_value_t *v = jl_get_binding_value(b);
         dep_message = v; // use as gc-root
         if (v) {

--- a/src/module.c
+++ b/src/module.c
@@ -81,6 +81,12 @@ struct implicit_search_resolution {
     // If non-null, the unique binding imported. For PARTITION_KIND_IMPLICIT_GLOBAL, always matches binding_or_const.
     // Must have trust_cache = 0.
     jl_binding_t *debug_only_ultimate_binding;
+    // For a deprecated constant, which resolves through PARTITION_KIND_IMPLICIT_GLOBAL to its
+    // defining binding (so the deprecation warning still fires on access), this is the constant
+    // value that binding holds. It lets two deprecated constants that name an `egal` value
+    // unify, so importing the same deprecated constant from two modules is not spuriously
+    // ambiguous. NULL otherwise.
+    jl_value_t *deprecated_const_val;
 };
 
 static size_t WORLDMAX(size_t a, size_t b) { return a > b ? a : b; }
@@ -105,12 +111,23 @@ static void update_implicit_resolution(struct implicit_search_resolution *to_upd
     if (to_update->ultimate_kind == PARTITION_KIND_GUARD) {
         to_update->ultimate_kind = resolution.ultimate_kind;
         to_update->binding_or_const = resolution.binding_or_const;
+        to_update->deprecated_const_val = resolution.deprecated_const_val;
         to_update->debug_only_import_from = resolution.debug_only_import_from;
         to_update->debug_only_ultimate_binding = resolution.debug_only_ultimate_binding;
         return;
     }
-    if (resolution.ultimate_kind == to_update->ultimate_kind &&
-        resolution.binding_or_const == to_update->binding_or_const) {
+    int same = resolution.ultimate_kind == to_update->ultimate_kind &&
+               resolution.binding_or_const == to_update->binding_or_const;
+    // Two deprecated constants that name the same value are not ambiguous.
+    if (!same &&
+        resolution.ultimate_kind == PARTITION_KIND_IMPLICIT_GLOBAL &&
+        to_update->ultimate_kind == PARTITION_KIND_IMPLICIT_GLOBAL &&
+        resolution.deprecated_const_val != NULL &&
+        to_update->deprecated_const_val != NULL &&
+        jl_egal(resolution.deprecated_const_val, to_update->deprecated_const_val)) {
+        same = 1;
+    }
+    if (same) {
         if (resolution.debug_only_import_from != to_update->debug_only_import_from) {
             to_update->debug_only_import_from = NULL;
         }
@@ -121,6 +138,7 @@ static void update_implicit_resolution(struct implicit_search_resolution *to_upd
     }
     to_update->ultimate_kind = PARTITION_KIND_FAILED;
     to_update->binding_or_const = NULL;
+    to_update->deprecated_const_val = NULL;
     to_update->debug_only_import_from = NULL;
     to_update->debug_only_ultimate_binding = NULL;
 }
@@ -213,7 +231,7 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
         modstack_t *tmp = st;
         for (; tmp != NULL; tmp = tmp->prev) {
             if (tmp->b == b) {
-                return (struct implicit_search_resolution){ PARTITION_FAKE_KIND_CYCLE, NULL, 0, ~(size_t)0, 1, 0, NULL, NULL };
+                return (struct implicit_search_resolution){ PARTITION_FAKE_KIND_CYCLE, NULL, 0, ~(size_t)0, 1, 0, NULL, NULL, NULL };
             }
         }
     }
@@ -226,7 +244,7 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
     struct implicit_search_resolution depimpstate;
     size_t min_world = 0;
     size_t max_world = ~(size_t)0;
-    impstate = depimpstate = (struct implicit_search_resolution){ PARTITION_KIND_GUARD, NULL, min_world, max_world, 0, 0, NULL, NULL };
+    impstate = depimpstate = (struct implicit_search_resolution){ PARTITION_KIND_GUARD, NULL, min_world, max_world, 0, 0, NULL, NULL, NULL };
 
     JL_LOCK(&m->lock);
     int i = (int)module_usings_length(m) - 1;
@@ -302,7 +320,7 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
             comparison = &depimpstate;
         }
 
-        struct implicit_search_resolution imp_resolution = { PARTITION_KIND_GUARD, NULL, min_world, max_world, 0, 0, NULL, NULL };
+        struct implicit_search_resolution imp_resolution = { PARTITION_KIND_GUARD, NULL, min_world, max_world, 0, 0, NULL, NULL, NULL };
         if (!tempbpart_valid) {
             imp_resolution = jl_resolve_implicit_import(tempb, &top, world, trust_cache);
             // imp_resolution is the resolution for import into tempb (which may have been cached for tempb
@@ -338,6 +356,7 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
                     // const-folded as before.
                     imp_resolution.binding_or_const = (jl_value_t *)tempb;
                     imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_GLOBAL;
+                    imp_resolution.deprecated_const_val = tempbpart->restriction;
                 }
                 else {
                     imp_resolution.binding_or_const = tempbpart->restriction;

--- a/src/module.c
+++ b/src/module.c
@@ -81,13 +81,17 @@ struct implicit_search_resolution {
     // If non-null, the unique binding imported. For PARTITION_KIND_IMPLICIT_GLOBAL, always matches binding_or_const.
     // Must have trust_cache = 0.
     jl_binding_t *debug_only_ultimate_binding;
-    // For a deprecated constant, which resolves through PARTITION_KIND_IMPLICIT_GLOBAL to its
-    // defining binding (so the deprecation warning still fires on access), this is the constant
-    // value that binding holds. It lets two deprecated constants that name an `egal` value
-    // unify, so importing the same deprecated constant from two modules is not spuriously
-    // ambiguous. NULL otherwise.
-    jl_value_t *deprecated_const_val;
+    // Deprecation flags (PARTITION_FLAG_DEPRECATED / _DEPWARN) to stamp onto the resolved
+    // partition. A deprecated constant imported through `using` resolves to IMPLICIT_CONST
+    // (its value), so -- unlike a deprecated global, whose flag lives on the leaf the depwarn
+    // walk reaches -- there is no leaf to carry the deprecation. Recording it here and OR-ing
+    // it onto the importer's partition lets the walk (and `should_depwarn`/`isdeprecated`)
+    // find it directly on the resolved partition, so access through `using` warns consistently
+    // for constants and globals. It is OR-ed together when constants unify.
+    size_t deprecation_flags;
 };
+
+static const size_t DEPWARN_FLAGS = PARTITION_FLAG_DEPRECATED | PARTITION_FLAG_DEPWARN;
 
 static size_t WORLDMAX(size_t a, size_t b) { return a > b ? a : b; }
 static size_t WORLDMIN(size_t a, size_t b) { return a > b ? b : a; }
@@ -111,23 +115,31 @@ static void update_implicit_resolution(struct implicit_search_resolution *to_upd
     if (to_update->ultimate_kind == PARTITION_KIND_GUARD) {
         to_update->ultimate_kind = resolution.ultimate_kind;
         to_update->binding_or_const = resolution.binding_or_const;
-        to_update->deprecated_const_val = resolution.deprecated_const_val;
+        to_update->deprecation_flags = resolution.deprecation_flags;
         to_update->debug_only_import_from = resolution.debug_only_import_from;
         to_update->debug_only_ultimate_binding = resolution.debug_only_ultimate_binding;
         return;
     }
-    int same = resolution.ultimate_kind == to_update->ultimate_kind &&
-               resolution.binding_or_const == to_update->binding_or_const;
-    // Two deprecated constants that name the same value are not ambiguous.
-    if (!same &&
-        resolution.ultimate_kind == PARTITION_KIND_IMPLICIT_GLOBAL &&
-        to_update->ultimate_kind == PARTITION_KIND_IMPLICIT_GLOBAL &&
-        resolution.deprecated_const_val != NULL &&
-        to_update->deprecated_const_val != NULL &&
-        jl_egal(resolution.deprecated_const_val, to_update->deprecated_const_val)) {
-        same = 1;
+    int same;
+    if (resolution.ultimate_kind != to_update->ultimate_kind) {
+        same = 0;
+    }
+    else if (resolution.ultimate_kind == PARTITION_KIND_IMPLICIT_CONST) {
+        // Unify constants by value with `jl_egal`, so the same constant defined in two
+        // modules -- including distinct boxes of an equal immutable, such as an integer --
+        // is not spuriously ambiguous. (A deprecated constant is an IMPLICIT_CONST here too,
+        // carrying its deprecation in `deprecation_flags`, so two deprecated constants that
+        // name an egal value unify just like non-deprecated ones.)
+        same = jl_egal(resolution.binding_or_const, to_update->binding_or_const);
+    }
+    else {
+        same = resolution.binding_or_const == to_update->binding_or_const;
     }
     if (same) {
+        // Deprecation is weak: unified constants are deprecated only if every contributing
+        // import was (`impstate`/`depimpstate` keep deprecated and non-deprecated resolutions
+        // apart, so this only OR-s together same-strength imports).
+        to_update->deprecation_flags |= resolution.deprecation_flags;
         if (resolution.debug_only_import_from != to_update->debug_only_import_from) {
             to_update->debug_only_import_from = NULL;
         }
@@ -138,14 +150,17 @@ static void update_implicit_resolution(struct implicit_search_resolution *to_upd
     }
     to_update->ultimate_kind = PARTITION_KIND_FAILED;
     to_update->binding_or_const = NULL;
-    to_update->deprecated_const_val = NULL;
+    to_update->deprecation_flags = 0;
     to_update->debug_only_import_from = NULL;
     to_update->debug_only_ultimate_binding = NULL;
 }
 
 static jl_binding_partition_t *jl_implicit_import_resolved(jl_binding_t *b, struct implicit_search_gap gap, struct implicit_search_resolution resolution) JL_CANSAFEPOINT
 {
-    size_t new_kind = resolution.ultimate_kind | gap.inherited_flags;
+    // The deprecation flags come from the resolution (the imported binding), not from the
+    // importer's own inherited flags, so a stale deprecation from a prior resolution of this
+    // binding does not persist across a re-resolution (e.g. after the source is un-deprecated).
+    size_t new_kind = resolution.ultimate_kind | (gap.inherited_flags & ~DEPWARN_FLAGS) | resolution.deprecation_flags;
     // If the resolution indicates this should be reexported, add the implicit export flag
     if (resolution.should_be_reexported) {
         new_kind |= PARTITION_FLAG_IMPLICITLY_EXPORTED;
@@ -231,7 +246,7 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
         modstack_t *tmp = st;
         for (; tmp != NULL; tmp = tmp->prev) {
             if (tmp->b == b) {
-                return (struct implicit_search_resolution){ PARTITION_FAKE_KIND_CYCLE, NULL, 0, ~(size_t)0, 1, 0, NULL, NULL, NULL };
+                return (struct implicit_search_resolution){ PARTITION_FAKE_KIND_CYCLE, NULL, 0, ~(size_t)0, 1, 0, NULL, NULL, 0 };
             }
         }
     }
@@ -244,7 +259,7 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
     struct implicit_search_resolution depimpstate;
     size_t min_world = 0;
     size_t max_world = ~(size_t)0;
-    impstate = depimpstate = (struct implicit_search_resolution){ PARTITION_KIND_GUARD, NULL, min_world, max_world, 0, 0, NULL, NULL, NULL };
+    impstate = depimpstate = (struct implicit_search_resolution){ PARTITION_KIND_GUARD, NULL, min_world, max_world, 0, 0, NULL, NULL, 0 };
 
     JL_LOCK(&m->lock);
     int i = (int)module_usings_length(m) - 1;
@@ -320,7 +335,7 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
             comparison = &depimpstate;
         }
 
-        struct implicit_search_resolution imp_resolution = { PARTITION_KIND_GUARD, NULL, min_world, max_world, 0, 0, NULL, NULL, NULL };
+        struct implicit_search_resolution imp_resolution = { PARTITION_KIND_GUARD, NULL, min_world, max_world, 0, 0, NULL, NULL, 0 };
         if (!tempbpart_valid) {
             imp_resolution = jl_resolve_implicit_import(tempb, &top, world, trust_cache);
             // imp_resolution is the resolution for import into tempb (which may have been cached for tempb
@@ -341,27 +356,9 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
                 imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_GLOBAL;
             } else if (jl_bkind_is_defined_constant(kind)) {
                 assert(tempbpart->restriction);
-                if (tempbpart_flags & PARTITION_FLAG_DEPRECATED) {
-                    // A deprecated constant: resolve like a global/backdated
-                    // const (point at the owning binding) instead of absorbing
-                    // the value into an `IMPLICIT_CONST` partition -- which
-                    // would drop the deprecation flag and silently stop the
-                    // depwarn walk here. Deferring to the owner keeps the
-                    // deprecation on the leaf the walk reaches, so access
-                    // through `using` warns like a deprecated global and like
-                    // a direct access (an explicit `using M: x`/`import M: x`
-                    // still suppresses it). Encoding the state in the kind
-                    // also makes (un)deprecation force a fresh resolution. The
-                    // leaf is still a defined const, so the value is
-                    // const-folded as before.
-                    imp_resolution.binding_or_const = (jl_value_t *)tempb;
-                    imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_GLOBAL;
-                    imp_resolution.deprecated_const_val = tempbpart->restriction;
-                }
-                else {
-                    imp_resolution.binding_or_const = tempbpart->restriction;
-                    imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_CONST;
-                }
+                imp_resolution.binding_or_const = tempbpart->restriction;
+                imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_CONST;
+                imp_resolution.deprecation_flags = tempbpart_flags & DEPWARN_FLAGS;
                 imp_resolution.debug_only_ultimate_binding = tempb;
             } else if (kind == PARTITION_KIND_FAILED) {
                 imp_resolution.binding_or_const = NULL;
@@ -401,7 +398,8 @@ JL_DLLEXPORT jl_binding_partition_t *jl_maybe_reresolve_implicit(jl_binding_t *b
         assert(bpart == jl_atomic_load_relaxed(&b->partitions));
         assert(bpart);
         struct implicit_search_resolution resolution = jl_resolve_implicit_import(b, NULL, new_max_world+1, 0);
-        int resolution_unchanged = bpart->restriction == resolution.binding_or_const && jl_binding_kind(bpart) == resolution.ultimate_kind;
+        int resolution_unchanged = bpart->restriction == resolution.binding_or_const && jl_binding_kind(bpart) == resolution.ultimate_kind &&
+                                   (bpart->kind & DEPWARN_FLAGS) == resolution.deprecation_flags;
         size_t bpart_min_world = jl_atomic_load_relaxed(&bpart->min_world);
         if (resolution.min_world == bpart_min_world) {
             // The resolution has the same world bounds - it must be unchanged
@@ -431,7 +429,7 @@ JL_DLLEXPORT void jl_update_loaded_bpart(jl_binding_t *b, jl_binding_partition_t
     jl_atomic_store_relaxed(&bpart->min_world, resolution.min_world);
     jl_atomic_store_relaxed(&bpart->max_world, resolution.max_world);
     jl_gc_write(bpart, bpart->restriction, jl_value_t, resolution.binding_or_const);
-    bpart->kind = resolution.ultimate_kind;
+    bpart->kind = resolution.ultimate_kind | resolution.deprecation_flags;
 }
 
 static void jl_walk_binding_inplace(jl_binding_t **bnd, jl_binding_partition_t **pbpart, size_t world) JL_CANSAFEPOINT
@@ -1037,7 +1035,9 @@ JL_DLLEXPORT jl_value_t *jl_get_binding_value_in_world(jl_binding_t *b, size_t w
     return jl_atomic_load_relaxed(&b->value);
 }
 
-static jl_value_t *jl_get_binding_value_depwarn(jl_binding_t *b, size_t world) JL_CANSAFEPOINT
+// Read a binding's value at `world`, warning if it is deprecated (unless reached through an
+// explicit import, which `jl_walk_binding_inplace_depwarn` suppresses).
+static jl_value_t *jl_get_binding_value_depwarn_(jl_binding_t *b, size_t world, int seqcst) JL_CANSAFEPOINT
 {
     assert(b); // alloc=1 parameter ensured that jl_get_module_binding returns a valid binding
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
@@ -1058,23 +1058,17 @@ static jl_value_t *jl_get_binding_value_depwarn(jl_binding_t *b, size_t world) J
         return bpart->restriction;
     }
     assert(!jl_bkind_is_some_import(kind));
-    return jl_atomic_load_relaxed(&b->value);
+    return seqcst ? jl_atomic_load(&b->value) : jl_atomic_load_relaxed(&b->value);
+}
+
+static jl_value_t *jl_get_binding_value_depwarn(jl_binding_t *b, size_t world) JL_CANSAFEPOINT
+{
+    return jl_get_binding_value_depwarn_(b, world, 0);
 }
 
 JL_DLLEXPORT jl_value_t *jl_get_binding_value_seqcst(jl_binding_t *b) JL_CANSAFEPOINT
 {
-    size_t world = jl_current_task->world_age;
-    jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
-    jl_walk_binding_inplace(&b, &bpart, world);
-    enum jl_partition_kind kind = jl_binding_kind(bpart);
-    if (jl_bkind_is_some_guard(kind))
-        return NULL;
-    if (jl_bkind_is_some_constant(kind)) {
-        check_backdated_binding(b, kind);
-        return bpart->restriction;
-    }
-    assert(!jl_bkind_is_some_import(kind));
-    return jl_atomic_load(&b->value);
+    return jl_get_binding_value_depwarn_(b, jl_current_task->world_age, 1);
 }
 
 JL_DLLEXPORT jl_value_t *jl_get_latest_binding_value_if_const(jl_binding_t *b)
@@ -1887,7 +1881,9 @@ JL_DLLEXPORT jl_binding_partition_t *jl_replace_binding_locked2(jl_binding_t *b,
     if ((kind & PARTITION_MASK_KIND) == PARTITION_FAKE_KIND_IMPLICIT_RECOMPUTE) {
         assert(!restriction_val);
         struct implicit_search_resolution resolution = jl_resolve_implicit_import(b, NULL, new_world, 0);
-        new_bpart->kind = resolution.ultimate_kind | (kind & PARTITION_MASK_FLAG);
+        // Deprecation comes fresh from the resolution (see `jl_implicit_import_resolved`), so
+        // mask any prior deprecation out of the carried flags before OR-ing the new one in.
+        new_bpart->kind = resolution.ultimate_kind | ((kind & PARTITION_MASK_FLAG) & ~DEPWARN_FLAGS) | resolution.deprecation_flags;
         // If the resolution indicates this should be reexported, add the implicit export flag
         if (resolution.should_be_reexported) {
             new_bpart->kind |= PARTITION_FLAG_IMPLICITLY_EXPORTED;
@@ -1987,7 +1983,6 @@ JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var)
 
 // set the deprecated flag for a binding:
 //   0=not deprecated, 1=renamed, 2=moved to another package
-static const size_t DEPWARN_FLAGS = PARTITION_FLAG_DEPRECATED | PARTITION_FLAG_DEPWARN;
 JL_DLLEXPORT void jl_deprecate_binding(jl_module_t *m, jl_sym_t *var, int flag) JL_CANSAFEPOINT
 {
     jl_binding_t *b = jl_get_binding(m, var);
@@ -2049,13 +2044,13 @@ static int should_depwarn(jl_binding_t *b, uint8_t flag) JL_CANSAFEPOINT
     // is not the use itself, but rather the `using` or `import` (which already prints
     // an appropriate warning).
     //
-    // Walk imports so this matches the value access warning and codegen's
-    // `maybe_depwarn`: a deprecated constant reached through an implicit
-    // `using` resolves via `IMPLICIT_GLOBAL`, so the deprecation lives on the
-    // leaf and only shows up if we walk to it (the top partition carries no
-    // flag). Checking only the top partition would miss it here, so the
-    // codegen-emitted `jl_binding_deprecation_check` would silently skip the
-    // warning even though inference kept the effect.
+    // Walk imports so this matches the value access warning and codegen's `maybe_depwarn`.
+    // A deprecated global reached through an implicit `using` resolves via `IMPLICIT_GLOBAL`,
+    // so its deprecation lives on the leaf and only shows up once we walk to it; a deprecated
+    // constant instead carries its deprecation on the importer's `IMPLICIT_CONST` partition,
+    // which the walk also inspects. Either way, checking only the top partition without the
+    // walk would miss the global case, so the codegen-emitted `jl_binding_deprecation_check`
+    // would silently skip the warning even though inference kept the effect.
     size_t world = jl_current_task->world_age;
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
     int found = 0;
@@ -2071,9 +2066,7 @@ JL_DLLEXPORT void jl_binding_deprecation_check(jl_binding_t *b) JL_CANSAFEPOINT
 
 JL_DLLEXPORT int jl_is_binding_deprecated(jl_module_t *m, jl_sym_t *var) JL_CANSAFEPOINT
 {
-    jl_binding_t *b = jl_get_module_binding(m, var, 0);
-    if (!b)
-        return 0;
+    jl_binding_t *b = jl_get_module_binding(m, var, 1);
     return should_depwarn(b, PARTITION_FLAG_DEPRECATED);
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -323,9 +323,27 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
                 imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_GLOBAL;
             } else if (jl_bkind_is_defined_constant(kind)) {
                 assert(tempbpart->restriction);
-                imp_resolution.binding_or_const = tempbpart->restriction;
+                if (tempbpart_flags & PARTITION_FLAG_DEPRECATED) {
+                    // A deprecated constant: resolve like a global/backdated
+                    // const (point at the owning binding) instead of absorbing
+                    // the value into an `IMPLICIT_CONST` partition -- which
+                    // would drop the deprecation flag and silently stop the
+                    // depwarn walk here. Deferring to the owner keeps the
+                    // deprecation on the leaf the walk reaches, so access
+                    // through `using` warns like a deprecated global and like
+                    // a direct access (an explicit `using M: x`/`import M: x`
+                    // still suppresses it). Encoding the state in the kind
+                    // also makes (un)deprecation force a fresh resolution. The
+                    // leaf is still a defined const, so the value is
+                    // const-folded as before.
+                    imp_resolution.binding_or_const = (jl_value_t *)tempb;
+                    imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_GLOBAL;
+                }
+                else {
+                    imp_resolution.binding_or_const = tempbpart->restriction;
+                    imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_CONST;
+                }
                 imp_resolution.debug_only_ultimate_binding = tempb;
-                imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_CONST;
             } else if (kind == PARTITION_KIND_FAILED) {
                 imp_resolution.binding_or_const = NULL;
                 imp_resolution.debug_only_ultimate_binding = tempb;
@@ -411,19 +429,24 @@ static void jl_walk_binding_inplace(jl_binding_t **bnd, jl_binding_partition_t *
     *pbpart = bpart;
 }
 
-static void jl_walk_binding_inplace_depwarn(jl_binding_t **bnd, jl_binding_partition_t **pbpart, size_t world, int *depwarn) JL_CANSAFEPOINT
+// Walk imports to the leaf while reporting whether any partition along the way carries a
+// deprecation `flag` (`PARTITION_FLAG_DEPWARN` for the access warning, or
+// `PARTITION_FLAG_DEPRECATED` for `isdeprecated`), suppressed once an explicit import is
+// passed (the `import`/`using: x` site is what should be fixed). Keeping the single walk
+// used by both the access-warning and `isdeprecated` paths ensures they agree.
+static void jl_walk_binding_inplace_depwarn(jl_binding_t **bnd, jl_binding_partition_t **pbpart, size_t world, size_t flag, int *found) JL_CANSAFEPOINT
 {
     int passed_explicit = 0;
     jl_binding_partition_t *bpart = *pbpart;
     while (1) {
         enum jl_partition_kind kind = jl_binding_kind(bpart);
         if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL) {
-            if (!passed_explicit && depwarn)
-                *depwarn |= bpart->kind & PARTITION_FLAG_DEPWARN;
+            if (!passed_explicit && found)
+                *found |= bpart->kind & flag;
             break;
         }
-        if (!passed_explicit && depwarn)
-            *depwarn |= bpart->kind & PARTITION_FLAG_DEPWARN;
+        if (!passed_explicit && found)
+            *found |= bpart->kind & flag;
         if (kind != PARTITION_KIND_IMPLICIT_GLOBAL)
             passed_explicit = 1;
         *bnd = (jl_binding_t*)bpart->restriction;
@@ -1001,7 +1024,7 @@ static jl_value_t *jl_get_binding_value_depwarn(jl_binding_t *b, size_t world) J
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
     if (jl_options.depwarn) {
         int needs_depwarn = 0;
-        jl_walk_binding_inplace_depwarn(&b, &bpart, world, &needs_depwarn);
+        jl_walk_binding_inplace_depwarn(&b, &bpart, world, PARTITION_FLAG_DEPWARN, &needs_depwarn);
         if (needs_depwarn)
             jl_binding_deprecation_warning(b);
     }
@@ -1326,7 +1349,7 @@ JL_DLLEXPORT void jl_module_import(jl_task_t *ct, jl_module_t *to, jl_module_t *
                 deprecated Base bindings should simply export the new
                 binding */
             jl_printf(JL_STDERR,
-                        "WARNING: importing deprecated binding %s.%s into %s%s%s.\n",
+                        "WARNING: importing deprecated binding %s.%s into %s%s%s",
                         jl_symbol_name(from->name), jl_symbol_name(s),
                         jl_symbol_name(to->name),
                         asname == s ? "" : " as ",
@@ -2006,10 +2029,19 @@ static int should_depwarn(jl_binding_t *b, uint8_t flag) JL_CANSAFEPOINT
     // (`using` or `import`). The logic here is that the thing that needs to be adjusted
     // is not the use itself, but rather the `using` or `import` (which already prints
     // an appropriate warning).
-    jl_binding_partition_t *bpart = jl_get_binding_partition(b, jl_current_task->world_age);
-    if (bpart->kind & flag)
-        return 1;
-    return 0;
+    //
+    // Walk imports so this matches the value access warning and codegen's
+    // `maybe_depwarn`: a deprecated constant reached through an implicit
+    // `using` resolves via `IMPLICIT_GLOBAL`, so the deprecation lives on the
+    // leaf and only shows up if we walk to it (the top partition carries no
+    // flag). Checking only the top partition would miss it here, so the
+    // codegen-emitted `jl_binding_deprecation_check` would silently skip the
+    // warning even though inference kept the effect.
+    size_t world = jl_current_task->world_age;
+    jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
+    int found = 0;
+    jl_walk_binding_inplace_depwarn(&b, &bpart, world, flag, &found);
+    return found != 0;
 }
 
 JL_DLLEXPORT void jl_binding_deprecation_check(jl_binding_t *b) JL_CANSAFEPOINT

--- a/src/module.c
+++ b/src/module.c
@@ -342,6 +342,8 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
             imp_resolution.should_be_reexported = 0;
         } else {
             enum jl_partition_kind kind = jl_binding_kind(tempbpart);
+            // Copy the imported binding's deprecation onto the importer's partition.
+            imp_resolution.deprecation_flags = tempbpart_flags & DEPWARN_FLAGS;
             if (kind == PARTITION_KIND_IMPLICIT_GLOBAL) {
                 imp_resolution.binding_or_const = tempbpart->restriction;
                 imp_resolution.debug_only_ultimate_binding = (jl_binding_t*)tempbpart->restriction;
@@ -354,7 +356,6 @@ static struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t
                 assert(tempbpart->restriction);
                 imp_resolution.binding_or_const = tempbpart->restriction;
                 imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_CONST;
-                imp_resolution.deprecation_flags = tempbpart_flags & DEPWARN_FLAGS;
                 imp_resolution.debug_only_ultimate_binding = tempb;
             } else if (kind == PARTITION_KIND_FAILED) {
                 imp_resolution.binding_or_const = NULL;
@@ -2080,28 +2081,20 @@ JL_DLLEXPORT void jl_module_set_visibility(jl_module_t *m, jl_sym_t *var, int st
 
 static int should_depwarn(jl_binding_t *b, uint8_t flag) JL_CANSAFEPOINT
 {
-    // We consider bindings deprecated, if:
+    // We consider a binding deprecated if:
     //
     // 1. The binding itself is deprecated, or
-    // 2. We implicitly import any deprecated binding.
+    // 2. it implicitly imports (through `using`) a deprecated binding.
     //
-    // However, we do not consider the binding deprecated if the import was an explicit
-    // (`using` or `import`). The logic here is that the thing that needs to be adjusted
-    // is not the use itself, but rather the `using` or `import` (which already prints
-    // an appropriate warning).
-    //
-    // Walk imports so this matches the value access warning and codegen's `maybe_depwarn`.
-    // A deprecated global reached through an implicit `using` resolves via `IMPLICIT_GLOBAL`,
-    // so its deprecation lives on the leaf and only shows up once we walk to it; a deprecated
-    // constant instead carries its deprecation on the importer's `IMPLICIT_CONST` partition,
-    // which the walk also inspects. Either way, checking only the top partition without the
-    // walk would miss the global case, so the codegen-emitted `jl_binding_deprecation_check`
-    // would silently skip the warning even though inference kept the effect.
-    size_t world = jl_current_task->world_age;
-    jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
-    int found = 0;
-    jl_walk_binding_inplace_depwarn(&b, &bpart, world, flag, &found);
-    return found != 0;
+    // We do not consider it deprecated when reached through an explicit import (`import`/
+    // `using M: x`): the thing that should be adjusted is the import, not the use, and the
+    // import site already warned. Implicit resolution records both of these on the importer's
+    // own partition -- it stamps the deprecation flag onto the resolved partition for every
+    // implicitly-imported deprecated binding (constant or global, transparently through
+    // reexports), while explicit imports never take that path and so carry no flag. Checking
+    // the top partition therefore suffices, and matches codegen's const-fold `maybe_depwarn`.
+    jl_binding_partition_t *bpart = jl_get_binding_partition(b, jl_current_task->world_age);
+    return (bpart->kind & flag) != 0;
 }
 
 JL_DLLEXPORT void jl_binding_deprecation_check(jl_binding_t *b) JL_CANSAFEPOINT

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -258,9 +258,9 @@ module DeprecatedUsingTest
     @test !Base.isdeprecated(Consumer, :DepC)
 end
 
-# Importing the same deprecated constant from two modules must unify by value,
-# not report an ambiguity. Constants with unequal values still are ambiguous,
-# and a non-deprecated peer still wins.
+# Importing the same deprecated constant from two modules must unify by value, not report an
+# ambiguity, and still warn (with each source's deprecation message) on access. Constants with
+# unequal values are still ambiguous, and a non-deprecated peer still wins (no warning).
 module DeprecatedUsingUnifyTest
     using Test
     # Two deprecated constants with equal values.
@@ -277,9 +277,12 @@ module DeprecatedUsingUnifyTest
     using .A, .B
     read2() = DepC
     fold2() = DepC === 0x123456789 ? true : nothing
-    @test (@test_warn "DepC is deprecated" read2()) === 0x123456789
-    @test (@test_warn "DepC is deprecated" getglobal(@__MODULE__, :DepC)) === 0x123456789
+    # The compiled/const-folded read and the dynamic read both warn, and the warning reports
+    # each contributing source module's deprecation message.
+    @test (@test_warn r"DepC is deprecated, use _a instead\., use _b instead\."s read2()) === 0x123456789
+    @test (@test_warn "DepC is deprecated, use _a instead." getglobal(@__MODULE__, :DepC)) === 0x123456789
     @test Base.isdeprecated(@__MODULE__, :DepC)
+    # The value still const-folds through the unified resolution.
     @test Base.infer_return_type(fold2, Tuple{}) === Bool
 
     # Two deprecated constants with unequal values stay ambiguous.

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -278,6 +278,7 @@ module DeprecatedUsingUnifyTest
     read2() = DepC
     fold2() = DepC === 0x123456789 ? true : nothing
     @test (@test_warn "DepC is deprecated" read2()) === 0x123456789
+    @test (@test_warn "DepC is deprecated" getglobal(@__MODULE__, :DepC)) === 0x123456789
     @test Base.isdeprecated(@__MODULE__, :DepC)
     @test Base.infer_return_type(fold2, Tuple{}) === Bool
 

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -315,3 +315,36 @@ module DeprecatedUsingUnifyTest
     @test (@test_nowarn readmix()) === 0xff
     @test !Base.isdeprecated(@__MODULE__, :MixC)
 end
+
+# The deprecation is carried on the importer's partition for globals as well as constants, and
+# transparently through reexports: a `using` of a module that only reexports a deprecated
+# binding still reports it deprecated (`isdeprecated`) and warns on access, without walking to
+# the defining owner. An explicit `import` still suppresses the use-site warning.
+module DeprecatedReexportTest
+    using Test
+    module Src
+        export DepC, DepG
+        const _c = 0x1234
+        Base.@deprecate_binding DepC _c false
+        newg() = 1
+        Base.@deprecate_binding DepG newg false ", use newg instead." false
+    end
+    module Reexport
+        using ..Src
+        export DepC, DepG                                           # reexport both
+    end
+    using .Reexport
+    readc() = DepC
+    readg() = DepG
+    # Reached through `using .Reexport`; the deprecation is visible on this module's partition.
+    @test Base.isdeprecated(@__MODULE__, :DepC)
+    @test Base.isdeprecated(@__MODULE__, :DepG)
+    @test (@test_warn "DepC is deprecated" readc()) === Src._c
+    @test (@test_warn "DepG is deprecated, use newg instead." readg()) === Src.newg
+
+    # An explicit selective import of the reexported binding suppresses the use-site warning.
+    ex = :(module Consumer; import ..Reexport: DepC; getdep() = DepC; end)
+    @test_warn "importing deprecated binding" eval(ex)
+    @test (@test_nowarn Consumer.getdep()) === Src._c
+    @test !Base.isdeprecated(Consumer, :DepC)
+end

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -229,3 +229,60 @@ begin #@deprecated error message
         @eval @deprecate Foo{T} where {T <: Int} g true
     )
 end
+
+# A deprecated binding reached through `using` must warn on access, consistently for
+# constants and globals, matching a direct access and the runtime `getglobal`. Previously
+# the implicit-`using` resolution absorbed a deprecated const's value into an
+# `IMPLICIT_CONST` partition and dropped the deprecation flag, so access through `using`
+# silently skipped the warning (a deprecated global was unaffected -- it warns via the walk
+# to its owner). An explicit `import M: x` still suppresses the warning (the import site is
+# what should be fixed). The constant must still be constant-folded despite the deprecation.
+# Bare `@test` (no `@testset`) as elsewhere in this sub-processed file, so no summary print
+# leaks into the parent test runner.
+module DeprecatedUsingTest
+    using Test
+    module Src
+        export DepC, OkC
+        const _real = 0x1234
+        Base.@deprecate_binding DepC _real false   # DepC: deprecated const, value == _real
+        const OkC = 0x5678                          # control: not deprecated
+    end
+    using .Src                                      # implicit import of DepC, OkC
+
+    read_dep() = DepC
+    read_ok()  = OkC
+    # Const-propagation probes: if the deprecated const still propagates as a compile-time
+    # `Const`, the identity comparison folds and the branch is eliminated, so these infer
+    # `Bool`. If the deprecation regressed the read to a dynamic/widened value, `fold_dep`
+    # would infer `Union{Bool,Nothing}`.
+    fold_dep() = DepC === 0x1234 ? true : nothing
+    fold_ok()  = OkC  === 0x5678 ? true : nothing
+
+    # Access through the implicit `using` warns (compiled read and runtime getglobal),
+    # consistently with a direct access and a deprecated global; the control does not warn.
+    @test (@test_warn "DepC is deprecated" read_dep()) === Src._real
+    @test (@test_warn "DepC is deprecated" getglobal(@__MODULE__, :DepC)) === Src._real
+    @test (@test_nowarn read_ok()) === Src.OkC
+    # Const-propagation is preserved despite the deprecation: the deferred resolution still
+    # lands on the defining const leaf, so the value folds at inference (only the deprecation
+    # side effect is kept). The control folds the same way.
+    @test Base.infer_return_type(fold_dep, Tuple{}) === Bool
+    @test Base.infer_return_type(fold_ok,  Tuple{}) === Bool
+    # `isdeprecated` must agree with the access warning (otherwise consumers that guard with
+    # it, e.g. `InteractiveUtils.subtypes`, would then throw in `getglobal` under
+    # `--depwarn=error`): the deprecated binding reached through the implicit `using` reports
+    # deprecated, the control does not.
+    @test Base.isdeprecated(@__MODULE__, :DepC)
+    @test !Base.isdeprecated(@__MODULE__, :OkC)
+
+    # An explicit selective import warns once at the import site (asserted here so it does
+    # not leak), and then suppresses the deprecation warning on use. The import warning's
+    # deprecation message reads as one sentence (not stranded on its own line).
+    ex = :(module Consumer; import ..Src: DepC; getdep() = DepC; end)
+    @test_warn "importing deprecated binding Src.DepC into Consumer, use _real instead." eval(ex)
+    @Core.latestworld
+    @test (@test_nowarn Consumer.getdep()) === Src._real
+    # The explicit import suppresses the use-site deprecation, so `isdeprecated` reports it
+    # as not deprecated there too -- consistent with `getglobal` not warning.
+    @test !Base.isdeprecated(Consumer, :DepC)
+end

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -230,59 +230,84 @@ begin #@deprecated error message
     )
 end
 
-# A deprecated binding reached through `using` must warn on access, consistently for
-# constants and globals, matching a direct access and the runtime `getglobal`. Previously
-# the implicit-`using` resolution absorbed a deprecated const's value into an
-# `IMPLICIT_CONST` partition and dropped the deprecation flag, so access through `using`
-# silently skipped the warning (a deprecated global was unaffected -- it warns via the walk
-# to its owner). An explicit `import M: x` still suppresses the warning (the import site is
-# what should be fixed). The constant must still be constant-folded despite the deprecation.
-# Bare `@test` (no `@testset`) as elsewhere in this sub-processed file, so no summary print
-# leaks into the parent test runner.
+# A deprecated binding reached through `using` must warn on access,
+# consistently for constants and globals, matching a direct access and the
+# runtime `getglobal`. An explicit `import M: x` still suppresses the warning
+# (the import site is what should warn). The constant must still be
+# constant-folded despite the deprecation.
 module DeprecatedUsingTest
     using Test
     module Src
-        export DepC, OkC
+        export DepC
         const _real = 0x1234
-        Base.@deprecate_binding DepC _real false   # DepC: deprecated const, value == _real
-        const OkC = 0x5678                          # control: not deprecated
+        Base.@deprecate_binding DepC _real false
     end
-    using .Src                                      # implicit import of DepC, OkC
+    using .Src
 
     read_dep() = DepC
-    read_ok()  = OkC
-    # Const-propagation probes: if the deprecated const still propagates as a compile-time
-    # `Const`, the identity comparison folds and the branch is eliminated, so these infer
-    # `Bool`. If the deprecation regressed the read to a dynamic/widened value, `fold_dep`
-    # would infer `Union{Bool,Nothing}`.
     fold_dep() = DepC === 0x1234 ? true : nothing
-    fold_ok()  = OkC  === 0x5678 ? true : nothing
 
-    # Access through the implicit `using` warns (compiled read and runtime getglobal),
-    # consistently with a direct access and a deprecated global; the control does not warn.
     @test (@test_warn "DepC is deprecated" read_dep()) === Src._real
     @test (@test_warn "DepC is deprecated" getglobal(@__MODULE__, :DepC)) === Src._real
-    @test (@test_nowarn read_ok()) === Src.OkC
-    # Const-propagation is preserved despite the deprecation: the deferred resolution still
-    # lands on the defining const leaf, so the value folds at inference (only the deprecation
-    # side effect is kept). The control folds the same way.
     @test Base.infer_return_type(fold_dep, Tuple{}) === Bool
-    @test Base.infer_return_type(fold_ok,  Tuple{}) === Bool
-    # `isdeprecated` must agree with the access warning (otherwise consumers that guard with
-    # it, e.g. `InteractiveUtils.subtypes`, would then throw in `getglobal` under
-    # `--depwarn=error`): the deprecated binding reached through the implicit `using` reports
-    # deprecated, the control does not.
     @test Base.isdeprecated(@__MODULE__, :DepC)
-    @test !Base.isdeprecated(@__MODULE__, :OkC)
 
-    # An explicit selective import warns once at the import site (asserted here so it does
-    # not leak), and then suppresses the deprecation warning on use. The import warning's
-    # deprecation message reads as one sentence (not stranded on its own line).
     ex = :(module Consumer; import ..Src: DepC; getdep() = DepC; end)
     @test_warn "importing deprecated binding Src.DepC into Consumer, use _real instead." eval(ex)
-    @Core.latestworld
     @test (@test_nowarn Consumer.getdep()) === Src._real
-    # The explicit import suppresses the use-site deprecation, so `isdeprecated` reports it
-    # as not deprecated there too -- consistent with `getglobal` not warning.
     @test !Base.isdeprecated(Consumer, :DepC)
+end
+
+# Importing the same deprecated constant from two modules must unify by value,
+# not report an ambiguity. Constants with unequal values still are ambiguous,
+# and a non-deprecated peer still wins.
+module DeprecatedUsingUnifyTest
+    using Test
+    # Two deprecated constants with equal values.
+    module A
+        export DepC
+        const _a = 0x123456789
+        Base.@deprecate_binding DepC _a false
+    end
+    module B
+        export DepC
+        const _b = 0x123456789
+        Base.@deprecate_binding DepC _b false
+    end
+    using .A, .B
+    read2() = DepC
+    fold2() = DepC === 0x123456789 ? true : nothing
+    @test (@test_warn "DepC is deprecated" read2()) === 0x123456789
+    @test Base.isdeprecated(@__MODULE__, :DepC)
+    @test Base.infer_return_type(fold2, Tuple{}) === Bool
+
+    # Two deprecated constants with unequal values stay ambiguous.
+    module C
+        export DiffC
+        const _c = 0x0001
+        Base.@deprecate_binding DiffC _c false
+    end
+    module D
+        export DiffC
+        const _d = 0x0002
+        Base.@deprecate_binding DiffC _d false
+    end
+    using .C, .D
+    @test_throws UndefVarError getglobal(@__MODULE__, :DiffC)
+
+    # A deprecated and a non-deprecated constant naming the same value:
+    # the non-deprecated one wins, so access should not warn.
+    module E
+        export MixC
+        const _e = 0xff
+        Base.@deprecate_binding MixC _e false
+    end
+    module F
+        export MixC
+        const MixC = 0xff
+    end
+    using .E, .F
+    readmix() = MixC
+    @test (@test_nowarn readmix()) === 0xff
+    @test !Base.isdeprecated(@__MODULE__, :MixC)
 end


### PR DESCRIPTION
A binding deprecated in its defining module warns on access when reached
directly or through an implicit `using`, except for constants: the
implicit resolution copied a deprecated constant's value into a
`PARTITION_KIND_IMPLICIT_CONST` partition without copying deprecations.
Since there is no leaf binding left for the depwarn walk to reach, the
deprecation was silently dropped and access through `using` skipped the
warning.

Record the deprecation as part of the implicit resolution instead.
`jl_resolve_implicit_import` now carries the imported partition's
`PARTITION_FLAG_DEPRECATED`/`PARTITION_FLAG_DEPWARN` in its result and
stamps them onto the importer's own resolved partition, so the flag is
present where the access check looks, for constants and globals alike,
and transparently through reexports (a `using` of a module that merely
reexports a deprecated binding now reports it as deprecated without
having to walk to the defining owner). Because the flags come fresh from
each resolution rather than being inherited from the previous partition,
(un)deprecating the source forces a re-resolution, and
`jl_maybe_reresolve_implicit` compares them when deciding whether a
resolution actually changed. The value is still stored in the partition,
so it continues to be constant-folded and propagated by inference.

Two constants of equal value imported from different modules are now
unified by `jl_egal` rather than pointer identity, and their deprecation
flags are OR-ed together. Deprecation remains weak: a non-deprecated
import still wins over a deprecated one, and unequal values are still
ambiguous.

With the flag recorded on the importer's partition, `should_depwarn`
reduces to a check of the top partition, which is what codegen's
constant-folding path (`maybe_depwarn`) already does, so the dynamic and
compiled reads agree. `Base.isdeprecated` becomes accurate for
implicitly imported bindings — it resolves the binding rather than
reporting `false` when the importing module has no binding table entry
yet — and the walk that reports deprecation is generalized over which
flag it is looking for so `isdeprecated` and the access warning share
it. Its stale "vaguely broken" comment is replaced with a description of
what it does and does not cover (`@deprecate` deprecates a method, not
the binding). `jl_get_binding_value_seqcst` also routes through the
depwarn path, so a runtime `getglobal` warns like every other read.

The deprecation message needed a corresponding fix: a binding deprecated
only through `using` has no `_dep_message_<name>` in the accessing
module, since the message lives in the source module(s), which do not
export it. When the local lookup finds nothing, walk the module's
`using` list to each exported source of the name, resolve reexports to
the defining leaf, and print each deprecated source's message, so
importing the same deprecated constant from several modules reports
every one's guidance instead of falling back to describing the value.
The import-time warning also appended the message (`, use X instead.`)
after a completed sentence and a newline, leaving it stranded on its own
line; drop that trailing punctuation so it reads as one sentence, as the
access warning already does.

Finally, `Base.@deprecate_binding` — the macro users are meant to reach
for when deprecating a constant or global, and the one this fix makes
behave consistently — had no docstring and was not exported. Document it
and export it alongside `@deprecate`.

Assisted-by: Claude Opus 4.8