### PR TITLE
jloptions: don't truncate `--help` output

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -561,8 +561,6 @@ restart_switch:
             jl_safe_fprintf(ios_stdout, "julia version %s\n", JULIA_VERSION_STRING);
             exit(0);
         case 'h': // help
-            // not jl_safe_fprintf, which formats through a fixed 1000-byte
-            // buffer and would truncate the help text
             ios_puts(usage, ios_stdout);
             ios_puts(opts, ios_stdout);
             ios_flush(ios_stdout);

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -561,10 +561,16 @@ restart_switch:
             jl_safe_fprintf(ios_stdout, "julia version %s\n", JULIA_VERSION_STRING);
             exit(0);
         case 'h': // help
-            jl_safe_fprintf(ios_stdout, "%s%s", usage, opts);
+            // not jl_safe_fprintf, which formats through a fixed 1000-byte
+            // buffer and would truncate the help text
+            ios_puts(usage, ios_stdout);
+            ios_puts(opts, ios_stdout);
+            ios_flush(ios_stdout);
             exit(0);
         case opt_help_hidden:
-            jl_safe_fprintf(ios_stdout, "%s%s", usage, opts_hidden);
+            ios_puts(usage, ios_stdout);
+            ios_puts(opts_hidden, ios_stdout);
+            ios_flush(ios_stdout);
             exit(0);
         case 'g': // debug info
             if (optarg != NULL) {

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -95,7 +95,7 @@ JL_DLLEXPORT int64_t ios_filesize(ios_t *s);
 JL_DLLEXPORT int ios_trunc(ios_t *s, size_t size) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int ios_eof(ios_t *s);
 JL_DLLEXPORT int ios_eof_blocking(ios_t *s);
-JL_DLLEXPORT int ios_flush(ios_t *s);
+JL_DLLEXPORT int ios_flush(ios_t *s) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int ios_close(ios_t *s) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int ios_isopen(ios_t *s);
 JL_DLLEXPORT char *ios_take_buffer(ios_t *s, size_t *psize) JL_NOTSAFEPOINT;  // nul terminate and release buffer to caller


### PR DESCRIPTION
Fixes regression introduced by #62175 where `--help` was being truncated.

Claude:

---

JuliaLang/julia#62175 switched help/version printing from `jl_printf` to `jl_safe_fprintf` to satisfy the `JL_NOTSAFEPOINT` annotation on `jl_parse_opts`, but `jl_safe_fprintf` formats through a fixed 1000-byte buffer, so `--help` and `--help-hidden` were truncated to the first ~1000 characters (and the trailing partial line was then dropped by the line-buffered stream at exit).

Print the usage and options strings with `ios_puts` and flush explicitly instead, which has no length limit and remains safepoint-free. `ios_flush` is annotated `JL_NOTSAFEPOINT` (it only performs plain buffered-IO syscalls) so the `jl_parse_opts` annotation still holds.