### PR TITLE
Don't let an interrupt during REPL parsing kill the frontend

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -737,6 +737,7 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
         while true
             try
                 line *= readline(repl.terminal, keep=true)
+                ast = parse_repl_input_line(line, repl)
             catch e
                 if isa(e,InterruptException)
                     try # raise the debugger if present
@@ -753,7 +754,6 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
                     rethrow()
                 end
             end
-            ast = parse_repl_input_line(line, repl)
             (isa(ast,Expr) && ast.head === :incomplete) || break
         end
         if !isempty(line)


### PR DESCRIPTION
`run_frontend(::BasicREPL)` only guarded `readline()` against an `InterruptException`, while the parse of the submitted line sat outside the try-catch. Because a SIGINT is raised at the next safepoint rather than on arrival and parsing does IO (`parse_repl_input_line()` checks the active project), Ctrl-C pressed at an idle prompt could be delivered in the parsing after the line has been submitted, which would cause the whole REPL session to exit.

Found by Claude when looking into the test failures for #61504: https://buildkite.com/julialang/julia-pr/builds/655/list?sid=019f866f-6704-41ab-971b-820c1c69568a&tab=output

Tested locally by running that particular test in a loop, previously it failed 3/100 times. It'll probably still fail occasionally until cancellation is implemented though.