### PR TITLE
Compiler: use the correct value for JL_OPTIONS_COMPILE_MIN in precompile.jl

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -47,6 +47,7 @@ using Core: ABIOverride, Builtin, CodeInstance, IntrinsicFunction, AnyType, Meth
 using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospecializeinfer,
     PARTITION_KIND_GLOBAL, PARTITION_KIND_UNDEF_CONST, PARTITION_KIND_BACKDATED_CONST, PARTITION_KIND_DECLARED,
     PARTITION_FLAG_DEPWARN,
+    JL_OPTIONS_COMPILE_OFF, JL_OPTIONS_COMPILE_MIN,
     Base, BitVector, Bottom, Callable, DataTypeFieldDesc,
     EffectsOverride, Filter, Generator, NUM_EFFECTS_OVERRIDES,
     OneTo, Ordering, RefValue, _NAMEDTUPLE_NAME,

--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -358,7 +358,7 @@ function compile_and_emit_native(worlds::Vector{UInt},
             f = Core.invoke_in_world(latestworld, getglobal, mod, :__init__)
             # Get module compile setting
             setting = ccall(:jl_get_module_compile, Cint, (Any,), mod)
-            if setting != 0 && setting != 3  # JL_OPTIONS_COMPILE_OFF=0, JL_OPTIONS_COMPILE_MIN=3
+            if setting != JL_OPTIONS_COMPILE_OFF && setting != JL_OPTIONS_COMPILE_MIN
                 tt = Tuple{Core.Typeof(f)}
                 compile_hint(tt)
                 trim_mode == 0x00 || add_entrypoint(tt)

--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -358,7 +358,7 @@ function compile_and_emit_native(worlds::Vector{UInt},
             f = Core.invoke_in_world(latestworld, getglobal, mod, :__init__)
             # Get module compile setting
             setting = ccall(:jl_get_module_compile, Cint, (Any,), mod)
-            if setting != 0 && setting != 1  # JL_OPTIONS_COMPILE_OFF=0, JL_OPTIONS_COMPILE_MIN=1
+            if setting != 0 && setting != 3  # JL_OPTIONS_COMPILE_OFF=0, JL_OPTIONS_COMPILE_MIN=3
                 tt = Tuple{Core.Typeof(f)}
                 compile_hint(tt)
                 trim_mode == 0x00 || add_entrypoint(tt)

--- a/base/options.jl
+++ b/base/options.jl
@@ -83,6 +83,12 @@ end
 
 JLOptions() = unsafe_load(cglobal(:jl_options, JLOptions))
 
+# NOTE: Keep in sync with the JL_OPTIONS_COMPILE_* defines in src/julia.h
+const JL_OPTIONS_COMPILE_OFF = 0
+const JL_OPTIONS_COMPILE_ON  = 1
+const JL_OPTIONS_COMPILE_ALL = 2
+const JL_OPTIONS_COMPILE_MIN = 3
+
 function colored_text(opts::JLOptions)
     return if opts.color != 0
         opts.color == 1

--- a/base/util.jl
+++ b/base/util.jl
@@ -175,11 +175,11 @@ function julia_cmd(julia=joinpath(Sys.BINDIR, julia_exename()); cpu_target::Unio
     end
     image_file = unsafe_string(opts.image_file)
     addflags = String[]
-    let compile = if opts.compile_enabled == 0
+    let compile = if opts.compile_enabled == JL_OPTIONS_COMPILE_OFF
                       "no"
-                  elseif opts.compile_enabled == 2
+                  elseif opts.compile_enabled == JL_OPTIONS_COMPILE_ALL
                       "all"
-                  elseif opts.compile_enabled == 3
+                  elseif opts.compile_enabled == JL_OPTIONS_COMPILE_MIN
                       "min"
                   else
                       "" # default = "yes"


### PR DESCRIPTION
Found by Claude 🤖. Branch name by me 👨 

First commit:

The check for whether to precompile a module's `__init__` compared the
module compile setting against 1, which is JL_OPTIONS_COMPILE_ON;
JL_OPTIONS_COMPILE_MIN is 3. As a result, modules declared with
`Experimental.@compiler_options compile=min` still had their `__init__`
precompiled and registered as an entrypoint.

Regression from https://github.com/JuliaLang/julia/pull/59361 it seems.

The second commit makes the `JL_OPTIONS_COMPILE_` definitions happen in one place and used throughout. 


