### PR TITLE
[backports-release-1.13] jitlayers: Add `libjulia` to ORC DynamicLibrary search order

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1973,17 +1973,29 @@ JuliaOJIT::JuliaOJIT()
     if(!ErrorStr.empty())
         report_fatal_error(llvm::Twine("FATAL: unable to dlopen libjulia-internal\n") + ErrorStr);
 
-    // Make sure SectionMemoryManager::getSymbolAddressInProcess can resolve
-    // symbols in the program as well. The nullptr argument to the function
-    // tells DynamicLibrary to load the program, not a library.
-    if (sys::DynamicLibrary::LoadLibraryPermanently(nullptr, &ErrorStr))
-        report_fatal_error(llvm::Twine("FATAL: unable to dlopen self\n") + ErrorStr);
-
     GlobalJD.addGenerator(
       std::make_unique<orc::DynamicLibrarySearchGenerator>(
         libjulia_internal_dylib,
         DL.getGlobalPrefix(),
         orc::DynamicLibrarySearchGenerator::SymbolPredicate()));
+
+    // For the same reason, place libjulia first in the DynamicLibrary order
+    // since it exports many runtime data symbols (e.g. `jl_emptytuple`)
+    sys::DynamicLibrary libjulia_dylib = sys::DynamicLibrary::addPermanentLibrary(
+      jl_libjulia_handle, &ErrorStr);
+    if(!ErrorStr.empty())
+        report_fatal_error(llvm::Twine("FATAL: unable to dlopen libjulia\n") + ErrorStr);
+    GlobalJD.addGenerator(
+      std::make_unique<orc::DynamicLibrarySearchGenerator>(
+        libjulia_dylib,
+        DL.getGlobalPrefix(),
+        orc::DynamicLibrarySearchGenerator::SymbolPredicate()));
+
+    // Make sure SectionMemoryManager::getSymbolAddressInProcess can resolve
+    // symbols in the program as well. The nullptr argument to the function
+    // tells DynamicLibrary to load the program, not a library.
+    if (sys::DynamicLibrary::LoadLibraryPermanently(nullptr, &ErrorStr))
+        report_fatal_error(llvm::Twine("FATAL: unable to dlopen self\n") + ErrorStr);
 
     GlobalJD.addGenerator(
       cantFail(orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(


### PR DESCRIPTION
Also marked for backport to 1.12 / 1.10

This was fixed on master by #60988, but it is still an issue for released versions of Julia.

#48712 tried to improve this, but failed to notice that `libjulia` also houses e.g. runtime data symbols that are not simple re-exports of symbols from `libjulia-internal`. https://github.com/JuliaLang/julia/pull/50632 exposed this bug by causing the JIT to resolve more symbols, but downstream Julia-in-Julia consumers only updated recently to catch this.