### PR TITLE
gc: isolate errno and GetLastError across finalizer runs

### DIFF
--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -308,6 +308,16 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     memcpy(&save_rngState[0], &ct->rngState[0], sizeof(save_rngState));
     jl_rng_split(ct->rngState, finalizer_rngState);
 
+    // Isolate the error state like the RNG state: finalizers run at
+    // effectively arbitrary points, so their errno/GetLastError side effects
+    // must not leak into the interrupted code (jl_gc_collect happens to
+    // restore around its own finalizer run, but deferred flushes via
+    // jl_gc_run_pending_finalizers have no such wrapper).
+    int last_errno = errno;
+#ifdef _OS_WINDOWS_
+    DWORD last_error = GetLastError();
+#endif
+
     // This releases the finalizers lock.
     int8_t was_in_finalizer = ct->ptls->in_finalizer;
     ct->ptls->in_finalizer = !finalizers_thread;
@@ -315,6 +325,10 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     ct->ptls->in_finalizer = was_in_finalizer;
     arraylist_free(&copied_list);
 
+#ifdef _OS_WINDOWS_
+    SetLastError(last_error);
+#endif
+    errno = last_errno;
     memcpy(&ct->rngState[0], &save_rngState[0], sizeof(save_rngState));
 }
 

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -304,15 +304,10 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     jl_atomic_store_relaxed(&jl_gc_have_pending_finalizers, 0);
     arraylist_new(&to_finalize, 0);
 
+    // Finalizers shouldn't affect either rng or errno state
     uint64_t save_rngState[JL_RNG_SIZE];
     memcpy(&save_rngState[0], &ct->rngState[0], sizeof(save_rngState));
     jl_rng_split(ct->rngState, finalizer_rngState);
-
-    // Isolate the error state like the RNG state: finalizers run at
-    // effectively arbitrary points, so their errno/GetLastError side effects
-    // must not leak into the interrupted code (jl_gc_collect happens to
-    // restore around its own finalizer run, but deferred flushes via
-    // jl_gc_run_pending_finalizers have no such wrapper).
     int last_errno = errno;
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
@@ -325,11 +320,11 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     ct->ptls->in_finalizer = was_in_finalizer;
     arraylist_free(&copied_list);
 
+    memcpy(&ct->rngState[0], &save_rngState[0], sizeof(save_rngState));
 #ifdef _OS_WINDOWS_
     SetLastError(last_error);
 #endif
     errno = last_errno;
-    memcpy(&ct->rngState[0], &save_rngState[0], sizeof(save_rngState));
 }
 
 JL_DLLEXPORT void jl_gc_run_pending_finalizers(jl_task_t *ct)


### PR DESCRIPTION
Finalizers run at effectively arbitrary points in user code, so their
error-state side effects must not leak into the interrupted code, the
same way their RNG use must not perturb the task RNG stream.
jl_gc_collect happens to save and restore errno around collections,
which covers finalizers that run inside the collection, but deferred
finalizers flushed via jl_gc_run_pending_finalizers had no such
wrapper, so a finalizer clobbering errno was observable in the resumed
code (test/misc.jl errno round-trip tests under tiered compilation,
which shifts when the deferred flushes run).

This commit was written with the assistance of generative AI.