### PR TITLE
codegen: pin call-target CodeInstances that are not cache-reachable

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -268,6 +268,14 @@ StringRef jl_codegen_output_t::get_call_target(jl_code_instance_t *ci, bool spec
     }
     std::string protoname = make_name(JL_SYMBOL_SPECPTR_PROTO, api,
                                       name_from_method_instance(jl_get_ci_mi(ci)));
+    // The linking metadata holds this CodeInstance until the module is
+    // materialized, and linkCallTarget dereferences it on the dispatcher
+    // thread at that point. CIs in their MI's cache are rooted through the
+    // method table, but inference-local edge CIs have no other root once
+    // inference drops its results, and the pending window is arbitrarily
+    // long. Pin those. TODO: scope this root to the pending materialization.
+    if (!jl_mi_cache_has_ci(jl_get_ci_mi(ci), ci) && !jl_is_globally_rooted((jl_value_t*)ci))
+        jl_as_global_root((jl_value_t*)ci, 1);
     jl_codegen_call_target_t &target = call_targets[{ci, api}];
     target.external_linkage = !always_inline;
     target.private_linkage = always_inline;


### PR DESCRIPTION
The linking metadata of an emitted module holds raw pointers to its
call-target CodeInstances, and JuliaOJIT::linkCallTarget dereferences
them when the module is materialized. Compiler.add_codeinsts_to_jit!
maintains the rooting invariant by cache-inserting the CIs it compiles,
but callees with invalid ABI sparams are skipped without rooting while
the caller still records them as call targets. Upstream the pending
window is a few statements (materialization happens within the same
jl_compile_method_internal call); under tiered batching, materialization
is deferred to the compiled code's first call, so the collected CI is
dereferenced on a JIT dispatcher thread arbitrarily later. Observed at
test/core.jl's issue-#47476 tests (exactly the invalid-sparams shape) on
both macOS architectures:
https://buildkite.com/julialang/julia-pr/builds/316#019f4d6f-5f10-406d-9aff-2bdb6bc7717f

Pin such CIs as global roots at emission. TODO: scope the root to the
pending materialization instead.

This commit was written with the assistance of generative AI (Claude).
