### PR TITLE
runtime: reject free typevars in opaque-closure signatures

### DIFF
--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -33,10 +33,7 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
     if (!jl_is_tuple_type((jl_value_t*)argt)) {
         jl_error("OpaqueClosure argument tuple must be a tuple type");
     }
-    // the closure is allocated with typeof == OpaqueClosure{argt, rt}, so that
-    // type must be concrete; free typevars in the signature or return type
-    // would otherwise produce a value whose typeof has no layout (segfaults on
-    // first use, e.g. tuple construction)
+    // the closure must not have free typevars otherwise it's not possible to instantiate it
     if (jl_has_free_typevars((jl_value_t*)argt))
         jl_error("OpaqueClosure argument tuple may not contain free typevars");
     if (jl_has_free_typevars(rt_ub) || jl_has_free_typevars(rt_lb))

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -33,6 +33,14 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
     if (!jl_is_tuple_type((jl_value_t*)argt)) {
         jl_error("OpaqueClosure argument tuple must be a tuple type");
     }
+    // the closure is allocated with typeof == OpaqueClosure{argt, rt}, so that
+    // type must be concrete; free typevars in the signature or return type
+    // would otherwise produce a value whose typeof has no layout (segfaults on
+    // first use, e.g. tuple construction)
+    if (jl_has_free_typevars((jl_value_t*)argt))
+        jl_error("OpaqueClosure argument tuple may not contain free typevars");
+    if (jl_has_free_typevars(rt_ub) || jl_has_free_typevars(rt_lb))
+        jl_error("OpaqueClosure return type may not contain free typevars");
     JL_TYPECHK(new_opaque_closure, type, rt_lb);
     JL_TYPECHK(new_opaque_closure, type, rt_ub);
     JL_TYPECHK(new_opaque_closure, method, source_);

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -499,3 +499,13 @@ end
         @test invoke(oc, Tuple{Int}, 5) == 15
     end
 end
+
+@testset "free typevars in the signature are rejected" begin
+    ci = Base.uncompressed_ir(first(methods(identity)))
+    tv = TypeVar(:T)
+    sig = Tuple{Type{Vector{tv}}}
+    @test_throws ErrorException Base.Experimental.generate_opaque_closure(
+        sig, Union{}, Any, ci, 1, false; isinferred=false, do_compile=true)
+    @test_throws ErrorException Base.Experimental.generate_opaque_closure(
+        Tuple{Int}, Union{}, Vector{tv}, ci, 1, false; isinferred=false, do_compile=true)
+end


### PR DESCRIPTION
new_opaque_closure allocates the closure with
typeof == OpaqueClosure{argt, rt} and annotates that type as always
concrete, but nothing validated it: an argument tuple or return type
containing a free TypeVar (a legal runtime value, reachable from any
generate_opaque_closure caller with a runtime-derived signature)
produced a value whose typeof is non-concrete and has no layout, which
segfaults on first use — e.g. constructing a tuple containing the
closure dies computing the tuple layout in arg_tuple. Throw at
construction instead.

This commit was written with the assistance of generative AI.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HV8LhKdQRKRMsAR6hdVXfJ
