### PR TITLE
interrupting: Make asynchronous interrupts survivable at the REPL

### DIFF
--- a/src/julia-task-dispatcher.h
+++ b/src/julia-task-dispatcher.h
@@ -349,11 +349,8 @@ private:
 
 }; // class JuliaTaskDispatcher
 
-// An InterruptException raised at a safepoint inside dispatcher work would
-// longjmp past the dispatcher's C++ state, deadlocking other waiters on a
-// future that never completes, so defer signal delivery. Unlike
-// JL_SIGATOMIC_END, the destructor does not raise a pending sigint — these
-// frames are not unwind-safe; it is raised at a later sigint safepoint.
+// Dispatcher work is not unwind-safe, so deliver pending SIGINTs at a later
+// safepoint instead of raising an InterruptException inside it.
 struct dispatcher_sigdefer_guard {
   jl_ptls_t ptls;
   dispatcher_sigdefer_guard() JL_NOTSAFEPOINT : ptls(jl_current_task->ptls) {

--- a/src/julia-task-dispatcher.h
+++ b/src/julia-task-dispatcher.h
@@ -349,6 +349,23 @@ private:
 
 }; // class JuliaTaskDispatcher
 
+// An InterruptException raised at a safepoint inside dispatcher work would
+// longjmp past the dispatcher's C++ state, deadlocking other waiters on a
+// future that never completes, so defer signal delivery. Unlike
+// JL_SIGATOMIC_END, the destructor does not raise a pending sigint — these
+// frames are not unwind-safe; it is raised at a later sigint safepoint.
+struct dispatcher_sigdefer_guard {
+  jl_ptls_t ptls;
+  dispatcher_sigdefer_guard() JL_NOTSAFEPOINT : ptls(jl_current_task->ptls) {
+    ptls->defer_signal++;
+    jl_signal_fence();
+  }
+  ~dispatcher_sigdefer_guard() JL_NOTSAFEPOINT {
+    jl_signal_fence();
+    ptls->defer_signal--;
+  }
+};
+
 void JuliaTaskDispatcher::dispatch(std::unique_ptr<Task> T) { // NOLINT(julia-first-decl-annotations)
   if (!InCooperativeContext) {
     // Not inside work_until/process_tasks — run inline to prevent deadlock
@@ -358,8 +375,9 @@ void JuliaTaskDispatcher::dispatch(std::unique_ptr<Task> T) { // NOLINT(julia-fi
     // continuations that fulfill the caller's std::future can fire before
     // we return.
     InCooperativeContext = true;
-    T->run();
     {
+      dispatcher_sigdefer_guard defer;
+      T->run();
       jl_unique_gcsafe_lock Lock{DispatchMutex};
       process_tasks(Lock);
     }
@@ -380,6 +398,7 @@ void JuliaTaskDispatcher::shutdown() {
 void JuliaTaskDispatcher::work_until(future_base &F) {
   bool WasCooperative = InCooperativeContext;
   InCooperativeContext = true;
+  dispatcher_sigdefer_guard defer;
   jl_unique_gcsafe_lock Lock{DispatchMutex};
   while (!F.ready()) {
     process_tasks(Lock);

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -327,8 +327,6 @@ static void mach_safepoint_trampoline(jl_ptls_t ptls)
     if (jl_atomic_load_relaxed(&ct->tid) != 0)
         return;
     if (ptls->defer_signal || ct->eh == NULL) {
-        // throwing with no handler in the context would be fatal; keep the
-        // sigint pending for a later safepoint
         jl_safepoint_defer_sigint();
     }
     else if (jl_safepoint_consume_sigint()) {
@@ -629,7 +627,7 @@ static void jl_try_deliver_sigint(void)
     jl_safepoint_enable_sigint();
     int force = jl_check_force_sigint();
     jl_task_t *ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
-    int can_throw = ct2 != NULL && ct2->eh != NULL; // throwing with no handler in the context would be fatal
+    int can_throw = ct2 != NULL && ct2->eh != NULL;
     if (can_throw && (force || (!ptls2->defer_signal && ptls2->io_wait))) {
         jl_safepoint_consume_sigint();
         if (force)

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -326,7 +326,9 @@ static void mach_safepoint_trampoline(jl_ptls_t ptls)
     jl_set_gc_and_wait(ct);
     if (jl_atomic_load_relaxed(&ct->tid) != 0)
         return;
-    if (ptls->defer_signal) {
+    if (ptls->defer_signal || ct->eh == NULL) {
+        // throwing with no handler in the context would be fatal; keep the
+        // sigint pending for a later safepoint
         jl_safepoint_defer_sigint();
     }
     else if (jl_safepoint_consume_sigint()) {
@@ -626,7 +628,9 @@ static void jl_try_deliver_sigint(void)
 
     jl_safepoint_enable_sigint();
     int force = jl_check_force_sigint();
-    if (force || (!ptls2->defer_signal && ptls2->io_wait)) {
+    jl_task_t *ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
+    int can_throw = ct2 != NULL && ct2->eh != NULL; // throwing with no handler in the context would be fatal
+    if (can_throw && (force || (!ptls2->defer_signal && ptls2->io_wait))) {
         jl_safepoint_consume_sigint();
         if (force)
             jl_safe_printf("WARNING: Force throwing a SIGINT\n");

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -533,8 +533,6 @@ JL_NO_ASAN static void segv_handler(int sig, siginfo_t *info, void *context) JL_
         // instruction and end up right back here, or we start to run the
         // exception handler and immediately hit the safepoint there.
         if (ct->ptls->defer_signal || ct->eh == NULL) {
-            // throwing with no handler in the context would be fatal; keep the
-            // sigint pending for a later safepoint
             jl_safepoint_defer_sigint();
         }
         else if (jl_safepoint_consume_sigint()) {
@@ -748,7 +746,6 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
     if (request == 2) {
         int force = jl_check_force_sigint();
         jl_jmp_buf *saferestore = jl_get_safe_restore();
-        // throwing with no handler in the context would be fatal
         int can_throw = saferestore != NULL || ct->eh != NULL;
         if (can_throw && (force || (!ptls->defer_signal && ptls->io_wait))) {
             jl_safepoint_consume_sigint();
@@ -932,13 +929,8 @@ static void kqueue_signal(int *sigqueue, struct kevent *ev, int sig)
         *sigqueue = -1;
     }
     else {
-        // kqueue gets signals before the disposition applies, but does not remove
-        // them from pending (unlike sigwait), so the default disposition must be
-        // replaced. SIGINT must get `sigint_handler` rather than SIG_IGN: this
-        // (running on the listener thread) races with the main thread's
-        // `jl_install_default_signal_handlers` and the last writer wins, and if
-        // SIG_IGN wins, the `jl_ignore_sigint` debugger probe never observes its
-        // self-raised signal and every SIGINT is silently ignored.
+        // kqueue gets signals before SIG_IGN, but does not remove them from pending (unlike sigwait)
+        // Installing SIG_IGN for SIGINT can race with its handler installation.
         signal(sig, sig == SIGINT ? sigint_handler : SIG_IGN);
     }
 }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -532,7 +532,9 @@ JL_NO_ASAN static void segv_handler(int sig, siginfo_t *info, void *context) JL_
         // thread. That will quickly be rectified when we rerun the faulting
         // instruction and end up right back here, or we start to run the
         // exception handler and immediately hit the safepoint there.
-        if (ct->ptls->defer_signal) {
+        if (ct->ptls->defer_signal || ct->eh == NULL) {
+            // throwing with no handler in the context would be fatal; keep the
+            // sigint pending for a later safepoint
             jl_safepoint_defer_sigint();
         }
         else if (jl_safepoint_consume_sigint()) {
@@ -745,13 +747,15 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
     jl_atomic_cmpswap(&ptls->signal_request, &processing, 0);
     if (request == 2) {
         int force = jl_check_force_sigint();
-        if (force || (!ptls->defer_signal && ptls->io_wait)) {
+        jl_jmp_buf *saferestore = jl_get_safe_restore();
+        // throwing with no handler in the context would be fatal
+        int can_throw = saferestore != NULL || ct->eh != NULL;
+        if (can_throw && (force || (!ptls->defer_signal && ptls->io_wait))) {
             jl_safepoint_consume_sigint();
             if (force)
                 jl_safe_printf("WARNING: Force throwing a SIGINT\n");
             // Force a throw
             jl_clear_force_sigint();
-            jl_jmp_buf *saferestore = jl_get_safe_restore();
             if (saferestore) // restarting jl_ or profile
                 jl_longjmp_in_ctx(sig, ctx, *saferestore);
             else

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -920,6 +920,7 @@ static void jl_sigsetset(sigset_t *sset)
 }
 
 #ifdef HAVE_KEVENT
+static void sigint_handler(int sig);
 static void kqueue_signal(int *sigqueue, struct kevent *ev, int sig)
 {
     if (*sigqueue == -1)
@@ -931,8 +932,14 @@ static void kqueue_signal(int *sigqueue, struct kevent *ev, int sig)
         *sigqueue = -1;
     }
     else {
-        // kqueue gets signals before SIG_IGN, but does not remove them from pending (unlike sigwait)
-        signal(sig, SIG_IGN);
+        // kqueue gets signals before the disposition applies, but does not remove
+        // them from pending (unlike sigwait), so the default disposition must be
+        // replaced. SIGINT must get `sigint_handler` rather than SIG_IGN: this
+        // (running on the listener thread) races with the main thread's
+        // `jl_install_default_signal_handlers` and the last writer wins, and if
+        // SIG_IGN wins, the `jl_ignore_sigint` debugger probe never observes its
+        // self-raised signal and every SIGINT is silently ignored.
+        signal(sig, sig == SIGINT ? sigint_handler : SIG_IGN);
     }
 }
 #endif

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2948,11 +2948,6 @@ function run_interface(terminal::TextTerminal, m::ModalInterface, s::MIState=ini
             end
             Base.invokelatest(mode(state(s)).on_done, s, buf, ok)
         catch e
-            # An asynchronous interrupt is raised at the next safepoint after
-            # delivery, so it can land outside the guarded read loop (e.g. while
-            # refreshing the prompt); abort the current line rather than tearing
-            # down the session, clearing partial input and transient mode state
-            # like the ^C keymap handler does
             isa(e, InterruptException) || rethrow()
             try
                 cancel_beep(s)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2940,12 +2940,30 @@ end
 
 function run_interface(terminal::TextTerminal, m::ModalInterface, s::MIState=init_state(terminal, m))
     while !s.aborted
-        buf, ok, suspend = prompt!(terminal, m, s)
-        while suspend
-            @static if Sys.isunix(); ccall(:jl_repl_raise_sigtstp, Cint, ()); end
+        try
             buf, ok, suspend = prompt!(terminal, m, s)
+            while suspend
+                @static if Sys.isunix(); ccall(:jl_repl_raise_sigtstp, Cint, ()); end
+                buf, ok, suspend = prompt!(terminal, m, s)
+            end
+            Base.invokelatest(mode(state(s)).on_done, s, buf, ok)
+        catch e
+            # An asynchronous interrupt is raised at the next safepoint after
+            # delivery, so it can land outside the guarded read loop (e.g. while
+            # refreshing the prompt); abort the current line rather than tearing
+            # down the session, clearing partial input and transient mode state
+            # like the ^C keymap handler does
+            isa(e, InterruptException) || rethrow()
+            try
+                cancel_beep(s)
+                move_input_end(s)
+                refresh_line(s)
+                print(terminal(s), "^C\n\n")
+                transition(s, :reset)
+                refresh_line(s)
+            catch
+            end
         end
-        Base.invokelatest(mode(state(s)).on_done, s, buf, ok)
     end
 end
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -451,20 +451,14 @@ function repl_backend_loop(backend::REPLBackend, get_module::Function)
     while true
         tls = task_local_storage()
         tls[:SOURCE_PATH] = nothing
-        # An asynchronous interrupt may be raised in this task if user code
-        # finished evaluating just as Ctrl-C arrived (issue #58689). Wait without
-        # consuming, so an interrupt raised mid-`take!` cannot drop a request and
-        # leave the frontend blocked on a response that never comes.
+        # Fetch without consuming, then retry removal so an interrupt cannot lose
+        # or duplicate a request.
         request = try
             fetch(backend.repl_channel)
         catch e
             e isa InterruptException && continue
             rethrow()
         end
-        # consume the request exactly once: retry until the channel no longer
-        # holds it (only this loop removes requests, and no new request can
-        # arrive before we respond to this one), so an interrupt striking the
-        # removal can neither drop the request nor leave it to be evaluated twice
         while isready(backend.repl_channel)
             try
                 take!(backend.repl_channel)
@@ -777,10 +771,6 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
             write(repl.terminal, '\n')
             ((!interrupted && isempty(line)) || hit_eof) && break
         catch e
-            # An asynchronous interrupt is raised at the next safepoint after
-            # delivery, so it can land outside the guarded `readline` (e.g. while
-            # writing the prompt or printing a response); treat it as an aborted
-            # line rather than exiting the REPL
             isa(e, InterruptException) || rethrow()
         end
     end
@@ -1176,18 +1166,10 @@ find_hist_file() = get(ENV, "JULIA_HISTORY",
 backend(r::AbstractREPL) = hasproperty(r, :backendref) && isdefined(r, :backendref) ? r.backendref : nothing
 
 
-# Send a request to the backend and wait for its response, keeping the
-# request/response channels paired in the presence of asynchronous interrupts:
-# once the request is sent, the backend owes a response — abandoning it would
-# leave the channels permanently out of sync, so keep waiting for it.
-# (N.B. sigatomic cannot make the send-and-record step atomic: `defer_signal`
-# is per-thread and the backend task's own sigatomic sections interleave on
-# this thread, so an interrupt landing between the enqueue completing and
-# `sent = true` remains a small unprotected window.)
+# Keep request and response channels paired across asynchronous interrupts.
 function exchange_on_backend(backend::REPLBackendRef, request)
-    # exchanges are serialized on the frontend task, so anything already in the
-    # response channel is a stale response to an abandoned request (see the
-    # note above); discard it rather than pairing it with this request
+    # A response can be stale if an interrupt lands after enqueueing but before
+    # `sent` is recorded.
     while isready(backend.response_channel)
         take!(backend.response_channel)
     end
@@ -1209,7 +1191,7 @@ function exchange_on_backend(backend::REPLBackendRef, request)
     end
 end
 eval_on_backend(ast, backend::REPLBackendRef) =
-    exchange_on_backend(backend, (ast, 1)) # (ast, show_value)
+    exchange_on_backend(backend, (ast, 1))
 function call_on_backend(f, backend::REPLBackendRef)
     applicable(f) || error("internal error: f is not callable")
     return exchange_on_backend(backend, (f, 2)) # (f, show_value) 2 indicates function (rather than ast)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -451,15 +451,28 @@ function repl_backend_loop(backend::REPLBackend, get_module::Function)
     while true
         tls = task_local_storage()
         tls[:SOURCE_PATH] = nothing
-        ast_or_func, show_value = try
-            take!(backend.repl_channel)
+        # An asynchronous interrupt may be raised in this task if user code
+        # finished evaluating just as Ctrl-C arrived (issue #58689). Wait without
+        # consuming, so an interrupt raised mid-`take!` cannot drop a request and
+        # leave the frontend blocked on a response that never comes.
+        request = try
+            fetch(backend.repl_channel)
         catch e
-            # An asynchronous interrupt may be forwarded to this task if user code
-            # finished evaluating just as Ctrl-C arrived (issue #58689); ignore it
-            # rather than tearing down the REPL session.
             e isa InterruptException && continue
             rethrow()
         end
+        # consume the request exactly once: retry until the channel no longer
+        # holds it (only this loop removes requests, and no new request can
+        # arrive before we respond to this one), so an interrupt striking the
+        # removal can neither drop the request nor leave it to be evaluated twice
+        while isready(backend.repl_channel)
+            try
+                take!(backend.repl_channel)
+            catch e
+                e isa InterruptException || rethrow()
+            end
+        end
+        ast_or_func, show_value = request
         if show_value == -1
             # exit flag
             break
@@ -729,39 +742,47 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
     dopushdisplay && pushdisplay(d)
     hit_eof = false
     while true
-        Base.reseteof(repl.terminal)
-        write(repl.terminal, JULIA_PROMPT)
-        line = ""
-        ast = nothing
-        interrupted = false
-        while true
-            try
-                line *= readline(repl.terminal, keep=true)
-            catch e
-                if isa(e,InterruptException)
-                    try # raise the debugger if present
-                        ccall(:jl_raise_debugger, Int, ())
-                    catch
+        try
+            Base.reseteof(repl.terminal)
+            write(repl.terminal, JULIA_PROMPT)
+            line = ""
+            ast = nothing
+            interrupted = false
+            while true
+                try
+                    line *= readline(repl.terminal, keep=true)
+                catch e
+                    if isa(e,InterruptException)
+                        try # raise the debugger if present
+                            ccall(:jl_raise_debugger, Int, ())
+                        catch
+                        end
+                        line = ""
+                        interrupted = true
+                        break
+                    elseif isa(e,EOFError)
+                        hit_eof = true
+                        break
+                    else
+                        rethrow()
                     end
-                    line = ""
-                    interrupted = true
-                    break
-                elseif isa(e,EOFError)
-                    hit_eof = true
-                    break
-                else
-                    rethrow()
                 end
+                ast = parse_repl_input_line(line, repl)
+                (isa(ast,Expr) && ast.head === :incomplete) || break
             end
-            ast = parse_repl_input_line(line, repl)
-            (isa(ast,Expr) && ast.head === :incomplete) || break
+            if !isempty(line)
+                response = eval_on_backend(ast, backend)
+                print_response(repl, response, !ends_with_semicolon(line), false)
+            end
+            write(repl.terminal, '\n')
+            ((!interrupted && isempty(line)) || hit_eof) && break
+        catch e
+            # An asynchronous interrupt is raised at the next safepoint after
+            # delivery, so it can land outside the guarded `readline` (e.g. while
+            # writing the prompt or printing a response); treat it as an aborted
+            # line rather than exiting the REPL
+            isa(e, InterruptException) || rethrow()
         end
-        if !isempty(line)
-            response = eval_on_backend(ast, backend)
-            print_response(repl, response, !ends_with_semicolon(line), false)
-        end
-        write(repl.terminal, '\n')
-        ((!interrupted && isempty(line)) || hit_eof) && break
     end
     # terminate backend
     put!(backend.repl_channel, (nothing, -1))
@@ -1155,14 +1176,43 @@ find_hist_file() = get(ENV, "JULIA_HISTORY",
 backend(r::AbstractREPL) = hasproperty(r, :backendref) && isdefined(r, :backendref) ? r.backendref : nothing
 
 
-function eval_on_backend(ast, backend::REPLBackendRef)
-    put!(backend.repl_channel, (ast, 1)) # (f, show_value)
-    return take!(backend.response_channel) # (val, iserr)
+# Send a request to the backend and wait for its response, keeping the
+# request/response channels paired in the presence of asynchronous interrupts:
+# once the request is sent, the backend owes a response — abandoning it would
+# leave the channels permanently out of sync, so keep waiting for it.
+# (N.B. sigatomic cannot make the send-and-record step atomic: `defer_signal`
+# is per-thread and the backend task's own sigatomic sections interleave on
+# this thread, so an interrupt landing between the enqueue completing and
+# `sent = true` remains a small unprotected window.)
+function exchange_on_backend(backend::REPLBackendRef, request)
+    # exchanges are serialized on the frontend task, so anything already in the
+    # response channel is a stale response to an abandoned request (see the
+    # note above); discard it rather than pairing it with this request
+    while isready(backend.response_channel)
+        take!(backend.response_channel)
+    end
+    sent = false
+    try
+        put!(backend.repl_channel, request)
+        sent = true
+        return take!(backend.response_channel) # (val, iserr)
+    catch e
+        isa(e, InterruptException) || rethrow()
+        sent || rethrow()
+        while true
+            try
+                return take!(backend.response_channel)
+            catch e2
+                isa(e2, InterruptException) || rethrow()
+            end
+        end
+    end
 end
+eval_on_backend(ast, backend::REPLBackendRef) =
+    exchange_on_backend(backend, (ast, 1)) # (ast, show_value)
 function call_on_backend(f, backend::REPLBackendRef)
     applicable(f) || error("internal error: f is not callable")
-    put!(backend.repl_channel, (f, 2)) # (f, show_value) 2 indicates function (rather than ast)
-    return take!(backend.response_channel) # (val, iserr)
+    return exchange_on_backend(backend, (f, 2)) # (f, show_value) 2 indicates function (rather than ast)
 end
 # if no backend just eval (used by tests)
 eval_on_backend(ast, backend::Nothing) = error("no backend for eval ast")


### PR DESCRIPTION
Trying again to make interrupting more robust and fix the new flaky tests (without just making them retry more).

Supersedes #62459, which guarded the parse window in `BasicREPL`. Thanks @JamesWrigley.

Claude:

---

Hardens REPL interrupt handling after flaky FreeBSD and macOS CI failures ([build 659](https://buildkite.com/julialang/julia-pr/builds/659#019f8702-fa81-4462-84ed-2e58adf28bbc), [build 712](https://buildkite.com/julialang/julia-pr/builds/712#019f8c25-7466-4b00-89c0-a0761db554bb)). Supersedes #62459.

- Keep `BasicREPL` and `LineEdit` alive when an asynchronous `InterruptException` lands outside their read loops, and keep frontend/backend request and response channels synchronized across interrupts.
- Defer SIGINT delivery when the current task has no exception handler or is inside the unwind-unsafe JIT task dispatcher.
- On kqueue platforms, install `sigint_handler` instead of `SIG_IGN` for SIGINT to avoid racing the default handler installation.

Stress testing previously failed 9/10 sessions within 20 interrupts; with these changes, sessions remain alive and the channel protocol stays synchronized.
