### PR TITLE
Profile: performance improvements

### DIFF
--- a/src/gc-alloc-profiler.c
+++ b/src/gc-alloc-profiler.c
@@ -135,20 +135,34 @@ typedef struct {
 
 static jl_alloc_profile_t g_alloc_profile;
 _Atomic(int) g_alloc_profile_enabled = 0;
-// number of threads currently inside `_maybe_record_alloc_to_profile`
-static _Atomic(int) g_recording_threads = 0;
+// number of threads currently inside `_maybe_record_alloc_to_profile`, striped
+// over cache-line-padded counters (indexed by tid) to avoid contention on a
+// single cache line while recording
+#define RECORDER_STRIPES 16
+static struct {
+    _Atomic(int) count;
+    char _pad[64 - sizeof(_Atomic(int))];
+} g_recording_threads[RECORDER_STRIPES];
 static alloc_array_t g_combined_allocs; // Will live forever.
 
-// Must only be called while `g_alloc_profile_enabled` is 0, so that once the
-// count reaches zero no new recorder can start touching the profile arrays.
+static _Atomic(int) *recorder_counter(size_t tid) JL_NOTSAFEPOINT
+{
+    return &g_recording_threads[tid % RECORDER_STRIPES].count;
+}
+
+// Must only be called while `g_alloc_profile_enabled` is 0, so that once a
+// stripe reaches zero no new recorder on it can start touching the profile
+// arrays (the same Dekker-style argument as for a single counter, per stripe).
 static void wait_for_recorders(void) JL_NOTSAFEPOINT
 {
     // a recorder can take a while (unwinding takes locks and mallocs), so back off
-    for (int spins = 0; jl_atomic_load(&g_recording_threads) != 0; spins++) {
-        if (spins < 128)
-            jl_cpu_pause();
-        else
-            jl_cpu_suspend();
+    for (int i = 0; i < RECORDER_STRIPES; i++) {
+        for (int spins = 0; jl_atomic_load(&g_recording_threads[i].count) != 0; spins++) {
+            if (spins < 128)
+                jl_cpu_pause();
+            else
+                jl_cpu_suspend();
+        }
     }
 }
 
@@ -312,7 +326,9 @@ void jl_gc_foreach_alloc_profile_root(jl_alloc_profile_root_cb_t f, void *env) J
 
 void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t *type) JL_NOTSAFEPOINT
 {
-    jl_atomic_fetch_add(&g_recording_threads, 1);
+    size_t thread_id = jl_atomic_load_relaxed(&jl_current_task->tid);
+    _Atomic(int) *recording = recorder_counter(thread_id);
+    jl_atomic_fetch_add(recording, 1);
     // re-check the flag under the recorder count: either we see the stop and
     // leave, or the stopping thread waits for us to finish (Dekker-style
     // synchronization; both sides use sequentially consistent operations)
@@ -320,7 +336,6 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t 
         goto done;
 
     {
-        size_t thread_id = jl_atomic_load_relaxed(&jl_current_task->tid);
         if (thread_id >= g_alloc_profile.num_profiles)
             goto done; // ignore allocations on threads started after the alloc-profile started
 
@@ -342,5 +357,5 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t 
     }
 
 done:
-    jl_atomic_fetch_add(&g_recording_threads, -1);
+    jl_atomic_fetch_add(recording, -1);
 }

--- a/src/gc-alloc-profiler.c
+++ b/src/gc-alloc-profiler.c
@@ -53,10 +53,71 @@ static void type_array_push(type_array_t *a, jl_datatype_t *val) JL_NOTSAFEPOINT
 
 #define TYPE_FILTER_SIZE 256 // must be a power of two
 
-// Per-thread profile: a growable array of alloc records, plus the types they
-// refer to, which have to be reported to the GC as roots.
+// Bump arena for the recorded backtraces, to avoid a malloc per sample.
+// Blocks are only freed all at once in `jl_free_alloc_profile`, since records
+// combined into `g_combined_allocs` keep pointing into them.
+typedef struct jl_bt_arena_block_t {
+    struct jl_bt_arena_block_t *next;
+    size_t used; // in elements
+    size_t cap;  // in elements
+    jl_bt_element_t data[];
+} jl_bt_arena_block_t;
+
+typedef struct {
+    jl_bt_arena_block_t *head;
+} jl_bt_arena_t;
+
+#define BT_ARENA_BLOCK_ELEMENTS (size_t)(64 * 1024 / sizeof(jl_bt_element_t))
+
+static jl_bt_element_t *bt_arena_alloc(jl_bt_arena_t *arena, size_t n) JL_NOTSAFEPOINT
+{
+    jl_bt_arena_block_t *block = arena->head;
+    if (n >= BT_ARENA_BLOCK_ELEMENTS) {
+        // oversized: give it a dedicated block, keeping the current block (and
+        // its remaining space) as the head
+        jl_bt_arena_block_t *big = (jl_bt_arena_block_t*)malloc_s(
+            sizeof(jl_bt_arena_block_t) + n * sizeof(jl_bt_element_t));
+        big->used = big->cap = n;
+        if (block == NULL) {
+            big->next = NULL;
+            arena->head = big;
+        }
+        else {
+            big->next = block->next;
+            block->next = big;
+        }
+        return big->data;
+    }
+    if (block == NULL || block->cap - block->used < n) {
+        block = (jl_bt_arena_block_t*)malloc_s(
+            sizeof(jl_bt_arena_block_t) + BT_ARENA_BLOCK_ELEMENTS * sizeof(jl_bt_element_t));
+        block->next = arena->head;
+        block->used = 0;
+        block->cap = BT_ARENA_BLOCK_ELEMENTS;
+        arena->head = block;
+    }
+    jl_bt_element_t *p = &block->data[block->used];
+    block->used += n;
+    return p;
+}
+
+static void bt_arena_free(jl_bt_arena_t *arena) JL_NOTSAFEPOINT
+{
+    jl_bt_arena_block_t *block = arena->head;
+    while (block != NULL) {
+        jl_bt_arena_block_t *next = block->next;
+        free(block);
+        block = next;
+    }
+    arena->head = NULL;
+}
+
+// Per-thread profile: a growable array of alloc records, the arena that owns
+// their backtrace memory, and the types they refer to, which have to be
+// reported to the GC as roots.
 typedef struct {
     alloc_array_t allocs;
+    jl_bt_arena_t bt_arena;
     type_array_t type_roots;
     // direct-mapped filter over `type_roots`, so that it doesn't grow with every
     // sample. Owning thread only; a collision just lets a duplicate through.
@@ -128,7 +189,7 @@ static void record_type_root(jl_per_thread_alloc_profile_t *p, jl_datatype_t *ty
 
 // === stack stuff ===
 
-static jl_raw_backtrace_t get_raw_backtrace(void) JL_NOTSAFEPOINT
+static jl_raw_backtrace_t get_raw_backtrace(jl_bt_arena_t *arena) JL_NOTSAFEPOINT
 {
     // We first record the backtrace onto a MAX-sized buffer, so that we don't have to
     // allocate the buffer until we know the size. To ensure thread-safety, we use a
@@ -144,9 +205,8 @@ static jl_raw_backtrace_t get_raw_backtrace(void) JL_NOTSAFEPOINT
     size_t bt_size = rec_backtrace(shared_bt_data_buffer, JL_MAX_BT_SIZE, 2);
 
     // Then we copy only the needed bytes out of the buffer into our profile.
-    size_t bt_bytes = bt_size * sizeof(jl_bt_element_t);
-    jl_bt_element_t *bt_data = (jl_bt_element_t *)malloc_s(bt_bytes);
-    memcpy(bt_data, shared_bt_data_buffer, bt_bytes);
+    jl_bt_element_t *bt_data = bt_arena_alloc(arena, bt_size);
+    memcpy(bt_data, shared_bt_data_buffer, bt_size * sizeof(jl_bt_element_t));
 
     jl_raw_backtrace_t result;
     result.data = bt_data;
@@ -220,24 +280,16 @@ JL_DLLEXPORT void jl_free_alloc_profile(void)
     // in-flight recorders may be pushing onto the arrays we are about to free
     int was_enabled = suspend_recording();
 
-    // Free any allocs that remain in the per-thread profiles, that haven't
-    // been combined yet (which happens in jl_fetch_alloc_profile()).
+    // The per-thread arenas own all backtrace memory, including that of allocs
+    // already combined into `g_combined_allocs` by jl_fetch_alloc_profile().
     for (size_t i = 0; i < g_alloc_profile.num_profiles; i++) {
         jl_per_thread_alloc_profile_t *p = &g_alloc_profile.per_thread_profiles[i];
-        for (size_t j = 0; j < p->allocs.len; j++) {
-            free(p->allocs.data[j].backtrace.data);
-        }
         alloc_array_clear(&p->allocs);
+        bt_arena_free(&p->bt_arena);
         // no alloc record refers to these types any more
         p->type_roots.len = 0;
         memset(p->type_filter, 0, sizeof(p->type_filter));
     }
-
-    // Free the allocs that have been already combined into the combined results object.
-    for (size_t i = 0; i < g_combined_allocs.len; i++) {
-        free(g_combined_allocs.data[i].backtrace.data);
-    }
-
     alloc_array_clear(&g_combined_allocs);
     resume_recording(was_enabled);
 }
@@ -281,7 +333,7 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t 
 
         jl_raw_alloc_t alloc;
         alloc.type_address = type;
-        alloc.backtrace = get_raw_backtrace();
+        alloc.backtrace = get_raw_backtrace(&p->bt_arena);
         alloc.size = size;
         alloc.task = (void *)jl_current_task;
         alloc.timestamp = cycleclock();

--- a/src/gc-alloc-profiler.c
+++ b/src/gc-alloc-profiler.c
@@ -126,7 +126,10 @@ typedef struct {
 
 // Global profile state.
 typedef struct {
-    double sample_rate;
+    // `cong(UINT64_MAX, ...)` draw at or below which an allocation is sampled. Read
+    // by recorders that have not yet joined the recorder count, so it has to be
+    // atomic even though it is only written while the profiler is stopped.
+    _Atomic(uint64_t) sample_threshold;
     jl_per_thread_alloc_profile_t *per_thread_profiles;
     size_t num_profiles;
 } jl_alloc_profile_t;
@@ -247,7 +250,12 @@ JL_DLLEXPORT void jl_start_alloc_profile(double sample_rate)
         g_alloc_profile.num_profiles = nthreads;
     }
 
-    g_alloc_profile.sample_rate = sample_rate;
+    // `cong` draws from the open interval [0, UINT64_MAX), so a threshold of
+    // UINT64_MAX samples every allocation
+    uint64_t threshold = sample_rate >= 1.0 ? UINT64_MAX :
+                         sample_rate <= 0.0 ? 0 :
+                         (uint64_t)(sample_rate * (double)UINT64_MAX);
+    jl_atomic_store_relaxed(&g_alloc_profile.sample_threshold, threshold);
     jl_atomic_store_release(&g_alloc_profile_enabled, 1);
 }
 
@@ -326,7 +334,17 @@ void jl_gc_foreach_alloc_profile_root(jl_alloc_profile_root_cb_t f, void *env) J
 
 void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t *type) JL_NOTSAFEPOINT
 {
-    size_t thread_id = jl_atomic_load_relaxed(&jl_current_task->tid);
+    jl_task_t *ct = jl_current_task;
+    // draw the sample before joining the recorder count: the RNG is thread-local, so
+    // the common case of an allocation that isn't sampled costs no shared-memory
+    // traffic beyond the relaxed threshold load. A concurrent restart can at worst
+    // have this draw against the previous session's rate, which only perturbs the
+    // sampling of the allocations in flight across the restart.
+    if (cong(UINT64_MAX, &ct->ptls->rngseed) >
+            jl_atomic_load_relaxed(&g_alloc_profile.sample_threshold))
+        return;
+
+    size_t thread_id = jl_atomic_load_relaxed(&ct->tid);
     _Atomic(int) *recording = recorder_counter(thread_id);
     jl_atomic_fetch_add(recording, 1);
     // re-check the flag under the recorder count: either we see the stop and
@@ -340,11 +358,6 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t 
             goto done; // ignore allocations on threads started after the alloc-profile started
 
         jl_per_thread_alloc_profile_t *p = &g_alloc_profile.per_thread_profiles[thread_id];
-
-        jl_ptls_t ptls = jl_current_task->ptls;
-        double sample_val = (double)cong(UINT64_MAX, &ptls->rngseed) / (double)UINT64_MAX;
-        if (sample_val > g_alloc_profile.sample_rate)
-            goto done;
 
         jl_raw_alloc_t alloc;
         alloc.type_address = type;

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -332,11 +332,14 @@ function parse_flat(::Type{T}, data::Vector{Alloc}, C::Bool) where T
     n = Int[]
     m = Int[]
     lilist_idx = Dict{T, Int}()
-    recursive = Set{T}()
+    # generation at which each lilist entry was last counted; a per-record
+    # generation bump replaces an expensive Set of frames for recursion dedup
+    seen_gen = Int[]
+    gen = 0
     totalbytes = 0
     for r in data
         first = true
-        empty!(recursive)
+        gen += 1
         nb = r.size # or 1 for counting
         totalbytes += nb
         for frame in r.stacktrace
@@ -344,12 +347,12 @@ function parse_flat(::Type{T}, data::Vector{Alloc}, C::Bool) where T
             key = (T === UInt64 ? frame.pointer : frame)
             idx = get!(lilist_idx, key, length(lilist) + 1)
             if idx > length(lilist)
-                push!(recursive, key)
+                push!(seen_gen, gen)
                 push!(lilist, frame)
                 push!(n, nb)
                 push!(m, 0)
-            elseif !(key in recursive)
-                push!(recursive, key)
+            elseif seen_gen[idx] != gen
+                seen_gen[idx] = gen
                 n[idx] += nb
             end
             if first

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -186,21 +186,34 @@ function load_type(ptr::Ptr{Type})
     return unsafe_pointer_to_objref(ptr)
 end
 
-function decode_alloc(cache::BacktraceCache, raw_alloc::RawAlloc)::Alloc
-    Alloc(
-        load_type(raw_alloc.type),
-        stacktrace_memoized(cache, load_backtrace(raw_alloc.backtrace)),
-        UInt(raw_alloc.size),
-        raw_alloc.task,
-        raw_alloc.timestamp
-    )
-end
-
 function decode(raw_results::RawResults)::AllocResults
+    raw_allocs = [unsafe_load(raw_results.allocs, i) for i in 1:raw_results.num_allocs]
+    backtraces = [load_backtrace(a.backtrace) for a in raw_allocs]
+    # symbol lookup dominates decoding, so do it once per unique ip, in parallel
+    # (the same approach as `Profile.getdict!`)
     cache = BacktraceCache()
+    unique_ips = unique(Iterators.flatten(backtraces))
+    if !isempty(unique_ips)
+        sort!(unique_ips) # help each thread to get a disjoint set of libraries, as much as possible
+        lookups = Vector{Vector{StackFrame}}(undef, length(unique_ips))
+        @sync for part in Iterators.partition(eachindex(unique_ips), div(length(unique_ips), Threads.threadpoolsize(), RoundUp))
+            Threads.@spawn for i in part
+                lookups[i] = lookup(unique_ips[i])
+            end
+        end
+        for i in eachindex(unique_ips)
+            cache[unique_ips[i]] = lookups[i]
+        end
+    end
     allocs = [
-        decode_alloc(cache, unsafe_load(raw_results.allocs, i))
-        for i in 1:raw_results.num_allocs
+        Alloc(
+            load_type(raw_allocs[i].type),
+            stacktrace_memoized(cache, backtraces[i]),
+            UInt(raw_allocs[i].size),
+            raw_allocs[i].task,
+            raw_allocs[i].timestamp
+        )
+        for i in eachindex(raw_allocs)
     ]
     return AllocResults(allocs)
 end

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -187,12 +187,23 @@ function load_type(ptr::Ptr{Type})
 end
 
 function decode(raw_results::RawResults)::AllocResults
-    raw_allocs = [unsafe_load(raw_results.allocs, i) for i in 1:raw_results.num_allocs]
-    backtraces = [load_backtrace(a.backtrace) for a in raw_allocs]
+    n_allocs = Int(raw_results.num_allocs)
     # symbol lookup dominates decoding, so do it once per unique ip, in parallel
-    # (the same approach as `Profile.getdict!`)
+    # (the same approach as `Profile.getdict!`). The backtraces are decoded into a
+    # reused buffer, rather than kept as one vector per sample, since holding a
+    # decoded copy of every backtrace at once is a lot of memory at high sample rates.
     cache = BacktraceCache()
-    unique_ips = unique(Iterators.flatten(backtraces))
+    trace = Vector{BTElement}()
+    unique_ips = Vector{BTElement}()
+    let seen = Set{BTElement}()
+        for i in 1:n_allocs
+            raw = unsafe_load(raw_results.allocs, i)
+            load_backtrace!(empty!(trace), raw.backtrace)
+            for ip in trace
+                ip in seen || (push!(seen, ip); push!(unique_ips, ip))
+            end
+        end
+    end
     if !isempty(unique_ips)
         sort!(unique_ips) # help each thread to get a disjoint set of libraries, as much as possible
         lookups = Vector{Vector{StackFrame}}(undef, length(unique_ips))
@@ -205,21 +216,24 @@ function decode(raw_results::RawResults)::AllocResults
             cache[unique_ips[i]] = lookups[i]
         end
     end
-    allocs = [
-        Alloc(
-            load_type(raw_allocs[i].type),
-            stacktrace_memoized(cache, backtraces[i]),
-            UInt(raw_allocs[i].size),
-            raw_allocs[i].task,
-            raw_allocs[i].timestamp
+    allocs = Vector{Alloc}(undef, n_allocs)
+    for i in 1:n_allocs
+        raw = unsafe_load(raw_results.allocs, i)
+        load_backtrace!(empty!(trace), raw.backtrace)
+        allocs[i] = Alloc(
+            load_type(raw.type),
+            stacktrace_memoized(cache, trace),
+            UInt(raw.size),
+            raw.task,
+            raw.timestamp
         )
-        for i in eachindex(raw_allocs)
-    ]
+    end
     return AllocResults(allocs)
 end
 
-function load_backtrace(trace::RawBacktrace)::Vector{BTElement}
-    out = Vector{BTElement}()
+load_backtrace(trace::RawBacktrace)::Vector{BTElement} = load_backtrace!(Vector{BTElement}(), trace)
+
+function load_backtrace!(out::Vector{BTElement}, trace::RawBacktrace)::Vector{BTElement}
     n = Int(trace.size)
     i = 1
     while i <= n

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -303,57 +303,75 @@ function print(io::IO,
             Base.print(io, "Overhead ╎ [+additional indent] Count File:Line  Function\n")
             Base.print(io, "=========================================================\n")
         end
+        # partition the data per group in one pass, rather than rescanning the
+        # whole buffer for every group
+        blocks = collect_blocks(data)
+        # reverse-appearance order for tasks, matching `get_task_ids`, sorted for threads
+        taskids_of(bs) = unique(b[2] for b in Iterators.reverse(bs))
+        threadids_of(bs) = sort!(unique(b[1] for b in bs))
         if groupby == [:task, :thread]
-            taskids = intersect(get_task_ids(data), tasks)
+            bytask = bucket_blocks(UInt, b -> b[2], blocks)
+            taskids = intersect(taskids_of(blocks), tasks)
             isempty(taskids) && (any_nosamples = true)
             for taskid in taskids
-                threadids = intersect(get_thread_ids(data, taskid), threads)
+                taskblocks = bytask[taskid]
+                threadids = intersect(threadids_of(taskblocks), threads)
                 if length(threadids) == 0
                     any_nosamples = true
                 else
+                    bythread = bucket_blocks(Int, b -> b[1], taskblocks)
                     nl = length(threadids) > 1 ? "\n" : ""
                     printstyled(io, "Task $(Base.repr(taskid))$nl"; bold=true, color=Base.debug_color())
                     for threadid in threadids
                         printstyled(io, " Thread $threadid ($(Threads.threadpooldescription(threadid))) "; bold=true, color=Base.info_color())
-                        nosamples = print_group(io, data, lidict, pf, format, threadid, taskid, true)
+                        gdata = group_data(data, bythread[threadid], Returns(true))
+                        nosamples = print_group(io, gdata, lidict, pf, format, threadid, taskid, true)
                         nosamples && (any_nosamples = true)
                         println(io)
                     end
                 end
             end
         elseif groupby == [:thread, :task]
-            threadids = intersect(get_thread_ids(data), threads)
+            bythread = bucket_blocks(Int, b -> b[1], blocks)
+            threadids = intersect(threadids_of(blocks), threads)
             isempty(threadids) && (any_nosamples = true)
             for threadid in threadids
-                taskids = intersect(get_task_ids(data, threadid), tasks)
+                threadblocks = bythread[threadid]
+                taskids = intersect(taskids_of(threadblocks), tasks)
                 if length(taskids) == 0
                     any_nosamples = true
                 else
+                    bytask = bucket_blocks(UInt, b -> b[2], threadblocks)
                     nl = length(taskids) > 1 ? "\n" : ""
                     printstyled(io, "Thread $threadid ($(Threads.threadpooldescription(threadid)))$nl"; bold=true, color=Base.info_color())
                     for taskid in taskids
                         printstyled(io, " Task $(Base.repr(taskid)) "; bold=true, color=Base.debug_color())
-                        nosamples = print_group(io, data, lidict, pf, format, threadid, taskid, true)
+                        gdata = group_data(data, bytask[taskid], Returns(true))
+                        nosamples = print_group(io, gdata, lidict, pf, format, threadid, taskid, true)
                         nosamples && (any_nosamples = true)
                         println(io)
                     end
                 end
             end
         elseif groupby === :task
-            taskids = intersect(get_task_ids(data), tasks)
+            bytask = bucket_blocks(UInt, b -> b[2], blocks)
+            taskids = intersect(taskids_of(blocks), tasks)
             isempty(taskids) && (any_nosamples = true)
             for taskid in taskids
                 printstyled(io, "Task $(Base.repr(taskid)) "; bold=true, color=Base.debug_color())
-                nosamples = print_group(io, data, lidict, pf, format, threads, taskid, true)
+                gdata = group_data(data, bytask[taskid], (t, k) -> t in threads)
+                nosamples = print_group(io, gdata, lidict, pf, format, threads, taskid, true)
                 nosamples && (any_nosamples = true)
                 println(io)
             end
         elseif groupby === :thread
-            threadids = intersect(get_thread_ids(data), threads)
+            bythread = bucket_blocks(Int, b -> b[1], blocks)
+            threadids = intersect(threadids_of(blocks), threads)
             isempty(threadids) && (any_nosamples = true)
             for threadid in threadids
                 printstyled(io, "Thread $threadid ($(Threads.threadpooldescription(threadid))) "; bold=true, color=Base.info_color())
-                nosamples = print_group(io, data, lidict, pf, format, threadid, tasks, true)
+                gdata = group_data(data, bythread[threadid], (t, k) -> k in tasks)
+                nosamples = print_group(io, gdata, lidict, pf, format, threadid, tasks, true)
                 nosamples && (any_nosamples = true)
                 println(io)
             end
@@ -398,6 +416,53 @@ function print_group(io::IO, data::Vector{<:Unsigned}, lidict::Union{LineInfoDic
     else
         throw(ArgumentError("output format $(repr(format)) not recognized"))
     end
+end
+
+const ProfileBlock = Tuple{Int,UInt,UnitRange{Int}}
+
+# One forward pass over `data`, returning (threadid, taskid, range) per sample
+# block, where `range` spans the block's frames and its trailing metadata.
+function collect_blocks(data::Vector{<:Unsigned})
+    blocks = ProfileBlock[]
+    block_start = 1
+    for i in eachindex(data)
+        if is_block_end(data, i)
+            threadid = Int(data[i - META_OFFSET_THREADID])
+            taskid = UInt(data[i - META_OFFSET_TASKID])
+            push!(blocks, (threadid, taskid, block_start:i))
+            block_start = i + 1
+        end
+    end
+    return blocks
+end
+
+# Partition `blocks` by `key(block)`, preserving block order within each bucket, so
+# that a group can be emitted from its own bucket rather than by rescanning every
+# block. Each block lands in exactly one bucket, so bucketing costs one pass in
+# total rather than one pass per group.
+function bucket_blocks(::Type{K}, key::F, blocks::Vector{ProfileBlock}) where {K, F}
+    buckets = Dict{K,Vector{ProfileBlock}}()
+    for b in blocks
+        push!(get!(Vector{ProfileBlock}, buckets, key(b)::K), b)
+    end
+    return buckets
+end
+
+# Concatenate the blocks selected by `pred(threadid, taskid)` into a standalone
+# profile buffer. Aggregation is insensitive to inter-block order.
+function group_data(data::Vector{T}, blocks::Vector{ProfileBlock}, pred::F) where {T<:Unsigned, F}
+    n = 0
+    for (threadid, taskid, r) in blocks
+        pred(threadid, taskid) && (n += length(r))
+    end
+    out = Vector{T}(undef, n)
+    pos = 1
+    for (threadid, taskid, r) in blocks
+        pred(threadid, taskid) || continue
+        copyto!(out, pos, data, first(r), length(r))
+        pos += length(r)
+    end
+    return out
 end
 
 function get_task_ids(data::Vector{<:Unsigned}, threadid = nothing)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -764,7 +764,10 @@ function parse_flat(::Type{T}, data::Vector{UInt64}, lidict::Union{LineInfoDict,
     n = Int[]
     m = Int[]
     lilist_idx = Dict{T, Int}()
-    recursive = Set{T}()
+    # generation at which each lilist entry was last counted; a per-sample
+    # generation bump replaces an expensive Set of frames for recursion dedup
+    seen_gen = Int[]
+    gen = 1
     leaf = 0
     totalshots = 0
     startframe = length(data)
@@ -792,7 +795,7 @@ function parse_flat(::Type{T}, data::Vector{UInt64}, lidict::Union{LineInfoDict,
             end
             skip = false
             totalshots += 1
-            empty!(recursive)
+            gen += 1
             if leaf != 0
                 m[leaf] += 1
             end
@@ -808,12 +811,12 @@ function parse_flat(::Type{T}, data::Vector{UInt64}, lidict::Union{LineInfoDict,
                 key = (T === UInt64 ? ip : frame)
                 idx = get!(lilist_idx, key, length(lilist) + 1)
                 if idx > length(lilist)
-                    push!(recursive, key)
+                    push!(seen_gen, gen)
                     push!(lilist, frame)
                     push!(n, 1)
                     push!(m, 0)
-                elseif !(key in recursive)
-                    push!(recursive, key)
+                elseif seen_gen[idx] != gen
+                    seen_gen[idx] = gen
                     n[idx] += 1
                 end
                 leaf = idx

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -427,7 +427,8 @@ function collect_blocks(data::Vector{<:Unsigned})
     block_start = 1
     for i in eachindex(data)
         if is_block_end(data, i)
-            threadid = Int(data[i - META_OFFSET_THREADID])
+            # the task profiler records -1 for a task that isn't running on a thread
+            threadid = data[i - META_OFFSET_THREADID] % Int
             taskid = UInt(data[i - META_OFFSET_TASKID])
             push!(blocks, (threadid, taskid, block_start:i))
             block_start = i + 1

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -108,8 +108,10 @@ function assemble_snapshot(in_prefix, io::IO)
     nodes = Nodes(node_count, edge_count)
 
     orphans = Set{UInt}() # nodes that have no incoming edges
-    # Parse nodes with empty edge counts that we need to fill later
-    open(string(in_prefix, ".nodes"), "r") do nodes_file
+    # Parse nodes with empty edge counts that we need to fill later.
+    # Read each part file into memory up front: parsing field-at-a-time from an
+    # IOStream is dominated by per-call locking overhead.
+    let nodes_file = IOBuffer(read(string(in_prefix, ".nodes")))
         for i in 1:length(nodes)
             node_type = read(nodes_file, UInt32)
             node_name_idx = read(nodes_file, UInt)
@@ -133,7 +135,7 @@ function assemble_snapshot(in_prefix, io::IO)
     end
 
     # Parse the edges to fill in the edge counts for nodes and correct the to_node offsets
-    open(string(in_prefix, ".edges"), "r") do edges_file
+    let edges_file = IOBuffer(read(string(in_prefix, ".edges")))
         for i in 1:length(nodes.edges)
             edge_type = read(edges_file, UInt32)
             edge_name_or_index = read(edges_file, UInt)
@@ -206,7 +208,7 @@ function assemble_snapshot(in_prefix, io::IO)
     println(io, "\"locations\":[],")
 
     println(io, "\"strings\":[")
-    open(string(in_prefix, ".strings"), "r") do strings_io
+    let strings_io = IOBuffer(read(string(in_prefix, ".strings")))
         first = true
         while !eof(strings_io)
             str_size = read(strings_io, UInt)

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -166,6 +166,8 @@ function assemble_snapshot(in_prefix, io::IO)
         for i in 1:n_edges
             seek(edges_file, (i - 1) * k_edge_record_bytes + k_edge_from_node_offset)
             from_node = read(edges_file, UInt)
+            from_node < node_count ||
+                error("malformed edges file `$(in_prefix).edges`: from_node $(from_node) is out of range for $(node_count) nodes")
             nodes.edge_count[from_node + 1] += UInt(1)  # C and JSON use 0-based indexing
         end
         # position in `nodes.edges` of the next edge leaving each node

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -288,30 +288,37 @@ end
 
 function print_str_escape_json(stream::IO, s::AbstractString)
     print(stream, '"')
-    for c in s
-        if c == '"'
-            print(stream, "\\\"")
+    # write the string in runs, so that a stretch of characters needing no escaping
+    # costs one write rather than one per character
+    runstart = firstindex(s)
+    for (i, c) in pairs(s)
+        escaped = if c == '"'
+            "\\\""
         elseif c == '\\'
-            print(stream, "\\\\")
+            "\\\\"
         elseif c == '\b'
-            print(stream, "\\b")
+            "\\b"
         elseif c == '\f'
-            print(stream, "\\f")
+            "\\f"
         elseif c == '\n'
-            print(stream, "\\n")
+            "\\n"
         elseif c == '\r'
-            print(stream, "\\r")
+            "\\r"
         elseif c == '\t'
-            print(stream, "\\t")
+            "\\t"
         elseif '\x00' <= c <= '\x1f'
-            print(stream, "\\u", lpad(string(UInt16(c), base=16), 4, '0'))
+            string("\\u", lpad(string(UInt16(c), base=16), 4, '0'))
         elseif !isvalid(c)
             # we have to do this because vscode's viewer doesn't like the replace character
-            print(stream, "[invalid unicode character]")
+            "[invalid unicode character]"
         else
-            print(stream, c)
+            continue
         end
+        i > runstart && print(stream, SubString(s, runstart, prevind(s, i)))
+        print(stream, escaped)
+        runstart = nextind(s, i)
     end
+    runstart <= lastindex(s) && print(stream, SubString(s, runstart))
     print(stream, '"')
 end
 

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -23,7 +23,7 @@ struct Nodes
     name_idx::Vector{UInt32} # index into `snapshot.strings`
     id::Vector{UInt}           # unique id, in julia it is the address of the object
     self_size::Vector{Int}     # size of the object itself, not including the size of its fields
-    edge_count::Vector{UInt} # number of outgoing edges
+    edge_count::Vector{UInt}   # number of outgoing edges
     # This is the main complexity of the .heapsnapshot format, and it's the reason we need
     # to read in all the data before writing it out. The edges vector contains all edges,
     # but organized by which node they came from. First, it contains all the edges coming
@@ -38,7 +38,7 @@ function Nodes(n::Int, e::Int)
         Vector{UInt32}(undef, n),
         Vector{UInt}(undef, n),
         Vector{Int}(undef, n),
-        Vector{UInt32}(undef, n),
+        Vector{UInt}(undef, n),
         Edges(e),
     )
 end
@@ -166,7 +166,7 @@ function assemble_snapshot(in_prefix, io::IO)
         for i in 1:n_edges
             seek(edges_file, (i - 1) * k_edge_record_bytes + k_edge_from_node_offset)
             from_node = read(edges_file, UInt)
-            nodes.edge_count[from_node + 1] += UInt32(1)  # C and JSON use 0-based indexing
+            nodes.edge_count[from_node + 1] += UInt(1)  # C and JSON use 0-based indexing
         end
         # position in `nodes.edges` of the next edge leaving each node
         cursor = Vector{Int}(undef, length(nodes))

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -24,13 +24,13 @@ struct Nodes
     id::Vector{UInt}           # unique id, in julia it is the address of the object
     self_size::Vector{Int}     # size of the object itself, not including the size of its fields
     edge_count::Vector{UInt} # number of outgoing edges
-    edges::Edges               # outgoing edges
     # This is the main complexity of the .heapsnapshot format, and it's the reason we need
     # to read in all the data before writing it out. The edges vector contains all edges,
     # but organized by which node they came from. First, it contains all the edges coming
-    # out of node 0, then all edges leaving node 1, etc. So we need to have visited all
-    # edges, and assigned them to their corresponding nodes, before we can emit the file.
-    edge_idxs::Vector{Vector{UInt}} # indexes into edges, keeping per-node outgoing edge ids
+    # out of node 0, then all edges leaving node 1, etc. So we store the edges in that
+    # order, which means an edge's position is determined by the number of edges leaving
+    # all the preceding nodes, and no per-node index is needed.
+    edges::Edges               # outgoing edges, grouped by source node
 end
 function Nodes(n::Int, e::Int)
     Nodes(
@@ -40,12 +40,17 @@ function Nodes(n::Int, e::Int)
         Vector{Int}(undef, n),
         Vector{UInt32}(undef, n),
         Edges(e),
-        [Vector{UInt}() for _ in 1:n],  # Take care to construct n separate empty vectors
     )
 end
 Base.length(n::Nodes) = length(n.type)
 
 const k_node_number_of_fields = 7
+
+# the streaming .edges format writes each edge as a packed
+# (type, name_or_index, from_node, to_node) record; see `serialize_edge` in
+# src/gc-heap-snapshot.c
+const k_edge_record_bytes = sizeof(UInt32) + 3 * sizeof(UInt)
+const k_edge_from_node_offset = sizeof(UInt32) + sizeof(UInt)
 
 # Like Base.dec, but doesn't allocate a string and writes directly to the io object
 # We know all of the numbers we're about to write fit into a UInt and are non-negative
@@ -134,19 +139,39 @@ function assemble_snapshot(in_prefix, io::IO)
         end
     end
 
-    # Parse the edges to fill in the edge counts for nodes and correct the to_node offsets
-    let edges_file = IOBuffer(read(string(in_prefix, ".edges")))
-        for i in 1:length(nodes.edges)
+    # Parse the edges to fill in the edge counts for nodes and correct the to_node offsets.
+    # The edges are stored grouped by source node, which is the order they have to be
+    # emitted in, so a first pass counts the edges leaving each node and a second one
+    # places each edge at its position within its source node's group.
+    let edges_data = read(string(in_prefix, ".edges"))
+        n_edges = length(nodes.edges)
+        length(edges_data) == n_edges * k_edge_record_bytes ||
+            error("malformed edges file `$(in_prefix).edges`: expected $(n_edges * k_edge_record_bytes) bytes for $(n_edges) edges, got $(length(edges_data))")
+        edges_file = IOBuffer(edges_data)
+        for i in 1:n_edges
+            seek(edges_file, (i - 1) * k_edge_record_bytes + k_edge_from_node_offset)
+            from_node = read(edges_file, UInt)
+            nodes.edge_count[from_node + 1] += UInt32(1)  # C and JSON use 0-based indexing
+        end
+        # position in `nodes.edges` of the next edge leaving each node
+        cursor = Vector{Int}(undef, length(nodes))
+        pos = 1
+        for n in 1:length(nodes)
+            cursor[n] = pos
+            pos += nodes.edge_count[n]
+        end
+        seekstart(edges_file)
+        for _ in 1:n_edges
             edge_type = read(edges_file, UInt32)
             edge_name_or_index = read(edges_file, UInt)
             from_node = read(edges_file, UInt)
             to_node = read(edges_file, UInt)
 
+            i = cursor[from_node + 1]
+            cursor[from_node + 1] = i + 1
             nodes.edges.type[i] = edge_type
             nodes.edges.name_or_index[i] = edge_name_or_index
             nodes.edges.to_pos[i] = to_node * k_node_number_of_fields # 7 fields per node, the streaming format doesn't multiply the offset by 7
-            nodes.edge_count[from_node + 1] += UInt32(1)  # C and JSON use 0-based indexing
-            push!(nodes.edge_idxs[from_node + 1], i) # Index into nodes.edges
             # remove the node from the orphans if it has at least one incoming edge
             if to_node in orphans
                 delete!(orphans, to_node)
@@ -179,13 +204,10 @@ function assemble_snapshot(in_prefix, io::IO)
     end
     print(io, "],\n")
     print(io, "\"edges\":[")
-    e = 1
+    i = 1
     for n in 1:length(nodes)
-        count = nodes.edge_count[n]
-        len_edges = length(nodes.edge_idxs[n])
-        @assert count == len_edges "For node $n: $count != $len_edges"
-        for i in nodes.edge_idxs[n]
-            e > 1 && print(io, ",")
+        for _ in 1:nodes.edge_count[n]
+            i > 1 && print(io, ",")
             println(io)
             _write_decimal_number(io, nodes.edges.type[i], _digits_buf)
             print(io, ",")
@@ -195,7 +217,7 @@ function assemble_snapshot(in_prefix, io::IO)
             if !(nodes.edges.to_pos[i] % k_node_number_of_fields == 0)
                 @warn "Bug in to_pos for edge $i from node $n: $(nodes.edges.to_pos[i])"
             end
-            e += 1
+            i += 1
         end
     end
     println(io, "],")

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -112,7 +112,10 @@ function assemble_snapshot(in_prefix, io::IO)
 
     nodes = Nodes(node_count, edge_count)
 
-    orphans = Set{UInt}() # nodes that have no incoming edges
+    # whether each node has at least one incoming edge; the uber node has none by
+    # construction, so mark it up front
+    has_incoming = falses(node_count)
+    node_count > 0 && (has_incoming[1] = true)
     # Parse nodes with empty edge counts that we need to fill later.
     # Read each part file into memory up front: parsing field-at-a-time from an
     # IOStream is dominated by per-call locking overhead.
@@ -134,8 +137,6 @@ function assemble_snapshot(in_prefix, io::IO)
             nodes.id[i] = id
             nodes.self_size[i] = self_size
             nodes.edge_count[i] = 0 # edge_count
-            # populate the orphans set with node index
-            push!(orphans, i-1)
         end
     end
 
@@ -172,18 +173,17 @@ function assemble_snapshot(in_prefix, io::IO)
             nodes.edges.type[i] = edge_type
             nodes.edges.name_or_index[i] = edge_name_or_index
             nodes.edges.to_pos[i] = to_node * k_node_number_of_fields # 7 fields per node, the streaming format doesn't multiply the offset by 7
-            # remove the node from the orphans if it has at least one incoming edge
-            if to_node in orphans
-                delete!(orphans, to_node)
-            end
+            to_node < node_count ||
+                error("malformed edges file `$(in_prefix).edges`: to_node $(to_node) is out of range for $(node_count) nodes")
+            has_incoming[to_node + 1] = true
         end
     end
 
-    delete!(orphans, 0) # the uber node has no incoming edges by construction
-
-    isempty(orphans) ||
+    if !all(has_incoming)
+        orphans = findall(!, has_incoming) .- 1 # C and JSON use 0-based indexing
         error("malformed snapshot `$(in_prefix)`: $(length(orphans)) of $(length(nodes)) nodes have no incoming edges: ",
               join(Iterators.take(orphans, 10), ", "), length(orphans) > 10 ? ", ..." : "")
+    end
 
     _digits_buf = zeros(UInt8, ndigits(typemax(UInt)))
     println(io, @view(preamble[1:end-1]), ",") # remove trailing "}" to reopen the object

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -76,6 +76,20 @@ let _dec_d100 = UInt16[(0x30 + i % 10) << 0x8 + (0x30 + i ÷ 10) for i = 0:99]
     end
 end
 
+const k_output_chunk_bytes = 1 << 20
+
+# Hand the buffered output over to `io` once at least `limit` bytes have accumulated,
+# reusing the buffer. Pass `limit = 0` to flush what's left.
+function _maybe_flush(io::IO, buf::IOBuffer, limit::Int = k_output_chunk_bytes)
+    n = position(buf)
+    if n >= limit
+        GC.@preserve buf unsafe_write(io, pointer(buf.data), n)
+        truncate(buf, 0)
+        seekstart(buf)
+    end
+    return nothing
+end
+
 """
     assemble_snapshot(in_prefix::AbstractString, out_file::AbstractString = in_prefix)
 
@@ -186,50 +200,55 @@ function assemble_snapshot(in_prefix, io::IO)
     end
 
     _digits_buf = zeros(UInt8, ndigits(typemax(UInt)))
-    println(io, @view(preamble[1:end-1]), ",") # remove trailing "}" to reopen the object
+    # the snapshot is emitted a field at a time, and a write to an `IOStream` takes a
+    # lock and enters the runtime, so batch the output and hand it to `io` in chunks
+    out = IOBuffer(sizehint = k_output_chunk_bytes)
+    println(out, @view(preamble[1:end-1]), ",") # remove trailing "}" to reopen the object
 
-    println(io, "\"nodes\":[")
+    println(out, "\"nodes\":[")
     for i in 1:length(nodes)
-        i > 1 && println(io, ",")
-        _write_decimal_number(io, nodes.type[i], _digits_buf)
-        print(io, ",")
-        _write_decimal_number(io, nodes.name_idx[i], _digits_buf)
-        print(io, ",")
-        _write_decimal_number(io, nodes.id[i], _digits_buf)
-        print(io, ",")
-        _write_decimal_number(io, nodes.self_size[i], _digits_buf)
-        print(io, ",")
-        _write_decimal_number(io, nodes.edge_count[i], _digits_buf)
-        print(io, ",0,0")
+        i > 1 && println(out, ",")
+        _write_decimal_number(out, nodes.type[i], _digits_buf)
+        print(out, ",")
+        _write_decimal_number(out, nodes.name_idx[i], _digits_buf)
+        print(out, ",")
+        _write_decimal_number(out, nodes.id[i], _digits_buf)
+        print(out, ",")
+        _write_decimal_number(out, nodes.self_size[i], _digits_buf)
+        print(out, ",")
+        _write_decimal_number(out, nodes.edge_count[i], _digits_buf)
+        print(out, ",0,0")
+        _maybe_flush(io, out)
     end
-    print(io, "],\n")
-    print(io, "\"edges\":[")
+    print(out, "],\n")
+    print(out, "\"edges\":[")
     i = 1
     for n in 1:length(nodes)
         for _ in 1:nodes.edge_count[n]
-            i > 1 && print(io, ",")
-            println(io)
-            _write_decimal_number(io, nodes.edges.type[i], _digits_buf)
-            print(io, ",")
-            _write_decimal_number(io, nodes.edges.name_or_index[i], _digits_buf)
-            print(io, ",")
-            _write_decimal_number(io, nodes.edges.to_pos[i], _digits_buf)
+            i > 1 && print(out, ",")
+            println(out)
+            _write_decimal_number(out, nodes.edges.type[i], _digits_buf)
+            print(out, ",")
+            _write_decimal_number(out, nodes.edges.name_or_index[i], _digits_buf)
+            print(out, ",")
+            _write_decimal_number(out, nodes.edges.to_pos[i], _digits_buf)
             if !(nodes.edges.to_pos[i] % k_node_number_of_fields == 0)
                 @warn "Bug in to_pos for edge $i from node $n: $(nodes.edges.to_pos[i])"
             end
             i += 1
+            _maybe_flush(io, out)
         end
     end
-    println(io, "],")
+    println(out, "],")
 
     # not used. Required by microsoft/vscode-v8-heap-tools
     # This order of these fields is required by chrome dev tools otherwise loading fails
-    println(io, "\"trace_function_infos\":[],")
-    println(io, "\"trace_tree\":[],")
-    println(io, "\"samples\":[],")
-    println(io, "\"locations\":[],")
+    println(out, "\"trace_function_infos\":[],")
+    println(out, "\"trace_tree\":[],")
+    println(out, "\"samples\":[],")
+    println(out, "\"locations\":[],")
 
-    println(io, "\"strings\":[")
+    println(out, "\"strings\":[")
     let strings_io = IOBuffer(read(string(in_prefix, ".strings")))
         first = true
         while !eof(strings_io)
@@ -241,12 +260,14 @@ function assemble_snapshot(in_prefix, io::IO)
             if first
                 first = false
             else
-                print(io, ",\n")
+                print(out, ",\n")
             end
-            print_str_escape_json(io, str)
+            print_str_escape_json(out, str)
+            _maybe_flush(io, out)
         end
     end
-    print(io, "]}")
+    print(out, "]}")
+    _maybe_flush(io, out, 0)
 
     return nothing
 end

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -80,6 +80,25 @@ test_profile()
 close(ch)
 test_has_task_profiler_sample_in_buffer()
 
+@testset "Profile.print() groupby options on a task profile" begin
+    data, lidict = Profile.retrieve()
+    # the task profiler records -1 as the thread id of a task that isn't running on
+    # one, which the grouped report has to tolerate
+    @test any(eachindex(data)) do i
+        Profile.is_block_end(data, i) &&
+            data[i - Profile.META_OFFSET_THREADID] == reinterpret(UInt, -1)
+    end
+    iobuf = IOBuffer()
+    with_logger(NullLogger()) do
+        @testset for format in [:flat, :tree]
+            @testset for groupby in Any[:none, :thread, :task, [:thread, :task], [:task, :thread]]
+                Profile.print(iobuf, data, lidict; groupby, format)
+                @test !isempty(String(take!(iobuf)))
+            end
+        end
+    end
+end
+
 Profile.clear()
 
 @profile busywait(1, 20)


### PR DESCRIPTION
Performance improvements to profile report generation, the allocation profiler, and heap snapshot assembly.

Claude:

---

## Benchmarks

> [!IMPORTANT]  
> The `Profile.Allocs.@profile` speedup is overstated here because #62449 introduced the regression it fixed. See [correction comment below](https://github.com/JuliaLang/julia/pull/62473#issuecomment-5154713354)

Measured against nightly `1.14.0-DEV.2779` (= master `5621f8ed44`) on macOS/Apple silicon.

### CPU profile report generation (4 threads)

| Benchmark | nightly | this PR | speedup |
|---|---|---|---|
| `Profile.print(format=:flat)`, 228k samples | 0.053s | 0.031s | **1.7x** |
| `Profile.print(groupby=:task)`, walltime profile of 200 tasks | 0.236s | 0.087s | **2.7x** |

The grouped-printing speedup grows with the number of groups × buffer size.

### Allocation profiler (8 threads)

| Benchmark | nightly | this PR | speedup |
|---|---|---|---|
| recording: 16M allocations at `sample_rate=1e-4` | 3.99s | 0.068s | **~59x** |
| ↳ same, as a ratio to the unprofiled workload | 85x slower | 1.5x slower | |
| `Allocs.fetch()` decode, 420k samples | 0.571s, 1.30 GiB | 0.470s, 1.11 GiB | **1.2x** |
| `Allocs.print(format=:flat)`, 420k samples | 0.412s | 0.238s | **1.7x** |

The recording figure combines the striped recorder counter and the earlier sampling draw
(master has neither). It is the fast path — the allocations that are *not* sampled — that
improves; at high sample rates the backtrace unwinding of the sampled allocations dominates
and the difference is small.

### Heap snapshot assembly

| Benchmark | nightly | this PR | speedup |
|---|---|---|---|
| `assemble_snapshot`, 132 MiB of parts | 1.41s, 377 MiB allocated | 0.45s, 319 MiB allocated | **3.1x** |
| `assemble_snapshot`, 1.26 GiB of parts → 1.21 GiB output | 15.1s | 8.6s | **1.8x** |

At the larger size, writing the 1.2 GiB of output to disk is a growing share of the remaining
time, so the ratio is lower than for the smaller snapshot.

## CPU profile report generation

- **Partition data once for grouped printing.** `Profile.print` with `groupby` reran
  `tree!`/`parse_flat` (and `get_task_ids`/`get_thread_ids`) over the entire buffer for every
  group, making grouped reports O(groups × samples). The blocks and their (threadid, taskid)
  metadata are now collected in a single pass and each group receives a buffer assembled from
  just its own blocks.
- **Generation counters in `parse_flat`.** Recursion dedup within a sample used a
  `Set{StackFrame}`, paying a StackFrame hash per frame per sample; an integer generation check
  with an O(1) per-sample reset replaces it.
- **Fix: don't convert the task profiler's -1 thread id.** The single-pass partitioning above
  converted every block's thread id to `Int`, which throws an `InexactError` on data from
  `@profile_walltime`, where a task that isn't currently running on a thread is recorded with a
  thread id of -1. The stored word is now reinterpreted, so those blocks are filtered out by the
  `threads` selector exactly as they were before. Caught while benchmarking this PR; the
  existing `groupby` tests only covered `@profile` data, so a regression test over a walltime
  profile is included.

## Allocation profiler

### Recording

- **Arena-allocate recorded backtraces.** Each sample `malloc`'d an exact-size copy of its
  backtrace; copies are now bump-allocated from per-thread arena blocks, freed all at once in
  `jl_free_alloc_profile`.
- **Stripe the recorder counter.** Every recording thread performed two seq_cst `fetch_add`s on
  the single shared counter added by #62449, bouncing its cache line across cores under heavy
  multithreaded allocation. The counter is now striped over cache-line-padded slots indexed by
  tid; the stop-side synchronization argument is unchanged, applied per stripe.
- **Draw the sample before joining the recorder count.** Those two atomics were paid by *every*
  allocation, before the sampling decision was made, so at the default rate nine out of ten of
  them were pure overhead. The sampling draw only touches the thread-local RNG, so it now
  happens first and the recorder count covers just the recording itself. This does read
  `sample_rate` outside the recorder guard; it is only written while the profiler is stopped, so
  at worst a concurrent restart has one allocation sampled at the previous rate, which the
  following flag check discards anyway.

### Decoding and reporting

- **Parallel symbol lookup when decoding.** `Profile.Allocs.fetch` looked up every instruction
  pointer serially; it now looks up the unique ips on all threads, the same approach
  `Profile.getdict!` already uses. As with `getdict!`, repeated warm fetches pay a few ms of lock
  contention; the cold first fetch after profiling is the case that matters.
- **Decode backtraces through a reused buffer.** Decoding materialized a separate vector for
  every sample's backtrace and held them all alive to collect the distinct ips before building
  the stack traces — a lot of short-lived memory at high sample rates. Both passes now decode
  into one reused buffer, and the result vector is preallocated.
- **Generation counters in `Allocs.parse_flat`**, the same change as for the CPU profile's
  `parse_flat`.

## Heap snapshot assembly

- **Read the part files into memory before parsing.** `assemble_snapshot` parsed the streamed
  parts field-at-a-time from an `IOStream` (6 reads per node, 4 per edge, each paying per-call
  locking overhead); they are now read into an `IOBuffer` up front.
- **Group edges by source node instead of per-node index vectors.** Assembly allocated one
  `Vector{UInt}` per node to hold that node's outgoing edge indices and grew each by `push!` —
  a heap object plus repeated reallocation per node, and the bulk of the memory use on large
  snapshots. A first pass now counts the edges leaving each node and the second stores each edge
  directly at its position within its source node's group, which is the order the format
  requires them to be emitted in anyway, so no index vectors are needed at all.
- **Track orphan nodes with a bit vector.** Checking that every node has an incoming edge
  inserted each node index into a hash set and then did a lookup and a delete per edge; it is now
  one bit per node and one store per edge, with the offending nodes collected only on failure.
- **Buffer the output.** Emission wrote every field with its own call on the output stream, about
  eleven per node and seven per edge, each taking the stream lock and entering the runtime.
  Output is now accumulated and handed over in 1 MiB chunks.
- **Escape strings in runs.** `print_str_escape_json` issued one write per character of every
  string in the snapshot; stretches needing no escaping are now a single substring write.
- **Fix the element type of the edge counts.** The `Nodes` field was declared `Vector{UInt}`
  while the constructor passed a `Vector{UInt32}`, so every snapshot silently converted the
  array, allocating and copying a second full-length vector.

Two malformed-input cases that were previously a `BoundsError` or a silent skip are now reported
as errors: an `.edges` file whose length doesn't match the edge count in the metadata, and a
`to_node` outside the node range.

## Notes

Output of `assemble_snapshot` is byte-identical to master's on the snapshots tested.