### PR TITLE
strings: fast path for `String` conversion of dense StringViews

### DIFF
--- a/base/strings/stringview.jl
+++ b/base/strings/stringview.jl
@@ -23,6 +23,8 @@ pointer(x::SubString{<:DenseStringView}, i::Integer) = pointer(x.string) + x.off
 unsafe_convert(::Type{Ptr{UInt8}}, s::DenseStringViewAndSub) = pointer(s)
 unsafe_convert(::Type{Ptr{Int8}}, s::DenseStringViewAndSub) = convert(Ptr{Int8}, pointer(s))
 
+String(s::DenseStringViewAndSub) = GC.@preserve s unsafe_string(pointer(s), ncodeunits(s))
+
 cconvert(::Type{Ptr{UInt8}}, s::DenseStringViewAndSub) = s
 cconvert(::Type{Ptr{Int8}}, s::DenseStringViewAndSub) = s
 


### PR DESCRIPTION
The generic method copies through `StringVector` + `copyto!`, which for
dense (pointer-backed) views is much slower than a direct `unsafe_string`
memcpy: ~4x for short strings.

```julia-repl
julia> using BenchmarkTools

julia> old_String(s) = String(copyto!(Base.StringVector(ncodeunits(s)), codeunits(s)));

julia> new_String(s) = GC.@preserve s unsafe_string(pointer(s), ncodeunits(s));

julia> ss = SubString(StringView(rand(UInt8('a'):UInt8('z'), 38)), 2, 37);  # 36 bytes, uuid-sized

julia> @btime old_String($ss);
  22.231 ns (3 allocations: 128 bytes)

julia> @btime new_String($ss);
  4.738 ns (1 allocation: 64 bytes)
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
