### PR TITLE
deprecate fld1, fldmod1 for cld, cldmod1

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -706,8 +706,4 @@ function setindex!(x::Threads.Atomic, v)
     return @atomic x[] = v
 end
 
-# fld1 == cld for integers, and randomly rounds up or down for floats.
-@deprecate fldmod1 cldmod1
-@deprecate fld1 cld
-
 # END 1.14 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -706,4 +706,8 @@ function setindex!(x::Threads.Atomic, v)
     return @atomic x[] = v
 end
 
+# fld1 == cld for integers, and randomly rounds up or down for floats.
+@deprecate fldmod1 cldmod1
+@deprecate fld1 cld
+
 # END 1.14 deprecations

--- a/base/div.jl
+++ b/base/div.jl
@@ -92,16 +92,16 @@ without any intermediate rounding.
 - if `r == RoundToZero` (default), then the result is exact, and in the interval
   ``[0, |y|)`` if `x` is positive, or ``(-|y|, 0]`` otherwise. See also [`RoundToZero`](@ref).
 
-- if `r == RoundDown`, then the result is in the interval ``[0, y)`` if `y` is positive, or
-  ``(y, 0]`` otherwise. The result may not be exact if `x` and `y` have different signs, and
+- if `r == RoundDown`, then the result is in the interval ``[0, |y|)`` if `y` is positive, or
+  ``(-|y|, 0]`` otherwise. The result may not be exact if `x` and `y` have different signs, and
   `abs(x) < abs(y)`. See also [`RoundDown`](@ref).
 
-- if `r == RoundUp`, then the result is in the interval ``(-y, 0]`` if `y` is positive, or
-  ``[0, -y)`` otherwise. The result may not be exact if `x` and `y` have the same sign, and
+- if `r == RoundUp`, then the result is in the interval ``(-|y|, 0]`` if `y` is positive, or
+  ``[0, |y|)`` otherwise. The result may not be exact if `x` and `y` have the same sign, and
   `abs(x) < abs(y)`. See also [`RoundUp`](@ref).
 
-- if `r == RoundFromZero`, then the result is in the interval ``(-y, 0]`` if `y` is positive, or
-  ``[0, -y)`` otherwise. The result may not be exact if `x` and `y` have the same sign, and
+- if `r == RoundFromZero`, then the result is in the interval ``(-|y|, 0]`` if `x` is positive, or
+  ``[0, |y|)`` otherwise. The result may not be exact if `x` and `y` have the same sign, and
   `abs(x) < abs(y)`. See also [`RoundFromZero`](@ref).
 
 !!! compat "Julia 1.9"
@@ -153,7 +153,7 @@ end
 
 Largest integer less than or equal to `x / y`. Equivalent to `div(x, y, RoundDown)`.
 
-See also [`div`](@ref), [`cld`](@ref), [`fld1`](@ref).
+See also [`div`](@ref), [`cld`](@ref), [`mod`](@ref), [`fldmod`](@ref).
 
 # Examples
 ```jldoctest
@@ -200,7 +200,7 @@ fld(a, b) = div(a, b, RoundDown)
 
 Smallest integer larger than or equal to `x / y`. Equivalent to `div(x, y, RoundUp)`.
 
-See also [`div`](@ref), [`fld`](@ref).
+See also [`div`](@ref), [`fld`](@ref), [`mod1`](@ref), [`cldmod1`](@ref).
 
 # Examples
 ```jldoctest
@@ -250,7 +250,7 @@ The quotient and remainder from Euclidean division.
 Equivalent to `(div(x, y, r), rem(x, y, r))`. Equivalently, with the default
 value of `r`, this call is equivalent to `(x ÷ y, x % y)`.
 
-See also [`fldmod`](@ref), [`cld`](@ref).
+See also [`fldmod`](@ref), [`cldmod1`](@ref), [`div`](@ref), [`rem`](@ref).
 
 # Examples
 ```jldoctest
@@ -373,7 +373,7 @@ end
 The floored quotient and modulus after division. A convenience wrapper for
 `divrem(x, y, RoundDown)`. Equivalent to `(fld(x, y), mod(x, y))`.
 
-See also [`fld`](@ref), [`cld`](@ref), [`fldmod1`](@ref).
+See also [`fld`](@ref), [`mod`](@ref), [`divrem`](@ref), [`cldmod1`](@ref).
 """
 fldmod(x, y) = divrem(x, y, RoundDown)
 

--- a/base/div.jl
+++ b/base/div.jl
@@ -242,6 +242,15 @@ julia> cld.(-5:5, 3)'
 """
 cld(a, b) = div(a, b, RoundUp)
 
+"""
+    fld1(a, b)
+
+Legacy spelling of `cld(a, b)` for integers.
+
+See also [`cld`](@ref).
+"""
+fld1(a, b) = cld(a, b)
+
 # divrem
 """
     divrem(x, y, r::RoundingMode=RoundToZero)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -324,6 +324,7 @@ export
     fld1,
     fldmod,
     fldmod1,
+    cldmod1,
     flipsign,
     float,
     tryparse,

--- a/base/int.jl
+++ b/base/int.jl
@@ -304,7 +304,7 @@ exceptions, see note below).
     type, and so rounding error may occur. In particular, if the exact result is very
     close to `y`, then it may be rounded to `y`.
 
-See also: [`rem`](@ref), [`div`](@ref), [`fld`](@ref), [`mod1`](@ref), [`invmod`](@ref).
+See also: [`rem`](@ref), [`fld`](@ref), [`mod1`](@ref), [`fldmod`](@ref), [`invmod`](@ref).
 
 ```jldoctest
 julia> mod(8, 3)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -870,67 +870,59 @@ const ÷ = div
 """
     mod1(x, y)
 
-Modulus after flooring division, returning a value `r` such that `mod(r, y) == mod(x, y)`
-in the range ``(0, y]`` for positive `y` and in the range ``[y,0)`` for negative `y`.
+Equivalent to `rem(x, y, RoundUp) + x*sign(y)`. Returns a value in the range
+``(0, y]`` for positive `y` and ``[-|y|,0)`` for negative `y`.
 
-With integer arguments and positive `y`, this is equal to `mod(x, 1:y)`, and hence natural
-for 1-based indexing. By comparison, `mod(x, y) == mod(x, 0:y-1)` is natural for computations with
-offsets or strides.
+With integer arguments and positive `y`, this is equal to `mod(x, 1:y)`, and hence natural for
+1-based indexing. By comparison, `mod(x, y) == mod(x, 0:y-1)` is natural for 0-based indexing.
 
-See also [`mod`](@ref), [`fld1`](@ref), [`fldmod1`](@ref).
+See also [`rem`](@ref), [`mod`](@ref), [`cld`](@ref), [`cldmod1`](@ref).
 
 # Examples
 ```jldoctest
 julia> mod1(4, 2)
 2
 
-julia> mod1.(-5:5, 3)'
-1×11 adjoint(::Vector{Int64}) with eltype Int64:
- 1  2  3  1  2  3  1  2  3  1  2
+julia> [-7:7  mod1.(-7:7, 3)]'
+2×15 adjoint(::Matrix{Int64}) with eltype Int64:
+ -7  -6  -5  -4  -3  -2  -1  0  1  2  3  4  5  6  7
+  2   3   1   2   3   1   2  3  1  2  3  1  2  3  1
 
-julia> mod1.([-0.1, 0, 0.1, 1, 2, 2.9, 3, 3.1]', 3)
+julia> mod1.([-0.1  0  0.1  1  2  2.9  3  3.1], 3)
 1×8 Matrix{Float64}:
  2.9  3.0  0.1  1.0  2.0  2.9  3.0  0.1
 ```
 """
-mod1(x::T, y::T) where {T<:Real} = (m = mod(x, y); ifelse(m == 0, y, m))
+mod1(x::T, y::T) where {T<:Real} = (m = mod(x, y); iszero(m) ? y : m)
 
 
 """
-    fld1(x, y)
+    cldmod1(x, y)
 
-Flooring division, returning a value consistent with `mod1(x,y)`
+Return `(cld(x,y), mod1(x,y))`. For positive integer inputs, this is the (col, row) index
+of the xᵗʰ element in a column major matrix with y rows.
 
-See also [`mod1`](@ref), [`fldmod1`](@ref).
+See also [`cld`](@ref), [`mod1`](@ref), [`divrem`](@ref), [`fldmod`](@ref).
 
 # Examples
 ```jldoctest
-julia> x = 15; y = 4;
+julia> col, row = cldmod1(20, 6)
+(4, 2)
 
-julia> fld1(x, y)
-4
-
-julia> x == fld(x, y) * y + mod(x, y)
+julia> 20 == (col - 1) * 6 + row
 true
 
-julia> x == (fld1(x, y) - 1) * y + mod1(x, y)
-true
+julia> reshape(1:36, 6, 6)
+6×6 reshape(::UnitRange{Int64}, 6, 6) with eltype Int64:
+ 1   7  13  19  25  31
+ 2   8  14  20  26  32
+ 3   9  15  21  27  33
+ 4  10  16  22  28  34
+ 5  11  17  23  29  35
+ 6  12  18  24  30  36
 ```
 """
-fld1(x::T, y::T) where {T<:Real} = (m = mod1(x, y); fld((x - m) + y, y))
-function fld1(x::T, y::T) where T<:Integer
-    d = div(x, y)
-    return d + (!signbit(x ⊻ y) & (d * y != x))
-end
-
-"""
-    fldmod1(x, y)
-
-Return `(fld1(x,y), mod1(x,y))`.
-
-See also [`fld1`](@ref), [`mod1`](@ref).
-"""
-fldmod1(x, y) = (fld1(x, y), mod1(x, y))
+cldmod1(x, y) = (cld(x, y), mod1(x, y))
 
 
 """

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -924,6 +924,14 @@ julia> reshape(1:36, 6, 6)
 """
 cldmod1(x, y) = (cld(x, y), mod1(x, y))
 
+"""
+    fldmod1(x, y)
+
+Legacy spelling of `cldmod1(x, y)` for integers.
+
+See also [`cldmod1`](@ref).
+"""
+fldmod1(x, y) = cldmod1(x, y)
 
 """
     widen(x)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -519,9 +519,7 @@ end
 
 rem(x::Real, y::Real) = rem(promote(x,y)...)
 mod(x::Real, y::Real) = mod(promote(x,y)...)
-
 mod1(x::Real, y::Real) = mod1(promote(x,y)...)
-fld1(x::Real, y::Real) = fld1(promote(x,y)...)
 
 max(x::Real, y::Real) = max(promote(x,y)...)
 min(x::Real, y::Real) = min(promote(x,y)...)

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -17,16 +17,15 @@ Base.div
 Base.div(::Any, ::Any, ::RoundingMode)
 Base.fld
 Base.cld
-Base.mod
 Base.rem
 Base.rem(::Any, ::Any, ::RoundingMode)
 Base.rem2pi
+Base.mod
 Base.Math.mod2pi
+Base.mod1
 Base.divrem
 Base.fldmod
-Base.fld1
-Base.mod1
-Base.fldmod1
+Base.cldmod1
 Base.:(//)
 Base.rationalize
 Base.numerator

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2448,10 +2448,10 @@ let x = big(-0.0)
     @test signbit(x) && !signbit(abs(x))
 end
 
-@testset "mod1 and fld1" begin
+@testset "mod1 and cld" begin
     @test all(x -> (m=mod1(x,3); 0<m<=3), -5:+5)
-    @test all(x -> x == (fld1(x,3)-1)*3 + mod1(x,3), -5:+5)
-    @test all(x -> fldmod1(x,3) == (fld1(x,3), mod1(x,3)), -5:+5)
+    @test all(x -> x == (cld(x,3)-1)*3 + mod1(x,3), -5:+5)
+    @test all(x -> cldmod1(x,3) == (cld(x,3), mod1(x,3)), -5:+5)
 end
 #Issue #5570
 @test map(x -> Int(mod1(UInt(x),UInt(5))), 0:15) == [5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5]

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -251,7 +251,7 @@ Base.:(<)(x::TypeWrapper, y::TypeWrapper) = (x.t <: y.t) & (x.t != y.t)
 end
 
 # issue #20355
-@testset "mod1, fld1" begin
+@testset "mod1, cld" begin
     for T in [Int8, Int16, Int32, Int64],
         x in T[typemin(T); typemin(T) + 1; -10:10; typemax(T)-1; typemax(T)],
         y in T[typemin(T); typemin(T) + 1; -10:-1; 1:10; typemax(T)-1; typemax(T)]
@@ -264,9 +264,9 @@ end
             @test y <= m < 0
         end
         if x == typemin(T) && y == -1
-            @test_throws DivideError fld1(x, y)
+            @test_throws DivideError cld(x, y)
         else
-            f = fld1(x, y)
+            f = cld(x, y)
             @test (f - 1) * y + m == x
         end
     end
@@ -278,7 +278,7 @@ end
         m = mod1(x, y)
         @test mod(x, y) == mod(m, y)
         @test 0 < m <= y
-        f = fld1(x, y)
+        f = cld(x, y)
         @test (f - 1) * y + m == x
     end
 
@@ -293,14 +293,14 @@ end
         else
             @test y <= m < 0
         end
-        f = fld1(x, y)
+        f = cld(x, y)
         @test (f - 1) * y + m == x
     end
 
-    @test fldmod1(4.0, 3) == fldmod1(4, 3)
+    @test cldmod1(4.0, 3) == cldmod1(4, 3)
 
     # issue 28973
-    @test fld1(0.4, 0.9) == fld1(nextfloat(0.4), 0.9) == 1.0
+    @test cld(0.4, 0.9) == cld(nextfloat(0.4), 0.9) == 1.0
 end
 
 @testset "Fix12" begin


### PR DESCRIPTION
`fld1` is identical to `cld` for integer inputs, and is essentially random for non-integer inputs. this deprecates its use. also cleans up related docs a bit
fixes #62426