### PR TITLE
recognize Tuple and AbstractVector as Ordered in Base.OrderStyle

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3123,6 +3123,8 @@ their starting indices, and then lexicographically by their elements.
 """
 isless(A::AbstractVector, B::AbstractVector) = cmp(A, B) < 0
 
+OrderStyle(::Type{<:AbstractVector{T}}) where {T} = OrderStyle(T)
+
 function (==)(A::AbstractArray, B::AbstractArray)
     if axes(A) != axes(B)
         return false

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -13,6 +13,13 @@ OrderStyle(::Type{Symbol}) = Ordered()
 OrderStyle(::Type{<:Any}) = Unordered()
 OrderStyle(::Type{Union{}}, slurp...) = Ordered()
 
+OrderStyle(T::Type{<:Tuple}) = _tuple_ordering(T)
+
+_tuple_ordering(::Type{Tuple{}}) = Ordered()
+function _tuple_ordering(T::Type{<:Tuple})
+    OrderStyle(fieldtype(T,1)) === Ordered() ? _tuple_ordering(Tuple{tail(fieldtypes(T))...}) : Unordered()
+end
+
 # trait for objects that support arithmetic
 abstract type ArithmeticStyle end
 struct ArithmeticRounds <: ArithmeticStyle end     # least significant bits can be lost

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -13,11 +13,9 @@ OrderStyle(::Type{Symbol}) = Ordered()
 OrderStyle(::Type{<:Any}) = Unordered()
 OrderStyle(::Type{Union{}}, slurp...) = Ordered()
 
-OrderStyle(T::Type{<:Tuple}) = _tuple_ordering(T)
-
-_tuple_ordering(::Type{Tuple{}}) = Ordered()
-function _tuple_ordering(T::Type{<:Tuple})
-    OrderStyle(fieldtype(T,1)) === Ordered() ? _tuple_ordering(Tuple{tail(fieldtypes(T))...}) : Unordered()
+function OrderStyle(T::Type{<:Tuple})
+    isconcretetype(T) || return Unordered()
+    all(map(S -> OrderStyle(S) === Ordered(), fieldtypes(T))) ? Ordered() : Unordered() # map() allows compiler to evaluate each fieldtype at compile time
 end
 
 # trait for objects that support arithmetic

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -15,7 +15,7 @@ OrderStyle(::Type{Union{}}, slurp...) = Ordered()
 
 function OrderStyle(T::Type{<:Tuple})
     isconcretetype(T) || return Unordered()
-    all(map(S -> OrderStyle(S) === Ordered(), fieldtypes(T))) ? Ordered() : Unordered() # map() allows compiler to evaluate each fieldtype at compile time
+    all(map(S -> OrderStyle(S) === Ordered(), fieldtypes(T))) ? Ordered() : Unordered()
 end
 
 # trait for objects that support arithmetic


### PR DESCRIPTION
As mentioned in issue #61959 `unique!` and `allunique` have a sorted fast path method gated on `Base.OrderStyle`, but the trait only  applies to a short, obvious list(Real, AbstractString, Symbol and Union{}), leaving the fast path unreachable for any other valid case. Since Tuples and Vectors both famously have a total ordering which satisfies the contiguous requirement of `unique!` they should be included

Added:
- `OrderStyle(::Type{<:AbstractVector{T}})` : vector is Ordered iff T is 
- _tuple_ordering() : Recursively checks that every field type is Ordered
```
julia> b = @be sort!([(rand(1:20), rand(1:20)) for _ in 1:100]) unique!
Benchmark: 4523 samples with 6 evaluations
 min    1.100 μs (11 allocs: 5.981 KiB)
 median 1.400 μs (11 allocs: 5.999 KiB)
 mean   2.611 μs (11 allocs: 5.999 KiB, 0.19% gc time)
 max    538.167 μs (11 allocs: 6.015 KiB, 99.52% gc time)
 ```
```
 julia> b = @be sort!([(rand(1:20), rand(1:20)) for _ in 1:100]) unique!
Benchmark: 2390 samples with 337 evaluations
 min    76.558 ns
 median 88.131 ns
 mean   88.775 ns
 max    359.644 ns
```
The original issue also mentioned CartesianIndex and other user defined types that simply wrap tuples/vectors but I'd like maintainer input before tackling that 