### PR TITLE
Consistent field access functions by supporting `Integer` indices

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -89,6 +89,7 @@ const setproperty! = Core.setfield!
 const swapproperty! = Core.swapfield!
 const modifyproperty! = Core.modifyfield!
 const replaceproperty! = Core.replacefield!
+const fieldtype = Core._fieldtype
 const _DOCS_ALIASING_WARNING = ""
 
 ccall(:jl_set_istopmod, Cvoid, (Any, Bool), Compiler, false)

--- a/NEWS.md
+++ b/NEWS.md
@@ -122,6 +122,9 @@ New library features
   along with the type of the entries in a vector of new `DirEntry` objects to provide more efficient `isfile`
   etc. checks. `readdir(::DirEntry)` accepts a `DirEntry` as input and, like `readdir(::AbstractString)`,
   returns a `Vector{String}` of names. `DirEntry` is exported from `Base` ([#55358]).
+* Field-reflection functions now accept any `Integer` field index in addition to an `Int` or `Symbol`,
+  so a field can be selected by a non-`Int` index such as a `UInt8`. This applies to `fieldtype`,
+  `isconst`, `isfieldatomic`, and to `getproperty`/`setproperty!` on tuples.
 
 Standard library changes
 ------------------------

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -55,6 +55,9 @@ setproperty!(x::Array, f::Symbol, v) = error("setfield! fields of Array should n
 getproperty(x::Tuple, f::Int) = (@inline; getfield(x, f))
 setproperty!(x::Tuple, f::Int, v) = setfield!(x, f, v) # to get a decent error
 
+getproperty(x::Tuple, f::Integer) = (@inline; getfield(x, Int(f)))
+setproperty!(x::Tuple, f::Integer, v) = setfield!(x, Int(f), v) # to get a decent error
+
 getproperty(x, f::Symbol) = (@inline; getfield(x, f))
 function setproperty!(x, f::Symbol, v)
     ty = fieldtype(typeof(x), f)
@@ -78,6 +81,9 @@ getproperty(x::Type, f::Symbol, order::Symbol) = (@inline; getfield(x, f, order)
 setproperty!(x::Type, f::Symbol, v, order::Symbol) = error("setfield! fields of Types should not be changed")
 getproperty(x::Tuple, f::Int, order::Symbol) = (@inline; getfield(x, f, order))
 setproperty!(x::Tuple, f::Int, v, order::Symbol) = setfield!(x, f, v, order) # to get a decent error
+
+getproperty(x::Tuple, f::Integer, order::Symbol) = (@inline; getfield(x, Int(f), order))
+setproperty!(x::Tuple, f::Integer, v, order::Symbol) = setfield!(x, Int(f), v, order) # to get a decent error
 
 getproperty(x, f::Symbol, order::Symbol) = (@inline; getfield(x, f, order))
 function setproperty!(x, f::Symbol, v, order::Symbol)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -381,6 +381,13 @@ unsafe_convert(::Type{T}, x::T) where {T} = x
 # will be inserted by the frontend for closures
 _typeof_captured_variable(@nospecialize t) = (@_total_meta; t isa Type && has_free_typevars(t) ? typeof(t) : Typeof(t))
 
+# `fieldtype` is a wrapper around the `_fieldtype` builtin so that any `Integer`
+# field index is accepted (the builtin only accepts `Int` or `Symbol`).
+fieldtype(@nospecialize(t), name::Symbol) = (@_foldable_meta; _fieldtype(t, name))
+fieldtype(@nospecialize(t), i::Integer) = (@_foldable_meta; _fieldtype(t, Int(i)))
+fieldtype(@nospecialize(t), name::Symbol, boundscheck::Bool) = (@_foldable_meta; _fieldtype(t, name, boundscheck))
+fieldtype(@nospecialize(t), i::Integer, boundscheck::Bool) = (@_foldable_meta; _fieldtype(t, Int(i), boundscheck))
+
 # dispatch token indicating a kwarg (keyword sorter) call
 function kwcall end
 # deprecated internal functions:

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -509,7 +509,7 @@ function isconst(g::GlobalRef)
 end
 
 """
-    isconst(t::DataType, s::Union{Int,Symbol})::Bool
+    isconst(t::DataType, s::Union{Integer,Symbol})::Bool
 
 Determine whether a field `s` is const in a given type `t`
 in the sense that a read from said field is consistent
@@ -523,8 +523,9 @@ function isconst(@nospecialize(t::Type), s::Symbol)
     isa(t, DataType) || return false
     return isconst(t, fieldindex(t, s, false))
 end
-function isconst(@nospecialize(t::Type), s::Int)
+function isconst(@nospecialize(t::Type), s::Integer)
     @_foldable_meta
+    s = Int(s)
     t = unwrap_unionall(t)
     # TODO: what to do for `Union`?
     isa(t, DataType) || return false # uncertain

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -538,7 +538,7 @@ function isconst(@nospecialize(t::Type), s::Integer)
 end
 
 """
-    isfieldatomic(t::DataType, s::Union{Int,Symbol})::Bool
+    isfieldatomic(t::DataType, s::Union{Integer,Symbol})::Bool
 
 Determine whether a field `s` is declared `@atomic` in a given type `t`.
 """
@@ -548,8 +548,9 @@ function isfieldatomic(@nospecialize(t::Type), s::Symbol)
     isa(t, DataType) || return false
     return isfieldatomic(t, fieldindex(t, s, false))
 end
-function isfieldatomic(@nospecialize(t::Type), s::Int)
+function isfieldatomic(@nospecialize(t::Type), s::Integer)
     @_foldable_meta
+    s = Int(s)
     t = unwrap_unionall(t)
     # TODO: what to do for `Union`?
     isa(t, DataType) || return false # uncertain

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1258,7 +1258,7 @@ fieldoffset(x::DataType, idx::Integer) = (@_foldable_meta; ccall(:jl_get_field_o
 fieldoffset(x::DataType, name::Symbol) = fieldoffset(x, fieldindex(x, name))
 
 """
-    fieldtype(T, name::Symbol | index::Int)
+    fieldtype(T, name::Symbol | index::Integer)
 
 Determine the declared type of a field (specified by name or index) in a composite DataType `T`.
 

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -29,7 +29,7 @@ extern "C" {
     XX(compilerbarrier,"compilerbarrier") \
     XX(current_scope,"current_scope") \
     XX(donotdelete,"donotdelete") \
-    XX(fieldtype,"fieldtype") \
+    XX(fieldtype,"_fieldtype") \
     XX(finalizer,"finalizer") \
     XX(get_binding_type,"get_binding_type") \
     XX(getfield,"getfield") \

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -800,7 +800,7 @@
                                                      (if (and (not selftype?) (equal? type-params params) (memq fty params) (memq fty sparams))
                                                       fty ; the field type is a simple parameter, the usage here is of a
                                                           ; local variable (currently just handles sparam) for the bijection of params to type-params
-                                                      `(call (core fieldtype) ,tn ,(+ fld 1)))
+                                                      `(call (core _fieldtype) ,tn ,(+ fld 1)))
                                                       #f
                                                       #f)))))
     (cond ((> (num-non-varargs args) (length field-names))

--- a/test/core.jl
+++ b/test/core.jl
@@ -7952,7 +7952,7 @@ let code = code_lowered(FieldConvert)[1].code
     @test all(is_globalref.(calls[1][2].args[1:3], (GlobalRef(Core, :apply_type), GlobalRef(@__MODULE__, :FieldConvert), GlobalRef(@__MODULE__, :FieldTypeA))))
 
     # calls[2]
-    @test all(is_globalref.(calls[2][2].args[1:1], (GlobalRef(Core, :fieldtype),)))
+    @test all(is_globalref.(calls[2][2].args[1:1], (GlobalRef(Core, :_fieldtype),)))
     @test all(calls[2][2].args[2:3] .== (calls[1][1], 1))
 
     # calls[3] - isa
@@ -7966,7 +7966,7 @@ let code = code_lowered(FieldConvert)[1].code
     end
 
     # calls[5]
-    @test all(is_globalref.(calls[5][2].args[1:1], (GlobalRef(Core, :fieldtype),)))
+    @test all(is_globalref.(calls[5][2].args[1:1], (GlobalRef(Core, :_fieldtype),)))
     @test all(calls[5][2].args[2:3] .== (calls[1][1], 2))
 end
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -530,6 +530,25 @@ tlayout = TLayout(5,7,11)
 @test fieldtype(Union{Tuple{Char},Tuple{Char,Char}},2) === Char
 @test_throws BoundsError fieldtype(Union{Tuple{Char},Tuple{Char,Char}},3)
 
+# field-index queries accept any `Integer`, not just `Int`
+mutable struct IntIdxFields
+    @atomic a::Int
+    const b::Float64
+    c::Int
+end
+@test fieldtype(TLayout, 0x2) === Int16
+@test fieldtype(TLayout, Int8(3)) === Int32
+@test fieldtype(TLayout, big(1)) === Int8
+@test fieldtype(TLayout, UInt(2)) === Int16
+@test fieldtype(Tuple{Vararg{Int8}}, 0x1) === Int8
+@test_throws BoundsError fieldtype(TLayout, 0x0)
+@test Base.isfieldatomic(IntIdxFields, 0x1)
+@test !Base.isfieldatomic(IntIdxFields, UInt8(3))
+@test Base.isfieldatomic(IntIdxFields, big(1))
+@test Base.isconst(IntIdxFields, 0x2)
+@test !Base.isconst(IntIdxFields, Int8(1))
+@test Base.isconst(IntIdxFields, UInt(2))
+
 @test [fieldindex(TLayout, i) for i = (:x, :y, :z)] == [1, 2, 3]
 @test fieldname(TLayout, fieldindex(TLayout, :z)) === :z
 @test fieldindex(TLayout, fieldname(TLayout, 3)) === 3
@@ -705,15 +724,15 @@ test_typed_ir_printing(g15714, Tuple{Vector{Float32}},
 #@test used_dup_var_tested15715
 @test used_unique_var_tested15714
 
-let li = only(methods(fieldtype)).unspecialized,
+let li = only(methods(nfields)).unspecialized,
     lrepr = string(li),
     mrepr = string(li.def),
     lmime = repr("text/plain", li),
     mmime = repr("text/plain", li.def)
 
-    @test lrepr == lmime == "MethodInstance for fieldtype(::Vararg{Any})"
-    @test mrepr == "fieldtype(...) @ Core none:0"       # simple print
-    @test mmime == "fieldtype(...)\n     @ Core none:0" # verbose print
+    @test lrepr == lmime == "MethodInstance for nfields(::Vararg{Any})"
+    @test mrepr == "nfields(...) @ Core none:0"       # simple print
+    @test mmime == "nfields(...)\n     @ Core none:0" # verbose print
 end
 
 # Linfo Tracing test

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -548,6 +548,9 @@ end
 @test Base.isconst(IntIdxFields, 0x2)
 @test !Base.isconst(IntIdxFields, Int8(1))
 @test Base.isconst(IntIdxFields, UInt(2))
+@test getproperty((10, 20, 30), 0x2) === 20
+@test getproperty((10, 20, 30), big(3)) === 30
+@test getproperty((10, 20, 30), Int8(1)) === 10
 
 @test [fieldindex(TLayout, i) for i = (:x, :y, :z)] == [1, 2, 3]
 @test fieldname(TLayout, fieldindex(TLayout, :z)) === :z

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -106,10 +106,10 @@ let src = Meta.lower(Main, quote let x = 1 end end).args[1]::Core.CodeInfo
     repr = string(sf)
     @test repr == "Toplevel MethodInstance thunk at b:3"
 end
-let li = only(methods(fieldtype)).unspecialized,
+let li = only(methods(nfields)).unspecialized,
     sf = StackFrame(:a, :b, 3, li, false, false, 0),
     repr = string(sf)
-    @test repr == "fieldtype(::Vararg{Any}) at b:3"
+    @test repr == "nfields(::Vararg{Any}) at b:3"
 end
 
 let ctestptr = cglobal((:ctest, "libccalltest")),


### PR DESCRIPTION
Currently `fieldname` and `fieldoffset` accept an `Integer` index for selecting the field. For consistency reasons, this PR adds support for `fieldtype`, `isconst`, `isfieldatomic`, `getproperty` and `setproperty`.

Some needed more changes than others, so they are split into different commits, so that they can be decided separately. I can create 4 separate PRs if that is preferred, but it sounded like too much overhead for the discussion to do so.

I used Opus 4.8 while creating the PR.