### PR TITLE
Improve type stability in `compileable_specialization()`

### DIFF
--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -776,7 +776,7 @@ end
 
 function compileable_specialization(code::Union{MethodInstance,CodeInstance}, effects::Effects,
     et::InliningEdgeTracker, @nospecialize(info::CallInfo), state::InliningState)
-    mi = code isa CodeInstance ? code.def : code
+    mi = code isa CodeInstance ? get_ci_mi(code) : code
     mi_invoke = mi
     method, atype, sparams = mi.def::Method, mi.specTypes, mi.sparam_vals
     if OptimizationParams(state.interp).compilesig_invokes
@@ -922,10 +922,10 @@ end
 
 function retrieve_ir_for_inlining(cached_result::CodeInstance, src::String)
     src = _uncompressed_ir(cached_result, src)
-    return inflate_ir!(src, cached_result.def), SpecInfo(src), src.debuginfo
+    return inflate_ir!(src, get_ci_mi(cached_result)), SpecInfo(src), src.debuginfo
 end
 function retrieve_ir_for_inlining(cached_result::CodeInstance, src::CodeInfo)
-    return inflate_ir!(copy(src), cached_result.def), SpecInfo(src), src.debuginfo
+    return inflate_ir!(copy(src), get_ci_mi(cached_result)), SpecInfo(src), src.debuginfo
 end
 function retrieve_ir_for_inlining(mi::MethodInstance, src::CodeInfo, preserve_local_sources::Bool)
     if preserve_local_sources
@@ -1427,7 +1427,7 @@ end
 
 function handle_semi_concrete_result!(cases::Vector{InliningCase}, result::SemiConcreteResult,
     match::MethodMatch, @nospecialize(info::CallInfo), flag::UInt32, state::InliningState)
-    mi = result.edge.def
+    mi = get_ci_mi(result.edge)
     validate_sparams(mi.sparam_vals) || return false
     item = semiconcrete_result_item(result, info, flag, state)
     item === nothing && return false


### PR DESCRIPTION
`CodeInstance.def` is Any so everything downstream of `mi` also got inferred to Any. Should fix these invalidations seen when loading CUDA.jl on 1.13:
```julia
inserting any(f::Function, a::StaticArraysCore.StaticArray; dims) @ StaticArrays ~/.julia/packages/StaticArrays/0cEwi/src/mapreduce.jl:308 invalidated:
   backedges: 1: superseding any(f::Function, a::AbstractArray; dims) @ Base reducedim.jl:993 with MethodInstance for any(::Compiler.var"#compileable_specialization##0#compileable_specialization##1", ::AbstractArray) (584 children)
```

That being said I couldn't actually test it because GPUCompiler currently doesn't work on nightly, so here's `code_warntype` before:
<details>
<summary>Nightly</summary>

```julia
julia> C = Base.Compiler
Compiler

julia> code_warntype(Base.Compiler.compileable_specialization, Tuple{Core.CodeInstance, C.Effects, C.InliningEdgeTracker, C.CallInfo, C.InliningState})
MethodInstance for Compiler.compileable_specialization(::Core.CodeInstance, ::Compiler.Effects, ::Compiler.InliningEdgeTracker, ::Compiler.CallInfo, ::Compiler.InliningState)
  from compileable_specialization(code::Union{Core.CodeInstance, Core.MethodInstance}, effects::Compiler.Effects, et::Compiler.InliningEdgeTracker, info::Compiler.CallInfo, state::Compiler.InliningState) @ Compiler ../usr/share/julia/Compiler/src/ssair/inlining.jl:777
Arguments
  #self#::Core.Const(Compiler.compileable_specialization)
  code@_2::Core.CodeInstance
  effects::Compiler.Effects
  et::Compiler.InliningEdgeTracker
  info::Compiler.CallInfo
  state::Compiler.InliningState
Locals
  #217::Compiler.var"#compileable_specialization##0#compileable_specialization##1"
  @_8::Int64
  cached::Union{Nothing, Compiler.InferenceResult, Core.CodeInstance}
  keep_direct_edge::Bool
  new_atype::Any
  sparams::Any
  atype::Any
  method::Method
  mi_invoke::Any
  mi::Any
  code@_17::Any
  @_18::Any
  @_19::Bool
  @_20::Bool
  @_21::Bool
Body::Union{Nothing, Compiler.InvokeCase}
1 ──        nothing
│           (code@_17 = code@_2)
│           Core.NewvarNode(:(cached))
│           Core.NewvarNode(:(sparams))
│           Core.NewvarNode(:(mi_invoke))
│    %6   = Compiler.isa::Core.Const(isa)
│    %7   = code@_17::Core.CodeInstance
│    %8   = Compiler.CodeInstance::Core.Const(Core.CodeInstance)
│    %9   = (%6)(%7, %8)::Core.Const(true)
└───        goto #3 if not %9
2 ── %11  = code@_17::Core.CodeInstance
│           (@_18 = Compiler.getproperty(%11, :def))
└───        goto #4
3 ──        Core.Const(:(code@_17))
└───        Core.Const(:(@_18 = %14))
4 ┄─ %16  = @_18::Any
│           (mi = %16)
│    %18  = mi::Any
│           (mi_invoke = %18)
│    %20  = Compiler.getproperty(mi, :def)::Any
│    %21  = Compiler.Method::Core.Const(Method)
│    %22  = Core.typeassert(%20, %21)::Method
│    %23  = Compiler.getproperty(mi, :specTypes)::Any
│    %24  = Compiler.getproperty(mi, :sparam_vals)::Any
│           (method = %22)
│           (atype = %23)
│           (sparams = %24)
│    %28  = Compiler.OptimizationParams::Core.Const(Compiler.OptimizationParams)
│    %29  = Compiler.getproperty(state, :interp)::Compiler.AbstractInterpreter
│    %30  = (%28)(%29)::Compiler.OptimizationParams
│    %31  = Compiler.getproperty(%30, :compilesig_invokes)::Bool
└───        goto #12 if not %31
5 ── %33  = Compiler.get_compileable_sig::Core.Const(Compiler.get_compileable_sig)
│    %34  = sparams::Any
│           (new_atype = (%33)(method, atype, %34))
│    %36  = Compiler.:(===)::Core.Const(===)
│    %37  = Compiler.nothing::Core.Const(nothing)
│    %38  = (%36)(new_atype, %37)::Bool
└───        goto #8 if not %38
6 ── %40  = Compiler.nothing::Core.Const(nothing)
└───        return %40
7 ──        Core.Const(:(goto %43))
8 ┄─ %43  = Compiler.:!==::Core.Const(!==)
│    %44  = (%43)(atype, new_atype)::Bool
└───        goto #11 if not %44
9 ── %46  = Compiler.typeintersect_env::Core.Const(Base.typeintersect_env)
│    %47  = Compiler.getproperty(method, :sig)::Type
│    %48  = (%46)(new_atype, %47)::Pair{Any, Core.SimpleVector}
│    %49  = Compiler.indexed_iterate(%48, 1)::Core.PartialStruct(Tuple{Any, Int64}, Union{Nothing, Bool}[0, 0], Any[Any, Core.Const(2)])
│           Core.getfield(%49, 1)
│           (@_8 = Core.getfield(%49, 2))
│    %52  = Compiler.indexed_iterate(%48, 2, @_8)::Core.PartialStruct(Tuple{Core.SimpleVector, Int64}, Union{Nothing, Bool}[0, 0], Any[Core.SimpleVector, Core.Const(3)])
│           (sparams = Core.getfield(%52, 1))
│    %54  = Compiler.specialize_method::Core.Const(Base.specialize_method)
│    %55  = sparams::Core.SimpleVector
│           (mi_invoke = (%54)(method, new_atype, %55))
│    %57  = Compiler.:(===)::Core.Const(===)
│    %58  = mi_invoke::Core.MethodInstance
│    %59  = Compiler.nothing::Core.Const(nothing)
│    %60  = (%57)(%58, %59)::Core.Const(false)
└───        goto #11 if not %60
10 ─        Core.Const(:(Compiler.nothing))
│           Core.Const(:(return %62))
└───        Core.Const(:(goto %65))
11 ┄        goto #14
12 ─ %66  = Compiler.any::Core.Const(any)
│    %67  = Compiler.:(var"#compileable_specialization##0#compileable_specialization##1")::Core.Const(Compiler.var"#compileable_specialization##0#compileable_specialization##1")
│           (#217 = %new(%67))
│    %69  = Compiler.getproperty(mi, :sparam_vals)::Any
│    %70  = (%66)(#217, %69)::Any
└───        goto #14 if not %70
13 ─ %72  = Compiler.nothing::Core.Const(nothing)
└───        return %72
14 ┄ %74  = Compiler.:!=::Core.Const(!=)
│    %75  = Compiler.unionall_depth::Core.Const(Compiler.unionall_depth)
│    %76  = Compiler.getproperty(method, :sig)::Type
│    %77  = (%75)(%76)::Int64
│    %78  = Compiler.length::Core.Const(length)
│    %79  = sparams::Any
│    %80  = (%78)(%79)::Any
│    %81  = (%74)(%77, %80)::Any
└───        goto #16 if not %81
15 ─        goto #17
16 ─ %84  = Compiler.:!::Core.Const(!)
│    %85  = Compiler.validate_sparams::Core.Const(Compiler.validate_sparams)
│    %86  = sparams::Any
│    %87  = (%85)(%86)::Bool
│    %88  = (%84)(%87)::Bool
└───        goto #18 if not %88
17 ┄ %90  = Compiler.nothing::Core.Const(nothing)
└───        return %90
18 ─ %92  = Compiler.isa::Core.Const(isa)
│    %93  = code@_17::Core.CodeInstance
│    %94  = Compiler.CodeInstance::Core.Const(Core.CodeInstance)
│    %95  = (%92)(%93, %94)::Core.Const(true)
└───        goto #23 if not %95
19 ─ %97  = Compiler.:!==::Core.Const(!==)
│    %98  = mi_invoke::Any
│    %99  = (%97)(mi, %98)::Bool
└───        goto #21 if not %99
20 ─ %101 = Compiler.has_typeegal_slot::Core.Const(Compiler.has_typeegal_slot)
│           (@_20 = (%101)(atype))
└───        goto #22
21 ─        (@_20 = false)
22 ┄ %105 = @_20::Bool
│           (@_19 = %105)
└───        goto #24
23 ─        Core.Const(:(@_19 = false))
24 ┄ %109 = @_19::Bool
│           (keep_direct_edge = %109)
│    %111 = Compiler.:!::Core.Const(!)
│    %112 = (%111)(keep_direct_edge)::Bool
└───        goto #34 if not %112
25 ─ %114 = Compiler.get::Core.Const(get)
│    %115 = Compiler.code_cache::Core.Const(Compiler.code_cache)
│    %116 = (%115)(state)::Compiler.OptimizerCache{Compiler.OverlayCodeCache{Compiler.InternalCodeCache}}
│    %117 = mi_invoke::Any
│    %118 = Compiler.nothing::Core.Const(nothing)
│           (cached = (%114)(%116, %117, %118))
│    %120 = Compiler.isa::Core.Const(isa)
│    %121 = cached::Union{Nothing, Compiler.InferenceResult, Core.CodeInstance}
│    %122 = Compiler.InferenceResult::Core.Const(Compiler.InferenceResult)
│    %123 = (%120)(%121, %122)::Bool
└───        goto #27 if not %123
26 ─ %125 = cached::Compiler.InferenceResult
│           (cached = Compiler.getproperty(%125, :ci))
└───        goto #27
27 ┄ %128 = Compiler.isa::Core.Const(isa)
│    %129 = cached::Union{Nothing, Core.CodeInstance}
│    %130 = Compiler.CodeInstance::Core.Const(Core.CodeInstance)
│    %131 = (%128)(%129, %130)::Bool
└───        goto #29 if not %131
28 ─ %133 = cached::Core.CodeInstance
│           (code@_17 = %133)
└───        goto #34
29 ─ %136 = Compiler.:!::Core.Const(!)
│    %137 = Compiler.isa::Core.Const(isa)
│    %138 = code@_17::Core.CodeInstance
│    %139 = Compiler.CodeInstance::Core.Const(Core.CodeInstance)
│    %140 = (%137)(%138, %139)::Core.Const(true)
└───        goto #31 if not %140
30 ─ %142 = Compiler.:(===)::Core.Const(===)
│    %143 = code@_17::Core.CodeInstance
│    %144 = Compiler.getproperty(%143, :def)::Any
│    %145 = mi_invoke::Any
│           (@_21 = (%142)(%144, %145))
└───        goto #32
31 ─        Core.Const(:(@_21 = false))
32 ┄ %149 = @_21::Bool
│    %150 = (%136)(%149)::Bool
└───        goto #34 if not %150
33 ─ %152 = mi_invoke::Any
└───        (code@_17 = %152)
34 ┄ %154 = Compiler.add_inlining_edge!::Core.Const(Compiler.add_inlining_edge!)
│    %155 = code@_17::Any
│           (%154)(et, %155)
│    %157 = Compiler.InvokeCase::Core.Const(Compiler.InvokeCase)
│    %158 = code@_17::Any
│    %159 = (%157)(%158, effects, info)::Compiler.InvokeCase
└───        return %159
```
</details>

And after:
<details>
<summary>PR</summary>

```julia
julia> C = Base.Compiler
Compiler

julia> code_warntype(Base.Compiler.compileable_specialization, Tuple{Core.CodeInstance, C.Effects, C.InliningEdgeTracker, C.CallInfo, C.InliningState})
MethodInstance for Compiler.compileable_specialization(::Core.CodeInstance, ::Compiler.Effects, ::Compiler.InliningEdgeTracker, ::Compiler.CallInfo, ::Compiler.InliningState)
  from compileable_specialization(code::Union{Core.CodeInstance, Core.MethodInstance}, effects::Compiler.Effects, et::Compiler.InliningEdgeTracker, info::Compiler.CallInfo, state::Compiler.InliningState) @ Compiler ../usr/share/julia/Compiler/src/ssair/inlining.jl:777
Arguments
  #self#::Core.Const(Compiler.compileable_specialization)
  code@_2::Core.CodeInstance
  effects::Compiler.Effects
  et::Compiler.InliningEdgeTracker
  info::Compiler.CallInfo
  state::Compiler.InliningState
Locals
  #217::Compiler.var"#compileable_specialization##0#compileable_specialization##1"
  @_8::Int64
  cached::Union{Nothing, Compiler.InferenceResult, Core.CodeInstance}
  keep_direct_edge::Bool
  new_atype::Any
  sparams::Core.SimpleVector
  atype::Any
  method::Method
  mi_invoke::Core.MethodInstance
  mi::Core.MethodInstance
  code@_17::Union{Core.CodeInstance, Core.MethodInstance}
  @_18::Core.MethodInstance
  @_19::Bool
  @_20::Bool
  @_21::Bool
Body::Union{Nothing, Compiler.InvokeCase}
1 ──        nothing
│           (code@_17 = code@_2)
│           Core.NewvarNode(:(cached))
│           Core.NewvarNode(:(sparams))
│           Core.NewvarNode(:(mi_invoke))
│    %6   = Compiler.isa::Core.Const(isa)
│    %7   = code@_17::Core.CodeInstance
│    %8   = Compiler.CodeInstance::Core.Const(Core.CodeInstance)
│    %9   = (%6)(%7, %8)::Core.Const(true)
└───        goto #3 if not %9
2 ── %11  = Compiler.get_ci_mi::Core.Const(Base.get_ci_mi)
│    %12  = code@_17::Core.CodeInstance
│           (@_18 = (%11)(%12))
└───        goto #4
3 ──        Core.Const(:(code@_17))
└───        Core.Const(:(@_18 = %15))
4 ┄─ %17  = @_18::Core.MethodInstance
│           (mi = %17)
│    %19  = mi::Core.MethodInstance
│           (mi_invoke = %19)
│    %21  = Compiler.getproperty(mi, :def)::Union{Method, Module}
│    %22  = Compiler.Method::Core.Const(Method)
│    %23  = Core.typeassert(%21, %22)::Method
│    %24  = Compiler.getproperty(mi, :specTypes)::Any
│    %25  = Compiler.getproperty(mi, :sparam_vals)::Core.SimpleVector
│           (method = %23)
│           (atype = %24)
│           (sparams = %25)
│    %29  = Compiler.OptimizationParams::Core.Const(Compiler.OptimizationParams)
│    %30  = Compiler.getproperty(state, :interp)::Compiler.AbstractInterpreter
│    %31  = (%29)(%30)::Compiler.OptimizationParams
│    %32  = Compiler.getproperty(%31, :compilesig_invokes)::Bool
└───        goto #12 if not %32
5 ── %34  = Compiler.get_compileable_sig::Core.Const(Compiler.get_compileable_sig)
│    %35  = sparams::Core.SimpleVector
│           (new_atype = (%34)(method, atype, %35))
│    %37  = Compiler.:(===)::Core.Const(===)
│    %38  = Compiler.nothing::Core.Const(nothing)
│    %39  = (%37)(new_atype, %38)::Bool
└───        goto #8 if not %39
6 ── %41  = Compiler.nothing::Core.Const(nothing)
└───        return %41
7 ──        Core.Const(:(goto %44))
8 ┄─ %44  = Compiler.:!==::Core.Const(!==)
│    %45  = (%44)(atype, new_atype)::Bool
└───        goto #11 if not %45
9 ── %47  = Compiler.typeintersect_env::Core.Const(Base.typeintersect_env)
│    %48  = Compiler.getproperty(method, :sig)::Type
│    %49  = (%47)(new_atype, %48)::Pair{Any, Core.SimpleVector}
│    %50  = Compiler.indexed_iterate(%49, 1)::Core.PartialStruct(Tuple{Any, Int64}, Union{Nothing, Bool}[0, 0], Any[Any, Core.Const(2)])
│           Core.getfield(%50, 1)
│           (@_8 = Core.getfield(%50, 2))
│    %53  = Compiler.indexed_iterate(%49, 2, @_8)::Core.PartialStruct(Tuple{Core.SimpleVector, Int64}, Union{Nothing, Bool}[0, 0], Any[Core.SimpleVector, Core.Const(3)])
│           (sparams = Core.getfield(%53, 1))
│    %55  = Compiler.specialize_method::Core.Const(Base.specialize_method)
│    %56  = sparams::Core.SimpleVector
│           (mi_invoke = (%55)(method, new_atype, %56))
│    %58  = Compiler.:(===)::Core.Const(===)
│    %59  = mi_invoke::Core.MethodInstance
│    %60  = Compiler.nothing::Core.Const(nothing)
│    %61  = (%58)(%59, %60)::Core.Const(false)
└───        goto #11 if not %61
10 ─        Core.Const(:(Compiler.nothing))
│           Core.Const(:(return %63))
└───        Core.Const(:(goto %66))
11 ┄        goto #14
12 ─ %67  = Compiler.any::Core.Const(any)
│    %68  = Compiler.:(var"#compileable_specialization##0#compileable_specialization##1")::Core.Const(Compiler.var"#compileable_specialization##0#compileable_specialization##1")
│           (#217 = %new(%68))
│    %70  = Compiler.getproperty(mi, :sparam_vals)::Core.SimpleVector
│    %71  = (%67)(#217, %70)::Bool
└───        goto #14 if not %71
13 ─ %73  = Compiler.nothing::Core.Const(nothing)
└───        return %73
14 ┄ %75  = Compiler.:!=::Core.Const(!=)
│    %76  = Compiler.unionall_depth::Core.Const(Compiler.unionall_depth)
│    %77  = Compiler.getproperty(method, :sig)::Type
│    %78  = (%76)(%77)::Int64
│    %79  = Compiler.length::Core.Const(length)
│    %80  = sparams::Core.SimpleVector
│    %81  = (%79)(%80)::Int64
│    %82  = (%75)(%78, %81)::Bool
└───        goto #16 if not %82
15 ─        goto #17
16 ─ %85  = Compiler.:!::Core.Const(!)
│    %86  = Compiler.validate_sparams::Core.Const(Compiler.validate_sparams)
│    %87  = sparams::Core.SimpleVector
│    %88  = (%86)(%87)::Bool
│    %89  = (%85)(%88)::Bool
└───        goto #18 if not %89
17 ┄ %91  = Compiler.nothing::Core.Const(nothing)
└───        return %91
18 ─ %93  = Compiler.isa::Core.Const(isa)
│    %94  = code@_17::Core.CodeInstance
│    %95  = Compiler.CodeInstance::Core.Const(Core.CodeInstance)
│    %96  = (%93)(%94, %95)::Core.Const(true)
└───        goto #23 if not %96
19 ─ %98  = Compiler.:!==::Core.Const(!==)
│    %99  = mi_invoke::Core.MethodInstance
│    %100 = (%98)(mi, %99)::Bool
└───        goto #21 if not %100
20 ─ %102 = Compiler.has_typeegal_slot::Core.Const(Compiler.has_typeegal_slot)
│           (@_20 = (%102)(atype))
└───        goto #22
21 ─        (@_20 = false)
22 ┄ %106 = @_20::Bool
│           (@_19 = %106)
└───        goto #24
23 ─        Core.Const(:(@_19 = false))
24 ┄ %110 = @_19::Bool
│           (keep_direct_edge = %110)
│    %112 = Compiler.:!::Core.Const(!)
│    %113 = (%112)(keep_direct_edge)::Bool
└───        goto #34 if not %113
25 ─ %115 = Compiler.get::Core.Const(get)
│    %116 = Compiler.code_cache::Core.Const(Compiler.code_cache)
│    %117 = (%116)(state)::Compiler.OptimizerCache{Compiler.OverlayCodeCache{Compiler.InternalCodeCache}}
│    %118 = mi_invoke::Core.MethodInstance
│    %119 = Compiler.nothing::Core.Const(nothing)
│           (cached = (%115)(%117, %118, %119))
│    %121 = Compiler.isa::Core.Const(isa)
│    %122 = cached::Union{Nothing, Compiler.InferenceResult, Core.CodeInstance}
│    %123 = Compiler.InferenceResult::Core.Const(Compiler.InferenceResult)
│    %124 = (%121)(%122, %123)::Bool
└───        goto #27 if not %124
26 ─ %126 = cached::Compiler.InferenceResult
│           (cached = Compiler.getproperty(%126, :ci))
└───        goto #27
27 ┄ %129 = Compiler.isa::Core.Const(isa)
│    %130 = cached::Union{Nothing, Core.CodeInstance}
│    %131 = Compiler.CodeInstance::Core.Const(Core.CodeInstance)
│    %132 = (%129)(%130, %131)::Bool
└───        goto #29 if not %132
28 ─ %134 = cached::Core.CodeInstance
│           (code@_17 = %134)
└───        goto #34
29 ─ %137 = Compiler.:!::Core.Const(!)
│    %138 = Compiler.isa::Core.Const(isa)
│    %139 = code@_17::Core.CodeInstance
│    %140 = Compiler.CodeInstance::Core.Const(Core.CodeInstance)
│    %141 = (%138)(%139, %140)::Core.Const(true)
└───        goto #31 if not %141
30 ─ %143 = Compiler.:(===)::Core.Const(===)
│    %144 = code@_17::Core.CodeInstance
│    %145 = Compiler.getproperty(%144, :def)::Any
│    %146 = mi_invoke::Core.MethodInstance
│           (@_21 = (%143)(%145, %146))
└───        goto #32
31 ─        Core.Const(:(@_21 = false))
32 ┄ %150 = @_21::Bool
│    %151 = (%137)(%150)::Bool
└───        goto #34 if not %151
33 ─ %153 = mi_invoke::Core.MethodInstance
└───        (code@_17 = %153)
34 ┄ %155 = Compiler.add_inlining_edge!::Core.Const(Compiler.add_inlining_edge!)
│    %156 = code@_17::Union{Core.CodeInstance, Core.MethodInstance}
│           (%155)(et, %156)
│    %158 = Compiler.InvokeCase::Core.Const(Compiler.InvokeCase)
│    %159 = code@_17::Union{Core.CodeInstance, Core.MethodInstance}
│    %160 = (%158)(%159, effects, info)::Compiler.InvokeCase
└───        return %160
```
</details>

Importantly, `mi` is now inferred as a `MethodInstance` so `mi.sparam_vals` infers to `SimpleVector`.

Debugged with Claude :robot: