### PR TITLE
codegen: Apply odd-bit storage widths consistently

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -2325,8 +2325,9 @@ jl_cgval_t function_sig_t::emit_a_ccall(
             if (static_rt)
                 return mark_julia_slot(result, rt, NULL, ctx.alias().stack);
             ++SRetCCalls;
-            result = ctx.builder.CreateLoad(sretty, result);
+            result = ctx.builder.CreateLoad(zext_struct_type(sretty), result);
             setName(ctx.emission_context, result, "returned");
+            result = trunc_struct_helper(ctx, result, sretty);
         }
     }
     else {

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1137,7 +1137,7 @@ static Value *box_ccall_result(jl_codectx_t &ctx, Value *result, Value *runtime_
     MDNode *tbaa = jl_is_mutable(rt) ? ctx.tbaa().tbaa_mutab : ctx.tbaa().tbaa_immut;
     Value *strct = emit_allocobj(ctx, nb, runtime_dt, true, align);
     setName(ctx.emission_context, strct, "ccall_result_box");
-    init_bits_value(ctx, strct, result, tbaa);
+    init_bits_value(ctx, strct, result, tbaa, rt);
     return strct;
 }
 
@@ -2242,7 +2242,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
                     emit_memcpy(ctx, strct, ai, slot, ai, rtsz, boxalign, boxalign);
                 }
                 else {
-                    init_bits_value(ctx, strct, result, tbaa, boxalign);
+                    init_bits_value(ctx, strct, result, tbaa, rt, boxalign);
                 }
                 return mark_julia_type(ctx, strct, true, rt);
             }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -723,6 +723,19 @@ static unsigned julia_alignment(jl_value_t *jt)
     return alignment;
 }
 
+// Byte-rounded type for accessing an integer in Julia memory: an odd-bit
+// integer is stored zero-extended to whole bytes. Non-integers pass through.
+static Type *julia_primitive_storage_type(Type *register_type)
+{
+    auto *IT = dyn_cast<IntegerType>(register_type);
+    if (!IT)
+        return register_type;
+    unsigned storage_bits = alignTo(IT->getBitWidth(), 8);
+    if (storage_bits == IT->getBitWidth())
+        return register_type;
+    return IntegerType::get(IT->getContext(), storage_bits);
+}
+
 static inline void maybe_mark_argument_dereferenceable(AttrBuilder &B, jl_value_t *jt) JL_CANSAFEPOINT
 {
     B.addAttribute(Attribute::NonNull);
@@ -2514,7 +2527,12 @@ static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, j
         return mark_julia_slot(val, jltype, NULL, result_ai, std::move(roots));
     }
     Type *realelty = elty;
-    if (Order != AtomicOrdering::NotAtomic) {
+    // The GEP above indexes by the allocation size, but the memory access
+    // itself uses the byte-rounded storage width.
+    if (Order == AtomicOrdering::NotAtomic) {
+        elty = zext_struct_type(elty);
+    }
+    else {
         if (!isboxed && !elty->isIntOrPtrTy()) {
             intcast = emit_static_alloca(ctx, elty, Align(alignment));
             setName(ctx.emission_context, intcast, "atomic_load_box");
@@ -2553,7 +2571,7 @@ static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, j
                                   isboxed, true, jltype);
     }
     if (elty != realelty)
-        instr = ctx.builder.CreateTrunc(instr, realelty);
+        instr = trunc_struct_helper(ctx, instr, realelty);
     if (intcast) {
         ctx.builder.CreateAlignedStore(instr, intcast, Align(alignment));
         instr = nullptr;
@@ -2699,7 +2717,11 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             }
         }
         realelty = elty;
-        if (Order != AtomicOrdering::NotAtomic && isa<IntegerType>(elty)) {
+        // Memory accesses use the byte-rounded storage width; realelty stays
+        // the register width.
+        if (Order == AtomicOrdering::NotAtomic)
+            elty = zext_struct_type(elty);
+        else if (isa<IntegerType>(elty)) {
             unsigned nb2 = PowerOf2Ceil(nb);
             unsigned bitwidth = cast<IntegerType>(elty)->getBitWidth();
             if (nb != nb2 || bitwidth != 8 * nb)
@@ -2717,8 +2739,10 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             else if (aliasscope || Order != AtomicOrdering::NotAtomic || (tracked_pointers && rhs.inline_roots.empty())) {
                 r = emit_unbox(ctx, realelty, rhs);
             }
-            if (realelty != elty)
-                r = ctx.builder.CreateZExt(r, elty);
+            // If r is unset, the value is stored by emit_unbox_store instead,
+            // which performs the storage widening itself.
+            if (r && realelty != elty)
+                r = zext_struct_helper(ctx, r, elty);
         }
     }
     // This pre-write barrier must be emitted before the store, while also not
@@ -2739,7 +2763,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         else if (r) {
             Value *wbval = r;
             if (realelty != elty)
-                wbval = ctx.builder.CreateTrunc(wbval, realelty);
+                wbval = trunc_struct_helper(ctx, wbval, realelty);
             if (intcast) {
                 ctx.builder.CreateStore(wbval, intcast);
                 wbval = ctx.builder.CreateLoad(intcast_eltyp, intcast);
@@ -2938,7 +2962,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             else {
                 Value *realCompare = Compare;
                 if (realelty != elty)
-                    realCompare = ctx.builder.CreateTrunc(realCompare, realelty);
+                    realCompare = trunc_struct_helper(ctx, realCompare, realelty);
                 if (intcast) {
                     assert(!isboxed);
                     ctx.builder.CreateStore(realCompare, intcast);
@@ -2972,7 +2996,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                 else if (intcast) {
                     Value *realCompare = Compare;
                     if (realelty != elty)
-                        realCompare = ctx.builder.CreateTrunc(realCompare, realelty);
+                        realCompare = trunc_struct_helper(ctx, realCompare, realelty);
                     emit_unbox_store(ctx, rhs, intcast, ctx.alias().stack, MaybeAlign(), intcast->getAlign());
                     r = ctx.builder.CreateLoad(realelty, intcast);
                     if (!tracked_pointers) // oldval is a slot, so put the oldval back
@@ -2981,8 +3005,8 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                 else if (Order != AtomicOrdering::NotAtomic || (tracked_pointers && rhs.inline_roots.empty())) {
                     r = emit_unbox(ctx, realelty, rhs);
                 }
-                if (realelty != elty)
-                    r = ctx.builder.CreateZExt(r, elty);
+                if (r && realelty != elty)
+                    r = zext_struct_helper(ctx, r, elty);
             }
             // As an optimization, we could hoist this pre-write barrier after the cmpxchg
             // loop if we had a barrier form that explicitly takes in `oldval`. However it
@@ -3000,11 +3024,14 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                 oldval = load_union();
             }
             else {
-                assert(elty == realelty && !intcast);
+                assert(!intcast);
                 AtomicOrdering loadOrder = isboxed ? AtomicOrdering::Monotonic : AtomicOrdering::NotAtomic;
                 auto *load = emit_aliased_load(ctx, elty, ptr, Align(alignment), ai, aliasscope, loadOrder);
                 instr = load;
-                oldval = mark_julia_type(ctx, load, isboxed, jltype);
+                Value *realinstr = load;
+                if (realelty != elty)
+                    realinstr = trunc_struct_helper(ctx, realinstr, realelty);
+                oldval = mark_julia_type(ctx, realinstr, isboxed, jltype);
             }
             // Compare
             Value *first_ptr = nullptr;
@@ -3123,7 +3150,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         if (!is_union) {
             // For non-union, convert instr (raw Value*) to oldval (jl_cgval_t)
             if (realelty != elty)
-                instr = ctx.builder.Insert(CastInst::Create(Instruction::Trunc, instr, realelty));
+                instr = trunc_struct_helper(ctx, instr, realelty);
             if (intcast) {
                 ctx.builder.CreateStore(instr, intcast);
                 if (tracked_pointers)
@@ -3740,7 +3767,7 @@ static void init_bits_value(jl_codectx_t &ctx, Value *newv, Value *v, const jl_a
                             Align alignment = Align(sizeof(void*))) // min alignment in julia's gc is pointer-aligned
 {
     // newv should already be tagged
-    ai.decorateInst(ctx.builder.CreateAlignedStore(v, newv, alignment));
+    ai.decorateInst(ctx.builder.CreateAlignedStore(zext_struct(ctx, v), newv, alignment));
 }
 
 static void init_bits_cgval(jl_codectx_t &ctx, Value *newv, const jl_cgval_t &v) JL_CANSAFEPOINT

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3888,8 +3888,6 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
     jl_value_t *jt = vinfo.typ;
     if (jt == (jl_value_t*)jl_bool_type)
         return track_pjlvalue(ctx, julia_bool(ctx, ctx.builder.CreateTrunc(as_value(ctx, t, vinfo), getInt1Ty(ctx.builder.getContext()))));
-    if (t == getInt1Ty(ctx.builder.getContext()))
-        return track_pjlvalue(ctx, julia_bool(ctx, as_value(ctx, t, vinfo)));
 
     if (ctx.linfo && jl_is_method(ctx.linfo->def.method) && vinfo.V && vinfo.inline_roots.empty() && !vinfo.ispointer()) { // don't bother codegen pre-boxing for toplevel
         if (Constant *c = dyn_cast<Constant>(vinfo.V)) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -698,6 +698,25 @@ static unsigned julia_alignment(jl_value_t *jt)
     return alignment;
 }
 
+// Return the byte-rounded type used to access a primitive integer in Julia
+// memory: an odd-bit integer lives in memory zero-extended to its storage
+// bytes (jl_datatype_size), so stores widen the register value and loads
+// truncate it back. Keep ABI-coerced and other non-canonical register types
+// unchanged, since their memory representation is not ours to define.
+static Type *julia_primitive_storage_type(Type *register_type, jl_value_t *jt)
+{
+    if (!jl_is_primitivetype(jt) || !register_type->isIntegerTy())
+        return register_type;
+    unsigned register_bits = cast<IntegerType>(register_type)->getBitWidth();
+    unsigned logical_bits = jl_datatype_nbits((jl_datatype_t*)jt);
+    if (register_bits != logical_bits)
+        return register_type;
+    unsigned storage_bits = 8 * jl_datatype_size(jt);
+    if (register_bits == storage_bits)
+        return register_type;
+    return Type::getIntNTy(register_type->getContext(), storage_bits);
+}
+
 static inline void maybe_mark_argument_dereferenceable(AttrBuilder &B, jl_value_t *jt) JL_CANSAFEPOINT
 {
     B.addAttribute(Attribute::NonNull);
@@ -2467,6 +2486,10 @@ static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, j
         return mark_julia_slot(val, jltype, NULL, result_tbaa, std::move(roots));
     }
     Type *realelty = elty;
+    // The GEP above indexes by the allocation size, but the memory access
+    // itself uses the byte-rounded storage width.
+    if (Order == AtomicOrdering::NotAtomic)
+        elty = julia_primitive_storage_type(elty, jltype);
     if (Order != AtomicOrdering::NotAtomic) {
         if (!isboxed && !elty->isIntOrPtrTy()) {
             intcast = emit_static_alloca(ctx, elty, Align(alignment));
@@ -2653,6 +2676,10 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             }
         }
         realelty = elty;
+        // Memory accesses use the byte-rounded storage width, while realelty
+        // remains the register width of the values being exchanged.
+        if (Order == AtomicOrdering::NotAtomic)
+            elty = julia_primitive_storage_type(elty, jltype);
         if (Order != AtomicOrdering::NotAtomic && isa<IntegerType>(elty)) {
             unsigned nb2 = PowerOf2Ceil(nb);
             unsigned bitwidth = cast<IntegerType>(elty)->getBitWidth();
@@ -2671,7 +2698,9 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             else if (aliasscope || Order != AtomicOrdering::NotAtomic || (tracked_pointers && rhs.inline_roots.empty())) {
                 r = emit_unbox(ctx, realelty, rhs);
             }
-            if (realelty != elty)
+            // If r is unset, the value is stored by emit_unbox_store instead,
+            // which performs the storage widening itself.
+            if (r && realelty != elty)
                 r = ctx.builder.CreateZExt(r, elty);
         }
     }
@@ -2931,7 +2960,9 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                 else if (Order != AtomicOrdering::NotAtomic || (tracked_pointers && rhs.inline_roots.empty())) {
                     r = emit_unbox(ctx, realelty, rhs);
                 }
-                if (realelty != elty)
+                // If r is unset, the value is stored by emit_unbox_store instead,
+                // which performs the storage widening itself.
+                if (r && realelty != elty)
                     r = ctx.builder.CreateZExt(r, elty);
             }
             // As an optimization, we could hoist this pre-write barrier after the cmpxchg
@@ -2950,11 +2981,14 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                 oldval = load_union();
             }
             else {
-                assert(elty == realelty && !intcast);
+                assert(!intcast);
                 AtomicOrdering loadOrder = isboxed ? AtomicOrdering::Monotonic : AtomicOrdering::NotAtomic;
                 auto *load = emit_aliased_load(ctx, elty, ptr, Align(alignment), tbaa, aliasscope, loadOrder);
                 instr = load;
-                oldval = mark_julia_type(ctx, load, isboxed, jltype);
+                Value *realinstr = load;
+                if (realelty != elty)
+                    realinstr = ctx.builder.CreateTrunc(realinstr, realelty);
+                oldval = mark_julia_type(ctx, realinstr, isboxed, jltype);
             }
             // Compare
             Value *first_ptr = nullptr;
@@ -3725,10 +3759,13 @@ static Value *emit_genericmemoryowner(jl_codectx_t &ctx, Value *t) JL_CANSAFEPOI
 static Value *emit_allocobj(jl_codectx_t &ctx, jl_datatype_t *jt, bool fully_initialized) JL_CANSAFEPOINT;
 
 static void init_bits_value(jl_codectx_t &ctx, Value *newv, Value *v, MDNode *tbaa,
-                            Align alignment = Align(sizeof(void*))) // min alignment in julia's gc is pointer-aligned
+                            jl_value_t *jt, Align alignment = Align(sizeof(void*))) // min alignment in julia's gc is pointer-aligned
 {
     jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, tbaa);
     // newv should already be tagged
+    Type *storage_type = julia_primitive_storage_type(v->getType(), jt);
+    if (storage_type != v->getType())
+        v = ctx.builder.CreateZExt(v, storage_type);
     ai.decorateInst(ctx.builder.CreateAlignedStore(v, newv, alignment));
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7870,7 +7870,10 @@ static Function *gen_cfun_wrapper(
                     inputarg = ghostValue(ctx, jargty);
                 }
                 else {
-                    val = ctx.builder.CreateAlignedLoad(T, val, Align(1)); // make no alignment assumption about pointer from C
+                    Type *loadT = julia_primitive_storage_type(T, jargty);
+                    val = ctx.builder.CreateAlignedLoad(loadT, val, Align(1)); // make no alignment assumption about pointer from C
+                    if (loadT != T)
+                        val = ctx.builder.CreateTrunc(val, T);
                     inputarg = mark_julia_type(ctx, val, false, jargty);
                 }
             }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2582,7 +2582,10 @@ static bool valid_as_globalinit(const Value *v) {
     return isa<Constant>(v);
 }
 
+static Type *zext_struct_type(Type *T);
 static Value *zext_struct(jl_codectx_t &ctx, Value *V);
+static Value *zext_struct_helper(jl_codectx_t &ctx, Value *V, Type *T2);
+static Value *trunc_struct_helper(jl_codectx_t &ctx, Value *V, Type *T2);
 
 // TODO: in the future, assume all callers will handle the interior pointers separately, and have
 // have zext_struct strip them out, so we aren't saving those to the stack here causing shadow stores
@@ -6332,7 +6335,7 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
                 setName(ctx.emission_context, ssaslot, varslot->getName() + StringRef(".ssa"));
                 ssaslot->insertAfter(varslot);
                 if (vi.isVolatile) {
-                    Value *unbox = ctx.builder.CreateAlignedLoad(ssaslot->getAllocatedType(), varslot, varslot->getAlign(), true);
+                    Value *unbox = ctx.builder.CreateAlignedLoad(zext_struct_type(ssaslot->getAllocatedType()), varslot, varslot->getAlign(), true);
                     stack_ai.decorateInst(ctx.builder.CreateAlignedStore(unbox, ssaslot, ssaslot->getAlign()));
                 }
                 else {
@@ -8199,8 +8202,9 @@ static Function *gen_cfun_wrapper(
                     inputarg = ghostValue(ctx, jargty);
                 }
                 else {
-                    val = ctx.builder.CreateAlignedLoad(T, val, Align(1)); // make no alignment assumption about pointer from C
-                    inputarg = mark_julia_type(ctx, val, false, jargty);
+                    // make no alignment assumption about pointer from C
+                    val = ctx.builder.CreateAlignedLoad(zext_struct_type(T), val, Align(1));
+                    inputarg = mark_julia_type(ctx, trunc_struct_helper(ctx, val, T), false, jargty);
                 }
             }
             else if (static_at || (!jl_is_typevar(jargty) && (!jl_is_datatype(jargty) || jl_is_abstracttype(jargty) || jl_is_mutable_datatype(jargty)))) {
@@ -8263,7 +8267,9 @@ static Function *gen_cfun_wrapper(
                 // undo whatever we might have done to this poor argument
                 assert(jl_is_datatype(jargty));
                 if (sig.byRefList[i]) {
-                    val = ctx.builder.CreateAlignedLoad(sig.fargt[i], val, Align(1)); // unknown alignment from C
+                    // unknown alignment from C
+                    val = ctx.builder.CreateAlignedLoad(zext_struct_type(sig.fargt[i]), val, Align(1));
+                    val = trunc_struct_helper(ctx, val, sig.fargt[i]);
                 }
                 else {
                     bool issigned = jl_signed_type && jl_subtype(jargty_proper, (jl_value_t*)jl_signed_type);
@@ -8323,7 +8329,7 @@ static Function *gen_cfun_wrapper(
         Value *v = emit_unbox(ctx, sig.lrt, retval);
         r = llvm_type_rewrite(ctx, v, prt, issigned);
         if (sig.sret) {
-            ctx.builder.CreateStore(r, sretPtr);
+            ctx.builder.CreateStore(zext_struct(ctx, r), sretPtr);
             r = NULL;
         }
     }
@@ -10186,7 +10192,7 @@ static jl_llvm_functions_t
                 }
                 else if (retvalinfo.V) {
                     Align align(returninfo.union_align);
-                    sret_ai.decorateInst(ctx.builder.CreateAlignedStore(retvalinfo.V, sret, align));
+                    sret_ai.decorateInst(ctx.builder.CreateAlignedStore(zext_struct(ctx, retvalinfo.V), sret, align));
                     assert(retvalinfo.TIndex == NULL && "unreachable"); // unimplemented representation
                 }
             }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -334,31 +334,31 @@ static Constant *undef_value_for_type(Type *T) {
     return undef;
 }
 
-// rebuild a struct type with any i1 Bool (e.g. the llvmcall type) widened to i8 (the native size for memcpy)
+// The type an aggregate occupies in memory: every integer element byte-rounded
+// (e.g. i1 Bool in llvmcall types). Returns T itself when nothing widens, so
+// identified struct types survive the round trip.
 static Type *zext_struct_type(Type *T)
 {
     if (auto *AT = dyn_cast<ArrayType>(T)) {
-        return ArrayType::get(AT->getElementType(), AT->getNumElements());
+        return ArrayType::get(zext_struct_type(AT->getElementType()), AT->getNumElements());
     }
     else if (auto *ST = dyn_cast<StructType>(T)) {
         SmallVector<Type*> Elements(ST->element_begin(), ST->element_end());
+        bool widened = false;
         for (size_t i = 0; i < Elements.size(); i++) {
-            Elements[i] = zext_struct_type(Elements[i]);
+            Type *E = zext_struct_type(Elements[i]);
+            widened |= E != Elements[i];
+            Elements[i] = E;
         }
-        return StructType::get(ST->getContext(), Elements, ST->isPacked());
+        return widened ? StructType::get(ST->getContext(), Elements, ST->isPacked()) : T;
     }
     else if (auto *VT = dyn_cast<VectorType>(T)) {
         return VectorType::get(zext_struct_type(VT->getElementType()), VT);
     }
-    else if (auto *IT = dyn_cast<IntegerType>(T)) {
-        unsigned BitWidth = IT->getBitWidth();
-        if (alignTo(BitWidth, 8) != BitWidth)
-            return IntegerType::get(IT->getContext(), alignTo(BitWidth, 8));
-    }
-    return T;
+    return julia_primitive_storage_type(T);
 }
 
-// rebuild a struct with any i1 Bool (e.g. the llvmcall type) widened to i8 (the native size for memcpy)
+// Rebuild a value to match zext_struct_type.
 static Value *zext_struct_helper(jl_codectx_t &ctx, Value *V, Type *T2)
 {
     Type *T = V->getType();
@@ -389,6 +389,35 @@ static Value *zext_struct_helper(jl_codectx_t &ctx, Value *V, Type *T2)
 static Value *zext_struct(jl_codectx_t &ctx, Value *V)
 {
     return zext_struct_helper(ctx, V, zext_struct_type(V->getType()));
+}
+
+// Inverse of zext_struct_helper: narrow a value loaded at its storage width
+// back to the register type T2.
+static Value *trunc_struct_helper(jl_codectx_t &ctx, Value *V, Type *T2)
+{
+    Type *T = V->getType();
+    if (T == T2)
+        return V;
+    if (auto *AT = dyn_cast<ArrayType>(T2)) {
+        Value *V2 = undef_value_for_type(AT);
+        for (size_t i = 0; i < AT->getNumElements(); i++) {
+            Value *E = trunc_struct_helper(ctx, ctx.builder.CreateExtractValue(V, i), AT->getElementType());
+            V2 = ctx.builder.CreateInsertValue(V2, E, i);
+        }
+        return V2;
+    }
+    else if (auto *ST = dyn_cast<StructType>(T2)) {
+        Value *V2 = undef_value_for_type(ST);
+        for (size_t i = 0; i < ST->getNumElements(); i++) {
+            Value *E = trunc_struct_helper(ctx, ctx.builder.CreateExtractValue(V, i), ST->getElementType(i));
+            V2 = ctx.builder.CreateInsertValue(V2, E, i);
+        }
+        return V2;
+    }
+    else if (T2->isIntegerTy() || T2->isVectorTy()) {
+        return ctx.builder.CreateTrunc(V, T2);
+    }
+    return V;
 }
 
 static Value *emit_unboxed_coercion(jl_codectx_t &ctx, Type *to, Value *unboxed)
@@ -495,9 +524,10 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, Maybe
         ai = combined_ai;
     }
     assert(p); // clang-sa doesn't know that x.ispointer() implied this is true
-    Instruction *load = ctx.builder.CreateAlignedLoad(to, p, alignment);
+    Instruction *load = ctx.builder.CreateAlignedLoad(zext_struct_type(to), p, alignment);
     setName(ctx.emission_context, load, p->getName() + ".unbox");
-    return ai.decorateInst(load);
+    ai.decorateInst(load);
+    return trunc_struct_helper(ctx, load, to);
 }
 
 // emit code to store a raw value into a destination
@@ -608,12 +638,13 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, ArrayRef<jl_cgval_t> argv) 
         // the dynamic checks above ensure only primitive types reach here
         if (isboxed)
             vxt = llvmt;
-        auto storage_type = vxt->isIntegerTy(1) ? getInt8Ty(ctx.builder.getContext()) : vxt;
+        auto register_type = vxt->isIntegerTy(1) ? getInt8Ty(ctx.builder.getContext()) : vxt;
         jl_aliasinfo_t ai = v.aliasinfo;
         vx = ai.decorateInst(ctx.builder.CreateLoad(
-            storage_type,
+            zext_struct_type(register_type),
             maybe_decay_tracked(ctx, v.V)));
         setName(ctx.emission_context, vx, "bitcast");
+        vx = trunc_struct_helper(ctx, vx, register_type);
     }
 
     vxt = vx->getType();

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -334,11 +334,13 @@ static Constant *undef_value_for_type(Type *T) {
     return undef;
 }
 
-// rebuild a struct type with any i1 Bool (e.g. the llvmcall type) widened to i8 (the native size for memcpy)
+// Rebuild a type, widening any integer whose bit width is not a multiple of 8
+// (e.g. i1 Bool in llvmcall types, or odd-bit primitives) to its byte-rounded
+// storage width.
 static Type *zext_struct_type(Type *T)
 {
     if (auto *AT = dyn_cast<ArrayType>(T)) {
-        return ArrayType::get(AT->getElementType(), AT->getNumElements());
+        return ArrayType::get(zext_struct_type(AT->getElementType()), AT->getNumElements());
     }
     else if (auto *ST = dyn_cast<StructType>(T)) {
         SmallVector<Type*> Elements(ST->element_begin(), ST->element_end());
@@ -358,7 +360,8 @@ static Type *zext_struct_type(Type *T)
     return T;
 }
 
-// rebuild a struct with any i1 Bool (e.g. the llvmcall type) widened to i8 (the native size for memcpy)
+// Rebuild a value to match the type produced by zext_struct_type,
+// zero-extending each widened integer element.
 static Value *zext_struct_helper(jl_codectx_t &ctx, Value *V, Type *T2)
 {
     Type *T = V->getType();
@@ -495,9 +498,11 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, Maybe
         ai = combined_ai;
     }
     assert(p); // clang-sa doesn't know that x.ispointer() implied this is true
-    Instruction *load = ctx.builder.CreateAlignedLoad(to, p, alignment);
+    Type *load_type = julia_primitive_storage_type(to, x.typ);
+    Instruction *load = ctx.builder.CreateAlignedLoad(load_type, p, alignment);
     setName(ctx.emission_context, load, p->getName() + ".unbox");
-    return ai.decorateInst(load);
+    ai.decorateInst(load);
+    return emit_unboxed_coercion(ctx, to, load);
 }
 
 // emit code to store a raw value into a destination
@@ -657,7 +662,7 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, ArrayRef<jl_cgval_t> argv) 
         unsigned align = sizeof(void*); // Allocations are at least pointer aligned
         Value *box = emit_allocobj(ctx, nb, bt_value_rt, true, align);
         setName(ctx.emission_context, box, "bitcast_box");
-        init_bits_value(ctx, box, vx, ctx.tbaa().tbaa_immut);
+        init_bits_value(ctx, box, vx, ctx.tbaa().tbaa_immut, (jl_value_t*)bt);
         return mark_julia_type(ctx, box, true, bt->name->wrapper);
     }
 }
@@ -731,7 +736,7 @@ static jl_cgval_t generic_cast(
         unsigned align = sizeof(void*); // Allocations are at least pointer aligned
         Value *box = emit_allocobj(ctx, nb, targ_rt, true, align);
         setName(ctx.emission_context, box, "cast_box");
-        init_bits_value(ctx, box, ans, ctx.tbaa().tbaa_immut);
+        init_bits_value(ctx, box, ans, ctx.tbaa().tbaa_immut, (jl_value_t*)jlto);
         return mark_julia_type(ctx, box, true, jlto->name->wrapper);
     }
 }
@@ -909,7 +914,7 @@ static jl_cgval_t emit_pointerarith(jl_codectx_t &ctx, intrinsic f,
     else {
         Value *box = emit_allocobj(ctx, (jl_datatype_t *)ptrtyp, true);
         setName(ctx.emission_context, box, "ptr_box");
-        init_bits_value(ctx, box, ans, ctx.tbaa().tbaa_immut);
+        init_bits_value(ctx, box, ans, ctx.tbaa().tbaa_immut, ptrtyp);
         return mark_julia_type(ctx, box, true, (jl_datatype_t *)ptrtyp);
     }
 }

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -112,6 +112,89 @@ end
     x17 = Core.Intrinsics.trunc_int(TestUInt17, UInt32(0xffff_ffff))
     @test Core.Intrinsics.zext_int(UInt32, x17) === 0x0001_ffff
 
+    # Memory operations use the byte-rounded storage width.
+    load17(p::Ptr{TestUInt17}) = unsafe_load(p)
+    store17(p::Ptr{TestUInt17}, x::TestUInt17) = unsafe_store!(p, x)
+    load_boxed17(x::Any) = Core.Intrinsics.zext_int(UInt32, x::TestUInt17)
+    bitcast17(x::Any) = Core.Intrinsics.bitcast(TestInt17, x::TestUInt17)
+    load_tuple17(x::Any) = x::Tuple{TestUInt17,TestUInt17}
+    # Under Revise these `code_llvm` queries can fail in InteractiveUtils'
+    # reflective inference path before reaching the odd-bit lowering.
+    if !isdefined(Main, :Revise)
+        load_ir = sprint(io -> code_llvm(io, load17, Tuple{Ptr{TestUInt17}};
+            debuginfo=:none, optimize=false))
+        @test occursin(r"\bload i24\b", load_ir)
+        @test occursin(r"\btrunc i24\b", load_ir)
+        boxed_ir = sprint(io -> code_llvm(io, load_boxed17, Tuple{Any};
+            debuginfo=:none, optimize=false))
+        @test occursin(r"\bload i24\b", boxed_ir)
+        @test occursin(r"\btrunc i24\b", boxed_ir)
+        store_ir = sprint(io -> code_llvm(io, store17,
+            Tuple{Ptr{TestUInt17}, TestUInt17}; debuginfo=:none, optimize=false))
+        @test occursin(r"\bzext i17\b.*\bto i24\b", store_ir)
+        @test occursin(r"\bstore i24\b", store_ir)
+        bitcast_ir = sprint(io -> code_llvm(io, bitcast17, Tuple{Any};
+            debuginfo=:none, optimize=false))
+        @test occursin(r"\bload i24\b", bitcast_ir)
+        # Aggregate elements widen elementwise, not just bare primitives. On
+        # 32-bit targets the tuple is returned through sret as a single memcpy
+        # instead, which never materializes the elements.
+        if Sys.WORD_SIZE == 64
+            tuple_ir = sprint(io -> code_llvm(io, load_tuple17, Tuple{Any};
+                debuginfo=:none, optimize=false))
+            @test occursin(r"\bload \[2 x i24\]", tuple_ir)
+            @test occursin(r"\btrunc i24\b", tuple_ir)
+        end
+    end
+
+    # Round-trips through mutable fields, Memory, and field-modification
+    # builtins (the non-atomic typed_store paths in codegen).
+    mutable struct Mut17
+        x::TestUInt17
+    end
+    u17(x) = Core.Intrinsics.trunc_int(TestUInt17, UInt32(x))
+    let m = Mut17(u17(5))
+        setfield!(m, :x, u17(6))
+        @test getfield(m, :x) === u17(6)
+        @test swapfield!(m, :x, u17(7)) === u17(6)
+        @test getfield(m, :x) === u17(7)
+        let r = replacefield!(m, :x, u17(7), u17(8))
+            @test r.success && r.old === u17(7)
+        end
+        @test getfield(m, :x) === u17(8)
+        @test modifyfield!(m, :x, (a, b) -> b, u17(9)).second === u17(9)
+        @test getfield(m, :x) === u17(9)
+    end
+    let mem = Memory{TestUInt17}(undef, 3)
+        for i = 1:3
+            mem[i] = u17(0x1fff0 + i)
+        end
+        @test mem[1] === u17(0x1fff1) && mem[3] === u17(0x1fff3)
+    end
+    let t = (u17(1), u17(0x1ffff))
+        @test t[1] === u17(1) && t[2] === u17(0x1ffff)
+        @test Ref{Any}(t)[] === t
+    end
+
+    # Bits above the logical width belong to nobody: a load must drop them,
+    # even when the memory was written by something other than codegen.
+    let dirty = fill(0xff, 8)
+        GC.@preserve dirty begin
+            p = Ptr{TestUInt17}(pointer(dirty))
+            @test Core.Intrinsics.zext_int(UInt32, unsafe_load(p)) === 0x0001_ffff
+            @test unsafe_load(Ptr{Tuple{TestUInt17,TestUInt17}}(p)) ===
+                (u17(0x1ffff), u17(0x1ffff))
+        end
+    end
+    for (T, mask) in ((TestUInt5, 0x1f), (TestUInt17, 0x0001_ffff),
+                      (TestUInt24, 0x00ff_ffff), (TestUInt40, 0x0000_00ff_ffff_ffff),
+                      (TestUInt63, 0x7fff_ffff_ffff_ffff))
+        dirty = fill(0xff, sizeof(T))
+        v = GC.@preserve dirty ccall(:jl_new_bits, Any, (Any, Ptr{Cvoid}), T, pointer(dirty))
+        @test Core.Intrinsics.zext_int(UInt64, v::T) == mask
+        @test v::T === Core.Intrinsics.trunc_int(T, typemax(UInt64))
+    end
+
     x63 = Core.Intrinsics.trunc_int(TestUInt63, UInt64(0xffff_ffff_ffff_ffff))
     @test Core.Intrinsics.zext_int(UInt64, x63) === 0x7fff_ffff_ffff_ffff
 

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -195,6 +195,25 @@ end
         @test v::T === Core.Intrinsics.trunc_int(T, typemax(UInt64))
     end
 
+    # A 1-bit primitive is not a Bool: boxing must keep its own type.
+    primitive type TestUInt1 1 end
+    box1(n::UInt8) = Ref{Any}(Core.Intrinsics.trunc_int(TestUInt1, n))[]
+    let one = Ref(0x01)[], zero = Ref(0x00)[]
+        @test box1(one) isa TestUInt1
+        @test box1(one) === Core.Intrinsics.trunc_int(TestUInt1, one)
+        @test box1(one) !== box1(zero)
+    end
+    # Bool keeps boxing to the `jl_true`/`jl_false` singletons, which `===` on
+    # Bool depends on (`jl_pointer_egal`); `===` alone compares by value here,
+    # so check the address. Both boxing paths: plain and via a union.
+    addr(@nospecialize x) = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), x)
+    boxbool(b::Bool) = Ref{Any}(b)[]
+    boxboolunion(x::Union{Bool,Int}) = Ref{Any}(x)[]
+    let t = Ref(true)[], f = Ref(false)[]
+        @test addr(boxbool(t)) === addr(true) && addr(boxbool(f)) === addr(false)
+        @test addr(boxboolunion(t)) === addr(true) && addr(boxboolunion(f)) === addr(false)
+    end
+
     x63 = Core.Intrinsics.trunc_int(TestUInt63, UInt64(0xffff_ffff_ffff_ffff))
     @test Core.Intrinsics.zext_int(UInt64, x63) === 0x7fff_ffff_ffff_ffff
 

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -112,6 +112,54 @@ end
     x17 = Core.Intrinsics.trunc_int(TestUInt17, UInt32(0xffff_ffff))
     @test Core.Intrinsics.zext_int(UInt32, x17) === 0x0001_ffff
 
+    # Memory operations use the byte-rounded storage width.
+    load17(p::Ptr{TestUInt17}) = unsafe_load(p)
+    store17(p::Ptr{TestUInt17}, x::TestUInt17) = unsafe_store!(p, x)
+    load_boxed17(x::Any) = Core.Intrinsics.zext_int(UInt32, x::TestUInt17)
+    if !isdefined(Main, :Revise)
+        load_ir = sprint(io -> code_llvm(io, load17, Tuple{Ptr{TestUInt17}};
+            debuginfo=:none, optimize=false))
+        @test occursin(r"\bload i24\b", load_ir)
+        @test occursin(r"\btrunc i24\b", load_ir)
+        boxed_ir = sprint(io -> code_llvm(io, load_boxed17, Tuple{Any};
+            debuginfo=:none, optimize=false))
+        @test occursin(r"\bload i24\b", boxed_ir)
+        @test occursin(r"\btrunc i24\b", boxed_ir)
+        store_ir = sprint(io -> code_llvm(io, store17,
+            Tuple{Ptr{TestUInt17}, TestUInt17}; debuginfo=:none, optimize=false))
+        @test occursin(r"\bzext i17\b.*\bto i24\b", store_ir)
+        @test occursin(r"\bstore i24\b", store_ir)
+    end
+
+    # Round-trips through mutable fields, Memory, and field-modification
+    # builtins (the non-atomic typed_store paths in codegen).
+    mutable struct Mut17
+        x::TestUInt17
+    end
+    u17(x) = Core.Intrinsics.trunc_int(TestUInt17, UInt32(x))
+    let m = Mut17(u17(5))
+        setfield!(m, :x, u17(6))
+        @test getfield(m, :x) === u17(6)
+        @test swapfield!(m, :x, u17(7)) === u17(6)
+        @test getfield(m, :x) === u17(7)
+        let r = replacefield!(m, :x, u17(7), u17(8))
+            @test r.success && r.old === u17(7)
+        end
+        @test getfield(m, :x) === u17(8)
+        @test modifyfield!(m, :x, (a, b) -> b, u17(9)).second === u17(9)
+        @test getfield(m, :x) === u17(9)
+    end
+    let mem = Memory{TestUInt17}(undef, 3)
+        for i = 1:3
+            mem[i] = u17(0x1fff0 + i)
+        end
+        @test mem[1] === u17(0x1fff1) && mem[3] === u17(0x1fff3)
+    end
+    let t = (u17(1), u17(0x1ffff))
+        @test t[1] === u17(1) && t[2] === u17(0x1ffff)
+        @test Ref{Any}(t)[] === t
+    end
+
     x63 = Core.Intrinsics.trunc_int(TestUInt63, UInt64(0xffff_ffff_ffff_ffff))
     @test Core.Intrinsics.zext_int(UInt64, x63) === 0x7fff_ffff_ffff_ffff
 


### PR DESCRIPTION
An odd-bit primitive like `primitive type T 17 end` lives in a register as i17 but in memory zero-extended to `jl_datatype_size` bytes. Codegen accessed it as i17, leaving the padding bits of a load unspecified and the padding bits of a store up to whatever LLVM happened to emit.

Rebuild `zext_struct_type` on a byte-rounding rule shared with `julia_primitive_storage_type`, add the load-side inverse `trunc_struct_helper`, and use the pair wherever a value crosses between register and memory: unboxing, box initialization, typed loads and stores, `generic_bitcast`, volatile variable slots, sret returns, ccall sret results, and `Ref` arguments in cfunction wrappers. Aggregates need this as much as bare primitives, so these widen the whole element type rather than only the primitive case.

ABI-coerced register types pass through untouched: byte-rounding only changes types that are not already whole bytes.

---

This is meant to address part 1 of #62441.

A note on what this does and does not fix, since an earlier version of this description overstated it: the in-tree behavioural tests pass without the codegen change too, because the surrounding zext/trunc/store chain happens to mask the padding bits today. `load i17` genuinely does leave them unspecified — spliced in via `llvmcall`, `load i17` + `zext i32` over bytes `ff ff ff` yields `0xffffff` — so this is about not depending on that, rather than a miscompile anyone has hit. The regression tests here are the IR-shape ones.

Written with the assistance of generative AI.

CC @topolarity
