### PR TITLE
precompilation: preserve `PkgId` identity when precompiling by identity

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -175,7 +175,7 @@ end
 
 # A request to do precompilation work, either in a new session or merged into a running one.
 struct PrecompileRequest
-    pkgs::Vector{String}
+    pkgs::Union{Vector{String}, Vector{PkgId}}
     internal_call::Bool
     strict::Bool
     warn_loaded::Bool
@@ -1022,7 +1022,7 @@ end
 # Filter the dependency graph to only include requested packages and their transitive deps.
 # Returns true if the graph became empty (caller should return early).
 function filter_dep_graph!(direct_deps, pkg_names, ext_to_parent, requested_pkgids)
-    isempty(pkg_names) && return false
+    isempty(pkg_names) && isempty(requested_pkgids) && return false
     keep = Set{PkgId}()
     for dep_pkgid in keys(direct_deps)
         if dep_pkgid.name in pkg_names
@@ -1602,8 +1602,11 @@ function launch_background_precompile(pkgs::Union{Vector{String}, Vector{PkgId}}
         BG.work_channel = Channel{PrecompileRequest}(Inf)
     end
 
-    # Capture necessary context for background task
-    pkg_names = pkgs isa Vector{String} ? copy(pkgs) : String[pkg.name for pkg in pkgs]
+    # Capture necessary context for background task. Preserve the original element
+    # type so a `Vector{PkgId}` request keeps its package identities; `do_precompile`
+    # resolves names against the active project only, which would drop workspace or
+    # manifest deps that are not direct deps of the active project.
+    requested_pkgs = copy(pkgs)
 
     # Register an atexit hook (once) to cleanly shut down background precompilation
     # before the event loop is torn down.
@@ -1614,7 +1617,7 @@ function launch_background_precompile(pkgs::Union{Vector{String}, Vector{PkgId}}
         wc = BG.work_channel
         BG.task = Threads.@spawn :samepool begin
             try
-                ret = do_precompile(pkg_names, internal_call, strict, warn_loaded, timing, _from_loading,
+                ret = do_precompile(requested_pkgs, internal_call, strict, warn_loaded, timing, _from_loading,
                                     configs, io, fancyprint, manifest, ignore_loaded, detachable, wc)
 
                 @lock BG begin
@@ -1686,8 +1689,10 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
         did_inject = @lock BG begin
             if BG.task !== nothing && !istaskdone(BG.task) &&
                     isopen(BG.work_channel)
-                pkg_names = pkgs isa Vector{String} ? copy(pkgs) : String[pkg.name for pkg in pkgs]
-                req = PrecompileRequest(pkg_names, internal_call, strict, warn_loaded, timing, _from_loading,
+                # Preserve the original element type so a `Vector{PkgId}` request keeps its
+                # package identities across the channel; the drainer resolves names against
+                # the active project only, which would drop workspace deps.
+                req = PrecompileRequest(copy(pkgs), internal_call, strict, warn_loaded, timing, _from_loading,
                                         configs, io, fancyprint′, manifest, ignore_loaded, detachable,
                                         Channel{Any}(1))
                 try
@@ -2353,10 +2358,13 @@ function drain_work_channel!(s::PrecompileSession, work_channel::Channel{Precomp
             waiter_spawned = false
             try
                 new_env = ExplicitEnv()
-                req_pkgids = PkgId[]
-                for name in request.pkgs
-                    pkgid = Base.identify_package(name)
-                    pkgid !== nothing && push!(req_pkgids, pkgid)
+                if request.pkgs isa Vector{PkgId}
+                    # Resolved by identity; no names needed (see `do_precompile`).
+                    req_pkgids = copy(request.pkgs)
+                    req_pkg_names = String[]
+                else
+                    req_pkgids = PkgId[pkgid for name in request.pkgs if (pkgid = Base.identify_package(name)) !== nothing]
+                    req_pkg_names = copy(request.pkgs)
                 end
                 new_graph = build_dep_graph(new_env, request.manifest, request._from_loading, req_pkgids)
                 # When no specific packages were requested, treat project deps as the requested set
@@ -2370,7 +2378,7 @@ function drain_work_channel!(s::PrecompileSession, work_channel::Channel{Precomp
                     union!(s.serial_deps, new_graph.serial_deps)
                     union!(s.requested_pkgids, effective_pkgids)
                 end
-                new_pkg_names = copy(request.pkgs)
+                new_pkg_names = req_pkg_names
                 new_dd = new_graph.direct_deps
                 filter_dep_graph!(new_dd, new_pkg_names, new_graph.ext_to_parent, req_pkgids)
                 skip_pkgs = Set{PkgId}()
@@ -2425,7 +2433,7 @@ function drain_work_channel!(s::PrecompileSession, work_channel::Channel{Precomp
                 new_tasks = spawn_precompile_tasks!(s;
                     direct_deps=new_dd, was_processed=new_wp, configs=request.configs,
                     circular_deps=new_circular, requested_pkgids=effective_pkgids,
-                    pkg_names=request.pkgs, requested_pkgs=request.pkgs,
+                    pkg_names=new_pkg_names, requested_pkgs=request.pkgs,
                     from_loading=request._from_loading)
                 append!(s.injected_tasks, new_tasks)
                 waiter = Threads.@spawn :samepool begin
@@ -2672,7 +2680,9 @@ function do_precompile(pkgs::Union{Vector{String}, Vector{PkgId}},
                         detachable::Bool,
                         work_channel::Channel{PrecompileRequest})
     requested_pkgs = copy(pkgs)
-    pkg_names = pkgs isa Vector{String} ? copy(pkgs) : String[pkg.name for pkg in pkgs]
+    # A `Vector{PkgId}` request is resolved purely by identity (`requested_pkgids`);
+    # names are only used to filter and report the `Vector{String}` path.
+    pkg_names = pkgs isa Vector{String} ? copy(pkgs) : String[]
     if pkgs isa Vector{PkgId}
         requested_pkgids = copy(pkgs)
     else
@@ -2734,6 +2744,9 @@ function do_precompile(pkgs::Union{Vector{String}, Vector{PkgId}},
 
     circular_deps = detect_circular_deps!(graph.direct_deps, graph.serial_deps, was_processed, io, graph.ext_to_parent)
 
+    # `pkg_names` is empty for a `Vector{PkgId}` request, so the graph is filtered by
+    # identity via `requested_pkgids`. Matching on name would be incorrect when two
+    # packages with different UUIDs share the same name.
     if filter_dep_graph!(graph.direct_deps, pkg_names, graph.ext_to_parent, requested_pkgids)
         @lock BG BG.result = ""
         return

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2774,6 +2774,69 @@ end
     end
 end
 
+# A `Vector{PkgId}` request must precompile the package with the requested UUID, even
+# when a different package with the same name exists in the manifest (as happens for
+# distinct workspace members that share a package name). Name-based resolution would
+# resolve the name against the active project's direct deps and pick the wrong UUID.
+@testset "precompilepkgs Vector{PkgId} disambiguates same-name packages" begin
+    mkdepottempdir() do depot
+        function devpkg(dirname, name, uuid, body; deps="")
+            dir = joinpath(depot, "dev", dirname)
+            mkpath(joinpath(dir, "src"))
+            write(joinpath(dir, "Project.toml"),
+                  "name = \"$name\"\nuuid = \"$uuid\"\nversion = \"0.1.0\"\n$deps")
+            write(joinpath(dir, "src", "$name.jl"), body)
+        end
+
+        a = "aaaaaaaa-0000-0000-0000-000000000001" # "Shared", precompiles cleanly
+        b = "bbbbbbbb-0000-0000-0000-000000000002" # "Shared", errors if precompiled
+        w = "cccccccc-0000-0000-0000-000000000003" # "Wrapper", depends on Shared (UUID a)
+
+        # Both "Shared" packages live under distinct directories to avoid a path clash.
+        devpkg("SharedA", "Shared", a, "module Shared\nend\n")
+        devpkg("SharedB", "Shared", b, "module Shared\nerror(\"UUID B must not be precompiled\")\nend\n")
+        devpkg("Wrapper", "Wrapper", w, "module Wrapper\nend\n"; deps="\n[deps]\nShared = \"$a\"\n")
+
+        project = joinpath(depot, "testenv")
+        mkpath(project)
+        # The active project's direct `Shared` is UUID B, so name resolution picks it.
+        write(joinpath(project, "Project.toml"), "[deps]\nWrapper = \"$w\"\nShared = \"$b\"\n")
+        write(joinpath(project, "Manifest.toml"),
+              """
+              manifest_format = "2.0"
+
+              [[deps.Shared]]
+              uuid = "$a"
+              path = "../dev/SharedA/"
+
+              [[deps.Shared]]
+              uuid = "$b"
+              path = "../dev/SharedB/"
+
+              [[deps.Wrapper]]
+              deps = {Shared = "$a"}
+              uuid = "$w"
+              path = "../dev/Wrapper/"
+              """)
+
+        original_depot_path = copy(Base.DEPOT_PATH)
+        old_proj = Base.active_project()
+        try
+            push!(empty!(DEPOT_PATH), depot)
+            Base.set_active_project(project)
+            shared_a = Base.PkgId(Base.UUID(a), "Shared")
+            r = Base.Precompilation.precompilepkgs([shared_a]; io=IOContext{IO}(IOBuffer()),
+                                                   fancyprint=false, manifest=true)
+            # Only Shared (UUID A) is precompiled; Shared (UUID B) would have errored.
+            @test r isa Vector{String}
+            @test length(r) == 1
+        finally
+            Base.set_active_project(old_proj)
+            append!(empty!(DEPOT_PATH), original_depot_path)
+        end
+    end
+end
+
 precompile_test_harness("invalidation for 'foreign-keyed' Preferences") do load_path
     # Test that compile-time preferences invalidate, even when queried from a
     # "foreign" UUID / package namespace


### PR DESCRIPTION
`precompilepkgs` can be handed a `Vector{PkgId}` to precompile specific packages by exact identity rather than by name. #60943 resolved by name against the active project's direct dependencies. When two packages share a name but have different UUIDs — as happens for distinct workspace members that share a manifest — the wrong package could be selected.

To fix this, the `PkgId`s are used directly instead of the chain `Correct UUID` -> `ambiguous name` -> `Incorrect UUID`.

This is a bugfix, but it is also an enabler for precompiling multiple environments of a workspace in parallel.

This change was written with the support from Claude Opus 4.8.