### PR TITLE
loading: fix race on temporary cache files

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3410,8 +3410,6 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
                            internal_stderr::IO = stderr, internal_stdout::IO = stdout, loadable_exts::Union{Vector{PkgId},Nothing}=nothing;
                            report_timing::Bool=false)
     @nospecialize internal_stderr internal_stdout
-    rm(output, force=true)   # Remove file if it exists
-    output_o === nothing || rm(output_o, force=true)
     depot_path = String[abspath(x) for x in DEPOT_PATH]
     dl_load_path = String[abspath(x) for x in DL_LOAD_PATH]
     load_path = String[abspath(x) for x in Base.load_path()]


### PR DESCRIPTION
If these files are deleted before they are used, there is a brief window where the filename is available to `mkstemp()` (`GetTempFileName` on Windows) on parallel workers before it is re-created.

This can lead to cache file collisions, especially on Windows where `GetTempFileName` uses the current (millisecond) tick count to salt the filename by default. Instead the tempfile must remain in place until it is used so that we hold onto the filesystem reservation, which we can do by simply not deleting it since it is already truncated by the writer process.

Found by Claude Opus 🤖  after I asked it to investigate https://buildkite.com/julialang/julia-pr/builds/802#019f9490-e8de-4cae-af5e-8347fb5fc593/L2978