### PR TITLE
partr: do not let a pinned task block a multiqueue heap head

### DIFF
--- a/base/partr.jl
+++ b/base/partr.jl
@@ -172,6 +172,23 @@ function multiq_insert(task::Task, priority::UInt16)
     return true
 end
 
+# Pop the root task off `heap`, whose lock must be held and which must be
+# non-empty, restoring the heap invariant and its advertised priority.
+function multiq_heappop!(heap::taskheap)
+    task = heap.tasks[1]
+    ntasks = heap.ntasks
+    @atomic :monotonic heap.ntasks = ntasks - Int32(1)
+    heap.tasks[1] = heap.tasks[ntasks]
+    Base._unsetindex!(heap.tasks, Int(ntasks))
+    prio1 = typemax(UInt16)
+    if ntasks > 1
+        multiq_sift_down(heap, Int32(1))
+        prio1 = heap.tasks[1].priority
+    end
+    @atomic :monotonic heap.priority = prio1
+    return task
+end
+
 function multiq_deletemin()
     local rn1::UInt32
     local heap, task
@@ -213,28 +230,32 @@ function multiq_deletemin()
         heap = tpheaps[rn1]
         task = heap.tasks[1]
         if ccall(:jl_set_task_tid, Cint, (Any, Cint), task, tid-1) == 0
-            # This task is sticky to a different thread, so we can't run it.
-            # Wake that thread so it can come pick up its own work, then keep
-            # looking for something we are allowed to run.
+            # The task is pinned to another thread (sticky there, on a
+            # thread-local copied stack, or still switching away from it), so
+            # only that thread can run it. It must not stay at the head of the
+            # heap: no other task in this heap can be popped past it, so if the
+            # pinned thread never drains this multiqueue (e.g. an adopted
+            # foreign thread), it would block every task queued behind it
+            # forever, while `multiq_check_empty` keeps every pool thread
+            # spinning on the unpoppable entry. Hand it to the pinned thread's
+            # own workqueue - where `enq_work` routes pinned tasks, and which
+            # that thread checks before the multiqueue - then wake that thread
+            # and keep looking for something we are allowed to run.
             task_tid = ccall(:jl_get_task_tid, Int16, (Any,), task)
-            unlock(heap.lock)
-            if task_tid != Int16(-1)
-                ccall(:jl_wakeup_thread, Cint, (Int16,), task_tid)
+            if task_tid == Int16(-1)
+                # the pin was released concurrently; retry the pop
+                unlock(heap.lock)
+                continue
             end
+            multiq_heappop!(heap)
+            unlock(heap.lock)
+            push!(Base.workqueue_for(Int(task_tid) + 1), task)
+            ccall(:jl_wakeup_thread, Cint, (Int16,), task_tid)
             continue
         end
         break
     end
-    ntasks = heap.ntasks
-    @atomic :monotonic heap.ntasks = ntasks - Int32(1)
-    heap.tasks[1] = heap.tasks[ntasks]
-    Base._unsetindex!(heap.tasks, Int(ntasks))
-    prio1 = typemax(UInt16)
-    if ntasks > 1
-        multiq_sift_down(heap, Int32(1))
-        prio1 = heap.tasks[1].priority
-    end
-    @atomic :monotonic heap.priority = prio1
+    task = multiq_heappop!(heap)
     unlock(heap.lock)
 
     return task

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1752,6 +1752,37 @@ end
     end
 end
 
+@testset "multiq: pinned task at a heap head does not block the queue" begin
+    # A runnable task whose tid is pinned to another thread (sticky there, on
+    # a thread-local copied stack, or still switching away) can reach the head
+    # of a multiqueue heap. It must be handed off to the pinned thread's own
+    # workqueue rather than left blocking every task queued behind it, which
+    # livelocks the pool when the pinned thread never drains the multiqueue.
+    tids = Threads.threadpooltids(Threads.threadpool())
+    if length(tids) >= 2
+        othertid = tids[something(findfirst(!=(Threads.threadid()), tids))]
+        pinned = Task(() -> nothing)
+        pinned.sticky = false
+        @test ccall(:jl_set_task_threadpoolid, Cint, (Any, Int8), pinned,
+                    Threads._sym_to_tpid(Threads.threadpool())) == 1
+        @test ccall(:jl_set_task_tid, Cint, (Any, Cint), pinned, othertid - 1) == 1
+        @test Base.Partr.multiq_insert(pinned, UInt16(0))
+        # deletemin must never return the pinned task to this thread; it hands
+        # it to `othertid`'s workqueue (or that thread pops and runs it first).
+        # Requeue any unrelated task it happens to give us.
+        for _ in 1:1000
+            (pinned.queue !== nothing || istaskdone(pinned)) && break
+            t = Base.Partr.multiq_deletemin()
+            @test t !== pinned
+            t === nothing || Base.enq_work(t)
+        end
+        @test pinned.queue !== nothing || istaskdone(pinned)
+        # the relocated task is still runnable by the thread it is pinned to
+        wait(pinned)
+        @test istaskdone(pinned)
+    end
+end
+
 include("threads_comprehensions.jl")
 
 # This test is designed to trigger the performance regression from #60241:


### PR DESCRIPTION
`multiq_deletemin` only ever examines the root of the heap it probes. When that root is a task whose tid is pinned to another thread (`jl_set_task_tid` fails: the task is sticky there, on a thread-local copied stack, or still switching away), the popping thread would leave it in place, wake the pinned thread, and rescan. If the pinned thread never drains this pool's multiqueue - an adopted foreign thread, for example - that wake is meaningless and the heap is poisoned: every task queued behind the unpoppable root is unreachable forever, while `multiq_check_empty` keeps reporting work so every pool thread spins at 100% without sleeping. Any workload whose progress funnels through the multiqueue then livelocks; a `Threads.@threads :greedy` loop (producer and consumers repeatedly re-scheduled through the multiqueue) hangs this way once its wakeups land behind the poisoned root, observed as a threads-test watchdog kill on CI:
https://buildkite.com/julialang/julia-pr/builds/788#019f9158-9be0-4a5d-b34d-b0aa3bc47124

Instead of skipping in place, pop the pinned task and hand it to the pinned thread's own workqueue - where `enq_work` routes pinned tasks, and which that thread checks before the multiqueue - then wake that thread and keep scanning. The heap root is freed for the tasks behind it, and the pinned task remains runnable by its owner exactly as before.