### PR TITLE
build: add output time measurement for bootstrap sysimage builds

### DIFF
--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -410,5 +410,43 @@ Core._setlowerer!(fl_lower)
 @assert !isassigned(_included_files, 1)
 _included_files[1] = (@__MODULE__, ccall(:jl_prepend_cwd, Any, (Any,), "Base_compiler.jl"))
 
+## postoutput: register post output hooks ##
+## like atexit but runs after any requested output.
+const postoutput_hooks = Callable[]
+
+postoutput(f::Function) = (pushfirst!(postoutput_hooks, f); nothing)
+
+function _postoutput()
+    while !isempty(postoutput_hooks)
+        f = popfirst!(postoutput_hooks)
+        try
+            f()
+        catch ex
+            # `showerror` is not available yet when this runs during the compiler
+            # image build; `jl_postoutput_hook` reports whatever escapes from here
+            showerror(stderr, ex)
+            show_backtrace(stderr, catch_backtrace())
+            println(stderr)
+        end
+    end
+end
+
+if JLOptions().outputo != C_NULL || JLOptions().outputbc != C_NULL
+    # Time the output of this image (LLVM codegen + object emission)
+    Core.println(Core.stdout, "Outputting compiler image...")
+    let pre_output_time = RefValue{UInt64}(time_ns())
+        ccall(:jl_set_precompile_field_replace, Cvoid, (Any, Any, Any),
+              pre_output_time, :x, UInt64(0))
+        postoutput() do
+            pre_output_time[] == 0 && return nothing
+            output_time = time_ns() - pre_output_time[]
+            @ccall jl_printf(Core.io_pointer(Core.stdout)::Ptr{Cvoid},
+                             "Output ────── %10.6f seconds\n"::Ptr{UInt8};
+                             (output_time / 1e9)::Cdouble)::Cint
+            return nothing
+        end
+    end
+end
+
 end # module Base
 using .Base

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -548,26 +548,6 @@ function _atexit(exitcode::Cint)
     end
 end
 
-## postoutput: register post output hooks ##
-## like atexit but runs after any requested output.
-## any hooks saved in the sysimage are cleared in Base._start
-const postoutput_hooks = Callable[]
-
-postoutput(f::Function) = (pushfirst!(postoutput_hooks, f); nothing)
-
-function _postoutput()
-    while !isempty(postoutput_hooks)
-        f = popfirst!(postoutput_hooks)
-        try
-            f()
-        catch ex
-            showerror(stderr, ex)
-            show_backtrace(stderr, catch_backtrace())
-            println(stderr)
-        end
-    end
-end
-
 ## hook for disabling threaded libraries ##
 
 library_threading_enabled::Bool = true

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -1,5 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+# clear any hooks that the compiler image saved for its own output: this build
+# stage has no `Base._start` to do it (see the definition in client.jl)
+empty!(Base.postoutput_hooks)
+
 Base.include("Base.jl") # finish populating Base (currently just has the Compiler)
 
 # Set up Main module by importing from Base
@@ -157,5 +161,13 @@ Base.TOML.reinit!(Base.TOML_CACHE.p, "")
 @eval Sys begin
     BINDIR = ""
     STDLIB = ""
+end
+
+println(stdout, "Outputting sysimage file...")
+let pre_output_time = time_ns(), stdout = stdout
+    Base.postoutput() do
+        output_time = time_ns() - pre_output_time
+        print(stdout, "Output ────── "); Base.time_print(stdout, output_time); println(stdout)
+    end
 end
 end


### PR DESCRIPTION
This sysimage output (LLVM codegen + object emission) can be very significant so we should print it to the developer, since otherwise CI timestamps are the only way to recover this timing. It also makes it clear how much time is spent in LLVM (or not) during bootstrap.

This PR adds `Output ────── 536.061291 seconds` timing for `sysbase.so` and `basecompiler.so` (rather than just `sys.so`).

Noticed in https://github.com/JuliaCI/julia-buildkite/pull/572