### PR TITLE
threads: deny task switching on adopted threads by default

### DIFF
--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -497,6 +497,9 @@ this as implicit synchronization needs to be checked for correctness.
 function make_io_thread()
     tid = UInt[0]
     threadwork = @cfunction function(arg::Ptr{Cvoid})
+            # this thread is donated to the runtime for good: opt in to task
+            # switching, which adopted threads are otherwise denied
+            @ccall jl_allow_adopted_task_switching(1::Cint)::Cint
             current_task().donenotify = Base.ThreadSynchronizer() #TODO: Should this happen by default in adopt thread?
             Base.errormonitor(current_task()) # this may not go particularly well if the IO loop is dead, but try anyways
             @ccall jl_set_io_loop_tid((Threads.threadid() - 1)::Int16)::Cvoid

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -499,7 +499,7 @@ function make_io_thread()
     threadwork = @cfunction function(arg::Ptr{Cvoid})
             # this thread is donated to the runtime for good: opt in to task
             # switching, which adopted threads are otherwise denied
-            @ccall jl_allow_adopted_task_switching(1::Cint)::Cint
+            @ccall jl_thread_allow_task_switching(1::Cint)::Cint
             current_task().donenotify = Base.ThreadSynchronizer() #TODO: Should this happen by default in adopt thread?
             Base.errormonitor(current_task()) # this may not go particularly well if the IO loop is dead, but try anyways
             @ccall jl_set_io_loop_tid((Threads.threadid() - 1)::Int16)::Cvoid

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -4,6 +4,7 @@
     XX(jl_active_task_stack) \
     XX(jl_adopt_thread) \
     XX(jl_alignment) \
+    XX(jl_allow_adopted_task_switching) \
     XX(jl_alloc_array_1d) \
     XX(jl_alloc_array_2d) \
     XX(jl_alloc_array_3d) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -4,7 +4,6 @@
     XX(jl_active_task_stack) \
     XX(jl_adopt_thread) \
     XX(jl_alignment) \
-    XX(jl_allow_adopted_task_switching) \
     XX(jl_alloc_array_1d) \
     XX(jl_alloc_array_2d) \
     XX(jl_alloc_array_3d) \
@@ -457,6 +456,7 @@
     XX(jl_task_get_next) \
     XX(jl_termios_size) \
     XX(jl_test_cpu_feature) \
+    XX(jl_thread_allow_task_switching) \
     XX(jl_threadid) \
     XX(jl_threadpoolid) \
     XX(jl_get_ptls_rng) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -2388,6 +2388,10 @@ JL_DLLEXPORT void JL_NORETURN jl_raise(int signo);
 JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_pathname_for_symbol(void *symbol) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void) JL_CANSAFEPOINT_ENTER;
+// Allow or disallow task switching on the current (adopted) thread; returns
+// the previous setting. Adopted threads default to disallowed: Julia code
+// running on them may block in place, but may not switch to other tasks.
+JL_DLLEXPORT int jl_allow_adopted_task_switching(int allow) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
 JL_DLLEXPORT jl_image_buf_t jl_preload_sysimg(const char *fname) JL_NOTSAFEPOINT;

--- a/src/julia.h
+++ b/src/julia.h
@@ -2391,7 +2391,7 @@ JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void) JL_CANSAFEPOINT_ENTER;
 // Allow or disallow task switching on the current (adopted) thread; returns
 // the previous setting. Adopted threads default to disallowed: Julia code
 // running on them may block in place, but may not switch to other tasks.
-JL_DLLEXPORT int jl_allow_adopted_task_switching(int allow) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_thread_allow_task_switching(int allow) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
 JL_DLLEXPORT jl_image_buf_t jl_preload_sysimg(const char *fname) JL_NOTSAFEPOINT;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -153,6 +153,13 @@ typedef struct _jl_tls_states_t {
     // as it may make compilation undecidable
     int16_t in_pure_callback;
     int16_t in_finalizer;
+    // Adopted (foreign) threads may not switch tasks: their owner handed us
+    // this thread only for the duration of a cfunction call, and parking it
+    // on another task's work would prevent that call from returning (and pin
+    // tasks to a thread that may never re-enter the scheduler). 0 on adopted
+    // threads unless explicitly opted in via `jl_allow_adopted_task_switching`;
+    // always 1 on threads the runtime owns.
+    int16_t allow_task_switching;
     int16_t disable_gc;
     // Counter to disable finalizer **on the current thread**
     int finalizers_inhibited;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -157,7 +157,7 @@ typedef struct _jl_tls_states_t {
     // this thread only for the duration of a cfunction call, and parking it
     // on another task's work would prevent that call from returning (and pin
     // tasks to a thread that may never re-enter the scheduler). 0 on adopted
-    // threads unless explicitly opted in via `jl_allow_adopted_task_switching`;
+    // threads unless explicitly opted in via `jl_thread_allow_task_switching`;
     // always 1 on threads the runtime owns.
     int16_t allow_task_switching;
     int16_t disable_gc;

--- a/src/task.c
+++ b/src/task.c
@@ -677,11 +677,11 @@ JL_DLLEXPORT void jl_switch(void) JL_CANSAFEPOINT_ENTER_LEAVE
         // Adopted (foreign) threads run Julia only for the duration of an
         // entered cfunction: the caller expects that call to return, so this
         // thread may block in place but must not be parked on other tasks'
-        // work. Opt in with `jl_allow_adopted_task_switching(1)`. Note that a
+        // work. Opt in with `jl_thread_allow_task_switching(1)`. Note that a
         // task that blocks with nothing else to run never reaches here - its
         // resumption is the `t == ct` no-op switch above.
         jl_error("task switch not allowed on an adopted foreign thread "
-                 "(call jl_allow_adopted_task_switching(1) to opt in)");
+                 "(call jl_thread_allow_task_switching(1) to opt in)");
     if (!jl_set_task_tid(t, jl_atomic_load_relaxed(&ct->tid))) // manually yielding to a task
         jl_error("cannot switch to task running on another thread");
 

--- a/src/task.c
+++ b/src/task.c
@@ -673,6 +673,15 @@ JL_DLLEXPORT void jl_switch(void) JL_CANSAFEPOINT_ENTER_LEAVE
         jl_error("task switch not allowed from inside gc finalizer");
     if (ptls->in_pure_callback)
         jl_error("task switch not allowed from inside staged nor pure functions");
+    if (__unlikely(!ptls->allow_task_switching))
+        // Adopted (foreign) threads run Julia only for the duration of an
+        // entered cfunction: the caller expects that call to return, so this
+        // thread may block in place but must not be parked on other tasks'
+        // work. Opt in with `jl_allow_adopted_task_switching(1)`. Note that a
+        // task that blocks with nothing else to run never reaches here - its
+        // resumption is the `t == ct` no-op switch above.
+        jl_error("task switch not allowed on an adopted foreign thread "
+                 "(call jl_allow_adopted_task_switching(1) to opt in)");
     if (!jl_set_task_tid(t, jl_atomic_load_relaxed(&ct->tid))) // manually yielding to a task
         jl_error("cannot switch to task running on another thread");
 

--- a/src/threading.c
+++ b/src/threading.c
@@ -369,6 +369,9 @@ jl_ptls_t jl_init_threadtls(int16_t tid)
 #endif
     ptls->system_id = uv_thread_self();
     ptls->rngseed = jl_rand();
+    // adopted threads (tid == -1 here) may not switch tasks unless they
+    // explicitly opt in: their owner expects the entered cfunction to return
+    ptls->allow_task_switching = (tid != -1);
     if (tid == 0) {
         ptls->disable_gc = 1;
 #ifdef _OS_WINDOWS_
@@ -905,6 +908,14 @@ void jl_start_threads(void)
 
 _Atomic(unsigned) _threadedregion; // keep track of whether to prioritize IO or threading
 _Atomic(uint16_t) io_loop_tid; // mark which thread is assigned to run the uv_loop
+
+JL_DLLEXPORT int jl_allow_adopted_task_switching(int allow) JL_NOTSAFEPOINT
+{
+    jl_ptls_t ptls = jl_current_task->ptls;
+    int prev = ptls->allow_task_switching;
+    ptls->allow_task_switching = (int16_t)!!allow;
+    return prev;
+}
 
 JL_DLLEXPORT int jl_in_threaded_region(void)
 {

--- a/src/threading.c
+++ b/src/threading.c
@@ -909,7 +909,7 @@ void jl_start_threads(void)
 _Atomic(unsigned) _threadedregion; // keep track of whether to prioritize IO or threading
 _Atomic(uint16_t) io_loop_tid; // mark which thread is assigned to run the uv_loop
 
-JL_DLLEXPORT int jl_allow_adopted_task_switching(int allow) JL_NOTSAFEPOINT
+JL_DLLEXPORT int jl_thread_allow_task_switching(int allow) JL_NOTSAFEPOINT
 {
     jl_ptls_t ptls = jl_current_task->ptls;
     int prev = ptls->allow_task_switching;

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -424,6 +424,63 @@ end
     @test io_thread_test()
 end
 
+@testset "adopted threads deny task switching without opt-in" begin
+    # An adopted (foreign) thread's caller expects the entered cfunction to
+    # return, so Julia code on it may block in place (host `wait()` and be
+    # resumed by a notify), but may not be parked on other tasks' work: a
+    # switch to a *different* task errors unless the thread opts in with
+    # `jl_allow_adopted_task_switching`.
+    blocked_ok = Ref{Any}(nothing)
+    denied = Ref{Any}(nothing)
+    optin = Ref{Any}(nothing)
+    ch = Channel{Int}(1)
+    cl = function ()
+        try
+            blocked_ok[] = take!(ch) # blocking without a switch must still work
+        catch e
+            blocked_ok[] = e
+        end
+        try
+            @async nothing # a sticky task in this thread's workqueue...
+            yield()        # ...forces a switch to a different task
+            denied[] = :switched
+        catch e
+            denied[] = e
+        end
+        prev = @ccall jl_allow_adopted_task_switching(1::Cint)::Cint
+        try
+            t = @async :ran
+            yield()
+            optin[] = (Int(prev), fetch(t))
+        catch e
+            optin[] = e
+        end
+        nothing
+    end
+    function threadcallclosure(tid::Ref{UInt}, cl::Ref{F}) where {F}
+        threadwork = @cfunction cl -> cl() Cvoid (Ref{F},)
+        err = @ccall uv_thread_create(tid::Ptr{UInt}, threadwork::Ptr{Cvoid}, cl::Ref{F})::Cint
+        err == 0 || Base.uv_error("uv_thread_create", err)
+        nothing
+    end
+    tid = Ref{UInt}(0)
+    clr = Ref(cl)
+    GC.@preserve clr begin
+        Base.preserve_handle(clr)
+        threadcallclosure(tid, clr)
+        put!(ch, 42) # unblock the adopted thread
+        gc_state = @ccall jl_gc_safe_enter()::Int8
+        err = @ccall uv_thread_join(tid::Ptr{UInt})::Cint
+        @ccall jl_gc_safe_leave(gc_state::Int8)::Cvoid
+        err == 0 || Base.uv_error("uv_thread_join", err)
+        Base.unpreserve_handle(clr)
+    end
+    @test blocked_ok[] === 42
+    @test denied[] isa ErrorException
+    @test occursin("task switch not allowed on an adopted foreign thread", (denied[]::ErrorException).msg)
+    @test optin[] === (0, :ran)
+end
+
 # Make sure default number of BLAS threads respects CPU affinity: issue #55572.
 @testset "LinearAlgebra number of default threads" begin
     if AFFINITY_SUPPORTED

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -429,7 +429,7 @@ end
     # return, so Julia code on it may block in place (host `wait()` and be
     # resumed by a notify), but may not be parked on other tasks' work: a
     # switch to a *different* task errors unless the thread opts in with
-    # `jl_allow_adopted_task_switching`.
+    # `jl_thread_allow_task_switching`.
     blocked_ok = Ref{Any}(nothing)
     denied = Ref{Any}(nothing)
     optin = Ref{Any}(nothing)
@@ -447,7 +447,7 @@ end
         catch e
             denied[] = e
         end
-        prev = @ccall jl_allow_adopted_task_switching(1::Cint)::Cint
+        prev = @ccall jl_thread_allow_task_switching(1::Cint)::Cint
         try
             t = @async :ran
             yield()


### PR DESCRIPTION
A thread that enters Julia through a cfunction was lent to the runtime only for the duration of that call: its owner expects the call to return. Letting the scheduler park such a thread on other tasks' work breaks that expectation, and also stamps those tasks' tids with a thread that may never re-enter the scheduler - leaving them pinned to a thread that cannot be woken and will never pop the queues they wait in (the failure mechanism behind the multiqueue livelock addressed on kf/multiq-pinned-head).

Deny switching to a different task on adopted threads. Blocking in place remains fully supported: a task that blocks with nothing else to run hosts the scheduler on its own stack and its resumption is the `t == ct` no-op switch, so cfunction code that takes locks, does IO, or waits on channels behaves as before. Threads that are deliberately donated to the runtime opt in via the new
`jl_allow_adopted_task_switching`; `Base.Experimental.make_io_thread`
- whose entered cfunction is intentionally never expected to return - does so. A survey of the in-tree test suites (threads, channels, ccall, misc) found no other adopted-thread code relying on switching.
