### PR TITLE
test: Ignore test-defined isequal methods in missing.jl's inference s…

### DIFF
--- a/test/missing.jl
+++ b/test/missing.jl
@@ -80,7 +80,16 @@ end
     @test isapprox(missing, 1.0, atol=1e-6) === missing
     @test isapprox(1.0, missing, rtol=1e-6) === missing
 
-    @test all(==(Bool), Base.return_types(isequal, Tuple{Any,Any}))
+    # Only assert the methods shipped with Base and the stdlibs: test files
+    # that ran earlier in the same process may have added their own isequal
+    # methods (e.g. arrayops' totally_not_five26034), and what those infer
+    # depends on the session's accumulated method tables, not on `missing`.
+    let ms = collect(methods(isequal, Tuple{Any,Any})),
+        rts = Base.return_types(isequal, Tuple{Any,Any})
+        @test all(zip(ms, rts)) do (m, rt)
+            Base.moduleroot(parentmodule(m)) === Main || rt === Bool
+        end
+    end
 end
 
 @testset "arithmetic operators" begin


### PR DESCRIPTION
…weep

The all-methods return_types(isequal, Tuple{Any,Any}) sweep from #49800 asserts over every isequal method in the session - including ones added by OTHER test files sharing the worker process. test/arrayops.jl defines isequal(::totally_not_five26034, ::Number) (and its mirror), which infer Bool in isolation but degrade to Any once the LinearAlgebra tests have inflated the ==/Number method tables earlier in the same process. The failure therefore appears whenever the scheduler happens to run arrayops (after the LinearAlgebra tests) before missing on one worker - deterministically reproducible with

    JULIA_CPU_THREADS=1 julia test/runtests.jl LinearAlgebra/triangular2 \
        LinearAlgebra/structuredbroadcast triplequote intrinsics iobuffer \
        staged arrayops combinatorics euler client terminfo errorshow \
        goto llvmcall some docs interpreter floatfuncs missing

Restrict the assertion to methods owned by Base and the stdlibs (module root not Main); in a fresh process this still covers all 27 shipped methods.

CI failure: https://buildkite.com/julialang/julia-pr/builds/392#019f59bc-668b-4c95-81ed-e80a15899a30