### PR TITLE
Don't dereference pointer to C function in sweep_finalizer_list

### DIFF
--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -168,8 +168,8 @@ void schedule_finalization(void *o, void *f) JL_NOTSAFEPOINT
 
 void run_finalizer(jl_task_t *ct, void *o, void *ff)
 {
-    int ptr_finalizer = gc_ptr_tag(o, 1);
-    o = gc_ptr_clear_tag(o, 3);
+    int ptr_finalizer = gc_ptr_tag(o, GC_FIN_CFUNC_TAG);
+    o = gc_ptr_clear_tag(o, GC_FIN_TAG_MASK);
     if (ptr_finalizer) {
         ((void (*)(void*))ff)((void*)o);
         return;
@@ -207,7 +207,7 @@ static void finalize_object(arraylist_t *list, jl_value_t *o,
     for (size_t i = 0; i < len; i += 2) {
         void *v = items[i];
         int move = 0;
-        if (o == (jl_value_t*)gc_ptr_clear_tag(v, 1)) {
+        if (o == (jl_value_t*)gc_ptr_clear_tag(v, GC_FIN_CFUNC_TAG)) {
             void *f = items[i + 1];
             move = 1;
             arraylist_push(copied_list, v);
@@ -449,14 +449,14 @@ void jl_gc_add_finalizer_(jl_ptls_t ptls, void *v, void *f) JL_NOTSAFEPOINT
 
 JL_DLLEXPORT void jl_gc_add_ptr_finalizer(jl_ptls_t ptls, jl_value_t *v, void *f) JL_NOTSAFEPOINT
 {
-    jl_gc_add_finalizer_(ptls, (void*)(((uintptr_t)v) | 1), f);
+    jl_gc_add_finalizer_(ptls, (void*)(((uintptr_t)v) | GC_FIN_CFUNC_TAG), f);
 }
 
 // schedule f(v) to call at the next quiescent interval (aka after the next safepoint/region on all threads)
 JL_DLLEXPORT void jl_gc_add_quiescent(jl_ptls_t ptls, void **v, void *f) JL_NOTSAFEPOINT
 {
-    assert(!gc_ptr_tag(v, 3));
-    jl_gc_add_finalizer_(ptls, (void*)(((uintptr_t)v) | 3), f);
+    assert(!gc_ptr_tag(v, GC_FIN_TAG_MASK));
+    jl_gc_add_finalizer_(ptls, (void*)(((uintptr_t)v) | GC_FIN_TAG_MASK), f);
 }
 
 JL_DLLEXPORT void jl_gc_add_finalizer_th(jl_ptls_t ptls, jl_value_t *v, jl_value_t *f) JL_NOTSAFEPOINT

--- a/src/gc-common.h
+++ b/src/gc-common.h
@@ -186,10 +186,13 @@ void jl_gc_wait_for_the_world(jl_ptls_t* gc_all_tls_states, int gc_n_threads);
 // list of another thread
 extern jl_mutex_t finalizers_lock;
 // `ptls->finalizers` and `finalizer_list_marked` might have tagged pointers.
-// If an object pointer has the lowest bit set, the next pointer is an unboxed c function pointer.
-// If an object pointer has the second lowest bit set, the current pointer is a c object pointer.
+// If an object pointer has `GC_FIN_CFUNC_TAG` set, the next pointer is an unboxed c function pointer.
+// If an object pointer has `GC_FIN_COBJ_TAG` set, the current pointer is a c object pointer.
 //   It must be aligned at least 4, and it finalized immediately (at "quiescence").
 // `to_finalize` should not have tagged pointers.
+#define GC_FIN_CFUNC_TAG 1
+#define GC_FIN_COBJ_TAG  2
+#define GC_FIN_TAG_MASK  3
 extern arraylist_t finalizer_list_marked;
 extern arraylist_t to_finalize;
 

--- a/src/gc-mmtk/mmtk_julia/src/julia_finalizer.rs
+++ b/src/gc-mmtk/mmtk_julia/src/julia_finalizer.rs
@@ -13,6 +13,16 @@ use crate::jl_gc_get_marked_finalizers_list;
 use crate::jl_gc_get_thread_finalizer_list;
 use crate::jl_gc_get_to_finalize_list;
 
+// Entries in the thread-local and marked finalizer lists may have tagged object
+// pointers. These must match the `GC_FIN_*` defines in gc-common.h.
+/// The paired finalizer is an unboxed c function pointer.
+pub const GC_FIN_CFUNC_TAG: usize = 0x1;
+/// The object pointer is a c object pointer, not a `jl_value_t *`.  It must
+/// have alignment >= 4 and will be finalized at the next quiescent period.
+pub const GC_FIN_COBJ_TAG: usize = 0x2;
+/// All bits used to tag finalizer list entries.
+pub const GC_FIN_TAG_MASK: usize = GC_FIN_CFUNC_TAG | GC_FIN_COBJ_TAG;
+
 /// This is a Rust implementation of finalizer scanning in _jl_gc_collect() in gc.c
 pub fn scan_finalizers_in_rust<T: ObjectTracer>(tracer: &mut T) {
     use crate::mmtk::vm::ActivePlan;
@@ -141,7 +151,9 @@ fn sweep_finalizer_list(
     let mut j = 0;
     while i < list.len {
         let v0: Address = list.get(i);
-        let v = unsafe { ObjectReference::from_raw_address_unchecked(gc_ptr_clear_tag(v0, 3)) };
+        let v = unsafe {
+            ObjectReference::from_raw_address_unchecked(gc_ptr_clear_tag(v0, GC_FIN_TAG_MASK))
+        };
         if v0.is_zero() {
             i += 2;
             // remove from this list
@@ -149,7 +161,7 @@ fn sweep_finalizer_list(
         }
 
         let fin = list.get(i + 1);
-        let (isfreed, isold) = if gc_ptr_tag(v0, 2) {
+        let (isfreed, isold) = if gc_ptr_tag(v0, GC_FIN_COBJ_TAG) {
             (true, false)
         } else {
             let isfreed = !memory_manager::is_live_object(v);
@@ -200,17 +212,17 @@ fn mark_finlist<T: ObjectTracer>(list: &mut ArrayListT, start: usize, tracer: &m
             continue;
         }
 
-        let new_obj_addr = if gc_ptr_tag(cur, 1) {
+        let new_obj_addr = if gc_ptr_tag(cur, GC_FIN_CFUNC_TAG) {
             // Skip next
             i += 1;
             debug_assert!(i < list.len);
-            cur_tag = 1;
-            gc_ptr_clear_tag(cur, 1)
+            cur_tag = GC_FIN_CFUNC_TAG;
+            gc_ptr_clear_tag(cur, GC_FIN_CFUNC_TAG)
         } else {
             // unsafe: We checked `cur.is_zero()` before.
             cur
         };
-        if gc_ptr_tag(cur, 2) {
+        if gc_ptr_tag(cur, GC_FIN_COBJ_TAG) {
             i += 1;
             continue;
         }

--- a/src/gc-mmtk/mmtk_julia/src/julia_scanning.rs
+++ b/src/gc-mmtk/mmtk_julia/src/julia_scanning.rs
@@ -431,17 +431,17 @@ pub unsafe fn mmtk_scan_gcstack<EV: SlotVisitor<JuliaVMSlot>>(
                         get_stack_addr(rts.shift::<Address>(i as isize), offset, lb, ub);
 
                     let slot = read_stack(rts.shift::<Address>(i as isize), offset, lb, ub);
-                    use crate::julia_finalizer::gc_ptr_tag;
+                    use crate::julia_finalizer::{gc_ptr_tag, GC_FIN_CFUNC_TAG, GC_FIN_TAG_MASK};
                     // malloced pointer tagged in jl_gc_add_quiescent
                     // skip both the next element (native function), and the object
-                    if slot & 3usize == 3 {
+                    if slot & GC_FIN_TAG_MASK == GC_FIN_TAG_MASK {
                         i += 2;
                         continue;
                     }
 
                     // pointer is not malloced but function is native, so skip it
-                    if gc_ptr_tag(slot, 1) {
-                        process_offset_slot(closure, real_addr, 1);
+                    if gc_ptr_tag(slot, GC_FIN_CFUNC_TAG) {
+                        process_offset_slot(closure, real_addr, GC_FIN_CFUNC_TAG);
                         i += 2;
                         continue;
                     }

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3131,7 +3131,8 @@ static void sweep_finalizer_list(arraylist_t *list) JL_NOTSAFEPOINT
             isfreed = !gc_marked(jl_astaggedvalue(v)->bits.gc);
             isold = (list != &finalizer_list_marked &&
                      jl_astaggedvalue(v)->bits.gc == GC_OLD_MARKED &&
-                     jl_astaggedvalue(fin)->bits.gc == GC_OLD_MARKED);
+                     (gc_ptr_tag(v0, GC_FIN_CFUNC_TAG) ||
+                      jl_astaggedvalue(fin)->bits.gc == GC_OLD_MARKED));
         }
         if (isfreed || isold) {
             // remove from this list

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -2225,13 +2225,13 @@ STATIC_INLINE void gc_mark_stack(jl_ptls_t ptls, jl_gcframe_t *s, uint32_t nroot
             }
             else {
                 new_obj = (jl_value_t *)gc_read_stack(&rts[i], offset, lb, ub);
-                if (gc_ptr_tag(new_obj, 1)) {
+                if (gc_ptr_tag(new_obj, GC_FIN_CFUNC_TAG)) {
                     // handle tagged pointers in finalizer list
-                    new_obj = (jl_value_t *)gc_ptr_clear_tag(new_obj, 1);
+                    new_obj = (jl_value_t *)gc_ptr_clear_tag(new_obj, GC_FIN_CFUNC_TAG);
                     // skip over the finalizer fptr
                     i++;
                 }
-                if (gc_ptr_tag(new_obj, 2))
+                if (gc_ptr_tag(new_obj, GC_FIN_COBJ_TAG))
                     continue;
                 // conservatively check for the presence of any smalltag type, instead of just NULL
                 // in the very unlikely event that codegen decides to root the result of julia.typeof
@@ -2337,12 +2337,12 @@ static void gc_mark_finlist_(jl_gc_markqueue_t *mq, jl_value_t *fl_parent, jl_va
         new_obj = *slot;
         if (__unlikely(new_obj == NULL))
             continue;
-        if (gc_ptr_tag(new_obj, 1)) {
-            new_obj = (jl_value_t *)gc_ptr_clear_tag(new_obj, 1);
+        if (gc_ptr_tag(new_obj, GC_FIN_CFUNC_TAG)) {
+            new_obj = (jl_value_t *)gc_ptr_clear_tag(new_obj, GC_FIN_CFUNC_TAG);
             fl_begin++;
             assert(fl_begin < fl_end);
         }
-        if (gc_ptr_tag(new_obj, 2))
+        if (gc_ptr_tag(new_obj, GC_FIN_COBJ_TAG))
             continue;
         gc_try_claim_and_push(mq, new_obj, NULL);
         if (fl_parent != NULL) {
@@ -3114,7 +3114,7 @@ static void sweep_finalizer_list(arraylist_t *list) JL_NOTSAFEPOINT
     size_t j = 0;
     for (size_t i=0; i < len; i+=2) {
         void *v0 = items[i];
-        void *v = gc_ptr_clear_tag(v0, 3);
+        void *v = gc_ptr_clear_tag(v0, GC_FIN_TAG_MASK);
         if (__unlikely(!v0)) {
             // remove from this list
             continue;
@@ -3123,7 +3123,7 @@ static void sweep_finalizer_list(arraylist_t *list) JL_NOTSAFEPOINT
         void *fin = items[i+1];
         int isfreed;
         int isold;
-        if (gc_ptr_tag(v0, 2)) {
+        if (gc_ptr_tag(v0, GC_FIN_COBJ_TAG)) {
             isfreed = 1;
             isold = 0;
         }


### PR DESCRIPTION
It's low priority, but we might as well fix it so Claude stops getting stunlocked when it reads `gc-stock.c`.  To help future humans and agents, there's a second commit cleaning up the magic numbers we use to tag entries in finalizer lists.