### PR TITLE
Printf: fix '-0' bug when formatting near-zero floats as integers

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -381,7 +381,7 @@ toint(x) = x
 toint(x::Rational) = Integer(x)
 
 fmt(buf, pos, arg::AbstractFloat, spec::Spec{T}) where {T <: Ints} =
-    fmt(buf, pos, arg, floatfmt(spec))
+    fmt(buf, pos, iszero(round(arg)) ? zero(arg) : arg, floatfmt(spec))
 
 function fmt(buf, pos, arg, spec::Spec{T}) where {T <: Ints}
     leftalign, plus, space, zero, hash, width, prec =

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -486,6 +486,15 @@ end
     # print float as %d uses round(x)
     @test @sprintf("%d", 25.5) == "26"
 
+    # 61985
+    @test @sprintf("%d", -0.0) == "0"
+    @test @sprintf("%d", -0.3) == "0"
+    @test @sprintf("%d", -0.5) == "0"
+    @test @sprintf("%d", big"-0.0") == "0"
+    @test @sprintf("%05d", -0.0) == "00000"
+    @test @sprintf("%+d", -0.0) == "+0"
+    @test @sprintf("%d", -0.6) == "-1"
+
     # 37539
     @test @sprintf(" %.1e\n", 0.999) == " 1.0e+00\n"
     @test @sprintf("   %.1f", 9.999) == "   10.0"


### PR DESCRIPTION
Formatting a float that rounds to zero with an int specifier, e.g. `@sprintf("%d", -0.0)`, emits a stray negative sign (`"-0"`) because the method hands it off to `floatfmt` indiscriminately. Added a check to round to zero *before* the handoff.

```julia
julia> @sprintf("%d", -0.0)
"0"

julia> @sprintf("%+d", -0.0)
"+0"

julia> @sprintf("%d", -0.6)
"-1"
```

Addresses #61985