### PR TITLE
agents: Add a CI timing comparison script and `ci-timing` skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ repo_key
 
 # Buildkite: Ignore any agent keys (public or private) we have stored
 agent_key*
+contrib/ci-timing/Manifest.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ canonical `SKILL.md` directly.
 - [`doc/src/devdocs/agents/skills/c-static-analysis/`](doc/src/devdocs/agents/skills/c-static-analysis/SKILL.md) — Clang static analysis and GC-rooting for C/C++ changes under `src/`.
 - [`doc/src/devdocs/agents/skills/external-deps/`](doc/src/devdocs/agents/skills/external-deps/SKILL.md) — modifying external dependencies (`deps/`, patches) and JLLs.
 - [`doc/src/devdocs/agents/skills/buildkite-logs/`](doc/src/devdocs/agents/skills/buildkite-logs/SKILL.md) — fetching and inspecting Buildkite CI logs without web sign-in.
+- [`doc/src/devdocs/agents/skills/ci-timing/`](doc/src/devdocs/agents/skills/ci-timing/SKILL.md) — comparing a PR's Buildkite job durations against recent CI history.
 - [`doc/src/devdocs/agents/skills/compiler-jl/`](doc/src/devdocs/agents/skills/compiler-jl/SKILL.md) — developing and testing Compiler.jl.
 - [`doc/src/devdocs/agents/skills/julia-syntax-lowering/`](doc/src/devdocs/agents/skills/julia-syntax-lowering/SKILL.md) — developing and testing JuliaSyntax and JuliaLowering.
 

--- a/contrib/ci-timing/Project.toml
+++ b/contrib/ci-timing/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/contrib/ci-timing/ci_timing_compare.jl
+++ b/contrib/ci-timing/ci_timing_compare.jl
@@ -1,0 +1,135 @@
+#!/usr/bin/env julia
+#
+# Compare one Buildkite build's job durations against the last N days of Julia CI history.
+#
+# Usage (from the julia repo root):
+#   julia --project=contrib/ci-timing contrib/ci-timing <PR-number>
+#     [--days 7] [--include-failed] [--min-seconds 0]
+#   julia --project=contrib/ci-timing contrib/ci-timing --build julia-pr/853 [...]
+#
+# Prints a markdown table (one row per job, sorted slowest first) plus a TOTAL row.
+# No Buildkite token needed: job data comes from the build page's public JSON
+# endpoint, history from https://perf.julialang.org/data/timing_summary.json.gz
+# (the JuliaCI/julia-ci-timing dataset, cached in the temp dir for 6h).
+# Resolving a PR number to a build needs the `gh` CLI; --build does not.
+
+using Pkg
+Pkg.instantiate()
+
+using JSON, Downloads, Dates, Statistics, Printf
+
+const HISTORY_URL = "https://perf.julialang.org/data/timing_summary.json.gz"
+const CACHE = joinpath(tempdir(), "julia_timing_summary.json.gz")
+const CACHE_MAX_AGE = 6 * 3600
+
+getjson(url) = JSON.parse(sprint(io -> Downloads.download(url, io;
+                                headers = ["Accept" => "application/json"])))
+
+"Find the newest Buildkite build on a JuliaLang/julia PR, plus its title and sha."
+function build_from_pr(pr)
+    out = read(`gh pr view $pr --repo JuliaLang/julia --json statusCheckRollup,title,headRefOid`, String)
+    data = JSON.parse(out)
+    builds = Set{Tuple{String, Int}}()
+    for c in data["statusCheckRollup"]
+        m = match(r"buildkite\.com/julialang/([\w-]+)/builds/(\d+)", something(get(c, "targetUrl", nothing), ""))
+        m === nothing || push!(builds, (m[1], parse(Int, m[2])))
+    end
+    isempty(builds) && error("no Buildkite build found on PR #$pr")
+    pipeline, number = last(sort!(collect(builds); by = last))
+    return pipeline, number, data["title"], data["headRefOid"][1:9]
+end
+
+parsetime(s) = DateTime(s, dateformat"yyyy-mm-dd\THH:MM:SS.sssZ")
+
+"(name, duration, failed) for every finished job of a build, newest attempt only."
+function fetch_jobs(pipeline, number)
+    records = getjson("https://buildkite.com/julialang/$pipeline/builds/$number/data/jobs")["records"]
+    jobs = Tuple{String, Float64, Bool}[]
+    for j in records
+        # skip unnamed steps, broken (never ran) and running jobs, and superseded retries
+        (get(j, "name", nothing) isa String && j["state"] == "finished" &&
+            j["started_at"] isa String && j["finished_at"] isa String &&
+            get(j, "retried_at", nothing) === nothing) || continue
+        dur = Dates.value(parsetime(j["finished_at"]) - parsetime(j["started_at"])) / 1000
+        push!(jobs, (j["name"], dur, get(j, "exit_status", 1) != 0))
+    end
+    return jobs
+end
+
+function history()
+    if !isfile(CACHE) || time() - mtime(CACHE) > CACHE_MAX_AGE
+        Downloads.download(HISTORY_URL, CACHE)
+    end
+    return JSON.parse(read(pipeline(`gzip -dc $CACHE`), String))["jobs"]
+end
+
+fmt(sec) = (m = round(Int, sec); @sprintf("%d:%02d", m ÷ 60, m % 60))
+
+function main(args)
+    pr = nothing; build = nothing; days = 7; include_failed = false; min_seconds = 0.0
+    i = 1
+    while i <= length(args)
+        a = args[i]
+        if a == "--build"; build = args[i += 1]
+        elseif a == "--days"; days = parse(Int, args[i += 1])
+        elseif a == "--min-seconds"; min_seconds = parse(Float64, args[i += 1])
+        elseif a == "--include-failed"; include_failed = true
+        elseif !startswith(a, "-"); pr = parse(Int, a)
+        else error("unknown argument $a")
+        end
+        i += 1
+    end
+
+    title = sha = nothing
+    if build !== nothing
+        p, n = split(build, '/')
+        pipeline, number = String(p), parse(Int, n)
+    elseif pr !== nothing
+        pipeline, number, title, sha = build_from_pr(pr)
+    else
+        error("give a PR number or --build <pipeline>/<number>")
+    end
+
+    jobs = fetch_jobs(pipeline, number)
+    hist = history()
+    latest = maximum(DateTime(r["date"], dateformat"yyyy-mm-dd HH:MM")
+                     for v in values(hist) for r in v["recent"])
+    cut = latest - Day(days)
+
+    rows = NamedTuple[]; failed_out = String[]; nobase = String[]
+    for (name, dur, failed) in jobs
+        if failed && !include_failed
+            push!(failed_out, name); continue
+        end
+        vals = Float64[r["duration"] for r in get(get(hist, name, Dict()), "recent", [])
+                       if r["state"] == "passed" && r["duration"] !== nothing &&
+                          DateTime(r["date"], dateformat"yyyy-mm-dd HH:MM") >= cut]
+        if isempty(vals)
+            push!(nobase, name); continue
+        end
+        m = mean(vals)
+        m < min_seconds && continue
+        push!(rows, (; name = name * (failed ? " *(failed)*" : ""), dur,
+                       mean = m, mn = minimum(vals), mx = maximum(vals), n = length(vals)))
+    end
+    sort!(rows; by = r -> -r.dur)
+
+    label = pr === nothing ? "$pipeline#$number" : "PR #$pr"
+    title === nothing || println("<!-- $title ($sha), $pipeline#$number; baseline ",
+        Dates.format(cut, "yyyy-mm-dd HH:MM"), "..", Dates.format(latest, "yyyy-mm-dd HH:MM"),
+        " UTC, passed runs only -->")
+    println("| Job | $label | Mean | Min | Max | N | Δ vs mean |")
+    println("|---|---:|---:|---:|---:|---:|---:|")
+    for r in rows
+        flag = r.dur > r.mx ? " ⚠️" : r.dur < r.mn ? " ✅" : ""
+        @printf("| %s | %s | %s | %s | %s | %d | %+.1f%%%s |\n", r.name, fmt(r.dur),
+                fmt(r.mean), fmt(r.mn), fmt(r.mx), r.n, 100 * (r.dur - r.mean) / r.mean, flag)
+    end
+    tp = sum(r -> r.dur, rows); tm = sum(r -> r.mean, rows)
+    @printf("| **TOTAL (%d jobs)** | **%s** | **%s** | — | — | — | **%+.1f%%** |\n",
+            length(rows), fmt(tp), fmt(tm), 100 * (tp - tm) / tm)
+    isempty(failed_out) || println("<!-- failed, excluded: ", join(failed_out, ", "), " -->")
+    isempty(nobase) || println("<!-- no baseline: ", join(nobase, ", "), " -->")
+end
+
+main(ARGS)

--- a/doc/src/devdocs/agents/README.md
+++ b/doc/src/devdocs/agents/README.md
@@ -16,5 +16,6 @@ The documentation build renders each canonical `SKILL.md` with its Agent Skill m
 - [`c-static-analysis`](skills/c-static-analysis/index.md) — Clang static analysis and GC-rooting for C/C++ changes under `src/`.
 - [`external-deps`](skills/external-deps/index.md) — modifying external dependencies (`deps/`, patches) and JLLs.
 - [`buildkite-logs`](skills/buildkite-logs/index.md) — fetching and inspecting Buildkite CI logs without web sign-in.
+- [`ci-timing`](skills/ci-timing/index.md) — comparing a PR's Buildkite job durations against recent CI history.
 - [`compiler-jl`](skills/compiler-jl/index.md) — developing and testing Compiler.jl.
 - [`julia-syntax-lowering`](skills/julia-syntax-lowering/index.md) — developing and testing JuliaSyntax and JuliaLowering.

--- a/doc/src/devdocs/agents/skills/ci-timing/SKILL.md
+++ b/doc/src/devdocs/agents/skills/ci-timing/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: ci-timing
+description: Compare a Julia PR's Buildkite job durations against recent CI history (per-job mean/min/max over the last N days). Use when asked whether a PR slows down or speeds up CI, or to check a build's timings against the weekly baseline.
+---
+
+# CI timing analysis
+
+```sh
+julia --startup-file=no --project=contrib/ci-timing contrib/ci-timing/ci_timing_compare.jl <PR-number>
+```
+
+Prints a markdown table, slowest job first, plus a TOTAL row: each job's duration
+in the PR's `julia-pr` build vs. the mean/min/max of the same job name over the
+last 7 days of [julia-ci-timing](https://github.com/JuliaCI/julia-ci-timing)
+history. `⚠️` = above the weekly max, `✅` = below the weekly min. No Buildkite
+token needed; `gh` is only needed to turn a PR number into a build.
+
+Flags: `--build julia-pr/853`, `--days N`, `--include-failed`, `--min-seconds N`
+(hides short jobs).
+
+Caveats when reading it:
+
+- One build vs. a week of samples — anything inside the min/max band is agent
+  variance, and even ⚠️/✅ rows need a second build to mean anything.
+- `juliasyntax`/`Launch *` jobs are seconds long, so their percentages are noise;
+  `--min-seconds 120` drops them.
+- A fleet-wide shift in one direction skews TOTAL and is not a PR effect.
+- Broken (never run), running, and superseded retry jobs are excluded; a failed
+  job's time is cut short or stretched by the failure.
+
+For logs behind a slow or failed job, see the `buildkite-logs` skill.


### PR DESCRIPTION
Adds a skill for generating CI timing comparisons like this for a PR https://github.com/JuliaLang/julia/pull/62392#issuecomment-5079182143

Hoping to make it easier to review PR times before merge, given the recent build jobs slowdowns

<img width="1186" height="570" alt="Screenshot 2026-07-25 at 12 43 37 PM" src="https://github.com/user-attachments/assets/4ccd5722-8700-4534-94da-6581bf0ae0b1" />


Claude:

---

`contrib/ci-timing/ci_timing_compare.jl <PR>` prints a markdown table of the PR's Buildkite job durations against the mean/min/max of the same job names over the last 7 days of the JuliaCI/julia-ci-timing dataset, so a PR that plausibly affects CI cost can be checked in one command.

Job data comes from the build page's public JSON endpoint, so no Buildkite token is needed; `gh` is only used to turn a PR number into a build number. Broken, running and superseded retry jobs are excluded.

The `ci-timing` skill points agents at the script and records how to read the result (single build vs. a week of samples, short jobs being noise).