### PR TITLE
coverage: fix a performance regression, instrument the interpreter, and clean up several bugs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,11 +55,24 @@ Compiler/Runtime improvements
   the LLVM threads each spawns to compile its native image, sharing a single thread budget so idle cores are
   filled during the long tail without oversubscribing the machine when many packages compile at once. The total
   budget can be set with the new `JULIA_PRECOMPILE_THREADS` environment variable ([#61958]).
+* Coverage reports now include code executed by the interpreter, such as top-level statements and method
+  bodies run with `--compile=min`. Consequently, LCOV output and `.cov` files may contain source lines that
+  were absent in earlier releases ([#62514]).
+* Coverage and allocation tracking no longer update counters atomically. This reduces the overhead of
+  instrumented code, but counter values may be inaccurate when the same source line runs concurrently on
+  multiple threads ([#62514]).
+* `--code-coverage=user` no longer includes inlined Base methods whose module cannot be recovered from debug
+  information. This prevents coverage from writing `.cov` files for Base sources into the Julia installation
+  ([#62514]).
 
 Command-line option changes
 ---------------------------
 
 * `-P <project>` is now a shorthand for `--project <project>` ([#59867]).
+* `--code-coverage=@<path>` and `--track-allocation=@<path>` now restrict tracking to the specified file or
+  directory tree. For example, `@/src/Foo` tracks `/src/Foo/x.jl`, but not `/src/Foobar/x.jl`. Specifying the
+  filesystem root as `@/` tracks every absolute path. `Base.is_file_tracked` now returns `false`, rather than
+  crashing, when Julia was not started with either `@<path>` option ([#62514]).
 
 Multi-threading changes
 -----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -101,8 +101,8 @@ Command-line option changes
 * `-P <project>` is now a shorthand for `--project <project>` ([#59867]).
 * `--code-coverage=@<path>` and `--track-allocation=@<path>` now restrict tracking to the specified file or
   directory tree. For example, `@/src/Foo` tracks `/src/Foo/x.jl`, but not `/src/Foobar/x.jl`. Specifying the
-  filesystem root as `@/` tracks every absolute path. `Base.is_file_tracked` now returns `false`, rather than
-  crashing, when Julia was not started with either `@<path>` option ([#62514]).
+  filesystem root as `@/` tracks every absolute path. `Base.is_file_tracked` now returns `false` when Julia was
+  not started with either `@<path>` option ([#62514]).
 
 Multi-threading changes
 -----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -85,11 +85,24 @@ Compiler/Runtime improvements
   the LLVM threads each spawns to compile its native image, sharing a single thread budget so idle cores are
   filled during the long tail without oversubscribing the machine when many packages compile at once. The total
   budget can be set with the new `JULIA_PRECOMPILE_THREADS` environment variable ([#61958]).
+* Coverage reports now include code executed by the interpreter, such as top-level statements and method
+  bodies run with `--compile=min`. Consequently, LCOV output and `.cov` files may contain source lines that
+  were absent in earlier releases ([#62514]).
+* Coverage and allocation tracking no longer update counters atomically. This reduces the overhead of
+  instrumented code, but counter values may be inaccurate when the same source line runs concurrently on
+  multiple threads ([#62514]).
+* `--code-coverage=user` no longer includes inlined Base methods whose module cannot be recovered from debug
+  information. This prevents coverage from writing `.cov` files for Base sources into the Julia installation
+  ([#62514]).
 
 Command-line option changes
 ---------------------------
 
 * `-P <project>` is now a shorthand for `--project <project>` ([#59867]).
+* `--code-coverage=@<path>` and `--track-allocation=@<path>` now restrict tracking to the specified file or
+  directory tree. For example, `@/src/Foo` tracks `/src/Foo/x.jl`, but not `/src/Foobar/x.jl`. Specifying the
+  filesystem root as `@/` tracks every absolute path. `Base.is_file_tracked` now returns `false`, rather than
+  crashing, when Julia was not started with either `@<path>` option ([#62514]).
 
 Multi-threading changes
 -----------------------

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3222,9 +3222,11 @@ static void visitLine(jl_codectx_t &ctx, uint64_t *ptr, Value *addend, const cha
     Value *pv = ConstantExpr::getIntToPtr(
         ConstantInt::get(ctx.types().T_size, (uintptr_t)ptr),
         getPointerTy(ctx.builder.getContext()));
-    ctx.builder.CreateAtomicRMW(AtomicRMWInst::Add, pv,
-                                           addend, MaybeAlign(),
-                                           AtomicOrdering::Monotonic);
+    Value *v = ctx.builder.CreateLoad(getInt64Ty(ctx.builder.getContext()), pv, true, name);
+    v = ctx.builder.CreateAdd(v, addend);
+    ctx.builder.CreateStore(v, pv, true); // volatile, not atomic, so this may undercount across
+                                          // threads, but an atomic RMW in a hot loop is far more
+                                          // expensive than the exactness is worth (#62424)
 }
 
 // Code coverage

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9688,7 +9688,8 @@ static jl_llvm_functions_t
                 !jl_is_submodule(mod, jl_core_module));
     };
     auto in_tracked_path = [] (StringRef file) { // falls within an explicitly set file or directory
-        return jl_options.tracked_path != NULL && file.starts_with(jl_options.tracked_path);
+        // file comes from a Symbol name or a literal, so it is NUL-terminated
+        return jl_path_is_tracked(file.data());
     };
     bool mod_is_user_mod = in_user_mod(ctx.module);
     bool mod_is_tracked = in_tracked_path(ctx.file);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3222,11 +3222,16 @@ static void visitLine(jl_codectx_t &ctx, uint64_t *ptr, Value *addend, const cha
     Value *pv = ConstantExpr::getIntToPtr(
         ConstantInt::get(ctx.types().T_size, (uintptr_t)ptr),
         getPointerTy(ctx.builder.getContext()));
+    // Volatile, not atomic, so concurrent updates to the same counter may be lost. An
+    // atomic RMW in a hot loop costs far more than the exactness is worth (#62424), and
+    // this is what 1.11 and earlier did. Note both callers rely on a lost update never
+    // driving a counter back to zero, which is how the writers tell an uncovered line
+    // ("0") from one that is not code at all ("-"): `jl_coverage_alloc_line` /
+    // `jl_malloc_data_pointer` seed every instrumented line to 1, and `addend` is
+    // non-negative, so every value ever stored here is >= 1.
     Value *v = ctx.builder.CreateLoad(getInt64Ty(ctx.builder.getContext()), pv, true, name);
     v = ctx.builder.CreateAdd(v, addend);
-    ctx.builder.CreateStore(v, pv, true); // volatile, not atomic, so this may undercount across
-                                          // threads, but an atomic RMW in a hot loop is far more
-                                          // expensive than the exactness is worth (#62424)
+    ctx.builder.CreateStore(v, pv, true);
 }
 
 // Code coverage

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3181,13 +3181,8 @@ static void visitLine(jl_codectx_t &ctx, uint64_t *ptr, Value *addend, const cha
     Value *pv = ConstantExpr::getIntToPtr(
         ConstantInt::get(ctx.types().T_size, (uintptr_t)ptr),
         getPointerTy(ctx.builder.getContext()));
-    // Volatile, not atomic, so concurrent updates to the same counter may be lost. An
-    // atomic RMW in a hot loop costs far more than the exactness is worth (#62424), and
-    // this is what 1.11 and earlier did. Note both callers rely on a lost update never
-    // driving a counter back to zero, which is how the writers tell an uncovered line
-    // ("0") from one that is not code at all ("-"): `jl_coverage_alloc_line` /
-    // `jl_malloc_data_pointer` seed every instrumented line to 1, and `addend` is
-    // non-negative, so every value ever stored here is >= 1.
+    // These approximate counters are seeded to 1 and only incremented, so racy
+    // updates stay nonzero. Avoiding an atomic RMW prevents #62424.
     Value *v = ctx.builder.CreateLoad(getInt64Ty(ctx.builder.getContext()), pv, true, name);
     v = ctx.builder.CreateAdd(v, addend);
     ctx.builder.CreateStore(v, pv, true);
@@ -9504,18 +9499,14 @@ static jl_llvm_functions_t
         return (!jl_is_submodule(mod, jl_base_module) &&
                 !jl_is_submodule(mod, jl_core_module));
     };
-    auto in_tracked_path = [] (StringRef file) { // falls within an explicitly set file or directory
-        // file comes from a Symbol name or a literal, so it is NUL-terminated
+    auto in_tracked_path = [] (StringRef file) {
+        // Symbol names and literals are NUL-terminated.
         return jl_path_is_tracked(file.data());
     };
     bool mod_is_user_mod = in_user_mod(ctx.module);
     bool mod_is_tracked = in_tracked_path(ctx.file);
-    // `modu` is NULL for a frame whose provenance we cannot recover: a macro
-    // expansion, or a body produced by a generator. Falling back to `ctx.module` for
-    // all of those attributes Base code to whatever module inlined it (#26573).
-    // Sources compiled into the sysimage are recorded with relative paths while
-    // everything else is absolutized, so use that to tell them apart - a macro
-    // defined in another user file still counts as user code.
+    // A missing module occurs for macro expansions and generated bodies. Sysimage
+    // source paths are relative; other source paths are absolute.
     auto frame_is_user_code = [&] (jl_module_t *modu, StringRef file) {
         if (modu == NULL)
             return mod_is_user_mod && jl_isabspath(file.data());

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9693,8 +9693,8 @@ static jl_llvm_functions_t
     };
     bool mod_is_user_mod = in_user_mod(ctx.module);
     bool mod_is_tracked = in_tracked_path(ctx.file);
-    // A missing module occurs for macro expansions and generated bodies. Sysimage
-    // source paths are relative; other source paths are absolute.
+    // Treat an unknown-module frame with an absolute path as user code. This
+    // preserves user macro coverage but can misclassify absolute sysimage paths.
     auto frame_is_user_code = [&] (jl_module_t *modu, StringRef file) {
         if (modu == NULL)
             return mod_is_user_mod && jl_isabspath(file.data());

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9693,6 +9693,19 @@ static jl_llvm_functions_t
     };
     bool mod_is_user_mod = in_user_mod(ctx.module);
     bool mod_is_tracked = in_tracked_path(ctx.file);
+    // `modu` is NULL for a frame whose provenance we cannot recover: a macro
+    // expansion, or a body produced by a generator. Falling back to `ctx.module` for
+    // all of those attributes Base code to whatever module inlined it (#26573).
+    // Sources compiled into the sysimage are recorded with relative paths while
+    // everything else is absolutized, so use that to tell them apart - a macro
+    // defined in another user file still counts as user code.
+    auto frame_is_user_code = [&] (jl_module_t *modu, StringRef file) {
+        if (modu == NULL)
+            return mod_is_user_mod && jl_isabspath(file.data());
+        if (modu == ctx.module)
+            return mod_is_user_mod;
+        return in_user_mod(modu);
+    };
     struct DebugLineTable {
         DebugLoc loc;
         StringRef file;
@@ -9738,8 +9751,6 @@ static jl_llvm_functions_t
                     DebugLineTable info;
                     info.edgeid = to;
                     jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
-                    if (modu == NULL)
-                        modu = ctx.module;
                     info.file = jl_cdi_file(debuginfo);
                     info.line = i;
                     info.line0 = 0;
@@ -9750,10 +9761,7 @@ static jl_llvm_functions_t
                     }
                     if (info.file.empty())
                         info.file = "<missing>";
-                    if (modu == ctx.module)
-                        info.is_user_code = mod_is_user_mod;
-                    else
-                        info.is_user_code = in_user_mod(modu);
+                    info.is_user_code = frame_is_user_code(modu, info.file);
                     if (debug_enabled) {
                         StringRef fname = jl_debuginfo_name(func);
                         // Encode outermost (codeinstance) debuginfo PC on
@@ -9949,16 +9957,10 @@ static jl_llvm_functions_t
             while (jl_is_debuginfo(debuginfo->linetable))
                 debuginfo = (jl_debuginfo_t*)debuginfo->linetable;
             jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
-            if (modu == NULL)
-                modu = ctx.module;
             StringRef file = jl_cdi_file(debuginfo);
             if (file.empty())
                 file = "<missing>";
-            bool is_user_code;
-            if (modu == ctx.module)
-                is_user_code = mod_is_user_mod;
-            else
-                is_user_code = in_user_mod(modu);
+            bool is_user_code = frame_is_user_code(modu, file);
             bool is_tracked = in_tracked_path(file);
             if (do_coverage(is_user_code, is_tracked)) {
                 int32_t extraline = jl_cdi_external_firstline(debuginfo);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9505,6 +9505,19 @@ static jl_llvm_functions_t
     };
     bool mod_is_user_mod = in_user_mod(ctx.module);
     bool mod_is_tracked = in_tracked_path(ctx.file);
+    // `modu` is NULL for a frame whose provenance we cannot recover: a macro
+    // expansion, or a body produced by a generator. Falling back to `ctx.module` for
+    // all of those attributes Base code to whatever module inlined it (#26573).
+    // Sources compiled into the sysimage are recorded with relative paths while
+    // everything else is absolutized, so use that to tell them apart - a macro
+    // defined in another user file still counts as user code.
+    auto frame_is_user_code = [&] (jl_module_t *modu, StringRef file) {
+        if (modu == NULL)
+            return mod_is_user_mod && jl_isabspath(file.data());
+        if (modu == ctx.module)
+            return mod_is_user_mod;
+        return in_user_mod(modu);
+    };
     struct DebugLineTable {
         DebugLoc loc;
         StringRef file;
@@ -9550,8 +9563,6 @@ static jl_llvm_functions_t
                     DebugLineTable info;
                     info.edgeid = to;
                     jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
-                    if (modu == NULL)
-                        modu = ctx.module;
                     info.file = jl_cdi_file(debuginfo);
                     info.line = i;
                     info.line0 = 0;
@@ -9562,10 +9573,7 @@ static jl_llvm_functions_t
                     }
                     if (info.file.empty())
                         info.file = "<missing>";
-                    if (modu == ctx.module)
-                        info.is_user_code = mod_is_user_mod;
-                    else
-                        info.is_user_code = in_user_mod(modu);
+                    info.is_user_code = frame_is_user_code(modu, info.file);
                     if (debug_enabled) {
                         StringRef fname = jl_debuginfo_name(func);
                         // Encode outermost (codeinstance) debuginfo PC on
@@ -9761,16 +9769,10 @@ static jl_llvm_functions_t
             while (jl_is_debuginfo(debuginfo->linetable))
                 debuginfo = (jl_debuginfo_t*)debuginfo->linetable;
             jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
-            if (modu == NULL)
-                modu = ctx.module;
             StringRef file = jl_cdi_file(debuginfo);
             if (file.empty())
                 file = "<missing>";
-            bool is_user_code;
-            if (modu == ctx.module)
-                is_user_code = mod_is_user_mod;
-            else
-                is_user_code = in_user_mod(modu);
+            bool is_user_code = frame_is_user_code(modu, file);
             bool is_tracked = in_tracked_path(file);
             if (do_coverage(is_user_code, is_tracked)) {
                 int32_t extraline = jl_cdi_external_firstline(debuginfo);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3181,9 +3181,11 @@ static void visitLine(jl_codectx_t &ctx, uint64_t *ptr, Value *addend, const cha
     Value *pv = ConstantExpr::getIntToPtr(
         ConstantInt::get(ctx.types().T_size, (uintptr_t)ptr),
         getPointerTy(ctx.builder.getContext()));
-    ctx.builder.CreateAtomicRMW(AtomicRMWInst::Add, pv,
-                                           addend, MaybeAlign(),
-                                           AtomicOrdering::Monotonic);
+    Value *v = ctx.builder.CreateLoad(getInt64Ty(ctx.builder.getContext()), pv, true, name);
+    v = ctx.builder.CreateAdd(v, addend);
+    ctx.builder.CreateStore(v, pv, true); // volatile, not atomic, so this may undercount across
+                                          // threads, but an atomic RMW in a hot loop is far more
+                                          // expensive than the exactness is worth (#62424)
 }
 
 // Code coverage

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9500,7 +9500,8 @@ static jl_llvm_functions_t
                 !jl_is_submodule(mod, jl_core_module));
     };
     auto in_tracked_path = [] (StringRef file) { // falls within an explicitly set file or directory
-        return jl_options.tracked_path != NULL && file.starts_with(jl_options.tracked_path);
+        // file comes from a Symbol name or a literal, so it is NUL-terminated
+        return jl_path_is_tracked(file.data());
     };
     bool mod_is_user_mod = in_user_mod(ctx.module);
     bool mod_is_tracked = in_tracked_path(ctx.file);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3181,11 +3181,16 @@ static void visitLine(jl_codectx_t &ctx, uint64_t *ptr, Value *addend, const cha
     Value *pv = ConstantExpr::getIntToPtr(
         ConstantInt::get(ctx.types().T_size, (uintptr_t)ptr),
         getPointerTy(ctx.builder.getContext()));
+    // Volatile, not atomic, so concurrent updates to the same counter may be lost. An
+    // atomic RMW in a hot loop costs far more than the exactness is worth (#62424), and
+    // this is what 1.11 and earlier did. Note both callers rely on a lost update never
+    // driving a counter back to zero, which is how the writers tell an uncovered line
+    // ("0") from one that is not code at all ("-"): `jl_coverage_alloc_line` /
+    // `jl_malloc_data_pointer` seed every instrumented line to 1, and `addend` is
+    // non-negative, so every value ever stored here is >= 1.
     Value *v = ctx.builder.CreateLoad(getInt64Ty(ctx.builder.getContext()), pv, true, name);
     v = ctx.builder.CreateAdd(v, addend);
-    ctx.builder.CreateStore(v, pv, true); // volatile, not atomic, so this may undercount across
-                                          // threads, but an atomic RMW in a hot loop is far more
-                                          // expensive than the exactness is worth (#62424)
+    ctx.builder.CreateStore(v, pv, true);
 }
 
 // Code coverage

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3222,13 +3222,8 @@ static void visitLine(jl_codectx_t &ctx, uint64_t *ptr, Value *addend, const cha
     Value *pv = ConstantExpr::getIntToPtr(
         ConstantInt::get(ctx.types().T_size, (uintptr_t)ptr),
         getPointerTy(ctx.builder.getContext()));
-    // Volatile, not atomic, so concurrent updates to the same counter may be lost. An
-    // atomic RMW in a hot loop costs far more than the exactness is worth (#62424), and
-    // this is what 1.11 and earlier did. Note both callers rely on a lost update never
-    // driving a counter back to zero, which is how the writers tell an uncovered line
-    // ("0") from one that is not code at all ("-"): `jl_coverage_alloc_line` /
-    // `jl_malloc_data_pointer` seed every instrumented line to 1, and `addend` is
-    // non-negative, so every value ever stored here is >= 1.
+    // These approximate counters are seeded to 1 and only incremented, so racy
+    // updates stay nonzero. Avoiding an atomic RMW prevents #62424.
     Value *v = ctx.builder.CreateLoad(getInt64Ty(ctx.builder.getContext()), pv, true, name);
     v = ctx.builder.CreateAdd(v, addend);
     ctx.builder.CreateStore(v, pv, true);
@@ -9692,18 +9687,14 @@ static jl_llvm_functions_t
         return (!jl_is_submodule(mod, jl_base_module) &&
                 !jl_is_submodule(mod, jl_core_module));
     };
-    auto in_tracked_path = [] (StringRef file) { // falls within an explicitly set file or directory
-        // file comes from a Symbol name or a literal, so it is NUL-terminated
+    auto in_tracked_path = [] (StringRef file) {
+        // Symbol names and literals are NUL-terminated.
         return jl_path_is_tracked(file.data());
     };
     bool mod_is_user_mod = in_user_mod(ctx.module);
     bool mod_is_tracked = in_tracked_path(ctx.file);
-    // `modu` is NULL for a frame whose provenance we cannot recover: a macro
-    // expansion, or a body produced by a generator. Falling back to `ctx.module` for
-    // all of those attributes Base code to whatever module inlined it (#26573).
-    // Sources compiled into the sysimage are recorded with relative paths while
-    // everything else is absolutized, so use that to tell them apart - a macro
-    // defined in another user file still counts as user code.
+    // A missing module occurs for macro expansions and generated bodies. Sysimage
+    // source paths are relative; other source paths are absolute.
     auto frame_is_user_code = [&] (jl_module_t *modu, StringRef file) {
         if (modu == NULL)
             return mod_is_user_mod && jl_isabspath(file.data());

--- a/src/coverage.c
+++ b/src/coverage.c
@@ -210,14 +210,10 @@ static void write_log_data(logdata_t *logData, const char *extension) JL_NOTSAFE
         snprintf(outpath, sizeof(outpath), "%s%s", fullpath, extension);
         FILE *outf = fopen(outpath, "wb");
         if (outf) {
-            char line[1024];
             int l = 1;
             unsigned block = 0;
-            int ret = 0;
-            while (ret != EOF && (ret = fscanf(inf, "%1023[^\n]", line)) != EOF) {
-                // Skip n non-newline chars and a single trailing newline
-                if ((ret = fscanf(inf, "%*[^\n]")) != EOF)
-                    ret = fscanf(inf, "%*1[\n]");
+            int c = getc(inf);
+            while (c != EOF) {
                 logdata_block *data = NULL;
                 if (block < values->len) {
                     data = values->blocks[block];
@@ -231,8 +227,14 @@ static void write_log_data(logdata_t *logData, const char *extension) JL_NOTSAFE
                     fprintf(outf, "        -");
                 else
                     fprintf(outf, "%9" PRIu64, value - 1);
-                fprintf(outf, " %s\n", line);
-                line[0] = 0;
+                putc(' ', outf);
+                while (c != EOF && c != '\n') {
+                    putc(c, outf);
+                    c = getc(inf);
+                }
+                putc('\n', outf);
+                if (c == '\n')
+                    c = getc(inf);
             }
             fclose(outf);
         }

--- a/src/coverage.c
+++ b/src/coverage.c
@@ -83,9 +83,6 @@ static int is_skip_filename(const char *filename) JL_NOTSAFEPOINT
     return 0;
 }
 
-// Whether `path` falls within the file or directory named by `--code-coverage=@`
-// or `--track-allocation=@`. A prefix only counts at a path component boundary,
-// so `@/src/Foo` does not also match `/src/Foobar/x.jl`.
 JL_DLLEXPORT int jl_path_is_tracked(const char *path) JL_NOTSAFEPOINT
 {
     const char *tracked = jl_options.tracked_path;
@@ -104,8 +101,6 @@ JL_DLLEXPORT int jl_path_is_tracked(const char *path) JL_NOTSAFEPOINT
     return next == '\0' || next == '/' || next == PATHSEPSTRING[0];
 }
 
-// Whether code from `filename` belonging to `m` should be logged under the current
-// --code-coverage setting. `m` may be NULL when the module is unknown.
 JL_DLLEXPORT int jl_coverage_enabled_for(jl_module_t *m, const char *filename) JL_NOTSAFEPOINT
 {
     if (codegen_imaging_mode() || jl_generating_output() || is_skip_filename(filename))

--- a/src/coverage.c
+++ b/src/coverage.c
@@ -92,10 +92,12 @@ JL_DLLEXPORT int jl_path_is_tracked(const char *path) JL_NOTSAFEPOINT
     if (tracked == NULL || path == NULL)
         return 0;
     size_t tlen = strlen(tracked);
+    if (tlen == 0)
+        return 1; // no path given: everything is tracked
     while (tlen > 0 && (tracked[tlen - 1] == '/' || tracked[tlen - 1] == PATHSEPSTRING[0]))
         tlen--;
     if (tlen == 0)
-        return 1;
+        return jl_isabspath(path); // the filesystem root: every absolute path
     if (strncmp(path, tracked, tlen) != 0)
         return 0;
     char next = path[tlen];

--- a/src/coverage.c
+++ b/src/coverage.c
@@ -83,6 +83,25 @@ static int is_skip_filename(const char *filename) JL_NOTSAFEPOINT
     return 0;
 }
 
+// Whether `path` falls within the file or directory named by `--code-coverage=@`
+// or `--track-allocation=@`. A prefix only counts at a path component boundary,
+// so `@/src/Foo` does not also match `/src/Foobar/x.jl`.
+JL_DLLEXPORT int jl_path_is_tracked(const char *path) JL_NOTSAFEPOINT
+{
+    const char *tracked = jl_options.tracked_path;
+    if (tracked == NULL || path == NULL)
+        return 0;
+    size_t tlen = strlen(tracked);
+    while (tlen > 0 && (tracked[tlen - 1] == '/' || tracked[tlen - 1] == PATHSEPSTRING[0]))
+        tlen--;
+    if (tlen == 0)
+        return 1;
+    if (strncmp(path, tracked, tlen) != 0)
+        return 0;
+    char next = path[tlen];
+    return next == '\0' || next == '/' || next == PATHSEPSTRING[0];
+}
+
 JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line)
 {
     assert(!codegen_imaging_mode());

--- a/src/coverage.c
+++ b/src/coverage.c
@@ -102,6 +102,25 @@ JL_DLLEXPORT int jl_path_is_tracked(const char *path) JL_NOTSAFEPOINT
     return next == '\0' || next == '/' || next == PATHSEPSTRING[0];
 }
 
+// Whether code from `filename` belonging to `m` should be logged under the current
+// --code-coverage setting. `m` may be NULL when the module is unknown.
+JL_DLLEXPORT int jl_coverage_enabled_for(jl_module_t *m, const char *filename) JL_NOTSAFEPOINT
+{
+    if (codegen_imaging_mode() || jl_generating_output() || is_skip_filename(filename))
+        return 0;
+    switch (jl_options.code_coverage) {
+    case JL_LOG_ALL:
+        return 1;
+    case JL_LOG_USER:
+        return m != NULL && jl_base_module != NULL && jl_core_module != NULL &&
+               !jl_is_submodule(m, jl_base_module) && !jl_is_submodule(m, jl_core_module);
+    case JL_LOG_PATH:
+        return jl_path_is_tracked(filename);
+    default:
+        return 0;
+    }
+}
+
 JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line)
 {
     assert(!codegen_imaging_mode());

--- a/src/coverage.c
+++ b/src/coverage.c
@@ -62,7 +62,7 @@ static uint64_t *allocLine(logdata_vec_t *vec, int line) JL_NOTSAFEPOINT
         logdata_vec_resize(vec, block + 1);
     jl_assume(vec->blocks != NULL);
     if (vec->blocks[block] == NULL) {
-        vec->blocks[block] = (logdata_block *)calloc(1, sizeof(logdata_block));
+        vec->blocks[block] = (logdata_block *)calloc_s(sizeof(logdata_block));
     }
     logdata_block *data = vec->blocks[block];
     if ((*data)[line] == 0)

--- a/src/init.c
+++ b/src/init.c
@@ -537,9 +537,7 @@ int jl_isabspath(const char *in) JL_NOTSAFEPOINT
 
 JL_DLLEXPORT int jl_is_file_tracked(jl_sym_t *path)
 {
-    const char* path_ = jl_symbol_name(path);
-    int tpath_len = strlen(jl_options.tracked_path);
-    return (strlen(path_) >= tpath_len) && (strncmp(path_, jl_options.tracked_path, tpath_len) == 0);
+    return jl_path_is_tracked(jl_symbol_name(path));
 }
 
 static void jl_set_io_wait(int v)

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -549,9 +549,13 @@ typedef struct {
     int n;
 } coverage_frames_t;
 
-static void coverage_collect(jl_debuginfo_t *debuginfo, jl_value_t *func,
-                             jl_module_t *enclosing, size_t pc,
-                             coverage_frames_t *out) JL_NOTSAFEPOINT
+// Returns 0 if this statement reports no location update, in which case `out` is
+// meaningless and must be discarded: codegen's append_lineinfo propagates the same
+// result out of its recursion, and update_lineinfo then throws away the frames it
+// had started to build and keeps the previous statement's.
+static int coverage_collect(jl_debuginfo_t *debuginfo, jl_value_t *func,
+                            jl_module_t *enclosing, size_t pc,
+                            coverage_frames_t *out) JL_NOTSAFEPOINT
 {
     while (1) {
         if (!jl_is_symbol(debuginfo->def)) // this is a path
@@ -559,12 +563,13 @@ static void coverage_collect(jl_debuginfo_t *debuginfo, jl_value_t *func,
         struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, pc);
         int32_t i = lineidx.loc;
         if (i < 0) // pc out of range: broken debuginfo?
-            return;
+            return 0;
         if (i == 0 && lineidx.to == 0) // no update
-            return;
+            return 0;
         if (pc > 0 && jl_is_debuginfo(debuginfo->linetable)) {
             // indirection node: `i` is a pc in the linetable, not a line
-            coverage_collect((jl_debuginfo_t*)debuginfo->linetable, func, enclosing, i, out);
+            if (!coverage_collect((jl_debuginfo_t*)debuginfo->linetable, func, enclosing, i, out))
+                return 0;
         }
         else if (i > 0 && out->n < COVERAGE_MAX_FRAMES) {
             const char *file = jl_cdi_file(debuginfo);
@@ -579,7 +584,7 @@ static void coverage_collect(jl_debuginfo_t *debuginfo, jl_value_t *func,
             out->tracked[n] = jl_coverage_enabled_for(modu, file);
         }
         if (lineidx.to == 0)
-            return;
+            return 1;
         pc = lineidx.pc;
         debuginfo = (jl_debuginfo_t*)jl_svecref(debuginfo->edges, lineidx.to - 1);
         func = NULL;
@@ -592,10 +597,8 @@ static void coverage_visit_stmt(jl_code_info_t *src, jl_module_t *module,
 {
     coverage_frames_t cur;
     cur.n = 0;
-    coverage_collect(src->debuginfo, mi ? (jl_value_t*)mi : NULL, module, pc, &cur);
-    if (cur.n == 0)
-        return; // no location for this statement: keep the frames we already had,
-                // as codegen's update_lineinfo does when it reports no update
+    if (!coverage_collect(src->debuginfo, mi ? (jl_value_t*)mi : NULL, module, pc, &cur))
+        return; // no location for this statement: keep the frames we already had
     int d = 0;
     while (d < cur.n && d < prev->n &&
            cur.line[d] == prev->line[d] && cur.file[d] == prev->file[d])

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -533,14 +533,89 @@ static size_t eval_phi(jl_array_t *stmts, interpreter_state *s, size_t ns, size_
     return ip;
 }
 
+// Code that the interpreter runs is never seen by codegen, so record its coverage
+// here instead. A statement's debuginfo can stand for several frames - macro
+// expansions and indirections through a linetable - so resolve it the same way
+// codegen's append_lineinfo does, then log the frames that differ from the previous
+// statement, as codegen's coverageVisitStmt does.
+#define COVERAGE_MAX_FRAMES 12
+typedef struct {
+    const char *file[COVERAGE_MAX_FRAMES];
+    int32_t line[COVERAGE_MAX_FRAMES];
+    int tracked[COVERAGE_MAX_FRAMES];
+    int n;
+} coverage_frames_t;
+
+static void coverage_collect(jl_debuginfo_t *debuginfo, jl_value_t *func,
+                             jl_module_t *enclosing, size_t pc,
+                             coverage_frames_t *out) JL_NOTSAFEPOINT
+{
+    while (1) {
+        if (!jl_is_symbol(debuginfo->def)) // this is a path
+            func = debuginfo->def; // this is inlined
+        struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, pc);
+        int32_t i = lineidx.loc;
+        if (i < 0) // pc out of range: broken debuginfo?
+            return;
+        if (i == 0 && lineidx.to == 0) // no update
+            return;
+        if (pc > 0 && jl_is_debuginfo(debuginfo->linetable)) {
+            // indirection node: `i` is a pc in the linetable, not a line
+            coverage_collect((jl_debuginfo_t*)debuginfo->linetable, func, enclosing, i, out);
+        }
+        else if (i > 0 && out->n < COVERAGE_MAX_FRAMES) {
+            const char *file = jl_cdi_file(debuginfo);
+            jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
+            // provenance is unrecoverable for a macro expansion; attribute it to the
+            // enclosing module only if it came from a source outside the sysimage
+            if (modu == NULL && jl_isabspath(file))
+                modu = enclosing;
+            int n = out->n++;
+            out->file[n] = file;
+            out->line[n] = i;
+            out->tracked[n] = jl_coverage_enabled_for(modu, file);
+        }
+        if (lineidx.to == 0)
+            return;
+        pc = lineidx.pc;
+        debuginfo = (jl_debuginfo_t*)jl_svecref(debuginfo->edges, lineidx.to - 1);
+        func = NULL;
+    }
+}
+
+static void coverage_visit_stmt(jl_code_info_t *src, jl_module_t *module,
+                                jl_method_instance_t *mi, size_t pc,
+                                coverage_frames_t *prev) JL_CANSAFEPOINT
+{
+    coverage_frames_t cur;
+    cur.n = 0;
+    coverage_collect(src->debuginfo, mi ? (jl_value_t*)mi : NULL, module, pc, &cur);
+    int d = 0;
+    while (d < cur.n && d < prev->n &&
+           cur.line[d] == prev->line[d] && cur.file[d] == prev->file[d])
+        d++;
+    for (int k = d; k < cur.n; k++)
+        if (cur.tracked[k])
+            jl_coverage_visit_line(cur.file[k], strlen(cur.file[k]), cur.line[k]);
+    *prev = cur;
+}
+
 static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip, int toplevel)
 {
     jl_handler_t __eh;
     size_t ns = jl_array_nrows(stmts);
     jl_task_t *ct = jl_current_task;
+    // top-level statements carry no line info here; they are logged from
+    // jl_toplevel_eval_flex instead
+    int track_coverage = !toplevel && jl_options.code_coverage != JL_LOG_NONE &&
+                         s->src->debuginfo != NULL;
+    coverage_frames_t prev_coverage;
+    prev_coverage.n = 0;
 
     while (1) {
         s->ip = ip;
+        if (track_coverage && ip < ns)
+            coverage_visit_stmt(s->src, s->module, s->mi, ip + 1, &prev_coverage);
         if (ip >= ns)
             jl_error("`body` expression must terminate in `return`. Use `block` instead.");
         jl_value_t *stmt = jl_array_ptr_ref(stmts, ip);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -623,9 +623,10 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
     size_t ns = jl_array_nrows(stmts);
     jl_task_t *ct = jl_current_task;
     // top-level statements carry no line info here; they are logged from
-    // jl_toplevel_eval_flex instead
+    // jl_toplevel_eval_flex instead. Sysimage and pkgimage generation is not tracked,
+    // so skip the per-statement debuginfo walk entirely there.
     int track_coverage = !toplevel && jl_options.code_coverage != JL_LOG_NONE &&
-                         s->src->debuginfo != NULL;
+                         !jl_generating_output() && s->src->debuginfo != NULL;
     coverage_frames_t prev_coverage;
     prev_coverage.n = 0;
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -538,6 +538,9 @@ static size_t eval_phi(jl_array_t *stmts, interpreter_state *s, size_t ns, size_
 // expansions and indirections through a linetable - so resolve it the same way
 // codegen's append_lineinfo does, then log the frames that differ from the previous
 // statement, as codegen's coverageVisitStmt does.
+// Codegen has no equivalent bound; overflow drops the innermost frames of a very
+// deeply nested macro expansion, which loses coverage for those rather than
+// misreporting it.
 #define COVERAGE_MAX_FRAMES 12
 typedef struct {
     const char *file[COVERAGE_MAX_FRAMES];
@@ -590,6 +593,9 @@ static void coverage_visit_stmt(jl_code_info_t *src, jl_module_t *module,
     coverage_frames_t cur;
     cur.n = 0;
     coverage_collect(src->debuginfo, mi ? (jl_value_t*)mi : NULL, module, pc, &cur);
+    if (cur.n == 0)
+        return; // no location for this statement: keep the frames we already had,
+                // as codegen's update_lineinfo does when it reports no update
     int d = 0;
     while (d < cur.n && d < prev->n &&
            cur.line[d] == prev->line[d] && cur.file[d] == prev->file[d])

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -583,23 +583,23 @@ static int coverage_collect(jl_debuginfo_t *debuginfo, jl_value_t *func,
     }
 }
 
-static void coverage_visit_stmt(jl_code_info_t *src, jl_module_t *module,
-                                jl_method_instance_t *mi, size_t pc,
-                                coverage_frames_t *prev) JL_CANSAFEPOINT
+static int coverage_visit_stmt(jl_code_info_t *src, jl_module_t *module,
+                               jl_method_instance_t *mi, size_t pc,
+                               coverage_frames_t *prev,
+                               coverage_frames_t *cur) JL_CANSAFEPOINT
 {
-    coverage_frames_t cur;
-    cur.n = 0;
-    if (!coverage_collect(src->debuginfo, mi ? (jl_value_t*)mi : NULL, module, 0, pc, &cur))
-        return;
+    cur->n = 0;
+    if (!coverage_collect(src->debuginfo, mi ? (jl_value_t*)mi : NULL, module, 0, pc, cur))
+        return 0;
     int d = 0;
     // Keep this in sync with codegen's DebugLineTable::sameframe.
-    while (d < cur.n && d < prev->n &&
-           cur.line[d] == prev->line[d] && cur.edgeid[d] == prev->edgeid[d])
+    while (d < cur->n && d < prev->n &&
+           cur->line[d] == prev->line[d] && cur->edgeid[d] == prev->edgeid[d])
         d++;
-    for (int k = d; k < cur.n; k++)
-        if (cur.tracked[k])
-            jl_coverage_visit_line(cur.file[k], strlen(cur.file[k]), cur.line[k]);
-    *prev = cur;
+    for (int k = d; k < cur->n; k++)
+        if (cur->tracked[k])
+            jl_coverage_visit_line(cur->file[k], strlen(cur->file[k]), cur->line[k]);
+    return 1;
 }
 
 static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip, int toplevel)
@@ -610,13 +610,20 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
     // Top-level coverage is recorded in jl_toplevel_eval_flex.
     int track_coverage = !toplevel && jl_options.code_coverage != JL_LOG_NONE &&
                          !jl_generating_output() && s->src->debuginfo != NULL;
-    coverage_frames_t prev_coverage;
-    prev_coverage.n = 0;
+    coverage_frames_t coverage_frames[2];
+    coverage_frames_t *prev_coverage = &coverage_frames[0];
+    coverage_frames_t *cur_coverage = &coverage_frames[1];
+    prev_coverage->n = 0;
 
     while (1) {
         s->ip = ip;
-        if (track_coverage && ip < ns)
-            coverage_visit_stmt(s->src, s->module, s->mi, ip + 1, &prev_coverage);
+        if (track_coverage && ip < ns &&
+                coverage_visit_stmt(s->src, s->module, s->mi, ip + 1,
+                                    prev_coverage, cur_coverage)) {
+            coverage_frames_t *tmp = prev_coverage;
+            prev_coverage = cur_coverage;
+            cur_coverage = tmp;
+        }
         if (ip >= ns)
             jl_error("`body` expression must terminate in `return`. Use `block` instead.");
         jl_value_t *stmt = jl_array_ptr_ref(stmts, ip);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -533,18 +533,8 @@ static size_t eval_phi(jl_array_t *stmts, interpreter_state *s, size_t ns, size_
     return ip;
 }
 
-// Code that the interpreter runs is never seen by codegen, so record its coverage
-// here instead. A statement's debuginfo can stand for several frames - macro
-// expansions and indirections through a linetable - so resolve it the same way
-// codegen's append_lineinfo does, then log the frames that differ from the previous
-// statement, as codegen's coverageVisitStmt does.
-// Codegen has no equivalent bound; overflow drops the innermost frames of a very
-// deeply nested macro expansion, which loses coverage for those rather than
-// misreporting it.
-// Two things codegen records that this does not, so a method that is only ever
-// interpreted reports fewer hits on those lines than a compiled one:
-//   - the function definition line, which codegen covers once from `topinfo`
-//   - `jl_cdi_external_firstline` at pc=1 (codegen's `line0`)
+// Resolve interpreter coverage frames like codegen's append_lineinfo and
+// coverageVisitStmt. Deeply nested expansions may lose innermost frames.
 #define COVERAGE_MAX_FRAMES 12
 typedef struct {
     const char *file[COVERAGE_MAX_FRAMES];
@@ -554,33 +544,28 @@ typedef struct {
     int n;
 } coverage_frames_t;
 
-// Returns 0 if this statement reports no location update, in which case `out` is
-// meaningless and must be discarded: codegen's append_lineinfo propagates the same
-// result out of its recursion, and update_lineinfo then throws away the frames it
-// had started to build and keeps the previous statement's.
+// On failure, `out` may contain a partial frame list and must be discarded.
 static int coverage_collect(jl_debuginfo_t *debuginfo, jl_value_t *func,
                             jl_module_t *enclosing, int32_t to, size_t pc,
                             coverage_frames_t *out) JL_NOTSAFEPOINT
 {
     while (1) {
-        if (!jl_is_symbol(debuginfo->def)) // this is a path
-            func = debuginfo->def; // this is inlined
+        if (!jl_is_symbol(debuginfo->def))
+            func = debuginfo->def;
         struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, pc);
         int32_t i = lineidx.loc;
-        if (i < 0) // pc out of range: broken debuginfo?
+        if (i < 0)
             return 0;
-        if (i == 0 && lineidx.to == 0) // no update
+        if (i == 0 && lineidx.to == 0)
             return 0;
         if (pc > 0 && jl_is_debuginfo(debuginfo->linetable)) {
-            // indirection node: `i` is a pc in the linetable, not a line
             if (!coverage_collect((jl_debuginfo_t*)debuginfo->linetable, func, enclosing, to, i, out))
                 return 0;
         }
         else if (i > 0 && out->n < COVERAGE_MAX_FRAMES) {
             const char *file = jl_cdi_file(debuginfo);
             jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
-            // provenance is unrecoverable for a macro expansion; attribute it to the
-            // enclosing module only if it came from a source outside the sysimage
+            // Sysimage source paths are relative; other source paths are absolute.
             if (modu == NULL && jl_isabspath(file))
                 modu = enclosing;
             int n = out->n++;
@@ -605,9 +590,9 @@ static void coverage_visit_stmt(jl_code_info_t *src, jl_module_t *module,
     coverage_frames_t cur;
     cur.n = 0;
     if (!coverage_collect(src->debuginfo, mi ? (jl_value_t*)mi : NULL, module, 0, pc, &cur))
-        return; // no location for this statement: keep the frames we already had
+        return;
     int d = 0;
-    // the same test as codegen's DebugLineTable::sameframe
+    // Keep this in sync with codegen's DebugLineTable::sameframe.
     while (d < cur.n && d < prev->n &&
            cur.line[d] == prev->line[d] && cur.edgeid[d] == prev->edgeid[d])
         d++;
@@ -622,9 +607,7 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
     jl_handler_t __eh;
     size_t ns = jl_array_nrows(stmts);
     jl_task_t *ct = jl_current_task;
-    // top-level statements carry no line info here; they are logged from
-    // jl_toplevel_eval_flex instead. Sysimage and pkgimage generation is not tracked,
-    // so skip the per-statement debuginfo walk entirely there.
+    // Top-level coverage is recorded in jl_toplevel_eval_flex.
     int track_coverage = !toplevel && jl_options.code_coverage != JL_LOG_NONE &&
                          !jl_generating_output() && s->src->debuginfo != NULL;
     coverage_frames_t prev_coverage;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -541,10 +541,15 @@ static size_t eval_phi(jl_array_t *stmts, interpreter_state *s, size_t ns, size_
 // Codegen has no equivalent bound; overflow drops the innermost frames of a very
 // deeply nested macro expansion, which loses coverage for those rather than
 // misreporting it.
+// Two things codegen records that this does not, so a method that is only ever
+// interpreted reports fewer hits on those lines than a compiled one:
+//   - the function definition line, which codegen covers once from `topinfo`
+//   - `jl_cdi_external_firstline` at pc=1 (codegen's `line0`)
 #define COVERAGE_MAX_FRAMES 12
 typedef struct {
     const char *file[COVERAGE_MAX_FRAMES];
     int32_t line[COVERAGE_MAX_FRAMES];
+    int32_t edgeid[COVERAGE_MAX_FRAMES];
     int tracked[COVERAGE_MAX_FRAMES];
     int n;
 } coverage_frames_t;
@@ -554,7 +559,7 @@ typedef struct {
 // result out of its recursion, and update_lineinfo then throws away the frames it
 // had started to build and keeps the previous statement's.
 static int coverage_collect(jl_debuginfo_t *debuginfo, jl_value_t *func,
-                            jl_module_t *enclosing, size_t pc,
+                            jl_module_t *enclosing, int32_t to, size_t pc,
                             coverage_frames_t *out) JL_NOTSAFEPOINT
 {
     while (1) {
@@ -568,7 +573,7 @@ static int coverage_collect(jl_debuginfo_t *debuginfo, jl_value_t *func,
             return 0;
         if (pc > 0 && jl_is_debuginfo(debuginfo->linetable)) {
             // indirection node: `i` is a pc in the linetable, not a line
-            if (!coverage_collect((jl_debuginfo_t*)debuginfo->linetable, func, enclosing, i, out))
+            if (!coverage_collect((jl_debuginfo_t*)debuginfo->linetable, func, enclosing, to, i, out))
                 return 0;
         }
         else if (i > 0 && out->n < COVERAGE_MAX_FRAMES) {
@@ -581,12 +586,14 @@ static int coverage_collect(jl_debuginfo_t *debuginfo, jl_value_t *func,
             int n = out->n++;
             out->file[n] = file;
             out->line[n] = i;
+            out->edgeid[n] = to;
             out->tracked[n] = jl_coverage_enabled_for(modu, file);
         }
-        if (lineidx.to == 0)
+        to = lineidx.to;
+        if (to == 0)
             return 1;
         pc = lineidx.pc;
-        debuginfo = (jl_debuginfo_t*)jl_svecref(debuginfo->edges, lineidx.to - 1);
+        debuginfo = (jl_debuginfo_t*)jl_svecref(debuginfo->edges, to - 1);
         func = NULL;
     }
 }
@@ -597,11 +604,12 @@ static void coverage_visit_stmt(jl_code_info_t *src, jl_module_t *module,
 {
     coverage_frames_t cur;
     cur.n = 0;
-    if (!coverage_collect(src->debuginfo, mi ? (jl_value_t*)mi : NULL, module, pc, &cur))
+    if (!coverage_collect(src->debuginfo, mi ? (jl_value_t*)mi : NULL, module, 0, pc, &cur))
         return; // no location for this statement: keep the frames we already had
     int d = 0;
+    // the same test as codegen's DebugLineTable::sameframe
     while (d < cur.n && d < prev->n &&
-           cur.line[d] == prev->line[d] && cur.file[d] == prev->file[d])
+           cur.line[d] == prev->line[d] && cur.edgeid[d] == prev->edgeid[d])
         d++;
     for (int k = d; k < cur.n; k++)
         if (cur.tracked[k])

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2159,6 +2159,7 @@ jl_value_t *simple_union(jl_value_t *a, jl_value_t *b) JL_CANSAFEPOINT;
 jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi) JL_CANSAFEPOINT;
 int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion) JL_CANSAFEPOINT;
 void jl_rng_split(uint64_t dst[JL_RNG_SIZE], uint64_t src[JL_RNG_SIZE]) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_path_is_tracked(const char *path) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2160,6 +2160,8 @@ jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi) JL_CANSA
 int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion) JL_CANSAFEPOINT;
 void jl_rng_split(uint64_t dst[JL_RNG_SIZE], uint64_t src[JL_RNG_SIZE]) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_path_is_tracked(const char *path) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_coverage_enabled_for(jl_module_t *m, const char *filename) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_coverage_visit_line(const char *filename, size_t len, int line) JL_CANSAFEPOINT;
 JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2152,6 +2152,7 @@ jl_value_t *simple_union(jl_value_t *a, jl_value_t *b) JL_CANSAFEPOINT;
 jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi) JL_CANSAFEPOINT;
 int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion) JL_CANSAFEPOINT;
 void jl_rng_split(uint64_t dst[JL_RNG_SIZE], uint64_t src[JL_RNG_SIZE]) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_path_is_tracked(const char *path) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2153,6 +2153,8 @@ jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi) JL_CANSA
 int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion) JL_CANSAFEPOINT;
 void jl_rng_split(uint64_t dst[JL_RNG_SIZE], uint64_t src[JL_RNG_SIZE]) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_path_is_tracked(const char *path) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_coverage_enabled_for(jl_module_t *m, const char *filename) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_coverage_visit_line(const char *filename, size_t len, int line) JL_CANSAFEPOINT;
 JL_DLLEXPORT void jl_coverage_alloc_line(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -629,8 +629,7 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_val
             // Not thread safe. For debugging and last resort error messages (jl_fprint_critical_error) only.
             jl_atomic_store_relaxed(&jl_filename, *toplevel_filename);
             jl_atomic_store_relaxed(&jl_lineno, *toplevel_lineno);
-            // top-level statements are run by the interpreter, and their thunks carry
-            // no line info, so this is the only place their coverage can be recorded
+            // Top-level thunks carry no line information.
             if (jl_options.code_coverage != JL_LOG_NONE && *toplevel_lineno > 0 &&
                     jl_coverage_enabled_for(m, *toplevel_filename))
                 jl_coverage_visit_line(*toplevel_filename, strlen(*toplevel_filename),

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -629,6 +629,12 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_val
             // Not thread safe. For debugging and last resort error messages (jl_fprint_critical_error) only.
             jl_atomic_store_relaxed(&jl_filename, *toplevel_filename);
             jl_atomic_store_relaxed(&jl_lineno, *toplevel_lineno);
+            // top-level statements are run by the interpreter, and their thunks carry
+            // no line info, so this is the only place their coverage can be recorded
+            if (jl_options.code_coverage != JL_LOG_NONE && *toplevel_lineno > 0 &&
+                    jl_coverage_enabled_for(m, *toplevel_filename))
+                jl_coverage_visit_line(*toplevel_filename, strlen(*toplevel_filename),
+                                       *toplevel_lineno);
             return jl_nothing;
         }
         return jl_interpret_toplevel_expr_in(m, e, NULL, NULL);

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -776,7 +776,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
 
         # the .cov writer must reproduce source lines of any length
         mktempdir() do tdir
-            srcfile = joinpath(tdir, "longline.jl")
+            srcfile = joinpath(realpath(tdir), "longline.jl")
             long = "x" ^ 4000
             write(srcfile, "f(x) = x + 1 # $long\nf(1)\n")
             pid = readchomp(`$cov_exename -E "getpid()" -L $srcfile --code-coverage=@$tdir`)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -788,6 +788,18 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             @test endswith(got[2], " f(1)")
         end
 
+        # `@/` is the filesystem root: absolute paths only, not the relative names
+        # sysimage sources are recorded under
+        mktempdir() do tdir
+            srcfile = joinpath(realpath(tdir), "root.jl")
+            write(srcfile, "f(v) = sort(v)\nf([3, 1, 2])\n")
+            outfile = joinpath(dir, "root.info")
+            run(`$cov_exename --code-coverage=$outfile --code-coverage=@/ $srcfile`)
+            sfs = [l[4:end] for l in eachline(outfile) if startswith(l, "SF:")]
+            rm(outfile)
+            @test all(isabspath, sfs) context=sfs
+        end
+
         # is_file_tracked must not read an unset tracked path
         @test readchomp(`$cov_exename -E "Base.is_file_tracked(:foo)"`) == "false"
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -658,6 +658,25 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
         @test isempty(got)
         rm(covfile)
 
+        # a tracked path only matches at a path component boundary
+        mktempdir() do parent
+            foo = realpath(mkdir(joinpath(parent, "Foo")))
+            foobar = realpath(mkdir(joinpath(parent, "Foobar")))
+            srcfile = joinpath(foobar, "boundary.jl")
+            write(srcfile, "f(x) = x + 1\nf(1)\n")
+            outfile = joinpath(dir, "boundary.info")
+            # "<parent>/Foo" is a string prefix of "<parent>/Foobar", but not a path prefix
+            run(`$cov_exename --code-coverage=$outfile --code-coverage=@$foo $srcfile`)
+            @test !contains(read(outfile, String), realpath(srcfile))
+            rm(outfile)
+            run(`$cov_exename --code-coverage=$outfile --code-coverage=@$foobar $srcfile`)
+            @test contains(read(outfile, String), realpath(srcfile))
+            rm(outfile)
+        end
+
+        # is_file_tracked must not read an unset tracked path
+        @test readchomp(`$cov_exename -E "Base.is_file_tracked(:foo)"`) == "false"
+
         function coverage_info_for(src::String)
             mktemp(dir) do srcfile, io
                 write(io, src); close(io)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -674,6 +674,20 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             rm(outfile)
         end
 
+        # the .cov writer must reproduce source lines of any length
+        mktempdir() do tdir
+            srcfile = joinpath(tdir, "longline.jl")
+            long = "x" ^ 4000
+            write(srcfile, "f(x) = x + 1 # $long\nf(1)\n")
+            pid = readchomp(`$cov_exename -E "getpid()" -L $srcfile --code-coverage=@$tdir`)
+            covfile = "$srcfile.$pid.cov"
+            got = readlines(covfile)
+            rm(covfile)
+            @test length(got) == 2
+            @test endswith(got[1], " f(x) = x + 1 # $long")
+            @test endswith(got[2], " f(1)")
+        end
+
         # is_file_tracked must not read an unset tracked path
         @test readchomp(`$cov_exename -E "Base.is_file_tracked(:foo)"`) == "false"
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -674,6 +674,38 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             rm(outfile)
         end
 
+        # --code-coverage=user must not attribute inlined Base code to the calling
+        # module, which used to drop .cov files into the Julia installation (#26573)
+        mktempdir() do tdir
+            srcfile = joinpath(tdir, "user.jl")
+            # `sort` inlines the optionally-generated `Base.merge`, whose body has no
+            # module recorded in its debuginfo
+            write(srcfile, "f(v) = sort(v)\nf([3, 1, 2])\n")
+            outfile = joinpath(dir, "user.info")
+            run(`$cov_exename --code-coverage=$outfile --code-coverage=user $srcfile`)
+            sfs = [l[4:end] for l in eachline(outfile) if startswith(l, "SF:")]
+            rm(outfile)
+            @test !isempty(sfs)
+            # Base files are recorded under a bare relative name; user files are absolute
+            @test all(isabspath, sfs) context=sfs
+        end
+
+        # Frames with no module in their debuginfo are classified by whether their
+        # file is absolute (see `frame_is_user_code` in src/codegen.cpp). If sysimage
+        # sources ever stop being recorded relatively, that rule silently starts
+        # calling Base user code again - and the =user test above would still pass,
+        # since the leaked records would now be absolute. So assert it directly.
+        mktempdir() do tdir
+            srcfile = joinpath(realpath(tdir), "paths.jl")
+            write(srcfile, "f(v) = sort(v)\nf([3, 1, 2])\n")
+            outfile = joinpath(dir, "paths.info")
+            run(`$cov_exename --code-coverage=$outfile --code-coverage=all $srcfile`)
+            sfs = [l[4:end] for l in eachline(outfile) if startswith(l, "SF:")]
+            rm(outfile)
+            @test any(!isabspath, sfs) # sysimage sources, e.g. "sort.jl"
+            @test srcfile in sfs # everything else is absolutized
+        end
+
         # the .cov writer must reproduce source lines of any length
         mktempdir() do tdir
             srcfile = joinpath(tdir, "longline.jl")

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -704,6 +704,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
         # must resolve it to the macro's own lines rather than to the call site
         let macrofile = realpath(joinpath(helperdir, "coverage_macros.jl")),
             usefile = realpath(joinpath(helperdir, "coverage_macrouse.jl"))
+            counts = Dict()
             for extra in (``, `--compile=min`), mode in (`--code-coverage=user`, `--code-coverage=all`)
                 outfile = joinpath(dir, "macro.info")
                 @test success(`$cov_exename $extra --code-coverage=$outfile $mode $usefile`)
@@ -715,7 +716,13 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
                 for ln in (13, 14) # the body of `@twice`, expanded into `usesmac`
                     @test get(hits, ln, 0) > 0 context=(extra, mode, ln)
                 end
+                # lines 12-14 are the macro body only; unlike line 11 they are not
+                # also a top-level statement, so every mode must agree on them.
+                # Interpreted counts drifting above compiled ones means the frames
+                # carried over between statements are not being tracked correctly.
+                counts[(string(extra), string(mode))] = [get(hits, ln, 0) for ln in 12:14]
             end
+            @test allequal(values(counts)) context=counts
         end
 
         # interpreted code is tracked too, including under --compile=min (#37059)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -674,6 +674,42 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             rm(outfile)
         end
 
+        # a macro defined in another user file expands into a frame with no module
+        # in its debuginfo; that must still count as user code, and the interpreter
+        # must resolve it to the macro's own lines rather than to the call site
+        let macrofile = realpath(joinpath(helperdir, "coverage_macros.jl")),
+            usefile = realpath(joinpath(helperdir, "coverage_macrouse.jl"))
+            for extra in (``, `--compile=min`), mode in (`--code-coverage=user`, `--code-coverage=all`)
+                outfile = joinpath(dir, "macro.info")
+                @test success(`$cov_exename $extra --code-coverage=$outfile $mode $usefile`)
+                record = only(filter(contains("SF:" * macrofile),
+                                     split(read(outfile, String), "end_of_record")))
+                rm(outfile)
+                hits = Dict(parse(Int, m[1]) => parse(Int, m[2])
+                            for m in eachmatch(r"^DA:(\d+),(\d+)$"m, record))
+                for ln in (13, 14) # the body of `@twice`, expanded into `usesmac`
+                    @test get(hits, ln, 0) > 0 context=(extra, mode, ln)
+                end
+            end
+        end
+
+        # interpreted code is tracked too, including under --compile=min (#37059)
+        let topfile = realpath(joinpath(helperdir, "coverage_toplevel.jl"))
+            for extra in (``, `--compile=min`)
+                outfile = joinpath(dir, "toplevel.info")
+                @test success(`$cov_exename $extra --code-coverage=$outfile --code-coverage=@$topfile $topfile`)
+                hits = Dict(parse(Int, m[1]) => parse(Int, m[2])
+                            for m in eachmatch(r"^DA:(\d+),(\d+)$"m, read(outfile, String)))
+                rm(outfile)
+                for ln in (7, 8, 9, 14) # every top-level statement that runs
+                    @test get(hits, ln, 0) > 0 context=(extra, ln)
+                end
+                # a top-level `if` is one statement with one LineNumberNode, and its
+                # thunk carries no line info, so lines inside it are still not tracked
+                @test !haskey(hits, 10)
+            end
+        end
+
         # --code-coverage=user must not attribute inlined Base code to the calling
         # module, which used to drop .cov files into the Julia installation (#26573)
         mktempdir() do tdir
@@ -747,14 +783,16 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             end
             do_test()
             """), """
+            DA:1,1
             DA:2,1
             DA:3,1
             DA:5,1
             DA:6,0
-            DA:9,1
+            DA:9,2
             DA:10,1
-            LH:5
-            LF:6
+            DA:12,1
+            LH:7
+            LF:8
             """)
         @test contains(coverage_info_for("""
             function cov_bug()
@@ -773,7 +811,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             end
             cov_bug()
             """), """
-            DA:1,1
+            DA:1,2
             DA:2,1
             DA:3,1
             DA:4,1
@@ -781,8 +819,9 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             DA:8,0
             DA:11,0
             DA:13,1
-            LH:5
-            LF:8
+            DA:15,1
+            LH:6
+            LF:9
             """)
 
         # counters must survive being driven from many threads at once (#59355, #62424)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -665,7 +665,6 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             srcfile = joinpath(foobar, "boundary.jl")
             write(srcfile, "f(x) = x + 1\nf(1)\n")
             outfile = joinpath(dir, "boundary.info")
-            # "<parent>/Foo" is a string prefix of "<parent>/Foobar", but not a path prefix
             run(`$cov_exename --code-coverage=$outfile --code-coverage=@$foo $srcfile`)
             @test !contains(read(outfile, String), realpath(srcfile))
             rm(outfile)
@@ -682,26 +681,23 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
                         for m in eachmatch(r"^DA:(\d+),(\d+)$"m, read(outfile, String)))
             rm(outfile)
             covered = [
-                9, 10, 11,      # `local` without an assignment (#39307)
-                15, 16, 17,     # `let` without an assignment (#39307)
-                23, 24,         # lines a macro adds (#41043)
-                29,
-                34, 36,         # implicit returns (#53557)
-                41, 42,         # a :foldable body that is also concrete-evaluated (#61175)
-                48,
-                55,             # the branch @static keeps (#43237)
+                8, 9, 10,       # `local` without an assignment (#39307)
+                14, 15, 16,     # `let` without an assignment (#39307)
+                22, 23,         # lines a macro adds (#41043)
+                28,
+                33, 35,         # implicit returns (#53557)
+                40, 41,         # a :foldable body that is also concrete-evaluated (#61175)
+                47,
+                54,             # the branch @static keeps (#43237)
             ]
             for ln in covered
                 @test get(hits, ln, 0) > 0 context=ln
             end
-            # the branch @static discards is compiled out, so it must not be reported
-            # as an uncovered line
-            @test !haskey(hits, 57)
+            # compiled-out branch
+            @test !haskey(hits, 56)
         end
 
-        # a macro defined in another user file expands into a frame with no module
-        # in its debuginfo; that must still count as user code, and the interpreter
-        # must resolve it to the macro's own lines rather than to the call site
+        # coverage for a macro defined in another user file
         let macrofile = realpath(joinpath(helperdir, "coverage_macros.jl")),
             usefile = realpath(joinpath(helperdir, "coverage_macrouse.jl"))
             counts = Dict()
@@ -713,14 +709,11 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
                 rm(outfile)
                 hits = Dict(parse(Int, m[1]) => parse(Int, m[2])
                             for m in eachmatch(r"^DA:(\d+),(\d+)$"m, record))
-                for ln in (13, 14) # the body of `@twice`, expanded into `usesmac`
+                for ln in (11, 12)
                     @test get(hits, ln, 0) > 0 context=(extra, mode, ln)
                 end
-                # lines 12-14 are the macro body only; unlike line 11 they are not
-                # also a top-level statement, so every mode must agree on them.
-                # Interpreted counts drifting above compiled ones means the frames
-                # carried over between statements are not being tracked correctly.
-                counts[(string(extra), string(mode))] = [get(hits, ln, 0) for ln in 12:14]
+                # Exclude line 9, which is also counted as a top-level statement.
+                counts[(string(extra), string(mode))] = [get(hits, ln, 0) for ln in 10:12]
             end
             @test allequal(values(counts)) context=counts
         end
@@ -733,45 +726,37 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
                 hits = Dict(parse(Int, m[1]) => parse(Int, m[2])
                             for m in eachmatch(r"^DA:(\d+),(\d+)$"m, read(outfile, String)))
                 rm(outfile)
-                for ln in (7, 8, 9, 14) # every top-level statement that runs
+                for ln in (5, 6, 7, 12) # every top-level statement that runs
                     @test get(hits, ln, 0) > 0 context=(extra, ln)
                 end
-                # a top-level `if` is one statement with one LineNumberNode, and its
-                # thunk carries no line info, so lines inside it are still not tracked
-                @test !haskey(hits, 10)
+                # The top-level `if` thunk has no line information for its body.
+                @test !haskey(hits, 8)
             end
         end
 
-        # --code-coverage=user must not attribute inlined Base code to the calling
-        # module, which used to drop .cov files into the Julia installation (#26573)
+        # --code-coverage=user excludes inlined Base code (#26573)
         mktempdir() do tdir
             srcfile = joinpath(tdir, "user.jl")
-            # `sort` inlines the optionally-generated `Base.merge`, whose body has no
-            # module recorded in its debuginfo
+            # `sort` inlines generated `Base.merge` code with no recorded module.
             write(srcfile, "f(v) = sort(v)\nf([3, 1, 2])\n")
             outfile = joinpath(dir, "user.info")
             run(`$cov_exename --code-coverage=$outfile --code-coverage=user $srcfile`)
-            sfs = [l[4:end] for l in eachline(outfile) if startswith(l, "SF:")]
+            source_files = [l[4:end] for l in eachline(outfile) if startswith(l, "SF:")]
             rm(outfile)
-            @test !isempty(sfs)
-            # Base files are recorded under a bare relative name; user files are absolute
-            @test all(isabspath, sfs) context=sfs
+            @test !isempty(source_files)
+            @test all(isabspath, source_files) context=source_files
         end
 
-        # Frames with no module in their debuginfo are classified by whether their
-        # file is absolute (see `frame_is_user_code` in src/codegen.cpp). If sysimage
-        # sources ever stop being recorded relatively, that rule silently starts
-        # calling Base user code again - and the =user test above would still pass,
-        # since the leaked records would now be absolute. So assert it directly.
+        # The unknown-module heuristic requires relative sysimage source paths.
         mktempdir() do tdir
             srcfile = joinpath(realpath(tdir), "paths.jl")
             write(srcfile, "f(v) = sort(v)\nf([3, 1, 2])\n")
             outfile = joinpath(dir, "paths.info")
             run(`$cov_exename --code-coverage=$outfile --code-coverage=all $srcfile`)
-            sfs = [l[4:end] for l in eachline(outfile) if startswith(l, "SF:")]
+            source_files = [l[4:end] for l in eachline(outfile) if startswith(l, "SF:")]
             rm(outfile)
-            @test any(!isabspath, sfs) # sysimage sources, e.g. "sort.jl"
-            @test srcfile in sfs # everything else is absolutized
+            @test any(!isabspath, source_files)
+            @test srcfile in source_files
         end
 
         # the .cov writer must reproduce source lines of any length
@@ -788,16 +773,15 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             @test endswith(got[2], " f(1)")
         end
 
-        # `@/` is the filesystem root: absolute paths only, not the relative names
-        # sysimage sources are recorded under
+        # `@/` tracks absolute paths only.
         mktempdir() do tdir
             srcfile = joinpath(realpath(tdir), "root.jl")
             write(srcfile, "f(v) = sort(v)\nf([3, 1, 2])\n")
             outfile = joinpath(dir, "root.info")
             run(`$cov_exename --code-coverage=$outfile --code-coverage=@/ $srcfile`)
-            sfs = [l[4:end] for l in eachline(outfile) if startswith(l, "SF:")]
+            source_files = [l[4:end] for l in eachline(outfile) if startswith(l, "SF:")]
             rm(outfile)
-            @test all(isabspath, sfs) context=sfs
+            @test all(isabspath, source_files) context=source_files
         end
 
         # is_file_tracked must not read an unset tracked path
@@ -877,7 +861,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             rm(outfile)
             hits = Dict(parse(Int, m[1]) => parse(Int, m[2])
                         for m in eachmatch(r"^DA:(\d+),(\d+)$"m, record))
-            for ln in 5:10 # the body of `hot`
+            for ln in 5:10
                 @test get(hits, ln, 0) > 0
             end
         end

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -719,6 +719,20 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             LH:5
             LF:8
             """)
+
+        # counters must survive being driven from many threads at once (#59355, #62424)
+        let threadfile = realpath(joinpath(helperdir, "coverage_threads.jl"))
+            outfile = joinpath(dir, "threads.info")
+            @test success(`$cov_exename -t4 --code-coverage=$outfile $threadfile`)
+            record = only(filter(contains(threadfile),
+                                 split(read(outfile, String), "end_of_record")))
+            rm(outfile)
+            hits = Dict(parse(Int, m[1]) => parse(Int, m[2])
+                        for m in eachmatch(r"^DA:(\d+),(\d+)$"m, record))
+            for ln in 5:10 # the body of `hot`
+                @test get(hits, ln, 0) > 0
+            end
+        end
     end
 
     # --track-allocation

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -674,6 +674,31 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             rm(outfile)
         end
 
+        # constructs that have regressed before; see testhelpers/coverage_constructs.jl
+        let constructs = realpath(joinpath(helperdir, "coverage_constructs.jl"))
+            outfile = joinpath(dir, "constructs.info")
+            @test success(`$cov_exename --code-coverage=$outfile --code-coverage=@$constructs $constructs`)
+            hits = Dict(parse(Int, m[1]) => parse(Int, m[2])
+                        for m in eachmatch(r"^DA:(\d+),(\d+)$"m, read(outfile, String)))
+            rm(outfile)
+            covered = [
+                9, 10, 11,      # `local` without an assignment (#39307)
+                15, 16, 17,     # `let` without an assignment (#39307)
+                23, 24,         # lines a macro adds (#41043)
+                29,
+                34, 36,         # implicit returns (#53557)
+                41, 42,         # a :foldable body that is also concrete-evaluated (#61175)
+                48,
+                55,             # the branch @static keeps (#43237)
+            ]
+            for ln in covered
+                @test get(hits, ln, 0) > 0 context=ln
+            end
+            # the branch @static discards is compiled out, so it must not be reported
+            # as an uncovered line
+            @test !haskey(hits, 57)
+        end
+
         # a macro defined in another user file expands into a frame with no module
         # in its debuginfo; that must still count as user code, and the interpreter
         # must resolve it to the macro's own lines rather than to the call site

--- a/test/testhelpers/coverage_constructs.jl
+++ b/test/testhelpers/coverage_constructs.jl
@@ -1,7 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# Constructs that have been reported as missing coverage; see test/cmdlineargs.jl
-# for the expected line numbers.
+# Coverage for constructs that have regressed; expected lines are in test/cmdlineargs.jl.
 
 module CoverageConstructs
 

--- a/test/testhelpers/coverage_constructs.jl
+++ b/test/testhelpers/coverage_constructs.jl
@@ -1,0 +1,71 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Constructs that have been reported as missing coverage; see test/cmdlineargs.jl
+# for the expected line numbers.
+
+module CoverageConstructs
+
+function with_local(x)
+    local y
+    y = x + 1
+    return y
+end
+
+function with_let(x)
+    let z
+        z = x
+        return z
+    end
+end
+
+macro adds_lines()
+    quote
+        a = 1
+        a + 1
+    end
+end
+
+function uses_macro()
+    @adds_lines
+end
+
+function implicit_return(x)
+    if x > 0
+        x + 1
+    else
+        x - 1
+    end
+end
+
+Base.@assume_effects :foldable function foldable(x)
+    y = x + 1
+    return y * 2
+end
+
+function folds(n)
+    s = 0
+    for _ in 1:n
+        s += foldable(3)
+    end
+    return s
+end
+
+function only_active_branch(x)
+    @static if true
+        return x + 1
+    else
+        return x - 1
+    end
+end
+
+end # module
+
+const C = CoverageConstructs
+ok = C.with_local(1) == 2 &&
+     C.with_let(1) == 1 &&
+     C.uses_macro() == 2 &&
+     C.implicit_return(1) == 2 &&
+     C.implicit_return(-1) == -2 &&
+     C.folds(3) == 24 &&
+     C.only_active_branch(1) == 2
+exit(ok ? 0 : 1)

--- a/test/testhelpers/coverage_file.info
+++ b/test/testhelpers/coverage_file.info
@@ -1,5 +1,5 @@
 SF:<FILENAME>
-DA:3,1
+DA:3,2
 DA:4,2
 DA:5,0
 DA:7,1
@@ -9,11 +9,13 @@ DA:10,5
 DA:11,1
 DA:12,1
 DA:14,0
-DA:17,1
+DA:17,2
 DA:18,1
 DA:19,1
 DA:20,1
 DA:22,1
-LH:13
-LF:15
+DA:25,1
+DA:27,1
+LH:15
+LF:17
 end_of_record

--- a/test/testhelpers/coverage_macros.jl
+++ b/test/testhelpers/coverage_macros.jl
@@ -1,8 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# A macro defined in a different file from where it is used; see
-# testhelpers/coverage_macrouse.jl. The expansion has no module recorded in its
-# debuginfo, so it must not be mistaken for a sysimage source.
+# Coverage for a macro body defined in a different source file.
 
 module CoverageMacros
 

--- a/test/testhelpers/coverage_macros.jl
+++ b/test/testhelpers/coverage_macros.jl
@@ -1,0 +1,18 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# A macro defined in a different file from where it is used; see
+# testhelpers/coverage_macrouse.jl. The expansion has no module recorded in its
+# debuginfo, so it must not be mistaken for a sysimage source.
+
+module CoverageMacros
+
+export @twice
+
+macro twice(x)
+    quote
+        v = $(esc(x))
+        v + v
+    end
+end
+
+end

--- a/test/testhelpers/coverage_macrouse.jl
+++ b/test/testhelpers/coverage_macrouse.jl
@@ -1,0 +1,10 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+include(joinpath(@__DIR__, "coverage_macros.jl"))
+using .CoverageMacros
+
+function usesmac(n)
+    return @twice(n)
+end
+
+exit(usesmac(21) == 42 ? 0 : 1)

--- a/test/testhelpers/coverage_threads.jl
+++ b/test/testhelpers/coverage_threads.jl
@@ -1,0 +1,18 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Drives the coverage counters from several threads at once (#59355).
+
+function hot(n)
+    s = 0
+    for i in 1:n
+        s += i
+    end
+    return s
+end
+
+function spawn_all(n)
+    tasks = [Threads.@spawn hot(n) for _ in 1:(4 * Threads.nthreads())]
+    return all(t -> fetch(t) == hot(n), tasks)
+end
+
+exit(spawn_all(1000) ? 0 : 1)

--- a/test/testhelpers/coverage_toplevel.jl
+++ b/test/testhelpers/coverage_toplevel.jl
@@ -1,8 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# Top-level statements run in the interpreter rather than through codegen (#37059).
-# Note the `if` below is a single top-level statement: only its first line is
-# tracked, since the thunk it lowers to carries no line info.
+# Coverage for top-level statements, whose lowered thunks carry no line information.
 
 x = 1
 y = x + 1

--- a/test/testhelpers/coverage_toplevel.jl
+++ b/test/testhelpers/coverage_toplevel.jl
@@ -1,0 +1,14 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Top-level statements run in the interpreter rather than through codegen (#37059).
+# Note the `if` below is a single top-level statement: only its first line is
+# tracked, since the thunk it lowers to carries no line info.
+
+x = 1
+y = x + 1
+if y > 1
+    z = 10
+else
+    z = 20
+end
+exit(z == 10 ? 0 : 1)


### PR DESCRIPTION
A general look at coverage mechanics by the bots (Opus 5 -> Sol -> Fable -> Opus)

Fixes #62424
Fixes #37059
Fixes #26573

Note that they concluded that these open coverage issues can be closed already: 
#39307 #41043 #53557 #61175 #43237 #36284


Claude:

---

One performance regression, two long-standing gaps in what gets tracked, and a
handful of smaller bugs found while auditing the coverage paths. Each fix is a
separate commit with a test.

## Instrumentation is ~3x slower than it needs to be (#62424)

`de2f3f2594` (#59517, in 1.12) fixed the corruption in #59355 by locking the
coverage hash table, and in the same change switched the counter update from a
volatile load/add/store to an atomic RMW. The lock is what fixed the corruption;
the atomic is what made instrumented code so much more expensive.

Lattice-Boltzmann kernel from the issue, aarch64, single-threaded:

| | uninstrumented | `--code-coverage=user` | ratio |
|---|---|---|---|
| 1.11.9 | 71.2 Msite/s | 28.1 | 2.5x |
| master | 71.8 | 11.4 | 6.3x |
| this PR | 70.9 | 33.1 | **2.1x** |

master executes *fewer* counter updates than 1.11 here, so the cost is the atomic
itself: it stops the inner loops unrolling and issues an `ldadd` to the same cache
line every iteration (17 `ldadd`/13 `fmul` on master, 0/13 here, 0/58
uninstrumented). The counters were never exact and the emitted counts are not
statement execution counts in any useful sense, so this goes back to the volatile
update and keeps the lock.

## Interpreted code was never tracked (#37059)

Coverage was only emitted by codegen, so anything the interpreter ran was
invisible: every top-level statement lowering does not force through codegen, and
under `--compile=min` method bodies too — hence no coverage files at all with that
flag.

Top-level thunks carry no line info of their own, so those are logged from
`jl_toplevel_eval_flex`. Method bodies do have debuginfo, but a statement's
location is not simply its `jl_uncompress1_codeloc` — that can be a pc into a
nested linetable, and one statement can stand for several frames via macro
expansion. So `eval_body` resolves it the way codegen's `append_lineinfo` does and
logs only the frames that differ from the previous statement, as
`coverageVisitStmt` does. Interpreted and compiled coverage agree line-for-line on
the cross-file macro fixture added here.

Known limitations, all counts-only or documented:

- Lines nested inside a top-level block are still untracked — the whole block is
  one statement with one `LineNumberNode`.
- A top-level statement that is also compiled is counted twice, once from each side.
- Codegen pre-registers every line via `jl_coverage_alloc_line` so unrun lines
  report `DA:n,0`; the interpreter has no equivalent, so under `--compile=min` a
  never-taken branch in a method body reads `-` rather than `0`. A pre-pass would
  run per interpreted call rather than once per compilation, a poor trade here.

## `--code-coverage=user` wrote into the Julia installation (#26573)

`f(v) = sort(v); f([3, 1, 2])` creates
`<prefix>/share/julia/base/namedtuple.jl.<pid>.cov`. `sort` inlines the
optionally-generated `Base.merge`, whose body carries no module in its debuginfo,
so coverage fell back to `ctx.module` — the *user's* module for inlined code. These
files accumulate one set per process id in a shared directory.

Macro expansions produce module-less frames too, and codegen clears provenance when
descending into an edge, so the two cannot be told apart that way; dropping the
fallback outright loses coverage for macros defined in another file. What does
separate them is the path: sysimage sources are recorded relatively
(`namedtuple.jl`), everything else absolutized — which is why the `.cov` writer
resolves relative names against `<bindir>/../share/julia/base/`. That is the rule
used here. It is a property of the build rather than real provenance, so a test
asserts it directly; without one a change there would silently restore the old
behaviour while the `=user` test kept passing, since the leaked records would then
be absolute.

## Smaller fixes

- `allocLine` dereferenced a bare `calloc`; everything else in the file uses
  `calloc_s`.
- `jl_is_file_tracked` and codegen's `in_tracked_path` were separate implementations
  of the same predicate, and the runtime one called `strlen` on a possibly-NULL
  `tracked_path`, so `Base.is_file_tracked` crashed without `--code-coverage=@`.
  Both now use `jl_path_is_tracked`, which also requires the prefix to end at a path
  component boundary (`@/src/Foo` no longer matches `/src/Foobar/x.jl`) and treats a
  separators-only option as the filesystem root rather than "match everything".
- The `.cov`/`.mem` writer read lines with `fscanf(inf, "%1023[^\n]", ...)`, silently
  truncating any line over 1023 characters. These files are meant to be the source
  with a count column, so the line is copied through verbatim.

## Issue triage

Already fixed on master — verified working, and the last commit pins the first five
with regression tests. Closeable independently of this PR: #39307 (`local`/`let`
without assignment), #41043 (macros adding lines), #53557 (implicit returns), #61175
(`:foldable` bodies), #43237 (`@static`), #36284 (`quote` bodies).

**#52458 is still live and not fixed here.** I first assessed it as fixed, because a
repro built from an already-resolved path works. The new tests caught that:
`tracked_path` is passed through `absrealpath` but recorded source paths are not.
The two ends do not even agree — `include`/`-L` records a resolved path while a
script named on the command line is recorded as given, so whether tracking works
depends on how the file was loaded. The tests here pass `realpath`-ed paths, as the
existing coverage tests already did. Fixing it needs a decision on which end to
normalize.

Not addressed: #54214/#54980 (methods never natively compiled produce no records at
all, so they read as "not code" rather than "uncovered" — the largest remaining
accuracy problem, but fixing it means emitting line records at definition time,
which changes every `LF`/`LH` count; wants its own PR and #50834 discussion) and
#59985/#49978 (coverage altering `@inferred` and effects is inherent to
`insert_coverage`; should be documented, not "fixed").

## Test plan

`Base.runtests("cmdlineargs")` passes: 582 pass, 5 pre-existing broken. Coverage
previously had one 27-line fixture plus flag parsing, with nothing exercising the
`.cov` output path, top-level statements, `--compile=min`, or threads. Added
fixtures for threaded counters, top-level statements, previously-regressed
constructs, and a cross-file macro checked across `{normal, --compile=min}` x
`{=user, =all}` with counts required to match; plus assertions for the tracked-path
boundary, `@/`, unset `tracked_path`, long source lines, and no relative (Base)
`SF:` records under `=user`.

`coverage_file.info` and the two inline LCOV expectations gain records for the
newly-tracked top-level statements, and function-definition lines go from 1 to 2.