### PR TITLE
Base: Fix checked_length return type docstring

### DIFF
--- a/base/checked.jl
+++ b/base/checked.jl
@@ -380,7 +380,7 @@ checked_power_by_squaring(x::Bool, p::Integer) = Base.power_by_squaring(x, p)
     Base.checked_length(r)
 
 Calculates `length(r)`, but may check for overflow errors where applicable when
-the result doesn't fit into `Union{Integer(eltype(r)),Int}`.
+the result doesn't fit into `Union{eltype(r),Int}`.
 """
 checked_length(r) = length(r) # for most things, length doesn't error
 


### PR DESCRIPTION
Replace the invalid `Integer(eltype(r))` construction with `eltype(r)` in the documented return type union.

Fixes #53645

This pull request was prepared with assistance from OpenCode using OpenAI gpt-5.6-sol. I reviewed and understand the complete change.

Validation: `git diff --check` passes. Julia and GNU Make are unavailable in this environment, so `make fix-whitespace` and a Julia expression check could not be run locally.