### PR TITLE
codegen: clear PhiC slots once their catch block is unreachable

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6309,6 +6309,8 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r) J
     return;
 }
 
+static void emit_phic_slot_clear(jl_codectx_t &ctx, jl_varinfo_t &vi) JL_CANSAFEPOINT;
+
 static void emit_ssaval_assign(jl_codectx_t &ctx, ssize_t ssaidx_0based, jl_value_t *r) JL_CANSAFEPOINT
 {
     assert(!ctx.ssavalue_assigned[ssaidx_0based]);
@@ -6323,6 +6325,9 @@ static void emit_ssaval_assign(jl_codectx_t &ctx, ssize_t ssaidx_0based, jl_valu
             it = ctx.phic_slots.emplace(ssaidx_0based, jl_varinfo_t(ctx.builder.getContext())).first;
         }
         slot = emit_varinfo(ctx, it->second, jl_symbol("phic"));
+        // `emit_varinfo` copied the contents somewhere rooted independently of the
+        // slot, and this is the only read of it, so the slot is now dead (#52533).
+        emit_phic_slot_clear(ctx, it->second);
     }
     else {
         slot = emit_expr(ctx, r, ssaidx_0based);
@@ -6443,6 +6448,44 @@ static void emit_assignment(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r, ssi
     // its memory location.
 }
 
+// Reset a PhiC slot to an undefined (but GC-safe) state. Only valid where the
+// PhiC node can no longer be dynamically observed.
+static void emit_phic_slot_clear(jl_codectx_t &ctx, jl_varinfo_t &vi) JL_CANSAFEPOINT
+{
+    if (vi.boxroot) {
+        // memory optimization: eagerly clear this gc-root now
+        ctx.builder.CreateAlignedStore(Constant::getNullValue(ctx.types().T_prjlvalue), vi.boxroot, Align(sizeof(void*)), true);
+    }
+    if (vi.pTIndex) {
+        // We don't care what the contents of the variable are, but it
+        // does need to satisfy the union invariants (i.e. inbounds
+        // tindex).
+        ctx.builder.CreateAlignedStore(
+            vi.boxroot ? ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER) :
+                         ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x01),
+            vi.pTIndex, Align(1), true);
+    }
+    else if (vi.value.V && !vi.value.constant && vi.value.typ != jl_bottom_type) {
+        assert(vi.inline_roots || vi.value.ispointer());
+        if (vi.inline_roots) {
+            // memory optimization: make gc pointers re-initialized to NULL
+            AllocaInst *ssaroots = vi.inline_roots;
+            size_t nroots = vi.inline_roots_count;
+            auto T_prjlvalue = ssaroots->getAllocatedType();
+            if (auto AT = dyn_cast<ArrayType>(T_prjlvalue)) {
+                nroots *= AT->getNumElements();
+                T_prjlvalue = AT->getElementType();
+            }
+            assert(T_prjlvalue == ctx.types().T_prjlvalue);
+            Value *nullval = Constant::getNullValue(T_prjlvalue);
+            auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
+            for (size_t i = 0; i < nroots; i++) {
+                stack_ai.decorateInst(ctx.builder.CreateAlignedStore(nullval, emit_ptrgep(ctx, ssaroots, i * sizeof(void*)), ssaroots->getAlign(), true));
+            }
+        }
+    }
+}
+
 static void emit_upsilonnode(jl_codectx_t &ctx, ssize_t phic, jl_value_t *val) JL_CANSAFEPOINT
 {
     auto it = ctx.phic_slots.find(phic);
@@ -6467,38 +6510,27 @@ static void emit_upsilonnode(jl_codectx_t &ctx, ssize_t phic, jl_value_t *val) J
             emit_varinfo_assign(ctx, vi, rval_info, NULL, true);
         }
     }
-    if (!val) {
-        if (vi.boxroot) {
-            // memory optimization: eagerly clear this gc-root now
-            ctx.builder.CreateAlignedStore(Constant::getNullValue(ctx.types().T_prjlvalue), vi.boxroot, Align(sizeof(void*)), true);
+    if (!val)
+        emit_phic_slot_clear(ctx, vi);
+}
+
+// Clear every PhiC slot of the catch block starting at statement `catch_dest`
+// (1-based). Safe once the handler is popped: a catch block is only reached from
+// its `EnterNode`, and slot2ssa re-initializes the slots at the top of every
+// enter block, so re-entering the region restores them.
+static void emit_phic_slots_clear_for_catch(jl_codectx_t &ctx, intptr_t catch_dest) JL_CANSAFEPOINT
+{
+    intptr_t nstmts = jl_array_nrows(ctx.code);
+    for (intptr_t i = catch_dest - 1; i < nstmts; i++) {
+        jl_value_t *stmt = jl_array_ptr_ref(ctx.code, i);
+        if (jl_is_phicnode(stmt)) {
+            auto it = ctx.phic_slots.find((int)i);
+            if (it != ctx.phic_slots.end())
+                emit_phic_slot_clear(ctx, it->second);
         }
-        if (vi.pTIndex) {
-            // We don't care what the contents of the variable are, but it
-            // does need to satisfy the union invariants (i.e. inbounds
-            // tindex).
-            ctx.builder.CreateAlignedStore(
-                vi.boxroot ? ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER) :
-                             ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x01),
-                vi.pTIndex, Align(1), true);
-        }
-        else if (vi.value.V && !vi.value.constant && vi.value.typ != jl_bottom_type) {
-            assert(vi.inline_roots || vi.value.ispointer());
-            if (vi.inline_roots) {
-                // memory optimization: make gc pointers re-initialized to NULL
-                AllocaInst *ssaroots = vi.inline_roots;
-                size_t nroots = vi.inline_roots_count;
-                auto T_prjlvalue = ssaroots->getAllocatedType();
-                if (auto AT = dyn_cast<ArrayType>(T_prjlvalue)) {
-                    nroots *= AT->getNumElements();
-                    T_prjlvalue = AT->getElementType();
-                }
-                assert(T_prjlvalue == ctx.types().T_prjlvalue);
-                Value *nullval = Constant::getNullValue(T_prjlvalue);
-                auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
-                for (size_t i = 0; i < nroots; i++) {
-                    stack_ai.decorateInst(ctx.builder.CreateAlignedStore(nullval, emit_ptrgep(ctx, ssaroots, i * sizeof(void*)), ssaroots->getAlign(), true));
-                }
-            }
+        else if (stmt != jl_nothing && !jl_is_phinode(stmt)) {
+            // end of the phi block at the top of the catch block
+            break;
         }
     }
 }
@@ -6579,6 +6611,7 @@ static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr, int ssaval_result)
     else if (head == jl_leave_sym) {
         Value *scope_to_restore = nullptr, *token = nullptr;
         SmallVector<AllocaInst*> handler_to_end;
+        SmallVector<intptr_t> catch_dests_to_clear;
         for (size_t i = 0; i < jl_expr_nargs(ex); ++i) {
             jl_value_t *arg = args[i];
             if (arg == jl_nothing)
@@ -6603,16 +6636,22 @@ static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr, int ssaval_result)
                 std::tie(token, scope_to_restore) = ctx.scope_restore[enter_idx];
                 ctx.builder.CreateCall(prepare_call(gc_preserve_end_func), {token});
             }
-            if (jl_enternode_catch_dest(enter_stmt)) {
+            if (intptr_t catch_dest = jl_enternode_catch_dest(enter_stmt)) {
                 handler_to_end.push_back(ctx.eh_buffers[enter_stmt]);
                 // We're not actually setting up the exception frames for these, so
                 // we don't need to exit them.
                 scope_to_restore = nullptr; // restored by exception handler
+                catch_dests_to_clear.push_back(catch_dest);
             }
         }
         ctx.builder.CreateCall(prepare_call(jlleave_noexcept_func), {get_current_task(ctx), ConstantInt::get(getInt32Ty(ctx.builder.getContext()), handler_to_end.size())});
         for (AllocaInst *handler : handler_to_end) {
             ctx.builder.CreateLifetimeEnd(handler);
+        }
+        // Deferred until after the pop: until then an asynchronous exception could
+        // still reach the catch block and observe the cleared slots.
+        for (intptr_t catch_dest : catch_dests_to_clear) {
+            emit_phic_slots_clear_for_catch(ctx, catch_dest);
         }
         if (scope_to_restore) {
             Value *scope_ptr = get_scope_field(ctx);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2070,6 +2070,7 @@ public:
     // local var info. globals are not in here.
     SmallVector<jl_varinfo_t, 0> slots;
     std::map<int, jl_varinfo_t> phic_slots;
+    std::map<int, SmallVector<int, 0>> phic_slots_for_catch; // catch_dest (1-based) -> PhiC statement indices
     std::map<int, std::pair<Value*, Value*> > scope_restore;
     std::map<jl_value_t*, AllocaInst*> eh_buffers;
     SmallVector<jl_cgval_t, 0> SAvalues;
@@ -6309,7 +6310,7 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r) J
     return;
 }
 
-static void emit_phic_slot_clear(jl_codectx_t &ctx, jl_varinfo_t &vi) JL_CANSAFEPOINT;
+static void emit_phic_slot_clear(jl_codectx_t &ctx, jl_varinfo_t &vi, bool dead=false) JL_CANSAFEPOINT;
 
 static void emit_ssaval_assign(jl_codectx_t &ctx, ssize_t ssaidx_0based, jl_value_t *r) JL_CANSAFEPOINT
 {
@@ -6327,7 +6328,7 @@ static void emit_ssaval_assign(jl_codectx_t &ctx, ssize_t ssaidx_0based, jl_valu
         slot = emit_varinfo(ctx, it->second, jl_symbol("phic"));
         // `emit_varinfo` copied the contents somewhere rooted independently of the
         // slot, and this is the only read of it, so the slot is now dead (#52533).
-        emit_phic_slot_clear(ctx, it->second);
+        emit_phic_slot_clear(ctx, it->second, /*dead*/true);
     }
     else {
         slot = emit_expr(ctx, r, ssaidx_0based);
@@ -6449,14 +6450,39 @@ static void emit_assignment(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r, ssi
 }
 
 // Reset a PhiC slot to an undefined (but GC-safe) state. Only valid where the
-// PhiC node can no longer be dynamically observed.
-static void emit_phic_slot_clear(jl_codectx_t &ctx, jl_varinfo_t &vi) JL_CANSAFEPOINT
+// PhiC node can no longer be dynamically observed. When `dead`, the slot will
+// never be read again, so only the gc references need dropping -- the union
+// tindex does not have to be left in bounds, and a slot holding no references
+// needs no store at all.
+static void emit_phic_slot_clear(jl_codectx_t &ctx, jl_varinfo_t &vi, bool dead) JL_CANSAFEPOINT
 {
+    if (dead && !vi.boxroot && !vi.inline_roots)
+        return;
     if (vi.boxroot) {
         // memory optimization: eagerly clear this gc-root now
         ctx.builder.CreateAlignedStore(Constant::getNullValue(ctx.types().T_prjlvalue), vi.boxroot, Align(sizeof(void*)), true);
     }
+    // note that a union slot may carry inline roots alongside its tindex, so this
+    // is deliberately not part of the `pTIndex` else-branch below
+    if (vi.inline_roots) {
+        // memory optimization: make gc pointers re-initialized to NULL
+        AllocaInst *ssaroots = vi.inline_roots;
+        size_t nroots = vi.inline_roots_count;
+        auto T_prjlvalue = ssaroots->getAllocatedType();
+        if (auto AT = dyn_cast<ArrayType>(T_prjlvalue)) {
+            nroots *= AT->getNumElements();
+            T_prjlvalue = AT->getElementType();
+        }
+        assert(T_prjlvalue == ctx.types().T_prjlvalue);
+        Value *nullval = Constant::getNullValue(T_prjlvalue);
+        auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
+        for (size_t i = 0; i < nroots; i++) {
+            stack_ai.decorateInst(ctx.builder.CreateAlignedStore(nullval, emit_ptrgep(ctx, ssaroots, i * sizeof(void*)), ssaroots->getAlign(), true));
+        }
+    }
     if (vi.pTIndex) {
+        if (dead)
+            return;
         // We don't care what the contents of the variable are, but it
         // does need to satisfy the union invariants (i.e. inbounds
         // tindex).
@@ -6465,24 +6491,9 @@ static void emit_phic_slot_clear(jl_codectx_t &ctx, jl_varinfo_t &vi) JL_CANSAFE
                          ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x01),
             vi.pTIndex, Align(1), true);
     }
-    else if (vi.value.V && !vi.value.constant && vi.value.typ != jl_bottom_type) {
-        assert(vi.inline_roots || vi.value.ispointer());
-        if (vi.inline_roots) {
-            // memory optimization: make gc pointers re-initialized to NULL
-            AllocaInst *ssaroots = vi.inline_roots;
-            size_t nroots = vi.inline_roots_count;
-            auto T_prjlvalue = ssaroots->getAllocatedType();
-            if (auto AT = dyn_cast<ArrayType>(T_prjlvalue)) {
-                nroots *= AT->getNumElements();
-                T_prjlvalue = AT->getElementType();
-            }
-            assert(T_prjlvalue == ctx.types().T_prjlvalue);
-            Value *nullval = Constant::getNullValue(T_prjlvalue);
-            auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
-            for (size_t i = 0; i < nroots; i++) {
-                stack_ai.decorateInst(ctx.builder.CreateAlignedStore(nullval, emit_ptrgep(ctx, ssaroots, i * sizeof(void*)), ssaroots->getAlign(), true));
-            }
-        }
+    else {
+        assert(!vi.value.V || vi.value.constant || vi.value.typ == jl_bottom_type ||
+               vi.inline_roots || vi.value.ispointer());
     }
 }
 
@@ -6520,18 +6531,13 @@ static void emit_upsilonnode(jl_codectx_t &ctx, ssize_t phic, jl_value_t *val) J
 // enter block, so re-entering the region restores them.
 static void emit_phic_slots_clear_for_catch(jl_codectx_t &ctx, intptr_t catch_dest) JL_CANSAFEPOINT
 {
-    intptr_t nstmts = jl_array_nrows(ctx.code);
-    for (intptr_t i = catch_dest - 1; i < nstmts; i++) {
-        jl_value_t *stmt = jl_array_ptr_ref(ctx.code, i);
-        if (jl_is_phicnode(stmt)) {
-            auto it = ctx.phic_slots.find((int)i);
-            if (it != ctx.phic_slots.end())
-                emit_phic_slot_clear(ctx, it->second);
-        }
-        else if (stmt != jl_nothing && !jl_is_phinode(stmt)) {
-            // end of the phi block at the top of the catch block
-            break;
-        }
+    auto phics = ctx.phic_slots_for_catch.find(catch_dest);
+    if (phics == ctx.phic_slots_for_catch.end())
+        return;
+    for (int i : phics->second) {
+        auto it = ctx.phic_slots.find(i);
+        if (it != ctx.phic_slots.end())
+            emit_phic_slot_clear(ctx, it->second, /*dead*/true);
     }
 }
 
@@ -8841,6 +8847,36 @@ static jl_llvm_functions_t
 
     // determine which vars need to be volatile
     mark_volatile_vars(stmts, ctx.slots, branch_targets);
+
+    // Record the PhiC nodes of each catch block, so that `Expr(:leave, ...)` can
+    // drop the gc roots they hold. They sit in the phi block at the top of the
+    // catch block; bound the scan there so it cannot run into a following block.
+    for (i = 0; i < stmtslen; i++) {
+        jl_value_t *stmt = jl_array_ptr_ref(stmts, i);
+        if (!jl_is_enternode(stmt))
+            continue;
+        intptr_t catch_dest = jl_enternode_catch_dest(stmt);
+        if (!catch_dest)
+            continue;
+        // Clearing at a `leave` is only sound if this is the sole handler using
+        // the block; otherwise an outer region could still read the slots.
+        auto prev = ctx.phic_slots_for_catch.find(catch_dest);
+        if (prev != ctx.phic_slots_for_catch.end()) {
+            assert(false && "catch block shared between handlers");
+            prev->second.clear(); // give up rather than clear while still readable
+            continue;
+        }
+        SmallVector<int, 0> &phics = ctx.phic_slots_for_catch[catch_dest];
+        for (intptr_t j = catch_dest - 1; j < (intptr_t)stmtslen; j++) {
+            if (j != catch_dest - 1 && branch_targets.count(j + 1))
+                break; // start of the next basic block
+            jl_value_t *cstmt = jl_array_ptr_ref(stmts, j);
+            if (jl_is_phicnode(cstmt))
+                phics.push_back(j);
+            else if (cstmt != jl_nothing && !jl_is_phinode(cstmt))
+                break; // end of the phi block
+        }
+    }
 
     // step 4. determine function signature
     if (!specsig)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6449,11 +6449,11 @@ static void emit_assignment(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r, ssi
     // its memory location.
 }
 
-// Reset a PhiC slot to an undefined (but GC-safe) state. Only valid where the
-// PhiC node can no longer be dynamically observed. When `dead`, the slot will
-// never be read again, so only the gc references need dropping -- the union
-// tindex does not have to be left in bounds, and a slot holding no references
-// needs no store at all.
+// Drop the gc references a PhiC slot holds, by storing null over them. Only
+// valid where the PhiC node can no longer be dynamically observed. When `dead`,
+// the slot will never be read again, so only the references need dropping -- the
+// union tindex is left stale rather than in bounds, and a slot holding no
+// references needs no store at all.
 static void emit_phic_slot_clear(jl_codectx_t &ctx, jl_varinfo_t &vi, bool dead) JL_CANSAFEPOINT
 {
     if (dead && !vi.boxroot && !vi.inline_roots)

--- a/test/core.jl
+++ b/test/core.jl
@@ -9262,3 +9262,23 @@ mutable struct Issue52533 end
 end
 @test issue52533(Ref(false), false)  # normal exit from the try region
 @test issue52533(Ref(false), true)   # exit through the catch block
+
+# ... and this holds for a value the try region never touches on the executed
+# path: slot2ssa snapshots each PhiC variable into its slot ahead of the `enter`,
+# so the region pins whatever the variable held on the way in
+@noinline issue52533_never() = Base.inferencebarrier(false)::Bool
+@noinline function issue52533_beside(freed::Ref{Bool})
+    b = Issue52533()
+    finalizer(_ -> (freed[] = true), b)
+    Base.donotdelete(b)
+    try
+        Base.inferencebarrier(identity)(nothing)
+        issue52533_never() && (b = nothing)
+    catch
+        b === nothing || Base.donotdelete(b)
+    end
+    b = nothing
+    GC.gc(true); GC.gc(true)
+    return freed[]
+end
+@test issue52533_beside(Ref(false))

--- a/test/core.jl
+++ b/test/core.jl
@@ -9241,3 +9241,24 @@ pinned_gci_62001(::Type{<:PinnedSA62001{<:PinnedPL62001}}, ::Type{<:Type{Val{S}}
 # a generated function's generator receives the representative value
 @generated pinned_gg_62001(::Type{<:Type{Val{S}}}) where {S} = QuoteNode(S)
 @test pinned_gg_62001(Type{Val{pinned_schema_62001}}) === pinned_schema_62001
+
+# issue #52533: an unrelated try/catch should not keep values rooted in its PhiC
+# slots for the remainder of the enclosing function
+mutable struct Issue52533 end
+@noinline function issue52533(freed::Ref{Bool}, throw_::Bool)
+    b = nothing
+    try
+        x = Issue52533()
+        finalizer(_ -> (freed[] = true), x)
+        b = x
+        throw_ && Base.inferencebarrier(throw)(ErrorException("52533"))
+        Base.inferencebarrier(identity)(nothing)
+    catch
+        b isa Issue52533 && Base.donotdelete(b)
+    end
+    b = nothing
+    GC.gc(true); GC.gc(true)
+    return freed[]
+end
+@test issue52533(Ref(false), false)  # normal exit from the try region
+@test issue52533(Ref(false), true)   # exit through the catch block


### PR DESCRIPTION
Fixes #52533

#52533 can make GPU training quite unfriendly. I've wanted this fixed for a long time, so I asked the bots to help. I'm a bit out of my depth on this one though, if you could take a look @maleadt or @gbaraldi or someone familiar. Thanks!

The added test passes on this PR and fails on all julia versions 1.10+ (untested further back).

Claude (in collaboration with sol):

---

Each `PhiCNode` is backed by a volatile, GC-rooted alloca that `UpsilonNode`s store into. Nothing ever cleared those slots, so after a try region was exited the slot still held whatever the last upsilon stored, keeping that value rooted in the GC frame for the remainder of the function. This happened even on the normal path, where the `PhiC` is never read, so an entirely unrelated try/catch could pin a large object -- painfully visible with GPU arrays, where a single retained buffer is enough to exhaust device memory, and is commonly triggered by a `@info "iteration $i"` type log that unobviously introduces a try-catch.

Clear the slots at both exits from the region. On the normal path that is `Expr(:leave, ...)`, after the handlers have been popped: until then an asynchronous exception could still transfer control into the catch block, which would observe the cleared slots. On the exception path it is the `PhiC` read itself, whose values are copied into locations rooted independently of the slot.

Both are safe because a catch block is only ever reached from its `EnterNode`, and `slot2ssa` emits fresh initial `UpsilonNode`s at the top of every enter block, so re-entering the region always re-initializes the slots.