### PR TITLE
test: Replace #58229 regression test with cheaper alternative

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1516,7 +1516,7 @@ end
 let n = 6000
     code = """
     f(x, ::Val{i}) where {i} = x + i
-    @generated g(x) = Expr(:call, :+, (:(f(x, Val(\$i))) for i in 1:$n)...)
+    @eval g(x) = +(\$((:(f(x, Val(\$i))) for i in 1:$n)...))
     print(g(1))
     """
     @test test_read_success(`$(Base.julia_cmd()) --startup-file=no --inline=no -e $code`) == string(sum(1:n) + n)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1509,7 +1509,18 @@ end
 end
 
 # https://github.com/JuliaLang/julia/issues/58229 Recursion in jitlinking with inline=no
-@test "" == test_read_success(`$(Base.julia_cmd()) --inline=no -e 'Base.compilecache(Base.identify_package("Pkg"))'`)
+# Compiling a single entry point whose inferred call graph contains thousands of
+# CodeInstances used to overflow the stack in the JIT linker's recursive task
+# dispatcher (threshold ~4k with an 8MB stack); `--inline=no` keeps every callee as a
+# separately-linked function so they all land in one lookup batch.
+let n = 6000
+    code = """
+    f(x, ::Val{i}) where {i} = x + i
+    @generated g(x) = Expr(:call, :+, (:(f(x, Val(\$i))) for i in 1:$n)...)
+    print(g(1))
+    """
+    @test test_read_success(`$(Base.julia_cmd()) --startup-file=no --inline=no -e $code`) == string(sum(1:n) + n)
+end
 
 # https://github.com/JuliaLang/julia/issues/59103
 @test test_read_success(setenv(`$(Base.julia_cmd()) -g2 -e 'println("done")'`, "ENABLE_GDBLISTENER" => "1")) == "done"


### PR DESCRIPTION
We should move all of these sysimage compilation tests to a separate testset from `cmdlineargs.jl` but for now this improves this fairly expensive regression test. Previously this was consuming 260s CPU-time / 98s wall time. This alternative is still slow, but only ~20s CPU-time on my machine.