### PR TITLE
special: Preserve signs in floating-point integer powers

### DIFF
--- a/base/special/pow.jl
+++ b/base/special/pow.jl
@@ -56,19 +56,19 @@ end
 end
 
 @constprop :aggressive @inline function ^(x::Float64, n::Integer)
-    n = clamp(n, Int64)
-    n == 0 && return one(x)
-    if use_power_by_squaring(n)
-        return pow_body(x, n)
+    n64 = clamp(n, Int64)
+    n64 == 0 && return one(x)
+    if use_power_by_squaring(n64)
+        return pow_body(x, n64)
     else
-        s = ifelse(x < 0 && isodd(n), -1.0, 1.0)
+        s = ifelse(signbit(x) && isodd(n), -1.0, 1.0)
         x = abs(x)
-        y = float(n)
-        if y == n
+        y = float(n64)
+        if y == n64
             return copysign(pow_body(x, y), s)
         else
-            n2 = n % 1024
-            y = float(n - n2)
+            n2 = n64 % 1024
+            y = float(n64 - n2)
             return pow_body(x, y) * copysign(pow_body(x, n2), s)
         end
     end
@@ -77,14 +77,14 @@ end
 # @constprop aggressive to help the compiler see the switch between the integer and float
 # variants for callers with constant `y`
 @constprop :aggressive @inline function ^(x::T, n::Integer) where T <: Union{Float16, Float32}
-    n = clamp(n, Int32)
+    n32 = clamp(n, Int32)
     # Exponents greater than this will always overflow or underflow.
     # Note that NaN can pass through this, but that will end up fine.
-    n == 0 && return one(x)
-    use_power_by_squaring(n) && return pow_body(x, n)
-    s = ifelse(x < 0 && isodd(n), -one(T), one(T))
+    n32 == 0 && return one(x)
+    use_power_by_squaring(n32) && return pow_body(x, n32)
+    s = ifelse(signbit(x) && isodd(n), -one(T), one(T))
     x = abs(x)
-    return pow_body(x, widen(T)(n))
+    return copysign(pow_body(x, widen(T)(n32)), s)
 end
 
 @assume_effects :foldable @noinline function pow_body(x::Float64, y::Float64)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1639,6 +1639,31 @@ end
     @test E^n == Inf
     @test E^float(n) == Inf
 
+    # integer power of a negative Float16/Float32 base must keep its sign when the
+    # exponent bypasses `pow_by_squaring` (|n| outside -2^12:3*2^13); the sign `s`
+    # used to be computed and then dropped.
+    @testset "sign of $T integer powers" for T in (Float16, Float32)
+        x = -nextfloat(one(T))
+        for n in (24577, 32769, -24577, -32769)   # odd, outside pow_by_squaring range
+            @test signbit(x^n)
+        end
+        for n in (24578, 32768, -24578)            # even, outside pow_by_squaring range
+            @test !signbit(x^n)
+        end
+    end
+    @testset "sign across clamped $T integer exponents" for (T, I) in
+            ((Float16, Int32), (Float32, Int32), (Float64, Int64))
+        W = widen(I)
+        nmax = W(typemax(I))
+        nmin = W(typemin(I))
+        @test !signbit((-T(2))^(nmax + 1))
+        @test signbit((-T(2))^(nmax + 2))
+        @test signbit((-T(2))^(nmin - 1))
+        @test !signbit((-T(2))^(nmin - 2))
+        @test signbit((-zero(T))^24577)
+        @test signbit((-zero(T))^-24577)
+    end
+
     # issue #55831
     @testset "literal pow zero sign" begin
         @testset "T: $T" for T ∈ (Float16, Float32, Float64, BigFloat)


### PR DESCRIPTION
The `Float16` and `Float32` integer-power fallback computed the sign of the result but discarded it, so negative bases with odd exponents outside the power-by-squaring range produced positive results.

Apply the sign while deriving it from the original exponent before clamping. Clamping loses parity for `Integer` values outside the `Int32` or `Int64` range and can otherwise assign the wrong sign. Use `signbit` to preserve signed zero, and apply the same handling to the `Float64` fallback.