### PR TITLE
coreir: Remove unused `InterConditional`/`InterMustAlias` constructors

### DIFF
--- a/base/coreir.jl
+++ b/base/coreir.jl
@@ -112,15 +112,9 @@ while processing a call, then `Conditional` everywhere else.
 """
 Core.InterConditional
 
-Core.InterConditional(var::SlotNumber, @nospecialize(thentype), @nospecialize(elsetype)) =
-    InterConditional(slot_id(var), thentype, elsetype)
-
 """
     alias::InterMustAlias
 
 This lattice element is used in a very similar way as `InterConditional`, but corresponds to `MustAlias`.
 """
 Core.InterMustAlias
-
-InterMustAlias(var::SlotNumber, @nospecialize(vartyp), fldidx::Int, @nospecialize(fldtyp)) =
-    InterMustAlias(slot_id(var), vartyp, fldidx, fldtyp)


### PR DESCRIPTION
The `Core.InterConditional` and `Core.InterMustAlias` constructors defined in Base called `slot_id`, which is only defined in the Compiler, so constructing either lattice element from Base throws `UndefVarError`, indicating these constructors are no longer used.