### PR TITLE
Iterators: Import identity so findeach(itr) works

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -14,7 +14,7 @@ using .Base:
     @propagate_inbounds, @isdefined, @boundscheck, @inbounds, Generator, IdDict,
     AbstractRange, AbstractUnitRange, UnitRange, LinearIndices, TupleOrBottom,
     (:), |, +, -, *, !==, !, ==, !=, <=, <, >, >=, =>, missing,
-    any, eachindex, ntuple, zero, prod, reduce, in, firstindex, lastindex,
+    any, eachindex, ntuple, zero, prod, identity, reduce, in, firstindex, lastindex,
     tail, fieldtypes, min, max, minimum, zero, oneunit, promote, promote_shape, LazyString,
     afoldl, mod1, @default_eltype
 using .Core

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -259,6 +259,8 @@ end
 
         f = findeach(isodd, Dict(1 => 2, 2 => 3, 3 => 4))
         @test only(f) == 2
+
+        @test collect(findeach([true,false,true])) == [1,3]
     end
 end
 


### PR DESCRIPTION
`findeach(it) = findeach(identity, it)` references `identity`, which was not imported into the `Iterators` baremodule, so the single-argument `findeach` threw an `UndefVarError`. Import `identity` from Base.