### PR TITLE
client: Restore `active_repl_backend` as a global

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -540,7 +540,7 @@ function run_std_repl(REPL::Module, quiet::Bool, banner::Symbol, history_file::B
     finally
         popdisplay(d)
         active_repl = last_active_repl
-        active_repl_backend = last_active_repl_backend
+        global active_repl_backend = last_active_repl_backend
     end
     nothing
 end


### PR DESCRIPTION
The `finally` block of `run_std_repl` assigned `active_repl_backend` without a `global` declaration, so within the function it was treated as a local and the restore was a no-op (the global was never put back). Declare the assignment `global`, matching how `active_repl` is handled in the same function.