### PR TITLE
Base: Qualify unexported `Base` names referenced from submodules

### DIFF
--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -692,7 +692,7 @@ function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real
         end
         return res
     catch
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::IntrusiveLinkedList{Task}, ct)
+        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.IntrusiveLinkedList{Task}, ct)
         rethrow()
     finally
         Base.relockall(c.lock, token)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -1199,10 +1199,10 @@ Note: `nextfloat()`, `prevfloat()` do not use the precision mentioned by
     The `base` keyword requires at least Julia 1.8.
 """
 function setprecision(f::Function, ::Type{T}, prec::Integer; kws...) where T
-    depwarn("""
-            The fallback `setprecision(::Function, ...)` method is deprecated. Packages overloading this method should
-            implement their own specialization using `ScopedValue` instead.
-            """, :setprecision)
+    Base.depwarn("""
+                 The fallback `setprecision(::Function, ...)` method is deprecated. Packages overloading this method should
+                 implement their own specialization using `ScopedValue` instead.
+                 """, :setprecision)
     old_prec = precision(T)
     setprecision(T, prec; kws...)
     try

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -486,6 +486,16 @@ end
     # issue 15659
     @test (setprecision(53) do; big(1/3); end) < 1//3
 end
+# a throwaway precision type that reaches MPFR's deprecated generic
+# `setprecision(f, ::Type{T}, prec)` fallback
+struct DeprecatedSetprecType end
+const _deprec_setprec = Ref(10)
+Base.precision(::Type{DeprecatedSetprecType}) = _deprec_setprec[]
+Base.setprecision(::Type{DeprecatedSetprecType}, p::Integer) = (_deprec_setprec[] = p)
+@testset "deprecated setprecision(f, ::Type, prec) fallback" begin
+    @test_deprecated setprecision(() -> precision(DeprecatedSetprecType), DeprecatedSetprecType, 5)
+    @test _deprec_setprec[] == 10   # precision was restored afterwards
+end
 @testset "isinteger" begin
     @test !isinteger(BigFloat(1.2))
     @test isinteger(BigFloat(12))


### PR DESCRIPTION
`IntrusiveLinkedList` (in `Base.Experimental.wait_with_timeout`) and `depwarn` (in `Base.MPFR.setprecision`) are unexported Base internals that are not imported into those submodules, so the unqualified references threw an `UndefVarError` when reached.