### PR TITLE
Base: Remove unused imports flagged by JETLS

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -32,6 +32,8 @@ end
 
 # metaprogramming
 include("meta.jl")
+using .Meta
+using .Meta: is_id_char
 
 # Strings
 include("multimedia.jl")

--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -26,7 +26,6 @@ export
     raw!
 
 import Base:
-    check_open, # stream.jl
     displaysize,
     flush,
     pipe_reader,

--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -1,9 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import .Base: setindex!, getindex, unsafe_convert
+import .Base: getindex
 import .Base: getindex_atomic, setindex_atomic!, swapindex_atomic!, modifyindex_atomic!,
     replaceindex_atomic!, setindexonce_atomic!
-import .Base.Sys: ARCH, WORD_SIZE
 
 export
     Atomic,

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -8,8 +8,7 @@ Module containing the broadcasting implementation.
 module Broadcast
 
 using .Base.Cartesian
-using .Base: Indices, OneTo, tail, to_shape, isoperator, promote_typejoin, promote_typejoin_union,
-             _msk_end, unsafe_bitgetindex, bitcache_chunks, bitcache_size, dumpbitcache, unalias, negate
+using .Base: OneTo, tail, isoperator, promote_typejoin, promote_typejoin_union, unalias, negate
 import .Base: copy, copyto!, axes
 export broadcast, broadcast!, BroadcastStyle, broadcast_axes, broadcastable, dotview, @__dot__, BroadcastFunction
 

--- a/base/checked.jl
+++ b/base/checked.jl
@@ -18,11 +18,9 @@ export checked_neg, checked_abs, checked_add, checked_sub, checked_mul,
 
 import Core: Intrinsics
 import .Intrinsics:
-       checked_sadd_int, checked_ssub_int, checked_smul_int, checked_sdiv_int,
-       checked_srem_int,
-       checked_uadd_int, checked_usub_int, checked_umul_int, checked_udiv_int,
-       checked_urem_int
-import Base: no_op_err, @inline, @noinline, checked_length, BitInteger
+       checked_sadd_int, checked_ssub_int, checked_smul_int,
+       checked_uadd_int, checked_usub_int, checked_umul_int
+import Base: no_op_err, @inline, @noinline, checked_length
 
 # define promotion behavior for checked operations
 checked_add(x::Integer, y::Integer) = checked_add(promote(x,y)...)

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -65,8 +65,7 @@ function.
 
 include("bindings.jl")
 
-import .Base.Meta: quot, isexpr, unblock, unescape, uncurly
-import .Base: Callable, with_output_color
+import .Base.Meta: quot, isexpr, unblock, unescape
 using .Base: RefValue, mapany
 import ..CoreDocs: lazy_iterpolate
 

--- a/base/docs/core.jl
+++ b/base/docs/core.jl
@@ -2,7 +2,7 @@
 
 module CoreDocs
 
-import Core: @nospecialize, SimpleVector
+import Core: SimpleVector
 
 struct DocLinkedList
     doc::SimpleVector

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -4,12 +4,12 @@ module GMP
 
 export BigInt
 
-import .Base: *, *%, +, +%, -, -%, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor, nand, nor,
+import .Base: *, *%, +, +%, -, -%, /, <, <<, >>, >>>, <=, ==, >, >=, ^, ~, &, |, xor,
              binomial, cmp, convert, div, divrem, factorial, cld, fld, gcd, gcdx, lcm, mod,
              ndigits, promote_rule, rem, show, isqrt, string, powermod, sum, prod,
              trailing_zeros, trailing_ones, count_ones, count_zeros, tryparse_internal,
-             bin, oct, dec, hex, isequal, invmod, _prevpow2, _nextpow2, ndigits0zpb,
-             widen, signed, unsafe_trunc, trunc, iszero, isone, big, flipsign, signbit,
+             invmod, _prevpow2, _nextpow2, ndigits0zpb,
+             widen, signed, unsafe_trunc, iszero, isone, big, flipsign, signbit,
              sign, isodd, iseven, digits!, hash, hash_integer, top_set_bit,
              ispositive, isnegative, clamp
 
@@ -873,7 +873,7 @@ if Limb === UInt64 === UInt
     # an optimized version for BigInt of hash_integer (used e.g. for Rational{BigInt}),
     # and of hash
 
-    using .Base: HASH_SECRET, hash_bytes, hash_finalizer
+    using .Base: HASH_SECRET, hash_bytes
 
     # UnsafeLimbView provides a safe iterator interface to BigInt limb data
     struct UnsafeLimbView <: AbstractVector{UInt8}

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -9,24 +9,24 @@ baremodule Iterators
 import Base: @__MODULE__, parentmodule
 const Base = parentmodule(@__MODULE__)
 using .Base:
-    @inline, Pair, Pairs, AbstractDict, IndexLinear, IndexStyle, AbstractVector, Vector,
+    @inline, Pair, Pairs, IndexLinear, AbstractVector, Vector,
     SizeUnknown, HasLength, HasShape, IsInfinite, EltypeUnknown, HasEltype, OneTo,
-    @propagate_inbounds, @isdefined, @boundscheck, @inbounds, Generator, IdDict,
+    @propagate_inbounds, @boundscheck, @inbounds, Generator, IdDict,
     AbstractRange, AbstractUnitRange, UnitRange, LinearIndices, TupleOrBottom,
-    (:), |, +, -, *, !==, !, ==, !=, <=, <, >, >=, =>, missing,
-    any, eachindex, ntuple, zero, prod, identity, reduce, in, firstindex, lastindex,
-    tail, fieldtypes, min, max, minimum, zero, oneunit, promote, promote_shape, LazyString,
+    :, |, +, -, *, !==, !, ==, !=, <=, <, >, >=, =>, missing,
+    any, eachindex, ntuple, zero, identity, reduce, in, firstindex, lastindex,
+    tail, fieldtypes, min, max, zero, oneunit, promote, promote_shape, LazyString,
     afoldl, mod1, @default_eltype
 using .Core
 using Core: @doc
 
 using Base:
-    cld, fld, resize!, IndexCartesian, Checked
+    cld, resize!, IndexCartesian, Checked
 using .Checked: checked_mul
 
 import Base:
     first, last,
-    isempty, length, size, axes, ndims,
+    length, size, axes, ndims,
     eltype, IteratorSize, IteratorEltype, promote_typejoin,
     haskey, keys, values, pairs,
     getindex, setindex!, get, iterate,
@@ -276,7 +276,7 @@ CartesianIndex(1, 2) d
 CartesianIndex(2, 2) e
 ```
 
-See also [`IndexStyle`](@ref), [`axes`](@ref).
+See also [`Base.IndexStyle`](@ref), [`axes`](@ref).
 """
 pairs(::IndexLinear,    A::AbstractArray) = Pairs(A, LinearIndices(A))
 

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -7,7 +7,7 @@ Interface to libc, the C standard library.
 
 import Base: transcode, windowserror, show
 # these need to be defined separately for bootstrapping but belong to Libc
-import Base: memcpy, memmove, memset, memcmp
+import Base: memcmp, memcpy, memmove, memset
 import Core.Intrinsics: bitcast
 
 export FILE, TmStruct, strftime, strptime, getpid, gethostname, free, malloc, memcpy,

--- a/base/locks-mt.jl
+++ b/base/locks-mt.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import .Base: unsafe_convert, lock, trylock, unlock, islocked, wait, notify, AbstractLock
+import .Base: lock, trylock, unlock, islocked, AbstractLock
 
 export SpinLock
 public PaddedSpinLock

--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -3,7 +3,7 @@
 module CoreLogging
 
 import Base: isless, +, -, convert, show
-import Base.ScopedValues: ScopedValue, with, @with
+import Base.ScopedValues: ScopedValue, @with
 
 export
     AbstractLogger,

--- a/base/math.jl
+++ b/base/math.jl
@@ -23,7 +23,7 @@ import .Base: log, exp, sin, cos, tan, sinh, cosh, tanh, asin,
 using .Base: sign_mask, exponent_mask, exponent_one,
             exponent_half, uinttype, significand_mask,
             significand_bits, exponent_bits, exponent_bias,
-            exponent_max, exponent_raw_max, clamp, clamp!, two_mul
+            exponent_raw_max, clamp, clamp!, two_mul
 
 using Core.Intrinsics: sqrt_llvm, min_float, max_float
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -9,14 +9,14 @@ export
 import
     .Base: *, +, -, /, <, <=, ==, >, >=, ^, ceil, cmp, convert, copysign, div,
         inv, exp, exp2, exponent, factorial, floor, fma, muladd, hypot, isinteger,
-        isfinite, isinf, isnan, issubnormal, ldexp, log, log2, log10, max, min, mod, modf,
+        isfinite, isinf, isnan, issubnormal, ldexp, log, log2, log10, max, min, modf,
         nextfloat, prevfloat, promote_rule, rem, rem2pi, round, show, float,
         sum, sqrt, string, print, trunc, precision, _precision, exp10, expm1, log1p,
-        eps, signbit, sign, sin, cos, sincos, tan, sec, csc, cot, acos, asin, atan,
+        eps, signbit, sign, sin, cos, sincos, tan, sec, csc, acos, asin, atan,
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, lerpi,
         cbrt, typemax, typemin, unsafe_trunc, floatmin, floatmax, rounding,
         setrounding, maxintfloat, widen, significand, frexp, tryparse, iszero,
-        isone, big, _string_n, decompose, minmax, _precision_with_base_2,
+        isone, big, decompose, minmax, _precision_with_base_2,
         sinpi, cospi, sincospi, tanpi, sind, cosd, tand, asind, acosd, atand,
         uinttype, exponent_max, exponent_min, ieee754_representation, significand_mask,
         ispositive, isnegative

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -2,7 +2,7 @@
 
 module Multimedia
 
-import .Base: show, print, convert, repr
+import .Base: show, print, repr
 
 export AbstractDisplay, display, pushdisplay, popdisplay, displayable, redisplay,
     MIME, @MIME_str, istextmime,

--- a/base/multinverses.jl
+++ b/base/multinverses.jl
@@ -3,7 +3,6 @@
 module MultiplicativeInverses
 
 import Base: div, divrem, mul_hi, rem, unsigned, mod
-using  Base: IndexLinear, IndexCartesian, tail
 export multiplicativeinverse
 
 unsigned(::Type{Bool}) = UInt

--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -6,8 +6,8 @@ module Order
 import Base: @__MODULE__, parentmodule
 const Base = parentmodule(@__MODULE__)
 import .Base:
-    AbstractVector, @propagate_inbounds, isless, identity, getindex, reverse,
-    +, -, !, &, <, |
+    AbstractVector, @propagate_inbounds, isless, identity, reverse,
+    !, &, <, |
 
 ## notions of element ordering ##
 

--- a/base/partr.jl
+++ b/base/partr.jl
@@ -2,7 +2,7 @@
 
 module Partr
 
-using ..Threads: SpinLock, maxthreadid, threadid
+using ..Threads: SpinLock
 
 # a task minheap
 mutable struct taskheap

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -1,8 +1,8 @@
 module Precompilation
 
-using Base: CoreLogging, PkgId, UUID, SHA1, StaleCacheKey, parsed_toml, project_file_name_uuid, project_names,
-            project_file_manifest_path, get_deps, preferences_names, isaccessibledir, isfile_casesensitive,
-            base_project, env_project_file, isdefined
+using Base: CoreLogging, PkgId, UUID, SHA1, StaleCacheKey, parsed_toml,
+            project_file_manifest_path, get_deps, preferences_names,
+            base_project, isdefined
 
 const Config = Pair{Cmd, Base.CacheFlags}
 const PkgConfig = Tuple{PkgId,Config}

--- a/base/ryu/Ryu.jl
+++ b/base/ryu/Ryu.jl
@@ -1,7 +1,7 @@
 module Ryu
 
 using .Base.Libc
-import .Base: significand_bits, significand_mask, exponent_bits, exponent_mask, exponent_bias, exponent_max, uinttype
+using .Base: significand_bits, significand_mask, exponent_mask, exponent_bias, exponent_max, uinttype
 
 include("utils.jl")
 include("shortest.jl")

--- a/base/show.jl
+++ b/base/show.jl
@@ -1,8 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using .Meta: isidentifier, isoperator, isunaryoperator, isbinaryoperator, ispostfixoperator,
-            is_id_start_char, is_id_char, _isoperator, is_syntactic_operator, is_valid_identifier,
-            is_unary_and_binary_operator
+using .Meta: _isoperator, is_id_start_char, is_unary_and_binary_operator,
+    is_valid_identifier
 
 function show(io::IO, ::MIME"text/plain", u::UndefInitializer)
     show(io, u)

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -5,14 +5,13 @@ module Sort
 using Base.Order
 
 using Base: copymutable, midpoint, require_one_based_indexing, uinttype, tail,
-    sub_with_overflow, add_with_overflow, OneTo, BitSigned, BitIntegerType, top_set_bit
+    sub_with_overflow, add_with_overflow, BitSigned, BitIntegerType, top_set_bit
 
 import Base:
     sort,
     sort!,
     issorted,
-    sortperm,
-    to_indices
+    sortperm
 
 export # also exported by Base
     # order-only:

--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -60,7 +60,7 @@ open(fname) do f
         x = map(s -> rstrip(s, [' ','\t','\n']),
                 split(replace(L, r"[{}\"]+" => "\t"), "\t"))
         c = Char(parse(Int, x[2], base = 16))
-        if (Base.is_id_char(c) || Base.isoperator(Symbol(c))) &&
+        if (Base.Meta.is_id_char(c) || Base.isoperator(Symbol(c))) &&
            string(c) ∉ latex_strings && !isascii(c)
             tabcomname = escape_string(x[3])
             if startswith(tabcomname, "\\\\math")

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -90,7 +90,6 @@ function repl_workload()
     f(x) = x03
     f(1,2)
     [][1]
-    Base.Iterators.minimum
     cd("complete_path\t\t$CTRL_C
     \x12?\x7f\e[A\e[B\t history\r
     println("done")


### PR DESCRIPTION
Drop imports that JETLS reported as unused across Base. Each removed name was checked to be neither referenced, method-extended, used in an `include`d file, nor re-exported by the enclosing module.