### PR TITLE
Base: Remove dead stores and unused bindings flagged by JETLS

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -967,7 +967,7 @@ detected.
 """
 function detect_libgfortran_version()
     libgfortran_path = _get_libgfortran_path()
-    name, version = parse_dl_name_version(libgfortran_path, os())
+    _, version = parse_dl_name_version(libgfortran_path, os())
     if version === nothing
         # Even though we complain about this, we allow it to continue in the hopes that
         # we shall march on to a BRIGHTER TOMORROW.  One in which we are not shackled

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -303,7 +303,7 @@ function copy_to_bitarray_chunks!(Bc::Vector{UInt64}, pos_d::Int, C::Array{Bool}
     if nc8 > 0
         ind8 = 1
         P8 = Ptr{UInt64}(pointer(C, ind)) # unaligned i64 pointer
-        @inbounds for i = 1:nc8
+        @inbounds for _ = 1:nc8
             c = UInt64(0)
             for j = 0:7
                 # unaligned load
@@ -315,7 +315,7 @@ function copy_to_bitarray_chunks!(Bc::Vector{UInt64}, pos_d::Int, C::Array{Bool}
         end
         ind += (ind8-1) << 3
     end
-    @inbounds for i = (nc8+1):nc
+    @inbounds for _ = (nc8+1):nc
         c = UInt64(0)
         for j = 0:63
             c |= (UInt64(C[ind]) << j)
@@ -630,7 +630,6 @@ function gen_bitarray_from_itr(itr)
 end
 
 function fill_bitarray_from_itr!(B::BitArray, itr)
-    n = length(B)
     C = Vector{Bool}(undef, bitcache_size)
     Bc = B.chunks
     ind = 1
@@ -708,7 +707,6 @@ function _unsafe_setindex!(B::BitArray, X::AbstractArray, I::BitArray)
     Ic = I.chunks
     length(Bc) == length(Ic) || throw_boundserror(B, I)
     lc = length(Bc)
-    lx = length(X)
     last_chunk_len = _mod64(length(B)-1)+1
 
     Xi = first(eachindex(X))
@@ -717,7 +715,7 @@ function _unsafe_setindex!(B::BitArray, X::AbstractArray, I::BitArray)
         @inbounds Imsk = Ic[i]
         @inbounds C = Bc[i]
         u = UInt64(1)
-        for j = 1:(i < lc ? 64 : last_chunk_len)
+        for _ = 1:(i < lc ? 64 : last_chunk_len)
             if Imsk & u != 0
                 Xi > lastXi && throw_setindex_mismatch(X, count(I))
                 @inbounds x = convert(Bool, X[Xi])
@@ -1145,7 +1143,7 @@ function (-)(B::BitArray)
     for i = 1:length(Bc)-1
         u = UInt64(1)
         c = Bc[i]
-        for j = 1:64
+        for _ = 1:64
             if c & u != 0
                 A[ind] = -1
             end
@@ -1155,7 +1153,7 @@ function (-)(B::BitArray)
     end
     u = UInt64(1)
     c = Bc[end]
-    for j = 0:_mod64(l-1)
+    for _ = 0:_mod64(l-1)
         if c & u != 0
             A[ind] = -1
         end
@@ -1854,7 +1852,6 @@ function hcat(A::Union{BitMatrix,BitVector}...)
     nargs = length(A)
     nrows = size(A[1], 1)
     ncols = 0
-    dense = true
     for j = 1:nargs
         Aj = A[j]
         nd = ndims(Aj)
@@ -1919,7 +1916,7 @@ write(s::IO, B::BitArray) = write(s, B.chunks)
 function read!(s::IO, B::BitArray)
     n = length(B)
     Bc = B.chunks
-    nc = length(read!(s, Bc))
+    read!(s, Bc)
     if length(Bc) > 0 && Bc[end] & _msk_end(n) ≠ Bc[end]
         Bc[end] &= _msk_end(n) # ensure that the BitArray is not broken
         throw(DimensionMismatch("read mismatch, found non-zero bits after BitArray length"))

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1043,7 +1043,7 @@ end
         end
     end
     @inbounds if bitst != 0
-        destc[indc+=1] = remain
+        destc[indc+1] = remain
     end
     return dest
 end

--- a/base/c.jl
+++ b/base/c.jl
@@ -262,7 +262,6 @@ The above input outputs this:
 """
 function ccall_macro_parse(exprs)
     gc_safe = false
-    expr = nothing
     if exprs isa Expr
         expr = exprs
     elseif length(exprs) == 1

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -48,7 +48,7 @@ function _nloops(N::Int, itersym::Symbol, esc_rng::Bool, rangeexpr::Expr, args::
         throw(ArgumentError("second argument must be an anonymous function expression to compute the range"))
     end
     if !(1 <= length(args) <= 3)
-        throw(ArgumentError("number of arguments must be 1 ≤ length(args) ≤ 3, got $nargs"))
+        throw(ArgumentError("number of arguments must be 1 ≤ length(args) ≤ 3, got $(length(args))"))
     end
     body = args[end]
     ex = Expr(:escape, body)

--- a/base/client.jl
+++ b/base/client.jl
@@ -171,8 +171,6 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
                 lasterr = scrub_repl_backtrace(lasterr)
                 istrivialerror(lasterr) || setglobal!(Base.MainInclude, :err, lasterr)
                 invokelatest(display_error, errio, lasterr)
-                errcount = 0
-                lasterr = nothing
             else
                 ast = __repl_entry_client_lower(Main, ast)
                 value = __repl_entry_client_eval(Main, ast)
@@ -484,7 +482,6 @@ function run_fallback_repl(interactive::Bool)
                 for stmt in ex.args
                     eval_user_input(stderr, stmt, true)
                 end
-                body = ex.args
             else
                 eval_user_input(stderr, ex, true)
             end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -193,6 +193,7 @@ macro deprecate(old, new, export_old=true)
         newcall = sprint(show_unquoted, new)
         # if old.head is a :where, step down one level to the :call to avoid code duplication below
         callexpr = old.head === :call ? old : old.args[1]
+        maybe_export = nothing
         if callexpr.head === :call
             fnexpr = callexpr.args[1]
             if fnexpr isa Expr && fnexpr.head === :curly
@@ -204,8 +205,6 @@ macro deprecate(old, new, export_old=true)
                 else
                     cannot_export_nonsymbol()
                 end
-            else
-                maybe_export = nothing
             end
         else
             error("invalid usage of @deprecate")

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -673,7 +673,6 @@ function docm(source::LineNumberNode, mod::Module, ex)
     else
         return simple_lookup_doc(ex)
     end
-    return nothing
 end
 # Drop incorrect line numbers produced by nested macro calls.
 docm(source::LineNumberNode, mod::Module, _, _, x...) = docm(source, mod, x...)

--- a/base/env.jl
+++ b/base/env.jl
@@ -249,7 +249,7 @@ end # os-test
 #TODO: Make these more efficient
 function length(::EnvDict)
     i = 0
-    for (k,v) in ENV
+    for _ in ENV
         i += 1
     end
     return i

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -659,7 +659,6 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs=[])
     # Displays the closest candidates of the given function by looping over the
     # functions methods and counting the number of matching arguments.
     f = ex.f
-    ft = typeof(f)
     lines = String[]
     line_score = Int[]
     # These functions are special cased to only show if first argument is matched.
@@ -815,7 +814,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs=[])
             if !isempty(kwargs)::Bool
                 unexpected = Symbol[]
                 if isempty(kwords) || !(any(endswith(string(kword), "...") for kword in kwords))
-                    for (k, v) in kwargs
+                    for (k, _) in kwargs
                         if !(k::Symbol in kwords)
                             push!(unexpected, k::Symbol)
                         end
@@ -896,7 +895,6 @@ function _backtrace_find_and_remove_cycles(t)
     # Third:  number of cycle repetitions
 
     t_curr = 1
-    frame_counter = 1
 
     while t_curr ≤ length(t)
         (last_frame, n) = t[t_curr]
@@ -1006,7 +1004,7 @@ function show_processed_backtrace(io::IO, trace::Vector, num_frames::Int, repeat
 
         print_stackframe(io, frame_counter, frame, ndigits_max, max_nested_cycles, nactive_cycles, ncycle_starts, STACKTRACE_FIXEDCOLORS, STACKTRACE_MODULECOLORS; prefix)
 
-        frame_counter, nactive_cycles = _backtrace_print_repetition_closings!(io, i, current_cycles, frame_counter, max_nested_cycles, nactive_cycles, ndigits_max; prefix)
+        frame_counter, _nactive_cycles = _backtrace_print_repetition_closings!(io, i, current_cycles, frame_counter, max_nested_cycles, nactive_cycles, ndigits_max; prefix)
         frame_counter += 1
 
         if i < length(trace)
@@ -1285,7 +1283,6 @@ function _backtrace_collapse_repeated_locations!(trace)
                 params, last_params = Base.unwrap_unionall(m.sig).parameters::SimpleVector, Base.unwrap_unionall(last_m.sig).parameters::SimpleVector
                 if last_m.nkw != 0
                     pos_sig_params = last_params[(last_m.nkw+2):end]
-                    issame = true
                     if pos_sig_params == params
                         kept_frames[i] = false
                     end

--- a/base/file.jl
+++ b/base/file.jl
@@ -616,7 +616,7 @@ function prepare_for_deletion(path::AbstractString)
     catch ex
         ex isa IOError || ex isa SystemError || rethrow()
     end
-    for (root, dirs, files) in walkdir(path; onerror=x->())
+    for (root, dirs, _) in walkdir(path; onerror=x->())
         for dir in dirs
             dpath = joinpath(root, dir)
             try
@@ -675,7 +675,7 @@ end
 
 function temp_cleanup_purge_all()
     may_need_gc = Ref(false)
-    @lock TEMP_CLEANUP_LOCK filter!(TEMP_CLEANUP) do (path, asap)
+    @lock TEMP_CLEANUP_LOCK filter!(TEMP_CLEANUP) do (path, _)
         try
             ispath(path) || return false
             may_need_gc[] = true
@@ -752,7 +752,7 @@ function _tempname(parent::AbstractString, suffix::AbstractString, max_tries::In
 
     prefix = joinpath(parent, temp_prefix)
     filename = nothing
-    for i in 1:max_tries
+    for _ in 1:max_tries
         filename = string(prefix, _rand_filename(), suffix)
         if ispath(filename)
             filename = nothing

--- a/base/float.jl
+++ b/base/float.jl
@@ -177,6 +177,7 @@ function ieee754_representation(
     ret |= exponent_field
     ret <<= significand_bits(F)
     ret |= significand_field
+    return ret
 end
 
 # ±floatmax(T)
@@ -508,7 +509,6 @@ function _to_float(number::U, ep) where {U<:Unsigned}
     lz::signed(U) = unsafe_trunc(S, Core.Intrinsics.ctlz_int(number) - U(exponent_bits(F)))
     number <<= lz
     epint -= lz
-    bits = U(0)
     if epint >= 0
         bits = number & significand_mask(F)
         bits |= ((epint + S(1)) << significand_bits(F)) & exponent_mask(F)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -724,7 +724,7 @@ const powers_of_ten = [
 function bit_ndigits0z(x::Base.BitUnsigned64)
     lz = top_set_bit(x)
     nd = (1233*lz)>>12+1
-    nd -= x < powers_of_ten[nd]
+    return nd - (x < powers_of_ten[nd])
 end
 function bit_ndigits0z(x::UInt128)
     n = 0
@@ -946,7 +946,6 @@ function append_c_digits(olength::Int, digits::Unsigned, buf, pos::Int)
     end
     if i == 1
         @inbounds buf[pos] = UInt8('0') + rem(digits, 0xa) % UInt8
-        i -= 1
     end
     return pos + olength
 end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -643,7 +643,7 @@ end
         # If we can't fit all the requested data in the new buffer, we need to
         # fit as much as possible, so we must compact
         if !iszero(reclaimable_bytes)
-            desired_size -= compact!(io)
+            compact!(io)
         end
         # Max out the buffer size if we want more than the buffer size
         if length(io.data) < io.maxsize

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -863,7 +863,7 @@ length(d::Drop) = _diff_length(d.xs, 1:d.n, IteratorSize(d.xs), HasLength())
 
 function iterate(it::Drop)
     y = iterate(it.xs)
-    for i in 1:it.n
+    for _ in 1:it.n
         y === nothing && return y
         y = iterate(it.xs, y[2])
     end
@@ -1569,7 +1569,7 @@ approx_iter_type(itrT::Type) = _approx_iter_type(itrT, Base._return_type(iterate
 # having to typesplit on Nothing
 function doiterate(itr, valstate::Union{Nothing, Tuple{Any, Any}})
     valstate === nothing && return nothing
-    val, st = valstate
+    _, st = valstate
     return iterate(itr, st)
 end
 function _approx_iter_type(itrT::Type, vstate::Type)

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -248,7 +248,7 @@ end
 function wait_no_relock(c::GenericCondition)
     ct = current_task()
     _wait2(c, ct)
-    token = unlockall(c.lock)
+    unlockall(c.lock)
     try
         return wait()
     catch

--- a/base/math.jl
+++ b/base/math.jl
@@ -108,13 +108,13 @@ function evalpoly(z::Complex, p::Tuple)
         end
         ai = :a0
         push!(as, :($ai = $a))
-        C = Expr(:block,
-                 :(x = real(z)),
-                 :(y = imag(z)),
-                 :(r = x + x),
-                 :(s = muladd(x, x, y*y)),
-                 as...,
-                 :(muladd($ai, z, $b)))
+        Expr(:block,
+             :(x = real(z)),
+             :(y = imag(z)),
+             :(r = x + x),
+             :(s = muladd(x, x, y*y)),
+             as...,
+             :(muladd($ai, z, $b)))
     else
         _evalpoly(z, p)
     end
@@ -742,7 +742,7 @@ function _hypot(x, y)
 
     # Order the operands
     if ay > ax
-        axu, ayu = ayu, axu
+        axu = ayu
         ax, ay = ay, ax
     end
 

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -71,7 +71,7 @@ function arg_decl_parts(m::Method, html=false)
         decls[1] = ("", sprint(show_signature_function, unwrapva(sig.parameters[1]), false, decls[1][1], html,
                                context = show_env))
     else
-        decls = Tuple{String,String}[("", "") for i = 1:length(sig.parameters::SimpleVector)]
+        decls = Tuple{String,String}[("", "") for _ = 1:length(sig.parameters::SimpleVector)]
     end
     return tv, decls, file, line
 end
@@ -441,7 +441,7 @@ function url(m::Method)
 end
 
 function show(io::IO, ::MIME"text/html", m::Method)
-    tv, decls, file, line = arg_decl_parts(m, true)
+    tv, decls, _file, line = arg_decl_parts(m, true)
     sig = unwrap_unionall(m.sig)
     if sig <: Tuple{Core.Builtin, Vararg}
         print(io, m.name, "(...) in ", parentmodule(m))

--- a/base/module.jl
+++ b/base/module.jl
@@ -22,7 +22,6 @@ function eval_import_path(at::Module, from::Union{Module, Nothing}, path::Expr, 
         v
     end
     v = next!()
-    m = nothing
 
     if from !== nothing
         m = from

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -747,7 +747,7 @@ end
 
 
 # More efficient commutative operations
-for (fJ, fC, fI) in ((:+, :add, 0), (:*, :mul, 1))
+for (fJ, fC) in ((:+, :add), (:*, :mul))
     @eval begin
         function ($fJ)(a::BigFloat, b::BigFloat, c::BigFloat)
             z = BigFloat()
@@ -1151,7 +1151,7 @@ isnegative(x::BigFloat) = signbit(x) && !iszero(x) && !isnan(x)
 
 function nextfloat!(x::BigFloat, n::Integer=1)
     signbit(n) && return prevfloat!(x, abs(n))
-    for i = 1:n
+    for _ = 1:n
         ccall((:mpfr_nextabove, libmpfr), Int32, (Ref{BigFloat},), x)
     end
     return x
@@ -1159,7 +1159,7 @@ end
 
 function prevfloat!(x::BigFloat, n::Integer=1)
     signbit(n) && return nextfloat!(x, abs(n))
-    for i = 1:n
+    for _ = 1:n
         ccall((:mpfr_nextbelow, libmpfr), Int32, (Ref{BigFloat},), x)
     end
     return x

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -81,7 +81,7 @@ function parseint_preamble(signed::Bool, base::Int, s::AbstractString, startpos:
             c, i = iterate(s,i)::Tuple{Char, Int}
             base = c=='b' ? 2 : c=='o' ? 8 : c=='x' ? 16 : 10
             if base != 10
-                c, i, j = parseint_iterate(s,i,endpos)
+                _c, _i, j = parseint_iterate(s,i,endpos)
             end
         else
             base = 10
@@ -106,6 +106,7 @@ end
         _A <= _c <= _Z ? _c-_A+ UInt32(10) :
         _a <= _c <= _z ? _c-_a+a           :
         base
+    return d
 end
 
 

--- a/base/path.jl
+++ b/base/path.jl
@@ -738,9 +738,9 @@ function _win_profile_from_registry(username::AbstractString)
     buf_size = Ref{UInt32}(0)
     # RRF_RT_REG_SZ | RRF_RT_REG_EXPAND_SZ = 0x00000006
     HKEY_LOCAL_MACHINE = 0x80000002 % UInt
-    ret = ccall((:RegGetValueW, "advapi32"), stdcall, Clong,
-                (UInt, Ptr{UInt16}, Ptr{UInt16}, UInt32, Ptr{UInt32}, Ptr{UInt16}, Ptr{UInt32}),
-                HKEY_LOCAL_MACHINE, subkey, value, 0x00000006, C_NULL, C_NULL, buf_size)
+    ccall((:RegGetValueW, "advapi32"), stdcall, Clong,
+          (UInt, Ptr{UInt16}, Ptr{UInt16}, UInt32, Ptr{UInt32}, Ptr{UInt16}, Ptr{UInt32}),
+          HKEY_LOCAL_MACHINE, subkey, value, 0x00000006, C_NULL, C_NULL, buf_size)
     buf_size[] == 0 && return nothing
     buf = Vector{UInt16}(undef, buf_size[] ÷ 2)
     ret = ccall((:RegGetValueW, "advapi32"), stdcall, Clong,

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -78,7 +78,7 @@ function unsafe_convert(::Type{Ptr{Cvoid}}, a::GenericMemoryRef{<:Any,T,Core.CPU
     MemT = typeof(mem)
     arrayelem = datatype_arrayelem(MemT)
     elsz = datatype_layoutsize(MemT)
-    isboxed = 1; isunion = 2
+    isunion = 2
     if arrayelem == isunion || elsz == 0
         offset = UInt(offset) * elsz
         offset += unsafe_convert(Ptr{Cvoid}, mem)

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -1462,7 +1462,7 @@ function monitor_background_precompile(io::IO = stderr, detachable::Bool = true,
     end
 
     # If waiting for a specific package, spawn a watcher that exits when it's done
-    pkg_watcher = if wait_for_pkg !== nothing
+    if wait_for_pkg !== nothing
         Threads.@spawn :samepool begin
             @lock BG.pkg_done begin
                 # Wait for the package to appear in pending_pkgids (it may not be
@@ -1547,7 +1547,7 @@ function monitor_background_precompile(io::IO = stderr, detachable::Bool = true,
         end
 
         wait(task; throw=false)
-    catch e
+    catch
         # Clean up on error
         @lock BG BG.monitoring = false
         if key_task !== nothing
@@ -1919,11 +1919,9 @@ function spawn_print_loop!(s::PrecompileSession)
             t = Timer(0; interval=1/10)
             anim_chars = ["◐","◓","◑","◒"]
             i = 1
-            last_length = 0
             bar = MiniProgressBar(; indent=0, header = "Precompiling packages ", color = :green, percentage=false, always_reprint=true)
             bar.max = s.n_total - s.n_already_precomp
             final_loop = false
-            n_print_rows = 0
             last_poll_time = time()
             cpu_pcts = Dict{Int32, Float64}()
             rss_bytes = Dict{Int32, UInt64}()
@@ -2026,7 +2024,6 @@ function spawn_print_loop!(s::PrecompileSession)
                             println(iostr, Base._truncate_at_width_or_chars(true, line, termwidth))
                         end
                     end
-                    last_length = length(pkg_queue_show)
                     n_print_rows = count("\n", str_)
                     s.printloop_should_exit = s.interrupted_or_done && final_loop
                     final_loop = s.interrupted_or_done
@@ -2056,7 +2053,7 @@ function spawn_print_loop!(s::PrecompileSession)
 end
 
 function precompilepkgs_monitor_std(s::PrecompileSession, pkg_config, job::PrecompileJob, pipe, single_requested_pkg::Bool)
-    pkg, config = pkg_config
+    pkg, _ = pkg_config
     liveprinting = false
     thistaskwaiting = false
     while !eof(pipe)
@@ -2102,12 +2099,12 @@ function precompile_pkgs_maybe_cachefile_lock(f, s::PrecompileSession, pkg_confi
         return f()
     end
     pkg, config = pkg_config
-    flags, cacheflags = config
+    _, cacheflags = config
     stale_age = Base.compilecache_pidlock_stale_age
     pidfile = Base.compilecache_pidfile_path(pkg, flags=cacheflags)
     cachefile = @invokelatest Base.trymkpidlock_hook(f, pidfile; stale_age)
     if cachefile === false
-        pid, hostname, age = @invokelatest Base.parse_pidfile_hook(pidfile)
+        pid, hostname, _ = @invokelatest Base.parse_pidfile_hook(pidfile)
         job.lock_holder = if isempty(hostname) || hostname == gethostname()
             if pid == getpid()
                 "an async task in this process (pidfile: $pidfile)"
@@ -2618,7 +2615,7 @@ function report_precompile_results!(s::PrecompileSession)
                     plural1 = length(std_outputs) == 1 ? "y" : "ies"
                     print(iostr, "  ", color_string("$(length(std_outputs))", Base.warn_color(), s.hascolor), " dependenc$(plural1) had output during precompilation:")
                     for (pkg_config, err) in std_outputs
-                        pkg, config = pkg_config
+                        pkg, _ = pkg_config
                         err = if pkg == s.pkg_liveprinted
                             "[Output was shown above]"
                         else

--- a/base/range.jl
+++ b/base/range.jl
@@ -668,9 +668,8 @@ function print_range(io::IO, r::AbstractArray,
     if !haskey(io, :compact)
         io = IOContext(io, :compact => true)
     end
-    screenheight, screenwidth = sz[1] - 4, sz[2]
+    _, screenwidth = sz[1] - 4, sz[2]
     screenwidth -= length(pre) + length(post)
-    postsp = ""
     sepsize = length(sep)
     m = 1 # treat the range as a one-row matrix
     n = length(r)
@@ -1244,7 +1243,7 @@ function intersect(r::StepRange, s::StepRange)
     start2, step2, stop2 = first_step_last_ascending(s)
     a = lcm(step1, step2)
 
-    g, x, y = gcdx(step1, step2)
+    g, x, _ = gcdx(step1, step2)
 
     if !iszero(rem(start1 - start2, g))
         # Unaligned, no overlap possible.

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -259,7 +259,6 @@ function rationalize(::Type{T}, x::AbstractFloat, tol::Real) where T<:Integer
     y = one(x)
     tolx = oftype(x, tol)
     nt, t, tt = tolx, zero(tolx), tolx
-    ia = np = nq = zero(T)
 
     # compute the successive convergents of the continued fraction
     #  np // nq = (p*a + pp) // (q*a + qq)
@@ -402,7 +401,7 @@ function -(x::Rational{T}) where T<:Unsigned
 end
 
 function +(x::Rational, y::Rational)
-    xp, yp = promote(x, y)::NTuple{2,Rational}
+    xp, _ = promote(x, y)::NTuple{2,Rational}
     if isinf(x) && x == y
         return xp
     end
@@ -420,7 +419,7 @@ function +%(x::Rational, y::Rational)
 end
 
 function -(x::Rational, y::Rational)
-    xp, yp = promote(x, y)::NTuple{2,Rational}
+    xp, _ = promote(x, y)::NTuple{2,Rational}
     if isinf(x) && x == -y
         return xp
     end

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -239,7 +239,7 @@ Extract first entry of slices of array A into existing array R.
 copyfirst!(R::AbstractArray, A::AbstractArray) = mapfirst!(identity, R, A)
 
 function mapfirst!(f::F, R::AbstractArray, A::AbstractArray{<:Any,N}) where {N, F}
-    lsiz = check_reducedims(R, A)
+    check_reducedims(R, A)
     t = _firstreducedslice(axes(R), axes(A))
     map!(f, R, view(A, t...))
 end
@@ -259,7 +259,6 @@ function _mapreducedim!(f, op, R::AbstractArray, A::AbstractArrayOrBroadcasted)
 
     if has_fast_linear_indexing(A) && lsiz > 16
         # use mapreduce_impl, which is probably better tuned to achieve higher performance
-        nslices = div(length(A), lsiz)
         ibase = first(LinearIndices(A))-1
         for i in eachindex(R)
             r = op(@inbounds(R[i]), mapreduce_impl(f, op, A, ibase+1, ibase+lsiz))
@@ -1015,7 +1014,7 @@ end
 #
 function findminmax!(f, op, Rval, Rind, A::AbstractArray{T,N}) where {T,N}
     (isempty(Rval) || isempty(A)) && return Rval, Rind
-    lsiz = check_reducedims(Rval, A)
+    check_reducedims(Rval, A)
     for i = 1:N
         axes(Rval, i) == axes(Rind, i) || throw(DimensionMismatch("Find-reduction: outputs must have the same indices"))
     end
@@ -1216,7 +1215,7 @@ function _findminmax_inittype(f, A::AbstractArray)
     # Second conditional: handle missing specifically, as most often, f(missing) = missing;
     # certainly, some predicate functions return Bool, but not all.
     # Else, return the type of the transformation.
-    Tr = v0 isa T ? T : Missing <: eltype(A) ? Union{Missing, typeof(v0)} : typeof(v0)
+    return v0 isa T ? T : Missing <: eltype(A) ? Union{Missing, typeof(v0)} : typeof(v0)
 end
 
 reducedim1(R, A) = length(axes1(R)) == 1

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -34,7 +34,7 @@ function code_lowered(@nospecialize(argtypes::Union{Tuple,Type{<:Tuple}}); gener
                 code = ccall(:jl_code_for_staged, Ref{CodeInfo}, (Any, UInt, Ptr{Cvoid}), m, world, C_NULL)
             else
                 error("Could not expand generator for `@generated` method ", m, ". ",
-                      "This can happen if the provided argument types (", t, ") are ",
+                      "This can happen if the provided argument types (", argtypes, ") are ",
                       "not concrete types, but the `generated` argument is `true`.")
             end
         else

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -655,7 +655,6 @@ end
                     nbytes_copied += nb
                     a.parent[ind_start + i, tailinds...] = s[]
                     i += 1
-                    sidx = 0
                 end
                 # Deal with the main body of elements
                 while nbytes_copied < sizeof(T) && (sizeof(T) - nbytes_copied) > sizeof(S)

--- a/base/ryu/exp.jl
+++ b/base/ryu/exp.jl
@@ -49,7 +49,6 @@ function writeexp(buf, pos, v::T,
         e2 = exp - 1023 - 52
         m2 = (Int64(1) << 52) | mant
     end
-    nonzero = false
     precision += 1
     digits = zero(UInt32)
     printedDigits = 0
@@ -140,12 +139,11 @@ function writeexp(buf, pos, v::T,
     end
     lastDigit = zero(UInt32)
     if availableDigits > maximum
-        for k = 0:(availableDigits - maximum - 1)
+        for _ = 0:(availableDigits - maximum - 1)
             lastDigit = digits % UInt32(10)
             digits = div(digits, UInt32(10))
         end
     end
-    roundUp = 0
     if lastDigit != 5
         roundUp = lastDigit > 5 ? 1 : 0
     else

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -177,7 +177,6 @@ function get(val::AbstractScopedValue{T}) where {T}
         v === nothing && return nothing
         return Some{T}(something(v)::T)
     end
-    return nothing
 end
 
 function Base.getindex(val::AbstractScopedValue{T})::T where T

--- a/base/set.jl
+++ b/base/set.jl
@@ -526,7 +526,7 @@ function _hashed_allunique(C)
     seen = Set{@default_eltype(C)}()
     x = iterate(C)
     if haslength(C) && length(C) > 1000
-        for i in OneTo(1000)
+        for _ in OneTo(1000)
             v, s = something(x)
             in!(v, seen) && return false
             x = iterate(C, s)

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -137,7 +137,7 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                 popfirst!(st)
             end
         elseif interpolate && !in_single_quotes && c == '$'
-            i = consume_upto!(arg, s, i, j)
+            consume_upto!(arg, s, i, j)
             result = parse_dollar_interp(st, s)
             s = result[2]
             last_arg = result[3]
@@ -153,7 +153,6 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                 elseif redirect_mode === :stdout; seg_stdout = re
                 else; seg_stderr = re; end
                 empty!(arg)
-                redirect_mode = :none
             elseif redirect_mode == :none && (!isempty(arg) || word_has_special)
                 append_2to1!(args, arg)
             end
@@ -226,7 +225,7 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                     end
                 elseif in_double_quotes
                     isempty(st) && error("unterminated double quote")
-                    k, c′ = peek(st)::P
+                    _, c′ = peek(st)::P
                     if c′ == '"' || c′ == '$' || c′ == '\\'
                         i = consume_upto!(arg, s, i, j)
                         _ = popfirst!(st)

--- a/base/show.jl
+++ b/base/show.jl
@@ -175,6 +175,7 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
     isempty(t) && return
     print(io, ":")
     show_circular(io, t) && return
+    keywidth = 0
     if limit
         sz = displaysize(io)
         rows, cols = sz[1] - 3, sz[2]
@@ -187,7 +188,6 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
         hascolor = get(recur_io, :color, false)
         ks = Vector{String}(undef, min(rows, length(t)))
         vs = Vector{String}(undef, min(rows, length(t)))
-        keywidth = 0
         valwidth = 0
         for (i, (k, v)) in enumerate(t)
             i > rows && break
@@ -705,7 +705,7 @@ function make_typealias(@nospecialize(x::Type), io::Union{IO,Nothing}=nothing)
                 if alias isa Type && !has_free_typevars(alias) && !print_without_params(alias) && properx <: alias
                     if alias isa UnionAll
                         free_before = find_free_typevars(x)
-                        (ti, env) = typeintersect_env(x, unbounded_typealias(alias))
+                        (_ti, env) = typeintersect_env(x, unbounded_typealias(alias))
                         # ti === Union{} && continue # impossible, since we already checked that x <: alias
                         env = env::SimpleVector
                         # unwrap `svec(tvar, constrained)` env markers down to the TypeVar
@@ -823,7 +823,7 @@ function show_typealias_name(io::IO, name::GlobalRef)
     return nothing
 end
 
-function show_typealias(io::IO, name::GlobalRef, x::Type, env::SimpleVector, wheres::Vector)
+function show_typealias(io::IO, name::GlobalRef, env::SimpleVector, wheres::Vector)
     show_typealias_name(io, name)
     isempty(env) && return
     io = IOContext(io)
@@ -888,7 +888,7 @@ function show_typealias(io::IO, @nospecialize(x::Type))
     alias = make_typealias(x, io)
     alias === nothing && return false
     wheres = make_wheres(io, alias[2], x)
-    show_typealias(io, alias[1], x, alias[2], wheres)
+    show_typealias(io, alias[1], alias[2], wheres)
     show_wheres(io, wheres)
     return true
 end
@@ -900,7 +900,6 @@ function make_typealiases(@nospecialize(x::Type))
     mods = modulesof!(Set{Module}(), x)
     replace!(mods, Core=>Base)
     free_before = find_free_typevars(x)
-    vars = Dict{Symbol,TypeVar}()
     xenv = UnionAll[]
     each = Any[]
     for p in uniontypes(unwrap_unionall(x))
@@ -999,7 +998,7 @@ function show_unionaliases(io::IO, x::Union)
         alias = aliases[1]
         env = alias[2]::SimpleVector
         wheres = make_wheres(io, env, x)
-        show_typealias(io, alias[1], x, env, wheres)
+        show_typealias(io, alias[1], env, wheres)
         show_wheres(io, wheres)
     else
         for alias in aliases
@@ -1007,7 +1006,7 @@ function show_unionaliases(io::IO, x::Union)
             first = false
             env = alias[2]::SimpleVector
             wheres = make_wheres(io, env, x)
-            show_typealias(io, alias[1], x, env, wheres)
+            show_typealias(io, alias[1], env, wheres)
             show_wheres(io, wheres)
         end
         if tvar
@@ -1603,7 +1602,7 @@ end
 show(io::IO, t::Tuple) = show_delim_array(io, t, '(', ',', ')', true)
 show(io::IO, v::SimpleVector) = show_delim_array(io, v, "svec(", ',', ')', false)
 
-show(io::IO, s::Symbol) = show_unquoted_quote_expr(io, s, 0, 0, 0)
+show(io::IO, s::Symbol) = show_unquoted_quote_expr(io, s, 0, 0)
 
 ## Abstract Syntax Tree (AST) printing ##
 
@@ -1642,7 +1641,7 @@ const ExprNode = Union{Expr, QuoteNode, SlotNumber, LineNumberNode, SSAValue,
 # head is :$ and which is not inside a quote to fallback to the "unhandled" case:
 # this is behavior is triggered by IOContext(io, :unquote_fallback => true)
 print(        io::IO, ex::ExprNode)    = (show_unquoted(IOContext(io, :unquote_fallback => false), ex, 0, -1); nothing)
-show(         io::IO, ex::ExprNode)    = show_unquoted_quote_expr(IOContext(io, :unquote_fallback => true), ex, 0, -1, 0)
+show(         io::IO, ex::ExprNode)    = show_unquoted_quote_expr(IOContext(io, :unquote_fallback => true), ex, 0, -1)
 show_unquoted(io::IO, ex)              = show_unquoted(io, ex, 0, 0)
 show_unquoted(io::IO, ex, indent::Int) = show_unquoted(io, ex, indent, 0)
 show_unquoted(io::IO, ex, ::Int,::Int) = show(io, ex)
@@ -1794,7 +1793,7 @@ function show_list(io::IO, items, sep, indent::Int, prec::Int=0, quote_level::In
             show_unquoted(io, Expr(:(=), item.args[1], item.args[2]), indent, parens ? 0 : prec, quote_level)
         elseif kw && is_expr(item, :(=), 2)
             item = item::Expr
-            show_unquoted_expr_fallback(io, item, indent, quote_level)
+            show_unquoted_expr_fallback(io, item)
         else
             show_unquoted(io, item, indent, parens ? 0 : prec, quote_level)
         end
@@ -1896,9 +1895,9 @@ function show_unquoted(io::IO, ex::SlotNumber, ::Int, ::Int)
     end
 end
 
-function show_unquoted(io::IO, ex::QuoteNode, indent::Int, prec::Int)
+function show_unquoted(io::IO, ex::QuoteNode, indent::Int, _prec::Int)
     if isa(ex.value, Symbol)
-        show_unquoted_quote_expr(io, ex.value, indent, prec, 0)
+        show_unquoted_quote_expr(io, ex.value, indent, 0)
     else
         print(io, "\$(QuoteNode(")
         # QuoteNode does not allows for interpolation, so if ex.value is an
@@ -1909,7 +1908,7 @@ function show_unquoted(io::IO, ex::QuoteNode, indent::Int, prec::Int)
     end
 end
 
-function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int, quote_level::Int)
+function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, quote_level::Int)
     if isa(value, Symbol)
         sym = value::Symbol
         if value in quoted_syms
@@ -2015,7 +2014,7 @@ is_core_macro(@nospecialize(arg), macro_name::Symbol) = false
 # as an ordinary symbol, which is true in indexing expressions.
 const beginsym = gensym(:beginsym)
 
-function show_unquoted_expr_fallback(io::IO, ex::Expr, indent::Int, quote_level::Int)
+function show_unquoted_expr_fallback(io::IO, ex::Expr)
     print(io, "\$(Expr(")
     show(io, ex.head)
     for arg in ex.args
@@ -2466,7 +2465,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
         end
 
     elseif head === :quote && nargs == 1 && isa(args[1], Symbol)
-        show_unquoted_quote_expr(IOContext(io, beginsym=>false), args[1]::Symbol, indent, 0, quote_level+1)
+        show_unquoted_quote_expr(IOContext(io, beginsym=>false), args[1]::Symbol, indent, quote_level+1)
     elseif head === :quote && !(get(io, :unquote_fallback, true)::Bool)
         if nargs == 1 && is_expr(args[1], :block)
             show_block(IOContext(io, beginsym=>false), "quote", Expr(:quote, (args[1]::Expr).args...), indent,
@@ -2572,12 +2571,12 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
         # Reset SOURCE_SLOTNAMES. Raw SlotNumbers are not valid in Expr(:toplevel), but
         # we want to show bad ASTs reasonably to make errors understandable.
         lambda_io = IOContext(io, :SOURCE_SLOTNAMES => false)
-        show_unquoted_expr_fallback(lambda_io, ex, indent, quote_level)
+        show_unquoted_expr_fallback(lambda_io, ex)
     else
         unhandled = true
     end
     if unhandled
-        show_unquoted_expr_fallback(io, ex, indent, quote_level)
+        show_unquoted_expr_fallback(io, ex)
     end
     nothing
 end

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1386,7 +1386,7 @@ end
 function _cosc(x::Union{Float32, Float64})
     if x isa Float32
         pols = _cosc_f32
-    elseif x isa Float64
+    else
         pols = _cosc_f64
     end
     _cos_cardinal_eval(x, pols)

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -235,7 +235,6 @@ function lookup(ip::Base.InterpreterIP)
     end
     res = Vector{StackFrame}(undef, length(scopes))
     inlined = false
-    def_local = def
     for i in eachindex(scopes)
         lno = scopes[i]
         if inlined

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1242,7 +1242,7 @@ _fd(x::Union{OS_HANDLE, RawFD}) = x
 function _fd(x::Union{LibuvStream, LibuvServer})
     fd = Ref{OS_HANDLE}(INVALID_OS_HANDLE)
     if x.status != StatusUninit && x.status != StatusClosed && x.handle != C_NULL
-        err = ccall(:uv_fileno, Int32, (Ptr{Cvoid}, Ptr{OS_HANDLE}), x.handle, fd)
+        ccall(:uv_fileno, Int32, (Ptr{Cvoid}, Ptr{OS_HANDLE}), x.handle, fd)
         # handle errors by returning INVALID_OS_HANDLE
     end
     return fd[]

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -730,7 +730,7 @@ function unindent(str::AbstractString, indent::Int; tabwidth=8)
                 col = div(col + tabwidth, tabwidth) * tabwidth
             elseif ch == '\n'
                 # Now we need to output enough indentation
-                for i = 1:col-indent
+                for _ = 1:col-indent
                     print(buf, ' ')
                 end
                 col = 0
@@ -739,7 +739,7 @@ function unindent(str::AbstractString, indent::Int; tabwidth=8)
                 cutting = false
                 # Now we need to output enough indentation to get to
                 # correct place
-                for i = 1:col-indent
+                for _ = 1:col-indent
                     print(buf, ' ')
                 end
                 col += 1
@@ -749,7 +749,7 @@ function unindent(str::AbstractString, indent::Int; tabwidth=8)
             upd = div(col + tabwidth, tabwidth) * tabwidth
             # output the number of spaces that would have been seen
             # with original indentation
-            for i = 1:(upd-col)
+            for _ = 1:(upd-col)
                 print(buf, ' ')
             end
             col = upd
@@ -765,7 +765,7 @@ function unindent(str::AbstractString, indent::Int; tabwidth=8)
     # If we were still "cutting" when we hit the end of the string,
     # we need to output the right number of spaces for the indentation
     if cutting
-        for i = 1:col-indent
+        for _ = 1:col-indent
             print(buf, ' ')
         end
     end

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -256,7 +256,7 @@ typemin(::String) = typemin(String)
     @boundscheck between(i, 1, n) || throw(BoundsError(s, i))
     @inbounds b = codeunit(s, i)
     (b & 0xc0 == 0x80) & (i-1 > 0) || return i
-    (@noinline function _thisind_continued(s, i, n) # mark the rest of the function as a slow-path
+    (@noinline function _thisind_continued(s, i) # mark the rest of the function as a slow-path
         local b
         @inbounds b = codeunit(s, i-1)
         between(b, 0b11000000, 0b11110111) && return i-1
@@ -267,7 +267,7 @@ typemin(::String) = typemin(String)
         @inbounds b = codeunit(s, i-3)
         between(b, 0b11110000, 0b11110111) && return i-3
         return i
-    end)(s, i, n)
+    end)(s, i)
 end
 
 @propagate_inbounds nextind(s::String, i::Int) = _nextind_str(s, i)
@@ -372,7 +372,6 @@ const _UTF8DFAState = UInt32
 const _UTF8_DFA_TABLE = let # let block rather than function doesn't pollute base
     num_classes=12
     num_states=10
-    bit_per_state = 6
 
     # These shifts were derived using a SMT solver
     state_shifts = [0, 4, 10, 14, 18, 24, 8, 20, 12, 26]

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -386,8 +386,6 @@ end
         has_cr = has_lf & two_bytes & (@inbounds(cu[ncu - two_bytes]) == 0x0d)
         ncu - (has_lf + has_cr)
     end
-    off = s isa String ? 0 : s.offset
-    par = s isa String ? s : s.string
     @inbounds raw_substring(s, 1, len)
 end
 """

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -101,7 +101,6 @@ let
     # PackageCompiler can filter out stdlibs so it can be empty
     maxlen = maximum(textwidth.(string.(stdlibs)); init=0)
 
-    tot_time_stdlib = 0.0
     # use a temp module to avoid leaving the type of this closure in Main
     push!(empty!(LOAD_PATH), "@stdlib")
     m = Module()

--- a/base/toml/parser.jl
+++ b/base/toml/parser.jl
@@ -394,7 +394,7 @@ end
 
 # Return true if `f` was accepted `n` times
 @inline function accept_n(l::Parser, n, f::F)::Bool where {F}
-    for i in 1:n
+    for _ in 1:n
         if !accept(l, f)
             return false
         end
@@ -482,7 +482,7 @@ function parse_toplevel(l::Parser)::Err{Nothing}
         skip_ws_comment(l)
         # SPEC: "There must be a newline (or EOF) after a key/value pair."
         if !(peek(l) == '\n' || peek(l) == '\r' || peek(l) == '#' || peek(l) == EOF_CHAR)
-            c = eat_char(l)
+            eat_char(l)
             return ParserError(ErrExpectedNewLineKeyValue)
         end
     end
@@ -822,9 +822,6 @@ function accept_batch_underscore(l::Parser, f::ValidSigs, fail_if_underscore=tru
 end
 
 function parse_number_or_date_start(l::Parser)
-    integer = true
-    read_dot = false
-
     set_marker!(l)
     sgn = 1
     parsed_sign = false
@@ -913,8 +910,7 @@ function parse_number_or_date_start(l::Parser)
         accept(l, x-> x == '+' || x == '-')
         # SPEC: (which follows the same rules as decimal integer values but may include leading zeros)
         read_digit = accept_batch(l, isdigit)
-        ate, read_underscore = @try accept_batch_underscore(l, isdigit, !read_digit)
-        contains_underscore |= read_underscore
+        _, read_underscore = @try accept_batch_underscore(l, isdigit, !read_digit)
     end
     if !ok_end_value(peek(l))
         eat_char(l)
@@ -1145,7 +1141,7 @@ function _parse_local_time(l::Parser, skip_hour=false)::Err{NTuple{4, Int64}}
         if accept(l, '.')
             set_marker!(l)
             found_fractional_digit = false
-            for i in 1:3
+            for _ in 1:3
                 found_fractional_digit |= accept(l, isdigit)
             end
             if !found_fractional_digit

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -649,8 +649,8 @@ function range_start_stop_length(start::T, stop::T, len::Integer) where {T<:IEEE
         return steprangelen_hp(T, start, zero(T), 0, len, 1)
     end
     # Attempt to find exact rational approximations
-    start_n, start_d = rat(start)
-    stop_n, stop_d = rat(stop)
+    _, start_d = rat(start)
+    _, stop_d = rat(stop)
     if start_d != 0 && stop_d != 0
         den = lcm_unchecked(start_d, stop_d)
         m = maxintfloat(T, Int)

--- a/base/version.jl
+++ b/base/version.jl
@@ -460,7 +460,6 @@ function Base.union!(ranges::Vector{<:VersionRange})
 
     sort!(ranges, lt = (a, b) -> (isless_ll(a.lower, b.lower) || (a.lower == b.lower && isless_uu(a.upper, b.upper))))
 
-    k0 = 1
     ks = findfirst(!isempty, ranges)
     ks === nothing && return empty!(ranges)
 

--- a/base/views.jl
+++ b/base/views.jl
@@ -20,7 +20,7 @@ function replace_ref_begin_end_!(__module__::Module, ex, withex, in_quote_contex
     @nospecialize
     used_withex = false
     function escapes(@nospecialize(ex), escs::Int)
-        for i = 1:escs
+        for _ = 1:escs
             ex = esc(ex)
         end
         return ex


### PR DESCRIPTION
Drop values that are assigned but never read, rename unused loop/destructuring variables and arguments to `_`, and remove a couple of straggler unused names and allocations, across Base.