### PR TITLE
fix flaky hvcat splatting test when SparseArrays is loaded

### DIFF
--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1483,7 +1483,9 @@ end
     t = (1, 2)
     @test [t...; 3 4] == [1 2; 3 4]
     @test [0 t...; t... 0] == [0 1 2; 1 2 0]
-    @test_throws ArgumentError [t...; 3 4 5]
+    # Base throws ArgumentError here, but SparseArrays' hvcat override (which
+    # may be loaded from an earlier test on the same worker) throws DimensionMismatch
+    @test_throws Union{ArgumentError, DimensionMismatch} [t...; 3 4 5]
 
     @test Int[t...; 3 4] == [1 2; 3 4]
     @test Int[0 t...; t... 0] == [0 1 2; 1 2 0]


### PR DESCRIPTION
Seen on the 1.12 backports PR CI (#62443): the base test suite reuses worker processes across test files, and SparseArrays tests are scheduled first (`test/runtests.jl`). If `abstractarray` later lands on a worker that ran them, SparseArrays is loaded and its `hvcat` disambiguation method (`sparsevector.jl`, `hvcat(rows, n1::N, ns::Vararg{N}) where {N<:Number}`) shadows Base's homogeneous-Number method. That routes through `Base.typed_hvcat`, which checks row shape before argument count, so `[t...; 3 4 5]` throws `DimensionMismatch` instead of `ArgumentError` and the `@test_throws` at `test/abstractarray.jl:1486` fails.

Accept both exception types in the test. Arguably the underlying bug is that loading SparseArrays changes the exception type of plain-number `hvcat` at all (and that Base's two number paths disagree on the error type), but that's a behavior change to sort out separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)