### PR TITLE
aotcompile: do not allow `JULIA_IMAGE_THREADS` to override jobserver

### DIFF
--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -217,15 +217,16 @@ number of effective CPU threads.
 
 Unlike [`JULIA_NUM_PRECOMPILE_TASKS`](@ref JULIA_NUM_PRECOMPILE_TASKS) (which caps
 worker *processes*) and [`JULIA_IMAGE_THREADS`](@ref JULIA_IMAGE_THREADS) (which
-pins a *per-worker* thread count), this is the shared total. Setting
-`JULIA_IMAGE_THREADS` alone bypasses the budget, but if `JULIA_PRECOMPILE_THREADS`
-is also set, it takes precedence and the shared budget is used instead. For example:
+caps a *per-worker* thread count), this is the shared total. The two compose:
+the budget bounds what all workers may use together, while `JULIA_IMAGE_THREADS`
+bounds what any one worker may use. Setting `JULIA_IMAGE_THREADS` alone uses a fixed
+number of threads in each worker and leaves total threads unconstrained. For example:
 
   * neither set: budget = `EFFECTIVE_CPU_THREADS + 1`
-  * `JULIA_PRECOMPILE_THREADS=8`: budget = 8
-  * `JULIA_IMAGE_THREADS=4`: no shared budget; every worker is pinned to 4 threads
-  * `JULIA_IMAGE_THREADS=4` and `JULIA_PRECOMPILE_THREADS=8`: budget = 8
-    (`JULIA_IMAGE_THREADS` is ignored)
+  * `JULIA_PRECOMPILE_THREADS=8`: 8 total threads
+  * `JULIA_IMAGE_THREADS=4`: every worker is pinned to 4 threads; no total thread limit
+  * `JULIA_IMAGE_THREADS=4` and `JULIA_PRECOMPILE_THREADS=8`: budget = 8 total threads,
+    with no worker exceeding 4 imaging threads of its own
 
 ### [`JULIA_PKG_DEVDIR`](@id JULIA_PKG_DEVDIR)
 
@@ -409,13 +410,11 @@ ignored if the module is a small module. If left unspecified, the smaller
 of the value of [`JULIA_CPU_THREADS`](@ref JULIA_CPU_THREADS) or half the
 number of logical CPU cores is used in its place.
 
-During parallel package precompilation, workers instead coordinate their CPU
-usage through a shared token pool sized by
+During parallel package precompilation, workers additionally coordinate their
+CPU usage through a shared token pool sized by
 [`JULIA_PRECOMPILE_THREADS`](@ref JULIA_PRECOMPILE_THREADS), so their combined
-thread count stays bounded. Setting `JULIA_IMAGE_THREADS` overrides that
-coordination and pins the given codegen-thread count for every worker, unless
-`JULIA_PRECOMPILE_THREADS` is also set, in which case the shared budget takes
-precedence and `JULIA_IMAGE_THREADS` is ignored.
+thread count stays bounded. If set, `JULIA_IMAGE_THREADS` limits the imaging
+threads for a single worker and does not affect the total thread limit.
 
 ### [`JULIA_IMAGE_TIMINGS`](@id JULIA_IMAGE_TIMINGS)
 

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2115,8 +2115,7 @@ static SmallVector<AOTOutputs, 16> add_output(Module &M, TargetMachine &TM, Stri
     return outputs;
 }
 
-static unsigned compute_image_thread_count(const ModuleInfo &info, bool jobserver_active, bool &explicit_override) {
-    explicit_override = false;
+static unsigned compute_image_thread_count(const ModuleInfo &info, bool jobserver_active) {
     // 32-bit systems are very memory-constrained
 #ifdef _P32
     LLVM_DEBUG(dbgs() << "32-bit systems are restricted to a single thread\n");
@@ -2144,7 +2143,9 @@ static unsigned compute_image_thread_count(const ModuleInfo &info, bool jobserve
         threads = max_threads;
     }
 
-    // environment variable override
+    // environment variable override.
+    // this controls how many threads we request from the jobserver (if it is enabled)
+    // but the question of whether to enable it or not is decided upstream
     const char *env_threads = getenv("JULIA_IMAGE_THREADS");
     bool env_threads_set = false;
     if (env_threads) {
@@ -2174,10 +2175,6 @@ static unsigned compute_image_thread_count(const ModuleInfo &info, bool jobserve
     }
 
     threads = std::max(threads, 1u);
-
-    // An explicit JULIA_IMAGE_THREADS request takes precedence over the
-    // jobserver: honor the user's fixed count rather than rationing tokens.
-    explicit_override = env_threads_set;
 
     return threads;
 }
@@ -2370,9 +2367,8 @@ static void jl_dump_native_locked(jl_native_code_desc_t *data, const char *bc_fn
                 << "    clones: " << module_info.clones << "\n"
                 << "    weight: " << module_info.weight << "\n"
             );
-            bool explicit_threads = false;
-            threads = compute_image_thread_count(module_info, jobserver.active(), explicit_threads);
-            if (jobserver.active() && !explicit_threads && threads > 1) {
+            threads = compute_image_thread_count(module_info, jobserver.active());
+            if (jobserver.active() && threads > 1) {
                 // `threads` is the partition count and concurrency ceiling;
                 // add_output rations the actual pool size from the shared
                 // token budget, growing it as sibling workers finish.


### PR DESCRIPTION
Sizing the worker-specific threads using environment variables here is fine, but it should not override using the jobserver.

This changes `JULIA_IMAGE_THREADS` / `JULIA_CPU_THREADS` to cap the number of imaging threads as before, but leaves the jobserver enabled so that we simultaneously respect the total thread budget. 

Previously, setting `JULIA_IMAGE_THREADS` could easily over-subscribe since it disabled adherence to the jobserver. This seems like a more natural composition of the configuration to me.

x-ref: https://github.com/JuliaLang/julia/pull/62495#issuecomment-5092151557