### PR TITLE
[1.11] Mark leftover external data declarations dllimport on Windows

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -525,6 +525,33 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
         juliapersonality_func->setDLLStorageClass(GlobalValue::DLLImportStorageClass);
     }
 
+    if (TT.isOSWindows()) {
+        // Any global variable still left as a declaration at this point is
+        // resolved from outside the image, i.e. from libjulia: the module has
+        // been merged but not yet split into partitions, so cross-partition
+        // references are all still definitions here.
+        //
+        // Such data has to be referenced through the import table. COFF can
+        // resolve an unmarked *function* through an import thunk, but there is
+        // no equivalent for data, and images are linked with
+        // --disable-auto-import --disable-runtime-pseudo-reloc, so an unmarked
+        // data reference fails to link outright.
+        //
+        // JuliaVariable::realize normally marks these when it creates them, but
+        // it only does so when the module it is creating them in targets
+        // Windows, and it returns any existing declaration untouched. A global
+        // first created while emitting for another target -- as happens when an
+        // external consumer such as GPUCompiler.jl drives codegen with its own
+        // module -- therefore keeps an unmarked declaration, which then poisons
+        // every reference to that symbol once the modules are linked together.
+        //Safe b/c context is locked by params
+        for (GlobalVariable &G : clone.getModuleUnlocked()->globals()) {
+            if (G.isDeclaration() && !G.hasLocalLinkage() && !G.isDSOLocal() &&
+                    G.getDLLStorageClass() == GlobalValue::DefaultStorageClass)
+                G.setDLLStorageClass(GlobalValue::DLLImportStorageClass);
+        }
+    }
+
     // move everything inside, now that we've merged everything
     // (before adding the exported headers)
     if (policy == CompilationPolicy::Default) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -533,8 +533,18 @@ public:
     JuliaVariable(const JuliaVariable&) = delete;
     JuliaVariable(const JuliaVariable&&) = delete;
     GlobalVariable *realize(Module *m) {
-        if (GlobalValue *V = m->getNamedValue(name))
-            return cast<GlobalVariable>(V);
+        if (GlobalValue *V = m->getNamedValue(name)) {
+            auto var = cast<GlobalVariable>(V);
+            // The declaration may have been created while emitting for a
+            // different target -- an external consumer such as GPUCompiler.jl
+            // can drive codegen with its own module -- in which case it was not
+            // marked below and COFF has no fallback for unmarked data.
+            if (var->isDeclaration() && !var->isDSOLocal() &&
+                    var->getDLLStorageClass() == GlobalValue::DefaultStorageClass &&
+                    Triple(m->getTargetTriple()).isOSWindows())
+                var->setDLLStorageClass(GlobalValue::DLLStorageClassTypes::DLLImportStorageClass);
+            return var;
+        }
         auto T_size = m->getDataLayout().getIntPtrType(m->getContext());
         auto var = new GlobalVariable(*m, _type(T_size),
                 isconst, GlobalVariable::ExternalLinkage,


### PR DESCRIPTION
On Windows a global variable that is only declared in an image has to be referenced through the COFF import table. Unlike a function, which the linker resolves through an import thunk, data has no such fallback, and images are linked with --disable-auto-import --disable-runtime-pseudo-reloc, so a single unmarked data reference fails the link outright:

    lld: error: undefined symbol: jl_boxed_uint8_cache
    >>> referenced by text#0.o:(.refptr.jl_boxed_uint8_cache)

JuliaVariable::realize marks these when it creates them, but only when the module being emitted into targets Windows, and it returns an already existing declaration untouched. An external consumer such as GPUCompiler.jl drives codegen with its own module, and jl_create_native takes the target triple and data layout from the module it is handed, so a global first realized during such a run is created unmarked. Once the modules are linked the merged declaration keeps that unmarked form, and every reference to the symbol in the image becomes unresolvable.

The effect is visible within a single object: jl_boxed_int8_cache and jl_boxed_uint8_cache are emitted by the same line of load_i8box and are declared identically, yet one is referenced as __imp_jl_boxed_int8_cache and the other as .refptr.jl_boxed_uint8_cache.

Fix this in jl_create_native_impl by marking any global variable still left as a declaration once the modules have been merged. That point is chosen deliberately: the merge has happened but the image has not yet been split into partitions, so cross-partition references are all still definitions, and only genuinely external data -- resolved from libjulia -- remains declared. Globals that are dso_local or that already carry a storage class are left alone, the former because DLLImport and dso_local cannot be combined.

Also mark unmarked declarations on realize's early-return path. That does not fix the case above, since the unmarked declaration arrives through linking rather than through another realize call, but it stops the same hole being reopened.

Found on 1.11, where precompiling a package that compiles a GPU kernel in its precompile workload fails to link on Windows. realize, load_i8box and the link flags are identical on 1.10 and 1.12 and neither re-applies the annotation during image emission, so the defect is latent there as well; 1.11 is simply where it is known to be reachable.

written with claude