### PR TITLE
Remove malloc  as a Julia allocation path

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -20,10 +20,10 @@ struct GC_Num
     # Number of `realloc` calls (never reset by the runtime)
     realloc::Int64
     # Number of pool allocation calls (never reset by the runtime)
-    # NOTE: Julia's stock GC uses an internal (pool) allocator for objects up to 2032 bytes.
-    # Larger objects are allocated through `malloc/calloc`.
+    # NOTE: Julia's stock GC uses an internal (pool) allocator for objects up to 10232 bytes.
+    # Larger objects are allocated through the big-object allocator.
     poolalloc::Int64
-    # Number of allocations for "big objects" (non-array objects larger than 2032 bytes)
+    # Number of allocations for "big objects" (non-array objects larger than 10232 bytes)
     # (never reset by the runtime)
     bigalloc::Int64
     # Number of `free` calls (never reset by the runtime)

--- a/src/Makefile
+++ b/src/Makefile
@@ -497,6 +497,10 @@ $(BUILDDIR)/llvm-alloc-opt.o $(BUILDDIR)/llvm-alloc-opt.dbg.obj: $(SRCDIR)/llvm-
 $(BUILDDIR)/llvm-cpufeatures.o $(BUILDDIR)/llvm-cpufeatures.dbg.obj: $(SRCDIR)/jitlayers.h
 $(BUILDDIR)/llvm-demote-float16.o $(BUILDDIR)/llvm-demote-float16.dbg.obj: $(SRCDIR)/jitlayers.h
 $(BUILDDIR)/llvm-final-gc-lowering.o $(BUILDDIR)/llvm-final-gc-lowering.dbg.obj: $(SRCDIR)/llvm-gc-interface-passes.h
+# The per-GC lowering implementations bake pool offsets and size classes into the
+# code they emit, so they must be rebuilt whenever those definitions change.
+$(BUILDDIR)/llvm-final-gc-lowering-stock.o $(BUILDDIR)/llvm-final-gc-lowering-stock.dbg.obj: $(SRCDIR)/llvm-gc-interface-passes.h
+$(BUILDDIR)/llvm-final-gc-lowering-mmtk.o $(BUILDDIR)/llvm-final-gc-lowering-mmtk.dbg.obj: $(SRCDIR)/llvm-gc-interface-passes.h
 $(BUILDDIR)/llvm-gc-invariant-verifier.o $(BUILDDIR)/llvm-gc-invariant-verifier.dbg.obj: $(SRCDIR)/llvm-codegen-shared.h
 $(BUILDDIR)/llvm-julia-licm.o $(BUILDDIR)/llvm-julia-licm.dbg.obj: $(SRCDIR)/llvm-codegen-shared.h $(SRCDIR)/llvm-alloc-helpers.h $(SRCDIR)/llvm-pass-helpers.h
 $(BUILDDIR)/llvm-late-gc-lowering.o $(BUILDDIR)/llvm-late-gc-lowering.dbg.obj: $(SRCDIR)/llvm-gc-interface-passes.h

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -320,7 +320,7 @@ static void gc_verify_tags_page(jl_gc_pagemeta_t *pg)
             assert(page_metadata(next)->osize == osize);
             freelist_zerod = 0;
         }
-        else if (pg->fl_begin_offset != (uint16_t)-1) {
+        else if (pg->fl_begin_offset != (uint32_t)-1) {
             // part of free list exists on this page
             next = page_pfl_beg(pg);
             freelist_zerod = 0;

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -44,10 +44,10 @@ typedef struct {
     // Number of `realloc` calls (never reset by the runtime)
     uint64_t realloc;
     // Number of pool allocation calls (never reset by the runtime)
-    // NOTE: Julia's stock GC uses an internal (pool) allocator for objects up to 2032 bytes.
-    // Larger objects are allocated through `malloc/calloc`.
+    // NOTE: Julia's stock GC uses an internal (pool) allocator for objects up to 10232 bytes.
+    // Larger objects are allocated through the big-object allocator.
     uint64_t poolalloc;
-    // Number of allocations for "big objects" (non-array objects larger than 2032 bytes)
+    // Number of allocations for "big objects" (non-array objects larger than 10232 bytes)
     // (never reset by the runtime)
     uint64_t bigalloc;
     // Number of `free` calls (never reset by the runtime)

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -1,103 +1,863 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+// Slab-based page allocator: pool pages, big pages for objects above the pool
+// limit, and malloc'd Memory buffers. See the overview comment in gc-stock.h.
+
 #include "gc-common.h"
 #include "gc-stock.h"
-#ifndef _OS_WINDOWS_
-#  include <sys/resource.h>
-#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-uv_mutex_t gc_pages_lock;
+uv_mutex_t gc_big_lock;
+
+static size_t gc_big_class_sz[GC_N_BIG_CLASSES];
+
+// Map an allocation size (<= GC_BIG_CLASS_MAX_SZ) to its size class.
+STATIC_INLINE int gc_big_szclass(size_t sz) JL_NOTSAFEPOINT
+{
+    if (sz <= GC_BIG_CLASS_MIN_SZ)
+        return 0;
+    // 4 classes per power of two: for sz in (2^lg, 2^(lg+1)], class sizes are
+    // 2^lg + (r+1) * 2^(lg-2) for r in 0:3
+    int lg = 63 - __builtin_clzll((uint64_t)(sz - 1));
+    size_t base = (size_t)1 << lg;
+    int sub = (int)((sz - base - 1) >> (lg - 2));
+    int c = 4 * (lg - 11) + sub + 1;
+    assert(c > 0 && c < GC_N_BIG_CLASSES);
+    assert(gc_big_class_sz[c] >= sz && (c == 0 || gc_big_class_sz[c - 1] < sz));
+    return c;
+}
+
+// log2 of the page size used for a size class (mimalloc's tiering rule:
+// a page must hold several objects of its class, see gc-stock.h)
+STATIC_INLINE int gc_big_page_lg2(size_t class_sz) JL_NOTSAFEPOINT
+{
+    if (class_sz <= GC_BIG_SMALL_PAGE_MAX_SZ)
+        return 16; // 64 KiB
+    if (class_sz <= GC_BIG_MEDIUM_PAGE_MAX_SZ)
+        return 19; // 512 KiB
+    return GC_SLAB_LG2; // a whole slab
+}
+
+// per-class stacks of pages with free slots; popped lock-free by mutators,
+// (re)filled only during sweep while the world is stopped. Refill prefers the
+// fullest bucket (see gc_occupancy_bucket).
+typedef struct {
+    _Atomic(jl_gc_bigpagemeta_t *) bottom;
+} gc_big_page_stack_t;
+
+static gc_big_page_stack_t gc_big_partial_pages[GC_N_BIG_CLASSES][GC_OCCUPANCY_BUCKETS];
+
+STATIC_INLINE int gc_big_page_bucket(jl_gc_bigpagemeta_t *pg) JL_NOTSAFEPOINT
+{
+    return gc_occupancy_bucket((size_t)pg->nfree * pg->osize,
+                               (size_t)1 << pg->page_lg2);
+}
+
+STATIC_INLINE void gc_big_stack_push(gc_big_page_stack_t *st, jl_gc_bigpagemeta_t *pg) JL_NOTSAFEPOINT
+{
+    // only called during sweep with the world stopped, no CAS needed
+    pg->next = jl_atomic_load_relaxed(&st->bottom);
+    jl_atomic_store_relaxed(&st->bottom, pg);
+}
+
+STATIC_INLINE jl_gc_bigpagemeta_t *gc_big_stack_pop(gc_big_page_stack_t *st) JL_NOTSAFEPOINT
+{
+    while (1) {
+        jl_gc_bigpagemeta_t *pg = jl_atomic_load_relaxed(&st->bottom);
+        if (pg == NULL)
+            return NULL;
+        if (jl_atomic_cmpswap(&st->bottom, &pg, pg->next))
+            return pg;
+        jl_cpu_pause();
+    }
+}
+
+// ======================================================================== //
+// slab map: two-level radix tree from `addr >> GC_SLAB_LG2` to slab metadata.
+// Every address handed out by this allocator has its containing (2 MiB-
+// aligned) slab registered here; huge mappings are 2 MiB-aligned so their
+// base address identifies them uniquely.
+// ======================================================================== //
+
+#ifdef _P64
+#define GC_SLAB_MAP0_BITS 16 // bits 21..36
+#define GC_SLAB_MAP1_BITS 9  // bits 37..45
+#define GC_SLAB_MAP2_BITS 18 // bits 46..63
+#else
+// Only bits 21..31 exist above the slab shift, so a single leaf level covers the
+// whole address space and the upper levels collapse to one entry each.
+#define GC_SLAB_MAP0_BITS 11 // bits 21..31
+#define GC_SLAB_MAP1_BITS 0
+#define GC_SLAB_MAP2_BITS 0
+#endif
+
+typedef struct {
+    jl_gc_slabmeta_t *meta[1 << GC_SLAB_MAP0_BITS];
+} gc_slab_map0_t;
+
+typedef struct {
+    gc_slab_map0_t *map0[1 << GC_SLAB_MAP1_BITS];
+} gc_slab_map1_t;
+
+static gc_slab_map1_t *gc_slab_map[1 << GC_SLAB_MAP2_BITS];
+
+// Requires `gc_big_lock` when `create` is set. Lookups without `create` may
+// run without the lock: interior nodes are never freed, and leaf slots are
+// only read for addresses this allocator handed out (whose entries were
+// published before the allocation was visible to anyone).
+static jl_gc_slabmeta_t **gc_slab_map_slot(void *p, int create) JL_NOTSAFEPOINT
+{
+    // 64-bit even on 32-bit targets: the shift counts below exceed the width of
+    // a 32-bit pointer, which would be undefined behaviour on `uintptr_t`.
+    uint64_t a = (uint64_t)(uintptr_t)p;
+    unsigned i2 = (unsigned)((a >> (GC_SLAB_LG2 + GC_SLAB_MAP0_BITS + GC_SLAB_MAP1_BITS)) & ((1 << GC_SLAB_MAP2_BITS) - 1));
+    gc_slab_map1_t *m1 = gc_slab_map[i2];
+    if (m1 == NULL) {
+        if (!create)
+            return NULL;
+        m1 = (gc_slab_map1_t*)calloc_s(sizeof(gc_slab_map1_t));
+        gc_slab_map[i2] = m1;
+    }
+    unsigned i1 = (unsigned)((a >> (GC_SLAB_LG2 + GC_SLAB_MAP0_BITS)) & ((1 << GC_SLAB_MAP1_BITS) - 1));
+    gc_slab_map0_t *m0 = m1->map0[i1];
+    if (m0 == NULL) {
+        if (!create)
+            return NULL;
+        m0 = (gc_slab_map0_t*)calloc_s(sizeof(gc_slab_map0_t));
+        m1->map0[i1] = m0;
+    }
+    return &m0->meta[(size_t)((a >> GC_SLAB_LG2) & ((1 << GC_SLAB_MAP0_BITS) - 1))];
+}
+
+STATIC_INLINE jl_gc_slabmeta_t *gc_slab_map_lookup(void *p) JL_NOTSAFEPOINT
+{
+    jl_gc_slabmeta_t **slot = gc_slab_map_slot(p, 0);
+    return slot == NULL ? NULL : *slot;
+}
+
+// ======================================================================== //
+// OS memory
+// ======================================================================== //
+
+static int gc_use_hugepages = 1;
+
+#ifndef MAP_NORESERVE // not defined in POSIX, FreeBSD, etc.
+#define MAP_NORESERVE (0)
+#endif
+
+// Reserve a GC_SLAB_SZ-aligned region of `sz` bytes (a multiple of
+// GC_SLAB_SZ). On POSIX the memory is immediately usable; on Windows it is
+// only reserved and each slab must be committed before use.
+// Updates bytes_mapped; the caller is responsible for bytes_resident.
+// `raw_base_out`, if non-NULL, receives the base of the underlying OS mapping
+// (needed to release it on Windows; equal to the returned pointer on POSIX).
+static char *gc_reserve_aligned(size_t sz, void **raw_base_out) JL_NOTSAFEPOINT
+{
+#ifdef _OS_WINDOWS_
+    // over-reserve to align; the unused head/tail cannot be released
+    // separately on Windows, so it is simply never committed
+    char *mem = (char*)VirtualAlloc(NULL, sz + GC_SLAB_SZ, MEM_RESERVE, PAGE_READWRITE);
+    if (mem == NULL)
+        return NULL;
+    char *base = (char*)LLT_ALIGN((uintptr_t)mem, GC_SLAB_SZ);
+    if (raw_base_out != NULL)
+        *raw_base_out = mem;
+#else
+    char *mem = (char*)mmap(0, sz + GC_SLAB_SZ, PROT_READ | PROT_WRITE,
+                            MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (mem == MAP_FAILED)
+        return NULL;
+    char *base = (char*)LLT_ALIGN((uintptr_t)mem, GC_SLAB_SZ);
+    // trim the unaligned head and tail
+    if (base != mem)
+        munmap(mem, base - mem);
+    munmap(base + sz, mem + GC_SLAB_SZ - base);
+    if (raw_base_out != NULL)
+        *raw_base_out = base;
+#ifdef MADV_HUGEPAGE
+    if (gc_use_hugepages)
+        madvise(base, sz, MADV_HUGEPAGE);
+#endif
+#endif
+    // On Windows the head/tail of the over-reservation cannot be released
+    // separately, so the whole reservation stays charged to bytes_mapped;
+    // on POSIX it has been trimmed away and only `sz` remains mapped.
+#ifdef _OS_WINDOWS_
+    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_mapped, sz + GC_SLAB_SZ);
+#else
+    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_mapped, sz);
+#endif
+    return base;
+}
+
+// Commit a decommitted (or never-committed) slab. Returns 0 on failure.
+static int gc_slab_commit(char *data) JL_NOTSAFEPOINT
+{
+#ifdef _OS_WINDOWS_
+    if (VirtualAlloc(data, GC_SLAB_SZ, MEM_COMMIT, PAGE_READWRITE) == NULL)
+        return 0;
+#endif
+    // POSIX: MADV_FREE/DONTNEED memory recommits transparently on touch
+    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_resident, GC_SLAB_SZ);
+    return 1;
+}
+
+static void gc_slab_decommit(char *data) JL_NOTSAFEPOINT
+{
+#ifdef _OS_WINDOWS_
+    VirtualFree(data, GC_SLAB_SZ, MEM_DECOMMIT);
+#elif defined(MADV_FREE)
+    static _Atomic(int) supports_madv_free = 1;
+    if (jl_atomic_load_relaxed(&supports_madv_free)) {
+        if (madvise(data, GC_SLAB_SZ, MADV_FREE) == -1) {
+            assert(errno == EINVAL);
+            jl_atomic_store_relaxed(&supports_madv_free, 0);
+        }
+    }
+    if (!jl_atomic_load_relaxed(&supports_madv_free))
+        madvise(data, GC_SLAB_SZ, MADV_DONTNEED);
+#else
+    madvise(data, GC_SLAB_SZ, MADV_DONTNEED);
+#endif
+    msan_unpoison(data, GC_SLAB_SZ);
+    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_resident, -(int64_t)GC_SLAB_SZ);
+}
+
+// ======================================================================== //
+// slab management (all under gc_big_lock)
+// ======================================================================== //
+
+#define GC_SLAB_BLOCK_NSLABS 32 // 64 MB blocks
+
+static jl_gc_slabmeta_t *gc_partial_slabs; // slabs with some (not all) units free
+static jl_gc_slabmeta_t *gc_free_slabs;    // fully free slabs
+
+static void gc_partial_slab_link(jl_gc_slabmeta_t **head, jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
+{
+    s->prev = NULL;
+    s->next = *head;
+    if (*head != NULL)
+        (*head)->prev = s;
+    *head = s;
+}
+
+static void gc_partial_slab_unlink(jl_gc_slabmeta_t **head, jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
+{
+    if (s->prev != NULL)
+        s->prev->next = s->next;
+    else
+        *head = s->next;
+    if (s->next != NULL)
+        s->next->prev = s->prev;
+    s->next = s->prev = NULL;
+}
+
+// Requires `gc_big_lock`. The slab must be fully free and not on the
+// partial-slab list.
+static void gc_release_slab(jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
+{
+    assert(s->free_unit_map == UINT32_MAX);
+    assert(s->free_segs[0] == NULL && s->free_segs[1] == NULL &&
+           "releasing a slab that still has free segments registered");
+    s->next = gc_free_slabs;
+    gc_free_slabs = s;
+    s->free_sweeps = 0;
+}
+
+// Map a new block of slabs, register them, and return one of them; the rest
+// go onto the free-slab list. Returns NULL if the OS is out of memory.
+static jl_gc_slabmeta_t *gc_alloc_slab_block(void) JL_NOTSAFEPOINT
+{
+    int nslabs = GC_SLAB_BLOCK_NSLABS;
+    char *base;
+    void *raw_base;
+    while (1) {
+        base = gc_reserve_aligned((size_t)nslabs << GC_SLAB_LG2, &raw_base);
+        if (base != NULL)
+            break;
+        if (nslabs == 1)
+            return NULL;
+        nslabs = nslabs / 4 > 0 ? nslabs / 4 : 1;
+    }
+#ifndef _OS_WINDOWS_
+    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_resident, (size_t)nslabs << GC_SLAB_LG2);
+#endif
+    jl_gc_slabmeta_t *metas = (jl_gc_slabmeta_t*)calloc_s(nslabs * sizeof(jl_gc_slabmeta_t));
+    for (int i = 0; i < nslabs; i++) {
+        jl_gc_slabmeta_t *s = &metas[i];
+        s->data = base + ((size_t)i << GC_SLAB_LG2);
+        s->free_unit_map = UINT32_MAX;
+#ifdef _OS_WINDOWS_
+        s->resident = 0;
+#else
+        s->resident = 1;
+#endif
+        *gc_slab_map_slot(s->data, 1) = s;
+        if (i != 0) {
+            s->next = gc_free_slabs;
+            gc_free_slabs = s;
+        }
+    }
+    // Remember the base of the OS reservation on the block's first slab. Slab
+    // blocks are never unmapped (only decommitted slab by slab), but on Windows
+    // this is the only pointer VirtualFree would accept, so dropping it would
+    // make the reservation permanently unreleasable.
+    metas[0].map_base = raw_base;
+    metas[0].map_sz = (size_t)nslabs << GC_SLAB_LG2;
+    return &metas[0];
+}
+
+// Take a fully-free slab. Returns NULL if the OS is out of memory.
+static jl_gc_slabmeta_t *gc_take_slab(void) JL_NOTSAFEPOINT
+{
+    jl_gc_slabmeta_t *s = gc_free_slabs;
+    if (s != NULL) {
+        gc_free_slabs = s->next;
+        s->next = NULL;
+        s->free_sweeps = 0;
+    }
+    else {
+        s = gc_alloc_slab_block();
+        if (s == NULL)
+            return NULL;
+    }
+    if (!s->resident) {
+        if (!gc_slab_commit(s->data)) {
+            // undo and report OOM
+            s->next = gc_free_slabs;
+            gc_free_slabs = s;
+            return NULL;
+        }
+        s->resident = 1;
+    }
+    return s;
+}
+
+// Segment size levels: 0 -> 1 unit (64 KiB), 1 -> 8 units (512 KiB),
+// 2 -> 32 units (whole slab). A page is always one of these three sizes.
+static const int gc_level_nunits[3] = {1, 8, GC_UNITS_PER_SLAB};
+
+STATIC_INLINE int gc_seg_level(int nunits) JL_NOTSAFEPOINT
+{
+    return nunits == 1 ? 0 : nunits == 8 ? 1 : 2;
+}
+
+// A free segment threads its list links through its own (free) page memory.
+// It carries no size class, so any class of the matching page size can reuse
+// it: only the three page sizes, not the size classes, can fragment.
+typedef struct _gc_free_seg_t {
+    struct _gc_free_seg_t *next;
+    struct _gc_free_seg_t *prev;
+} gc_free_seg_t;
+
+STATIC_INLINE gc_free_seg_t *gc_seg_at(jl_gc_slabmeta_t *s, int u) JL_NOTSAFEPOINT
+{
+    return (gc_free_seg_t*)(s->data + ((size_t)u << GC_UNIT_LG2));
+}
+
+STATIC_INLINE int gc_seg_unit(jl_gc_slabmeta_t *s, gc_free_seg_t *n) JL_NOTSAFEPOINT
+{
+    return (int)(((char*)n - s->data) >> GC_UNIT_LG2);
+}
+
+// free_unit_map bits for the run of `nunits` units starting at unit `u`
+STATIC_INLINE uint32_t gc_unit_run_mask(int u, int nunits) JL_NOTSAFEPOINT
+{
+    return (nunits >= GC_UNITS_PER_SLAB ? UINT32_MAX : ((uint32_t)1 << nunits) - 1) << u;
+}
+
+#ifndef JL_NDEBUG
+// Requires `gc_big_lock`. The free-segment lists live inside the free page
+// memory itself, so a stale list entry turns the `n->prev->next` store in
+// `gc_seg_unlink` into a wild write that no other invariant would catch.
+// Check the lists against `free_unit_map`, which is the authoritative oracle:
+// every free unit must be covered by exactly one segment, at the right level,
+// aligned to that level, and the links must be consistent both ways.
+static void gc_seg_verify(jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
+{
+    uint32_t covered = 0;
+    for (int lvl = 0; lvl < 2; lvl++) {
+        int nunits = gc_level_nunits[lvl];
+        gc_free_seg_t *prev = NULL;
+        int guard = 0;
+        for (gc_free_seg_t *n = (gc_free_seg_t*)s->free_segs[lvl]; n != NULL; n = n->next) {
+            assert(++guard <= GC_UNITS_PER_SLAB && "cycle in free-segment list");
+            assert(n->prev == prev && "broken free-segment back link");
+            int u = gc_seg_unit(s, n);
+            assert(u >= 0 && u < GC_UNITS_PER_SLAB && "free segment outside its slab");
+            assert(u % nunits == 0 && "free segment misaligned for its level");
+            uint32_t run = gc_unit_run_mask(u, nunits);
+            assert((s->free_unit_map & run) == run && "free segment covers an allocated unit");
+            assert((covered & run) == 0 && "free unit covered by two segments");
+            covered |= run;
+            prev = n;
+        }
+    }
+    // A fully-free slab is released to the free-slab list and keeps no
+    // segments; every other slab must have each free unit in a segment.
+    assert((covered == s->free_unit_map ||
+            (s->free_unit_map == UINT32_MAX && covered == 0)) &&
+           "free unit not covered by any segment");
+}
+#else
+#define gc_seg_verify(s) ((void)0)
+#endif
+
+// Requires `gc_big_lock`. Push the unit run at `u` onto its slab's level-`lvl`
+// free-segment list.
+STATIC_INLINE void gc_seg_push(jl_gc_slabmeta_t *s, int lvl, int u) JL_NOTSAFEPOINT
+{
+    gc_free_seg_t *n = gc_seg_at(s, u);
+    msan_unpoison(n, sizeof(*n));
+    gc_free_seg_t *head = (gc_free_seg_t*)s->free_segs[lvl];
+    n->prev = NULL;
+    n->next = head;
+    if (head != NULL)
+        head->prev = n;
+    s->free_segs[lvl] = n;
+}
+
+#ifndef JL_NDEBUG
+// Requires `gc_big_lock`. Is `n` really on the level-`lvl` list of `s`?
+static int gc_seg_on_list(jl_gc_slabmeta_t *s, int lvl, gc_free_seg_t *n) JL_NOTSAFEPOINT
+{
+    int guard = 0;
+    for (gc_free_seg_t *m = (gc_free_seg_t*)s->free_segs[lvl]; m != NULL; m = m->next) {
+        if (m == n)
+            return 1;
+        if (++guard > GC_UNITS_PER_SLAB)
+            break;
+    }
+    return 0;
+}
+#endif
+
+// Requires `gc_big_lock`. Unlink a known-present segment from its list.
+STATIC_INLINE void gc_seg_unlink(jl_gc_slabmeta_t *s, int lvl, gc_free_seg_t *n) JL_NOTSAFEPOINT
+{
+    // The links live in the free page memory itself, so unlinking a segment
+    // that is not actually on the list stores through whatever the last user of
+    // that page left behind -- i.e. an arbitrary wild write. Catch it here.
+    assert(gc_seg_on_list(s, lvl, n) && "unlinking a free segment that is not on its list");
+    if (n->prev != NULL)
+        n->prev->next = n->next;
+    else
+        s->free_segs[lvl] = n->next;
+    if (n->next != NULL)
+        n->next->prev = n->prev;
+}
+
+// Requires `gc_big_lock`. Return a free run of `gc_level_nunits[lvl]` units,
+// splitting a larger segment (or a fresh slab) when the level is empty.
+// `*s_out` receives the owning slab; returns the first unit or -1 on OOM.
+static int gc_get_segment(int lvl, jl_gc_slabmeta_t **s_out) JL_NOTSAFEPOINT
+{
+    // reuse a same-size free segment from any partial slab; a whole-slab page has
+    // no segment list, since a wholly free slab is on the free-slab list instead
+    if (lvl != 2) {
+        for (jl_gc_slabmeta_t *s = gc_partial_slabs; s != NULL; s = s->next) {
+            gc_free_seg_t *n = (gc_free_seg_t*)s->free_segs[lvl];
+            if (n != NULL) {
+                gc_seg_unlink(s, lvl, n);
+                *s_out = s;
+                return gc_seg_unit(s, n);
+            }
+        }
+    }
+    else {
+        // a whole-slab page needs a fresh (or wholly free) slab
+        jl_gc_slabmeta_t *s = gc_take_slab();
+        if (s == NULL)
+            return -1;
+        gc_partial_slab_link(&gc_partial_slabs, s);
+        *s_out = s;
+        return 0;
+    }
+    // split a segment one size up: keep the first child, free the rest, so a
+    // whole group is broken only when no loose unit of this size is left.
+    jl_gc_slabmeta_t *s;
+    int pu = gc_get_segment(lvl + 1, &s);
+    if (pu < 0)
+        return -1;
+    int child = gc_level_nunits[lvl];
+    int parent = gc_level_nunits[lvl + 1];
+    for (int off = child; off < parent; off += child)
+        gc_seg_push(s, lvl, pu + off);
+    *s_out = s;
+    return pu;
+}
+
+// Requires `gc_big_lock`. Claim an aligned run of `nunits` (1, 8, or 32) units.
+// Returns NULL if the OS is out of memory.
+static jl_gc_slabmeta_t *gc_carve_units(int nunits, int *unit_out) JL_NOTSAFEPOINT
+{
+    jl_gc_slabmeta_t *s;
+    int u = gc_get_segment(gc_seg_level(nunits), &s);
+    if (u < 0)
+        return NULL;
+    assert(u % nunits == 0 && "carved run is misaligned for its size");
+    uint32_t run = gc_unit_run_mask(u, nunits);
+    assert((s->free_unit_map & run) == run);
+    s->free_unit_map &= ~run;
+    if (s->free_unit_map == 0)
+        gc_partial_slab_unlink(&gc_partial_slabs, s); // now full
+    gc_seg_verify(s);
+    *unit_out = u;
+    return s;
+}
+
+// Requires `gc_big_lock`. Return an aligned run of units to its slab, then
+// coalesce as far up the size levels as the free-unit map allows; a fully-free
+// slab moves to the free-slab list.
+static void gc_free_units(jl_gc_slabmeta_t *s, int u, int nunits) JL_NOTSAFEPOINT
+{
+    int lvl = gc_seg_level(nunits);
+    gc_seg_verify(s);
+    assert(u % nunits == 0 && "freed run is misaligned for its size");
+    uint32_t run = gc_unit_run_mask(u, nunits);
+    assert((s->free_unit_map & run) == 0);
+    int was_full = s->free_unit_map == 0;
+    s->free_unit_map |= run;
+    if (was_full)
+        gc_partial_slab_link(&gc_partial_slabs, s);
+    // coalesce: while the parent-aligned group of this segment is entirely
+    // free, absorb the sibling segments and rise a level.
+    while (lvl < 2) {
+        int parent = gc_level_nunits[lvl + 1];
+        int group = (u / parent) * parent;
+        uint32_t pmask = parent >= GC_UNITS_PER_SLAB ? UINT32_MAX
+                       : (((uint32_t)1 << parent) - 1) << group;
+        if ((s->free_unit_map & pmask) != pmask)
+            break; // parent not fully free: this segment stays at its level
+        int child = gc_level_nunits[lvl];
+        for (int off = 0; off < parent; off += child) {
+            int cu = group + off;
+            if (cu != u) // the freed run is not on any list yet
+                gc_seg_unlink(s, lvl, gc_seg_at(s, cu));
+        }
+        u = group;
+        lvl++;
+    }
+    if (lvl == 2) {
+        // whole slab free
+        gc_partial_slab_unlink(&gc_partial_slabs, s);
+        gc_release_slab(s);
+    }
+    else {
+        gc_seg_push(s, lvl, u);
+    }
+    gc_seg_verify(s);
+}
+
+// ======================================================================== //
+// big pages
+// ======================================================================== //
+
+// Take a fresh page for `szclass` from the slab layer and make it the
+// caller's current page. Returns NULL if the OS is out of memory.
+static NOINLINE jl_gc_bigpagemeta_t *gc_big_fresh_page(int szclass) JL_NOTSAFEPOINT
+{
+    size_t osize = gc_big_class_sz[szclass];
+    int page_lg2 = gc_big_page_lg2(osize);
+    int nunits = 1 << (page_lg2 - GC_UNIT_LG2);
+    uv_mutex_lock(&gc_big_lock);
+    int u;
+    jl_gc_slabmeta_t *s = gc_carve_units(nunits, &u);
+    if (s == NULL) {
+        uv_mutex_unlock(&gc_big_lock);
+        return NULL;
+    }
+    if (s->pages == NULL)
+        s->pages = (jl_gc_bigpagemeta_t*)calloc_s(GC_UNITS_PER_SLAB * sizeof(jl_gc_bigpagemeta_t));
+    for (int j = 0; j < nunits; j++)
+        s->unit_page_start[u + j] = (uint8_t)u;
+    uv_mutex_unlock(&gc_big_lock);
+
+    jl_gc_bigpagemeta_t *pg = &s->pages[u];
+    pg->data = s->data + ((size_t)u << GC_UNIT_LG2);
+    pg->page_lg2 = (uint8_t)page_lg2;
+    pg->szclass = szclass;
+    pg->osize = (uint32_t)osize;
+    pg->nobjs = (uint32_t)(((size_t)1 << page_lg2) / osize);
+    pg->nfree = pg->nobjs;
+    pg->freelist = NULL;
+    pg->bump = pg->data;
+    pg->sweep_next = NULL;
+    pg->on_sweep_list = 0;
+    return pg;
+}
+
+// ======================================================================== //
+// huge allocations
+// ======================================================================== //
+
+static void *gc_huge_alloc(size_t allocsz, size_t *usable_sz)
+{
+    size_t sz = LLT_ALIGN(allocsz, jl_page_size);
+    size_t map_sz = LLT_ALIGN(sz, GC_SLAB_SZ);
+    // reserve at slab granularity so the base address owns its slab-map slots
+    void *raw_base;
+    char *base = gc_reserve_aligned(map_sz, &raw_base);
+    if (base == NULL)
+        return NULL;
+    jl_gc_slabmeta_t *s = (jl_gc_slabmeta_t*)calloc_s(sizeof(jl_gc_slabmeta_t));
+    s->is_huge = 1;
+    s->data = base;
+    s->map_base = raw_base;
+    s->map_sz = map_sz;
+    s->usable_sz = sz;
+    s->resident = 1;
+#ifdef _OS_WINDOWS_
+    if (VirtualAlloc(base, sz, MEM_COMMIT, PAGE_READWRITE) == NULL) {
+        VirtualFree(raw_base, 0, MEM_RELEASE);
+        jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_mapped,
+                                    -(int64_t)(map_sz + GC_SLAB_SZ));
+        free(s);
+        return NULL;
+    }
+#endif
+    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_resident, sz);
+    uv_mutex_lock(&gc_big_lock);
+    *gc_slab_map_slot(base, 1) = s;
+    uv_mutex_unlock(&gc_big_lock);
+    *usable_sz = sz;
+    return base;
+}
+
+static size_t gc_huge_free(jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
+{
+    size_t usable = s->usable_sz;
+    // Take the lock: the slab map is also read without it (gc_slab_map_lookup)
+    // and grown under it (gc_slab_map_slot(.., 1)) by other threads, including
+    // the concurrent page sweeper.
+    uv_mutex_lock(&gc_big_lock);
+    jl_gc_slabmeta_t **slot = gc_slab_map_slot(s->data, 0);
+    assert(slot != NULL && *slot == s && "huge allocation missing from the slab map");
+    if (slot != NULL)
+        *slot = NULL;
+    uv_mutex_unlock(&gc_big_lock);
+#ifdef _OS_WINDOWS_
+    // releases the whole over-reservation, head and tail included
+    VirtualFree(s->map_base, 0, MEM_RELEASE);
+    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_mapped,
+                                -(int64_t)(s->map_sz + GC_SLAB_SZ));
+#else
+    munmap(s->data, s->map_sz);
+    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_mapped, -(int64_t)s->map_sz);
+#endif
+    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_resident, -(int64_t)usable);
+    free(s);
+    return usable;
+}
+
+void *jl_gc_big_mem_alloc(jl_ptls_t ptls, size_t allocsz, size_t *usable_sz)
+{
+    if (allocsz > GC_BIG_CLASS_MAX_SZ)
+        return gc_huge_alloc(allocsz, usable_sz);
+    int c = gc_big_szclass(allocsz);
+    size_t osize = gc_big_class_sz[c];
+    *usable_sz = osize;
+    jl_gc_bigpagemeta_t *pg = ptls->gc_tls.big_pages[c];
+    while (1) {
+        if (pg != NULL) {
+            void *p = pg->freelist;
+            if (p != NULL) {
+                pg->freelist = *(void**)p;
+                pg->nfree--;
+                return p;
+            }
+            if (pg->bump + osize <= pg->data + (size_t)pg->nobjs * osize) {
+                p = pg->bump;
+                pg->bump += osize;
+                pg->nfree--;
+                return p;
+            }
+            assert(pg->nfree == 0);
+            pg->state = GC_BIG_PAGE_FULL; // retire; sweep picks it back up
+        }
+        // take the fullest available partial page so emptier pages drain
+        pg = NULL;
+        for (int b = 0; b < GC_OCCUPANCY_BUCKETS && pg == NULL; b++)
+            pg = gc_big_stack_pop(&gc_big_partial_pages[c][b]);
+        if (pg == NULL) {
+            pg = gc_big_fresh_page(c);
+            if (pg == NULL) {
+                ptls->gc_tls.big_pages[c] = NULL;
+                return NULL;
+            }
+        }
+        pg->state = GC_BIG_PAGE_CURRENT;
+        ptls->gc_tls.big_pages[c] = pg;
+    }
+}
+
+// ======================================================================== //
+// sweep integration
+// ======================================================================== //
+
+// pages that received at least one free slot during the current sweep
+static jl_gc_bigpagemeta_t *gc_sweep_touched_pages;
+
+// pages given up by exiting threads while they still had free slots, linked
+// through `next`. They are on no per-class stack, so nothing but the next
+// sweep will ever hand their remaining slots out again. Requires `gc_big_lock`.
+static jl_gc_bigpagemeta_t *gc_orphaned_pages;
+
+size_t jl_gc_big_mem_free(void *p) JL_NOTSAFEPOINT
+{
+    jl_gc_slabmeta_t *s = gc_slab_map_lookup(p);
+    assert(s != NULL && "freeing a pointer not allocated by jl_gc_big_mem_alloc");
+    if (s->is_huge) {
+        assert(p == s->data);
+        return gc_huge_free(s);
+    }
+    int u = (int)(((uintptr_t)p >> GC_UNIT_LG2) & (GC_UNITS_PER_SLAB - 1));
+    jl_gc_bigpagemeta_t *pg = &s->pages[s->unit_page_start[u]];
+    assert(pg->state != GC_BIG_PAGE_FREE);
+    *(void**)p = pg->freelist;
+    pg->freelist = p;
+    pg->nfree++;
+    if (!pg->on_sweep_list) {
+        pg->on_sweep_list = 1;
+        pg->sweep_next = gc_sweep_touched_pages;
+        gc_sweep_touched_pages = pg;
+    }
+    return pg->osize;
+}
+
+// Return a fully-free page's units to its slab. Requires `gc_big_lock`.
+static void gc_big_release_page(jl_gc_bigpagemeta_t *pg) JL_NOTSAFEPOINT
+{
+    jl_gc_slabmeta_t *s = gc_slab_map_lookup(pg->data);
+    int u = (int)((pg->data - s->data) >> GC_UNIT_LG2);
+    assert(&s->pages[u] == pg);
+    pg->state = GC_BIG_PAGE_FREE;
+    pg->freelist = NULL;
+    gc_free_units(s, u, 1 << (pg->page_lg2 - GC_UNIT_LG2));
+}
+
+// Requires `gc_big_lock`. Not a current page and not on the sweep list.
+static void gc_big_dispose_page(jl_gc_bigpagemeta_t *pg) JL_NOTSAFEPOINT
+{
+    assert(pg->state != GC_BIG_PAGE_CURRENT);
+    if (pg->nfree == pg->nobjs) {
+        gc_big_release_page(pg);
+    }
+    else if (pg->nfree > 0) {
+        pg->state = GC_BIG_PAGE_PARTIAL;
+        gc_big_stack_push(&gc_big_partial_pages[pg->szclass][gc_big_page_bucket(pg)], pg);
+    }
+    else {
+        pg->state = GC_BIG_PAGE_FULL;
+    }
+}
+
+// Give up the current allocation pages of a thread that is going away. Sweep
+// only ever re-sorts pages that are not GC_BIG_PAGE_CURRENT, so pages left
+// pointing at a dead thread would keep their units forever.
+void jl_gc_big_mem_thread_exit(jl_ptls_t ptls) JL_NOTSAFEPOINT
+{
+    uv_mutex_lock(&gc_big_lock);
+    for (int c = 0; c < GC_N_BIG_CLASSES; c++) {
+        jl_gc_bigpagemeta_t *pg = ptls->gc_tls.big_pages[c];
+        if (pg == NULL)
+            continue;
+        ptls->gc_tls.big_pages[c] = NULL;
+        assert(pg->state == GC_BIG_PAGE_CURRENT);
+        if (pg->nfree == pg->nobjs && !pg->on_sweep_list) {
+            // nothing live in it: hand the units straight back
+            gc_big_release_page(pg);
+        }
+        else {
+            // Can't push to a per-class stack outside stop-the-world; queue it
+            // for the next sweep to re-sort.
+            pg->state = GC_BIG_PAGE_FULL;
+            if (!pg->on_sweep_list) {
+                pg->next = gc_orphaned_pages;
+                gc_orphaned_pages = pg;
+            }
+        }
+    }
+    uv_mutex_unlock(&gc_big_lock);
+}
+
+void jl_gc_big_mem_finish_sweep(void) JL_NOTSAFEPOINT
+{
+    uv_mutex_lock(&gc_big_lock);
+    // The per-class partial stacks and the sweep-touched list may overlap, and
+    // pages in the stacks may have become fully free (which requires removing
+    // them, impossible in-place). Drain everything and re-sort.
+    for (int c = 0; c < GC_N_BIG_CLASSES; c++) {
+        jl_gc_bigpagemeta_t *pg;
+        jl_gc_bigpagemeta_t *untouched = NULL;
+        for (int b = 0; b < GC_OCCUPANCY_BUCKETS; b++) {
+            while ((pg = gc_big_stack_pop(&gc_big_partial_pages[c][b])) != NULL) {
+                if (pg->on_sweep_list)
+                    continue; // will be re-sorted from the sweep-touched list
+                pg->next = untouched;
+                untouched = pg;
+            }
+        }
+        while (untouched != NULL) {
+            pg = untouched;
+            untouched = pg->next;
+            gc_big_dispose_page(pg);
+        }
+    }
+    // Pages orphaned by exiting threads, before the sweep-touched list for the
+    // same reason the per-class stacks are drained first: a page can be on both,
+    // and disposing it twice would push it onto two bucket stacks.
+    jl_gc_bigpagemeta_t *orphan = gc_orphaned_pages;
+    gc_orphaned_pages = NULL;
+    while (orphan != NULL) {
+        jl_gc_bigpagemeta_t *nxt = orphan->next;
+        orphan->next = NULL;
+        if (!orphan->on_sweep_list)
+            gc_big_dispose_page(orphan); // else re-sorted from the list below
+        orphan = nxt;
+    }
+    jl_gc_bigpagemeta_t *pg = gc_sweep_touched_pages;
+    gc_sweep_touched_pages = NULL;
+    while (pg != NULL) {
+        jl_gc_bigpagemeta_t *nxt = pg->sweep_next;
+        pg->sweep_next = NULL;
+        pg->on_sweep_list = 0;
+        if (pg->state != GC_BIG_PAGE_CURRENT)
+            gc_big_dispose_page(pg);
+        pg = nxt;
+    }
+    // Return cold slabs to the OS. Every sweep end is a heap low point, so a
+    // slab that was already free at the end of the previous sweep and is still
+    // free now was not needed for a whole GC cycle; decommit it.
+    for (jl_gc_slabmeta_t *s = gc_free_slabs; s != NULL; s = s->next) {
+        if (!s->resident)
+            continue;
+        if (s->free_sweeps == 0) {
+            s->free_sweeps = 1;
+        }
+        else {
+            gc_slab_decommit(s->data);
+            s->resident = 0;
+        }
+    }
+    uv_mutex_unlock(&gc_big_lock);
+}
+
+// ======================================================================== //
+// pool pages: one slab unit each. Freed units return to their slab's bitmap;
+// memory is returned to the OS only in whole slabs (see
+// jl_gc_big_mem_finish_sweep), which also keeps transparent huge pages intact.
+// ======================================================================== //
 
 JL_DLLEXPORT uint64_t jl_get_pg_size(void)
 {
     return GC_PAGE_SZ;
 }
 
-// Try to allocate memory in chunks to permit faster allocation
-// and improve memory locality of the pools
-#ifdef _P64
-#define DEFAULT_BLOCK_PG_ALLOC (4096) // 64 MB
-#else
-#define DEFAULT_BLOCK_PG_ALLOC (1024) // 16 MB
-#endif
-#define MIN_BLOCK_PG_ALLOC (1) // 16 KB
-
-static int block_pg_cnt = DEFAULT_BLOCK_PG_ALLOC;
-
-void jl_gc_init_page(void)
-{
-    if (GC_PAGE_SZ * block_pg_cnt < jl_page_size)
-        block_pg_cnt = jl_page_size / GC_PAGE_SZ; // exact division
-}
-
-#ifndef MAP_NORESERVE // not defined in POSIX, FreeBSD, etc.
-#define MAP_NORESERVE (0)
-#endif
-
-// Try to allocate a memory block for multiple pages
-// Return `NULL` if allocation failed. Result is aligned to `GC_PAGE_SZ`.
-static char *jl_gc_try_alloc_pages_(int pg_cnt) JL_NOTSAFEPOINT
-{
-    size_t pages_sz = GC_PAGE_SZ * pg_cnt;
-#ifdef _OS_WINDOWS_
-    char *mem = (char*)VirtualAlloc(NULL, pages_sz + GC_PAGE_SZ,
-                                    MEM_RESERVE, PAGE_READWRITE);
-    if (mem == NULL)
-        return NULL;
-#else
-    if (GC_PAGE_SZ > jl_page_size)
-        pages_sz += GC_PAGE_SZ;
-    char *mem = (char*)mmap(0, pages_sz, PROT_READ | PROT_WRITE,
-                            MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (mem == MAP_FAILED)
-        return NULL;
-#endif
-    if (GC_PAGE_SZ > jl_page_size)
-        // round data pointer up to the nearest gc_page_data-aligned
-        // boundary if mmap didn't already do so.
-        mem = (char*)gc_page_data(mem + GC_PAGE_SZ - 1);
-    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_mapped, pages_sz);
-    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_resident, pages_sz);
-    return mem;
-}
-
-// Allocate the memory for a new page. Starts with `block_pg_cnt` number
-// of pages. Decrease 4x every time so that there is enough space for a few
-// more chunks (or other allocations). The final page count is recorded
-// and will be used as the starting count next time. If the page count is
-// smaller `MIN_BLOCK_PG_ALLOC` a `jl_memory_exception` is thrown.
-// Assumes `gc_pages_lock` is acquired, the lock is released before the
-// exception is thrown.
-STATIC_INLINE char *jl_gc_try_alloc_pages(void) JL_NOTSAFEPOINT_LEAVE_ENTER
-{
-    unsigned pg_cnt = block_pg_cnt;
-    char *mem = NULL;
-    while (1) {
-        if (__likely((mem = jl_gc_try_alloc_pages_(pg_cnt))))
-            break;
-        size_t min_block_pg_alloc = MIN_BLOCK_PG_ALLOC;
-        if (GC_PAGE_SZ * min_block_pg_alloc < jl_page_size)
-            min_block_pg_alloc = jl_page_size / GC_PAGE_SZ; // exact division
-        if (pg_cnt >= 4 * min_block_pg_alloc) {
-            pg_cnt /= 4;
-            block_pg_cnt = pg_cnt;
-        }
-        else if (pg_cnt > min_block_pg_alloc) {
-            block_pg_cnt = pg_cnt = min_block_pg_alloc;
-        }
-        else {
-            uv_mutex_unlock(&gc_pages_lock);
-            jl_throw(jl_memory_exception);
-        }
-    }
-    return mem;
-}
-
-// get a new page, either from the freemap
+// get a new page, either from a slab with free units
 // or from the kernel if none are available
 NOINLINE jl_gc_pagemeta_t *jl_gc_alloc_page(void) JL_NOTSAFEPOINT
 {
@@ -105,116 +865,67 @@ NOINLINE jl_gc_pagemeta_t *jl_gc_alloc_page(void) JL_NOTSAFEPOINT
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
 #endif
-    jl_gc_pagemeta_t *meta = NULL;
-
-    // try to get page from `pool_lazily_freed`
-    meta = pop_lf_back(&global_page_pool_lazily_freed);
-    if (meta != NULL) {
-        gc_alloc_map_set(meta->data, GC_PAGE_ALLOCATED);
-        // page is already mapped
-        return meta;
-    }
-
-    // try to get page from `pool_clean`
-    meta = pop_lf_back(&global_page_pool_clean);
+    // try to get a page that was lazily freed during the last sweep
+    jl_gc_pagemeta_t *meta = pop_lf_back(&global_page_pool_lazily_freed);
     if (meta != NULL) {
         gc_alloc_map_set(meta->data, GC_PAGE_ALLOCATED);
         goto exit;
     }
 
-    // try to get page from `pool_freed`
-    meta = pop_lf_back(&global_page_pool_freed);
-    if (meta != NULL) {
-        jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_resident, GC_PAGE_SZ);
-        gc_alloc_map_set(meta->data, GC_PAGE_ALLOCATED);
-        goto exit;
-    }
-
-    uv_mutex_lock(&gc_pages_lock);
-    // another thread may have allocated a large block while we were waiting...
-    meta = pop_lf_back(&global_page_pool_clean);
-    if (meta != NULL) {
-        uv_mutex_unlock(&gc_pages_lock);
-        gc_alloc_map_set(meta->data, GC_PAGE_ALLOCATED);
-        goto exit;
-    }
-    {
-        // must map a new set of pages
-        char *data = jl_gc_try_alloc_pages();
-        meta = (jl_gc_pagemeta_t*)malloc_s(block_pg_cnt * sizeof(jl_gc_pagemeta_t));
-        for (int i = 0; i < block_pg_cnt; i++) {
-            jl_gc_pagemeta_t *pg = &meta[i];
-            pg->data = data + GC_PAGE_SZ * i;
-            gc_alloc_map_maybe_create(pg->data);
-            if (i == 0) {
-                gc_alloc_map_set(pg->data, GC_PAGE_ALLOCATED);
-            }
-            else {
-                push_lf_back(&global_page_pool_clean, pg);
-            }
-        }
-        uv_mutex_unlock(&gc_pages_lock);
-    }
-exit:
+    uv_mutex_lock(&gc_big_lock);
+    int u;
+    jl_gc_slabmeta_t *s = gc_carve_units(1, &u);
+    if (s == NULL) {
+        uv_mutex_unlock(&gc_big_lock);
 #ifdef _OS_WINDOWS_
-    // The page was previously only reserved (jl_gc_try_alloc_pages_) or has been
-    // decommitted (jl_gc_free_page), so it needs to be committed before use. This
-    // charges the page against the system commit limit and can fail when that is
-    // exhausted; returning it anyway would hand out memory that raises an access
-    // violation on first touch, so undo and report out-of-memory instead (as
-    // jl_gc_try_alloc_pages does when the reservation itself fails).
-    if (VirtualAlloc(meta->data, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE) == NULL) {
-        gc_alloc_map_set(meta->data, GC_PAGE_FREED);
-        push_lf_back(&global_page_pool_freed, meta);
-        jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_resident, -(int64_t)GC_PAGE_SZ);
         SetLastError(last_error);
+#endif
         errno = last_errno;
         jl_throw(jl_memory_exception);
     }
+    if (s->pool_pages == NULL)
+        s->pool_pages = (jl_gc_pagemeta_t*)calloc_s(GC_UNITS_PER_SLAB * sizeof(jl_gc_pagemeta_t));
+    meta = &s->pool_pages[u];
+    if (meta->data == NULL) {
+        meta->data = s->data + ((size_t)u << GC_UNIT_LG2);
+        gc_alloc_map_maybe_create(meta->data);
+    }
+    uv_mutex_unlock(&gc_big_lock);
+    gc_alloc_map_set(meta->data, GC_PAGE_ALLOCATED);
+exit:
+#ifdef _OS_WINDOWS_
     SetLastError(last_error);
 #endif
     errno = last_errno;
     return meta;
 }
 
-// return a page to the freemap allocator
+// return a page's unit to its slab; whole-slab decommit happens at the end of sweep
 NOINLINE void jl_gc_free_page(jl_gc_pagemeta_t *pg) JL_NOTSAFEPOINT
 {
-    void *p = pg->data;
-    gc_alloc_map_set((char*)p, GC_PAGE_FREED);
-    // tell the OS we don't need these pages right now
-    size_t decommit_size = GC_PAGE_SZ;
-    if (GC_PAGE_SZ < jl_page_size) {
-        // ensure so we don't release more memory than intended
-        size_t n_pages = jl_page_size / GC_PAGE_SZ; // exact division
-        decommit_size = jl_page_size;
-        void *otherp = (void*)((uintptr_t)p & ~(jl_page_size - 1)); // round down to the nearest physical page
-        p = otherp;
-        while (n_pages--) {
-            if (gc_alloc_map_is_set((char*)otherp)) {
-                return;
-            }
-            otherp = (void*)((char*)otherp + GC_PAGE_SZ);
-        }
+    gc_alloc_map_set(pg->data, GC_PAGE_FREED);
+    msan_unpoison(pg->data, GC_PAGE_SZ);
+    uv_mutex_lock(&gc_big_lock);
+    jl_gc_slabmeta_t *s = gc_slab_map_lookup(pg->data);
+    assert(s != NULL && !s->is_huge);
+    int u = (int)(((uintptr_t)pg->data >> GC_UNIT_LG2) & (GC_UNITS_PER_SLAB - 1));
+    gc_free_units(s, u, 1);
+    uv_mutex_unlock(&gc_big_lock);
+}
+
+void jl_gc_init_big_pages(void)
+{
+    uv_mutex_init(&gc_big_lock);
+    gc_big_class_sz[0] = GC_BIG_CLASS_MIN_SZ;
+    for (int c = 1; c < GC_N_BIG_CLASSES; c++) {
+        int q = (c - 1) / 4, r = (c - 1) % 4;
+        gc_big_class_sz[c] = ((size_t)GC_BIG_CLASS_MIN_SZ << q) +
+            (size_t)(r + 1) * ((size_t)(GC_BIG_CLASS_MIN_SZ / 4) << q);
     }
-#ifdef _OS_WINDOWS_
-    VirtualFree(p, decommit_size, MEM_DECOMMIT);
-#elif defined(MADV_FREE)
-    static int supports_madv_free = 1;
-    if (supports_madv_free) {
-        if (madvise(p, decommit_size, MADV_FREE) == -1) {
-            assert(errno == EINVAL);
-            supports_madv_free = 0;
-        }
-    }
-    if (!supports_madv_free) {
-        madvise(p, decommit_size, MADV_DONTNEED);
-    }
-#else
-    madvise(p, decommit_size, MADV_DONTNEED);
-#endif
-    msan_unpoison(p, decommit_size);
-    jl_atomic_fetch_add_relaxed(&gc_heap_stats.bytes_resident, -decommit_size);
+    assert(gc_big_class_sz[GC_N_BIG_CLASSES - 1] == GC_BIG_CLASS_MAX_SZ);
+    char *env = getenv("JULIA_GC_HUGEPAGES");
+    if (env != NULL && env[0] == '0')
+        gc_use_hugepages = 0;
 }
 
 #ifdef __cplusplus

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -232,36 +232,52 @@ static void gc_slab_decommit(char *data) JL_NOTSAFEPOINT
 
 #define GC_SLAB_BLOCK_NSLABS 32 // 64 MB blocks
 
-static jl_gc_slabmeta_t *gc_partial_slabs; // slabs with some (not all) units free
-static jl_gc_slabmeta_t *gc_free_slabs;    // fully free slabs
+// Slabs with some (not all) units free, bucketed by occupancy so that carving
+// prefers the fullest slab and the emptiest ones drain to wholly free (and so
+// become decommittable). Without this, a slab lands at the head of the list
+// exactly when something in it is freed, and would be the first refilled.
+static jl_gc_slabmeta_t *gc_partial_slabs[GC_OCCUPANCY_BUCKETS];
+static jl_gc_slabmeta_t *gc_free_slabs; // fully free slabs
 
-static void gc_partial_slab_link(jl_gc_slabmeta_t **head, jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
+// Requires `gc_big_lock`. The slab must have some, but not all, units free.
+static void gc_partial_slab_link(jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
 {
+    assert(s->partial_bucket < 0 && "slab is already on a partial list");
+    assert(s->free_unit_map != 0 && s->free_unit_map != UINT32_MAX);
+    int b = gc_occupancy_bucket((size_t)__builtin_popcount(s->free_unit_map) << GC_UNIT_LG2,
+                                GC_SLAB_SZ);
+    s->partial_bucket = (int8_t)b;
     s->prev = NULL;
-    s->next = *head;
-    if (*head != NULL)
-        (*head)->prev = s;
-    *head = s;
+    s->next = gc_partial_slabs[b];
+    if (s->next != NULL)
+        s->next->prev = s;
+    gc_partial_slabs[b] = s;
 }
 
-static void gc_partial_slab_unlink(jl_gc_slabmeta_t **head, jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
+// Requires `gc_big_lock`. No-op if the slab is not on a partial list. The
+// bucket is remembered rather than recomputed, so this stays correct however
+// `free_unit_map` has changed since the slab was linked.
+static void gc_partial_slab_unlink(jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
 {
+    int b = s->partial_bucket;
+    if (b < 0)
+        return;
     if (s->prev != NULL)
         s->prev->next = s->next;
     else
-        *head = s->next;
+        gc_partial_slabs[b] = s->next;
     if (s->next != NULL)
         s->next->prev = s->prev;
     s->next = s->prev = NULL;
+    s->partial_bucket = -1;
 }
 
-// Requires `gc_big_lock`. The slab must be fully free and not on the
+// Requires `gc_big_lock`. The slab must be fully free and not on a
 // partial-slab list.
 static void gc_release_slab(jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
 {
     assert(s->free_unit_map == UINT32_MAX);
-    assert(s->free_segs[0] == NULL && s->free_segs[1] == NULL &&
-           "releasing a slab that still has free segments registered");
+    assert(s->partial_bucket < 0);
     s->next = gc_free_slabs;
     gc_free_slabs = s;
     s->free_sweeps = 0;
@@ -290,6 +306,7 @@ static jl_gc_slabmeta_t *gc_alloc_slab_block(void) JL_NOTSAFEPOINT
         jl_gc_slabmeta_t *s = &metas[i];
         s->data = base + ((size_t)i << GC_SLAB_LG2);
         s->free_unit_map = UINT32_MAX;
+        s->partial_bucket = -1; // wholly free: on the free-slab list, not a partial one
 #ifdef _OS_WINDOWS_
         s->resident = 0;
 #else
@@ -336,32 +353,13 @@ static jl_gc_slabmeta_t *gc_take_slab(void) JL_NOTSAFEPOINT
     return s;
 }
 
-// Segment size levels: 0 -> 1 unit (64 KiB), 1 -> 8 units (512 KiB),
-// 2 -> 32 units (whole slab). A page is always one of these three sizes.
-static const int gc_level_nunits[3] = {1, 8, GC_UNITS_PER_SLAB};
-
-STATIC_INLINE int gc_seg_level(int nunits) JL_NOTSAFEPOINT
-{
-    return nunits == 1 ? 0 : nunits == 8 ? 1 : 2;
-}
-
-// A free segment threads its list links through its own (free) page memory.
-// It carries no size class, so any class of the matching page size can reuse
-// it: only the three page sizes, not the size classes, can fragment.
-typedef struct _gc_free_seg_t {
-    struct _gc_free_seg_t *next;
-    struct _gc_free_seg_t *prev;
-} gc_free_seg_t;
-
-STATIC_INLINE gc_free_seg_t *gc_seg_at(jl_gc_slabmeta_t *s, int u) JL_NOTSAFEPOINT
-{
-    return (gc_free_seg_t*)(s->data + ((size_t)u << GC_UNIT_LG2));
-}
-
-STATIC_INLINE int gc_seg_unit(jl_gc_slabmeta_t *s, gc_free_seg_t *n) JL_NOTSAFEPOINT
-{
-    return (int)(((char*)n - s->data) >> GC_UNIT_LG2);
-}
+// A page is always 1 unit (64 KiB), 8 units (512 KiB), or a whole slab.
+// `free_unit_map` is the only record of which units of a slab are free: runs
+// are found by masking it, and freed runs coalesce implicitly when their bits
+// go back. A free run carries no size class, so any class of the matching page
+// size can reuse it: only the three page sizes, not the size classes, can
+// fragment.
+#define GC_UNITS_PER_MEDIUM 8
 
 // free_unit_map bits for the run of `nunits` units starting at unit `u`
 STATIC_INLINE uint32_t gc_unit_run_mask(int u, int nunits) JL_NOTSAFEPOINT
@@ -369,187 +367,110 @@ STATIC_INLINE uint32_t gc_unit_run_mask(int u, int nunits) JL_NOTSAFEPOINT
     return (nunits >= GC_UNITS_PER_SLAB ? UINT32_MAX : ((uint32_t)1 << nunits) - 1) << u;
 }
 
-#ifndef JL_NDEBUG
-// Requires `gc_big_lock`. The free-segment lists live inside the free page
-// memory itself, so a stale list entry turns the `n->prev->next` store in
-// `gc_seg_unlink` into a wild write that no other invariant would catch.
-// Check the lists against `free_unit_map`, which is the authoritative oracle:
-// every free unit must be covered by exactly one segment, at the right level,
-// aligned to that level, and the links must be consistent both ways.
-static void gc_seg_verify(jl_gc_slabmeta_t *s) JL_NOTSAFEPOINT
+// mask of the units belonging to the 8-unit group containing unit `u`
+STATIC_INLINE uint32_t gc_medium_group_mask(int u) JL_NOTSAFEPOINT
 {
-    uint32_t covered = 0;
-    for (int lvl = 0; lvl < 2; lvl++) {
-        int nunits = gc_level_nunits[lvl];
-        gc_free_seg_t *prev = NULL;
-        int guard = 0;
-        for (gc_free_seg_t *n = (gc_free_seg_t*)s->free_segs[lvl]; n != NULL; n = n->next) {
-            assert(++guard <= GC_UNITS_PER_SLAB && "cycle in free-segment list");
-            assert(n->prev == prev && "broken free-segment back link");
-            int u = gc_seg_unit(s, n);
-            assert(u >= 0 && u < GC_UNITS_PER_SLAB && "free segment outside its slab");
-            assert(u % nunits == 0 && "free segment misaligned for its level");
-            uint32_t run = gc_unit_run_mask(u, nunits);
-            assert((s->free_unit_map & run) == run && "free segment covers an allocated unit");
-            assert((covered & run) == 0 && "free unit covered by two segments");
-            covered |= run;
-            prev = n;
-        }
+    return (uint32_t)0xff << (u & ~(GC_UNITS_PER_MEDIUM - 1));
+}
+
+// Units of `free` that lie in an entirely free 8-unit group. Handing one of
+// these out to a 64 KiB page destroys a 512 KiB page's worth of contiguity.
+STATIC_INLINE uint32_t gc_units_in_full_groups(uint32_t free) JL_NOTSAFEPOINT
+{
+    uint32_t full = 0;
+    for (int u = 0; u < GC_UNITS_PER_SLAB; u += GC_UNITS_PER_MEDIUM) {
+        uint32_t m = gc_medium_group_mask(u);
+        if ((free & m) == m)
+            full |= m;
     }
-    // A fully-free slab is released to the free-slab list and keeps no
-    // segments; every other slab must have each free unit in a segment.
-    assert((covered == s->free_unit_map ||
-            (s->free_unit_map == UINT32_MAX && covered == 0)) &&
-           "free unit not covered by any segment");
-}
-#else
-#define gc_seg_verify(s) ((void)0)
-#endif
-
-// Requires `gc_big_lock`. Push the unit run at `u` onto its slab's level-`lvl`
-// free-segment list.
-STATIC_INLINE void gc_seg_push(jl_gc_slabmeta_t *s, int lvl, int u) JL_NOTSAFEPOINT
-{
-    gc_free_seg_t *n = gc_seg_at(s, u);
-    msan_unpoison(n, sizeof(*n));
-    gc_free_seg_t *head = (gc_free_seg_t*)s->free_segs[lvl];
-    n->prev = NULL;
-    n->next = head;
-    if (head != NULL)
-        head->prev = n;
-    s->free_segs[lvl] = n;
+    return full;
 }
 
-#ifndef JL_NDEBUG
-// Requires `gc_big_lock`. Is `n` really on the level-`lvl` list of `s`?
-static int gc_seg_on_list(jl_gc_slabmeta_t *s, int lvl, gc_free_seg_t *n) JL_NOTSAFEPOINT
+// Requires `gc_big_lock`. First unit of an aligned free run of `nunits` units
+// in some partial slab, or -1 if no partial slab has one. Under
+// `avoid_breakup`, a single unit is taken only from outside an entirely free
+// 8-unit group; the caller retries without it, so a group is broken up only
+// once no loose unit is left in *any* slab -- keeping 512 KiB pages
+// allocatable for as long as possible.
+static int gc_find_in_partials(int nunits, int avoid_breakup,
+                               jl_gc_slabmeta_t **s_out) JL_NOTSAFEPOINT
 {
-    int guard = 0;
-    for (gc_free_seg_t *m = (gc_free_seg_t*)s->free_segs[lvl]; m != NULL; m = m->next) {
-        if (m == n)
-            return 1;
-        if (++guard > GC_UNITS_PER_SLAB)
-            break;
-    }
-    return 0;
-}
-#endif
-
-// Requires `gc_big_lock`. Unlink a known-present segment from its list.
-STATIC_INLINE void gc_seg_unlink(jl_gc_slabmeta_t *s, int lvl, gc_free_seg_t *n) JL_NOTSAFEPOINT
-{
-    // The links live in the free page memory itself, so unlinking a segment
-    // that is not actually on the list stores through whatever the last user of
-    // that page left behind -- i.e. an arbitrary wild write. Catch it here.
-    assert(gc_seg_on_list(s, lvl, n) && "unlinking a free segment that is not on its list");
-    if (n->prev != NULL)
-        n->prev->next = n->next;
-    else
-        s->free_segs[lvl] = n->next;
-    if (n->next != NULL)
-        n->next->prev = n->prev;
-}
-
-// Requires `gc_big_lock`. Return a free run of `gc_level_nunits[lvl]` units,
-// splitting a larger segment (or a fresh slab) when the level is empty.
-// `*s_out` receives the owning slab; returns the first unit or -1 on OOM.
-static int gc_get_segment(int lvl, jl_gc_slabmeta_t **s_out) JL_NOTSAFEPOINT
-{
-    // reuse a same-size free segment from any partial slab; a whole-slab page has
-    // no segment list, since a wholly free slab is on the free-slab list instead
-    if (lvl != 2) {
-        for (jl_gc_slabmeta_t *s = gc_partial_slabs; s != NULL; s = s->next) {
-            gc_free_seg_t *n = (gc_free_seg_t*)s->free_segs[lvl];
-            if (n != NULL) {
-                gc_seg_unlink(s, lvl, n);
-                *s_out = s;
-                return gc_seg_unit(s, n);
+    // Fullest bucket first. Note this is the inner preference: not breaking up
+    // a free 8-unit group loses a whole page size and outranks draining a slab,
+    // so the caller sweeps every bucket with `avoid_breakup` before retrying.
+    for (int b = 0; b < GC_OCCUPANCY_BUCKETS; b++) {
+        for (jl_gc_slabmeta_t *s = gc_partial_slabs[b]; s != NULL; s = s->next) {
+            uint32_t free = s->free_unit_map;
+            int u;
+            if (nunits == 1) {
+                if (avoid_breakup)
+                    free &= ~gc_units_in_full_groups(free);
+                if (free == 0)
+                    continue;
+                u = __builtin_ctz(free);
             }
+            else {
+                assert(nunits == GC_UNITS_PER_MEDIUM);
+                // a whole free slab would be on the free-slab list, not here, so
+                // there is no larger run for this to break up
+                uint32_t groups = gc_units_in_full_groups(free);
+                if (groups == 0)
+                    continue;
+                u = __builtin_ctz(groups);
+            }
+            *s_out = s;
+            return u;
         }
     }
-    else {
-        // a whole-slab page needs a fresh (or wholly free) slab
-        jl_gc_slabmeta_t *s = gc_take_slab();
-        if (s == NULL)
-            return -1;
-        gc_partial_slab_link(&gc_partial_slabs, s);
-        *s_out = s;
-        return 0;
-    }
-    // split a segment one size up: keep the first child, free the rest, so a
-    // whole group is broken only when no loose unit of this size is left.
-    jl_gc_slabmeta_t *s;
-    int pu = gc_get_segment(lvl + 1, &s);
-    if (pu < 0)
-        return -1;
-    int child = gc_level_nunits[lvl];
-    int parent = gc_level_nunits[lvl + 1];
-    for (int off = child; off < parent; off += child)
-        gc_seg_push(s, lvl, pu + off);
-    *s_out = s;
-    return pu;
+    return -1;
 }
 
 // Requires `gc_big_lock`. Claim an aligned run of `nunits` (1, 8, or 32) units.
 // Returns NULL if the OS is out of memory.
 static jl_gc_slabmeta_t *gc_carve_units(int nunits, int *unit_out) JL_NOTSAFEPOINT
 {
-    jl_gc_slabmeta_t *s;
-    int u = gc_get_segment(gc_seg_level(nunits), &s);
-    if (u < 0)
-        return NULL;
+    jl_gc_slabmeta_t *s = NULL;
+    int u = -1;
+    // Reuse space in a slab already in use before committing a fresh one. A
+    // whole-slab page can never fit in a partial slab, so don't bother looking.
+    if (nunits != GC_UNITS_PER_SLAB) {
+        u = gc_find_in_partials(nunits, 1, &s);
+        if (u < 0 && nunits == 1)
+            u = gc_find_in_partials(nunits, 0, &s);
+    }
+    if (u < 0) {
+        s = gc_take_slab(); // arrives on no list
+        if (s == NULL)
+            return NULL;
+        u = 0;
+    }
     assert(u % nunits == 0 && "carved run is misaligned for its size");
     uint32_t run = gc_unit_run_mask(u, nunits);
     assert((s->free_unit_map & run) == run);
+    // relink rather than mutate in place: the slab's occupancy, and hence its
+    // bucket, changes here
+    gc_partial_slab_unlink(s);
     s->free_unit_map &= ~run;
-    if (s->free_unit_map == 0)
-        gc_partial_slab_unlink(&gc_partial_slabs, s); // now full
-    gc_seg_verify(s);
+    if (s->free_unit_map != 0)
+        gc_partial_slab_link(s);
     *unit_out = u;
     return s;
 }
 
-// Requires `gc_big_lock`. Return an aligned run of units to its slab, then
-// coalesce as far up the size levels as the free-unit map allows; a fully-free
-// slab moves to the free-slab list.
+// Requires `gc_big_lock`. Return an aligned run of units to its slab, where it
+// coalesces with any adjacent free run; a fully-free slab moves to the
+// free-slab list, from where it can be decommitted.
 static void gc_free_units(jl_gc_slabmeta_t *s, int u, int nunits) JL_NOTSAFEPOINT
 {
-    int lvl = gc_seg_level(nunits);
-    gc_seg_verify(s);
     assert(u % nunits == 0 && "freed run is misaligned for its size");
     uint32_t run = gc_unit_run_mask(u, nunits);
     assert((s->free_unit_map & run) == 0);
-    int was_full = s->free_unit_map == 0;
+    gc_partial_slab_unlink(s); // no-op for a slab with no free units left
     s->free_unit_map |= run;
-    if (was_full)
-        gc_partial_slab_link(&gc_partial_slabs, s);
-    // coalesce: while the parent-aligned group of this segment is entirely
-    // free, absorb the sibling segments and rise a level.
-    while (lvl < 2) {
-        int parent = gc_level_nunits[lvl + 1];
-        int group = (u / parent) * parent;
-        uint32_t pmask = parent >= GC_UNITS_PER_SLAB ? UINT32_MAX
-                       : (((uint32_t)1 << parent) - 1) << group;
-        if ((s->free_unit_map & pmask) != pmask)
-            break; // parent not fully free: this segment stays at its level
-        int child = gc_level_nunits[lvl];
-        for (int off = 0; off < parent; off += child) {
-            int cu = group + off;
-            if (cu != u) // the freed run is not on any list yet
-                gc_seg_unlink(s, lvl, gc_seg_at(s, cu));
-        }
-        u = group;
-        lvl++;
-    }
-    if (lvl == 2) {
-        // whole slab free
-        gc_partial_slab_unlink(&gc_partial_slabs, s);
+    if (s->free_unit_map == UINT32_MAX)
         gc_release_slab(s);
-    }
-    else {
-        gc_seg_push(s, lvl, u);
-    }
-    gc_seg_verify(s);
+    else
+        gc_partial_slab_link(s);
 }
 
 // ======================================================================== //
@@ -605,6 +526,7 @@ static void *gc_huge_alloc(size_t allocsz, size_t *usable_sz)
         return NULL;
     jl_gc_slabmeta_t *s = (jl_gc_slabmeta_t*)calloc_s(sizeof(jl_gc_slabmeta_t));
     s->is_huge = 1;
+    s->partial_bucket = -1; // huge slabs are never carved into units
     s->data = base;
     s->map_base = raw_base;
     s->map_sz = map_sz;

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -312,7 +312,14 @@ STATIC_INLINE void gc_setmark_pool_(jl_ptls_t ptls, jl_taggedvalue_t *o,
 STATIC_INLINE void gc_setmark_pool(jl_ptls_t ptls, jl_taggedvalue_t *o,
                                    uint8_t mark_mode) JL_NOTSAFEPOINT
 {
-    gc_setmark_pool_(ptls, o, mark_mode, page_metadata((char*)o));
+#ifdef MEMDEBUG
+    gc_setmark_pool_(ptls, o, mark_mode, NULL);
+#else
+    // callers only reach here for pool-allocated objects, so the alloc-map check
+    // in page_metadata() is already known to pass
+    assert(page_metadata_unsafe((char*)o) == page_metadata((char*)o));
+    gc_setmark_pool_(ptls, o, mark_mode, page_metadata_unsafe((char*)o));
+#endif
 }
 
 STATIC_INLINE void gc_setmark(jl_ptls_t ptls, jl_taggedvalue_t *o,
@@ -530,20 +537,21 @@ STATIC_INLINE jl_value_t *jl_gc_big_alloc_inner(jl_ptls_t ptls, size_t sz) JL_CA
     size_t allocsz = LLT_ALIGN(sz + offs, JL_CACHE_BYTE_ALIGNMENT);
     if (allocsz < sz)  // overflow in adding offs, size was "negative"
         jl_throw(jl_memory_exception);
-    bigval_t *v = (bigval_t*)malloc_cache_align(allocsz);
+    size_t usable_sz;
+    bigval_t *v = (bigval_t*)jl_gc_big_mem_alloc(ptls, allocsz, &usable_sz);
     if (v == NULL)
         jl_throw(jl_memory_exception);
     gc_invoke_callbacks(jl_gc_cb_notify_external_alloc_t,
-        gc_cblist_notify_external_alloc, (v, allocsz));
+        gc_cblist_notify_external_alloc, (v, usable_sz));
     jl_atomic_store_relaxed(&ptls->gc_tls_common.gc_num.allocd,
-        jl_atomic_load_relaxed(&ptls->gc_tls_common.gc_num.allocd) + allocsz);
+        jl_atomic_load_relaxed(&ptls->gc_tls_common.gc_num.allocd) + usable_sz);
     jl_atomic_store_relaxed(&ptls->gc_tls_common.gc_num.bigalloc,
         jl_atomic_load_relaxed(&ptls->gc_tls_common.gc_num.bigalloc) + 1);
-    jl_batch_accum_heap_size(ptls, allocsz);
+    jl_batch_accum_heap_size(ptls, usable_sz);
 #ifdef MEMDEBUG
     memset(v, 0xee, allocsz);
 #endif
-    v->sz = allocsz;
+    v->sz = usable_sz;
 #ifndef NDEBUG
     v->header = 0; // must be initialized (and not gc_bigval_sentinel_tag) or gc_big_object_link assertions will get confused
 #endif
@@ -576,7 +584,7 @@ FORCE_INLINE void sweep_unlink_and_free(bigval_t *v) JL_NOTSAFEPOINT
     memset(v, 0xbb, v->sz);
 #endif
     gc_invoke_callbacks(jl_gc_cb_notify_external_free_t, gc_cblist_notify_external_free, (v));
-    jl_free_aligned(v);
+    jl_gc_big_mem_free(v);
 }
 
 static bigval_t *sweep_list_of_young_bigvals(bigval_t *young) JL_NOTSAFEPOINT
@@ -738,12 +746,17 @@ static void jl_gc_free_memory(jl_genericmemory_t *m, int isaligned) JL_NOTSAFEPO
     assert(jl_is_genericmemory(m));
     assert(jl_genericmemory_how(m) == JL_GENERICMEMORY_GCMANAGED);
     char *d = (char*)m->ptr;
-    size_t freed_bytes = memory_block_usable_size(d, isaligned);
-    assert(freed_bytes != 0);
-    if (isaligned)
-        jl_free_aligned(d);
-    else
+    size_t freed_bytes;
+    // aligned buffers come from jl_gc_big_mem_alloc; unaligned ones are
+    // user-provided malloc'd buffers adopted by `unsafe_wrap(own_buffer=true)`
+    if (isaligned) {
+        freed_bytes = jl_gc_big_mem_free(d);
+    }
+    else {
+        freed_bytes = memory_block_usable_size(d, 0);
         free(d);
+    }
+    assert(freed_bytes != 0);
     jl_atomic_store_relaxed(&gc_heap_stats.heap_size,
         jl_atomic_load_relaxed(&gc_heap_stats.heap_size) - freed_bytes);
     gc_num.freed += freed_bytes;
@@ -792,14 +805,12 @@ STATIC_INLINE jl_taggedvalue_t *gc_reset_page(jl_ptls_t ptls2, const jl_gc_pool_
     jl_atomic_store_relaxed(&pg->has_weak_processing, 0);
     pg->prev_nold = 0;
     pg->nold = 0;
-    pg->fl_begin_offset = UINT16_MAX;
-    pg->fl_end_offset = UINT16_MAX;
+    pg->fl_begin_offset = UINT32_MAX;
+    pg->fl_end_offset = UINT32_MAX;
     return beg;
 }
 
 jl_gc_page_stack_t global_page_pool_lazily_freed;
-jl_gc_page_stack_t global_page_pool_clean;
-jl_gc_page_stack_t global_page_pool_freed;
 pagetable_t alloc_map;
 
 // Add a new page to the pool. Discards any pages in `p->newpages` before.
@@ -841,6 +852,11 @@ STATIC_INLINE jl_value_t *jl_gc_small_alloc_inner(jl_ptls_t ptls, int offset,
     // first try to use the freelist
     jl_taggedvalue_t *v = p->freelist;
     if (v != NULL) {
+        // a corrupt free-list entry would otherwise only show up as a fault on use
+        assert(gc_alloc_map_is_set((char*)v) &&
+               "pool free list entry is not in an allocated page");
+        assert(page_metadata_unsafe(v)->osize == p->osize &&
+               "pool free list entry belongs to a different size class");
         jl_taggedvalue_t *next = v->next;
         p->freelist = next;
         if (__unlikely(gc_page_data(v) != gc_page_data(next))) {
@@ -1059,8 +1075,8 @@ FORCE_INLINE int gc_sweep_page_cells(gc_page_profiler_serializer_t *s, jl_gc_pag
         pg->fl_end_offset = (char*)pfl - data;
     }
     else {
-        pg->fl_begin_offset = UINT16_MAX;
-        pg->fl_end_offset = UINT16_MAX;
+        pg->fl_begin_offset = UINT32_MAX;
+        pg->fl_end_offset = UINT32_MAX;
     }
 
     pg->nfree = pg_nfree;
@@ -1167,6 +1183,7 @@ static void gc_sweep_other(jl_ptls_t ptls, int sweep_full) JL_NOTSAFEPOINT
     gc_sweep_foreign_objs();
     sweep_malloced_memory();
     sweep_big(ptls);
+    jl_gc_big_mem_finish_sweep();
     uint64_t t_free_mallocd_memory_end = jl_hrtime();
     gc_num.total_sweep_free_mallocd_memory_time += t_free_mallocd_memory_end - t_free_mallocd_memory_start;
     jl_engine_sweep(gc_all_tls_states);
@@ -1310,7 +1327,7 @@ JL_DLLEXPORT void jl_gc_sweep_stack_pools_and_mtarraylist_buffers(jl_ptls_t ptls
 
 static void gc_pool_sync_nfree(jl_gc_pagemeta_t *pg, jl_taggedvalue_t *last) JL_NOTSAFEPOINT
 {
-    assert(pg->fl_begin_offset != UINT16_MAX);
+    assert(pg->fl_begin_offset != UINT32_MAX);
     char *cur_pg = gc_page_data(last);
     // Fast path for page that has no allocation
     jl_taggedvalue_t *fl_beg = (jl_taggedvalue_t*)(cur_pg + pg->fl_begin_offset);
@@ -1502,7 +1519,6 @@ static void gc_free_pages(void) JL_NOTSAFEPOINT
             continue;
         }
         jl_gc_free_page(pg);
-        push_lf_back(&global_page_pool_freed, pg);
     }
     // If concurrent page sweeping is disabled, then `gc_free_pages` will be called in the stop-the-world
     // phase. We can guarantee, therefore, that there won't be any concurrent modifications to
@@ -1524,6 +1540,26 @@ static void gc_free_pages(void) JL_NOTSAFEPOINT
     }
 }
 
+// A pool's free list is built by splicing each swept page's run of free cells
+// onto one of these chains, then concatenating the chains in bucket order.
+typedef struct {
+    jl_taggedvalue_t *head;
+    jl_taggedvalue_t **tail;
+} gc_fl_chain_t;
+
+// The free list is consumed in stitch order, so linking the fullest pages first
+// (see gc_occupancy_bucket) decides which pages allocation refills.
+STATIC_INLINE int gc_page_fl_bucket(jl_gc_pagemeta_t *pg) JL_NOTSAFEPOINT
+{
+    return gc_occupancy_bucket((size_t)pg->nfree * pg->osize,
+                               GC_PAGE_SZ - GC_PAGE_OFFSET);
+}
+
+STATIC_INLINE size_t gc_fl_index(size_t t_i, int pool_n, int bucket) JL_NOTSAFEPOINT
+{
+    return (t_i * JL_GC_N_POOLS + (size_t)pool_n) * GC_OCCUPANCY_BUCKETS + (size_t)bucket;
+}
+
 // setup the data-structures for a sweep over all memory pools
 static void gc_sweep_pool(void) JL_NOTSAFEPOINT
 {
@@ -1533,20 +1569,17 @@ static void gc_sweep_pool(void) JL_NOTSAFEPOINT
     // doesn't change over the course of this function
     size_t n_threads = gc_n_threads;
 
-    // allocate enough space to hold the end of the free list chain
-    // for every thread and pool size
-    jl_taggedvalue_t ***pfl = (jl_taggedvalue_t ***) malloc_s(n_threads * JL_GC_N_POOLS * sizeof(jl_taggedvalue_t**));
+    // one chain per thread, pool size and occupancy bucket, spliced together in
+    // bucket order once the page walk is done
+    size_t n_fl = n_threads * JL_GC_N_POOLS * GC_OCCUPANCY_BUCKETS;
+    gc_fl_chain_t *fl = (gc_fl_chain_t *) malloc_s(n_fl * sizeof(gc_fl_chain_t));
 
     // update metadata of pages that were pointed to by freelist or newpages from a pool
     // i.e. pages being the current allocation target
     for (int t_i = 0; t_i < n_threads; t_i++) {
         jl_ptls_t ptls2 = gc_all_tls_states[t_i];
-        if (ptls2 == NULL) {
-            for (int i = 0; i < JL_GC_N_POOLS; i++) {
-                pfl[t_i * JL_GC_N_POOLS + i] = NULL;
-            }
-            continue;
-        }
+        if (ptls2 == NULL)
+            continue; // nothing walks or splices the chains of a dead thread
         jl_atomic_store_relaxed(&ptls2->gc_tls_common.gc_num.pool_live_bytes, 0);
         for (int i = 0; i < JL_GC_N_POOLS; i++) {
             jl_gc_pool_t *p = &ptls2->gc_tls.heap.norm_pools[i];
@@ -1557,7 +1590,11 @@ static void gc_sweep_pool(void) JL_NOTSAFEPOINT
                 pg->has_young = 1;
             }
             p->freelist =  NULL;
-            pfl[t_i * JL_GC_N_POOLS + i] = &p->freelist;
+            for (int b = 0; b < GC_OCCUPANCY_BUCKETS; b++) {
+                gc_fl_chain_t *c = &fl[gc_fl_index(t_i, i, b)];
+                c->head = NULL;
+                c->tail = &c->head;
+            }
 
             last = p->newpages;
             if (last != NULL) {
@@ -1601,29 +1638,44 @@ static void gc_sweep_pool(void) JL_NOTSAFEPOINT
             jl_gc_pagemeta_t *pg = jl_atomic_load_relaxed(&ptls2->gc_tls.page_metadata_allocd.bottom);
             while (pg != NULL) {
                 jl_gc_pagemeta_t *pg2 = pg->next;
-                if (pg->fl_begin_offset != UINT16_MAX) {
+                if (pg->fl_begin_offset != UINT32_MAX) {
                     char *cur_pg = pg->data;
+                    assert(pg->pool_n < JL_GC_N_POOLS && "swept page has a bogus pool index");
+                    assert(pg->fl_begin_offset < GC_PAGE_SZ && pg->fl_end_offset < GC_PAGE_SZ &&
+                           "swept page free list offset is out of range");
+                    assert(pg->osize == ptls2->gc_tls.heap.norm_pools[pg->pool_n].osize &&
+                           "swept page size class disagrees with its pool");
                     jl_taggedvalue_t *fl_beg = (jl_taggedvalue_t*)(cur_pg + pg->fl_begin_offset);
                     jl_taggedvalue_t *fl_end = (jl_taggedvalue_t*)(cur_pg + pg->fl_end_offset);
-                    *pfl[t_i * JL_GC_N_POOLS + pg->pool_n] = fl_beg;
-                    pfl[t_i * JL_GC_N_POOLS + pg->pool_n] = &fl_end->next;
+                    gc_fl_chain_t *c = &fl[gc_fl_index(t_i, pg->pool_n, gc_page_fl_bucket(pg))];
+                    *c->tail = fl_beg;
+                    c->tail = &fl_end->next;
                 }
                 pg = pg2;
             }
         }
 
-        // null out terminal pointers of free lists
+        // concatenate the buckets into each pool's free list, fullest pages first
         for (int t_i = 0; t_i < n_threads; t_i++) {
             jl_ptls_t ptls2 = gc_all_tls_states[t_i];
             if (ptls2 != NULL) {
                 for (int i = 0; i < JL_GC_N_POOLS; i++) {
-                    *pfl[t_i * JL_GC_N_POOLS + i] = NULL;
+                    jl_gc_pool_t *p = &ptls2->gc_tls.heap.norm_pools[i];
+                    jl_taggedvalue_t **tail = &p->freelist;
+                    for (int b = 0; b < GC_OCCUPANCY_BUCKETS; b++) {
+                        gc_fl_chain_t *c = &fl[gc_fl_index(t_i, i, b)];
+                        if (c->head != NULL) {
+                            *tail = c->head;
+                            tail = c->tail;
+                        }
+                    }
+                    *tail = NULL;
                 }
             }
         }
 
         // cleanup
-        free(pfl);
+        free(fl);
         free(new_gc_allocd_scratch);
     }
     uint64_t t_page_walk_end = jl_hrtime();
@@ -3850,6 +3902,7 @@ void jl_init_thread_heap(jl_ptls_t ptls)
 
 void jl_free_thread_gc_state(jl_ptls_t ptls)
 {
+    jl_gc_big_mem_thread_exit(ptls);
     jl_gc_markqueue_t *mq = &ptls->gc_tls.mark_queue;
     ws_queue_t *cq = &mq->chunk_queue;
     free_ws_array(jl_atomic_load_relaxed(&cq->array));
@@ -3973,7 +4026,6 @@ void jl_gc_init(void)
     arraylist_new(&image_remset, 0);
     uv_mutex_init(&page_profile_lock);
     uv_mutex_init(&gc_perm_lock);
-    uv_mutex_init(&gc_pages_lock);
     uv_mutex_init(&gc_threads_lock);
     uv_cond_init(&gc_threads_cond);
     uv_sem_init(&gc_sweep_assists_needed, 0);
@@ -3984,7 +4036,7 @@ void jl_gc_init(void)
     oldest_generation_of_bigvals = (bigval_t*)calloc_s(sizeof(bigval_t)); // sentinel
     oldest_generation_of_bigvals->header = gc_bigval_sentinel_tag;
 
-    jl_gc_init_page();
+    jl_gc_init_big_pages();
     jl_gc_debug_init();
 
     arraylist_new(&finalizer_list_marked, 0);
@@ -4119,26 +4171,10 @@ JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz)
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
 #endif
-    #ifdef MADV_HUGEPAGE
-        void *b = NULL;
-        if (allocsz >= 1u<<18u) {
-            b = malloc_page_align(allocsz);
-            if (jl_hugepage_size > 0) {
-                size_t leftover = jl_hugepage_size - (allocsz % jl_hugepage_size);
-                if ((leftover <= allocsz / 4) || (leftover == jl_hugepage_size))  // limit fragmentation
-                    madvise(b, allocsz, MADV_HUGEPAGE);
-            }
-        }
-        else {
-            b = malloc_cache_align(allocsz);
-        }
-    #else
-        void *b = malloc_cache_align(allocsz);
-    #endif
+    size_t allocated_bytes;
+    void *b = jl_gc_big_mem_alloc(ptls, allocsz, &allocated_bytes);
     if (b == NULL)
         jl_throw(jl_memory_exception);
-
-    size_t allocated_bytes = memory_block_usable_size(b, 1);
     assert(allocated_bytes >= allocsz);
     jl_atomic_store_relaxed(&ptls->gc_tls_common.gc_num.allocd,
         jl_atomic_load_relaxed(&ptls->gc_tls_common.gc_num.allocd) + allocated_bytes);
@@ -4314,7 +4350,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p)
             jl_gc_pool_t *pool =
                 gc_all_tls_states[meta->thread_n]->gc_tls.heap.norm_pools +
                 meta->pool_n;
-            if (meta->fl_begin_offset == UINT16_MAX) {
+            if (meta->fl_begin_offset == UINT32_MAX) {
                 // case 2: this is a page on the newpages list
                 jl_taggedvalue_t *newpages = pool->newpages;
                 // Check if the page is being allocated from via newpages

--- a/src/gc-stock.h
+++ b/src/gc-stock.h
@@ -41,11 +41,7 @@
 extern "C" {
 #endif
 
-#ifdef GC_SMALL_PAGE
-#define GC_PAGE_LG2 12 // log2(size of a page)
-#else
-#define GC_PAGE_LG2 14 // log2(size of a page)
-#endif
+#define GC_PAGE_LG2 16 // log2(size of a page)
 #define GC_PAGE_SZ (1 << GC_PAGE_LG2)
 #define GC_PAGE_OFFSET (JL_HEAP_ALIGNMENT - (sizeof(jl_taggedvalue_t) % JL_HEAP_ALIGNMENT))
 
@@ -137,15 +133,13 @@ typedef struct _jl_gc_pagemeta_t {
     // Invalid if pool that owns this page is allocating objects from this page
     uint16_t nfree;
     uint16_t osize;           // Size of each object in this page
-    uint16_t fl_begin_offset; // Offset of first free object in this page
-    uint16_t fl_end_offset;   // Offset of last free object in this page
+    uint32_t fl_begin_offset; // Offset of first free object in this page (UINT32_MAX if none)
+    uint32_t fl_end_offset;   // Offset of last free object in this page
     uint16_t thread_n;        // Thread id of the heap that owns this page
     char *data;               // Pointer to the start of the regions where objects are allocated
 } jl_gc_pagemeta_t;
 
 extern jl_gc_page_stack_t global_page_pool_lazily_freed;
-extern jl_gc_page_stack_t global_page_pool_clean;
-extern jl_gc_page_stack_t global_page_pool_freed;
 
 /*
  * Simple lock-free stack implementation for `jl_gc_page_stack_t`.
@@ -282,38 +276,20 @@ extern gc_heapstatus_t gc_heap_stats;
  *     address spaces by subdividing memory into regions.
  */
 
-#ifdef GC_SMALL_PAGE
-#ifdef _P64
-#define REGION0_PG_COUNT (1 << 16)
-#define REGION1_PG_COUNT (1 << 18)
-#define REGION2_PG_COUNT (1 << 18)
-#define REGION0_INDEX(p) (((uintptr_t)(p) >> 12) & 0xFFFF) // shift by GC_PAGE_LG2
-#define REGION1_INDEX(p) (((uintptr_t)(p) >> 28) & 0x3FFFF)
-#define REGION_INDEX(p)  (((uintptr_t)(p) >> 46) & 0x3FFFF)
-#else
-#define REGION0_PG_COUNT (1 << 10)
-#define REGION1_PG_COUNT (1 << 10)
-#define REGION2_PG_COUNT (1 << 0)
-#define REGION0_INDEX(p) (((uintptr_t)(p) >> 12) & 0x3FF) // shift by GC_PAGE_LG2
-#define REGION1_INDEX(p) (((uintptr_t)(p) >> 22) & 0x3FF)
-#define REGION_INDEX(p)  (0)
-#endif
-#else
 #ifdef _P64
 #define REGION0_PG_COUNT (1 << 16)
 #define REGION1_PG_COUNT (1 << 16)
-#define REGION2_PG_COUNT (1 << 18)
-#define REGION0_INDEX(p) (((uintptr_t)(p) >> 14) & 0xFFFF) // shift by GC_PAGE_LG2
-#define REGION1_INDEX(p) (((uintptr_t)(p) >> 30) & 0xFFFF)
-#define REGION_INDEX(p)  (((uintptr_t)(p) >> 46) & 0x3FFFF)
+#define REGION2_PG_COUNT (1 << 16)
+#define REGION0_INDEX(p) (((uintptr_t)(p) >> 16) & 0xFFFF) // shift by GC_PAGE_LG2
+#define REGION1_INDEX(p) (((uintptr_t)(p) >> 32) & 0xFFFF)
+#define REGION_INDEX(p)  (((uintptr_t)(p) >> 48) & 0xFFFF)
 #else
 #define REGION0_PG_COUNT (1 << 8)
-#define REGION1_PG_COUNT (1 << 10)
+#define REGION1_PG_COUNT (1 << 8)
 #define REGION2_PG_COUNT (1 << 0)
-#define REGION0_INDEX(p) (((uintptr_t)(p) >> 14) & 0xFF) // shift by GC_PAGE_LG2
-#define REGION1_INDEX(p) (((uintptr_t)(p) >> 22) & 0x3FF)
+#define REGION0_INDEX(p) (((uintptr_t)(p) >> 16) & 0xFF) // shift by GC_PAGE_LG2
+#define REGION1_INDEX(p) (((uintptr_t)(p) >> 24) & 0xFF)
 #define REGION_INDEX(p)  (0)
-#endif
 #endif
 
 #define GC_PAGE_UNMAPPED        0
@@ -473,6 +449,19 @@ STATIC_INLINE jl_taggedvalue_t *page_pfl_end(jl_gc_pagemeta_t *p) JL_NOTSAFEPOIN
     return (jl_taggedvalue_t*)(p->data + p->fl_end_offset);
 }
 
+// Partially-free pages are bucketed by occupancy so that allocation refills from
+// the fullest bucket first, leaving the emptiest pages to drain to fully free
+// rather than being topped up. Bucket 0 is the fullest.
+#define GC_OCCUPANCY_BUCKETS 4
+
+STATIC_INLINE int gc_occupancy_bucket(size_t free_bytes, size_t capacity_bytes) JL_NOTSAFEPOINT
+{
+    assert(free_bytes > 0 && free_bytes <= capacity_bytes);
+    // callers pass a constant capacity where they can, so this is a multiply
+    size_t b = (GC_OCCUPANCY_BUCKETS * free_bytes) / capacity_bytes;
+    return (int)(b < GC_OCCUPANCY_BUCKETS ? b : GC_OCCUPANCY_BUCKETS - 1);
+}
+
 extern int gc_first_tid;
 
 STATIC_INLINE int gc_first_parallel_collector_thread_id(void) JL_NOTSAFEPOINT
@@ -533,6 +522,118 @@ STATIC_INLINE void gc_check_ptls_of_parallel_collector_thread(jl_ptls_t ptls) JL
     assert(jl_atomic_load_relaxed(&ptls->gc_state) == JL_GC_PARALLEL_COLLECTOR_THREAD);
 }
 
+// =========================================================================== //
+// Page allocator (gc-pages.c)
+//
+// Serves both the pool pages and, for heap memory larger than the pool limit,
+// big pages -- which come from here instead of malloc.
+// Following mimalloc's design, each "big page" holds a single size class
+// (mimalloc bin spacing: 4 classes per power of two), and the page size for a
+// class is chosen so that a page holds at least 6 objects, bounding the
+// unusable remainder plus rounding waste at roughly 1/6 of the page:
+//  - classes <= 10 KiB:  64 KiB pages
+//  - classes <= 80 KiB:  512 KiB pages
+//  - classes <= 256 KiB: 2 MiB pages (a whole slab)
+//  - larger: "huge" objects, each in its own dedicated OS mapping aligned to
+//    2 MiB.
+// Pages are carved out of 2 MiB slabs as aligned runs of 64 KiB units,
+// tracked by a per-slab bitmap of free units. All page sizes -- including
+// the GC's pool pages, which are one unit -- share the same slabs, and freed
+// runs coalesce implicitly in the bitmap. Slabs come from large (64 MB)
+// 2 MiB-aligned OS mappings and are the unit of commit/decommit and of
+// transparent huge pages.
+//
+// The GC is the synchronization point: memory on these paths is freed only
+// while the world is stopped during sweep, so page free lists have a single
+// writer at any time and need no atomics (unlike mimalloc's design).
+// =========================================================================== //
+
+#define GC_SLAB_LG2 21 // log2(size of a slab)
+#define GC_SLAB_SZ ((size_t)1 << GC_SLAB_LG2)
+// smallest big size class; everything smaller is pool-allocated (or, for
+// MEMDEBUG builds where everything is "big", rounded up to this class)
+#define GC_BIG_CLASS_MIN_SZ 2048
+// largest size class allocated from a shared page (mimalloc's rule: a whole-
+// slab page must hold at least 8); larger allocations get a huge mapping
+#define GC_BIG_CLASS_MAX_SZ (GC_SLAB_SZ / 8)
+// largest class stored in 64 KiB pages resp. 512 KiB pages (>= 6 objects each)
+#define GC_BIG_SMALL_PAGE_MAX_SZ 10240
+#define GC_BIG_MEDIUM_PAGE_MAX_SZ 81920
+// number of big classes: 4 per power of two plus the base class.
+// Must be kept in sync with JL_GC_N_BIG_CLASSES in `src/gc-tls-stock.h`
+#define GC_N_BIG_CLASSES JL_GC_N_BIG_CLASSES
+static_assert(GC_N_BIG_CLASSES == 4 * (GC_SLAB_LG2 - 14) + 1, "");
+
+// big page states
+#define GC_BIG_PAGE_FREE    0 // unused, tracked in its slab's free-page map
+#define GC_BIG_PAGE_CURRENT 1 // some thread's active allocation page
+#define GC_BIG_PAGE_FULL    2 // no free slots; floating until sweep frees one
+#define GC_BIG_PAGE_PARTIAL 3 // has free slots; in the global per-class stack
+
+typedef struct _jl_gc_bigpagemeta_t {
+    struct _jl_gc_bigpagemeta_t *next;       // link in the per-class partial-page stack
+    struct _jl_gc_bigpagemeta_t *sweep_next; // link in the sweep-touched list
+    char *data;     // start of the page (aligned to the page size)
+    void *freelist; // singly-linked list of free slots (threaded through the slots)
+    char *bump;     // start of the never-yet-allocated tail of the page
+    uint32_t nfree; // free slots (freelist plus bump region)
+    uint32_t nobjs; // slot capacity of the page for its current size class
+    uint32_t osize; // slot size (== size class)
+    uint8_t page_lg2; // log2 of the page size (16, 19, or GC_SLAB_LG2)
+    uint8_t szclass;
+    uint8_t state;
+    uint8_t on_sweep_list;
+} jl_gc_bigpagemeta_t;
+
+// slabs are carved at 64 KiB granularity ("units")
+#define GC_UNIT_LG2 16
+static_assert(GC_UNIT_LG2 == GC_PAGE_LG2, "pool pages must be one slab unit");
+#define GC_UNITS_PER_SLAB (1 << (GC_SLAB_LG2 - GC_UNIT_LG2))
+
+typedef struct _jl_gc_slabmeta_t {
+    // links in the partial-slab list (some units free); `next` doubles as the
+    // free-slab list link (all units free)
+    struct _jl_gc_slabmeta_t *next;
+    struct _jl_gc_slabmeta_t *prev;
+    char *data;       // the slab (GC_SLAB_SZ-aligned); for huge, start of the object
+    // base and size of the OS reservation this slab came from. Set on a huge
+    // allocation's own metadata, and on the first slab of a slab block (where
+    // it only keeps the reservation releasable; blocks are never unmapped).
+    void *map_base;
+    size_t map_sz;
+    size_t usable_sz; // bytes charged to the heap (huge only)
+    uint8_t is_huge;
+    uint8_t resident;     // memory is committed / not madvised away
+    uint8_t free_sweeps;  // sweeps ended with this slab fully free (see finish_sweep)
+    uint32_t free_unit_map; // bitmap of free 64 KiB units (coalescing oracle)
+    // heads of the free-segment lists, one per shared page size (1 and 8 units);
+    // a wholly free slab is released to the free-slab list instead
+    void *free_segs[2];
+    // first unit of the big page covering each unit (meaningless for units
+    // holding pool pages, which are looked up through their own metadata)
+    uint8_t unit_page_start[GC_UNITS_PER_SLAB];
+    // metadata for big pages carved from this slab; entry i describes the
+    // page starting at unit i (lazily allocated, then kept)
+    jl_gc_bigpagemeta_t *pages;
+    // metadata for pool pages carved from this slab, one per unit
+    // (lazily allocated, then kept)
+    struct _jl_gc_pagemeta_t *pool_pages;
+} jl_gc_slabmeta_t;
+
+extern uv_mutex_t gc_big_lock;
+void jl_gc_init_big_pages(void);
+// Allocate `allocsz` bytes (64-byte aligned). Returns NULL on OOM. Stores the
+// number of bytes actually reserved for the allocation in `*usable_sz`.
+void *jl_gc_big_mem_alloc(jl_ptls_t ptls, size_t allocsz, size_t *usable_sz);
+// Free an allocation made by `jl_gc_big_mem_alloc`, returning its usable size.
+// May only be called while the world is stopped during GC sweep.
+size_t jl_gc_big_mem_free(void *p) JL_NOTSAFEPOINT;
+// Redistribute swept pages and return fully-free memory to the OS.
+// Must be called at the end of sweep, after the last `jl_gc_big_mem_free`.
+void jl_gc_big_mem_finish_sweep(void) JL_NOTSAFEPOINT;
+// Release the current allocation pages of a thread that is shutting down.
+void jl_gc_big_mem_thread_exit(jl_ptls_t ptls) JL_NOTSAFEPOINT;
+
 extern uintptr_t gc_bigval_sentinel_tag;
 extern bigval_t *oldest_generation_of_bigvals;
 
@@ -591,8 +692,6 @@ void jl_gc_debug_init(void) JL_NOTSAFEPOINT;
 extern uv_mutex_t gc_perm_lock;
 
 // GC pages
-extern uv_mutex_t gc_pages_lock;
-void jl_gc_init_page(void) JL_NOTSAFEPOINT;
 NOINLINE jl_gc_pagemeta_t *jl_gc_alloc_page(void) JL_NOTSAFEPOINT;
 NOINLINE void jl_gc_free_page(jl_gc_pagemeta_t *p) JL_NOTSAFEPOINT;
 

--- a/src/gc-stock.h
+++ b/src/gc-stock.h
@@ -605,10 +605,12 @@ typedef struct _jl_gc_slabmeta_t {
     uint8_t is_huge;
     uint8_t resident;     // memory is committed / not madvised away
     uint8_t free_sweeps;  // sweeps ended with this slab fully free (see finish_sweep)
-    uint32_t free_unit_map; // bitmap of free 64 KiB units (coalescing oracle)
-    // heads of the free-segment lists, one per shared page size (1 and 8 units);
-    // a wholly free slab is released to the free-slab list instead
-    void *free_segs[2];
+    // occupancy bucket whose partial-slab list this slab is on, or -1 for none
+    int8_t partial_bucket;
+    // bitmap of free 64 KiB units: the only record of which units are in use,
+    // so freed runs coalesce implicitly and only the three page sizes -- not
+    // the size classes -- can fragment
+    uint32_t free_unit_map;
     // first unit of the big page covering each unit (meaningless for units
     // holding pool pages, which are looked up through their own metadata)
     uint8_t unit_page_start[GC_UNITS_PER_SLAB];

--- a/src/gc-tls-stock.h
+++ b/src/gc-tls-stock.h
@@ -51,8 +51,14 @@ typedef struct {
     _Atomic(struct _jl_gc_pagemeta_t *) bottom;
 } jl_gc_page_stack_t;
 
+// Big size classes (2 KiB - 256 KiB), 4 per power of two.
+// Must be kept in sync with `src/gc-stock.h`
+#define JL_GC_N_BIG_CLASSES 29
+
 typedef struct {
     jl_thread_heap_t heap;
+    // current allocation page for each big size class
+    struct _jl_gc_bigpagemeta_t *big_pages[JL_GC_N_BIG_CLASSES];
     jl_gc_page_stack_t page_metadata_allocd;
     jl_gc_markqueue_t mark_queue;
     jl_gc_mark_cache_t gc_cache;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -542,7 +542,11 @@ JL_DLLEXPORT int jl_gc_classify_pools(size_t sz, int *osize) JL_NOTSAFEPOINT;
 extern arraylist_t image_remset;
 extern jl_mutex_t image_remset_lock;
 
-// pools are 16376 bytes large (GC_POOL_SZ - GC_PAGE_OFFSET)
+// Pool size classes use mimalloc's bin spacing: 8-byte spacing through 64
+// bytes, then 4 bins per power of two (relative waste <= 1/8) up to 10240,
+// mimalloc's small-object max for a 64 KiB page (waste <= ~page/6).
+// The classes that are not multiples of 16 (24, 40, 56) can only be reached
+// through `jl_gc_szclass_align8`; `jl_gc_szclass` skips them.
 static const int jl_gc_sizeclasses[] = {
 #ifdef _P64
     8,
@@ -553,55 +557,24 @@ static const int jl_gc_sizeclasses[] = {
 #else
     4, 8, 12,
 #endif
-
-    // 16 pools at 8-byte spacing
-    // the 8-byte aligned pools are only used for Strings
-    16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136,
-    // 8 pools at 16-byte spacing
-    144, 160, 176, 192, 208, 224, 240, 256,
-
-    // the following tables are computed for maximum packing efficiency via the formula:
-    // pg = GC_SMALL_PAGE ? 2^12 : 2^14
-    // sz = (div.(pg-8, rng).÷16)*16; hcat(sz, (pg-8).÷sz, pg .- (pg-8).÷sz.*sz)'
-
-#ifdef GC_SMALL_PAGE
-    // rng = 15:-1:2 (14 pools)
-    272, 288, 304, 336, 368, 400, 448, 496, 576, 672, 816, 1008, 1360, 2032
-//  15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, /pool
-//  16, 64, 144, 64, 48, 96, 64, 128, 64, 64, 16, 64, 16, 32, bytes lost
-#else
-    // rng = 60:-4:32 (8 pools)
-    272, 288, 304, 336, 368, 400, 448, 496,
-//  60, 56, 53, 48, 44, 40, 36, 33, /pool
-//  64, 256, 272, 256, 192, 384, 256,  16, bytes lost
-
-    // rng = 30:-2:16 (8 pools)
-    544, 576, 624, 672, 736, 816, 896, 1008,
-//  30, 28, 26, 24, 22, 20, 18, 16, /pool
-//  64, 256, 160, 256, 192,  64, 256, 256, bytes lost
-
-    // rng = 15:-1:8 (8 pools)
-    1088, 1168, 1248, 1360, 1488, 1632, 1808, 2032
-//   15, 14, 13, 12, 11, 10, 9, 8, /pool
-//   64, 32, 160, 64, 16, 64, 112,  128, bytes lost
-#endif
+    // 7 bins at 8-byte spacing
+    16, 24, 32, 40, 48, 56, 64,
+    // 4 bins per power of two
+    80, 96, 112, 128,
+    160, 192, 224, 256,
+    320, 384, 448, 512,
+    640, 768, 896, 1024,
+    1280, 1536, 1792, 2048,
+    2560, 3072, 3584, 4096,
+    5120, 6144, 7168, 8192,
+    10240
 };
-#ifdef GC_SMALL_PAGE
 #ifdef _P64
+#  define JL_GC_N_POOLS 37
+#elif MAX_ALIGN > 4
+#  define JL_GC_N_POOLS 38
+#else
 #  define JL_GC_N_POOLS 39
-#elif MAX_ALIGN > 4
-#  define JL_GC_N_POOLS 40
-#else
-#  define JL_GC_N_POOLS 41
-#endif
-#else
-#ifdef _P64
-#  define JL_GC_N_POOLS 49
-#elif MAX_ALIGN > 4
-#  define JL_GC_N_POOLS 50
-#else
-#  define JL_GC_N_POOLS 51
-#endif
 #endif
 static_assert(sizeof(jl_gc_sizeclasses) / sizeof(jl_gc_sizeclasses[0]) == JL_GC_N_POOLS, "");
 
@@ -627,47 +600,50 @@ STATIC_INLINE int jl_gc_alignment(size_t sz) JL_NOTSAFEPOINT
 }
 JL_DLLEXPORT int jl_alignment(size_t sz) JL_NOTSAFEPOINT;
 
-// the following table is computed as:
-// [searchsortedfirst(jl_gc_sizeclasses, i) - 1 for i = 0:16:jl_gc_sizeclasses[end]]
-static const uint8_t szclass_table[] =
-#ifdef GC_SMALL_PAGE
-    {0,1,3,5,7,9,11,13,15,17,18,19,20,21,22,23,24,25,26,27,28,28,29,29,30,30,31,31,31,32,32,32,33,33,33,33,33,34,34,34,34,34,34,35,35,35,35,35,35,35,35,35,36,36,36,36,36,36,36,36,36,36,36,36,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38};
-#else
-    {0,1,3,5,7,9,11,13,15,17,18,19,20,21,22,23,24,25,26,27,28,28,29,29,30,30,31,31,31,32,32,32,33,33,33,34,34,35,35,35,36,36,36,37,37,37,37,38,38,38,38,38,39,39,39,39,39,40,40,40,40,40,40,40,41,41,41,41,41,42,42,42,42,42,43,43,43,43,43,44,44,44,44,44,44,44,45,45,45,45,45,45,45,45,46,46,46,46,46,46,46,46,46,47,47,47,47,47,47,47,47,47,47,47,48,48,48,48,48,48,48,48,48,48,48,48,48,48};
-#endif
-static_assert(sizeof(szclass_table) == 128, "");
+// Index of the class for `sz > 64` in `jl_gc_sizeclasses`, whose bins above 64
+// are 4 per power of two: for sz in (2^b, 2^(b+1)], bins are spaced 2^(b-2).
+// `N` is the number of arch-specific classes preceding the 16..64 bins.
+STATIC_INLINE uint8_t JL_CONST_FUNC jl_gc_szclass_big(unsigned sz, int N) JL_NOTSAFEPOINT
+{
+    unsigned b = 31 - __builtin_clz(sz - 1); // sz in (2^b, 2^(b+1)], b >= 6
+    unsigned sub = (sz - (1u << b) - 1) >> (b - 2);
+    return N + 7 + 4 * (b - 6) + sub;
+}
 
 STATIC_INLINE uint8_t JL_CONST_FUNC jl_gc_szclass(unsigned sz) JL_NOTSAFEPOINT
 {
-    assert(sz <= 2032);
+    assert(sz <= 10240);
 #ifdef _P64
     if (sz <= 8)
         return 0;
-    const int N = 0;
+    const int N = 1;
 #elif MAX_ALIGN > 4
     if (sz <= 8)
         return (sz >= 4 ? 1 : 0);
-    const int N = 1;
+    const int N = 2;
 #else
     if (sz <= 12)
         return (sz >= 8 ? 2 : (sz >= 4 ? 1 : 0));
-    const int N = 2;
+    const int N = 3;
 #endif
-    uint8_t klass = szclass_table[(sz + 15) / 16];
-    return klass + N;
+    if (sz <= 64) // 16-byte aligned bins 16, 32, 48, 64
+        return N + 2 * ((sz + 15) / 16) - 2;
+    return jl_gc_szclass_big(sz, N);
 }
 
+// Strings only need 8-byte alignment, so they may also use the bins between
+// the 16-byte aligned ones (24, 40, 56).
 STATIC_INLINE uint8_t JL_CONST_FUNC jl_gc_szclass_align8(unsigned sz) JL_NOTSAFEPOINT
 {
-    if (sz >= 16 && sz <= 152) {
+    if (sz >= 16 && sz <= 64) {
 #ifdef _P64
-        const int N = 0;
-#elif MAX_ALIGN > 4
         const int N = 1;
-#else
+#elif MAX_ALIGN > 4
         const int N = 2;
+#else
+        const int N = 3;
 #endif
-        return (sz + 7)/8 - 1 + N;
+        return N + (sz + 7)/8 - 2;
     }
     return jl_gc_szclass(sz);
 }
@@ -675,7 +651,7 @@ STATIC_INLINE uint8_t JL_CONST_FUNC jl_gc_szclass_align8(unsigned sz) JL_NOTSAFE
 #define JL_SMALL_BYTE_ALIGNMENT 16
 // JL_HEAP_ALIGNMENT is the maximum alignment that the GC can provide
 #define JL_HEAP_ALIGNMENT JL_SMALL_BYTE_ALIGNMENT
-#define GC_MAX_SZCLASS (2032-sizeof(void*))
+#define GC_MAX_SZCLASS (10240-sizeof(void*))
 static_assert(ARRAY_CACHE_ALIGN_THRESHOLD > GC_MAX_SZCLASS, "");
 
 /* Programming style note: When using jl_gc_alloc, do not JL_GC_PUSH it into a

--- a/src/llvm-final-gc-lowering-stock.cpp
+++ b/src/llvm-final-gc-lowering-stock.cpp
@@ -19,6 +19,13 @@ Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
         // This is strongly architecture and OS dependent
         int osize;
         int offset = jl_gc_classify_pools(sz, &osize);
+        // `offset` is baked into the emitted code, so codegen's view of the ptls
+        // layout must match the runtime's. A stale object file here silently
+        // corrupts the heap on the first pool allocation, so check it.
+        assert((offset < 0 ||
+                (offset == (int)(intptr_t)&((jl_ptls_t)0)->gc_tls.heap.norm_pools[jl_gc_szclass(sz + sizeof(jl_taggedvalue_t))] &&
+                 osize == jl_gc_sizeclasses[jl_gc_szclass(sz + sizeof(jl_taggedvalue_t))])) &&
+               "codegen and runtime disagree about the GC pool layout");
         if (offset < 0) {
             newI = builder.CreateCall(
                 bigAllocFunc,

--- a/src/options.h
+++ b/src/options.h
@@ -19,8 +19,10 @@
 #define ARRAY_INLINE_NBYTES (2048*sizeof(void*))
 
 // Arrays at least this size will get larger alignment (JL_CACHE_BYTE_ALIGNMENT).
-// Must be bigger than GC_MAX_SZCLASS.
-#define ARRAY_CACHE_ALIGN_THRESHOLD 2048
+// Must be bigger than GC_MAX_SZCLASS: a pooled buffer is stored inline in its
+// Memory object and so only gets JL_SMALL_BYTE_ALIGNMENT, hence only buffers
+// too large to pool can promise cache alignment.
+#define ARRAY_CACHE_ALIGN_THRESHOLD 10240
 
 // codegen options ------------------------------------------------------------
 
@@ -76,8 +78,6 @@
 
 // pool allocator configuration options
 
-// GC_SMALL_PAGE allocates objects in 4k pages
-// #define GC_SMALL_PAGE
 
 
 // method dispatch profiling --------------------------------------------------

--- a/test/core.jl
+++ b/test/core.jl
@@ -4982,8 +4982,8 @@ partialsort(a,b) = 0
 end
 @test M15455.partialsort(1,2)==0
 
-# check that medium-sized array is 64-byte aligned (#15139)
-@test Int(pointer(Vector{Float64}(undef, 1024))) % 64 == 0
+# too large to pool, so cache-aligned (#15139); see ARRAY_CACHE_ALIGN_THRESHOLD
+@test Int(pointer(Vector{Float64}(undef, 4096))) % 64 == 0
 
 # PR #15413
 # Make sure arrayset can handle `Array{T}` (where `T` is a type and not a

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -26,8 +26,8 @@ end
 
 function run_pg_size_test()
     page_size = @ccall jl_get_pg_size()::UInt64
-    # supported page sizes: 4KB and 16KB
-    @test page_size == (1 << 12) || page_size == (1 << 14)
+    # supported page sizes: 4KB, 16KB and 64KB
+    @test page_size == (1 << 12) || page_size == (1 << 14) || page_size == (1 << 16)
 end
 
 function issue_54275_alloc_string()


### PR DESCRIPTION
Use a vaguely mimalloc v3 inspired design with a few changes (we know all our free's happen during GC so we be a bit simpler and smarter.

The strategy is:
1. get memory from the OS in 64mb slabs.
2. These chunks can be broken into pages of 64kib, 256kib, or 2mb holding objects of <8kib, 64kib and <256kib respectively.
3. Bigger objects are mmaped directly.
4.  Upon GC, re-order pages to allocate from the most full pages first, and then from pages that are adjacent to other pages of the same size (buddy allocator-like) to minimize fragmentation.

GCbenchmarks show some improvements (~10% very noisy) but I definitely want more thorough benchmarks before even thinking about merging.