### PR TITLE
signals: report fault location for crashes on foreign threads

### DIFF
--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -10,6 +10,10 @@
 #ifndef _OS_WINDOWS_
 #include <sys/mman.h>
 #endif
+#ifdef _OS_LINUX_
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -733,6 +737,9 @@ void jl_fprint_critical_error(ios_t *s, int sig, int si_code, bt_context_t *cont
     jl_bt_element_t *bt_data = ct ? ct->ptls->bt_data : NULL;
     size_t *bt_size = ct ? &ct->ptls->bt_size : NULL;
     size_t i, n = ct ? *bt_size : 0;
+    // Threads unknown to Julia have no ptls, and hence no pre-allocated
+    // backtrace buffer; a small stack buffer is used for them instead.
+    jl_bt_element_t bt_data_foreign[JL_BT_MAX_ENTRY_SIZE * 8];
     if (sig) {
         // kill this task, so that we cannot get back to it accidentally (via an untimely ^C or jl_fprint_backtrace in jl_exit)
         // and also resets the state of ct and ptls so that some code can run on this task again
@@ -771,9 +778,29 @@ void jl_fprint_critical_error(ios_t *s, int sig, int si_code, bt_context_t *cont
         // is properly rooted.
         *bt_size = n = rec_backtrace_ctx(bt_data, JL_MAX_BT_SIZE, context, NULL);
     }
+    else if (context) {
+        // The faulting thread was not created or adopted by Julia (e.g. a
+        // thread started by foreign code that crashed without ever calling
+        // into Julia), so it has no Julia task or backtrace buffer. Record a
+        // native-only backtrace into the local buffer instead, so that at
+        // least the faulting instruction pointer is reported.
+#ifdef _OS_LINUX_
+        char thread_name[16]; // the kernel limits thread names to 16 bytes (TASK_COMM_LEN)
+        if (prctl(PR_GET_NAME, (unsigned long)thread_name, 0, 0, 0) != 0)
+            thread_name[0] = '\0';
+        jl_safe_fprintf(s, "unknown thread \"%s\" (os tid %ld); this thread is not managed by Julia, no Julia backtrace available\n",
+                        thread_name, (long)syscall(SYS_gettid));
+#else
+        jl_safe_fprintf(s, "unknown thread; this thread is not managed by Julia, no Julia backtrace available\n");
+#endif
+        bt_data = bt_data_foreign;
+        n = rec_backtrace_ctx(bt_data, sizeof(bt_data_foreign) / sizeof(jl_bt_element_t), context, NULL);
+    }
     for (i = 0; i < n; i += jl_bt_entry_size(bt_data + i)) {
         jl_fprint_bt_entry_codeloc(s, bt_data + i);
     }
+    if (n == 0 && context)
+        jl_safe_fprintf(s, "no backtrace could be recorded from the signal context\n");
     jl_gc_debug_fprint_status(s);
     jl_gc_debug_fprint_critical_error(s);
 }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -356,6 +356,10 @@ static void sigdie_handler(int sig, siginfo_t *info, void *context) JL_CANSAFEPO
     uv_tty_reset_mode();
     if (sig == SIGILL)
         jl_fprint_sigill(ios_safe_stderr, context);
+    // si_addr is only valid for fault-generated signals (positive si_code),
+    // not for signals sent by kill/sigqueue and friends
+    if ((sig == SIGSEGV || sig == SIGBUS) && info->si_code > 0)
+        jl_safe_fprintf(ios_safe_stderr, "Fault at memory address: %p\n", info->si_addr);
     jl_task_t *ct = jl_get_current_task();
     jl_fprint_critical_error(ios_safe_stderr, sig, info->si_code, jl_to_bt_context(context), ct);
     if (ct)


### PR DESCRIPTION
🤖 When a fatal signal (e.g. SIGSEGV) arrives on a thread that Julia did not create or adopt, `jl_fprint_critical_error` has no ptls backtrace buffer to use, so it printed no frames at all -- not even the faulting instruction pointer. For example, a segfault in foreign code on such a thread (observed with a juliac-compiled shared library running under a foreign host runtime) produced only:

    [2] signal 11 (1): Segmentation fault
    in expression starting at none:0
    Allocations: 1318316 (Pool: 1318267; Big: 49); GC: 2

which gives nothing to debug with, even though the signal context is available at that point. Diagnosing such crashes previously required installing a custom chained signal handler just to learn the pc and thread identity.

Improve the crash report in this situation:

- If the crashing thread has no Julia task context, record a native-only backtrace from the signal context into a small stack buffer (all of the machinery involved -- `rec_backtrace_ctx`, safe-restore, and `jl_fprint_native_codeloc` -- is already safe to use on unmanaged threads), and note the OS thread id and name (Linux) so the thread can be identified.
- Print the fault address (`si_addr`) for kernel-generated SIGSEGV and SIGBUS, in the same place `jl_fprint_sigill` prints its extra fault detail.
- If backtrace collection yields no frames at all, say so explicitly instead of printing nothing.

The report for crashes on Julia-managed threads is unchanged apart from the new fault address line.