### PR TITLE
inference: Simplify `PartialTask` and restore per-builtin `CallInfo` types

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -2595,7 +2595,7 @@ function abstract_finalizer(interp::AbstractInterpreter, argtypes::Vector{Any}, 
         finalizer_argvec = Any[argtypes[2], argtypes[3]]
         call = abstract_call(interp, ArgInfo(nothing, finalizer_argvec), StmtInfo(false, false), vtypes, sv, #=max_methods=#1)::Future
         return Future{CallMeta}(call, interp, sv) do call, _, _
-            return CallMeta(Nothing, Any, Effects(), IndirectCallInfo(call.info, call.effects, false))
+            return CallMeta(Nothing, Any, Effects(), FinalizerInfo(call.info, call.effects))
         end
     end
     return Future(CallMeta(Nothing, Any, Effects(), NoCallInfo()))
@@ -3527,11 +3527,12 @@ function abstract_eval_task_builtin(interp::AbstractInterpreter, arginfo::ArgInf
 end
 
 # Convert the `CallMeta` of the task body call into the `CallMeta` of the `Core._task`
-# call that creates it, tracking the body's result type with a `PartialTask`.
+# call that creates it, tracking the body's result type with a `PartialTask` and keeping
+# its call information for the inlining pass.
 function task_callmeta(call::CallMeta, ::AbstractInterpreter, ::AbsIntState)
     fetch_type = widenconst(call.rt)
     rt_result = fetch_type === Any ? Task : PartialTask(fetch_type)
-    info_result = IndirectCallInfo(call.info, call.effects, true)
+    info_result = TaskCallInfo(call.info)
     return CallMeta(rt_result, Any, TASK_BUILTIN_EFFECTS, info_result)
 end
 

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3527,15 +3527,10 @@ function abstract_eval_task_builtin(interp::AbstractInterpreter, arginfo::ArgInf
 end
 
 # Convert the `CallMeta` of the task body call into the `CallMeta` of the `Core._task`
-# call that creates it, tracking the body's result/error types with a `PartialTask`.
+# call that creates it, tracking the body's result type with a `PartialTask`.
 function task_callmeta(call::CallMeta, ::AbstractInterpreter, ::AbsIntState)
     fetch_type = widenconst(call.rt)
-    fetch_error = widenconst(call.exct)
-    if fetch_type === Any && fetch_error === Any
-        rt_result = Task
-    else
-        rt_result = PartialTask(fetch_type, fetch_error)
-    end
+    rt_result = fetch_type === Any ? Task : PartialTask(fetch_type)
     info_result = IndirectCallInfo(call.info, call.effects, true)
     return CallMeta(rt_result, Any, TASK_BUILTIN_EFFECTS, info_result)
 end

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1198,10 +1198,10 @@ function narrow_opaque_closure!(ir::IRCode, stmt::Expr, @nospecialize(info::Call
     return nothing
 end
 
-function handle_task_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallInfo, state::InliningState)
-    length(stmt.args) == 3 || return
+function handle_task_call!(ir::IRCode, idx::Int, stmt::Expr, info::TaskCallInfo, state::InliningState)
+    length(stmt.args) == 3 || return nothing
     # Extract the CodeInstance from the inference result if available
-    info_edge = extract_indirect_invoke(info)
+    info_edge = extract_indirect_invoke(info.info)
     info_edge === nothing && return nothing
     info, edge = info_edge
     case = compileable_specialization(edge, Effects(), InliningEdgeTracker(state), info, state)
@@ -1216,8 +1216,7 @@ function handle_task_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallI
     return nothing
 end
 
-function extract_indirect_invoke(info::IndirectCallInfo)
-    info = info.info
+function extract_indirect_invoke(@nospecialize info::CallInfo)
     info isa MethodResultPure && (info = info.info)
     info isa MethodMatchInfo || return nothing
     length(info.edges) == length(info.results) == 1 || return nothing
@@ -1522,8 +1521,8 @@ function handle_opaque_closure_call!(todo::Vector{Pair{Int,Any}},
     return nothing
 end
 
-function handle_modifyop!_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallInfo, state::InliningState)
-    info_edge = extract_indirect_invoke(info)
+function handle_modifyop!_call!(ir::IRCode, idx::Int, stmt::Expr, info::ModifyOpInfo, state::InliningState)
+    info_edge = extract_indirect_invoke(info.info)
     info_edge === nothing && return nothing
     info, edge = info_edge
     case = compileable_specialization(edge, Effects(), InliningEdgeTracker(state), info, state)
@@ -1534,7 +1533,7 @@ function handle_modifyop!_call!(ir::IRCode, idx::Int, stmt::Expr, info::Indirect
     return nothing
 end
 
-function handle_finalizer_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallInfo,
+function handle_finalizer_call!(ir::IRCode, idx::Int, stmt::Expr, info::FinalizerInfo,
                                 state::InliningState)
     # Finalizers don't return values, so if their execution is not observable,
     # we can just not register them
@@ -1644,22 +1643,16 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
         end
 
         # handle special cased builtins
-        f = sig.f
         if isa(info, OpaqueClosureCallInfo)
             handle_opaque_closure_call!(todo, ir, idx, stmt, info, flag, sig, state)
-        elseif isa(info, IndirectCallInfo)
-            if f === Core.finalizer
-                handle_finalizer_call!(ir, idx, stmt, info, state)
-            elseif f === modifyfield! ||
-                   f === Core.modifyglobal! ||
-                   f === Core.memoryrefmodify! ||
-                   f === atomic_pointermodify
-                handle_modifyop!_call!(ir, idx, stmt, info, state)
-            elseif f === Core._task
-                handle_task_call!(ir, idx, stmt, info, state)
-            end
-        elseif f === Core.invoke
+        elseif isa(info, ModifyOpInfo)
+            handle_modifyop!_call!(ir, idx, stmt, info, state)
+        elseif isa(info, TaskCallInfo)
+            handle_task_call!(ir, idx, stmt, info, state)
+        elseif sig.f === Core.invoke
             handle_invoke_call!(todo, ir, idx, stmt, info, flag, sig, state)
+        elseif isa(info, FinalizerInfo)
+            handle_finalizer_call!(ir, idx, stmt, info, state)
         else
             # cascade to the generic (and extendable) handler
             handle_call!(todo, ir, idx, stmt, info, flag, sig, state)

--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -1398,7 +1398,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
         elseif is_known_call(stmt, Core.finalizer, compact)
             3 <= length(stmt.args) <= 5 || continue
             info = compact[SSAValue(idx)][:info]
-            if isa(info, IndirectCallInfo)
+            if isa(info, FinalizerInfo)
                 is_finalizer_inlineable(info.effects) || continue
             else
                 # Inlining performs legality checks on the finalizer to determine
@@ -1785,7 +1785,7 @@ function try_resolve_finalizer!(ir::IRCode, alloc_idx::Int, finalizer_idx::Int, 
 
     finalizer_stmt = ir[SSAValue(finalizer_idx)][:stmt]
     argexprs = Any[finalizer_stmt.args[2], finalizer_stmt.args[3]]
-    flag = isa(info, IndirectCallInfo) ? flags_for_effects(info.effects) : IR_FLAG_NULL
+    flag = isa(info, FinalizerInfo) ? flags_for_effects(info.effects) : IR_FLAG_NULL
     if length(finalizer_stmt.args) >= 4
         inline = finalizer_stmt.args[4]
         if inline === nothing

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -441,31 +441,44 @@ end
 add_edges_impl(edges::Vector{Any}, info::ReturnTypeCallInfo) = add_edges!(edges, info.info)
 
 """
-    info::IndirectCallInfo <: CallInfo
+    info::FinalizerInfo <: CallInfo
 
-Represents information about a call that involves an indirect/nested function call.
-Used for:
- - `modifyfield!(obj, name, op, x, [order])` where `op(getval(), x)` is called
- - `modifyglobal!(mod, var, op, x, order)` where `op(getval(), x)` is called
- - `memoryrefmodify!(memref, op, x, order, boundscheck)` where `op(getval(), x)` is called
- - `Intrinsics.atomic_pointermodify(ptr, op, x, order)` where `op(getval(), x)` is called
- - `Core._task(f, size)` where `f()` will be called when the task runs
- - `Core.finalizer(f, obj)` where `f(obj)` will be called during garbage collection
-
-Contains the `CallInfo` for the indirect function call, its effects, and whether
-the indirect call should contribute edges for invalidation tracking.
+Represents the information of a potential (later) call to the finalizer on the given
+object type.
 """
-struct IndirectCallInfo <: CallInfo
-    info::CallInfo   # the callinfo for the indirect function call
-    effects::Effects # the effects for the indirect function call
-    add_edges::Bool  # whether to add edges for invalidation tracking
+struct FinalizerInfo <: CallInfo
+    info::CallInfo   # the callinfo for the finalizer call
+    effects::Effects # the effects for the finalizer call
 end
-function add_edges_impl(edges::Vector{Any}, info::IndirectCallInfo)
-    if info.add_edges
-        add_edges!(edges, info.info)
-    end
-    # otherwise add no edges (e.g., for finalizers that don't imply edges unless inlined)
+# merely allocating a finalizer does not imply edges (unless it gets inlined later)
+add_edges_impl(::Vector{Any}, ::FinalizerInfo) = nothing
+
+"""
+    info::ModifyOpInfo <: CallInfo
+
+Represents a resolved call of one of:
+ - `modifyfield!(obj, name, op, x, [order])`
+ - `modifyglobal!(mod, var, op, x, order)`
+ - `memoryrefmodify!(memref, op, x, order, boundscheck)`
+ - `Intrinsics.atomic_pointermodify(ptr, op, x, order)`
+
+`info.info` wraps the call information of `op(getval(), x)`.
+"""
+struct ModifyOpInfo <: CallInfo
+    info::CallInfo # the callinfo for the `op(getval(), x)` call
 end
+add_edges_impl(edges::Vector{Any}, info::ModifyOpInfo) = add_edges!(edges, info.info)
+
+"""
+    info::TaskCallInfo <: CallInfo
+
+Represents a resolved call of `Core._task(f, size)`. `info.info` wraps the call
+information of the deferred `f()` call that runs when the created task is scheduled.
+"""
+struct TaskCallInfo <: CallInfo
+    info::CallInfo # the callinfo for the deferred `f()` call
+end
+add_edges_impl(edges::Vector{Any}, info::TaskCallInfo) = add_edges!(edges, info.info)
 
 struct VirtualMethodMatchInfo <: CallInfo
     info::Union{MethodMatchInfo,UnionSplitInfo,InvokeCallInfo}

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1509,7 +1509,7 @@ end
             elseif isconcretetype(RT) && has_nontrivial_extended_info(𝕃ᵢ, TF2) # isconcrete condition required to form a PartialStruct
                 RT = PartialStruct(fallback_lattice, RT, Union{Nothing,Bool}[false,false], Any[TF, TF2])
             end
-            info = IndirectCallInfo(callinfo.info, callinfo.effects, true)
+            info = ModifyOpInfo(callinfo.info)
             return CallMeta(RT, Any, Effects(), info)
         end
     end
@@ -3392,7 +3392,7 @@ function intrinsic_effects(f::IntrinsicFunction, argtypes::Vector{Any})
         # llvmcall can do arbitrary things
         return Effects()
     elseif f === atomic_pointermodify
-        # atomic_pointermodify has memory effects, plus any effects from the IndirectCallInfo
+        # atomic_pointermodify has memory effects, plus any effects from the ModifyOpInfo
         return Effects()
     end
     is_effect_free = _is_effect_free_infer(f)

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -504,7 +504,7 @@ end
     end
     if isa(a, PartialTask)
         if isa(b, PartialTask)
-            return ⊑(lattice, a.fetch_type, b.fetch_type) && ⊑(lattice, a.fetch_error, b.fetch_error)
+            return ⊑(lattice, a.fetch_type, b.fetch_type)
         end
         return ⊑(widenlattice(lattice), Task, b)
     elseif isa(b, PartialTask)
@@ -579,7 +579,7 @@ end
     isa(b, PartialOpaque) && return false
     if isa(a, PartialTask)
         isa(b, PartialTask) || return false
-        return is_lattice_equal(lattice, a.fetch_type, b.fetch_type) && is_lattice_equal(lattice, a.fetch_error, b.fetch_error)
+        return is_lattice_equal(lattice, a.fetch_type, b.fetch_type)
     end
     isa(b, PartialTask) && return false
     return is_lattice_equal(widenlattice(lattice), a, b)

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -405,8 +405,7 @@ end
         return false
     elseif typea isa PartialTask
         typeb isa PartialTask || return false
-        return issimplertype(𝕃, typea.fetch_type, typeb.fetch_type) &&
-               issimplertype(𝕃, typea.fetch_error, typeb.fetch_error)
+        return issimplertype(𝕃, typea.fetch_type, typeb.fetch_type)
     end
     return true
 end
@@ -733,14 +732,11 @@ end
     apt = isa(typea, PartialTask)
     bpt = isa(typeb, PartialTask)
     if apt && bpt
-        # Both are PartialTask - merge their fetch types and errors
+        # Both are PartialTask - merge their fetch types
         merged_fetch_type = tmerge(lattice, typea.fetch_type, typeb.fetch_type)
-        merged_fetch_error = tmerge(lattice, typea.fetch_error, typeb.fetch_error)
-        # If both are Any, no additional type information - return Task
-        if merged_fetch_type === Any && merged_fetch_error === Any
-            return Task
-        end
-        return PartialTask(merged_fetch_type, merged_fetch_error)
+        # Any carries no additional type information - return Task
+        merged_fetch_type === Any && return Task
+        return PartialTask(merged_fetch_type)
     elseif apt
         typea = Task
     elseif bpt

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -684,8 +684,7 @@ end
 
 struct PartialTask
     fetch_type
-    fetch_error
-    PartialTask(@nospecialize(fetch_type), @nospecialize(fetch_error)) = new(fetch_type, fetch_error)
+    PartialTask(@nospecialize(fetch_type)) = new(fetch_type)
 end
 
 eval(Core, quote

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -118,10 +118,14 @@ pessimistically assumed to have fully unknown effects.
 
 **File: `Compiler/src/stmtinfo.jl`**
 ```julia
-# For builtins that perform indirect calls, use IndirectCallInfo.
-# Set add_edges=true, unless the info is only for inlining and not used by inference
-#
-info_result = IndirectCallInfo(callinfo.info, callinfo.effects, true)
+# For builtins that perform deferred/indirect calls, define a `CallInfo` wrapping
+# the call information of the deferred call (see e.g. `FinalizerInfo`, `ModifyOpInfo`
+# and `TaskCallInfo`). Define `add_edges_impl` to forward the wrapped edges, unless
+# merely creating the object should not imply invalidation edges.
+struct YourBuiltinCallInfo <: CallInfo
+    info::CallInfo # the callinfo for the deferred call
+end
+add_edges_impl(edges::Vector{Any}, info::YourBuiltinCallInfo) = add_edges!(edges, info.info)
 ```
 
 **File: `Compiler/src/abstractinterpretation.jl`**


### PR DESCRIPTION
Follow-up to #59221 with two behavior-neutral cleanups that reverse design choices from the original PR:

- Drop the unused `PartialTask.fetch_error` field.
  Nothing consumes it (`task_result_type_tfunc` only reads `fetch_type`), and it made `Core._task` produce `PartialTask(Any, Union{})` for task bodies that return `Any` but are proven nothrow — a lattice element enabling no additional benefit over plain `Task`.
  Exception-type tracking can be reintroduced together with an actual consumer, e.g. refining the `TaskFailedException` thrown by `fetch`.

- Restore per-builtin `CallInfo` types.
  Split `IndirectCallInfo` back into `FinalizerInfo`/`ModifyOpInfo` with their original layouts and introduce `TaskCallInfo` for `Core._task`. The unified type required an `add_edges::Bool` field to encode edge behavior the type itself should express, carried an `effects` field that was dead data for two of the three cases, and forced `assemble_inline_todo!` to re-dispatch on the called function rather than on the call information. This also keeps external `AbstractInterpreter` consumers of `FinalizerInfo`/`ModifyOpInfo` working without changes.