### PR TITLE
Add `TypeName.concrete_only` flag to opt-in to inference barrier for abstract calls (1.13 backport)

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -125,6 +125,17 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
 
     (; valid_worlds, applicable) = matches
     update_valid_age!(sv, valid_worlds) # need to record the negative world now, since even if we don't generate any useful information, inlining might want to add an invoke edge and it won't have this information anymore
+    # Concrete-only functions refuse to commit (and record no backedge) when any
+    # applicable match has a non-concrete signature, regardless of scope. This is the
+    # generalization of the top-level `!isdispatchtuple` bail below to a per-function opt-in.
+    if is_concrete_only(func)
+        for i = 1:length(applicable)
+            if !isdispatchtuple(applicable[i].match.spec_types)
+                add_remark!(interp, sv, "Refusing to infer non-concrete call site for concrete-only function")
+                return Future(CallMeta(Any, Any, Effects(), NoCallInfo()))
+            end
+        end
+    end
     if bail_out_toplevel_call(interp, sv)
         local napplicable = length(applicable)
         for i = 1:napplicable

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -1118,6 +1118,15 @@ function get_max_methods_for_func(@nospecialize(f))
     end
     return nothing
 end
+
+# Whether `f` is marked to only allow inference of call sites with fully concrete
+# argument types. `f === nothing` means the callee value is unknown.
+function is_concrete_only(@nospecialize(f))
+    f === nothing && return false
+    isa(f, DataType) && return f.name.concrete_only
+    return typeof(f).name.concrete_only
+end
+
 get_max_methods_for_module(sv::AbsIntState) = get_max_methods_for_module(frame_module(sv))
 function get_max_methods_for_module(mod::Module)
     max_methods = ccall(:jl_get_module_max_methods, Cint, (Any,), mod) % Int

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -5046,6 +5046,15 @@ g_max_methods(x) = f_max_methods(x)
 @test only(Base.return_types(g_max_methods, Tuple{Int})) === Int
 @test only(Base.return_types(g_max_methods, Tuple{Any})) === Any
 
+# Test that `Core.TypeName.concrete_only` makes inference give up at call sites with
+# non-concrete argument types while keeping concrete call sites precise
+function f_concrete_only end
+typeof(f_concrete_only).name.concrete_only = true
+f_concrete_only(x) = 1
+g_concrete_only(x) = f_concrete_only(x)
+@test only(Base.return_types(g_concrete_only, Tuple{Int})) === Int
+@test only(Base.return_types(g_concrete_only, Tuple{Integer})) === Any
+
 # Test that a module-wise `@max_methods` works as expected
 module Test43370
 using Test

--- a/Compiler/test/invalidation.jl
+++ b/Compiler/test/invalidation.jl
@@ -361,3 +361,37 @@ end
     @test occursin("precompile(Tuple{typeof(Main.drop_cache_test_g), $Int})", err_before)
     @test occursin("precompile(Tuple{typeof(Main.drop_cache_test_g), $Int}) # recompile", err_after)
 end
+
+# `Core.TypeName.concrete_only`: inference records no backedge at call sites with
+# non-concrete argument types, so adding a more-specific method later does not
+# invalidate the caller's compiled code
+abstract type COStyle end
+struct CODefStyle <: COStyle end
+struct COFill end
+function co_callee end
+typeof(co_callee).name.concrete_only = true
+co_callee(::COStyle, op, x) = 1
+struct COBox
+    s::COStyle
+    x::Any
+end
+co_caller(b::COBox) = co_callee(b.s, zero, b.x)
+
+# the non-concrete call site gives up to `Any`
+@test Base.return_types((COBox,); interp=InvalidationTester()) do b
+    co_caller(b)
+end |> only === Any
+
+let mi = Base.method_instance(co_caller, (COBox,))
+    ci = mi.cache
+    @test ci.owner === InvalidationTesterToken()
+    @test ci.max_world == typemax(UInt)
+end
+
+# add a more-specific method; the caller must remain valid
+co_callee(::CODefStyle, op, x::COFill) = 2
+let mi = Base.method_instance(co_caller, (COBox,))
+    ci = mi.cache
+    @test ci.owner === InvalidationTesterToken()
+    @test ci.max_world == typemax(UInt)
+end

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -194,6 +194,8 @@ end
 struct AndAnd end
 const andand = AndAnd()
 broadcasted(::AndAnd, a, b) = broadcasted((a, b) -> a && b, a, b)
+typeof(broadcasted).name.concrete_only = true
+
 function broadcasted(::AndAnd, a, bc::Broadcasted)
     bcf = flatten(bc)
     # Vararg type signature to specialize on args count. This is necessary for performance

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -93,6 +93,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     jl_atomic_store_relaxed(&tn->max_args, 0);
     jl_atomic_store_relaxed(&tn->cache_entry_count, 0);
     tn->constprop_heustic = 0;
+    tn->concrete_only = 0;
     return tn;
 }
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3032,19 +3032,20 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_typename_type->name->wrapper = (jl_value_t*)jl_typename_type;
     jl_typename_type->super = jl_any_type;
     jl_typename_type->parameters = jl_emptysvec;
-    jl_typename_type->name->n_uninitialized = 18 - 2;
-    jl_typename_type->name->names = jl_perm_symsvec(18, "name", "module", "singletonname",
+    jl_typename_type->name->n_uninitialized = 19 - 2;
+    jl_typename_type->name->names = jl_perm_symsvec(19, "name", "module", "singletonname",
                                                     "names", "atomicfields", "constfields",
                                                     "wrapper", "Typeofwrapper", "cache", "linearcache",
                                                     "partial", "hash", "max_args", "n_uninitialized",
                                                     "flags", // "abstract", "mutable", "mayinlinealloc",
-                                                    "cache_entry_count", "max_methods", "constprop_heuristic");
-    const static uint32_t typename_constfields[1]  = { 0b000110100001001011 }; // TODO: put back atomicfields and constfields in this list
-    const static uint32_t typename_atomicfields[1] = { 0b001001001110000000 };
+                                                    "cache_entry_count", "max_methods", "constprop_heuristic",
+                                                    "concrete_only");
+    const static uint32_t typename_constfields[1]  = { 0b0000110100001001011 }; // TODO: put back atomicfields and constfields in this list
+    const static uint32_t typename_atomicfields[1] = { 0b0001001001110000000 };
     jl_typename_type->name->constfields = typename_constfields;
     jl_typename_type->name->atomicfields = typename_atomicfields;
     jl_precompute_memoized_dt(jl_typename_type, 1);
-    jl_typename_type->types = jl_svec(18, jl_symbol_type, jl_any_type /*jl_module_type*/, jl_symbol_type,
+    jl_typename_type->types = jl_svec(19, jl_symbol_type, jl_any_type /*jl_module_type*/, jl_symbol_type,
                                       jl_simplevector_type,
                                       jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/,
                                       jl_type_type, jl_simplevector_type, jl_simplevector_type,
@@ -3055,7 +3056,8 @@ void jl_init_types(void) JL_GC_DISABLED
                                       jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/,
-                                      jl_any_type /*jl_uint8_type*/);
+                                      jl_any_type /*jl_uint8_type*/,
+                                      jl_any_type /*jl_bool_type*/);
 
     jl_methcache_type->name = jl_new_typename_in(jl_symbol("MethodCache"), core, 0, 1);
     jl_methcache_type->name->wrapper = (jl_value_t*)jl_methcache_type;
@@ -3882,6 +3884,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_typename_type->types, 15, jl_uint8_type);
     jl_svecset(jl_typename_type->types, 16, jl_uint8_type);
     jl_svecset(jl_typename_type->types, 17, jl_uint8_type);
+    jl_svecset(jl_typename_type->types, 18, jl_bool_type);
     jl_svecset(jl_methcache_type->types, 2, jl_long_type); // voidpointer
     jl_svecset(jl_methcache_type->types, 3, jl_long_type); // uint32_t plus alignment
     jl_svecset(jl_methtable_type->types, 3, jl_module_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -561,6 +561,7 @@ typedef struct {
     _Atomic(uint8_t) cache_entry_count; // (approximate counter of TypeMapEntry for heuristics)
     uint8_t max_methods; // override for inference's max_methods setting (0 = no additional limit or relaxation)
     uint8_t constprop_heustic; // override for inference's constprop heuristic
+    uint8_t concrete_only; // Bool: inference refuses to commit (records no backedge) at non-concrete call sites
 } jl_typename_t;
 
 typedef struct {


### PR DESCRIPTION
Manual backport of #61504 because it didn't apply cleanly.