### PR TITLE
Mark `promote_rule()` and `reduce_first()` as concrete-only

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -351,6 +351,7 @@ Specifies what type should be used by [`promote`](@ref) when given values of typ
 it for new types as appropriate.
 """
 function promote_rule end
+typeof(promote_rule).name.concrete_only = true
 
 promote_rule(::Type, ::Type) = Bottom
 # Define some methods to avoid needing to enumerate unrelated possibilities when presented


### PR DESCRIPTION
Fixes these invalidations seen when loading CurveFit on 1.13:
```julia
 inserting reduce_first(::typeof(+), x::FillArrays.AbstractOnes) @ FillArrays ~/.julia/packages/FillArrays/zA1cC/src/fillalgebra.jl:432 invalidated:                                                                                           
   backedges: 1: superseding reduce_first(op, x) @ Base reduce.jl:401 with MethodInstance for Base.reduce_first(::typeof(+), ::Any) (191 children)                                                                                             

 inserting promote_rule(::Type{R}, ::Type{ForwardDiff.Dual{T, V, N}}) where {R<:Real, T, V, N} @ ForwardDiff ~/.julia/packages/ForwardDiff/mIdKV/src/dual.jl:456 invalidated:                                                                  
   backedges: 1: superseding promote_rule(::Type, ::Type) @ Base promotion.jl:334 with MethodInstance for promote_rule(::Type{Int64}, ::Type{S} where S<:Number) (2 children)                                                                  
              2: superseding promote_rule(::Type, ::Type) @ Base promotion.jl:334 with MethodInstance for promote_rule(::Type{Int64}, ::Type{S} where S<:Real) (3 children)                                                                    
              3: superseding promote_rule(::Type, ::Type) @ Base promotion.jl:334 with MethodInstance for promote_rule(::Type{UInt8}, ::Type) (9 children)                                                                                     
              4: superseding promote_rule(::Type, ::Type) @ Base promotion.jl:334 with MethodInstance for promote_rule(::Type{Int64}, ::Type) (365 children)                                                                                   
```