### PR TITLE
bitarray: Respect source length in `BitArray.map!`

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1742,8 +1742,8 @@ map(::typeof(one), A::BitArray) = fill!(similar(A), true)
 map(::typeof(identity), A::BitArray) = copy(A)
 
 map!(::Union{typeof(~), typeof(!)}, dest::BitArray, A::BitArray) = bit_map!(~, dest, A)
-map!(::typeof(zero), dest::BitArray, A::BitArray) = fill!(dest, false)
-map!(::typeof(one), dest::BitArray, A::BitArray) = fill!(dest, true)
+map!(::typeof(zero), dest::BitArray, A::BitArray) = bit_map_constant!(dest, A, false)
+map!(::typeof(one), dest::BitArray, A::BitArray) = bit_map_constant!(dest, A, true)
 map!(::typeof(identity), dest::BitArray, A::BitArray) = copyto!(dest, A)
 
 for (T, f) in ((:(Union{typeof(&), typeof(*), typeof(min)}), :(&)),
@@ -1767,6 +1767,12 @@ function bit_map(f::F, A::BitArray, B::BitArray) where F
     AB = zip(A, B)
     dest = similar(BitArray, _similar_shape(AB, IteratorSize(AB)))
     bit_map!(f, dest, A, B)
+end
+
+function bit_map_constant!(dest::BitArray, A::BitArray, x::Bool)
+    length(A) <= length(dest) || throw(DimensionMismatch("length of destination must be >= length of collection"))
+    fill_chunks!(dest.chunks, x, 1, length(A))
+    return dest
 end
 
 function bit_map!(f::F, dest::BitArray, A::BitArray) where F

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1511,6 +1511,22 @@ timesofar("reductions")
         end
     end
 
+    # Constant maps preserve destination bits beyond the input collection.
+    @testset "map! with a longer destination" begin
+        for l in [0, 1, 63, 64, 65, 127, 128, 129]
+            src = bitrand(l)
+            dest = trues(l + 65)
+            @test map!(zero, dest, src) === dest
+            @test dest == vcat(falses(l), trues(65))
+
+            dest = falses(l + 65)
+            @test map!(one, dest, src) === dest
+            @test dest == vcat(trues(l), falses(65))
+        end
+        @test_throws DimensionMismatch map!(zero, falses(1), bitrand(2))
+        @test_throws DimensionMismatch map!(one, falses(1), bitrand(2))
+    end
+
     @testset "Issue #17970" begin
         A17970 = [1,2,3] .== [3,2,1]
         B17970 = map(x -> x ? 1 : 2, A17970)


### PR DESCRIPTION
Match the generic `map!` behavior, which stops at the shortest input collection and leaves the remainder of a longer destination unchanged.

Found this in another round of JuliaLang/julia#62526.