### PR TITLE
path: Bind exception in `homedir(username)`

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -684,7 +684,7 @@ function homedir(username::AbstractString)
     # For the current user, just return homedir().
     current_user = try
         Sys.username()
-    catch
+    catch err
         err isa IOError || rethrow()
         nothing
     end


### PR DESCRIPTION
Bind the exception thrown by `Sys.username()` before checking whether it is an `IOError`, avoiding an `UndefVarError` in the Windows fallback path.

Found in a follow-up audit for JuliaLang/julia#62526.