### PR TITLE
Base: Remove unused internal arguments and bindings

### DIFF
--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -254,7 +254,7 @@ function iterate(itr::AsyncCollector)
     return iterate(itr, AsyncCollectorState(chnl, worker_tasks, exec_func, itr.batch_size, nothing))
 end
 
-function wait_done(itr::AsyncCollector, state::AsyncCollectorState)
+function wait_done(state::AsyncCollectorState)
     close(state.chnl)
 
     # wait for all tasks to finish
@@ -272,7 +272,7 @@ function iterate(itr::AsyncCollector, state::AsyncCollectorState)
         iterate(itr.enumerator, state.enum_state) :
         iterate(itr.enumerator)
     if isnothing(y)
-        wait_done(itr, state)
+        wait_done(state)
         return nothing
     end
     (i, args), state.enum_state = y

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -908,7 +908,7 @@ struct PersistentDict{K,V} <: AbstractDict{K,V}
     global function _keyvalueset(dict::PersistentDict{K, V}, key, val) where {K, V}
         trie = dict.trie
         h = HAMT.HashState(key)
-        found, present, trie, i, bi, top, hs = HAMT.path(trie, key, h, #=persistent=#true)
+        found, present, trie, i, bi, top, hs = HAMT.path(trie, h, #=persistent=#true)
         HAMT.insert!(found, present, trie, i, bi, hs, val)
         return new{K, V}(top)
     end
@@ -919,7 +919,7 @@ struct PersistentDict{K,V} <: AbstractDict{K,V}
     global function _keyvalueset(dict::PersistentDict{K, V}, key) where {K, V}
         trie = dict.trie
         h = HAMT.HashState(key)
-        found, present, trie, i, bi, top, _ = HAMT.path(trie, key, h, #=persistent=#true)
+        found, present, trie, i, bi, top, _ = HAMT.path(trie, h, #=persistent=#true)
         if found && present
             deleteat!(trie.data, i)
             HAMT.unset!(trie, bi)
@@ -1031,7 +1031,7 @@ end
         return nothing
     end
     h = HAMT.HashState(key)
-    found, present, trie, i, _, _, _ = HAMT.path(trie, key, h)
+    found, present, trie, i, _, _, _ = HAMT.path(trie, h)
     if found && present
         leaf = @inbounds trie.data[i]::HAMT.Leaf{K,V}
         return Some{V}(leaf.val)

--- a/base/hamt.jl
+++ b/base/hamt.jl
@@ -155,7 +155,7 @@ as the current `level`.
 If a copy function is provided `copyf` use the return `top` for the
 new persistent tree.
 """
-@inline @Base.assume_effects :noub :terminates_locally function path(trie::HAMT{K,V}, key, h::HashState, copy=false) where {K, V}
+@inline Base.@assume_effects :noub :terminates_locally function path(trie::HAMT{K,V}, h::HashState, copy=false) where {K, V}
     if copy
         trie = top = HAMT{K,V}(Base.copy(trie.data), trie.bitmap)
     else

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -248,7 +248,7 @@ end
 function wait_no_relock(c::GenericCondition)
     ct = current_task()
     w = _wait2(c, ct)
-    token = unlockall(c.lock)
+    unlockall(c.lock)
     try
         return wait()
     catch

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -269,7 +269,7 @@ function _mapreducedim!(f, op, R::AbstractArray, A::AbstractArrayOrBroadcasted)
     end
     indsAt, indsRt = safe_tail(axes(A)), safe_tail(axes(R)) # handle d=1 manually
     keep, Idefault = Broadcast.shapeindexer(indsRt)
-    if reducedim1(R, A)
+    if reducedim1(R)
         # keep the accumulator as a local variable when reducing along the first dimension
         i1 = first(axes1(R))
         for IA in CartesianIndices(indsAt)
@@ -1025,7 +1025,7 @@ function findminmax!(f, op, Rval, Rind, A::AbstractArray{T,N}) where {T,N}
     ks = keys(A)
     y = iterate(ks)
     zi = zero(eltype(ks))
-    if reducedim1(Rval, A)
+    if reducedim1(Rval)
         i1 = first(axes1(Rval))
         for IA in CartesianIndices(indsAt)
             IR = Broadcast.newindex(IA, keep, Idefault)
@@ -1218,7 +1218,7 @@ function _findminmax_inittype(f, A::AbstractArray)
     return v0 isa T ? T : Missing <: eltype(A) ? Union{Missing, typeof(v0)} : typeof(v0)
 end
 
-reducedim1(R, A) = length(axes1(R)) == 1
+reducedim1(R) = length(axes1(R)) == 1
 
 """
     argmin(A; dims) -> indices

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -48,15 +48,15 @@ function Slices(A::P, slicemap::SM, ax::AX) where {P,SM,AX}
     Slices{P,SM,AX,S,N}(A, slicemap, ax)
 end
 
-_slice_check_dims(N) = nothing
-function _slice_check_dims(N, dim, dims...)
+_slice_check_dims() = nothing
+function _slice_check_dims(dim, dims...)
     1 <= dim || throw(DimensionMismatch("Invalid dimension $dim"))
     dim in dims && throw(DimensionMismatch("Dimensions $dims are not unique"))
-    _slice_check_dims(N,dims...)
+    _slice_check_dims(dims...)
 end
 
 @constprop :aggressive function _eachslice(A::AbstractArray{T,N}, dims::NTuple{M,Integer}, drop::Bool) where {T,N,M}
-    _slice_check_dims(N,dims...)
+    _slice_check_dims(dims...)
     N_ = foldl(max, dims; init=N)
 
     if drop


### PR DESCRIPTION
Remove stale arguments from internal async-map, reduction, and slice helpers, and avoid binding the unused result of `unlockall` in `wait_no_relock`. These helpers are internal and all call sites are updated together.

Found in a follow-up audit for JuliaLang/julia#62526.