### PR TITLE
ci: honor a `.github/_typos.toml` config in the typo check

### DIFF
--- a/.github/_typos.toml
+++ b/.github/_typos.toml
@@ -1,0 +1,4 @@
+# Configuration for the `typos` spell checker (.github/workflows/Typos.yml)
+[default.extend-words]
+# allowlist for typo check
+invokee = "invokee"

--- a/.github/workflows/Typos.yml
+++ b/.github/workflows/Typos.yml
@@ -40,12 +40,12 @@ jobs:
             | tar -xz -C "${{ runner.temp }}/typos" ./typos
           "${{ runner.temp }}/typos/typos" --version
 
-          echo -n $NEW_FILES | xargs "${{ runner.temp }}/typos/typos" --format json >> ${{ runner.temp }}/new_typos.jsonl || true
+          echo -n $NEW_FILES | xargs "${{ runner.temp }}/typos/typos" --config .github/_typos.toml --format json >> ${{ runner.temp }}/new_typos.jsonl || true
           git checkout FETCH_HEAD -- $OLD_FILES
           if [ -z "$OLD_FILES" ]; then
             touch "${{ runner.temp }}/old_typos.jsonl" # No old files, so no old typos.
           else
-            echo -n $OLD_FILES | xargs "${{ runner.temp }}/typos/typos" --format json >> ${{ runner.temp }}/old_typos.jsonl || true
+            echo -n $OLD_FILES | xargs "${{ runner.temp }}/typos/typos" --config .github/_typos.toml --format json >> ${{ runner.temp }}/old_typos.jsonl || true
           fi
 
 


### PR DESCRIPTION
Not very important since the cached typos will be updated after merge.

But it's best not to deepen the habit of forgiving CI failures 😉 