### PR TITLE
cancellation: Hook up libuv to cancellation

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -507,6 +507,7 @@ function sizeof_nothrow(@nospecialize(x))
     x = unwrap_unionall(t)
     # instances are variable-sized, so the type itself has no definite size
     x === Core.CancellationTokenSource && return false
+    x === Core.WaitEntryN && return false
     if isconcrete
         if isa(x, DataType) && x.layout != C_NULL
             # there's just a few concrete types with an opaque layout

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -110,6 +110,7 @@ include("iobuffer.jl")
 
 # Concurrency (part 1)
 include("linked_list.jl")
+include("park.jl")
 include("condition.jl")
 include("threads.jl")
 include("lock.jl")

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -98,15 +98,17 @@ include("some.jl")
 include("dict.jl")
 include("set.jl")
 
+# Dynamic scopes (types only; the ScopedValues API is included much later)
+include("scope.jl")
+# Cancellation tokens (the `cancel` keyword-argument machinery is used from
+# the I/O layer onwards)
+include("cancellation.jl")
+
 # Core I/O
 include("io.jl")
 include("iobuffer.jl")
 
-# Dynamic scopes (types only; the ScopedValues API is included much later)
-include("scope.jl")
-
 # Concurrency (part 1)
-include("cancellation.jl")
 include("linked_list.jl")
 include("condition.jl")
 include("threads.jl")

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -46,11 +46,15 @@ the async condition object itself.
 """
 function AsyncCondition(cb::Function)
     async = AsyncCondition()
-    t = @task begin
-        unpreserve_handle(async)
-        while _trywait(async)
-            cb(async)
-            isopen(async) || return
+    # Shielded like the `Timer` callback task below: this task owns the
+    # handle's lifetime and must survive a cancelled constructing scope.
+    t = ScopedValues.with(CANCEL_TOKEN => nothing) do
+        @task begin
+            unpreserve_handle(async)
+            while _trywait(async)
+                cb(async)
+                isopen(async) || return
+            end
         end
     end
     # here we are mimicking parts of _trywait, in coordination with task `t`
@@ -161,7 +165,10 @@ unsafe_convert(::Type{Ptr{Cvoid}}, async::AsyncCondition) = async.handle
 
 # if this returns true, the object has been signaled
 # if this returns false, the object is closed
-function _trywait(t::Union{Timer, AsyncCondition})
+# a cancellation of the governing token is thrown as a CancellationRequest
+_trywait(t::Union{Timer, AsyncCondition}; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    _trywait(t, resolve_cancel_token(cancel))
+function _trywait(t::Union{Timer, AsyncCondition}, tok::MaybeToken)
     set = t.set
     if set
         # full barrier now for AsyncCondition
@@ -181,12 +188,19 @@ function _trywait(t::Union{Timer, AsyncCondition})
             lock(t.cond)
             try
                 set = t.set
-                if !set && t.handle != C_NULL # wait for set or handle, but not the isopen flag
+                while !set && t.handle != C_NULL # wait for set or handle, but not the isopen flag
                     iolock_end()
-                    set = wait(t.cond)
+                    ret = wait(t.cond, tok)
                     unlock(t.cond)
                     iolock_begin()
                     lock(t.cond)
+                    if ret isa Bool
+                        set = ret
+                        break
+                    end
+                    # A wakeup that did not come from this object's notify:
+                    # re-check the state and re-park.
+                    set = t.set
                 end
             finally
                 unlock(t.cond)
@@ -199,8 +213,14 @@ function _trywait(t::Union{Timer, AsyncCondition})
     return set
 end
 
-function wait(t::Union{Timer, AsyncCondition})
-    _trywait(t) || throw(EOFError())
+waitqueue(t::Union{Timer, AsyncCondition}) = waitqueue(t.cond)
+
+wait(t::Union{Timer, AsyncCondition}; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    wait(t, check_cancel_arg(cancel))
+function wait(t::Union{Timer, AsyncCondition}, tok::MaybeToken)
+    ok = _trywait(t, tok)
+    @cancel_check(tok)
+    ok || throw(EOFError())
     nothing
 end
 
@@ -229,7 +249,9 @@ function close(t::Union{Timer, AsyncCondition})
         try
             while t.handle != C_NULL
                 iolock_end()
-                wait(t.cond)
+                # close is the cleanup primitive: its (bounded) completion
+                # wait is shielded from cancellation
+                wait(t.cond, nothing)
                 unlock(t.cond)
                 iolock_begin()
                 lock(t.cond)
@@ -311,14 +333,24 @@ function uv_timercb(handle::Ptr{Cvoid})
 end
 
 """
-    sleep(seconds)
+    sleep(seconds; cancel=Base.DEFAULT_CANCEL)
 
 Block the current task for a specified number of seconds. The minimum sleep time is 1
 millisecond or input of `0.001`.
+
+A cancellation of the governing token (by default the scoped token, see
+[`CancellationToken`](@ref)) interrupts the sleep by throwing the
+[`CancellationRequest`](@ref).
 """
-function sleep(sec::Real)
+function sleep(sec::Real; cancel::CancelTokenArg=DEFAULT_CANCEL)
     sec ≥ 0 || throw(ArgumentError("cannot sleep for $sec seconds"))
-    wait(Timer(sec))
+    tok = check_cancel_arg(cancel)
+    t = Timer(sec)
+    try
+        wait(t, tok)
+    finally
+        close(t)
+    end
     nothing
 end
 
@@ -363,17 +395,23 @@ julia> begin
 function Timer(cb::Function, timeout; spawn::Union{Nothing,Bool}=nothing, kwargs...)
     sticky = spawn === nothing ? current_task().sticky : !spawn
     timer = Timer(timeout; kwargs...)
-    t = @task begin
-        unpreserve_handle(timer)
-        while _trywait(timer)
-            try
-                cb(timer)
-            catch err
-                write(stderr, "Error in Timer:\n")
-                showerror(stderr, err, catch_backtrace())
-                return
+    # The callback task carries the timer's lifetime (its preserve is
+    # balanced in the body): shield it from the constructing scope's
+    # cancellation token, so a cancelled scope can neither leak the preserve
+    # nor stop the timer - like before, `close(t)` ends it.
+    t = ScopedValues.with(CANCEL_TOKEN => nothing) do
+        @task begin
+            unpreserve_handle(timer)
+            while _trywait(timer)
+                try
+                    cb(timer)
+                catch err
+                    write(stderr, "Error in Timer:\n")
+                    showerror(stderr, err, catch_backtrace())
+                    return
+                end
+                isopen(timer) || return
             end
-            isopen(timer) || return
         end
     end
     t.sticky = sticky

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -186,14 +186,19 @@ function _trywait(t::Union{Timer, AsyncCondition}, tok::MaybeToken)
         if !set
             preserve_handle(t)
             lock(t.cond)
+            locked = true
             try
                 set = t.set
                 while !set && t.handle != C_NULL # wait for set or handle, but not the isopen flag
                     iolock_end()
+                    locked = false
                     ret = wait(t.cond, tok)
+                    locked = true
                     unlock(t.cond)
+                    locked = false
                     iolock_begin()
                     lock(t.cond)
+                    locked = true
                     if ret isa Bool
                         set = ret
                         break
@@ -203,7 +208,7 @@ function _trywait(t::Union{Timer, AsyncCondition}, tok::MaybeToken)
                     set = t.set
                 end
             finally
-                unlock(t.cond)
+                locked && unlock(t.cond)
                 unpreserve_handle(t)
             end
         end
@@ -246,18 +251,23 @@ function close(t::Union{Timer, AsyncCondition})
         # implement _trywait here without the auto-reset function, just waiting for the final close signal
         preserve_handle(t)
         lock(t.cond)
+        locked = true
         try
             while t.handle != C_NULL
                 iolock_end()
                 # close is the cleanup primitive: its (bounded) completion
                 # wait is shielded from cancellation
+                locked = false
                 wait(t.cond, nothing)
+                locked = true
                 unlock(t.cond)
+                locked = false
                 iolock_begin()
                 lock(t.cond)
+                locked = true
             end
         finally
-            unlock(t.cond)
+            locked && unlock(t.cond)
             unpreserve_handle(t)
         end
     elseif t.isopen

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -63,7 +63,7 @@ function AsyncCondition(cb::Function)
         if async.set
             schedule(t)
         else
-            _wait2(async.cond, t)
+            schedule_on_notify!(async.cond, t)
         end
     end
     return async
@@ -431,7 +431,7 @@ function Timer(cb::Function, timeout; spawn::Union{Nothing,Bool}=nothing, kwargs
         if timer.set
             schedule(t)
         else
-            _wait2(timer.cond, t)
+            schedule_on_notify!(timer.cond, t)
         end
     end
     return timer

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -468,3 +468,51 @@ function timedwait(testcb, timeout::Real; pollint::Real=0.1)
     end
     return :timed_out
 end
+
+## A deadline as a waitable (see base/park.jl): `TimeoutWait(dt)` in a
+## park's waitables wakes the wait with `:timed_out` after `dt` seconds.
+## Its enqueue - running inside `park!`, after the arm - starts the timer
+## and spawns the claimer task, which wakes the parked task through the
+## standard expected-entry claim CAS. That CAS is a *specific-wait* waker:
+## it is only sound against a fresh, single-use entry (which the entry
+## cache contract supplies automatically - any non-canonical waitable
+## shape gets a fresh entry), since entry identity is what scopes the
+## claim to this wait and not a later one of the same task. The claimed
+## waitq registration is left for the driver's lazy settle; the dequeue
+## closes the timer on every exit path.
+mutable struct TimeoutWait
+    const timeout::Float64
+    timer::Union{Timer, Nothing}
+    TimeoutWait(timeout::Real) = new(Float64(timeout), nothing)
+end
+
+function wait_enqueue!(x::TimeoutWait, w::WaitEntry, first::Bool)
+    ct = current_task()
+    timer = Timer(x.timeout)
+    x.timer = timer
+    t = Task() do
+        try
+            # not cancellable: internal mechanism; closing the timer wakes
+            # this task on every exit path of the governed wait
+            wait(timer; cancel=nothing)
+        catch e
+            # a closed timer means the wait ended first; do nothing
+            e isa EOFError && return
+            rethrow()
+        end
+        if (@atomicreplace ct.waiting_on w => nothing).success
+            schedule(ct, :timed_out)
+        end
+    end
+    t.sticky = false
+    Threads._spawn_set_thrpool(t, :interactive)
+    schedule(t)
+    return true
+end
+
+function wait_dequeue!(x::TimeoutWait, w::WaitEntry, why::UInt8)
+    timer = x.timer
+    timer === nothing || close(timer)
+    x.timer = nothing
+    return nothing
+end

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -408,7 +408,7 @@ function Timer(cb::Function, timeout; spawn::Union{Nothing,Bool}=nothing, kwargs
     # The callback task carries the timer's lifetime (its preserve is
     # balanced in the body): shield it from the constructing scope's
     # cancellation token, so a cancelled scope can neither leak the preserve
-    # nor stop the timer - like before, `close(t)` ends it.
+    # nor stop the timer - `close(timer)` is what ends it.
     t = ScopedValues.with(CANCEL_TOKEN => nothing) do
         @task begin
             unpreserve_handle(timer)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1916,19 +1916,8 @@ end
 # hvcat -> use fallbacks in abstractarray.jl
 
 
-# BitArray I/O
-
-write(s::IO, B::BitArray) = write(s, B.chunks)
-function read!(s::IO, B::BitArray)
-    n = length(B)
-    Bc = B.chunks
-    read!(s, Bc)
-    if length(Bc) > 0 && Bc[end] & _msk_end(n) ≠ Bc[end]
-        Bc[end] &= _msk_end(n) # ensure that the BitArray is not broken
-        throw(DimensionMismatch("read mismatch, found non-zero bits after BitArray length"))
-    end
-    return B
-end
+# BitArray I/O lives in io.jl (it takes a `cancel` keyword, whose plumbing
+# is not yet loaded at this point of bootstrap)
 
 sizeof(B::BitArray) = sizeof(B.chunks)
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -214,6 +214,7 @@
 #    @atomic finished_at::UInt64
 #    @atomic waiting_on::Any
 #    cached_wait_entry::Any
+#    cached_cancel_entry::Any
 #    invoked::Any
 #    @atomic bound_cancel_token::Any
 #end

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -630,14 +630,6 @@ function unregister_cancellation!(src::CancellationTokenSource, w::WaitEntry)
     return nothing
 end
 
-# Deliver the cancellation that made a source registration refuse (the
-# caller has already withdrawn its waitee-side registration and released
-# any locks the throw must not hold).
-@noinline function _deliver_refused_cancellation(src::CancellationTokenSource)
-    checkcancel(src)
-    error("cancellation registration refused, but the source is not cancelled")
-end
-
 # Mark the single-use entry `w` as done with its (sticky) source
 # registrations: walks then collect it like an entry of a completed task.
 # For per-call entries (`Experimental.wait_with_timeout`, waitany) whose

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -98,8 +98,7 @@ const CANCEL_REQUEST_ABANDON_ALL = CancellationRequest(0x4)
 const STATUS_PREEMPT_BIT = 0x40
 const SEVERITY_MASK = 0x3f
 
-# A request's payload is the plain severity; kept as an accessor for the
-# delivery layer's comparisons.
+# The severity of a request, for the delivery layer's comparisons.
 severity(cr::CancellationRequest) = cr.request
 
 """
@@ -193,19 +192,15 @@ end
 
 ## Wait registrations (used by condition.jl and every parked wait)
 
-# A task's registration on the things it waits for. An entry carries
-# uniform {owner, next, aux} slots (see the accessors below): a waitee
-# slot's fields are protected by the waitee's lock (its `owner` holds the
-# queue's identity - see `waitqueue` - while enqueued, acting as the "am I
-# registered, and on what" witness, and `nothing` otherwise), a
-# cancellation-source slot's by the registration protocol further below;
-# `task` is written by the owning task before enqueueing, so it is ordered
-# by the same lock for lock-holding readers - but it is also read (and
-# scrubbed) by walkers that hold none of the owner's locks (the
-# cancellation walk, `_waitq_isempty`), so like the slot owners it is an
-# atomic field accessed relaxed: the values are identity witnesses whose
-# staleness the protocols tolerate (a claim is validated by the
-# `waiting_on` CAS, never by the `task` read alone).
+# A task's registration on the things it waits for: `task` plus uniform
+# {owner, next, aux} slots, one per waitable, with a waitee slot's `owner`
+# holding the queue's identity (see `waitqueue`) while enqueued - the "am
+# I registered, and on what" witness - and `nothing` otherwise. Field
+# protection and atomicity live with the accessors ("Uniform slot access"
+# below); the key liberty is that `task` and the slot owners are identity
+# witnesses read racily by walkers (the cancellation walk,
+# `_waitq_isempty`), whose staleness the protocols tolerate: a claim is
+# validated by the `waiting_on` CAS, never by those reads alone.
 #
 # The wake-claim protocol: a parked task `t` points to its current
 # registration through the atomic field `t.waiting_on`. Whoever wants to wake
@@ -229,19 +224,15 @@ end
 #     single-use entry: single-use-ness is what guarantees their
 #     expected-value CAS cannot mistakenly claim a later, unrelated wait.
 #
-# Entries are heap objects. A task whose interrupted wait left a stale registration
-# behind can immediately register anew - e.g. park on a lock during its cleanup - with a fresh entry.
-# A wait registration is a small set of {owner, link, aux} slots - one per
-# thing the wait is registered on, with `owner` doubling as the membership
-# witness ("am I registered, and on what") - sharing the task's single
-# wake-claim word. Entries come in kinds by slot count: the 1-slot kind
-# covers plain parks (one waitee slot), the 2-slot kind adds the
-# cancellation-source slot for cancellable parks. (A variable-slot "many"
-# kind for wait-any over arbitrary waitables - waitany, timeouts - is
-# planned to follow; consumers locate their slot by scanning for their own
-# identity, so links always point at whole entries.) The kinds share their
-# leading layout; `WaitEntry` is the union of all kinds, and hot paths
-# union-split on it.
+# Entries are heap objects: a task whose interrupted wait left a stale
+# registration behind can immediately register anew - e.g. park on a lock
+# during its cleanup - with a fresh entry. Entries come in kinds by slot
+# count: the 1-slot kind covers plain parks (one waitee slot), the 2-slot
+# kind adds the cancellation-source slot for cancellable parks, and the
+# variable-slot `WaitEntryN` covers parks on several waitables at once
+# (multi-waitable `park!`, and hence waitany/timeouts). The kinds share
+# their leading layout; `WaitEntry` is the union of all kinds, and hot
+# paths union-split on it.
 typegroup
     mutable struct WaitEntry1
         @atomic task::Union{Task, Nothing}
@@ -284,13 +275,9 @@ _nslots(w::WaitEntry1) = 1
 _nslots(w::WaitEntry2) = 2
 _nslots(w::WaitEntryN) = Int(w.nslots)
 
-# Slot owners are read by threads that do not hold the slot's protecting
-# lock (walks and unlink sweeps scan every slot of an entry for their own
-# identity), so they are atomic fields accessed relaxed: the values are
-# identity witnesses whose staleness the protocols tolerate, and where an
-# owner read carries ordering obligations, the ordering is supplied
-# elsewhere (the waitee's lock, or the seq_cst publish/recheck dance of
-# the source registration - `SourceWait` in base/park.jl).
+# Where an owner read carries ordering obligations, the ordering is
+# supplied elsewhere (the waitee's lock, or the seq_cst publish/recheck
+# dance of the source registration - `SourceWait` in base/park.jl).
 @inline _slot_owner(w::WaitEntry1, i::Int) = @atomic :monotonic w.owner1
 @inline _slot_owner(w::WaitEntry2, i::Int) =
     i == 1 ? (@atomic :monotonic w.owner1) : (@atomic :monotonic w.owner2)
@@ -459,9 +446,9 @@ end
 # be armed for a wait that is not cancellable under it. (Aux data outside
 # the claim word - the severity floors - is read racily by the walk and may
 # be judged against an adjacent arm of the same entry; that misfire is
-# tolerable for a teardown wait's floor, never for a shield. See the model
-# in tla/WaitClaim.tla: sharing one entry lets a walk claim a shielded
-# re-arm using the previous arm's eligibility.)
+# tolerable for a teardown wait's floor, never for a shield: sharing one
+# entry would let a walk claim a shielded re-arm using the previous arm's
+# eligibility.)
 function _cached_wait_entry(waiter::Task)
     w = waiter.cached_wait_entry
     if w isa WaitEntry1 && (@atomic :monotonic w.owner1) === nothing
@@ -726,8 +713,7 @@ function _walk_waiters!(node::CancellationTokenSource, sev::UInt8)
     # a push this read misses is later in the total order, so that
     # registrant's state recheck observes the cancellation (see
     # `SourceWait`'s registration, base/park.jl); pairs with the seq_cst
-    # state read the caller
-    # performed under the walk lock.
+    # state read the caller performed under the walk lock.
     x = @atomic :sequentially_consistent node.waiters_head
     w = x isa WaitEntry ? x : nothing
     while w isa WaitEntry
@@ -769,10 +755,10 @@ function _walk_waiters!(node::CancellationTokenSource, sev::UInt8)
             # here is sound. The claim CAS itself may still land on a
             # *later* arm of the same entry than the one whose aux was
             # judged - which is why every arm of a source-linked entry must
-            # be a cancellable park under it (shields arm a distinct entry;
-            # see _cached_wait_entry and tla/WaitClaim.tla): the worst
-            # misfire is then a spurious below-floor wake into a teardown
-            # re-park, which handles it like any interruption of its wait
+            # be a cancellable park under it (shields arm a distinct
+            # entry; see _cached_wait_entry): the worst misfire is then a
+            # spurious below-floor wake into a teardown re-park, which
+            # handles it like any interruption of its wait
             # (conservatively, e.g. by detaching the awaited request).
             if sev != 0x00 && (@atomic :sequentially_consistent t.waiting_on) === w &&
                     slot.aux % UInt8 <= sev
@@ -816,11 +802,11 @@ function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
     _unlock_walk(node)
     while towake !== nothing
         ((t, w), towake) = towake::Tuple{Tuple{Task, WaitEntry}, Any}
-        # N.B.: an ABANDON_ALL request currently also delivers by
-        # interruption; freezing the task in place instead arrives with the
-        # escalation machinery. The delivery is claim-scoped - the claim
-        # above is the wake ticket, so no re-claiming swap - and dropped
-        # when the task has re-armed meanwhile (see deliver_claimed_wake!).
+        # N.B.: an ABANDON_ALL request also delivers by interruption for
+        # now (freezing the task in place is not yet implemented). The
+        # delivery is claim-scoped - the claim above is the wake ticket, so
+        # no re-claiming swap - and dropped when the task has re-armed
+        # meanwhile (see deliver_claimed_wake!).
         deliver_claimed_wake!(t, w, creq)
     end
     # Walk the node's (weak, intrusive) child list, advancing every child to

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -98,6 +98,10 @@ const CANCEL_REQUEST_ABANDON_ALL = CancellationRequest(0x4)
 const STATUS_PREEMPT_BIT = 0x40
 const SEVERITY_MASK = 0x3f
 
+# A request's payload is the plain severity; kept as an accessor for the
+# delivery layer's comparisons.
+severity(cr::CancellationRequest) = cr.request
+
 """
     cancel_severity(src::CancellationTokenSource) -> Union{Nothing, CancellationRequest}
     cancel_severity(tok::CancellationToken)

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -290,7 +290,7 @@ _nslots(w::WaitEntryN) = Int(w.nslots)
 # identity witnesses whose staleness the protocols tolerate, and where an
 # owner read carries ordering obligations, the ordering is supplied
 # elsewhere (the waitee's lock, or the seq_cst publish/recheck dance of
-# `register_cancellation!`).
+# the source registration - `SourceWait` in base/park.jl).
 @inline _slot_owner(w::WaitEntry1, i::Int) = @atomic :monotonic w.owner1
 @inline _slot_owner(w::WaitEntry2, i::Int) =
     i == 1 ? (@atomic :monotonic w.owner1) : (@atomic :monotonic w.owner2)
@@ -584,55 +584,10 @@ end
     return h isa WaitEntry ? h : nothing
 end
 
-# Register the armed wait entry `w` (see `_cancel_wait_entry`/`_arm_wait`)
-# on `src`'s waiter list, so the cancellation walk can find and claim the
-# parked task, and close the arm-vs-cancel race. Returns `false` when `src`
-# was already cancelled at `w.min_severity` or above *and* this call claimed
-# the wake back: the caller must withdraw its waitee-side state and deliver
-# the refusal itself (`_deliver_refused_cancellation`); the sticky source
-# registration stays. Returns `true` when the park should proceed -
-# including when a concurrent cancellation walk claimed the freshly armed
-# entry, in which case its wake delivers the request into the park.
-function register_cancellation!(src::CancellationTokenSource, w::WaitEntry)
-    i = _find_slot(w, src)
-    if i == 0
-        # First park under `src`: claim a slot (the slot's `owner` is the
-        # push ticket - setting it before the publishing CAS orders it for
-        # any walk that can see the entry) and publish the entry with a
-        # lock-free push.
-        slot = slots(w)[_acquire_slot!(w, src)]
-        while true
-            h = _waiters_head(src)
-            slot.next = h
-            # seq_cst, pairing with the cancellation walk's state-write-
-            # then-head-read: if the walk's head read misses this push, this
-            # push is later in the total order, so the state recheck below
-            # observes the raised state (same dance as the child-attach in
-            # jl_new_cancel_source).
-            if (@atomicreplace :sequentially_consistent :monotonic src.waiters_head h => w).success
-                break
-            end
-        end
-    else
-        slot = slots(w)[i]
-        # Sticky re-arm (the entry is already registered on `src`): upgrade
-        # this thread's arm-then-recheck to the store-load ordering the
-        # race argument needs (the arm CAS itself is only `release`).
-        Core.Intrinsics.atomic_fence(:sequentially_consistent, :system)
-    end
-    # Post-publication recheck: either the concurrent cancellation walk
-    # observes our push/arm, or we observe its state write here.
-    st = @atomic :sequentially_consistent src.state
-    if st != 0x00 && st >= slot.aux % UInt8
-        t = (@atomic :monotonic w.task)::Task
-        if (@atomicreplace t.waiting_on w => nothing).success
-            return false
-        end
-        # A concurrent walk claimed the wake first; its schedule delivers
-        # the request into the park.
-    end
-    return true
-end
+# (Source registration - the sticky lock-free push, the re-arm fence, and
+# the post-publication state recheck - lives in base/park.jl as
+# `SourceWait`'s `wait_enqueue!`/`wait_recheck` methods; the refusal is
+# the driver's fired path.)
 
 # Owner-side physical unregistration of `w` from `src`'s waiter list: an
 # O(list) walk under the walk lock. Used on the rare paths that must drop a
@@ -675,7 +630,7 @@ function unregister_cancellation!(src::CancellationTokenSource, w::WaitEntry)
     return nothing
 end
 
-# Deliver the cancellation that made `register_cancellation!` refuse (the
+# Deliver the cancellation that made a source registration refuse (the
 # caller has already withdrawn its waitee-side registration and released
 # any locks the throw must not hold).
 @noinline function _deliver_refused_cancellation(src::CancellationTokenSource)
@@ -778,7 +733,8 @@ function _walk_waiters!(node::CancellationTokenSource, sev::UInt8)
     # seq_cst: the S-ordered counterpart of a registrant's seq_cst push -
     # a push this read misses is later in the total order, so that
     # registrant's state recheck observes the cancellation (see
-    # register_cancellation!); pairs with the seq_cst state read the caller
+    # `SourceWait`'s registration, base/park.jl); pairs with the seq_cst
+    # state read the caller
     # performed under the walk lock.
     x = @atomic :sequentially_consistent node.waiters_head
     w = x isa WaitEntry ? x : nothing
@@ -816,7 +772,7 @@ function _walk_waiters!(node::CancellationTokenSource, sev::UInt8)
             # (the minimum delivery severity) is only meaningful for the arm
             # it was staged for, and reading it after observing the arm pins
             # it to that arm or a later one. An arm this (seq_cst, pairing
-            # with the re-arm fence in register_cancellation!) read misses
+            # with the source registration's re-arm fence) read misses
             # is covered by its own post-arm state recheck, so skipping it
             # here is sound. The claim CAS itself may still land on a
             # *later* arm of the same entry than the one whose aux was
@@ -854,7 +810,7 @@ function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
     # own raise of the node was lost, this load is the walk's sole operation
     # on the state that can order the winner's write before the child_head
     # read below; it also pairs with the seq_cst push/arm-fence in
-    # `register_cancellation!` (state write before walk on this side, push
+    # the source registration (state write before walk on this side, push
     # or arm before state recheck on the registrant's).
     st = @atomic :sequentially_consistent node.state
     sev < st && (sev = st)

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -11,8 +11,8 @@
 # may only *react* to cancellation; the source is the capability to *request*
 # it.
 #
-# For convenience, the scoped value `CANCEL_TOKEN` carries the governing token
-# carries the default cancellation token.
+# For convenience, the scoped value `CANCEL_TOKEN` carries the default
+# cancellation token governing the current dynamic extent.
 
 const CancellationTokenSource = Core.CancellationTokenSource
 
@@ -187,6 +187,521 @@ function _raise_state!(src::CancellationTokenSource, sev::UInt8)
     end
 end
 
+## Wait registrations (used by condition.jl and every parked wait)
+
+# A task's registration on the things it waits for. An entry carries
+# uniform {owner, next, aux} slots (see the accessors below): a waitee
+# slot's fields are protected by the waitee's lock (its `owner` holds the
+# queue's identity - see `waitqueue` - while enqueued, acting as the "am I
+# registered, and on what" witness, and `nothing` otherwise), a
+# cancellation-source slot's by the registration protocol further below;
+# `task` is written by the owning task before enqueueing, so it is ordered
+# by the same lock for lock-holding readers - but it is also read (and
+# scrubbed) by walkers that hold none of the owner's locks (the
+# cancellation walk, `_waitq_isempty`), so like the slot owners it is an
+# atomic field accessed relaxed: the values are identity witnesses whose
+# staleness the protocols tolerate (a claim is validated by the
+# `waiting_on` CAS, never by the `task` read alone).
+#
+# The wake-claim protocol: a parked task `t` points to its current
+# registration through the atomic field `t.waiting_on`. Whoever wants to wake
+# it must first claim the wake by atomically clearing that field:
+#
+#   - `notify` (holding the waitee's lock) pops an entry `w` and claims via
+#     CAS(t.waiting_on, w => nothing). The expected-value CAS makes stale
+#     entries harmless: if `t` was interrupted and has since registered
+#     elsewhere, the CAS fails and the popped corpse is simply dropped.
+#   - an interrupter (`schedule(t, exc, error=true)`) claims via an
+#     unconditional swap: it is directed at the *task*, not at any particular
+#     wait, so claiming whatever `t` is currently registered on is correct.
+#     It then opportunistically unlinks the claimed entry under the waitee's
+#     lock via `trylock` (see `try_unlink_claimed!`); if the lock is
+#     unavailable the entry stays linked and is collected lazily, either by
+#     the interrupted task's own wait cleanup or by the `notify` that pops
+#     and drops it. The cancellation walk claims like `notify` (expected-entry
+#     CAS) but leaves the entry linked for the same lazy collection.
+#   - wake sources directed at one *specific* wait (e.g. the timeout task of
+#     `Experimental.wait_with_timeout`) must register the wait with a fresh,
+#     single-use entry: single-use-ness is what guarantees their
+#     expected-value CAS cannot mistakenly claim a later, unrelated wait.
+#
+# Entries are heap objects. A task whose interrupted wait left a stale registration
+# behind can immediately register anew - e.g. park on a lock during its cleanup - with a fresh entry.
+# A wait registration is a small set of {owner, link, aux} slots - one per
+# thing the wait is registered on, with `owner` doubling as the membership
+# witness ("am I registered, and on what") - sharing the task's single
+# wake-claim word. Entries come in kinds by slot count: the 1-slot kind
+# covers plain parks (one waitee slot), the 2-slot kind adds the
+# cancellation-source slot for cancellable parks. (A variable-slot "many"
+# kind for wait-any over arbitrary waitables - waitany, timeouts - is
+# planned to follow; consumers locate their slot by scanning for their own
+# identity, so links always point at whole entries.) The kinds share their
+# leading layout; `WaitEntry` is the union of all kinds, and hot paths
+# union-split on it.
+typegroup
+    mutable struct WaitEntry1
+        @atomic task::Union{Task, Nothing}
+        @atomic owner1::Any
+        next1::Union{WaitEntry1, WaitEntry2, Core.WaitEntryN, Nothing}
+        aux1::UInt64
+        WaitEntry1(task::Union{Task, Nothing}) = new(task, nothing, nothing, 0x0)
+    end
+    mutable struct WaitEntry2
+        @atomic task::Union{Task, Nothing}
+        @atomic owner1::Any
+        next1::Union{WaitEntry1, WaitEntry2, Core.WaitEntryN, Nothing}
+        aux1::UInt64
+        @atomic owner2::Any
+        next2::Union{WaitEntry1, WaitEntry2, Core.WaitEntryN, Nothing}
+        aux2::UInt64
+        WaitEntry2(task::Union{Task, Nothing}) =
+            new(task, nothing, nothing, 0x0, nothing, nothing, 0x0)
+    end
+end
+const WaitEntryN = Core.WaitEntryN
+WaitEntryN(task::Union{Task, Nothing}, nslots::Integer) =
+    ccall(:jl_new_wait_entry, Any, (Any, Csize_t), task, nslots)::WaitEntryN
+const WaitEntry = Union{WaitEntry1, WaitEntry2, WaitEntryN}
+
+## Uniform slot access
+#
+# Every kind is a `task` plus `_nslots` uniform {owner, next, aux} slots
+# (1-based). `task` and the slot `owner`s are atomic, accessed relaxed
+# (walkers read them without the owner's locks - see the notes above and
+# below); the `owner` doubles as the membership witness (`nothing` = free
+# slot). `next` and `aux` are plain, each protected by its owner's
+# discipline: waitee slots by the waitee's lock, cancellation-source slots
+# by the registration protocol below, and free slots by the owning task.
+# Lists link whole entries: a traversal locates its slot in each entry by
+# scanning for its own identity (`_find_slot`), so an entry may be
+# registered on several waitables at once (wait-any). At most one slot per
+# owner per entry.
+_nslots(w::WaitEntry1) = 1
+_nslots(w::WaitEntry2) = 2
+_nslots(w::WaitEntryN) = Int(w.nslots)
+
+# Slot owners are read by threads that do not hold the slot's protecting
+# lock (walks and unlink sweeps scan every slot of an entry for their own
+# identity), so they are atomic fields accessed relaxed: the values are
+# identity witnesses whose staleness the protocols tolerate, and where an
+# owner read carries ordering obligations, the ordering is supplied
+# elsewhere (the waitee's lock, or the seq_cst publish/recheck dance of
+# `register_cancellation!`).
+@inline _slot_owner(w::WaitEntry1, i::Int) = @atomic :monotonic w.owner1
+@inline _slot_owner(w::WaitEntry2, i::Int) =
+    i == 1 ? (@atomic :monotonic w.owner1) : (@atomic :monotonic w.owner2)
+@inline _slot_owner(w::WaitEntryN, i::Int) =
+    ccall(:jl_wait_entry_slot_owner, Any, (Any, Csize_t), w, i - 1)
+
+@inline function _set_slot_owner!(w::WaitEntry1, i::Int, @nospecialize(v))
+    @atomic :monotonic w.owner1 = v
+    return nothing
+end
+@inline function _set_slot_owner!(w::WaitEntry2, i::Int, @nospecialize(v))
+    if i == 1
+        @atomic :monotonic w.owner1 = v
+    else
+        @atomic :monotonic w.owner2 = v
+    end
+    return nothing
+end
+@inline _set_slot_owner!(w::WaitEntryN, i::Int, @nospecialize(v)) =
+    ccall(:jl_wait_entry_set_slot_owner, Cvoid, (Any, Csize_t, Any), w, i - 1, v)
+
+@inline _slot_next(w::WaitEntry1, i::Int) = w.next1
+@inline _slot_next(w::WaitEntry2, i::Int) = i == 1 ? w.next1 : w.next2
+@inline _slot_next(w::WaitEntryN, i::Int) =
+    ccall(:jl_wait_entry_slot_next, Any, (Any, Csize_t), w, i - 1)::Union{WaitEntry, Nothing}
+
+@inline _set_slot_next!(w::WaitEntry1, i::Int, v::Union{WaitEntry, Nothing}) = (w.next1 = v; nothing)
+@inline function _set_slot_next!(w::WaitEntry2, i::Int, v::Union{WaitEntry, Nothing})
+    i == 1 ? (w.next1 = v) : (w.next2 = v)
+    return nothing
+end
+@inline _set_slot_next!(w::WaitEntryN, i::Int, v::Union{WaitEntry, Nothing}) =
+    ccall(:jl_wait_entry_set_slot_next, Cvoid, (Any, Csize_t, Any), w, i - 1,
+          v === nothing ? nothing : v)
+
+@inline _slot_aux(w::WaitEntry1, i::Int) = w.aux1
+@inline _slot_aux(w::WaitEntry2, i::Int) = i == 1 ? w.aux1 : w.aux2
+@inline _slot_aux(w::WaitEntryN, i::Int) =
+    ccall(:jl_wait_entry_slot_aux, UInt64, (Any, Csize_t), w, i - 1)
+
+@inline _set_slot_aux!(w::WaitEntry1, i::Int, v::UInt64) = (w.aux1 = v; nothing)
+@inline function _set_slot_aux!(w::WaitEntry2, i::Int, v::UInt64)
+    i == 1 ? (w.aux1 = v) : (w.aux2 = v)
+    return nothing
+end
+@inline _set_slot_aux!(w::WaitEntryN, i::Int, v::UInt64) =
+    ccall(:jl_wait_entry_set_slot_aux, Cvoid, (Any, Csize_t, UInt64), w, i - 1, v)
+
+# The slot registered on `owner`, or 0.
+@inline _find_slot(w::WaitEntry1, @nospecialize(owner)) =
+    (@atomic :monotonic w.owner1) === owner ? 1 : 0
+@inline _find_slot(w::WaitEntry2, @nospecialize(owner)) =
+    (@atomic :monotonic w.owner1) === owner ? 1 :
+    (@atomic :monotonic w.owner2) === owner ? 2 : 0
+function _find_slot(w::WaitEntryN, @nospecialize(owner))
+    for i in 1:_nslots(w)
+        _slot_owner(w, i) === owner && return i
+    end
+    return 0
+end
+
+# The first free slot, or 0.
+@inline _free_slot(w::WaitEntry1) = (@atomic :monotonic w.owner1) === nothing ? 1 : 0
+@inline _free_slot(w::WaitEntry2) =
+    (@atomic :monotonic w.owner1) === nothing ? 1 :
+    (@atomic :monotonic w.owner2) === nothing ? 2 : 0
+_free_slot(w::WaitEntryN) = _find_slot(w, nothing)
+
+@noinline _slot_overflow_error() =
+    throw(ConcurrencyViolationError("wait entry has no free slot for this registration"))
+
+# Claim a free slot for `owner` (which must not already have one).
+@inline function _acquire_slot!(w::WaitEntry, @nospecialize(owner))
+    i = _free_slot(w)
+    i == 0 && _slot_overflow_error()
+    _set_slot_owner!(w, i, owner)
+    return i
+end
+
+# A reference to one slot of a wait entry, with `owner`/`next`/`aux`
+# property access (owner accesses are relaxed-atomic; see above), and a
+# vector view of an entry's slots. `slots(w)[i].owner === src`,
+# `slot.next = x`, `for slot in slots(w)` are the intended spellings for
+# code that is generic over the slot count.
+struct WaitSlotRef{T<:WaitEntry}
+    entry::T
+    i::Int
+end
+@inline function getproperty(s::WaitSlotRef, f::Symbol)
+    f === :owner && return _slot_owner(getfield(s, :entry), getfield(s, :i))
+    f === :next && return _slot_next(getfield(s, :entry), getfield(s, :i))
+    f === :aux && return _slot_aux(getfield(s, :entry), getfield(s, :i))
+    return getfield(s, f)
+end
+@inline function setproperty!(s::WaitSlotRef, f::Symbol, @nospecialize(v))
+    if f === :owner
+        _set_slot_owner!(getfield(s, :entry), getfield(s, :i), v)
+    elseif f === :next
+        _set_slot_next!(getfield(s, :entry), getfield(s, :i), v::Union{WaitEntry, Nothing})
+    elseif f === :aux
+        _set_slot_aux!(getfield(s, :entry), getfield(s, :i), v::UInt64)
+    else
+        throw(FieldError(WaitSlotRef, f))
+    end
+    return v
+end
+
+struct WaitSlots{T<:WaitEntry} <: AbstractVector{WaitSlotRef{T}}
+    entry::T
+end
+size(s::WaitSlots) = (_nslots(getfield(s, :entry)),)
+@inline getindex(s::WaitSlots, i::Int) = WaitSlotRef(getfield(s, :entry), i)
+slots(w::WaitEntry) = WaitSlots(w)
+
+# Free slot `i` of `w`: `next` and `aux` are cleared first (a freed slot's
+# payload must not leak into its next registration - e.g. the uv write
+# cancel flag, see base/stream.jl) and the `owner` witness last - its
+# clearing is what hands the slot back for reuse.
+@inline function _release_slot!(w::WaitEntry, i::Int)
+    _set_slot_next!(w, i, nothing)
+    _set_slot_aux!(w, i, UInt64(0))
+    _set_slot_owner!(w, i, nothing)
+    return nothing
+end
+
+# The entry after `w` on `owner`'s list (`nothing` at its end, or -
+# defensively - when `w` has no slot for `owner`).
+@inline function _next_on(w::WaitEntry, @nospecialize(owner))
+    i = _find_slot(w, owner)
+    return i == 0 ? nothing : _slot_next(w, i)
+end
+
+# Set/clear a bare waitee witness (a registration that marks the entry as
+# in-use for `x` without linking it into any list - the libuv request
+# waits): the slot's `owner` is the reuse gate, `next` stays free.
+_set_wait_witness!(w::WaitEntry, @nospecialize(x)) = (_acquire_slot!(w, x); nothing)
+function _clear_wait_witness!(w::WaitEntry, @nospecialize(x))
+    i = _find_slot(w, x)
+    i == 0 || _release_slot!(w, i)
+    return nothing
+end
+
+# Release the waitee witness of a uv request wait from its completion
+# callback, which holds the entry but not the waitee: uv entries carry one
+# witness slot alongside an optional cancellation-source slot, which stays
+# registered (sticky).
+function _clear_uv_witness!(w::WaitEntry)
+    for slot in slots(w)
+        o = slot.owner
+        (o === nothing || o isa CancellationTokenSource) && continue
+        slot.next = nothing
+        slot.aux = UInt64(0) # e.g. the uv write cancel flag; see _release_slot!
+        slot.owner = nothing
+        break
+    end
+    return nothing
+end
+
+# Return `waiter`'s cached wait entry for a *plain* (non-cancellable) park,
+# or a fresh (and newly cached) one if the cached one is still in use.
+#
+# Plain parks arm a *distinct* entry from cancellable parks
+# (`_cancel_wait_entry`), and that identity split is what keeps shields
+# shielded: the cancellation walk's only sound eligibility gate is its
+# expected-entry claim CAS, so an entry registered on a source must never
+# be armed for a wait that is not cancellable under it. (Aux data outside
+# the claim word - the severity floors - is read racily by the walk and may
+# be judged against an adjacent arm of the same entry; that misfire is
+# tolerable for a teardown wait's floor, never for a shield. See the model
+# in tla/WaitClaim.tla: sharing one entry lets a walk claim a shielded
+# re-arm using the previous arm's eligibility.)
+function _cached_wait_entry(waiter::Task)
+    w = waiter.cached_wait_entry
+    if w isa WaitEntry1 && (@atomic :monotonic w.owner1) === nothing
+        @atomic :monotonic w.task = waiter
+    else
+        w = WaitEntry1(waiter)
+        waiter.cached_wait_entry = w
+    end
+    return w
+end
+
+# Return the entry for a cancellable park of `waiter` governed by `src`,
+# with the minimum delivery severity staged on the source slot. Must run
+# before the arm: the cancellation walk reads the slot's aux only through
+# an armed entry, so it has to be in place when `waiting_on` is published.
+# Convention: `min_severity` is the lowest severity that may wake the wait
+# (inclusive comparisons on both the registration and walk sides); a
+# teardown wait that already acknowledged a delivery at severity `s` stages
+# `s + 0x01` so only an escalation wakes it.
+#
+# The cached entry is reused when its sticky source slot is compatible:
+# already on `src` (the common case - a task parking repeatedly under its
+# ambient token pays no registry work after the first park), or free. When
+# it is bound to a *different* source (the task's governing token changed),
+# the owner unregisters it - the one O(list) operation on a park path, paid
+# once per token migration - and rebinds. A cache entry stuck on a wait
+# queue (stale registration from an interrupted wait, not yet collected)
+# leaves a fresh single-use entry whose source registration becomes an
+# unarmed corpse for pruning.
+function _cancel_wait_entry(waiter::Task, src::CancellationTokenSource,
+                            min_severity::UInt8)
+    w = waiter.cached_cancel_entry
+    if w isa WaitEntry2 && (@atomic :monotonic w.owner1) === nothing
+        o = @atomic :monotonic w.owner2
+        if !(o === src || o === nothing)
+            # rebind: physically drop the stale sticky registration first
+            unregister_cancellation!(o::CancellationTokenSource, w)
+        end
+        @atomic :monotonic w.task = waiter
+    elseif w isa WaitEntry2
+        w = WaitEntry2(waiter)
+    else
+        w = WaitEntry2(waiter)
+        waiter.cached_cancel_entry = w
+    end
+    w.aux2 = UInt64(min_severity)
+    return w
+end
+
+@noinline function _wait_registration_error()
+    throw(ConcurrencyViolationError("Task is already registered on a wait queue"))
+end
+
+# Publish `w` as `waiter`'s only armed wait registration.
+function _arm_wait(waiter::Task, w::WaitEntry)
+    armed = @atomicreplace :release :monotonic waiter.waiting_on nothing => w
+    armed.success || _wait_registration_error()
+    return w
+end
+
+# Claim the wake of the wait that `w` was registered for (returns whether the
+# claim succeeded). `w` must be an entry armed for `t` by `_wait2`.
+function claim_wait(t::Task, w::WaitEntry)
+    return (@atomicreplace t.waiting_on w => nothing).success
+end
+
+## Waiter registration
+#
+# The waiter list is lock-free on every hot path (like the source's child
+# list): registration is a CAS push of the entry onto `waiters_head`, a
+# normal wakeup does no registry work at all (the entry stays registered -
+# armed/unarmed is tracked by the task's `waiting_on` claim word), and a
+# repeat park under the same source re-arms the already-registered entry
+# with no shared-memory operation. Only walks (cancellation delivery,
+# pruning, and the owner-side `unregister_cancellation!`) rewrite links,
+# serialized by the source's `walk_lock`, which no park or wakeup ever
+# takes.
+
+# Serialize walks on `src` (cancellation delivery, pruning, owner-side
+# unregistration). Never taken on park/wake paths; contended walkers sleep.
+# The lock object is installed lazily by the first walker, so sources that
+# are never walked stay two words smaller than a ReentrantLock.
+function _walk_lock(src::CancellationTokenSource)
+    l = @atomic :acquire src.walk_lock
+    l === nothing || return l::ReentrantLock
+    newl = ReentrantLock()
+    old, ok = @atomicreplace :acquire_release :acquire src.walk_lock nothing => newl
+    return ok ? newl : old::ReentrantLock
+end
+# A walk delivers (or collects for) cancellations, possibly of the very
+# scope the walking task runs under: the acquire must be shielded.
+_lock_walk(src::CancellationTokenSource) = lock(_walk_lock(src); cancel=nothing)
+_trylock_walk(src::CancellationTokenSource) = trylock(_walk_lock(src))
+_unlock_walk(src::CancellationTokenSource) = unlock(_walk_lock(src))
+
+# Pruning: dead registrations (retired entries, entries of completed tasks)
+# are counted where they die - `retire_cancellation_entry!` and the task
+# teardown hook - and the incrementer that trips the threshold runs a prune
+# walk, so corpses cannot accumulate without bound on a long-lived source
+# that never gets cancelled. Sources are mostly scope-lifetime, so in
+# practice the dominant reclaimer is the source dying.
+const _PRUNE_DEAD_THRESHOLD = UInt32(16)
+
+# Account a newly dead registration on `src` and prune when enough have
+# accumulated. `>=`, not `==`: when the incrementer that crosses the
+# threshold loses `_try_prune!`'s trylock to a concurrent walk, corpses that
+# walk had already passed remain counted here, and the next death must retry
+# the prune rather than let the count sail past the threshold forever.
+function _note_dead_registration!(src::CancellationTokenSource)
+    dc = @atomic :monotonic src.dead_count += UInt32(1)
+    dc >= _PRUNE_DEAD_THRESHOLD && _try_prune!(src)
+    return nothing
+end
+
+# Relaxed load of the waiter-list head (an `Any` field whose non-entry
+# initial value means the empty list). The walk's seq_cst head read stays
+# spelled out at its use site.
+@inline function _waiters_head(src::CancellationTokenSource)
+    h = @atomic :monotonic src.waiters_head
+    return h isa WaitEntry ? h : nothing
+end
+
+# Register the armed wait entry `w` (see `_cancel_wait_entry`/`_arm_wait`)
+# on `src`'s waiter list, so the cancellation walk can find and claim the
+# parked task, and close the arm-vs-cancel race. Returns `false` when `src`
+# was already cancelled at `w.min_severity` or above *and* this call claimed
+# the wake back: the caller must withdraw its waitee-side state and deliver
+# the refusal itself (`_deliver_refused_cancellation`); the sticky source
+# registration stays. Returns `true` when the park should proceed -
+# including when a concurrent cancellation walk claimed the freshly armed
+# entry, in which case its wake delivers the request into the park.
+function register_cancellation!(src::CancellationTokenSource, w::WaitEntry)
+    i = _find_slot(w, src)
+    if i == 0
+        # First park under `src`: claim a slot (the slot's `owner` is the
+        # push ticket - setting it before the publishing CAS orders it for
+        # any walk that can see the entry) and publish the entry with a
+        # lock-free push.
+        slot = slots(w)[_acquire_slot!(w, src)]
+        while true
+            h = _waiters_head(src)
+            slot.next = h
+            # seq_cst, pairing with the cancellation walk's state-write-
+            # then-head-read: if the walk's head read misses this push, this
+            # push is later in the total order, so the state recheck below
+            # observes the raised state (same dance as the child-attach in
+            # jl_new_cancel_source).
+            if (@atomicreplace :sequentially_consistent :monotonic src.waiters_head h => w).success
+                break
+            end
+        end
+    else
+        slot = slots(w)[i]
+        # Sticky re-arm (the entry is already registered on `src`): upgrade
+        # this thread's arm-then-recheck to the store-load ordering the
+        # race argument needs (the arm CAS itself is only `release`).
+        Core.Intrinsics.atomic_fence(:sequentially_consistent, :system)
+    end
+    # Post-publication recheck: either the concurrent cancellation walk
+    # observes our push/arm, or we observe its state write here.
+    st = @atomic :sequentially_consistent src.state
+    if st != 0x00 && st >= slot.aux % UInt8
+        t = (@atomic :monotonic w.task)::Task
+        if (@atomicreplace t.waiting_on w => nothing).success
+            return false
+        end
+        # A concurrent walk claimed the wake first; its schedule delivers
+        # the request into the park.
+    end
+    return true
+end
+
+# Owner-side physical unregistration of `w` from `src`'s waiter list: an
+# O(list) walk under the walk lock. Used on the rare paths that must drop a
+# sticky registration eagerly - rebinding the cached cancel entry after a
+# token migration - not on any wakeup path (normal wakeups leave the
+# registration in place). `w` must be unarmed and owned by the caller.
+function unregister_cancellation!(src::CancellationTokenSource, w::WaitEntry)
+    wi = _find_slot(w, src)
+    wi == 0 && return nothing
+    wslot = slots(w)[wi]
+    _lock_walk(src)
+    prev = nothing # the predecessor's slot for `src`, once past the head
+    x = _waiters_head(src)
+    while x isa WaitEntry
+        xi = x === w ? wi : _find_slot(x, src)
+        # a linked entry always has a slot for this source (see
+        # _walk_waiters!); bail out without touching the structure otherwise
+        xi == 0 && break
+        slot = slots(x)[xi]
+        xnext = slot.next
+        if x === w
+            if prev === nothing
+                # racing pushes prepend; retrying against the fresh head
+                # re-finds `w`'s predecessor
+                if !(@atomicreplace :monotonic :monotonic src.waiters_head x => xnext).success
+                    x = _waiters_head(src)
+                    continue
+                end
+            else
+                prev.next = xnext
+            end
+            wslot.next = nothing
+            break
+        end
+        prev = slot
+        x = xnext
+    end
+    wslot.owner = nothing
+    _unlock_walk(src)
+    return nothing
+end
+
+# Deliver the cancellation that made `register_cancellation!` refuse (the
+# caller has already withdrawn its waitee-side registration and released
+# any locks the throw must not hold).
+@noinline function _deliver_refused_cancellation(src::CancellationTokenSource)
+    checkcancel(src)
+    error("cancellation registration refused, but the source is not cancelled")
+end
+
+# Mark the single-use entry `w` as done with its (sticky) source
+# registrations: walks then collect it like an entry of a completed task.
+# For per-call entries (`Experimental.wait_with_timeout`, waitany) whose
+# task may live - and keep registering - indefinitely.
+function retire_cancellation_entry!(w::WaitEntry)
+    @atomic :monotonic w.task = nothing
+    for slot in slots(w)
+        o = slot.owner
+        o isa CancellationTokenSource && _note_dead_registration!(o)
+    end
+    return nothing
+end
+
+# Prune walk: collect unarmed corpses (completed tasks, retired entries).
+# Never delivers - delivery is `cancel!`'s walk, and any registrant racing
+# a cancellation is covered by its own state recheck.
+@noinline function _try_prune!(src::CancellationTokenSource)
+    _trylock_walk(src) || return nothing  # a running walk collects anyway
+    _walk_waiters!(src, 0x00)
+    _unlock_walk(src)
+    return nothing
+end
+
 ## Cancellation
 #
 # Cancellation is uniformly level-triggered: while the governing token is
@@ -218,6 +733,9 @@ function cancel!(src::CancellationTokenSource,
         throw(ArgumentError("invalid cancellation severity $(repr(request.request))"))
     end
     raised = _raise_state!(src, sev)
+    # Mark the cancelled subgraph (waking parked waiters): each node is
+    # marked before its children so a concurrent construction of a child
+    # source is level-triggered.
     _cancel_walk!(src, sev)
     Threads.atomic_fence_heavy()
     # Shoot down any task now bound to a cancelled source: threads inside a
@@ -230,6 +748,10 @@ function cancel!(src::CancellationTokenSource,
 end
 
 function _cancel_walk!(src::CancellationTokenSource, sev::UInt8)
+    # Iterative worklist (no recursion): a deep source chain must not
+    # overflow the canceller's stack, and a reconverging ("linked") graph
+    # must deliver at each node once, not once per path (deduplicated by the
+    # visited set).
     visited = IdSet{CancellationTokenSource}()
     push!(visited, src)
     pending = CancellationTokenSource[src]
@@ -239,11 +761,125 @@ function _cancel_walk!(src::CancellationTokenSource, sev::UInt8)
     return nothing
 end
 
+# Walk `node`'s waiter list under the walk lock: physically unlink the
+# registrations of completed tasks and retired entries (the only removal in
+# the registry - a live task's registration is sticky and stays linked
+# between parks) and, when `sev` is nonzero, claim armed waiters eligible
+# at that severity. Returns the claimed tasks as a `(t, rest)` cons list;
+# the caller wakes them after releasing the walk lock.
+function _walk_waiters!(node::CancellationTokenSource, sev::UInt8)
+    @atomic :monotonic node.dead_count = UInt32(0)
+    towake = nothing
+    prev = nothing # the predecessor's slot for `node`, once past the head
+    # seq_cst: the S-ordered counterpart of a registrant's seq_cst push -
+    # a push this read misses is later in the total order, so that
+    # registrant's state recheck observes the cancellation (see
+    # register_cancellation!); pairs with the seq_cst state read the caller
+    # performed under the walk lock.
+    x = @atomic :sequentially_consistent node.waiters_head
+    w = x isa WaitEntry ? x : nothing
+    while w isa WaitEntry
+        wi = _find_slot(w, node)
+        # a linked entry always has a slot for this source (its owner is
+        # the membership witness, cleared only on unlink, under this lock);
+        # bail out without touching the structure if that is ever violated
+        wi == 0 && break
+        slot = slots(w)[wi]
+        wnext = slot.next
+        t = @atomic :monotonic w.task
+        if t === nothing || istaskdone(t)
+            # Unlink. Interior links are rewritten only under the walk lock,
+            # so they are plain stores; unlinking the head races concurrent
+            # pushes and simply keeps the entry for the next walk when it
+            # loses.
+            unlinked = if prev === nothing
+                (@atomicreplace :monotonic :monotonic node.waiters_head w => wnext).success
+            else
+                prev.next = wnext
+                true
+            end
+            if unlinked
+                # The slot `owner` is cleared last: it is the membership
+                # witness whose clearing hands the (dead) slot back.
+                slot.next = nothing
+                t === nothing || (@atomic :monotonic w.task = nothing)
+                slot.owner = nothing
+            else
+                prev = slot
+            end
+        else
+            # Claim order: the armed check must come first - the slot's aux
+            # (the minimum delivery severity) is only meaningful for the arm
+            # it was staged for, and reading it after observing the arm pins
+            # it to that arm or a later one. An arm this (seq_cst, pairing
+            # with the re-arm fence in register_cancellation!) read misses
+            # is covered by its own post-arm state recheck, so skipping it
+            # here is sound. The claim CAS itself may still land on a
+            # *later* arm of the same entry than the one whose aux was
+            # judged - which is why every arm of a source-linked entry must
+            # be a cancellable park under it (shields arm a distinct entry;
+            # see _cached_wait_entry and tla/WaitClaim.tla): the worst
+            # misfire is then a spurious below-floor wake into a teardown
+            # re-park, which handles it like any interruption of its wait
+            # (conservatively, e.g. by detaching the awaited request).
+            if sev != 0x00 && (@atomic :sequentially_consistent t.waiting_on) === w &&
+                    slot.aux % UInt8 <= sev
+                if (@atomicreplace t.waiting_on w => nothing).success
+                    towake = ((t, w), towake)
+                end
+                # a lost claim: a completion or interrupter won the race;
+                # the waiter resumes through that wake
+            end
+            prev = slot
+        end
+        w = wnext
+    end
+    return towake
+end
+
 function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
                             pending::Vector{CancellationTokenSource},
                             visited::IdSet{CancellationTokenSource})
+    _lock_walk(node)
+    # Deliver at least the node's current severity: a concurrent higher-
+    # severity cancel! may have raised the state after this walk's own
+    # transition, and its walk can run before this one takes the walk lock -
+    # the claims below must then honor the escalated request. (Read under
+    # the walk lock so the claim section cannot act on a stale, lower
+    # severity.) seq_cst, matching the C-side propagate: when this walk's
+    # own raise of the node was lost, this load is the walk's sole operation
+    # on the state that can order the winner's write before the child_head
+    # read below; it also pairs with the seq_cst push/arm-fence in
+    # `register_cancellation!` (state write before walk on this side, push
+    # or arm before state recheck on the registrant's).
     st = @atomic :sequentially_consistent node.state
     sev < st && (sev = st)
+    creq = CancellationRequest(sev)
+    towake = _walk_waiters!(node, sev)
+    # The actual wakes happen after the walk lock is released: holding it
+    # across `schedule` would only stretch the window against concurrent
+    # escalation walks. Claimed entries stay registered (sticky); the
+    # claimed *waitee*-queue entry also stays linked, and the waiter's own
+    # cleanup (or a later notify) lazily unlinks it.
+    _unlock_walk(node)
+    while towake !== nothing
+        ((t, w), towake) = towake::Tuple{Tuple{Task, WaitEntry}, Any}
+        # N.B.: an ABANDON_ALL request currently also delivers by
+        # interruption; freezing the task in place instead arrives with the
+        # escalation machinery. The delivery is claim-scoped - the claim
+        # above is the wake ticket, so no re-claiming swap - and dropped
+        # when the task has re-armed meanwhile (see deliver_claimed_wake!).
+        deliver_claimed_wake!(t, w, creq)
+    end
+    # Walk the node's (weak, intrusive) child list, advancing every child to
+    # this severity and queueing the ones not yet visited (a reconverging
+    # graph must deliver at each node once, not once per path). The seq_cst
+    # `child_head` read below (paired with the seq_cst state access above)
+    # closes the race against a concurrent attach: a child that this read
+    # misses was published after our state write, so its constructor
+    # observes that write and the child is born at (at least) this severity.
+    # Children attached concurrently *during* the walk are prepended before
+    # the list positions already traversed and are likewise born cancelled.
     c = @atomic node.child_head
     while c !== nothing
         c = c::CancellationTokenSource
@@ -347,6 +983,8 @@ end
 # Throw the `CancellationRequest` if `src` is cancelled (level-triggered:
 # no per-task state is consulted). Unlike `@cancel_check` this is not a
 # compiled cancellation point (it opens no async-interruptible region).
+# This is the entry check of every blocking API taking a `cancel` keyword
+# argument: it must run *before* the operation has any side effects.
 @inline function checkcancel(src::CancellationTokenSource)
     st = @atomic :monotonic src.state
     st == 0x00 && return nothing
@@ -399,3 +1037,44 @@ end
     tok === nothing && return nothing
     return (tok::CancellationToken).source
 end
+
+## `cancel` keyword-argument plumbing
+
+# The sentinel default for `cancel` keyword arguments: "use the scoped
+# default token". Resolution to a concrete token happens once, at the first
+# potential-block point of an operation, so fast paths never pay for the
+# scope lookup. `cancel = nothing` makes a wait explicitly non-cancellable.
+#
+# N.B.: a resolved token (`Union{Nothing, CancellationToken}`) is passed
+# through *positional* arguments internally: passing the union as a keyword
+# argument builds an abstractly-typed NamedTuple whose kwcall the optimizer
+# cannot devirtualize (which, among other things, breaks `juliac --trim`).
+struct UseDefaultToken end
+const DEFAULT_CANCEL = UseDefaultToken()
+const CancelTokenArg = Union{UseDefaultToken, CancellationToken, Nothing}
+const MaybeToken = Union{Nothing, CancellationToken}
+
+@inline resolve_cancel_token(::UseDefaultToken) = default_cancel_token()
+@inline resolve_cancel_token(tok::Union{CancellationToken, Nothing}) = tok
+
+# The source of a resolved token (`nothing` stays `nothing`).
+cancel_source(tok::CancellationToken) = tok.source
+cancel_source(::Nothing) = nothing
+
+# The entry check of a public API taking a `cancel` keyword argument:
+# resolve the token and throw if it is already cancelled (uniformly
+# level-triggered for the scoped default and explicit tokens alike).
+@inline function check_cancel_arg(cancel::CancelTokenArg)
+    tok = resolve_cancel_token(cancel)
+    tok === nothing || checkcancel(tok.source)
+    return tok
+end
+
+# The lighter entry check for APIs with a non-blocking fast path: an
+# explicitly passed token is resolved and checked (throwing when already
+# cancelled) right here, while the scoped-default sentinel passes through
+# untouched, deferring the scope lookup - and its (level-triggered) check -
+# to the operation's first potential-block point, so fast paths pay neither.
+# Spelled `cancel = precheck_cancel_arg(cancel)` at the top of such APIs.
+@inline precheck_cancel_arg(cancel::CancelTokenArg) =
+    cancel isa UseDefaultToken ? cancel : check_cancel_arg(cancel)

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -523,7 +523,7 @@ function _arm_wait(waiter::Task, w::WaitEntry)
 end
 
 # Claim the wake of the wait that `w` was registered for (returns whether the
-# claim succeeded). `w` must be an entry armed for `t` by `_wait2`.
+# claim succeeded). `w` must be an entry armed for `t` (`_arm_wait`).
 function claim_wait(t::Task, w::WaitEntry)
     return (@atomicreplace t.waiting_on w => nothing).success
 end
@@ -975,6 +975,27 @@ complete while the surrounding computation is being cancelled.
 The current value can be read with `Base.CANCEL_TOKEN[]`.
 """
 const CANCEL_TOKEN = CancelTokenKey()
+
+# The cancellation source a task inherited at birth: the CANCEL_TOKEN
+# binding of the scope captured at its construction (`nothing` for tasks
+# constructed outside any governing scope, or shielded with
+# `CANCEL_TOKEN => nothing`). Subscriptions (`schedule_on_notify!`) are
+# governed by this source: a task whose birth source is cancelled dies
+# instead of starting.
+function _birth_cancel_source(t::Task)
+    # Raw field read: the `t.scope` property guard exists because a
+    # *running* task swaps its scope as `with` blocks enter and exit -
+    # racy to read from outside. Subscriptions enforce a never-started
+    # waiter (see schedule_on_notify!), whose construction-time scope is
+    # stable until its first schedule.
+    scope = getfield(t, :scope)
+    scope isa Scope || return nothing
+    v = KeyValue.get(scope.values, CANCEL_TOKEN)
+    v === nothing && return nothing
+    tok = something(v)
+    tok === nothing && return nothing
+    return (tok::CancellationToken).source
+end
 
 @inline function default_cancel_token()
     scope = Core.current_scope()::Union{Scope, Nothing}

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -411,6 +411,7 @@ end
 
 function put_buffered(c::Channel, v, cancel::CancelTokenArg=DEFAULT_CANCEL)
     lock(c; cancel)
+    locked = true
     did_buffer = false
     try
         # Increment channel n_avail eagerly (before push!) to count data in the
@@ -420,7 +421,9 @@ function put_buffered(c::Channel, v, cancel::CancelTokenArg=DEFAULT_CANCEL)
             tok = resolve_cancel_token(cancel)
             while length(c.data) == c.sz_max
                 check_channel_state(c)
+                locked = false
                 wait(c.cond_put, tok)
+                locked = true
             end
         end
         check_channel_state(c)
@@ -429,8 +432,11 @@ function put_buffered(c::Channel, v, cancel::CancelTokenArg=DEFAULT_CANCEL)
         # notify all, since some of the waiters may be on a "fetch" call.
         notify(c.cond_take, nothing, true, false)
     finally
-        # Decrement the available items if this task had an exception before pushing the
-        # item to the buffer (e.g., during `wait(c.cond_put)`):
+        # Decrement the available items if this task had an exception before
+        # pushing the item to the buffer (e.g., during `wait(c.cond_put)`).
+        # The fixup needs the lock: reacquire (shielded) when a wait-throw
+        # released this frame's level.
+        locked || lock(c; cancel=nothing)
         did_buffer || _increment_n_avail(c, -1)
         unlock(c)
     end
@@ -439,6 +445,7 @@ end
 
 function put_unbuffered(c::Channel, v, cancel::CancelTokenArg=DEFAULT_CANCEL)
     lock(c; cancel)
+    locked = true
     taker = try
         _increment_n_avail(c, 1)
         tok = resolve_cancel_token(cancel)
@@ -447,7 +454,9 @@ function put_unbuffered(c::Channel, v, cancel::CancelTokenArg=DEFAULT_CANCEL)
             while isempty(c.cond_take.waitq)
                 check_channel_state(c)
                 notify(c.cond_wait)
+                locked = false
                 wait(c.cond_put, tok)
+                locked = true
             end
             check_channel_state(c)
             # unfair scheduled version of: notify(c.cond_take, v, false, false); yield()
@@ -462,6 +471,8 @@ function put_unbuffered(c::Channel, v, cancel::CancelTokenArg=DEFAULT_CANCEL)
         end
         taker
     finally
+        # the decrement needs the lock (see put_buffered's finally)
+        locked || lock(c; cancel=nothing)
         _increment_n_avail(c, -1)
         unlock(c)
     end
@@ -500,17 +511,20 @@ function fetch(c::Channel; cancel::CancelTokenArg=DEFAULT_CANCEL)
 end
 function fetch_buffered(c::Channel, cancel::CancelTokenArg=DEFAULT_CANCEL)
     lock(c; cancel)
+    locked = true
     try
         if isempty(c.data)
             tok = resolve_cancel_token(cancel)
             while isempty(c.data)
                 check_channel_state(c)
+                locked = false
                 wait(c.cond_take, tok)
+                locked = true
             end
         end
         return c.data[1]
     finally
-        unlock(c)
+        locked && unlock(c)
     end
 end
 fetch_unbuffered(c::Channel) = throw(ErrorException("`fetch` is not supported on an unbuffered Channel."))
@@ -551,12 +565,15 @@ function take!(c::Channel; cancel::CancelTokenArg=DEFAULT_CANCEL)
 end
 function take_buffered(c::Channel, cancel::CancelTokenArg=DEFAULT_CANCEL)
     lock(c; cancel)
+    locked = true
     try
         if isempty(c.data)
             tok = resolve_cancel_token(cancel)
             while isempty(c.data)
                 check_channel_state(c)
+                locked = false
                 wait(c.cond_take, tok)
+                locked = true
             end
         end
         v = popfirst!(c.data)
@@ -564,19 +581,23 @@ function take_buffered(c::Channel, cancel::CancelTokenArg=DEFAULT_CANCEL)
         notify(c.cond_put, nothing, false, false) # notify only one, since only one slot has become available for a put!.
         return v
     finally
-        unlock(c)
+        locked && unlock(c)
     end
 end
 
 # 0-size channel
 function take_unbuffered(c::Channel{T}, cancel::CancelTokenArg=DEFAULT_CANCEL) where T
     lock(c; cancel)
+    locked = true
     try
         check_channel_state(c)
         notify(c.cond_put, nothing, false, false)
-        return wait(c.cond_take, resolve_cancel_token(cancel))::T
+        locked = false
+        v = wait(c.cond_take, resolve_cancel_token(cancel))::T
+        locked = true
+        return v
     finally
-        unlock(c)
+        locked && unlock(c)
     end
 end
 
@@ -702,16 +723,19 @@ function wait(c::Channel; cancel::CancelTokenArg=DEFAULT_CANCEL)
     cancel = precheck_cancel_arg(cancel)
     isready(c) && return
     lock(c; cancel)
+    locked = true
     try
         if !isready(c)
             tok = resolve_cancel_token(cancel)
             while !isready(c)
                 check_channel_state(c)
+                locked = false
                 wait(c.cond_wait, tok)
+                locked = true
             end
         end
     finally
-        unlock(c)
+        locked && unlock(c)
     end
     nothing
 end

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -327,9 +327,14 @@ Stacktrace:
 ```
 """
 function bind(c::Channel, task::Task)
-    T = Task(() -> close_chnl_on_taskdone(task, c))
+    # the close hook is cleanup: shield it from the constructing scope's
+    # cancellation, so a bound channel is closed (and its blocked users
+    # released) even when the scope that bound it is cancelled
+    T = ScopedValues.with(CANCEL_TOKEN => nothing) do
+        Task(() -> close_chnl_on_taskdone(task, c))
+    end
     T.sticky = false
-    _wait2(task, T)
+    schedule_on_notify!(task, T)
     return c
 end
 

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -392,10 +392,11 @@ task.
 !!! compat "Julia 1.1"
     `v` now gets converted to the channel's type with [`convert`](@ref) as `put!` is called.
 """
-function put!(c::Channel{T}, v) where T
+function put!(c::Channel{T}, v; cancel::CancelTokenArg=DEFAULT_CANCEL) where T
     check_channel_state(c)
     v = convert(T, v)
-    return isbuffered(c) ? put_buffered(c, v) : put_unbuffered(c, v)
+    cancel = precheck_cancel_arg(cancel)
+    return isbuffered(c) ? put_buffered(c, v, cancel) : put_unbuffered(c, v, cancel)
 end
 
 # Atomically update channel n_avail, *assuming* we hold the channel lock.
@@ -408,16 +409,19 @@ function _increment_n_avail(c, inc)
     @atomic :monotonic c.n_avail_items = newlen
 end
 
-function put_buffered(c::Channel, v)
-    lock(c)
+function put_buffered(c::Channel, v, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    lock(c; cancel)
     did_buffer = false
     try
         # Increment channel n_avail eagerly (before push!) to count data in the
         # buffer as well as offers from tasks which are blocked in wait().
         _increment_n_avail(c, 1)
-        while length(c.data) == c.sz_max
-            check_channel_state(c)
-            wait(c.cond_put)
+        if length(c.data) == c.sz_max
+            tok = resolve_cancel_token(cancel)
+            while length(c.data) == c.sz_max
+                check_channel_state(c)
+                wait(c.cond_put, tok)
+            end
         end
         check_channel_state(c)
         push!(c.data, v)
@@ -433,21 +437,22 @@ function put_buffered(c::Channel, v)
     return v
 end
 
-function put_unbuffered(c::Channel, v)
-    lock(c)
+function put_unbuffered(c::Channel, v, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    lock(c; cancel)
     taker = try
         _increment_n_avail(c, 1)
+        tok = resolve_cancel_token(cancel)
         local taker
         while true
             while isempty(c.cond_take.waitq)
                 check_channel_state(c)
                 notify(c.cond_wait)
-                wait(c.cond_put)
+                wait(c.cond_put, tok)
             end
             check_channel_state(c)
             # unfair scheduled version of: notify(c.cond_take, v, false, false); yield()
             w = popfirst!(waitqueue(c.cond_take))
-            t = w.task
+            t = @atomic :monotonic w.task
             if t isa Task && claim_wait(t, w)
                 taker = t
                 break
@@ -489,13 +494,19 @@ julia> collect(c)  # item is not removed
  3
 ```
 """
-fetch(c::Channel) = isbuffered(c) ? fetch_buffered(c) : fetch_unbuffered(c)
-function fetch_buffered(c::Channel)
-    lock(c)
+function fetch(c::Channel; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
+    return isbuffered(c) ? fetch_buffered(c, cancel) : fetch_unbuffered(c)
+end
+function fetch_buffered(c::Channel, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    lock(c; cancel)
     try
-        while isempty(c.data)
-            check_channel_state(c)
-            wait(c.cond_take)
+        if isempty(c.data)
+            tok = resolve_cancel_token(cancel)
+            while isempty(c.data)
+                check_channel_state(c)
+                wait(c.cond_take, tok)
+            end
         end
         return c.data[1]
     finally
@@ -534,13 +545,19 @@ julia> take!(c)
 1
 ```
 """
-take!(c::Channel) = isbuffered(c) ? take_buffered(c) : take_unbuffered(c)
-function take_buffered(c::Channel)
-    lock(c)
+function take!(c::Channel; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
+    return isbuffered(c) ? take_buffered(c, cancel) : take_unbuffered(c, cancel)
+end
+function take_buffered(c::Channel, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    lock(c; cancel)
     try
-        while isempty(c.data)
-            check_channel_state(c)
-            wait(c.cond_take)
+        if isempty(c.data)
+            tok = resolve_cancel_token(cancel)
+            while isempty(c.data)
+                check_channel_state(c)
+                wait(c.cond_take, tok)
+            end
         end
         v = popfirst!(c.data)
         _increment_n_avail(c, -1)
@@ -552,12 +569,12 @@ function take_buffered(c::Channel)
 end
 
 # 0-size channel
-function take_unbuffered(c::Channel{T}) where T
-    lock(c)
+function take_unbuffered(c::Channel{T}, cancel::CancelTokenArg=DEFAULT_CANCEL) where T
+    lock(c; cancel)
     try
         check_channel_state(c)
         notify(c.cond_put, nothing, false, false)
-        return wait(c.cond_take)::T
+        return wait(c.cond_take, resolve_cancel_token(cancel))::T
     finally
         unlock(c)
     end
@@ -649,7 +666,10 @@ true
 """
 isfull(c::Channel) = n_avail(c) ≥ c.sz_max
 
-lock(c::Channel) = lock(c.cond_take)
+# the `cancel` forward makes the channel operations' preliminary lock
+# acquisitions honor their resolved token (or explicit shield); see
+# lock(::GenericCondition{ReentrantLock})
+lock(c::Channel; cancel::CancelTokenArg=DEFAULT_CANCEL) = lock(c.cond_take; cancel)
 lock(f, c::Channel) = lock(f, c.cond_take)
 unlock(c::Channel) = unlock(c.cond_take)
 trylock(c::Channel) = trylock(c.cond_take)
@@ -678,13 +698,17 @@ julia> istaskdone(task)  # task is now unblocked
 true
 ```
 """
-function wait(c::Channel)
+function wait(c::Channel; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
     isready(c) && return
-    lock(c)
+    lock(c; cancel)
     try
-        while !isready(c)
-            check_channel_state(c)
-            wait(c.cond_wait)
+        if !isready(c)
+            tok = resolve_cancel_token(cancel)
+            while !isready(c)
+                check_channel_state(c)
+                wait(c.cond_wait, tok)
+            end
         end
     finally
         unlock(c)

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -21,7 +21,7 @@ function unlock end
 function trylock end
 function islocked end
 unlockall(l::AbstractLock) = unlock(l) # internal function for implementing `wait`
-relockall(l::AbstractLock, token::Nothing) = lock(l) # internal function for implementing `wait`
+relockall(l::AbstractLock, state::Nothing) = lock(l) # internal function for implementing `wait`
 assert_havelock(l::AbstractLock, tid::Integer) =
     (islocked(l) && tid == Threads.threadid()) ? nothing : concurrency_violation()
 assert_havelock(l::AbstractLock, tid::Task) =
@@ -138,12 +138,22 @@ function wait_enqueue!(c::GenericCondition, w::WaitEntry, first::Bool)
     end
     return true
 end
-wait_release!(c::GenericCondition) = unlockall(c.lock)
-wait_reacquire!(c::GenericCondition, token) = relockall(c.lock, token)
 function wait_dequeue!(c::GenericCondition, w::WaitEntry, why::UInt8)
-    # under the (re)acquired lock on every path that reaches here; a no-op
-    # when a notify already popped the entry
-    list_deletefirst!(waitqueue(c), w)
+    # a no-op when a notify already popped the entry. WAKE_VALUE/WAKE_FIRED
+    # run under the caller's held lock (the settle after a wake; the fired
+    # branch); the cleanup/withdraw whys take it themselves - shielded, a
+    # cleanup may be unwinding the very request a cancellable acquire would
+    # rethrow
+    if why == WAKE_INTERRUPTED || why == WAKE_WITHDRAWN
+        _uncancellable_lock(c.lock)
+        try
+            list_deletefirst!(waitqueue(c), w)
+        finally
+            unlock(c.lock)
+        end
+    else
+        list_deletefirst!(waitqueue(c), w)
+    end
     return nothing
 end
 
@@ -226,18 +236,40 @@ wait(c::GenericCondition; first::Bool=false,
 # it; see e.g. _uv_write_cancelled_finish.
 function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
               min_severity::UInt8=0x00)
+    ct = current_task()
     assert_havelock(c)
     src = cancel_source(tok)
     # entry check: throw before enqueueing anything (skipped for teardown
     # waits that re-park after acknowledging a severity)
     src === nothing || min_severity != 0x00 || checkcancel(src)
-    src === nothing && return park!((c,), true, first)
-    r = park!((c, SourceWait(src, min_severity)), true, first)
-    # `nothing` may be a fired source recheck (the refusal) or a legit
-    # nothing-valued notify: re-derive with the same check the entry made.
-    # Level-triggered either way - and thrown with the lock held, like a
-    # normal-wake return, so the caller's unlock discipline covers both.
-    r === nothing && checkcancel(src)
+    if src === nothing
+        ws = (c,)
+        w = _cached_wait_entry(ct)
+    else
+        ws = (c, SourceWait(src, min_severity))
+        w = _cancel_wait_entry(ct, src, min_severity)
+    end
+    if !park!(ws, w, first)
+        # the source refused at the registration recheck (the only
+        # fireable waitable here): withdraw under the still-held lock and
+        # deliver, exactly like the entry check
+        withdraw!(ws, w, WAKE_FIRED)
+        checkcancel(src)
+        error("park fired without a cancelled source")
+    end
+    lockstate = unlockall(c.lock)
+    r = try
+        wait_safe_interrupt(ws, w)
+    catch
+        # the cleanup already withdrew every registration; all that is
+        # owed here is this wait's lock contract - the caller's unwind
+        # (`finally unlock`) requires an exceptional exit to hold the
+        # lock, so reacquire (relockall shields itself) and rethrow
+        relockall(c.lock, lockstate)
+        rethrow()
+    end
+    relockall(c.lock, lockstate)
+    withdraw!(ws, w, WAKE_VALUE)   # lazy settle under the reacquired lock
     return r
 end
 

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -54,59 +54,9 @@ islocked(::AlwaysLockedST) = true
 
 ## condition variables
 
-# A task's registration on a wait queue. All fields are plain: `next` and
-# `queue` are protected by the waitee's lock (`queue` holds the queue's
-# identity - see `waitqueue` - while the entry is enqueued, acting as the
-# "am I registered, and on what" witness, and `nothing` otherwise); `task`
-# is written by the owning task before enqueueing, so it is ordered by the
-# same lock for lock-holding readers.
-#
-# The wake-claim protocol: a parked task `t` points to its current
-# registration through the atomic field `t.waiting_on`. Whoever wants to wake
-# it must first claim the wake by atomically clearing that field:
-#
-# CAS(w => nothing) succeeds: the claim is won, and the owner may schedule
-# N.B.: Interrupters currently claim unconditionally, normal waiters claim
-# a specific entry. In the future this will be managed by the cancellation system.
-#
-# Entries are heap objects. A task whose interrupted wait left a stale registration
-# behind can immediately register anew - e.g. park on a lock during its cleanup - with a fresh entry.
-mutable struct WaitEntry
-    task::Union{Task, Nothing}
-    next::Union{WaitEntry, Nothing}
-    queue::Any
-    WaitEntry(task::Union{Task, Nothing}) = new(task, nothing, nothing)
-end
-
-# Return the cached entry of `waiter` if it is free, else a fresh (and newly
-# cached) one.
-function _cached_wait_entry(waiter::Task)
-    w = waiter.cached_wait_entry
-    if w isa WaitEntry && w.queue === nothing
-        w.task = waiter
-    else
-        w = WaitEntry(waiter)
-        waiter.cached_wait_entry = w
-    end
-    return w
-end
-
-@noinline function _wait_registration_error()
-    throw(ConcurrencyViolationError("Task is already registered on a wait queue"))
-end
-
-# Publish `w` as `waiter`'s only armed wait registration.
-function _arm_wait(waiter::Task, w::WaitEntry)
-    armed = @atomicreplace :release :monotonic waiter.waiting_on nothing => w
-    armed.success || _wait_registration_error()
-    return w
-end
-
-# Claim the wake of the wait that `w` was registered for (returns whether the
-# claim succeeded). `w` must be an entry armed for `t` by `_wait2`.
-function claim_wait(t::Task, w::WaitEntry)
-    return (@atomicreplace t.waiting_on w => nothing).success
-end
+# (The WaitEntry registration type and the wake-claim protocol live in
+# cancellation.jl, which is included earlier in bootstrap: registrations
+# carry the cancellation half of a parked wait.)
 
 """
     GenericCondition
@@ -134,27 +84,31 @@ optimization. If the queue is locked by another task, the entry will remain link
 be unlinked upon the next wakeup attempt.
 """
 function try_unlink_claimed!(w::WaitEntry)
-    q = w.queue
-    q === nothing && return true
-    # Manual split for --trim
-    if q isa Task
-        dn = q.donenotify
-        dn isa GenericCondition{Threads.SpinLock} || return false
-        return _try_unlink_from!(dn, q, w)
-    elseif q isa GenericCondition{Threads.SpinLock}
-        return _try_unlink_from!(q, q, w)
-    elseif q isa GenericCondition{ReentrantLock}
-        return _try_unlink_from!(q, q, w)
-    elseif q isa GenericCondition{AlwaysLockedST}
-        return _try_unlink_from!(q, q, w)
+    ok = true
+    for slot in slots(w)
+        q = slot.owner
+        q === nothing && continue
+        # Manual split for --trim (every waitq's identity is its
+        # condition - see waitqueue)
+        if q isa GenericCondition{Threads.SpinLock}
+            _try_unlink_from!(q, w) || (ok = false)
+        elseif q isa GenericCondition{ReentrantLock}
+            _try_unlink_from!(q, w) || (ok = false)
+        elseif q isa GenericCondition{AlwaysLockedST}
+            _try_unlink_from!(q, w) || (ok = false)
+        elseif q isa CancellationTokenSource
+            # sticky source registrations stay in place
+        else
+            ok = false
+        end
     end
-    return false
+    return ok
 end
 
-function _try_unlink_from!(c::GenericCondition, @nospecialize(waitee), w::WaitEntry)
+function _try_unlink_from!(c::GenericCondition, w::WaitEntry)
     trylock(c.lock) || return false
     try
-        list_deletefirst!(ILLRef(c.waitq, waitee), w)
+        list_deletefirst!(waitqueue(c), w)
     finally
         unlock(c.lock)
     end
@@ -165,25 +119,27 @@ show(io::IO, c::GenericCondition) = print(io, GenericCondition, "(", c.lock, ")"
 
 assert_havelock(c::GenericCondition) = assert_havelock(c.lock)
 lock(c::GenericCondition) = lock(c.lock)
+# (the `cancel`-forwarding lock method for ReentrantLock-backed conditions
+# lives in lock.jl, after ReentrantLock is defined)
 unlock(c::GenericCondition) = unlock(c.lock)
 trylock(c::GenericCondition) = trylock(c.lock)
 islocked(c::GenericCondition) = islocked(c.lock)
 
 lock(f, c::GenericCondition) = lock(f, c.lock)
 
-# have waiter wait for c: register `waiter` on c's wait queue (with `waitee`
-# recorded as the queue identity) and arm the registration for a wake.
+# have waiter wait for c: register `waiter` on c's wait queue (the queue's
+# identity is the condition itself) and arm the registration for a wake.
 # Returns the registration entry.
 function _wait2(c::GenericCondition, waiter::Task, first::Bool=false;
-                waitee=c, entry::Union{WaitEntry, Nothing}=nothing)
+                entry::Union{WaitEntry, Nothing}=nothing)
     ct = current_task()
     assert_havelock(c)
     w = entry === nothing ? _cached_wait_entry(waiter) : entry
     _arm_wait(waiter, w)
     if first
-        pushfirst!(ILLRef(c.waitq, waitee), w)
+        pushfirst!(waitqueue(c), w)
     else
-        push!(ILLRef(c.waitq, waitee), w)
+        push!(waitqueue(c), w)
     end
     # since _wait2 is similar to schedule, we should observe the sticky bit now
     if waiter.sticky && Threads.threadid(waiter) == 0 && !GC.in_finalizer()
@@ -223,43 +179,121 @@ proceeding.
 function wait end
 
 """
-    wait(c::GenericCondition; first::Bool=false)
+    wait(c::GenericCondition; first::Bool=false, cancel=Base.DEFAULT_CANCEL)
 
 Wait for [`notify`](@ref) on `c` and return the `val` parameter passed to `notify`.
 
 If the keyword `first` is set to `true`, the waiter will be put _first_
 in line to wake up on `notify`. Otherwise, `wait` has first-in-first-out (FIFO) behavior.
+
+The `cancel` keyword argument controls which cancellation token may interrupt
+the wait (throwing the [`CancellationRequest`](@ref) into the waiter): by
+default the scoped token (see `Base.CANCEL_TOKEN`); pass a
+[`CancellationToken`](@ref) to override it, or `nothing` to make the wait
+non-cancellable.
 """
-function wait(c::GenericCondition; first::Bool=false, waitee=c)
+wait(c::GenericCondition; first::Bool=false,
+     cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    wait(c, check_cancel_arg(cancel); first)
+
+# Cleanup of a park that was resumed without a wake having been delivered
+# through its registration `w`: either an interrupter claimed the wake
+# (leaving the entry linked for us to clean up), or the task got a raw
+# `throwto`. The caller rethrows afterwards, with whatever lock state
+# `relock` established. In order:
+#  1. Disarm the registration - before the relock in step 2 can register a
+#     new wait. When the disarm loses, a claimer got the wake: its
+#     schedule is either already enqueued or still in flight under the
+#     waitee's lock.
+#  2. Run `relock` with the cached entry blanked: a notifier may have popped
+#     the stale entry without scheduling us and may still retain its
+#     identity for the wake-claim CAS, so `w` must not be reused (e.g. by a
+#     park inside `relock`) before the unlink below.
+#  3. Unlink `w` from the waitee's queue (a no-op if a `notify` already
+#     popped and dropped it).
+#  4. Drop a claimed-and-enqueued wake this unwind will never consume, so a
+#     later wait of this task does not consume it spuriously. This runs
+#     after the relock on purpose: a notifier that claimed our wake did so
+#     under the waitee's lock, so once `relock` returns, its enqueue has
+#     landed and the drop here is deterministic - dropping before the
+#     relock would race the notifier's in-flight schedule and leak the
+#     wake into the task's next wait. (If the *relock itself* parked and
+#     consumed the stale wake as a spurious lock wake, its acquire loop
+#     re-tested and re-parked - lock parks tolerate spurious wakes - and
+#     there is nothing left to drop. A claim-less raw wake delivered
+#     outside any lock - the documented-unsafe `schedule(t, exc,
+#     error=true)` of a running task - can still land after this drop;
+#     that hazard is the primitive's, not this path's.)
+#  5. Now `w` is safe to reuse: restore it to its cache unless the relock
+#     parked and cached a replacement. In that case `w` is unreachable
+#     garbage (unarmed, off every waitq), so retire it: its sticky source
+#     registration must be counted dead for pruning, or a long-lived
+#     source would retain the task through the orphaned entry.
+function _interrupted_wait_cleanup(relock, c::GenericCondition, w::WaitEntry)
+    ct = current_task()
+    @atomicreplace ct.waiting_on w => nothing
+    was_plain = ct.cached_wait_entry === w
+    was_cancel = !was_plain && ct.cached_cancel_entry === w
+    was_plain && (ct.cached_wait_entry = nothing)
+    was_cancel && (ct.cached_cancel_entry = nothing)
+    relock()
+    list_deletefirst!(waitqueue(c), w)
+    q = ct.queue
+    q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
+    if was_plain
+        if ct.cached_wait_entry === nothing
+            ct.cached_wait_entry = w
+        else
+            retire_cancellation_entry!(w)
+        end
+    elseif was_cancel
+        if ct.cached_cancel_entry === nothing
+            ct.cached_cancel_entry = w
+        else
+            retire_cancellation_entry!(w)
+        end
+    end
+    return nothing
+end
+
+# `min_severity` is the lowest severity that may wake (cancel) this wait -
+# the comparisons are inclusive on both the registration and walk sides. A
+# teardown wait that re-parks after acknowledging a delivery at severity
+# `s` must therefore pass `s + 0x01` (exclusive staging), so a re-cancel at
+# the acknowledged severity leaves it parked and only an escalation wakes
+# it; see e.g. _uv_write_cancelled_finish.
+function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
+              min_severity::UInt8=0x00)
     ct = current_task()
     assert_havelock(c)
-    w = _wait2(c, ct, first; waitee)
+    src = cancel_source(tok)
+    # entry check: throw before enqueueing anything (skipped for teardown
+    # waits that re-park after acknowledging a severity)
+    src === nothing || min_severity != 0x00 || checkcancel(src)
+    entry = src === nothing ? nothing : _cancel_wait_entry(ct, src, min_severity)
+    w = _wait2(c, ct, first; entry)
+    if src !== nothing && !register_cancellation!(src, w)
+        # The governing source is already cancelled and the wake was claimed
+        # back for us: withdraw the waitee-queue registration (the sticky
+        # source registration stays) and deliver the cancellation ourselves.
+        list_deletefirst!(waitqueue(c), w)
+        _deliver_refused_cancellation(src)
+    end
     token = unlockall(c.lock)
     ret = try
         wait()
     catch
-        # Error path - this could have come from an interrupt or other error.
-        # Clean up our wait condition.
-        # TODO: Replace this with the proper cancellation protocol.
-        @atomicreplace ct.waiting_on w => nothing
-        # Our wake may already have been claimed and turned into a workqueue
-        # enqueue that this unwind will never consume - drop that too, so a
-        # later `schedule` of this task does not find it spuriously queued.
-        q = ct.queue
-        q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
-        # WARNING: Do not use `w` for establish a wait on any tokens - otherwise
-        # we risk ABA issues by attempting to use the cached token for the lock wait.
-        was_cached = ct.cached_wait_entry === w
-        was_cached && (ct.cached_wait_entry = nothing)
-        relockall(c.lock, token)
-        list_deletefirst!(ILLRef(c.waitq, waitee), w)
-        if was_cached && ct.cached_wait_entry === nothing
-            ct.cached_wait_entry = w
-        end
+        # resumed without a wake through `w`; see _interrupted_wait_cleanup
+        _interrupted_wait_cleanup(() -> relockall(c.lock, token), c, w)
         rethrow()
     end
-    # a normal wake implies our claim was won and our entry already unlinked
+    # a normal wake implies our claim was won and our waitee-queue entry was
+    # already unlinked by the notifier (a wake that arrived as a value from
+    # something other than this waitee's notify leaves the entry to us - the
+    # delete below is a no-op in the common case); the sticky source
+    # registration needs no cleanup at all
     relockall(c.lock, token)
+    list_deletefirst!(waitqueue(c), w)
     return ret
 end
 
@@ -278,7 +312,11 @@ function notify(c::GenericCondition, @nospecialize(arg), all, error)
     cnt = 0
     while !isempty(c.waitq)
         w = popfirst!(waitqueue(c))
-        t = w.task
+        # An entry whose wake was already claimed by an interrupter does not
+        # count as woken: drop it and continue to the next waiter (the
+        # interrupted task resumes via whatever its claimer scheduled and
+        # will find its entry already unlinked).
+        t = @atomic :monotonic w.task
         if !(t isa Task && claim_wait(t, w))
             continue
         end
@@ -296,13 +334,7 @@ notify_error(c::GenericCondition, err) = notify(c, err, true, true)
 
 Return `true` if no tasks are waiting on the condition, `false` otherwise.
 """
-function isempty(c::GenericCondition)
-    for w in c.waitq
-        t = w.task
-        t isa Task && (@atomic t.waiting_on) === w && return false
-    end
-    return true
-end
+isempty(c::GenericCondition) = _waitq_isempty(waitqueue(c))
 
 
 # default (Julia v1.0) is currently single-threaded

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -167,11 +167,12 @@ end
 @noinline _fresh_waiter_error() =
     throw(ConcurrencyViolationError("schedule_on_notify! requires a fresh task: never started, scheduled, or armed"))
 
-# Freshness is stricter than `!istaskstarted`: a task `schedule`/`@async`
-# has merely ENQUEUED hasn't run yet, but arming it here would collide
-# with the arm its own first park performs once it starts (that park's
-# `_arm_wait` CAS fails and unwinds a wait's lock choreography from the
-# outside). Reject anything started, queued, or already armed.
+# Freshness is stricter than `!istaskstarted`: a task that
+# `schedule`/`@async` has merely enqueued hasn't run yet, but arming it
+# here would collide with the arm its own first park performs once it
+# starts (that park's `_arm_wait` CAS fails and unwinds a wait's lock
+# choreography from the outside). Reject anything started, queued, or
+# already armed.
 _assert_fresh_waiter(waiter::Task) =
     if istaskstarted(waiter) || waiter.queue !== nothing ||
        (@atomic :monotonic waiter.waiting_on) !== nothing
@@ -322,7 +323,7 @@ function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
     # waits that re-park after acknowledging a severity). Like every throw
     # out of this internal layer, the waiting frame's own lock level is
     # released first - callers use the `locked && unlock` idiom; the
-    # public kwarg method shims the old lock-held contract back on.
+    # public kwarg method restores the lock-held contract.
     if src !== nothing && min_severity == 0x00 && iscancelled(src)
         unlock(c.lock)
         checkcancel(src)

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -127,14 +127,33 @@ islocked(c::GenericCondition) = islocked(c.lock)
 
 lock(f, c::GenericCondition) = lock(f, c.lock)
 
+## GenericCondition as a waitable (see base/park.jl): the lock-carried
+## kind - its lock is caller-held from before phase 4 into the suspend
+## bracket, which is what makes its recheck vacuous.
+function wait_enqueue!(c::GenericCondition, w::WaitEntry, first::Bool)
+    if first
+        pushfirst!(waitqueue(c), w)
+    else
+        push!(waitqueue(c), w)
+    end
+    return true
+end
+wait_release!(c::GenericCondition) = unlockall(c.lock)
+wait_reacquire!(c::GenericCondition, token) = relockall(c.lock, token)
+function wait_dequeue!(c::GenericCondition, w::WaitEntry, why::UInt8)
+    # under the (re)acquired lock on every path that reaches here; a no-op
+    # when a notify already popped the entry
+    list_deletefirst!(waitqueue(c), w)
+    return nothing
+end
+
 # have waiter wait for c: register `waiter` on c's wait queue (the queue's
 # identity is the condition itself) and arm the registration for a wake.
 # Returns the registration entry.
-function _wait2(c::GenericCondition, waiter::Task, first::Bool=false;
-                entry::Union{WaitEntry, Nothing}=nothing)
+function _wait2(c::GenericCondition, waiter::Task, first::Bool=false)
     ct = current_task()
     assert_havelock(c)
-    w = entry === nothing ? _cached_wait_entry(waiter) : entry
+    w = _cached_wait_entry(waiter)
     _arm_wait(waiter, w)
     if first
         pushfirst!(waitqueue(c), w)
@@ -196,65 +215,8 @@ wait(c::GenericCondition; first::Bool=false,
      cancel::CancelTokenArg=DEFAULT_CANCEL) =
     wait(c, check_cancel_arg(cancel); first)
 
-# Cleanup of a park that was resumed without a wake having been delivered
-# through its registration `w`: either an interrupter claimed the wake
-# (leaving the entry linked for us to clean up), or the task got a raw
-# `throwto`. The caller rethrows afterwards, with whatever lock state
-# `relock` established. In order:
-#  1. Disarm the registration - before the relock in step 2 can register a
-#     new wait. When the disarm loses, a claimer got the wake: its
-#     schedule is either already enqueued or still in flight under the
-#     waitee's lock.
-#  2. Run `relock` with the cached entry blanked: a notifier may have popped
-#     the stale entry without scheduling us and may still retain its
-#     identity for the wake-claim CAS, so `w` must not be reused (e.g. by a
-#     park inside `relock`) before the unlink below.
-#  3. Unlink `w` from the waitee's queue (a no-op if a `notify` already
-#     popped and dropped it).
-#  4. Drop a claimed-and-enqueued wake this unwind will never consume, so a
-#     later wait of this task does not consume it spuriously. This runs
-#     after the relock on purpose: a notifier that claimed our wake did so
-#     under the waitee's lock, so once `relock` returns, its enqueue has
-#     landed and the drop here is deterministic - dropping before the
-#     relock would race the notifier's in-flight schedule and leak the
-#     wake into the task's next wait. (If the *relock itself* parked and
-#     consumed the stale wake as a spurious lock wake, its acquire loop
-#     re-tested and re-parked - lock parks tolerate spurious wakes - and
-#     there is nothing left to drop. A claim-less raw wake delivered
-#     outside any lock - the documented-unsafe `schedule(t, exc,
-#     error=true)` of a running task - can still land after this drop;
-#     that hazard is the primitive's, not this path's.)
-#  5. Now `w` is safe to reuse: restore it to its cache unless the relock
-#     parked and cached a replacement. In that case `w` is unreachable
-#     garbage (unarmed, off every waitq), so retire it: its sticky source
-#     registration must be counted dead for pruning, or a long-lived
-#     source would retain the task through the orphaned entry.
-function _interrupted_wait_cleanup(relock, c::GenericCondition, w::WaitEntry)
-    ct = current_task()
-    @atomicreplace ct.waiting_on w => nothing
-    was_plain = ct.cached_wait_entry === w
-    was_cancel = !was_plain && ct.cached_cancel_entry === w
-    was_plain && (ct.cached_wait_entry = nothing)
-    was_cancel && (ct.cached_cancel_entry = nothing)
-    relock()
-    list_deletefirst!(waitqueue(c), w)
-    q = ct.queue
-    q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
-    if was_plain
-        if ct.cached_wait_entry === nothing
-            ct.cached_wait_entry = w
-        else
-            retire_cancellation_entry!(w)
-        end
-    elseif was_cancel
-        if ct.cached_cancel_entry === nothing
-            ct.cached_cancel_entry = w
-        else
-            retire_cancellation_entry!(w)
-        end
-    end
-    return nothing
-end
+# (The interrupted-wait cleanup lives in base/park.jl as
+# interrupted_park_cleanup!, shared by every park site.)
 
 # `min_severity` is the lowest severity that may wake (cancel) this wait -
 # the comparisons are inclusive on both the registration and walk sides. A
@@ -264,37 +226,16 @@ end
 # it; see e.g. _uv_write_cancelled_finish.
 function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
               min_severity::UInt8=0x00)
-    ct = current_task()
     assert_havelock(c)
     src = cancel_source(tok)
     # entry check: throw before enqueueing anything (skipped for teardown
     # waits that re-park after acknowledging a severity)
     src === nothing || min_severity != 0x00 || checkcancel(src)
-    entry = src === nothing ? nothing : _cancel_wait_entry(ct, src, min_severity)
-    w = _wait2(c, ct, first; entry)
-    if src !== nothing && !register_cancellation!(src, w)
-        # The governing source is already cancelled and the wake was claimed
-        # back for us: withdraw the waitee-queue registration (the sticky
-        # source registration stays) and deliver the cancellation ourselves.
-        list_deletefirst!(waitqueue(c), w)
-        _deliver_refused_cancellation(src)
-    end
-    token = unlockall(c.lock)
-    ret = try
-        wait()
-    catch
-        # resumed without a wake through `w`; see _interrupted_wait_cleanup
-        _interrupted_wait_cleanup(() -> relockall(c.lock, token), c, w)
-        rethrow()
-    end
-    # a normal wake implies our claim was won and our waitee-queue entry was
-    # already unlinked by the notifier (a wake that arrived as a value from
-    # something other than this waitee's notify leaves the entry to us - the
-    # delete below is a no-op in the common case); the sticky source
-    # registration needs no cleanup at all
-    relockall(c.lock, token)
-    list_deletefirst!(waitqueue(c), w)
-    return ret
+    # the refusal (a cancelled source at the registration recheck) throws
+    # with the lock held, like a normal-wake return - the caller's unlock
+    # discipline covers both
+    src === nothing && return park!((c,), true, first)
+    return park!((c, SourceWait(src, min_severity)), true, first)
 end
 
 """

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -22,6 +22,13 @@ function trylock end
 function islocked end
 unlockall(l::AbstractLock) = unlock(l) # internal function for implementing `wait`
 relockall(l::AbstractLock, state::Nothing) = lock(l) # internal function for implementing `wait`
+# Restore all but one level of a hold captured by `unlockall` - the
+# enclosing frames' levels, consuming the waiting frame's own - for the
+# exceptional unwind out of the internal wait layer. A no-op when that
+# frame's level was the only one (the common case: a depth-1 cancellation
+# unwind performs no lock operation at all). The state stays opaque;
+# shielded like `relockall` - a restore has no correct cancellable use.
+relockall_but_one(l::AbstractLock, state::Nothing) = nothing
 assert_havelock(l::AbstractLock, tid::Integer) =
     (islocked(l) && tid == Threads.threadid()) ? nothing : concurrency_violation()
 assert_havelock(l::AbstractLock, tid::Task) =
@@ -221,9 +228,25 @@ default the scoped token (see `Base.CANCEL_TOKEN`); pass a
 [`CancellationToken`](@ref) to override it, or `nothing` to make the wait
 non-cancellable.
 """
-wait(c::GenericCondition; first::Bool=false,
-     cancel::CancelTokenArg=DEFAULT_CANCEL) =
-    wait(c, check_cancel_arg(cancel); first)
+function wait(c::GenericCondition; first::Bool=false,
+              cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # Check the caller contract here, not just in the internal layer: a
+    # violation (not locked, or locked by another task) must propagate
+    # with the lock state untouched - the restore in the catch below is
+    # only correct for throws that consumed this frame's lock level.
+    assert_havelock(c)
+    tok = check_cancel_arg(cancel)   # an entry refusal throws lock-held
+    try
+        return wait(c, tok; first)
+    catch
+        # the internal layer throws having released this frame's lock
+        # level; the public contract is rethrow-with-lock-held (callers
+        # are written `lock(c); try ... finally unlock(c)`), so restore
+        # one shielded level
+        _uncancellable_lock(c.lock)
+        rethrow()
+    end
+end
 
 # (The interrupted-wait cleanup lives in base/park.jl as
 # interrupted_park_cleanup!, shared by every park site.)
@@ -239,9 +262,16 @@ function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
     ct = current_task()
     assert_havelock(c)
     src = cancel_source(tok)
-    # entry check: throw before enqueueing anything (skipped for teardown
-    # waits that re-park after acknowledging a severity)
-    src === nothing || min_severity != 0x00 || checkcancel(src)
+    # Entry check: throw before enqueueing anything (skipped for teardown
+    # waits that re-park after acknowledging a severity). Like every throw
+    # out of this internal layer, the waiting frame's own lock level is
+    # released first - callers use the `locked && unlock` idiom; the
+    # public kwarg method shims the old lock-held contract back on.
+    if src !== nothing && min_severity == 0x00 && iscancelled(src)
+        unlock(c.lock)
+        checkcancel(src)
+        error("cancelled source did not throw")
+    end
     if src === nothing
         ws = (c,)
         w = _cached_wait_entry(ct)
@@ -251,9 +281,10 @@ function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
     end
     if !park!(ws, w, first)
         # the source refused at the registration recheck (the only
-        # fireable waitable here): withdraw under the still-held lock and
-        # deliver, exactly like the entry check
+        # fireable waitable here): withdraw under the still-held lock,
+        # release this frame's level, and deliver like the entry check
         withdraw!(ws, w, WAKE_FIRED)
+        unlock(c.lock)
         checkcancel(src)
         error("park fired without a cancelled source")
     end
@@ -261,11 +292,11 @@ function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
     r = try
         wait_safe_interrupt(ws, w)
     catch
-        # the cleanup already withdrew every registration; all that is
-        # owed here is this wait's lock contract - the caller's unwind
-        # (`finally unlock`) requires an exceptional exit to hold the
-        # lock, so reacquire (relockall shields itself) and rethrow
-        relockall(c.lock, lockstate)
+        # the cleanup already withdrew every registration; restore the
+        # enclosing frames' hold, consuming this waiting frame's level -
+        # a depth-1 unwind (the common case, e.g. the cancellation being
+        # delivered) touches no lock at all
+        relockall_but_one(c.lock, lockstate)
         rethrow()
     end
     relockall(c.lock, lockstate)

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -164,27 +164,83 @@ function wait_dequeue!(c::GenericCondition, w::WaitEntry, why::UInt8)
     return nothing
 end
 
-# have waiter wait for c: register `waiter` on c's wait queue (the queue's
-# identity is the condition itself) and arm the registration for a wake.
-# Returns the registration entry.
-function _wait2(c::GenericCondition, waiter::Task, first::Bool=false)
-    ct = current_task()
+@noinline _fresh_waiter_error() =
+    throw(ConcurrencyViolationError("schedule_on_notify! requires a fresh task: never started, scheduled, or armed"))
+
+# Freshness is stricter than `!istaskstarted`: a task `schedule`/`@async`
+# has merely ENQUEUED hasn't run yet, but arming it here would collide
+# with the arm its own first park performs once it starts (that park's
+# `_arm_wait` CAS fails and unwinds a wait's lock choreography from the
+# outside). Reject anything started, queued, or already armed.
+_assert_fresh_waiter(waiter::Task) =
+    if istaskstarted(waiter) || waiter.queue !== nothing ||
+       (@atomic :monotonic waiter.waiting_on) !== nothing
+        _fresh_waiter_error()
+    end
+
+# Start `waiter` with the (level-triggered) cancellation of its birth
+# source: a subscribed task whose governing source is cancelled dies
+# instead of running its body - a never-started task raises the scheduled
+# exception at start.
+function _schedule_subscription_cancelled(waiter::Task, src::CancellationTokenSource)
+    st = @atomic :acquire src.state
+    schedule(waiter, CancellationRequest(st), error=true)
+    return nothing
+end
+
+# Subscribe the not-yet-started task `waiter` to `c`'s next notify: arm
+# its registration and enqueue it, so the notify's claim-and-schedule is
+# the task's first schedule - a start trigger; the current task does not
+# suspend. Waits of the *current* task go through `park!` (base/park.jl).
+#
+# Subscriptions are governed by the *waiter's* birth cancellation source
+# (the CANCEL_TOKEN of the scope captured at its construction): if that
+# source is - or becomes, while still subscribed - cancelled, the task
+# dies with the CancellationRequest instead of starting. Cleanup-class
+# subscribers (Timer/AsyncCondition callback tasks, channel close hooks,
+# errormonitor, REPL teardown) are constructed under
+# `CANCEL_TOKEN => nothing` and so are never killed this way.
+# Returns the registration entry (or `nothing` when the subscription was
+# refused and the waiter scheduled to die).
+function schedule_on_notify!(c::GenericCondition, waiter::Task, first::Bool=false)
     assert_havelock(c)
-    w = _cached_wait_entry(waiter)
+    _assert_fresh_waiter(waiter)
+    src = _birth_cancel_source(waiter)
+    if src !== nothing && iscancelled(src)
+        # born cancelled: never enqueue anything
+        _schedule_subscription_cancelled(waiter, src)
+        return nothing
+    end
+    w = src === nothing ? _cached_wait_entry(waiter) :
+                          _cancel_wait_entry(waiter, src, 0x00)
     _arm_wait(waiter, w)
     if first
         pushfirst!(waitqueue(c), w)
     else
         push!(waitqueue(c), w)
     end
-    # since _wait2 is similar to schedule, we should observe the sticky bit now
+    if src !== nothing
+        # the sticky source registration + the publish-then-recheck dance,
+        # exactly like a park's phases 4-5 - but claiming back the *waiter's*
+        # arm on refusal
+        sw = SourceWait(src, 0x00)
+        wait_enqueue!(sw, w, false)
+        if wait_recheck(sw, w) && disarm!(waiter, w)
+            list_deletefirst!(waitqueue(c), w)   # under the held lock
+            _schedule_subscription_cancelled(waiter, src)
+            return nothing
+        end
+        # a lost disarm means a concurrent walk claimed the fresh arm: its
+        # delivery kills the waiter at start
+    end
+    # since this is similar to schedule, we should observe the sticky bit now
     if waiter.sticky && Threads.threadid(waiter) == 0 && !GC.in_finalizer()
         # Issue #41324
         # t.sticky && tid == 0 is a task that needs to be co-scheduled with
         # the parent task. If the parent (current_task) is not sticky we must
         # set it to be sticky.
         # XXX: Ideally we would be able to unset this
-        ct.sticky = true
+        current_task().sticky = true
         tid = Threads.threadid()
         ccall(:jl_set_task_tid, Cint, (Any, Cint), waiter, tid-1)
     end
@@ -279,7 +335,23 @@ function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
         ws = (c, SourceWait(src, min_severity))
         w = _cancel_wait_entry(ct, src, min_severity)
     end
-    if !park!(ws, w, first)
+    local parked::Bool
+    try
+        parked = park!(ws, w, first)
+    catch
+        # an arm-phase throw (contract misuse: this task already carries
+        # a foreign registration) happens before any suspend. Nothing is
+        # enqueued to settle, but this frame's lock level must still be
+        # consumed like every other throw out of this layer - the
+        # caller's `locked && unlock` idiom would otherwise leak a held
+        # lock, and a leaked SpinLock wedges the process on the next
+        # lock of the same object
+        disarm!(ct, w)
+        withdraw!(ws, w, WAKE_FIRED)
+        unlock(c.lock)
+        rethrow()
+    end
+    if !parked
         # the source refused at the registration recheck (the only
         # fireable waitable here): withdraw under the still-held lock,
         # release this frame's level, and deliver like the entry check

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -231,11 +231,14 @@ function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
     # entry check: throw before enqueueing anything (skipped for teardown
     # waits that re-park after acknowledging a severity)
     src === nothing || min_severity != 0x00 || checkcancel(src)
-    # the refusal (a cancelled source at the registration recheck) throws
-    # with the lock held, like a normal-wake return - the caller's unlock
-    # discipline covers both
     src === nothing && return park!((c,), true, first)
-    return park!((c, SourceWait(src, min_severity)), true, first)
+    r = park!((c, SourceWait(src, min_severity)), true, first)
+    # `nothing` may be a fired source recheck (the refusal) or a legit
+    # nothing-valued notify: re-derive with the same check the entry made.
+    # Level-triggered either way - and thrown with the lock held, like a
+    # normal-wake return, so the caller's unlock discipline covers both.
+    r === nothing && checkcancel(src)
+    return r
 end
 
 """

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -181,3 +181,21 @@ function deepcopy_internal(x::GenericCondition, stackdict::IdDict)
     stackdict[x] = y
     return y
 end
+
+# Core.WaitEntryN has a hidden variable-length slot tail that the generic
+# path above - which allocates only the fixed datatype size - cannot
+# reproduce (the GC would then scan a nonexistent tail). Allocate through
+# the runtime allocator instead. The slots are transient registration
+# state, meaningless outside the live wait registries (a copy is not
+# enqueued anywhere), so the copy gets fresh, free slots
+# (owner = nothing, next = nothing, aux = 0) rather than copies of the
+# originals; the `task` reference is kept as-is (`deepcopy` of a Task is
+# the identity, see above).
+function deepcopy_internal(x::Core.WaitEntryN, stackdict::IdDict)
+    if haskey(stackdict, x)
+        return stackdict[x]::typeof(x)
+    end
+    y = WaitEntryN((@atomic :monotonic x.task), _nslots(x))
+    stackdict[x] = y
+    return y
+end

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -659,13 +659,24 @@ If `timeout` is specified, cancel the `wait` when it expires and return
 `:timed_out`. The minimum value for `timeout` is 0.001 seconds, i.e. 1
 millisecond.
 """
-function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real=0.0)
+function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real=0.0,
+                           cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
     ct = current_task()
+    tok = Base.check_cancel_arg(cancel)
+    src = Base.cancel_source(tok)
     # This wait has a wake source directed at it specifically (the timeout
     # task below), so it must register with a fresh, single-use entry: only
     # single-use-ness guarantees that the timeout task's expected-entry CAS
     # cannot claim a later, unrelated wait of `ct`.
-    w = Base._wait2(c, ct, first; entry=Base.WaitEntry(ct))
+    w = Base._wait2(c, ct, first;
+                    entry=(src === nothing ? Base.WaitEntry1(ct) : Base.WaitEntry2(ct)))
+    if src !== nothing && !Base.register_cancellation!(src, w)
+        # The governing token is already cancelled and the wake was claimed
+        # back for us: don't park.
+        Base.list_deletefirst!(Base.waitqueue(c), w)
+        Base.retire_cancellation_entry!(w)
+        Base._deliver_refused_cancellation(src)
+    end
     token = Base.unlockall(c.lock)
 
     timer::Union{Timer, Nothing} = nothing
@@ -690,18 +701,23 @@ function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real
         Base.relockall(c.lock, token)
         timer !== nothing && close(timer)
         Base.list_deletefirst!(Base.waitqueue(c), w)
+        # single-use entry: hand its sticky source registration to pruning
+        src === nothing || Base.retire_cancellation_entry!(w)
         rethrow()
     end
     # a normal wake (notify or timeout) claimed and unlinked our registration
     Base.relockall(c.lock, token)
     timer !== nothing && close(timer)
+    src === nothing || Base.retire_cancellation_entry!(w)
     return res
 end
 
 function _wait_with_timeout_task(c::GenericCondition, ct::Task, w::Base.WaitEntry, timer::Timer)
     return Task() do
         try
-            wait(timer)
+            # not cancellable: this is internal mechanism; closing the timer
+            # wakes it in all exit paths of wait_with_timeout
+            wait(timer; cancel=nothing)
         catch e
             # if the timer was closed, the waiting task has been scheduled; do nothing
             e isa EOFError && return

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -640,18 +640,31 @@ function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real
                            cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
     tok = Base.check_cancel_arg(cancel)
     src = Base.cancel_source(tok)
+    ct = current_task()
     if timeout > 0.0
         tw = Base.TimeoutWait(timeout)
-        src === nothing && return Base.park!((c, tw), true, first)
-        r = Base.park!((c, Base.SourceWait(src, 0x00), tw), true, first)
-        r === nothing && Base.checkcancel(src)
-        return r
+        ws = src === nothing ? (c, tw) : (c, Base.SourceWait(src, 0x00), tw)
     else
-        src === nothing && return Base.park!((c,), true, first)
-        r = Base.park!((c, Base.SourceWait(src, 0x00)), true, first)
-        r === nothing && Base.checkcancel(src)
-        return r
+        ws = src === nothing ? (c,) : (c, Base.SourceWait(src, 0x00))
     end
+    # non-canonical shapes get a fresh entry - exactly what makes the
+    # deadline claimer's specific-wait CAS sound
+    w = Base.acquire_wait_entry!(ct, ws)
+    if !Base.park!(ws, w, first)
+        Base.withdraw!(ws, w, Base.WAKE_FIRED)
+        src === nothing || Base.checkcancel(src)
+        error("park fired without a cancelled source")
+    end
+    lockstate = Base.unlockall(c.lock)
+    r = try
+        Base.wait_safe_interrupt(ws, w)
+    catch
+        Base.relockall(c.lock, lockstate)
+        rethrow()
+    end
+    Base.relockall(c.lock, lockstate)
+    Base.withdraw!(ws, w, Base.WAKE_VALUE)   # closes the timer, retires
+    return r
 end
 
 """

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -643,10 +643,14 @@ function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real
     if timeout > 0.0
         tw = Base.TimeoutWait(timeout)
         src === nothing && return Base.park!((c, tw), true, first)
-        return Base.park!((c, Base.SourceWait(src, 0x00), tw), true, first)
+        r = Base.park!((c, Base.SourceWait(src, 0x00), tw), true, first)
+        r === nothing && Base.checkcancel(src)
+        return r
     else
         src === nothing && return Base.park!((c,), true, first)
-        return Base.park!((c, Base.SourceWait(src, 0x00)), true, first)
+        r = Base.park!((c, Base.SourceWait(src, 0x00)), true, first)
+        r === nothing && Base.checkcancel(src)
+        return r
     end
 end
 

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -616,36 +616,13 @@ end
 # specification of a timeout. This is experimental as it will likely
 # be dropped when a cancellation framework is added.
 #
-# The parallel behavior of wait_with_timeout is specified here. There
-# are three concurrent entities that can interact:
-# 1. Task W: the task that calls wait_with_timeout.
-# 2. Task T: the task created to handle a timeout.
-# 3. Task N: the task that notifies the Condition being waited on.
-#
-# Typical flow:
-# - W registers on the Condition's wait queue with a fresh, single-use
-#   WaitEntry `w` (see the wake-claim protocol in condition.jl).
-# - W creates T and stops running (calls wait()).
-# - T, when scheduled, waits on a Timer.
-# - Two common outcomes:
-#   - N notifies the Condition: N claims W's wake (clearing W's
-#     `waiting_on`) and pops `w`. W starts running, closes the Timer and
-#     returns the notify'ed value. The closed Timer throws an EOFError
-#     to T which simply ends.
-#   - The Timer expires.
-#     - T starts running, locks the Condition, and tries to claim W's
-#       wake via CAS(W.waiting_on, w => nothing). Because `w` is
-#       single-use, the claim can only succeed while W is still parked
-#       in *this* wait - never in a later wait of W, even one on the
-#       same Condition.
-#     - If the claim succeeds, T removes `w` from the wait queue,
-#       unlocks the Condition and schedules W with the special
-#       :timed_out value.
-#     - W runs and returns :timed_out.
-#
-# The single CAS on W's `waiting_on` arbitrates every race between N, T
-# and any interrupter: whoever wins the claim (and only that entity)
-# schedules W.
+# Implemented as a `park!` over the condition, the governing cancellation
+# source, and a `Base.TimeoutWait` deadline (see base/park.jl and
+# base/asyncevent.jl): the deadline's claimer arbitrates against notifies
+# and interrupters through the single wake-claim CAS on the waiting
+# task's `waiting_on`, and the non-canonical waitable shape makes the
+# entry cache hand out a fresh, single-use entry - which is exactly what
+# makes the deadline's specific-wait claim sound.
 
 """
     wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real=0.0)
@@ -661,80 +638,15 @@ millisecond.
 """
 function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real=0.0,
                            cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
-    ct = current_task()
     tok = Base.check_cancel_arg(cancel)
     src = Base.cancel_source(tok)
-    # This wait has a wake source directed at it specifically (the timeout
-    # task below), so it must register with a fresh, single-use entry: only
-    # single-use-ness guarantees that the timeout task's expected-entry CAS
-    # cannot claim a later, unrelated wait of `ct`.
-    w = Base._wait2(c, ct, first;
-                    entry=(src === nothing ? Base.WaitEntry1(ct) : Base.WaitEntry2(ct)))
-    if src !== nothing && !Base.register_cancellation!(src, w)
-        # The governing token is already cancelled and the wake was claimed
-        # back for us: don't park.
-        Base.list_deletefirst!(Base.waitqueue(c), w)
-        Base.retire_cancellation_entry!(w)
-        Base._deliver_refused_cancellation(src)
-    end
-    token = Base.unlockall(c.lock)
-
-    timer::Union{Timer, Nothing} = nothing
     if timeout > 0.0
-        timer = Timer(timeout)
-        # start a task to wait on the timer
-        t = _wait_with_timeout_task(c, ct, w, timer)
-        t.sticky = false
-        Threads._spawn_set_thrpool(t, :interactive)
-        schedule(t)
-    end
-
-    local res
-    try
-        res = wait()
-    catch
-        # resumed without a wake through our registration (interrupter or raw
-        # throwto): disarm it, then unlink our entry under the lock
-        @atomicreplace ct.waiting_on w => nothing
-        q = ct.queue
-        q === nothing || Base.list_deletefirst!(q::Base.StickyWorkqueue, ct)
-        Base.relockall(c.lock, token)
-        timer !== nothing && close(timer)
-        Base.list_deletefirst!(Base.waitqueue(c), w)
-        # single-use entry: hand its sticky source registration to pruning
-        src === nothing || Base.retire_cancellation_entry!(w)
-        rethrow()
-    end
-    # a normal wake (notify or timeout) claimed and unlinked our registration
-    Base.relockall(c.lock, token)
-    timer !== nothing && close(timer)
-    src === nothing || Base.retire_cancellation_entry!(w)
-    return res
-end
-
-function _wait_with_timeout_task(c::GenericCondition, ct::Task, w::Base.WaitEntry, timer::Timer)
-    return Task() do
-        try
-            # not cancellable: this is internal mechanism; closing the timer
-            # wakes it in all exit paths of wait_with_timeout
-            wait(timer; cancel=nothing)
-        catch e
-            # if the timer was closed, the waiting task has been scheduled; do nothing
-            e isa EOFError && return
-        end
-        dosched = false
-        lock(c.lock)
-        # Claim the wake of the specific wait `w` was registered for; `w` is
-        # single-use, so a successful claim means `ct` is still parked in
-        # that wait. If the claim fails (already notified or interrupted),
-        # do nothing.
-        if Base.claim_wait(ct, w)
-            dosched = true
-            Base.list_deletefirst!(Base.waitqueue(c), w)
-        end
-        unlock(c.lock)
-        # send the waiting task a timeout
-        dosched && schedule(ct, :timed_out)
+        tw = Base.TimeoutWait(timeout)
+        src === nothing && return Base.park!((c, tw), true, first)
+        return Base.park!((c, Base.SourceWait(src, 0x00), tw), true, first)
+    else
+        src === nothing && return Base.park!((c,), true, first)
+        return Base.park!((c, Base.SourceWait(src, 0x00)), true, first)
     end
 end
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -943,6 +943,7 @@ export
     unsafe_read,
     unsafe_write,
     write,
+    writepartial,
 
 # multimedia I/O
     AbstractDisplay,

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -514,7 +514,25 @@ function _atexit(exitcode::Cint)
     # this exit came from a signal for example), then try to clear that state
     # to minimize scheduler issues later
     ct = current_task()
-    q = ct.queue; q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
+    q = ct.queue
+    if q !== nothing
+        try
+            list_deletefirst!(q::StickyWorkqueue, ct)
+        catch
+            # best-effort cleanup on the way out
+        end
+    end
+    # If this task's wait registration is still armed (e.g. this exit came
+    # from a signal while parked), disarm it: the waitee-queue entry is
+    # stale and gets dropped by whoever pops it, and the sticky source
+    # registration is collected by a walk once this task is done.
+    @atomicswap ct.waiting_on = nothing
+    # We are exiting: any pending cancellation of this task's scope is moot
+    # and would only disrupt the atexit hooks - run them in a shielded scope.
+    return ScopedValues.@with(CANCEL_TOKEN => nothing, _run_atexit_hooks(exitcode))
+end
+
+function _run_atexit_hooks(exitcode::Cint)
     # Don't hold the lock around the iteration, just in case any other thread executing in
     # parallel tries to register a new atexit hook while this is running. We don't want to
     # block that thread from proceeding, and we can allow it to register its hook which we

--- a/base/io.jl
+++ b/base/io.jl
@@ -328,6 +328,19 @@ Base.RefValue{MyStruct}(MyStruct(42.0))
 ```
 """
 function write end
+
+"""
+    writepartial(io::IO, x) -> Int
+
+Write `x` to `io` with partial-write cancellation semantics: where
+[`write`](@ref) throws the `CancellationRequest` when its governing
+cancellation token is cancelled mid-write, `writepartial` returns the
+number of bytes the stream had already accepted, and the (level-triggered)
+cancellation is delivered at the next cancellation point instead. Callers
+using it must be prepared for short counts. For IO types whose writes
+cannot block on cancellable resources it is equivalent to `write`.
+"""
+writepartial(io::IO, x) = write(io, x)
 typeof(write).name.max_methods = UInt8(1)
 
 read(s::IO, ::Type{UInt8}) = error(typeof(s)," does not support byte I/O")
@@ -484,6 +497,7 @@ for f in (:flush, :closewrite)
                                     $(f)(pipe_writer(io)::IO; cancel)
 end
 write(io::AbstractPipe, byte::UInt8) = write(pipe_writer(io)::IO, byte)
+writepartial(io::AbstractPipe, x) = writepartial(pipe_writer(io)::IO, x)
 write(to::IO, from::AbstractPipe) = write(to, pipe_reader(from))
 unsafe_write(io::AbstractPipe, p::Ptr{UInt8}, nb::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL) =
     (cancel === DEFAULT_CANCEL ? unsafe_write(pipe_writer(io)::IO, p, nb) :

--- a/base/io.jl
+++ b/base/io.jl
@@ -472,32 +472,55 @@ end
 function pipe_reader end
 function pipe_writer end
 
-for f in (:flush, :closewrite, :iswritable)
-    @eval $(f)(io::AbstractPipe) = $(f)(pipe_writer(io)::IO)
+iswritable(io::AbstractPipe) = iswritable(pipe_writer(io)::IO)
+# flush/closewrite/unsafe_write accept `cancel` like their LibuvStream
+# counterparts, so a keyword call on a compound pipe does not miss these
+# forwarders (only an explicit token is forwarded: the sentinel keeps the
+# plain call, which any user-defined method of the inner IO supports; see
+# readbytes! below)
+for f in (:flush, :closewrite)
+    @eval $(f)(io::AbstractPipe; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+        cancel === DEFAULT_CANCEL ? $(f)(pipe_writer(io)::IO) :
+                                    $(f)(pipe_writer(io)::IO; cancel)
 end
 write(io::AbstractPipe, byte::UInt8) = write(pipe_writer(io)::IO, byte)
 write(to::IO, from::AbstractPipe) = write(to, pipe_reader(from))
-unsafe_write(io::AbstractPipe, p::Ptr{UInt8}, nb::UInt) = unsafe_write(pipe_writer(io)::IO, p, nb)::Union{Int,UInt}
+unsafe_write(io::AbstractPipe, p::Ptr{UInt8}, nb::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    (cancel === DEFAULT_CANCEL ? unsafe_write(pipe_writer(io)::IO, p, nb) :
+                                 unsafe_write(pipe_writer(io)::IO, p, nb; cancel))::Union{Int,UInt}
 buffer_writes(io::AbstractPipe, args...) = buffer_writes(pipe_writer(io)::IO, args...)
 
 for f in (
         # peek/mark interface
         :mark, :unmark, :reset, :ismarked,
         # Simple reader functions
-        :read, :readavailable, :bytesavailable, :reseteof, :isreadable)
+        :read, :bytesavailable, :reseteof, :isreadable)
     @eval $(f)(io::AbstractPipe) = $(f)(pipe_reader(io)::IO)
 end
-read(io::AbstractPipe, byte::Type{UInt8}) = read(pipe_reader(io)::IO, byte)::UInt8
+# explicit-token-forwarding reader forwarders (same pattern as readbytes!
+# below: the sentinel keeps the plain call)
+readavailable(io::AbstractPipe; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    cancel === DEFAULT_CANCEL ? readavailable(pipe_reader(io)::IO) :
+                                readavailable(pipe_reader(io)::IO; cancel)
+read(io::AbstractPipe, byte::Type{UInt8}; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    (cancel === DEFAULT_CANCEL ? read(pipe_reader(io)::IO, byte) :
+                                 read(pipe_reader(io)::IO, byte; cancel))::UInt8
 unsafe_read(io::AbstractPipe, p::Ptr{UInt8}, nb::UInt) = unsafe_read(pipe_reader(io)::IO, p, nb)
 copyuntil(out::IO, io::AbstractPipe, arg::UInt8; kw...) = copyuntil(out, pipe_reader(io)::IO, arg; kw...)
 copyuntil(out::IO, io::AbstractPipe, arg::AbstractChar; kw...) = copyuntil(out, pipe_reader(io)::IO, arg; kw...)
 copyuntil(out::IO, io::AbstractPipe, arg::AbstractString; kw...) = copyuntil(out, pipe_reader(io)::IO, arg; kw...)
 copyuntil(out::IO, io::AbstractPipe, arg::AbstractVector; kw...) = copyuntil(out, pipe_reader(io)::IO, arg; kw...)
 readuntil_vector!(io::AbstractPipe, target::AbstractVector, keep::Bool, out) = readuntil_vector!(pipe_reader(io)::IO, target, keep, out)
-readbytes!(io::AbstractPipe, target::AbstractVector{UInt8}, n=length(target)) = readbytes!(pipe_reader(io)::IO, target, n)
+# (only an explicit token is forwarded: the sentinel keeps the plain call,
+# which any user-defined readbytes! method supports)
+readbytes!(io::AbstractPipe, target::AbstractVector{UInt8}, n=length(target); cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    cancel === DEFAULT_CANCEL ? readbytes!(pipe_reader(io)::IO, target, n) :
+                                readbytes!(pipe_reader(io)::IO, target, n; cancel)
 peek(io::AbstractPipe, ::Type{T}) where {T} = peek(pipe_reader(io)::IO, T)::T
 wait_readnb(io::AbstractPipe, nb::Int) = wait_readnb(pipe_reader(io)::IO, nb)
-eof(io::AbstractPipe) = eof(pipe_reader(io)::IO)::Bool
+eof(io::AbstractPipe; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    (cancel === DEFAULT_CANCEL ? eof(pipe_reader(io)::IO) :
+                                 eof(pipe_reader(io)::IO; cancel))::Bool
 
 isopen(io::AbstractPipe) = isopen(pipe_writer(io)::IO) || isopen(pipe_reader(io)::IO)
 close(io::AbstractPipe) = (close(pipe_writer(io)::IO); close(pipe_reader(io)::IO))
@@ -545,6 +568,13 @@ typeof(read!).name.max_methods = UInt8(1)
 
 read!(filename::AbstractString, a) = open(io->read!(io, a), convert(String, filename)::String)
 
+# The generic-IO `cancel` convention (referenced as such below): in methods
+# over abstract `IO`, the inner reads/writes go through arbitrary, possibly
+# user-extended methods that need not accept a `cancel` keyword. The
+# resolved token therefore gates *between* those calls, via explicit
+# cancellation points, while any parks inside them run under the ambient
+# scope.
+
 """
     readuntil(stream::IO, delim; keep::Bool = false)
     readuntil(filename::AbstractString, delim; keep::Bool = false)
@@ -572,9 +602,12 @@ julia> rm("my_file.txt")
 ```
 """
 readuntil(filename::AbstractString, delim; kw...) = open(io->readuntil(io, delim; kw...), convert(String, filename)::String)
-readuntil(stream::IO, delim::UInt8; kw...) = _unsafe_take!(copyuntil(IOBuffer(sizehint=16), stream, delim; kw...))
-readuntil(stream::IO, delim::Union{AbstractChar, AbstractString}; kw...) = takestring!(copyuntil(IOBuffer(sizehint=16), stream, delim; kw...))
-readuntil(stream::IO, delim::T; keep::Bool=false) where T = _copyuntil(Vector{T}(), stream, delim, keep)
+readuntil(stream::IO, delim::UInt8; cancel::CancelTokenArg=DEFAULT_CANCEL, kw...) =
+    _unsafe_take!(copyuntil(IOBuffer(sizehint=16), stream, delim; cancel, kw...))
+readuntil(stream::IO, delim::Union{AbstractChar, AbstractString}; cancel::CancelTokenArg=DEFAULT_CANCEL, kw...) =
+    takestring!(copyuntil(IOBuffer(sizehint=16), stream, delim; cancel, kw...))
+readuntil(stream::IO, delim::T; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL) where T =
+    _copyuntil(Vector{T}(), stream, delim, keep, resolve_cancel_token(cancel))
 
 
 """
@@ -646,9 +679,12 @@ Logan
 "Logan"
 ```
 """
-readline(filename::AbstractString; keep::Bool=false) =
-    open(io -> readline(io; keep), filename)
-readline(s::IO=stdin; keep::Bool=false) = takestring!(copyline(IOBuffer(sizehint=16), s; keep))
+function readline(filename::AbstractString; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    return open(io -> readline(io; keep, cancel=tok), filename)
+end
+readline(s::IO=stdin; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    takestring!(copyline(IOBuffer(sizehint=16), s; keep, cancel))
 
 """
     copyline(out::IO, io::IO=stdin; keep::Bool=false)
@@ -685,16 +721,23 @@ julia> rm("my_file.txt")
 !!! compat "Julia 1.11"
     `copyline` was introduced in Julia 1.11.
 """
-copyline(out::IO, filename::AbstractString; keep::Bool=false) =
-    open(io -> copyline(out, io; keep), filename)
+function copyline(out::IO, filename::AbstractString; keep::Bool=false,
+                  cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    return open(io -> copyline(out, io; keep, cancel=tok), filename)
+end
 
 # fallback to optimized methods for IOBuffer in iobuffer.jl
-function copyline(out::IO, s::IO; keep::Bool=false)
+function copyline(out::IO, s::IO; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
     if keep
-        return copyuntil(out, s, 0x0a, keep=true)
+        return copyuntil(out, s, 0x0a; keep=true, cancel)
     else
+        tok = resolve_cancel_token(cancel)
+        @cancel_check tok
         # more complicated to deal with CRLF logic
         while !eof(s)
+            # token-gate between the reads (generic-IO cancel convention)
+            @cancel_check tok
             b = read(s, UInt8)
             b == 0x0a && break
             if b == 0x0d && !eof(s)
@@ -739,7 +782,8 @@ function readlines(filename::AbstractString; kw...)
         readlines(f; kw...)
     end
 end
-readlines(s=stdin; kw...) = collect(eachline(s; kw...))
+readlines(s=stdin; cancel::CancelTokenArg=DEFAULT_CANCEL, kw...) =
+    collect(eachline(s; cancel, kw...))
 
 ## byte-order mark, ntoh & hton ##
 
@@ -824,9 +868,13 @@ isreadonly(s) = isreadable(s) && !iswritable(s)
 ## binary I/O ##
 
 write(io::IO, x) = throw(MethodError(write, (io, x)))
-function write(io::IO, x1, xs...)
+function write(io::IO, x1, xs...; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # token-gate between the per-value writes (generic-IO cancel convention)
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
     written::Int = write(io, x1)
     for x in xs
+        @cancel_check tok
         written += write(io, x)
     end
     return written
@@ -851,7 +899,9 @@ end
 write(s::IO, x::Bool) = write(s, UInt8(x))
 write(to::IO, p::Ptr) = write(to, convert(UInt, p))
 
-function write(s::IO, A::AbstractArray)
+function write(s::IO, A::AbstractArray; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
     if !isbitstype(eltype(A))
         error("`write` is not supported on non-isbits arrays")
     end
@@ -864,7 +914,9 @@ function write(s::IO, A::AbstractArray)
     return nb
 end
 
-function write(s::IO, A::StridedArray)
+function write(s::IO, A::StridedArray; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
     if !isbitstype(eltype(A))
         error("`write` is not supported on non-isbits arrays")
     end
@@ -942,7 +994,9 @@ end
 read(s::IO, ::Type{Bool}) = (read(s, UInt8) != 0)
 read(s::IO, ::Type{Ptr{T}}) where {T} = convert(Ptr{T}, read(s, UInt))
 
-function read!(s::IO, A::AbstractArray{T}) where {T}
+function read!(s::IO, A::AbstractArray{T}; cancel::CancelTokenArg=DEFAULT_CANCEL) where {T}
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
     if isbitstype(T) && _checkcontiguous(Bool, A)
         GC.@preserve A unsafe_read(s, pointer(A), elsize(A) * length(A))
     else
@@ -961,7 +1015,32 @@ function read!(s::IO, A::AbstractArray{T}) where {T}
     return A
 end
 
-function read!(s::IO, A::StridedArray{T}) where {T}
+# BitArray I/O (moved from bitarray.jl, which loads before the `cancel`
+# plumbing). These must accept `cancel` themselves: a keyword call
+# dispatches only among keyword-accepting methods, so without it
+# `write(io, B; cancel=...)` would fall through to the generic per-element
+# array loop above and produce the wrong - unpacked - format; likewise
+# `read!` would consume the unpacked format and skip tail validation.
+function write(s::IO, B::BitArray; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # entry gate, then the packed representation as always
+    @cancel_check resolve_cancel_token(cancel)
+    return write(s, B.chunks)
+end
+function read!(s::IO, B::BitArray; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    @cancel_check resolve_cancel_token(cancel)
+    n = length(B)
+    Bc = B.chunks
+    read!(s, Bc)
+    if length(Bc) > 0 && Bc[end] & _msk_end(n) ≠ Bc[end]
+        Bc[end] &= _msk_end(n) # ensure that the BitArray is not broken
+        throw(DimensionMismatch("read mismatch, found non-zero bits after BitArray length"))
+    end
+    return B
+end
+
+function read!(s::IO, A::StridedArray{T}; cancel::CancelTokenArg=DEFAULT_CANCEL) where {T}
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
     if !isbitstype(T) || _checkcontiguous(Bool, A)
         return invoke(read!, Tuple{IO, AbstractArray}, s, A)
     end
@@ -1011,11 +1090,15 @@ end
 # read(io, T) is not defined for other AbstractChar: implementations
 # must provide their own encoding-specific method.
 
-function copyuntil(out::IO, s::IO, delim::AbstractChar; keep::Bool=false)
+function copyuntil(out::IO, s::IO, delim::AbstractChar; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
     if delim ≤ '\x7f'
-        return copyuntil(out, s, delim % UInt8; keep)
+        return copyuntil(out, s, delim % UInt8; keep, cancel)
     end
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
     for c in readeach(s, Char)
+        # token-gate between the reads (generic-IO cancel convention)
+        @cancel_check tok
         if c == delim
             keep && write(out, c)
             break
@@ -1027,12 +1110,15 @@ end
 
 # note: optimized methods of copyuntil for IOStreams and delim::UInt8 in iostream.jl
 #       and for IOBuffer with delim::UInt8 in iobuffer.jl
-copyuntil(out::IO, s::IO, delim; keep::Bool=false) = _copyuntil(out, s, delim, keep)
+copyuntil(out::IO, s::IO, delim; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    _copyuntil(out, s, delim, keep, resolve_cancel_token(cancel))
 
 # supports out::Union{IO, AbstractVector} for use with both copyuntil & readuntil
-function _copyuntil(out, s::IO, delim::T, keep::Bool) where T
+function _copyuntil(out, s::IO, delim::T, keep::Bool, tok::MaybeToken=nothing) where T
     output! = isa(out, IO) ? write : push!
     for c in readeach(s, T)
+        # token-gate between the reads (generic-IO cancel convention)
+        @cancel_check tok
         if c == delim
             keep && output!(out, c)
             break
@@ -1128,29 +1214,40 @@ function readuntil_vector!(io::IO, target::AbstractVector{T}, keep::Bool, out) w
     return false
 end
 
-function copyuntil(out::IO, io::IO, target::AbstractString; keep::Bool=false)
+function copyuntil(out::IO, io::IO, target::AbstractString; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
     # small-string target optimizations
     x = Iterators.peel(target)
     isnothing(x) && return out
     c, rest = x
     if isempty(rest) && c <= '\x7f'
-        return copyuntil(out, io, c % UInt8; keep)
+        return copyuntil(out, io, c % UInt8; keep, cancel)
     end
     # convert String to a utf8-byte-iterator
     if !(target isa String) && !(target isa SubString{String})
         target = String(target)
     end
     target = codeunits(target)::AbstractVector
-    return copyuntil(out, io, target, keep=keep)
+    return copyuntil(out, io, target; keep, cancel)
 end
 
-function readuntil(io::IO, target::AbstractVector{T}; keep::Bool=false) where T
+# like the vector copyuntil below: without the `cancel` keyword here, a
+# keyword call would bypass this method for the scalar-delimiter catch-all
+# above (keyword dispatch only sees keyword-accepting methods)
+function readuntil(io::IO, target::AbstractVector{T}; keep::Bool=false,
+                   cancel::CancelTokenArg=DEFAULT_CANCEL) where T
+    # entry gate only (generic-IO cancel convention)
+    @cancel_check resolve_cancel_token(cancel)
     out = (T === UInt8 ? resize!(StringVector(16), 0) : Vector{T}())
     readuntil_vector!(io, target, keep, out)
     return out
 end
-copyuntil(out::IO, io::IO, target::AbstractVector; keep::Bool=false) =
-    (readuntil_vector!(io, target, keep, out); out)
+function copyuntil(out::IO, io::IO, target::AbstractVector; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # entry gate only, ahead of readuntil_vector!'s generic reads
+    # (generic-IO cancel convention)
+    @cancel_check resolve_cancel_token(cancel)
+    readuntil_vector!(io, target, keep, out)
+    return out
+end
 
 """
     readchomp(x)
@@ -1168,7 +1265,12 @@ julia> readchomp("my_file.txt")
 julia> rm("my_file.txt");
 ```
 """
-readchomp(x) = chomp(read(x, String))
+function readchomp(x; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # `x` may be anything readable (a stream, file name, command): entry
+    # gate only (generic-IO cancel convention)
+    @cancel_check resolve_cancel_token(cancel)
+    return chomp(read(x, String))
+end
 
 # read up to nb bytes into nb, returning # bytes read
 
@@ -1179,11 +1281,15 @@ Read at most `nb` bytes from `stream` into `b`, returning the number of bytes re
 The size of `b` will be increased if needed (i.e. if `nb` is greater than `length(b)`
 and enough bytes could be read), but it will never be decreased.
 """
-function readbytes!(s::IO, b::AbstractArray{UInt8}, nb=length(b))
+function readbytes!(s::IO, b::AbstractArray{UInt8}, nb=length(b); cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
     require_one_based_indexing(b)
     olb = lb = length(b)
     nr = 0
     while nr < nb && !eof(s)
+        # token-gate between the reads (generic-IO cancel convention)
+        @cancel_check tok
         a = read(s, UInt8)
         nr += 1
         if nr > lb
@@ -1203,15 +1309,25 @@ end
 
 Read at most `nb` bytes from `s`, returning a `Vector{UInt8}` of the bytes read.
 """
-function read(s::IO, nb::Integer = typemax(Int))
+function read(s::IO, nb::Integer = typemax(Int); cancel::CancelTokenArg=DEFAULT_CANCEL)
     # Let readbytes! grow the array progressively by default
     # instead of taking the risk of over-allocating
     b = Vector{UInt8}(undef, nb == typemax(Int) ? 1024 : nb)
-    nr = readbytes!(s, b, nb)
+    # an explicit token is forwarded to readbytes! (whose Base methods all
+    # accept it); the default sentinel keeps the plain call, which any
+    # user-defined readbytes! method supports
+    nr = cancel === DEFAULT_CANCEL ? readbytes!(s, b, nb) : readbytes!(s, b, nb; cancel)
     return resize!(b, nr)
 end
 
-read(s::IO, ::Type{String}) = String(read(s)::Vector{UInt8})
+function read(s::IO, ::Type{String}; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # thread the token (or an explicit `nothing` shield) into the inner
+    # read, which does the actual blocking; the sentinel keeps the plain
+    # call, which any user-defined `read` method supports
+    cancel === DEFAULT_CANCEL && return String(read(s)::Vector{UInt8})
+    cancel = check_cancel_arg(cancel)
+    return String(read(s; cancel)::Vector{UInt8})
+end
 read(s::IO, T::Type) = error("The IO stream does not support reading objects of type $T.")
 
 ## high-level iterator interfaces ##
@@ -1220,8 +1336,10 @@ struct EachLine{IOT <: IO}
     stream::IOT
     ondone::Function
     keep::Bool
-    EachLine(stream::IO=stdin; ondone::Function=()->nothing, keep::Bool=false) =
-        new{typeof(stream)}(stream, ondone, keep)
+    cancel::MaybeToken
+    EachLine(stream::IO=stdin; ondone::Function=()->nothing, keep::Bool=false,
+             cancel::MaybeToken=nothing) =
+        new{typeof(stream)}(stream, ondone, keep, cancel)
 end
 
 """
@@ -1257,18 +1375,20 @@ julia> rm("my_file.txt");
 !!! compat "Julia 1.8"
        Julia 1.8 is required to use `Iterators.reverse` or `last` with `eachline` iterators.
 """
-function eachline(stream::IO=stdin; keep::Bool=false)
-    EachLine(stream, keep=keep)::EachLine
+function eachline(stream::IO=stdin; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    EachLine(stream; keep, cancel=resolve_cancel_token(cancel))::EachLine
 end
 
-function eachline(filename::AbstractString; keep::Bool=false)
+function eachline(filename::AbstractString; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
     s = open(filename)
-    EachLine(s, ondone=()->close(s), keep=keep)::EachLine
+    EachLine(s; ondone=()->close(s), keep, cancel=resolve_cancel_token(cancel))::EachLine
 end
 
 function iterate(itr::EachLine, state=nothing)
+    # token-gate between lines (generic-IO cancel convention)
+    @cancel_check itr.cancel
     eof(itr.stream) && return (itr.ondone(); nothing)
-    (readline(itr.stream, keep=itr.keep), nothing)
+    (readline(itr.stream; keep=itr.keep, cancel=itr.cancel), nothing)
 end
 
 eltype(::Type{<:EachLine}) = String

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -896,7 +896,11 @@ function write(to::IO, from::GenericIOBuffer)
     return written
 end
 
-function unsafe_write(to::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
+# writing to an in-memory buffer never blocks; accept (and entry-gate)
+# `cancel` so that explicit-token writes forwarded here (e.g.
+# `write(io, ::String; cancel=...)`) keep working
+function unsafe_write(to::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    precheck_cancel_arg(cancel)
     ensureroom(to, nb)
     size = to.size
     append = to.append
@@ -981,7 +985,12 @@ function occursin(delim::UInt8, buf::GenericIOBuffer)
     return in(delim, view(buf.data, buf.ptr:buf.size))
 end
 
-function copyuntil(out::IO, io::GenericIOBuffer, delim::UInt8; keep::Bool=false)
+# Reading from an in-memory buffer never blocks, but the write to `out`
+# may: an explicit token (or `nothing` shield) is forwarded to it, so
+# shielded chains (e.g. `readline(stream; cancel=nothing)`, which lands
+# here through the stream's copyuntil) compose; the sentinel keeps the
+# plain call, which any IO's write supports.
+function copyuntil(out::IO, io::GenericIOBuffer, delim::UInt8; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
     data = view(io.data, io.ptr:io.size)
     # note: findfirst + copyto! is much faster than a single loop
     #       except for nout ≲ 20.  A single loop is 2x faster for nout=5.
@@ -989,12 +998,20 @@ function copyuntil(out::IO, io::GenericIOBuffer, delim::UInt8; keep::Bool=false)
     if !keep && nout > 0 && data[nout] == delim
         nout -= 1
     end
-    write(out, view(io.data, io.ptr:io.ptr+nout-1))
+    if cancel === DEFAULT_CANCEL
+        write(out, view(io.data, io.ptr:io.ptr+nout-1))
+    else
+        write(out, view(io.data, io.ptr:io.ptr+nout-1); cancel)
+    end
     io.ptr += nread
     return out
 end
 
-function copyline(out::GenericIOBuffer, s::IO; keep::Bool=false)
+function copyline(out::GenericIOBuffer, s::IO; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
+    # the resolved token (or explicit shield) governs the inner copyuntil,
+    # which does the actual blocking reads
     # If the data is copied into the middle of the buffer of `out` instead of appended to the end,
     # and !keep, and the line copied ends with \r\n, then the copyuntil (even if keep=false)
     # will overwrite one too many bytes with the new \r byte.
@@ -1002,7 +1019,7 @@ function copyline(out::GenericIOBuffer, s::IO; keep::Bool=false)
     # Could perhaps be done better
     if !out.append && out.ptr < out.size + 1
         newbuf = IOBuffer()
-        copyuntil(newbuf, s, 0x0a, keep=true)
+        copyuntil(newbuf, s, 0x0a; keep=true, cancel=tok)
         v = take!(newbuf)
         # Remove \r\n or \n if present
         if !keep
@@ -1013,12 +1030,14 @@ function copyline(out::GenericIOBuffer, s::IO; keep::Bool=false)
                 pop!(v)
             end
         end
-        write(out, v)
+        # `tok` is resolved above: the write to `out` runs under it (or its
+        # explicit shield), not the ambient scope
+        write(out, v; cancel=tok)
         return out
     else
         # Else, we can just copy the data directly into the buffer, and then
         # subtract the last one or two bytes depending on `keep`.
-        copyuntil(out, s, 0x0a, keep=true)
+        copyuntil(out, s, 0x0a; keep=true, cancel=tok)
         line = out.data
         i = out.size
         if keep || i == out.offset_or_compacted || line[i] != 0x0a
@@ -1036,7 +1055,7 @@ function copyline(out::GenericIOBuffer, s::IO; keep::Bool=false)
     end
 end
 
-function _copyline(out::IO, io::GenericIOBuffer; keep::Bool=false)
+function _copyline(out::IO, io::GenericIOBuffer; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
     data = view(io.data, io.ptr:io.size)
     # note: findfirst + copyto! is much faster than a single loop
     #       except for nout ≲ 20.  A single loop is 2x faster for nout=5.
@@ -1046,13 +1065,20 @@ function _copyline(out::IO, io::GenericIOBuffer; keep::Bool=false)
         nout -= 1
         nout > 0 && data[nout] == 0x0d && (nout -= 1)
     end
-    write(out, view(io.data, io.ptr:io.ptr+nout-1))
+    if cancel === DEFAULT_CANCEL
+        write(out, view(io.data, io.ptr:io.ptr+nout-1))
+    else
+        write(out, view(io.data, io.ptr:io.ptr+nout-1); cancel)
+    end
     io.ptr += nread
     return out
 end
 
-copyline(out::IO, io::GenericIOBuffer; keep::Bool=false) = _copyline(out, io; keep)
-copyline(out::GenericIOBuffer, io::GenericIOBuffer; keep::Bool=false) = _copyline(out, io; keep)
+# reading from an in-memory buffer never blocks, but the write to `out`
+# may; an explicit token (or shield) is forwarded to it (see copyuntil
+# above)
+copyline(out::IO, io::GenericIOBuffer; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL) = _copyline(out, io; keep, cancel)
+copyline(out::GenericIOBuffer, io::GenericIOBuffer; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL) = _copyline(out, io; keep, cancel)
 
 
 # copy-free crc32c of IOBuffer:

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -261,7 +261,8 @@ end
 
 _eof_nolock(s::IOStream) = ccall(:ios_eof_blocking, Cint, (Ptr{Cvoid},), s.ios) != 0
 function eof(s::IOStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
-    # entry check only: the C-side read is not interruptible
+    # entry check only: IOStream reads block in C and are not
+    # interruptible (likewise for every bare `@cancel_check` below)
     @cancel_check resolve_cancel_token(cancel)
     @_lock_ios s _eof_nolock(s)
 end
@@ -423,7 +424,6 @@ end
 bytesavailable(s::IOStream) = @_lock_ios s ccall(:jl_nb_available, Int32, (Ptr{Cvoid},), s.ios)
 
 function readavailable(s::IOStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
-    # entry check only: the C-side read is not interruptible
     @cancel_check resolve_cancel_token(cancel)
     lock(s.lock)
     nb = ccall(:jl_nb_available, Int32, (Ptr{Cvoid},), s.ios)
@@ -483,7 +483,6 @@ take!(s::IOStream) =
     @_lock_ios s ccall(:jl_take_buffer, Vector{UInt8}, (Ptr{Cvoid},), s.ios)
 
 function readuntil(s::IOStream, delim::UInt8; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
-    # entry check only: the C-side read is not interruptible
     @cancel_check resolve_cancel_token(cancel)
     @_lock_ios s ccall(:jl_readuntil, Vector{UInt8}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, delim, 0, !keep)
 end
@@ -500,13 +499,11 @@ function readuntil(s::IOStream, delim::AbstractChar; keep::Bool=false, cancel::C
 end
 
 function readline(s::IOStream; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
-    # entry check only: the C-side read is not interruptible
     @cancel_check resolve_cancel_token(cancel)
     @_lock_ios s ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, '\n', 1, keep ? 0 : 2)
 end
 
 function copyuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
-    # entry check only: the C-side read is not interruptible
     @cancel_check resolve_cancel_token(cancel)
     ensureroom(out, 1) # make sure we can read at least 1 byte, for iszero(n) check below
     while true
@@ -532,7 +529,6 @@ function copyuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false, c
 end
 
 function copyuntil(out::IOStream, s::IOStream, delim::UInt8; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
-    # entry check only: the C-side read is not interruptible
     @cancel_check resolve_cancel_token(cancel)
     @_lock_ios out @_lock_ios s ccall(:ios_copyuntil, Csize_t,
         (Ptr{Cvoid}, Ptr{Cvoid}, UInt8, Cint), out.ios, s.ios, delim, keep)
@@ -598,7 +594,6 @@ all stream types support the `all` option.
 """
 function readbytes!(s::IOStream, b::MutableDenseArrayType{UInt8}, nb=length(b); all::Bool=true,
                     cancel::CancelTokenArg=DEFAULT_CANCEL)
-    # entry check only: the C-side read is not interruptible
     @cancel_check resolve_cancel_token(cancel)
     return all ? readbytes_all!(s, b, nb) : readbytes_some!(s, b, nb)
 end
@@ -645,7 +640,6 @@ requested bytes, until an error or end-of-file occurs. If `all` is `false`, at m
 all stream types support the `all` option.
 """
 function read(s::IOStream, nb::Integer; all::Bool=true, cancel::CancelTokenArg=DEFAULT_CANCEL)
-    # entry check only: the C-side read is not interruptible
     @cancel_check resolve_cancel_token(cancel)
     # When all=false we have to allocate a buffer of the requested size upfront
     # since a single call will be made

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -260,7 +260,11 @@ function filesize(s::IOStream)
 end
 
 _eof_nolock(s::IOStream) = ccall(:ios_eof_blocking, Cint, (Ptr{Cvoid},), s.ios) != 0
-eof(s::IOStream) = @_lock_ios s _eof_nolock(s)
+function eof(s::IOStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # entry check only: the C-side read is not interruptible
+    @cancel_check resolve_cancel_token(cancel)
+    @_lock_ios s _eof_nolock(s)
+end
 
 ## constructing and opening streams ##
 
@@ -403,7 +407,14 @@ function write(s::IOStream, b::UInt8)
     Int(@_lock_ios s ccall(:ios_putc, Cint, (Cint, Ptr{Cvoid}), b, s.ios))
 end
 
-function unsafe_write(s::IOStream, p::Ptr{UInt8}, nb::UInt)
+function unsafe_write(s::IOStream, p::Ptr{UInt8}, nb::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # Explicit tokens gate at entry (which keeps explicit-token writes -
+    # e.g. `write(io, ::String; cancel=...)` - working on files); the
+    # sentinel deliberately passes without resolving the ambient scope: a
+    # plain print to a file is not a cancellation point (unlike the
+    # C-side-blocking reads above), so e.g. logging during cancellation
+    # cleanup keeps working unshielded.
+    precheck_cancel_arg(cancel)
     iswritable(s) || throw(ArgumentError("write failed, IOStream is not writeable"))
     return Int(@_lock_ios s ccall(:ios_write, Csize_t, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t), s.ios, p, nb))
 end
@@ -411,7 +422,9 @@ end
 # num bytes available without blocking
 bytesavailable(s::IOStream) = @_lock_ios s ccall(:jl_nb_available, Int32, (Ptr{Cvoid},), s.ios)
 
-function readavailable(s::IOStream)
+function readavailable(s::IOStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # entry check only: the C-side read is not interruptible
+    @cancel_check resolve_cancel_token(cancel)
     lock(s.lock)
     nb = ccall(:jl_nb_available, Int32, (Ptr{Cvoid},), s.ios)
     if nb == 0
@@ -469,7 +482,9 @@ end
 take!(s::IOStream) =
     @_lock_ios s ccall(:jl_take_buffer, Vector{UInt8}, (Ptr{Cvoid},), s.ios)
 
-function readuntil(s::IOStream, delim::UInt8; keep::Bool=false)
+function readuntil(s::IOStream, delim::UInt8; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # entry check only: the C-side read is not interruptible
+    @cancel_check resolve_cancel_token(cancel)
     @_lock_ios s ccall(:jl_readuntil, Vector{UInt8}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, delim, 0, !keep)
 end
 
@@ -477,15 +492,22 @@ end
 function readuntil_string(s::IOStream, delim::UInt8, keep::Bool)
     @_lock_ios s ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, delim, 1, !keep)
 end
-readuntil(s::IOStream, delim::AbstractChar; keep::Bool=false) =
-    isascii(delim) ? readuntil_string(s, delim % UInt8, keep) :
-    takestring!(copyuntil(IOBuffer(sizehint=70), s, delim; keep))
+function readuntil(s::IOStream, delim::AbstractChar; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
+    return isascii(delim) ? readuntil_string(s, delim % UInt8, keep) :
+        takestring!(copyuntil(IOBuffer(sizehint=70), s, delim; keep, cancel=tok))
+end
 
-function readline(s::IOStream; keep::Bool=false)
+function readline(s::IOStream; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # entry check only: the C-side read is not interruptible
+    @cancel_check resolve_cancel_token(cancel)
     @_lock_ios s ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, '\n', 1, keep ? 0 : 2)
 end
 
-function copyuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false)
+function copyuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # entry check only: the C-side read is not interruptible
+    @cancel_check resolve_cancel_token(cancel)
     ensureroom(out, 1) # make sure we can read at least 1 byte, for iszero(n) check below
     while true
         d = out.data
@@ -509,7 +531,9 @@ function copyuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false)
     return out
 end
 
-function copyuntil(out::IOStream, s::IOStream, delim::UInt8; keep::Bool=false)
+function copyuntil(out::IOStream, s::IOStream, delim::UInt8; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # entry check only: the C-side read is not interruptible
+    @cancel_check resolve_cancel_token(cancel)
     @_lock_ios out @_lock_ios s ccall(:ios_copyuntil, Csize_t,
         (Ptr{Cvoid}, Ptr{Cvoid}, UInt8, Cint), out.ios, s.ios, delim, keep)
     return out
@@ -572,7 +596,10 @@ requested bytes, until an error or end-of-file occurs. If `all` is `false`, at m
 `read` call is performed, and the amount of data returned is device-dependent. Note that not
 all stream types support the `all` option.
 """
-function readbytes!(s::IOStream, b::MutableDenseArrayType{UInt8}, nb=length(b); all::Bool=true)
+function readbytes!(s::IOStream, b::MutableDenseArrayType{UInt8}, nb=length(b); all::Bool=true,
+                    cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # entry check only: the C-side read is not interruptible
+    @cancel_check resolve_cancel_token(cancel)
     return all ? readbytes_all!(s, b, nb) : readbytes_some!(s, b, nb)
 end
 
@@ -617,7 +644,9 @@ requested bytes, until an error or end-of-file occurs. If `all` is `false`, at m
 `read` call is performed, and the amount of data returned is device-dependent. Note that not
 all stream types support the `all` option.
 """
-function read(s::IOStream, nb::Integer; all::Bool=true)
+function read(s::IOStream, nb::Integer; all::Bool=true, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # entry check only: the C-side read is not interruptible
+    @cancel_check resolve_cancel_token(cancel)
     # When all=false we have to allocate a buffer of the requested size upfront
     # since a single call will be made
     b = Vector{UInt8}(undef, all && nb == typemax(Int) ? 1024 : nb)

--- a/base/linked_list.jl
+++ b/base/linked_list.jl
@@ -177,3 +177,117 @@ function list_deletefirst!(q::LinkedList{T}, val::T) where T
     end
     return q
 end
+
+## Wait-entry lists
+#
+# Wait entries carry uniform {owner, next, aux} slots (see cancellation.jl)
+# and can be registered on several waitables at once (wait-any), so the
+# list operations locate each entry's slot for *this* list through the
+# ILLRef's waitee identity - every list is populated under exactly one
+# identity (the ILLRef invariant above). The generic `.next`/`.queue`
+# methods above keep serving Task scheduler lists.
+
+function push!(qr::ILLRef{WaitEntry}, val::WaitEntry)
+    _find_slot(val, qr.waitee) == 0 || error("val already in this list")
+    _acquire_slot!(val, qr.waitee)
+    q = qr.list
+    tail = q.tail
+    if tail === nothing
+        q.head = q.tail = val
+    else
+        tail = tail::WaitEntry
+        _set_slot_next!(tail, _find_slot(tail, qr.waitee), val)
+        q.tail = val
+    end
+    return q
+end
+
+function pushfirst!(qr::ILLRef{WaitEntry}, val::WaitEntry)
+    _find_slot(val, qr.waitee) == 0 || error("val already in this list")
+    i = _acquire_slot!(val, qr.waitee)
+    q = qr.list
+    head = q.head
+    if head === nothing
+        q.head = q.tail = val
+    else
+        _set_slot_next!(val, i, head)
+        q.head = val
+    end
+    return q
+end
+
+function popfirst!(qr::ILLRef{WaitEntry})
+    q = qr.list
+    val = q.head::WaitEntry
+    i = _find_slot(val, qr.waitee)
+    vnext = _slot_next(val, i)
+    q.head = vnext
+    vnext === nothing && (q.tail = nothing)
+    _release_slot!(val, i)
+    return val
+end
+
+function pop!(qr::ILLRef{WaitEntry})
+    val = qr.list.tail::WaitEntry
+    list_deletefirst!(qr, val) # expensive!
+    return val
+end
+
+# Delete `val` from the list, but only if it is actually in it, as witnessed
+# by its slot for this list's identity. This makes deletion a no-op if `val`
+# was concurrently popped, which various cleanup paths rely upon.
+function list_deletefirst!(qr::ILLRef{WaitEntry}, val::WaitEntry)
+    vi = _find_slot(val, qr.waitee)
+    vi == 0 && return qr.list
+    q = qr.list
+    o = qr.waitee
+    head = q.head
+    if head === val
+        vnext = _slot_next(val, vi)
+        q.head = vnext
+        vnext === nothing && (q.tail = nothing)
+    else
+        head === nothing && return q
+        prev = head::WaitEntry
+        while true
+            previ = _find_slot(prev, o)
+            previ == 0 && return q
+            prevslot = slots(prev)[previ]
+            cur = prevslot.next
+            cur === nothing && return q
+            cur = cur::WaitEntry
+            if cur === val
+                vnext = _slot_next(val, vi)
+                prevslot.next = vnext
+                vnext === nothing && (q.tail = prev)
+                break
+            end
+            prev = cur
+        end
+    end
+    _release_slot!(val, vi)
+    return q
+end
+
+function length(qr::ILLRef{WaitEntry})
+    n = 0
+    w = qr.list.head
+    while w !== nothing
+        n += 1
+        w = _next_on(w::WaitEntry, qr.waitee)
+    end
+    return n
+end
+
+# Whether any entry on the list is still armed (the emptiness that matters
+# to waiters-pending queries; claimed corpses linger until popped).
+function _waitq_isempty(qr::ILLRef{WaitEntry})
+    w = qr.list.head
+    while w !== nothing
+        w = w::WaitEntry
+        t = @atomic :monotonic w.task
+        t isa Task && (@atomic t.waiting_on) === w && return false
+        w = _next_on(w, qr.waitee)
+    end
+    return true
+end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2404,10 +2404,12 @@ function canstart_loading(modkey::PkgId, build_id::UInt128, stalecheck::Bool)
         for each in package_locks
             cond2 = each[2][2]
             assert_havelock(cond2.lock)
-            for w in cond2.waitq
-                waiting = w.task
-                waiting isa Task || continue
-                push!(waiters, waiting => (each[2][1] => each[1]))
+            w = cond2.waitq.head
+            while w !== nothing
+                w = w::WaitEntry
+                waiting = @atomic :monotonic w.task
+                waiting isa Task && push!(waiters, waiting => (each[2][1] => each[1]))
+                w = _next_on(w, cond2)
             end
         end
         while true

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -264,30 +264,14 @@ lock(c::GenericCondition{ReentrantLock}; cancel::CancelTokenArg=DEFAULT_CANCEL) 
     lock(c.lock; cancel)
 
 function wait_no_relock(c::GenericCondition, tok::MaybeToken)
-    ct = current_task()
+    # relock=false: a normal wake returns without retaking the lock (the
+    # notifier's handoff popped our entry), the refusal releases before
+    # throwing (e.g. a token cancelled while we were still spinning and
+    # thus not interruptibly waiting), and the interrupted cleanup retakes
+    # the lock only for its unlink
     src = cancel_source(tok)
-    entry = src === nothing ? nothing : _cancel_wait_entry(ct, src, 0x00)
-    w = _wait2(c, ct; entry)
-    if src !== nothing && !register_cancellation!(src, w)
-        # The governing token is already cancelled (e.g. it was cancelled
-        # while we were still spinning and thus not interruptibly waiting)
-        # and the wake was claimed back for us: don't park. (The sticky
-        # source registration stays.)
-        list_deletefirst!(waitqueue(c), w)
-        unlock(c.lock)
-        _deliver_refused_cancellation(src)
-    end
-    unlockall(c.lock)
-    try
-        # a normal wake needs no source-registration cleanup (sticky)
-        return wait()
-    catch
-        # resumed without a wake through `w`; see _interrupted_wait_cleanup
-        # (no relock for the caller: the lock is retaken only for the unlink)
-        _interrupted_wait_cleanup(() -> lock(c.lock), c, w)
-        unlock(c.lock)
-        rethrow()
-    end
+    src === nothing && return park!((c,), false, false)
+    return park!((c, SourceWait(src, 0x00)), false, false)
 end
 
 

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -191,9 +191,13 @@ wait for it to become available.
 
 Each `lock` must be matched by an [`unlock`](@ref).
 """
-@inline function lock(rl::ReentrantLock)
-    trylock(rl) || (@noinline function slowlock(rl::ReentrantLock)
+@inline function lock(rl::ReentrantLock; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
+    trylock(rl) || (@noinline function slowlock(rl::ReentrantLock, cancel::CancelTokenArg)
         Threads.lock_profiling() && Threads.inc_lock_conflict_count()
+        # resolve the scoped default once; a cancelled acquisition throws the
+        # CancellationRequest without the lock held
+        tok = resolve_cancel_token(cancel)
         c = rl.cond_wait
         ct = current_task()
         iteration = 1
@@ -236,33 +240,37 @@ Each `lock` must be matched by an [`unlock`](@ref).
             end
 
             # It was locked, so now wait for the unlock to notify us
-            wait_no_relock(c)
+            wait_no_relock(c, tok)
 
             # Loop back and try locking again
             iteration = 1
         end
-    end)(rl)
+    end)(rl, cancel)
     return
 end
 
-function wait_no_relock(c::GenericCondition)
+function wait_no_relock(c::GenericCondition, tok::MaybeToken)
     ct = current_task()
-    w = _wait2(c, ct)
+    src = cancel_source(tok)
+    entry = src === nothing ? nothing : _cancel_wait_entry(ct, src, 0x00)
+    w = _wait2(c, ct; entry)
+    if src !== nothing && !register_cancellation!(src, w)
+        # The governing token is already cancelled (e.g. it was cancelled
+        # while we were still spinning and thus not interruptibly waiting)
+        # and the wake was claimed back for us: don't park. (The sticky
+        # source registration stays.)
+        list_deletefirst!(waitqueue(c), w)
+        unlock(c.lock)
+        _deliver_refused_cancellation(src)
+    end
     unlockall(c.lock)
     try
+        # a normal wake needs no source-registration cleanup (sticky)
         return wait()
     catch
-        # See disarm protocol in condition.jl
-        @atomicreplace ct.waiting_on w => nothing
-        q = ct.queue
-        q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
-        was_cached = ct.cached_wait_entry === w
-        was_cached && (ct.cached_wait_entry = nothing)
-        lock(c.lock)
-        list_deletefirst!(waitqueue(c), w)
-        if was_cached && ct.cached_wait_entry === nothing
-            ct.cached_wait_entry = w
-        end
+        # resumed without a wake through `w`; see _interrupted_wait_cleanup
+        # (no relock for the caller: the lock is retaken only for the unlink)
+        _interrupted_wait_cleanup(() -> lock(c.lock), c, w)
         unlock(c.lock)
         rethrow()
     end
@@ -319,7 +327,11 @@ function unlockall(rl::ReentrantLock)
 end
 
 function relockall(rl::ReentrantLock, n::UInt32)
-    lock(rl)
+    # The reacquire is the cleanup half of a wait whose outcome (including a
+    # cancellation) has already been delivered: it must not itself be
+    # cancellable, or a cancelled scope would throw out of here without the
+    # lock and the caller's queue cleanup would run unlocked.
+    lock(rl; cancel=nothing)
     old = @atomicswap :not_atomic rl.reentrancy_cnt = n
     old == 0x0000_0001 || concurrency_violation()
     return

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -576,8 +576,6 @@ blocking until one can be acquired.
 """
 function acquire(s::Semaphore; cancel::CancelTokenArg=DEFAULT_CANCEL)
     cancel = precheck_cancel_arg(cancel)
-    # the preliminary lock honors the operation's token (or explicit
-    # shield), not the ambient scope
     lock(s.cond_wait; cancel)
     locked = true
     try
@@ -713,8 +711,6 @@ function wait(e::Event; cancel::CancelTokenArg=DEFAULT_CANCEL)
     else
         (@atomic e.set) && return # full barrier also
     end
-    # the preliminary lock honors the operation's token (or explicit
-    # shield), not the ambient scope
     lock(e.notify; cancel) # acquire barrier
     locked = true
     try

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -269,13 +269,30 @@ function wait_no_relock(c::GenericCondition, tok::MaybeToken)
     # throwing (e.g. a token cancelled while we were still spinning and
     # thus not interruptibly waiting), and the interrupted cleanup retakes
     # the lock only for its unlink
+    ct = current_task()
     src = cancel_source(tok)
-    src === nothing && return park!((c,), false, false)
-    r = park!((c, SourceWait(src, 0x00)), false, false)
-    # a fired source recheck returned `nothing` with the lock already
-    # released (relock=false): deliver the refusal
-    r === nothing && checkcancel(src)
-    return r
+    if src === nothing
+        ws = (c,)
+        w = _cached_wait_entry(ct)
+    else
+        ws = (c, SourceWait(src, 0x00))
+        w = _cancel_wait_entry(ct, src, 0x00)
+    end
+    if !park!(ws, w, false)
+        # refused at the registration recheck (e.g. a token cancelled
+        # while we were still spinning and thus not interruptibly
+        # waiting): withdraw under the held lock, release, deliver
+        withdraw!(ws, w, WAKE_FIRED)
+        unlock(c.lock)
+        checkcancel(src)
+        error("park fired without a cancelled source")
+    end
+    unlockall(c.lock)
+    # no relock on any path: a normal wake was handed the lock's baton by
+    # the notifying unlock, and an exceptional unwind - possibly the
+    # delivered cancellation itself - must not sleep on locks it does not
+    # need (the cleanup's unlink takes the lock transiently itself)
+    return wait_safe_interrupt(ws, w)
 end
 
 
@@ -287,6 +304,8 @@ Releases ownership of the `lock`.
 If this is a recursive lock which has been acquired before, decrement an
 internal counter and return immediately.
 """
+_uncancellable_lock(l::ReentrantLock) = lock(l; cancel=nothing)
+
 @inline function unlock(rl::ReentrantLock)
     rl.locked_by === current_task() ||
         error(rl.reentrancy_cnt == 0x0000_0000 ? "unlock count must match lock count" : "unlock from wrong thread")

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -296,6 +296,14 @@ function wait_no_relock(c::GenericCondition, tok::MaybeToken)
 end
 
 
+_uncancellable_lock(l::ReentrantLock) = lock(l; cancel=nothing)
+
+function relockall_but_one(rl::ReentrantLock, state::UInt32)
+    state == 0x0000_0001 && return nothing
+    relockall(rl, state - 0x0000_0001)
+    return nothing
+end
+
 """
     unlock(lock)
 
@@ -304,8 +312,6 @@ Releases ownership of the `lock`.
 If this is a recursive lock which has been acquired before, decrement an
 internal counter and return immediately.
 """
-_uncancellable_lock(l::ReentrantLock) = lock(l; cancel=nothing)
-
 @inline function unlock(rl::ReentrantLock)
     rl.locked_by === current_task() ||
         error(rl.reentrancy_cnt == 0x0000_0000 ? "unlock count must match lock count" : "unlock from wrong thread")
@@ -573,17 +579,20 @@ function acquire(s::Semaphore; cancel::CancelTokenArg=DEFAULT_CANCEL)
     # the preliminary lock honors the operation's token (or explicit
     # shield), not the ambient scope
     lock(s.cond_wait; cancel)
+    locked = true
     try
         if s.curr_cnt >= s.sem_size
             tok = resolve_cancel_token(cancel)
             while s.curr_cnt >= s.sem_size
                 # a cancelled wait throws before the permit is taken
+                locked = false
                 wait(s.cond_wait, tok)
+                locked = true
             end
         end
         s.curr_cnt = s.curr_cnt + 1
     finally
-        unlock(s.cond_wait)
+        locked && unlock(s.cond_wait)
     end
     return
 end
@@ -707,15 +716,18 @@ function wait(e::Event; cancel::CancelTokenArg=DEFAULT_CANCEL)
     # the preliminary lock honors the operation's token (or explicit
     # shield), not the ambient scope
     lock(e.notify; cancel) # acquire barrier
+    locked = true
     try
         if e.autoreset
             (@atomicswap :acquire_release e.set = false) && return
         else
             e.set && return
         end
+        locked = false
         wait(e.notify, resolve_cancel_token(cancel))
+        locked = true
     finally
-        unlock(e.notify) # release barrier
+        locked && unlock(e.notify) # release barrier
     end
     nothing
 end

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -271,7 +271,11 @@ function wait_no_relock(c::GenericCondition, tok::MaybeToken)
     # the lock only for its unlink
     src = cancel_source(tok)
     src === nothing && return park!((c,), false, false)
-    return park!((c, SourceWait(src, 0x00)), false, false)
+    r = park!((c, SourceWait(src, 0x00)), false, false)
+    # a fired source recheck returned `nothing` with the lock already
+    # released (relock=false): deliver the refusal
+    r === nothing && checkcancel(src)
+    return r
 end
 
 

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -210,6 +210,13 @@ Each `lock` must be matched by an [`unlock`](@ref).
                 if result.success
                     rl.reentrancy_cnt = 0x0000_0001
                     @atomic :release rl.locked_by = ct
+                    # Mirror the park path's refusal (see wait_no_relock): a
+                    # token that got cancelled while we were spinning must
+                    # not hand out the lock - release it and deliver.
+                    if tok !== nothing && iscancelled(tok.source)
+                        unlock(rl)
+                        checkcancel(tok.source)
+                    end
                     return
                 end
                 GC.enable_finalizers()
@@ -248,6 +255,13 @@ Each `lock` must be matched by an [`unlock`](@ref).
     end)(rl, cancel)
     return
 end
+
+# ReentrantLock-backed conditions (Threads.Condition) forward `cancel` into
+# the lock acquisition, so operations that resolved a token (or an explicit
+# `nothing` shield) can make their preliminary lock honor it instead of the
+# ambient scope - see e.g. the Channel operations.
+lock(c::GenericCondition{ReentrantLock}; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    lock(c.lock; cancel)
 
 function wait_no_relock(c::GenericCondition, tok::MaybeToken)
     ct = current_task()
@@ -354,6 +368,15 @@ See also [`@lock`](@ref).
 """
 function lock(f, l::AbstractLock)
     lock(l)
+    try
+        return f()
+    finally
+        unlock(l)
+    end
+end
+
+function lock(f, l::ReentrantLock; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    lock(l; cancel)
     try
         return f()
     finally
@@ -538,11 +561,18 @@ end
 Wait for one of the `sem_size` permits to be available,
 blocking until one can be acquired.
 """
-function acquire(s::Semaphore)
-    lock(s.cond_wait)
+function acquire(s::Semaphore; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
+    # the preliminary lock honors the operation's token (or explicit
+    # shield), not the ambient scope
+    lock(s.cond_wait; cancel)
     try
-        while s.curr_cnt >= s.sem_size
-            wait(s.cond_wait)
+        if s.curr_cnt >= s.sem_size
+            tok = resolve_cancel_token(cancel)
+            while s.curr_cnt >= s.sem_size
+                # a cancelled wait throws before the permit is taken
+                wait(s.cond_wait, tok)
+            end
         end
         s.curr_cnt = s.curr_cnt + 1
     finally
@@ -575,8 +605,8 @@ end
     This method requires at least Julia 1.8.
 
 """
-function acquire(f, s::Semaphore)
-    acquire(s)
+function acquire(f, s::Semaphore; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    acquire(s; cancel)
     try
         return f()
     finally
@@ -660,20 +690,23 @@ mutable struct Event
     Event(autoreset::Bool=false) = new(Threads.Condition(), autoreset, false)
 end
 
-function wait(e::Event)
+function wait(e::Event; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
     if e.autoreset
         (@atomicswap :acquire_release e.set = false) && return
     else
         (@atomic e.set) && return # full barrier also
     end
-    lock(e.notify) # acquire barrier
+    # the preliminary lock honors the operation's token (or explicit
+    # shield), not the ambient scope
+    lock(e.notify; cancel) # acquire barrier
     try
         if e.autoreset
             (@atomicswap :acquire_release e.set = false) && return
         else
             e.set && return
         end
-        wait(e.notify)
+        wait(e.notify, resolve_cancel_token(cancel))
     finally
         unlock(e.notify) # release barrier
     end

--- a/base/park.jl
+++ b/base/park.jl
@@ -31,9 +31,17 @@
 #                                        declined (one-shot waitables)
 #   wait_recheck(x, w) -> Bool           phase 5, after ALL enqueues;
 #                                        vacuous default
-#   wait_dequeue!(x, w, why) -> Nothing  withdraw x's slot per policy
-#   wait_release!(x) -> token            suspend bracket for protection
-#   wait_reacquire!(x, token)            held across phases 4-5
+#   wait_dequeue!(x, w, why) -> Nothing  withdraw x's slot. Lock
+#                                        discipline is per `why`: on
+#                                        WAKE_VALUE/WAKE_FIRED the caller
+#                                        holds the kind's protection; on
+#                                        WAKE_INTERRUPTED/WAKE_WITHDRAWN
+#                                        the method takes it itself
+#
+# The driver takes and releases no locks: lock choreography is plain
+# caller code (`unlockall`/`relockall` around `wait_safe_interrupt`,
+# `iolock_end`/`iolock_begin` at the uv sites, ...), so there is no
+# release/reacquire protocol and no relock policy.
 #
 # Lock rule: from phase 3 on the entry is the task's armed registration,
 # so a lock acquisition *inside* phase 4 must never park (a nested park
@@ -52,8 +60,12 @@ const WAKE_WITHDRAWN   = 0x04  # withdraw! - the caller is done waiting
 function wait_enqueue! end
 function wait_dequeue! end
 wait_recheck(@nospecialize(x), w::WaitEntry) = false
-wait_release!(@nospecialize(x)) = nothing
-wait_reacquire!(@nospecialize(x), token) = nothing
+
+# Lock acquisition for self-protecting `wait_dequeue!` methods (the
+# cleanup/withdraw paths): must not observe cancellation - the cleanup
+# may be unwinding the very CancellationRequest a cancellable acquire
+# would rethrow. The `ReentrantLock` method (lock.jl) shields itself.
+_uncancellable_lock(l) = lock(l)
 
 ## The cancellation source as a waitable
 #
@@ -85,6 +97,8 @@ acquire_wait_entry!(ct::Task, ws) = WaitEntryN(ct, length(ws))
 # registrations become prunable corpses. Cached entries stay live.
 function release_wait_entry!(ct::Task, w::WaitEntry)
     (w === ct.cached_wait_entry || w === ct.cached_cancel_entry) && return nothing
+    # idempotent: several exits may withdraw the same fresh entry
+    (@atomic :monotonic w.task) === nothing && return nothing
     retire_cancellation_entry!(w)
     return nothing
 end
@@ -95,37 +109,28 @@ disarm!(ct::Task, w::WaitEntry) = (@atomicreplace ct.waiting_on w => nothing).su
 ## The verbs
 
 """
-    park!(ws, [w::WaitEntry,] relock::Bool, first::Bool)
+    park!(ws, w::WaitEntry, first::Bool) -> Bool
 
-Park the current task on the waitables `ws` (any flat iterable - one
-element per slot) through the six-phase protocol. Returns the consumed
-wake's payload, or `nothing` when a waitable fired before the suspend.
-The driver never throws a fired outcome: on a `nothing` return the
-caller re-derives what happened from its own conditions - in particular
-a park governed by a `SourceWait` must re-check cancellation
-(`checkcancel`), which throws the refusal exactly like its entry check.
+Phases 3-5 of the protocol over the flat waitable iterable `ws`: arm
+`w`, enqueue it with every waitable, and run the rechecks. Returns
+`true` when the task is parked - a wake is (or will be) in flight, and
+the caller must suspend through [`wait_safe_interrupt`](@ref) to consume
+it. Returns `false` when a waitable fired and the self-claim won:
+nothing is in flight, and the caller owns the outcome (for a fired
+source, re-checking cancellation - `checkcancel` - throws the refusal
+exactly like the entry check) as well as every remaining registration
+(usually `withdraw!(ws, w, WAKE_FIRED)` under its still-held locks). A
+fired recheck whose self-claim *loses* returns `true`: the concurrent
+claimer's wake delivers the outcome.
 
-`relock` selects whether the phase-4 protection is reacquired after the
-wake (and kept across an exceptional unwind); `first` puts the waiter at
-the front of FIFO waitee queues. Locks the caller holds across `park!`
-follow the per-kind release/reacquire hooks; on the throwing fired path
-(a source refusal) they are released first when `relock` is false.
+The driver takes and releases no locks: protection the caller holds is
+held throughout - which is what makes the enqueue/recheck window sound -
+and lock choreography around the suspend is plain caller code. The one
+dequeue the driver performs itself is the *fired slot* on the `false`
+path (self-protecting; a done-but-still-linked predicate would re-fire
+on every `repark!` until its notify drains).
 """
-# The one-shot form owns the entry lifecycle: the entry never escapes,
-# so a fresh one is retired on normal return (a cached one is left in
-# its cache). The explicit-entry form leaves the lifecycle to the caller
-# (the multi-wait loop retires through `withdraw!`). Exceptional exits
-# retire through the refusal path or the interrupted cleanup.
-@inline function park!(ws, relock::Bool, first::Bool)
-    ct = current_task()
-    w = acquire_wait_entry!(ct, ws)
-    r = park!(ws, w, relock, first, true)
-    release_wait_entry!(ct, w)
-    return r
-end
-
-function park!(ws, w::WaitEntry, relock::Bool, first::Bool,
-               fired_dequeues_all::Bool=false)
+function park!(ws, w::WaitEntry, first::Bool)
     ct = current_task()
     _arm_wait(ct, w)                                     # 3
     fired = false
@@ -145,60 +150,20 @@ function park!(ws, w::WaitEntry, relock::Bool, first::Bool,
         end
     end
     if fired && disarm!(ct, w)
-        # The driver never throws a fired outcome: it returns `nothing`
-        # and the caller re-derives what happened from its own conditions
-        # (for a fired source, the same `checkcancel` its entry made -
-        # level-triggered, the state is still cancelled).
-        if fired_dequeues_all
-            # this park is over and nobody else will withdraw (the
-            # one-shot/owning-caller lifecycle): dequeue everything under
-            # the still-held phase-4 protection (sticky kinds no-op),
-            # then release per policy
-            for x in ws
-                wait_dequeue!(x, w, WAKE_FIRED)
-            end
-            if !relock
-                for x in ws
-                    wait_release!(x)
-                end
-            end
-        else
-            # the multi-wait loop: eagerly dequeue the fired slot only
-            # (so a later repark! recheck cannot re-fire on it); the rest
-            # stay registered for the loop
-            wait_dequeue!(fx, w, WAKE_FIRED)
-        end
-        return nothing
+        wait_dequeue!(fx, w, WAKE_FIRED)
+        return false
     end
-    # not fired, or the self-claim lost (a claimer owns our wake): suspend
-    toks = map(wait_release!, ws)                        # 6
-    local r
-    try
-        r = wait()
-    catch
-        interrupted_park_cleanup!(ct, ws, toks, w, relock)
-        rethrow()
-    end
-    if relock
-        for (x, t) in zip(ws, toks)
-            wait_reacquire!(x, t)
-        end
-        for x in ws
-            wait_dequeue!(x, w, WAKE_VALUE)
-        end
-    end
-    return r
+    return true
 end
 
 """
-    repark!(ws, w::WaitEntry)
+    repark!(ws, w::WaitEntry) -> Bool
 
-Re-park on the still-enqueued registration `w`: arm, run the phase-5
-rechecks, and suspend unless one fired. For the multi-wait loop - the
-caller's bookkeeping between wakes runs unarmed (a completion landing
-there pops-and-drops the unarmed entry; the recheck here catches the
-fired predicate before suspending, so nothing is lost). All of `ws` must
-be transient kinds: nothing may be held across the suspend.
+Re-park on the still-enqueued registration `w`: arm and recheck, with
+the same `Bool` contract as [`park!`](@ref). For the multi-wait loop -
+the caller's bookkeeping between wakes runs unarmed (a completion
+landing there pops-and-drops the unarmed entry; the recheck here catches
+the fired predicate before suspending, so nothing is lost).
 """
 function repark!(ws, w::WaitEntry)
     ct = current_task()
@@ -212,94 +177,99 @@ function repark!(ws, w::WaitEntry)
         end
     end
     if fired && disarm!(ct, w)
-        # fired => `nothing`; the loop's caller re-derives the outcome
-        # (checkcancel for its source) and owns the withdrawal
         wait_dequeue!(fx, w, WAKE_FIRED)
-        return nothing
+        return false
     end
+    return true
+end
+
+"""
+    wait_safe_interrupt(ws, w::WaitEntry)
+
+Phase 6: suspend and consume exactly one wake of the park `park!`
+armed, returning its payload. This is the only legal way to suspend on
+an armed park - a raw `wait()` would miss the interrupted-wait cleanup.
+The caller must have released any parking locks it holds (plain caller
+code, e.g. `unlockall`); on a normal wake it returns with no locks
+touched, and the caller reacquires per its own contract.
+
+On an exceptional resume (an interrupter's claim, a delivered
+cancellation, a raw `throwto`) the cleanup runs here, then the exception
+propagates: disarm; blank the entry's cache slot; withdraw every
+registration through its kind's *self-protecting* dequeue - each takes
+its own lock, and those round-trips serialize any claimer's in-flight
+schedule - and only then drop a claimed-and-enqueued wake this unwind
+will never consume (dropping earlier would race the in-flight claimer
+and leak the wake into the task's next park); finally restore or retire
+the entry. Because the registrations are already withdrawn when the
+exception reaches the caller, its catch owes nothing to the protocol -
+it only restores whatever lock contract its own callers require
+(reacquiring shielded, and only what that contract demands: an unwind
+that is itself a cancellation should not sleep on locks it does not
+need).
+"""
+function wait_safe_interrupt(ws, w::WaitEntry)
+    ct = current_task()
     local r
     try
         r = wait()
     catch
-        interrupted_park_cleanup!(ct, ws, nothing, w, true)
+        interrupted_park_cleanup!(ct, ws, w)
         rethrow()
     end
     return r
 end
 
 """
-    withdraw!(ws, w::WaitEntry)
+    withdraw!(ws, w::WaitEntry, why::UInt8=WAKE_WITHDRAWN)
 
-Leave the wait: dequeue every registration per its policy and retire the
-entry if it was fresh. With `repark!` owning the arm, every caller
-decision point runs unarmed, so no disarm is needed here.
+Withdraw every registration of `w` per its kind's policy and release the
+entry (retiring it when fresh; idempotent). The lock discipline follows
+`why`: `WAKE_VALUE`/`WAKE_FIRED` run under the caller's still-held
+protection (the lazy settle after a wake; the fired branch), while
+`WAKE_WITHDRAWN` dequeues are self-protecting (leaving a multi-wait).
 """
-function withdraw!(ws, w::WaitEntry)
+function withdraw!(ws, w::WaitEntry, why::UInt8=WAKE_WITHDRAWN)
     for x in ws
-        wait_dequeue!(x, w, WAKE_WITHDRAWN)
+        wait_dequeue!(x, w, why)
     end
     release_wait_entry!(current_task(), w)
     return nothing
 end
 
-# Cleanup of a park that was resumed without a wake having been delivered
-# through its registration `w`: an interrupter claimed the wake (leaving
-# the entry linked for us to clean up), the task got a raw `throwto`, or
-# a cancellation was delivered. The caller rethrows afterwards. In order:
-#  1. Disarm the registration - before the reacquire in step 3 can
-#     register a new wait. When the disarm loses, a claimer got the wake:
-#     its schedule is either already enqueued or still in flight under
-#     the waitee's lock.
+# The interrupted-wait cleanup (see wait_safe_interrupt). In order:
+#  1. Disarm the registration - before any reacquire below can register a
+#     new wait. When the disarm loses, a claimer got the wake: its
+#     schedule is either already enqueued or still in flight under the
+#     waitee's protection.
 #  2. Blank the entry's cache slot: a notifier may have popped the stale
 #     entry without scheduling us and may still retain its identity for
 #     the wake-claim CAS, so `w` must not be reused (e.g. by a park
-#     inside the reacquire) before the unlink below.
-#  3. Reacquire per kind and unlink `w` (a no-op where a `notify` already
-#     popped and dropped it).
-#  4. Drop a claimed-and-enqueued wake this unwind will never consume, so
-#     a later wait of this task does not consume it spuriously. This runs
-#     after the reacquire on purpose: a claimer that claimed our wake did
-#     so under the waitee's protection, so once the reacquire returns its
-#     enqueue has landed and the drop is deterministic - dropping before
-#     the reacquire would race the in-flight schedule and leak the wake
-#     into the task's next wait. (If the reacquire itself parked and
-#     consumed the stale wake as a spurious lock wake, its acquire loop
-#     re-tested and re-parked - lock parks tolerate spurious wakes - and
-#     there is nothing left to drop. A claim-less raw wake delivered
-#     outside any lock - the documented-unsafe `schedule(t, exc,
-#     error=true)` of a running task - can still land after this drop;
-#     that hazard is the primitive's, not this path's.)
-#  5. Now `w` is safe to reuse: restore it to its cache unless the
-#     reacquire parked and cached a replacement - then `w` is unreachable
-#     garbage (unarmed, off every waitq), so retire it: its sticky source
-#     registration must be counted dead for pruning, or a long-lived
-#     source would retain the task through the orphaned entry. Fresh
-#     entries are always retired.
-function interrupted_park_cleanup!(ct::Task, ws, toks, w::WaitEntry, relock::Bool)
+#     inside a self-protecting dequeue's lock acquire) before the
+#     unlinks below.
+#  3. Withdraw every registration through its kind's self-protecting
+#     dequeue; the per-kind lock round-trips serialize any claimer's
+#     in-flight schedule ...
+#  4. ... which is what makes the pending-wake drop here deterministic:
+#     a wake claimed-and-enqueued by such a claimer must not leak into
+#     this task's next wait. (A claim-less raw wake delivered outside any
+#     lock - the documented-unsafe `schedule(t, exc, error=true)` of a
+#     running task - can still land after this drop; that hazard is the
+#     primitive's, not this path's.)
+#  5. Restore `w` to its cache slot unless a nested park cached a
+#     replacement - then `w` is unreachable garbage (unarmed, off every
+#     waitq), so retire it; fresh entries are always retired.
+function interrupted_park_cleanup!(ct::Task, ws, w::WaitEntry)
     @atomicreplace ct.waiting_on w => nothing
     was_plain = ct.cached_wait_entry === w
     was_cancel = !was_plain && ct.cached_cancel_entry === w
     was_plain && (ct.cached_wait_entry = nothing)
     was_cancel && (ct.cached_cancel_entry = nothing)
-    if toks === nothing
-        for x in ws
-            wait_reacquire!(x, nothing)
-        end
-    else
-        for (x, t) in zip(ws, toks)
-            wait_reacquire!(x, t)
-        end
-    end
     for x in ws
         wait_dequeue!(x, w, WAKE_INTERRUPTED)
     end
     q = ct.queue
     q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
-    if !relock
-        for x in ws
-            wait_release!(x)
-        end
-    end
     if was_plain
         if ct.cached_wait_entry === nothing
             ct.cached_wait_entry = w
@@ -313,10 +283,13 @@ function interrupted_park_cleanup!(ct::Task, ws, toks, w::WaitEntry, relock::Boo
             retire_cancellation_entry!(w)
         end
     else
-        retire_cancellation_entry!(w)
+        release_wait_entry!(ct, w)
     end
     return nothing
 end
+
+## SourceWait methods (the struct and its doc live above, before the
+## entry-acquisition contract that dispatches on it)
 
 function wait_enqueue!(x::SourceWait, w::WaitEntry, first::Bool)
     src = x.src

--- a/base/park.jl
+++ b/base/park.jl
@@ -3,8 +3,7 @@
 ## The parked-wait driver
 #
 # Every parked wait proceeds in six phases, uniformly over the set of
-# things it waits for (see also the formal model of the claim protocol,
-# tla/WaitClaim.tla, whose parker process is this driver):
+# things it waits for:
 #
 #   1. CHECK    the caller's fast-path satisfaction tests - no allocation,
 #               no publication (stays at the call sites).
@@ -72,10 +71,10 @@ _uncancellable_lock(l) = lock(l)
 # `SourceWait(src, floor)` in a park's waitables makes the wait
 # cancellable under `src` at severities >= `floor`: its enqueue is the
 # sticky lock-free registration, its recheck is the seq_cst state read
-# closing the arm-vs-cancel race (the Dekker whose two seq_cst upgrades
-# are shown necessary in tla/WaitDekkerTSO.tla), and its fired outcome
-# throws the refusal. Registrations are sticky: no dequeue on any path -
-# collection is the walk's job (prune/dead accounting).
+# closing the arm-vs-cancel race (a Dekker - both sides need their
+# seq_cst upgrade), and its fired outcome throws the refusal.
+# Registrations are sticky: no dequeue on any path - collection is the
+# walk's job (prune/dead accounting).
 struct SourceWait
     src::CancellationTokenSource
     floor::UInt8

--- a/base/park.jl
+++ b/base/park.jl
@@ -31,12 +31,6 @@
 #                                        declined (one-shot waitables)
 #   wait_recheck(x, w) -> Bool           phase 5, after ALL enqueues;
 #                                        vacuous default
-#   wait_fired(x, w)                     fired outcome, after a WON
-#                                        self-claim: predicate kinds
-#                                        return, the source throws
-#   wait_fired_throws(x) -> Bool         compile-time kind property: does
-#                                        wait_fired throw? (drives the
-#                                        full-withdraw-before-throw rule)
 #   wait_dequeue!(x, w, why) -> Nothing  withdraw x's slot per policy
 #   wait_release!(x) -> token            suspend bracket for protection
 #   wait_reacquire!(x, token)            held across phases 4-5
@@ -51,16 +45,13 @@
 
 # why-codes for wait_dequeue!
 const WAKE_VALUE       = 0x00  # normal wake consumed (lazy settle)
-const WAKE_FIRED       = 0x01  # fired; self-claim won; loop continues
-const WAKE_REFUSED     = 0x02  # throwing fired (source refusal)
+const WAKE_FIRED       = 0x01  # fired; self-claim won; no suspend
 const WAKE_INTERRUPTED = 0x03  # exceptional wake (cleanup path)
 const WAKE_WITHDRAWN   = 0x04  # withdraw! - the caller is done waiting
 
 function wait_enqueue! end
 function wait_dequeue! end
-function wait_fired end
 wait_recheck(@nospecialize(x), w::WaitEntry) = false
-wait_fired_throws(@nospecialize(x)) = false
 wait_release!(@nospecialize(x)) = nothing
 wait_reacquire!(@nospecialize(x), token) = nothing
 
@@ -108,9 +99,11 @@ disarm!(ct::Task, w::WaitEntry) = (@atomicreplace ct.waiting_on w => nothing).su
 
 Park the current task on the waitables `ws` (any flat iterable - one
 element per slot) through the six-phase protocol. Returns the consumed
-wake's payload, or `nothing` when a waitable fired before the suspend
-(callers rescan their own predicates; a value-carrying wait cannot be
-ambiguous - its only fireable tuple-mate is the source, which throws).
+wake's payload, or `nothing` when a waitable fired before the suspend.
+The driver never throws a fired outcome: on a `nothing` return the
+caller re-derives what happened from its own conditions - in particular
+a park governed by a `SourceWait` must re-check cancellation
+(`checkcancel`), which throws the refusal exactly like its entry check.
 
 `relock` selects whether the phase-4 protection is reacquired after the
 wake (and kept across an exceptional unwind); `first` puts the waiter at
@@ -126,12 +119,13 @@ follow the per-kind release/reacquire hooks; on the throwing fired path
 @inline function park!(ws, relock::Bool, first::Bool)
     ct = current_task()
     w = acquire_wait_entry!(ct, ws)
-    r = park!(ws, w, relock, first)
+    r = park!(ws, w, relock, first, true)
     release_wait_entry!(ct, w)
     return r
 end
 
-function park!(ws, w::WaitEntry, relock::Bool, first::Bool)
+function park!(ws, w::WaitEntry, relock::Bool, first::Bool,
+               fired_dequeues_all::Bool=false)
     ct = current_task()
     _arm_wait(ct, w)                                     # 3
     fired = false
@@ -151,24 +145,29 @@ function park!(ws, w::WaitEntry, relock::Bool, first::Bool)
         end
     end
     if fired && disarm!(ct, w)
-        if wait_fired_throws(fx)
-            # the throwing fired path (the refusal): full withdrawal under
-            # the still-held phase-4 protection, release per policy, throw
+        # The driver never throws a fired outcome: it returns `nothing`
+        # and the caller re-derives what happened from its own conditions
+        # (for a fired source, the same `checkcancel` its entry made -
+        # level-triggered, the state is still cancelled).
+        if fired_dequeues_all
+            # this park is over and nobody else will withdraw (the
+            # one-shot/owning-caller lifecycle): dequeue everything under
+            # the still-held phase-4 protection (sticky kinds no-op),
+            # then release per policy
             for x in ws
-                wait_dequeue!(x, w, WAKE_REFUSED)
+                wait_dequeue!(x, w, WAKE_FIRED)
             end
-            release_wait_entry!(ct, w)
             if !relock
                 for x in ws
                     wait_release!(x)
                 end
             end
-            wait_fired(fx, w)
-            error("wait_fired of a throwing waitable kind returned")
+        else
+            # the multi-wait loop: eagerly dequeue the fired slot only
+            # (so a later repark! recheck cannot re-fire on it); the rest
+            # stay registered for the loop
+            wait_dequeue!(fx, w, WAKE_FIRED)
         end
-        # returning fired: eagerly dequeue the fired slot (so a later
-        # repark! recheck cannot re-fire on it) and let the caller rescan
-        wait_dequeue!(fx, w, WAKE_FIRED)
         return nothing
     end
     # not fired, or the self-claim lost (a claimer owns our wake): suspend
@@ -213,14 +212,8 @@ function repark!(ws, w::WaitEntry)
         end
     end
     if fired && disarm!(ct, w)
-        if wait_fired_throws(fx)
-            for x in ws
-                wait_dequeue!(x, w, WAKE_REFUSED)
-            end
-            release_wait_entry!(ct, w)
-            wait_fired(fx, w)
-            error("wait_fired of a throwing waitable kind returned")
-        end
+        # fired => `nothing`; the loop's caller re-derives the outcome
+        # (checkcancel for its source) and owns the withdrawal
         wait_dequeue!(fx, w, WAKE_FIRED)
         return nothing
     end
@@ -362,6 +355,4 @@ function wait_recheck(x::SourceWait, w::WaitEntry)
     return st != 0x00 && st >= x.floor
 end
 
-wait_fired_throws(x::SourceWait) = true
-wait_fired(x::SourceWait, w::WaitEntry) = _deliver_refused_cancellation(x.src)
 wait_dequeue!(x::SourceWait, w::WaitEntry, why::UInt8) = nothing

--- a/base/park.jl
+++ b/base/park.jl
@@ -1,0 +1,367 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+## The parked-wait driver
+#
+# Every parked wait proceeds in six phases, uniformly over the set of
+# things it waits for (see also the formal model of the claim protocol,
+# tla/WaitClaim.tla, whose parker process is this driver):
+#
+#   1. CHECK    the caller's fast-path satisfaction tests - no allocation,
+#               no publication (stays at the call sites).
+#   2. ENTRY    allocate the wait entry or reuse the task's cached one;
+#               stage per-slot aux (severity floors) that the claim side
+#               may read through an already-linked entry.
+#   3. ARM      publish the entry as the task's sole claimable
+#               registration: CAS(t.waiting_on, nothing => w).
+#   4. ENQUEUE  register the entry with every waitable, each under that
+#               waitable's own protection discipline.
+#   5. RECHECK  re-test satisfaction where the enqueue could have raced
+#               the firing; on a hit, self-claim: won => withdraw and
+#               return (or deliver the refusal); lost => a waker owns our
+#               wake - suspend and consume it.
+#   6. SUSPEND  release the locks that must not be held while parked,
+#               `wait()`, then reacquire per policy and settle.
+#
+# A *waitable* is the identity a slot's `owner` records. The waitable
+# protocol is ordinary generic functions - the set is open; each call
+# site's concrete container type carries the dispatch:
+#
+#   wait_enqueue!(x, w, first) -> Bool   phase 4, under x's discipline;
+#                                        false = x already fired and
+#                                        declined (one-shot waitables)
+#   wait_recheck(x, w) -> Bool           phase 5, after ALL enqueues;
+#                                        vacuous default
+#   wait_fired(x, w)                     fired outcome, after a WON
+#                                        self-claim: predicate kinds
+#                                        return, the source throws
+#   wait_fired_throws(x) -> Bool         compile-time kind property: does
+#                                        wait_fired throw? (drives the
+#                                        full-withdraw-before-throw rule)
+#   wait_dequeue!(x, w, why) -> Nothing  withdraw x's slot per policy
+#   wait_release!(x) -> token            suspend bracket for protection
+#   wait_reacquire!(x, token)            held across phases 4-5
+#
+# Lock rule: from phase 3 on the entry is the task's armed registration,
+# so a lock acquisition *inside* phase 4 must never park (a nested park
+# would try to arm a second registration). Parking locks must be
+# caller-held before `park!` begins (the `wait(c)` contract); locks a
+# `wait_enqueue!` method takes itself must be spin locks. The cleanup's
+# reacquire is exempt: it runs disarmed and may itself park with a fresh
+# entry (the cache-blank dance below exists for exactly that).
+
+# why-codes for wait_dequeue!
+const WAKE_VALUE       = 0x00  # normal wake consumed (lazy settle)
+const WAKE_FIRED       = 0x01  # fired; self-claim won; loop continues
+const WAKE_REFUSED     = 0x02  # throwing fired (source refusal)
+const WAKE_INTERRUPTED = 0x03  # exceptional wake (cleanup path)
+const WAKE_WITHDRAWN   = 0x04  # withdraw! - the caller is done waiting
+
+function wait_enqueue! end
+function wait_dequeue! end
+function wait_fired end
+wait_recheck(@nospecialize(x), w::WaitEntry) = false
+wait_fired_throws(@nospecialize(x)) = false
+wait_release!(@nospecialize(x)) = nothing
+wait_reacquire!(@nospecialize(x), token) = nothing
+
+## The cancellation source as a waitable
+#
+# `SourceWait(src, floor)` in a park's waitables makes the wait
+# cancellable under `src` at severities >= `floor`: its enqueue is the
+# sticky lock-free registration, its recheck is the seq_cst state read
+# closing the arm-vs-cancel race (the Dekker whose two seq_cst upgrades
+# are shown necessary in tla/WaitDekkerTSO.tla), and its fired outcome
+# throws the refusal. Registrations are sticky: no dequeue on any path -
+# collection is the walk's job (prune/dead accounting).
+struct SourceWait
+    src::CancellationTokenSource
+    floor::UInt8
+end
+
+## Entry acquisition - the cache contract
+#
+# The two canonical tuple shapes are served from the task's caches; any
+# other iterable gets a fresh, single-use entry. Freshness is what makes
+# specific-wait wakers (a timeout's expected-entry CAS) safe: entry
+# identity scopes a claim to this wait - the same principle that gives
+# shielded parks a distinct entry from cancellable ones.
+acquire_wait_entry!(ct::Task, ws::Tuple{Any}) = _cached_wait_entry(ct)
+acquire_wait_entry!(ct::Task, ws::Tuple{Any, SourceWait}) =
+    _cancel_wait_entry(ct, ws[2].src, ws[2].floor)
+acquire_wait_entry!(ct::Task, ws) = WaitEntryN(ct, length(ws))
+
+# Retire a fresh (uncached) entry that is done waiting: its sticky source
+# registrations become prunable corpses. Cached entries stay live.
+function release_wait_entry!(ct::Task, w::WaitEntry)
+    (w === ct.cached_wait_entry || w === ct.cached_cancel_entry) && return nothing
+    retire_cancellation_entry!(w)
+    return nothing
+end
+
+# Self-claim: take back the wake of our own armed registration.
+disarm!(ct::Task, w::WaitEntry) = (@atomicreplace ct.waiting_on w => nothing).success
+
+## The verbs
+
+"""
+    park!(ws, [w::WaitEntry,] relock::Bool, first::Bool)
+
+Park the current task on the waitables `ws` (any flat iterable - one
+element per slot) through the six-phase protocol. Returns the consumed
+wake's payload, or `nothing` when a waitable fired before the suspend
+(callers rescan their own predicates; a value-carrying wait cannot be
+ambiguous - its only fireable tuple-mate is the source, which throws).
+
+`relock` selects whether the phase-4 protection is reacquired after the
+wake (and kept across an exceptional unwind); `first` puts the waiter at
+the front of FIFO waitee queues. Locks the caller holds across `park!`
+follow the per-kind release/reacquire hooks; on the throwing fired path
+(a source refusal) they are released first when `relock` is false.
+"""
+# The one-shot form owns the entry lifecycle: the entry never escapes,
+# so a fresh one is retired on normal return (a cached one is left in
+# its cache). The explicit-entry form leaves the lifecycle to the caller
+# (the multi-wait loop retires through `withdraw!`). Exceptional exits
+# retire through the refusal path or the interrupted cleanup.
+@inline function park!(ws, relock::Bool, first::Bool)
+    ct = current_task()
+    w = acquire_wait_entry!(ct, ws)
+    r = park!(ws, w, relock, first)
+    release_wait_entry!(ct, w)
+    return r
+end
+
+function park!(ws, w::WaitEntry, relock::Bool, first::Bool)
+    ct = current_task()
+    _arm_wait(ct, w)                                     # 3
+    fired = false
+    local fx
+    for x in ws                                          # 4
+        if !wait_enqueue!(x, w, first)
+            fired = true; fx = x
+            break
+        end
+    end
+    if !fired
+        for x in ws                                      # 5
+            if wait_recheck(x, w)
+                fired = true; fx = x
+                break
+            end
+        end
+    end
+    if fired && disarm!(ct, w)
+        if wait_fired_throws(fx)
+            # the throwing fired path (the refusal): full withdrawal under
+            # the still-held phase-4 protection, release per policy, throw
+            for x in ws
+                wait_dequeue!(x, w, WAKE_REFUSED)
+            end
+            release_wait_entry!(ct, w)
+            if !relock
+                for x in ws
+                    wait_release!(x)
+                end
+            end
+            wait_fired(fx, w)
+            error("wait_fired of a throwing waitable kind returned")
+        end
+        # returning fired: eagerly dequeue the fired slot (so a later
+        # repark! recheck cannot re-fire on it) and let the caller rescan
+        wait_dequeue!(fx, w, WAKE_FIRED)
+        return nothing
+    end
+    # not fired, or the self-claim lost (a claimer owns our wake): suspend
+    toks = map(wait_release!, ws)                        # 6
+    local r
+    try
+        r = wait()
+    catch
+        interrupted_park_cleanup!(ct, ws, toks, w, relock)
+        rethrow()
+    end
+    if relock
+        for (x, t) in zip(ws, toks)
+            wait_reacquire!(x, t)
+        end
+        for x in ws
+            wait_dequeue!(x, w, WAKE_VALUE)
+        end
+    end
+    return r
+end
+
+"""
+    repark!(ws, w::WaitEntry)
+
+Re-park on the still-enqueued registration `w`: arm, run the phase-5
+rechecks, and suspend unless one fired. For the multi-wait loop - the
+caller's bookkeeping between wakes runs unarmed (a completion landing
+there pops-and-drops the unarmed entry; the recheck here catches the
+fired predicate before suspending, so nothing is lost). All of `ws` must
+be transient kinds: nothing may be held across the suspend.
+"""
+function repark!(ws, w::WaitEntry)
+    ct = current_task()
+    _arm_wait(ct, w)
+    fired = false
+    local fx
+    for x in ws
+        if wait_recheck(x, w)
+            fired = true; fx = x
+            break
+        end
+    end
+    if fired && disarm!(ct, w)
+        if wait_fired_throws(fx)
+            for x in ws
+                wait_dequeue!(x, w, WAKE_REFUSED)
+            end
+            release_wait_entry!(ct, w)
+            wait_fired(fx, w)
+            error("wait_fired of a throwing waitable kind returned")
+        end
+        wait_dequeue!(fx, w, WAKE_FIRED)
+        return nothing
+    end
+    local r
+    try
+        r = wait()
+    catch
+        interrupted_park_cleanup!(ct, ws, nothing, w, true)
+        rethrow()
+    end
+    return r
+end
+
+"""
+    withdraw!(ws, w::WaitEntry)
+
+Leave the wait: dequeue every registration per its policy and retire the
+entry if it was fresh. With `repark!` owning the arm, every caller
+decision point runs unarmed, so no disarm is needed here.
+"""
+function withdraw!(ws, w::WaitEntry)
+    for x in ws
+        wait_dequeue!(x, w, WAKE_WITHDRAWN)
+    end
+    release_wait_entry!(current_task(), w)
+    return nothing
+end
+
+# Cleanup of a park that was resumed without a wake having been delivered
+# through its registration `w`: an interrupter claimed the wake (leaving
+# the entry linked for us to clean up), the task got a raw `throwto`, or
+# a cancellation was delivered. The caller rethrows afterwards. In order:
+#  1. Disarm the registration - before the reacquire in step 3 can
+#     register a new wait. When the disarm loses, a claimer got the wake:
+#     its schedule is either already enqueued or still in flight under
+#     the waitee's lock.
+#  2. Blank the entry's cache slot: a notifier may have popped the stale
+#     entry without scheduling us and may still retain its identity for
+#     the wake-claim CAS, so `w` must not be reused (e.g. by a park
+#     inside the reacquire) before the unlink below.
+#  3. Reacquire per kind and unlink `w` (a no-op where a `notify` already
+#     popped and dropped it).
+#  4. Drop a claimed-and-enqueued wake this unwind will never consume, so
+#     a later wait of this task does not consume it spuriously. This runs
+#     after the reacquire on purpose: a claimer that claimed our wake did
+#     so under the waitee's protection, so once the reacquire returns its
+#     enqueue has landed and the drop is deterministic - dropping before
+#     the reacquire would race the in-flight schedule and leak the wake
+#     into the task's next wait. (If the reacquire itself parked and
+#     consumed the stale wake as a spurious lock wake, its acquire loop
+#     re-tested and re-parked - lock parks tolerate spurious wakes - and
+#     there is nothing left to drop. A claim-less raw wake delivered
+#     outside any lock - the documented-unsafe `schedule(t, exc,
+#     error=true)` of a running task - can still land after this drop;
+#     that hazard is the primitive's, not this path's.)
+#  5. Now `w` is safe to reuse: restore it to its cache unless the
+#     reacquire parked and cached a replacement - then `w` is unreachable
+#     garbage (unarmed, off every waitq), so retire it: its sticky source
+#     registration must be counted dead for pruning, or a long-lived
+#     source would retain the task through the orphaned entry. Fresh
+#     entries are always retired.
+function interrupted_park_cleanup!(ct::Task, ws, toks, w::WaitEntry, relock::Bool)
+    @atomicreplace ct.waiting_on w => nothing
+    was_plain = ct.cached_wait_entry === w
+    was_cancel = !was_plain && ct.cached_cancel_entry === w
+    was_plain && (ct.cached_wait_entry = nothing)
+    was_cancel && (ct.cached_cancel_entry = nothing)
+    if toks === nothing
+        for x in ws
+            wait_reacquire!(x, nothing)
+        end
+    else
+        for (x, t) in zip(ws, toks)
+            wait_reacquire!(x, t)
+        end
+    end
+    for x in ws
+        wait_dequeue!(x, w, WAKE_INTERRUPTED)
+    end
+    q = ct.queue
+    q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
+    if !relock
+        for x in ws
+            wait_release!(x)
+        end
+    end
+    if was_plain
+        if ct.cached_wait_entry === nothing
+            ct.cached_wait_entry = w
+        else
+            retire_cancellation_entry!(w)
+        end
+    elseif was_cancel
+        if ct.cached_cancel_entry === nothing
+            ct.cached_cancel_entry = w
+        else
+            retire_cancellation_entry!(w)
+        end
+    else
+        retire_cancellation_entry!(w)
+    end
+    return nothing
+end
+
+function wait_enqueue!(x::SourceWait, w::WaitEntry, first::Bool)
+    src = x.src
+    i = _find_slot(w, src)
+    if i == 0
+        # First registration under `src`: claim a slot (the slot's `owner`
+        # is the push ticket) and stage the floor - pre-publication, so
+        # any walk that can see the slot sees its aux - then publish with
+        # a lock-free push. seq_cst, pairing with the cancellation walk's
+        # state-write-then-head-read: if the walk's head read misses this
+        # push, this push is later in the total order, so the recheck
+        # below observes the raised state.
+        i = _acquire_slot!(w, src)
+        _set_slot_aux!(w, i, UInt64(x.floor))
+        slot = slots(w)[i]
+        while true
+            h = _waiters_head(src)
+            slot.next = h
+            if (@atomicreplace :sequentially_consistent :monotonic src.waiters_head h => w).success
+                break
+            end
+        end
+    else
+        # Sticky re-arm (already registered): upgrade this thread's
+        # arm-then-recheck to the store-load ordering the race argument
+        # needs (the arm CAS itself is only `release`).
+        Core.Intrinsics.atomic_fence(:sequentially_consistent, :system)
+    end
+    return true
+end
+
+function wait_recheck(x::SourceWait, w::WaitEntry)
+    # Post-publication recheck: either the concurrent cancellation walk
+    # observes our push/arm, or we observe its state write here.
+    st = @atomic :sequentially_consistent x.src.state
+    return st != 0x00 && st >= x.floor
+end
+
+wait_fired_throws(x::SourceWait) = true
+wait_fired(x::SourceWait, w::WaitEntry) = _deliver_refused_cancellation(x.src)
+wait_dequeue!(x::SourceWait, w::WaitEntry, why::UInt8) = nothing

--- a/base/process.jl
+++ b/base/process.jl
@@ -97,7 +97,15 @@ function as_cpumask(cpus::Vector{UInt16})
 end
 
 # handle marshalling of `Cmd` arguments from Julia to C
-@noinline function _spawn_primitive(file, cmd::Cmd, stdio::SpawnIOs)
+@noinline function _spawn_primitive(file, cmd::Cmd, stdio::SpawnIOs,
+                                    tok::MaybeToken=default_cancel_token())
+    # Entry cancellation check before the child exists: a spawn under an
+    # already-cancelled token must not run the command (its side effects
+    # cannot be taken back). `tok` is the *resolved* token of the public
+    # operation (run/open/success/read), threaded down here so an explicit
+    # token - or an explicit `cancel = nothing` shield - governs the spawn
+    # itself, not whatever the ambient scope happens to be.
+    @cancel_check tok
     loop = eventloop()
     cpumask = cmd.cpus
     cpumask === nothing || (cpumask = as_cpumask(cpumask))
@@ -150,24 +158,28 @@ end
     end
 end
 
-_spawn(cmds::AbstractCmd) = _spawn(cmds, SpawnIOs())
+# The `tok::MaybeToken` threaded through the _spawn chain is the resolved
+# token of the public operation; see _spawn_primitive.
+_spawn(cmds::AbstractCmd, tok::MaybeToken=default_cancel_token()) =
+    _spawn(cmds, SpawnIOs(), tok)
 
-function _spawn(cmd::AbstractCmd, stdios::Vector{Redirectable})
+function _spawn(cmd::AbstractCmd, stdios::Vector{Redirectable},
+                tok::MaybeToken=default_cancel_token())
     pp = setup_stdios(stdios) do stdios
-        return _spawn(cmd, stdios)
+        return _spawn(cmd, stdios, tok)
     end
     return pp
 end
 
 # optimization: we can spawn `Cmd` directly without allocating the ProcessChain
-function _spawn(cmd::Cmd, stdios::SpawnIOs)
+function _spawn(cmd::Cmd, stdios::SpawnIOs, tok::MaybeToken=default_cancel_token())
     isempty(cmd.exec) && throw(ArgumentError("cannot spawn empty command"))
-    return _spawn_primitive(cmd.exec[1], cmd, stdios)
+    return _spawn_primitive(cmd.exec[1], cmd, stdios, tok)
 end
 
 # assume that having a ProcessChain means that the stdio are setup
-function _spawn(cmds::AbstractCmd, stdios::SpawnIOs)
-    return _spawn(cmds, stdios, ProcessChain())
+function _spawn(cmds::AbstractCmd, stdios::SpawnIOs, tok::MaybeToken=default_cancel_token())
+    return _spawn(cmds, stdios, ProcessChain(), tok)
 end
 
 # helper function for making a copy of a SpawnIOs, with replacement
@@ -179,24 +191,35 @@ function _stdio_copy(stdios::SpawnIOs, fd::Int, @nospecialize replace)
     return new
 end
 
-function _spawn(redirect::CmdRedirect, stdios::SpawnIOs, args...)
+function _spawn(redirect::CmdRedirect, stdios::SpawnIOs, tok::MaybeToken=default_cancel_token())
     fdnum = redirect.stream_no + 1
     io, close_io = setup_stdio(redirect.handle, redirect.readable)
     try
         stdios = _stdio_copy(stdios, fdnum, io)
-        return _spawn(redirect.cmd, stdios, args...)
+        return _spawn(redirect.cmd, stdios, tok)
     finally
         close_io && close_stdio(io)
     end
 end
 
-function _spawn(cmds::OrCmds, stdios::SpawnIOs, chain::ProcessChain)
+function _spawn(redirect::CmdRedirect, stdios::SpawnIOs, chain::ProcessChain, tok::MaybeToken)
+    fdnum = redirect.stream_no + 1
+    io, close_io = setup_stdio(redirect.handle, redirect.readable)
+    try
+        stdios = _stdio_copy(stdios, fdnum, io)
+        return _spawn(redirect.cmd, stdios, chain, tok)
+    finally
+        close_io && close_stdio(io)
+    end
+end
+
+function _spawn(cmds::OrCmds, stdios::SpawnIOs, chain::ProcessChain, tok::MaybeToken)
     in_pipe, out_pipe = link_pipe(false, false)
     try
         stdios_left = _stdio_copy(stdios, 2, out_pipe)
-        _spawn(cmds.a, stdios_left, chain)
+        _spawn(cmds.a, stdios_left, chain, tok)
         stdios_right = _stdio_copy(stdios, 1, in_pipe)
-        _spawn(cmds.b, stdios_right, chain)
+        _spawn(cmds.b, stdios_right, chain, tok)
     finally
         close_pipe_sync(out_pipe)
         close_pipe_sync(in_pipe)
@@ -204,13 +227,13 @@ function _spawn(cmds::OrCmds, stdios::SpawnIOs, chain::ProcessChain)
     return chain
 end
 
-function _spawn(cmds::ErrOrCmds, stdios::SpawnIOs, chain::ProcessChain)
+function _spawn(cmds::ErrOrCmds, stdios::SpawnIOs, chain::ProcessChain, tok::MaybeToken)
     in_pipe, out_pipe = link_pipe(false, false)
     try
         stdios_left = _stdio_copy(stdios, 3, out_pipe)
-        _spawn(cmds.a, stdios_left, chain)
+        _spawn(cmds.a, stdios_left, chain, tok)
         stdios_right = _stdio_copy(stdios, 1, in_pipe)
-        _spawn(cmds.b, stdios_right, chain)
+        _spawn(cmds.b, stdios_right, chain, tok)
     finally
         close_pipe_sync(out_pipe)
         close_pipe_sync(in_pipe)
@@ -218,15 +241,15 @@ function _spawn(cmds::ErrOrCmds, stdios::SpawnIOs, chain::ProcessChain)
     return chain
 end
 
-function _spawn(cmds::AndCmds, stdios::SpawnIOs, chain::ProcessChain)
-    _spawn(cmds.a, stdios, chain)
-    _spawn(cmds.b, stdios, chain)
+function _spawn(cmds::AndCmds, stdios::SpawnIOs, chain::ProcessChain, tok::MaybeToken)
+    _spawn(cmds.a, stdios, chain, tok)
+    _spawn(cmds.b, stdios, chain, tok)
     return chain
 end
 
-function _spawn(cmd::Cmd, stdios::SpawnIOs, chain::ProcessChain)
+function _spawn(cmd::Cmd, stdios::SpawnIOs, chain::ProcessChain, tok::MaybeToken)
     isempty(cmd.exec) && throw(ArgumentError("cannot spawn empty command"))
-    pp = _spawn_primitive(cmd.exec[1], cmd, stdios)
+    pp = _spawn_primitive(cmd.exec[1], cmd, stdios, tok)
     push!(chain.processes, pp)
     return chain
 end
@@ -357,12 +380,14 @@ spawn_opts_swallow(in::Redirectable=devnull, out::Redirectable=devnull, err::Red
 spawn_opts_inherit(in::Redirectable=RawFD(0), out::Redirectable=RawFD(1), err::Redirectable=RawFD(2), extra::Redirectable...) =
     Redirectable[in, out, err, extra...]
 
-function eachline(cmd::AbstractCmd; keep::Bool=false)
+function eachline(cmd::AbstractCmd; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
     out = PipeEndpoint()
-    processes = _spawn(cmd, Redirectable[devnull, out, stderr])
+    processes = _spawn(cmd, Redirectable[devnull, out, stderr], tok)
     # if the user consumes all the data, also check process exit status for success
-    ondone = () -> (success(processes) || pipeline_error(processes); nothing)
-    return EachLine(out, keep=keep, ondone=ondone)::EachLine
+    ondone = () -> (success(processes; cancel=tok) || pipeline_error(processes); nothing)
+    return EachLine(out; keep, ondone, cancel=tok)::EachLine
 end
 
 """
@@ -379,13 +404,14 @@ Possible mode strings are:
 | `r+` | read, write | `read = true, write = true`      |
 | `w+` | read, write | `read = true, write = true`      |
 """
-function open(cmds::AbstractCmd, mode::AbstractString, stdio::Redirectable=devnull)
+function open(cmds::AbstractCmd, mode::AbstractString, stdio::Redirectable=devnull;
+              cancel::CancelTokenArg=DEFAULT_CANCEL)
     if mode == "r+" || mode == "w+"
-        return open(cmds, stdio, read = true, write = true)
+        return open(cmds, stdio, read = true, write = true; cancel)
     elseif mode == "r"
-        return open(cmds, stdio)
+        return open(cmds, stdio; cancel)
     elseif mode == "w"
-        return open(cmds, stdio, write = true)
+        return open(cmds, stdio, write = true; cancel)
     else
         throw(ArgumentError("mode must be \"r\", \"w\", \"r+\", or \"w+\", not $(repr(mode))"))
     end
@@ -402,25 +428,27 @@ the process's standard input and `stdio` optionally specifies the process's stan
 stream.
 The process's standard error stream is connected to the current global `stderr`.
 """
-function open(cmds::AbstractCmd, stdio::Redirectable=devnull; write::Bool=false, read::Bool=!write)
+function open(cmds::AbstractCmd, stdio::Redirectable=devnull; write::Bool=false, read::Bool=!write,
+              cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
     if read && write
         stdio === devnull || throw(ArgumentError("no stream can be specified for `stdio` in read-write mode"))
         in = PipeEndpoint()
         out = PipeEndpoint()
-        processes = _spawn(cmds, Redirectable[in, out, stderr])
+        processes = _spawn(cmds, Redirectable[in, out, stderr], tok)
         processes.in = in
         processes.out = out
     elseif read
         out = PipeEndpoint()
-        processes = _spawn(cmds, Redirectable[stdio, out, stderr])
+        processes = _spawn(cmds, Redirectable[stdio, out, stderr], tok)
         processes.out = out
     elseif write
         in = PipeEndpoint()
-        processes = _spawn(cmds, Redirectable[in, stdio, stderr])
+        processes = _spawn(cmds, Redirectable[in, stdio, stderr], tok)
         processes.in = in
     else
         stdio === devnull || throw(ArgumentError("no stream can be specified for `stdio` in no-access mode"))
-        processes = _spawn(cmds, Redirectable[devnull, devnull, stderr])
+        processes = _spawn(cmds, Redirectable[devnull, devnull, stderr], tok)
     end
     return processes
 end
@@ -484,10 +512,12 @@ end
 
 Run `command` and return the resulting output as an array of bytes.
 """
-function read(cmd::AbstractCmd)
-    procs = open(cmd, "r", devnull)
-    bytes = read(procs.out)
-    success(procs) || pipeline_error(procs)
+function read(cmd::AbstractCmd; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
+    procs = open(cmd, "r", devnull; cancel=tok)
+    bytes = read(procs.out; cancel=tok)
+    success(procs; cancel=tok) || pipeline_error(procs)
     return bytes::Vector{UInt8}
 end
 
@@ -496,7 +526,8 @@ end
 
 Run `command` and return the resulting output as a `String`.
 """
-read(cmd::AbstractCmd, ::Type{String}) = String(read(cmd))::String
+read(cmd::AbstractCmd, ::Type{String}; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    String(read(cmd; cancel))::String
 
 """
     run(command, args...; wait::Bool = true)
@@ -519,13 +550,15 @@ Use [`pipeline`](@ref) to control I/O redirection.
 
 See also: [`Cmd`](@ref).
 """
-function run(cmds::AbstractCmd, args...; wait::Bool = true)
+function run(cmds::AbstractCmd, args...; wait::Bool = true, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
     if wait
-        ps = _spawn(cmds, spawn_opts_inherit(args...))
-        success(ps) || pipeline_error(ps)
+        ps = _spawn(cmds, spawn_opts_inherit(args...), tok)
+        success(ps; cancel=tok) || pipeline_error(ps)
     else
         stdios = spawn_opts_swallow(args...)
-        ps = _spawn(cmds, stdios)
+        ps = _spawn(cmds, stdios, tok)
         # for each stdio input argument, guess whether the user
         # passed a `stdio` placeholder object as input, and thus
         # might be able to use the return AbstractProcess as an IO object
@@ -566,12 +599,14 @@ function test_success(proc::Process)
     return proc.exitcode == 0 && proc.termsignal == 0
 end
 
-function success(x::Process)
-    wait(x)
+function success(x::Process; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    wait(x; cancel)
     return test_success(x)
 end
-success(procs::Vector{Process}) = mapreduce(success, &, procs)
-success(procs::ProcessChain) = success(procs.processes)
+success(procs::Vector{Process}; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    mapreduce(p -> success(p; cancel), &, procs)
+success(procs::ProcessChain; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    success(procs.processes; cancel)
 
 """
     success(command)
@@ -580,7 +615,11 @@ Run a command object, constructed with backticks (see the [Running External Prog
 section in the manual), and tell whether it was successful (exited with a code of 0).
 An exception is raised if the process cannot be started.
 """
-success(cmd::AbstractCmd) = success(_spawn(cmd))
+function success(cmd::AbstractCmd; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(cancel)
+    @cancel_check tok
+    return success(_spawn(cmd, tok); cancel=tok)
+end
 
 
 """
@@ -697,7 +736,8 @@ function process_status(s::Process)
            error("process status error")
 end
 
-function wait(x::Process, syncd::Bool=true)
+function wait(x::Process, syncd::Bool=true; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = check_cancel_arg(cancel)
     if !process_exited(x)
         iolock_begin()
         if !process_exited(x)
@@ -705,7 +745,7 @@ function wait(x::Process, syncd::Bool=true)
             lock(x.exitnotify)
             iolock_end()
             try
-                wait(x.exitnotify)
+                wait(x.exitnotify, tok)
             finally
                 unlock(x.exitnotify)
                 unpreserve_handle(x)
@@ -716,12 +756,13 @@ function wait(x::Process, syncd::Bool=true)
     end
     # and make sure all sync'd Tasks are complete too
     syncd && for t in x.syncd
-        wait(t)
+        wait(t, tok)
     end
     nothing
 end
 
-wait(x::ProcessChain, syncd::Bool=true) = foreach(p -> wait(p, syncd), x.processes)
+wait(x::ProcessChain, syncd::Bool=true; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    foreach(p -> wait(p, syncd; cancel), x.processes)
 
 show(io::IO, p::Process) = print(io, "Process(", p.cmd, ", ", process_status(p), ")")
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -744,10 +744,13 @@ function wait(x::Process, syncd::Bool=true; cancel::CancelTokenArg=DEFAULT_CANCE
             preserve_handle(x)
             lock(x.exitnotify)
             iolock_end()
+            locked = true
             try
+                locked = false
                 wait(x.exitnotify, tok)
+                locked = true
             finally
-                unlock(x.exitnotify)
+                locked && unlock(x.exitnotify)
                 unpreserve_handle(x)
             end
         else

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -101,9 +101,10 @@ end
 
 bytesavailable(s::LibuvStream) = bytesavailable(s.buffer)
 
-function eof(s::LibuvStream)
+function eof(s::LibuvStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
     bytesavailable(s) > 0 && return false
-    wait_readnb(s, 1)
+    wait_readnb(s, 1, resolve_cancel_token(cancel))
     # This function is race-y if used from multiple threads, but we guarantee
     # it to never return true until the stream is definitively exhausted
     # and that we won't return true if there's a readerror pending (it'll instead get thrown).
@@ -386,7 +387,7 @@ function check_open(x::Union{LibuvStream, LibuvServer})
     end
 end
 
-function wait_readnb(x::LibuvStream, nb::Int)
+function wait_readnb(x::LibuvStream, nb::Int, tok::MaybeToken=default_cancel_token())
     # fast path before iolock acquire
     bytesavailable(x.buffer) >= nb && return
     open = isopen(x) && x.status != StatusEOF # must precede readerror check
@@ -410,7 +411,7 @@ function wait_readnb(x::LibuvStream, nb::Int)
             x.throttle = max(nb, x.throttle)
             start_reading(x) # ensure we are reading
             iolock_end()
-            wait(x.cond)
+            wait(x.cond, tok)
             unlock(x.cond)
             iolock_begin()
             lock(x.cond)
@@ -431,12 +432,205 @@ function wait_readnb(x::LibuvStream, nb::Int)
     nothing
 end
 
-function closewrite(s::LibuvStream)
+## Waits on libuv requests
+#
+# A libuv request (write, shutdown, UDP send, DNS lookup) is issued under the
+# iolock with its data field C_NULL and completes by a callback (also run
+# under the iolock) that wakes the parked issuer through the standard
+# wake-claim protocol. The request's data field tracks who owns freeing it:
+#   pointer to the wait entry - a waiter is parked on the request;
+#   C_NULL                    - the completion callback has run; the waiter
+#                               owns the request;
+#   UV_REQ_DETACHED           - the waiter departed (interrupted/refused
+#                               wait, or fire-and-forget): the callback owns
+#                               freeing it, plus any buffer root recorded in
+#                               `_detached_uvreq_roots`.
+
+# Sentinel for a uv request's data field: see above.
+const UV_REQ_DETACHED = Ptr{Cvoid}(UInt(0x1))
+
+# Aux flag on a uv write wait's *witness* slot (the slot whose owner is the
+# stream; its aux is otherwise unused): set, under the iolock, immediately
+# before Julia itself issues `uv_cancel` on a write request it keeps
+# awaiting, so the completion callback can tell a Julia-requested
+# cancellation (UV_ECANCELED is then the expected outcome, delivered as a
+# partial-count wake) from a close-induced one (a real write error - libuv
+# also fails queued writes with UV_ECANCELED when the stream closes).
+# Cleared whenever the slot is released for reuse (_release_slot!/
+# _clear_uv_witness!). The detach path (_end_uvreq_wait!) does not set it:
+# there the request is detached in the same iolock critical section, so no
+# callback can observe a waiter - the flag only matters to waited requests.
+const _UVREQ_AUX_CANCEL_REQUESTED = UInt64(0x1)
+
+function _mark_uvreq_cancel_requested!(w::WaitEntry, @nospecialize(witness))
+    i = _find_slot(w, witness)
+    i == 0 || _set_slot_aux!(w, i, _slot_aux(w, i) | _UVREQ_AUX_CANCEL_REQUESTED)
+    return nothing
+end
+
+# Whether the waiter flagged this request's cancellation as its own. Read
+# by the completion callback (under the iolock) *before* the claim releases
+# the witness slot.
+function _uvreq_cancel_requested(req::Ptr{Cvoid})
+    d = uv_req_data(req)
+    (d == C_NULL || d == UV_REQ_DETACHED) && return false
+    w = unsafe_pointer_to_objref(d)::WaitEntry
+    for slot in slots(w)
+        o = slot.owner
+        (o === nothing || o isa CancellationTokenSource) && continue
+        return slot.aux & _UVREQ_AUX_CANCEL_REQUESTED != 0
+    end
+    return false
+end
+
+# Buffers of detached write requests. A detached request keeps referencing
+# the caller's memory until its completion callback runs - long after the
+# issuing frame, whose GC.@preserve was the buffer's only root, has unwound.
+# When the write's Julia owner is known it is rooted here, keyed by the
+# request, and released by the completion callback. Guarded by the iolock
+# (callbacks run under it). Raw-pointer writes (the generic unsafe_write
+# interface) have no discoverable owner - their contract is pointer validity
+# for the duration of the call - and detaching them retains the pre-existing
+# hazard; owner-carrying entry points avoid it.
+const _detached_uvreq_roots = IdDict{Ptr{Cvoid}, Any}()
+
+function _root_detached_uvreq!(req::Ptr{Cvoid}, @nospecialize(owner))
+    owner === nothing || (_detached_uvreq_roots[req] = owner)
+    return nothing
+end
+_unroot_detached_uvreq!(req::Ptr{Cvoid}) =
+    (isempty(_detached_uvreq_roots) || delete!(_detached_uvreq_roots, req); nothing)
+
+# The entry check of a cancellable uv operation, made under the iolock
+# before the request is issued: when `src` is already cancelled, release the
+# iolock and throw the request - before the operation has any side effects.
+function _iolocked_checkcancel(src::Union{Nothing, CancellationTokenSource})
+    if src !== nothing && iscancelled(src)
+        iolock_end()
+        checkcancel(src)
+    end
+    return nothing
+end
+
+# Arm the wait for the issued uv request `req`: pick the wait entry (with a
+# cancellation-source slot when governed by `src`), arm it, record `witness`
+# (the waitee identity - the handle, or the request itself when there is
+# none) as the entry's reuse gate, and point the request at the entry.
+# Leaves the caller's iolock held, inside a sigatomic section.
+function _begin_uvreq_wait!(src::Union{Nothing, CancellationTokenSource},
+                            @nospecialize(witness), req::Ptr{Cvoid})
+    ct = current_task()
+    w = src === nothing ? _cached_wait_entry(ct) : _cancel_wait_entry(ct, src, 0x00)
+    _arm_wait(ct, w)
+    _set_wait_witness!(w, witness)
+    preserve_handle(ct)
+    sigatomic_begin()
+    uv_req_set_data(req, pointer_from_objref(w))
+    return w
+end
+
+# Wind down a uv request wait (caller holds the iolock, at the sigatomic
+# level of the wait): resolve the request's ownership, release the wait
+# witness, disarm the registration (a no-op when a claimer already did),
+# and unwind the iolock, the sigatomic section, and the handle preservation.
+# When the completion callback has already run (data == C_NULL) the request
+# is ours to free; otherwise - the wait was interrupted or refused, or the
+# task was resumed by an unexpected `schedule` - the request is detached for
+# the callback to free, `uv_cancel`ed first when `trycancel` is set (so e.g.
+# an abandoned write stops spamming the stream), with `owner` kept rooted
+# until then. The sticky source registration needs no cleanup at all.
+function _end_uvreq_wait!(w::WaitEntry, @nospecialize(witness), req::Ptr{Cvoid},
+                          trycancel::Bool, @nospecialize(owner))
+    ct = current_task()
+    if uv_req_data(req) == C_NULL
+        Libc.free(req)
+    else
+        trycancel && ccall(:uv_cancel, Cint, (Ptr{Cvoid},), req) # ignore any errors
+        uv_req_set_data(req, UV_REQ_DETACHED)
+        _root_detached_uvreq!(req, owner)
+    end
+    _clear_wait_witness!(w, witness)
+    @atomicreplace ct.waiting_on w => nothing
+    # Drop a claimed-and-enqueued wake an interrupted teardown will never
+    # consume. The completion callback claims and schedules under the
+    # iolock this function holds, so the drop is deterministic here (cf.
+    # step 4 of _interrupted_wait_cleanup).
+    q = ct.queue
+    q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
+    iolock_end()
+    sigatomic_end()
+    unpreserve_handle(ct)
+    return nothing
+end
+
+# Park on the completion of the issued uv request `req` and return the value
+# its completion callback delivers. A cancellation of `src` interrupts the
+# wait and throws the CancellationRequest - without parking at all when
+# `src` got cancelled between the caller's entry check and the registration
+# here; either way the request is left to its callback (see
+# _end_uvreq_wait!). The caller must have issued `req` under the still-held
+# iolock - so the callback cannot have run yet - and gets it back with the
+# iolock released.
+function _wait_uvreq(src::Union{Nothing, CancellationTokenSource}, @nospecialize(witness),
+                     req::Ptr{Cvoid}, trycancel::Bool, @nospecialize(owner))
+    w = _begin_uvreq_wait!(src, witness, req)
+    if src !== nothing && !register_cancellation!(src, w)
+        # the wake was claimed back for us: don't park
+        _end_uvreq_wait!(w, witness, req, trycancel, owner)
+        _deliver_refused_cancellation(src)
+    end
+    iolock_end()
+    local r
+    try
+        sigatomic_end()
+        r = wait()
+        sigatomic_begin()
+    catch
+        # (catch restored the sigatomic level from the try entry)
+        iolock_begin()
+        _end_uvreq_wait!(w, witness, req, trycancel, owner)
+        rethrow()
+    end
+    iolock_begin()
+    _end_uvreq_wait!(w, witness, req, trycancel, owner)
+    return r
+end
+
+# Completion-callback side of the wait (runs under the iolock): resolve
+# request ownership and claim the parked waiter's wake. Returns the task to
+# schedule, or `nothing` when there is nobody to wake - either no waiter
+# remains (fire-and-forget, or the waiter departed and detached the request,
+# which is freed here together with any recorded buffer root), or a
+# canceller claimed the wake first (the waiter's teardown then observes
+# data == C_NULL and takes over the request).
+function _claim_uvreq_waiter(req::Ptr{Cvoid})
+    d = uv_req_data(req)
+    if d == C_NULL || d == UV_REQ_DETACHED
+        _unroot_detached_uvreq!(req)
+        Libc.free(req)
+        return nothing
+    end
+    # mark the callback as done; the waiter (which inspects the request
+    # under the iolock) owns freeing it
+    uv_req_set_data(req, C_NULL)
+    w = unsafe_pointer_to_objref(d)::WaitEntry
+    t = @atomic :monotonic w.task
+    if t isa Task && claim_wait(t, w)
+        _clear_uv_witness!(w)
+        return t
+    end
+    return nothing
+end
+
+function closewrite(s::LibuvStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
     iolock_begin()
     if !iswritable(s)
         iolock_end()
         return
     end
+    src = cancel_source(resolve_cancel_token(cancel))
+    # entry check: throw before issuing the shutdown request
+    _iolocked_checkcancel(src)
     req = Libc.malloc(_sizeof_uv_shutdown)
     uv_req_set_data(req, C_NULL) # in case we get interrupted before arriving at the wait call
     err = ccall(:uv_shutdown, Int32, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
@@ -445,32 +639,9 @@ function closewrite(s::LibuvStream)
         Libc.free(req)
         uv_error("shutdown", err)
     end
-    ct = current_task()
-    preserve_handle(ct)
-    sigatomic_begin()
-    uv_req_set_data(req, ct)
-    iolock_end()
-    local status
-    try
-        sigatomic_end()
-        status = wait()::Cint
-        sigatomic_begin()
-    finally
-        # try-finally unwinds the sigatomic level, so need to repeat sigatomic_end
-        sigatomic_end()
-        iolock_begin()
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::StickyWorkqueue, ct)
-        if uv_req_data(req) != C_NULL
-            # req is still alive,
-            # so make sure we won't get spurious notifications later
-            uv_req_set_data(req, C_NULL)
-        else
-            # done with req
-            Libc.free(req)
-        end
-        iolock_end()
-        unpreserve_handle(ct)
-    end
+    # A shutdown request itself cannot be cancelled, so an interrupted wait
+    # detaches it (its completion callback frees it).
+    status = _wait_uvreq(src, s, req, false, nothing)::Cint
     if isopen(s)
         if status < 0 || ccall(:uv_is_readable, Cint, (Ptr{Cvoid},), s.handle) == 0
             close(s)
@@ -487,7 +658,10 @@ function wait_close(x::Union{LibuvStream, LibuvServer})
     lock(x.cond)
     try
         while isopen(x)
-            wait(x.cond)
+            # close is the cleanup primitive: its completion wait is shielded
+            # from cancellation (completion depends only on the event loop,
+            # not on any peer, so this wait is bounded)
+            wait(x.cond, nothing)
         end
     finally
         unlock(x.cond)
@@ -917,25 +1091,26 @@ end
 # bulk read / write
 
 readbytes!(s::LibuvStream, a::Vector{UInt8}, nb = length(a)) = readbytes!(s, a, Int(nb))
-function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int)
+function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(precheck_cancel_arg(cancel))
     iolock_begin()
     sbuf = s.buffer
     @assert sbuf.seekable == false "buffer should not be seekable"
     @assert sbuf.maxsize >= nb "insufficient buffer size"
 
-    function wait_locked(s, buf, nb)
+    function wait_locked(s, buf, nb, tok)
         while bytesavailable(buf) < nb
             s.readerror === nothing || throw(s.readerror)
             isopen(s) || break
             s.status != StatusEOF || break
             iolock_end()
-            wait_readnb(s, nb)
+            wait_readnb(s, nb, tok)
             iolock_begin()
         end
     end
 
     if nb <= SZ_UNBUFFERED_IO # Under this limit we are OK with copying the array from the stream's buffer
-        wait_locked(s, sbuf, nb)
+        wait_locked(s, sbuf, nb, tok)
     end
     if bytesavailable(sbuf) >= nb
         nread = readbytes!(sbuf, a, nb)
@@ -945,7 +1120,7 @@ function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int)
         nread = try
             s.buffer = newbuf
             write(newbuf, sbuf)
-            wait_locked(s, newbuf, nb)
+            wait_locked(s, newbuf, nb, tok)
             bytesavailable(newbuf)
         finally
             s.buffer = sbuf
@@ -957,33 +1132,34 @@ function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int)
     return nread
 end
 
-function read(stream::LibuvStream)
-    wait_readnb(stream, typemax(Int))
+function read(stream::LibuvStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    wait_readnb(stream, typemax(Int), resolve_cancel_token(precheck_cancel_arg(cancel)))
     iolock_begin()
     bytes = take!(stream.buffer)
     iolock_end()
     return bytes
 end
 
-function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
+function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(precheck_cancel_arg(cancel))
     iolock_begin()
     sbuf = s.buffer
     @assert sbuf.seekable == false "buffer should not be seekable"
     @assert sbuf.maxsize >= nb "insufficient buffer size"
 
-    function wait_locked(s, buf, nb)
+    function wait_locked(s, buf, nb, tok)
         while bytesavailable(buf) < nb
             s.readerror === nothing || throw(s.readerror)
             isopen(s) || throw(EOFError())
             s.status != StatusEOF || throw(EOFError())
             iolock_end()
-            wait_readnb(s, nb)
+            wait_readnb(s, nb, tok)
             iolock_begin()
         end
     end
 
     if nb <= SZ_UNBUFFERED_IO # Under this limit we are OK with copying the array from the stream's buffer
-        wait_locked(s, sbuf, Int(nb))
+        wait_locked(s, sbuf, Int(nb), tok)
     end
     if bytesavailable(sbuf) >= nb
         unsafe_read(sbuf, p, nb)
@@ -992,7 +1168,7 @@ function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
         try
             s.buffer = newbuf
             write(newbuf, sbuf)
-            wait_locked(s, newbuf, Int(nb))
+            wait_locked(s, newbuf, Int(nb), tok)
         finally
             s.buffer = sbuf
         end
@@ -1001,13 +1177,14 @@ function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
     nothing
 end
 
-function read(this::LibuvStream, ::Type{UInt8})
+function read(this::LibuvStream, ::Type{UInt8}; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
     iolock_begin()
     sbuf = this.buffer
     @assert sbuf.seekable == false "buffer should not be seekable"
     while bytesavailable(sbuf) < 1
         iolock_end()
-        eof(this) && throw(EOFError())
+        eof(this; cancel) && throw(EOFError())
         iolock_begin()
     end
     c = read(sbuf, UInt8)
@@ -1015,8 +1192,8 @@ function read(this::LibuvStream, ::Type{UInt8})
     return c
 end
 
-function readavailable(this::LibuvStream)
-    wait_readnb(this, 1) # unlike the other `read` family of functions, this one doesn't guarantee error reporting
+function readavailable(this::LibuvStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    wait_readnb(this, 1, resolve_cancel_token(precheck_cancel_arg(cancel))) # unlike the other `read` family of functions, this one doesn't guarantee error reporting
     iolock_begin()
     buf = this.buffer
     @assert buf.seekable == false "buffer should not be seekable"
@@ -1025,7 +1202,8 @@ function readavailable(this::LibuvStream)
     return bytes
 end
 
-function copyuntil(out::IO, x::LibuvStream, c::UInt8; keep::Bool=false)
+function copyuntil(out::IO, x::LibuvStream, c::UInt8; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(precheck_cancel_arg(cancel))
     iolock_begin()
     buf = x.buffer
     @assert buf.seekable == false "buffer should not be seekable"
@@ -1041,7 +1219,7 @@ function copyuntil(out::IO, x::LibuvStream, c::UInt8; keep::Bool=false)
                     x.status != StatusEOF || break
                     start_reading(x) # ensure we are reading
                     iolock_end()
-                    wait(x.cond)
+                    wait(x.cond, tok)
                     unlock(x.cond)
                     iolock_begin()
                     lock(x.cond)
@@ -1055,60 +1233,194 @@ function copyuntil(out::IO, x::LibuvStream, c::UInt8; keep::Bool=false)
             end
         end
     end
-    copyuntil(out, buf, c; keep)
+    # thread the resolved token (or explicit shield): the in-memory copy's
+    # write to `out` is itself token-gated
+    copyuntil(out, buf, c; keep, cancel=tok)
     iolock_end()
     return out
 end
 
-uv_write(s::LibuvStream, p::Vector{UInt8}) = GC.@preserve p uv_write(s, pointer(p), UInt(sizeof(p)))
+uv_write(s::LibuvStream, p::Vector{UInt8}, cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    GC.@preserve p _uv_write_owned(s, pointer(p), UInt(sizeof(p)), cancel, p)
 
-# caller must have acquired the iolock
-function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
-    uvw = uv_write_async(s, p, n)
-    status = uv_write_wait(uvw)
-    if status < 0
-        throw(_UVError("write", status))
+# Issue the write and wait for its completion, delivering a cancellation of
+# `tok` by interrupting the wait (the caller adds the post-write cancellation
+# point that turns a cancelled-but-completed write into a throw). The caller
+# must have acquired the iolock, which is released before returning.
+function _uv_write_wait(s::LibuvStream, p::Ptr{UInt8}, n::UInt,
+                        tok::MaybeToken, @nospecialize(owner))
+    src = cancel_source(tok)
+    # entry check: throw before handing anything to libuv
+    _iolocked_checkcancel(src)
+    local uvw, lastn
+    try
+        uvw, lastn = uv_write_async(s, p, n)
+    catch
+        # E.g. the stream was (or gets) closed: release the iolock so that
+        # errors propagate without it.
+        iolock_end()
+        rethrow()
     end
-    return Int(n)
-end
-
-# wait for the write request to complete and return its status,
-# caller must have acquired the iolock, which is released before waiting
-function uv_write_wait(uvw::Ptr{Cvoid})
-    ct = current_task()
-    preserve_handle(ct)
-    sigatomic_begin()
-    uv_req_set_data(uvw, ct)
+    # Whether the write went out as a single request: only then may a
+    # cancellation `uv_cancel` it - see _uv_write_cancelled_finish. (The
+    # wait is on the *last* request either way: completion callbacks run in
+    # order unless a request is dequeued by uv_cancel.)
+    single = lastn == n
+    w = _begin_uvreq_wait!(src, s, uvw)
+    if src !== nothing && !register_cancellation!(src, w)
+        # The token was cancelled since the entry check and the wake was
+        # claimed back for us: don't park. Resolve the in-flight write and
+        # report the bytes that reached the OS; the caller observes the
+        # cancellation at its next cancellation point.
+        iolock_end()
+        nwritten = _uv_write_cancelled_finish(s, w, uvw,
+            severity(cancel_severity(src)::CancellationRequest), src, owner, single)
+        return Int(n - lastn + nwritten)
+    end
     iolock_end()
-    local status
+    local nwritten::Csize_t
+    creq = nothing
     try
         sigatomic_end()
         # wait for the last chunk to complete (or error)
         # assume that any errors would be sticky,
         # (so we don't need to monitor the error status of the intermediate writes)
-        status = wait()::Cint
+        nwritten = wait()::Csize_t
         sigatomic_begin()
-    finally
-        # try-finally unwinds the sigatomic level, so need to repeat sigatomic_end
-        sigatomic_end()
-        iolock_begin()
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::StickyWorkqueue, ct)
-        if uv_req_data(uvw) != C_NULL
-            # uvw is still alive,
-            # so make sure we won't get spurious notifications later
-            uv_req_set_data(uvw, C_NULL)
+    catch err
+        # (catch restored the sigatomic level from the try entry)
+        if err isa CancellationRequest
+            # Cancellation is an expected outcome of a write, not an error:
+            # resolve the request's ownership below and return the partial
+            # count - the caller's next cancellation point (re)delivers the
+            # request. (The delivery is level-triggered, so nothing is
+            # lost by not propagating this throw.)
+            creq = err
         else
-            # done with uvw
-            Libc.free(uvw)
+            # interrupted by something other than a cancellation (an
+            # interrupter or raw throwto); a split write must not be
+            # uv_cancel'ed on detach (see _uv_write_cancelled_finish)
+            iolock_begin()
+            _end_uvreq_wait!(w, s, uvw, single, owner)
+            rethrow()
         end
-        iolock_end()
-        unpreserve_handle(ct)
     end
-    return status
+    if creq !== nothing
+        nwritten = _uv_write_cancelled_finish(s, w, uvw, severity(creq), src, owner, single)
+    else
+        # normal completion (or the wake lost the race to a completion that
+        # ran anyway): the callback handed us the request to free
+        iolock_begin()
+        _end_uvreq_wait!(w, s, uvw, single, owner)
+    end
+    return Int(n - lastn + nwritten)
 end
 
-# helper function for uv_write that returns the uv_write_t struct for the write
-# rather than waiting on it, caller must hold the iolock
+# Resolve the ownership of a cancelled write's uv request and return the
+# last chunk's partial write count (0 when the request had to be detached
+# without awaiting its completion). For SAFE cancellations this awaits the
+# completion callback, so the caller's buffer is provably no longer in use
+# by the OS when this returns; only a severity escalation interrupts that
+# bounded wait. `single` says whether the write went out as one request;
+# only then is the request `uv_cancel`ed. Enters with the iolock released
+# at the sigatomic level of the interrupted wait; unwinds both and the
+# handle preservation.
+function _uv_write_cancelled_finish(s::LibuvStream, w::WaitEntry, uvw::Ptr{Cvoid},
+                                    sev::UInt8, src::CancellationTokenSource,
+                                    @nospecialize(owner), single::Bool)
+    ct = current_task()
+    nwritten::Csize_t = 0
+    awaited = false
+    iolock_begin()
+    d = uv_req_data(uvw)
+    if d == C_NULL
+        # the completion callback already ran (it lost the wake claim): the
+        # request is ours and knows the count
+        awaited = true
+        nwritten = ccall(:uv_write_nwritten, Csize_t, (Ptr{Cvoid},), uvw)
+    else
+        # The write is still in flight. Only a write issued as a *single*
+        # request may be asked to cancel: our libuv patch dequeues the
+        # targeted request out of order and completes it with UV_ECANCELED,
+        # so cancelling the last chunk of a split write would say nothing
+        # about the earlier chunks - they could still be queued, still
+        # referencing the buffer, when the "cancelled" callback fires. For
+        # a split write even a SAFE cancellation therefore awaits the last
+        # callback *without* uv_cancel: nothing is dequeued, completion
+        # stays in-order, and the last chunk's callback implies every
+        # earlier chunk is done with the buffer.
+        if single
+            # flag the request as cancelled-by-us first (on the witness
+            # slot's aux, under the iolock), so the completion callback can
+            # tell our UV_ECANCELED from a close-induced one - see
+            # uv_writecb_task
+            _mark_uvreq_cancel_requested!(w, s)
+            ccall(:uv_cancel, Cint, (Ptr{Cvoid},), uvw) # ignore any errors
+        end
+        if sev < severity(CANCEL_REQUEST_ABANDON_EXTERNAL)
+            # SAFE cancellation: await the completion callback, so that the
+            # caller's buffer is provably no longer in use when this
+            # returns. Only a severity escalation may interrupt this bounded
+            # teardown wait: stage the raised eligibility floor, then re-arm
+            # the (still registered) entry - the re-park needs no new
+            # registration.
+            slots(w)[_find_slot(w, src)].aux = UInt64(sev + 0x01)
+            _arm_wait(ct, w)
+            if register_cancellation!(src, w)
+                iolock_end()
+                try
+                    nwritten = wait()::Csize_t
+                    awaited = true
+                catch
+                    # escalated (or interrupted) during the teardown wait:
+                    # fall through to detach
+                end
+                iolock_begin()
+                if !awaited && uv_req_data(uvw) == C_NULL
+                    # the callback ran anyway (our wake lost a race)
+                    awaited = true
+                    nwritten = ccall(:uv_write_nwritten, Csize_t, (Ptr{Cvoid},), uvw)
+                end
+            end
+            # (a refused registration means the state already escalated)
+        end
+    end
+    # Not awaited (abandoning severity, or an escalation during teardown):
+    # _end_uvreq_wait! detaches the request - the completion callback frees
+    # it - keeping the written buffer rooted until it does; the last chunk's
+    # count is then unknown and reported as 0. (No re-cancel: for a single
+    # request the uv_cancel above was already issued; a split write must
+    # never be uv_cancel'ed - the detached last chunk completing in order is
+    # what keeps the rooted buffer valid for the earlier chunks.)
+    _end_uvreq_wait!(w, s, uvw, false, owner)
+    return nwritten
+end
+
+function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL,
+                  owner=nothing)
+    return _uv_write_owned(s, p, n, cancel, owner)
+end
+
+# Positional core of uv_write: an `owner::Any` keyword call is not statically
+# resolvable (the NamedTuple type is abstract), which breaks trimmed builds.
+function _uv_write_owned(s::LibuvStream, p::Ptr{UInt8}, n::UInt, cancel::CancelTokenArg,
+                         @nospecialize(owner))
+    tok = resolve_cancel_token(cancel)
+    # branch on the token explicitly: a Union-typed `tok` alongside the
+    # deliberately unspecialized `owner` leaves the callee unresolvable
+    # for trimmed builds
+    nb = tok === nothing ? _uv_write_wait(s, p, n, nothing, owner) :
+                           _uv_write_wait(s, p, n, tok, owner)
+    # nb < n means the wait was cancelled: the write reports the partial
+    # count (like a short write) and the cancellation itself is delivered at
+    # the caller's next cancellation point - level-triggered, nothing is
+    # lost by returning normally here.
+    return nb
+end
+
+# helper function for uv_write that returns the uv_write_t struct of the last
+# chunk's write (and that chunk's size) rather than waiting on it, caller must
+# hold the iolock
 function uv_write_async(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
     check_open(s)
     while true
@@ -1128,7 +1440,7 @@ function uv_write_async(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
         n -= nwrite
         p += nwrite
         if n == 0
-            return uvw
+            return uvw, nwrite
         end
     end
 end
@@ -1138,7 +1450,55 @@ end
 # - smaller writes are buffered, final uv write on flush or when buffer full
 # - large isbits arrays are unbuffered and written directly
 
-function unsafe_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
+function write(s::LibuvStream, a::Vector{UInt8}; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
+    # Like the generic unsafe_write fallback below, but carrying the buffer's
+    # owner so a detached (abandoned) write keeps it rooted; see
+    # _detached_uvreq_roots.
+    GC.@preserve a begin
+        return Int(_unsafe_write_owned(s, pointer(a), UInt(sizeof(a)), cancel, a))
+    end
+end
+
+# The public String path must be owner-carrying for the same reason: the
+# generic method (strings/io.jl) preserves the string only until
+# unsafe_write returns, but an abandoning cancellation can detach the
+# in-flight request, which then references the string until its completion
+# callback runs.
+function write(s::LibuvStream, str::Union{String, SubString{String}};
+               cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
+    GC.@preserve str begin
+        return Int(_unsafe_write_owned(s, pointer(str), UInt(sizeof(str)), cancel, str))
+    end
+end
+
+# Owner-carrying counterpart of the generic `write(::IO, ::Array)` methods,
+# again so a detached request keeps the array rooted (bits element types
+# only; others error in the generic method anyway).
+function write(s::LibuvStream, a::Array; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    if isbitstype(eltype(a))
+        cancel = precheck_cancel_arg(cancel)
+        GC.@preserve a begin
+            return Int(_unsafe_write_owned(s, Ptr{UInt8}(pointer(a)), UInt(sizeof(a)), cancel, a))
+        end
+    end
+    return invoke(write, Tuple{IO, AbstractArray}, s, a; cancel)
+end
+
+# Raw-pointer writes have no discoverable owner: the caller's documented
+# contract is pointer validity for the duration of the call - which an
+# abandoning cancellation extends past the return, until the detached
+# request's completion callback has run (see _detached_uvreq_roots). The
+# owner-carrying entry points above (Vector{UInt8}, Array, String) do not
+# have this hazard and are what the public `write` paths use.
+function unsafe_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
+    return _unsafe_write_owned(s, p, n, cancel, nothing)
+end
+
+function _unsafe_write_owned(s::LibuvStream, p::Ptr{UInt8}, n::UInt, cancel::CancelTokenArg,
+                             @nospecialize(owner))
     while true
         # try to add to the send buffer
         iolock_begin()
@@ -1153,19 +1513,49 @@ function unsafe_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
         bytesavailable(buf) == 0 && break
         # perform flush(s)
         arr = take!(buf)
-        uv_write(s, arr)
+        nb = uv_write(s, arr, cancel)
+        # a cancelled flush-write returns short: splice the unwritten tail
+        # back (ahead of concurrent appends) so no buffered byte is lost -
+        # the next iteration's write delivers the (level-triggered)
+        # cancellation at its entry check
+        nb < length(arr) && _requeue_unwritten!(s, arr, nb)
     end
     # perform the output to the kernel
-    return uv_write(s, p, n)
+    return _uv_write_owned(s, p, n, cancel, owner)
 end
 
-function flush(s::LibuvStream)
+# Splice the unwritten tail of a cancelled buffered-flush write back to the
+# *front* of `s.sendbuf` - ahead of anything appended while the write was in
+# flight, preserving stream order. `arr` was taken off the send buffer and
+# only its first `nwritten` bytes reached the stream.
+function _requeue_unwritten!(s::LibuvStream, arr::Vector{UInt8}, nwritten::Int)
+    nwritten < length(arr) || return nothing
+    iolock_begin()
+    buf = s.sendbuf
+    if buf !== nothing
+        appended = bytesavailable(buf) > 0 ? take!(buf) : nothing
+        write(buf, @view arr[nwritten+1:end])
+        appended === nothing || write(buf, appended)
+    end
+    iolock_end()
+    return nothing
+end
+
+# Cancellation contract of flush: a cancellation interrupts the wait, but
+# never silently discards data - buffered bytes that did not reach the
+# stream are put back in the send buffer, the partial state is left
+# consistent, and the CancellationRequest itself is delivered at the
+# caller's next cancellation point (delivery is level-triggered).
+function flush(s::LibuvStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
     iolock_begin()
     buf = s.sendbuf
     if buf !== nothing
         if bytesavailable(buf) > 0
             arr = take!(buf)
-            uv_write(s, arr)
+            nb = uv_write(s, arr, cancel)
+            # cancelled short: requeue the unwritten tail rather than drop it
+            nb < length(arr) && _requeue_unwritten!(s, arr, nb)
             return
         end
     end
@@ -1173,15 +1563,11 @@ function flush(s::LibuvStream)
     # errors from it: previously queued writes have already reported their
     # errors to their writers, and the peer closing the stream after a
     # completed exchange must not make flush throw
-    local uvw
     try
-        uvw = uv_write_async(s, Ptr{UInt8}(Base.eventloop()), UInt(0))
+        _uv_write_owned(s, Ptr{UInt8}(Base.eventloop()), UInt(0), cancel, nothing)
     catch ex
         ex isa IOError || rethrow()
-        iolock_end()
-        return
     end
-    uv_write_wait(uvw) # discard the status
     return
 end
 
@@ -1206,32 +1592,38 @@ function write(s::LibuvStream, b::UInt8)
         end
         iolock_end()
     end
-    return write(s, Ref{UInt8}(b))
+    # carry the Ref as the owner (rather than the generic ownerless
+    # `write(s, ::Ref)` path): an abandoning cancellation may detach the
+    # in-flight request, which must keep the byte's storage rooted
+    r = Ref{UInt8}(b)
+    GC.@preserve r begin
+        return Int(_unsafe_write_owned(s, unsafe_convert(Ptr{UInt8}, r), UInt(1), DEFAULT_CANCEL, r))
+    end
 end
 
 function uv_writecb_task(req::Ptr{Cvoid}, status::Cint)
-    d = uv_req_data(req)
-    if d != C_NULL
-        uv_req_set_data(req, C_NULL) # let the Task know we got the writecb
-        t = unsafe_pointer_to_objref(d)::Task
-        schedule(t, status)
-    else
-        # no owner for this req, safe to just free it
-        Libc.free(req)
+    # An expected-by-the-waiter UV_ECANCELED must be read off the entry
+    # before the claim below releases the witness slot.
+    cancel_requested = status == UV_ECANCELED && _uvreq_cancel_requested(req)
+    t = _claim_uvreq_waiter(req)
+    if t !== nothing
+        if status == 0 || cancel_requested
+            # For writes cancelled by the waiter, this is the partial write
+            # count.
+            schedule(t, ccall(:uv_write_nwritten, Csize_t, (Ptr{Cvoid},), req))
+        else
+            # A real error - including a close-induced UV_ECANCELED (libuv
+            # fails still-queued writes with it when the stream closes),
+            # which must not masquerade as a benign short write.
+            schedule(t, _UVError("write", status); error=true)
+        end
     end
     nothing
 end
 
 function uv_shutdowncb_task(req::Ptr{Cvoid}, status::Cint)
-    d = uv_req_data(req)
-    if d != C_NULL
-        uv_req_set_data(req, C_NULL) # let the Task know we got the shutdowncb
-        t = unsafe_pointer_to_objref(d)::Task
-        schedule(t, status)
-    else
-        # no owner for this req, safe to just free it
-        Libc.free(req)
-    end
+    t = _claim_uvreq_waiter(req)
+    t === nothing || schedule(t, status)
     nothing
 end
 
@@ -1541,7 +1933,15 @@ end
 
 isopen(s::BufferStream) = s.status != StatusClosed
 
-closewrite(s::BufferStream) = close(s)
+# BufferStream <: LibuvStream, so every keyword-accepting LibuvStream
+# method a `cancel=` call would select must be re-specialized here: keyword
+# calls dispatch only among keyword-accepting methods, and the LibuvStream
+# ones touch fields (handle, sendbuf) a BufferStream does not have.
+function closewrite(s::BufferStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # closing is in-memory and immediate: entry gate only
+    precheck_cancel_arg(cancel)
+    close(s)
+end
 
 function close(s::BufferStream)
     lock(s.cond) do
@@ -1553,16 +1953,18 @@ end
 uvfinalize(s::BufferStream) = nothing
 setup_stdio(stream::BufferStream, child_readable::Bool) = invoke(setup_stdio, Tuple{IO, Bool}, stream, child_readable)
 
-function read(s::BufferStream, ::Type{UInt8})
+function read(s::BufferStream, ::Type{UInt8}; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(precheck_cancel_arg(cancel))
     nread = lock(s.cond) do
-        wait_readnb(s, 1)
+        wait_readnb(s, 1, tok)
         read(s.buffer, UInt8)
     end
     return nread
 end
-function unsafe_read(s::BufferStream, a::Ptr{UInt8}, nb::UInt)
+function unsafe_read(s::BufferStream, a::Ptr{UInt8}, nb::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(precheck_cancel_arg(cancel))
     lock(s.cond) do
-        wait_readnb(s, Int(nb))
+        wait_readnb(s, Int(nb), tok)
         unsafe_read(s.buffer, a, nb)
         nothing
     end
@@ -1572,17 +1974,18 @@ bytesavailable(s::BufferStream) = bytesavailable(s.buffer)
 isreadable(s::BufferStream) = (isopen(s) || bytesavailable(s) > 0) && s.buffer.readable
 iswritable(s::BufferStream) = isopen(s) && s.buffer.writable
 
-function wait_readnb(s::BufferStream, nb::Int)
+function wait_readnb(s::BufferStream, nb::Int, tok::MaybeToken=default_cancel_token())
     lock(s.cond) do
         while isopen(s) && bytesavailable(s.buffer) < nb
-            wait(s.cond)
+            wait(s.cond, tok)
         end
     end
 end
 
-function readavailable(this::BufferStream)
+function readavailable(this::BufferStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(precheck_cancel_arg(cancel))
     bytes = lock(this.cond) do
-        wait_readnb(this, 1)
+        wait_readnb(this, 1, tok)
         buf = this.buffer
         @assert buf.seekable == false "buffer should not be seekable"
         take!(buf)
@@ -1590,31 +1993,33 @@ function readavailable(this::BufferStream)
     return bytes
 end
 
-function read(stream::BufferStream)
+function read(stream::BufferStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(precheck_cancel_arg(cancel))
     bytes = lock(stream.cond) do
-        wait_close(stream)
+        wait_close(stream, tok)
         take!(stream.buffer)
     end
     return bytes
 end
 
-function readbytes!(s::BufferStream, a::Vector{UInt8}, nb::Int)
+function readbytes!(s::BufferStream, a::Vector{UInt8}, nb::Int; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(precheck_cancel_arg(cancel))
     sbuf = s.buffer
     @assert sbuf.seekable == false "buffer should not be seekable"
     @assert sbuf.maxsize >= nb "insufficient buffer size"
 
-    function wait_locked(s, buf, nb)
+    function wait_locked(s, buf, nb, tok)
         while bytesavailable(buf) < nb
             s.readerror === nothing || throw(s.readerror)
             isopen(s) || break
             s.status != StatusEOF || break
-            wait_readnb(s, nb)
+            wait_readnb(s, nb, tok)
         end
     end
 
     bytes = lock(s.cond) do
         if nb <= SZ_UNBUFFERED_IO # Under this limit we are OK with copying the array from the stream's buffer
-            wait_locked(s, sbuf, nb)
+            wait_locked(s, sbuf, nb, tok)
         end
         if bytesavailable(sbuf) >= nb
             nread = readbytes!(sbuf, a, nb)
@@ -1624,7 +2029,7 @@ function readbytes!(s::BufferStream, a::Vector{UInt8}, nb::Int)
             nread = try
                 s.buffer = newbuf
                 write(newbuf, sbuf)
-                wait_locked(s, newbuf, nb)
+                wait_locked(s, newbuf, nb, tok)
                 bytesavailable(newbuf)
             finally
                 s.buffer = sbuf
@@ -1639,20 +2044,23 @@ end
 
 show(io::IO, s::BufferStream) = print(io, "BufferStream(bytes waiting=", bytesavailable(s.buffer), ", isopen=", isopen(s), ")")
 
-function readuntil(s::BufferStream, c::UInt8; keep::Bool=false)
+function readuntil(s::BufferStream, c::UInt8; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(precheck_cancel_arg(cancel))
     bytes = lock(s.cond) do
         while isopen(s) && !occursin(c, s.buffer)
-            wait(s.cond)
+            # a cancelled wait unwinds with the buffer intact (nothing has
+            # been consumed until the delimiter is present)
+            wait(s.cond, tok)
         end
         readuntil(s.buffer, c, keep=keep)
     end
     return bytes
 end
 
-function wait_close(s::BufferStream)
+function wait_close(s::BufferStream, tok::MaybeToken=default_cancel_token())
     lock(s.cond) do
         while isopen(s)
-            wait(s.cond)
+            wait(s.cond, tok)
         end
     end
 end
@@ -1661,7 +2069,39 @@ start_reading(s::BufferStream) = Int32(0)
 stop_reading(s::BufferStream) = nothing
 
 write(s::BufferStream, b::UInt8) = write(s, Ref{UInt8}(b))
-function unsafe_write(s::BufferStream, p::Ptr{UInt8}, nb::UInt)
+# BufferStream writes are in-memory: no uv request can outlive the caller, so
+# the LibuvStream method's detached-owner bookkeeping does not apply here.
+function write(s::BufferStream, a::Vector{UInt8}; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # the write itself is in-memory and cannot block for long (the advisory
+    # lock's park runs under the ambient scope): the explicit token only
+    # gates at entry
+    precheck_cancel_arg(cancel)
+    GC.@preserve a begin
+        return Int(unsafe_write(s, pointer(a), UInt(sizeof(a))))
+    end
+end
+# In-memory counterparts of the owner-carrying LibuvStream methods (which
+# must not apply here: they track uv requests and the send buffer).
+function write(s::BufferStream, str::Union{String, SubString{String}};
+               cancel::CancelTokenArg=DEFAULT_CANCEL)
+    precheck_cancel_arg(cancel)
+    GC.@preserve str begin
+        return Int(unsafe_write(s, pointer(str), UInt(sizeof(str))))
+    end
+end
+function write(s::BufferStream, a::Array; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    precheck_cancel_arg(cancel)
+    if isbitstype(eltype(a))
+        GC.@preserve a begin
+            return Int(unsafe_write(s, Ptr{UInt8}(pointer(a)), UInt(sizeof(a))))
+        end
+    end
+    return invoke(write, Tuple{IO, AbstractArray}, s, a)
+end
+function unsafe_write(s::BufferStream, p::Ptr{UInt8}, nb::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # in-memory write, cannot block for long: entry gate only (see the
+    # BufferStream `write` above)
+    precheck_cancel_arg(cancel)
     nwrite = lock(s.cond) do
         check_open(s)
         rv = unsafe_write(s.buffer, p, nb)
@@ -1671,10 +2111,11 @@ function unsafe_write(s::BufferStream, p::Ptr{UInt8}, nb::UInt)
     return nwrite
 end
 
-function eof(s::BufferStream)
+function eof(s::BufferStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    tok = resolve_cancel_token(precheck_cancel_arg(cancel))
     bytesavailable(s) > 0 && return false
     iseof = lock(s.cond) do
-        wait_readnb(s, 1)
+        wait_readnb(s, 1, tok)
         return !isopen(s) && bytesavailable(s) <= 0
     end
     return iseof
@@ -1682,7 +2123,9 @@ end
 
 # If buffer_writes is called, it will delay notifying waiters till a flush is called.
 buffer_writes(s::BufferStream, bufsize=0) = (s.buffer_writes = true; s)
-function flush(s::BufferStream)
+function flush(s::BufferStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # in-memory flush (a notify), nothing to wait for: entry gate only
+    precheck_cancel_arg(cancel)
     lock(s.cond) do
         check_open(s)
         notify(s.cond)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -458,18 +458,47 @@ end
 # Sentinel for a uv request's data field: see above.
 const UV_REQ_DETACHED = Ptr{Cvoid}(UInt(0x1))
 
-# Aux flag on a uv write wait's *witness* slot (the slot whose owner is the
-# stream; its aux is otherwise unused): set, under the iolock, immediately
-# before Julia itself issues `uv_cancel` on a write request it keeps
-# awaiting, so the completion callback can tell a Julia-requested
-# cancellation (UV_ECANCELED is then the expected outcome, delivered as a
-# partial-count wake) from a close-induced one (a real write error - libuv
-# also fails queued writes with UV_ECANCELED when the stream closes).
+# Aux word on a uv write wait's *witness* slot (the slot whose owner is the
+# stream; its aux is otherwise unused). Every reader and writer runs under
+# the iolock, so the packing needs no atomics:
+#
+#   bit  0      - CANCEL_REQUESTED: set immediately before Julia itself
+#                 issues `uv_cancel` on write request(s) it keeps awaiting,
+#                 so the completion callback can tell a Julia-requested
+#                 cancellation (UV_ECANCELED is then the expected outcome,
+#                 delivered as a partial-count wake) from a close-induced
+#                 one (a real write error - libuv also fails queued writes
+#                 with UV_ECANCELED when the stream closes).
+#   bits 8..23  - the negated status of the first real error a chunk of a
+#                 split write completed with (0 = none): a real error must
+#                 win the final wake even when later chunks fail with the
+#                 close-induced UV_ECANCELED cascade.
+#   bits 32..63 - the number of pending completion callbacks of a split
+#                 write. 0 means the wait is on a single request (the
+#                 common case, whose protocol is unchanged); a split write
+#                 counts down here and only the callback that reaches 0
+#                 claims and wakes the waiter.
+#
 # Cleared whenever the slot is released for reuse (_release_slot!/
-# _clear_uv_witness!). The detach path (_end_uvreq_wait!) does not set it:
-# there the request is detached in the same iolock critical section, so no
-# callback can observe a waiter - the flag only matters to waited requests.
+# _clear_uv_witness!). The detach paths do not set the flag: there the
+# requests are detached in the same iolock critical section, so no callback
+# can observe a waiter - the flag only matters to waited requests.
 const _UVREQ_AUX_CANCEL_REQUESTED = UInt64(0x1)
+const _UVREQ_AUX_STATUS_SHIFT = 8
+const _UVREQ_AUX_STATUS_MASK = UInt64(0xffff) << _UVREQ_AUX_STATUS_SHIFT
+const _UVREQ_AUX_PENDING_SHIFT = 32
+
+# The witness slot of a uv-request wait entry: the one whose owner is
+# neither empty nor the cancellation source. Callbacks locate it without
+# knowing the witness object.
+function _uvreq_witness_slot(w::WaitEntry)
+    for (i, slot) in enumerate(slots(w))
+        o = slot.owner
+        (o === nothing || o isa CancellationTokenSource) && continue
+        return i
+    end
+    return 0
+end
 
 function _mark_uvreq_cancel_requested!(w::WaitEntry, @nospecialize(witness))
     i = _find_slot(w, witness)
@@ -484,12 +513,8 @@ function _uvreq_cancel_requested(req::Ptr{Cvoid})
     d = uv_req_data(req)
     (d == C_NULL || d == UV_REQ_DETACHED) && return false
     w = unsafe_pointer_to_objref(d)::WaitEntry
-    for slot in slots(w)
-        o = slot.owner
-        (o === nothing || o isa CancellationTokenSource) && continue
-        return slot.aux & _UVREQ_AUX_CANCEL_REQUESTED != 0
-    end
-    return false
+    i = _uvreq_witness_slot(w)
+    return i != 0 && _slot_aux(w, i) & _UVREQ_AUX_CANCEL_REQUESTED != 0
 end
 
 # Buffers of detached write requests. A detached request keeps referencing
@@ -1334,25 +1359,38 @@ uv_write(s::LibuvStream, p::Vector{UInt8}, cancel::CancelTokenArg=DEFAULT_CANCEL
 # point. The caller must have acquired the iolock, which is released before
 # returning.
 function _uv_write_wait(s::LibuvStream, p::Ptr{UInt8}, n::UInt,
-                        tok::MaybeToken, @nospecialize(owner), partial::Bool)
+                        tok::MaybeToken, @nospecialize(owner), partial::Bool,
+                        chunk::UInt=MAX_OS_WRITE)
     src = cancel_source(tok)
     # entry check: throw before handing anything to libuv
     _iolocked_checkcancel(src)
-    local uvw, lastn
+    local uvw, lastn, others
     try
-        uvw, lastn = uv_write_async(s, p, n)
+        uvw, lastn, others = uv_write_async(s, p, n, chunk)
     catch
         # E.g. the stream was (or gets) closed: release the iolock so that
         # errors propagate without it.
         iolock_end()
         rethrow()
     end
-    # Whether the write went out as a single request: only then may a
-    # cancellation `uv_cancel` it - see _uv_write_cancelled_finish. (The
-    # wait is on the *last* request either way: completion callbacks run in
-    # order unless a request is dequeued by uv_cancel.)
-    single = lastn == n
     w = _begin_uvreq_wait!(src, s, uvw)
+    if others !== nothing
+        # A split write: point every chunk request at the wait entry and
+        # store the pending-callback count on the witness slot's aux (all
+        # under the iolock hold that covers submission, so no callback can
+        # have run yet). Completions count down; only the last claims and
+        # wakes. The waiter owns - and, once all callbacks have run, sums
+        # and frees - every chunk request, which is what makes the total
+        # accepted-byte count exact even when a cancellation sweep
+        # completes the requests out of order.
+        wp = pointer_from_objref(w)
+        for r in others
+            uv_req_set_data(r, wp)
+        end
+        i = _find_slot(w, s)
+        _set_slot_aux!(w, i, _slot_aux(w, i) |
+                       (UInt64(length(others) + 1) << _UVREQ_AUX_PENDING_SHIFT))
+    end
     refused = false
     if src !== nothing
         sw = SourceWait(src, 0x00)
@@ -1368,20 +1406,21 @@ function _uv_write_wait(s::LibuvStream, p::Ptr{UInt8}, n::UInt,
         # observes the cancellation at its next cancellation point.
         iolock_end()
         nwritten = _uv_write_cancelled_finish(s, w, uvw,
-            severity(cancel_severity(src)::CancellationRequest), src, owner, single)
+            severity(cancel_severity(src)::CancellationRequest), src, owner, others)
         # level-triggered: the throw below (and any later cancellation
         # point) reads the current severity
         partial || checkcancel(src)
-        return Int(n - lastn + nwritten)
+        return others === nothing ? Int(n - lastn + nwritten) : Int(nwritten)
     end
     iolock_end()
     local nwritten::Csize_t
     creq = nothing
     try
         sigatomic_end()
-        # wait for the last chunk to complete (or error)
-        # assume that any errors would be sticky,
-        # (so we don't need to monitor the error status of the intermediate writes)
+        # wait for the write to complete (or error): the last request's
+        # callback for a single-request write, the pending count reaching
+        # zero for a split one (whose wake also carries the first real
+        # error of any chunk)
         nwritten = wait()::Csize_t
         sigatomic_begin()
     catch err
@@ -1395,68 +1434,77 @@ function _uv_write_wait(s::LibuvStream, p::Ptr{UInt8}, n::UInt,
             creq = err
         else
             # interrupted by something other than a cancellation (an
-            # interrupter or raw throwto); a split write must not be
-            # uv_cancel'ed on detach (see _uv_write_cancelled_finish)
+            # interrupter or raw throwto): cancel whatever is still
+            # cancellable and detach the rest to the callbacks
             iolock_begin()
-            _end_uvreq_wait!(w, s, uvw, single, owner)
+            if others === nothing
+                _end_uvreq_wait!(w, s, uvw, true, owner)
+            else
+                _end_split_uvreq_wait!(w, s, uvw, others, true, owner)
+            end
             rethrow()
         end
     end
     if creq !== nothing
-        nwritten = _uv_write_cancelled_finish(s, w, uvw, severity(creq), src, owner, single)
+        nwritten = _uv_write_cancelled_finish(s, w, uvw, severity(creq), src, owner, others)
         # the in-flight request is resolved (SAFE: the buffer is provably
         # out of OS hands); deliver the cancellation now unless the caller
         # asked for the partial count
         partial || checkcancel(src::CancellationTokenSource)
     else
         # normal completion (or the wake lost the race to a completion that
-        # ran anyway): the callback handed us the request to free
+        # ran anyway): the callback(s) handed us the request(s) to free
         iolock_begin()
-        _end_uvreq_wait!(w, s, uvw, single, owner)
+        if others === nothing
+            _end_uvreq_wait!(w, s, uvw, true, owner)
+        else
+            nwritten = _end_split_uvreq_wait!(w, s, uvw, others, false, owner)
+        end
     end
-    return Int(n - lastn + nwritten)
+    return others === nothing ? Int(n - lastn + nwritten) : Int(nwritten)
 end
 
-# Resolve the ownership of a cancelled write's uv request and return the
-# last chunk's partial write count (0 when the request had to be detached
-# without awaiting its completion). For SAFE cancellations this awaits the
-# completion callback, so the caller's buffer is provably no longer in use
-# by the OS when this returns; only a severity escalation interrupts that
-# bounded wait. `single` says whether the write went out as one request;
-# only then is the request `uv_cancel`ed. Enters with the iolock released
-# at the sigatomic level of the interrupted wait; unwinds both and the
-# handle preservation.
+# Resolve the ownership of a cancelled write's uv request(s) and return the
+# partial write count: the last chunk's for a single-request write, the
+# exact total of accepted bytes for a split one (0 for whatever had to be
+# detached without awaiting completion). Every in-flight request is
+# `uv_cancel`ed, tail-first for a split write: our chunks sit contiguously
+# in the stream's queue, so cancelling from the tail dequeues behind the
+# still-active head and the wire always keeps a clean prefix. For SAFE
+# cancellations this awaits the completion callback(s), so the caller's
+# buffer is provably no longer in use by the OS when this returns; only a
+# severity escalation interrupts that bounded wait. Enters with the iolock
+# released at the sigatomic level of the interrupted wait; unwinds both and
+# the handle preservation.
 function _uv_write_cancelled_finish(s::LibuvStream, w::WaitEntry, uvw::Ptr{Cvoid},
                                     sev::UInt8, src::CancellationTokenSource,
-                                    @nospecialize(owner), single::Bool)
+                                    @nospecialize(owner),
+                                    others::Union{Nothing, Vector{Ptr{Cvoid}}})
     ct = current_task()
     nwritten::Csize_t = 0
     awaited = false
     iolock_begin()
-    d = uv_req_data(uvw)
-    if d == C_NULL
-        # the completion callback already ran (it lost the wake claim): the
-        # request is ours and knows the count
+    if others === nothing ? uv_req_data(uvw) == C_NULL : _split_complete(uvw, others)
+        # the completion callback(s) already ran (the wake lost its claim
+        # race): the requests are ours and know their counts
         awaited = true
-        nwritten = ccall(:uv_write_nwritten, Csize_t, (Ptr{Cvoid},), uvw)
+        if others === nothing
+            nwritten = ccall(:uv_write_nwritten, Csize_t, (Ptr{Cvoid},), uvw)
+        end
     else
-        # The write is still in flight. Only a write issued as a *single*
-        # request may be asked to cancel: our libuv patch dequeues the
-        # targeted request out of order and completes it with UV_ECANCELED,
-        # so cancelling the last chunk of a split write would say nothing
-        # about the earlier chunks - they could still be queued, still
-        # referencing the buffer, when the "cancelled" callback fires. For
-        # a split write even a SAFE cancellation therefore awaits the last
-        # callback *without* uv_cancel: nothing is dequeued, completion
-        # stays in-order, and the last chunk's callback implies every
-        # earlier chunk is done with the buffer.
-        if single
-            # flag the request as cancelled-by-us first (on the witness
-            # slot's aux, under the iolock), so the completion callback can
-            # tell our UV_ECANCELED from a close-induced one - see
-            # uv_writecb_task
-            _mark_uvreq_cancel_requested!(w, s)
+        # The write is still in flight: flag it as cancelled-by-us first
+        # (on the witness slot's aux, under the iolock), so the completion
+        # callback(s) can tell our UV_ECANCELED from a close-induced one -
+        # see uv_writecb_task - then sweep, tail-first.
+        _mark_uvreq_cancel_requested!(w, s)
+        uv_req_data(uvw) == C_NULL ||
             ccall(:uv_cancel, Cint, (Ptr{Cvoid},), uvw) # ignore any errors
+        if others !== nothing
+            for j in lastindex(others):-1:firstindex(others)
+                r = others[j]
+                uv_req_data(r) == C_NULL ||
+                    ccall(:uv_cancel, Cint, (Ptr{Cvoid},), r) # ignore any errors
+            end
         end
         if sev < severity(CANCEL_REQUEST_ABANDON_EXTERNAL)
             # SAFE cancellation: await the completion callback, so that the
@@ -1479,23 +1527,78 @@ function _uv_write_cancelled_finish(s::LibuvStream, w::WaitEntry, uvw::Ptr{Cvoid
                     # fall through to detach
                 end
                 iolock_begin()
-                if !awaited && uv_req_data(uvw) == C_NULL
-                    # the callback ran anyway (our wake lost a race)
+                if !awaited &&
+                   (others === nothing ? uv_req_data(uvw) == C_NULL :
+                                         _split_complete(uvw, others))
+                    # the callback(s) ran anyway (our wake lost a race)
                     awaited = true
-                    nwritten = ccall(:uv_write_nwritten, Csize_t, (Ptr{Cvoid},), uvw)
+                    if others === nothing
+                        nwritten = ccall(:uv_write_nwritten, Csize_t, (Ptr{Cvoid},), uvw)
+                    end
                 end
             end
             # (a refused registration means the state already escalated)
         end
     end
-    # Not awaited (abandoning severity, or an escalation during teardown):
-    # _end_uvreq_wait! detaches the request - the completion callback frees
-    # it - keeping the written buffer rooted until it does; the last chunk's
-    # count is then unknown and reported as 0. (No re-cancel: for a single
-    # request the uv_cancel above was already issued; a split write must
-    # never be uv_cancel'ed - the detached last chunk completing in order is
-    # what keeps the rooted buffer valid for the earlier chunks.)
-    _end_uvreq_wait!(w, s, uvw, false, owner)
+    # Resolve ownership. Awaited or not, completed requests are ours (a
+    # split write sums their exact counts); anything still in flight - an
+    # abandoning severity, or an escalation during the teardown wait - is
+    # detached for its callback to free, with the written buffer kept
+    # rooted until every detached callback has run; those requests' counts
+    # are unknown and contribute 0. (No re-cancel: the sweep above already
+    # cancelled everything that was in flight.)
+    if others === nothing
+        _end_uvreq_wait!(w, s, uvw, false, owner)
+    else
+        nwritten = _end_split_uvreq_wait!(w, s, uvw, others, false, owner)
+    end
+    return nwritten
+end
+
+# Whether every request of a split write has completed (data == C_NULL).
+function _split_complete(uvw::Ptr{Cvoid}, others::Vector{Ptr{Cvoid}})
+    uv_req_data(uvw) == C_NULL || return false
+    for r in others
+        uv_req_data(r) == C_NULL || return false
+    end
+    return true
+end
+
+# Split-write counterpart of _end_uvreq_wait! (caller holds the iolock, at
+# the sigatomic level of the wait): resolve the ownership of every chunk
+# request and return the total of the completed ones' accepted-byte counts.
+# Completed requests (data == C_NULL) are summed and freed; in-flight ones
+# are detached for their callbacks to free - `uv_cancel`ed first, tail-first
+# (last request first, then earlier chunks in reverse submission order, so
+# the queue keeps a clean prefix), when `trycancel` is set - with `owner`
+# kept rooted under each until its callback runs. Then unwinds the witness,
+# the registration, the iolock, the sigatomic section, and the handle
+# preservation, exactly like _end_uvreq_wait!.
+function _end_split_uvreq_wait!(w::WaitEntry, @nospecialize(witness), uvw::Ptr{Cvoid},
+                                others::Vector{Ptr{Cvoid}}, trycancel::Bool,
+                                @nospecialize(owner))
+    ct = current_task()
+    nwritten::Csize_t = 0
+    for j in (lastindex(others) + 1):-1:firstindex(others)
+        req = j > lastindex(others) ? uvw : others[j]
+        if uv_req_data(req) == C_NULL
+            nwritten += ccall(:uv_write_nwritten, Csize_t, (Ptr{Cvoid},), req)
+            Libc.free(req)
+        else
+            trycancel && ccall(:uv_cancel, Cint, (Ptr{Cvoid},), req) # ignore any errors
+            uv_req_set_data(req, UV_REQ_DETACHED)
+            _root_detached_uvreq!(req, owner)
+        end
+    end
+    _clear_wait_witness!(w, witness)
+    @atomicreplace ct.waiting_on w => nothing
+    # Drop a claimed-and-enqueued wake an interrupted teardown will never
+    # consume (cf. _end_uvreq_wait!).
+    q = ct.queue
+    q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
+    iolock_end()
+    sigatomic_end()
+    unpreserve_handle(ct)
     return nwritten
 end
 
@@ -1522,16 +1625,24 @@ function _uv_write_owned(s::LibuvStream, p::Ptr{UInt8}, n::UInt, cancel::CancelT
     return nb
 end
 
-# helper function for uv_write that returns the uv_write_t struct of the last
-# chunk's write (and that chunk's size) rather than waiting on it, caller must
-# hold the iolock
-function uv_write_async(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
+# helper function for uv_write that submits the write as one request per
+# OS-sized chunk rather than waiting, caller must hold the iolock. Returns
+# the last chunk's uv_write_t, that chunk's size, and - for split writes -
+# the vector of the earlier chunks' requests (nothing for the common
+# single-request case). All requests go out with data C_NULL
+# (fire-and-forget); a waiter that wants completion re-points them at its
+# wait entry under the same iolock hold (see _uv_write_wait).
+function uv_write_async(s::LibuvStream, p::Ptr{UInt8}, n::UInt, chunk::UInt=MAX_OS_WRITE)
     check_open(s)
+    others = nothing
     while true
         uvw = Libc.malloc(_sizeof_uv_write)
         uv_req_set_data(uvw, C_NULL) # in case we get interrupted before arriving at the wait call
-        nwrite = min(n, MAX_OS_WRITE) # split up the write into chunks the OS can handle.
-        # TODO: use writev instead of a loop
+        nwrite = min(n, chunk) # split up the write into chunks the OS can handle.
+        # TODO: use writev instead of a loop (requires libuv to bound the
+        # per-syscall submission: as of now it recombines all bufs of a
+        # request into one writev/WSASend, blowing through the OS limits
+        # this chunking exists to respect)
         err = ccall(:jl_uv_write,
                     Int32,
                     (Ptr{Cvoid}, Ptr{Cvoid}, UInt, Ptr{Cvoid}, Ptr{Cvoid}),
@@ -1544,8 +1655,10 @@ function uv_write_async(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
         n -= nwrite
         p += nwrite
         if n == 0
-            return uvw, nwrite
+            return uvw, nwrite, others
         end
+        others === nothing && (others = Ptr{Cvoid}[])
+        push!(others::Vector{Ptr{Cvoid}}, uvw)
     end
 end
 
@@ -1742,6 +1855,38 @@ function write(s::LibuvStream, b::UInt8)
 end
 
 function uv_writecb_task(req::Ptr{Cvoid}, status::Cint)
+    # A chunk of a waited *split* write counts down on the witness slot's
+    # aux instead of waking: the waiter owns (and later frees) every chunk
+    # request, so the callback only records completion (data = C_NULL) and
+    # any first real error; the callback that brings the count to 0 falls
+    # through to the ordinary claim-and-wake below.
+    d = uv_req_data(req)
+    if d != C_NULL && d != UV_REQ_DETACHED
+        w = unsafe_pointer_to_objref(d)::WaitEntry
+        i = _uvreq_witness_slot(w)
+        if i != 0
+            aux = _slot_aux(w, i)
+            pending = aux >> _UVREQ_AUX_PENDING_SHIFT
+            if pending > 1
+                uv_req_set_data(req, C_NULL)
+                if status != 0 &&
+                   !(status == UV_ECANCELED && aux & _UVREQ_AUX_CANCEL_REQUESTED != 0) &&
+                   aux & _UVREQ_AUX_STATUS_MASK == 0
+                    aux |= (UInt64(-status) << _UVREQ_AUX_STATUS_SHIFT) & _UVREQ_AUX_STATUS_MASK
+                end
+                _set_slot_aux!(w, i, (aux & ~(typemax(UInt64) << _UVREQ_AUX_PENDING_SHIFT)) |
+                                     ((pending - 1) << _UVREQ_AUX_PENDING_SHIFT))
+                return nothing
+            end
+            # pending == 1: final chunk of a split write - a real error
+            # recorded by an earlier chunk must win the wake even if this
+            # chunk itself completed cleanly (or with the expected
+            # UV_ECANCELED of a cancellation sweep)
+            if pending == 1 && aux & _UVREQ_AUX_STATUS_MASK != 0
+                status = Cint(-((aux & _UVREQ_AUX_STATUS_MASK) >> _UVREQ_AUX_STATUS_SHIFT))
+            end
+        end
+    end
     # An expected-by-the-waiter UV_ECANCELED must be read off the entry
     # before the claim below releases the witness slot.
     cancel_requested = status == UV_ECANCELED && _uvreq_cancel_requested(req)
@@ -1749,7 +1894,8 @@ function uv_writecb_task(req::Ptr{Cvoid}, status::Cint)
     if t !== nothing
         if status == 0 || cancel_requested
             # For writes cancelled by the waiter, this is the partial write
-            # count.
+            # count. (For a split write the value is ignored: the waiter
+            # recomputes the total from the chunk requests it owns.)
             schedule(t, ccall(:uv_write_nwritten, Csize_t, (Ptr{Cvoid},), req))
         else
             # A real error - including a close-induced UV_ECANCELED (libuv

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -621,9 +621,14 @@ function _wait_uvreq(src::Union{Nothing, CancellationTokenSource}, @nospecialize
     ct = current_task()
     uvw = UvReqWait(req, witness, owner, trycancel)
     if src === nothing
-        return park!((uvw,), _cached_wait_entry(ct), true, false)
+        return park!((uvw,), _cached_wait_entry(ct), true, false, true)
     else
-        return park!((uvw, SourceWait(src, 0x00)), _cancel_wait_entry(ct, src, 0x00), true, false)
+        r = park!((uvw, SourceWait(src, 0x00)), _cancel_wait_entry(ct, src, 0x00),
+                  true, false, true)
+        # a fired source recheck resolved the request (the dequeue ran)
+        # and returned `nothing`: deliver the refusal
+        r === nothing && checkcancel(src)
+        return r
     end
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1304,11 +1304,19 @@ function _uv_write_wait(s::LibuvStream, p::Ptr{UInt8}, n::UInt,
     # order unless a request is dequeued by uv_cancel.)
     single = lastn == n
     w = _begin_uvreq_wait!(src, s, uvw)
-    if src !== nothing && !register_cancellation!(src, w)
-        # The token was cancelled since the entry check and the wake was
-        # claimed back for us: don't park. Resolve the in-flight write and
-        # report the bytes that reached the OS; the caller observes the
-        # cancellation at its next cancellation point.
+    refused = false
+    if src !== nothing
+        sw = SourceWait(src, 0x00)
+        wait_enqueue!(sw, w, false)
+        # a lost self-claim means a concurrent walk claimed the freshly
+        # armed entry: its wake delivers the request into the park below
+        refused = wait_recheck(sw, w) && disarm!(current_task(), w)
+    end
+    if refused
+        # The token was cancelled since the entry check and the recheck's
+        # self-claim won the wake back: don't park. Resolve the in-flight
+        # write and report the bytes that reached the OS; the caller
+        # observes the cancellation at its next cancellation point.
         iolock_end()
         nwritten = _uv_write_cancelled_finish(s, w, uvw,
             severity(cancel_severity(src)::CancellationRequest), src, owner, single)
@@ -1409,8 +1417,10 @@ function _uv_write_cancelled_finish(s::LibuvStream, w::WaitEntry, uvw::Ptr{Cvoid
             # the (still registered) entry - the re-park needs no new
             # registration.
             slots(w)[_find_slot(w, src)].aux = UInt64(sev + 0x01)
+            sw = SourceWait(src, UInt8(sev + 0x01))
             _arm_wait(ct, w)
-            if register_cancellation!(src, w)
+            wait_enqueue!(sw, w, false)  # sticky: the seq_cst re-arm fence
+            if !(wait_recheck(sw, w) && disarm!(ct, w))
                 iolock_end()
                 try
                     nwritten = wait()::Csize_t

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -580,19 +580,19 @@ struct UvReqWait
 end
 
 function wait_enqueue!(x::UvReqWait, w::WaitEntry, first::Bool)
-    ct = current_task()
     _set_wait_witness!(w, x.witness)
-    preserve_handle(ct)
-    sigatomic_begin()
     uv_req_set_data(x.req, pointer_from_objref(w))
     return true
 end
 
-wait_release!(x::UvReqWait) = (iolock_end(); sigatomic_end(); nothing)
-wait_reacquire!(x::UvReqWait, token) = (sigatomic_begin(); iolock_begin(); nothing)
-
+# Resolve the request's ownership and release the witness. On
+# WAKE_VALUE/WAKE_FIRED the caller holds the iolock (the settle and the
+# refusal both run under it); the cleanup why takes it itself. The
+# iolock/sigatomic/handle-preservation choreography around the park is
+# the site's own code (_wait_uvreq, _uv_write_wait).
 function wait_dequeue!(x::UvReqWait, w::WaitEntry, why::UInt8)
-    ct = current_task()
+    selflock = why == WAKE_INTERRUPTED || why == WAKE_WITHDRAWN
+    selflock && iolock_begin()
     req = x.req
     if uv_req_data(req) == C_NULL
         Libc.free(req)
@@ -602,9 +602,7 @@ function wait_dequeue!(x::UvReqWait, w::WaitEntry, why::UInt8)
         _root_detached_uvreq!(req, x.owner)
     end
     _clear_wait_witness!(w, x.witness)
-    iolock_end()
-    sigatomic_end()
-    unpreserve_handle(ct)
+    selflock && iolock_end()
     return nothing
 end
 
@@ -621,15 +619,42 @@ function _wait_uvreq(src::Union{Nothing, CancellationTokenSource}, @nospecialize
     ct = current_task()
     uvw = UvReqWait(req, witness, owner, trycancel)
     if src === nothing
-        return park!((uvw,), _cached_wait_entry(ct), true, false, true)
+        ws = (uvw,)
+        w = _cached_wait_entry(ct)
     else
-        r = park!((uvw, SourceWait(src, 0x00)), _cancel_wait_entry(ct, src, 0x00),
-                  true, false, true)
-        # a fired source recheck resolved the request (the dequeue ran)
-        # and returned `nothing`: deliver the refusal
-        r === nothing && checkcancel(src)
-        return r
+        ws = (uvw, SourceWait(src, 0x00))
+        w = _cancel_wait_entry(ct, src, 0x00)
     end
+    preserve_handle(ct)
+    sigatomic_begin()
+    if !park!(ws, w, false)
+        # refused at the registration recheck: resolve the request under
+        # the still-held iolock, unwind the brackets, deliver
+        withdraw!(ws, w, WAKE_FIRED)
+        iolock_end()
+        sigatomic_end()
+        unpreserve_handle(ct)
+        checkcancel(src)
+        error("park fired without a cancelled source")
+    end
+    iolock_end()
+    sigatomic_end()
+    local r
+    try
+        r = wait_safe_interrupt(ws, w)
+    catch
+        # (the catch restored the sigatomic level from the try entry; the
+        # cleanup's dequeue resolved the request under its own iolock)
+        unpreserve_handle(ct)
+        rethrow()
+    end
+    sigatomic_begin()
+    iolock_begin()
+    withdraw!(ws, w, WAKE_VALUE)   # resolve the request under the iolock
+    iolock_end()
+    sigatomic_end()
+    unpreserve_handle(ct)
+    return r
 end
 
 # Completion-callback side of the wait (runs under the iolock): resolve

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1271,15 +1271,21 @@ function copyuntil(out::IO, x::LibuvStream, c::UInt8; keep::Bool=false, cancel::
     return out
 end
 
-uv_write(s::LibuvStream, p::Vector{UInt8}, cancel::CancelTokenArg=DEFAULT_CANCEL) =
-    GC.@preserve p _uv_write_owned(s, pointer(p), UInt(sizeof(p)), cancel, p)
+uv_write(s::LibuvStream, p::Vector{UInt8}, cancel::CancelTokenArg=DEFAULT_CANCEL,
+         partial::Bool=false) =
+    GC.@preserve p _uv_write_owned(s, pointer(p), UInt(sizeof(p)), cancel, p, partial)
 
 # Issue the write and wait for its completion, delivering a cancellation of
-# `tok` by interrupting the wait (the caller adds the post-write cancellation
-# point that turns a cancelled-but-completed write into a throw). The caller
-# must have acquired the iolock, which is released before returning.
+# `tok` by interrupting the wait. A cancelled wait first resolves the
+# in-flight request per the severity (SAFE awaits the completion callback,
+# so the buffer is provably out of OS hands); then, with `partial` unset,
+# the CancellationRequest is thrown - bytes already accepted stay written -
+# and with `partial` set the count of accepted bytes is returned and the
+# (level-triggered) cancellation is left to the caller's next cancellation
+# point. The caller must have acquired the iolock, which is released before
+# returning.
 function _uv_write_wait(s::LibuvStream, p::Ptr{UInt8}, n::UInt,
-                        tok::MaybeToken, @nospecialize(owner))
+                        tok::MaybeToken, @nospecialize(owner), partial::Bool)
     src = cancel_source(tok)
     # entry check: throw before handing anything to libuv
     _iolocked_checkcancel(src)
@@ -1306,6 +1312,9 @@ function _uv_write_wait(s::LibuvStream, p::Ptr{UInt8}, n::UInt,
         iolock_end()
         nwritten = _uv_write_cancelled_finish(s, w, uvw,
             severity(cancel_severity(src)::CancellationRequest), src, owner, single)
+        # level-triggered: the throw below (and any later cancellation
+        # point) reads the current severity
+        partial || checkcancel(src)
         return Int(n - lastn + nwritten)
     end
     iolock_end()
@@ -1338,6 +1347,10 @@ function _uv_write_wait(s::LibuvStream, p::Ptr{UInt8}, n::UInt,
     end
     if creq !== nothing
         nwritten = _uv_write_cancelled_finish(s, w, uvw, severity(creq), src, owner, single)
+        # the in-flight request is resolved (SAFE: the buffer is provably
+        # out of OS hands); deliver the cancellation now unless the caller
+        # asked for the partial count
+        partial || checkcancel(src::CancellationTokenSource)
     else
         # normal completion (or the wake lost the race to a completion that
         # ran anyway): the callback handed us the request to free
@@ -1429,23 +1442,24 @@ end
 
 function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL,
                   owner=nothing)
-    return _uv_write_owned(s, p, n, cancel, owner)
+    return _uv_write_owned(s, p, n, cancel, owner, false)
 end
 
 # Positional core of uv_write: an `owner::Any` keyword call is not statically
 # resolvable (the NamedTuple type is abstract), which breaks trimmed builds.
 function _uv_write_owned(s::LibuvStream, p::Ptr{UInt8}, n::UInt, cancel::CancelTokenArg,
-                         @nospecialize(owner))
+                         @nospecialize(owner), partial::Bool)
     tok = resolve_cancel_token(cancel)
     # branch on the token explicitly: a Union-typed `tok` alongside the
     # deliberately unspecialized `owner` leaves the callee unresolvable
     # for trimmed builds
-    nb = tok === nothing ? _uv_write_wait(s, p, n, nothing, owner) :
-                           _uv_write_wait(s, p, n, tok, owner)
-    # nb < n means the wait was cancelled: the write reports the partial
-    # count (like a short write) and the cancellation itself is delivered at
-    # the caller's next cancellation point - level-triggered, nothing is
-    # lost by returning normally here.
+    nb = tok === nothing ? _uv_write_wait(s, p, n, nothing, owner, partial) :
+                           _uv_write_wait(s, p, n, tok, owner, partial)
+    # With `partial` set, nb < n means the wait was cancelled: the write
+    # reports the count of accepted bytes (like a short write) and the
+    # cancellation itself is delivered at the caller's next cancellation
+    # point - level-triggered, nothing is lost by returning normally here.
+    # Without it, a cancelled wait has already thrown.
     return nb
 end
 
@@ -1487,7 +1501,14 @@ function write(s::LibuvStream, a::Vector{UInt8}; cancel::CancelTokenArg=DEFAULT_
     # owner so a detached (abandoned) write keeps it rooted; see
     # _detached_uvreq_roots.
     GC.@preserve a begin
-        return Int(_unsafe_write_owned(s, pointer(a), UInt(sizeof(a)), cancel, a))
+        return Int(_unsafe_write_owned(s, pointer(a), UInt(sizeof(a)), cancel, a, false))
+    end
+end
+
+function writepartial(s::LibuvStream, a::Vector{UInt8}; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
+    GC.@preserve a begin
+        return Int(_unsafe_write_owned(s, pointer(a), UInt(sizeof(a)), cancel, a, true))
     end
 end
 
@@ -1500,7 +1521,15 @@ function write(s::LibuvStream, str::Union{String, SubString{String}};
                cancel::CancelTokenArg=DEFAULT_CANCEL)
     cancel = precheck_cancel_arg(cancel)
     GC.@preserve str begin
-        return Int(_unsafe_write_owned(s, pointer(str), UInt(sizeof(str)), cancel, str))
+        return Int(_unsafe_write_owned(s, pointer(str), UInt(sizeof(str)), cancel, str, false))
+    end
+end
+
+function writepartial(s::LibuvStream, str::Union{String, SubString{String}};
+                      cancel::CancelTokenArg=DEFAULT_CANCEL)
+    cancel = precheck_cancel_arg(cancel)
+    GC.@preserve str begin
+        return Int(_unsafe_write_owned(s, pointer(str), UInt(sizeof(str)), cancel, str, true))
     end
 end
 
@@ -1511,7 +1540,17 @@ function write(s::LibuvStream, a::Array; cancel::CancelTokenArg=DEFAULT_CANCEL)
     if isbitstype(eltype(a))
         cancel = precheck_cancel_arg(cancel)
         GC.@preserve a begin
-            return Int(_unsafe_write_owned(s, Ptr{UInt8}(pointer(a)), UInt(sizeof(a)), cancel, a))
+            return Int(_unsafe_write_owned(s, Ptr{UInt8}(pointer(a)), UInt(sizeof(a)), cancel, a, false))
+        end
+    end
+    return invoke(write, Tuple{IO, AbstractArray}, s, a; cancel)
+end
+
+function writepartial(s::LibuvStream, a::Array; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    if isbitstype(eltype(a))
+        cancel = precheck_cancel_arg(cancel)
+        GC.@preserve a begin
+            return Int(_unsafe_write_owned(s, Ptr{UInt8}(pointer(a)), UInt(sizeof(a)), cancel, a, true))
         end
     end
     return invoke(write, Tuple{IO, AbstractArray}, s, a; cancel)
@@ -1525,11 +1564,11 @@ end
 # have this hazard and are what the public `write` paths use.
 function unsafe_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL)
     cancel = precheck_cancel_arg(cancel)
-    return _unsafe_write_owned(s, p, n, cancel, nothing)
+    return _unsafe_write_owned(s, p, n, cancel, nothing, false)
 end
 
 function _unsafe_write_owned(s::LibuvStream, p::Ptr{UInt8}, n::UInt, cancel::CancelTokenArg,
-                             @nospecialize(owner))
+                             @nospecialize(owner), partial::Bool)
     while true
         # try to add to the send buffer
         iolock_begin()
@@ -1544,15 +1583,21 @@ function _unsafe_write_owned(s::LibuvStream, p::Ptr{UInt8}, n::UInt, cancel::Can
         bytesavailable(buf) == 0 && break
         # perform flush(s)
         arr = take!(buf)
-        nb = uv_write(s, arr, cancel)
-        # a cancelled flush-write returns short: splice the unwritten tail
-        # back (ahead of concurrent appends) so no buffered byte is lost -
-        # the next iteration's write delivers the (level-triggered)
-        # cancellation at its entry check
-        nb < length(arr) && _requeue_unwritten!(s, arr, nb)
+        nb = uv_write(s, arr, cancel, true)
+        if nb < length(arr)
+            # a cancelled flush-write returns short: splice the unwritten
+            # tail back (ahead of concurrent appends) so no buffered byte
+            # is lost, then deliver - or, for the partial form, let the
+            # next iteration's entry check deliver (level-triggered)
+            _requeue_unwritten!(s, arr, nb)
+            if !partial
+                tok = resolve_cancel_token(cancel)
+                tok === nothing || checkcancel(tok.source)
+            end
+        end
     end
     # perform the output to the kernel
-    return _uv_write_owned(s, p, n, cancel, owner)
+    return _uv_write_owned(s, p, n, cancel, owner, partial)
 end
 
 # Splice the unwritten tail of a cancelled buffered-flush write back to the
@@ -1572,11 +1617,10 @@ function _requeue_unwritten!(s::LibuvStream, arr::Vector{UInt8}, nwritten::Int)
     return nothing
 end
 
-# Cancellation contract of flush: a cancellation interrupts the wait, but
-# never silently discards data - buffered bytes that did not reach the
-# stream are put back in the send buffer, the partial state is left
-# consistent, and the CancellationRequest itself is delivered at the
-# caller's next cancellation point (delivery is level-triggered).
+# Cancellation contract of flush: a cancellation interrupts the wait and
+# throws, but never silently discards data - buffered bytes that did not
+# reach the stream are put back in the send buffer (a later flush retries
+# them) and the partial state is left consistent.
 function flush(s::LibuvStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
     cancel = precheck_cancel_arg(cancel)
     iolock_begin()
@@ -1584,9 +1628,15 @@ function flush(s::LibuvStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
     if buf !== nothing
         if bytesavailable(buf) > 0
             arr = take!(buf)
-            nb = uv_write(s, arr, cancel)
-            # cancelled short: requeue the unwritten tail rather than drop it
-            nb < length(arr) && _requeue_unwritten!(s, arr, nb)
+            nb = uv_write(s, arr, cancel, true)
+            if nb < length(arr)
+                # cancelled short: requeue the unwritten tail rather than
+                # drop it - it stays buffered for a later flush - then
+                # deliver the cancellation
+                _requeue_unwritten!(s, arr, nb)
+                tok = resolve_cancel_token(cancel)
+                tok === nothing || checkcancel(tok.source)
+            end
             return
         end
     end
@@ -1595,7 +1645,7 @@ function flush(s::LibuvStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
     # errors to their writers, and the peer closing the stream after a
     # completed exchange must not make flush throw
     try
-        _uv_write_owned(s, Ptr{UInt8}(Base.eventloop()), UInt(0), cancel, nothing)
+        _uv_write_owned(s, Ptr{UInt8}(Base.eventloop()), UInt(0), cancel, nothing, false)
     catch ex
         ex isa IOError || rethrow()
     end
@@ -1628,7 +1678,7 @@ function write(s::LibuvStream, b::UInt8)
     # in-flight request, which must keep the byte's storage rooted
     r = Ref{UInt8}(b)
     GC.@preserve r begin
-        return Int(_unsafe_write_owned(s, unsafe_convert(Ptr{UInt8}, r), UInt(1), DEFAULT_CANCEL, r))
+        return Int(_unsafe_write_owned(s, unsafe_convert(Ptr{UInt8}, r), UInt(1), DEFAULT_CANCEL, r, false))
     end
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -403,6 +403,7 @@ function wait_readnb(x::LibuvStream, nb::Int, tok::MaybeToken=default_cancel_tok
     oldthrottle = x.throttle
     preserve_handle(x)
     lock(x.cond)
+    locked = true
     try
         while bytesavailable(x.buffer) < nb
             x.readerror === nothing || throw(x.readerror)
@@ -411,12 +412,20 @@ function wait_readnb(x::LibuvStream, nb::Int, tok::MaybeToken=default_cancel_tok
             x.throttle = max(nb, x.throttle)
             start_reading(x) # ensure we are reading
             iolock_end()
+            locked = false
             wait(x.cond, tok)
+            locked = true
             unlock(x.cond)
+            locked = false
             iolock_begin()
             lock(x.cond)
+            locked = true
         end
     finally
+        # the teardown reads the waiter queue and the throttle under the
+        # cond lock: reacquire when a wait-throw released this frame's
+        # level (a spin lock; stop_reading takes the iolock itself)
+        locked || lock(x.cond)
         if isempty(x.cond)
             stop_reading(x) # stop reading iff there are currently no other read clients of the stream
         end
@@ -717,15 +726,18 @@ end
 function wait_close(x::Union{LibuvStream, LibuvServer})
     preserve_handle(x)
     lock(x.cond)
+    locked = true
     try
         while isopen(x)
             # close is the cleanup primitive: its completion wait is shielded
             # from cancellation (completion depends only on the event loop,
             # not on any peer, so this wait is bounded)
+            locked = false
             wait(x.cond, nothing)
+            locked = true
         end
     finally
-        unlock(x.cond)
+        locked && unlock(x.cond)
         unpreserve_handle(x)
     end
     nothing
@@ -1273,6 +1285,7 @@ function copyuntil(out::IO, x::LibuvStream, c::UInt8; keep::Bool=false, cancel::
         if isopen(x) && x.status != StatusEOF
             preserve_handle(x)
             lock(x.cond)
+            locked = true
             try
                 while !occursin(c, x.buffer)
                     x.readerror === nothing || throw(x.readerror)
@@ -1280,12 +1293,18 @@ function copyuntil(out::IO, x::LibuvStream, c::UInt8; keep::Bool=false, cancel::
                     x.status != StatusEOF || break
                     start_reading(x) # ensure we are reading
                     iolock_end()
+                    locked = false
                     wait(x.cond, tok)
+                    locked = true
                     unlock(x.cond)
+                    locked = false
                     iolock_begin()
                     lock(x.cond)
+                    locked = true
                 end
             finally
+                # see wait_readnb's teardown note
+                locked || lock(x.cond)
                 if isempty(x.cond)
                     stop_reading(x) # stop reading iff there are currently no other read clients of the stream
                 end
@@ -2096,11 +2115,18 @@ isreadable(s::BufferStream) = (isopen(s) || bytesavailable(s) > 0) && s.buffer.r
 iswritable(s::BufferStream) = isopen(s) && s.buffer.writable
 
 function wait_readnb(s::BufferStream, nb::Int, tok::MaybeToken=default_cancel_token())
-    lock(s.cond) do
+    lock(s.cond)
+    locked = true
+    try
         while isopen(s) && bytesavailable(s.buffer) < nb
+            locked = false
             wait(s.cond, tok)
+            locked = true
         end
+    finally
+        locked && unlock(s.cond)
     end
+    nothing
 end
 
 function readavailable(this::BufferStream; cancel::CancelTokenArg=DEFAULT_CANCEL)
@@ -2167,23 +2193,36 @@ show(io::IO, s::BufferStream) = print(io, "BufferStream(bytes waiting=", bytesav
 
 function readuntil(s::BufferStream, c::UInt8; keep::Bool=false, cancel::CancelTokenArg=DEFAULT_CANCEL)
     tok = resolve_cancel_token(precheck_cancel_arg(cancel))
-    bytes = lock(s.cond) do
+    lock(s.cond)
+    locked = true
+    bytes = try
         while isopen(s) && !occursin(c, s.buffer)
             # a cancelled wait unwinds with the buffer intact (nothing has
             # been consumed until the delimiter is present)
+            locked = false
             wait(s.cond, tok)
+            locked = true
         end
         readuntil(s.buffer, c, keep=keep)
+    finally
+        locked && unlock(s.cond)
     end
     return bytes
 end
 
 function wait_close(s::BufferStream, tok::MaybeToken=default_cancel_token())
-    lock(s.cond) do
+    lock(s.cond)
+    locked = true
+    try
         while isopen(s)
+            locked = false
             wait(s.cond, tok)
+            locked = true
         end
+    finally
+        locked && unlock(s.cond)
     end
+    nothing
 end
 
 start_reading(s::BufferStream) = Int32(0)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -554,9 +554,54 @@ function _end_uvreq_wait!(w::WaitEntry, @nospecialize(witness), req::Ptr{Cvoid},
     # Drop a claimed-and-enqueued wake an interrupted teardown will never
     # consume. The completion callback claims and schedules under the
     # iolock this function holds, so the drop is deterministic here (cf.
-    # step 4 of _interrupted_wait_cleanup).
+    # the interrupted cleanup in base/park.jl).
     q = ct.queue
     q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
+    iolock_end()
+    sigatomic_end()
+    unpreserve_handle(ct)
+    return nothing
+end
+
+## An in-flight libuv request as a waitable (see base/park.jl): the
+## held-resource kind. The caller issues the request under the iolock and
+## keeps it held into `park!` - the completion callback runs under that
+## same lock, so the recheck is vacuous - and the request's data pointer
+## doubles as the completion/detach handshake: the dequeue resolves its
+## ownership on every exit path (callback already ran => we free it;
+## otherwise it is detached to the callback, `uv_cancel`ed when
+## requested, with the write's buffer kept rooted until then). The
+## dequeue also consumes the reacquired iolock/sigatomic bracket.
+struct UvReqWait
+    req::Ptr{Cvoid}
+    witness::Any      # the waitee identity (the handle, or the request)
+    owner::Any        # buffer root for a detached request
+    trycancel::Bool
+end
+
+function wait_enqueue!(x::UvReqWait, w::WaitEntry, first::Bool)
+    ct = current_task()
+    _set_wait_witness!(w, x.witness)
+    preserve_handle(ct)
+    sigatomic_begin()
+    uv_req_set_data(x.req, pointer_from_objref(w))
+    return true
+end
+
+wait_release!(x::UvReqWait) = (iolock_end(); sigatomic_end(); nothing)
+wait_reacquire!(x::UvReqWait, token) = (sigatomic_begin(); iolock_begin(); nothing)
+
+function wait_dequeue!(x::UvReqWait, w::WaitEntry, why::UInt8)
+    ct = current_task()
+    req = x.req
+    if uv_req_data(req) == C_NULL
+        Libc.free(req)
+    else
+        x.trycancel && ccall(:uv_cancel, Cint, (Ptr{Cvoid},), req) # ignore any errors
+        uv_req_set_data(req, UV_REQ_DETACHED)
+        _root_detached_uvreq!(req, x.owner)
+    end
+    _clear_wait_witness!(w, x.witness)
     iolock_end()
     sigatomic_end()
     unpreserve_handle(ct)
@@ -567,33 +612,19 @@ end
 # its completion callback delivers. A cancellation of `src` interrupts the
 # wait and throws the CancellationRequest - without parking at all when
 # `src` got cancelled between the caller's entry check and the registration
-# here; either way the request is left to its callback (see
-# _end_uvreq_wait!). The caller must have issued `req` under the still-held
-# iolock - so the callback cannot have run yet - and gets it back with the
-# iolock released.
+# here; either way the request is left to its callback (see the dequeue
+# above). The caller must have issued `req` under the still-held iolock -
+# so the callback cannot have run yet - and gets it back with the iolock
+# released.
 function _wait_uvreq(src::Union{Nothing, CancellationTokenSource}, @nospecialize(witness),
                      req::Ptr{Cvoid}, trycancel::Bool, @nospecialize(owner))
-    w = _begin_uvreq_wait!(src, witness, req)
-    if src !== nothing && !register_cancellation!(src, w)
-        # the wake was claimed back for us: don't park
-        _end_uvreq_wait!(w, witness, req, trycancel, owner)
-        _deliver_refused_cancellation(src)
+    ct = current_task()
+    uvw = UvReqWait(req, witness, owner, trycancel)
+    if src === nothing
+        return park!((uvw,), _cached_wait_entry(ct), true, false)
+    else
+        return park!((uvw, SourceWait(src, 0x00)), _cancel_wait_entry(ct, src, 0x00), true, false)
     end
-    iolock_end()
-    local r
-    try
-        sigatomic_end()
-        r = wait()
-        sigatomic_begin()
-    catch
-        # (catch restored the sigatomic level from the try entry)
-        iolock_begin()
-        _end_uvreq_wait!(w, witness, req, trycancel, owner)
-        rethrow()
-    end
-    iolock_begin()
-    _end_uvreq_wait!(w, witness, req, trycancel, owner)
-    return r
 end
 
 # Completion-callback side of the wait (runs under the iolock): resolve

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -475,9 +475,8 @@ const UV_REQ_DETACHED = Ptr{Cvoid}(UInt(0x1))
 #                 close-induced UV_ECANCELED cascade.
 #   bits 32..63 - the number of pending completion callbacks of a split
 #                 write. 0 means the wait is on a single request (the
-#                 common case, whose protocol is unchanged); a split write
-#                 counts down here and only the callback that reaches 0
-#                 claims and wakes the waiter.
+#                 common case); a split write counts down here and only
+#                 the callback that reaches 0 claims and wakes the waiter.
 #
 # Cleared whenever the slot is released for reuse (_release_slot!/
 # _clear_uv_witness!). The detach paths do not set the flag: there the
@@ -2375,19 +2374,17 @@ start_reading(s::BufferStream) = Int32(0)
 stop_reading(s::BufferStream) = nothing
 
 write(s::BufferStream, b::UInt8) = write(s, Ref{UInt8}(b))
-# BufferStream writes are in-memory: no uv request can outlive the caller, so
-# the LibuvStream method's detached-owner bookkeeping does not apply here.
+# BufferStream counterparts of the owner-carrying LibuvStream write
+# methods, which must not apply here (they track uv requests and the send
+# buffer; a BufferStream write is in-memory, so no request can outlive the
+# caller). These writes cannot block for long (the advisory lock's park
+# runs under the ambient scope): an explicit token gates at entry only.
 function write(s::BufferStream, a::Vector{UInt8}; cancel::CancelTokenArg=DEFAULT_CANCEL)
-    # the write itself is in-memory and cannot block for long (the advisory
-    # lock's park runs under the ambient scope): the explicit token only
-    # gates at entry
     precheck_cancel_arg(cancel)
     GC.@preserve a begin
         return Int(unsafe_write(s, pointer(a), UInt(sizeof(a))))
     end
 end
-# In-memory counterparts of the owner-carrying LibuvStream methods (which
-# must not apply here: they track uv requests and the send buffer).
 function write(s::BufferStream, str::Union{String, SubString{String}};
                cancel::CancelTokenArg=DEFAULT_CANCEL)
     precheck_cancel_arg(cancel)
@@ -2405,8 +2402,7 @@ function write(s::BufferStream, a::Array; cancel::CancelTokenArg=DEFAULT_CANCEL)
     return invoke(write, Tuple{IO, AbstractArray}, s, a)
 end
 function unsafe_write(s::BufferStream, p::Ptr{UInt8}, nb::UInt; cancel::CancelTokenArg=DEFAULT_CANCEL)
-    # in-memory write, cannot block for long: entry gate only (see the
-    # BufferStream `write` above)
+    # entry gate only (see the BufferStream `write` methods above)
     precheck_cancel_arg(cancel)
     nwrite = lock(s.cond) do
         check_open(s)

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -234,8 +234,13 @@ function show(
 end
 
 # optimized methods to avoid iterating over chars
-write(io::IO, s::Union{String,SubString{String}}) =
-    GC.@preserve s (unsafe_write(io, pointer(s), reinterpret(UInt, sizeof(s))) % Int)::Int
+# (an explicit token is forwarded to unsafe_write, whose cancellable methods
+# accept it; the default sentinel keeps the plain call, which any IO's
+# unsafe_write method supports)
+write(io::IO, s::Union{String,SubString{String}}; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    cancel === DEFAULT_CANCEL ?
+        GC.@preserve(s, (unsafe_write(io, pointer(s), reinterpret(UInt, sizeof(s))) % Int)::Int) :
+        GC.@preserve(s, (unsafe_write(io, pointer(s), reinterpret(UInt, sizeof(s)); cancel) % Int)::Int)
 print(io::IO, s::Union{String,SubString{String}}) = (write(io, s); nothing)
 
 """

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -65,6 +65,20 @@ function summarysize(obj;
             # parent links, enumerated here rather than via the layout
             nf = Int(x.nparents)
             val = _cancel_parent(x, i)
+        elseif isa(x, Core.WaitEntryN)
+            # `task` plus the (strong) owner/next pair of each hidden
+            # trailing wait slot
+            ns = _nslots(x)
+            nf = 1 + 2 * ns
+            if i == 1
+                t = @atomic :monotonic x.task
+                t === nothing || (val = t)
+            else
+                si, k = divrem(i - 2, 2)
+                slot = slots(x)[si + 1]
+                v = k == 0 ? slot.owner : slot.next
+                v === nothing || (val = v)
+            end
         elseif isa(x, GenericMemory)
             T = eltype(x)
             if allocatedinline(T)
@@ -219,6 +233,17 @@ function (ss::SummarySize)(obj::Core.CancellationTokenSource)
         push!(ss.frontier_x, obj)
         push!(ss.frontier_i, 1)
     end
+    return ss.count ? 1 : Core.sizeof(obj)
+end
+
+function (ss::SummarySize)(obj::Core.WaitEntryN)
+    key = pointer_from_objref(obj)
+    haskey(ss.seen, key) ? (return 0) : (ss.seen[key] = true)
+    # Variable-sized: Core.sizeof includes the trailing wait slots, whose
+    # strong owner/next references (invisible to the layout) are traversed
+    # through the iterative frontier alongside `task`.
+    push!(ss.frontier_x, obj)
+    push!(ss.frontier_i, 1)
     return ss.count ? 1 : Core.sizeof(obj)
 end
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -446,6 +446,51 @@ function collect_tasks(waiting_tasks)
     return tasks
 end
 
+## Task completion as a waitable (see base/park.jl): a one-shot predicate
+## kind - enqueue declines when the task is already done (its only notify
+## has fired), and the recheck is membership-qualified: the slot witness,
+## cleared when the completion notify pops the entry, is the
+## already-delivered bit (without it a repark! would re-fire forever on
+## consumed completions).
+struct DoneWait
+    t::Task
+end
+
+function wait_enqueue!(x::DoneWait, w::WaitEntry, first::Bool)
+    t = x.t
+    donenotify = t.donenotify::ThreadSynchronizer
+    lock(donenotify)
+    if istaskdone(t)
+        unlock(donenotify)
+        return false
+    end
+    # a duplicate of an already-registered task shares its slot
+    if _find_slot(w, donenotify) == 0
+        push!(waitqueue(t), w)
+    end
+    unlock(donenotify)
+    return true
+end
+
+function wait_recheck(x::DoneWait, w::WaitEntry)
+    t = x.t
+    istaskdone(t) || return false
+    return _find_slot(w, t.donenotify::ThreadSynchronizer) != 0
+end
+
+function wait_dequeue!(x::DoneWait, w::WaitEntry, why::UInt8)
+    # lazy on a normal wake: the claiming completion notify popped its own
+    # registration; eager everywhere else (fired slots must not re-fire,
+    # withdrawal and cleanup must not leave the entry reachable)
+    why == WAKE_VALUE && return nothing
+    t = x.t
+    donenotify = t.donenotify::ThreadSynchronizer
+    lock(donenotify)
+    list_deletefirst!(waitqueue(t), w)
+    unlock(donenotify)
+    return nothing
+end
+
 function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=false, failfast::Bool=false,
                         tok::MaybeToken=default_cancel_token())
     if (all && !failfast) || length(tasks) <= 1
@@ -491,96 +536,41 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
     end
 
     # Park on all remaining tasks at once through a single multi-slot wait
-    # entry - one slot per pending task plus one for the governing
-    # cancellation source. Each task's completion notify claims the entry
-    # through the standard wake-claim protocol; the entry stays registered
-    # on the still-pending tasks across re-parks, so `waitall` re-arms it
-    # instead of re-registering after every completion.
+    # entry - one flat waitable per pending task (duplicates share a slot)
+    # plus the governing cancellation source. Each completion notify claims
+    # the entry through the standard wake-claim protocol; the registrations
+    # stay in place across re-parks, so the loop re-arms (`repark!`)
+    # instead of re-registering after every completion, and the driver's
+    # membership-qualified rechecks make the arm-then-suspend sound while
+    # this bookkeeping runs unarmed.
     ct = current_task()
     src = cancel_source(tok)
     src === nothing || checkcancel(src)
-    w = WaitEntryN(ct, nremaining + (src === nothing ? 0 : 1))
-    registered = falses(length(tasks))
-    function unlink_multiwait!()
-        for i in findall(registered)
-            t = tasks[i]
-            donenotify = t.donenotify::ThreadSynchronizer
-            lock(donenotify)
-            list_deletefirst!(waitqueue(t), w)
-            unlock(donenotify)
-            registered[i] = false
-        end
-        src === nothing || retire_cancellation_entry!(w)
-        return nothing
-    end
-    _arm_wait(ct, w)
+    ws = Vector{Union{DoneWait, SourceWait}}()
     for (i, done) in enumerate(done_mask)
-        done && continue
-        t = tasks[i]
-        donenotify = t.donenotify::ThreadSynchronizer
-        lock(donenotify)
-        if istaskdone(t)
-            unlock(donenotify)
-            done_mask[i] = true
-            exception |= istaskfailed(t)
-            nremaining -= 1
-        else
-            # a duplicate of an already-registered task shares its slot (the
-            # completion rescan below accounts for every index of it)
-            if _find_slot(w, donenotify) == 0
-                push!(waitqueue(t), w)
-                registered[i] = true
+        done || push!(ws, DoneWait(tasks[i]))
+    end
+    src === nothing || push!(ws, SourceWait(src, 0x00))
+    w = acquire_wait_entry!(ct, ws)
+    park!(ws, w, true, false)
+    while true
+        # collect completions (a wake happens-after its completing notify,
+        # so the istaskdone reads below observe it)
+        for (i, done) in enumerate(done_mask)
+            done && continue
+            t = tasks[i]
+            if istaskdone(t)
+                done_mask[i] = true
+                exception |= istaskfailed(t)
+                nremaining -= 1
             end
-            unlock(donenotify)
         end
-    end
-    if src !== nothing && !register_cancellation!(src, w)
-        # The governing source is already cancelled and the wake was claimed
-        # back for us: withdraw and deliver.
-        unlink_multiwait!()
-        _deliver_refused_cancellation(src)
-    end
-    try
-        while true
-            # collect completions (a wake happens-after its completing
-            # notify, so the istaskdone reads below observe it)
-            for (i, done) in enumerate(done_mask)
-                done && continue
-                t = tasks[i]
-                if istaskdone(t)
-                    done_mask[i] = true
-                    exception |= istaskfailed(t)
-                    nremaining -= 1
-                end
-            end
-            if nremaining == 0 || (!all && any(done_mask)) || (exception && failfast)
-                # Disarm; when the disarm loses to a concurrent claim,
-                # consume the wake it scheduled (possibly rethrowing a
-                # delivered cancellation) so it cannot linger in the run
-                # queue.
-                (@atomicreplace ct.waiting_on w => nothing).success || wait()
-                break
-            end
-            wait()
-            # re-arm before rescanning: a completion that lands between the
-            # rescan and the next park must be able to claim the entry
-            _arm_wait(ct, w)
+        if nremaining == 0 || (!all && any(done_mask)) || (exception && failfast)
+            break
         end
-    catch
-        # The wait was interrupted (e.g. by cancellation of the current
-        # scope): disarm, withdraw the registrations, and drop a wake this
-        # unwind will never consume. The drop runs after the unlink walk on
-        # purpose: a completion notify that claimed our wake did so under
-        # its donenotify lock, so the lock round-trips in
-        # `unlink_multiwait!` make its enqueue visible and the drop
-        # deterministic (cf. step 4 of _interrupted_wait_cleanup).
-        @atomicreplace ct.waiting_on w => nothing
-        unlink_multiwait!()
-        q = ct.queue
-        q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
-        rethrow()
+        repark!(ws, w)
     end
-    unlink_multiwait!()
+    withdraw!(ws, w)
 
     if nremaining == 0
         if throwexc && exception

--- a/base/task.jl
+++ b/base/task.jl
@@ -552,11 +552,14 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
     end
     src === nothing || push!(ws, SourceWait(src, 0x00))
     w = acquire_wait_entry!(ct, ws)
-    park!(ws, w, true, false)
+    parked = park!(ws, w, false)
     while true
-        # the caller-side cancellation check the driver's nothing-return
-        # contract requires: a fired source recheck (or any cancelled
-        # state - delivery is level-triggered) withdraws and throws here
+        # suspend only when the park armed (a `false` park/re-park means a
+        # waitable fired - a completion, or the source - and the driver
+        # already dequeued the fired slot)
+        parked && wait_safe_interrupt(ws, w)
+        # the fired-source outcome (and, level-triggered, any cancelled
+        # state) delivers here: withdraw and throw
         if src !== nothing && iscancelled(src)
             withdraw!(ws, w)
             checkcancel(src)
@@ -575,7 +578,7 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
         if nremaining == 0 || (!all && any(done_mask)) || (exception && failfast)
             break
         end
-        repark!(ws, w)
+        parked = repark!(ws, w)
     end
     withdraw!(ws, w)
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -447,7 +447,7 @@ function collect_tasks(waiting_tasks)
 end
 
 function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=false, failfast::Bool=false,
-                        tok::Union{Nothing, CancellationToken}=default_cancel_token())
+                        tok::MaybeToken=default_cancel_token())
     if (all && !failfast) || length(tasks) <= 1
         exception = false
         # Force everything to finish synchronously for the case of waitall
@@ -490,74 +490,97 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
         end
     end
 
-    chan = Channel{Int}(Inf)
-    sentinel = current_task()
-    waiter_tasks = fill(sentinel, length(tasks))
-
+    # Park on all remaining tasks at once through a single multi-slot wait
+    # entry - one slot per pending task plus one for the governing
+    # cancellation source. Each task's completion notify claims the entry
+    # through the standard wake-claim protocol; the entry stays registered
+    # on the still-pending tasks across re-parks, so `waitall` re-arms it
+    # instead of re-registering after every completion.
+    ct = current_task()
+    src = cancel_source(tok)
+    src === nothing || checkcancel(src)
+    w = WaitEntryN(ct, nremaining + (src === nothing ? 0 : 1))
+    registered = falses(length(tasks))
+    function unlink_multiwait!()
+        for i in findall(registered)
+            t = tasks[i]
+            donenotify = t.donenotify::ThreadSynchronizer
+            lock(donenotify)
+            list_deletefirst!(waitqueue(t), w)
+            unlock(donenotify)
+            registered[i] = false
+        end
+        src === nothing || retire_cancellation_entry!(w)
+        return nothing
+    end
+    _arm_wait(ct, w)
     for (i, done) in enumerate(done_mask)
         done && continue
         t = tasks[i]
+        donenotify = t.donenotify::ThreadSynchronizer
+        lock(donenotify)
         if istaskdone(t)
+            unlock(donenotify)
             done_mask[i] = true
             exception |= istaskfailed(t)
             nremaining -= 1
-            exception && failfast && break
         else
-            waiter = @task put!(chan, i)
-            waiter.sticky = false
-            _wait2(t, waiter)
-            waiter_tasks[i] = waiter
-        end
-    end
-
-    try
-        while nremaining > 0
-            exception && failfast && break
-            i = tok === nothing ? take!(chan) : take!(chan; cancel=tok)
-            t = tasks[i]
-            waiter_tasks[i] = sentinel
-            done_mask[i] = true
-            exception |= istaskfailed(t)
-            nremaining -= 1
-            # stop early if requested
-            all || break
-        end
-    catch
-        # The wait was interrupted (e.g. by cancellation of the current scope):
-        # deregister our waiter tasks before propagating, claiming each
-        # never-started waiter's wake so a concurrent completion notify skips
-        # it (same as the remaining-tasks cleanup below).
-        for i in findall(.~done_mask)
-            waiter = waiter_tasks[i]
-            waiter === sentinel && continue
-            donenotify = tasks[i].donenotify::ThreadSynchronizer
-            lock(donenotify)
-            w = @atomicswap waiter.waiting_on = nothing
-            w isa WaitEntry && list_deletefirst!(waitqueue(tasks[i]), w)
+            # a duplicate of an already-registered task shares its slot (the
+            # completion rescan below accounts for every index of it)
+            if _find_slot(w, donenotify) == 0
+                push!(waitqueue(t), w)
+                registered[i] = true
+            end
             unlock(donenotify)
         end
-        close(chan)
+    end
+    if src !== nothing && !register_cancellation!(src, w)
+        # The governing source is already cancelled and the wake was claimed
+        # back for us: withdraw and deliver.
+        unlink_multiwait!()
+        _deliver_refused_cancellation(src)
+    end
+    try
+        while true
+            # collect completions (a wake happens-after its completing
+            # notify, so the istaskdone reads below observe it)
+            for (i, done) in enumerate(done_mask)
+                done && continue
+                t = tasks[i]
+                if istaskdone(t)
+                    done_mask[i] = true
+                    exception |= istaskfailed(t)
+                    nremaining -= 1
+                end
+            end
+            if nremaining == 0 || (!all && any(done_mask)) || (exception && failfast)
+                # Disarm; when the disarm loses to a concurrent claim,
+                # consume the wake it scheduled (possibly rethrowing a
+                # delivered cancellation) so it cannot linger in the run
+                # queue.
+                (@atomicreplace ct.waiting_on w => nothing).success || wait()
+                break
+            end
+            wait()
+            # re-arm before rescanning: a completion that lands between the
+            # rescan and the next park must be able to claim the entry
+            _arm_wait(ct, w)
+        end
+    catch
+        # The wait was interrupted (e.g. by cancellation of the current
+        # scope): disarm, withdraw the registrations, and drop a wake this
+        # unwind will never consume. The drop runs after the unlink walk on
+        # purpose: a completion notify that claimed our wake did so under
+        # its donenotify lock, so the lock round-trips in
+        # `unlink_multiwait!` make its enqueue visible and the drop
+        # deterministic (cf. step 4 of _interrupted_wait_cleanup).
+        @atomicreplace ct.waiting_on w => nothing
+        unlink_multiwait!()
+        q = ct.queue
+        q === nothing || list_deletefirst!(q::StickyWorkqueue, ct)
         rethrow()
     end
-
-    close(chan)
-
-    # now just read which tasks finished directly: the channel is not needed anymore for that
-    # repeat until we get (acquire) the list of all dependent-exited tasks
-    changed = true
-    while changed
-        changed = false
-        for (i, done) in enumerate(done_mask)
-            done && continue
-            t = tasks[i]
-            if istaskdone(t)
-                done_mask[i] = true
-                exception |= istaskfailed(t)
-                nremaining -= 1
-                changed = true
-            end
-        end
-    end
+    unlink_multiwait!()
 
     if nremaining == 0
         if throwexc && exception
@@ -566,25 +589,12 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
         end
         return tasks, Task[]
     else
-        remaining_mask = .~done_mask
-        for i in findall(remaining_mask)
-            waiter = waiter_tasks[i]
-            waiter === sentinel && continue
-            donenotify = tasks[i].donenotify::ThreadSynchronizer
-            lock(donenotify)
-            # Claim the never-started waiter's wake so that a concurrent
-            # completion notify skips it, then unlink its registration (a
-            # no-op if a notify already popped it).
-            w = @atomicswap waiter.waiting_on = nothing
-            w isa WaitEntry && list_deletefirst!(waitqueue(tasks[i]), w)
-            unlock(donenotify)
-        end
         done_tasks = tasks[done_mask]
         if throwexc && exception
             exceptions = [TaskFailedException(t) for t in done_tasks if istaskfailed(t)]
             throw(CompositeException(exceptions))
         else
-            return done_tasks, tasks[remaining_mask]
+            return done_tasks, tasks[.~done_mask]
         end
     end
 end

--- a/base/task.jl
+++ b/base/task.jl
@@ -319,12 +319,15 @@ function _wait(t::Task, tok::MaybeToken; min_severity::UInt8=0x00)
     if !istaskdone(t)
         donenotify = t.donenotify::ThreadSynchronizer
         lock(donenotify)
+        locked = true
         try
             while !istaskdone(t)
+                locked = false
                 wait(donenotify, tok; min_severity=min_severity)
+                locked = true
             end
         finally
-            unlock(donenotify)
+            locked && unlock(donenotify)
         end
     end
     nothing

--- a/base/task.jl
+++ b/base/task.jl
@@ -335,10 +335,13 @@ end
 
 waitqueue(t::Task) = waitqueue(t.donenotify::ThreadSynchronizer)
 
-# have `waiter` wait for `t`
-function _wait2(t::Task, waiter::Task)
+# Subscribe the not-yet-started `waiter` to `t`'s completion (see the
+# GenericCondition method's contract in condition.jl: a start trigger
+# governed by the waiter's birth cancellation source, not a park)
+function schedule_on_notify!(t::Task, waiter::Task)
+    _assert_fresh_waiter(waiter)
     if !istaskdone(t)
-        # since _wait2 is similar to schedule, we should observe the sticky
+        # since this is similar to schedule, we should observe the sticky
         # bit, even if we don't call `schedule` with early-return below
         if waiter.sticky && Threads.threadid(waiter) == 0 && !GC.in_finalizer()
             # Issue #41324
@@ -354,16 +357,22 @@ function _wait2(t::Task, waiter::Task)
         lock(donenotify)
         try
             if !istaskdone(t)
-                w = _cached_wait_entry(waiter)
-                _arm_wait(waiter, w)
-                push!(waitqueue(t), w)
+                schedule_on_notify!(donenotify, waiter)
                 return nothing
             end
         finally
             unlock(donenotify)
         end
     end
-    schedule(waiter)
+    # `t` already done: start (or, under a cancelled birth source, kill)
+    # the waiter now
+    _assert_fresh_waiter(waiter)
+    src = _birth_cancel_source(waiter)
+    if src !== nothing && iscancelled(src)
+        _schedule_subscription_cancelled(waiter, src)
+    else
+        schedule(waiter)
+    end
     nothing
 end
 
@@ -838,7 +847,10 @@ Stacktrace:
 ```
 """
 function errormonitor(t::Task)
-    t2 = Task() do
+    # the monitor is diagnostic cleanup: shield it from the constructing
+    # scope's cancellation so a cancelled scope still gets its report
+    t2 = ScopedValues.with(CANCEL_TOKEN => nothing) do
+        Task() do
         if istaskfailed(t)
             local errs = stderr
             try # try to display the failure atomically
@@ -865,8 +877,9 @@ function errormonitor(t::Task)
         end
         nothing
     end
+    end
     t2.sticky = false
-    _wait2(t, t2)
+    schedule_on_notify!(t, t2)
     return t
 end
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -554,6 +554,13 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
     w = acquire_wait_entry!(ct, ws)
     park!(ws, w, true, false)
     while true
+        # the caller-side cancellation check the driver's nothing-return
+        # contract requires: a fired source recheck (or any cancelled
+        # state - delivery is level-triggered) withdraws and throws here
+        if src !== nothing && iscancelled(src)
+            withdraw!(ws, w)
+            checkcancel(src)
+        end
         # collect completions (a wake happens-after its completing notify,
         # so the istaskdone reads below observe it)
         for (i, done) in enumerate(done_mask)

--- a/base/task.jl
+++ b/base/task.jl
@@ -413,7 +413,8 @@ completed tasks, and the other consists of uncompleted tasks.
 !!! compat "Julia 1.12"
     This function requires at least Julia 1.12.
 """
-waitany(tasks; throw=true) = _wait_multiple(collect_tasks(tasks), throw)
+waitany(tasks; throw=true, cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    _wait_multiple(collect_tasks(tasks), throw, false, false, check_cancel_arg(cancel))
 
 """
     waitall(tasks; failfast=true, throw=true) -> (done_tasks, remaining_tasks)
@@ -433,7 +434,8 @@ completed tasks, and the other consists of uncompleted tasks.
 !!! compat "Julia 1.12"
     This function requires at least Julia 1.12.
 """
-waitall(tasks; failfast=true, throw=true) = _wait_multiple(collect_tasks(tasks), throw, true, failfast)
+waitall(tasks; failfast=true, throw=true, cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    _wait_multiple(collect_tasks(tasks), throw, true, failfast, check_cancel_arg(cancel))
 
 function collect_tasks(waiting_tasks)
     tasks = Task[]
@@ -444,13 +446,14 @@ function collect_tasks(waiting_tasks)
     return tasks
 end
 
-function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=false, failfast::Bool=false)
+function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=false, failfast::Bool=false,
+                        tok::Union{Nothing, CancellationToken}=default_cancel_token())
     if (all && !failfast) || length(tasks) <= 1
         exception = false
         # Force everything to finish synchronously for the case of waitall
         # with failfast=false
         for t in tasks
-            _wait(t)
+            _wait(t, tok)
             exception |= istaskfailed(t)
         end
         if exception && throwexc
@@ -507,16 +510,34 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
         end
     end
 
-    while nremaining > 0
-        exception && failfast && break
-        i = take!(chan)
-        t = tasks[i]
-        waiter_tasks[i] = sentinel
-        done_mask[i] = true
-        exception |= istaskfailed(t)
-        nremaining -= 1
-        # stop early if requested
-        all || break
+    try
+        while nremaining > 0
+            exception && failfast && break
+            i = tok === nothing ? take!(chan) : take!(chan; cancel=tok)
+            t = tasks[i]
+            waiter_tasks[i] = sentinel
+            done_mask[i] = true
+            exception |= istaskfailed(t)
+            nremaining -= 1
+            # stop early if requested
+            all || break
+        end
+    catch
+        # The wait was interrupted (e.g. by cancellation of the current scope):
+        # deregister our waiter tasks before propagating, claiming each
+        # never-started waiter's wake so a concurrent completion notify skips
+        # it (same as the remaining-tasks cleanup below).
+        for i in findall(.~done_mask)
+            waiter = waiter_tasks[i]
+            waiter === sentinel && continue
+            donenotify = tasks[i].donenotify::ThreadSynchronizer
+            lock(donenotify)
+            w = @atomicswap waiter.waiting_on = nothing
+            w isa WaitEntry && list_deletefirst!(waitqueue(tasks[i]), w)
+            unlock(donenotify)
+        end
+        close(chan)
+        rethrow()
     end
 
     close(chan)

--- a/base/task.jl
+++ b/base/task.jl
@@ -312,14 +312,16 @@ function task_local_storage(body::Function, key, val)
 end
 
 # just wait for a task to be done, no error propagation
-function _wait(t::Task)
+_wait(t::Task; cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    _wait(t, resolve_cancel_token(cancel))
+function _wait(t::Task, tok::MaybeToken; min_severity::UInt8=0x00)
     t === current_task() && throw(ConcurrencyViolationError("deadlock detected: cannot wait on current task"))
     if !istaskdone(t)
         donenotify = t.donenotify::ThreadSynchronizer
         lock(donenotify)
         try
             while !istaskdone(t)
-                wait(donenotify; waitee=t)
+                wait(donenotify, tok; min_severity=min_severity)
             end
         finally
             unlock(donenotify)
@@ -328,7 +330,7 @@ function _wait(t::Task)
     nothing
 end
 
-waitqueue(t::Task) = ILLRef((t.donenotify::ThreadSynchronizer).waitq, t)
+waitqueue(t::Task) = waitqueue(t.donenotify::ThreadSynchronizer)
 
 # have `waiter` wait for `t`
 function _wait2(t::Task, waiter::Task)
@@ -363,18 +365,26 @@ function _wait2(t::Task, waiter::Task)
 end
 
 """
-    wait(t::Task; throw=true)
+    wait(t::Task; throw=true, cancel=Base.DEFAULT_CANCEL)
 
 Wait for a `Task` to finish.
 
 The keyword `throw` (defaults to `true`) controls whether a failed task results
 in an error, thrown as a [`TaskFailedException`](@ref) which wraps the failed task.
 
+The `cancel` keyword argument controls which cancellation token may interrupt
+the wait (see [`CancellationToken`](@ref)); by default the scoped token. A
+cancelled wait throws the [`CancellationRequest`](@ref) and leaves `t`
+unaffected: cancellation reaches `t` only through its own governing token
+(e.g. when both waiter and waitee run under the same cancelled scope).
+
 Throws a `ConcurrencyViolationError` if `t` is the currently running task, to prevent deadlocks.
 """
-@noinline function wait(t::Task; throw=true)
+wait(t::Task; throw=true, cancel::CancelTokenArg=DEFAULT_CANCEL) =
+    wait(t, check_cancel_arg(cancel); throw)
+@noinline function wait(t::Task, tok::MaybeToken; throw=true)
     # Inlining a blocking call buys nothing; this also keeps the inlineable `fetch(::Task)` small.
-    _wait(t)
+    _wait(t, tok)
     if throw && istaskfailed(t)
         Core.throw(TaskFailedException(t))
     end
@@ -572,8 +582,10 @@ Wait for a [`Task`](@ref) to finish, then return its result value.
 If the task fails with an exception, a [`TaskFailedException`](@ref) (which wraps the failed task)
 is thrown.
 """
-@inline function fetch(t::Task)
-    wait(t)
+@inline function fetch(t::Task; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    # `cancel` governs the *wait* for the task: a cancellation unwinds this
+    # fetch, the fetched task keeps running.
+    wait(t; cancel)
     # This typeassert looks redundant, but is required for soundness and must not be
     # removed: `Task.code`/`Task.result` are mutable, so the precise type inference
     # may derive here (via `PartialTask`) is a claim that must be re-checked at
@@ -585,6 +597,19 @@ end
 
 struct ScheduledAfterSyncException <: Exception
     values::Vector{Any}
+end
+
+function showerror(io::IO, cr::CancellationRequest)
+    print(io, "CancellationRequest: ")
+    if cr === CANCEL_REQUEST_SAFE
+        print(io, "Safe Cancellation (CANCEL_REQUEST_SAFE)")
+    elseif cr === CANCEL_REQUEST_ABANDON_EXTERNAL
+        print(io, "Abandonment of External Resources (CANCEL_REQUEST_ABANDON_EXTERNAL)")
+    elseif cr === CANCEL_REQUEST_ABANDON_ALL
+        print(io, "Task Abandonment (CANCEL_REQUEST_ABANDON_ALL)")
+    else
+        print(io, "Unknown ($(cr.request))")
+    end
 end
 
 function showerror(io::IO, ex::ScheduledAfterSyncException)
@@ -871,6 +896,12 @@ end
 
 # runtime system hook called when a task finishes
 function task_done_hook(t::Task)
+    # a sticky cancellation-source registration of this task is garbage now
+    w = t.cached_cancel_entry
+    if w isa WaitEntry2
+        o = @atomic :monotonic w.owner2
+        o isa CancellationTokenSource && _note_dead_registration!(o)
+    end
     # `finish_task` sets `sigatomic` before entering this function
     err = istaskfailed(t)
     result = task_result(t)
@@ -1117,6 +1148,32 @@ function schedule(t::Task, @nospecialize(arg); error=false)
     maybe_record_enqueued!(t)
     enq_work(t)
     return t
+end
+
+# Deliver `exc` into the parked wait whose wake the caller already claimed
+# by CASing `t.waiting_on` from `w` to nothing (the cancellation walk).
+# Unlike `schedule(t, exc, error=true)` - whose unconditional swap *takes*
+# a claim - this must not re-claim: the claim was the wake ticket. If a
+# claim-less wake (a raw interrupter, `throwto`) resumed the task first and
+# it has since registered a new wait, the claimed park no longer exists and
+# the delivery is dropped - a task still eligibly parked under the
+# cancelled source is impossible (its registration recheck refuses), and
+# anything else must not observe this request.
+function deliver_claimed_wake!(t::Task, w::WaitEntry, @nospecialize(exc))
+    (@atomic :monotonic t.waiting_on) === nothing || return nothing
+    # the claimed waitee-queue entry stays linked (the walk does not take
+    # waitee locks); collect it opportunistically like an interrupter would
+    try_unlink_claimed!(w)
+    # a pending wake somebody enqueued claim-lessly is superseded by the
+    # cancellation delivery, like an interrupt overriding a claimed value
+    q = t.queue
+    q === nothing || list_deletefirst!(q::StickyWorkqueue, t)
+    t._state === task_state_runnable || return nothing
+    setfield!(t, :result, exc)
+    setfield!(t, :_isexception, true)
+    maybe_record_enqueued!(t)
+    enq_work(t)
+    return nothing
 end
 
 """

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -38,7 +38,7 @@ precompile(Tuple{typeof(Base.Terminals.height), Base.Terminals.TTYTerminal})
 precompile(Tuple{typeof(Base.write), Base.Terminals.TTYTerminal, Array{UInt8, 1}})
 precompile(Tuple{typeof(Base.isempty), Base.AnnotatedString{String}})
 # The owner-carrying write paths (String/Array) call _unsafe_write_owned
-# directly, so the workload session no longer compiles the raw-pointer
+# directly, so the workload session does not compile the raw-pointer
 # unsafe_write entry points on its own; interactive startup still reaches
 # them through generic IO plumbing
 precompile(Tuple{typeof(Base.unsafe_write), Base.TTY, Ptr{UInt8}, UInt})

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -37,6 +37,12 @@ precompile(Tuple{typeof(Base.Terminals.width), Base.Terminals.TTYTerminal})
 precompile(Tuple{typeof(Base.Terminals.height), Base.Terminals.TTYTerminal})
 precompile(Tuple{typeof(Base.write), Base.Terminals.TTYTerminal, Array{UInt8, 1}})
 precompile(Tuple{typeof(Base.isempty), Base.AnnotatedString{String}})
+# The owner-carrying write paths (String/Array) call _unsafe_write_owned
+# directly, so the workload session no longer compiles the raw-pointer
+# unsafe_write entry points on its own; interactive startup still reaches
+# them through generic IO plumbing
+precompile(Tuple{typeof(Base.unsafe_write), Base.TTY, Ptr{UInt8}, UInt})
+precompile(Tuple{typeof(Base.unsafe_write), Base.GenericIOBuffer{Memory{UInt8}}, Ptr{UInt8}, UInt})
 
 # loading.jl - without these each precompile worker would precompile these because they're hit before pkgimages are loaded
 precompile(Base.__require, (Module, Symbol))

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -21,6 +21,7 @@ Base.flush
 Base.close
 Base.closewrite
 Base.write
+Base.writepartial
 Base.read
 Base.read!
 Base.readbytes!

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -58,6 +58,28 @@ Base.@lock
 Base.Lockable
 ```
 
+## Cancellation
+
+Cooperative cancellation of blocked waits and (in future steps of this work)
+running computations is organized around cancellation token sources and the
+tokens they hand out. Blocking operations across `Base`, `Sockets` and
+`FileWatching` accept a `cancel` keyword argument governing which token may
+interrupt them; the scoped default is [`Base.CANCEL_TOKEN`](@ref).
+
+```@docs
+Base.CancellationTokenSource
+Base.CancellationToken
+Base.CancellationRequest
+Base.cancel!
+Base.iscancelled
+Base.cancel_severity
+Base.CANCEL_TOKEN
+Base.@cancel_check
+Base.CANCEL_REQUEST_SAFE
+Base.CANCEL_REQUEST_ABANDON_EXTERNAL
+Base.CANCEL_REQUEST_ABANDON_ALL
+```
+
 ## Channels
 
 ```@docs

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -60,8 +60,8 @@ Base.Lockable
 
 ## Cancellation
 
-Cooperative cancellation of blocked waits and (in future steps of this work)
-running computations is organized around cancellation token sources and the
+Cooperative cancellation of blocked waits (and, eventually, running
+computations) is organized around cancellation token sources and the
 tokens they hand out. Blocking operations across `Base`, `Sockets` and
 `FileWatching` accept a `cancel` keyword argument governing which token may
 interrupt them; the scoped default is [`Base.CANCEL_TOKEN`](@ref).

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -330,6 +330,7 @@ JL_DLLEXPORT int jl_egal__bitstag(const jl_value_t *a JL_MAYBE_UNROOTED, const j
         case jl_bool_tag:
         case jl_nothing_tag:
         case jl_cancel_source_tag: // mutable: identity (a == b checked above)
+        case jl_wait_entry_tag:    // mutable: identity (a == b checked above)
             return 0;
         case jl_simplevector_tag:
             return compare_svec((jl_svec_t*)a, (jl_svec_t*)b);
@@ -631,7 +632,8 @@ JL_CALLABLE(jl_f_sizeof)
                 jl_errorf("Argument is an incomplete %s type and does not have a definite size.", jl_symbol_name(dx->name->name));
         }
         if (jl_is_layout_opaque(dx->layout) || // includes all GenericMemory{kind,T}
-            dx == jl_cancel_source_type)       // variable-sized (layout covers only the fixed fields)
+            dx == jl_cancel_source_type ||     // variable-sized (layout covers only the fixed fields)
+            dx == jl_wait_entry_type)          // variable-sized likewise
             jl_errorf("Type %s does not have a definite size.", jl_symbol_name(dx->name->name));
         return jl_box_long(jl_datatype_size(x));
     }
@@ -648,6 +650,12 @@ JL_CALLABLE(jl_f_sizeof)
         jl_cancel_source_t *cs = (jl_cancel_source_t*)x;
         return jl_box_long(sizeof(jl_cancel_source_t) +
                            cs->nparents * sizeof(jl_cancel_parent_link_t));
+    }
+    if (jl_is_wait_entry(x)) {
+        // variable-sized: one wait slot per `nslots` follows the fixed fields
+        jl_wait_entry_t *w = (jl_wait_entry_t*)x;
+        return jl_box_long(sizeof(jl_wait_entry_t) +
+                           w->nslots * sizeof(jl_wait_slot_t));
     }
     jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(x);
     assert(jl_is_datatype(dt));
@@ -2828,6 +2836,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("LLVMPtr", (jl_value_t*)jl_llvmpointer_type);
     add_builtin("Task", (jl_value_t*)jl_task_type);
     add_builtin("CancellationTokenSource", (jl_value_t*)jl_cancel_source_type);
+    add_builtin("WaitEntryN", (jl_value_t*)jl_wait_entry_type);
 
     add_builtin("AddrSpace", (jl_value_t*)jl_addrspace_type);
     add_builtin("Ref", (jl_value_t*)jl_ref_type);

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -752,6 +752,14 @@ int gc_slot_to_arrayidx(void *obj, void *_slot) JL_NOTSAFEPOINT
         len = s->nparents;
         elsize = sizeof(jl_cancel_parent_link_t);
     }
+    else if (vt == jl_wait_entry_type) {
+        // the `owner`/`next` slots of the trailing wait slots are marked as
+        // strided arrays (see gc-stock.c)
+        jl_wait_entry_t *w = (jl_wait_entry_t*)obj;
+        start = (char*)jl_wait_entry_slots(w);
+        len = w->nslots;
+        elsize = sizeof(jl_wait_slot_t);
+    }
     if (slot < start || slot >= start + elsize * len)
         return -1;
     return (slot - start) / elsize;

--- a/src/gc-heap-snapshot.c
+++ b/src/gc-heap-snapshot.c
@@ -414,6 +414,13 @@ static size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
         self_size = sizeof(jl_cancel_source_t) +
                     ((jl_cancel_source_t*)a)->nparents * sizeof(jl_cancel_parent_link_t);
     }
+    else if (jl_is_wait_entry(a)) {
+        // variable-sized: one wait slot per waitable follows the fixed fields
+        node_type = "jl_wait_entry_t";
+        name = "WaitEntryN";
+        self_size = sizeof(jl_wait_entry_t) +
+                    ((jl_wait_entry_t*)a)->nslots * sizeof(jl_wait_slot_t);
+    }
     else if (jl_is_datatype(a)) {
         ios_need_close = 1;
         ios_mem(&str_, 0);

--- a/src/gc-mmtk/mmtk_julia/build.rs
+++ b/src/gc-mmtk/mmtk_julia/build.rs
@@ -129,6 +129,8 @@ fn main() {
         .allowlist_item("jl_datatype_t")
         .allowlist_item("jl_weakref_t")
         .allowlist_item("jl_cancel_source_t")
+        .allowlist_item("jl_wait_entry_t")
+        .allowlist_item("jl_wait_slot_t")
         .allowlist_item("jl_cancel_parent_link_t")
         .allowlist_item("jl_binding_partition_t")
         .allowlist_item("jl_bt_element_t")

--- a/src/gc-mmtk/mmtk_julia/src/julia_scanning.rs
+++ b/src/gc-mmtk/mmtk_julia/src/julia_scanning.rs
@@ -190,13 +190,29 @@ pub unsafe fn scan_julia_object<SV: SlotVisitor<JuliaVMSlot>>(obj: Address, clos
             // (strong) `parent` slot of each entry is traced; `child_head`
             // and the `next`/`pprev` slots are weak references with
             // unlink-on-death semantics (see jl_gc_sweep_weak_processing)
-            // and must not be traced.
+            // and must not be traced. The waiter-list head is a strong
+            // fixed slot.
             let cs = obj.to_ptr::<jl_cancel_source_t>();
+            process_slot(closure, obj + offset_of!(jl_cancel_source_t, waiters_head));
+            process_slot(closure, obj + offset_of!(jl_cancel_source_t, walk_lock));
             let np = (*cs).nparents as usize;
             let mut slot = obj + std::mem::size_of::<jl_cancel_source_t>();
             for _ in 0..np {
                 process_slot(closure, slot);
                 slot = slot + std::mem::size_of::<jl_cancel_parent_link_t>();
+            }
+        } else if vtag_usize == ((jl_small_typeof_tags_jl_wait_entry_tag as usize) << 4) {
+            // Variable-sized wait entry: `nslots` {owner, next, aux} wait
+            // slots follow the fixed fields. `task` and the per-slot
+            // `owner` and `next` are strong references; `aux` is data.
+            let we = obj.to_ptr::<jl_wait_entry_t>();
+            process_slot(closure, obj + offset_of!(jl_wait_entry_t, task));
+            let ns = (*we).nslots as usize;
+            let mut slot = obj + std::mem::size_of::<jl_wait_entry_t>();
+            for _ in 0..ns {
+                process_slot(closure, slot + offset_of!(jl_wait_slot_t, owner));
+                process_slot(closure, slot + offset_of!(jl_wait_slot_t, next));
+                slot = slot + std::mem::size_of::<jl_wait_slot_t>();
             }
         } else if vtag_usize == ((jl_small_typeof_tags_jl_string_tag as usize) << 4)
             && PRINT_OBJ_TYPE

--- a/src/gc-mmtk/mmtk_julia/src/object_model.rs
+++ b/src/gc-mmtk/mmtk_julia/src/object_model.rs
@@ -235,6 +235,15 @@ pub unsafe fn get_so_object_size(object: ObjectReference) -> usize {
             );
 
             return llt_align(dtsz + JULIA_HEADER_SIZE, 16);
+        } else if vtag_usize == ((jl_small_typeof_tags_jl_wait_entry_tag as usize) << 4) {
+            // Variable-sized: `nslots` {owner, next, aux} wait slots follow
+            // the fixed fields.
+            let we = obj_address.to_ptr::<jl_wait_entry_t>();
+            let ns = (*we).nslots as usize;
+            let dtsz =
+                std::mem::size_of::<jl_wait_entry_t>() + ns * std::mem::size_of::<jl_wait_slot_t>();
+
+            return llt_align(dtsz + JULIA_HEADER_SIZE, 16);
         } else if vtag_usize == ((jl_small_typeof_tags_jl_string_tag as usize) << 4) {
             let length = object.to_raw_address().load::<usize>();
             let dtsz = length + std::mem::size_of::<usize>() + 1;

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -2572,6 +2572,12 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                 size_t dtsz = sizeof(jl_cancel_source_t) + np * sizeof(jl_cancel_parent_link_t);
                 if (update_meta)
                     gc_setmark(ptls, o, bits, dtsz);
+                // the waiter-list head and the walk lock are strong
+                // (adjacent) slots (the world is stopped; the relaxed
+                // mutator ordering is irrelevant here)
+                gc_mark_objarray(ptls, new_obj, (jl_value_t**)&cs->waiters_head,
+                                 (jl_value_t**)&cs->waiters_head + 2, 1,
+                                 (2 << 2) | (bits & GC_OLD));
                 if (np > 0) {
                     jl_value_t **objary_begin = (jl_value_t**)jl_cancel_source_links(cs);
                     // stride over the link entries, visiting only the
@@ -2580,6 +2586,32 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     jl_value_t **objary_end = objary_begin + step * np;
                     uintptr_t nptr = (np << 2) | (bits & GC_OLD);
                     gc_mark_objarray(ptls, new_obj, objary_begin, objary_end, step, nptr);
+                }
+            }
+            else if (vtag == jl_wait_entry_tag << 4) {
+                // Variable-sized: `nslots` {owner, next, aux} wait slots
+                // follow the fixed fields; `task` and the per-slot `owner`
+                // and `next` are strong references, `aux` is data.
+                jl_wait_entry_t *we = (jl_wait_entry_t*)new_obj;
+                size_t ns = we->nslots;
+                size_t dtsz = sizeof(jl_wait_entry_t) + ns * sizeof(jl_wait_slot_t);
+                if (update_meta)
+                    gc_setmark(ptls, o, bits, dtsz);
+                jl_value_t **task = (jl_value_t**)&we->task;
+                gc_mark_objarray(ptls, new_obj, task, task + 1, 1,
+                                 (1 << 2) | (bits & GC_OLD));
+                if (ns > 0) {
+                    jl_value_t **b = (jl_value_t**)jl_wait_entry_slots(we);
+                    uint32_t step = sizeof(jl_wait_slot_t) / sizeof(jl_value_t*);
+                    uintptr_t nptr = (ns << 2) | (bits & GC_OLD);
+                    // two strided passes: the `owner` slot of each entry...
+                    gc_mark_objarray(ptls, new_obj, b, b + step * ns, step, nptr);
+                    // ...and the `next` slot. The endpoint must stay within
+                    // (or one past) the object: `b + 1 + step*ns` would point
+                    // a full word past its end, so end one past the last
+                    // `next` slot instead - the strided walk stops at the
+                    // same last element either way.
+                    gc_mark_objarray(ptls, new_obj, b + 1, b + step * (ns - 1) + 2, step, nptr);
                 }
             }
             else if (vtag == jl_string_tag << 4) {

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -152,6 +152,7 @@
     XX(vararg_type, jl_datatype_t*) \
     XX(vecelement_typename, jl_typename_t*) \
     XX(voidpointer_type, jl_datatype_t*) \
+    XX(wait_entry_type, jl_datatype_t*) \
     XX(weakref_type, jl_datatype_t*) \
     XX(typeapp_type, jl_datatype_t*)
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4320,30 +4320,60 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_cancel_source_type = (jl_datatype_t*)
         jl_new_datatype(jl_symbol("CancellationTokenSource"), core, jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(3,
+                        jl_perm_symsvec(6,
                                         "child_head",
+                                        "waiters_head",
+                                        "walk_lock",
                                         "state",
-                                        "nparents"),
-                        jl_svec(3,
+                                        "nparents",
+                                        "dead_count"),
+                        jl_svec(6,
                                 jl_any_type, // Union{Nothing, CancellationTokenSource}, weak
+                                jl_any_type, // Union{Nothing, WaitEntry}, strong
+                                jl_any_type, // Union{Nothing, ReentrantLock}, strong
                                 jl_uint8_type,
-                                jl_uint16_type),
+                                jl_uint16_type,
+                                jl_uint32_type),
                         jl_emptysvec,
-                        0, 1, 3);
-    // Field 3 (nparents) is const; fields 1-2 (child_head, state) are atomic
-    const static uint32_t cancel_source_constfields[1]  = { 0b100 };
-    const static uint32_t cancel_source_atomicfields[1] = { 0b011 };
+                        0, 1, 6);
+    // Field 5 (nparents) is const; fields 1-4 (child_head, waiters_head,
+    // walk_lock, state) and 6 (dead_count) are atomic
+    const static uint32_t cancel_source_constfields[1]  = { 0b010000 };
+    const static uint32_t cancel_source_atomicfields[1] = { 0b101111 };
     jl_cancel_source_type->name->constfields = cancel_source_constfields;
     jl_cancel_source_type->name->atomicfields = cancel_source_atomicfields;
     XX(cancel_source);
     assert(jl_datatype_size(jl_cancel_source_type) == sizeof(jl_cancel_source_t));
+
+    // Variable-sized (see jl_wait_entry_t) - only the fixed fields are exposed
+    // to julia; the trailing wait slots are reached through the
+    // jl_wait_entry_slot_* accessors.
+    jl_wait_entry_type = (jl_datatype_t*)
+        jl_new_datatype(jl_symbol("WaitEntryN"), core, jl_any_type,
+                        jl_emptysvec,
+                        jl_perm_symsvec(2,
+                                        "task",
+                                        "nslots"),
+                        jl_svec(2,
+                                jl_any_type, // Union{Nothing, Task}
+                                jl_uint32_type),
+                        jl_emptysvec,
+                        0, 1, 2);
+    // Field 2 (nslots) is const; field 1 (task) is atomic (accessed
+    // relaxed - see jl_wait_entry_t)
+    const static uint32_t wait_entry_constfields[1] = { 0b10 };
+    const static uint32_t wait_entry_atomicfields[1] = { 0b01 };
+    jl_wait_entry_type->name->constfields = wait_entry_constfields;
+    jl_wait_entry_type->name->atomicfields = wait_entry_atomicfields;
+    XX(wait_entry);
+    assert(jl_datatype_size(jl_wait_entry_type) == sizeof(jl_wait_entry_t));
 
     jl_task_type = (jl_datatype_t*)
         jl_new_datatype(jl_symbol("Task"),
                         NULL,
                         jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(31,
+                        jl_perm_symsvec(32,
                                         "next",
                                         "queue",
                                         "storage",
@@ -4373,9 +4403,10 @@ void jl_init_types(void) JL_GC_DISABLED
                                         "finished_at",
                                         "waiting_on",
                                         "cached_wait_entry",
+                                        "cached_cancel_entry",
                                         "invoked",
                                         "bound_cancel_token"),
-                        jl_svec(31,
+                        jl_svec(32,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
@@ -4406,6 +4437,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                 jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
+                                jl_any_type,
                                 jl_any_type),
                         jl_emptysvec,
                         0, 1, 6);
@@ -4414,9 +4446,9 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_task_type->types, 0, listt);
     // Set field 20 (metrics_enabled) as const
     // Set fields 8 (_state), 12 (preempt_request), 24-27 (metric counters),
-    // 28 (waiting_on) and 31 (bound_cancel_token) as atomic
-    const static uint32_t task_constfields[1]  = { 0b0000000000010000000000000000000 };
-    const static uint32_t task_atomicfields[1] = { 0b1001111100000000000100010000000 };
+    // 28 (waiting_on) and 32 (bound_cancel_token) as atomic
+    const static uint32_t task_constfields[1]  = { 0b00000000000010000000000000000000 };
+    const static uint32_t task_atomicfields[1] = { 0b10001111100000000000100010000000 };
     jl_task_type->name->constfields = task_constfields;
     jl_task_type->name->atomicfields = task_atomicfields;
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -2563,7 +2563,7 @@ struct _jl_handler_t {
 JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t*, jl_value_t*, size_t) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t nparents) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_cancel_source_parent(jl_cancel_source_t *src, size_t i);
-JL_DLLEXPORT jl_value_t *jl_new_wait_entry(jl_value_t *task, size_t nslots);
+JL_DLLEXPORT jl_value_t *jl_new_wait_entry(jl_value_t *task, size_t nslots) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_wait_entry_slot_owner(jl_value_t *w, size_t i) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_wait_entry_set_slot_owner(jl_value_t *w, size_t i, jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_wait_entry_slot_next(jl_value_t *w, size_t i) JL_NOTSAFEPOINT;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1122,6 +1122,7 @@ typedef struct {
     XX(typeeq) \
     XX(typeegal) \
     XX(cancel_source) \
+    XX(wait_entry) \
     /* Add new tags here to keep existing builds ABI stable - we don't guarantee ABI \
        stability, but it'll help PkgEval to not break it unnecessarily */ \
     /* end of JL_SMALL_TYPEOF */
@@ -1772,6 +1773,7 @@ static inline int jl_field_isconst(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 #define jl_is_mcache(v)      jl_typetagis(v,jl_methcache_type)
 #define jl_is_task(v)        jl_typetagis(v,jl_task_tag<<4)
 #define jl_is_cancel_source(v) jl_typetagis(v,jl_cancel_source_tag<<4)
+#define jl_is_wait_entry(v)  jl_typetagis(v,jl_wait_entry_tag<<4)
 #define jl_is_string(v)      jl_typetagis(v,jl_string_tag<<4)
 #define jl_is_cpointer(v)    jl_is_cpointer_type(jl_typeof(v))
 #define jl_is_pointer(v)     jl_is_cpointer_type(jl_typeof(v))
@@ -2561,6 +2563,13 @@ struct _jl_handler_t {
 JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t*, jl_value_t*, size_t) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t nparents) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_cancel_source_parent(jl_cancel_source_t *src, size_t i);
+JL_DLLEXPORT jl_value_t *jl_new_wait_entry(jl_value_t *task, size_t nslots);
+JL_DLLEXPORT jl_value_t *jl_wait_entry_slot_owner(jl_value_t *w, size_t i) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_wait_entry_set_slot_owner(jl_value_t *w, size_t i, jl_value_t *v) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_wait_entry_slot_next(jl_value_t *w, size_t i) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_wait_entry_set_slot_next(jl_value_t *w, size_t i, jl_value_t *v) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uint64_t jl_wait_entry_slot_aux(jl_value_t *w, size_t i) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_wait_entry_set_slot_aux(jl_value_t *w, size_t i, uint64_t v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_cancel_source_next_child(jl_cancel_source_t *parent, jl_cancel_source_t *child) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_cancel_source_relink(jl_cancel_source_t *src) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_switchto(jl_task_t **pt) JL_CANSAFEPOINT_ENTER_LEAVE;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -442,7 +442,7 @@ typedef struct _jl_task_t {
     // This task's current registration on a wait queue (a `Base.WaitEntry`),
     // or `nothing`. Doubles as the wake-claim word: whoever atomically clears
     // it (notify via CAS against the specific entry, an interrupter via swap)
-    // owns waking the task. See the wake-claim protocol in base/condition.jl.
+    // owns waking the task. See the wake-claim protocol in base/cancellation.jl.
     _Atomic(jl_value_t*) waiting_on;
     // The wait entries cached for reuse across this task's parks (or
     // `nothing`), so the common park does not allocate. Owned by this task.
@@ -450,7 +450,7 @@ typedef struct _jl_task_t {
     // cancellation walk's expected-entry claim CAS is its only sound
     // eligibility gate, so an entry registered on a source must never be
     // armed for a wait that is not cancellable under it (see the wake-claim
-    // protocol in base/cancellation.jl and tla/WaitClaim.tla).
+    // protocol in base/cancellation.jl).
     // The `Base.WaitEntry1` for plain parks - never registered on a source.
     jl_value_t *cached_wait_entry;
     // The `Base.WaitEntry2` for cancellable parks. Its cancellation-source

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -313,12 +313,31 @@ struct _jl_cancel_source_t {
     // Weak (spliced by the GC): most recently attached live child;
     // `jl_nothing`-terminated. Union{Nothing, CancellationTokenSource}.
     _Atomic(jl_value_t*) child_head;
+    // Parked waiters: a lock-free intrusive singly-linked LIFO of wait
+    // entries (any kind, linked through their source slot), where the
+    // cancellation walk finds tasks blocked under this source. Strong
+    // references (the GC's special-cased marking traces the head).
+    // Registration CAS-pushes here; entries are never unlinked on the wake
+    // path (they stay registered across parks and are collected by walks) -
+    // interior links are rewritten only under `walk_lock`. See the
+    // registration protocol in base/cancellation.jl.
+    _Atomic(jl_value_t*) waiters_head;   // Union{Nothing, Base.WaitEntry}
+    // Serializes walks (cancellation delivery, pruning, owner-side
+    // unregistration) against each other; never taken on park/wake paths.
+    // A sleeping lock (Union{Nothing, Base.ReentrantLock}, strong),
+    // installed lazily by the first walker.
+    _Atomic(jl_value_t*) walk_lock;
     // 0x00 = uncancelled; otherwise the (nonzero) severity at which the
     // source is cancelled (0x1 SAFE, 0x3 ABANDON_EXTERNAL, 0x4 ABANDON_ALL).
     // Monotonic (CAS-max).
     _Atomic(uint8_t) state;
     // Number of parent links following the fixed fields. Const.
     uint16_t nparents;
+    // Dead registrations on the waiter list (retired entries and entries of
+    // completed tasks), counted at retirement/task teardown; crossing the
+    // threshold triggers a pruning walk. Approximate (relaxed); walks reset
+    // it.
+    _Atomic(uint32_t) dead_count;
     // jl_cancel_parent_link_t links[nparents];  (see jl_cancel_source_links)
 };
 
@@ -328,6 +347,49 @@ static inline jl_cancel_parent_link_t *jl_cancel_source_links(jl_cancel_source_t
 {
     // The struct size is already pointer-aligned on all supported platforms.
     return (jl_cancel_parent_link_t*)((char*)src + sizeof(jl_cancel_source_t));
+}
+
+// A wait registration slot: `owner` is the waitable this slot registers on
+// (a condition/waitee, a cancellation source, ...) and doubles as the
+// membership witness (`jl_nothing` = free); `next` is the intrusive link of
+// the owner's waiter list (links point at whole entries - a traversal finds
+// its slot in each entry by scanning for its own identity); `aux` carries
+// per-registration payload (e.g. the minimum delivery severity of a
+// cancellation-source slot). Both object slots are strong references.
+// `owner` is atomic, accessed relaxed: scans read every slot's owner from
+// threads that do not hold that slot's protecting lock, tolerating stale
+// values (any ordering an owner read needs is supplied by the surrounding
+// protocol). `next` and `aux` stay plain under their owner's discipline
+// (the waitee's lock, the source's registration protocol/walk lock, or the
+// owning task) - see base/cancellation.jl.
+typedef struct {
+    _Atomic(jl_value_t*) owner;
+    jl_value_t *next;
+    uint64_t aux;
+} jl_wait_slot_t;
+
+// The variable-sized "many" wait-entry kind (Core.WaitEntryN): `nslots`
+// slots follow the fixed fields. The 1- and 2-slot kinds are ordinary Julia
+// structs (Base.WaitEntry1/WaitEntry2) with the same slot semantics; this
+// kind serves wait-any over arbitrarily many waitables (waitany/waitall).
+// Only the fixed fields are exposed to the Julia field system; slots are
+// reached through the jl_wait_entry_slot_* accessors. Like the slot
+// `owner`s, `task` is atomic, accessed relaxed: walkers read (and scrub) it
+// without holding any of the entry owner's locks, tolerating staleness (a
+// wake claim is validated by the task's `waiting_on` CAS, never by the
+// `task` read alone). `next` and `aux` stay plain under their owner's
+// discipline.
+typedef struct {
+    JL_DATA_TYPE
+    _Atomic(jl_value_t*) task;   // Union{Nothing, Task}; nothing marks a retired entry
+    uint32_t nslots;    // const
+    // uint32_t padding
+    // jl_wait_slot_t slots[nslots];  (see jl_wait_entry_slots)
+} jl_wait_entry_t;
+
+static inline jl_wait_slot_t *jl_wait_entry_slots(jl_wait_entry_t *w) JL_NOTSAFEPOINT
+{
+    return (jl_wait_slot_t*)((char*)w + sizeof(jl_wait_entry_t));
 }
 
 // The link entry connecting `child` to `parent` (which must be one of its
@@ -382,9 +444,20 @@ typedef struct _jl_task_t {
     // it (notify via CAS against the specific entry, an interrupter via swap)
     // owns waking the task. See the wake-claim protocol in base/condition.jl.
     _Atomic(jl_value_t*) waiting_on;
-    // A `Base.WaitEntry` cached for reuse across parks (or `nothing`), so the
-    // common single-registration park does not allocate. Owned by this task.
+    // The wait entries cached for reuse across this task's parks (or
+    // `nothing`), so the common park does not allocate. Owned by this task.
+    // Plain (shielded) and cancellable parks arm *distinct* entries: the
+    // cancellation walk's expected-entry claim CAS is its only sound
+    // eligibility gate, so an entry registered on a source must never be
+    // armed for a wait that is not cancellable under it (see the wake-claim
+    // protocol in base/cancellation.jl and tla/WaitClaim.tla).
+    // The `Base.WaitEntry1` for plain parks - never registered on a source.
     jl_value_t *cached_wait_entry;
+    // The `Base.WaitEntry2` for cancellable parks. Its cancellation-source
+    // slot is sticky - the entry stays on the source's waiter list across
+    // parks, so only the first cancellable park under a source pays a
+    // registration.
+    jl_value_t *cached_cancel_entry;
     jl_value_t *invoked; // Method/CodeInstance/tuple Type for optimized task invocation
     // The cancellation token source last published by a cancellation point on
     // this task ("the token governing the compute currently running here").

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -911,6 +911,13 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
         for (size_t i = 0; i < cs->nparents; i++)
             jl_queue_for_serialization_(s, (jl_value_t*)links[i].parent, 1, immediate);
     }
+    else if (jl_is_wait_entry(v)) {
+        // Entirely transient wait state: the writer resets `task` and every
+        // slot, so queue nothing - in particular not the live Task the
+        // layout's field walk would otherwise pick up (mirroring the
+        // cancel-source case above, which skips its transient
+        // waiters_head/walk_lock).
+    }
     else if (layout->nfields > 0) {
         if (jl_options.trim) {
             if (jl_is_method(v)) {
@@ -1621,10 +1628,12 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
             assert(f == s->s);
             jl_cancel_source_t *cs = (jl_cancel_source_t*)v;
             write_pointerfield(s, jl_nothing); // child_head (weak; reset)
+            write_pointerfield(s, jl_nothing); // waiters_head (transient; reset)
+            write_pointerfield(s, jl_nothing); // walk_lock (transient; reset)
             write_uint8(f, jl_atomic_load_relaxed(&cs->state));
-            write_padding(f, offsetof(jl_cancel_source_t, nparents) - sizeof(void*) - sizeof(uint8_t));
+            write_padding(f, offsetof(jl_cancel_source_t, nparents) - 3 * sizeof(void*) - sizeof(uint8_t));
             ios_write(f, (char*)&cs->nparents, sizeof(uint16_t));
-            write_padding(f, sizeof(jl_cancel_source_t) - offsetof(jl_cancel_source_t, nparents) - sizeof(uint16_t));
+            write_padding(f, sizeof(jl_cancel_source_t) - offsetof(jl_cancel_source_t, nparents) - sizeof(uint16_t)); // incl. dead_count (transient; reset)
             jl_cancel_parent_link_t *links = jl_cancel_source_links(cs);
             for (size_t i = 0; i < cs->nparents; i++) {
                 write_pointerfield(s, (jl_value_t*)links[i].parent);
@@ -1633,6 +1642,19 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
             }
             // relink under the parents on load
             arraylist_push(&s->fixup_objs, (void*)reloc_offset);
+        }
+        else if (jl_is_wait_entry(v)) {
+            // Variable-sized; entirely transient wait state - reset on write.
+            assert(f == s->s);
+            jl_wait_entry_t *w = (jl_wait_entry_t*)v;
+            write_pointerfield(s, jl_nothing); // task (transient; reset)
+            ios_write(f, (char*)&w->nslots, sizeof(uint32_t));
+            write_padding(f, sizeof(jl_wait_entry_t) - offsetof(jl_wait_entry_t, nslots) - sizeof(uint32_t));
+            for (size_t i = 0; i < w->nslots; i++) {
+                write_pointerfield(s, jl_nothing); // owner (transient; reset)
+                write_pointerfield(s, jl_nothing); // next (transient; reset)
+                write_padding(f, sizeof(uint64_t)); // aux (transient; reset)
+            }
         }
         else if (jl_is_foreign_type(t) == 1) {
             abort(); // unreachable

--- a/src/task.c
+++ b/src/task.c
@@ -1100,6 +1100,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_fu
     t->queue = jl_nothing;
     jl_atomic_store_relaxed(&t->waiting_on, jl_nothing);
     t->cached_wait_entry = jl_nothing;
+    t->cached_cancel_entry = jl_nothing;
     t->tls = jl_nothing;
     jl_atomic_store_relaxed(&t->_state, JL_TASK_STATE_RUNNABLE);
     t->start = start;
@@ -1572,6 +1573,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     ct->queue = jl_nothing;
     jl_atomic_store_relaxed(&ct->waiting_on, jl_nothing);
     ct->cached_wait_entry = jl_nothing;
+    ct->cached_cancel_entry = jl_nothing;
     ct->tls = jl_nothing;
     jl_atomic_store_relaxed(&ct->_state, JL_TASK_STATE_RUNNABLE);
     ct->start = NULL;
@@ -1754,8 +1756,11 @@ JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
             jl_gc_set_weak_processing_target(ct->ptls, parents[i]);
     }
     jl_atomic_store_relaxed(&src->child_head, jl_nothing);
+    jl_atomic_store_relaxed(&src->waiters_head, jl_nothing);
+    jl_atomic_store_relaxed(&src->walk_lock, jl_nothing);
     jl_atomic_store_relaxed(&src->state, 0);
     src->nparents = (uint16_t)np;
+    jl_atomic_store_relaxed(&src->dead_count, 0);
     // Initialize every link entry before publishing the node under *any*
     // parent: a concurrent cancellation walk that reaches the node through
     // one parent scans all of its entries.
@@ -1769,6 +1774,72 @@ JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
     }
     cancel_source_attach(src);
     return (jl_value_t*)src;
+}
+
+// The variable-sized wait-entry kind (Core.WaitEntryN): storage only - the
+// registration protocols live in base/cancellation.jl. Slots are initialized
+// free (owner = nothing).
+JL_DLLEXPORT jl_value_t *jl_new_wait_entry(jl_value_t *task, size_t nslots)
+{
+    jl_task_t *ct = jl_current_task;
+    // `nslots` must fit the uint32_t field *and* keep the allocation-size
+    // arithmetic below from wrapping (on 32-bit, SIZE_MAX overflows long
+    // before UINT32_MAX slots do).
+    if (nslots > UINT32_MAX ||
+        nslots > (SIZE_MAX - sizeof(jl_wait_entry_t)) / sizeof(jl_wait_slot_t))
+        jl_error("WaitEntryN: too many slots");
+    jl_wait_entry_t *w = (jl_wait_entry_t*)jl_gc_alloc(
+        ct->ptls, sizeof(jl_wait_entry_t) + nslots * sizeof(jl_wait_slot_t),
+        jl_wait_entry_type);
+    jl_set_typetagof(w, jl_wait_entry_tag, 0);
+    jl_atomic_store_relaxed(&w->task, task);
+    w->nslots = (uint32_t)nslots;
+    jl_wait_slot_t *slots = jl_wait_entry_slots(w);
+    for (size_t i = 0; i < nslots; i++) {
+        jl_atomic_store_relaxed(&slots[i].owner, jl_nothing);
+        slots[i].next = jl_nothing;
+        slots[i].aux = 0;
+    }
+    return (jl_value_t*)w;
+}
+
+STATIC_INLINE jl_wait_slot_t *wait_entry_slot(jl_value_t *w, size_t i) JL_NOTSAFEPOINT
+{
+    assert(jl_is_wait_entry(w));
+    assert(i < ((jl_wait_entry_t*)w)->nslots);
+    return &jl_wait_entry_slots((jl_wait_entry_t*)w)[i];
+}
+
+JL_DLLEXPORT jl_value_t *jl_wait_entry_slot_owner(jl_value_t *w, size_t i) JL_NOTSAFEPOINT
+{
+    return jl_atomic_load_relaxed(&wait_entry_slot(w, i)->owner);
+}
+
+JL_DLLEXPORT void jl_wait_entry_set_slot_owner(jl_value_t *w, size_t i, jl_value_t *v) JL_NOTSAFEPOINT
+{
+    jl_atomic_store_relaxed(&wait_entry_slot(w, i)->owner, v);
+    jl_gc_wb(w, v);
+}
+
+JL_DLLEXPORT jl_value_t *jl_wait_entry_slot_next(jl_value_t *w, size_t i) JL_NOTSAFEPOINT
+{
+    return wait_entry_slot(w, i)->next;
+}
+
+JL_DLLEXPORT void jl_wait_entry_set_slot_next(jl_value_t *w, size_t i, jl_value_t *v) JL_NOTSAFEPOINT
+{
+    wait_entry_slot(w, i)->next = v;
+    jl_gc_wb(w, v);
+}
+
+JL_DLLEXPORT uint64_t jl_wait_entry_slot_aux(jl_value_t *w, size_t i) JL_NOTSAFEPOINT
+{
+    return wait_entry_slot(w, i)->aux;
+}
+
+JL_DLLEXPORT void jl_wait_entry_set_slot_aux(jl_value_t *w, size_t i, uint64_t v) JL_NOTSAFEPOINT
+{
+    wait_entry_slot(w, i)->aux = v;
 }
 
 // Push a (re)inherited cancelled state down `src`'s already-attached

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -314,12 +314,16 @@ mutable struct PollingFileWatcher
     closed::Bool # whether the user has explicitly destroyed this
     ioerrno::Int32 # the stat errno as of the last result
     prev_stat::StatStruct # the stat as of the last successful result
-    PollingFileWatcher(file::AbstractString, interval::Float64=5.007) = PollingFileWatcher(String(file), interval)
-    function PollingFileWatcher(file::String, interval::Float64=5.007) # same default as nodejs
+    PollingFileWatcher(file::AbstractString, interval::Float64=5.007; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) =
+        PollingFileWatcher(String(file), interval; cancel)
+    function PollingFileWatcher(file::String, interval::Float64=5.007;
+                                cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) # same default as nodejs
         stat_req = Memory{UInt8}(undef, Int(_sizeof_uv_fs))
         this = new(file, interval, Base.ThreadSynchronizer(), nothing, stat_req, false, false, 0, StatStruct())
         uv_req_set_data(stat_req, this)
-        wait(this) # initialize with the current stat before return
+        # the construction-time wait is governed by the caller's token (or
+        # explicit shield) - poll_file threads its resolved token here
+        wait(this; cancel) # initialize with the current stat before return
         return this
     end
 end
@@ -590,7 +594,7 @@ isopen(pfw::FDWatcher) = !pfw.mask.timedout
 Base.stat(pfw::PollingFileWatcher) = Base.checkstat(@lock pfw.notify pfw.prev_stat)
 
 # n.b. this _wait may return spuriously early with a timedout event
-function _wait(fdw::_FDWatcher, mask::FDEvent)
+function _wait(fdw::_FDWatcher, mask::FDEvent, tok::Base.MaybeToken)
     iolock_begin()
     preserve_handle(fdw)
     lock(fdw.notify)
@@ -614,7 +618,7 @@ function _wait(fdw::_FDWatcher, mask::FDEvent)
                 fdw.active = (readable, writable)
             end
             iolock_end()
-            return FDEvent(wait(fdw.notify)::Int32)
+            return FDEvent(wait(fdw.notify, tok)::Int32)
         else
             iolock_end()
             return events
@@ -625,13 +629,14 @@ function _wait(fdw::_FDWatcher, mask::FDEvent)
     end
 end
 
-function wait(fdw::_FDWatcher; readable=true, writable=true)
-    return wait(fdw, FDEvent(readable, writable, false, false))
+function wait(fdw::_FDWatcher; readable=true, writable=true, cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
+    return wait(fdw, FDEvent(readable, writable, false, false), tok)
 end
-function wait(fdw::_FDWatcher, mask::FDEvent)
+function wait(fdw::_FDWatcher, mask::FDEvent, tok::Base.MaybeToken)
     while true
         mask.timedout && return mask
-        events = _wait(fdw, mask)
+        events = _wait(fdw, mask, tok)
         if !events.timedout
             @lock fdw.notify fdw.events &= ~events.events
             return events
@@ -639,10 +644,11 @@ function wait(fdw::_FDWatcher, mask::FDEvent)
     end
 end
 
-function wait(fdw::FDWatcher)
+function wait(fdw::FDWatcher; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
     isopen(fdw) || throw(EOFError())
     while true
-        events = GC.@preserve fdw _wait(fdw.watcher, fdw.mask)
+        events = GC.@preserve fdw _wait(fdw.watcher, fdw.mask, tok)
         isopen(fdw) || throw(EOFError())
         if !events.timedout
             @lock fdw.watcher.notify fdw.watcher.events &= ~events.events
@@ -651,13 +657,14 @@ function wait(fdw::FDWatcher)
     end
 end
 
-function wait(socket::RawFD; readable=false, writable=false)
-    return wait(socket, FDEvent(readable, writable, false, false))
+function wait(socket::RawFD; readable=false, writable=false, cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
+    return wait(socket, FDEvent(readable, writable, false, false), tok)
 end
-function wait(fd::RawFD, mask::FDEvent)
+function wait(fd::RawFD, mask::FDEvent, tok::Base.MaybeToken=Base.default_cancel_token())
     fdw = _FDWatcher(fd, mask)
     try
-        return wait(fdw, mask)
+        return wait(fdw, mask, tok)
     finally
         close(fdw, mask)
     end
@@ -665,20 +672,22 @@ end
 
 
 if Sys.iswindows()
-    function wait(socket::WindowsRawSocket; readable=false, writable=false)
-        return wait(socket, FDEvent(readable, writable, false, false))
+    function wait(socket::WindowsRawSocket; readable=false, writable=false, cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+        tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
+        return wait(socket, FDEvent(readable, writable, false, false), tok)
     end
-    function wait(socket::WindowsRawSocket, mask::FDEvent)
+    function wait(socket::WindowsRawSocket, mask::FDEvent, tok::Base.MaybeToken=Base.default_cancel_token())
         fdw = _FDWatcher(socket, mask)
         try
-            return wait(fdw, mask)
+            return wait(fdw, mask, tok)
         finally
             close(fdw, mask)
         end
     end
 end
 
-function wait(pfw::PollingFileWatcher)
+function wait(pfw::PollingFileWatcher; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
     iolock_begin()
     lock(pfw.notify)
     prevstat = pfw.prev_stat
@@ -701,7 +710,7 @@ function wait(pfw::PollingFileWatcher)
             pfw.active = true
         end
         iolock_end()
-        havechange = wait(pfw.notify)::Bool
+        havechange = wait(pfw.notify, tok)::Bool
         unlock(pfw.notify)
         iolock_begin()
     catch
@@ -744,7 +753,8 @@ function wait(pfw::PollingFileWatcher)
     end
 end
 
-function wait(m::FileMonitor)
+function wait(m::FileMonitor; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
     (@atomic :monotonic m.handle) == C_NULL && throw(EOFError())
     preserve_handle(m)
     lock(m.notify)
@@ -756,7 +766,7 @@ function wait(m::FileMonitor)
             if m.ioerrno != 0
                 uv_error("FileMonitor", m.ioerrno)
             end
-            wait(m.notify)
+            wait(m.notify, tok)
         end
     finally
         unlock(m.notify)
@@ -764,14 +774,15 @@ function wait(m::FileMonitor)
     end
 end
 
-function wait(m::FolderMonitor)
+function wait(m::FolderMonitor; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
     (@atomic :monotonic m.handle) == C_NULL && throw(EOFError())
     preserve_handle(m)
     lock(m.notify)
     evt = try
             (@atomic :monotonic m.handle) == C_NULL && throw(EOFError())
             while isempty(m.channel)
-                wait(m.notify)
+                wait(m.notify, tok)
             end
             popfirst!(m.channel)
         finally
@@ -799,7 +810,8 @@ This is a thin wrapper over calling `wait` on a [`FDWatcher`](@ref), which imple
 functionality but requires the user to call `close` manually when finished with it, or risk
 serious crashes.
 """
-function poll_fd(s::Union{RawFD, Sys.iswindows() ? WindowsRawSocket : Union{}}, timeout_s::Real=-1; readable=false, writable=false)
+function poll_fd(s::Union{RawFD, Sys.iswindows() ? WindowsRawSocket : Union{}}, timeout_s::Real=-1; readable=false, writable=false, cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
     mask = FDEvent(readable, writable, false, false)
     mask.timedout && return mask
     fdw = _FDWatcher(s, mask)
@@ -816,7 +828,7 @@ function poll_fd(s::Union{RawFD, Sys.iswindows() ? WindowsRawSocket : Union{}}, 
             end
             try
                 while true
-                    events = _wait(fdw, mask)
+                    events = _wait(fdw, mask, tok)
                     if timedout[] || !events.timedout
                         @lock fdw.notify fdw.events &= ~events.events
                         return events
@@ -827,7 +839,7 @@ function poll_fd(s::Union{RawFD, Sys.iswindows() ? WindowsRawSocket : Union{}}, 
                 return FDEvent()
             end
         else
-            return wait(fdw, mask)
+            return wait(fdw, mask, tok)
         end
     finally
         if @isdefined(timer)
@@ -865,7 +877,8 @@ without being detected. To avoid this race, use
 
 directly, re-using the same `fm` each time you `wait`.
 """
-function watch_file(s::String, timeout_s::Float64=-1.0)
+function watch_file(s::String, timeout_s::Float64=-1.0; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
     fm = FileMonitor(s)
     local timer
     try
@@ -875,7 +888,7 @@ function watch_file(s::String, timeout_s::Float64=-1.0)
             end
         end
         try
-            return wait(fm)
+            return wait(fm; cancel=tok)
         catch ex
             ex isa EOFError && return FileEvent()
             rethrow()
@@ -885,7 +898,8 @@ function watch_file(s::String, timeout_s::Float64=-1.0)
         @isdefined(timer) && close(timer)
     end
 end
-watch_file(s::AbstractString, timeout_s::Real=-1) = watch_file(String(s), Float64(timeout_s))
+watch_file(s::AbstractString, timeout_s::Real=-1; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) =
+    watch_file(String(s), Float64(timeout_s); cancel)
 
 """
     watch_folder(path::AbstractString, timeout_s::Real=-1)
@@ -907,8 +921,10 @@ This behavior of this function varies slightly across platforms. See
 
 This function is a thin wrapper over calling `wait` on a [`FolderMonitor`](@ref), with added timeout support.
 """
-watch_folder(s::AbstractString, timeout_s::Real=-1) = watch_folder(String(s), timeout_s)
-function watch_folder(s::String, timeout_s::Real=-1)
+watch_folder(s::AbstractString, timeout_s::Real=-1; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) =
+    watch_folder(String(s), timeout_s; cancel)
+function watch_folder(s::String, timeout_s::Real=-1; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
     fm = @lock watched_folders get!(watched_folders[], s) do
         return FolderMonitor(s)
     end
@@ -917,7 +933,7 @@ function watch_folder(s::String, timeout_s::Real=-1)
         @lock fm.notify isempty(fm.channel) || return popfirst!(fm.channel)
         if timeout_s <= 0.010
             # for very small timeouts, we can just sleep for the whole timeout-interval
-            (timeout_s == 0) ? yield() : sleep(timeout_s)
+            (timeout_s == 0) ? yield() : sleep(timeout_s; cancel=tok)
             @lock fm.notify isempty(fm.channel) || return popfirst!(fm.channel)
             return "" => FileEvent() # timeout
         else
@@ -936,7 +952,7 @@ function watch_folder(s::String, timeout_s::Real=-1)
                 if @isdefined(timer)
                     isopen(timer) || return "" => FileEvent() # timeout
                 end
-                wait(fm.notify)
+                wait(fm.notify, tok)
             end
             popfirst!(fm.channel)
         finally
@@ -985,8 +1001,11 @@ This is a thin wrapper over calling `wait` on a [`PollingFileWatcher`](@ref), wh
 the functionality, but this function has a small race window between consecutive calls to
 `poll_file` where the file might change without being detected.
 """
-function poll_file(s::AbstractString, interval_seconds::Real=5.007, timeout_s::Real=-1)
-    pfw = PollingFileWatcher(s, Float64(interval_seconds))
+function poll_file(s::AbstractString, interval_seconds::Real=5.007, timeout_s::Real=-1; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
+    # the watcher constructor performs an initial wait: it must run under
+    # this operation's resolved token, not the ambient scope
+    pfw = PollingFileWatcher(s, Float64(interval_seconds); cancel=tok)
     local timer
     try
         if timeout_s >= 0
@@ -994,7 +1013,7 @@ function poll_file(s::AbstractString, interval_seconds::Real=5.007, timeout_s::R
                 close(pfw)
             end
         end
-        return wait(pfw)
+        return wait(pfw; cancel=tok)
     finally
         close(pfw)
         @isdefined(timer) && close(timer)

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -598,6 +598,7 @@ function _wait(fdw::_FDWatcher, mask::FDEvent, tok::Base.MaybeToken)
     iolock_begin()
     preserve_handle(fdw)
     lock(fdw.notify)
+    locked = true
     try
         events = FDEvent(fdw.events & mask.events)
         if !isopen(fdw) # !open
@@ -618,13 +619,16 @@ function _wait(fdw::_FDWatcher, mask::FDEvent, tok::Base.MaybeToken)
                 fdw.active = (readable, writable)
             end
             iolock_end()
-            return FDEvent(wait(fdw.notify, tok)::Int32)
+            locked = false
+            evt = wait(fdw.notify, tok)::Int32
+            locked = true
+            return FDEvent(evt)
         else
             iolock_end()
             return events
         end
     finally
-        unlock(fdw.notify)
+        locked && unlock(fdw.notify)
         unpreserve_handle(fdw)
     end
 end
@@ -690,6 +694,8 @@ function wait(pfw::PollingFileWatcher; cancel::Base.CancelTokenArg=Base.DEFAULT_
     tok = Base.resolve_cancel_token(Base.precheck_cancel_arg(cancel))
     iolock_begin()
     lock(pfw.notify)
+    locked = true
+    iolocked = true
     prevstat = pfw.prev_stat
     havechange = false
     timer = nothing
@@ -710,13 +716,21 @@ function wait(pfw::PollingFileWatcher; cancel::Base.CancelTokenArg=Base.DEFAULT_
             pfw.active = true
         end
         iolock_end()
+        iolocked = false
+        locked = false
         havechange = wait(pfw.notify, tok)::Bool
+        locked = true
         unlock(pfw.notify)
+        locked = false
         iolock_begin()
+        iolocked = true
     catch
         # stop_watching: cleanup any timers from before or after starting this wait before it failed, if there are no other watchers
+        # (reacquire what the cleanup reads - the wait-throw released both)
+        iolocked || iolock_begin()
         latetimer = nothing
         try
+            locked || lock(pfw.notify)
             if isempty(pfw.notify)
                 latetimer = pfw.timer
                 pfw.timer = nothing
@@ -730,6 +744,11 @@ function wait(pfw::PollingFileWatcher; cancel::Base.CancelTokenArg=Base.DEFAULT_
             latetimer === nothing || close(latetimer)
             iolock_begin()
         end
+        # rethrow WITHOUT the iolock: the normal path's trailing
+        # iolock_end is skipped on the exceptional exit, so the hold
+        # taken for this cleanup must be released here (leaking it
+        # starves the event loop process-wide)
+        iolock_end()
         rethrow()
     end
     iolock_end()
@@ -758,6 +777,7 @@ function wait(m::FileMonitor; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
     (@atomic :monotonic m.handle) == C_NULL && throw(EOFError())
     preserve_handle(m)
     lock(m.notify)
+    locked = true
     try
         while true
             (@atomic :monotonic m.handle) == C_NULL && throw(EOFError())
@@ -766,10 +786,12 @@ function wait(m::FileMonitor; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
             if m.ioerrno != 0
                 uv_error("FileMonitor", m.ioerrno)
             end
+            locked = false
             wait(m.notify, tok)
+            locked = true
         end
     finally
-        unlock(m.notify)
+        locked && unlock(m.notify)
         unpreserve_handle(m)
     end
 end
@@ -779,14 +801,17 @@ function wait(m::FolderMonitor; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
     (@atomic :monotonic m.handle) == C_NULL && throw(EOFError())
     preserve_handle(m)
     lock(m.notify)
+    locked = true
     evt = try
             (@atomic :monotonic m.handle) == C_NULL && throw(EOFError())
             while isempty(m.channel)
+                locked = false
                 wait(m.notify, tok)
+                locked = true
             end
             popfirst!(m.channel)
         finally
-            unlock(m.notify)
+            locked && unlock(m.notify)
             unpreserve_handle(m)
         end
     return evt::Pair{String, FileEvent}
@@ -946,17 +971,20 @@ function watch_folder(s::String, timeout_s::Real=-1; cancel::Base.CancelTokenArg
     (@atomic :monotonic fm.handle) == C_NULL && throw(EOFError())
     preserve_handle(fm)
     lock(fm.notify)
+    locked = true
     evt = try
             (@atomic :monotonic fm.handle) == C_NULL && throw(EOFError())
             while isempty(fm.channel)
                 if @isdefined(timer)
                     isopen(timer) || return "" => FileEvent() # timeout
                 end
+                locked = false
                 wait(fm.notify, tok)
+                locked = true
             end
             popfirst!(fm.channel)
         finally
-            unlock(fm.notify)
+            locked && unlock(fm.notify)
             unpreserve_handle(fm)
             @isdefined(timer) && close(timer)
         end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -3209,7 +3209,7 @@ function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_s
             notify(s.prompt_ready_event)
         end
         old_state = mode(s)
-        # spawn this because the main repl task is sticky (due to use of @async and _wait2)
+        # spawn this because the main repl task is sticky (due to use of @async and schedule_on_notify!)
         # and we want to not block typing when the repl task thread is busy
         t2 = Threads.@spawn :interactive while true
             eof(term) || peek(term) # wait before locking but don't consume

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -694,24 +694,27 @@ end
 function run_repl(repl::AbstractREPL, @nospecialize(consumer = x -> nothing); backend_on_current_task::Bool = true, backend = REPLBackend())
     backend_ref = REPLBackendRef(backend)
     get_module = () -> Base.active_module(repl)
-    cleanup_task(backend_ref, t) = @task try
+    # REPL teardown is cleanup: shield it from any scope cancellation
+    cleanup_task(backend_ref, t) = Base.ScopedValues.with(Base.CANCEL_TOKEN => nothing) do
+        @task try
             destroy(backend_ref, t)
         catch e
             Core.print(Core.stderr, "\nINTERNAL ERROR: ")
             Core.println(Core.stderr, e)
             Core.println(Core.stderr, catch_backtrace())
         end
+    end
     if backend_on_current_task
         t = @async run_frontend(repl, backend_ref)
         cleanup = cleanup_task(backend_ref, t)
         errormonitor(t)
-        Base._wait2(t, cleanup)
+        Base.schedule_on_notify!(t, cleanup)
         start_repl_backend(backend, consumer; get_module)
     else
         t = @async start_repl_backend(backend, consumer; get_module)
         cleanup = cleanup_task(backend_ref, t)
         errormonitor(t)
-        Base._wait2(t, cleanup)
+        Base.schedule_on_notify!(t, cleanup)
         run_frontend(repl, backend_ref)
     end
     return backend

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -609,6 +609,29 @@ function deserialize(s::AbstractSerializer, ::Type{Core.CancellationTokenSource}
     return src
 end
 
+# Core.WaitEntryN has a hidden variable-length slot tail that the generic
+# deserializer - which allocates only the fixed datatype size - cannot
+# reproduce (the GC would then scan a nonexistent tail). Its contents are
+# transient wait-registration state that does not round-trip: only the slot
+# count is written (plus a `nothing` task), and deserialization
+# reconstructs through the runtime allocator with fresh, free slots.
+function serialize(s::AbstractSerializer, w::Core.WaitEntryN)
+    serialize_cycle_header(s, w) && return
+    serialize(s, nothing)  # task: transient, never round-trips
+    serialize(s, Int64(w.nslots))
+    nothing
+end
+
+function deserialize(s::AbstractSerializer, ::Type{Core.WaitEntryN})
+    task = deserialize(s)::Union{Task, Nothing}
+    ns = Int(deserialize(s)::Int64)
+    0 <= ns <= typemax(UInt32) ||
+        throw(ArgumentError("invalid slot count $ns in serialized WaitEntryN"))
+    w = Base.WaitEntryN(task, ns)
+    deserialize_cycle(s, w)
+    return w
+end
+
 
 function serialize(s::AbstractSerializer, linfo::Core.MethodInstance)
     serialize_cycle(s, linfo) && return

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -678,7 +678,7 @@ let c1 = Threads.Condition()
     c2 = Threads.Condition(c1.lock)
     lock(c2)
     t = @task nothing
-    Base._wait2(c1, t)
+    Base.schedule_on_notify!(c1, t)
     c3, c4 = deserialize(IOBuffer(sprint(serialize, [c1, c2])))::Vector{Threads.Condition}
     @test c3.lock === c4.lock
     @test islocked(c1)

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -827,3 +827,27 @@ end
     data[end] = 0xbf # state byte: invalid severity 0xbf
     @test_throws ArgumentError deserialize(IOBuffer(data))
 end
+
+@testset "WaitEntryN" begin
+    # variable-sized runtime object: it must be reconstructed through the
+    # runtime allocator (the generic path would allocate only the fixed
+    # datatype size, and the GC would then scan a nonexistent slot tail)
+    w = Base.WaitEntryN(current_task(), 4)
+    buf = IOBuffer()
+    serialize(buf, w)
+    seekstart(buf)
+    w2 = deserialize(buf)
+    @test w2 isa Core.WaitEntryN
+    @test Base._nslots(w2) == 4
+    # transient wait state does not round-trip: no task, fresh free slots
+    @test (@atomic :monotonic w2.task) === nothing
+    @test all(i -> Base._slot_owner(w2, i) === nothing, 1:4)
+    GC.gc(true)
+    # identity sharing within one stream
+    buf = IOBuffer()
+    serialize(buf, (w, w))
+    seekstart(buf)
+    a, b = deserialize(buf)
+    @test a === b && Base._nslots(a) == 4
+    GC.gc(true)
+end

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -360,11 +360,14 @@ function recvfrom(sock::UDPSocket; cancel::Base.CancelTokenArg=Base.DEFAULT_CANC
     end
     sock.status = StatusActive
     lock(sock.recvnotify)
+    locked = true
     iolock_end()
     try
         From = Union{InetAddr{IPv4}, InetAddr{IPv6}}
         Data = Vector{UInt8}
+        locked = false
         from, data = wait(sock.recvnotify, tok)::Tuple{From, Data}
+        locked = true
         return (from, data)
     catch
         # A cancelled (or otherwise interrupted) wait must not leave
@@ -373,10 +376,11 @@ function recvfrom(sock::UDPSocket; cancel::Base.CancelTokenArg=Base.DEFAULT_CANC
         # dropped (`recvnotify` is edge-triggered), starving the next
         # recvfrom. Mirror the callback's stop logic; the iolock must be
         # (re)taken first - iolock before recvnotify is the callback's lock
-        # order (the wait's rethrow path reacquired only recvnotify).
-        unlock(sock.recvnotify)
+        # order (a wait-throw released this frame's level already).
+        locked && (unlock(sock.recvnotify); locked = false)
         iolock_begin()
         lock(sock.recvnotify)
+        locked = true
         if sock.status == StatusActive && isempty(sock.recvnotify)
             sock.status = StatusOpen
             ccall(:uv_udp_recv_stop, Cint, (Ptr{Cvoid},), sock)
@@ -384,7 +388,7 @@ function recvfrom(sock::UDPSocket; cancel::Base.CancelTokenArg=Base.DEFAULT_CANC
         iolock_end()
         rethrow()
     finally
-        unlock(sock.recvnotify)
+        locked && unlock(sock.recvnotify)
     end
 end
 
@@ -544,17 +548,22 @@ function wait_connected(x::LibuvStream, tok::Base.MaybeToken=Base.default_cancel
     isopen(x) || x.readerror === nothing || throw(x.readerror)
     preserve_handle(x)
     lock(x.cond)
+    locked = true
     try
         while x.status == StatusConnecting
             iolock_end()
+            locked = false
             wait(x.cond, tok)
+            locked = true
             unlock(x.cond)
+            locked = false
             iolock_begin()
             lock(x.cond)
+            locked = true
         end
         isopen(x) || x.readerror === nothing || throw(x.readerror)
     finally
-        unlock(x.cond)
+        locked && unlock(x.cond)
         unpreserve_handle(x)
     end
     iolock_end()
@@ -744,10 +753,13 @@ function accept(server::LibuvServer, client::LibuvStream; cancel::Base.CancelTok
         preserve_handle(server)
         lock(server.cond)
         iolock_end()
+        locked = true
         try
+            locked = false
             wait(server.cond, tok)
+            locked = true
         finally
-            unlock(server.cond)
+            locked && unlock(server.cond)
             unpreserve_handle(server)
         end
         iolock_begin()

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -150,7 +150,8 @@ Accepts a connection on the given server and returns a connection to the client.
 uninitialized client stream may be provided, in which case it will be used instead of
 creating a new stream.
 """
-accept(server::TCPServer) = accept(server, TCPSocket())
+accept(server::TCPServer; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) =
+    accept(server, TCPSocket(); cancel)
 
 function accept(callback, server::LibuvServer)
     task = @async try
@@ -326,8 +327,8 @@ end
 
 Read a UDP packet from the specified socket, and return the bytes received. This call blocks.
 """
-function recv(sock::UDPSocket)
-    addr, data = recvfrom(sock)
+function recv(sock::UDPSocket; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    addr, data = recvfrom(sock; cancel)
     return data
 end
 
@@ -343,7 +344,8 @@ Read a UDP packet from the specified socket, returning a tuple of `(host_port, d
     Prior to Julia version 1.3, the first returned value was an address (`IPAddr`).
     In version 1.3 it was changed to an `InetAddr`.
 """
-function recvfrom(sock::UDPSocket)
+function recvfrom(sock::UDPSocket; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.check_cancel_arg(cancel)
     iolock_begin()
     # If the socket has not been bound, it will be bound implicitly to ::0 and a random port
     if sock.status != StatusInit && sock.status != StatusOpen && sock.status != StatusActive
@@ -362,8 +364,25 @@ function recvfrom(sock::UDPSocket)
     try
         From = Union{InetAddr{IPv4}, InetAddr{IPv6}}
         Data = Vector{UInt8}
-        from, data = wait(sock.recvnotify)::Tuple{From, Data}
+        from, data = wait(sock.recvnotify, tok)::Tuple{From, Data}
         return (from, data)
+    catch
+        # A cancelled (or otherwise interrupted) wait must not leave
+        # continuous reception running with nobody waiting: a datagram
+        # arriving after this unwind would be consumed by the callback and
+        # dropped (`recvnotify` is edge-triggered), starving the next
+        # recvfrom. Mirror the callback's stop logic; the iolock must be
+        # (re)taken first - iolock before recvnotify is the callback's lock
+        # order (the wait's rethrow path reacquired only recvnotify).
+        unlock(sock.recvnotify)
+        iolock_begin()
+        lock(sock.recvnotify)
+        if sock.status == StatusActive && isempty(sock.recvnotify)
+            sock.status = StatusOpen
+            ccall(:uv_udp_recv_stop, Cint, (Ptr{Cvoid},), sock)
+        end
+        iolock_end()
+        rethrow()
     finally
         unlock(sock.recvnotify)
     end
@@ -418,13 +437,21 @@ function uv_recvcb(handle::Ptr{Cvoid}, nread::Cssize_t, buf::Ptr{Cvoid}, addr::P
     nothing
 end
 
+# completion callback for UDP sends: like Base.uv_writecb_task, but delivers
+# the raw status (a UDP send has no partial write count)
+function uv_sendcb_task(req::Ptr{Cvoid}, status::Cint)
+    t = Base._claim_uvreq_waiter(req)
+    t === nothing || schedule(t, status)
+    nothing
+end
+
 function _send_async(sock::UDPSocket, ipaddr::Union{IPv4, IPv6}, port::UInt16, buf)
     req = Libc.malloc(Base._sizeof_uv_udp_send)
     uv_req_set_data(req, C_NULL) # in case we get interrupted before arriving at the wait call
     host_in = Ref(hton(ipaddr.host))
     err = ccall(:jl_udp_send, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, UInt16, Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{Cvoid}, Cint),
                 req, sock, hton(port), host_in, buf, sizeof(buf),
-                @cfunction(Base.uv_writecb_task, Cvoid, (Ptr{Cvoid}, Cint)),
+                @cfunction(uv_sendcb_task, Cvoid, (Ptr{Cvoid}, Cint)),
                 ipaddr isa IPv6)
     if err < 0
         Libc.free(req)
@@ -438,36 +465,20 @@ end
 
 Send `msg` over `socket` to `host:port`.
 """
-function send(sock::UDPSocket, ipaddr::IPAddr, port::Integer, msg)
+function send(sock::UDPSocket, ipaddr::IPAddr, port::Integer, msg;
+              cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
     # If the socket has not been bound, it will be bound implicitly to ::0 and a random port
     iolock_begin()
     if sock.status != StatusInit && sock.status != StatusOpen && sock.status != StatusActive
         error("UDPSocket is not initialized and open")
     end
+    src = Base.cancel_source(Base.resolve_cancel_token(cancel))
+    # entry check: throw before handing anything to libuv
+    Base._iolocked_checkcancel(src)
     uvw = _send_async(sock, ipaddr, UInt16(port), msg)
-    ct = current_task()
-    preserve_handle(ct)
-    Base.sigatomic_begin()
-    uv_req_set_data(uvw, ct)
-    iolock_end()
-    status = try
-        Base.sigatomic_end()
-        wait()::Cint
-    finally
-        Base.sigatomic_end()
-        iolock_begin()
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.StickyWorkqueue, ct)
-        if uv_req_data(uvw) != C_NULL
-            # uvw is still alive,
-            # so make sure we won't get spurious notifications later
-            uv_req_set_data(uvw, C_NULL)
-        else
-            # done with uvw
-            Libc.free(uvw)
-        end
-        iolock_end()
-        unpreserve_handle(ct)
-    end
+    # A UDP send request itself cannot be cancelled, so an interrupted wait
+    # detaches it, with `msg` rooted until its completion callback frees it.
+    status = Base._wait_uvreq(src, sock, uvw, false, msg)::Cint
     uv_error("send", status)
     nothing
 end
@@ -527,7 +538,7 @@ end
 
 connect!(sock::TCPSocket, addr::InetAddr) = connect!(sock, addr.host, addr.port)
 
-function wait_connected(x::LibuvStream)
+function wait_connected(x::LibuvStream, tok::Base.MaybeToken=Base.default_cancel_token())
     iolock_begin()
     check_open(x)
     isopen(x) || x.readerror === nothing || throw(x.readerror)
@@ -536,7 +547,7 @@ function wait_connected(x::LibuvStream)
     try
         while x.status == StatusConnecting
             iolock_end()
-            wait(x.cond)
+            wait(x.cond, tok)
             unlock(x.cond)
             iolock_begin()
             lock(x.cond)
@@ -557,13 +568,16 @@ end
 
 Connect to the host `host` on port `port`.
 """
-connect(sock::TCPSocket, port::Integer) = connect(sock, localhost, port)
-connect(port::Integer) = connect(localhost, port)
+connect(sock::TCPSocket, port::Integer; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) =
+    connect(sock, localhost, port; cancel)
+connect(port::Integer; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) = connect(localhost, port; cancel)
 
 # Valid connect signatures for TCP
-connect(host::AbstractString, port::Integer) = connect(TCPSocket(), host, port)
-connect(addr::IPAddr, port::Integer) = connect(TCPSocket(), addr, port)
-connect(addr::InetAddr) = connect(TCPSocket(), addr)
+connect(host::AbstractString, port::Integer; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) =
+    connect(TCPSocket(), host, port; cancel)
+connect(addr::IPAddr, port::Integer; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) =
+    connect(TCPSocket(), addr, port; cancel)
+connect(addr::InetAddr; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) = connect(TCPSocket(), addr; cancel)
 
 function connect!(sock::TCPSocket, host::AbstractString, port::Integer)
     if sock.status != StatusInit
@@ -574,9 +588,26 @@ function connect!(sock::TCPSocket, host::AbstractString, port::Integer)
     return sock
 end
 
-function connect(sock::LibuvStream, args...)
+function connect(sock::LibuvStream, args::Vararg{Any, N}; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) where {N}
+    tok = Base.check_cancel_arg(cancel)
     connect!(sock, args...)
-    wait_connected(sock)
+    wait_connected(sock, tok)
+    return sock
+end
+
+# Hostname connect performs a DNS lookup first: the operation's resolved
+# token (or explicit shield) must govern that wait too, not just the final
+# connection wait, so thread it rather than let getaddrinfo default to the
+# ambient scope.
+function connect(sock::TCPSocket, host::AbstractString, port::Integer;
+                 cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.check_cancel_arg(cancel)
+    if sock.status != StatusInit
+        error("TCPSocket is not in initialization state")
+    end
+    ipaddr = getaddrinfo(host; cancel=tok)
+    connect!(sock, ipaddr, port)
+    wait_connected(sock, tok)
     return sock
 end
 
@@ -696,7 +727,8 @@ function accept_nonblock(server::TCPServer)
     return client
 end
 
-function accept(server::LibuvServer, client::LibuvStream)
+function accept(server::LibuvServer, client::LibuvStream; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.check_cancel_arg(cancel)
     iolock_begin()
     if server.status != StatusActive && server.status != StatusClosing && server.status != StatusClosed
         throw(ArgumentError("server not connected, make sure \"listen\" has been called"))
@@ -713,7 +745,7 @@ function accept(server::LibuvServer, client::LibuvStream)
         lock(server.cond)
         iolock_end()
         try
-            wait(server.cond)
+            wait(server.cond, tok)
         finally
             unlock(server.cond)
             unpreserve_handle(server)

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -18,33 +18,31 @@ function show(io::IO, err::DNSError)
 end
 
 function uv_getaddrinfocb(req::Ptr{Cvoid}, status::Cint, addrinfo::Ptr{Cvoid})
-    data = uv_req_data(req)
-    if data != C_NULL
-        t = unsafe_pointer_to_objref(data)::Task
-        uv_req_set_data(req, C_NULL)
-        if status != 0 || addrinfo == C_NULL
-            schedule(t, _UVError("getaddrinfo", status))
-        else
-            freeaddrinfo = addrinfo
-            addrs = IPAddr[]
-            while addrinfo != C_NULL
-                sockaddr = ccall(:jl_sockaddr_from_addrinfo, Ptr{Cvoid}, (Ptr{Cvoid},), addrinfo)
-                if ccall(:jl_sockaddr_is_ip4, Int32, (Ptr{Cvoid},), sockaddr) == 1
-                    ip4addr = ccall(:jl_sockaddr_host4, UInt32, (Ptr{Cvoid},), sockaddr)
-                    push!(addrs, IPv4(ntoh(ip4addr)))
-                elseif ccall(:jl_sockaddr_is_ip6, Int32, (Ptr{Cvoid},), sockaddr) == 1
-                    ip6addr = Ref{UInt128}()
-                    scope_id = ccall(:jl_sockaddr_host6, UInt32, (Ptr{Cvoid}, Ptr{UInt128}), sockaddr, ip6addr)
-                    push!(addrs, IPv6(ntoh(ip6addr[])))
-                end
-                addrinfo = ccall(:jl_next_from_addrinfo, Ptr{Cvoid}, (Ptr{Cvoid},), addrinfo)
-            end
-            ccall(:uv_freeaddrinfo, Cvoid, (Ptr{Cvoid},), freeaddrinfo)
-            schedule(t, addrs)
-        end
+    t = Base._claim_uvreq_waiter(req)
+    if t === nothing
+        # nobody to deliver to: also release the system-owned result
+        addrinfo == C_NULL || ccall(:uv_freeaddrinfo, Cvoid, (Ptr{Cvoid},), addrinfo)
+        return nothing
+    end
+    if status != 0 || addrinfo == C_NULL
+        schedule(t, _UVError("getaddrinfo", status))
     else
-        # no owner for this req, safe to just free it
-        Libc.free(req)
+        freeaddrinfo = addrinfo
+        addrs = IPAddr[]
+        while addrinfo != C_NULL
+            sockaddr = ccall(:jl_sockaddr_from_addrinfo, Ptr{Cvoid}, (Ptr{Cvoid},), addrinfo)
+            if ccall(:jl_sockaddr_is_ip4, Int32, (Ptr{Cvoid},), sockaddr) == 1
+                ip4addr = ccall(:jl_sockaddr_host4, UInt32, (Ptr{Cvoid},), sockaddr)
+                push!(addrs, IPv4(ntoh(ip4addr)))
+            elseif ccall(:jl_sockaddr_is_ip6, Int32, (Ptr{Cvoid},), sockaddr) == 1
+                ip6addr = Ref{UInt128}()
+                scope_id = ccall(:jl_sockaddr_host6, UInt32, (Ptr{Cvoid}, Ptr{UInt128}), sockaddr, ip6addr)
+                push!(addrs, IPv6(ntoh(ip6addr[])))
+            end
+            addrinfo = ccall(:jl_next_from_addrinfo, Ptr{Cvoid}, (Ptr{Cvoid},), addrinfo)
+        end
+        ccall(:uv_freeaddrinfo, Cvoid, (Ptr{Cvoid},), freeaddrinfo)
+        schedule(t, addrs)
     end
     nothing
 end
@@ -63,7 +61,8 @@ julia> getalladdrinfo("google.com")
  ip"2607:f8b0:4000:804::200e"
 ```
 """
-function getalladdrinfo(host::String)
+function getalladdrinfo(host::String; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.check_cancel_arg(cancel)
     req = Libc.malloc(Base._sizeof_uv_getaddrinfo)
     uv_req_set_data(req, C_NULL) # in case we get interrupted before arriving at the wait call
     iolock_begin()
@@ -79,30 +78,7 @@ function getalladdrinfo(host::String)
         end
         uv_error("getaddrinfo", status)
     end
-    ct = current_task()
-    preserve_handle(ct)
-    Base.sigatomic_begin()
-    uv_req_set_data(req, ct)
-    iolock_end()
-    r = try
-        Base.sigatomic_end()
-        wait()
-    finally
-        Base.sigatomic_end()
-        iolock_begin()
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.StickyWorkqueue, ct)
-        if uv_req_data(req) != C_NULL
-            # req is still alive,
-            # so make sure we don't get spurious notifications later
-            uv_req_set_data(req, C_NULL)
-            ccall(:uv_cancel, Int32, (Ptr{Cvoid},), req) # try to let libuv know we don't care anymore
-        else
-            # done with req
-            Libc.free(req)
-        end
-        iolock_end()
-        unpreserve_handle(ct)
-    end
+    r = _wait_dns_req(req, tok)
     if isa(r, IOError)
         code = r.code
         if code in (UV_EAI_ADDRFAMILY, UV_EAI_AGAIN, UV_EAI_BADFLAGS,
@@ -119,7 +95,16 @@ function getalladdrinfo(host::String)
     end
     return r::Vector{IPAddr}
 end
-getalladdrinfo(host::AbstractString) = getalladdrinfo(String(host))
+getalladdrinfo(host::AbstractString; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) =
+    getalladdrinfo(String(host); cancel)
+
+# Park on an in-flight uv getaddrinfo/getnameinfo request (already issued,
+# with its data field still C_NULL). There is no waitee object for a DNS
+# lookup, so the request itself doubles as the wait witness; a wait that
+# ends without the completion callback having run `uv_cancel`s the lookup
+# and detaches the request. Caller must hold the iolock.
+_wait_dns_req(req::Ptr{Cvoid}, tok::Base.MaybeToken) =
+    Base._wait_uvreq(Base.cancel_source(tok), req, req, true, nothing)
 
 """
     getaddrinfo(host::AbstractString, IPAddr) -> IPAddr
@@ -137,8 +122,8 @@ julia> getaddrinfo("localhost", IPv4)
 ip"127.0.0.1"
 ```
 """
-function getaddrinfo(host::String, T::Type{<:IPAddr})
-    addrs = getalladdrinfo(host)
+function getaddrinfo(host::String, T::Type{<:IPAddr}; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    addrs = getalladdrinfo(host; cancel)
     for addr in addrs
         if addr isa T
             return addr
@@ -146,7 +131,8 @@ function getaddrinfo(host::String, T::Type{<:IPAddr})
     end
     throw(DNSError(host, UV_EAI_NONAME))
 end
-getaddrinfo(host::AbstractString, T::Type{<:IPAddr}) = getaddrinfo(String(host), T)
+getaddrinfo(host::AbstractString, T::Type{<:IPAddr}; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL) =
+    getaddrinfo(String(host), T; cancel)
 
 """
     getaddrinfo(host::AbstractString) -> IPAddr
@@ -155,8 +141,8 @@ Gets the first available IP address of `host`, which may be either an `IPv4` or
 `IPv6` address. Uses the operating system's underlying getaddrinfo
 implementation, which may do a DNS lookup.
 """
-function getaddrinfo(host::AbstractString)
-    addrs = getalladdrinfo(String(host))
+function getaddrinfo(host::AbstractString; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    addrs = getalladdrinfo(String(host); cancel)
     if !isempty(addrs)
         return addrs[begin]::Union{IPv4,IPv6}
     end
@@ -164,18 +150,13 @@ function getaddrinfo(host::AbstractString)
 end
 
 function uv_getnameinfocb(req::Ptr{Cvoid}, status::Cint, hostname::Cstring, service::Cstring)
-    data = uv_req_data(req)
-    if data != C_NULL
-        t = unsafe_pointer_to_objref(data)::Task
-        uv_req_set_data(req, C_NULL)
+    t = Base._claim_uvreq_waiter(req)
+    if t !== nothing
         if status != 0
             schedule(t, _UVError("getnameinfo", status))
         else
             schedule(t, unsafe_string(hostname))
         end
-    else
-        # no owner for this req, safe to just free it
-        Libc.free(req)
     end
     nothing
 end
@@ -192,7 +173,8 @@ julia> getnameinfo(IPv4("8.8.8.8"))
 "google-public-dns-a.google.com"
 ```
 """
-function getnameinfo(address::Union{IPv4, IPv6})
+function getnameinfo(address::Union{IPv4, IPv6}; cancel::Base.CancelTokenArg=Base.DEFAULT_CANCEL)
+    tok = Base.check_cancel_arg(cancel)
     req = Libc.malloc(Base._sizeof_uv_getnameinfo)
     uv_req_set_data(req, C_NULL) # in case we get interrupted before arriving at the wait call
     port = hton(UInt16(0))
@@ -212,30 +194,7 @@ function getnameinfo(address::Union{IPv4, IPv6})
         end
         uv_error("getnameinfo", status)
     end
-    ct = current_task()
-    preserve_handle(ct)
-    Base.sigatomic_begin()
-    uv_req_set_data(req, ct)
-    iolock_end()
-    r = try
-        Base.sigatomic_end()
-        wait()
-    finally
-        Base.sigatomic_end()
-        iolock_begin()
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::Base.StickyWorkqueue, ct)
-        if uv_req_data(req) != C_NULL
-            # req is still alive,
-            # so make sure we don't get spurious notifications later
-            uv_req_set_data(req, C_NULL)
-            ccall(:uv_cancel, Int32, (Ptr{Cvoid},), req) # try to let libuv know we don't care anymore
-        else
-            # done with req
-            Libc.free(req)
-        end
-        iolock_end()
-        unpreserve_handle(ct)
-    end
+    r = _wait_dns_req(req, tok)
     if isa(r, IOError)
         code = r.code
         if code in (UV_EAI_ADDRFAMILY, UV_EAI_AGAIN, UV_EAI_BADFLAGS,

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -1147,6 +1147,65 @@ end
     @test 0 <= nwritten3[] < length(big)
     close(p3)
 
+    # split writes (multiple outstanding uv requests, forced via a tiny
+    # chunk size): cancellation sweeps the queued chunks tail-first and
+    # the reported count is exactly the bytes on the wire
+    let p = linked_pipe()
+        srcs = CancellationTokenSource()
+        toks = CancellationToken(srcs)
+        n = 1 << 20
+        data = rand(UInt8, n)
+        chunk = UInt(4096)
+        writer = @async GC.@preserve data begin
+            Base.iolock_begin()
+            Base._uv_write_wait(p.in, pointer(data), UInt(n), toks, data, true, chunk)
+        end
+        # observable progress gate: a successful read proves the writer is
+        # past its entry check with the chunks submitted (so the
+        # cancellation below interrupts the wait rather than the entry),
+        # then the kernel buffer refills and the writer parks with most
+        # chunks still queued in libuv
+        head = read(p.out, Int(chunk))
+        @test head == data[1:Int(chunk)]
+        @test timedwait(() -> (@atomic :monotonic writer.waiting_on) !== nothing, 20.0) == :ok
+        cancel!(srcs)
+        accepted = fetch(writer)::Int
+        @test length(head) <= accepted < n
+        # the stream survives the sweep: a follow-up write goes through
+        extra = rand(UInt8, 1000)
+        drained = @async read(p.out)
+        write(p.in, extra)
+        close(p.in)
+        received = vcat(head, fetch(drained)::Vector{UInt8})
+        # the accepted count is a clean prefix of the data, and the
+        # follow-up write arrives intact after it. On Windows the OS may
+        # underreport a cancelled write's count (see the manual), so only
+        # assert exactness elsewhere.
+        if !Sys.iswindows()
+            @test length(received) == accepted + length(extra)
+        end
+        @test length(received) >= accepted + length(extra)
+        @test received[1:accepted] == data[1:accepted]
+        @test received[(end - length(extra) + 1):end] == extra
+        close(p.out)
+    end
+
+    # split write, uncancelled: the countdown wake delivers the exact
+    # total and the requests are settled cleanly
+    let p = linked_pipe()
+        n = 1 << 18
+        data = rand(UInt8, n)
+        drained = @async read(p.out)
+        accepted = GC.@preserve data begin
+            Base.iolock_begin()
+            Base._uv_write_wait(p.in, pointer(data), UInt(n), nothing, data, false, UInt(4096))
+        end
+        @test accepted == n
+        close(p.in)
+        @test fetch(drained) == data
+        close(p.out)
+    end
+
     # live cancellation: Sockets.accept and recv with explicit tokens
     port, server = Sockets.listenany(Sockets.localhost, 0)
     src4 = CancellationTokenSource()

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -1072,7 +1072,7 @@ end
     expect_cancelled(t)
     close(p2)
 
-    # live cancellation: blocked write - the cancelled write returns the
+    # live cancellation: blocked write - `writepartial` returns the
     # partial byte count; the cancellation is delivered at the writer's
     # next cancellation point
     p3 = linked_pipe()
@@ -1081,7 +1081,7 @@ end
     tok3 = CancellationToken(src3)
     nwritten3 = Ref{Any}(nothing)
     t3 = @async begin
-        nwritten3[] = write(p3.in, big; cancel=tok3)
+        nwritten3[] = writepartial(p3.in, big; cancel=tok3)
         Base.@cancel_check tok3
     end
     sleep(0.5)
@@ -1132,23 +1132,37 @@ end
     p = linked_pipe()
     try
         # A write far exceeding the OS pipe buffer blocks until cancelled.
-        # The cancelled write does not throw: it returns the partial byte
-        # count (for a SAFE cancellation only once the completion callback
-        # has provably released the buffer), and the cancellation is
-        # delivered at the writer's next cancellation point.
+        # `write` throws the CancellationRequest (after the in-flight
+        # request is resolved - for a SAFE cancellation only once the
+        # completion callback has provably released the buffer); callers
+        # prepared for short counts use `writepartial`, which returns the
+        # partial byte count and leaves delivery to the next cancellation
+        # point.
+        big = zeros(UInt8, BIG_WRITE)
+        t, src = cancellable() do
+            write(p, big)
+        end
+        @test timedwait(() -> parked_on(t, p.in), 10.0) == :ok
+        cancel!(src)
+        expect_cancelled(t)
+    finally
+        close(p)
+    end
+    p2 = linked_pipe()
+    try
         big = zeros(UInt8, BIG_WRITE)
         nwritten = Ref{Any}(nothing)
         t, src = cancellable() do
-            nwritten[] = write(p, big)
+            nwritten[] = writepartial(p2.in, big)
             Base.@cancel_check
         end
-        @test timedwait(() -> parked_on(t, p.in), 10.0) == :ok
+        @test timedwait(() -> parked_on(t, p2.in), 10.0) == :ok
         cancel!(src)
         expect_cancelled(t)
         @test nwritten[] isa Int
         @test 0 <= nwritten[] < length(big)
     finally
-        close(p)
+        close(p2)
     end
 end
 
@@ -1158,9 +1172,8 @@ end
         # A blocked write keeps the shutdown request (which queues behind it)
         # from completing; the closewrite wait must still be interruptible.
         big = zeros(UInt8, BIG_WRITE)
-        # (the cancelled write itself returns a partial count; the trailing
-        # cancellation point delivers the request)
-        tw, srcw = cancellable(() -> (write(p, big); Base.@cancel_check))
+        # (the cancelled write itself throws the request)
+        tw, srcw = cancellable(() -> write(p, big))
         @test timedwait(() -> parked_on(tw, p.in), 10.0) == :ok
         ts, srcs = cancellable(() -> closewrite(p.in))
         @test timedwait(() -> parked_on(ts, p.in), 5.0) == :ok
@@ -1433,7 +1446,7 @@ end
         # a big direct write fills the OS pipe buffer and parks, so the
         # flush below queues behind it and cannot complete
         big = zeros(UInt8, BIG_WRITE)
-        tw, srcw = cancellable(() -> (write(p.in, big); Base.@cancel_check))
+        tw, srcw = cancellable(() -> write(p.in, big))
         @test timedwait(() -> parked_on(tw, p.in), 10.0) == :ok
         data = UInt8['a', 'b', 'c', 'd']
         write(p.in, data) # lands in the send buffer
@@ -1442,10 +1455,9 @@ end
         tf = @async flush(p.in; cancel=CancellationToken(srcf))
         @test timedwait(() -> parked_on(tf, p.in), 10.0) == :ok
         cancel!(srcf)
-        # flush returns normally (delivery is level-triggered, at the
-        # caller's next cancellation point) but must not discard the bytes:
-        # the unwritten tail is back in the send buffer
-        wait(tf)
+        # flush throws, but must not discard the bytes: the unwritten tail
+        # is back in the send buffer for a later flush to retry
+        expect_cancelled(tf)
         @test bytesavailable(p.in.sendbuf) == 4
         cancel!(srcw)
         @test_throws TaskFailedException wait(tw)

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -679,7 +679,7 @@ end
     wait(t5)
 
     # neither can a merely-queued one: @async has scheduled it, so its
-    # own first park owns the arm slot (subscribing it used to leak the
+    # own first park owns the arm slot (a subscription arm would leak the
     # sleep timer's cond lock and wedge the process at close)
     t6 = @async (sleep(0.01); 1)
     @test_throws ConcurrencyViolationError (@lock c Base.schedule_on_notify!(c, t6))
@@ -687,8 +687,8 @@ end
 end
 
 @testset "waiter registry: refused arm cannot leak into a shield" begin
-    # the model-found race (tla/WaitClaim.tla): a cancellation walk observes
-    # an armed cancellable park and judges it eligible; the park is then
+    # the race: a cancellation walk observes an armed cancellable park
+    # and judges it eligible; the park is then
     # claimed away (here: by the registration's own refusal) and the task
     # immediately re-parks shielded. The walk's claim CAS must fail against
     # the shielded arm. Hammered, since the window is two walk instructions.
@@ -1179,8 +1179,8 @@ end
         received = vcat(head, fetch(drained)::Vector{UInt8})
         # the accepted count is a clean prefix of the data, and the
         # follow-up write arrives intact after it. On Windows the OS may
-        # underreport a cancelled write's count (see the manual), so only
-        # assert exactness elsewhere.
+        # underreport a cancelled write's count, so only assert exactness
+        # elsewhere.
         if !Sys.iswindows()
             @test length(received) == accepted + length(extra)
         end

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -520,3 +520,967 @@ end
         @test t.result isa CancellationRequest
     end
 end
+## Request-delivery tests (cancellation of waiting tasks)
+
+# Start `f` as an @async-style (sticky, co-scheduled) task governed by a
+# fresh cancellation source; returns (task, source).
+function cancellable(f)
+    src = CancellationTokenSource()
+    t = with(() -> @async(f()), CANCEL_TOKEN => CancellationToken(src))
+    return t, src
+end
+
+# wait a little, so cancellation targets are (most likely) started and parked
+spin(n=4) = for _ in 1:n; yield(); end
+
+# wait for `t` and assert it failed with the delivered CancellationRequest
+function expect_cancelled(t::Task)
+    @test_throws TaskFailedException wait(t)
+    @test t.result isa CancellationRequest
+end
+
+# a Pipe with both ends linked and async-capable
+function linked_pipe()
+    p = Pipe()
+    Base.link_pipe!(p, reader_supports_async=true, writer_supports_async=true)
+    return p
+end
+
+# a portable long-running command (Windows has no `sleep` binary)
+sleep_cmd(secs::Real) = `$(Base.julia_cmd()) --startup-file=no -e "sleep($secs)"`
+
+# far exceeds any OS pipe buffer, so an uncancelled pipe write parks, while
+# staying a single uv request (well under Base.MAX_OS_WRITE)
+const BIG_WRITE = 8_000_000
+
+# whether `t` is parked (its wait registration is enqueued on some waitee)
+is_parked(t::Task) = (w = @atomic :acquire t.waiting_on; w isa Base.WaitEntry && Base._slot_owner(w, 1) !== nothing)
+parked_on(t::Task, @nospecialize(x)) = (w = @atomic :acquire t.waiting_on; x isa Task && (x = x.donenotify); w isa Base.WaitEntry && Base._find_slot(w, x) != 0)
+
+# The entries currently on `src`'s waiter list (test-only: assumes no
+# concurrent walk while traversing)
+function registry_entries(src::CancellationTokenSource)
+    entries = Base.WaitEntry[]
+    w = @atomic src.waiters_head
+    while w isa Base.WaitEntry
+        push!(entries, w)
+        w = Base._slot_next(w, Base._find_slot(w, src))
+    end
+    return entries
+end
+
+@testset "waiter registry: sticky registration" begin
+    src = CancellationTokenSource()
+    c = Channel{Int}(0)
+    done = Channel{Nothing}(1)
+    t = with(CANCEL_TOKEN => CancellationToken(src)) do
+        @async begin
+            take!(c)   # cancellable park #1: registers
+            put!(done, nothing)
+            take!(c)   # cancellable park #2: sticky re-arm, no new push
+        end
+    end
+    @test timedwait(() -> is_parked(t), 10.0) == :ok
+    entries = registry_entries(src)
+    @test length(entries) == 1
+    w1 = entries[1]
+    @test Base._find_slot(w1, src) != 0
+    @test w1 === t.cached_cancel_entry
+    put!(c, 1)
+    take!(done)
+    # a normal wake does no registry work: the registration stays in place
+    @test registry_entries(src) == [w1]
+    @test Base._find_slot(w1, src) != 0
+    # and the second park re-arms the same registered entry
+    @test timedwait(() -> is_parked(t), 10.0) == :ok
+    @test registry_entries(src) == [w1]
+    @test (@atomic t.waiting_on) === w1
+    put!(c, 2)
+    wait(t)
+    # the entry of a completed task is collected by the next walk
+    cancel!(src)
+    @test isempty(registry_entries(src))
+end
+
+@testset "waiter registry: shielded parks stay shielded" begin
+    # shielded parks arm a distinct entry from cancellable parks, so the
+    # walk's expected-entry claim CAS structurally cannot land on a shield -
+    # the sticky source registration stays linked but unarmed meanwhile
+    src = CancellationTokenSource()
+    c = Channel{Int}(0)
+    t = with(CANCEL_TOKEN => CancellationToken(src)) do
+        @async begin
+            take!(c)                 # cancellable park
+            take!(c; cancel=nothing) # shielded park of a distinct entry
+        end
+    end
+    @test timedwait(() -> is_parked(t), 10.0) == :ok
+    wc = t.cached_cancel_entry
+    @test wc isa Base.WaitEntry && (@atomic t.waiting_on) === wc
+    put!(c, 1)
+    @test timedwait(() -> (x = @atomic t.waiting_on;
+                           x isa Base.WaitEntry && Base._slot_owner(x, 1) !== nothing), 10.0) == :ok
+    @test (@atomic t.waiting_on) === t.cached_wait_entry # the plain entry
+    @test (@atomic t.waiting_on) !== wc
+    @test Base._find_slot(wc, src) != 0      # still registered (sticky)
+    cancel!(src)
+    spin()
+    @test !istaskdone(t)                     # the shielded wait is untouched
+    put!(c, 2)
+    wait(t)
+end
+
+@testset "waiter registry: refused arm cannot leak into a shield" begin
+    # the model-found race (tla/WaitClaim.tla): a cancellation walk observes
+    # an armed cancellable park and judges it eligible; the park is then
+    # claimed away (here: by the registration's own refusal) and the task
+    # immediately re-parks shielded. The walk's claim CAS must fail against
+    # the shielded arm. Hammered, since the window is two walk instructions.
+    for _ in 1:200
+        src = CancellationTokenSource()
+        tok = CancellationToken(src)
+        c = Channel{Int}(0)
+        entered = Threads.Event()
+        t = @async begin
+            notify(entered)
+            # cancellable wait racing the cancel below: either thrown at
+            # entry, refused at registration, or claimed by the walk
+            try
+                take!(c; cancel=tok)
+            catch err
+                err isa CancellationRequest || rethrow()
+            end
+            # immediately re-park shielded; a stale-eligibility claim from
+            # the same walk must not be able to interrupt this
+            take!(c; cancel=nothing)
+        end
+        wait(entered)
+        cancel!(src)
+        put!(c, 1)   # completes the shielded park (or the pre-cancel take!)
+        # a leaked claim throws CancellationRequest out of the shielded
+        # take! and fails the task
+        wait(t)
+        @test !istaskfailed(t)
+    end
+end
+
+@testset "waiter registry: token migration rebinds the cached entry" begin
+    src1 = CancellationTokenSource()
+    src2 = CancellationTokenSource()
+    c = Channel{Int}(0)
+    step = Channel{Nothing}(1)
+    t = @async begin
+        with(CANCEL_TOKEN => CancellationToken(src1)) do
+            take!(c)
+        end
+        put!(step, nothing)
+        with(CANCEL_TOKEN => CancellationToken(src2)) do
+            take!(c)
+        end
+    end
+    @test timedwait(() -> is_parked(t), 10.0) == :ok
+    w = t.cached_cancel_entry
+    @test w isa Base.WaitEntry && Base._find_slot(w, src1) != 0
+    @test registry_entries(src1) == [w]
+    put!(c, 1)
+    take!(step)
+    @test timedwait(() -> (x = @atomic t.waiting_on;
+                           x isa Base.WaitEntry && Base._slot_owner(x, 1) !== nothing &&
+                           Base._find_slot(x, src2) != 0), 10.0) == :ok
+    # parking under the new source physically unregistered the cached entry
+    # from the old one and rebound it
+    @test t.cached_cancel_entry === w
+    @test Base._find_slot(w, src2) != 0
+    @test isempty(registry_entries(src1))
+    @test registry_entries(src2) == [w]
+    put!(c, 2)
+    wait(t)
+end
+
+@testset "waiter registry: pruning" begin
+    # entries of completed tasks are pruned once enough dead registrations
+    # accumulate (the dead-count threshold), without any cancellation
+    src = CancellationTokenSource()
+    tok = CancellationToken(src)
+    for _ in 1:80
+        c = Channel{Int}(0)
+        t = with(() -> @async(take!(c)), CANCEL_TOKEN => tok)
+        @test timedwait(() -> is_parked(t), 10.0) == :ok
+        put!(c, 1)
+        wait(t)
+    end
+    @test length(registry_entries(src)) < 40
+
+    # single-use wait_with_timeout registrations are retired at wait exit
+    # and collected the same way
+    src2 = CancellationTokenSource()
+    cond = Threads.Condition()
+    with(CANCEL_TOKEN => CancellationToken(src2)) do
+        for _ in 1:80
+            lock(cond)
+            try
+                @test Base.Experimental.wait_with_timeout(cond; timeout=0.001) === :timed_out
+            finally
+                unlock(cond)
+            end
+        end
+    end
+    @test length(registry_entries(src2)) < 40
+end
+
+@testset "waiter registry: registration racing cancellation" begin
+    # hammer the push/arm-vs-cancel window: every task must observe the
+    # cancellation exactly once, whether it lost before parking (refusal),
+    # while parking, or parked
+    for _ in 1:50
+        src = CancellationTokenSource()
+        ts = Task[]
+        for _ in 1:8
+            push!(ts, with(() -> @async(sleep(10)), CANCEL_TOKEN => CancellationToken(src)))
+        end
+        cancel!(src)
+        for t in ts
+            @test timedwait(() -> istaskdone(t), 10.0) == :ok
+            @test istaskfailed(t) && t.result isa CancellationRequest
+        end
+    end
+end
+
+@testset "waiter registry: multi-slot wait-any entries" begin
+    # waitany parks through a single WaitEntryN with one slot per waited
+    # task plus the cancellation-source slot
+    src = CancellationTokenSource()
+    c = Channel{Int}(0)
+    ts = [@async take!(c) for _ in 1:3]
+    wa = with(CANCEL_TOKEN => CancellationToken(src)) do
+        @async waitany(ts)
+    end
+    @test timedwait(() -> (x = @atomic wa.waiting_on; x isa Base.WaitEntryN), 10.0) == :ok
+    w = (@atomic wa.waiting_on)::Base.WaitEntryN
+    @test Base._nslots(w) == 4
+    @test count(i -> Base._slot_owner(w, i) isa Base.ThreadSynchronizer, 1:4) == 3
+    @test registry_entries(src) == [w]
+    # first completion wins; the entry is withdrawn from every waitq and
+    # retired
+    put!(c, 1)
+    done, remaining = fetch(wa)
+    @test length(done) == 1 && length(remaining) == 2
+    @test (@atomic :monotonic w.task) === nothing
+    @test count(i -> Base._slot_owner(w, i) isa Base.ThreadSynchronizer, 1:4) == 0
+    # the retired source registration is collected by the next walk
+    cancel!(src)
+    @test isempty(registry_entries(src))
+    for t in ts
+        istaskdone(t) || put!(c, 0)
+    end
+    foreach(wait, ts)
+
+    # cancellation of the scope interrupts waitany and cleans up all slots;
+    # the waited tasks (in a different scope) are unaffected
+    src2 = CancellationTokenSource()
+    c2 = Channel{Int}(0)
+    ts2 = [@async take!(c2) for _ in 1:3]
+    wa2 = with(CANCEL_TOKEN => CancellationToken(src2)) do
+        @async waitany(ts2)
+    end
+    @test timedwait(() -> (x = @atomic wa2.waiting_on; x isa Base.WaitEntryN), 10.0) == :ok
+    w2 = (@atomic wa2.waiting_on)::Base.WaitEntryN
+    cancel!(src2)
+    @test timedwait(() -> istaskdone(wa2), 10.0) == :ok
+    @test istaskfailed(wa2) && wa2.result isa CancellationRequest
+    for t in ts2
+        @test !istaskdone(t)
+        @test Base._find_slot(w2, t.donenotify) == 0
+    end
+    for _ in ts2
+        put!(c2, 0)
+    end
+    foreach(wait, ts2)
+
+    # waitall re-arms the same registered entry across completions
+    c3 = Channel{Int}(0)
+    ts3 = [@async take!(c3) for _ in 1:3]
+    wa3 = @async waitall(ts3)
+    @test timedwait(() -> (x = @atomic wa3.waiting_on; x isa Base.WaitEntryN), 10.0) == :ok
+    w3 = (@atomic wa3.waiting_on)::Base.WaitEntryN
+    for _ in 1:3
+        put!(c3, 0)
+    end
+    done3, remaining3 = fetch(wa3)
+    @test length(done3) == 3 && isempty(remaining3)
+    @test (@atomic wa3.waiting_on) === nothing
+    @test count(i -> Base._slot_owner(w3, i) isa Base.ThreadSynchronizer, 1:Base._nslots(w3)) == 0
+end
+
+@testset "level-triggered delivery and shielding" begin
+    # cancellation is uniformly level-triggered: after catching the request,
+    # unshielded waits under the cancelled scope keep throwing; shielded
+    # cleanup proceeds, and the severity remains observable under the shield
+    src = CancellationTokenSource()
+    phase = Ref{Any}(:init)
+    t = with(CANCEL_TOKEN => CancellationToken(src)) do
+        @async try
+            sleep(1000)
+        catch e
+            e isa CancellationRequest || rethrow()
+            phase[] = :caught
+            rethrew = try
+                sleep(1000)
+                false
+            catch e2
+                e2 isa CancellationRequest
+            end
+            sleep(0.01; cancel=nothing) # shielded cleanup is permitted
+            rethrew &= Base.cancel_severity(CANCEL_TOKEN[]::CancellationToken) === CANCEL_REQUEST_SAFE
+            phase[] = rethrew ? :done : :no_retrigger
+        end
+    end
+    spin()
+    cancel!(src)
+    @test timedwait(() -> istaskdone(t), 10.0) == :ok
+    @test phase[] === :done
+
+    # an internal teardown re-park (min_severity) is woken only by
+    # escalation: the convention is that a teardown which acknowledged
+    # severity `s` stages the floor `s + 0x01` (min_severity is the lowest
+    # severity that may wake the wait), so a re-cancel at the acknowledged
+    # severity must leave the task parked
+    srcm = CancellationTokenSource()
+    cancel!(srcm)  # acknowledged severity: SAFE (0x1)
+    inner = @async sleep(5)
+    tm = @async Base._wait(inner, CancellationToken(srcm); min_severity=0x02)
+    @test timedwait(() -> is_parked(tm), 10.0) == :ok
+    cancel!(srcm)  # re-cancel at the acknowledged severity: no wake
+    spin()
+    @test !istaskdone(tm)
+    cancel!(srcm, CANCEL_REQUEST_ABANDON_EXTERNAL)  # escalation wakes it
+    expect_cancelled(tm)
+end
+
+@testset "cancellation of waiting tasks" begin
+    # Cancellation of `sleep`
+    t, src = cancellable(() -> sleep(1000))
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+
+    # After catching the request, cleanup that must block shields itself
+    t2, src2 = cancellable() do
+        try
+            sleep(1000)
+        catch e
+            e isa CancellationRequest || rethrow()
+            sleep(0.01; cancel=nothing) # shielded: parking for cleanup
+            return :cleanup_ok
+        end
+    end
+    spin()
+    cancel!(src2)
+    @test fetch(t2) === :cleanup_ok
+
+    # Cancellation of a task blocked on a Channel
+    c = Channel{Int}(0)
+    t, src = cancellable(() -> take!(c))
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+    # The channel remains usable
+    t2 = @async take!(c)
+    put!(c, 7)
+    @test fetch(t2) == 7
+
+    # Cancelling a scope reaches a task waiting on another task; the waited-on
+    # task (in the same scope) is cancelled through the same tree
+    local t_in
+    t, src = cancellable() do
+        t_in = @async sleep(1000)
+        wait(t_in)
+    end
+    spin()
+    cancel!(src)
+    @test_throws TaskFailedException wait(t)
+    @test timedwait(() -> istaskdone(t_in), 10.0) == :ok
+    @test istaskfailed(t_in)
+
+    # ... but a task waited on from a *different* scope is unaffected by the
+    # waiter's cancellation
+    t_out = @async sleep(5)
+    t, src = cancellable(() -> wait(t_out))
+    spin()
+    cancel!(src)
+    @test_throws TaskFailedException wait(t)
+    @test !istaskdone(t_out)
+    wait(t_out)
+    @test istaskdone(t_out) && !istaskfailed(t_out)
+end
+
+@testset "cancellation of lock and condition waits" begin
+    # Task blocked in lock(::ReentrantLock)
+    lk = ReentrantLock()
+    lock(lk)
+    t, src = cancellable(() -> lock(lk))
+    spin()
+    # let it spin through the fast path and park
+    @test timedwait(() -> is_parked(t), 5.0) == :ok
+    cancel!(src)
+    expect_cancelled(t)
+    # the lock remains functional
+    unlock(lk)
+    @test trylock(lk)
+    unlock(lk)
+    t2 = @async (lock(lk); unlock(lk); true)
+    @test fetch(t2)
+
+    # Task blocked in put! on a full channel
+    c = Channel{Int}(1)
+    put!(c, 1)
+    t, src = cancellable(() -> put!(c, 2))
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+    @test take!(c) == 1
+    put!(c, 3) # channel remains functional
+    @test take!(c) == 3
+
+    # Task blocked in wait(::Threads.Condition)
+    cond = Threads.Condition()
+    t, src = cancellable(() -> @lock cond wait(cond))
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+    @lock cond notify(cond) # still functional (no waiters)
+
+    # Task blocked in wait(::Base.Process); the process itself keeps running
+    p = run(sleep_cmd(1000); wait=false)
+    t, src = cancellable(() -> wait(p))
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+    @test process_running(p)
+    kill(p); wait(p)
+
+    # Task blocked in waitany; the awaited tasks live in different scopes and
+    # remain unaffected by the waiter's cancellation
+    t1, src1 = cancellable(() -> sleep(1000))
+    t2, src2 = cancellable(() -> sleep(1000))
+    t, src = cancellable(() -> waitany([t1, t2]))
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+    @test !istaskdone(t1) && !istaskdone(t2)
+    # their own scopes' cancellation reaches them
+    cancel!(src1); cancel!(src2)
+    @test_throws TaskFailedException wait(t1)
+    @test_throws TaskFailedException wait(t2)
+end
+
+# stdlibs exercised below (loaded through the loader, like other Base tests,
+# to avoid a test-environment dependency)
+const Sockets = Base.require(Base.PkgId(Base.UUID("6462fe0b-24de-5631-8697-dd941f90decc"), "Sockets"))
+const FileWatching = Base.require(Base.PkgId(Base.UUID("7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"), "FileWatching"))
+
+@testset "cancellation of stdlib waits (Sockets, FileWatching, Semaphore)" begin
+    # Base.Semaphore: a cancelled acquire does not leak a permit
+    sem = Base.Semaphore(1)
+    Base.acquire(sem)
+    t, src = cancellable(() -> Base.acquire(sem))
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+    Base.release(sem)
+    Base.acquire(sem) # the permit is still available
+    Base.release(sem)
+
+    # Sockets.accept
+    port, server = Sockets.listenany(Sockets.localhost, 0)
+    t, src = cancellable(() -> Sockets.accept(server))
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+    # the server keeps accepting afterwards
+    t2 = @async Sockets.accept(server)
+    sock = Sockets.connect(Sockets.localhost, port)
+    @test fetch(t2) isa Sockets.TCPSocket
+    close(sock); close(server)
+
+    # FileWatching: fd polling and file watching
+    if !Sys.iswindows() # fd polling requires a socket on Windows (ENOTSOCK)
+        p = linked_pipe()
+        fd = Base._fd(p.out)
+        t, src = cancellable(() -> FileWatching.wait(fd; readable=true)) # nothing is ever written
+        spin()
+        cancel!(src)
+        expect_cancelled(t)
+        close(p)
+    end
+
+    path = tempname()
+    touch(path)
+    t, src = cancellable(() -> FileWatching.watch_file(path, 100.0)) # the file never changes
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+    rm(path)
+end
+
+@testset "explicit cancel keyword arguments" begin
+    cancelled_src = CancellationTokenSource()
+    cancel!(cancelled_src)
+    ctok = CancellationToken(cancelled_src)
+
+    # a pre-cancelled token throws at entry, before any side effect
+    p = linked_pipe()
+    @test_throws CancellationRequest read(p.out, 10; cancel=ctok)
+    @test_throws CancellationRequest read(p.out; cancel=ctok)
+    @test_throws CancellationRequest read(p.out, String; cancel=ctok)
+    @test_throws CancellationRequest read(p.out, UInt8; cancel=ctok)
+    @test_throws CancellationRequest read!(p.out, zeros(UInt8, 4); cancel=ctok)
+    @test_throws CancellationRequest readbytes!(p.out, zeros(UInt8, 4); cancel=ctok)
+    @test_throws CancellationRequest readline(p.out; cancel=ctok)
+    @test_throws CancellationRequest readuntil(p.out, 0x0a; cancel=ctok)
+    @test_throws CancellationRequest readavailable(p.out; cancel=ctok)
+    @test_throws CancellationRequest eof(p.out; cancel=ctok)
+    @test_throws CancellationRequest write(p.in, zeros(UInt8, 8); cancel=ctok)
+    @test_throws CancellationRequest write(p.in, "hello"; cancel=ctok)
+    @test_throws CancellationRequest write(p.in, "a", "b"; cancel=ctok)
+    @test_throws CancellationRequest flush(p.in; cancel=ctok)
+    @test_throws CancellationRequest sleep(10; cancel=ctok)
+    @test_throws CancellationRequest wait(Timer(10); cancel=ctok)
+    @test_throws CancellationRequest run(sleep_cmd(5); cancel=ctok)
+    @test_throws CancellationRequest success(sleep_cmd(5); cancel=ctok)
+    @test_throws CancellationRequest read(sleep_cmd(5); cancel=ctok)
+    @test_throws CancellationRequest readchomp(sleep_cmd(5); cancel=ctok)
+    @test_throws CancellationRequest Sockets.getalladdrinfo("localhost"; cancel=ctok)
+    @test_throws CancellationRequest Sockets.getaddrinfo("localhost"; cancel=ctok)
+    @test_throws CancellationRequest Sockets.getnameinfo(Sockets.localhost; cancel=ctok)
+    @test_throws CancellationRequest FileWatching.watch_file(tempdir(), 5.0; cancel=ctok)
+    @test_throws CancellationRequest FileWatching.poll_fd(Base._fd(p.out), 5.0; readable=true, cancel=ctok)
+
+    # `cancel = nothing` shadows an (already cancelled) outer scope
+    write(p.in, "ab\n")
+    with(CANCEL_TOKEN => ctok) do
+        @test read(p.out, 2; cancel=nothing) == b"ab"
+    end
+    close(p)
+
+    # live cancellation through an explicit token: blocked read
+    p2 = linked_pipe()
+    src = CancellationTokenSource()
+    t = @async read(p2.out, 10; cancel=CancellationToken(src))
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+    close(p2)
+
+    # live cancellation: blocked write - the cancelled write returns the
+    # partial byte count; the cancellation is delivered at the writer's
+    # next cancellation point
+    p3 = linked_pipe()
+    src3 = CancellationTokenSource()
+    big = zeros(UInt8, BIG_WRITE)
+    tok3 = CancellationToken(src3)
+    nwritten3 = Ref{Any}(nothing)
+    t3 = @async begin
+        nwritten3[] = write(p3.in, big; cancel=tok3)
+        Base.@cancel_check tok3
+    end
+    sleep(0.5)
+    cancel!(src3)
+    expect_cancelled(t3)
+    @test nwritten3[] isa Int
+    @test 0 <= nwritten3[] < length(big)
+    close(p3)
+
+    # live cancellation: Sockets.accept and recv with explicit tokens
+    port, server = Sockets.listenany(Sockets.localhost, 0)
+    src4 = CancellationTokenSource()
+    t4 = @async Sockets.accept(server; cancel=CancellationToken(src4))
+    spin()
+    cancel!(src4)
+    expect_cancelled(t4)
+    close(server)
+
+    udp = Sockets.UDPSocket()
+    Sockets.bind(udp, Sockets.localhost, 0)
+    src5 = CancellationTokenSource()
+    t5 = @async Sockets.recv(udp; cancel=CancellationToken(src5))
+    spin()
+    cancel!(src5)
+    expect_cancelled(t5)
+    close(udp)
+
+    # live cancellation: FileWatching.watch_file with an explicit token
+    path = tempname()
+    touch(path)
+    src6 = CancellationTokenSource()
+    t6 = @async FileWatching.watch_file(path, 100.0; cancel=CancellationToken(src6))
+    spin()
+    cancel!(src6)
+    expect_cancelled(t6)
+    rm(path)
+
+    # live cancellation: run with an explicit token; the child process is
+    # not reaped by the cancelled wait
+    src7 = CancellationTokenSource()
+    t7 = @async run(sleep_cmd(5); cancel=CancellationToken(src7))
+    sleep(0.5)
+    cancel!(src7)
+    expect_cancelled(t7)
+end
+
+@testset "cancellation of blocked stream writes" begin
+    p = linked_pipe()
+    try
+        # A write far exceeding the OS pipe buffer blocks until cancelled.
+        # The cancelled write does not throw: it returns the partial byte
+        # count (for a SAFE cancellation only once the completion callback
+        # has provably released the buffer), and the cancellation is
+        # delivered at the writer's next cancellation point.
+        big = zeros(UInt8, BIG_WRITE)
+        nwritten = Ref{Any}(nothing)
+        t, src = cancellable() do
+            nwritten[] = write(p, big)
+            Base.@cancel_check
+        end
+        @test timedwait(() -> parked_on(t, p.in), 10.0) == :ok
+        cancel!(src)
+        expect_cancelled(t)
+        @test nwritten[] isa Int
+        @test 0 <= nwritten[] < length(big)
+    finally
+        close(p)
+    end
+end
+
+@testset "cancellation of closewrite (shutdown) waits" begin
+    p = linked_pipe()
+    try
+        # A blocked write keeps the shutdown request (which queues behind it)
+        # from completing; the closewrite wait must still be interruptible.
+        big = zeros(UInt8, BIG_WRITE)
+        # (the cancelled write itself returns a partial count; the trailing
+        # cancellation point delivers the request)
+        tw, srcw = cancellable(() -> (write(p, big); Base.@cancel_check))
+        @test timedwait(() -> parked_on(tw, p.in), 10.0) == :ok
+        ts, srcs = cancellable(() -> closewrite(p.in))
+        @test timedwait(() -> parked_on(ts, p.in), 5.0) == :ok
+        cancel!(srcs)
+        expect_cancelled(ts)
+        cancel!(srcw)
+        @test_throws TaskFailedException wait(tw)
+    finally
+        close(p)
+    end
+end
+
+@testset "cancelled condition waiter reacquiring a contended lock" begin
+    # A cancelled `wait(::Threads.Condition)` must rethrow the
+    # CancellationRequest after reacquiring the condition lock, even when
+    # the reacquire is contended: the waiter's stale (lazily collected)
+    # condition-queue entry stays linked while it parks on the lock with a
+    # fresh wait entry, and must not corrupt either queue.
+    cond = Threads.Condition()
+    src = Base.CancellationTokenSource()
+    waiter_result = Channel{Any}(1)
+    waiter = Threads.@spawn begin
+        try
+            Base.ScopedValues.with(Base.CANCEL_TOKEN => Base.CancellationToken(src)) do
+                lock(cond)
+                try
+                    wait(cond)
+                finally
+                    unlock(cond)
+                end
+            end
+            put!(waiter_result, :completed)
+        catch e
+            put!(waiter_result, e)
+        end
+    end
+    # wait until the waiter is parked on the condition
+    @test timedwait(10) do
+        lock(cond)
+        parked = !isempty(cond)
+        unlock(cond)
+        parked
+    end === :ok
+    # a holder keeps the condition lock while the cancellation is delivered
+    held = Base.Event()
+    release = Base.Event()
+    holder = Threads.@spawn begin
+        lock(cond)
+        notify(held)
+        wait(release; cancel=nothing)
+        unlock(cond)
+    end
+    wait(held)
+    Base.cancel!(src)
+    # give the woken waiter time to reach the contended reacquire and park
+    sleep(0.5)
+    notify(release)
+    wait(waiter)
+    result = take!(waiter_result)
+    @test result isa Base.CancellationRequest
+    # the condition lock must be intact and uncontended afterwards
+    @test trylock(cond.lock)
+    unlock(cond.lock)
+    wait(holder)
+    # the waiter's registration(s) - including an entry orphaned when the
+    # contended relock parked and cached a replacement - must not be
+    # retained by the long-lived source: the next walk collects them
+    @test timedwait(() -> istaskdone(waiter), 10.0) == :ok
+    cancel!(src, CANCEL_REQUEST_ABANDON_EXTERNAL) # escalation forces a walk
+    @test isempty(registry_entries(src))
+end
+
+@testset "pre-cancelled ambient token refuses a spun-in lock acquisition" begin
+    # the slow path can acquire by spinning when the holder releases during
+    # the spin window; a resolved cancelled token must refuse that
+    # acquisition just like the park path's refusal does
+    deadsrc = CancellationTokenSource()
+    cancel!(deadsrc)
+    lk = ReentrantLock()
+    lock(lk)
+    t = with(CANCEL_TOKEN => CancellationToken(deadsrc)) do
+        @async lock(lk)
+    end
+    spin() # let it reach the slow path while we hold the lock
+    unlock(lk) # release during its spin/park window
+    @test timedwait(() -> istaskdone(t), 10.0) == :ok
+    @test istaskfailed(t) && t.result isa CancellationRequest
+    # whichever path it took (spin-acquire refusal or park refusal), the
+    # lock is not left held
+    @test trylock(lk)
+    unlock(lk)
+end
+
+@testset "WaitEntryN memory accounting and deepcopy" begin
+    # variable-sized (like CancellationTokenSource): the type has no
+    # definite size, instances charge their slot tail
+    @test_throws ErrorException Core.sizeof(Core.WaitEntryN)
+    @test Base.infer_return_type(Core.sizeof, Tuple{Core.WaitEntryN}) == Int
+    base = Core.sizeof(Base.WaitEntryN(nothing, 0))
+    slotsz = 2 * sizeof(Ptr{Cvoid}) + sizeof(UInt64)
+    w = Base.WaitEntryN(nothing, 4)
+    @test Core.sizeof(w) == base + 4 * slotsz
+    @test Base.summarysize(w) == base + 4 * slotsz
+    @test Base.summarysize(w; count=true) == 1
+    # generic deepcopy would allocate only the fixed size and let the GC
+    # scan a nonexistent tail; the custom method goes through the allocator
+    d = deepcopy(w)
+    @test d isa Core.WaitEntryN && d !== w
+    @test Base._nslots(d) == 4
+    @test all(i -> Base._slot_owner(d, i) === nothing, 1:4)
+    GC.gc(true)
+    # the task reference is kept (Task deepcopy is the identity); reached
+    # through a containing object like any graph edge
+    dv = deepcopy(Any[Base.WaitEntryN(current_task(), 2)])
+    e = dv[1]::Core.WaitEntryN
+    @test (@atomic :monotonic e.task) === current_task()
+    @test Base._nslots(e) == 2
+    GC.gc(true)
+end
+
+@testset "cancel keyword does not bypass specialized methods" begin
+    # BitArray binary I/O keeps the packed format under a `cancel` call
+    B = BitVector([isodd(i) for i in 1:129])
+    plain = (io = IOBuffer(); write(io, B); take!(io))
+    kw = (io = IOBuffer(); write(io, B; cancel=nothing); take!(io))
+    @test kw == plain
+    @test length(kw) == sizeof(B.chunks) # packed, not one byte per bit
+    B2 = falses(129)
+    @test read!(IOBuffer(kw), B2; cancel=nothing) == B
+    @test B2 == B
+    # a short stream still fails cleanly through the packed method
+    @test_throws Union{EOFError, DimensionMismatch} read!(IOBuffer(kw[1:8]), falses(129); cancel=nothing)
+
+    # vector-delimiter readuntil selects the vector method, not the scalar
+    # catch-all (which would try to read Vector-typed values)
+    @test readuntil(IOBuffer("abcXYdef"), b"XY"; cancel=nothing) == b"abc"
+    @test readuntil(IOBuffer("abcXYdef"), b"XY"; keep=true, cancel=nothing) == b"abcXY"
+
+    # IOStream methods accept `cancel` (entry check only)
+    mktemp() do path, io
+        write(io, "line1\nline2\n")
+        flush(io); seekstart(io)
+        @test readuntil(io, '\n'; cancel=nothing) == "line1"
+        @test readline(io; cancel=nothing) == "line2"
+        seekstart(io)
+        @test read(io, 5; cancel=nothing) == b"line1"
+        @test readbytes!(io, zeros(UInt8, 2); cancel=nothing) == 2
+        @test !eof(io; cancel=nothing)
+        @test readavailable(io; cancel=nothing) == b"ine2\n"
+        @test eof(io; cancel=nothing)
+    end
+
+    # explicit-token writes to in-memory buffers keep working
+    io = IOBuffer()
+    @test write(io, "hi"; cancel=nothing) == 2
+    @test write(io, UInt8[0x21]; cancel=nothing) == 1
+    @test takestring!(io) == "hi!"
+
+    # BufferStream specializations (BufferStream <: LibuvStream, whose
+    # methods reference uv state a BufferStream does not have)
+    bs = Base.BufferStream()
+    write(bs, UInt8[0x01, 0x02, 0x03])
+    @test readuntil(bs, 0x03; cancel=nothing) == UInt8[0x01, 0x02]
+    write(bs, "xyz"; cancel=nothing)
+    flush(bs; cancel=nothing)
+    @test read(bs, UInt8; cancel=nothing) == UInt8('x')
+    byte9 = UInt8[0x09]
+    @test GC.@preserve(byte9, unsafe_write(bs, pointer(byte9), UInt(1); cancel=nothing)) == 1
+    closewrite(bs; cancel=nothing)
+    @test !eof(bs; cancel=nothing)
+    @test read(bs; cancel=nothing) == UInt8['y', 'z', 0x09]
+    @test eof(bs; cancel=nothing)
+    # a parked BufferStream readuntil is cancellable through its token
+    bs2 = Base.BufferStream()
+    src = CancellationTokenSource()
+    t = @async readuntil(bs2, 0x0a; cancel=CancellationToken(src))
+    spin()
+    cancel!(src)
+    expect_cancelled(t)
+    close(bs2)
+
+    # compound-Pipe forwarders reach the endpoint methods
+    p = linked_pipe()
+    cancelled_src = CancellationTokenSource()
+    cancel!(cancelled_src)
+    ctok = CancellationToken(cancelled_src)
+    @test_throws CancellationRequest eof(p; cancel=ctok)
+    @test_throws CancellationRequest flush(p; cancel=ctok)
+    @test_throws CancellationRequest read(p, UInt8; cancel=ctok)
+    @test_throws CancellationRequest readavailable(p; cancel=ctok)
+    @test write(p, UInt8['o', 'k']) == 2
+    flush(p; cancel=nothing)
+    @test read(p, UInt8; cancel=nothing) == UInt8('o')
+    close(p)
+end
+
+@testset "explicit tokens and shields thread through call chains" begin
+    deadsrc = CancellationTokenSource()
+    cancel!(deadsrc)
+    dead = CancellationToken(deadsrc)
+
+    # (a) an explicit live token cancels the blocked operation while the
+    # ambient scope stays clean
+    c = Channel{Int}(0)
+    src1 = CancellationTokenSource()
+    t1 = @async take!(c; cancel=CancellationToken(src1))
+    spin()
+    cancel!(src1)
+    expect_cancelled(t1)
+
+    p = linked_pipe()
+    src2 = CancellationTokenSource()
+    t2 = @async read(p.out, String; cancel=CancellationToken(src2))
+    spin()
+    cancel!(src2)
+    expect_cancelled(t2) # the inner read honors the operation's token
+
+    # (b) `cancel = nothing` operations complete under a cancelled ambient
+    # scope (the shield covers the preliminary lock, not just the wait)
+    c2 = Channel{Int}(0)
+    t3 = with(() -> @async(take!(c2; cancel=nothing)), CANCEL_TOKEN => dead)
+    put!(c2, 42)
+    @test fetch(t3) == 42
+
+    e = Base.Event()
+    t4 = with(() -> @async(begin wait(e; cancel=nothing); :ok end), CANCEL_TOKEN => dead)
+    spin()
+    notify(e)
+    @test fetch(t4) === :ok
+
+    sem = Base.Semaphore(1)
+    with(CANCEL_TOKEN => dead) do
+        Base.acquire(sem; cancel=nothing)
+    end
+    Base.release(sem)
+
+    write(p.in, "hello\nrest")
+    with(CANCEL_TOKEN => dead) do
+        # readline's inner copyuntil calls run under the shield
+        @test readline(p.out; cancel=nothing) == "hello"
+        @test read(p.out, 4; cancel=nothing) == b"rest"
+    end
+    close(p)
+
+    # a shielded run() under a cancelled ambient scope must spawn and
+    # complete (the spawn primitive honors the resolved shield)
+    with(CANCEL_TOKEN => dead) do
+        proc = run(sleep_cmd(0); cancel=nothing)
+        @test success(proc; cancel=nothing)
+    end
+
+    # (c) operations with an explicit live token do not throw from the
+    # cancelled ambient scope
+    with(CANCEL_TOKEN => dead) do
+        live = CancellationToken(CancellationTokenSource())
+        c3 = Channel{Int}(1)
+        put!(c3, 7; cancel=live)
+        @test fetch(c3; cancel=live) == 7
+        @test take!(c3; cancel=live) == 7
+        e2 = Base.Event()
+        notify(e2)
+        wait(e2; cancel=live)
+    end
+end
+
+@testset "cancelled flush requeues unwritten bytes" begin
+    p = linked_pipe()
+    try
+        Base.buffer_writes(p.in, 64)
+        # a big direct write fills the OS pipe buffer and parks, so the
+        # flush below queues behind it and cannot complete
+        big = zeros(UInt8, BIG_WRITE)
+        tw, srcw = cancellable(() -> (write(p.in, big); Base.@cancel_check))
+        @test timedwait(() -> parked_on(tw, p.in), 10.0) == :ok
+        data = UInt8['a', 'b', 'c', 'd']
+        write(p.in, data) # lands in the send buffer
+        @test bytesavailable(p.in.sendbuf) == 4
+        srcf = CancellationTokenSource()
+        tf = @async flush(p.in; cancel=CancellationToken(srcf))
+        @test timedwait(() -> parked_on(tf, p.in), 10.0) == :ok
+        cancel!(srcf)
+        # flush returns normally (delivery is level-triggered, at the
+        # caller's next cancellation point) but must not discard the bytes:
+        # the unwritten tail is back in the send buffer
+        wait(tf)
+        @test bytesavailable(p.in.sendbuf) == 4
+        cancel!(srcw)
+        @test_throws TaskFailedException wait(tw)
+    finally
+        close(p)
+    end
+end
+
+@testset "cancelled recvfrom stops reception (no dropped datagram)" begin
+    # bind the receiver to a known free port (found via listenany, like the
+    # Sockets tests; retried in case another process grabs it in between)
+    local udp, port
+    for attempt in 1:10
+        port, tcpserver = Sockets.listenany(Sockets.localhost, 0)
+        close(tcpserver)
+        udp = Sockets.UDPSocket()
+        Sockets.bind(udp, Sockets.localhost, port) && break
+        close(udp)
+        attempt == 10 && error("could not bind a UDP test port")
+    end
+    src = CancellationTokenSource()
+    t = @async Sockets.recvfrom(udp; cancel=CancellationToken(src))
+    @test timedwait(() -> is_parked(t), 10.0) == :ok
+    cancel!(src)
+    expect_cancelled(t)
+    # the cancelled waiter stopped continuous reception on unwind, so a
+    # datagram arriving now stays in the kernel buffer instead of being
+    # consumed-and-dropped by the callback ...
+    sender = Sockets.UDPSocket()
+    Sockets.send(sender, Sockets.localhost, port, UInt8['p', 'i', 'n', 'g'])
+    spin(20)
+    # ... and a fresh recvfrom receives it
+    t2 = @async Sockets.recvfrom(udp)
+    @test timedwait(() -> istaskdone(t2), 10.0) == :ok
+    @test fetch(t2)[2] == b"ping"
+    close(sender)
+    close(udp)
+end

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -331,10 +331,11 @@ end
                 yield()
             end
         end
-        try
-            wait(inner)
-        catch
-        end
+        # A cancellable wait would be interrupted by the delivery before
+        # `inner` observes the cancellation at its own cancellation point;
+        # the assertion is about `inner`'s own observation, so wait for its
+        # completion shielded.
+        Base._wait(inner, nothing)
         inner_result[] = inner.result
     end
     spin_started = timedwait(() -> istaskstarted(t2), 30.0)

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -630,6 +630,62 @@ end
     wait(t)
 end
 
+@testset "subscriptions die with their birth source" begin
+    # schedule_on_notify! subscribes a not-yet-started task; its birth
+    # scope's source governs it: cancelled => the task dies at start
+    src = CancellationTokenSource()
+    c = Threads.Condition()
+    t = with(() -> Task(() -> 42), CANCEL_TOKEN => CancellationToken(src))
+    t.sticky = false
+    @lock c Base.schedule_on_notify!(c, t)
+    cancel!(src)
+    @test timedwait(() -> istaskdone(t), 10.0) == :ok
+    @test istaskfailed(t)
+    @test t.result isa CancellationRequest
+
+    # born cancelled: refused at subscribe, never enqueued
+    t2 = with(() -> Task(() -> 42), CANCEL_TOKEN => CancellationToken(src))
+    t2.sticky = false
+    @lock c Base.schedule_on_notify!(c, t2)
+    @test timedwait(() -> istaskdone(t2), 10.0) == :ok
+    @test t2.result isa CancellationRequest
+
+    # a shielded subscriber survives the (already cancelled) scope and
+    # starts on notify
+    t3 = with(() -> Task(() -> 7), CANCEL_TOKEN => nothing)
+    t3.sticky = false
+    @lock c Base.schedule_on_notify!(c, t3)
+    @lock c notify(c)
+    @test timedwait(() -> istaskdone(t3), 10.0) == :ok
+    @test fetch(t3) == 7
+
+    # the task-completion variant: subscribe to a done task under a
+    # cancelled source - killed on the fast path too
+    donesrc = CancellationTokenSource()
+    host = @async 1
+    wait(host)
+    t4 = with(() -> Task(() -> 42), CANCEL_TOKEN => CancellationToken(donesrc))
+    t4.sticky = false
+    cancel!(donesrc)
+    Base.schedule_on_notify!(host, t4)
+    @test timedwait(() -> istaskdone(t4), 10.0) == :ok
+    @test t4.result isa CancellationRequest
+
+    # a started task cannot be subscribed
+    started = Base.Event()
+    t5 = @async (notify(started); sleep(0.05); 1)
+    wait(started)
+    @test_throws ConcurrencyViolationError (@lock c Base.schedule_on_notify!(c, t5))
+    wait(t5)
+
+    # neither can a merely-queued one: @async has scheduled it, so its
+    # own first park owns the arm slot (subscribing it used to leak the
+    # sleep timer's cond lock and wedge the process at close)
+    t6 = @async (sleep(0.01); 1)
+    @test_throws ConcurrencyViolationError (@lock c Base.schedule_on_notify!(c, t6))
+    wait(t6)
+end
+
 @testset "waiter registry: refused arm cannot leak into a shield" begin
     # the model-found race (tla/WaitClaim.tla): a cancellation walk observes
     # an armed cancellable park and judges it eligible; the park is then

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -1170,7 +1170,14 @@ end
         @test timedwait(() -> (@atomic :monotonic writer.waiting_on) !== nothing, 20.0) == :ok
         cancel!(srcs)
         accepted = fetch(writer)::Int
-        @test length(head) <= accepted < n
+        if Sys.iswindows()
+            # the OS pipe buffer can absorb the entire write before the
+            # cancellation lands (its quota is advisory and grows); the
+            # sweep then settles an already-completed write in full
+            @test length(head) <= accepted <= n
+        else
+            @test length(head) <= accepted < n
+        end
         # the stream survives the sweep: a follow-up write goes through
         extra = rand(UInt8, 1000)
         drained = @async read(p.out)

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -9,7 +9,8 @@ include("print_process_affinity.jl") # import `uv_thread_getaffinity`
 # whether `t` currently has an armed wait registration on `waitee`
 function parked_on(t::Task, @nospecialize(waitee))
     w = @atomic t.waiting_on
-    return w isa Base.WaitEntry && w.queue === waitee
+    waitee isa Task && (waitee = waitee.donenotify)
+    return w isa Base.WaitEntry && Base._find_slot(w, waitee) != 0
 end
 
 # simple sanity tests for locks under cooperative concurrent access
@@ -50,7 +51,7 @@ end
             w = Base._wait2(c1, t)
             @test_throws ConcurrencyViolationError Base._wait2(c2, t)
             @test (@atomic t.waiting_on) === w
-            @test length(c1.waitq) == 1
+            @test length(Base.waitqueue(c1)) == 1
             @test isempty(c2.waitq)
             @test notify(c1) == 1
             @test notify(c2) == 0
@@ -68,7 +69,7 @@ end
         w = @atomic waiter.waiting_on
         @test_throws ConcurrencyViolationError Base._wait2(target2, waiter)
         @test (@atomic waiter.waiting_on) === w
-        @test length((target1.donenotify::Base.ThreadSynchronizer).waitq) == 1
+        @test length(Base.waitqueue(target1)) == 1
         donenotify2 = target2.donenotify::Base.ThreadSynchronizer
         @test isempty(donenotify2.waitq)
         gotlock = trylock(donenotify2)
@@ -125,7 +126,7 @@ end
         # eager unlink: entry gone before t even runs
         @test !parked_on(t, cond)
         @test isempty(cond.waitq)
-        @test (w::Base.WaitEntry).queue === nothing # freed for reuse
+        @test Base._slot_owner(w::Base.WaitEntry, 1) === nothing # freed for reuse
         lock(cond)
         @test notify(cond) == 0
         unlock(cond)
@@ -221,7 +222,7 @@ end
             # stays linked for us (the "notifier") to pop
             wait(@async schedule(t, ErrorException("interrupt"), error=true))
             @test popfirst!(Base.waitqueue(cond)) === w
-            @test (w::Base.WaitEntry).queue === nothing
+            @test Base._slot_owner(w::Base.WaitEntry, 1) === nothing
             for _ in 1:1000
                 parked_on(t, cond.lock.cond_wait) && break
                 yield()
@@ -289,7 +290,7 @@ end
     # the cached entries were recycled, not replaced
     @test t.cached_wait_entry === w_spawned
     @test current_task().cached_wait_entry === w_driver
-    @test (w_driver::Base.WaitEntry).queue === nothing # free between parks
+    @test Base._slot_owner(w_driver::Base.WaitEntry, 1) === nothing # free between parks
     if Base.JLOptions().code_coverage == 0
         @test allocated == 0
     end

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -48,8 +48,8 @@ end
         lock(c1)
         lock(c2)
         try
-            w = Base._wait2(c1, t)
-            @test_throws ConcurrencyViolationError Base._wait2(c2, t)
+            w = Base.schedule_on_notify!(c1, t)
+            @test_throws ConcurrencyViolationError Base.schedule_on_notify!(c2, t)
             @test (@atomic t.waiting_on) === w
             @test length(Base.waitqueue(c1)) == 1
             @test isempty(c2.waitq)
@@ -65,9 +65,9 @@ end
         target1 = @task nothing
         target2 = @task nothing
         waiter = @task nothing
-        Base._wait2(target1, waiter)
+        Base.schedule_on_notify!(target1, waiter)
         w = @atomic waiter.waiting_on
-        @test_throws ConcurrencyViolationError Base._wait2(target2, waiter)
+        @test_throws ConcurrencyViolationError Base.schedule_on_notify!(target2, waiter)
         @test (@atomic waiter.waiting_on) === w
         @test length(Base.waitqueue(target1)) == 1
         donenotify2 = target2.donenotify::Base.ThreadSynchronizer
@@ -89,12 +89,12 @@ end
         live = @task nothing
         lock(cond)
         try
-            w_stale = Base._wait2(cond, stale)
+            w_stale = Base.schedule_on_notify!(cond, stale)
             @test !isempty(cond)
             @test Base.claim_wait(stale, w_stale)
             @test !isempty(cond.waitq)
             @test isempty(cond)
-            w_live = Base._wait2(cond, live)
+            w_live = Base.schedule_on_notify!(cond, live)
             @test !isempty(cond)
             @test Base.claim_wait(live, w_live)
             @test isempty(cond)


### PR DESCRIPTION
Extracted from #60281. Extends the wait protocol from #62430 with support for multiple simultaneous wait queues and uses this to wait for both cancellation and libuv completion at the same time.