### PR TITLE
threading: validate JULIA_NUM_GC_THREADS at startup

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -788,17 +788,18 @@ void jl_init_threading(void)
     if (jl_n_markthreads == -1) { // --gcthreads not specified
         if ((cp = getenv(NUM_GC_THREADS_NAME))) { // ENV[NUM_GC_THREADS_NAME] specified
             errno = 0;
-            jl_n_markthreads = (uint64_t)strtol(cp, &endptr, 10) - 1;
-            if (errno != 0 || endptr == cp || nthreads <= 0)
-                jl_n_markthreads = 0;
+            long nmarkthreads = strtol(cp, &endptr, 10);
+            if (errno != 0 || endptr == cp || nmarkthreads < 1 || nmarkthreads >= INT16_MAX)
+                jl_errorf("julia: %s=<n>[,<m>]; n must be an integer >= 1", NUM_GC_THREADS_NAME);
+            jl_n_markthreads = nmarkthreads - 1;
             cp = endptr;
             if (*cp == ',') {
                 cp++;
                 errno = 0;
-                jl_n_sweepthreads = strtol(cp, &endptri, 10);
-                if (errno != 0 || endptri == cp || jl_n_sweepthreads < 0) {
-                    jl_n_sweepthreads = 0;
-                }
+                long nsweepthreads = strtol(cp, &endptri, 10);
+                if (errno != 0 || endptri == cp || *endptri != 0 || nsweepthreads < 0 || nsweepthreads > 1)
+                    jl_errorf("julia: %s=<n>,<m>; m must be 0 or 1", NUM_GC_THREADS_NAME);
+                jl_n_sweepthreads = (int)nsweepthreads;
             }
         }
         else {

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -498,6 +498,15 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
         withenv("JULIA_NUM_GC_THREADS" => "2,1") do
             @test read(`$exename -e $code`, String) == "3"
         end
+
+        # invalid JULIA_NUM_GC_THREADS values must be rejected at startup
+        # like `--gcthreads`, not crash the GC later (e.g. `=0` used to
+        # underflow the mark-thread count and segfault at the first collection)
+        for ngc in ("0", "-1", "abc", "32767", "2,2", "2,-1", "2,1x")
+            withenv("JULIA_NUM_GC_THREADS" => ngc) do
+                @test errors_not_signals(`$exename -e $code`)
+            end
+        end
     end
 
     # --machine-file


### PR DESCRIPTION
JULIA_NUM_GC_THREADS=0 (or any invalid value) previously slipped past the env-var parser: "0" yielded jl_n_markthreads = -1, which shrank jl_all_tls_states_size below the mutator thread count while single_threaded_mark stayed false, so the parallel mark path indexed past the end of gc_all_tls_states through a NULL ptls and segfaulted at the first collection (deterministically, on 1.10 through master):

    $ JULIA_NUM_GC_THREADS=0 julia -e 'GC.gc()'
    signal 11 (1): Segmentation fault
    gc_ptr_queue_push at src/gc-stock.c ...

Validate the environment variable with the same checks and error style as the already-validated --gcthreads command-line path: n must be an integer
>= 1 (below INT16_MAX), and m must be 0 or 1. Erroring out at startup
mirrors the CLI behavior instead of silently clamping. This also fixes the old guard testing the unrelated `nthreads` variable instead of the parsed value.