### PR TITLE
[GMP] Fix _mpz_realloc patch when old size > alloc

### DIFF
--- a/deps/patches/gmp-mpz_realloc.patch
+++ b/deps/patches/gmp-mpz_realloc.patch
@@ -24,7 +24,7 @@
 -      mp = __GMP_REALLOCATE_FUNC_LIMBS (PTR (m), ALLOC (m), new_alloc);
 +      mp_ptr old_mp = PTR (m);
 +      mp_size_t old_alloc = ALLOC (m);
-+      mp_size_t copy_size = ABSIZ (m);
++      mp_size_t copy_size = MIN (ABSIZ (m), MIN (old_alloc, new_alloc));
 +      if (copy_size > new_alloc)
 +	copy_size = new_alloc;
 +      MPN_COPY (mp, old_mp, copy_size);


### PR DESCRIPTION
Some callers of `MPZ_REALLOC`, like `mpz_tdiv_r`, set the size of the `mpz_ptr` being reallocated to a value larger than the original allocation, before calling realloc:

https://gmplib.org/repo/gmp-6.3/file/tip/mpz/tdiv_r.c#l55
```c
      if (num != rem)
	{
	  SIZ (rem) = ns;
	  rp = MPZ_NEWALLOC (rem, nl);
	  np = PTR (num);
	  MPN_COPY (rp, np, nl);
	}
```

The docs also suggest GMP expects this of its reallocation functions in general, see https://gmplib.org/manual/Custom-Allocation:
> The block may be moved if necessary or if desired, and in that case
> the smaller of old_size and new_size bytes must be copied to the new
> location.

If we're unlucky, we hit this in `mpz_tdiv_r` and read past the end of the BigInt for the result.  Fix this by computing the minimum of the old and new allocation sizes.

I diagnosed this issue with GPT-5.6 Sol.

Fixes #62561, though I'm still suspicious of this patch and we should keep an eye out for similar bugs.