### PR TITLE
[JuliaLowering] Force `GlobalRef` for function-returning macro

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -429,6 +429,31 @@ function _mangle_writeonly(st, seen)
     end
 end
 
+function _note_32026_hack!(st, expansion_sc::SyntaxContext)
+    k = kind(st)
+    if st.context.layer === expansion_sc.layer &&
+        (k === K"function" || k === K"=" && is_eventually_call(st[1]))
+        setmeta!(st, :resolved_global_function_name, true)
+    end
+    st
+end
+_apply_32026_hack(st, sc::SyntaxContext) = @stm st begin
+    ([K"Identifier"], when=st.mod===nothing && st.context.layer===sc.layer) ->
+        @mknode(st; mod=sc.layer.mod)
+    [K"call" x args...] -> kind(x) === K"::" ? st :
+        @ast _ st [K"call" _apply_32026_hack(x, sc) args...]
+    [K"where" x args...] -> @ast _ st [K"where" _apply_32026_hack(x, sc) args...]
+    [K"::" x t] -> @ast _ st [K"::" _apply_32026_hack(x, sc) t]
+    [K"curly" x args...] -> @ast _ st [K"curly" _apply_32026_hack(x, sc) args...]
+    x -> x
+end
+function apply_32026_hack(st, orig)
+    is_flisp_compat(st) || return st
+    getmeta(orig, :resolved_global_function_name, false) || return st
+    @jl_assert is_flisp_compat(orig) orig
+    _apply_32026_hack(st, orig.context::SyntaxContext)
+end
+
 # nothing if not found, or symbol if 0-arg [no]specialize, or dict arg->meta
 function collect_body_arg_meta(st)
     out = nothing
@@ -587,6 +612,7 @@ function est_to_dst(st::SyntaxTree)
             # no fix_arglist needed, since this func can't be anonymous
             l = apply_arglist_meta(l, collect_body_arg_meta(r))
             l = force_readable_sparams(l)
+            l = apply_32026_hack(l, st)
             if has_if_generated(r)
                 gen, nongen = split_generated(r, true), split_generated(r, false)
                 r2 = @ast _ st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]
@@ -595,9 +621,12 @@ function est_to_dst(st::SyntaxTree)
             end
             @ast _ st [K"function" rec(l) r2]
         end
+        [K"function" [K"Identifier"]] ->
+            @ast _ st [K"function" apply_32026_hack(st[1], st)]
         [K"function" l r] -> let
             l = apply_arglist_meta(_dst_fix_arglist(l), collect_body_arg_meta(r))
             l = force_readable_sparams(l)
+            l = apply_32026_hack(l, st)
             if has_if_generated(r)
                 gen, nongen = split_generated(r, true), split_generated(r, false)
                 r2 = @ast _ st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -274,6 +274,7 @@ function expand_macro(ctx::MacroExpansionContext, st::SyntaxTree)
         ScopeLayer(mod_for_ast, sc_in.layer), st,
         (has_new_macro ? JL_NEW_SYNTAX_VERSION : JL_OLD_SYNTAX_VERSION), false)
     st_out2 = apply_expansion_layer(ctx, st_out, sc2, true, 0, 0)
+    has_new_macro || _note_32026_hack!(st_out2, sc2)
     !ctx.recursive ? st_out2 : expand_forms_1(ctx, st_out2)
 end
 

--- a/JuliaLowering/test/scopes.jl
+++ b/JuliaLowering/test/scopes.jl
@@ -574,8 +574,20 @@ end
         macro mesc(x); esc(x); end
     end
 
-    JuliaLowering.include_string(test_mod, "macro_mod.@m function f_local_1(); 1; end")
+    # A function not wrapped in anything is made a macro-module global (#32026)
+    JuliaLowering.include_string(test_mod, "macro_mod.@m function f_bug_1(); 1; end")
+    @test isdefined(test_mod.macro_mod, :f_bug_1)
+    JuliaLowering.include_string(test_mod, "macro_mod.@m function f_bug_2 end")
+    @test isdefined(test_mod.macro_mod, :f_bug_2)
+    JuliaLowering.include_string(test_mod, "macro_mod.@m f_bug_3(x) = 1")
+    @test isdefined(test_mod.macro_mod, :f_bug_3)
+    JuliaLowering.include_string(test_mod, "macro_mod.@m f_bug_4(x)::Int = 1")
+    @test isdefined(test_mod.macro_mod, :f_bug_4)
+    # (wrapped def is fine)
+    JuliaLowering.include_string(test_mod, "macro_mod.@m begin; f_local_1(x) = 1; end")
     @test !isdefined(test_mod.macro_mod, :f_local_1)
+    @test !isdefined(test_mod, :f_local_1)
+
     JuliaLowering.include_string(test_mod, "macro_mod.@mesc function f_nonlocal_2(); 1; end")
     @test isdefined(test_mod, :f_nonlocal_2)
     # An unescaped const should not error coming from an old-style macro

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -304,7 +304,7 @@
 ;; given the LHS of e.g. `x::Int -> y`, wrap the signature in `tuple` to normalize
 (define (tuple-wrap-arrow-sig e)
   (cond ((atom? e)             `(tuple ,e))
-        ((eq? (car e) 'where)  `(where ,(tuple-wrap-arrow-arglist (cadr e)) ,@(cddr e)))
+        ((eq? (car e) 'where)  `(where ,(tuple-wrap-arrow-sig (cadr e)) ,@(cddr e)))
         ((eq? (car e) 'tuple)  e)
         ((eq? (car e) 'escape) `(escape ,(tuple-wrap-arrow-sig (cadr e))))
         (else                  `(tuple ,e))))
@@ -599,6 +599,9 @@
         ((eq? (car e) 'escape)  '())
         ((eq? (car e) 'hygienic-scope)
          (resume-on-escape (lambda (e) (find-assigned-vars-in-expansion e outer)) (cadr e) 0))
+        ;; N.B. the `(not outer)` check means function defs not nested in any
+        ;; (non-hygienic-scope) expression are missed, and resolved to the
+        ;; macro-definition-module global (#32026).
         ((and (not outer) (function-def? e))
          ;; pick up only function name
          (let ((fname (cond ((eq? (car e) '=) (decl-var* (cadr e)))


### PR DESCRIPTION
Implements the bug from #32026.  I was incorrect before about function-name hygiene; I thought global unescaped function definitions were put in the macro-definition module on purpose, but that doesn't happen when wrapping the function in any other node*.  It looks like `find-assigned-vars-in-expansion` completely misses the name of the function being defined when the definition is "outermost", so the name resolves like any other unresolved reference (including when the expansion is nested in some function definition.)

```julia
# macroexpand.scm doesn't know about f, so it's implicitly global
julia> module M
           macro unescaped_function(x)
               :(function f(x); x; end)
           end
       end; @macroexpand M.@unescaped_function(0)
:(function Main.M.f(var"#23#x")
      #= REPL[17]:3 =#
      #= REPL[17]:3 =#
      var"#23#x"
  end)

# works OK in begin
julia> module M
           macro unescaped_function(x)
               :(begin; function f(x); x; end; end)
           end
       end; @macroexpand M.@unescaped_function(0)
quote
    #= REPL[18]:3 =#
    function var"#24#f"(var"#25#x")
        #= REPL[18]:3 =#
        #= REPL[18]:3 =#
        var"#25#x"
    end
end

# macroexpand.scm doesn't care if it's in outer_func
julia> module M
           macro unescaped_function(x)
               :(function f(x); x; end)
           end
       end; @macroexpand function outer_func(); M.@unescaped_function(0); end
:(function outer_func()
      #= REPL[19]:5 =#
      #= REPL[19]:5 =#
      function Main.M.f(var"#26#x")
          #= REPL[19]:3 =#
          #= REPL[19]:3 =#
          var"#26#x"
      end
  end)
```

Usually I would go ping package authors here, but this bug has been around since at least 1.0 and shows up in pkgeval (~180 failures, most probably caused by Plots.jl).  I also have the ability to limit it to the older syntax version, which I've done.  Still, speak up if you think I can get out of merging this :)

*There are a few places other than a new expansion where macroexpand.scm decides to reset, but I'm hoping that no one depends on that in practice.