### PR TITLE
loading: add a cache-fetch hook consulted before compiling a package

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1636,6 +1636,54 @@ function run_package_callbacks(modkey::PkgId)
     nothing
 end
 
+"""
+    Base.CACHE_FETCH_HOOK
+
+An optional callable consulted when `require` or precompilation has determined
+that no valid compile cache exists for a package and it is about to compile
+one. Called as
+
+    hook(pkg::PkgId, sourcepath::String)::Bool
+
+Returning `true` indicates the hook may have placed a cachefile in one of the
+`DEPOT_PATH` compile cache directories (e.g. by fetching it from a cache
+server); the caller then rescans the cache candidates and revalidates them
+through the normal staleness machinery, falling back to compiling if nothing
+valid appeared. Any other return value — or a thrown error, which is caught
+and logged at debug level — proceeds directly to compilation.
+
+The hook is advisory and its output is untrusted: fetched files undergo the
+same validation as any other cache candidate. Implementations must not load
+non-sysimage code, and must be safe to call from concurrent tasks. The hook
+is never invoked from output-generating (precompile worker) processes, nor
+reentrantly.
+"""
+const CACHE_FETCH_HOOK = Ref{Any}(nothing)
+
+"""
+    Base.maybe_fetch_cache(pkg::PkgId, sourcepath::String) -> Bool
+
+Invoke `CACHE_FETCH_HOOK` under its safety guards (never while generating
+output, never reentrantly, errors demoted to `false`). Returns whether the
+caller should rescan the compile cache candidates.
+"""
+function maybe_fetch_cache(pkg::PkgId, sourcepath::String)
+    h = CACHE_FETCH_HOOK[]
+    h === nothing && return false
+    generating_output() && return false
+    tls = task_local_storage()
+    haskey(tls, :in_cache_fetch_hook) && return false
+    tls[:in_cache_fetch_hook] = true
+    try
+        return @invokelatest(h(pkg, sourcepath)) === true
+    catch err
+        @debug "CACHE_FETCH_HOOK failed" pkg exception=(err, catch_backtrace())
+        return false
+    finally
+        delete!(tls, :in_cache_fetch_hook)
+    end
+end
+
 
 ##############
 # Extensions #
@@ -2879,6 +2927,7 @@ function __require_prelocked(pkg::PkgId, env)
     set_pkgorigin_version_path(pkg, path)
 
     parallel_precompile_attempted = Ref(false) # being safe to avoid getting stuck in a precompilepkgs loop
+    cache_fetch_attempted = Ref(false)         # the cache-fetch hook gets one shot, then we compile
     reasons = Dict{Symbol,Int}()
     # attempt to load the module file via the precompile cache locations
     if JLOptions().use_compiled_modules != 0
@@ -2914,7 +2963,8 @@ function __require_prelocked(pkg::PkgId, env)
                 @goto load_from_cache
             end
             # spawn off a new incremental pre-compile task for recursive `require` calls
-            loaded = let spec = spec, reasons = reasons, parallel_precompile_attempted = parallel_precompile_attempted
+            loaded = let spec = spec, reasons = reasons, parallel_precompile_attempted = parallel_precompile_attempted,
+                         cache_fetch_attempted = cache_fetch_attempted
                 maybe_cachefile_lock(pkg, spec.path) do
                     # double-check the search now that we have lock
                     m = _require_search_from_serialized(pkg, spec, UInt128(0), true)
@@ -2925,6 +2975,13 @@ function __require_prelocked(pkg::PkgId, env)
 
                     unlock(require_lock)
                     try
+                        # a cache-fetch hook gets one chance to materialize a
+                        # cachefile before we spend time compiling; returning
+                        # `nothing` retries the cache search from the top
+                        if !cache_fetch_attempted[] && CACHE_FETCH_HOOK[] !== nothing
+                            cache_fetch_attempted[] = true
+                            maybe_fetch_cache(pkg, spec.path) && return nothing
+                        end
                         if !generating_output() && !parallel_precompile_attempted[] && !disable_parallel_precompile && @isdefined(Precompilation)
                             parallel_precompile_attempted[] = true
                             # Note that we use @invokelatest here to avoid world

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1639,18 +1639,19 @@ end
 """
     Base.CACHE_FETCH_HOOK
 
-An optional callable consulted when `require` or precompilation has determined
-that no valid compile cache exists for a package and it is about to compile
-one. Called as
+An optional callable that is consulted when `require` or precompilation has
+determined that no valid compile cache exists for a package and it is about
+to compile one. The hook is called as
 
     hook(pkg::PkgId, sourcepath::String)::Bool
 
-Returning `true` indicates the hook may have placed a cachefile in one of the
-`DEPOT_PATH` compile cache directories (e.g. by fetching it from a cache
-server); the caller then rescans the cache candidates and revalidates them
-through the normal staleness machinery, falling back to compiling if nothing
-valid appeared. Any other return value — or a thrown error, which is caught
-and logged at debug level — proceeds directly to compilation.
+A return value of `true` indicates that the hook may have placed a cachefile
+in one of the `DEPOT_PATH` compile cache directories (e.g. by fetching it
+from a cache server); the caller then rescans the cache candidates,
+revalidates them through the normal staleness machinery, and falls back to
+compiling if nothing valid appeared. Any other return value — or a thrown
+error, which is caught and logged at debug level — proceeds directly to
+compilation.
 
 The hook is advisory and its output is untrusted: fetched files undergo the
 same validation as any other cache candidate. Implementations must not load
@@ -1664,8 +1665,8 @@ const CACHE_FETCH_HOOK = Ref{Any}(nothing)
     Base.maybe_fetch_cache(pkg::PkgId, sourcepath::String) -> Bool
 
 Invoke `CACHE_FETCH_HOOK` under its safety guards (never while generating
-output, never reentrantly, errors demoted to `false`). Returns whether the
-caller should rescan the compile cache candidates.
+output, never reentrantly, errors demoted to `false`) and return whether
+the caller should rescan the compile cache candidates.
 """
 function maybe_fetch_cache(pkg::PkgId, sourcepath::String)
     h = CACHE_FETCH_HOOK[]

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -2180,6 +2180,19 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                 freshpath = @lock s.cache_lock Base.compilecache_freshest_path(pkg; ignore_loaded=s.ignore_loaded,
                     stale_cache=s.stale_cache, cachepath_cache=s.cachepath_cache, cachepaths, sourcespec, flags=cacheflags)
                 is_stale = freshpath === nothing
+                if is_stale && !circular && Base.CACHE_FETCH_HOOK[] !== nothing
+                    # a cache-fetch hook gets one chance to materialize a
+                    # cachefile before we schedule a local compile; this runs
+                    # after the dep waits above, so dependency cachefiles are
+                    # in place for the hook to key against
+                    if Base.maybe_fetch_cache(pkg, sourcespec.path)
+                        local fetched_cachepaths = Base.find_all_in_cache_path(pkg)
+                        freshpath = @lock s.cache_lock Base.compilecache_freshest_path(pkg; ignore_loaded=s.ignore_loaded,
+                            stale_cache=s.stale_cache, cachepath_cache=s.cachepath_cache,
+                            cachepaths=fetched_cachepaths, sourcespec, flags=cacheflags)
+                        is_stale = freshpath === nothing
+                    end
+                end
                 if !is_stale
                     push!(freshpaths, freshpath)
                 end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -2165,3 +2165,102 @@ end
         rm(tmpdir; recursive=true, force=true)
     end
 end
+
+@testset "CACHE_FETCH_HOOK" begin
+    mktempdir() do dir
+        # a minimal package to precompile/load in child processes
+        pkgdir = joinpath(dir, "CacheHookPkg")
+        mkpath(joinpath(pkgdir, "src"))
+        write(joinpath(pkgdir, "Project.toml"), """
+            name = "CacheHookPkg"
+            uuid = "b1e9525c-3f39-4e6a-b8b8-c1d9f8d1a001"
+            version = "0.1.0"
+            """)
+        write(joinpath(pkgdir, "src", "CacheHookPkg.jl"),
+              "module CacheHookPkg\nanswer() = 42\nend\n")
+
+        depot = joinpath(dir, "depot")
+        stash = joinpath(dir, "stash")
+        mkpath(stash)
+        listsep = Sys.iswindows() ? ";" : ":"
+        childenv = ["JULIA_DEPOT_PATH" => depot * listsep,
+                    "JULIA_LOAD_PATH" => pkgdir * listsep * "@stdlib"]
+        runchild(script) = run(addenv(`$(Base.julia_cmd()) --startup-file=no -e $script`, childenv...))
+
+        # generate a genuine cachefile, then stash it away (leaving the depot
+        # cold). The stash/delete happens in *this* process: the child that
+        # loaded the package cannot remove its own pkgimage on Windows (mapped
+        # DLLs are locked while loaded)
+        runchild("using CacheHookPkg")
+        cachedir = joinpath(depot, "compiled", "v$(VERSION.major).$(VERSION.minor)", "CacheHookPkg")
+        @test isdir(cachedir)
+        for f in readdir(cachedir; join=true)
+            cp(f, joinpath(stash, basename(f)))
+        end
+        rm(cachedir; recursive=true)
+        @test !isempty(readdir(stash))
+
+        # a hook that restores the stashed files must satisfy loading with no
+        # local compile (exactly the stashed candidate files, hook hit once);
+        # exercised on both the parallel-driver and the serial path
+        fetch_script = serial -> """
+            Base.disable_parallel_precompile = $serial
+            hits = Ref(0)
+            Base.CACHE_FETCH_HOOK[] = function (pkg, sourcepath)
+                @assert pkg.name == "CacheHookPkg"
+                @assert isfile(sourcepath)
+                hits[] += 1
+                cachedir = joinpath(DEPOT_PATH[1], "compiled", "v\$(VERSION.major).\$(VERSION.minor)", pkg.name)
+                mkpath(cachedir)
+                for f in readdir($(repr(stash)); join=true)
+                    cp(f, joinpath(cachedir, basename(f)); force=true)
+                end
+                return true
+            end
+            using CacheHookPkg
+            @assert CacheHookPkg.answer() == 42
+            @assert hits[] == 1
+            cachedir = dirname(only(Base.find_all_in_cache_path(Base.identify_package("CacheHookPkg"))))
+            @assert sort(readdir(cachedir)) == sort(readdir($(repr(stash)))) # no extra (recompiled) files
+            """
+        @test success(runchild(fetch_script(false)))
+        rm(joinpath(depot, "compiled"); recursive=true, force=true)
+        @test success(runchild(fetch_script(true)))
+        rm(joinpath(depot, "compiled"); recursive=true, force=true)
+
+        # a hook serving garbage is harmless: normal compilation takes over
+        @test success(runchild("""
+            Base.CACHE_FETCH_HOOK[] = function (pkg, sourcepath)
+                cachedir = joinpath(DEPOT_PATH[1], "compiled", "v\$(VERSION.major).\$(VERSION.minor)", pkg.name)
+                mkpath(cachedir)
+                write(joinpath(cachedir, pkg.name * "_garbage.ji"), "not a cachefile")
+                return true
+            end
+            using CacheHookPkg
+            @assert CacheHookPkg.answer() == 42
+            """))
+        rm(joinpath(depot, "compiled"); recursive=true, force=true)
+
+        # a throwing hook is demoted to a miss
+        @test success(runchild("""
+            Base.CACHE_FETCH_HOOK[] = (pkg, sourcepath) -> error("boom")
+            using CacheHookPkg
+            @assert CacheHookPkg.answer() == 42
+            """))
+
+        # guards: reentrant invocation is refused, and the helper declines
+        # while generating output; both directly observable in-process
+        @test success(runchild("""
+            inner = Ref{Any}(:unset)
+            Base.CACHE_FETCH_HOOK[] = function (pkg, sourcepath)
+                if inner[] === :unset
+                    inner[] = :running
+                    inner[] = Base.maybe_fetch_cache(pkg, sourcepath)
+                end
+                return false
+            end
+            @assert Base.maybe_fetch_cache(Base.PkgId("Fake"), $(repr(joinpath(pkgdir, "src", "CacheHookPkg.jl")))) === false
+            @assert inner[] === false  # the nested call was refused by the guard
+            """))
+    end
+end


### PR DESCRIPTION
🤖 Base.CACHE_FETCH_HOOK, when set by a later-loaded coordination package, is called at the moment require or parallel precompilation has determined that no valid compile cache exists and a package is about to be compiled. The hook may materialize a cachefile (e.g. by fetching it from a cache server keyed on the full build context, which the caller has at exactly this point: deps are loaded/compiled, flags and preferences known); the loader then rescans the cache candidates and revalidates them through the normal staleness machinery, so hook output is untrusted and a bad file degrades to a local compile.