### PR TITLE
test: various fixes to the hang teardown hook

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,6 +249,14 @@ cd(@__DIR__) do
                     push!(stuck, pid)
                 end
             end
+            # Nothing here may yield to the scheduler. `jl_exit_thread0_cb` runs
+            # atexit hooks on whichever task the signal interrupted, and that
+            # task is usually registered on a wait queue, which makes scheduling
+            # it throw (`ConcurrencyViolationError`, see `enq_work`). So signal
+            # before reporting, report through `Core.stderr` (a raw write rather
+            # than `println`, which can block and yield), and sleep without
+            # yielding.
+            #
             # Send a `SIGQUIT` to the whole process tree of every stuck test so
             # each process produces a .core file and a stacktrace, deepest
             # first: the subprocess a test is blocked on is usually the real
@@ -262,18 +270,37 @@ cd(@__DIR__) do
                 ospid === nothing && continue
                 subtree = reverse!(descendant_pids(ospid))
                 wrkr == 1 && isempty(subtree) && continue
-                target = (wrkr == 1 ? "" : "it and ") * "its $(length(subtree)) subprocess(es)"
-                println(stderr, "Test $test is still running on worker $wrkr (pid $ospid) at teardown; sending SIGQUIT to $target for core dumps.")
                 foreach(quit!, subtree)
                 wrkr == 1 || quit!(ospid)
+                target = (wrkr == 1 ? "" : "it and ") * "its $(length(subtree)) subprocess(es)"
+                Core.print(Core.stderr, "Test $test is still running on worker $wrkr (pid $ospid) at teardown; sending SIGQUIT to $target for core dumps.\n")
             end
-            alive(pid) = ccall(:kill, Cint, (Cint, Cint), pid, 0) == 0
+            # A signalled process is a zombie until its parent reaps it, and
+            # `kill(pid, 0)` still succeeds for a zombie. Reaping cannot happen
+            # while we are in here, so check the process state directly: a
+            # zombie has finished dumping and must count as done, otherwise this
+            # loop always waits out the full deadline below.
+            function alive(pid)
+                if Sys.islinux()
+                    stat = try
+                        read("/proc/$pid/stat", String)
+                    catch
+                        return false    # already gone
+                    end
+                    # state is the field after the parenthesised comm
+                    state = split(stat[something(findlast(')', stat), 0)+1:end])[1]
+                    return state != "Z"
+                end
+                # Elsewhere, signal 0 cannot tell a zombie from a live process,
+                # so the loop may wait out its deadline as it did before.
+                return ccall(:kill, Cint, (Cint, Cint), pid, 0) == 0
+            end
             # This must stay comfortably below the watchdog's post-SIGTERM
             # escalation timeout (JL_KILL_TIMEOUT) so that we exit before it
             # escalates.
             deadline = time() + 300
             while time() < deadline && any(alive, stuck)
-                sleep(1)
+                Libc.systemsleep(1)
             end
         end
 


### PR DESCRIPTION
Take three at trying to collect these `.core` files (follow-up to #62542 #62408)

This is mostly working around a `ConcurrencyViolationError` introduced by https://github.com/JuliaLang/julia/pull/62430, but it also fixes some bugs in how the hang handler was waiting for its children.