### PR TITLE
`__source__` and `__module__` are (implicit) parameters not keywords.

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -387,7 +387,8 @@ function metadata(__source__, __module__, expr, ismodule)
     return :($(Dict{Symbol,Any})($(args...)))
 end
 
-function keyworddoc(__source__, __module__, str, def::Base.BaseDocs.Keyword)
+const EntryKind = Union{Base.BaseDocs.Keyword,Base.BaseDocs.Parameter}
+function entrydoc(__source__, __module__, str, def::EntryKind)
     @nospecialize str
     docstr = esc(docexpr(__source__, __module__, lazy_iterpolate(str), metadata(__source__, __module__, def, false)))
     return :($setindex!($(keywords), $docstr, $(esc(quot(def.name)))); nothing)
@@ -729,7 +730,7 @@ function _docm(source::LineNumberNode, mod::Module, meta, x, define::Bool = true
     #   kw"if", kw"else"
     #
     doc =
-    isa(x, Base.BaseDocs.Keyword) ? keyworddoc(source, mod, meta, x) :
+    isa(x, EntryKind) ? entrydoc(source, mod, meta, x) :
 
     # Method / macro definitions and "call" syntax.
     #

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -12,6 +12,13 @@ macro kw_str(text)
     return Keyword(Symbol(text))
 end
 
+struct Parameter
+    name::Symbol
+end
+macro par_str(text)
+    return Parameter(Symbol(text))
+end
+
 """
 **Welcome to Julia $(string(VERSION)).** The full manual is available at
 
@@ -269,7 +276,7 @@ The argument `__module__` is only visible inside the macro, and it provides info
 (in the form of a `Module` object) about the expansion context of the macro invocation.
 See the manual section on [Macro invocation](@ref) for more information.
 """
-kw"__module__"
+par"__module__"
 
 """
     __source__
@@ -278,7 +285,7 @@ The argument `__source__` is only visible inside the macro, and it provides info
 (in the form of a `LineNumberNode` object) about the parser location of the `@` sign from
 the macro invocation. See the manual section on [Macro invocation](@ref) for more information.
 """
-kw"__source__"
+par"__source__"
 
 """
     local


### PR DESCRIPTION
Related to clarifying #62572. Not exactly sure whether this is all it would take. The intent is just to trigger discussion :)

Rationale:
```julia-repl
julia> xp = :(macro m() __source__ end)
:(macro m()
      #= REPL[2]:1 =#
      #= REPL[2]:1 =#
      __source__
  end)

julia> s = xp.args[2].args[3]
:__source__

julia> s isa #= regular =# Symbol
true
```