### PR TITLE
codegen: avoid redundant bounds checks with `--check-bounds=yes`

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2272,6 +2272,26 @@ static bool bounds_check_enabled(jl_codectx_t &ctx, jl_value_t *inbounds) {
 #endif
 }
 
+// Bounds checking for the explicit `boundscheck` argument of the memoryref
+// intrinsics. Unlike `Expr(:boundscheck)` (which is how `@inbounds` reaches
+// codegen, and which `--check-bounds=yes` must override), a literal `false`
+// here is an assertion by the caller that the index was already validated --
+// e.g. `Base.getindex(::Array, ::Int)` does `@boundscheck checkbounds(A, i)`
+// and then passes `false` to `memoryrefnew`. Forcing that check back on under
+// `--check-bounds=yes` adds no safety, it just emits a second, redundant
+// bounds check per access.
+static bool memoryref_bounds_check_enabled(jl_codectx_t &ctx, jl_value_t *inbounds) {
+#if CHECK_BOUNDS==1
+    if (inbounds == jl_false)
+        return 0;
+    if (jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_OFF)
+        return 0;
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 static Value *emit_bounds_check(jl_codectx_t &ctx, const jl_cgval_t &ainfo, jl_value_t *ty, Value *i, Value *len, jl_value_t *boundscheck) JL_CANSAFEPOINT
 {
     Value *im1 = ctx.builder.CreateSub(i, ConstantInt::get(ctx.types().T_size, 1));
@@ -4990,7 +5010,7 @@ static jl_cgval_t emit_memoryref_direct(jl_codectx_t &ctx, const jl_cgval_t &mem
         return jl_cgval_t();
     Value *i = emit_unbox(ctx, ctx.types().T_size, idx);
     Value *idx0 = ctx.builder.CreateSub(i, ConstantInt::get(ctx.types().T_size, 1));
-    bool bc = bounds_check_enabled(ctx, inbounds);
+    bool bc = memoryref_bounds_check_enabled(ctx, inbounds);
     if (bc) {
         BasicBlock *failBB, *endBB;
         failBB = BasicBlock::Create(ctx.builder.getContext(), "oob");
@@ -5068,7 +5088,7 @@ static jl_cgval_t emit_memoryref(jl_codectx_t &ctx, const jl_cgval_t &ref, jl_cg
     Value *offset = ctx.builder.CreateSub(i, ConstantInt::get(ctx.types().T_size, 1));
     setName(ctx.emission_context, offset, "memoryref_offset");
     Value *elsz = emit_genericmemoryelsize(ctx, mem, ref.typ, false);
-    bool bc = bounds_check_enabled(ctx, inbounds);
+    bool bc = memoryref_bounds_check_enabled(ctx, inbounds);
 #if 1
     Value *ovflw = nullptr;
 #endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4294,7 +4294,7 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     }
     Value *mem = emit_memoryref_mem(ctx, ref, layout);
     Value *mlen = emit_genericmemorylen(ctx, mem, ref.typ);
-    if (bounds_check_enabled(ctx, boundscheck)) {
+    if (memoryref_bounds_check_enabled(ctx, boundscheck)) {
         BasicBlock *failBB, *endBB;
         failBB = BasicBlock::Create(ctx.builder.getContext(), "oob");
         endBB = BasicBlock::Create(ctx.builder.getContext(), "load");
@@ -4690,7 +4690,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             const jl_datatype_layout_t *layout = ((jl_datatype_t*)mty_dt)->layout;
             Value *mem = emit_memoryref_mem(ctx, ref, layout);
             Value *mlen = emit_genericmemorylen(ctx, mem, ref.typ);
-            if (bounds_check_enabled(ctx, boundscheck)) {
+            if (memoryref_bounds_check_enabled(ctx, boundscheck)) {
                 BasicBlock *failBB, *endBB;
                 failBB = BasicBlock::Create(ctx.builder.getContext(), "oob");
                 endBB = BasicBlock::Create(ctx.builder.getContext(), "load");
@@ -4811,7 +4811,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             emit_typecheck(ctx, argv[3], (jl_value_t*)jl_bool_type, fname);
             Value *mem = emit_memoryref_mem(ctx, ref, layout);
             Value *mlen = emit_genericmemorylen(ctx, mem, ref.typ);
-            Value *oob = bounds_check_enabled(ctx, boundscheck) ? ctx.builder.CreateIsNull(mlen) : nullptr;
+            Value *oob = memoryref_bounds_check_enabled(ctx, boundscheck) ? ctx.builder.CreateIsNull(mlen) : nullptr;
             bool isboxed = layout->flags.arrayelem_isboxed;
             if (isboxed || layout->first_ptr >= 0) {
                 bool needlock = layout->flags.arrayelem_islocked;

--- a/test/llvmpasses/memoryref-addrspace.jl
+++ b/test/llvmpasses/memoryref-addrspace.jl
@@ -7,8 +7,15 @@ include(joinpath("..", "testhelpers", "llvmpasses.jl"))
 # Test for GenericMemoryRef address space bug
 # Issue: stores incorrectly use addrspace(10) instead of addrspace(11)
 # in bounds checking code, causing LLVM assertion failures
+#
+# The `boundscheck` argument of `memoryrefnew` is passed explicitly here.
+# Writing `x[i]` would not do: `Base.getindex` validates the index with its own
+# `@boundscheck` and then passes `false`, so the intrinsic emits no check of its
+# own and this bounds-checking path would not be reached.
 function bf(i, x)
-    x[i] *= x[i]
+    ref = Core.memoryrefnew(getfield(x, :ref), i, true)
+    v = Core.memoryrefget(ref, :not_atomic, false)
+    Core.memoryrefset!(ref, v * v, :not_atomic, false)
     nothing
 end
 


### PR DESCRIPTION
`Base.getindex(::Array, ::Int)` and its relatives perform their own `@boundscheck checkbounds(A, i)` and then pass a literal `false` for the `boundscheck` argument of the `memoryrefnew`/`memoryrefget`/`memoryrefset!` intrinsics, since the index has already been validated at that point. `bounds_check_enabled` returns true unconditionally under `--check-bounds=yes` before it inspects that argument, so the intrinsic emits a check of its own and every array access ends up bounds checked twice.

`@inbounds` reaches codegen as `Expr(:boundscheck)` rather than through the intrinsic's explicit argument, so `--check-bounds=yes` keeps overriding it as before. The duplicated check therefore adds no safety.

It is not free, however. It is derived from pointer subtraction and adds a second branch pair per access, which stops LLVM from hoisting the checks out of loops. On 1.10, where `arrayref(true, ...)` was a single fused operation, `--check-bounds=yes` emitted machine code identical to the default and cost nothing. Since the `Array`-on-`Memory` rework it costs roughly 2.5x in compile time, and for vectorizable loops close to an order of magnitude at run time, because vectorization is lost entirely.

Use a separate predicate for the explicit `boundscheck` argument of the memoryref intrinsics so that a literal `false` is honoured, which restores parity with the default mode.

## Measurements

<details>
<summary>Details</summary>

Compile time, per fresh specialization of a bounds-checked gather kernel (min of 15; `JULIA_OBJCACHE=0` where applicable):

| version | `--check-bounds=yes` | default | penalty |
|---|---|---|---|
| 1.10.11 | 16.45 ms | 16.45 ms | 1.00x |
| 1.11.9 | 29.7 ms | 14.11 ms | 2.10x |
| 1.12.6 | 28.7 ms | 17.5 ms | 1.64x |
| 1.13.0-rc1 | 32.6 ms | 13.4 ms | 2.43x |
| master | 34.1 ms | 13.5 ms | 2.52x |
| master + this PR | 17.58 ms | 17.55 ms | **1.00x** |

Run time, ratio of `--check-bounds=yes` to default (µs/call, min of 100):

| kernel | 1.10 | 1.11 | 1.13 | this PR |
|---|---|---|---|---|
| `axpy!` | 0.82x | 11.9x | 5.8x | **1.00x** |
| stencil | 1.00x | 10.0x | 6.6x | **1.00x** |
| gather | 1.00x | 4.3x | 2.6x | 1.13x |
| matmul | 0.96x | 2.0x | 1.05x | 1.41x |

On 1.10 the machine code for `--check-bounds=yes` was byte-identical to the default (351 = 351 lines); on 1.11+ it is 2.5–3x larger. For a simple `axpy!` loop, `--check-bounds=yes` loses vectorization completely on 1.11+ (0 vector operations, versus 23 in the default mode) and this PR restores it. Related observations in #58634, whose table shows the same shape: free on 1.10, a 1.5–1.6x penalty on 1.11/1.12.

</details>

## Semantics

The one behavioural change is that `--check-bounds=yes` no longer re-checks accesses where a caller passes a hardcoded `false` after validating the index itself. This is intended to be the meaning of that argument — `--check-bounds=yes` exists to override user `@inbounds` — but it is a narrowing, and #60530 shows the boundary here is of interest, so it deserves a look from a maintainer rather than being treated as a pure optimization.

`@inbounds` overriding is unaffected. In particular the `OffsetVector` case from #60530, where an outer `checkbounds` succeeds but the inner `@inbounds` access on the backing array is out of bounds, still throws under `--check-bounds=yes`.

---

This pull request was written with the assistance of generative AI (Claude Code).