### PR TITLE
MPFR: fix MethodError in `setproperty!(::BigFloat, ::Symbol, v)`

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -197,7 +197,7 @@ end
 end
 
 # While BigFloat (like all Numbers) is considered immutable, for practical reasons
-# of writing the algorithms on it we allow mutating sign, exp, and the contents of d
+# of writing the algorithms on it we allow mutating sign and exp
 @inline function Base.setproperty!(x::BigFloat, s::Symbol, v)
     d = getfield(x, :d)
     p = Base.unsafe_convert(Ptr{Limb}, d)
@@ -205,9 +205,8 @@ end
         return GC.@preserve d unsafe_store!(Ptr{Cint}(p) + offset_sign, v)
     elseif s === :exp
         return GC.@preserve d unsafe_store!(Ptr{Clong}(p) + offset_exp, v)
-    #elseif s === :d || s === :prec # not mutable
     else
-        return throw(FieldError(x, s))
+        throw(FieldError(BigFloat, s))
     end
 end
 

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -1120,3 +1120,9 @@ end
         @test Base.cconvert(Ref{BigFloat}, x) isa Base.MPFR.BigFloatData
     end
 end
+
+@testset "BigFloat mutability" begin
+    @test_throws FieldError BigFloat(1).d = 1
+    @test_throws FieldError BigFloat(1).s = 1
+    @test_throws FieldError BigFloat(1).notfield = 1
+end

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -1121,8 +1121,4 @@ end
     end
 end
 
-@testset "BigFloat mutability" begin
-    @test_throws FieldError BigFloat(1).d = 1
-    @test_throws FieldError BigFloat(1).s = 1
-    @test_throws FieldError BigFloat(1).notfield = 1
-end
+@test_throws FieldError BigFloat(1).notfield = 1


### PR DESCRIPTION
Bug found by Claude while doing something unrelated