### PR TITLE
loading: speed up isprecompiled / compilecache_freshest_path

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1998,8 +1998,15 @@ function compilecache_freshest_path(pkg::PkgId;
         cachepath_cache::Dict{PkgId, Vector{String}}=Dict{PkgId, Vector{String}}(),
         cachepaths::Vector{String}=get(() -> find_all_in_cache_path(pkg), cachepath_cache, pkg),
         sourcespec::Union{PkgLoadSpec,Nothing}=Base.locate_package_load_spec(pkg),
-        flags::CacheFlags=CacheFlags())
+        flags::CacheFlags=CacheFlags(),
+        # this is a query, not a load: full-file corruption checks are skipped by
+        # default; a corrupted cache is rejected at load time anyway
+        verify_checksums::Bool=false)
     isnothing(sourcespec) && error("Cannot locate source for $(repr("text/plain", pkg))")
+    @lock require_lock begin
+    set_cache = LOADING_CACHE[] === nothing
+    set_cache && (LOADING_CACHE[] = LoadingCache())
+    try
     try_build_ids = UInt128[UInt128(0)]
     if !ignore_loaded
         let loaded = get(loaded_precompiles, pkg, nothing)
@@ -2012,7 +2019,7 @@ function compilecache_freshest_path(pkg::PkgId;
     end
     for build_id in try_build_ids
         @label next_path for path_to_try in cachepaths
-            staledeps = stale_cachefile(pkg, build_id, sourcespec, path_to_try; ignore_loaded, requested_flags=flags)
+            staledeps = stale_cachefile(pkg, build_id, sourcespec, path_to_try; ignore_loaded, requested_flags=flags, verify_checksums)
             if staledeps === true
                 continue
             end
@@ -2024,7 +2031,7 @@ function compilecache_freshest_path(pkg::PkgId;
                 modpaths = get(() -> find_all_in_cache_path(modkey), cachepath_cache, modkey)
                 for modpath_to_try in modpaths::Vector{String}
                     stale_cache_key = (modkey, modbuild_id, modspec, modpath_to_try, ignore_loaded, flags)::StaleCacheKey
-                    if get!(() -> stale_cachefile(modkey, modbuild_id, modspec, modpath_to_try; ignore_loaded, requested_flags=flags) === true,
+                    if get!(() -> stale_cachefile(modkey, modbuild_id, modspec, modpath_to_try; ignore_loaded, requested_flags=flags, verify_checksums) === true,
                             stale_cache, stale_cache_key)
                         continue
                     end
@@ -2040,6 +2047,11 @@ function compilecache_freshest_path(pkg::PkgId;
             end
             return path_to_try
         end
+    end
+    return nothing
+    finally
+        set_cache && (LOADING_CACHE[] = nothing)
+    end
     end
 end
 
@@ -4346,6 +4358,14 @@ function list_reasons(reasons::Dict{Symbol,Int})
 end
 list_reasons(::Nothing) = ""
 
+function in_package_store(path::String)
+    for depot in DEPOT_PATH
+        prefix = joinpath(depot, "packages", "")
+        startswith(path, prefix) && return true
+    end
+    return false
+end
+
 function any_includes_stale(includes::Vector{CacheHeaderIncludes}, cachefile::String, reasons::Union{Dict{Symbol,Int},Nothing}=nothing)
     for chi in includes
         f, fsize_req, hash_req, ftime_req = chi.filename, chi.fsize, chi.hash, chi.mtime
@@ -4384,6 +4404,11 @@ function any_includes_stale(includes::Vector{CacheHeaderIncludes}, cachefile::St
                 @debug "Rejecting stale cache file $cachefile because file size of $f has changed (file size $fsize, before $fsize_req)"
                 record_reason(reasons, :fsize_changed)
                 return true
+            end
+            # a read-only file in the content-addressed package store cannot have
+            # changed since precompilation, so trust the recorded hash
+            if !isdir(fstat) && filemode(fstat) & 0o222 == 0 && in_package_store(f)
+                continue
             end
             hash = isdir(fstat) ? _crc32c(join(readdir(f))) : open(_crc32c, f, "r")
             if hash != hash_req
@@ -4453,12 +4478,13 @@ end
 @constprop :none function stale_cachefile(modpath::String, cachefile::String; kwargs...)
     return stale_cachefile(PkgLoadSpec(modpath, VERSION), cachefile; kwargs...)
 end
-@constprop :none function stale_cachefile(modspec::PkgLoadSpec, cachefile::String; ignore_loaded::Bool = false, requested_flags::CacheFlags=CacheFlags(), reasons=nothing)
-    return stale_cachefile(PkgId(""), UInt128(0), modspec, cachefile; ignore_loaded, requested_flags, reasons)
+@constprop :none function stale_cachefile(modspec::PkgLoadSpec, cachefile::String; ignore_loaded::Bool = false, requested_flags::CacheFlags=CacheFlags(), reasons=nothing, verify_checksums::Bool=true)
+    return stale_cachefile(PkgId(""), UInt128(0), modspec, cachefile; ignore_loaded, requested_flags, reasons, verify_checksums)
 end
 @constprop :none function stale_cachefile(modkey::PkgId, build_id::UInt128, modspec::PkgLoadSpec, cachefile::String;
                                           ignore_loaded::Bool=false, requested_flags::CacheFlags=CacheFlags(),
-                                          reasons::Union{Dict{Symbol,Int},Nothing}=nothing, stalecheck::Bool=true)
+                                          reasons::Union{Dict{Symbol,Int},Nothing}=nothing, stalecheck::Bool=true,
+                                          verify_checksums::Bool=true)
     # n.b.: this function does nearly all of the file validation, not just those checks related to stale, so the name is potentially unclear
     io = try
         open(cachefile, "r")
@@ -4620,17 +4646,19 @@ end
             end
         end
 
-        if !isvalid_file_crc(io)
-            @debug "Rejecting cache file $cachefile because it has an invalid checksum"
-            record_reason(reasons, :checksum_invalid)
-            return true
-        end
-
-        if pkgimage
-            if !isvalid_pkgimage_crc(io, ocachefile::String)
-                @debug "Rejecting cache file $cachefile because $ocachefile has an invalid checksum"
-                record_reason(reasons, :ocache_checksum_invalid)
+        if verify_checksums
+            if !isvalid_file_crc(io)
+                @debug "Rejecting cache file $cachefile because it has an invalid checksum"
+                record_reason(reasons, :checksum_invalid)
                 return true
+            end
+
+            if pkgimage
+                if !isvalid_pkgimage_crc(io, ocachefile::String)
+                    @debug "Rejecting cache file $cachefile because $ocachefile has an invalid checksum"
+                    record_reason(reasons, :ocache_checksum_invalid)
+                    return true
+                end
             end
         end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1999,9 +1999,12 @@ function compilecache_freshest_path(pkg::PkgId;
         cachepaths::Vector{String}=get(() -> find_all_in_cache_path(pkg), cachepath_cache, pkg),
         sourcespec::Union{PkgLoadSpec,Nothing}=Base.locate_package_load_spec(pkg),
         flags::CacheFlags=CacheFlags(),
-        # this is a query, not a load: full-file corruption checks are skipped by
-        # default; a corrupted cache is rejected at load time anyway
-        verify_checksums::Bool=false)
+        # skipping the full-file corruption checks is only safe for advisory
+        # queries (e.g. `isprecompiled`): a caller whose verdict decides what
+        # gets loaded without further validation (like the precompilation
+        # driver) must keep them on, so that a corrupted cache is recompiled
+        # rather than reported as loadable
+        verify_checksums::Bool=true)
     isnothing(sourcespec) && error("Cannot locate source for $(repr("text/plain", pkg))")
     @lock require_lock begin
     set_cache = LOADING_CACHE[] === nothing
@@ -2069,7 +2072,7 @@ fresh julia session specify `ignore_loaded=true`.
     This function requires at least Julia 1.10.
 """
 function isprecompiled(pkg::PkgId; ignore_loaded::Bool=false)
-    path = compilecache_freshest_path(pkg; ignore_loaded)
+    path = compilecache_freshest_path(pkg; ignore_loaded, verify_checksums=false)
     return !isnothing(path)
 end
 
@@ -2083,7 +2086,7 @@ associated cache is relocatable.
     This function requires at least Julia 1.11.
 """
 function isrelocatable(pkg::PkgId)
-    path = compilecache_freshest_path(pkg)
+    path = compilecache_freshest_path(pkg; verify_checksums=false)
     isnothing(path) && return false
     io = open(path, "r")
     try


### PR DESCRIPTION
Checking whether a package is precompiled re-did a large amount of
redundant work for every stale_cachefile call in the dependency graph
walk, making Base.isprecompiled take hundreds of milliseconds for a
large environment. Three changes:

- Install a LoadingCache in compilecache_freshest_path (as __require
  already does) so load_path(), manifest path resolution and
  identify/locate lookups are memoized across the graph walk instead of
  recomputed from scratch on every call.

- Add a verify_checksums option to stale_cachefile and disable it in
  compilecache_freshest_path: the query path no longer computes CRCs of
  entire .ji and .so files. This is a query, not a load; a corrupted
  cache is still rejected at actual load time. Ref
  JuliaLang/julia#61459

- Skip re-hashing source file contents in any_includes_stale for files
  that pass the size check, live in a depot's content-addressed
  packages/ store, and are still read-only as installed by Pkg. A file
  made writable (e.g. chmod'ed for debugging) falls back to hashing.

Checking a large environment (GLMakie + ModelingToolkit + Plots) goes
from ~600 ms to ~140 ms with a warm page cache, and from ~1.75 s to
~0.58 s cold (after purging the OS disk cache).

This commit was written with the assistance of generative AI (Claude).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
