### PR TITLE
Profile: don't require a live -1 thread id sample in the task profile test

### DIFF
--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -82,12 +82,13 @@ test_has_task_profiler_sample_in_buffer()
 
 @testset "Profile.print() groupby options on a task profile" begin
     data, lidict = Profile.retrieve()
-    # the task profiler records -1 as the thread id of a task that isn't running on
-    # one, which the grouped report has to tolerate
-    @test any(eachindex(data)) do i
-        Profile.is_block_end(data, i) &&
-            data[i - Profile.META_OFFSET_THREADID] == reinterpret(UInt, -1)
-    end
+    # the task profiler records -1 as the thread id of a task that isn't running on one,
+    # which the grouped report has to tolerate. Such a sample isn't guaranteed to occur
+    # naturally (#62575), so mark one that way.
+    data = copy(data)
+    block_end = findfirst(i -> Profile.is_block_end(data, i), eachindex(data))
+    @test block_end !== nothing
+    data[block_end - Profile.META_OFFSET_THREADID] = reinterpret(UInt, -1)
     iobuf = IOBuffer()
     with_logger(NullLogger()) do
         @testset for format in [:flat, :tree]


### PR DESCRIPTION
Fixes #62575

:robot: The groupby testset asserted that a walltime task profile always contains a sample whose thread id is -1. That isn't guaranteed: on Windows the low MAX_STACK_MAPPINGS cap makes task stack allocation fall back to sticky copy-stacks, and those keep a pinned thread id when switched out, so no sample ever records -1.

The assertion was only a precondition for what the testset actually covers, which is that the grouped report tolerates that thread id. Mark one sample in the retrieved buffer instead, so the grouped report is exercised with it deterministically on every platform.

