### PR TITLE
jit: Add `yield()` to `test_gc_codeinst` test

### DIFF
--- a/test/jit.jl
+++ b/test/jit.jl
@@ -144,7 +144,9 @@ end
 function test_gc_codeinst()
     for i=1:10000
         @async eval(:(ccall(:sqrt, Float64, (Float64,), $i); wait()))
-        i % 100 == 0 && GC.gc()
+        # yield() so that the Tasks have a chance to be scheduled and then
+        # available for recollection by the GC
+        i % 100 == 0 && (yield(); GC.gc())
     end
     true
 end


### PR DESCRIPTION
I was curious what was exhausting our stack mappings on Windows x86-64. This test as-written accumulates ~10k Tasks that are not GC'd until they are (1) scheduled and then (2) freed by a full GC scan. Add a `yield()` so that they are scheduled sooner and available for recollection in a quick / young GC.

We have a low `MAX_STACK_MAPPINGS` limit on Windows (~500), so if `jit` was scheduled before `Profile` on the same worker on Windows x86-64 and a full GC did not run in time this caused https://github.com/JuliaLang/julia/issues/62575 .

Investigated by Claude Opus 5 🤖 