### PR TITLE
gf: allow non-leaf cache entries in the callsite dispatch cache

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -4717,10 +4717,25 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
 #define LOOP_BODY(_i) do { \
             i = _i; \
             entry = jl_atomic_load_relaxed(&call_cache[cache_idx[i]]); \
-            if (entry && nargs == jl_svec_len(entry->sig->parameters) && \
-                sig_match_fast(FT, args, jl_svec_data(entry->sig->parameters), nargs) && \
-                world >= jl_atomic_load_relaxed(&entry->min_world) && world <= jl_atomic_load_relaxed(&entry->max_world)) { \
-                goto have_entry; \
+            if (entry) { \
+                if (entry->isleafsig) { \
+                    if (nargs == jl_svec_len(entry->sig->parameters) && \
+                        sig_match_fast(FT, args, jl_svec_data(entry->sig->parameters), nargs) && \
+                        world >= jl_atomic_load_relaxed(&entry->min_world) && world <= jl_atomic_load_relaxed(&entry->max_world)) { \
+                        goto have_entry; \
+                    } \
+                } \
+                else { \
+                    /* root `entry` since jl_cache_entry_matches may safepoint, and \
+                     * a concurrent overwrite of the cache slot could otherwise \
+                     * drop the last reference to it */ \
+                    int matches; \
+                    JL_GC_PUSH1(&entry); \
+                    matches = jl_cache_entry_matches(entry, F, args, nargs, world); \
+                    JL_GC_POP(); \
+                    if (matches) \
+                        goto have_entry; \
+                } \
             } \
         } while (0);
     LOOP_BODY(0);
@@ -4757,8 +4772,10 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
                 }
             }
         }
-        if (entry != NULL && entry->isleafsig && entry->simplesig == (void*)jl_nothing && entry->guardsigs == jl_emptysvec) {
-            // put the entry into the cache if it's valid for a leafsig lookup,
+        if (entry != NULL && entry->issimplesig && entry->guardsigs == jl_emptysvec) {
+            // put the entry into the cache if a fast per-entry match
+            // (`jl_cache_entry_matches`) can be used for it, i.e. anything but
+            // signatures that require a subtyping test or guard entries,
             // using pick_which to slightly randomize where it ends up
             // (intentionally not atomically synchronized, since we're just using it for randomness)
             // TODO: use the thread's `cong` instead as a source of randomness

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1931,6 +1931,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
 
 jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t *arg1, jl_value_t **args, size_t n, int8_t offs, size_t world) JL_CANSAFEPOINT;
 jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *mn, jl_value_t *arg1, jl_value_t **args, size_t n, size_t world) JL_CANSAFEPOINT;
+int jl_cache_entry_matches(jl_typemap_entry_t *ml, jl_value_t *arg1, jl_value_t **args, size_t n, size_t world) JL_CANSAFEPOINT;
 STATIC_INLINE jl_typemap_entry_t *jl_typemap_assoc_exact(
     jl_typemap_t *ml_or_cache JL_PROPAGATES_ROOT,
     jl_value_t *arg1, jl_value_t **args, size_t n, int8_t offs, size_t world) JL_CANSAFEPOINT

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -1179,6 +1179,36 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
     }
 }
 
+// Test whether a single method-cache entry matches the concrete call
+// `(arg1, args...)` of `n` total arguments in `world`, applying the same tests
+// as `jl_typemap_entry_assoc_exact` does for one entry. Entries with guard
+// signatures or with signatures that require a subtyping test (`issimplesig`
+// unset) are rejected, so that a match implies the entry can be used directly
+// and the check itself stays cheap. Used by the callsite-associative dispatch
+// cache in gf.c, which may hold entries with non-leaf (e.g. `@nospecialize`d
+// or Vararg) signatures.
+int jl_cache_entry_matches(jl_typemap_entry_t *ml, jl_value_t *arg1, jl_value_t **args, size_t n, size_t world)
+{
+    if (world < jl_atomic_load_relaxed(&ml->min_world) || world > jl_atomic_load_relaxed(&ml->max_world))
+        return 0;
+    if (ml->guardsigs != jl_emptysvec || !ml->issimplesig)
+        return 0;
+    size_t lensig = jl_nparams(ml->sig);
+    if (!(lensig == n || (ml->va && lensig <= n + 1)))
+        return 0;
+    if (ml->isleafsig)
+        return sig_match_leaf(arg1, args, jl_svec_data(ml->sig->parameters), n);
+    if (ml->simplesig != (void*)jl_nothing) {
+        size_t lensimplesig = jl_nparams(ml->simplesig);
+        int isva = lensimplesig > 0 && jl_is_vararg(jl_tparam(ml->simplesig, lensimplesig - 1));
+        if (!(lensig == n || (isva && lensimplesig <= n + 1)))
+            return 0;
+        if (!sig_match_simple(arg1, args, n, jl_svec_data(ml->simplesig->parameters), isva, lensimplesig))
+            return 0;
+    }
+    return sig_match_simple(arg1, args, n, jl_svec_data(ml->sig->parameters), ml->va, lensig);
+}
+
 jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_value_t *arg1, jl_value_t **args, size_t n, size_t world)
 {
     // some manually-unrolled common special cases


### PR DESCRIPTION
The callsite-associative dispatch cache (`call_cache`) previously only admitted method-cache entries with fully-leaf signatures. Entries whose cached signature is widened (e.g. the `@nospecialize` compilation signatures inserted post-inference since #61997), has `Vararg` (the builtin/intrinsic catch-all signatures), or carries a `Type{T}`/`TypeEgal{T}` parameter (and hence a `simplesig`) could never be promoted to the fast path, so every dynamic call dispatching to such an entry repeated the full method-cache lookup: hashing the argument types and probing the leafcache, or walking the typemap tree.

This is extremely hot during bootstrap, where the compiler runs as dynamically-dispatched code compiled at `-O1`: profiling the `basecompiler` build showed 3.89 billion dispatch lookups, of which 2.55 billion repeatedly found such a cache-ineligible entry (740M alone on `Tuple{IntrinsicFunction, Vararg{Any}}`, 710M on `Tuple{typeof(getfield), Vararg{Any}}`), amounting to roughly half of the "Compiling the compiler" phase.

Instead, admit any unguarded entry whose signature supports the cheap `sig_match_simple` test (`issimplesig`), and probe cached non-leaf entries with a new `jl_cache_entry_matches` helper that applies the same per-entry tests as `jl_typemap_entry_assoc_exact`. A matched entry is exactly what the slow-path search would have returned for these calls, so dispatch behavior is unchanged.

Measured effects (8-core M-series macOS, `LLVM_ASSERTIONS=1`):

| Metric (bootstrap stage) | before | after |
|---|---|---|
| call-cache hit rate | 32% (1.25B/3.89B) | 93% (3.61B/3.89B) |
| typemap-walk hits per build | 2.33B | 107M |
| "Compiling the compiler" | 345s | 245s |
| sysimage pipeline (`basecompiler-o.a` → `sys.dylib`) | 611s | 468s |

The `sysbase-o.a` and `sys-o.a` stages are unchanged (LLVM-dominated). Validated with the `core`, `worlds`, and `ambiguous` test suites, a full `make` (all 108 stdlib pkgimage configurations precompile), and the Clang static-analysis/GC-rooting checks for `gf.c` and `typemap.c`.

Disclosure: this pull request was written with the assistance of generative AI (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
