### PR TITLE
lowering/runtime: Fix two define_method regressions from the builtin migration

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1680,14 +1680,18 @@ JL_CALLABLE(jl_f_define_method)
         jl_error("define_method requires 2 or 4 arguments");
     JL_TYPECHK(define_method, module, args[0]);
     jl_module_t *module = (jl_module_t *)args[0];
-    jl_check_top_level_effect(module, "define_method");
 
     // Generic function declaration: define_method(module, name)
+    // No eager top-level-effect check here: declaring an already-existing
+    // generic function is a no-op, which must remain legal for closed modules
+    // during incremental precompilation. Creating a genuinely new binding is
+    // still caught by check_safe_newbinding.
     if (nargs == 2) {
         JL_TYPECHK(define_method, symbol, args[1]);
         jl_sym_t *fname = (jl_sym_t*)args[1];
         return jl_declare_const_gf(module, fname);
     }
+    jl_check_top_level_effect(module, "define_method");
 
     // Method definition: define_method(module, fname_or_mt, argdata, code)
     jl_value_t *fname = args[1];

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -5360,8 +5360,6 @@ f(x) = yt(x)
                    (let ((val (make-ssavalue)))
                     (emit `(= ,val ,(cond ((not name)
                                            `(call (core define_method) (thismodule) (false) ,sig ,lam))
-                                          ((globalref? name)
-                                           `(call (core define_method) ,(cadr name) ,name ,sig ,lam))
                                           ((symbol? name)
                                            `(call (core define_method) (thismodule) (inert ,name) ,sig ,lam))
                                           (else

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -714,6 +714,16 @@ precompile_test_harness(false) do dir
         @test_throws Base.Precompilation.PkgPrecompileError Base.require(Main, :FooBar3)
     end
 
+    # Declaring an already-existing generic function of a closed module is a
+    # no-op and must not error during precompilation
+    FooBar3b_file = joinpath(dir, "FooBar3b.jl")
+    write(FooBar3b_file, """
+    module FooBar3b
+    Core.eval(Main, Expr(:function, GlobalRef(Base, :length)))
+    end
+    """)
+    @test Base.require(Main, :FooBar3b) isa Module
+
     # Test transitive dependency for #21266
     FooBarT_file = joinpath(dir, "FooBarT.jl")
     write(FooBarT_file,

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -4469,6 +4469,16 @@ end
 @test_throws TypeError Core.define_method(@__MODULE__, :invalid_method, nothing, nothing)
 @test_throws ErrorException Core.define_method(@__MODULE__, :invalid_method, Core.svec(), nothing)
 
+# A method defined through a GlobalRef name records the evaluating module,
+# not the GlobalRef's module
+module GlobalRefMethodModule62320
+function no_methods_yet end
+end
+let f = GlobalRefMethodModule62320.no_methods_yet
+    Core.eval(@__MODULE__, Expr(:function, Expr(:call, GlobalRef(GlobalRefMethodModule62320, :no_methods_yet)), nothing))
+    @test only(methods(f)).module === @__MODULE__
+end
+
 # Capturing a @nospecialize argument should result in an Any field in the closure
 module NoSpecClosure
     K(@nospecialize(x)) = y -> x


### PR DESCRIPTION
Follow-up #62320 and fix two regressions identified in post-commit review:
1. The definition module should always be the current module, even if we're defining with `GlobalRef`.
2. Move the effect legality check