### PR TITLE
loading: lazier cache file candidate search, fewer validation syscalls

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1371,42 +1371,55 @@ function cache_file_entry(pkg::PkgId)
         uuid === nothing ? pkg.name : package_slug(uuid)
 end
 
-function find_all_in_cache_path(pkg::PkgId, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
-    paths = String[]
+# Return cache candidates from `depot`, with pkgimages first. Do not open or
+# stat entries here; invalid entries are rejected during validation.
+function cachefile_candidates_in_depot(pkg::PkgId, depot::String)
     entrypath, entryfile = cache_file_entry(pkg)
-    for path in DEPOT_PATH
-        path = joinpath(path, entrypath)
-        isdir(path) || continue
-        for file in readdir(path, sort = false) # no sort given we sort later
-            if !((pkg.uuid === nothing && file == entryfile * ".ji") ||
-                 (pkg.uuid !== nothing && startswith(file, entryfile * "_") &&
-                  endswith(file, ".ji")))
-                 continue
-            end
-            filepath = joinpath(path, file)
-            isfile_casesensitive(filepath) && push!(paths, filepath)
+    dir = joinpath(depot, entrypath)
+    isdir(dir) || return String[]
+    entries = readdir(dir, sort = false)
+    paths = String[]
+    npkgimage = 0
+    use_pkgimages = JLOptions().use_pkgimages != 0
+    dlext_suffix = "." * Libc.Libdl.dlext
+    for file in entries
+        if !((pkg.uuid === nothing && file == entryfile * ".ji") ||
+             (pkg.uuid !== nothing && startswith(file, entryfile * "_") &&
+              endswith(file, ".ji")))
+             continue
+        end
+        filepath = joinpath(dir, file)
+        if use_pkgimages && string(chopsuffix(file, ".ji"), dlext_suffix) in entries
+            npkgimage += 1
+            insert!(paths, npkgimage, filepath)
+        else
+            push!(paths, filepath)
         end
     end
+    return paths
+end
+
+# Search the depot containing Sys.STDLIB first for bundled stdlibs.
+function cache_search_depots(sourcepath::String, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
+    startswith(sourcepath, Sys.STDLIB) || return DEPOT_PATH
+    return sort(DEPOT_PATH, by = depot -> !startswith(Sys.STDLIB, depot))
+end
+
+# Search one depot at a time and stop enumerating once a candidate is accepted.
+function lazy_cachefile_candidates(pkg::PkgId, sourcepath::String, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
+    return Iterators.flatten(cachefile_candidates_in_depot(pkg, depot)
+                             for depot in cache_search_depots(sourcepath, DEPOT_PATH))
+end
+
+function find_all_in_cache_path(pkg::PkgId, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
+    paths = String[]
+    for depot in DEPOT_PATH
+        append!(paths, cachefile_candidates_in_depot(pkg, depot))
+    end
     if length(paths) > 1
-        function sort_by(path)
-            # when using pkgimages, consider those cache files first
-            pkgimage = if JLOptions().use_pkgimages != 0
-                io = open(path, "r")
-                try
-                    if iszero(isvalid_cache_header(io))
-                        false
-                    else
-                        _, _, _, _, _, _, flags = parse_cache_header(io, path)
-                        CacheFlags(flags).use_pkgimages
-                    end
-                finally
-                    close(io)
-                end
-            else
-                false
-            end
-            (; pkgimage, mtime=mtime(path))
-        end
+        use_pkgimages = JLOptions().use_pkgimages != 0
+        # Prefer caches with a pkgimage, then those used most recently.
+        sort_by(path) = (; pkgimage=(use_pkgimages && isfile(ocachefile_from_cachefile(path))), mtime=mtime(path))
         function sort_lt(a, b)
             if a.pkgimage != b.pkgimage
                 return a.pkgimage < b.pkgimage
@@ -2192,7 +2205,7 @@ end
 # returns the set of modules restored if the cache load succeeded
 @constprop :none function _require_search_from_serialized(pkg::PkgId, sourcespec::PkgLoadSpec, build_id::UInt128, stalecheck::Bool; reasons=nothing, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
     assert_havelock(require_lock)
-    paths = find_all_in_cache_path(pkg, DEPOT_PATH)
+    paths = lazy_cachefile_candidates(pkg, sourcespec.path, DEPOT_PATH)
     newdeps = PkgId[]
     try_build_ids = UInt128[build_id]
     if build_id == UInt128(0)
@@ -2205,7 +2218,7 @@ end
         end
     end
     for build_id in try_build_ids
-        @label next_path for path_to_try in paths::Vector{String}
+        @label next_path for path_to_try in paths
             staledeps = stale_cachefile(pkg, build_id, sourcespec, path_to_try; reasons, stalecheck)
             if staledeps === true
                 continue
@@ -2250,7 +2263,7 @@ end
                     @assert canstart_loading(modkey, modbuild_id, stalecheck) === nothing
                     package_locks[modkey] = (current_task(), Threads.Condition(require_lock), modbuild_id)
                     startedloading = i
-                    modpaths = find_all_in_cache_path(modkey, DEPOT_PATH)
+                    modpaths = lazy_cachefile_candidates(modkey, modspec.path, DEPOT_PATH)
                     for modpath_to_try in modpaths
                         modstaledeps = stale_cachefile(modkey, modbuild_id, modspec, modpath_to_try; stalecheck)
                         if modstaledeps === true

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3815,8 +3815,12 @@ function restore_depot_path(path::AbstractString, depot::AbstractString)
     replace(path, r"^@depot" => depot; count=1)
 end
 
-function resolve_depot(inc::AbstractString)
+function resolve_depot(inc::AbstractString, hint::Union{String, Nothing}=nothing)
     startswith(inc, string("@depot", Filesystem.pathsep())) || return :not_relocatable
+    # Cache files usually come from one depot, so try the previous match first.
+    if hint !== nothing && ispath(restore_depot_path(inc, hint))
+        return hint
+    end
     for depot in DEPOT_PATH
         ispath(restore_depot_path(inc, depot)) && return depot
     end
@@ -3938,7 +3942,7 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
     any_no_depot_found = false
     multiple_depots_found = false
     for src in srcfiles
-        depot = resolve_depot(src)
+        depot = resolve_depot(src, srcdepot)
         if depot === :not_relocatable
             any_not_relocatable = true
         elseif depot === :no_depot_found
@@ -3966,7 +3970,7 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
     # unlike include() files, we allow each relocatable include_dependency() file to resolve
     # to a separate depot, #52161
     for inc in includes_depfiles
-        depot = resolve_depot(inc.filename)
+        depot = resolve_depot(inc.filename, srcdepot)
         if depot === :no_depot_found
             @debug("Unable to resolve @depot tag for include_dependency() file $(inc.filename) from cache file $cachefile", _group=:relocatable)
         elseif depot === :not_relocatable
@@ -4390,7 +4394,14 @@ function any_includes_stale(includes::Vector{CacheHeaderIncludes}, cachefile::St
             record_reason(reasons, :unresolved_depot)
             return true
         end
-        if !ispath(f)
+        fstat = try
+            stat(f)
+        catch err
+            err isa IOError || err isa SystemError || rethrow()
+            # Match ispath's behavior for inaccessible paths.
+            StatStruct()
+        end
+        if !ispath(fstat)
             _f = fixup_stdlib_path(f)
             if _f != f && isfile(_f) && startswith(_f, Sys.STDLIB)
                 continue
@@ -4401,7 +4412,7 @@ function any_includes_stale(includes::Vector{CacheHeaderIncludes}, cachefile::St
         end
         if ftime_req >= 0.0
             # this is an include_dependency for which we only recorded the mtime
-            ftime = mtime(f)
+            ftime = mtime(fstat)
             is_stale = ( ftime != ftime_req ) &&
                        ( ftime != floor(ftime_req) ) &&           # Issue #13606, PR #13613: compensate for Docker images rounding mtimes
                        ( ftime != ceil(ftime_req) ) &&            # PR: #47433 Compensate for CirceCI's truncating of timestamps in its caching
@@ -4414,7 +4425,6 @@ function any_includes_stale(includes::Vector{CacheHeaderIncludes}, cachefile::St
                 return true
             end
         else
-            fstat = stat(f)
             fsize = filesize(fstat)
             if fsize != fsize_req
                 @debug "Rejecting stale cache file $cachefile because file size of $f has changed (file size $fsize, before $fsize_req)"

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1371,56 +1371,74 @@ function cache_file_entry(pkg::PkgId)
         uuid === nothing ? pkg.name : package_slug(uuid)
 end
 
+# Return the cache file candidates in `depot` and whether each has a pkgimage
+# next to it, from a single directory listing without opening or stat'ing any
+# entry; invalid entries are rejected during validation.
+function cachefile_candidates_in_depot(pkg::PkgId, depot::String)
+    entrypath, entryfile = cache_file_entry(pkg)
+    dir = joinpath(depot, entrypath)
+    paths = String[]
+    pkgimages = Bool[]
+    isdir(dir) || return paths, pkgimages
+    entries = readdir(dir, sort = false)
+    use_pkgimages = JLOptions().use_pkgimages != 0
+    for file in entries
+        if !((pkg.uuid === nothing && file == entryfile * ".ji") ||
+             (pkg.uuid !== nothing && startswith(file, entryfile * "_") &&
+              endswith(file, ".ji")))
+             continue
+        end
+        push!(paths, joinpath(dir, file))
+        push!(pkgimages, use_pkgimages && ocachefile_from_cachefile(file) in entries)
+    end
+    return paths, pkgimages
+end
+
+# Sort candidates best-first: those with a pkgimage before those without, and
+# most recently modified first within each group, so that `touch`ing a cache
+# file makes it the first one tried on the next load.
+function sort_cachefile_candidates!(paths::Vector{String}, pkgimages::Vector{Bool})
+    length(paths) > 1 || return paths
+    sort_by(i) = (; pkgimage=pkgimages[i], mtime=mtime(paths[i]))
+    function sort_lt(a, b)
+        if a.pkgimage != b.pkgimage
+            return a.pkgimage < b.pkgimage
+        end
+        return a.mtime < b.mtime
+    end
+    # allocating the sort vector is less expensive than using sort!(.. by=sort_by),
+    # which would call the relatively slow mtime multiple times per path
+    p = sortperm(sort_by.(eachindex(paths)), lt=sort_lt, rev=true)
+    permute!(paths, p)
+    return paths
+end
+
+function sorted_cachefile_candidates_in_depot(pkg::PkgId, depot::String)
+    return sort_cachefile_candidates!(cachefile_candidates_in_depot(pkg, depot)...)
+end
+
+# Search the depot containing Sys.STDLIB first for bundled stdlibs.
+function cache_search_depots(sourcepath::String, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
+    stdlib_dir = joinpath(Sys.STDLIB, "") # trailing separator for path-boundary matching
+    startswith(sourcepath, stdlib_dir) || return DEPOT_PATH
+    return sort(DEPOT_PATH, by = depot -> !startswith(stdlib_dir, joinpath(depot, "")))
+end
+
+# Search one depot at a time and stop enumerating once a candidate is accepted.
+function lazy_cachefile_candidates(pkg::PkgId, sourcepath::String, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
+    return Iterators.flatten(sorted_cachefile_candidates_in_depot(pkg, depot)
+                             for depot in cache_search_depots(sourcepath, DEPOT_PATH))
+end
+
 function find_all_in_cache_path(pkg::PkgId, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
     paths = String[]
-    entrypath, entryfile = cache_file_entry(pkg)
-    for path in DEPOT_PATH
-        path = joinpath(path, entrypath)
-        isdir(path) || continue
-        for file in readdir(path, sort = false) # no sort given we sort later
-            if !((pkg.uuid === nothing && file == entryfile * ".ji") ||
-                 (pkg.uuid !== nothing && startswith(file, entryfile * "_") &&
-                  endswith(file, ".ji")))
-                 continue
-            end
-            filepath = joinpath(path, file)
-            isfile_casesensitive(filepath) && push!(paths, filepath)
-        end
+    pkgimages = Bool[]
+    for depot in DEPOT_PATH
+        depot_paths, depot_pkgimages = cachefile_candidates_in_depot(pkg, depot)
+        append!(paths, depot_paths)
+        append!(pkgimages, depot_pkgimages)
     end
-    if length(paths) > 1
-        function sort_by(path)
-            # when using pkgimages, consider those cache files first
-            pkgimage = if JLOptions().use_pkgimages != 0
-                io = open(path, "r")
-                try
-                    if isvalid_cache_header(io) === nothing
-                        false
-                    else
-                        _, _, _, _, _, _, flags = parse_cache_header(io, path)
-                        CacheFlags(flags).use_pkgimages
-                    end
-                finally
-                    close(io)
-                end
-            else
-                false
-            end
-            (; pkgimage, mtime=mtime(path))
-        end
-        function sort_lt(a, b)
-            if a.pkgimage != b.pkgimage
-                return a.pkgimage < b.pkgimage
-            end
-            return a.mtime < b.mtime
-        end
-
-        # allocating the sort vector is less expensive than using sort!(.. by=sort_by),
-        # which would call the relatively slow mtime multiple times per path
-        p = sortperm(sort_by.(paths), lt=sort_lt, rev=true)
-        return paths[p]
-    else
-        return paths
-    end
+    return sort_cachefile_candidates!(paths, pkgimages)
 end
 
 ocachefile_from_cachefile(cachefile) = string(chopsuffix(cachefile, ".ji"), ".", Libc.Libdl.dlext)
@@ -2241,10 +2259,6 @@ end
 # returns the set of modules restored if the cache load succeeded
 @constprop :none function _require_search_from_serialized(pkg::PkgId, sourcespec::PkgLoadSpec, build_id::UInt128, stalecheck::Bool; reasons=nothing, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
     assert_havelock(require_lock)
-    # Try the driver's validated cache first; fall back to the normal search.
-    pre = get(preresolved_cachefiles, pkg, nothing)
-    paths = find_all_in_cache_path(pkg, DEPOT_PATH)
-    pre !== nothing && pushfirst!(paths, pre)
     newdeps = PkgId[]
     try_build_ids = UInt128[build_id]
     if build_id == UInt128(0)
@@ -2256,8 +2270,15 @@ end
             end
         end
     end
+    # iterating the lazy candidates more than once would repeat directory listings
+    paths = length(try_build_ids) == 1 ?
+        lazy_cachefile_candidates(pkg, sourcespec.path, DEPOT_PATH) :
+        find_all_in_cache_path(pkg, DEPOT_PATH)
+    # Try the driver's validated cache first; fall back to the normal search.
+    pre = get(preresolved_cachefiles, pkg, nothing)
+    pre !== nothing && (paths = Iterators.flatten(((pre,), paths)))
     for build_id in try_build_ids
-        @label next_path for path_to_try in paths::Vector{String}
+        @label next_path for path_to_try in paths
             trusted = path_to_try === pre
             staledeps = stale_cachefile(pkg, build_id, sourcespec, path_to_try; reasons,
                                         stalecheck = stalecheck && !trusted, verify_checksums = !trusted)
@@ -2305,8 +2326,8 @@ end
                     package_locks[modkey] = (current_task(), Threads.Condition(require_lock), modbuild_id)
                     startedloading = i
                     mpre = get(preresolved_cachefiles, modkey, nothing)
-                    modpaths = find_all_in_cache_path(modkey, DEPOT_PATH)
-                    mpre !== nothing && pushfirst!(modpaths, mpre)
+                    modpaths = lazy_cachefile_candidates(modkey, modspec.path, DEPOT_PATH)
+                    mpre !== nothing && (modpaths = Iterators.flatten(((mpre,), modpaths)))
                     for modpath_to_try in modpaths
                         modtrusted = modpath_to_try === mpre
                         modstaledeps = stale_cachefile(modkey, modbuild_id, modspec, modpath_to_try;
@@ -3879,8 +3900,13 @@ function restore_depot_path(path::AbstractString, depot::AbstractString)
     replace(path, r"^@depot" => depot; count=1)
 end
 
-function resolve_depot(inc::AbstractString)
+function resolve_depot(inc::AbstractString, hint::Union{String, Nothing}=nothing)
     startswith(inc, string("@depot", Filesystem.pathsep())) || return :not_relocatable
+    # include_dependency() files usually live in the same depot as the source
+    # files of their cache, so try that depot first.
+    if hint !== nothing && ispath(restore_depot_path(inc, hint))
+        return hint
+    end
     for depot in DEPOT_PATH
         ispath(restore_depot_path(inc, depot)) && return depot
     end
@@ -3983,34 +4009,49 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
     # 1. If the cache is not relocatable because of an absolute path,
     #    we ignore that path for the depot search.
     #    Recompilation will be triggered by stale_cachefile() if that absolute path does not exist.
-    # 2. If we can't find a depot for a relocatable path,
-    #    we still replace it with the depot we found from other files.
-    #    Recompilation will be triggered by stale_cachefile() because the resolved path does not exist.
-    # 3. We require that relocatable paths all resolve to the same depot.
-    # 4. We explicitly check that all relocatable paths resolve to the same depot. This has two reasons:
-    #    - We want to scan all source files in order to provide logs for 1. and 2. above.
-    #    - It is possible that a depot might be missing source files.
-    #      Assume that we have two depots on DEPOT_PATH, depot_complete and depot_incomplete.
-    #      If DEPOT_PATH=["depot_complete","depot_incomplete"] then no recompilation shall happen,
-    #      because depot_complete will be picked.
-    #      If DEPOT_PATH=["depot_incomplete","depot_complete"] we trigger recompilation and
-    #      hopefully a meaningful error about missing files is thrown.
-    #      If we were to just select the first depot we find, then whether recompilation happens would
-    #      depend on whether the first relocatable file resolves to depot_complete or depot_incomplete.
-    srcdepot = nothing
+    # 2. We require that a single depot contains all relocatable paths, and pick the first such
+    #    depot in DEPOT_PATH order. This choice does not depend on the iteration order of
+    #    `srcfiles`: with a depot missing some of the files ("depot_incomplete") and a depot
+    #    containing all of them ("depot_complete") on DEPOT_PATH, depot_complete is picked
+    #    regardless of their relative order. Probing a depot stops at its first missing file,
+    #    so files of a cache belonging to a later depot (e.g. bundled stdlib caches) do not
+    #    pay one miss per file on each depot preceding theirs.
+    # 3. If no depot contains all relocatable paths, we scan the files individually, only to
+    #    provide logs distinguishing files missing from every depot from files spread over
+    #    several. The paths keep their @depot tag and stale_cachefile() will trigger
+    #    recompilation.
     any_not_relocatable = false
     any_no_depot_found = false
     multiple_depots_found = false
+    depot_tag = string("@depot", Filesystem.pathsep())
+    relocatable_srcfiles = String[]
     for src in srcfiles
-        depot = resolve_depot(src)
-        if depot === :not_relocatable
+        if startswith(src, depot_tag)
+            push!(relocatable_srcfiles, src)
+        else
             any_not_relocatable = true
-        elseif depot === :no_depot_found
-            any_no_depot_found = true
-        elseif isnothing(srcdepot)
-            srcdepot = depot
-        elseif depot != srcdepot
-            multiple_depots_found = true
+        end
+    end
+    srcdepot = nothing
+    if !isempty(relocatable_srcfiles)
+        for depot in DEPOT_PATH
+            if all(src -> ispath(restore_depot_path(src, depot)), relocatable_srcfiles)
+                srcdepot = depot
+                break
+            end
+        end
+        if srcdepot === nothing
+            founddepot = nothing
+            for src in relocatable_srcfiles
+                depot = resolve_depot(src)
+                if depot === :no_depot_found
+                    any_no_depot_found = true
+                elseif founddepot === nothing
+                    founddepot = depot
+                elseif depot != founddepot
+                    multiple_depots_found = true
+                end
+            end
         end
     end
     if any_no_depot_found
@@ -4030,7 +4071,7 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
     # unlike include() files, we allow each relocatable include_dependency() file to resolve
     # to a separate depot, #52161
     for inc in includes_depfiles
-        depot = resolve_depot(inc.filename)
+        depot = resolve_depot(inc.filename, srcdepot)
         if depot === :no_depot_found
             @debug("Unable to resolve @depot tag for include_dependency() file $(inc.filename) from cache file $cachefile", _group=:relocatable)
         elseif depot === :not_relocatable
@@ -4455,7 +4496,10 @@ function any_includes_stale(includes::Vector{CacheHeaderIncludes}, cachefile::St
             record_reason(reasons, :unresolved_depot)
             return true
         end
-        if !ispath(f)
+        # A single stat provides existence, mtime and size; permission errors
+        # propagate like they did from ispath()/mtime()/stat() before.
+        fstat = stat(f)
+        if !ispath(fstat)
             _f = fixup_stdlib_path(f)
             if _f != f && isfile(_f) && startswith(_f, Sys.STDLIB)
                 continue
@@ -4466,7 +4510,7 @@ function any_includes_stale(includes::Vector{CacheHeaderIncludes}, cachefile::St
         end
         if ftime_req >= 0.0
             # this is an include_dependency for which we only recorded the mtime
-            ftime = mtime(f)
+            ftime = mtime(fstat)
             is_stale = ( ftime != ftime_req ) &&
                        ( ftime != floor(ftime_req) ) &&           # Issue #13606, PR #13613: compensate for Docker images rounding mtimes
                        ( ftime != ceil(ftime_req) ) &&            # PR: #47433 Compensate for CirceCI's truncating of timestamps in its caching
@@ -4479,7 +4523,6 @@ function any_includes_stale(includes::Vector{CacheHeaderIncludes}, cachefile::St
                 return true
             end
         else
-            fstat = stat(f)
             fsize = filesize(fstat)
             if fsize != fsize_req
                 @debug "Rejecting stale cache file $cachefile because file size of $f has changed (file size $fsize, before $fsize_req)"

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -171,6 +171,47 @@ if !test_relocated_depot
         end
     end
 
+    @testset "depot selection with overlapping incomplete depots" begin
+        # A depot missing some of a cache's source files must not win the depot
+        # resolution over a depot containing all of them, regardless of the order
+        # of the two depots in DEPOT_PATH and of the order in which the source
+        # files are scanned.
+        test_harness() do
+            mkdepottempdir() do depot_complete
+                mkdepottempdir() do depot_incomplete
+                    pkgname = "DepotResolution"
+                    for depot in (depot_complete, depot_incomplete)
+                        srcdir = joinpath(depot, pkgname, "src")
+                        mkpath(srcdir)
+                        write(joinpath(srcdir, "$pkgname.jl"), """
+                            module $pkgname
+                            include("extra.jl")
+                            end
+                            """)
+                    end
+                    write(joinpath(depot_complete, pkgname, "src", "extra.jl"), "f() = 1\n")
+                    write(joinpath(depot_complete, pkgname, "Project.toml"), """
+                        name = "$pkgname"
+                        uuid = "00000000-0000-0000-0000-000000000003"
+                        version = "1.0.0"
+                        """)
+                    pushfirst!(LOAD_PATH, depot_complete)
+                    push!(DEPOT_PATH, depot_complete)
+                    pkg = Base.identify_package(pkgname)
+                    Base.compilecache(pkg)
+                    cachefile = only(Base.find_all_in_cache_path(pkg))
+                    for depots in ([depot_complete, depot_incomplete],
+                                   [depot_incomplete, depot_complete])
+                        copy!(DEPOT_PATH, depots)
+                        _, (includes, _, _), _... = Base.parse_cache_header(cachefile)
+                        @test all(inc -> startswith(inc.filename, depot_complete), includes)
+                        @test Base.isprecompiled(pkg)
+                    end
+                end
+            end
+        end
+    end
+
     @testset "#52161" begin
         # Take the src files from two pkgs Example1 and Example2,
         # which are each located in depot1 and depot2, respectively, and


### PR DESCRIPTION
Two changes to how candidate cache files are found and validated when loading packages, squashed into one commit and rebased on top of #62586.

**Lazy, per-depot candidate search.** Instead of enumerating every candidate in every depot up front and opening each one's header to sort the list, candidates are iterated depot by depot, stopping at the first one that passes `stale_cachefile`. Within a depot candidates are still ordered best-first (pkgimage detected from the directory listing, mtime stat'ed only when a depot holds several), so `touch`ing a cache file still makes it the first one tried. For bundled stdlibs the depot containing `Sys.STDLIB` is searched first. The cache file pre-validated by the precompile driver (#62586) is tried before any directory is listed. `find_all_in_cache_path` keeps its eager, fully sorted behavior for callers that need every candidate.

**Fewer syscalls per validated file.** `any_includes_stale` does a single `stat` per source file instead of `access` + `stat`. `@depot` resolution picks the first depot in `DEPOT_PATH` order that contains all relocatable `include()` files, probing each depot only until its first missing file. This is independent of the order the source files are scanned in, and bundled stdlib caches no longer pay one miss per file on each preceding depot. That depot is then tried first for `include_dependency()` files. One documented corner case changes: an incomplete depot listed before a complete one now resolves to the complete depot instead of recompiling (regression test included).

Matched from-scratch `Pkg.precompile` of a GLMakie + ModelingToolkit + Plots environment (394 deps, ~540 processes) vs `master` at the time (`76ffa8c2fc`), counting path-based `stat`/`lstat`/`access` calls:

| | master | this PR |
|---|---:|---:|
| total | 774,675 | 427,486 (**−44.8%**) |
| on `compiled/` paths | 204,090 | 43,195 (−78.8%) |

A warm `using ModelingToolkit` in a fresh session makes 58% fewer such calls (11,566 → 4,838).

All points from the review below are addressed in the current version.

Written with the assistance of generative AI (Claude Code, Claude Fable 5.1). 
