### PR TITLE
loading: reuse driver-validated cache files

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2241,7 +2241,10 @@ end
 # returns the set of modules restored if the cache load succeeded
 @constprop :none function _require_search_from_serialized(pkg::PkgId, sourcespec::PkgLoadSpec, build_id::UInt128, stalecheck::Bool; reasons=nothing, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
     assert_havelock(require_lock)
+    # Try the driver's validated cache first; fall back to the normal search.
+    pre = get(preresolved_cachefiles, pkg, nothing)
     paths = find_all_in_cache_path(pkg, DEPOT_PATH)
+    pre !== nothing && pushfirst!(paths, pre)
     newdeps = PkgId[]
     try_build_ids = UInt128[build_id]
     if build_id == UInt128(0)
@@ -2255,7 +2258,9 @@ end
     end
     for build_id in try_build_ids
         @label next_path for path_to_try in paths::Vector{String}
-            staledeps = stale_cachefile(pkg, build_id, sourcespec, path_to_try; reasons, stalecheck)
+            trusted = path_to_try === pre
+            staledeps = stale_cachefile(pkg, build_id, sourcespec, path_to_try; reasons,
+                                        stalecheck = stalecheck && !trusted, verify_checksums = !trusted)
             if staledeps === true
                 continue
             end
@@ -2299,9 +2304,13 @@ end
                     @assert canstart_loading(modkey, modbuild_id, stalecheck) === nothing
                     package_locks[modkey] = (current_task(), Threads.Condition(require_lock), modbuild_id)
                     startedloading = i
+                    mpre = get(preresolved_cachefiles, modkey, nothing)
                     modpaths = find_all_in_cache_path(modkey, DEPOT_PATH)
+                    mpre !== nothing && pushfirst!(modpaths, mpre)
                     for modpath_to_try in modpaths
-                        modstaledeps = stale_cachefile(modkey, modbuild_id, modspec, modpath_to_try; stalecheck)
+                        modtrusted = modpath_to_try === mpre
+                        modstaledeps = stale_cachefile(modkey, modbuild_id, modspec, modpath_to_try;
+                                                       stalecheck = stalecheck && !modtrusted, verify_checksums = !modtrusted)
                         if modstaledeps === true
                             continue
                         end
@@ -2480,6 +2489,9 @@ const include_callbacks = Any[]
 
 # used to optionally track dependencies when requiring a module:
 const _concrete_dependencies = Pair{PkgId,UInt128}[] # these dependency versions are "set in stone", because they are explicitly loaded, and the process should try to avoid invalidating them
+
+# Cache files supplied by the parent precompile driver.
+const preresolved_cachefiles = Dict{PkgId,String}() # protected by require_lock
 const _require_dependencies = Any[] # a list of (mod::Module, abspath::String, fsize::UInt64, hash::UInt32, mtime::Float64) tuples that are the file dependencies of the module currently being precompiled
 const _track_dependencies = Ref(false) # set this to true to track the list of file dependencies
 
@@ -3387,7 +3399,8 @@ const newly_inferred = []
 
 # this is called in the external process that generates precompiled package files
 function include_package_for_output(pkg::PkgId, input::String, syntax_version::VersionNumber, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String},
-                                    concrete_deps::typeof(_concrete_dependencies), source::Union{Nothing,String})
+                                    concrete_deps::typeof(_concrete_dependencies), source::Union{Nothing,String},
+                                    preresolved::Vector{Pair{PkgId,String}}=Pair{PkgId,String}[])
 
     @lock require_lock begin
     m = start_loading(pkg, UInt128(0), false)
@@ -3400,6 +3413,9 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
     Base._track_dependencies[] = true
     get!(Base.PkgOrigin, Base.pkgorigins, pkg).path = input
     append!(empty!(Base._concrete_dependencies), concrete_deps)
+    for (k, v) in preresolved
+        preresolved_cachefiles[k] = v
+    end
     end
 
     uuid_tuple = pkg.uuid === nothing ? (UInt64(0), UInt64(0)) : convert(NTuple{2, UInt64}, pkg.uuid)
@@ -3480,7 +3496,8 @@ const PRECOMPILE_VERBOSE_TIMING_MARKER = "__JL_PRECOMP_VERBOSE_TIMING__"
 function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, output_o::Union{Nothing, String},
                            concrete_deps::typeof(_concrete_dependencies), flags::Cmd=``, cacheflags::CacheFlags=CacheFlags(),
                            internal_stderr::IO = stderr, internal_stdout::IO = stdout, loadable_exts::Union{Vector{PkgId},Nothing}=nothing;
-                           report_timing::Bool=false)
+                           report_timing::Bool=false,
+                           preresolved::Vector{Pair{PkgId,String}} = @lock(require_lock, collect(preresolved_cachefiles)))
     @nospecialize internal_stderr internal_stdout
     depot_path = String[abspath(x) for x in DEPOT_PATH]
     dl_load_path = String[abspath(x) for x in DL_LOAD_PATH]
@@ -3545,7 +3562,7 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
         Base.loadable_extensions = $(_pkg_str(loadable_exts))
         Base.precompiling_extension = $(loading_extension)
         Base.include_package_for_output($(_pkg_str(pkg)), $(repr(abspath(input.path))), $(repr(input.julia_syntax_version)), $(repr(depot_path)), $(repr(dl_load_path)),
-            $(repr(load_path)), $(_pkg_str(concrete_deps)), $(repr(source_path(nothing))))
+            $(repr(load_path)), $(_pkg_str(concrete_deps)), $(repr(source_path(nothing))), $(_pkg_str(preresolved)))
         """)
     close(io.in)
     return io
@@ -3611,7 +3628,8 @@ const MAX_NUM_PRECOMPILE_FILES = Ref(10)
 function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stderr, internal_stdout::IO = stdout,
                       keep_loaded_modules::Bool = true; flags::Cmd=``, cacheflags::CacheFlags=CacheFlags(),
                       loadable_exts::Union{Vector{PkgId},Nothing}=nothing, signal_channel::Union{Channel{Int32},Nothing}=nothing,
-                      pid_channel::Union{Channel{Int32},Nothing}=nothing, report_timing::Bool=false)
+                      pid_channel::Union{Channel{Int32},Nothing}=nothing, report_timing::Bool=false,
+                      preresolved::Vector{Pair{PkgId,String}} = @lock(require_lock, collect(preresolved_cachefiles)))
 
     @nospecialize internal_stderr internal_stdout
     # decide where to put the resulting cache file
@@ -3649,7 +3667,7 @@ function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stder
             close(tmpio_o)
             close(tmpio_so)
         end
-        p = create_expr_cache(pkg, spec, tmppath, tmppath_o, concrete_deps, flags, cacheflags, internal_stderr, internal_stdout, loadable_exts; report_timing)
+        p = create_expr_cache(pkg, spec, tmppath, tmppath_o, concrete_deps, flags, cacheflags, internal_stderr, internal_stdout, loadable_exts; report_timing, preresolved)
 
         # Report the PID of the compilation subprocess
         if pid_channel !== nothing

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2205,7 +2205,12 @@ end
 # returns the set of modules restored if the cache load succeeded
 @constprop :none function _require_search_from_serialized(pkg::PkgId, sourcespec::PkgLoadSpec, build_id::UInt128, stalecheck::Bool; reasons=nothing, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT_PATH)
     assert_havelock(require_lock)
-    paths = lazy_cachefile_candidates(pkg, sourcespec.path, DEPOT_PATH)
+    # a cache file the precompilation driver already validated for this exact
+    # operation is tried first and trusted; anything else gets the full
+    # staleness treatment
+    pre = get(preresolved_cachefiles, pkg, nothing)
+    candidates = lazy_cachefile_candidates(pkg, sourcespec.path, DEPOT_PATH)
+    paths = pre === nothing ? candidates : Iterators.flatten(((pre,), candidates))
     newdeps = PkgId[]
     try_build_ids = UInt128[build_id]
     if build_id == UInt128(0)
@@ -2219,7 +2224,9 @@ end
     end
     for build_id in try_build_ids
         @label next_path for path_to_try in paths
-            staledeps = stale_cachefile(pkg, build_id, sourcespec, path_to_try; reasons, stalecheck)
+            trusted = path_to_try === pre
+            staledeps = stale_cachefile(pkg, build_id, sourcespec, path_to_try; reasons,
+                                        stalecheck = stalecheck && !trusted, verify_checksums = !trusted)
             if staledeps === true
                 continue
             end
@@ -2263,9 +2270,13 @@ end
                     @assert canstart_loading(modkey, modbuild_id, stalecheck) === nothing
                     package_locks[modkey] = (current_task(), Threads.Condition(require_lock), modbuild_id)
                     startedloading = i
-                    modpaths = lazy_cachefile_candidates(modkey, modspec.path, DEPOT_PATH)
+                    mpre = get(preresolved_cachefiles, modkey, nothing)
+                    modcandidates = lazy_cachefile_candidates(modkey, modspec.path, DEPOT_PATH)
+                    modpaths = mpre === nothing ? modcandidates : Iterators.flatten(((mpre,), modcandidates))
                     for modpath_to_try in modpaths
-                        modstaledeps = stale_cachefile(modkey, modbuild_id, modspec, modpath_to_try; stalecheck)
+                        modtrusted = modpath_to_try === mpre
+                        modstaledeps = stale_cachefile(modkey, modbuild_id, modspec, modpath_to_try;
+                                                       stalecheck = stalecheck && !modtrusted, verify_checksums = !modtrusted)
                         if modstaledeps === true
                             continue
                         end
@@ -2442,6 +2453,11 @@ const include_callbacks = Any[]
 
 # used to optionally track dependencies when requiring a module:
 const _concrete_dependencies = Pair{PkgId,UInt128}[] # these dependency versions are "set in stone", because they are explicitly loaded, and the process should try to avoid invalidating them
+
+# cache files for dependencies that the parent precompilation driver has already
+# validated or just created; they are tried first and trusted when loading
+# (like stdlib caches), with the regular candidate search as fallback
+const preresolved_cachefiles = Dict{PkgId,String}() # protected by require_lock
 const _require_dependencies = Any[] # a list of (mod::Module, abspath::String, fsize::UInt64, hash::UInt32, mtime::Float64) tuples that are the file dependencies of the module currently being precompiled
 const _track_dependencies = Ref(false) # set this to true to track the list of file dependencies
 
@@ -3345,7 +3361,8 @@ const newly_inferred = []
 
 # this is called in the external process that generates precompiled package files
 function include_package_for_output(pkg::PkgId, input::String, syntax_version::VersionNumber, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String},
-                                    concrete_deps::typeof(_concrete_dependencies), source::Union{Nothing,String})
+                                    concrete_deps::typeof(_concrete_dependencies), source::Union{Nothing,String},
+                                    preresolved::Vector{Pair{PkgId,String}}=Pair{PkgId,String}[])
 
     @lock require_lock begin
     m = start_loading(pkg, UInt128(0), false)
@@ -3358,6 +3375,9 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
     Base._track_dependencies[] = true
     get!(Base.PkgOrigin, Base.pkgorigins, pkg).path = input
     append!(empty!(Base._concrete_dependencies), concrete_deps)
+    for (k, v) in preresolved
+        preresolved_cachefiles[k] = v
+    end
     end
 
     uuid_tuple = pkg.uuid === nothing ? (UInt64(0), UInt64(0)) : convert(NTuple{2, UInt64}, pkg.uuid)
@@ -3438,7 +3458,8 @@ const PRECOMPILE_VERBOSE_TIMING_MARKER = "__JL_PRECOMP_VERBOSE_TIMING__"
 function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, output_o::Union{Nothing, String},
                            concrete_deps::typeof(_concrete_dependencies), flags::Cmd=``, cacheflags::CacheFlags=CacheFlags(),
                            internal_stderr::IO = stderr, internal_stdout::IO = stdout, loadable_exts::Union{Vector{PkgId},Nothing}=nothing;
-                           report_timing::Bool=false)
+                           report_timing::Bool=false,
+                           preresolved::Vector{Pair{PkgId,String}} = @lock(require_lock, collect(preresolved_cachefiles)))
     @nospecialize internal_stderr internal_stdout
     depot_path = String[abspath(x) for x in DEPOT_PATH]
     dl_load_path = String[abspath(x) for x in DL_LOAD_PATH]
@@ -3503,7 +3524,7 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
         Base.loadable_extensions = $(_pkg_str(loadable_exts))
         Base.precompiling_extension = $(loading_extension)
         Base.include_package_for_output($(_pkg_str(pkg)), $(repr(abspath(input.path))), $(repr(input.julia_syntax_version)), $(repr(depot_path)), $(repr(dl_load_path)),
-            $(repr(load_path)), $(_pkg_str(concrete_deps)), $(repr(source_path(nothing))))
+            $(repr(load_path)), $(_pkg_str(concrete_deps)), $(repr(source_path(nothing))), $(_pkg_str(preresolved)))
         """)
     close(io.in)
     return io
@@ -3569,7 +3590,8 @@ const MAX_NUM_PRECOMPILE_FILES = Ref(10)
 function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stderr, internal_stdout::IO = stdout,
                       keep_loaded_modules::Bool = true; flags::Cmd=``, cacheflags::CacheFlags=CacheFlags(),
                       loadable_exts::Union{Vector{PkgId},Nothing}=nothing, signal_channel::Union{Channel{Int32},Nothing}=nothing,
-                      pid_channel::Union{Channel{Int32},Nothing}=nothing, report_timing::Bool=false)
+                      pid_channel::Union{Channel{Int32},Nothing}=nothing, report_timing::Bool=false,
+                      preresolved::Vector{Pair{PkgId,String}} = @lock(require_lock, collect(preresolved_cachefiles)))
 
     @nospecialize internal_stderr internal_stdout
     # decide where to put the resulting cache file
@@ -3607,7 +3629,7 @@ function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stder
             close(tmpio_o)
             close(tmpio_so)
         end
-        p = create_expr_cache(pkg, spec, tmppath, tmppath_o, concrete_deps, flags, cacheflags, internal_stderr, internal_stdout, loadable_exts; report_timing)
+        p = create_expr_cache(pkg, spec, tmppath, tmppath_o, concrete_deps, flags, cacheflags, internal_stderr, internal_stdout, loadable_exts; report_timing, preresolved)
 
         # Report the PID of the compilation subprocess
         if pid_channel !== nothing

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -1162,6 +1162,12 @@ precompilation:
   is controlled by `JULIA_PRECOMPILE_THREADS` (defaults to CPU_THREADS + 1).
 - Extensions are precompiled when all their triggers are available in the environment.
 """
+# cache files this driver has already validated or created, to be trusted by
+# the workers it spawns (empty vectors belong to packages still in flight)
+function preresolved_snapshot(s::PrecompileSession)
+    @lock s.cache_lock Pair{Base.PkgId,String}[k => first(v) for (k, v) in s.cachepath_cache if !isempty(v)]
+end
+
 function precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}}=String[];
                         internal_call::Bool=false,
                         strict::Bool = false,
@@ -2223,7 +2229,8 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                             t = @elapsed ret = begin
                                 Base.compilecache(pkg, sourcespec, std_pipe, std_pipe, !s.ignore_loaded;
                                                   flags=flags_, cacheflags, loadable_exts, signal_channel=make_signal_channel(),
-                                                  pid_channel=pid_ch, report_timing=true)
+                                                  pid_channel=pid_ch, report_timing=true,
+                                                  preresolved=preresolved_snapshot(s))
                             end
                         else
                             fullname = full_name(s.ext_to_parent, pkg)
@@ -2248,7 +2255,8 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                                 end
                                 Base.compilecache(pkg, sourcespec, std_pipe, std_pipe, !s.ignore_loaded;
                                                   flags=flags_, cacheflags, loadable_exts, signal_channel=make_signal_channel(),
-                                                  pid_channel=pid_ch, report_timing=true)
+                                                  pid_channel=pid_ch, report_timing=true,
+                                                  preresolved=preresolved_snapshot(s))
                             end
                         end
                         if ret isa Exception

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -1162,6 +1162,11 @@ precompilation:
   is controlled by `JULIA_PRECOMPILE_THREADS` (defaults to CPU_THREADS + 1).
 - Extensions are precompiled when all their triggers are available in the environment.
 """
+# Include only cache files that are ready for workers.
+function preresolved_snapshot(s::PrecompileSession)
+    @lock s.cache_lock Pair{Base.PkgId,String}[k => first(v) for (k, v) in s.cachepath_cache if !isempty(v)]
+end
+
 function precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}}=String[];
                         internal_call::Bool=false,
                         strict::Bool = false,
@@ -2194,7 +2199,7 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                     end
                 end
                 if !is_stale
-                    push!(freshpaths, freshpath)
+                    @lock s.cache_lock push!(freshpaths, freshpath)
                 end
                 if !circular && is_stale
                     Base.acquire(s.parallel_limiter; cancel=() -> should_stop(s))
@@ -2236,7 +2241,8 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                             t = @elapsed ret = begin
                                 Base.compilecache(pkg, sourcespec, std_pipe, std_pipe, !s.ignore_loaded;
                                                   flags=flags_, cacheflags, loadable_exts, signal_channel=make_signal_channel(),
-                                                  pid_channel=pid_ch, report_timing=true)
+                                                  pid_channel=pid_ch, report_timing=true,
+                                                  preresolved=preresolved_snapshot(s))
                             end
                         else
                             fullname = full_name(s.ext_to_parent, pkg)
@@ -2253,7 +2259,7 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                                     stale_cache=s.stale_cache, cachepath_cache=s.cachepath_cache, cachepaths, sourcespec, flags=cacheflags)
                                 local is_stale = freshpath === nothing
                                 if !is_stale
-                                    push!(freshpaths, freshpath)
+                                    @lock s.cache_lock push!(freshpaths, freshpath)
                                     return nothing
                                 end
                                 s.logcalls === CoreLogging.Debug && @lock s.print_lock begin
@@ -2261,7 +2267,8 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                                 end
                                 Base.compilecache(pkg, sourcespec, std_pipe, std_pipe, !s.ignore_loaded;
                                                   flags=flags_, cacheflags, loadable_exts, signal_channel=make_signal_channel(),
-                                                  pid_channel=pid_ch, report_timing=true)
+                                                  pid_channel=pid_ch, report_timing=true,
+                                                  preresolved=preresolved_snapshot(s))
                             end
                         end
                         if ret isa Exception
@@ -2282,10 +2289,12 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                             if ret !== nothing
                                 mark_recompiled!(job)
                                 cachefile, _ = ret::Tuple{String, Union{Nothing, String}}
-                                push!(freshpaths, cachefile)
                                 build_id, _ = Base.parse_cache_buildid(cachefile)
                                 stale_cache_key = (pkg, build_id, sourcespec, cachefile, s.ignore_loaded, cacheflags)::StaleCacheKey
-                                @lock s.cache_lock s.stale_cache[stale_cache_key] = false
+                                @lock s.cache_lock begin
+                                    push!(freshpaths, cachefile)
+                                    s.stale_cache[stale_cache_key] = false
+                                end
                                 if loaded && Base.module_build_id(Base.loaded_modules[pkg]) != build_id
                                     @lock s.print_lock begin
                                         s.n_loaded += 1


### PR DESCRIPTION
The precompilation driver establishes, in dependency order, the fresh cache file for each package before spawning dependent workers. Previously, each worker independently repeated candidate search, environment lookups, source-file staleness checks, and full checksums of both the `.ji` and pkgimage for every dependency it loaded.

This PR passes the driver's validated `pkg => cachefile` snapshot to workers through the precompile-process bootstrap, next to `concrete_deps`. A worker tries the supplied file first without repeating stale checks or checksum verification. Cache-flag compatibility and dependency `build_id` equality remain enforced, and any rejection falls back to the regular search-and-validate path. Nested precompile processes forward the snapshot to their own children.

The driver's cache-path vectors are protected by `cache_lock` while they are updated and while a worker snapshot is taken. Packages still in flight are absent from the snapshot and use the normal path.

On current `master` (`1c0ffe69a0`), a matched from-scratch `Pkg.precompile` of an environment containing GLMakie, ModelingToolkit, and Plots precompiled 494 dependencies with 495 Julia processes in both runs. Instrumenting Julia's path-based `stat`/`lstat` wrappers measured:

- `master`: 318,970 calls
- this PR: 234,564 calls
- reduction: 84,406 calls (26.5%)

Workers also avoid reading entire pkgimages solely to checksum them before loading.

Design notes:

- With multiple configurations using different `CacheFlags`, an entry from another configuration is rejected by the worker's flag check and falls back. This is correct but unoptimized.
- A supplied file that disappears or fails validation falls back to the normal candidate search.
- There remains a trust/TOCTOU window if another process replaces a cache after the driver validates it and before a worker loads it. Dependency `build_id` checks still apply, but checksum verification is intentionally skipped for the supplied file.

Prepared with assistance from Claude Code (Claude Fable 5) and reviewed/rebased with Codex (GPT-5). 