### PR TITLE
[JuliaLowering] Some minor follow-ups to Julialang/julia#62474

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -86,7 +86,7 @@ macro mknode(attrs, old)
         end
         aname in seen_attrs && throw(ArgumentError("duplicate attr provided $__source__"))
         push!(seen_attrs, aname)
-        out_args[fieldindex(SyntaxTree, aname)] = aval
+        out_args[Base.fieldindex(SyntaxTree, aname)] = aval
     end
     old === DEFAULT_NODE && !((:kind, :source, :context) ⊆ seen_attrs) &&
         throw(ArgumentError("brand-new node from @mknode requires more attrs $__source__"))

--- a/JuliaSyntax/src/porcelain/syntax.jl
+++ b/JuliaSyntax/src/porcelain/syntax.jl
@@ -344,7 +344,8 @@ end
 
 "`provenance(st)[1]`, or `st` if that's empty"
 function prov(st::SyntaxTree)
-    st.source isa SyntaxTree ? st.source : st
+    source = st.source
+    source isa SyntaxTree ? source : st
 end
 
 "textref of st (possibly == st)"

--- a/JuliaSyntax/src/porcelain/syntax.jl
+++ b/JuliaSyntax/src/porcelain/syntax.jl
@@ -155,7 +155,8 @@ end
 const NO_CHILDREN = SyntaxTree[]
 
 function children(ex::SyntaxTree)
-    is_leaf(ex) ? NO_CHILDREN : ex.children
+    cs = ex.children
+    cs === nothing ? NO_CHILDREN : cs
 end
 
 function head(ex::SyntaxTree)

--- a/JuliaSyntax/test/syntax.jl
+++ b/JuliaSyntax/test/syntax.jl
@@ -38,9 +38,11 @@ end
     @test parsestmt(SyntaxTree, "x = 1._"; ignore_errors=true) isa SyntaxTree
 end
 
-@testset "SyntaxTree children" begin
+@testset "SyntaxTree type stability" begin
+    st0 = parsestmt(SyntaxTree, "f(::Int)")
     # `children` must not leak the `Union{Nothing}` of the raw field into inference.
-    @test @inferred(children(parsestmt(SyntaxTree, "f(::Int)"))) isa Vector{SyntaxTree}
+    @test @inferred(children(st0)) isa Vector{SyntaxTree}
+    @test @inferred(prov(st0)) isa SyntaxTree
 end
 
 @testset "SyntaxTree provenance accessors" begin

--- a/JuliaSyntax/test/syntax.jl
+++ b/JuliaSyntax/test/syntax.jl
@@ -38,6 +38,11 @@ end
     @test parsestmt(SyntaxTree, "x = 1._"; ignore_errors=true) isa SyntaxTree
 end
 
+@testset "SyntaxTree children" begin
+    # `children` must not leak the `Union{Nothing}` of the raw field into inference.
+    @test @inferred(children(parsestmt(SyntaxTree, "f(::Int)"))) isa Vector{SyntaxTree}
+end
+
 @testset "SyntaxTree provenance accessors" begin
 
     @testset "prov, prov_end, provenance, sourceref" begin


### PR DESCRIPTION
- b47d48aeaa97b5c1faabb5a6905d5e5da02c3b29 [[JuliaLowering] Qualify fieldindex in @mknode](https://github.com/JuliaLang/julia/commit/b47d48aeaa97b5c1faabb5a6905d5e5da02c3b29)
- b531c73d154f1871e00dded0601bc9b59a174205 [[JuliaSyntax] Preserve EST syntax flags](https://github.com/JuliaLang/julia/commit/b531c73d154f1871e00dded0601bc9b59a174205)

Found by updating JETLS to adapt Julialang/julia#62474.