### PR TITLE
Define atomic get/setindex ops on AtomicMemoryRef

### DIFF
--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -400,3 +400,83 @@ function replaceindex_atomic!(
         @_boundscheck,
     )
 end
+
+# AtomicMemoryRefs may only be accessed through the atomic indexing operations.
+getindex(ref::AtomicMemoryRef) = throw(CanonicalIndexError("getindex", typeof(ref)))
+setindex!(ref::AtomicMemoryRef, x) = throw(CanonicalIndexError("setindex!", typeof(ref)))
+
+# The following methods support using an AtomicMemoryRef as the indexed operand
+# of the low-level atomic indexing operations.
+function getindex_atomic(ref::AtomicMemoryRef, order::Symbol)
+    @_propagate_inbounds_meta
+    return memoryrefget(ref, order, @_boundscheck)
+end
+
+function setindex_atomic!(ref::AtomicMemoryRef{T}, order::Symbol, value::T) where {T}
+    @_propagate_inbounds_meta
+    return memoryrefset!(ref, value, order, @_boundscheck)
+end
+
+function setindex_atomic!(ref::AtomicMemoryRef{T}, order::Symbol, value) where {T}
+    @_propagate_inbounds_meta
+    return setindex_atomic!(ref, order, convert(T, value)::T)
+end
+
+function setindexonce_atomic!(
+    ref::AtomicMemoryRef{T},
+    success_order::Symbol,
+    fail_order::Symbol,
+    value::T,
+) where {T}
+    @_propagate_inbounds_meta
+    return Core.memoryrefsetonce!(ref, value, success_order, fail_order, @_boundscheck)
+end
+
+function setindexonce_atomic!(
+    ref::AtomicMemoryRef{T},
+    success_order::Symbol,
+    fail_order::Symbol,
+    value,
+) where {T}
+    @_propagate_inbounds_meta
+    return setindexonce_atomic!(ref, success_order, fail_order, convert(T, value)::T)
+end
+
+function swapindex_atomic!(ref::AtomicMemoryRef{T}, order::Symbol, value::T) where {T}
+    @_propagate_inbounds_meta
+    return Core.memoryrefswap!(ref, value, order, @_boundscheck)
+end
+
+function swapindex_atomic!(ref::AtomicMemoryRef{T}, order::Symbol, value) where {T}
+    @_propagate_inbounds_meta
+    return swapindex_atomic!(ref, order, convert(T, value)::T)
+end
+
+function replaceindex_atomic!(
+    ref::AtomicMemoryRef{T},
+    success_order::Symbol,
+    fail_order::Symbol,
+    expected,
+    desired::T,
+) where {T}
+    @_propagate_inbounds_meta
+    return Core.memoryrefreplace!(
+        ref,
+        expected,
+        desired,
+        success_order,
+        fail_order,
+        @_boundscheck,
+    )
+end
+
+function replaceindex_atomic!(
+    ref::AtomicMemoryRef{T},
+    success_order::Symbol,
+    fail_order::Symbol,
+    expected,
+    desired,
+) where {T}
+    @_propagate_inbounds_meta
+    return replaceindex_atomic!(ref, success_order, fail_order, expected, convert(T, desired)::T)
+end

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -402,7 +402,6 @@ function replaceindex_atomic!(
 end
 
 # AtomicMemoryRefs may only be accessed through the atomic indexing operations.
-getindex(ref::AtomicMemoryRef) = throw(CanonicalIndexError("getindex", typeof(ref)))
 setindex!(ref::AtomicMemoryRef, x) = throw(CanonicalIndexError("setindex!", typeof(ref)))
 
 # The following methods support using an AtomicMemoryRef as the indexed operand

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -526,6 +526,28 @@ function _test_atomic_setonce_replace(T, initial, desired)
         @test mem[idx] == expected
     end
 end
+
+# AtomicMemoryRefs reject ordinary indexing and their atomic macros convert stored values.
+@testset "atomic indexing with AtomicMemoryRef" begin
+    ref = memoryref(AtomicMemory{Int}(undef, 1))
+    @test_throws CanonicalIndexError ref[]
+    @test_throws CanonicalIndexError ref[] = 1
+    @test (@atomic ref[] = Int8(1)) === 1
+    @test (@atomic :acquire ref[]) === 1
+    @test (@atomicswap :acquire_release ref[] = Int8(2)) === 1
+    @test (@atomic :acquire ref[]) === 2
+    @test (@atomicreplace :acquire_release :acquire ref[] 2 => Int8(3)) == (old=2, success=true)
+    @test (@atomicreplace ref[] 2 => Int8(4)) == (old=3, success=false)
+    @test (@atomic ref[]) === 3
+
+    ref = GenericMemoryRef(AtomicMemory{BigInt}(undef, 1))
+    @test !isassigned(ref)
+    @test (@atomiconce :release :monotonic ref[] = Int8(1)) === true
+    @test isassigned(ref)
+    @test (@atomiconce ref[] = Int8(2)) === false
+    @test (@atomic ref[]) == BigInt(1)
+end
+
 @testset "@atomic with AtomicMemory" begin
 
     _test_atomic_get_set_swap_modify(Float64, rand(), rand(), 10)

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -530,7 +530,6 @@ end
 # AtomicMemoryRefs reject ordinary indexing and their atomic macros convert stored values.
 @testset "atomic indexing with AtomicMemoryRef" begin
     ref = memoryref(AtomicMemory{Int}(undef, 1))
-    @test_throws CanonicalIndexError ref[]
     @test_throws CanonicalIndexError ref[] = 1
     @test (@atomic ref[] = Int8(1)) === 1
     @test (@atomic :acquire ref[]) === 1


### PR DESCRIPTION
Currently, MemoryRef supports operations like `ref[]` and `ref[] = x`. However, atomic memory refs do not support any of the same ops that AtomicMemory does. This commit adds methods for `*_atomic!` functions for `AtomicMemoryRef`, which allows you to do e.g. `@atomic :release ref[] = x`.

Let me know if these needs more tests - the paths should already be exercised for `AtomicMemory`.