### PR TITLE
Base.Linking: declare the runtime's shared library dependencies

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -2029,6 +2029,61 @@ LOADER_DEBUG_INSTALL_DEP_LIBS = $(call build_deplibs, \
     @$(LIBJULIACODEGEN_DEBUG_INSTALL_DEPLIB) \
 )
 
+# The shared libraries, other than Julia's own, that the runtime depends on at run time.
+# These are a subset of the private libraries that the top level Makefile installs, which
+# also cover the libraries of standard libraries (LibGit2, OpenBLAS, ...) and libraries that
+# we ship without depending on them. They live here rather than in the top level Makefile so
+# that `base/Makefile` can see them too: it generates `Base.RUNTIME_LIBRARY_NAMES` from
+# them, which `Base.Linking.runtime_libraries` reports to tools that ship a program
+# embedding the runtime, such as `juliac`.
+#
+# The `-0`/`-1` suffix is the value of the corresponding `USE_SYSTEM_*` flag, because the
+# top level Makefile installs the two from different directories. Only `+=` is used, so that
+# `$(LLVM_SHARED_LIB_NAME)` is expanded by the consumer, which has `deps/llvm-ver.make`.
+JL_RUNTIME_LIBS-$(USE_SYSTEM_PCRE) += libpcre2-8
+JL_RUNTIME_LIBS-$(USE_SYSTEM_DSFMT) += libdSFMT
+JL_RUNTIME_LIBS-$(USE_SYSTEM_GMP) += libgmp
+JL_RUNTIME_LIBS-$(USE_SYSTEM_MPFR) += libmpfr
+JL_RUNTIME_LIBS-$(USE_SYSTEM_LIBUV) += libuv
+ifeq ($(OS),WINNT)
+JL_RUNTIME_LIBS-$(USE_SYSTEM_ZLIB) += zlib
+else
+JL_RUNTIME_LIBS-$(USE_SYSTEM_ZLIB) += libz
+endif
+JL_RUNTIME_LIBS-$(USE_SYSTEM_ZSTD) += libzstd
+JL_RUNTIME_LIBS-$(USE_SYSTEM_LIBUNWIND) += libunwind
+ifeq ($(USE_SYSTEM_LIBM),0)
+JL_RUNTIME_LIBS-$(USE_SYSTEM_OPENLIBM) += libopenlibm
+endif
+# compiler support libraries: anything we ship may depend on these. Note that `libc++` is
+# not here, because on macOS the runtime uses the one from the system, and neither is
+# `libpthread`, which the compiler support libraries do not ship on a current glibc.
+JL_RUNTIME_LIBS-$(USE_SYSTEM_CSL) += libgfortran libquadmath libstdc++ libgcc_s libgomp libssp libatomic
+ifeq ($(OS),WINNT)
+JL_RUNTIME_LIBS-$(USE_SYSTEM_CSL) += libwinpthread
+endif
+ifeq ($(SANITIZE),1)
+ifeq ($(USECLANG),1)
+JL_RUNTIME_LIBS-0 += libclang_rt.asan-*
+else
+JL_RUNTIME_LIBS-0 += libasan
+endif
+endif
+ifeq ($(WITH_TRACY),1)
+JL_RUNTIME_LIBS-0 += libTracyClient
+endif
+ifeq (${USE_THIRD_PARTY_GC},mmtk)
+JL_RUNTIME_LIBS-0 += libmmtk_julia
+endif
+JL_RUNTIME_LIBS = $(JL_RUNTIME_LIBS-0) $(JL_RUNTIME_LIBS-1)
+
+# Libraries that are only needed to generate native code at run time, reported separately so
+# that a program which never does can leave them out.
+ifeq ($(USE_LLVM_SHLIB),1)
+JL_RUNTIME_CODEGEN_LIBS-$(USE_SYSTEM_LLVM) += libLLVM $(LLVM_SHARED_LIB_NAME)
+endif
+JL_RUNTIME_CODEGEN_LIBS = $(JL_RUNTIME_CODEGEN_LIBS-0) $(JL_RUNTIME_CODEGEN_LIBS-1)
+
 # Colors for make
 ifndef VERBOSE
 VERBOSE := 0

--- a/Makefile
+++ b/Makefile
@@ -274,59 +274,26 @@ ifeq ($(USE_GPL_LIBS), 1)
 JL_PRIVATE_LIBS-$(USE_SYSTEM_LIBSUITESPARSE) += libcholmod librbio libspqr libumfpack
 endif
 JL_PRIVATE_LIBS-$(USE_SYSTEM_LIBBLASTRAMPOLINE) += libblastrampoline
-JL_PRIVATE_LIBS-$(USE_SYSTEM_PCRE) += libpcre2-8
-JL_PRIVATE_LIBS-$(USE_SYSTEM_DSFMT) += libdSFMT
-JL_PRIVATE_LIBS-$(USE_SYSTEM_GMP) += libgmp libgmpxx
-JL_PRIVATE_LIBS-$(USE_SYSTEM_MPFR) += libmpfr
+JL_PRIVATE_LIBS-$(USE_SYSTEM_GMP) += libgmpxx
 JL_PRIVATE_LIBS-$(USE_SYSTEM_LIBSSH2) += libssh2
 JL_PRIVATE_LIBS-$(USE_SYSTEM_NGHTTP2) += libnghttp2
 JL_PRIVATE_LIBS-$(USE_SYSTEM_OPENSSL) += libcrypto libssl
 JL_PRIVATE_LIBS-$(USE_SYSTEM_CURL) += libcurl
 JL_PRIVATE_LIBS-$(USE_SYSTEM_LIBGIT2) += libgit2
-JL_PRIVATE_LIBS-$(USE_SYSTEM_LIBUV) += libuv
-ifeq ($(OS),WINNT)
-JL_PRIVATE_LIBS-$(USE_SYSTEM_ZLIB) += zlib
-else
-JL_PRIVATE_LIBS-$(USE_SYSTEM_ZLIB) += libz
-endif
-JL_PRIVATE_LIBS-$(USE_SYSTEM_ZSTD) += libzstd
 JL_PRIVATE_EXES += zstd$(EXE) zstdmt$(EXE)
-ifeq ($(USE_LLVM_SHLIB),1)
-JL_PRIVATE_LIBS-$(USE_SYSTEM_LLVM) += libLLVM $(LLVM_SHARED_LIB_NAME)
-endif
 JL_PRIVATE_TOOLS += lld$(EXE) dsymutil$(EXE)
-JL_PRIVATE_LIBS-$(USE_SYSTEM_LIBUNWIND) += libunwind
-
-ifeq ($(USE_SYSTEM_LIBM),0)
-JL_PRIVATE_LIBS-$(USE_SYSTEM_OPENLIBM) += libopenlibm
-endif
 
 JL_PRIVATE_LIBS-$(USE_SYSTEM_BLAS) += $(LIBBLASNAME)
 ifneq ($(LIBLAPACKNAME),$(LIBBLASNAME))
 JL_PRIVATE_LIBS-$(USE_SYSTEM_LAPACK) += $(LIBLAPACKNAME)
 endif
 
-JL_PRIVATE_LIBS-$(USE_SYSTEM_CSL) += libgfortran libquadmath libstdc++ libgcc_s libgomp libssp libatomic
 ifeq ($(OS),Darwin)
 JL_PRIVATE_LIBS-$(USE_SYSTEM_CSL) += libc++
 endif
-ifeq ($(OS),WINNT)
-JL_PRIVATE_LIBS-$(USE_SYSTEM_CSL) += libwinpthread
-else
+ifneq ($(OS),WINNT)
 JL_PRIVATE_LIBS-$(USE_SYSTEM_CSL) += libpthread
 endif
-ifeq ($(SANITIZE),1)
-ifeq ($(USECLANG),1)
-JL_PRIVATE_LIBS-0 += libclang_rt.asan-*
-else
-JL_PRIVATE_LIBS-0 += libasan
-endif
-endif
-
-ifeq ($(WITH_TRACY),1)
-JL_PRIVATE_LIBS-0 += libTracyClient
-endif
-
 
 ifeq ($(OS),Darwin)
 ifeq ($(USE_SYSTEM_BLAS),1)
@@ -336,9 +303,10 @@ endif
 endif
 endif
 
-ifeq (${USE_THIRD_PARTY_GC},mmtk)
-JL_PRIVATE_LIBS-0 += libmmtk_julia
-endif
+# the libraries the runtime itself depends on, declared in Make.inc so that `base/Makefile`
+# can generate `Base.RUNTIME_LIBRARY_NAMES` from the same list
+JL_PRIVATE_LIBS-0 += $(JL_RUNTIME_LIBS-0) $(JL_RUNTIME_CODEGEN_LIBS-0)
+JL_PRIVATE_LIBS-1 += $(JL_RUNTIME_LIBS-1) $(JL_RUNTIME_CODEGEN_LIBS-1)
 
 # Note that we disable MSYS2's path munging here, as otherwise
 # it replaces our `:`-separated list as a `;`-separated one.

--- a/NEWS.md
+++ b/NEWS.md
@@ -105,6 +105,11 @@ New library functions
   `mod`, keyed by `(including_module, absolute_path)`. The table is stored inside the package
   image, so it survives precompilation; revision tools (e.g. Revise) use it to re-apply the
   original transform when an `include(mapexpr, …)`-ed file is edited.
+* `Base.Linking.runtime_libraries()` reports the shared libraries that the Julia runtime depends on, so that
+  tools which ship a program embedding the runtime (such as `juliac`) can ask Julia which libraries to bundle
+  instead of keeping their own list. The list is generated from the build system, and
+  `Base.Linking.library_files()` resolves further library names, such as those belonging to standard
+  libraries, against the same installation ([#62593]).
 
 New library features
 --------------------

--- a/base/Makefile
+++ b/base/Makefile
@@ -89,6 +89,16 @@ ifeq ($(OS), Darwin)
 endif
 	@printf "%s\n" "const BUILD_TRIPLET = \"$(BB_TRIPLET_LIBGFORTRAN_CXXABI)\"" >> $@
 
+	@# The libraries the runtime depends on, from `JL_RUNTIME_LIBS` in Make.inc, reported by
+	@# `Base.Linking.runtime_libraries`. A name may be a prefix followed by `*`, as the
+	@# sanitizer runtime is spelled in the build system.
+	@printf "%s\n" "const RUNTIME_LIBRARY_NAMES = String[" >> $@
+	@$(foreach lib,$(JL_RUNTIME_LIBS),printf "%s\n" "    \"$(lib)\"," >> $@;)
+	@printf "%s\n" "]" >> $@
+	@printf "%s\n" "const CODEGEN_LIBRARY_NAMES = String[" >> $@
+	@$(foreach lib,$(JL_RUNTIME_CODEGEN_LIBS),printf "%s\n" "    \"$(lib)\"," >> $@;)
+	@printf "%s\n" "]" >> $@
+
 	@# This to ensure that we always rebuild this file, but only when it is modified do we touch build_h.jl,
 	@# ensuring we rebuild the system image as infrequently as possible
 	@if ! cmp -s $@ build_h.jl; then \

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -869,21 +869,27 @@ this function returns `"libfoo", v"3.2"`.  If the path name is not a
 valid dynamic library, this method throws an error.  If no soversion
 can be extracted from the filename, as in "libbar.so" this method
 returns `"libbar", nothing`.
+
+A soversion may carry a trailing tag, as Julia's own LLVM does in
+"libLLVM.so.21.1jl"; the tag is not part of the name and is not reported, so this
+example returns `"libLLVM", v"21.1"`.
 """
 function parse_dl_name_version(path::String, os::String=_this_os_name())
-    # Use an extraction regex that matches the given OS
+    # Use an extraction regex that matches the given OS.
+    # The third group is a tag following the soversion, which only a version can be
+    # followed by (hence the lookbehind), so that a name is never mistaken for one.
     local dlregex
     # Keep this up to date with _this_os_name
     if os == "windows"
         # On Windows, libraries look like `libnettle-6.dll`.
         # Stay case-insensitive, the suffix might be `.DLL`.
-        dlregex = r"^(.*?)(?:-((?:[\.\d]+)*))?\.dll$"isa
+        dlregex = r"^(.*?)(?:-((?:[\.\d]+)*)((?<=\d)[A-Za-z][\w\.]*)?)?\.dll$"isa
     elseif os == "macos"
         # On OSX, libraries look like `libnettle.6.3.dylib`
-        dlregex = r"^(.*?)((?:\.[\d]+)*)\.dylib$"sa
+        dlregex = r"^(.*?)((?:\.[\d]+)*)((?<=\d)[A-Za-z][\w\-]*)?\.dylib$"sa
     else
         # On Linux and other BSDs, libraries look like `libnettle.so.6.3.0`
-        dlregex = r"^(.*?)\.so((?:\.[\d]+)*)$"sa
+        dlregex = r"^(.*?)\.so((?:\.[\d]+)*)((?<=\d)[A-Za-z][\w\-]*)?$"sa
     end
 
     m = match(dlregex, basename(path))

--- a/base/linking.jl
+++ b/base/linking.jl
@@ -68,14 +68,16 @@ end
 
 PATH() = dirname(lld_path())
 
+# The directories of this Julia installation that shared libraries live in, in the order in
+# which a library is looked for. On Windows the dynamic libraries (.dll) are in `Sys.BINDIR`
+# ("usr\\bin"), elsewhere the public ones are in the library directory itself; a build from
+# source keeps both in the same directory, hence the `unique!`.
+const library_dirs = OncePerProcess{Vector{String}}() do
+    unique!(String[private_libdir(), shlibdir()])
+end
+
 const LIBPATH = OncePerProcess{String}() do
-    if Sys.iswindows()
-        # On windows, the dynamic libraries (.dll) are in Sys.BINDIR ("usr\\bin")
-        LIBPATH_list = [abspath(Sys.BINDIR, Base.LIBDIR, "julia"), Sys.BINDIR]
-    else
-        LIBPATH_list = [abspath(Sys.BINDIR, Base.LIBDIR, "julia"), abspath(Sys.BINDIR, Base.LIBDIR)]
-    end
-    return join(LIBPATH_list, pathsep)
+    join(library_dirs(), pathsep)
 end
 
 function lld(; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
@@ -216,6 +218,183 @@ end
 
 function link_image(path, out, internal_stderr::IO=stderr, internal_stdout::IO=stdout)
     run(link_image_cmd(path, out), Base.DevNull(), internal_stderr, internal_stdout)
+end
+
+
+## Runtime library dependencies ##
+
+public runtime_libraries, library_files, DEFAULT_COMPONENTS
+
+"""
+    Base.Linking.DEFAULT_COMPONENTS
+
+The optional components of the Julia runtime that [`runtime_libraries`](@ref) reports the
+libraries of by default, i.e. all of them. Do not mutate this; pass the components you want
+as the `optional_components` keyword argument instead.
+
+!!! compat "Julia 1.14"
+    This constant requires Julia 1.14.
+"""
+const DEFAULT_COMPONENTS = [:codegen]
+
+# Guards against a misspelled component silently dropping a library set: leaving
+# `libjulia-codegen` out of a bundle by accident is exactly what this must not do.
+const COMPONENTS = (:codegen,)
+
+# Is `file` the name of a shared library file (or one of the version symlinks that go with
+# it) for the extension-less, unversioned library name `name`? A trailing `*` makes `name` a
+# prefix, which is how the build system spells the sanitizer runtime, whose name carries the
+# architecture.
+function _is_library_file(name::AbstractString, file::AbstractString)
+    if endswith(name, '*')
+        prefix = SubString(name, 1, prevind(name, lastindex(name)))
+        return startswith(file, prefix) && occursin(string('.', Libdl.dlext), file)
+    end
+    parsed = try
+        first(Base.BinaryPlatforms.parse_dl_name_version(file))
+    catch ex
+        ex isa ArgumentError || rethrow()
+        return false # not the name of a shared library file
+    end
+    parsed == name && return true
+    # A library may carry its soversion before the extension even on a platform where it
+    # normally follows it, as OpenBLAS does in `libopenblas64_.0.3.33.so`, which is the
+    # spelling macOS uses; strip such a soversion the same way.
+    Sys.isapple() && return false
+    parsed = first(Base.BinaryPlatforms.parse_dl_name_version(parsed * ".dylib", "macos"))
+    return parsed == name
+end
+
+# `readdir` each directory once, so that resolving many names stays two system calls
+_library_listings() = Pair{String,Vector{String}}[dir => readdir(dir; sort=true)
+                                                  for dir in library_dirs() if isdir(dir)]
+
+# Append the files of `name` to `paths`, and report whether this installation has it at all.
+function _library_files!(paths::Vector{String}, name::AbstractString, listings)
+    for (dir, files) in listings
+        found = false
+        for file in files
+            _is_library_file(name, file) || continue
+            push!(paths, joinpath(dir, file))
+            found = true
+        end
+        # a library is not shipped in more than one of these directories
+        found && return true
+    end
+    return false
+end
+
+"""
+    Base.Linking.library_files(name::AbstractString) -> Vector{String}
+    Base.Linking.library_files(names) -> Vector{String}
+
+The absolute paths of the shared library files that this Julia installation ships under the
+extension-less, unversioned library name `name` (e.g. `"libopenblas64_"`), including the
+version symlinks that go with them, in the spelling this platform uses (`libfoo.so.1.2`,
+`libfoo.1.2.dylib`, `libfoo-1.dll`).
+
+A name this installation does not ship contributes no paths, so an empty result means "not
+shipped here" rather than an error. Pass a collection of `names` to read the installation's
+directories only once.
+
+This resolves names the way [`runtime_libraries`](@ref) does, for tools that have their own
+list of libraries to find in a Julia installation, such as the libraries belonging to
+standard libraries. Only the directories this installation keeps shared libraries in are
+searched, never the system's.
+
+!!! compat "Julia 1.14"
+    This function requires Julia 1.14.
+"""
+function library_files(names)
+    listings = _library_listings()
+    paths = String[]
+    for name in names
+        _library_files!(paths, name, listings)
+    end
+    return unique!(paths)
+end
+library_files(name::AbstractString) = library_files((name,))
+
+function _runtime_library_names(optional_components)
+    for component in optional_components
+        component in COMPONENTS || throw(ArgumentError(
+            "unknown optional component $(repr(component)); the optional components are " *
+            join(map(repr, COMPONENTS), ", ")))
+    end
+    debug = isdebugbuild() ? "-debug" : ""
+    # Julia's own libraries, which every build has, so that a missing one is an error. In a
+    # framework build the runtime is the framework's `Julia` binary rather than a `libjulia`
+    # file in these directories.
+    required = String[]
+    Base.DARWIN_FRAMEWORK || push!(required, "libjulia$debug")
+    push!(required, "libjulia-internal$debug")
+    # The rest is generated from `JL_RUNTIME_LIBS` in Make.inc, and is optional because
+    # whether a library is shipped depends on how Julia was built: it may have been built
+    # against the system's copy (`USE_SYSTEM_GMP` and friends), or the library may belong to
+    # a build configuration that is off by default (a third party garbage collector, the
+    # Tracy profiler, a sanitizer build).
+    optional = copy(Base.RUNTIME_LIBRARY_NAMES)
+    if :codegen in optional_components
+        push!(required, "libjulia-codegen$debug")
+        # LLVM is not shipped when Julia is built against a system LLVM or links it
+        # statically, so it stays optional
+        append!(optional, Base.CODEGEN_LIBRARY_NAMES)
+    end
+    return required, optional
+end
+
+"""
+    Base.Linking.runtime_libraries(; optional_components = Base.Linking.DEFAULT_COMPONENTS) -> Vector{String}
+
+The absolute paths of the shared library files that this Julia installation ships and that a
+program embedding the Julia runtime needs at run time, including the version symlinks that
+go with them, in no particular order. This is the set of libraries that tools such as
+`juliac` bundle alongside the binaries they build.
+
+Every path lies inside the Julia installation. A bundle should place each file at the same
+location relative to `Sys.BINDIR` that it has here, so that the dependency paths embedded in
+`libjulia` keep resolving.
+
+`optional_components` selects the parts of the runtime whose libraries are wanted;
+[`DEFAULT_COMPONENTS`](@ref) is all of them. The components are:
+
+  * `:codegen`: generating native code at run time, i.e. `libjulia-codegen` and LLVM. Leave
+    it out for a program that never does, such as one built with `--trim`.
+
+Libraries this installation does not ship, because Julia was built to use a copy provided by
+the system or because they belong to a build configuration it was not built with, are not
+returned: those remain the system's to provide. A library that every build ships, such as
+`libjulia-internal`, is instead an error when missing, since that means the installation is
+incomplete.
+
+The Julia system image, package images, and the libraries belonging to standard libraries
+(OpenBLAS, for example) are not runtime libraries and are not returned; use
+[`library_files`](@ref) to find those in this installation.
+
+!!! compat "Julia 1.14"
+    This function requires Julia 1.14.
+"""
+function runtime_libraries(; optional_components::AbstractVector{Symbol} = DEFAULT_COMPONENTS)
+    required, optional = _runtime_library_names(optional_components)
+    return _runtime_libraries(required, optional, _library_listings())
+end
+
+function _runtime_libraries(required, optional, listings)
+    paths = String[]
+    absent = String[]
+    for name in required
+        _library_files!(paths, name, listings) || push!(absent, name)
+    end
+    if !isempty(absent)
+        error("this Julia installation does not contain the shared ",
+              length(absent) == 1 ? "library " : "libraries ", join(absent, ", "),
+              ", which every build of Julia ships; looked in ", join(library_dirs(), ", "),
+              ". The installation is incomplete.")
+    end
+    for name in optional
+        _library_files!(paths, name, listings)
+    end
+    return unique!(paths)
 end
 
 end # module Linking

--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -51,6 +51,26 @@ Alternatively, look at the `embedding.c` program in the Julia source tree in the
 The `cli/loader_exe.c` program is another simple example of how to set `jl_options` options while
 linking against `libjulia`.
 
+A program that embeds Julia needs more than `libjulia` at run time: the runtime loads a set
+of shared libraries out of the Julia installation, such as `libjulia-internal` and the
+libraries it in turn depends on. If the program is to be shipped without a Julia
+installation next to it, those libraries have to come along. Rather than keeping a list of
+them, ask the Julia installation you are building against:
+
+```julia-repl
+julia> Base.Linking.runtime_libraries()
+```
+
+Each path returned lies inside the Julia installation, and should be placed in the shipped
+tree at the same location relative to `Sys.BINDIR` that it has there, so that the dependency
+paths embedded in `libjulia` keep resolving. Pass `optional_components = Symbol[]` if the
+program never generates native code at run time, which drops `libjulia-codegen` and LLVM.
+This is what `juliac` does when it bundles a program it has compiled.
+
+The libraries reported are those of the runtime itself. A program that also needs libraries
+belonging to standard libraries, such as OpenBLAS, can find those in the same installation
+with `Base.Linking.library_files`, which takes the library names to look for.
+
 The first thing that must be done before calling any other Julia C function is to
 initialize Julia. This is done by calling `jl_init`, which tries to automatically determine
 Julia's install location. If you need to specify a custom location, or specify which system

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -365,27 +365,38 @@ end
     @test parse_dl_name_version("libgfortran.so", "linux") == ("libgfortran", nothing)
     @test parse_dl_name_version("libgfortran.so.3", "linux") == ("libgfortran", v"3")
     @test parse_dl_name_version("libgfortran.so.3.4", "linux") == ("libgfortran", v"3.4")
-    @test_throws ArgumentError parse_dl_name_version("libgfortran.so.3.4a", "linux")
     @test_throws ArgumentError parse_dl_name_version("libgfortran", "linux")
     @test_throws ArgumentError parse_dl_name_version("libgfortranso", "linux")
     @test parse_dl_name_version("libgfortran.so", "freebsd") == ("libgfortran", nothing)
     @test parse_dl_name_version("libgfortran.so.3", "freebsd") == ("libgfortran", v"3")
     @test parse_dl_name_version("libgfortran.so.3.4", "freebsd") == ("libgfortran", v"3.4")
-    @test_throws ArgumentError parse_dl_name_version("libgfortran.so.3.4a", "freebsd")
     @test_throws ArgumentError parse_dl_name_version("libgfortran", "freebsd")
     @test_throws ArgumentError parse_dl_name_version("libgfortranso", "freebsd")
     @test parse_dl_name_version("libgfortran.dylib", "macos") == ("libgfortran", nothing)
     @test parse_dl_name_version("libgfortran.3.dylib", "macos") == ("libgfortran", v"3")
     @test parse_dl_name_version("libgfortran.3.4.dylib", "macos") == ("libgfortran", v"3.4")
-    @test parse_dl_name_version("libgfortran.3.4a.dylib", "macos") == ("libgfortran.3.4a", nothing)
     @test_throws ArgumentError parse_dl_name_version("libgfortran", "macos")
     @test_throws ArgumentError parse_dl_name_version("libgfortrandylib", "macos")
     @test parse_dl_name_version("libgfortran.dll", "windows") == ("libgfortran", nothing)
     @test parse_dl_name_version("libgfortran-3.dll", "windows") == ("libgfortran", v"3")
     @test parse_dl_name_version("libgfortran-3.4.dll", "windows") == ("libgfortran", v"3.4")
-    @test parse_dl_name_version("libgfortran-3.4a.dll", "windows") == ("libgfortran-3.4a", nothing)
     @test_throws ArgumentError parse_dl_name_version("libgfortran", "windows")
     @test_throws ArgumentError parse_dl_name_version("libgfortrandll", "windows")
+
+    # a soversion may carry a tag, as Julia's own LLVM does; the tag belongs to the
+    # soversion rather than to the name, and is not reported
+    @test parse_dl_name_version("libgfortran.so.3.4a", "linux") == ("libgfortran", v"3.4")
+    @test parse_dl_name_version("libgfortran.so.3.4a", "freebsd") == ("libgfortran", v"3.4")
+    @test parse_dl_name_version("libgfortran.3.4a.dylib", "macos") == ("libgfortran", v"3.4")
+    @test parse_dl_name_version("libgfortran-3.4a.dll", "windows") == ("libgfortran", v"3.4")
+    @test parse_dl_name_version("libLLVM.so.21.1jl", "linux") == ("libLLVM", v"21.1")
+    @test parse_dl_name_version("libLLVM.21.1jl.dylib", "macos") == ("libLLVM", v"21.1")
+    @test parse_dl_name_version("libLLVM-21jl.dll", "windows") == ("libLLVM", v"21")
+    # a name is never mistaken for a tagged soversion: a tag has to follow a version
+    @test_throws ArgumentError parse_dl_name_version("libfoo.sofia", "linux")
+    @test parse_dl_name_version("libLLVM-21jl.so", "linux") == ("libLLVM-21jl", nothing)
+    @test parse_dl_name_version("libpcre2-8.so", "linux") == ("libpcre2-8", nothing)
+    @test parse_dl_name_version("libpcre2-8-0.dll", "windows") == ("libpcre2-8", v"0")
 end
 
 @testset "Sys.is* overloading" begin

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1670,6 +1670,59 @@ let errs = IOBuffer()
     @test occursin("disable_new_worlds", String(take!(errs)))
 end
 
+# the declared runtime libraries must be complete: everything the runtime loads out of this
+# Julia installation has to be in there, or bundled programs (e.g. from juliac) break
+@testset "Base.Linking.runtime_libraries" begin
+    libs = Base.Linking.runtime_libraries()
+    @test !isempty(libs)
+    @test allunique(libs)
+    @test all(isabspath, libs)
+    @test all(isfile, libs)
+    root = normpath(Sys.BINDIR, "..")
+    @test all(p -> startswith(p, root), libs)
+    for name in ("libjulia", "libjulia-internal")
+        name = Base.isdebugbuild() ? name * "-debug" : name
+        @test any(p -> startswith(basename(p), name), libs)
+    end
+    nocodegen = Base.Linking.runtime_libraries(; optional_components=Symbol[])
+    @test issubset(nocodegen, libs)
+    @test !any(p -> startswith(basename(p), "libLLVM") || startswith(basename(p), "libjulia-codegen"), nocodegen)
+    # a misspelled component must not quietly leave libraries out of a bundle
+    @test_throws ArgumentError Base.Linking.runtime_libraries(; optional_components=[:codgen])
+
+    # `library_files` resolves a name to the files this installation ships under it, and
+    # tells apart names that merely share a prefix
+    internal = "libjulia-internal" * (Base.isdebugbuild() ? "-debug" : "")
+    @test !isempty(Base.Linking.library_files(internal))
+    @test issubset(Base.Linking.library_files(internal), libs)
+    @test Base.Linking.library_files("libthis-is-not-shipped-anywhere") == String[]
+    @test allunique(Base.Linking.library_files(["libjulia", "libjulia"]))
+    for name in ("libz", "libgmp", "libjulia")
+        files = basename.(Base.Linking.library_files(name))
+        @test all(f -> Base.BinaryPlatforms.parse_dl_name_version(f)[1] == name, files)
+    end
+
+    # a library that every build ships is an error rather than a silent omission
+    listings = Base.Linking._library_listings()
+    @test_throws "installation is incomplete" Base.Linking._runtime_libraries(["libnope"], String[], listings)
+
+    # check the loaded libraries in a fresh process, so that libraries other tests have
+    # dlopen'd (e.g. `libccalltest`) don't interfere
+    script = """
+        declared = Set(basename.(Base.Linking.runtime_libraries()))
+        root = normpath(Sys.BINDIR, "..")
+        image = normpath(Base.unsafe_string(Base.JLOptions().image_file))
+        for lib in Base.Libc.Libdl.dllist()
+            occursin(string('.', Base.Libc.Libdl.dlext), basename(lib)) || continue
+            path = normpath(lib)
+            startswith(path, root) || continue # provided by the system, not ours to ship
+            path == image && continue # the system image is not a runtime library
+            basename(path) in declared || println(path)
+        end
+    """
+    @test readchomp(`$(Base.julia_cmd()) --startup-file=no -e $script`) == ""
+end
+
 @testset "`@constprop`, `@assume_effects` handling of an unknown setting" begin
     for x ∈ ("constprop", "assume_effects")
         try


### PR DESCRIPTION
Tools that ship a program embedding the Julia runtime have to know which shared libraries of a Julia installation to ship with it. Because Julia did not say, they keep their own lists: PackageCompiler.jl (and through it JuliaC.jl) hardcodes one per operating system. Such a list drifts as the runtime's dependencies change; `libzstd`, which `libjulia-internal` has needed since 1.13, is in those bundles today only because the entry for `libz` happens to be a prefix of it.

`Base.Linking.runtime_libraries()` now answers that question for the installation it is asked, returning the library files it ships, with `runtime_library_names()` giving the declaration behind it. Because the answer is resolved against the installation, a library that Julia was built to take from the system is left out, and a bundler no longer has to special case the layout of a Julia built from source, where the private libraries sit in the library directory itself.

The declaration is guarded against drift by a test that starts a fresh process and checks that every shared library the runtime loads from inside the installation is declared.

The consumer side is JuliaLang/JuliaC.jl#167, which drops its dependency on PackageCompiler's hardcoded list.

This pull request was written with the assistance of generative AI (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
