### PR TITLE
cancellation: Wire up compute cancellation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,20 @@ depending on your changes.
 After modifying any C/C++ file under `src/`, also run the Clang static analysis
 checks — see the `c-static-analysis` skill ([`doc/src/devdocs/agents/skills/c-static-analysis/`](doc/src/devdocs/agents/skills/c-static-analysis/SKILL.md)).
 
+### Testing LLVM-related changes
+
+When making changes to LLVM passes or codegen, add `LLVM_ASSERTIONS=1` to `Make.user` to enable
+LLVM assertions. This helps catch IR verification errors early:
+
+```bash
+echo "LLVM_ASSERTIONS=1" >> Make.user
+```
+
+To run LLVM pass tests:
+```bash
+make -C test/llvmpasses <testname>.ll
+```
+
 ## Using Revise
 
 If you have made changes to files included in the system image (base/ or stdlib/),

--- a/Compiler/src/effects.jl
+++ b/Compiler/src/effects.jl
@@ -11,28 +11,32 @@ The output represents the state of different effect properties in the following 
     - `+e` (green): `ALWAYS_TRUE`
     - `-e` (red): `ALWAYS_FALSE`
     - `?e` (yellow): `EFFECT_FREE_IF_INACCESSIBLEMEMONLY`
-3. `nothrow` (`n`):
+3. `reset_safe` (`re`):
+    - `+re` (green): `ALWAYS_TRUE`
+    - `-re` (red): `ALWAYS_FALSE`
+    - `?re` (yellow): `RESET_SAFE_IF_INACCESSIBLEMEMONLY`
+4. `nothrow` (`n`):
     - `+n` (green): `true`
     - `-n` (red): `false`
-4. `terminates` (`t`):
+5. `terminates` (`t`):
     - `+t` (green): `true`
     - `-t` (red): `false`
-5. `notaskstate` (`s`):
+6. `notaskstate` (`s`):
     - `+s` (green): `true`
     - `-s` (red): `false`
-6. `inaccessiblememonly` (`m`):
+7. `inaccessiblememonly` (`m`):
     - `+m` (green): `ALWAYS_TRUE`
     - `-m` (red): `ALWAYS_FALSE`
     - `?m` (yellow): `INACCESSIBLEMEM_OR_ARGMEMONLY`
-7. `noub` (`u`):
+8. `noub` (`u`):
     - `+u` (green): `true`
     - `-u` (red): `false`
     - `?u` (yellow): `NOUB_IF_NOINBOUNDS`
-8. `:nonoverlayed` (`o`):
+9. `:nonoverlayed` (`o`):
     - `+o` (green): `ALWAYS_TRUE`
     - `-o` (red): `ALWAYS_FALSE`
     - `?o` (yellow): `CONSISTENT_OVERLAY`
-9. `:nortcall` (`r`):
+10. `:nortcall` (`r`):
     - `+r` (green): `true`
     - `-r` (red): `false`
 """
@@ -62,6 +66,15 @@ following meanings:
     will not be refined anyway.
   * `EFFECT_FREE_IF_INACCESSIBLEMEMONLY`: the `:effect-free`-ness of this method can later be
     refined to `ALWAYS_TRUE` in a case when `:inaccessiblememonly` is proven.
+- `reset_safe::UInt8`
+  * The execution of this function may be interrupted and reset to an earlier cancellation
+    point at any point in the function. The interpretation is similar to `:effect_free`,
+    but has different guarantees.
+    N.B.: this bit describes the function's IPO contract only. Machinery the runtime
+    inserts implicitly to execute it (allocation, write barriers, runtime library calls)
+    is not covered by the contract and may not be safe to abandon - but this analysis
+    does not need to model that: it is deferred to codegen and the runtime (see
+    `llvm-cancellation-lowering.cpp`).
 - `nothrow::Bool`: this method is guaranteed to not throw an exception.
   If the execution of this method may raise `MethodError`s and similar exceptions, then
   the method is not considered as `:nothrow`.
@@ -119,6 +132,7 @@ $(effects_key_string)
 struct Effects
     consistent::UInt8
     effect_free::UInt8
+    reset_safe::UInt8
     nothrow::Bool
     terminates::Bool
     notaskstate::Bool
@@ -129,6 +143,7 @@ struct Effects
     function Effects(
         consistent::UInt8,
         effect_free::UInt8,
+        reset_safe::UInt8,
         nothrow::Bool,
         terminates::Bool,
         notaskstate::Bool,
@@ -139,6 +154,7 @@ struct Effects
         return new(
             consistent,
             effect_free,
+            reset_safe,
             nothrow,
             terminates,
             notaskstate,
@@ -175,14 +191,18 @@ const NOUB_IF_NOINBOUNDS = 0x01 << 1
 # :nonoverlayed bits
 const CONSISTENT_OVERLAY = 0x01 << 1
 
-const EFFECTS_TOTAL   = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  true,  true,  true,  ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE, true)
-const EFFECTS_THROWS  = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  false, true,  true,  ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE, true)
-const EFFECTS_UNKNOWN = Effects(ALWAYS_FALSE, ALWAYS_FALSE, false, false, false, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_TRUE, false) # unknown mostly, but it's not overlayed at least (e.g. it's not a call)
+# :reset_safe bits
+const RESET_SAFE_IF_INACCESSIBLEMEMONLY = 0x01 << 1
 
-function Effects(effects::Effects=Effects(
-    ALWAYS_FALSE, ALWAYS_FALSE, false, false, false, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_FALSE, false);
+const EFFECTS_TOTAL   = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE, true,  true,  true,  ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE, true)
+const EFFECTS_THROWS  = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE, false, true,  true,  ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE, true)
+const EFFECTS_UNKNOWN = Effects(ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_FALSE, false, false, false, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_TRUE, false) # unknown mostly, but it's not overlayed at least (e.g. it's not a call)
+const EFFECTS_MINIMAL = Effects(ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_FALSE, false, false, false, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_FALSE, false)
+
+function Effects(effects::Effects=EFFECTS_MINIMAL;
     consistent::UInt8 = effects.consistent,
     effect_free::UInt8 = effects.effect_free,
+    reset_safe::UInt8 = effects.reset_safe,
     nothrow::Bool = effects.nothrow,
     terminates::Bool = effects.terminates,
     notaskstate::Bool = effects.notaskstate,
@@ -193,6 +213,7 @@ function Effects(effects::Effects=Effects(
     return Effects(
         consistent,
         effect_free,
+        reset_safe,
         nothrow,
         terminates,
         notaskstate,
@@ -223,6 +244,14 @@ function is_better_effects(new::Effects, old::Effects)
         old.effect_free == ALWAYS_TRUE && return false
         any_improved |= old.effect_free != EFFECT_FREE_IF_INACCESSIBLEMEMONLY
     elseif new.effect_free != old.effect_free
+        return false
+    end
+    if new.reset_safe == ALWAYS_TRUE
+        any_improved |= old.reset_safe != ALWAYS_TRUE
+    elseif new.reset_safe == RESET_SAFE_IF_INACCESSIBLEMEMONLY
+        old.reset_safe == ALWAYS_TRUE && return false
+        any_improved |= old.reset_safe != RESET_SAFE_IF_INACCESSIBLEMEMONLY
+    elseif new.reset_safe != old.reset_safe
         return false
     end
     if new.nothrow
@@ -276,6 +305,7 @@ function merge_effects(old::Effects, new::Effects)
     return Effects(
         merge_effectbits(old.consistent, new.consistent),
         merge_effectbits(old.effect_free, new.effect_free),
+        merge_effectbits(old.reset_safe, new.reset_safe),
         merge_effectbits(old.nothrow, new.nothrow),
         merge_effectbits(old.terminates, new.terminates),
         merge_effectbits(old.notaskstate, new.notaskstate),
@@ -295,6 +325,7 @@ merge_effectbits(old::Bool, new::Bool) = old & new
 
 is_consistent(effects::Effects)          = effects.consistent === ALWAYS_TRUE
 is_effect_free(effects::Effects)         = effects.effect_free === ALWAYS_TRUE
+is_reset_safe(effects::Effects)          = effects.reset_safe === ALWAYS_TRUE
 is_nothrow(effects::Effects)             = effects.nothrow
 is_terminates(effects::Effects)          = effects.terminates
 is_notaskstate(effects::Effects)         = effects.notaskstate
@@ -331,6 +362,8 @@ is_consistent_if_inaccessiblememonly(effects::Effects) = !iszero(effects.consist
 
 is_effect_free_if_inaccessiblememonly(effects::Effects) = !iszero(effects.effect_free & EFFECT_FREE_IF_INACCESSIBLEMEMONLY)
 
+is_reset_safe_if_inaccessiblememonly(effects::Effects) = !iszero(effects.reset_safe & RESET_SAFE_IF_INACCESSIBLEMEMONLY)
+
 is_inaccessiblemem_or_argmemonly(effects::Effects) = effects.inaccessiblememonly === INACCESSIBLEMEM_OR_ARGMEMONLY
 
 is_consistent_overlay(effects::Effects) = effects.nonoverlayed === CONSISTENT_OVERLAY
@@ -345,13 +378,15 @@ function encode_effects(e::Effects)
            ((e.inaccessiblememonly % UInt32) << 8)  |
            ((e.noub                % UInt32) << 10) |
            ((e.nonoverlayed        % UInt32) << 12) |
-           ((e.nortcall            % UInt32) << 14)
+           ((e.nortcall            % UInt32) << 14) |
+           ((e.reset_safe          % UInt32) << 15)
 end
 
 function decode_effects(e::UInt32)
     return Effects(
         UInt8((e >> 0) & 0x07),
         UInt8((e >> 3) & 0x03),
+        UInt8((e >> 15) & 0x03),
         Bool((e >> 5) & 0x01),
         Bool((e >> 6) & 0x01),
         Bool((e >> 7) & 0x01),

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -39,6 +39,9 @@ const IR_FLAG_NOUB        = one(UInt32) << 10
 #const IR_FLAG_CONSISTENTOVERLAY = one(UInt32) << 12
 # This statement is :nortcall
 const IR_FLAG_NORTCALL = one(UInt32) << 13
+# This statement is proven :reset_safe
+const IR_FLAG_RESET_SAFE = one(UInt32) << 14
+# Reserved: one(UInt32) << 15 used for RSIIMO below
 # An optimization pass has updated this statement in a way that may
 # have exposed information that inference did not see. Re-running
 # inference on this statement may be profitable.
@@ -50,15 +53,21 @@ const IR_FLAG_UNUSED      = one(UInt32) << 17
 const IR_FLAG_EFIIMO      = one(UInt32) << 18
 # This statement is :inaccessiblememonly == INACCESSIBLEMEM_OR_ARGMEMONLY
 const IR_FLAG_INACCESSIBLEMEM_OR_ARGMEM = one(UInt32) << 19
+# This statement is :reset_safe == RESET_SAFE_IF_INACCESSIBLEMEMONLY
+const IR_FLAG_RSIIMO      = one(UInt32) << 20
 
 const NUM_IR_FLAGS = 3 # sync with julia.h
 
 const IR_FLAGS_EFFECTS =
     IR_FLAG_CONSISTENT | IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW |
-    IR_FLAG_TERMINATES | IR_FLAG_NOUB | IR_FLAG_NORTCALL
+    IR_FLAG_TERMINATES | IR_FLAG_NOUB | IR_FLAG_NORTCALL | IR_FLAG_RESET_SAFE
 
 const IR_FLAGS_REMOVABLE = IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW | IR_FLAG_TERMINATES
 
+# N.B.: RSIIMO is deliberately not included: `has_flag` requires all bits, and
+# nothing consumes an escape-analysis outcome for reset-safety yet. When such
+# a consumer exists, it needs its own (RSIIMO | INACCESSIBLEMEM_OR_ARGMEM)
+# qualification, not membership in this conjunction.
 const IR_FLAGS_NEEDS_EA = IR_FLAG_EFIIMO | IR_FLAG_INACCESSIBLEMEM_OR_ARGMEM
 
 has_flag(curr::UInt32, flag::UInt32) = (curr & flag) == flag
@@ -78,6 +87,20 @@ function flags_for_effects(effects::Effects)
         flags |= IR_FLAG_EFFECT_FREE
     elseif is_effect_free_if_inaccessiblememonly(effects)
         flags |= IR_FLAG_EFIIMO
+    end
+    # N.B.: Inference does not yet model `reset_safe` separately from
+    # `effect_free`, so until it does, only statements that are additionally
+    # proven effect-free may be treated as reset-safe (execution can safely
+    # be reset across them, since they have no externally visible effects).
+    # This flag describes the statement's IPO contract only: machinery the
+    # runtime inserts implicitly to execute it (allocation, write barriers,
+    # runtime library calls), whose frames must never be abandoned
+    # asynchronously, is handled separately by eagerly dropping the published
+    # reset context around it (see llvm-cancellation-lowering.cpp).
+    if is_reset_safe(effects) && is_effect_free(effects)
+        flags |= IR_FLAG_RESET_SAFE
+    elseif is_reset_safe_if_inaccessiblememonly(effects) && is_effect_free_if_inaccessiblememonly(effects)
+        flags |= IR_FLAG_RSIIMO
     end
     if is_nothrow(effects)
         flags |= IR_FLAG_NOTHROW

--- a/Compiler/src/ssair/show.jl
+++ b/Compiler/src/ssair/show.jl
@@ -1118,7 +1118,7 @@ function show_ir(io::IO, compact::IncrementalCompact, config::IRShowConfig=defau
     finish_show_ir(io, uncompacted_cfg, config)
 end
 
-function effectbits_letter(effects::Effects, name::Symbol, suffix::Char)
+function effectbits_letter(effects::Effects, name::Symbol, suffix::Union{Char, String})
     ft = fieldtype(Effects, name)
     if ft === UInt8
         prefix = getfield(effects, name) === ALWAYS_TRUE ? '+' :
@@ -1149,6 +1149,8 @@ function Base.show(io::IO, e::Effects)
     printstyled(io, effectbits_letter(e, :consistent,  'c'); color=effectbits_color(e, :consistent))
     print(io, ',')
     printstyled(io, effectbits_letter(e, :effect_free, 'e'); color=effectbits_color(e, :effect_free))
+    print(io, ',')
+    printstyled(io, effectbits_letter(e, :reset_safe, "re"); color=effectbits_color(e, :reset_safe))
     print(io, ',')
     printstyled(io, effectbits_letter(e, :nothrow,     'n'); color=effectbits_color(e, :nothrow))
     print(io, ',')

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -196,7 +196,7 @@
 #    sticky::UInt8
 #    priority::UInt16
 #    @atomic _isexception::UInt8
-#    pad00::UInt8
+#    @atomic preempt_request::UInt8
 #    pad01::UInt8
 #    pad02::UInt8
 #    rngState0::UInt64
@@ -214,6 +214,8 @@
 #    @atomic finished_at::UInt64
 #    @atomic waiting_on::Any
 #    cached_wait_entry::Any
+#    invoked::Any
+#    @atomic bound_cancel_token::Any
 #end
 
 export

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -90,6 +90,14 @@ frozen in place and never scheduled again.
 """
 const CANCEL_REQUEST_ABANDON_ALL = CancellationRequest(0x4)
 
+# The status byte reported by a cancellation point (`Core.cancellation_point!`)
+# is the governing source's state byte (0 while uncancelled, the severity once
+# cancelled) with the 0x40 bit merged in when the task has a pending
+# cooperative-yield request. The mask recovers the severity half of such a
+# status byte; source state reads themselves need no masking.
+const STATUS_PREEMPT_BIT = 0x40
+const SEVERITY_MASK = 0x3f
+
 """
     cancel_severity(src::CancellationTokenSource) -> Union{Nothing, CancellationRequest}
     cancel_severity(tok::CancellationToken)
@@ -245,14 +253,46 @@ end
 
 ## Cancellation points
 
-# The slow path of `@cancel_check`: `st` is the (non-zero) state byte of the
-# governing source.
-@noinline function handle_cancellation!(src::CancellationTokenSource, st::UInt8)
+# The slow path of `@cancel_check`: `st` is the (non-zero) status byte
+# reported by the cancellation point.
+@noinline function handle_cancellation!(src::Union{Nothing, CancellationTokenSource}, st::UInt8)
+    ct = current_task()
+    if st & STATUS_PREEMPT_BIT != 0x00
+        # consume the cooperative-yield request
+        @atomic :monotonic ct.preempt_request = 0x00
+    end
+    if st & SEVERITY_MASK == 0x00
+        # preempt-only (a pending yield request, or a preempt shootdown that
+        # reset this point): let another task run, then resume
+        yield()
+        return nothing
+    end
+    src = src::CancellationTokenSource
     # re-read: deliver the severity current at throw time, not the one the
     # fast path happened to observe
     st = @atomic :acquire src.state
     throw(CancellationRequest(st))
 end
+
+"""
+    Core.cancellation_point!(src::Union{Nothing, Core.CancellationTokenSource})::UInt8
+
+Check the cancellation state of `src` (see [`@cancel_check`](@ref)),
+additionally giving the optimizer license to establish this point as a
+cancellation reset point: when compiled, the source is published as the token
+binding governing the current computation, and the runtime may asynchronously
+unwind execution to the nearest preceding cancellation point when the source
+is cancelled. Returns a status byte: `0x00` if nothing is pending, the
+(nonzero) severity if `src` is cancelled, with the `0x40` bit set if a
+cooperative yield (preemption) was requested.
+
+!!! warning
+    `src` must remain otherwise reachable (e.g. through the scope binding
+    that supplied it, as [`@cancel_check`](@ref) guarantees) for the dynamic
+    extent of the region this point establishes: copies of the binding saved
+    by exception handlers are not GC-scanned.
+"""
+Core.cancellation_point!
 
 """
     @cancel_check
@@ -269,10 +309,18 @@ token; use it to hoist the token lookup out of a tight loop.
 """
 macro cancel_check()
     quote
-        # also a GC safepoint, so that a tight polling loop cannot starve a
-        # concurrent stop-the-world
-        ccall(:jl_gc_safepoint, Cvoid, ())
-        checkcancel(default_cancel_source())
+        # compiled cancellation points are also GC safepoints, so that a tight
+        # polling loop cannot starve a concurrent stop-the-world.
+        # The loop re-executes the point whenever the slow path returns (a
+        # preempt-only status yields and resumes): the slow-path call tears
+        # down the point's reset region, so passing the point again is what
+        # re-establishes it before the code the region is meant to cover.
+        local s = default_cancel_source()
+        while true
+            local st = Core.cancellation_point!(s)::UInt8
+            st == 0x00 && break
+            handle_cancellation!(s, st)
+        end
         nothing
     end
 end
@@ -280,14 +328,19 @@ end
 macro cancel_check(tok)
     quote
         local t = $(esc(tok))
-        ccall(:jl_gc_safepoint, Cvoid, ())
-        checkcancel(t === nothing ? nothing : (t::CancellationToken).source)
+        local s = t === nothing ? nothing : (t::CancellationToken).source
+        while true
+            local st = Core.cancellation_point!(s)::UInt8
+            st == 0x00 && break
+            handle_cancellation!(s, st)
+        end
         nothing
     end
 end
 
 # Throw the `CancellationRequest` if `src` is cancelled (level-triggered:
-# no per-task state is consulted).
+# no per-task state is consulted). Unlike `@cancel_check` this is not a
+# compiled cancellation point (it opens no async-interruptible region).
 @inline function checkcancel(src::CancellationTokenSource)
     st = @atomic :monotonic src.state
     st == 0x00 && return nothing

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -220,6 +220,12 @@ function cancel!(src::CancellationTokenSource,
     raised = _raise_state!(src, sev)
     _cancel_walk!(src, sev)
     Threads.atomic_fence_heavy()
+    # Shoot down any task now bound to a cancelled source: threads inside a
+    # compiled cancellation region are asynchronously reset to their
+    # cancellation point, which observes the cancellation and throws.
+    # Best-effort: a task the walk misses recovers level-triggered at its
+    # next cancellation point (or reset-safe allocation).
+    ccall(:jl_shootdown_cancelled_tasks, Cvoid, ())
     return raised
 end
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -868,7 +868,7 @@ Return the possible computation effects of the function call specified by `f` an
 julia> f1(x) = x * 2;
 
 julia> Base.infer_effects(f1, (Int,))
-(+c,+e,+n,+t,+s,+m,+i)
+(+c,+e,+re,+n,+t,+s,+m,+u,+o,+r)
 ```
 
 This function will return an `Effects` object with information about the computational
@@ -878,7 +878,7 @@ effects of the function `f1` when called with an `Int` argument.
 julia> f2(x::Int) = x * 2;
 
 julia> Base.infer_effects(f2, (Integer,))
-(+c,+e,!n,+t,+s,+m,+i)
+(+c,+e,+re,!n,+t,+s,+m,+u,+o,+r)
 ```
 
 This case is pretty much the same as with `f1`, but there's a key difference to note. For

--- a/src/Makefile
+++ b/src/Makefile
@@ -94,6 +94,7 @@ CODEGEN_SRCS_HASH := codegen.cpp jitlayers.cpp aotcompile.cpp debuginfo.cpp disa
 	llvm-pass-helpers.cpp llvm-ptls.cpp llvm-propagate-addrspaces.cpp \
 	llvm-multiversioning.cpp llvm-alloc-opt.cpp llvm-alloc-helpers.cpp cgmemmgr.cpp llvm-remove-addrspaces.cpp \
 	llvm-remove-ni.cpp llvm-julia-licm.cpp llvm-demote-float16.cpp llvm-cpufeatures.cpp llvm-expand-atomic-modify.cpp \
+	llvm-cancellation-lowering.cpp \
 	pipeline.cpp llvm_api.cpp \
 	cgutils.cpp intrinsics.cpp ccall.cpp \
 	abi_llvm.cpp abi_arm.cpp abi_aarch64.cpp abi_riscv.cpp abi_ppc64le.cpp abi_win32.cpp abi_win64.cpp abi_x86_64.cpp abi_x86.cpp \
@@ -107,6 +108,7 @@ CODEGEN_SRCS := codegen jitlayers aotcompile debuginfo disasm llvm-simdloop \
 	llvm-pass-helpers llvm-ptls llvm-propagate-addrspaces \
 	llvm-multiversioning llvm-alloc-opt llvm-alloc-helpers cgmemmgr llvm-remove-addrspaces \
 	llvm-remove-ni llvm-julia-licm llvm-demote-float16 llvm-cpufeatures llvm-expand-atomic-modify \
+	llvm-cancellation-lowering \
 	pipeline llvm_api objcache \
 	$(GC_CODEGEN_SRCS)
 FLAGS_COMMON += -I$(shell $(LLVM_CONFIG_HOST) --includedir)

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -28,6 +28,7 @@ extern "C" {
     XX(_using, "_using") \
     XX(applicable,"applicable") \
     XX(apply_type,"apply_type") \
+    XX(cancellation_point,"cancellation_point!") \
     XX(compilerbarrier,"compilerbarrier") \
     XX(current_scope,"current_scope") \
     XX(donotdelete,"donotdelete") \

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -739,6 +739,41 @@ JL_CALLABLE(jl_f__new_cancel_source)
     return jl_new_cancel_source(args, nargs);
 }
 
+// cancellation_point!(src::Union{Nothing, Core.CancellationTokenSource})::UInt8
+// Returns a status byte: 0x00 nothing pending; the (nonzero) severity if
+// `src` is cancelled; the 0x40 bit is set if a preempt (cooperative yield)
+// request is pending.
+// N.B.: this runtime version only *checks* the source. Publishing the source
+// into `ct->bound_cancel_token` is done exclusively by the codegen'ed
+// lowering: the binding describes the async-interruptible region that the
+// CancellationLowering pass produces around the compiled cancellation point
+// (reset_ctx), which has no interpreter equivalent.
+JL_CALLABLE(jl_f_cancellation_point)
+{
+    JL_NARGS(cancellation_point!, 1, 1);
+    jl_task_t *ct = jl_current_task;
+    jl_value_t *src = args[0];
+    // A cancellation point is also a GC safepoint (the compiled lowering
+    // emits one): keep that for the interpreted/fallback path too, so a
+    // polling loop that never reaches the specialized lowering cannot
+    // starve a stop-the-world request.
+    jl_gc_safepoint();
+    uint8_t st = 0;
+    if (src != jl_nothing) {
+        JL_TYPECHK(cancellation_point!, cancel_source, src);
+        st = jl_atomic_load_relaxed(&((jl_cancel_source_t*)src)->state);
+    }
+    // The 0x40 bit reports a pending cooperative-yield request. The
+    // compiled lowering additionally reports a delivered preempt shootdown
+    // (the reset point's setjmp returning JL_RESET_CODE_PREEMPT), which has
+    // no interpreter equivalent - just as there is no interpreted reset
+    // region - but the shootdown also sets preempt_request, so the request
+    // is never lost here.
+    if (jl_atomic_load_relaxed(&ct->preempt_request))
+        st |= 0x40;
+    return jl_box_uint8(st);
+}
+
 // apply ----------------------------------------------------------------------
 
 static NOINLINE jl_svec_t *_copy_to(size_t newalloc, jl_value_t **oldargs, size_t oldalloc) JL_CANSAFEPOINT

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1252,6 +1252,17 @@ static const auto jl_write_barrier_func = new JuliaFunction<>{
     },
 };
 
+static const auto jl_cancellation_point_func = new JuliaFunction<>{
+    "julia.cancellation_point",
+    [](LLVMContext &C) {
+        return FunctionType::get(getInt32Ty(C), {}, false);
+    },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            Attributes(C, {Attribute::ReturnsTwice}),
+            AttributeSet(),
+            {}); }
+};
+
 static const auto jlisa_func = new JuliaFunction<>{
     XSTR(jl_isa),
     [](LLVMContext &C) {
@@ -2100,6 +2111,14 @@ public:
     int nargs = 0;
     int nvargs = -1;
     bool is_opaque_closure = false;
+    // Index of the source statement currently being emitted, for ssaflags
+    // lookups (IR_FLAG_RESET_SAFE) by mark_reset_safe, which runs several
+    // call-emission layers below the statement loop where the index is no
+    // longer in scope. Statement-scoped context exactly like the debug
+    // location; it is reset to -1 outside statement emission so calls the
+    // compiler inserts on its own (prologue, phi copies, error paths) can
+    // never be tagged from a stale statement.
+    ssize_t current_stmt_idx = -1;
 
     Value *pgcstack = NULL;
     Instruction *topalloca = NULL;
@@ -2277,6 +2296,28 @@ static Value *emit_ptrgep(jl_codectx_t &ctx, Value *base, size_t byte_offset, co
     auto *gep = ctx.builder.CreateConstInBoundsGEP1_32(getInt8Ty(ctx.builder.getContext()), base, byte_offset);
     setName(ctx.emission_context, gep, Name);
     return gep;
+}
+
+// Check if the current statement has the reset_safe flag set
+static bool current_stmt_is_reset_safe(jl_codectx_t &ctx)
+{
+    if (ctx.current_stmt_idx < 0 || ctx.source == nullptr || ctx.source->ssaflags == nullptr)
+        return false;
+    size_t nstmts = jl_array_dim0(ctx.source->ssaflags);
+    if ((size_t)ctx.current_stmt_idx >= nstmts)
+        return false;
+    uint32_t flag = jl_array_data(ctx.source->ssaflags, uint32_t)[ctx.current_stmt_idx];
+    return (flag & IR_FLAG_RESET_SAFE) != 0;
+}
+
+// Mark a call instruction with reset_safe metadata if the current statement has the flag
+static void mark_reset_safe(jl_codectx_t &ctx, CallInst *call)
+{
+    if (call && current_stmt_is_reset_safe(ctx)) {
+        LLVMContext &llvmctx = ctx.builder.getContext();
+        MDNode *md = MDNode::get(llvmctx, {});
+        call->setMetadata("julia.reset_safe", md);
+    }
 }
 
 static Value *emit_ptrgep(jl_codectx_t &ctx, Value *base, Value *byte_offset, const Twine &Name="")
@@ -5437,6 +5478,120 @@ isdefined_unknown_idx:
         return true;
     }
 
+    else if (f == BUILTIN(cancellation_point) && nargs == 1) {
+        // Only lower inline when the argument is statically known to be a
+        // token source or nothing; fall back to the runtime builtin (which
+        // also type-checks) otherwise. CancellationTokenSource is concrete
+        // (hence final), so type equality is the full subtype check; Bottom
+        // and abstract types take the runtime call.
+        jl_value_t *srct = argv[1].typ;
+        auto ok_arm = [](jl_value_t *t) {
+            return t == (jl_value_t*)jl_nothing_type ||
+                   t == (jl_value_t*)jl_cancel_source_type;
+        };
+        bool known_src = srct == (jl_value_t*)jl_cancel_source_type;
+        bool known_nothing = srct == (jl_value_t*)jl_nothing_type;
+        bool known_union = known_src || known_nothing ||
+            (jl_is_uniontype(srct) && ok_arm(((jl_uniontype_t*)srct)->a) &&
+             ok_arm(((jl_uniontype_t*)srct)->b));
+        if (!known_union)
+            return false; // emit as a runtime call for the dynamic type check
+
+        Value *ct = get_current_task(ctx);
+        Value *src = boxed(ctx, argv[1]);
+        Value *bound_ptr = emit_ptrgep(ctx, ct, offsetof(jl_task_t, bound_cancel_token), "bound_cancel_token");
+        jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
+        Value *nothing_val = track_pjlvalue(ctx, literal_pointer_val(ctx, jl_nothing));
+        Type *T_int8 = getInt8Ty(ctx.builder.getContext());
+
+        BasicBlock *src_bb = BasicBlock::Create(ctx.builder.getContext(), "cancel_pt_src", ctx.f);
+        BasicBlock *rebind_bb = BasicBlock::Create(ctx.builder.getContext(), "cancel_pt_rebind", ctx.f);
+        BasicBlock *point_bb = BasicBlock::Create(ctx.builder.getContext(), "cancel_pt_point", ctx.f);
+        BasicBlock *loadst_bb = BasicBlock::Create(ctx.builder.getContext(), "cancel_pt_state", ctx.f);
+        BasicBlock *nothing_bb = BasicBlock::Create(ctx.builder.getContext(), "cancel_pt_nothing", ctx.f);
+        BasicBlock *clear_bb = BasicBlock::Create(ctx.builder.getContext(), "cancel_pt_clear", ctx.f);
+        BasicBlock *merge_bb = BasicBlock::Create(ctx.builder.getContext(), "cancel_pt_merge", ctx.f);
+
+        Value *is_nothing = known_src ? ConstantInt::getFalse(ctx.builder.getContext()) :
+            known_nothing ? ConstantInt::getTrue(ctx.builder.getContext()) :
+            ctx.builder.CreateICmpEQ(decay_derived(ctx, src), decay_derived(ctx, nothing_val));
+        ctx.builder.CreateCondBr(is_nothing, nothing_bb, src_bb);
+
+        // src === nothing: clear a stale binding (store only on change)
+        ctx.builder.SetInsertPoint(nothing_bb);
+        LoadInst *bound0 = ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, bound_ptr, ctx.types().alignof_ptr);
+        bound0->setOrdering(AtomicOrdering::Monotonic);
+        ai.decorateInst(bound0);
+        Value *already_clear = ctx.builder.CreateICmpEQ(decay_derived(ctx, bound0), decay_derived(ctx, nothing_val));
+        ctx.builder.CreateCondBr(already_clear, point_bb, clear_bb);
+
+        ctx.builder.SetInsertPoint(clear_bb);
+        StoreInst *clear_store = ctx.builder.CreateAlignedStore(nothing_val, bound_ptr, ctx.types().alignof_ptr);
+        clear_store->setOrdering(AtomicOrdering::Monotonic);
+        ai.decorateInst(clear_store);
+        ctx.builder.CreateBr(point_bb);
+
+        // src is a token source: publish the binding (store only on rebind,
+        // so steady-state checks in a loop do not dirty the cache line), then
+        // load its cancellation state
+        ctx.builder.SetInsertPoint(src_bb);
+        LoadInst *bound1 = ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, bound_ptr, ctx.types().alignof_ptr);
+        bound1->setOrdering(AtomicOrdering::Monotonic);
+        ai.decorateInst(bound1);
+        Value *same = ctx.builder.CreateICmpEQ(decay_derived(ctx, bound1), decay_derived(ctx, src));
+        ctx.builder.CreateCondBr(same, point_bb, rebind_bb);
+
+        ctx.builder.SetInsertPoint(rebind_bb);
+        StoreInst *bind_store = ctx.builder.CreateAlignedStore(src, bound_ptr, ctx.types().alignof_ptr);
+        bind_store->setOrdering(AtomicOrdering::Release);
+        ai.decorateInst(bind_store);
+        emit_write_barrier(ctx, ct, src);
+        ctx.builder.CreateBr(point_bb);
+
+        // The cancellation point intrinsic (which the CancellationLowering
+        // pass expands into the reset region publication) must come after all
+        // of the binding bookkeeping above: the rebind path's write barrier
+        // is an ordinary call, so the pass clears the published region before
+        // it. Emitting the intrinsic afterwards keeps the region live from
+        // here through a following reset_safe foreign call; only the state
+        // load below may follow it, so that a longjmp back onto the setjmp
+        // re-reads the now-cancelled state.
+        ctx.builder.SetInsertPoint(point_bb);
+        Value *marker = ctx.builder.CreateCall(prepare_call(jl_cancellation_point_func));
+        ctx.builder.CreateCondBr(is_nothing, merge_bb, loadst_bb);
+
+        ctx.builder.SetInsertPoint(loadst_bb);
+        Value *state_ptr = emit_ptrgep(ctx, decay_derived(ctx, src), offsetof(jl_cancel_source_t, state), "cancel_state");
+        LoadInst *st_load = ctx.builder.CreateAlignedLoad(T_int8, state_ptr, Align(1));
+        st_load->setOrdering(AtomicOrdering::Monotonic);
+        jl_aliasinfo_t ai_src = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_mutab);
+        ai_src.decorateInst(st_load);
+        ctx.builder.CreateBr(merge_bb);
+
+        // Merge and fold in the preempt bit (0x40): set when a cooperative
+        // yield is pending (preempt_request, level-triggered) or when the
+        // marker's setjmp returned the preempt shootdown code - the
+        // shootdown that reset this point also set the request, but its
+        // store may race this load, so both sources are honored.
+        ctx.builder.SetInsertPoint(merge_bb);
+        PHINode *st = ctx.builder.CreatePHI(T_int8, 2);
+        st->addIncoming(ConstantInt::get(T_int8, 0), point_bb);
+        st->addIncoming(st_load, loadst_bb);
+        Value *is_preempt_code = ctx.builder.CreateICmpEQ(marker,
+            ConstantInt::get(getInt32Ty(ctx.builder.getContext()), JL_RESET_CODE_PREEMPT));
+        Value *preempt_ptr = emit_ptrgep(ctx, ct, offsetof(jl_task_t, preempt_request), "preempt_request");
+        LoadInst *preempt = ctx.builder.CreateAlignedLoad(T_int8, preempt_ptr, Align(1));
+        preempt->setOrdering(AtomicOrdering::Monotonic);
+        ai.decorateInst(preempt);
+        Value *has_preempt = ctx.builder.CreateOr(is_preempt_code,
+            ctx.builder.CreateICmpNE(preempt, ConstantInt::get(T_int8, 0)));
+        Value *pbit = ctx.builder.CreateSelect(has_preempt, ConstantInt::get(T_int8, 0x40), ConstantInt::get(T_int8, 0));
+        Value *result = ctx.builder.CreateOr(st, pbit);
+
+        *ret = mark_julia_type(ctx, result, /*boxed*/ false, (jl_value_t*)jl_uint8_type);
+        return true;
+    }
+
     return false;
 }
 
@@ -5465,6 +5620,10 @@ static CallInst *emit_jlcall(jl_codectx_t &ctx, Value *theFptr, Value *theF,
     }
     CallInst *result = ctx.builder.CreateCall(TheTrampoline, theArgs);
     result->setAttributes(TheTrampoline->getAttributes());
+    // N.B.: no julia.reset_safe tag here even for reset_safe statements: the
+    // jlcall trampoline is implicitly-inserted runtime machinery (dispatch,
+    // builtin fallbacks), not covered by the statement's IPO contract, and
+    // CancellationLowering treats it as an unsafe point regardless.
     // TODO: we could add readonly attributes in many cases to the args
     return result;
 }
@@ -5586,6 +5745,14 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
         call->setCallingConv(CallingConv::Swift);
     if (returninfo.effects != 0)
         add_fn_attrs_for_effects(call, returninfo.effects);
+    // Mark as reset_safe only if the current statement has that flag AND the
+    // invoked code's own IPO effects agree: the statement flag may stem from
+    // a constant-propagation refinement stronger than the generic code being
+    // invoked here, and only callees whose own effects are reset_safe have
+    // their implicit runtime machinery instrumented to participate in a
+    // spanned reset region (see llvm-cancellation-lowering.cpp).
+    if (effects_ipo_reset_safe(returninfo.effects))
+        mark_reset_safe(ctx, call);
 
     jl_cgval_t retval;
     switch (returninfo.cc) {
@@ -9007,6 +9174,15 @@ static jl_llvm_functions_t
         FnAttrs.addAttribute("julia-optimization-level", optLevelStrings[optlevel]);
     }
 
+    // A function whose own IPO effects are reset_safe (the same condition
+    // under which call sites to it may carry the julia.reset_safe tag) can
+    // execute inside a caller's still-published compiled reset region. Mark
+    // it so CancellationLowering instruments its implicitly-inserted runtime
+    // machinery (allocation, write barriers, runtime library calls) to
+    // eagerly drop that region; all other functions need no instrumentation.
+    if (codeinst && effects_ipo_reset_safe(jl_atomic_load_relaxed(&codeinst->ipo_purity_bits)))
+        FnAttrs.addAttribute("julia.ipo_reset_safe");
+
     ctx.f = f;
 
     // Step 4b. determine debug info signature and other type info for locals
@@ -10029,7 +10205,11 @@ static jl_llvm_functions_t
             }
         }
         else {
+            // statement-scoped context for mark_reset_safe (see its
+            // declaration); cleared like the debug location below
+            ctx.current_stmt_idx = cursor;
             emit_stmtpos(ctx, stmt, cursor);
+            ctx.current_stmt_idx = -1;
             mallocVisitStmt(nullptr, have_dbg_update);
         }
         find_next_stmt(cursor + 1);

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -166,6 +166,10 @@ void schedule_finalization(void *o, void *f) JL_NOTSAFEPOINT
     jl_atomic_store_relaxed(&jl_gc_have_pending_finalizers, 1);
 }
 
+// see their definitions in the reset-safe allocation section below
+STATIC_INLINE jl_reset_ctx_t *reset_region_unpublish(jl_task_t *ct) JL_NOTSAFEPOINT;
+STATIC_INLINE void reset_region_republish(jl_task_t *ct, jl_reset_ctx_t *reset_ctx);
+
 void run_finalizer(jl_task_t *ct, void *o, void *ff)
 {
     int ptr_finalizer = gc_ptr_tag(o, GC_FIN_CFUNC_TAG);
@@ -258,6 +262,15 @@ static void jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NO
     // Avoid marking `ct` as non-migratable via an `@async` task (as noted in the docstring
     // of `finalizer`) in a finalizer:
     uint8_t sticky = ct->sticky;
+    // Finalizers hijack the current task, so like `sticky` and the RNG its
+    // cancellation state is bracketed: unpublish the reset region (finalizer
+    // frames must not be abandoned into it) and stash the token binding,
+    // which the finalizers' own cancellation points may rebind. Both are
+    // restored below; the republish performs any delivery that was missed
+    // while the region was unpublished.
+    jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
+    jl_value_t *bound_token = jl_atomic_load_relaxed(&ct->bound_cancel_token);
+    JL_GC_PUSH1(&bound_token);
     // empty out the first two entries for the GC frame
     arraylist_push(list, list->items[0]);
     arraylist_push(list, list->items[1]);
@@ -273,6 +286,10 @@ static void jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NO
     // matches the jl_gc_push_arraylist above
     JL_GC_POP();
     ct->sticky = sticky;
+    jl_atomic_store_relaxed(&ct->bound_cancel_token, bound_token);
+    jl_gc_wb_current_task(ct, bound_token);
+    JL_GC_POP(); // matches the JL_GC_PUSH1 above
+    reset_region_republish(ct, reset_ctx);
 }
 
 static uint64_t finalizer_rngState[JL_RNG_SIZE];
@@ -539,6 +556,95 @@ JL_DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz) JL_CANSAFEPOINT
 {
     jl_ptls_t ptls = jl_current_task->ptls;
     return jl_gc_alloc(ptls, sz, NULL);
+}
+
+// Reset-safe variants of the allocation and write-barrier entry points,
+// selected by FinalLowerGC for sites that may execute inside a published
+// cancellation reset region (see llvm-cancellation-lowering.cpp): the
+// region is unpublished around the operation - its internal frames must not
+// be abandoned by a delivered reset - and republished on the way out, so a
+// region survives allocation. The allocating variants write the object tag
+// before republishing, since the compiler's own tag store only happens
+// after the call returns and (stock) sweep reads every cell's header. No
+// safepoint lies between allocation and either tag store, so marking can
+// never observe an untagged live cell; a reset-abandoned cell is fully
+// tagged and merely unreachable.
+STATIC_INLINE jl_reset_ctx_t *reset_region_unpublish(jl_task_t *ct) JL_NOTSAFEPOINT
+{
+    jl_reset_ctx_t *reset_ctx = jl_atomic_load_relaxed(&ct->reset_ctx);
+    jl_atomic_store_relaxed(&ct->reset_ctx, NULL);
+    // synchronizes with the read of reset_ctx in the signal handler
+    jl_signal_fence();
+    return reset_ctx;
+}
+
+STATIC_INLINE void reset_region_republish(jl_task_t *ct, jl_reset_ctx_t *reset_ctx)
+{
+    jl_signal_fence();
+    jl_atomic_store_release(&ct->reset_ctx, reset_ctx);
+    if (reset_ctx == NULL)
+        return;
+    // A cancellation that arrived while the region was unpublished found no
+    // reset context and was dropped, and the code we return into may never
+    // poll. Re-check the region's governing source (republish first, so an
+    // arrival in between is the sender's to handle) and perform the missed
+    // delivery ourselves: the synchronous analog of the request-5 reset in
+    // signals-unix.c, with the exchange arbitrating against concurrent
+    // senders. bound_cancel_token is the region's governor here: everything
+    // that could have rebound it while the region was unpublished (nested
+    // cancellation points in finalizers, exception handlers) restores it
+    // together with the region.
+    jl_value_t *bound = jl_atomic_load_relaxed(&ct->bound_cancel_token);
+    if (bound == NULL || bound == jl_nothing ||
+        jl_atomic_load_relaxed(&((jl_cancel_source_t*)bound)->state) == 0)
+        return;
+    reset_ctx = jl_atomic_exchange(&ct->reset_ctx, NULL);
+    if (reset_ctx == NULL || reset_ctx->sp == 0)
+        return;
+    ct->gcstack = reset_ctx->gcstack;
+    ct->eh = reset_ctx->eh;
+    asan_unpoison_task_stack(ct, &reset_ctx->mctx);
+    jl_longjmp(reset_ctx->mctx, JL_RESET_CODE_CANCEL);
+}
+
+JL_DLLEXPORT jl_value_t *jl_gc_small_alloc_reset_safe(jl_ptls_t ptls, int offset, int osize,
+                                                      jl_value_t *type) JL_CANSAFEPOINT
+{
+    jl_task_t *ct = jl_atomic_load_relaxed(&ptls->current_task);
+    jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
+    jl_value_t *val = jl_gc_small_alloc(ptls, offset, osize, type);
+    jl_set_typeof(val, type);
+    reset_region_republish(ct, reset_ctx);
+    return val;
+}
+
+JL_DLLEXPORT jl_value_t *jl_gc_big_alloc_reset_safe(jl_ptls_t ptls, size_t sz,
+                                                    jl_value_t *type) JL_CANSAFEPOINT
+{
+    jl_task_t *ct = jl_atomic_load_relaxed(&ptls->current_task);
+    jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
+    jl_value_t *val = jl_gc_big_alloc(ptls, sz, type);
+    jl_set_typeof(val, type);
+    reset_region_republish(ct, reset_ctx);
+    return val;
+}
+
+JL_DLLEXPORT void *jl_gc_alloc_typed_reset_safe(jl_ptls_t ptls, size_t sz, void *ty) JL_CANSAFEPOINT
+{
+    jl_task_t *ct = jl_atomic_load_relaxed(&ptls->current_task);
+    jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
+    // jl_gc_alloc_typed writes the tag itself
+    void *val = jl_gc_alloc_typed(ptls, sz, ty);
+    reset_region_republish(ct, reset_ctx);
+    return val;
+}
+
+JL_DLLEXPORT void jl_gc_queue_root_reset_safe(const jl_value_t *ptr)
+{
+    jl_task_t *ct = jl_current_task;
+    jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
+    jl_gc_queue_root(ptr);
+    reset_region_republish(ct, reset_ctx);
 }
 
 // allocator entry points

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -224,6 +224,20 @@ JL_DLLEXPORT struct _jl_value_t *jl_gc_small_alloc(struct _jl_tls_states_t *ptls
 // allocation of that type in the allocation profiler.
 JL_DLLEXPORT struct _jl_value_t *jl_gc_big_alloc(struct _jl_tls_states_t *ptls, size_t sz,
                                                  struct _jl_value_t *type) JL_CANSAFEPOINT;
+// Reset-safe variants of jl_gc_small_alloc/jl_gc_big_alloc/jl_gc_alloc_typed/
+// jl_gc_queue_root, selected by the compiler for code that may run inside a
+// published cancellation reset region: they unpublish the current task's
+// reset context around the operation (whose internal frames must never be
+// abandoned by an asynchronously delivered reset), write the object tag, and
+// republish it on the way out. Implemented generically in gc-common.c.
+JL_DLLEXPORT struct _jl_value_t *jl_gc_small_alloc_reset_safe(struct _jl_tls_states_t *ptls,
+                                                              int offset, int osize,
+                                                              struct _jl_value_t *type) JL_CANSAFEPOINT;
+JL_DLLEXPORT struct _jl_value_t *jl_gc_big_alloc_reset_safe(struct _jl_tls_states_t *ptls, size_t sz,
+                                                            struct _jl_value_t *type) JL_CANSAFEPOINT;
+JL_DLLEXPORT void *jl_gc_alloc_typed_reset_safe(struct _jl_tls_states_t *ptls, size_t sz,
+                                                void *ty) JL_CANSAFEPOINT;
+JL_DLLEXPORT void jl_gc_queue_root_reset_safe(const struct _jl_value_t *ptr);
 // Wrapper around Libc malloc that updates Julia allocation counters.
 JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz) JL_CANSAFEPOINT;
 // Wrapper around Libc calloc that updates Julia allocation counters.

--- a/src/gc-mmtk/llvm-final-gc-lowering-mmtk.cpp
+++ b/src/gc-mmtk/llvm-final-gc-lowering-mmtk.cpp
@@ -13,6 +13,17 @@ Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
     IRBuilder<> builder(target);
     auto ptls = target->getArgOperand(0);
     auto type = target->getArgOperand(2);
+    // Sites that may execute with a cancellation reset region published
+    // (annotated by CancellationLowering) take their slow paths through the
+    // reset-safe entry points, which unpublish/republish the region
+    // themselves. The inline fastpath below is safe to span as-is: it only
+    // loads, bumps the cursor, and updates the allocation counter - a
+    // delivered reset can at worst abandon an unreferenced, still-untagged
+    // hole in the bump region and skew the allocation counter. Marking is
+    // not confused by the late tag store: it never reads headers of
+    // unreachable memory (sweep is line-liveness based), and on the normal
+    // path no safepoint lies between allocation and the tag store.
+    bool resetSafe = target->hasMetadata("julia.reset_region");
     uint64_t derefBytes = 0;
     if (auto CI = dyn_cast<ConstantInt>(target->getArgOperand(1))) {
         size_t sz = (size_t)CI->getZExtValue();
@@ -21,7 +32,7 @@ Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
         int offset = jl_gc_classify_pools(sz, &osize);
         if (offset < 0) {
             newI = builder.CreateCall(
-                bigAllocFunc,
+                resetSafe ? bigAllocResetSafeFunc : bigAllocFunc,
                 { ptls, ConstantInt::get(T_size, sz + sizeof(void*)), type });
             if (sz > 0)
                 derefBytes = sz;
@@ -78,7 +89,8 @@ Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
                 // slowpath
                 builder.SetInsertPoint(slowpath);
                 auto pool_offs = ConstantInt::get(Type::getInt32Ty(F.getContext()), 1);
-                auto new_call = builder.CreateCall(smallAllocFunc, { ptls, pool_offs, pool_osize_i32, type });
+                auto new_call = builder.CreateCall(resetSafe ? smallAllocResetSafeFunc : smallAllocFunc,
+                                                   { ptls, pool_offs, pool_osize_i32, type });
                 new_call->setAttributes(new_call->getCalledFunction()->getAttributes());
                 builder.CreateBr(next_instr->getParent());
 
@@ -106,7 +118,7 @@ Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
     } else {
         auto size = builder.CreateZExtOrTrunc(target->getArgOperand(1), T_size);
         // allocTypedFunc does not include the type tag in the allocation size!
-        newI = builder.CreateCall(allocTypedFunc, { ptls, size, type });
+        newI = builder.CreateCall(resetSafe ? allocTypedResetSafeFunc : allocTypedFunc, { ptls, size, type });
         derefBytes = sizeof(void*);
     }
     newI->setAttributes(newI->getCalledFunction()->getAttributes());
@@ -172,10 +184,16 @@ void FinalLowerGC::lowerWriteBarrier(CallInst *target, Function &F) {
 
             auto mayTriggerSlowpath = SplitBlockAndInsertIfThen(is_unlogged, target, false, MDB.createBranchWeights(Weights));
             builder.SetInsertPoint(mayTriggerSlowpath);
-            builder.CreateCall(getOrDeclare(jl_intrinsics::queueGCRoot), { parent });
+            auto qr = builder.CreateCall(getOrDeclare(jl_intrinsics::queueGCRoot), { parent });
+            // Propagate CancellationLowering's reset-region annotation so
+            // lowerQueueGCRoot selects the reset-safe entry.
+            if (auto *MD = target->getMetadata("julia.reset_region"))
+                qr->setMetadata("julia.reset_region", MD);
         } else {
             Function *wb_func = getOrDeclare(jl_intrinsics::queueGCRoot);
-            builder.CreateCall(wb_func, { parent });
+            auto qr = builder.CreateCall(wb_func, { parent });
+            if (auto *MD = target->getMetadata("julia.reset_region"))
+                qr->setMetadata("julia.reset_region", MD);
         }
     } else {
         // Using a plan that does not need write barriers

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -84,6 +84,15 @@ void addTargetPasses(legacy::PassManagerBase *PM, const Triple &triple, TargetIR
 GlobalVariable *jl_emit_RTLD_DEFAULT_var(Module *M) JL_NOTSAFEPOINT;
 DataLayout jl_create_datalayout(TargetMachine &TM) JL_NOTSAFEPOINT;
 
+// N.B.: kept in sync with Compiler/src/effects.jl (encode_effects); 0 means
+// "no recorded effects" and is treated conservatively.
+inline bool effects_ipo_reset_safe(uint32_t effects) JL_NOTSAFEPOINT
+{
+    return effects != 0 &&
+           ((effects >> 3) & 0x03u) == 0u && // is_effect_free
+           ((effects >> 15) & 0x03u) == 0u;  // is_reset_safe
+}
+
 // Translate Julia's inferred ipo_purity_bits into LLVM function attributes.
 // Optimistic attrs (memory(argmem: read), readnone on gcstack) are added for
 // pre-GC passes; LateLowerGCFrame widens them before safepoint analysis.

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -138,7 +138,9 @@
     XX(jl_gc_add_quiescent) \
     XX(jl_gc_allocobj) \
     XX(jl_gc_alloc_typed) \
+    XX(jl_gc_alloc_typed_reset_safe) \
     XX(jl_gc_big_alloc) \
+    XX(jl_gc_big_alloc_reset_safe) \
     XX(jl_gc_collect) \
     XX(jl_gc_conservative_gc_support_enabled) \
     XX(jl_gc_counted_calloc) \
@@ -165,8 +167,10 @@
     XX(jl_gc_new_weakref_th) \
     XX(jl_gc_num) \
     XX(jl_gc_small_alloc) \
+    XX(jl_gc_small_alloc_reset_safe) \
     XX(jl_gc_queue_multiroot) \
     XX(jl_gc_queue_root) \
+    XX(jl_gc_queue_root_reset_safe) \
     XX(jl_gc_safepoint) \
     XX(jl_gc_schedule_foreign_sweepfunc) \
     XX(jl_gc_set_cb_notify_external_alloc) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4343,7 +4343,7 @@ void jl_init_types(void) JL_GC_DISABLED
                         NULL,
                         jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(30,
+                        jl_perm_symsvec(31,
                                         "next",
                                         "queue",
                                         "storage",
@@ -4355,7 +4355,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                         "sticky",
                                         "priority",
                                         "_isexception",
-                                        "pad00",
+                                        "preempt_request",
                                         "pad01",
                                         "pad02",
                                         "rngState0",
@@ -4373,8 +4373,9 @@ void jl_init_types(void) JL_GC_DISABLED
                                         "finished_at",
                                         "waiting_on",
                                         "cached_wait_entry",
-                                        "invoked"),
-                        jl_svec(30,
+                                        "invoked",
+                                        "bound_cancel_token"),
+                        jl_svec(31,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
@@ -4404,6 +4405,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                 jl_uint64_type,
                                 jl_any_type,
                                 jl_any_type,
+                                jl_any_type,
                                 jl_any_type),
                         jl_emptysvec,
                         0, 1, 6);
@@ -4411,9 +4413,10 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);
     // Set field 20 (metrics_enabled) as const
-    // Set fields 8 (_state), 24-27 (metric counters) and 28 (waiting_on) as atomic
-    const static uint32_t task_constfields[1]  = { 0b00000000000010000000000000000000 };
-    const static uint32_t task_atomicfields[1] = { 0b00001111100000000000000010000000 };
+    // Set fields 8 (_state), 12 (preempt_request), 24-27 (metric counters),
+    // 28 (waiting_on) and 31 (bound_cancel_token) as atomic
+    const static uint32_t task_constfields[1]  = { 0b0000000000010000000000000000000 };
+    const static uint32_t task_atomicfields[1] = { 0b1001111100000000000100010000000 };
     jl_task_type->name->constfields = task_constfields;
     jl_task_type->name->atomicfields = task_atomicfields;
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -2566,6 +2566,9 @@ JL_DLLEXPORT void jl_cancel_source_relink(jl_cancel_source_t *src) JL_NOTSAFEPOI
 JL_DLLEXPORT void jl_switchto(jl_task_t **pt) JL_CANSAFEPOINT_ENTER_LEAVE;
 JL_DLLEXPORT int jl_set_task_tid(jl_task_t *task, int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_set_task_threadpoolid(jl_task_t *task, int8_t tpid) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_send_cancellation_signal(int16_t tid) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_send_preempt_signal(int16_t tid) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_shootdown_cancelled_tasks(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow_other(jl_value_t *e JL_MAYBE_UNROOTED);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2540,6 +2540,16 @@ struct _jl_handler_t {
     size_t locks_len;
     jl_timing_block_t *timing_stack;
     size_t world_age;
+    // The published reset context and its governing token binding at handler
+    // entry. Restored together when the handler is left or entered
+    // exceptionally, so that an exception thrown out of a reset region does
+    // not leave a context dangling whose establishing frame the unwind
+    // destroyed, and a republished region is never paired with a token that
+    // nested cancellation points rebound in the meantime. (The token is kept
+    // alive by the reachability contract on `Core.cancellation_point!`; the
+    // handler chain is not GC-scanned.)
+    struct _jl_reset_ctx_t *reset_ctx;
+    jl_value_t *bound_cancel_token;
     sig_atomic_t defer_signal;
     int8_t gc_state;
 };

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2158,6 +2158,12 @@ JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL
 JL_DLLEXPORT NOINLINE int failed_to_sample_task_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
 JL_DLLEXPORT NOINLINE int failed_to_stop_thread_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
 int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT;
+
+// Values a compiled cancellation reset point's setjmp returns when a
+// shootdown is delivered to it (the longjmp value; see
+// llvm-cancellation-lowering.cpp and the deliveries in signals-*.c):
+#define JL_RESET_CODE_CANCEL  1 // the region's governing source was cancelled
+#define JL_RESET_CODE_PREEMPT 2 // cooperative yield requested; no source checked
 void export_jl_small_typeof(void);
 void export_jl_sysimg_globals(void);
 
@@ -2216,6 +2222,8 @@ JL_DLLEXPORT uint32_t jl_crc32c(uint32_t crc, const char *buf, size_t len);
 // -- exports from codegen -- //
 
 #define IR_FLAG_INBOUNDS 0x01
+// This statement is proven :reset_safe (sync with Compiler/src/optimize.jl)
+#define IR_FLAG_RESET_SAFE (1 << 14)
 
 JL_DLLIMPORT void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec) JL_CANSAFEPOINT;
 JL_DLLIMPORT int jl_compile_codeinst(jl_code_instance_t *unspec) JL_CANSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2157,7 +2157,7 @@ JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) 
 JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT NOINLINE int failed_to_sample_task_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
 JL_DLLEXPORT NOINLINE int failed_to_stop_thread_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
-int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT;
+int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOINT;
 
 // Values a compiled cancellation reset point's setjmp returns when a
 // shootdown is delivered to it (the longjmp value; see

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -105,6 +105,36 @@ typedef struct {
 #endif
 } jl_ucontext_t;
 
+// The context published while a task is inside an asynchronously
+// interruptible region (`jl_task_t.reset_ctx`): established by a compiled
+// cancellation point (see llvm-cancellation-lowering.cpp), `mctx` holds a
+// setjmp context and `sp` identifies the establishing frame (nonzero for
+// this reset flavor; the discriminator leaves room for other context
+// flavors to be published through the same mechanism). The runtime may
+// deliver a pending cancellation to a running task by abandoning the
+// interrupted register state and longjmping to the reset point, whose
+// re-executed check observes the cancellation and throws (see the SIGUSR2
+// request-5 delivery in signals-unix.c and the suspend-based delivery in
+// signals-win.c).
+//
+// `gcstack` and `eh` record the task's GC-frame chain head and innermost
+// exception handler at establishment. The interrupt may land inside a
+// reset-safe *callee* that has pushed frames of its own onto either chain;
+// those frames die with the abandoned stack region, so delivery restores
+// both saved values before the longjmp (the same pair an exceptional unwind
+// restores through `jl_eh_restore_state`).
+//
+// Delivery is gated on the cancellation of the task's bound token source
+// (`jl_task_t.bound_cancel_token`), which is coherent with the published
+// region by construction: everything that temporarily takes over the task
+// and may rebind it - exception handlers, the finalizer bracket in
+// gc-common.c - saves and restores the (region, token) pair together.
+typedef struct _jl_reset_ctx_t {
+    uintptr_t sp;
+    struct _jl_gcframe_t *gcstack;
+    struct _jl_handler_t *eh;
+    jl_jmp_buf mctx;
+} jl_reset_ctx_t;
 
 // handle to reference an OS thread
 #ifdef _OS_WINDOWS_
@@ -327,7 +357,11 @@ typedef struct _jl_task_t {
     uint8_t sticky; // record whether this Task can be migrated to a new thread
     uint16_t priority;
     _Atomic(uint8_t) _isexception; // set if `result` is an exception to throw or that we exited with
-    uint8_t pad0[3];
+    // Level-triggered cooperative-yield request, honored (and cleared) at
+    // the task's next cancellation point; a preempt shootdown sets it and
+    // kicks the task out of any published reset region.
+    _Atomic(uint8_t) preempt_request;
+    uint8_t pad0[2];
     // === 64 bytes (cache line)
     uint64_t rngState[JL_RNG_SIZE];
     // flag indicating whether or not to record timing metrics for this task
@@ -352,6 +386,13 @@ typedef struct _jl_task_t {
     // common single-registration park does not allocate. Owned by this task.
     jl_value_t *cached_wait_entry;
     jl_value_t *invoked; // Method/CodeInstance/tuple Type for optimized task invocation
+    // The cancellation token source last published by a cancellation point on
+    // this task ("the token governing the compute currently running here").
+    // `nothing`, or a `Core.CancellationTokenSource`. Read by cancellers
+    // scanning for running computations governed by a cancelled subtree; may
+    // be stale between cancellation points (benign: level-triggered recovery
+    // at the next check).
+    _Atomic(jl_value_t *) bound_cancel_token;
 
 // hidden state:
 
@@ -381,6 +422,10 @@ typedef struct _jl_task_t {
     jl_handler_t *eh;
     // saved thread state
     jl_ucontext_t ctx; // pointer into stkbuf, if suspended
+    // The published reset (sp != 0) context of the current compiled
+    // cancellation region, NULL outside such regions. Only ever consumed
+    // for the thread's *current* task.
+    _Atomic(jl_reset_ctx_t *) reset_ctx;
 } jl_task_t;
 
 JL_DLLEXPORT void *jl_get_ptls_states(void);

--- a/src/llvm-cancellation-lowering.cpp
+++ b/src/llvm-cancellation-lowering.cpp
@@ -1,0 +1,654 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// This pass lowers the julia.cancellation_point intrinsic to:
+// 1. A stack buffer allocation for a jl_reset_ctx_t
+// 2. Saves of the task's gcstack and eh into the buffer
+// 3. A setjmp call on the buffer's mctx field
+// 4. Assignment of the buffer address to task->reset_ctx (atomic release)
+//
+// It also walks the function to find stores/calls without julia.reset_safe
+// metadata and inserts reset_ctx = NULL before them.
+//
+// Additionally, the pass runs on every function codegen marked with the
+// julia.ipo_reset_safe attribute (its own IPO effects are reset_safe - the
+// same condition under which call sites to it may be tagged), even when it
+// contains no cancellation point itself: such a function may execute inside
+// a caller's reset region that was kept open across a reset_safe call.
+// Machinery the runtime inserts implicitly (runtime library calls, dynamic
+// dispatch) is not part of the IPO contract that justified the tag - its
+// frames (malloc, exception setup, the JIT) must never be abandoned by a
+// delivered reset - so every such call (and every call not itself tagged
+// reset_safe) eagerly drops the published reset context; the caller's next
+// cancellation point re-establishes the region (delivery is
+// level-triggered). Allocations and write barriers are the exception: the
+// pass annotates each such site that may execute with a region published
+// (julia.reset_region metadata), and FinalLowerGC lowers those sites to
+// *_reset_safe runtime entry points that unpublish/republish the region
+// themselves, so they need no per-site drop and the region even survives
+// them. Functions that are not reset_safe need no instrumentation: no reset
+// region can be open while they run.
+
+#include "llvm-version.h"
+#include "passes.h"
+
+#include <llvm/ADT/SmallPtrSet.h>
+#include <llvm/IR/CFG.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/IntrinsicInst.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/Support/Debug.h>
+#include <llvm/ADT/Statistic.h>
+#include <llvm/TargetParser/Triple.h>
+
+#include "llvm-codegen-shared.h"
+#include "llvm-pass-helpers.h"
+#include "julia.h"
+#include "julia_internal.h"
+#include "julia_threads.h"
+
+#define DEBUG_TYPE "cancellation_lowering"
+
+STATISTIC(CancellationPointsLowered, "Number of cancellation points lowered");
+STATISTIC(ResetCtxClearsInserted, "Number of reset_ctx clears inserted");
+
+using namespace llvm;
+
+// Check if an instruction has the julia.reset_safe metadata
+static bool hasResetSafeMetadata(Instruction *I) {
+    return I->getMetadata("julia.reset_safe") != nullptr;
+}
+
+// Mark an instruction created by this pass as reset-safe, so the unsafe-point
+// walk does not treat the pass's own reset_ctx bookkeeping as program state
+// that a reset could tear.
+static void setResetSafeMetadata(Instruction *I) {
+    I->setMetadata("julia.reset_safe", MDNode::get(I->getContext(), {}));
+}
+
+// Machinery that codegen/the runtime inserts implicitly - calls into the
+// runtime library (boxing, error throws, generic dispatch, exception-stack
+// manipulation, ...) - is not part of the IPO contract that lets inference
+// tag a statement reset_safe, and the runtime-internal frames implementing
+// it (malloc, exception setup, the JIT) must never be abandoned by a
+// delivered reset. Such calls eagerly drop the published reset context in
+// every function, even where the covering source statement was proven
+// reset-safe. (Interrupt-safe insertions - the GC safepoint, pure address
+// computations - are exempted by the callers of this predicate, and
+// allocations/write barriers are handled by the *_reset_safe runtime entry
+// points selected in FinalLowerGC instead.)
+static bool isImplicitRuntimeCall(CallInst *CI) {
+    Function *Callee = CI->getCalledFunction();
+    if (!Callee || Callee->isIntrinsic())
+        return false;
+    StringRef Name = Callee->getName();
+    if (Name.starts_with("julia.call"))
+        return true;
+    // The setjmp calls emitted for exception handlers (and by this pass) are
+    // pure register/buffer saves.
+    if (Name == jl_setjmp_name)
+        return false;
+    // Runtime library helpers. This deliberately over-approximates (it also
+    // matches explicit ccalls into libjulia): dropping the region around a
+    // call that did not need it only delays delivery, never breaks it.
+    return Name.starts_with("ijl_") || Name.starts_with("jl_");
+}
+
+namespace {
+
+struct CancellationLowering {
+    Function *cancel_point_func;
+    Value *pgcstack;
+    Value *reset_ctx_ptr;  // Computed once in entry block, dominates all uses
+    Value *ptls_field_ptr; // Pointer to task->ptls, computed alongside reset_ctx_ptr
+    Value *eh_field_ptr;   // Pointer to task->eh, computed alongside reset_ctx_ptr
+
+    CancellationLowering(Module &M) : cancel_point_func(nullptr), pgcstack(nullptr), reset_ctx_ptr(nullptr), ptls_field_ptr(nullptr), eh_field_ptr(nullptr) {
+        cancel_point_func = M.getFunction("julia.cancellation_point");
+    }
+
+    bool runOnFunction(Function &F);
+
+private:
+    // Compute reset_ctx_ptr once in entry block
+    // If insertAfter is provided, insert after that instruction
+    // Otherwise insert at the beginning of the entry block (after allocas)
+    void computeResetCtxPtr(Function &F, Instruction *insertAfter);
+};
+
+void CancellationLowering::computeResetCtxPtr(Function &F, Instruction *insertAfter) {
+    if (!pgcstack)
+        return;
+
+    LLVMContext &LLVMCtx = F.getContext();
+    Type *I8Ty = Type::getInt8Ty(LLVMCtx);
+    Type *I64Ty = Type::getInt64Ty(LLVMCtx);
+
+    IRBuilder<> Builder(LLVMCtx);
+    if (insertAfter) {
+        // Insert right after pgcstack call
+        Builder.SetInsertPoint(insertAfter->getNextNode());
+    } else {
+        // pgcstack is an argument, insert at the start of entry block
+        // but after any allocas
+        BasicBlock &entry = F.getEntryBlock();
+        BasicBlock::iterator insertPt = entry.begin();
+        while (insertPt != entry.end() && isa<AllocaInst>(&*insertPt)) {
+            ++insertPt;
+        }
+        Builder.SetInsertPoint(&entry, insertPt);
+    }
+
+    // Get the offset of gcstack in jl_task_t
+    size_t gcstack_offset = offsetof(jl_task_t, gcstack);
+
+    Value *task_ptr = Builder.CreateGEP(I8Ty, pgcstack,
+                                        ConstantInt::get(I64Ty, -(int64_t)gcstack_offset),
+                                        "current_task");
+
+    // Get pointer to reset_ctx field in current task
+    size_t reset_ctx_offset = offsetof(jl_task_t, reset_ctx);
+
+    reset_ctx_ptr = Builder.CreateGEP(I8Ty, task_ptr,
+                                       ConstantInt::get(I64Ty, reset_ctx_offset),
+                                       "reset_ctx_ptr");
+
+    ptls_field_ptr = Builder.CreateGEP(I8Ty, task_ptr,
+                                       ConstantInt::get(I64Ty, offsetof(jl_task_t, ptls)),
+                                       "ptls_field_ptr");
+
+    eh_field_ptr = Builder.CreateGEP(I8Ty, task_ptr,
+                                     ConstantInt::get(I64Ty, offsetof(jl_task_t, eh)),
+                                     "eh_field_ptr");
+}
+
+bool CancellationLowering::runOnFunction(Function &F) {
+    bool Changed = false;
+
+    // Find pgcstack - either as a call to julia.get_pgcstack or as an argument with "gcstack" attribute
+    pgcstack = nullptr;
+    reset_ctx_ptr = nullptr;
+    eh_field_ptr = nullptr;
+    Instruction *pgcstack_inst = nullptr;  // Only set if pgcstack is from a call, not an argument
+    Function *pgcstack_getter = F.getParent()->getFunction("julia.get_pgcstack");
+    Function *adoptthread_func = F.getParent()->getFunction("julia.get_pgcstack_or_new");
+    if (pgcstack_getter || adoptthread_func) {
+        for (auto &I : F.getEntryBlock()) {
+            if (CallInst *callInst = dyn_cast<CallInst>(&I)) {
+                Value *callee = callInst->getCalledOperand();
+                if ((pgcstack_getter && callee == pgcstack_getter) ||
+                    (adoptthread_func && callee == adoptthread_func)) {
+                    pgcstack = callInst;
+                    pgcstack_inst = callInst;
+                    break;
+                }
+            }
+        }
+    }
+    // If not found via call, check for argument with "gcstack" attribute
+    if (!pgcstack) {
+        for (auto &arg : F.args()) {
+            AttributeSet attrs = F.getAttributes().getParamAttrs(arg.getArgNo());
+            if (attrs.hasAttribute("gcstack")) {
+                pgcstack = &arg;
+                break;
+            }
+        }
+    }
+
+    // First, find all cancellation_point intrinsics (walking the users of
+    // the declaration rather than every instruction of the function)
+    SmallVector<CallInst*, 4> CancellationPoints;
+
+    if (cancel_point_func) {
+        for (User *U : cancel_point_func->users()) {
+            if (auto *CI = dyn_cast<CallInst>(U)) {
+                if (CI->getFunction() == &F &&
+                    CI->getCalledOperand() == cancel_point_func)
+                    CancellationPoints.push_back(CI);
+            }
+        }
+    }
+
+    // A function without cancellation points of its own still participates
+    // when codegen marked it julia.ipo_reset_safe: it may run inside a
+    // caller's reset region (kept open across a reset_safe call), so its
+    // implicitly-inserted runtime machinery and untagged calls must eagerly
+    // drop the region. Any other function can never run inside an open
+    // region and needs no instrumentation. (Without access to the task
+    // pointer nothing can be done either - but then the function cannot
+    // contain the operations that need dropping.)
+    bool instrumented = !CancellationPoints.empty();
+    if (!instrumented && (!pgcstack || !F.hasFnAttribute("julia.ipo_reset_safe")))
+        return false;
+
+    // Sanitizer instrumentation runs AFTER this pass (see addSanitizerPasses
+    // in pipeline.cpp) and rewrites stores into sanitizer runtime calls -
+    // including this pass's own reset_ctx bookkeeping - inside code already
+    // classified as reset-safe. A delivered reset could then abandon a
+    // sanitizer runtime frame, whose bookkeeping cannot be repaired since
+    // Julia bypasses the sanitizers' longjmp interceptors (see jl_longjmp in
+    // julia.h). Under TSan, do not establish reset regions at all: lower
+    // cancellation points to a plain safepoint + status check (delivery
+    // degrades to level-triggered polling).
+    bool no_publish = F.hasFnAttribute(Attribute::SanitizeThread);
+    if (no_publish && !instrumented)
+        return false;
+
+
+    // Compute reset_ctx_ptr once in entry block (dominates all uses)
+    // pgcstack_inst is set when pgcstack comes from a call; null when it's an argument
+    if (instrumented)
+        computeResetCtxPtr(F, pgcstack_inst);
+
+    // Lower each cancellation point, remembering each region's publication
+    // for the reachability computation below
+    SmallVector<Instruction*, 4> PointPublishes;
+    for (CallInst *CI : CancellationPoints) {
+        ++CancellationPointsLowered;
+        Changed = true;
+
+        IRBuilder<> Builder(CI);
+        LLVMContext &LLVMCtx = F.getContext();
+        Type *I8Ty = Type::getInt8Ty(LLVMCtx);
+        Type *I32Ty = Type::getInt32Ty(LLVMCtx);
+        Type *I64Ty = Type::getInt64Ty(LLVMCtx);
+        Type *PtrTy = PointerType::getUnqual(LLVMCtx);
+
+        // Codegen materializes the current task before emitting the marker,
+        // so a function containing a cancellation point always has a
+        // pgcstack; silently folding the point away would swallow
+        // cancellation.
+        assert(reset_ctx_ptr && "julia.cancellation_point in a function without pgcstack");
+
+        if (no_publish) {
+            // A cancellation point remains a GC safepoint and a poll even
+            // without a reset region.
+            Value *ptls = Builder.CreateAlignedLoad(PtrTy, ptls_field_ptr, Align(sizeof(void*)), "ptls");
+            Type *T_size = F.getParent()->getDataLayout().getIntPtrType(LLVMCtx);
+            emit_gc_safepoint(Builder, T_size, ptls, nullptr, false);
+            CI->replaceAllUsesWith(ConstantInt::get(I32Ty, 0));
+            CI->eraseFromParent();
+            continue;
+        }
+
+        // Allocate a jl_reset_ctx_t on the stack
+        const size_t UContextSize = sizeof(jl_reset_ctx_t);
+        const size_t UContextAlign = alignof(jl_reset_ctx_t);
+
+        // Create the alloca at the start of the function
+        IRBuilder<> AllocaBuilder(&F.getEntryBlock().front());
+        Type *UContextTy = ArrayType::get(I8Ty, UContextSize);
+        AllocaInst *UContextBuf = AllocaBuilder.CreateAlloca(UContextTy, nullptr, "cancel_ucontext");
+        UContextBuf->setAlignment(Align(UContextAlign));
+
+        // N.B.: The buffer may only be published in `reset_ctx` while its
+        // contents are valid; a cancellation signal arriving in between would
+        // otherwise longjmp into garbage. Since `setjmp` below (re-)writes the
+        // buffer (cancellation points in loops re-execute it), unpublish the
+        // buffer first, then write it, then publish it. All reset_ctx stores
+        // and the buffer writes are volatile: delivery observes them
+        // asynchronously (a signal on the same thread, or a suspender), so
+        // they must be emitted exactly where placed. The single-thread
+        // (signal) fence keeps the buffer writes from being reordered above
+        // the unpublish by any later pass.
+        Value *null_ptr0 = ConstantPointerNull::get(cast<PointerType>(PtrTy));
+        StoreInst *unpub = Builder.CreateAlignedStore(null_ptr0, reset_ctx_ptr, Align(sizeof(void*)), /*isVolatile*/true);
+        unpub->setOrdering(AtomicOrdering::Release);
+        setResetSafeMetadata(unpub);
+        Builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SyncScope::SingleThread);
+
+        // A cancellation point is also a GC safepoint: code that polls for
+        // cancellation in a hot loop must not starve a stop-the-world request.
+        // This must be emitted while reset_ctx is unpublished, so that a
+        // concurrently delivered cancellation signal cannot longjmp us out of
+        // the safepoint wait.
+        Value *ptls = Builder.CreateAlignedLoad(PtrTy, ptls_field_ptr, Align(sizeof(void*)), "ptls");
+        Type *T_size = F.getParent()->getDataLayout().getIntPtrType(LLVMCtx);
+        emit_gc_safepoint(Builder, T_size, ptls, nullptr, false);
+
+        // Stamp the buffer's discriminator: a nonzero `sp` (the buffer's own
+        // frame address) marks it as a reset-flavor context (see
+        // jl_reset_ctx_t). Atomic monotonic since the delivery machinery
+        // reads it from another thread.
+        Value *sp_val = Builder.CreatePtrToInt(UContextBuf, T_size);
+        StoreInst *sp_store = Builder.CreateAlignedStore(sp_val, UContextBuf, Align(alignof(jl_reset_ctx_t)), /*isVolatile*/true);
+        sp_store->setOrdering(AtomicOrdering::Monotonic);
+        setResetSafeMetadata(sp_store);
+
+        // Record the task's GC-frame chain head and innermost exception
+        // handler at establishment: a delivered reset may interrupt a
+        // reset-safe callee that pushed frames of its own onto either chain,
+        // all of which die with the abandoned stack region, so the delivery
+        // restores both saved values before the longjmp. (pgcstack points
+        // directly at the task's gcstack field.)
+        Value *gcstack_val = Builder.CreateAlignedLoad(PtrTy, pgcstack, Align(sizeof(void*)), "saved_gcstack");
+        Value *GCStackSlot = Builder.CreateGEP(I8Ty, UContextBuf,
+                                               ConstantInt::get(I64Ty, offsetof(jl_reset_ctx_t, gcstack)),
+                                               "cancel_gcstack_slot");
+        StoreInst *gcstack_store = Builder.CreateAlignedStore(gcstack_val, GCStackSlot, Align(sizeof(void*)), /*isVolatile*/true);
+        setResetSafeMetadata(gcstack_store);
+        Value *eh_val = Builder.CreateAlignedLoad(PtrTy, eh_field_ptr, Align(sizeof(void*)), "saved_eh");
+        Value *EhSlot = Builder.CreateGEP(I8Ty, UContextBuf,
+                                          ConstantInt::get(I64Ty, offsetof(jl_reset_ctx_t, eh)),
+                                          "cancel_eh_slot");
+        StoreInst *eh_store = Builder.CreateAlignedStore(eh_val, EhSlot, Align(sizeof(void*)), /*isVolatile*/true);
+        setResetSafeMetadata(eh_store);
+
+        // Call setjmp on the mctx field.
+        // Use the platform-specific setjmp function name defined in julia.h
+        Value *MCtxPtr = Builder.CreateGEP(I8Ty, UContextBuf,
+                                           ConstantInt::get(I64Ty, offsetof(jl_reset_ctx_t, mctx)),
+                                           "cancel_mctx");
+        // Match the target-specific signature codegen uses for jl_setjmp
+        // (see setjmp_func in codegen.cpp): Windows' _setjmp variant takes
+        // only the buffer argument.
+        const Triple TT(F.getParent()->getTargetTriple());
+        FunctionType *SetjmpTy;
+        SmallVector<Value*, 2> SetjmpArgs;
+        if (TT.isOSWindows()) {
+            SetjmpTy = FunctionType::get(I32Ty, {PtrTy}, false);
+            SetjmpArgs.push_back(MCtxPtr);
+        }
+        else {
+            SetjmpTy = FunctionType::get(I32Ty, {PtrTy, I32Ty}, false);
+            SetjmpArgs.push_back(MCtxPtr);
+            SetjmpArgs.push_back(ConstantInt::get(I32Ty, 0));
+        }
+        FunctionCallee SetjmpFn = F.getParent()->getOrInsertFunction(jl_setjmp_name, SetjmpTy);
+
+        CallInst *SetjmpCall = Builder.CreateCall(SetjmpFn, SetjmpArgs);
+        SetjmpCall->addFnAttr(Attribute::ReturnsTwice);
+
+        // Publish the now-valid buffer address to reset_ctx (release, so that
+        // the buffer contents are visible before the pointer; the setjmp call
+        // itself keeps the store from moving up).
+        StoreInst *store = Builder.CreateAlignedStore(UContextBuf, reset_ctx_ptr, Align(sizeof(void*)), /*isVolatile*/true);
+        store->setOrdering(AtomicOrdering::Release);
+        setResetSafeMetadata(store);
+        PointPublishes.push_back(store);
+
+        // Replace uses and remove the intrinsic
+        CI->replaceAllUsesWith(SetjmpCall);
+        CI->eraseFromParent();
+    }
+
+    // When regions are not published (sanitizer builds), there is nothing
+    // to maintain either.
+    if (no_publish)
+        return Changed;
+
+    // A region can only be open at an instruction reachable from one of the
+    // publications (or anywhere, when the function may inherit an open
+    // region from its caller across a reset_safe call - it carries the
+    // julia.ipo_reset_safe attribute). Instructions outside that set need
+    // neither clears nor teardown nor site annotations.
+    bool inherits_region = F.hasFnAttribute("julia.ipo_reset_safe");
+    SmallPtrSet<BasicBlock*, 16> MayBeOpenAtEntry;
+    if (!inherits_region) {
+        SmallVector<BasicBlock*, 8> Worklist;
+        for (Instruction *Pub : PointPublishes)
+            for (BasicBlock *Succ : successors(Pub->getParent()))
+                Worklist.push_back(Succ);
+        while (!Worklist.empty()) {
+            BasicBlock *B = Worklist.pop_back_val();
+            if (MayBeOpenAtEntry.insert(B).second)
+                for (BasicBlock *Succ : successors(B))
+                    Worklist.push_back(Succ);
+        }
+    }
+    auto blockMayOpenAtEntry = [&](BasicBlock *B) {
+        return inherits_region || MayBeOpenAtEntry.count(B);
+    };
+    auto isPublishStore = [&](Instruction *I) {
+        auto *SI = dyn_cast<StoreInst>(I);
+        return SI && SI->getPointerOperand() == reset_ctx_ptr &&
+               !isa<ConstantPointerNull>(SI->getValueOperand());
+    };
+
+    // Now walk the function to find unsafe points and insert reset_ctx =
+    // NULL before them. In an instrumented function (one with cancellation
+    // points) every store/atomic/call without reset_safe metadata is an
+    // unsafe point; in any other function only implicitly-inserted runtime
+    // machinery is (its explicit operations are covered by the IPO contract
+    // of whatever reset_safe call the region was kept open across).
+    SmallVector<Instruction*, 16> UnsafePoints;
+
+    // We need to skip instructions that are part of our setup (pgcstack, task, reset_ctx_ptr)
+    // since they occur before reset_ctx_ptr is available (for the
+    // non-instrumented walk, reset_ctx_ptr is computed lazily below, right
+    // after the pgcstack instruction - so skip until we pass that instead)
+    Instruction *reset_ctx_ptr_inst = dyn_cast_or_null<Instruction>(reset_ctx_ptr);
+    Instruction *setup_sentinel = reset_ctx_ptr_inst ? reset_ctx_ptr_inst : pgcstack_inst;
+
+    for (auto &BB : F) {
+        bool past_setup = (&BB != &F.getEntryBlock()) || setup_sentinel == nullptr;
+        bool may_open = blockMayOpenAtEntry(&BB);
+        for (auto &I : BB) {
+            // In the entry block, skip instructions until after the setup point
+            if (!past_setup) {
+                if (&I == setup_sentinel) {
+                    past_setup = true;
+                }
+                continue;
+            }
+            if (isPublishStore(&I)) {
+                may_open = true;
+                continue;
+            }
+            if (!may_open)
+                continue;
+
+            // Stores, atomics, and volatile loads are unsafe points only in
+            // instrumented functions (those with cancellation points of
+            // their own). In a merely-reset_safe function, its explicit
+            // operations are covered by the IPO contract that let the caller
+            // keep the region open - only calls can smuggle in machinery
+            // that is not.
+            //
+            // Check for stores (the reset_ctx stores we just created carry
+            // the reset_safe metadata). Atomic stores are unsafe points like
+            // plain ones: a reset delivered around e.g. a lock-release store
+            // would leave the lock owned forever.
+            if (auto *SI = dyn_cast<StoreInst>(&I)) {
+                if (instrumented && !hasResetSafeMetadata(SI))
+                    UnsafePoints.push_back(SI);
+            }
+            // Atomic read-modify-write operations publish state a reset
+            // could tear (e.g. a cmpxchg acquiring a user spin lock).
+            else if (isa<AtomicCmpXchgInst>(&I) || isa<AtomicRMWInst>(&I)) {
+                if (instrumented && !hasResetSafeMetadata(&I))
+                    UnsafePoints.push_back(&I);
+            }
+            // Volatile loads can have side effects (MMIO, read-to-clear
+            // hardware registers): a reset delivered after such a load has
+            // taken effect would silently abandon it. The pass's own
+            // bookkeeping loads are non-volatile and thus exempt.
+            else if (auto *LI = dyn_cast<LoadInst>(&I)) {
+                if (instrumented && LI->isVolatile() && !hasResetSafeMetadata(LI))
+                    UnsafePoints.push_back(LI);
+            }
+            // Check for calls (but not debug intrinsics, lifetime markers, etc.)
+            else if (auto *CI = dyn_cast<CallInst>(&I)) {
+                // Skip debug intrinsics and other harmless intrinsics
+                if (isa<DbgInfoIntrinsic>(CI))
+                    continue;
+                if (CI->isLifetimeStartOrEnd())
+                    continue;
+
+                // Check for reset_safe metadata (in both walks: an untagged
+                // call in a merely-reset_safe function may invoke code whose
+                // own effects are weaker than the statement-level refinement
+                // that proved this function reset_safe, e.g. after constant
+                // propagation - only tagged callees are known to participate
+                // in a spanned region). Even a tagged call is an unsafe point
+                // when it is implicitly-inserted runtime machinery (the tag
+                // describes the source statement's IPO contract, not the
+                // runtime frames implementing it).
+                if (!hasResetSafeMetadata(CI) || isImplicitRuntimeCall(CI)) {
+                    // Also skip intrinsic calls that are known safe
+                    Function *Callee = CI->getCalledFunction();
+                    if (Callee && Callee->isIntrinsic()) {
+                        Intrinsic::ID ID = Callee->getIntrinsicID();
+                        if (ID == Intrinsic::lifetime_start ||
+                            ID == Intrinsic::lifetime_end ||
+                            ID == Intrinsic::dbg_declare ||
+                            ID == Intrinsic::dbg_value ||
+                            ID == Intrinsic::dbg_label ||
+                            ID == Intrinsic::assume ||
+                            ID == Intrinsic::expect ||
+                            ID == Intrinsic::prefetch) {
+                            continue;
+                        }
+                    }
+                    // Skip the setjmp and safepoint calls we just created
+                    if (Callee && (Callee->getName() == jl_setjmp_name ||
+                                   Callee->getName() == "julia.safepoint"))
+                        continue;
+                    // Known-safe julia runtime intrinsics: pure address
+                    // computations that neither observe nor publish state a
+                    // reset could tear. These commonly appear as ccall
+                    // argument-conversion glue (unsafe_convert of a mutable
+                    // object), and must not invalidate a reset region
+                    // published across an adjacent reset-safe foreign call.
+                    if (Callee && (Callee->getName() == "julia.pointer_from_objref" ||
+                                   Callee->getName() == "julia.gc_loaded"))
+                        continue;
+                    // Allocations and write barriers are safe to span:
+                    // FinalLowerGC (stock and MMTk) lowers annotated sites
+                    // to the *_reset_safe runtime entry points, which
+                    // unpublish the region around the operation and
+                    // republish it on the way out (so the region even
+                    // survives the operation).
+                    if (Callee && (Callee->getName() == "julia.gc_alloc_obj" ||
+                                   Callee->getName() == "julia.write_barrier"))
+                        continue;
+                    UnsafePoints.push_back(CI);
+                }
+            }
+        }
+    }
+
+    // For the non-instrumented walk, only materialize the task/reset_ctx
+    // address computation once we know there is something to drop.
+    if (!UnsafePoints.empty() && !reset_ctx_ptr)
+        computeResetCtxPtr(F, pgcstack_inst);
+
+    // Insert reset_ctx = NULL before each unsafe point. The clear is
+    // volatile and separated from the unsafe operation by a single-thread
+    // (signal) fence: no later pass may move the operation above the clear -
+    // a delivery observing the still-published region after the operation
+    // executed would longjmp over its effects.
+    for (Instruction *I : UnsafePoints) {
+        if (!reset_ctx_ptr)
+            continue;
+
+        ++ResetCtxClearsInserted;
+        Changed = true;
+
+        IRBuilder<> Builder(I);
+        LLVMContext &LLVMCtx = F.getContext();
+        Type *PtrTy = PointerType::getUnqual(LLVMCtx);
+
+        Value *null_ptr = ConstantPointerNull::get(cast<PointerType>(PtrTy));
+        StoreInst *store = Builder.CreateAlignedStore(null_ptr, reset_ctx_ptr, Align(sizeof(void*)), /*isVolatile*/true);
+        store->setOrdering(AtomicOrdering::Release);
+        setResetSafeMetadata(store);
+        Builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SyncScope::SingleThread);
+    }
+
+    // Insert reset_ctx = NULL before all return instructions
+    // This is necessary because the cancel_ucontext buffer is stack-allocated,
+    // and becomes invalid when the function returns. (Only functions that
+    // establish regions of their own need this: a non-instrumented function
+    // returning inside a caller's region must leave it published.)
+    if (instrumented && reset_ctx_ptr) {
+        LLVMContext &LLVMCtx = F.getContext();
+        Type *PtrTy = PointerType::getUnqual(LLVMCtx);
+        Value *null_ptr = ConstantPointerNull::get(cast<PointerType>(PtrTy));
+
+        for (auto &BB : F) {
+            auto *RI = dyn_cast<ReturnInst>(BB.getTerminator());
+            if (!RI)
+                continue;
+            // No teardown where no region can be open at the return
+            bool may_open = blockMayOpenAtEntry(&BB);
+            if (!may_open) {
+                for (auto &I : BB) {
+                    if (isPublishStore(&I)) {
+                        may_open = true;
+                        break;
+                    }
+                }
+            }
+            if (!may_open)
+                continue;
+            // LLVM requires a musttail call to be immediately followed
+            // (modulo an optional bitcast) by the return, so no teardown may
+            // be inserted between them: it goes in front of the call
+            // instead. This is done unconditionally - metadata is not a
+            // reliable proxy for whether the unsafe-point walk already
+            // cleared before the call (exempt calls, e.g.
+            // julia.pointer_from_objref, get no clear), and a duplicate
+            // clear is harmless.
+            Instruction *InsertPt = RI;
+            if (CallInst *MTC = BB.getTerminatingMustTailCall())
+                InsertPt = MTC;
+            IRBuilder<> Builder(InsertPt);
+            StoreInst *store = Builder.CreateAlignedStore(null_ptr, reset_ctx_ptr, Align(sizeof(void*)), /*isVolatile*/true);
+            store->setOrdering(AtomicOrdering::Release);
+            setResetSafeMetadata(store);
+            ++ResetCtxClearsInserted;
+        }
+    }
+
+    // Annotate the allocation and write-barrier sites that may execute while
+    // a reset region is published: FinalLowerGC lowers exactly these to the
+    // *_reset_safe runtime entry points, which unpublish/republish the
+    // region themselves (no per-site drop is needed, and the region survives
+    // the operation). Carrying an open region is a per-site property, not a
+    // function-level one, so track the clears and publishes inserted above
+    // through each block: a site escapes annotation only when every path to
+    // it has already cleared the region, or when no publication reaches it
+    // at all. Block entry state comes from the reachability computed above
+    // (everything, for a function that may inherit an open region from its
+    // caller); an unneeded annotation only costs the entry point's (cheap)
+    // region handling.
+    for (auto &BB : F) {
+        bool region_open = blockMayOpenAtEntry(&BB);
+        for (auto &I : BB) {
+            if (auto *SI = dyn_cast<StoreInst>(&I)) {
+                if (reset_ctx_ptr && SI->getPointerOperand() == reset_ctx_ptr)
+                    region_open = !isa<ConstantPointerNull>(SI->getValueOperand());
+            }
+            else if (auto *CI = dyn_cast<CallInst>(&I)) {
+                Function *Callee = CI->getCalledFunction();
+                if (!Callee)
+                    continue;
+                StringRef Name = Callee->getName();
+                if (region_open && (Name == "julia.gc_alloc_obj" ||
+                                    Name == "julia.write_barrier")) {
+                    CI->setMetadata("julia.reset_region", MDNode::get(F.getContext(), {}));
+                    Changed = true;
+                }
+            }
+        }
+    }
+
+    return Changed;
+}
+
+} // anonymous namespace
+
+PreservedAnalyses CancellationLoweringPass::run(Function &F, FunctionAnalysisManager &AM) {
+    CancellationLowering CL(*F.getParent());
+    if (CL.runOnFunction(F)) {
+#ifdef JL_VERIFY_PASSES
+        assert(!verifyLLVMIR(F));
+#endif
+        return PreservedAnalyses::allInSet<CFGAnalyses>();
+    }
+    return PreservedAnalyses::all();
+}

--- a/src/llvm-final-gc-lowering-stock.cpp
+++ b/src/llvm-final-gc-lowering-stock.cpp
@@ -13,6 +13,10 @@ Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
     IRBuilder<> builder(target);
     auto ptls = target->getArgOperand(0);
     auto type = target->getArgOperand(2);
+    // Sites that may execute with a cancellation reset region published
+    // (annotated by CancellationLowering) allocate through the reset-safe
+    // entry points, which unpublish/republish the region themselves.
+    bool resetSafe = target->hasMetadata("julia.reset_region");
     uint64_t derefBytes = 0;
     if (auto CI = dyn_cast<ConstantInt>(target->getArgOperand(1))) {
         size_t sz = (size_t)CI->getZExtValue();
@@ -21,7 +25,7 @@ Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
         int offset = jl_gc_classify_pools(sz, &osize);
         if (offset < 0) {
             newI = builder.CreateCall(
-                bigAllocFunc,
+                resetSafe ? bigAllocResetSafeFunc : bigAllocFunc,
                 { ptls, ConstantInt::get(T_size, sz + sizeof(void*)), type });
             if (sz > 0)
                 derefBytes = sz;
@@ -29,14 +33,16 @@ Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
         else {
             auto pool_offs = ConstantInt::get(Type::getInt32Ty(F.getContext()), offset);
             auto pool_osize = ConstantInt::get(Type::getInt32Ty(F.getContext()), osize);
-            newI = builder.CreateCall(smallAllocFunc, { ptls, pool_offs, pool_osize, type });
+            newI = builder.CreateCall(resetSafe ? smallAllocResetSafeFunc : smallAllocFunc,
+                                      { ptls, pool_offs, pool_osize, type });
             if (sz > 0)
                 derefBytes = sz;
         }
     } else {
         auto size = builder.CreateZExtOrTrunc(target->getArgOperand(1), T_size);
         // allocTypedFunc does not include the type tag in the allocation size!
-        newI = builder.CreateCall(allocTypedFunc, { ptls, size, type });
+        newI = builder.CreateCall(resetSafe ? allocTypedResetSafeFunc : allocTypedFunc,
+                                  { ptls, size, type });
         derefBytes = sizeof(void*);
     }
     newI->setAttributes(newI->getCalledFunction()->getAttributes());
@@ -79,7 +85,11 @@ void FinalLowerGC::lowerWriteBarrier(CallInst *target, Function &F) {
     trigTerm->getParent()->setName("trigger_wb");
     builder.SetInsertPoint(trigTerm);
     if (target->getCalledOperand() == write_barrier_func) {
-        builder.CreateCall(getOrDeclare(jl_intrinsics::queueGCRoot), parent);
+        auto qr = builder.CreateCall(getOrDeclare(jl_intrinsics::queueGCRoot), parent);
+        // Propagate CancellationLowering's reset-region annotation to the
+        // slow-path call, so lowerQueueGCRoot selects the reset-safe entry.
+        if (auto *MD = target->getMetadata("julia.reset_region"))
+            qr->setMetadata("julia.reset_region", MD);
     }
     else {
         assert(false);

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -104,7 +104,11 @@ void FinalLowerGC::lowerQueueGCRoot(CallInst *target, Function &F)
 {
     ++QueueGCRootCount;
     assert(target->arg_size() == 1);
-    target->setCalledFunction(queueRootFunc);
+    // The site may execute with a reset region published (metadata inherited
+    // from the write barrier CancellationLowering annotated).
+    target->setCalledFunction(target->hasMetadata("julia.reset_region")
+                                  ? queueRootResetSafeFunc
+                                  : queueRootFunc);
 }
 
 void FinalLowerGC::lowerSafepoint(CallInst *target, Function &F)
@@ -154,6 +158,10 @@ bool FinalLowerGC::runOnFunction(Function &F)
     smallAllocFunc = getOrDeclare(jl_well_known::GCSmallAlloc);
     bigAllocFunc = getOrDeclare(jl_well_known::GCBigAlloc);
     allocTypedFunc = getOrDeclare(jl_well_known::GCAllocTyped);
+    queueRootResetSafeFunc = getOrDeclare(jl_well_known::GCQueueRootResetSafe);
+    smallAllocResetSafeFunc = getOrDeclare(jl_well_known::GCSmallAllocResetSafe);
+    bigAllocResetSafeFunc = getOrDeclare(jl_well_known::GCBigAllocResetSafe);
+    allocTypedResetSafeFunc = getOrDeclare(jl_well_known::GCAllocTypedResetSafe);
     T_size = F.getParent()->getDataLayout().getIntPtrType(F.getContext());
 
 

--- a/src/llvm-gc-interface-passes.h
+++ b/src/llvm-gc-interface-passes.h
@@ -385,6 +385,15 @@ private:
     Function *smallAllocFunc;
     Function *bigAllocFunc;
     Function *allocTypedFunc;
+    // Reset-safe variants of the above, used for call sites that
+    // CancellationLowering annotated with julia.reset_region metadata (they
+    // may execute with a cancellation reset region published): these entry
+    // points unpublish/republish the region themselves, so no per-site drop
+    // is needed (see llvm-cancellation-lowering.cpp).
+    Function *queueRootResetSafeFunc;
+    Function *smallAllocResetSafeFunc;
+    Function *bigAllocResetSafeFunc;
+    Function *allocTypedResetSafeFunc;
     Value *pgcstack;
     Type *T_size;
 

--- a/src/llvm-julia-passes.inc
+++ b/src/llvm-julia-passes.inc
@@ -16,6 +16,7 @@ FUNCTION_PASS("AllocOpt", AllocOptPass())
 FUNCTION_PASS("PropagateJuliaAddrspaces", PropagateJuliaAddrspacesPass())
 FUNCTION_PASS("GCInvariantVerifier", GCInvariantVerifierPass())
 FUNCTION_PASS("FinalLowerGC", FinalLowerGCPass())
+FUNCTION_PASS("CancellationLowering", CancellationLoweringPass())
 FUNCTION_PASS("ExpandAtomicModify", ExpandAtomicModifyPass())
 #endif
 

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2041,6 +2041,11 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                     });
                 newI->setAttributes(allocBytesIntrinsic->getAttributes());
                 newI->addDereferenceableRetAttr(CI->getRetDereferenceableBytes());
+                // Preserve CancellationLowering's reset-region annotation:
+                // FinalLowerGC uses it to select the reset-safe allocation
+                // entry points.
+                if (auto *MD = CI->getMetadata("julia.reset_region"))
+                    newI->setMetadata("julia.reset_region", MD);
                 newI->takeName(CI);
                 // Now, finally, set the tag. We do this in IR instead of in the C alloc
                 // function, to provide possible optimization opportunities. (I think? TBH

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -32,7 +32,7 @@ JuliaPassContext::JuliaPassContext()
         gc_preserve_begin_func(nullptr), gc_preserve_end_func(nullptr),
         pointer_from_objref_func(nullptr), gc_loaded_func(nullptr), alloc_obj_func(nullptr),
         typeof_func(nullptr), blackbox_func(nullptr), write_barrier_func(nullptr), pop_handler_noexcept_func(nullptr),
-        call_func(nullptr), call2_func(nullptr), call3_func(nullptr), module(nullptr)
+        call_func(nullptr), call2_func(nullptr), call3_func(nullptr), cancel_point_func(nullptr), module(nullptr)
 {
 }
 
@@ -62,6 +62,7 @@ void JuliaPassContext::initFunctions(Module &M)
     call_func = M.getFunction("julia.call");
     call2_func = M.getFunction("julia.call2");
     call3_func = M.getFunction("julia.call3");
+    cancel_point_func = M.getFunction("julia.cancellation_point");
 }
 
 void JuliaPassContext::initAll(Module &M)
@@ -263,6 +264,10 @@ namespace jl_well_known {
     static const char *GC_SMALL_ALLOC_NAME = XSTR(jl_gc_small_alloc);
     static const char *GC_QUEUE_ROOT_NAME = XSTR(jl_gc_queue_root);
     static const char *GC_ALLOC_TYPED_NAME = XSTR(jl_gc_alloc_typed);
+    static const char *GC_BIG_ALLOC_RESET_SAFE_NAME = XSTR(jl_gc_big_alloc_reset_safe);
+    static const char *GC_SMALL_ALLOC_RESET_SAFE_NAME = XSTR(jl_gc_small_alloc_reset_safe);
+    static const char *GC_QUEUE_ROOT_RESET_SAFE_NAME = XSTR(jl_gc_queue_root_reset_safe);
+    static const char *GC_ALLOC_TYPED_RESET_SAFE_NAME = XSTR(jl_gc_alloc_typed_reset_safe);
 
     using jl_intrinsics::addGCAllocAttributes;
 
@@ -330,5 +335,86 @@ namespace jl_well_known {
                 GC_ALLOC_TYPED_NAME);
             allocTypedFunc->addFnAttr(Attribute::getWithAllocSizeArgs(ctx, 1, None));
             return addGCAllocAttributes(allocTypedFunc);
+        });
+
+    // Like addGCAllocAttributes, but without the narrowed memory effects:
+    // the reset-safe variants additionally unpublish/republish the current
+    // task's reset context, which is neither argument nor inaccessible
+    // memory.
+    static Function *addResetSafeGCAllocAttributes(Function *target)
+    {
+        auto FnAttrs = AttrBuilder(target->getContext());
+        FnAttrs.addAllocKindAttr(AllocFnKind::Alloc);
+        FnAttrs.addAttribute(Attribute::WillReturn);
+        FnAttrs.addAttribute(Attribute::NoUnwind);
+        target->addFnAttrs(FnAttrs);
+        addRetAttr(target, Attribute::NoAlias);
+        addRetAttr(target, Attribute::NonNull);
+        return target;
+    }
+
+    const WellKnownFunctionDescription GCBigAllocResetSafe(
+        GC_BIG_ALLOC_RESET_SAFE_NAME,
+        [](Type *T_size) {
+            auto &ctx = T_size->getContext();
+            auto T_prjlvalue = JuliaType::get_prjlvalue_ty(ctx);
+            auto bigAllocFunc = Function::Create(
+                FunctionType::get(
+                    T_prjlvalue,
+                    { PointerType::get(ctx, 0), T_size , T_size},
+                    false),
+                Function::ExternalLinkage,
+                GC_BIG_ALLOC_RESET_SAFE_NAME);
+            bigAllocFunc->addFnAttr(Attribute::getWithAllocSizeArgs(ctx, 1, None));
+            return addResetSafeGCAllocAttributes(bigAllocFunc);
+        });
+
+    const WellKnownFunctionDescription GCSmallAllocResetSafe(
+        GC_SMALL_ALLOC_RESET_SAFE_NAME,
+        [](Type *T_size) {
+            auto &ctx = T_size->getContext();
+            auto T_prjlvalue = JuliaType::get_prjlvalue_ty(ctx);
+            auto smallAllocFunc = Function::Create(
+                FunctionType::get(
+                    T_prjlvalue,
+                    { PointerType::get(ctx, 0), Type::getInt32Ty(ctx), Type::getInt32Ty(ctx), T_size },
+                    false),
+                Function::ExternalLinkage,
+                GC_SMALL_ALLOC_RESET_SAFE_NAME);
+            smallAllocFunc->addFnAttr(Attribute::getWithAllocSizeArgs(ctx, 2, None));
+            return addResetSafeGCAllocAttributes(smallAllocFunc);
+        });
+
+    const WellKnownFunctionDescription GCQueueRootResetSafe(
+        GC_QUEUE_ROOT_RESET_SAFE_NAME,
+        [](Type *T_size) {
+            auto &ctx = T_size->getContext();
+            auto T_prjlvalue = JuliaType::get_prjlvalue_ty(ctx);
+            auto func = Function::Create(
+                FunctionType::get(
+                    Type::getVoidTy(ctx),
+                    { T_prjlvalue },
+                    false),
+                Function::ExternalLinkage,
+                GC_QUEUE_ROOT_RESET_SAFE_NAME);
+            return func;
+        });
+
+    const WellKnownFunctionDescription GCAllocTypedResetSafe(
+        GC_ALLOC_TYPED_RESET_SAFE_NAME,
+        [](Type *T_size) {
+            auto &ctx = T_size->getContext();
+            auto T_prjlvalue = JuliaType::get_prjlvalue_ty(ctx);
+            auto allocTypedFunc = Function::Create(
+                FunctionType::get(
+                    T_prjlvalue,
+                    { PointerType::get(ctx, 0),
+                        T_size,
+                        T_size }, // type
+                    false),
+                Function::ExternalLinkage,
+                GC_ALLOC_TYPED_RESET_SAFE_NAME);
+            allocTypedFunc->addFnAttr(Attribute::getWithAllocSizeArgs(ctx, 1, None));
+            return addResetSafeGCAllocAttributes(allocTypedFunc);
         });
 }

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -65,6 +65,7 @@ struct JuliaPassContext {
     llvm::Function *call_func;
     llvm::Function *call2_func;
     llvm::Function *call3_func;
+    llvm::Function *cancel_point_func;
 
     // Creates a pass context. Type and function pointers
     // are set to `nullptr`. Metadata nodes are initialized.
@@ -157,6 +158,15 @@ namespace jl_well_known {
 
     // `jl_gc_alloc_typed`: allocates bytes.
     extern const WellKnownFunctionDescription GCAllocTyped;
+
+    // Reset-safe variants of the above (minus the narrowed memory effects):
+    // used in functions that may carry a published cancellation reset
+    // region, these unpublish/republish the current task's reset context
+    // around the operation (see llvm-cancellation-lowering.cpp).
+    extern const WellKnownFunctionDescription GCBigAllocResetSafe;
+    extern const WellKnownFunctionDescription GCSmallAllocResetSafe;
+    extern const WellKnownFunctionDescription GCQueueRootResetSafe;
+    extern const WellKnownFunctionDescription GCAllocTypedResetSafe;
 }
 
 void setName(llvm::Value *V, const llvm::Twine &Name, int debug_info);

--- a/src/passes.h
+++ b/src/passes.h
@@ -43,6 +43,11 @@ struct FinalLowerGCPass : PassInfoMixin<FinalLowerGCPass> {
     static bool isRequired() { return true; }
 };
 
+struct CancellationLoweringPass : PassInfoMixin<CancellationLoweringPass> {
+    PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT;
+    static bool isRequired() { return true; }
+};
+
 struct ExpandAtomicModifyPass : PassInfoMixin<ExpandAtomicModifyPass> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT;
 };

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -581,6 +581,7 @@ static void buildIntrinsicLoweringPipeline(ModulePassManager &MPM, PassBuilder *
         JULIA_PASS(MPM.addPass(RemoveNIPass()));
         {
             FunctionPassManager FPM;
+            JULIA_PASS(FPM.addPass(CancellationLoweringPass())); // Lower cancellation points to setjmp (before GC lowering)
             JULIA_PASS(FPM.addPass(LateLowerGCPass()));
             JULIA_PASS(FPM.addPass(FinalLowerGCPass()));
             JULIA_PASS(FPM.addPass(ExpandAtomicModifyPass())); // after LateLowerGCPass so that all IPO is valid

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -267,6 +267,8 @@ JL_DLLEXPORT void jl_enter_handler(jl_task_t *ct, jl_handler_t *eh)
     eh->prev = ct->eh;
     eh->gcstack = ct->gcstack;
     eh->scope = ct->scope;
+    eh->reset_ctx = jl_atomic_load_relaxed(&ct->reset_ctx);
+    eh->bound_cancel_token = jl_atomic_load_relaxed(&ct->bound_cancel_token);
     eh->gc_state = jl_atomic_load_relaxed(&ct->ptls->gc_state);
     eh->locks_len = ct->ptls->locks.len;
     eh->defer_signal = ct->ptls->defer_signal;
@@ -297,6 +299,9 @@ JL_DLLEXPORT void jl_eh_restore_state(jl_task_t *ct, jl_handler_t *eh) JL_NO_SAF
     sig_atomic_t old_defer_signal = ptls->defer_signal;
     ct->eh = eh->prev;
     ct->gcstack = eh->gcstack;
+    jl_atomic_store_relaxed(&ct->bound_cancel_token, eh->bound_cancel_token);
+    jl_gc_wb_current_task(ct, eh->bound_cancel_token);
+    jl_atomic_store_release(&ct->reset_ctx, eh->reset_ctx);
     jl_gc_wb_current_task(ct, eh->scope);
     ct->scope = eh->scope;
     small_arraylist_t *locks = &ptls->locks;
@@ -340,6 +345,9 @@ JL_DLLEXPORT void jl_eh_restore_state_noexcept(jl_task_t *ct, jl_handler_t *eh)
     jl_gc_wb_current_task(ct, eh->scope);
     ct->scope = eh->scope;
     ct->eh = eh->prev;
+    jl_atomic_store_relaxed(&ct->bound_cancel_token, eh->bound_cancel_token);
+    jl_gc_wb_current_task(ct, eh->bound_cancel_token);
+    jl_atomic_store_release(&ct->reset_ctx, eh->reset_ctx);
     ct->ptls->defer_signal = eh->defer_signal; // optional, but certain try-finally (in stream.jl) may be slightly harder to write without this
 }
 

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -578,6 +578,54 @@ static const char *jl_strsignal(int sig) JL_NOTSAFEPOINT
 #include "signals-unix.c"
 #endif
 
+// jl_send_reset_signal is the static per-platform delivery defined by the
+// file included above; `reset_code` becomes the reset point's setjmp return.
+
+JL_DLLEXPORT void jl_send_cancellation_signal(int16_t tid) JL_NOTSAFEPOINT
+{
+    jl_send_reset_signal(tid, JL_RESET_CODE_CANCEL);
+}
+
+// Request a cooperative yield from the target thread's current task: mark
+// the task (honored at its next cancellation point) before kicking it out
+// of any published reset region.
+JL_DLLEXPORT void jl_send_preempt_signal(int16_t tid) JL_NOTSAFEPOINT
+{
+    if (tid < 0 || tid >= jl_atomic_load_acquire(&jl_n_threads))
+        return;
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    if (ptls2 == NULL)
+        return;
+    jl_task_t *ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
+    if (ct2 == NULL)
+        return;
+    jl_atomic_store_release(&ct2->preempt_request, 1);
+    jl_send_reset_signal(tid, JL_RESET_CODE_PREEMPT);
+}
+
+// Deliver cancellation shootdowns to every thread whose current task is
+// bound to a now-cancelled token source; called by `cancel!` after
+// propagation and a heavy fence. The check is only a hint (the sender
+// re-validates; a missed task recovers level-triggered), and the unrooted
+// token read is safe because this thread runs GC-unsafe.
+JL_DLLEXPORT void jl_shootdown_cancelled_tasks(void) JL_NOTSAFEPOINT
+{
+    int nthreads = jl_atomic_load_acquire(&jl_n_threads);
+    for (int16_t tid = 0; tid < nthreads; tid++) {
+        jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+        if (ptls2 == NULL)
+            continue;
+        jl_task_t *ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
+        if (ct2 == NULL)
+            continue;
+        jl_value_t *bound = jl_atomic_load_relaxed(&ct2->bound_cancel_token);
+        if (bound == NULL || bound == jl_nothing ||
+            jl_atomic_load_relaxed(&((jl_cancel_source_t*)bound)->state) == 0)
+            continue;
+        jl_send_cancellation_signal(tid);
+    }
+}
+
 static uintptr_t jl_get_pc_from_ctx(const void *_ctx)
 {
 #if defined(_OS_LINUX_) && defined(_CPU_X86_64_)

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -253,12 +253,12 @@ static void jl_noreturn_call_in_state(host_thread_state_t *state, void (*fptr)(v
 #endif
 }
 
-static void jl_longjmp_in_state(host_thread_state_t *state, jl_jmp_buf jmpbuf)
+static void jl_longjmp_in_state(host_thread_state_t *state, jl_jmp_buf jmpbuf, int val)
 {
-    if (!jl_simulate_longjmp(jmpbuf, (bt_context_t*)state)) {
+    if (!jl_simulate_longjmp(jmpbuf, (bt_context_t*)state, val)) {
         // for sanitizer builds, fallback to calling longjmp on the original stack
         // (this will fail for stack overflow, but that is hardly sanitizer-legal anyways)
-        jl_noreturn_call_in_state(state, (void (*)(void))longjmp, (uintptr_t)jmpbuf, 1);
+        jl_noreturn_call_in_state(state, (void (*)(void))longjmp, (uintptr_t)jmpbuf, val);
     }
 }
 
@@ -280,7 +280,7 @@ int is_write_fault(host_exception_state_t exc_state) {
 static void jl_throw_in_state(jl_ptls_t ptls2, host_thread_state_t *state, jl_value_t *exception)
 {
     if (ptls2->safe_restore) {
-        jl_longjmp_in_state(state, *ptls2->safe_restore);
+        jl_longjmp_in_state(state, *ptls2->safe_restore, 1);
     }
     else {
         assert(exception);
@@ -290,10 +290,15 @@ static void jl_throw_in_state(jl_ptls_t ptls2, host_thread_state_t *state, jl_va
         ptls2->sig_exception = exception;
         ptls2->io_wait = 0;
         jl_task_t *ct = jl_atomic_load_relaxed(&ptls2->current_task);
+        // This redirect abandons every frame between the interrupted context
+        // and the handler; clear a published reset context so no
+        // cancellation sender consumes a buffer in the abandoned region
+        // (jl_eh_restore_state republishes the outer one at the catch).
+        jl_atomic_store_release(&ct->reset_ctx, NULL);
         jl_handler_t *eh = ct->eh;
         if (eh != NULL) {
             asan_unpoison_task_stack(ct, &eh->eh_ctx);
-            jl_longjmp_in_state(state, eh->eh_ctx);
+            jl_longjmp_in_state(state, eh->eh_ctx, 1);
         }
         else {
             jl_no_exc_handler(exception, ct);
@@ -399,7 +404,7 @@ static void segv_handler(int sig, siginfo_t *info, void *context)
     assert(sig == SIGSEGV || sig == SIGBUS);
     jl_jmp_buf *saferestore = jl_get_safe_restore();
     if (saferestore) { // restarting jl_ or jl_unwind_stepn
-        jl_longjmp_in_state((host_thread_state_t*)jl_to_bt_context(context), *saferestore);
+        jl_longjmp_in_state((host_thread_state_t*)jl_to_bt_context(context), *saferestore, 1);
         return;
     }
     jl_task_t *ct = jl_get_current_task();
@@ -610,6 +615,112 @@ void jl_thread_resume(int tid)
     HANDLE_MACH_ERROR("thread_resume", ret);
 }
 
+// Serializes every path that suspends a thread and rewrites its context
+// (jl_send_cancellation_signal on any thread, and jl_try_deliver_sigint) for
+// its complete suspend/rewrite/resume sequence: two rewriters working from
+// the same suspended snapshot would install conflicting continuations and
+// task chains. (The profiler does not need it: it only reads contexts, and
+// suspend counts nest.) It also prevents two threads delivering
+// cancellations at each other from freezing both: a rewriter always takes
+// this lock before suspending and never blocks while holding a suspension,
+// so a suspended thread can never hold it.
+static pthread_mutex_t ctx_rewrite_lock = PTHREAD_MUTEX_INITIALIZER;
+
+// Suspend-based shootdown delivery (see jl_send_reset_signal in
+// signals-win.c for the shared shape and locking rationale). Rather than
+// simulating the longjmp into a GP-only thread state - which cannot carry
+// the callee-saved SIMD registers the setjmp ABI requires - the frozen
+// thread is redirected to call the real longjmp on its own stack.
+// Best-effort: any failed check simply drops the request.
+static void jl_send_reset_signal(int16_t tid, int reset_code) JL_NOTSAFEPOINT
+{
+    if (tid < 0 || tid >= jl_atomic_load_acquire(&jl_n_threads))
+        return;
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    if (ptls2 == NULL)
+        return;
+    jl_task_t *ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
+    if (ct2 == NULL)
+        return;
+    // Only proceed if the task has a reset context published - a purely
+    // polling victim between cancellation points never has one. (A thread's
+    // own reset_ctx is always NULL here: the ccall reaching this function is
+    // itself an unsafe point, so a self-send returns without suspending.)
+    if (jl_atomic_load_relaxed(&ct2->reset_ctx) == NULL)
+        return;
+    pthread_mutex_lock(&ctx_rewrite_lock);
+    // Thread teardown clears current_task while holding the profile write
+    // lock (see jl_free_thread_gc_state): hold the read lock across the
+    // liveness re-check and the suspension, so the thread cannot exit (and
+    // its Mach port cannot die) in between. Suspension failure is still
+    // treated as a best-effort delivery failure, never a fatal error.
+    jl_lock_profile();
+    ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
+    if (ct2 == NULL) {
+        jl_unlock_profile();
+        pthread_mutex_unlock(&ctx_rewrite_lock);
+        return;
+    }
+    mach_port_t thread = pthread_mach_thread_np(ptls2->system_id);
+    kern_return_t ret = thread_suspend(thread);
+    jl_unlock_profile();
+    if (ret != KERN_SUCCESS) {
+        pthread_mutex_unlock(&ctx_rewrite_lock);
+        return;
+    }
+    host_thread_state_t state;
+    unsigned int count = MACH_THREAD_STATE_COUNT;
+    memset(&state, 0, sizeof(state));
+    if (thread_get_state(thread, MACH_THREAD_STATE, (thread_state_t)&state, &count) != KERN_SUCCESS)
+        goto resume;
+    // Re-check now that the thread cannot run: the current task may have
+    // switched before the freeze. Delivery is gated on an actual
+    // cancellation of the task's bound token source (kept coherent with the
+    // published region by the exception-handler and finalizer save/restore
+    // discipline) and on the thread running Julia code (gc_state == 0): a
+    // thread inside a GC-safe region may be raced by a concurrent
+    // stop-the-world, and a redirect back into Julia code would break that
+    // protocol.
+    ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
+    if (ct2 != NULL &&
+        jl_atomic_load_relaxed(&ptls2->gc_state) == JL_GC_STATE_UNSAFE) {
+        jl_reset_ctx_t *reset_ctx = jl_atomic_load_acquire(&ct2->reset_ctx);
+        jl_value_t *bound = jl_atomic_load_relaxed(&ct2->bound_cancel_token);
+        int bound_cancelled = bound != NULL && bound != jl_nothing &&
+            jl_atomic_load_relaxed(&((jl_cancel_source_t*)bound)->state) != 0;
+        if (reset_ctx != NULL && reset_ctx->sp != 0 &&
+            (reset_code == JL_RESET_CODE_PREEMPT || bound_cancelled)) {
+            // Consume the reset point with an exchange (off-thread senders
+            // may race each other, unlike the Unix in-handler consumer).
+            reset_ctx = jl_atomic_exchange(&ct2->reset_ctx, NULL);
+            if (reset_ctx != NULL && reset_ctx->sp != 0) {
+                // Redirect the frozen thread to call longjmp on its own
+                // stack (restoring callee-saved GP and SIMD state
+                // natively), and rewind the task's gcstack/eh chains only
+                // once the redirect is committed, so that any failure
+                // resumes the thread exactly as it was, with the
+                // (unconsumed) region republished.
+                jl_noreturn_call_in_state(&state, (void (*)(void))longjmp,
+                                          (uintptr_t)reset_ctx->mctx, reset_code);
+                if (thread_set_state(thread, MACH_THREAD_STATE,
+                                     (thread_state_t)&state,
+                                     MACH_THREAD_STATE_COUNT) == KERN_SUCCESS) {
+                    ct2->gcstack = reset_ctx->gcstack;
+                    ct2->eh = reset_ctx->eh;
+                }
+                else {
+                    jl_atomic_store_release(&ct2->reset_ctx, reset_ctx);
+                }
+            }
+        }
+    }
+resume:
+    if (thread_resume(thread) != KERN_SUCCESS)
+        jl_safe_printf("error: thread_resume failed in cancellation delivery\n");
+    pthread_mutex_unlock(&ctx_rewrite_lock);
+}
+
+
 // Throw jl_interrupt_exception if the master thread is in a signal async region
 // or if SIGINT happens too often.
 static void jl_try_deliver_sigint(void)
@@ -617,6 +728,9 @@ static void jl_try_deliver_sigint(void)
     jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[0];
     mach_port_t thread = pthread_mach_thread_np(ptls2->system_id);
 
+    // Hold the rewrite lock across the complete suspend/rewrite/resume
+    // sequence (see its definition above).
+    pthread_mutex_lock(&ctx_rewrite_lock);
     kern_return_t ret = thread_suspend(thread);
     HANDLE_MACH_ERROR("thread_suspend", ret);
 
@@ -641,6 +755,7 @@ static void jl_try_deliver_sigint(void)
 
     ret = thread_resume(thread);
     HANDLE_MACH_ERROR("thread_resume", ret);
+    pthread_mutex_unlock(&ctx_rewrite_lock);
 }
 
 static void jl_exit_thread0_cb(int signo)

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -64,7 +64,7 @@ static bt_context_t *jl_to_bt_context(void *sigctx) JL_NOTSAFEPOINT
 
 static int thread0_exit_count = 0;
 static void jl_exit_thread0(int signo, jl_bt_element_t *bt_data, size_t bt_size);
-static void jl_longjmp_in_ctx(int sig, void *_ctx, jl_jmp_buf jmpbuf);
+static void jl_longjmp_in_ctx(int sig, void *_ctx, jl_jmp_buf jmpbuf, int val);
 
 #if !defined(_OS_DARWIN_)
 extern void jl_fake_signal_return(void);
@@ -322,6 +322,14 @@ static void jl_throw_in_ctx(jl_task_t *ct, jl_value_t *e, int sig, void *sigctx)
 {
     jl_ptls_t ptls = ct->ptls;
     assert(!jl_get_safe_restore());
+    // This redirect abandons every frame between the interrupted context and
+    // the handler. A reset context published in one of those frames would
+    // dangle - and unlike the chains below, it may be consumed
+    // asynchronously (a pending cancellation signal, or an off-thread
+    // sender) before any handler code runs - so clear it before rewriting
+    // the context. The matching jl_eh_restore_state republishes the outer
+    // context saved at handler entry.
+    jl_atomic_store_release(&ct->reset_ctx, NULL);
     ptls->bt_size =
         rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE, jl_to_bt_context(sigctx),
                             ct->gcstack);
@@ -330,7 +338,7 @@ static void jl_throw_in_ctx(jl_task_t *ct, jl_value_t *e, int sig, void *sigctx)
     jl_handler_t *eh = ct->eh;
     if (eh != NULL) {
         asan_unpoison_task_stack(ct, &eh->eh_ctx);
-        jl_longjmp_in_ctx(sig, sigctx, eh->eh_ctx);
+        jl_longjmp_in_ctx(sig, sigctx, eh->eh_ctx, 1);
     }
     else {
         jl_no_exc_handler(e, ct);
@@ -517,7 +525,7 @@ JL_NO_ASAN static void segv_handler(int sig, siginfo_t *info, void *context) JL_
     assert(sig == SIGSEGV || sig == SIGBUS);
     jl_jmp_buf *saferestore = jl_get_safe_restore();
     if (saferestore) { // restarting jl_ or profile
-        jl_longjmp_in_ctx(sig, context, *saferestore);
+        jl_longjmp_in_ctx(sig, context, *saferestore, 1);
         return;
     }
     jl_task_t *ct = jl_get_current_task();
@@ -610,7 +618,13 @@ static int jl_thread_suspend_and_get_state(int tid, int timeout, bt_context_t *c
     }
     signals_inflight++;
     sig_atomic_t request = jl_atomic_exchange(&ptls2->signal_request, 1);
-    assert(request == 0 || request == -1);
+    // A parked best-effort cancellation request (5) may occupy the slot
+    // indefinitely - its victim may never consume it (e.g. a thread with
+    // SIGUSR2 blocked) - and its sender tolerates a lost delivery (recovery
+    // is level-triggered at the task's next cancellation point), so the
+    // suspend handshake may displace it. The handshake states 1-4/-1 cannot
+    // appear here: those settle under in_signal_lock, which we hold.
+    assert(request == 0 || request == -1 || request == 5 || request == 6);
     request = 1;
     err = pthread_kill(ptls2->system_id, SIGUSR2);
     if (err == 0) {
@@ -655,6 +669,46 @@ void jl_thread_resume(int tid)
     if (err != sizeof(eventfd_t)) abort();
     pthread_mutex_unlock(&in_signal_lock);
 }
+
+// Send a signal to the specified thread to deliver a pending cancellation of
+// its current task's bound token source to the task's published reset_ctx, if
+// available: longjmp to a compiled reset point (see usr2_handler request 5).
+static void jl_send_reset_signal(int16_t tid, int reset_code) JL_NOTSAFEPOINT
+{
+    sig_atomic_t request = reset_code == JL_RESET_CODE_PREEMPT ? 6 : 5;
+    if (tid < 0 || tid >= jl_atomic_load_acquire(&jl_n_threads))
+        return;
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    if (ptls2 == NULL)
+        return;
+    // Only send if the task has a reset context published - a purely polling
+    // victim between cancellation points never has one, and recovers
+    // level-triggered at its next check.
+    jl_task_t *ct = jl_atomic_load_relaxed(&ptls2->current_task);
+    if (ct == NULL || jl_atomic_load_relaxed(&ct->reset_ctx) == NULL)
+        return;
+    pthread_mutex_lock(&in_signal_lock);
+    // Re-check liveness under the lock: thread teardown clears current_task
+    // while holding in_signal_lock (see jl_free_thread_gc_state), so a
+    // non-NULL read here guarantees the thread has not exited and its
+    // pthread id is still valid to signal.
+    ct = jl_atomic_load_relaxed(&ptls2->current_task);
+    if (ct == NULL || jl_atomic_load_relaxed(&ct->reset_ctx) == NULL) {
+        pthread_mutex_unlock(&in_signal_lock);
+        return;
+    }
+    // This request is best-effort and produces no acknowledgment token (see
+    // the handler): do not count it in signals_inflight, and never clobber a
+    // request that is already pending or being processed - blindly storing
+    // over an in-flight suspend handshake would lose it; our caller retries
+    // delivery anyway.
+    sig_atomic_t expected = 0;
+    if (jl_atomic_cmpswap(&ptls2->signal_request, &expected, request))
+        pthread_kill(ptls2->system_id, SIGUSR2);
+    pthread_mutex_unlock(&in_signal_lock);
+}
+
+
 
 // Throw jl_interrupt_exception if the master thread is in a signal async region
 // or if SIGINT happens too often.
@@ -708,6 +762,12 @@ static void jl_exit_thread0(int signo, jl_bt_element_t *bt_data, size_t bt_size)
 //     is reached
 //  3: raise `thread0_exit_signo` and try to exit
 //  4: no-op
+//  5: deliver a pending cancellation of the current task's published
+//     reset_ctx, if available and its governing token source is cancelled
+//     (for task cancellation): longjmp to a compiled reset point
+//  6: preempt shootdown: like 5, but without checking any token source -
+//     the reset point's re-execution observes the JL_RESET_CODE_PREEMPT
+//     setjmp return and yields cooperatively
 void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
 {
     jl_task_t *ct = jl_get_current_task();
@@ -741,10 +801,16 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
         usr2_signal_context = NULL;
         assert(request == 2 || request == 3 || request == 4);
     }
-    int err;
-    eventfd_t got = 1;
-    err = write(signal_caught_cond, &got, sizeof(eventfd_t));
-    if (err != sizeof(eventfd_t)) abort();
+    if (request != 5 && request != 6) {
+        // Acknowledge the request to its synchronously waiting sender. The
+        // cancellation sender (request 5) is fire-and-forget and never
+        // consumes the token; writing it would poison the next suspend
+        // handshake with a stale acknowledgment.
+        int err;
+        eventfd_t got = 1;
+        err = write(signal_caught_cond, &got, sizeof(eventfd_t));
+        if (err != sizeof(eventfd_t)) abort();
+    }
     sig_atomic_t processing = -1;
     jl_atomic_cmpswap(&ptls->signal_request, &processing, 0);
     if (request == 2) {
@@ -758,13 +824,57 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
             // Force a throw
             jl_clear_force_sigint();
             if (saferestore) // restarting jl_ or profile
-                jl_longjmp_in_ctx(sig, ctx, *saferestore);
+                jl_longjmp_in_ctx(sig, ctx, *saferestore, 1);
             else
                 jl_throw_in_ctx(ct, jl_interrupt_exception, sig, ctx);
         }
     }
     else if (request == 3) {
         jl_call_in_ctx(ct->ptls, jl_exit_thread0_cb, sig, ctx);
+    }
+    else if (request == 5 || request == 6) {
+        // Deliver a pending cancellation (5) or preempt (6) shootdown to the
+        // published reset context of the current task's compiled
+        // cancellation region, if any. N.B.: the context is only ever
+        // consumed for the thread's *current* task, whose stack is live at
+        // its canonical address (copied stacks are swapped in before a task
+        // becomes current), so the buffer address is valid here.
+        // Cancellation delivery is gated on an actual cancellation of the
+        // region's governing token source: level-triggered, so a request
+        // racing the region's teardown is simply dropped and recovered at
+        // the task's next cancellation point. bound_cancel_token is coherent
+        // with the published region: everything that may rebind it while a
+        // region is live (exception handlers, the finalizer bracket) saves
+        // and restores the pair together. A preempt shootdown checks no
+        // source: the reset point's re-execution observes the setjmp return
+        // code and yields. Both are gated on the thread running Julia code
+        // (gc_state == 0): a thread inside a GC-safe region (e.g. a foreign
+        // call reached through a reset-safe callee) may be raced by a
+        // concurrent stop-the-world, and a longjmp back into Julia code
+        // would break that protocol.
+        int reset_code = request == 6 ? JL_RESET_CODE_PREEMPT : JL_RESET_CODE_CANCEL;
+        jl_reset_ctx_t *reset_ctx = jl_atomic_load_acquire(&ct->reset_ctx);
+        jl_value_t *bound = jl_atomic_load_relaxed(&ct->bound_cancel_token);
+        int bound_cancelled = bound != NULL && bound != jl_nothing &&
+            jl_atomic_load_relaxed(&((jl_cancel_source_t*)bound)->state) != 0;
+        if (reset_ctx != NULL && reset_ctx->sp != 0 &&
+            (request == 6 || bound_cancelled) &&
+            jl_atomic_load_relaxed(&ptls->gc_state) == JL_GC_STATE_UNSAFE) {
+            // Abandon the interrupted register state and longjmp to the
+            // reset point, whose re-executed check observes the cancellation
+            // and throws. Clear reset_ctx before the longjmp to prevent a
+            // double reset, and restore the GC-frame chain head and the
+            // innermost exception handler saved at establishment: the
+            // interrupt may have landed inside a reset-safe callee whose
+            // pushes onto either chain die with the abandoned stack region.
+            jl_atomic_store_relaxed(&ct->reset_ctx, NULL);
+            ct->gcstack = reset_ctx->gcstack;
+            ct->eh = reset_ctx->eh;
+            // The frames being abandoned were never unwound by the
+            // sanitizer's longjmp interceptor, so unpoison them explicitly.
+            asan_unpoison_task_stack(ct, &reset_ctx->mctx);
+            jl_longjmp_in_ctx(sig, ctx, reset_ctx->mctx, reset_code);
+        }
     }
     errno = errno_save;
 }
@@ -1278,7 +1388,7 @@ static void fpe_handler(int sig, siginfo_t *info, void *context) JL_CANSAFEPOINT
     (void)info;
     jl_jmp_buf *saferestore = jl_get_safe_restore();
     if (saferestore) { // restarting jl_ or profile
-        jl_longjmp_in_ctx(sig, context, *saferestore);
+        jl_longjmp_in_ctx(sig, context, *saferestore, 1);
         return;
     }
     jl_task_t *ct = jl_get_current_task();
@@ -1288,12 +1398,12 @@ static void fpe_handler(int sig, siginfo_t *info, void *context) JL_CANSAFEPOINT
         jl_throw_in_ctx(ct, jl_diverror_exception, sig, context);
 }
 
-static void jl_longjmp_in_ctx(int sig, void *_ctx, jl_jmp_buf jmpbuf)
+static void jl_longjmp_in_ctx(int sig, void *_ctx, jl_jmp_buf jmpbuf, int val)
 {
 #if defined(_OS_DARWIN_)
-    jl_longjmp_in_state((host_thread_state_t*)jl_to_bt_context(_ctx), jmpbuf);
+    jl_longjmp_in_state((host_thread_state_t*)jl_to_bt_context(_ctx), jmpbuf, val);
 #else
-    if (jl_simulate_longjmp(jmpbuf, jl_to_bt_context(_ctx)))
+    if (jl_simulate_longjmp(jmpbuf, jl_to_bt_context(_ctx), val))
         return;
     sigset_t sset;
     sigemptyset(&sset);

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -139,17 +139,24 @@ void restore_signals(void)
     SetConsoleCtrlHandler(NULL, 0);
 }
 
-int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT;
+int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOINT;
 
 static void jl_throw_in_ctx(jl_task_t *ct, jl_value_t *excpt, PCONTEXT ctxThread) JL_NOTSAFEPOINT
 {
     jl_jmp_buf *saferestore = jl_get_safe_restore();
     if (saferestore) { // restarting jl_ or profile
-        if (!jl_simulate_longjmp(*saferestore, ctxThread))
+        if (!jl_simulate_longjmp(*saferestore, ctxThread, 1))
             abort();
         return;
     }
     assert(ct && excpt);
+    // This redirect abandons every frame between the interrupted context and
+    // the handler. A reset context published in one of those frames would
+    // dangle - and may be consumed by an off-thread cancellation sender - so
+    // clear it before rewriting the context. The matching
+    // jl_eh_restore_state republishes the outer context saved at handler
+    // entry.
+    jl_atomic_store_release(&ct->reset_ctx, NULL);
     jl_ptls_t ptls = ct->ptls;
     ptls->bt_size = 0;
     if (excpt != jl_stackovf_exception) {
@@ -168,7 +175,7 @@ static void jl_throw_in_ctx(jl_task_t *ct, jl_value_t *excpt, PCONTEXT ctxThread
     jl_handler_t *eh = ct->eh;
     if (eh != NULL) {
         asan_unpoison_task_stack(ct, &eh->eh_ctx);
-        if (!jl_simulate_longjmp(eh->eh_ctx, ctxThread))
+        if (!jl_simulate_longjmp(eh->eh_ctx, ctxThread, 1))
             abort();
     }
     else {
@@ -178,10 +185,133 @@ static void jl_throw_in_ctx(jl_task_t *ct, jl_value_t *excpt, PCONTEXT ctxThread
 
 HANDLE hMainThread = INVALID_HANDLE_VALUE;
 
+// Serializes every path that suspends a thread and rewrites its context
+// (jl_send_cancellation_signal on any thread, and jl_try_deliver_sigint) for
+// its complete suspend/get/set/resume sequence: two rewriters working from
+// the same suspended snapshot would install conflicting continuations and
+// task chains. (The profiler does not need it: it only reads contexts, and
+// suspend counts nest.) It also prevents two threads delivering
+// cancellations at each other from freezing both (the suspend-count analog
+// of a deadlock): a rewriter always takes this lock before suspending and
+// never blocks while holding a suspension, so a suspended thread can never
+// hold it.
+static SRWLOCK ctx_rewrite_lock = SRWLOCK_INIT;
+
+// Deliver a cancellation or preempt shootdown to the target thread's current
+// task's published reset context, if available: the suspend-based analog of
+// the Unix SIGUSR2 request-5/6 delivery (see signals-unix.c). Rewrites the
+// suspended thread's context as if the reset point's setjmp had returned
+// again (with `reset_code` as the setjmp return), restoring the gcstack and
+// eh saved at establishment. Best-effort: any check failing simply drops the
+// request (recovery is level-triggered at the task's next cancellation
+// point), and the caller retries.
+static int jl_thread_suspend_and_get_state(int tid, int timeout, bt_context_t *ctx);
+void jl_thread_resume(int tid);
+
+static void jl_send_reset_signal(int16_t tid, int reset_code) JL_NOTSAFEPOINT
+{
+    jl_value_t *bound;
+    jl_reset_ctx_t *reset_ctx;
+    if (tid < 0 || tid >= jl_atomic_load_acquire(&jl_n_threads))
+        return;
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    if (ptls2 == NULL)
+        return;
+    jl_task_t *ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
+    if (ct2 == NULL)
+        return;
+    // Only proceed if the task has a reset context published - a purely
+    // polling victim between cancellation points never has one. (A thread's
+    // own reset_ctx is always NULL here: the ccall reaching this function is
+    // itself an unsafe point, so a self-send returns without suspending.)
+    if (jl_atomic_load_relaxed(&ct2->reset_ctx) == NULL)
+        return;
+    AcquireSRWLockExclusive(&ctx_rewrite_lock);
+    // The freeze must complete before any state is examined: validating (or
+    // consuming) the published context while the victim still runs races
+    // with it re-executing the establishing cancellation point (rewriting
+    // the buffer) or leaving the frame entirely, and a SetThreadContext
+    // computed from such a buffer redirects the thread into garbage.
+    // (jl_thread_suspend_and_get_state's GetThreadContext is what completes
+    // the asynchronous SuspendThread.) The profile (read) lock guarantees
+    // the thread is not frozen while holding the debuginfo write lock; it
+    // is only needed around the suspend itself.
+    CONTEXT ctxThread;
+    jl_lock_profile();
+    int suspended = jl_thread_suspend_and_get_state(tid, 0, &ctxThread);
+    jl_unlock_profile();
+    if (!suspended) {
+        ReleaseSRWLockExclusive(&ctx_rewrite_lock);
+        return;
+    }
+    // Re-check now that the thread cannot run (the current task may have
+    // switched before the freeze). Delivery is gated on an actual
+    // cancellation of the task's bound token source - coherent with the
+    // published region, since everything that may rebind it while a region
+    // is live (exception handlers, the finalizer bracket) restores the pair
+    // together - and on the thread running Julia code (gc_state == 0): a
+    // thread inside a GC-safe region may be raced by a concurrent
+    // stop-the-world, and a redirect back into Julia code would break that
+    // protocol.
+    ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
+    if (ct2 == NULL)
+        goto resume;
+    if (jl_atomic_load_relaxed(&ptls2->gc_state) != JL_GC_STATE_UNSAFE)
+        goto resume;
+    reset_ctx = jl_atomic_load_acquire(&ct2->reset_ctx);
+    if (reset_ctx == NULL || reset_ctx->sp == 0)
+        goto resume;
+    if (reset_code == JL_RESET_CODE_CANCEL) {
+        // A preempt shootdown checks no source; the re-executed point
+        // observes the setjmp return code and yields.
+        bound = jl_atomic_load_relaxed(&ct2->bound_cancel_token);
+        if (bound == NULL || bound == jl_nothing ||
+            jl_atomic_load_relaxed(&((jl_cancel_source_t*)bound)->state) == 0)
+            goto resume;
+    }
+    // Consume the reset point (prevents a double reset; unlike on Unix the
+    // consumer here is not the victim thread itself, so use an exchange to
+    // arbitrate against concurrent senders) and redirect the thread there,
+    // restoring the gcstack and eh recorded at establishment: the interrupt
+    // may have landed inside a reset-safe callee whose pushes onto either
+    // chain die with the abandoned stack region.
+    reset_ctx = jl_atomic_exchange(&ct2->reset_ctx, NULL);
+    if (reset_ctx == NULL || reset_ctx->sp == 0)
+        goto resume;
+    // Compute and install the redirected thread context first, and rewind
+    // the task's gcstack/eh chains only once the redirect is committed: if
+    // either step fails (e.g. jl_simulate_longjmp is unavailable under
+    // sanitizers), the thread must resume exactly as it was, with its
+    // deeper chains intact and the (unconsumed) region republished.
+    if (!jl_simulate_longjmp(reset_ctx->mctx, &ctxThread, reset_code))
+        goto republish;
+    ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT;
+    if (!SetThreadContext(ptls2->system_id, &ctxThread))
+        goto republish;
+    // Committed: restore the GC-frame chain head and innermost exception
+    // handler recorded at establishment - the interrupt may have landed
+    // inside a callee whose pushes onto either chain die with the abandoned
+    // stack region.
+    ct2->gcstack = reset_ctx->gcstack;
+    ct2->eh = reset_ctx->eh;
+    goto resume;
+republish:
+    jl_atomic_store_release(&ct2->reset_ctx, reset_ctx);
+resume:
+    jl_thread_resume(tid);
+    ReleaseSRWLockExclusive(&ctx_rewrite_lock);
+}
+
+
 // Try to throw the exception in the master thread.
 static void jl_try_deliver_sigint(void)
 {
     jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[0];
+    // Hold the rewrite lock until the thread is resumed: it serializes the
+    // complete suspend/get/set/resume sequence against other context
+    // rewriters (jl_send_cancellation_signal), which would otherwise install
+    // a conflicting continuation computed from the same suspended snapshot.
+    AcquireSRWLockExclusive(&ctx_rewrite_lock);
     jl_lock_profile();
     jl_safepoint_enable_sigint();
     jl_wake_libuv();
@@ -189,6 +319,7 @@ static void jl_try_deliver_sigint(void)
         // error
         jl_safe_printf("error: SuspendThread failed\n");
         jl_unlock_profile();
+        ReleaseSRWLockExclusive(&ctx_rewrite_lock);
         return;
     }
     jl_unlock_profile();
@@ -201,26 +332,30 @@ static void jl_try_deliver_sigint(void)
         jl_clear_force_sigint();
         CONTEXT ctxThread;
         memset(&ctxThread, 0, sizeof(CONTEXT));
-        ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+        ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT;
         if (!GetThreadContext(hMainThread, &ctxThread)) {
             // error
             jl_safe_printf("error: GetThreadContext failed\n");
+            ReleaseSRWLockExclusive(&ctx_rewrite_lock);
             return;
         }
         jl_task_t *ct = jl_atomic_load_relaxed(&ptls2->current_task);
         jl_throw_in_ctx(ct, jl_interrupt_exception, &ctxThread);
-        ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+        ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT;
         if (!SetThreadContext(hMainThread, &ctxThread)) {
             jl_safe_printf("error: SetThreadContext failed\n");
             // error
+            ReleaseSRWLockExclusive(&ctx_rewrite_lock);
             return;
         }
     }
     if ((DWORD)-1 == ResumeThread(hMainThread)) {
         jl_safe_printf("error: ResumeThread failed\n");
         // error
+        ReleaseSRWLockExclusive(&ctx_rewrite_lock);
         return;
     }
+    ReleaseSRWLockExclusive(&ctx_rewrite_lock);
 }
 
 static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guarantee __stdcall
@@ -445,7 +580,7 @@ static int jl_thread_suspend_and_get_state(int tid, int timeout, bt_context_t *c
     }
     assert(sizeof(*ctx) == sizeof(CONTEXT));
     memset(ctx, 0, sizeof(CONTEXT));
-    ctx->ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+    ctx->ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT;
     if (!GetThreadContext(hThread, ctx)) {
         if ((DWORD)-1 == ResumeThread(hThread))
             abort();

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1127,8 +1127,9 @@ _os_ptr_munge(uintptr_t ptr) JL_NOTSAFEPOINT
 // support shadow stacks, so if those are in use, you might need to use a direct
 // jl_longjmp instead to leave the signal frame instead of relying on simulating
 // it and attempting to return normally.
-int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
+int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOINT
 {
+    assert(val != 0); // setjmp's second return must be distinguishable
 #if (defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_))
     // https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/hwasan/hwasan_interceptors.cpp
     return 0;
@@ -1149,7 +1150,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     // c->MxCsr = _ctx->MxCsr;
     // c->FloatSave.ControlWord = _ctx->FpCsr;
     // c->SegGS[0] = _ctx->Frame;
-    c->Rax = 1;
+    c->Rax = val;
     c->Rsp += sizeof(void*);
     assert(c->Rsp % 16 == 0);
     return 1;
@@ -1162,7 +1163,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     c->Eip = _ctx->Eip;
     // c->SegFS[0] = _ctx->Registration;
     // c->FloatSave.ControlWord = _ctx->FpCsr;
-    c->Eax = 1;
+    c->Eax = val;
     c->Esp += sizeof(void*);
     assert(c->Esp % 16 == 0);
     return 1;
@@ -1191,7 +1192,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     // ifdef PTR_DEMANGLE ?
     mc->gregs[REG_ESP] = ptr_demangle(mc->gregs[REG_ESP]);
     mc->gregs[REG_EIP] = ptr_demangle(mc->gregs[REG_EIP]);
-    mc->gregs[REG_EAX] = 1;
+    mc->gregs[REG_EAX] = val;
     assert(mc->gregs[REG_ESP] % 16 == 0);
     return 1;
     #elif defined(_CPU_X86_64_)
@@ -1210,7 +1211,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     mc->gregs[REG_RBP] = ptr_demangle(mc->gregs[REG_RBP]);
     mc->gregs[REG_RSP] = ptr_demangle(mc->gregs[REG_RSP]);
     mc->gregs[REG_RIP] = ptr_demangle(mc->gregs[REG_RIP]);
-    mc->gregs[REG_RAX] = 1;
+    mc->gregs[REG_RAX] = val;
     assert(mc->gregs[REG_RSP] % 16 == 0);
     return 1;
     #elif defined(_CPU_ARM_)
@@ -1231,7 +1232,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     mc->arm_sp = ptr_demangle(mc->arm_sp);
     mc->arm_lr = ptr_demangle(mc->arm_lr);
     mc->arm_pc = mc->arm_lr;
-    mc->arm_r0 = 1;
+    mc->arm_r0 = val;
     assert(mc->arm_sp % 16 == 0);
     return 1;
     #elif defined(_CPU_AARCH64_)
@@ -1266,7 +1267,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     mc->sp = ptr_demangle(mc->sp);
     mc->regs[30] = ptr_demangle(mc->regs[30]);
     mc->pc = mc->regs[30];
-    mc->regs[0] = 1;
+    mc->regs[0] = val;
     assert(mc->sp % 16 == 0);
     return 1;
     #elif defined(_CPU_RISCV64_)
@@ -1304,7 +1305,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     mc->__gregs[REG_SP] = ptr_demangle(mc->__gregs[REG_SP]);
     mc->__gregs[REG_RA] = ptr_demangle(mc->__gregs[REG_RA]);
     mc->__gregs[REG_PC] = mc->__gregs[REG_RA];
-    mc->__gregs[REG_A0] = 1;
+    mc->__gregs[REG_A0] = val;
     assert(mc->__gregs[REG_SP] % 16 == 0);
     return 1;
     #else
@@ -1331,7 +1332,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     mc->__rbp = _OS_PTR_UNMUNGE(mc->__rbp);
     mc->__rsp = _OS_PTR_UNMUNGE(mc->__rsp);
     mc->__rip = _OS_PTR_UNMUNGE(mc->__rip);
-    mc->__rax = 1;
+    mc->__rax = val;
     assert(mc->__rsp % 16 == 0);
     return 1;
     #elif defined(_CPU_AARCH64_)
@@ -1369,7 +1370,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     // libunwind is broken for signed-pointers, but perhaps best not to leave the signed pointer lying around either
     mc->__pc = ptrauth_strip(mc->__lr, 0);
     mc->__pad = 0; // aka __ra_sign_state = not signed
-    mc->__x[0] = 1;
+    mc->__x[0] = val;
     assert(mc->__sp % 16 == 0);
     return 1;
     #else
@@ -1389,7 +1390,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     mc->mc_r13 = ((long*)mctx)[5];
     mc->mc_r14 = ((long*)mctx)[6];
     mc->mc_r15 = ((long*)mctx)[7];
-    mc->mc_rax = 1;
+    mc->mc_rax = val;
     mc->mc_rsp += sizeof(void*);
     assert(mc->mc_rsp % 16 == 0);
     return 1;
@@ -1415,7 +1416,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     mc->mc_fpregs.fp_q[12] = ((long*)mctx)[18];
     mc->mc_fpregs.fp_q[13] = ((long*)mctx)[19];
     mc->mc_fpregs.fp_q[14] = ((long*)mctx)[20];
-    mc->mc_gpregs.gp_x[0] = 1;
+    mc->mc_gpregs.gp_x[0] = val;
     assert(mc->mc_gpregs.gp_sp % 16 == 0);
     return 1;
     #else
@@ -1452,13 +1453,13 @@ static size_t rec_backtrace_task(jl_task_t *t, bt_context_t *c, int use_ctx,  jl
         jl_jmp_buf *mctx = &t->ctx.ctx->uc_mcontext;
 #if defined(JL_TASK_SWITCH_WINDOWS)
         memset(c, 0, sizeof(*c));
-        if (jl_simulate_longjmp(*mctx, c))
+        if (jl_simulate_longjmp(*mctx, c, 1))
             use_ctx = 1;
 #elif defined(JL_TASK_SWITCH_LIBUNWIND)
         context = t->ctx.ctx;
 #elif defined(JL_TASK_SWITCH_ASM)
         memset(c, 0, sizeof(*c));
-        if (jl_simulate_longjmp(*mctx, c))
+        if (jl_simulate_longjmp(*mctx, c, 1))
             use_ctx = 1;
 #else
      #pragma message("jl_record_backtrace not defined for unknown task system")

--- a/src/task.c
+++ b/src/task.c
@@ -1130,6 +1130,9 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_fu
     jl_atomic_store_relaxed(&t->running_time_ns, 0);
     jl_atomic_store_relaxed(&t->finished_at, 0);
     jl_timing_task_init(t);
+    jl_atomic_store_relaxed(&t->preempt_request, 0);
+    jl_atomic_store_relaxed(&t->bound_cancel_token, jl_nothing);
+    jl_atomic_store_relaxed(&t->reset_ctx, NULL);
 
     if (t->ctx.copy_stack)
         t->ctx.copy_ctx = NULL;
@@ -1600,6 +1603,9 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
         jl_atomic_store_relaxed(&ct->first_enqueued_at, 0);
         jl_atomic_store_relaxed(&ct->last_started_running_at, 0);
     }
+    jl_atomic_store_relaxed(&ct->preempt_request, 0);
+    jl_atomic_store_relaxed(&ct->bound_cancel_token, jl_nothing);
+    jl_atomic_store_relaxed(&ct->reset_ctx, NULL);
     ptls->root_task = ct;
     jl_atomic_store_relaxed(&ptls->current_task, ct);
     JL_GC_PROMISE_ROOTED(ct);

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -358,3 +358,164 @@ end
     @test t3.result isa CancellationRequest
     @test t3.result == CANCEL_REQUEST_ABANDON_EXTERNAL
 end
+
+# An effect-free (hence reset-safe) non-inlined spin: the enclosing compiled
+# cancellation region stays published across the call, so an asynchronous
+# reset can interrupt it even though it performs no checks of its own.
+@noinline function _pure_spin(x::Int)
+    a = x
+    while a >= 0
+        a = (a + 1) & typemax(Int)
+    end
+    return a
+end
+
+function _reset_victim(started::Threads.Atomic{Bool})
+    Threads.atomic_xchg!(started, true)
+    # The compiled cancellation point establishes the reset region and binds
+    # the scoped source; nothing between it and the reset-safe call below
+    # tears the region down.
+    Base.@cancel_check
+    return _pure_spin(0)
+end
+
+@testset "asynchronous reset delivery" begin
+    # `cancel!` delivers the shootdown itself: the reset (a signal on Unix,
+    # suspend + context redirect on Windows/Darwin) longjmps back to the
+    # reset point, whose re-executed check observes the cancellation and
+    # throws. The victim never polls, and a signal racing the point's own
+    # execution is covered by the point's level-triggered check.
+    # Needs a second default-pool thread to keep the driver running while
+    # the victim spins.
+    if Threads.nthreads(:default) >= 2
+        started = Threads.Atomic{Bool}(false)
+        t, src = cancellable_spawn(() -> _reset_victim(started))
+        @test timedwait(() -> started[], 30.0) == :ok
+        cancel!(src)
+        # rely on the test harness watchdog for hangs, like other testsets
+        wait(t; throw=false)
+        @test istaskfailed(t)
+        @test t.result isa CancellationRequest
+    end
+end
+
+# An effect-free (hence reset-safe) non-inlined spin that allocates every
+# iteration. Each allocation unpublishes the enclosing region around the
+# allocator (a reset-safe GC entry point) and republishes it afterwards; the
+# republish re-checks the task's bound source, so a cancellation is picked up
+# even though the spin never polls and no signal is ever sent.
+Base.@assume_effects :effect_free @noinline _obs(r::Base.RefValue{Int}) = r[]
+Base.@assume_effects :effect_free @noinline function _alloc_spin(x::Int)
+    a = x
+    while a >= 0
+        a = (_obs(Base.RefValue(a)) + 1) & typemax(Int)
+    end
+    return a
+end
+
+function _alloc_victim(started::Threads.Atomic{Bool})
+    Threads.atomic_xchg!(started, true)
+    Base.@cancel_check
+    return _alloc_spin(0)
+end
+
+# A compiled cancellation point that rebinds the task's bound_cancel_token
+# to an unrelated source, as a finalizer might do while running inside an
+# allocation that has the region temporarily unpublished.
+@noinline _rebind_point(src::CancellationTokenSource) = (Core.cancellation_point!(src); nothing)
+
+@testset "finalizer rebinding does not detach the region's source" begin
+    # Finalizers run synchronously by a collection triggered inside an
+    # allocation may execute nested cancellation points and rebind the
+    # task's bound_cancel_token field. The finalizer machinery brackets that
+    # state (finalizers hijack the task, so it is on them to save/restore
+    # it), so delivery - including the allocator's republish self-check -
+    # never observes the rebinding: cancelling the original source must
+    # still kill the victim, with no signal sent.
+    if Threads.nthreads(:default) >= 2
+        srcB = CancellationTokenSource()  # never cancelled
+        started = Threads.Atomic{Bool}(false)
+        stop = Threads.Atomic{Bool}(false)
+        t, src = cancellable_spawn(() -> _alloc_victim(started))
+        churner = Threads.@spawn begin
+            while !stop[]
+                obj = Ref(0)
+                finalizer(x -> _rebind_point(srcB), obj)
+                obj = nothing
+                GC.gc(false)
+                yield()
+            end
+        end
+        @test timedwait(() -> started[], 30.0) == :ok
+        # raise the state without cancel!'s shootdown walk: the republish
+        # self-check must deliver on its own despite the finalizers'
+        # (bracketed) rebinding
+        Base._raise_state!(src, 0x1)
+        # rely on the test harness watchdog for hangs, like other testsets
+        wait(t; throw=false)
+        stop[] = true
+        wait(churner)
+        @test istaskfailed(t)
+        @test t.result isa CancellationRequest
+    end
+end
+
+@testset "preempt shootdown" begin
+    # A preempt shootdown resets the task to its cancellation point without
+    # any source being cancelled: the re-executed point observes the
+    # JL_RESET_CODE_PREEMPT setjmp return (the 0x40 status bit), yields
+    # cooperatively, and resumes - it must never kill the task. A subsequent
+    # cancellation then must.
+    if Threads.nthreads(:default) >= 2
+        started = Threads.Atomic{Bool}(false)
+        t, src = cancellable_spawn(() -> _reset_victim(started))
+        @test timedwait(() -> started[], 30.0) == :ok
+        for _ in 1:50
+            tid = ccall(:jl_get_task_tid, Int16, (Any,), t)
+            tid >= 0 && ccall(:jl_send_preempt_signal, Cvoid, (Int16,), tid)
+            sleep(0.005)
+        end
+        @test !istaskdone(t)
+        cancel!(src) # shoots down the (re-established) region itself
+        # rely on the test harness watchdog for hangs, like other testsets
+        wait(t; throw=false)
+        @test istaskfailed(t)
+        @test t.result isa CancellationRequest
+    end
+end
+
+@testset "cancel! delivers to allocating regions" begin
+    # An allocating reset region additionally self-recovers: were the
+    # shootdown ever lost, the next allocation's republish re-check would
+    # perform the delivery.
+    if Threads.nthreads(:default) >= 2
+        started = Threads.Atomic{Bool}(false)
+        t, src = cancellable_spawn(() -> _alloc_victim(started))
+        @test timedwait(() -> started[], 30.0) == :ok
+        cancel!(src)
+        # rely on the test harness watchdog for hangs, like other testsets
+        wait(t; throw=false)
+        @test istaskfailed(t)
+        @test t.result isa CancellationRequest
+    end
+end
+
+@testset "reset region republish self-delivery" begin
+    # A cancellation that arrives while an allocation holds the region
+    # unpublished finds no reset context and is dropped by its sender; the
+    # allocator's republish must re-check the bound source and perform the
+    # missed delivery itself, or the wakeup would be lost. This makes an
+    # allocating reset region cancellable without any signal at all - to
+    # isolate that path from cancel!'s automatic shootdown, raise the
+    # source's state directly.
+    if Threads.nthreads(:default) >= 2
+        started = Threads.Atomic{Bool}(false)
+        t, src = cancellable_spawn(() -> _alloc_victim(started))
+        @test timedwait(() -> started[], 30.0) == :ok
+        Base._raise_state!(src, 0x1)
+        # rely on the test harness watchdog for hangs, like other testsets
+        wait(t; throw=false)
+        @test istaskfailed(t)
+        @test t.result isa CancellationRequest
+    end
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -48,7 +48,7 @@ for (T, c) in (
         (DataType, [:types, :layout]),
         (Core.Memory, []),
         (Core.GenericMemoryRef, []),
-        (Task, [:_state, :running_time_ns, :finished_at, :first_enqueued_at, :last_started_running_at, :waiting_on]),
+        (Task, [:_state, :preempt_request, :running_time_ns, :finished_at, :first_enqueued_at, :last_started_running_at, :waiting_on, :bound_cancel_token]),
         (Core.BindingPartition, [:min_world, :max_world, :next]),
     )
     @test Set((fieldname(T, i) for i in 1:fieldcount(T) if Base.isfieldatomic(T, i))) == Set(c)

--- a/test/llvmpasses/cancellation-lowering-codegen.jl
+++ b/test/llvmpasses/cancellation-lowering-codegen.jl
@@ -1,0 +1,26 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no -O2 %s %t -O && llvm-link -S %t/* | FileCheck %s
+
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+# Test that @cancel_check generates the expected cancellation lowering IR:
+# - A jl_setjmp call with returns_twice attribute
+# - A reset_ctx_ptr getelementptr
+# - Atomic store of ucontext buffer to reset_ctx
+# - Atomic store of null to reset_ctx before return (since ucontext is stack-allocated)
+
+# CHECK-LABEL: @julia_test_cancel_check
+# CHECK: %cancel_ucontext = alloca
+# CHECK: %reset_ctx_ptr = getelementptr
+# CHECK: call i32 @{{.*}}setjmp{{.*}}(ptr {{.*}}, i32 0) #[[ATTR:[0-9]+]]
+# CHECK-NEXT: store atomic volatile ptr %cancel_ucontext, ptr %reset_ctx_ptr release
+# CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+# CHECK: ret
+# CHECK: attributes #[[ATTR]] = {{{.*}}returns_twice{{.*}}}
+function test_cancel_check()
+    Base.@cancel_check
+    return 1
+end
+
+emit(test_cancel_check)

--- a/test/llvmpasses/cancellation-lowering.ll
+++ b/test/llvmpasses/cancellation-lowering.ll
@@ -1,0 +1,326 @@
+; This file is a part of Julia. License is MIT: https://julialang.org/license
+
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='CancellationLowering' -S %s | FileCheck %s
+
+; NOTE: the CHECK lines assume a 64-bit non-Windows host (the jl_reset_ctx_t
+; field offsets 8/16/24 and the two-argument setjmp form); the llvmpasses
+; suite only runs in such environments.
+
+declare i32 @julia.cancellation_point()
+declare ptr @julia.get_pgcstack()
+declare void @some_unsafe_call()
+declare void @some_safe_call()
+declare ptr @julia.gc_alloc_obj(ptr, i64, ptr)
+declare ptr @ijl_box_int64(i64)
+declare ptr @ijl_apply_generic(ptr, ptr, i32)
+declare i32 @tail_target(ptr)
+declare ptr @julia.pointer_from_objref(ptr addrspace(11))
+
+; Test basic cancellation point lowering with reset_ctx cleared before return
+define i32 @test_cancellation_point() {
+entry:
+; CHECK-LABEL: @test_cancellation_point
+; CHECK: %cancel_ucontext = alloca
+; CHECK: %pgcstack = call ptr @julia.get_pgcstack()
+; CHECK: %current_task = getelementptr i8, ptr %pgcstack
+; CHECK: %reset_ctx_ptr = getelementptr i8, ptr %current_task
+; The buffer may only be published while its contents are valid: unpublish,
+; write it (setjmp), then publish it. All the bookkeeping stores are volatile
+; (delivery observes them asynchronously), and the signal fence keeps the
+; buffer writes from being reordered above the unpublish. A GC safepoint is
+; emitted while the buffer is unpublished.
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: fence syncscope("singlethread") seq_cst
+; CHECK: call void @julia.safepoint(ptr %safepoint)
+; The sp discriminator word is stamped first; then the task's gcstack and eh
+; are saved (restored by a delivered reset); the jump buffer lives after them.
+; CHECK: store atomic volatile i64 %{{.*}}, ptr %cancel_ucontext monotonic
+; CHECK-NEXT: %saved_gcstack = load ptr, ptr %pgcstack
+; CHECK-NEXT: %cancel_gcstack_slot = getelementptr i8, ptr %cancel_ucontext, i64 8
+; CHECK-NEXT: store volatile ptr %saved_gcstack, ptr %cancel_gcstack_slot
+; CHECK-NEXT: %saved_eh = load ptr, ptr %eh_field_ptr
+; CHECK-NEXT: %cancel_eh_slot = getelementptr i8, ptr %cancel_ucontext, i64 16
+; CHECK-NEXT: store volatile ptr %saved_eh, ptr %cancel_eh_slot
+; CHECK-NEXT: %cancel_mctx = getelementptr i8, ptr %cancel_ucontext, i64 24
+; CHECK-NEXT: %{{.*}} = call i32 @{{.*}}setjmp{{.*}}(ptr %cancel_mctx, i32 0)
+; CHECK-NEXT: store atomic volatile ptr %cancel_ucontext, ptr %reset_ctx_ptr release
+; CHECK-NOT: call i32 @julia.cancellation_point()
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: ret i32
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  ret i32 %result
+}
+
+; Test that unsafe calls get reset_ctx = NULL inserted before them, separated
+; from the call by a signal fence so no later pass can move the call above
+; the clear
+define void @test_unsafe_call() {
+entry:
+; CHECK-LABEL: @test_unsafe_call
+; CHECK: %cancel_ucontext = alloca
+; CHECK: %pgcstack = call ptr @julia.get_pgcstack()
+; CHECK: %current_task = getelementptr i8, ptr %pgcstack
+; CHECK: %reset_ctx_ptr = getelementptr i8, ptr %current_task
+; CHECK: call i32 @{{.*}}setjmp
+; CHECK-NEXT: store atomic volatile ptr %cancel_ucontext, ptr %reset_ctx_ptr release
+; The unsafe call should have reset_ctx = NULL (plus the fence) before it
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: fence syncscope("singlethread") seq_cst
+; CHECK-NEXT: call void @some_unsafe_call()
+; Also reset_ctx = NULL before the return (no fence needed: an early clear
+; only drops a delivery)
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: ret void
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  call void @some_unsafe_call()
+  ret void
+}
+
+; Test that calls with reset_safe metadata don't get reset_ctx = NULL before them
+; but still get reset_ctx = NULL before return
+define void @test_safe_call() {
+entry:
+; CHECK-LABEL: @test_safe_call
+; CHECK: %cancel_ucontext = alloca
+; CHECK: %pgcstack = call ptr @julia.get_pgcstack()
+; CHECK: %current_task = getelementptr i8, ptr %pgcstack
+; CHECK: %reset_ctx_ptr = getelementptr i8, ptr %current_task
+; CHECK: call i32 @{{.*}}setjmp
+; The safe call should NOT have reset_ctx = NULL before it
+; CHECK: call void @some_safe_call(), !julia.reset_safe
+; But reset_ctx = NULL should be before the return
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: ret void
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  call void @some_safe_call(), !julia.reset_safe !0
+  ret void
+}
+
+; Test function without cancellation points is unchanged: it is not marked
+; julia.ipo_reset_safe, so no reset region can be open while it runs and no
+; instrumentation is needed - even around allocation.
+define ptr @test_no_cancellation_point(i64 %v) {
+entry:
+; CHECK-LABEL: @test_no_cancellation_point
+; CHECK-NOT: setjmp
+; CHECK-NOT: reset_ctx
+; CHECK: call void @some_unsafe_call()
+; CHECK-NOT: reset_ctx
+; CHECK: call ptr @julia.gc_alloc_obj
+  %pgcstack = call ptr @julia.get_pgcstack()
+  call void @some_unsafe_call()
+  %obj = call ptr @julia.gc_alloc_obj(ptr %pgcstack, i64 16, ptr null)
+  ret ptr %obj
+}
+
+; A function codegen marked julia.ipo_reset_safe (its own IPO effects are
+; reset_safe) may be running inside a caller's reset region kept open across
+; a reset_safe call, so machinery the runtime inserts implicitly - runtime
+; library calls - and any call not itself tagged reset_safe eagerly drops
+; the reset context. Tagged (non-implicit) calls stay spanned. Allocations
+; and write barriers do not drop: sites that may execute with a region
+; published are annotated with julia.reset_region instead, and FinalLowerGC
+; lowers them to reset-safe runtime entry points that unpublish/republish
+; the region themselves. A site on a path where the region was already
+; dropped (here: after the untagged call) is not annotated. No region is
+; established (no setjmp), and the region is NOT cleared at the return: it
+; belongs to the caller.
+define ptr @test_implicit_runtime_drop(i64 %v) "julia.ipo_reset_safe" {
+entry:
+; CHECK-LABEL: @test_implicit_runtime_drop
+; CHECK-NOT: setjmp
+; CHECK: %reset_ctx_ptr = getelementptr i8, ptr %current_task
+; CHECK: %obj = call ptr @julia.gc_alloc_obj({{.*}}), !julia.reset_region
+; CHECK-NEXT: call void @some_safe_call(), !julia.reset_safe
+; CHECK-NEXT: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: fence syncscope("singlethread") seq_cst
+; CHECK-NEXT: %box = call ptr @ijl_box_int64(i64 %v)
+; CHECK: %obj2 = call ptr @julia.gc_alloc_obj({{.*}}){{$}}
+; CHECK-NOT: setjmp
+; CHECK-NOT: store
+; CHECK: ret ptr %obj
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %obj = call ptr @julia.gc_alloc_obj(ptr %pgcstack, i64 16, ptr null)
+  call void @some_safe_call(), !julia.reset_safe !0
+  %box = call ptr @ijl_box_int64(i64 %v)
+  %obj2 = call ptr @julia.gc_alloc_obj(ptr %pgcstack, i64 16, ptr null)
+  ret ptr %obj
+}
+
+; In a function with cancellation points of its own, an allocation site
+; between the region's publication and the next drop is annotated (not
+; dropped): FinalLowerGC lowers it to a reset-safe entry point.
+define ptr @test_alloc_in_region() {
+entry:
+; CHECK-LABEL: @test_alloc_in_region
+; CHECK: call i32 @{{.*}}setjmp
+; CHECK-NEXT: store atomic volatile ptr %cancel_ucontext, ptr %reset_ctx_ptr release
+; CHECK-NEXT: %obj = call ptr @julia.gc_alloc_obj({{.*}}), !julia.reset_region
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: ret ptr %obj
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  %obj = call ptr @julia.gc_alloc_obj(ptr %pgcstack, i64 16, ptr null)
+  ret ptr %obj
+}
+
+; Even a reset_safe-tagged call is an unsafe point when it is
+; implicitly-inserted runtime machinery: the tag describes the source
+; statement's IPO contract, not the runtime frames implementing it (e.g. a
+; dynamic dispatch inside a reset_safe statement).
+define void @test_tagged_implicit_still_unsafe(ptr %x) {
+entry:
+; CHECK-LABEL: @test_tagged_implicit_still_unsafe
+; CHECK: call i32 @{{.*}}setjmp
+; CHECK-NEXT: store atomic volatile ptr %cancel_ucontext, ptr %reset_ctx_ptr release
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: fence syncscope("singlethread") seq_cst
+; CHECK-NEXT: %r = call ptr @ijl_apply_generic
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  %r = call ptr @ijl_apply_generic(ptr %x, ptr null, i32 0), !julia.reset_safe !0
+  ret void
+}
+
+; Atomic stores are unsafe points like plain ones: a reset delivered around
+; e.g. a lock-release store would leave the lock owned forever. Only the
+; pass's own bookkeeping stores (which carry the reset_safe metadata) are
+; exempt.
+define void @test_atomic_store_unsafe(ptr %lock) {
+entry:
+; CHECK-LABEL: @test_atomic_store_unsafe
+; CHECK: call i32 @{{.*}}setjmp
+; CHECK-NEXT: store atomic volatile ptr %cancel_ucontext, ptr %reset_ctx_ptr release
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: fence syncscope("singlethread") seq_cst
+; CHECK-NEXT: store atomic i64 0, ptr %lock release
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: ret void
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  store atomic i64 0, ptr %lock release, align 8
+  ret void
+}
+
+; Atomic read-modify-write operations publish state a reset could tear
+; (e.g. a cmpxchg acquiring a user spin lock).
+define void @test_atomic_rmw_unsafe(ptr %lock, ptr %counter) {
+entry:
+; CHECK-LABEL: @test_atomic_rmw_unsafe
+; CHECK: call i32 @{{.*}}setjmp
+; CHECK-NEXT: store atomic volatile ptr %cancel_ucontext, ptr %reset_ctx_ptr release
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: fence syncscope("singlethread") seq_cst
+; CHECK-NEXT: cmpxchg ptr %lock, i64 0, i64 1 acq_rel monotonic
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: fence syncscope("singlethread") seq_cst
+; CHECK-NEXT: atomicrmw add ptr %counter, i64 1 seq_cst
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: ret void
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  %acq = cmpxchg ptr %lock, i64 0, i64 1 acq_rel monotonic, align 8
+  %old = atomicrmw add ptr %counter, i64 1 seq_cst, align 8
+  ret void
+}
+
+; Volatile loads can have side effects (MMIO, read-to-clear hardware
+; registers): a reset delivered after the load has taken effect must not
+; silently abandon it.
+define i64 @test_volatile_load_unsafe(ptr %mmio) {
+entry:
+; CHECK-LABEL: @test_volatile_load_unsafe
+; CHECK: call i32 @{{.*}}setjmp
+; CHECK-NEXT: store atomic volatile ptr %cancel_ucontext, ptr %reset_ctx_ptr release
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: fence syncscope("singlethread") seq_cst
+; CHECK-NEXT: %v = load volatile i64, ptr %mmio
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: ret i64 %v
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  %v = load volatile i64, ptr %mmio, align 8
+  ret i64 %v
+}
+
+; A musttail call must stay immediately adjacent to its return, so the
+; return teardown is inserted in front of the call - unconditionally, even
+; when the unsafe-point clear before the call already tore the region down
+; (metadata is not a reliable proxy: exempt calls get no clear).
+define i32 @test_musttail(ptr %arg) {
+entry:
+; CHECK-LABEL: @test_musttail
+; CHECK: call i32 @{{.*}}setjmp
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: fence syncscope("singlethread") seq_cst
+; CHECK-NEXT: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: %r = musttail call i32 @tail_target(ptr %arg)
+; CHECK-NEXT: ret i32 %r
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  %r = musttail call i32 @tail_target(ptr %arg)
+  ret i32 %r
+}
+
+; A reset_safe-tagged musttail call gets no unsafe-point clear, so the
+; return teardown goes in front of the call instead (no fence needed: an
+; early clear only drops a delivery).
+define i32 @test_musttail_safe(ptr %arg) {
+entry:
+; CHECK-LABEL: @test_musttail_safe
+; CHECK: call i32 @{{.*}}setjmp
+; CHECK-NEXT: store atomic volatile ptr %cancel_ucontext, ptr %reset_ctx_ptr release
+; CHECK-NEXT: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: %r = musttail call i32 @tail_target(ptr %arg), !julia.reset_safe
+; CHECK-NEXT: ret i32 %r
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  %r = musttail call i32 @tail_target(ptr %arg), !julia.reset_safe !0
+  ret i32 %r
+}
+
+; Instructions not reachable from any cancellation point can never observe
+; an open region: no clears are inserted for them (the store and call before
+; the point below are untouched; only those after it are guarded).
+define void @test_unreachable_before_point(ptr %p) {
+entry:
+; CHECK-LABEL: @test_unreachable_before_point
+; CHECK: %reset_ctx_ptr = getelementptr i8, ptr %current_task
+; CHECK-NOT: store atomic volatile
+; CHECK: store i64 1, ptr %p
+; CHECK-NEXT: call void @some_unsafe_call()
+; CHECK: call i32 @{{.*}}setjmp
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: fence syncscope("singlethread") seq_cst
+; CHECK-NEXT: store i64 2, ptr %p
+; CHECK: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: ret void
+  %pgcstack = call ptr @julia.get_pgcstack()
+  store i64 1, ptr %p
+  call void @some_unsafe_call()
+  %result = call i32 @julia.cancellation_point()
+  store i64 2, ptr %p
+  ret void
+}
+
+; An exempt call (no unsafe-point clear, e.g. julia.pointer_from_objref)
+; that is a musttail still must not leave the stack reset context published
+; past the return: the teardown goes in front of the call.
+define ptr @test_musttail_exempt(ptr addrspace(11) %obj) {
+entry:
+; CHECK-LABEL: @test_musttail_exempt
+; CHECK: call i32 @{{.*}}setjmp
+; CHECK-NEXT: store atomic volatile ptr %cancel_ucontext, ptr %reset_ctx_ptr release
+; CHECK-NEXT: store atomic volatile ptr null, ptr %reset_ctx_ptr release
+; CHECK-NEXT: %r = musttail call ptr @julia.pointer_from_objref(ptr addrspace(11) %obj)
+; CHECK-NEXT: ret ptr %r
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %result = call i32 @julia.cancellation_point()
+  %r = musttail call ptr @julia.pointer_from_objref(ptr addrspace(11) %obj)
+  ret ptr %r
+}
+
+!0 = !{}

--- a/test/llvmpasses/final-lower-gc.ll
+++ b/test/llvmpasses/final-lower-gc.ll
@@ -80,6 +80,24 @@ top:
   ret {} addrspace(10)* %v
 }
 
+; Allocation sites annotated by CancellationLowering (they may execute with
+; a cancellation reset region published) lower to the reset-safe entry
+; points, which unpublish/republish the region themselves.
+define {} addrspace(10)* @gc_alloc_lowering_reset_region() {
+top:
+; CHECK-LABEL: @gc_alloc_lowering_reset_region
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  %ptls = call {}*** @julia.ptls_states()
+  %ptls_i8 = bitcast {}*** %ptls to i8*
+; OPAQUE: %v = call noalias nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) ptr addrspace(10) @ijl_gc_small_alloc_reset_safe
+  %v = call {} addrspace(10)* @julia.gc_alloc_bytes(i8* %ptls_i8, i64 8, i64 12341234), !julia.reset_region !3
+  %0 = bitcast {} addrspace(10)* %v to {} addrspace(10)* addrspace(10)*
+  %1 = getelementptr {} addrspace(10)*, {} addrspace(10)* addrspace(10)* %0, i64 -1
+  store {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* %1, align 8, !tbaa !0
+  ret {} addrspace(10)* %v
+}
+
 !0 = !{!1, !1, i64 0}
 !1 = !{!"jtbaa_gcframe", !2, i64 0}
 !2 = !{!"jtbaa"}
+!3 = !{}


### PR DESCRIPTION
This pulls out the intrinsic/LLVM pass from #60281. As written in this PR, interruption is not automatic - after cancellation of the task-bound source, a separate interrupt needs to be issued to have the cancelled task check it's cancellation. Doing that automatically will have to wait until after #62557 is merged.