### PR TITLE
Test: restore implicit world age increment in `@testset for`

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2089,12 +2089,13 @@ parent test set (with the context object appended to any failing tests.)
 !!! compat "Julia 1.13"
     Context is shown when a test errors since Julia 1.13.
 
-# Special implicit world age increment for `@testset begin`
+# Special implicit world age increment for `@testset begin` and `@testset for`
 
-World age inside `@testset begin` increments implicitly after every statement.
-This matches the behavior of ordinary toplevel code, but not that of ordinary
-`begin/end` blocks, i.e. with respect to world age, `@testset begin` behaves
-as if the body of the `begin/end` block was written at toplevel.
+World age inside `@testset begin` and inside the loop body of `@testset for`
+increments implicitly after every statement. This matches the behavior of
+ordinary toplevel code, but not that of ordinary `begin/end` blocks or `for`
+loops, i.e. with respect to world age, `@testset begin` and `@testset for`
+behave as if their bodies were written at toplevel.
 
 ## Examples
 ```jldoctest
@@ -2312,7 +2313,7 @@ function testset_forloop(args, testloop, source)
 
     # Uses a similar block as for `@testset`, except that it is
     # wrapped in the outer loop provided by the user
-    tests = testloop.args[2]
+    tests = insert_toplevel_latestworld(testloop.args[2])
     blk = quote
         _check_testset($testsettype, $(QuoteNode(testsettype.args[1])))
         ts = if ($testsettype === $DefaultTestSet) && $(isa(source, LineNumberNode))

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -2537,3 +2537,17 @@ end
         @test !occursin("Finished testset:", output)
     end
 end
+
+# world age increments implicitly after each statement in the body of both
+# `@testset begin` and `@testset for`, as a special case
+let m = Module()
+    Core.eval(m, :(f() = 0))
+    @testset "implicit world age increment in `@testset begin`" begin
+        Core.eval(m, :(f() = 42))
+        @test m.f() == 42
+    end
+    @testset "implicit world age increment in `@testset for` ($i)" for i in 1:2
+        Core.eval(m, :(f() = $i))
+        @test m.f() == i
+    end
+end


### PR DESCRIPTION
claude find, claude fix, but seems reasonable and more consistent

---------
#56509 made world age increments explicit. To keep the old top-level behavior, it gave `@testset begin` an implicit increment after every statement — but missed `@testset for`. Since 1.12 the loop body runs at a fixed world age, so this fails:

```julia
module Foo; _foo() = 0; end
@testset "for" for i in 1:1
    Foo.eval(:(_foo() = 42))
    @test Foo._foo() == 42   # FAIL on 1.12/1.13: 0 == 42
end
```

This inserts the same increments into the loop body, so `@testset for` behaves like a separate `@testset begin` per iteration, as it did through 1.11.

Written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
