### PR TITLE
RFC: introduce `Base.tracemark()` and `rethrow(; drop_{above,below})` to prune stacktraces exactly.

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -71,7 +71,8 @@ exception will continue propagation as if it had not been caught.
     described in [`current_exceptions`](@ref).
 """
 rethrow() = ccall(:jl_rethrow, Bottom, ())
-rethrow(@nospecialize(e)) = ccall(:jl_rethrow_other, Bottom, (Any,), e)
+rethrow(@nospecialize(e); drop_above = 0, drop_below = 0) =
+    ccall(:jl_rethrow_other, Bottom, (Any, Int, Int), e, drop_above, drop_below)
 
 struct InterpreterIP
     code::Union{CodeInfo,Core.MethodInstance,Core.CodeInstance,Nothing}
@@ -125,6 +126,16 @@ function backtrace()
     skip = 1
     bt1, bt2 = ccall(:jl_backtrace_from_here, Ref{SimpleVector}, (Cint, Cint), false, skip)
     return _reformat_bt(bt1::Vector{Ptr{Cvoid}}, bt2::Vector{Any})
+end
+
+# TODO: dedicate some simpler :jl_backtrace_size.
+function tracemark()
+    @noinline
+    skip = 1
+    # HELP: the results I am getting here seem not always consistent
+    # with the backtraces actually processed during `jl_rethrow_other`?
+    bt1, _ = ccall(:jl_backtrace_from_here, Ref{SimpleVector}, (Cint, Cint), false, skip)
+    return length(bt1) # TODO: protect result in opaque struct to disallow arithmetic.
 end
 
 """

--- a/src/ast.c
+++ b/src/ast.c
@@ -1087,7 +1087,7 @@ lno_ok:
                 margs[0] = jl_cstr_to_string("<macrocall>");
             margs[1] = jl_fieldref(lno, 0); // extract and allocate line number
             jl_rethrow_other(jl_new_struct(jl_loaderror_type, margs[0], margs[1],
-                                           jl_current_exception(ct)));
+                                           jl_current_exception(ct)), 0, 0);
         }
     }
     ct->world_age = last_age;

--- a/src/julia.h
+++ b/src/julia.h
@@ -2558,7 +2558,7 @@ JL_DLLEXPORT int jl_set_task_tid(jl_task_t *task, int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_set_task_threadpoolid(jl_task_t *task, int8_t tpid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);
-JL_DLLEXPORT void JL_NORETURN jl_rethrow_other(jl_value_t *e JL_MAYBE_UNROOTED);
+JL_DLLEXPORT void JL_NORETURN jl_rethrow_other(jl_value_t *e JL_MAYBE_UNROOTED, size_t drop_above, size_t drop_below);
 JL_DLLEXPORT void JL_NORETURN jl_no_exc_handler(jl_value_t *e JL_MAYBE_UNROOTED, jl_task_t *ct);
 
 

--- a/src/task.c
+++ b/src/task.c
@@ -832,7 +832,63 @@ JL_DLLEXPORT void JL_NO_SAFEPOINT_ANALYSIS jl_rethrow(void)
     throw_internal(ct, NULL);
 }
 
-JL_DLLEXPORT void JL_NO_SAFEPOINT_ANALYSIS jl_rethrow_other(jl_value_t *e JL_MAYBE_UNROOTED)
+JL_DLLEXPORT void JL_NO_SAFEPOINT_ANALYSIS jl_rethrow_other(
+    jl_value_t *e JL_MAYBE_UNROOTED,
+    size_t drop_above, size_t drop_below
+    // Where, as *inputs*:
+    //   "above" = top    of callstack = innermost scope = latest   call.
+    //   "below" = bottom of callstack = outermost scope = earliest call.
+    // With index 0 meaning bottom call and <backtrace size> meaning top call.
+    //
+    // But also where, since backtraces are captured upside down,
+    // we will internally transform (=complement) the indices to mean instead:
+    //    `a`bove = left = index 0.
+    //    `b`elow = right = backtrace size.
+    //
+    // Then, in the following situation (illustrated with transformed indices)..
+    //
+    //                                drop
+    //    (size, exception)     "below"   "above"
+    //                |            |         |        (current exception)
+    //      bt_1..    v bt_last..  v         v           v
+    //     |-------[s,e]----------->xxxxxxxxx<--------[s,e]   (remove 10/30)
+    //     ^            ^          ^         ^
+    //    raw         data        `b`       `a`
+    //                (0)    (included)    (excluded)
+    //                       (=dropped)       (=kept)
+    // .. end up there:
+    //
+    // ==> |-------[s,e]-----------<--------[s,e]||||||||||
+    //                                           (deinitialized)
+    // And in the following situation..
+    //
+    //     |-------[s,e]xxxxx<--------->xxxxxxxxxxxxxx[s,e]   (keep 10/30)
+    //                       ^         ^
+    //                       a         b
+    // .. end up there:
+    //
+    // ==> |-------[s,e]<---------[s,e]||||||||||||||||||||
+    //
+    //
+    // Limit case: drop everything:
+    //
+    //     |-------[s,e]>xxxxxxxxxxxxxxxxxxxxxxxxxxxxx[s,e]
+    //                  b=0                           a=s
+    //
+    // Limit case: keep everything:
+    //
+    //     |-------[s,e]<-----------------------------[s,e]
+    //                  a=0                           b=s
+    //
+    // Limit case: invalid input (meaningless):
+    //
+    //     |-------[s,e]------------X-----------------[s,e]
+    //                             a=b
+    //     The chosen (equal) input value is used to convey information then.
+    //     For instance "above" = "below" = 0 is a shorthand for 'drop nothing'.
+    //
+    // The rightmost 's' is updated and the rightmost 'e' overridden by input.
+  )
 {
     // TODO: Should uses of `rethrow(exc)` be replaced with a normal throw, now
     // that exception stacks allow root cause analysis?
@@ -840,8 +896,39 @@ JL_DLLEXPORT void JL_NO_SAFEPOINT_ANALYSIS jl_rethrow_other(jl_value_t *e JL_MAY
     jl_excstack_t *excstack = ct->excstack;
     if (!excstack || excstack->top == 0)
         jl_error("rethrow(exc) not allowed outside a catch block");
-    // overwrite exception on top of stack. see jl_excstack_exception
-    jl_excstack_raw(excstack)[excstack->top-1].jlvalue = e;
+
+    size_t top = excstack->top;
+    jl_bt_element_t *raw = jl_excstack_raw(excstack);
+    jl_bt_element_t *data = jl_excstack_bt_data(excstack, top);
+    size_t size = jl_excstack_bt_size(excstack, top);
+
+    if ((drop_above > size) || (drop_below > size))
+      jl_error("invalid index: cannot drop frames higher than the call stack");
+
+    if (drop_above == drop_below) {
+      if (drop_below == 0) { // Special value indicating default: drop nothing.
+        drop_above = size;
+      } else {
+        jl_error("invalid indices: frame cannot be both kept and dropped");
+      }
+    }
+
+    // Complement indices to match the above illustrations.
+    size_t a = size - drop_above; // The first item kept (from the left).
+    size_t b = size - drop_below; // The first item dropped (from the left).
+
+    // Move items kept above down, overwriting items dropped below.
+    size_t moved = ((a < b) ? b : size) - a;
+    if (moved && a)
+      memmove(data, data + a, sizeof(jl_bt_element_t) * moved);
+
+    // Update exception stack top.
+    size_t stayed = (a < b) ? 0 : b; // Items stayed still on the left.
+    size_t new_size = stayed + moved;
+    (data + new_size)->uintptr = new_size;
+    (data + new_size + 1)->jlvalue = e;
+    excstack->top = (data - raw) + new_size + 2;
+
     JL_GC_PROMISE_ROOTED(e);
     throw_internal(ct, NULL);
 }

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -78,7 +78,7 @@ void jl_module_run_initializer(jl_module_t *m)
         }
         else {
             jl_rethrow_other(jl_new_struct(jl_initerror_type, m->name,
-                                           jl_current_exception(ct)));
+                                           jl_current_exception(ct)), 0, 0);
         }
     }
 }
@@ -895,7 +895,7 @@ static jl_value_t *jl_parse_eval_all(jl_module_t *module, jl_value_t *text,
             jl_rethrow();
         else
             jl_rethrow_other(jl_new_struct(jl_loaderror_type, filename, result,
-                                           jl_current_exception(ct)));
+                                           jl_current_exception(ct)), 0, 0);
     }
     jl_atomic_store_relaxed(&jl_lineno, last_lineno);
     jl_atomic_store_relaxed(&jl_filename, last_filename);


### PR DESCRIPTION
Hello. This is a first shot at implementing the idea exposed in https://github.com/JuliaLang/julia/issues/62594, that I would like to suggest as a first step towards alleviating longstanding https://github.com/JuliaLang/julia/issues/40138. I would appreciate feedback, and if positive then I could use some help.

## Summary

Introduce `Base.tracemark()` and two optional arguments to `Base.rethrow(; drop_above, drop_below)` with the following semantics:
```julia
m = Base.tracemark()         # Obtain index into current call stack.
rethrow(exc; drop_above = m) # Rethrow exception, discarding stack frames opened after `m`.
rethrow(exc; drop_below = m) # Rethrow exception, discarding stack frames opened before `m`.
```

## Motivation

<details>

<summary>Case 1</summary>

The following common situation:
```julia
#-------------------------------------
module Internal
struct WrongInput <: Exception end
f(x::Int) = x
f(x) = throw(WrongInput())
g(x) = f(x)
h(x) = g(x)
export h
end

#-------------------------------------
module Exposed
using ..Internal

p(x) = h(x)
q(x) = p(x)
r(x) = q(x)
function guard(x)
    try
        r(x)
    catch e
        e isa Internal.WrongInput || rethrow(e)
        handle(e)
    end
end
s(x) = guard(x)
t(x) = s(x)
function welcome(x)
    t(x)
end
export welcome

handle(e) = u(e)
u(e) = v(e)
v(e) = w(e)
w(e) = begin
    up = NiceReport()
    rethrow(up)
end
struct NiceReport <: Exception end
Base.showerror(io::IO, ::NiceReport) =
    print(io, "Don't worry it's not that bad just try again <3")
end

#-------------------------------------
# User.
using .Exposed

my_a(x) = welcome(x)
my_b(x) = my_a(x)
my_c(x) = my_b(x)

my_c("hi")
```
produces the following unsatisfactory report:
```text
ERROR: LoadError: Don't worry it's not that bad just try again <3
Stacktrace:
  [1] f(x::String)               <<
    @ Main.Internal ./test.jl:5  <<
  [2] g(x::String)               <<
    @ Main.Internal ./test.jl:6  <<  Garbage (from user perspective).
  [3] h(x::String)               <<  Useless for debugging: not a bug (in the lib).
    @ Main.Internal ./test.jl:7  <<
  [4] p(x::String)               <<
    @ Main.Exposed ./test.jl:15  <<
  [5] q(x::String)               <<
    @ Main.Exposed ./test.jl:16  <<
  [6] r(x::String)               <<
    @ Main.Exposed ./test.jl:17  <<
  [7] guard(x::String)           <<
    @ Main.Exposed ./test.jl:20  <<
  [8] s(x::String)               <<
    @ Main.Exposed ./test.jl:26  <<
  [9] t(x::String)               <<
    @ Main.Exposed ./test.jl:27  <<
 [10] welcome(x::String)         <<
    @ Main.Exposed ./test.jl:29  <<
 [11] my_a(x::String)          <<
    @ Main ./test.jl:49        <<
 [12] my_b(x::String)          <<   *USEFUL* (from user perspective).
    @ Main ./test.jl:50        <<
 [13] my_c(x::String)          <<
    @ Main ./test.jl:51        <<
 [14] top-level scope          <<
    @ ./test.jl:53             <<
in expression starting at ./test.jl:53
```

With the proposed change, authors of `Exposed` can now trim the irrelevant part to avoid flooding their user:
```diff
! function guard(x, mark)
#     try
#         r(x)
#     catch e
#         e isa Internal.WrongInput || rethrow(e)
!         handle(e, mark)
#     end
# end
# s(x, m) = guard(x, m)
# t(x, m) = s(x, m)
# function welcome(x)
+     mark = Base.tracemark()
!     t(x, mark)
# end
# handle(e, m) = u(e, m)
# u(e, m) = v(e, m)
# v(e, m) = w(e, m)
! w(e, mark) = begin
#     rep = NiceReport()
+     rethrow(rep; drop_above = mark)
# end
```
```text
ERROR: LoadError: Don't worry it's not that bad just try again <3
Stacktrace:
 [1] welcome(x::String)          X
   @ Main.Exposed ./test.jl:30   X
 [2] my_a(x::String)             |
   @ Main ./test.jl:50           |
 [3] my_b(x::String)             |
   @ Main ./test.jl:51           |
 [4] my_c(x::String)             |
   @ Main ./test.jl:52           |
 [5] top-level scope             |
   @ ./test.jl:54
in expression starting at ./test.jl:54
```
</details>

<details>

<summary>Case 2</summary>

The following, more intricate situation:
```julia
#-------------------------------------
module Internal
struct CallBackError <: Exception
    user_err
end
function f(callback::Function)
    try
        callback()
    catch e
        handle(e)
    end
end
g(c) = f(c)
h(c) = g(c)
export h

handle(e) = i(e)
i(e) = j(e)
j(e) = k(e)
k(user_err) = begin
    rep = CallBackError(user_err)
    rethrow(rep)
end
end

#-------------------------------------
module Exposed
using ..Internal

p(c) = h(c)
q(c) = p(c)
r(c) = q(c)
function guard(c)
    try
        r(c)
    catch e
        e isa Internal.CallBackError || rethrow(e)
        handle(e)
    end
end
s(c) = guard(c)
t(c) = s(c)
function welcome(c)
    t(c)
end
export welcome

handle(e) = u(e)
u(e) = v(e)
v(e) = w(e)
w(e) = begin
    rep = NiceReport(e.user_err)
    rethrow(rep)
end
struct NiceReport <: Exception
    user_err
end
function Base.showerror(io::IO, r::NiceReport)
    println(io, "Your callback failed with the following error:")
    showerror(io, r.user_err)
    print(io, "Don't worry it's not that bad just try again <3")
end
end

#-------------------------------------
# User.
using .Exposed

my_a(c) = welcome(c)
my_b(c) = my_a(c)
my_c(c) = my_b(c)

my_x() = :oops + 1
my_y() = my_x()
my_z() = my_y()

my_c(my_z)
```
produces the following unsatisfactory report:
```text
ERROR: LoadError: Your callback failed with the following error:
MethodError: no method matching +(::Symbol, ::Int64)
The function `+` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  +(::Any, ::Any, !Matched::Any, !Matched::Any...)
   @ Base operators.jl:642
  +(!Matched::Base.CoreLogging.LogLevel, ::Integer)
   @ Base logging./test.jl:134
  +(!Matched::BigInt, ::Union{Int16, Int32, Int64, Int8})
   @ Base gmp.jl:556
  ...
Don't worry it's not that bad just try again <3
Stacktrace:
  [1] my_x()                    <<
    @ Main ./test.jl:73         <<  *USEFUL* (from user perspective).
  [2] my_y()                    <<
    @ Main ./test.jl:74         <<
  [3] my_z()                    <<
    @ Main ./test.jl:75         <<
  [4] f(callback::typeof(my_z))    <<
    @ Main.Internal ./test.jl:8    <<
  [5] g(c::Function)               <<
    @ Main.Internal ./test.jl:13   <<  Garbage (from user perspective).
  [6] h                            <<  Useless for debugging: not a bug (in the lib).
    @ ./test.jl:14 [inlined]       <<
  [7] p                            <<
    @ ./test.jl:30 [inlined]       <<
  [8] q                            <<
    @ ./test.jl:31 [inlined]       <<
  [9] r                            <<
    @ ./test.jl:32 [inlined]       <<
 [10] guard(c::Function)           <<
    @ Main.Exposed ./test.jl:35    <<
 [11] s                            <<
    @ ./test.jl:41 [inlined]       <<
 [12] t                            <<
    @ ./test.jl:42 [inlined]       <<
 [13] welcome                      <<
    @ ./test.jl:44 [inlined]       <<
 [14] my_a                      <<
    @ ./test.jl:69 [inlined]    <<
 [15] my_b                      <<  *USEFUL* (from user perspective).
    @ ./test.jl:70 [inlined]    <<
 [16] my_c(c::Function)         <<
    @ Main ./test.jl:71         <<
 [17] top-level scope           <<
    @ ./test.jl:77              <<
in expression starting at ./test.jl:77
```


With the proposed change, authors of `Internal` and `Exposed` can now coordinate to trim the irrelevant part and avoid flooding their user:
```diff
# struct CallBackError <: Exception
#     user_err
+     mark
# end
# function f(callback::Function)
+     mark = Base.tracemark()
#     try
#         callback()
#     catch e
!         handle(e, mark)
#     end
# end
# handle(e, m) = i(e, m)
# i(e, m) = j(e, m)
# j(e, m) = k(e, m)
! k(user_err, mark) = begin
+     rep = CallBackError(user_err, mark)
#     rethrow(rep)
# end
...
! function guard(c, mark)
#     try
#         r(c)
#     catch e
#         e isa Internal.CallBackError || rethrow(e)
!         handle(e, mark)
#     end
# end
# s(c, m) = guard(c, m)
# t(c, m) = s(c, m)
# function welcome(c)
+     mark = Base.tracemark()
!     t(c, mark)
# end
#
# handle(e, m) = u(e, m)
# u(e, m) = v(e, m)
# v(e, m) = w(e, m)
! w(err, us) = begin
+     them = e.mark
#     rep = NiceReport(e.user_err)
#     rethrow(rep;
+         drop_below = them,
+         drop_above = us,
#     )
# end
```
```text
ERROR: LoadError: Your callback failed with the following error:
  ...
Don't worry it's not that bad just try again <3
Stacktrace:
  [1] my_x()                     |
    @ Main ./test.jl:73          |
  [2] my_y()                     |
    @ Main ./test.jl:74          |
  [3] my_z()                     |
    @ Main ./test.jl:75          |
  [4] f(callback::typeof(my_z))  X
    @ Main.Internal ./test.jl:8  X
  [5] welcome                    X
    @ ./test.jl:44 [inlined]     X
  [6] my_a                       |
    @ ./test.jl:69 [inlined]     |
  [7] my_b                       |
    @ ./test.jl:70 [inlined]     |
  [8] my_c(c::Function)          |
    @ Main ./test.jl:71          |
  [9] top-level scope            |
    @ ./test.jl:77               |
in expression starting at ./test.jl:77
```
</details>

## Drawbacks

It is now the responsibility of lib devs to take care of guaranteeing bug-free paths that may safely be trimmed. This can be done using patterns like `err isa Expected || rethrow(err)` above, guarding against trimming in case of unexpected error within the lib.
This implies that the alleviating of #40138 can only occur after patient distillation of the practice throughout the ecosystem lib, starting with `Base.jl`.

## Alternatives

#40537 Suggests a heuristic approach instead, where julia chooses fine-tuned trimming defaults to improve user experience immediately in most cases, without the burden of trimming being endorsed by lib developers.

## Unresolved issues

- Blocking right now:

  - [ ] `rethrow(; drop_*)` Implementation currently relies on a rather [brutal erasure](https://github.com/iago-lito/julia/blob/e4fe07ff1f6fc070f1931bed4f2e535359b84c48/src/task.c#L923) of entries/elements within the live backtrace buffer. I am not confident enough about julia's GC-tracked memory management to be certain that no additional operation needs be taken when dropping these values. Should I carefully iterate over entries instead to clean each one up?

  - [ ] `Base.tracemark()` Implementation is currently just a [highjack of `:jl_backtrace_from_here`](https://github.com/iago-lito/julia/blob/e4fe07ff1f6fc070f1931bed4f2e535359b84c48/base/error.jl#L138). I suppose it could be made more efficient by just measuring the current backtrace size without allocating a frames array, but I have a deeper problem that the obtained result seems not always consistent with the eventual backtrace processing in `:jl_rethrow_other`, resulting in the second example above not reliably working. What am I missing? Do `:jl_backtrace_from_here` and `:jl_throw` iterate differently over frames? Which one (if any) should be trusted?

- Consider later if feedback is positive:
  - [ ] Wrap `mark`s in opaque, immutable struct to prevent user from performing arithmetics on it.
  - [ ] Brand `mark`s with a value that `:jl_rethrow_other` may check to enforce that it comes from the right backtrace?
  - [ ] Write formal tests.
  - [ ] Verify the feature composition with itself: libs pruning stacks chunks on `catch` paths prior to being caught and pruned themselves. Behaviour on complex `throw/rethrow` mixture paths.
  - [ ] Document.