### PR TITLE
Optimise in(::Char, ::Union{String, SubString{String}})

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -358,7 +358,8 @@ in(c::AbstractChar, s::AbstractString) = (findfirst(isequal(c),s)!==nothing)
 # nothrow+foldable: iteration over `String`/`SubString{String}` is total and
 # `Char` equality is total.
 @assume_effects :nothrow :foldable function in(c::Char, s::Union{String,SubString{String}})
-    @invoke in(c::AbstractChar, s::AbstractString)
+    pos = @inline findnext(==(c), s, 1)
+    return pos !== nothing
 end
 
 function _searchindex(s::Union{AbstractString,DenseUInt8OrInt8},


### PR DESCRIPTION
Optimise this slightly by inlining, which eliminates some dead code. For short strings, this is ~60% faster.

Supersedes https://github.com/JuliaLang/julia/pull/43989.
Closes #43980.

Benchmark:
```
s = "chalet"
@btime in('\0', $(Ref(s))[])
@btime in('t', $(Ref(s))[])
 s = "h"^1000*'t'
@btime in('\0', $(Ref(s))[])
@btime in('t', $(Ref(s))[])
```
Timings, before / after:
```
 7.410 ns  / 4.097 ns
 7.713 ns  / 4.097 ns
14.858 ns  / 8.695 ns
14.808 ns  / 8.755 ns
```

There are several other strategies discussed in that PR and that issue, but I believe this is a generally better strategy.

Using `memmem` is infeasible because checking for valid utf8 in the char takes too long. It may be better for long haystacks, though. In testing, the haystacks have to be _quite_ long before it's worth it- like, thousands of bytes. You could add a bunch of fast paths, but most of these are already implemented in `findfirst(::Char, ::String)`.