### PR TITLE
codegen: Shrink-wrap GC shadow-stack frames mk. 2

### DIFF
--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -16,15 +16,17 @@ void FinalLowerGC::lowerNewGCFrame(CallInst *target, Function &F)
     assert(target->arg_size() == 1);
     unsigned nRoots = cast<ConstantInt>(target->getArgOperand(0))->getLimitedValue(INT_MAX);
 
-    // Create the GC frame.
+    // Keep the backing allocation static even if the intrinsic was sunk.
     IRBuilder<> builder(target);
-    auto gcframe_alloca = builder.CreateAlloca(T_prjlvalue, ConstantInt::get(Type::getInt32Ty(F.getContext()), nRoots + 2));
+    IRBuilder<> entry_builder(&F.getEntryBlock(), F.getEntryBlock().begin());
+    auto gcframe_alloca = entry_builder.CreateAlloca(T_prjlvalue, ConstantInt::get(Type::getInt32Ty(F.getContext()), nRoots + 2));
     gcframe_alloca->setAlignment(Align(16));
     // addrspacecast as needed for non-0 alloca addrspace
     auto gcframe = cast<Instruction>(builder.CreateAddrSpaceCast(gcframe_alloca, PointerType::getUnqual(T_prjlvalue->getContext())));
     gcframe->takeName(target);
 
-    // Zero out the GC frame.
+    // Start its lifetime at setup so unused paths can share the stack storage.
+    builder.CreateLifetimeStart(gcframe_alloca);
     auto ptrsize = F.getParent()->getDataLayout().getPointerSize();
     auto memset_instr = builder.CreateMemSet(gcframe, Constant::getNullValue(Type::getInt8Ty(F.getContext())), ptrsize * (nRoots + 2), Align(16));
     memset_instr->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
@@ -77,6 +79,9 @@ void FinalLowerGC::lowerPopGCFrame(CallInst *target, Function &F)
         pgcstack,
         Align(sizeof(void*)));
     inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
+    // End the lifetime after unlinking if this is a lowered frame alloca.
+    if (auto *AI = dyn_cast<AllocaInst>(gcframe->stripPointerCasts()))
+        builder.CreateLifetimeEnd(AI);
     target->eraseFromParent();
 }
 
@@ -143,6 +148,7 @@ bool FinalLowerGC::runOnFunction(Function &F)
     pgcstack = getPGCstack(F);
 
     auto gc_alloc_bytes = getOrNull(jl_intrinsics::GCAllocBytes);
+    auto new_gc_frame = getOrNull(jl_intrinsics::newGCFrame);
     SmallVector<CallInst*, 0> write_barriers;
     SmallVector<CallInst*, 0> alloc_bytes;
 
@@ -201,6 +207,18 @@ bool FinalLowerGC::runOnFunction(Function &F)
         }
     }
 
+    // Block layout may place a pop before its sunk allocation. Lower
+    // allocations first so pop lowering can find the backing alloca.
+    if (new_gc_frame) {
+        for (auto &BB : F) {
+            for (auto &I : make_early_inc_range(BB)) {
+                auto *CI = dyn_cast<CallInst>(&I);
+                if (CI && CI->getCalledOperand() == new_gc_frame)
+                    lowerNewGCFrame(CI, F);
+            }
+        }
+    }
+
     // Lower all calls to supported intrinsics.
     for (auto &BB : F) {
         for (auto &I : make_early_inc_range(BB)) {
@@ -219,7 +237,6 @@ bool FinalLowerGC::runOnFunction(Function &F)
                 } \
             } while (0)
 
-            LOWER_INTRINSIC(newGCFrame, lowerNewGCFrame);
             LOWER_INTRINSIC(getGCFrameSlot, lowerGetGCFrameSlot);
             LOWER_INTRINSIC(pushGCFrame, lowerPushGCFrame);
             LOWER_INTRINSIC(popGCFrame, lowerPopGCFrame);

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -11,20 +11,16 @@ STATISTIC(GetGCFrameSlotCount, "Number of lowered getGCFrameSlotFunc intrinsics"
 STATISTIC(QueueGCRootCount, "Number of lowered queueGCRootFunc intrinsics");
 STATISTIC(SafepointCount, "Number of lowered safepoint intrinsics");
 
-// Debugging aid for shadow-stack corruption (enable e.g. via
-// JULIA_LLVM_ARGS="--julia-check-gc-frame-balance"): every push checks that it
-// does not self-link the frame and every pop checks that the frame it unlinks
-// is the current top of the shadow stack, so an unbalanced or misplaced
-// push/pop faults deterministically at the offending site instead of leaving a
-// dangling frame for a later collection to crash on.
+// Debugging aid (enable via JULIA_LLVM_ARGS="--julia-check-gc-frame-balance"):
+// each push checks that it does not self-link the frame and each pop checks
+// that it unlinks the current shadow-stack top, faulting at the offending
+// site instead of leaving a dangling frame for a later collection.
 static cl::opt<bool> ClCheckGCFrameBalance(
     "julia-check-gc-frame-balance", cl::init(false), cl::Hidden,
     cl::desc("Instrument GC frame pushes/pops with shadow-stack balance checks"));
 
-// Fault at the current insertion point when Bad is true, without needing CFG
-// surgery: volatile-store through a pointer that is null exactly when the
-// check fails. On success this clobbers the frame's nroots word, which every
-// caller either overwrites (push) or has retired (pop).
+// Fault when Bad is true without CFG surgery: volatile-store through a
+// pointer that is null exactly when the check fails.
 static void emitFrameBalanceCheck(IRBuilder<> &builder, Value *Bad, Value *gcframe, Type *T_size)
 {
     Value *Null = ConstantPointerNull::get(cast<PointerType>(gcframe->getType()));
@@ -48,11 +44,9 @@ void FinalLowerGC::lowerNewGCFrame(CallInst *target, Function &F)
     auto gcframe = cast<Instruction>(builder.CreateAddrSpaceCast(gcframe_alloca, PointerType::getUnqual(T_prjlvalue->getContext())));
     gcframe->takeName(target);
 
-    // For a sunk frame, start its lifetime at setup so unused paths can share
-    // the stack storage. Entry-block frames span the whole function, where the
-    // markers buy nothing; omitting them keeps that codegen unchanged.
-    if (target->getParent() != &F.getEntryBlock())
-        builder.CreateLifetimeStart(gcframe_alloca);
+    // No lifetime markers: the GC's reads of the frame are invisible to LLVM,
+    // so a lifetime.end would let DSE delete frame stores and let stack
+    // coloring reuse the slot while the frame is linked.
     auto ptrsize = F.getParent()->getDataLayout().getPointerSize();
     auto memset_instr = builder.CreateMemSet(gcframe, Constant::getNullValue(Type::getInt8Ty(F.getContext())), ptrsize * (nRoots + 2), Align(16));
     memset_instr->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
@@ -94,6 +88,13 @@ void FinalLowerGC::lowerPushGCFrame(CallInst *target, Function &F)
             gcframe,
             pgcstack,
             Align(sizeof(void*)));
+    // Keep the setup stores above alive: the GC's reads of the frame are
+    // invisible to LLVM, so DSE would otherwise delete them. An atomic
+    // monotonic load is a universal read clobber for alias analysis and
+    // lowers to a plain load; volatile keeps DCE from dropping it.
+    LoadInst *guard = builder.CreateAlignedLoad(T_size, gcframe, Align(sizeof(void*)), "gcframe.published");
+    guard->setAtomic(AtomicOrdering::Monotonic);
+    guard->setVolatile(true);
     target->eraseFromParent();
 }
 
@@ -115,23 +116,16 @@ void FinalLowerGC::lowerPopGCFrame(CallInst *target, Function &F)
     }
     Instruction *gcpop =
         cast<Instruction>(builder.CreateConstInBoundsGEP1_32(T_prjlvalue, gcframe, 1));
-    Instruction *inst = builder.CreateAlignedLoad(T_prjlvalue, gcpop, Align(sizeof(void*)), "frame.prev");
-    inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
-    inst = builder.CreateAlignedStore(
-        inst,
+    // Atomic so this load is a read clobber that keeps root-slot stores in
+    // the frame's region alive through DSE; see lowerPushGCFrame.
+    LoadInst *prev = builder.CreateAlignedLoad(T_prjlvalue, gcpop, Align(sizeof(void*)), "frame.prev");
+    prev->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
+    prev->setAtomic(AtomicOrdering::Monotonic);
+    Instruction *inst = builder.CreateAlignedStore(
+        prev,
         pgcstack,
         Align(sizeof(void*)));
     inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
-    // End the lifetime after unlinking if this is a lowered frame alloca whose
-    // lifetime was started at a sunk setup point.
-    if (auto *AI = dyn_cast<AllocaInst>(gcframe->stripPointerCasts())) {
-        bool HasLifetimeStart = llvm::any_of(AI->users(), [](User *U) {
-            auto *II = dyn_cast<IntrinsicInst>(U);
-            return II && II->getIntrinsicID() == Intrinsic::lifetime_start;
-        });
-        if (HasLifetimeStart)
-            builder.CreateLifetimeEnd(AI);
-    }
     target->eraseFromParent();
 }
 

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -1,6 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include "llvm-gc-interface-passes.h"
+#include "llvm/Support/CommandLine.h"
 
 #define DEBUG_TYPE "final_gc_lowering"
 STATISTIC(NewGCFrameCount, "Number of lowered newGCFrameFunc intrinsics");
@@ -9,6 +10,28 @@ STATISTIC(PopGCFrameCount, "Number of lowered popGCFrameFunc intrinsics");
 STATISTIC(GetGCFrameSlotCount, "Number of lowered getGCFrameSlotFunc intrinsics");
 STATISTIC(QueueGCRootCount, "Number of lowered queueGCRootFunc intrinsics");
 STATISTIC(SafepointCount, "Number of lowered safepoint intrinsics");
+
+// Debugging aid for shadow-stack corruption (enable e.g. via
+// JULIA_LLVM_ARGS="--julia-check-gc-frame-balance"): every push checks that it
+// does not self-link the frame and every pop checks that the frame it unlinks
+// is the current top of the shadow stack, so an unbalanced or misplaced
+// push/pop faults deterministically at the offending site instead of leaving a
+// dangling frame for a later collection to crash on.
+static cl::opt<bool> ClCheckGCFrameBalance(
+    "julia-check-gc-frame-balance", cl::init(false), cl::Hidden,
+    cl::desc("Instrument GC frame pushes/pops with shadow-stack balance checks"));
+
+// Fault at the current insertion point when Bad is true, without needing CFG
+// surgery: volatile-store through a pointer that is null exactly when the
+// check fails. On success this clobbers the frame's nroots word, which every
+// caller either overwrites (push) or has retired (pop).
+static void emitFrameBalanceCheck(IRBuilder<> &builder, Value *Bad, Value *gcframe, Type *T_size)
+{
+    Value *Null = ConstantPointerNull::get(cast<PointerType>(gcframe->getType()));
+    Value *Addr = builder.CreateSelect(Bad, Null, gcframe, "gcframe.check");
+    builder.CreateAlignedStore(ConstantInt::get(T_size, 0), Addr, Align(sizeof(void*)))
+        ->setVolatile(true);
+}
 
 void FinalLowerGC::lowerNewGCFrame(CallInst *target, Function &F)
 {
@@ -25,8 +48,11 @@ void FinalLowerGC::lowerNewGCFrame(CallInst *target, Function &F)
     auto gcframe = cast<Instruction>(builder.CreateAddrSpaceCast(gcframe_alloca, PointerType::getUnqual(T_prjlvalue->getContext())));
     gcframe->takeName(target);
 
-    // Start its lifetime at setup so unused paths can share the stack storage.
-    builder.CreateLifetimeStart(gcframe_alloca);
+    // For a sunk frame, start its lifetime at setup so unused paths can share
+    // the stack storage. Entry-block frames span the whole function, where the
+    // markers buy nothing; omitting them keeps that codegen unchanged.
+    if (target->getParent() != &F.getEntryBlock())
+        builder.CreateLifetimeStart(gcframe_alloca);
     auto ptrsize = F.getParent()->getDataLayout().getPointerSize();
     auto memset_instr = builder.CreateMemSet(gcframe, Constant::getNullValue(Type::getInt8Ty(F.getContext())), ptrsize * (nRoots + 2), Align(16));
     memset_instr->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
@@ -43,6 +69,14 @@ void FinalLowerGC::lowerPushGCFrame(CallInst *target, Function &F)
     unsigned nRoots = cast<ConstantInt>(target->getArgOperand(1))->getLimitedValue(INT_MAX);
 
     IRBuilder<> builder(target);
+    if (ClCheckGCFrameBalance) {
+        // A re-executed push would self-link the shadow stack.
+        auto *PtrTy = PointerType::getUnqual(F.getContext());
+        auto *top = builder.CreateAlignedLoad(PtrTy, pgcstack, Align(sizeof(void*)), "gcstack.top");
+        Value *SelfLinked = builder.CreateICmpEQ(
+                top, builder.CreatePointerCast(gcframe, PtrTy), "gcframe.selflinked");
+        emitFrameBalanceCheck(builder, SelfLinked, gcframe, T_size);
+    }
     StoreInst *inst = builder.CreateAlignedStore(
                 ConstantInt::get(T_size, JL_GC_ENCODE_PUSHARGS(nRoots)),
                 builder.CreateConstInBoundsGEP1_32(T_prjlvalue, gcframe, 0, "frame.nroots"),// GEP of 0 becomes a noop and eats the name
@@ -70,6 +104,15 @@ void FinalLowerGC::lowerPopGCFrame(CallInst *target, Function &F)
     auto gcframe = target->getArgOperand(0);
 
     IRBuilder<> builder(target);
+    if (ClCheckGCFrameBalance) {
+        // Popping anything but the current shadow-stack top would leave a
+        // dangling frame behind.
+        auto *PtrTy = PointerType::getUnqual(F.getContext());
+        auto *top = builder.CreateAlignedLoad(PtrTy, pgcstack, Align(sizeof(void*)), "gcstack.top");
+        Value *Mismatch = builder.CreateICmpNE(
+                top, builder.CreatePointerCast(gcframe, PtrTy), "gcframe.mismatch");
+        emitFrameBalanceCheck(builder, Mismatch, gcframe, T_size);
+    }
     Instruction *gcpop =
         cast<Instruction>(builder.CreateConstInBoundsGEP1_32(T_prjlvalue, gcframe, 1));
     Instruction *inst = builder.CreateAlignedLoad(T_prjlvalue, gcpop, Align(sizeof(void*)), "frame.prev");
@@ -79,9 +122,16 @@ void FinalLowerGC::lowerPopGCFrame(CallInst *target, Function &F)
         pgcstack,
         Align(sizeof(void*)));
     inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
-    // End the lifetime after unlinking if this is a lowered frame alloca.
-    if (auto *AI = dyn_cast<AllocaInst>(gcframe->stripPointerCasts()))
-        builder.CreateLifetimeEnd(AI);
+    // End the lifetime after unlinking if this is a lowered frame alloca whose
+    // lifetime was started at a sunk setup point.
+    if (auto *AI = dyn_cast<AllocaInst>(gcframe->stripPointerCasts())) {
+        bool HasLifetimeStart = llvm::any_of(AI->users(), [](User *U) {
+            auto *II = dyn_cast<IntrinsicInst>(U);
+            return II && II->getIntrinsicID() == Intrinsic::lifetime_start;
+        });
+        if (HasLifetimeStart)
+            builder.CreateLifetimeEnd(AI);
+    }
     target->eraseFromParent();
 }
 

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -16,15 +16,17 @@ void FinalLowerGC::lowerNewGCFrame(CallInst *target, Function &F)
     assert(target->arg_size() == 1);
     unsigned nRoots = cast<ConstantInt>(target->getArgOperand(0))->getLimitedValue(INT_MAX);
 
-    // Create the GC frame.
+    // Keep the backing allocation static even if the intrinsic was sunk.
     IRBuilder<> builder(target);
-    auto gcframe_alloca = builder.CreateAlloca(T_prjlvalue, ConstantInt::get(Type::getInt32Ty(F.getContext()), nRoots + 2));
+    IRBuilder<> entry_builder(&F.getEntryBlock(), F.getEntryBlock().begin());
+    auto gcframe_alloca = entry_builder.CreateAlloca(T_prjlvalue, ConstantInt::get(Type::getInt32Ty(F.getContext()), nRoots + 2));
     gcframe_alloca->setAlignment(Align(16));
     // addrspacecast as needed for non-0 alloca addrspace
     auto gcframe = cast<Instruction>(builder.CreateAddrSpaceCast(gcframe_alloca, PointerType::getUnqual(T_prjlvalue->getContext())));
     gcframe->takeName(target);
 
-    // Zero out the GC frame.
+    // Start its lifetime at setup so unused paths can share the stack storage.
+    builder.CreateLifetimeStart(gcframe_alloca);
     auto ptrsize = F.getParent()->getDataLayout().getPointerSize();
     auto memset_instr = builder.CreateMemSet(gcframe, Constant::getNullValue(Type::getInt8Ty(F.getContext())), ptrsize * (nRoots + 2), Align(16));
     memset_instr->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
@@ -77,6 +79,9 @@ void FinalLowerGC::lowerPopGCFrame(CallInst *target, Function &F)
         pgcstack,
         Align(sizeof(void*)));
     inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
+    // End the lifetime after unlinking if this is a lowered frame alloca.
+    if (auto *AI = dyn_cast<AllocaInst>(gcframe->stripPointerCasts()))
+        builder.CreateLifetimeEnd(AI);
     target->eraseFromParent();
 }
 
@@ -147,6 +152,7 @@ bool FinalLowerGC::runOnFunction(Function &F)
     pgcstack = getPGCstack(F);
 
     auto gc_alloc_bytes = getOrNull(jl_intrinsics::GCAllocBytes);
+    auto new_gc_frame = getOrNull(jl_intrinsics::newGCFrame);
     SmallVector<CallInst*, 0> write_barriers;
     SmallVector<CallInst*, 0> alloc_bytes;
 
@@ -209,6 +215,18 @@ bool FinalLowerGC::runOnFunction(Function &F)
         }
     }
 
+    // Block layout may place a pop before its sunk allocation. Lower
+    // allocations first so pop lowering can find the backing alloca.
+    if (new_gc_frame) {
+        for (auto &BB : F) {
+            for (auto &I : make_early_inc_range(BB)) {
+                auto *CI = dyn_cast<CallInst>(&I);
+                if (CI && CI->getCalledOperand() == new_gc_frame)
+                    lowerNewGCFrame(CI, F);
+            }
+        }
+    }
+
     // Lower all calls to supported intrinsics.
     for (auto &BB : F) {
         for (auto &I : make_early_inc_range(BB)) {
@@ -227,7 +245,6 @@ bool FinalLowerGC::runOnFunction(Function &F)
                 } \
             } while (0)
 
-            LOWER_INTRINSIC(newGCFrame, lowerNewGCFrame);
             LOWER_INTRINSIC(getGCFrameSlot, lowerGetGCFrameSlot);
             LOWER_INTRINSIC(pushGCFrame, lowerPushGCFrame);
             LOWER_INTRINSIC(popGCFrame, lowerPopGCFrame);

--- a/src/llvm-gc-interface-passes.h
+++ b/src/llvm-gc-interface-passes.h
@@ -359,7 +359,9 @@ private:
     void PlaceGCFrameStore(State &S, unsigned R, unsigned MinColorRoot, ArrayRef<int> Colors, Value *GCFrame, Instruction *InsertBefore);
     void PlaceGCFrameStores(State &S, unsigned MinColorRoot, ArrayRef<int> Colors, int PreAssignedColors, Value *GCFrame);
     void PlaceGCFrameReset(State &S, unsigned R, unsigned MinColorRoot, ArrayRef<int> Colors, Value *GCFrame, Instruction *InsertBefore);
-    void PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAssignedColors, State &S, std::map<Value *, std::pair<int, int>>);
+    BasicBlock *FindGCFramePushBlock(State &S, SmallVectorImpl<BasicBlock *> &PopBlocks,
+                                     SmallVectorImpl<std::pair<BasicBlock *, BasicBlock *>> &ExitEdges);
+    void PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAssignedColors, State &S, std::map<Value *, std::pair<int, int>>, bool *CFGModified);
     void CleanupWriteBarriers(Function &F, State *S, const SmallVector<CallInst*, 0> &WriteBarriers, bool *CFGModified);
     bool CleanupIR(Function &F, State *S, bool *CFGModified);
     void NoteUseChain(State &S, BBState &BBS, User *TheUser);

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1,6 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include "llvm-gc-interface-passes.h"
+#include "llvm/ADT/SCCIterator.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/Support/Casting.h"
@@ -2402,8 +2403,145 @@ void LateLowerGCFrame::PlaceGCFrameStores(State &S, unsigned MinColorRoot,
     }
 }
 
+// Select a once-executed common dominator of all frame users. Returns within
+// that region need pops, as do edges leaving it; unwind-only paths do not.
+BasicBlock *LateLowerGCFrame::FindGCFramePushBlock(State &S, SmallVectorImpl<BasicBlock *> &PopBlocks,
+        SmallVectorImpl<std::pair<BasicBlock *, BasicBlock *>> &ExitEdges)
+{
+    Function *F = S.F;
+    BasicBlock *Entry = &F->getEntryBlock();
+    auto UseEntry = [&]() {
+        PopBlocks.clear();
+        ExitEdges.clear();
+        for (auto &BB : *F)
+            if (isa<ReturnInst>(BB.getTerminator()))
+                PopBlocks.push_back(&BB);
+        return Entry;
+    };
+    // A returns-twice call hides control flow that can re-enter a popped region.
+    if (!S.ReturnsTwice.empty())
+        return UseEntry();
+    // The push loads from pgcstack, so it cannot be sunk past its definition.
+    if (auto *I = dyn_cast<Instruction>(pgcstack))
+        if (I->getParent() != Entry)
+            return UseEntry();
+    // Include safepoints with live slots and roots without liveness tracking.
+    SmallPtrSet<BasicBlock *, 16> NeedFrame;
+    bool RootsWithoutLiveness = !S.ArrayAllocas.empty() || !S.TrackedStores.empty();
+    for (auto &BB : *F) {
+        for (auto &I : BB) {
+            auto *CI = dyn_cast<CallBase>(&I);
+            Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+            if (Callee && (Callee == enter_handler_func || Callee == pop_handler_func ||
+                    Callee == pop_handler_noexcept_func))
+                return UseEntry();
+        }
+        const BBState &BBS = S.BBStates[&BB];
+        if (!BBS.HasSafepoint)
+            continue;
+        bool Need = RootsWithoutLiveness;
+        for (int Safepoint = BBS.FirstSafepoint; !Need && Safepoint >= BBS.LastSafepoint; --Safepoint)
+            Need = !S.LiveSets[Safepoint].empty();
+        if (!Need) {
+            LargeSparseBitVector LiveIn;
+            AddInPredecessorLiveOuts(&BB, LiveIn, S);
+            Need = !LiveIn.empty();
+        }
+        if (Need)
+            NeedFrame.insert(&BB);
+    }
+    // Follow derived slot addresses. PHIs need incoming blocks for dominance
+    // and their own blocks and users for lifetime coverage.
+    SmallPtrSet<Value *, 16> SeenSlotPointers;
+    SmallVector<Value *, 16> SlotPointers;
+    for (auto &AI : S.ArrayAllocas)
+        SlotPointers.push_back(AI.first);
+    while (!SlotPointers.empty()) {
+        Value *Root = SlotPointers.pop_back_val();
+        if (!SeenSlotPointers.insert(Root).second)
+            continue;
+        for (Use &U : Root->uses()) {
+            auto *I = cast<Instruction>(U.getUser());
+            if (isa<DbgInfoIntrinsic>(I))
+                continue;
+            if (auto *II = dyn_cast<IntrinsicInst>(I)) {
+                if (II->getIntrinsicID() == Intrinsic::lifetime_start ||
+                        II->getIntrinsicID() == Intrinsic::lifetime_end)
+                    continue;
+            }
+            if (auto *Phi = dyn_cast<PHINode>(I)) {
+                NeedFrame.insert(Phi->getIncomingBlock(U));
+                NeedFrame.insert(Phi->getParent());
+            }
+            else {
+                NeedFrame.insert(I->getParent());
+            }
+            if (isa<GetElementPtrInst>(I) || isa<BitCastInst>(I) ||
+                    isa<AddrSpaceCastInst>(I) || isa<PHINode>(I) ||
+                    isa<SelectInst>(I) || isa<FreezeInst>(I))
+                SlotPointers.push_back(I);
+        }
+    }
+    for (auto &Store : S.TrackedStores)
+        NeedFrame.insert(Store.first->getParent());
+    if (NeedFrame.empty())
+        return UseEntry();
+    if (!S.DT)
+        S.DT = &GetDT();
+    DominatorTree &DT = *S.DT;
+    BasicBlock *BB = nullptr;
+    for (BasicBlock *NB : NeedFrame) {
+        if (!DT.isReachableFromEntry(NB))
+            continue; // everything dominates unreachable code
+        BB = BB ? DT.findNearestCommonDominator(BB, NB) : NB;
+    }
+    if (!BB || BB == Entry)
+        return UseEntry();
+    SmallPtrSet<BasicBlock *, 16> CyclicBlocks;
+    for (auto I = scc_begin(F); !I.isAtEnd(); ++I) {
+        if (!I.hasCycle())
+            continue;
+        for (BasicBlock *CycleBB : *I)
+            CyclicBlocks.insert(CycleBB);
+    }
+    // A repeated push would self-link the shadow stack. SCCs include
+    // irreducible cycles that LoopInfo may miss.
+    while (BB != Entry) {
+        bool OK = !CyclicBlocks.contains(BB) && BB->getFirstInsertionPt() != BB->end();
+        if (OK) {
+            // Deduplicate exit edges because switch successors can repeat.
+            PopBlocks.clear();
+            ExitEdges.clear();
+            SmallSet<std::pair<BasicBlock *, BasicBlock *>, 8> SeenEdges;
+            for (auto &Cur : *F) {
+                if (!DT.isReachableFromEntry(&Cur) || !DT.dominates(BB, &Cur))
+                    continue;
+                if (isa<ReturnInst>(Cur.getTerminator()))
+                    PopBlocks.push_back(&Cur);
+                for (BasicBlock *Succ : successors(&Cur)) {
+                    if (DT.dominates(BB, Succ))
+                        continue;
+                    if (!isa<BranchInst>(Cur.getTerminator()) && !isa<SwitchInst>(Cur.getTerminator())) {
+                        // This edge type cannot be split (e.g. indirectbr or callbr).
+                        OK = false;
+                        break;
+                    }
+                    if (SeenEdges.insert({&Cur, Succ}).second)
+                        ExitEdges.push_back({&Cur, Succ});
+                }
+                if (!OK)
+                    break;
+            }
+            if (OK)
+                return BB;
+        }
+        BB = DT.getNode(BB)->getIDom()->getBlock();
+    }
+    return UseEntry();
+}
+
 void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAssignedColors, State &S,
-                                                std::map<Value *, std::pair<int, int>>) {
+                                                std::map<Value *, std::pair<int, int>>, bool *CFGModified) {
     auto F = S.F;
     auto T_int32 = Type::getInt32Ty(F->getContext());
     int MaxColor = -1;
@@ -2413,21 +2551,6 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
 
     // Insert instructions for the actual gc frame
     if (MaxColor != -1 || !S.ArrayAllocas.empty() || !S.TrackedStores.empty()) {
-        // Create and push a GC frame.
-        auto gcframe = CallInst::Create(
-            getOrDeclare(jl_intrinsics::newGCFrame),
-            {ConstantInt::get(T_int32, 0)},
-            "gcframe");
-        gcframe->insertBefore(F->getEntryBlock().begin());
-
-        auto pushGcframe = CallInst::Create(
-            getOrDeclare(jl_intrinsics::pushGCFrame),
-            {gcframe, ConstantInt::get(T_int32, 0)});
-        if (isa<Argument>(pgcstack))
-             pushGcframe->insertAfter(gcframe);
-         else
-             pushGcframe->insertAfter(cast<Instruction>(pgcstack));
-
         // we don't run memsetopt after this, so run a basic approximation of it
         // that removes any redundant memset calls in the prologue since getGCFrameSlot already includes the null store
         Instruction *toerase = nullptr;
@@ -2464,6 +2587,29 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
         if (toerase)
             toerase->eraseFromParent();
         toerase = nullptr;
+
+        // Create and push a GC frame.
+        SmallVector<BasicBlock *, 0> PopBlocks;
+        SmallVector<std::pair<BasicBlock *, BasicBlock *>, 0> ExitEdges;
+        BasicBlock *PushBB = FindGCFramePushBlock(S, PopBlocks, ExitEdges);
+        auto gcframe = CallInst::Create(
+            getOrDeclare(jl_intrinsics::newGCFrame),
+            {ConstantInt::get(T_int32, 0)},
+            "gcframe");
+        auto pushGcframe = CallInst::Create(
+            getOrDeclare(jl_intrinsics::pushGCFrame),
+            {gcframe, ConstantInt::get(T_int32, 0)});
+        if (PushBB != &F->getEntryBlock()) {
+            gcframe->insertBefore(PushBB->getFirstInsertionPt());
+            pushGcframe->insertAfter(gcframe);
+        }
+        else {
+            gcframe->insertBefore(F->getEntryBlock().begin());
+            if (isa<Argument>(pgcstack))
+                pushGcframe->insertAfter(gcframe);
+            else
+                pushGcframe->insertAfter(cast<Instruction>(pgcstack));
+        }
 
         // Replace Allocas
         unsigned AllocaSlot = 2; // first two words are metadata
@@ -2532,18 +2678,30 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
 
         // Insert GC frame stores
         PlaceGCFrameStores(S, AllocaSlot - 2, Colors, PreAssignedColors, gcframe);
-        // Insert GCFrame pops
-        for (auto &BB : *F) {
-            if (isa<ReturnInst>(BB.getTerminator())) {
-                auto popGcframe = CallInst::Create(
-                    getOrDeclare(jl_intrinsics::popGCFrame),
-                    {gcframe});
+        // Pop returns in the region and each distinct outgoing edge.
+        for (BasicBlock *BB : PopBlocks) {
+            auto popGcframe = CallInst::Create(
+                getOrDeclare(jl_intrinsics::popGCFrame),
+                {gcframe});
 #if JL_LLVM_VERSION >= 200000
-                popGcframe->insertBefore(BB.getTerminator()->getIterator());
+            popGcframe->insertBefore(BB->getTerminator()->getIterator());
 #else
-                popGcframe->insertBefore(BB.getTerminator());
+            popGcframe->insertBefore(BB->getTerminator());
 #endif
-            }
+        }
+        for (auto &Edge : ExitEdges) {
+            assert(S.DT);
+            BasicBlock *Split = SplitEdge(Edge.first, Edge.second, S.DT);
+            auto popGcframe = CallInst::Create(
+                getOrDeclare(jl_intrinsics::popGCFrame),
+                {gcframe});
+#if JL_LLVM_VERSION >= 200000
+            popGcframe->insertBefore(Split->getTerminator()->getIterator());
+#else
+            popGcframe->insertBefore(Split->getTerminator());
+#endif
+            if (CFGModified)
+                *CFGModified = true;
         }
     }
 }
@@ -2600,7 +2758,7 @@ bool LateLowerGCFrame::runOnFunction(Function &F, bool *CFGModified) {
         ComputeLiveness(S);
         auto Colors = ColorRoots(S);
         std::map<Value *, std::pair<int, int>> CallFrames; // = OptimizeCallFrames(S, Ordering);
-        PlaceRootsAndUpdateCalls(Colors.first, Colors.second, S, CallFrames);
+        PlaceRootsAndUpdateCalls(Colors.first, Colors.second, S, CallFrames, CFGModified);
       }
       CleanupIR(F, &S, CFGModified);
     }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2523,15 +2523,14 @@ BasicBlock *LateLowerGCFrame::FindGCFramePushBlock(State &S, SmallVectorImpl<Bas
     while (BB != Entry) {
         bool OK = !CyclicBlocks.contains(BB) && BB->getFirstInsertionPt() != BB->end();
         if (OK) {
-            // Deduplicate exit edges because switch successors can repeat.
             PopBlocks.clear();
             ExitEdges.clear();
-            SmallSet<std::pair<BasicBlock *, BasicBlock *>, 8> SeenEdges;
             for (auto &Cur : *F) {
                 if (!DT.isReachableFromEntry(&Cur) || !DT.dominates(BB, &Cur))
                     continue;
                 if (isa<ReturnInst>(Cur.getTerminator()))
                     PopBlocks.push_back(&Cur);
+                // Keep parallel switch edges: SplitEdge handles one occurrence per call.
                 for (BasicBlock *Succ : successors(&Cur)) {
                     if (DT.dominates(BB, Succ))
                         continue;
@@ -2540,8 +2539,7 @@ BasicBlock *LateLowerGCFrame::FindGCFramePushBlock(State &S, SmallVectorImpl<Bas
                         OK = false;
                         break;
                     }
-                    if (SeenEdges.insert({&Cur, Succ}).second)
-                        ExitEdges.push_back({&Cur, Succ});
+                    ExitEdges.push_back({&Cur, Succ});
                 }
                 if (!OK)
                     break;

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2509,15 +2509,14 @@ BasicBlock *LateLowerGCFrame::FindGCFramePushBlock(State &S, SmallVectorImpl<Bas
     while (BB != Entry) {
         bool OK = !CyclicBlocks.contains(BB) && BB->getFirstInsertionPt() != BB->end();
         if (OK) {
-            // Deduplicate exit edges because switch successors can repeat.
             PopBlocks.clear();
             ExitEdges.clear();
-            SmallSet<std::pair<BasicBlock *, BasicBlock *>, 8> SeenEdges;
             for (auto &Cur : *F) {
                 if (!DT.isReachableFromEntry(&Cur) || !DT.dominates(BB, &Cur))
                     continue;
                 if (isa<ReturnInst>(Cur.getTerminator()))
                     PopBlocks.push_back(&Cur);
+                // Keep parallel switch edges: SplitEdge handles one occurrence per call.
                 for (BasicBlock *Succ : successors(&Cur)) {
                     if (DT.dominates(BB, Succ))
                         continue;
@@ -2526,8 +2525,7 @@ BasicBlock *LateLowerGCFrame::FindGCFramePushBlock(State &S, SmallVectorImpl<Bas
                         OK = false;
                         break;
                     }
-                    if (SeenEdges.insert({&Cur, Succ}).second)
-                        ExitEdges.push_back({&Cur, Succ});
+                    ExitEdges.push_back({&Cur, Succ});
                 }
                 if (!OK)
                     break;

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1,6 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include "llvm-gc-interface-passes.h"
+#include "llvm/ADT/SCCIterator.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/Support/Casting.h"
@@ -2416,8 +2417,145 @@ void LateLowerGCFrame::PlaceGCFrameStores(State &S, unsigned MinColorRoot,
     }
 }
 
+// Select a once-executed common dominator of all frame users. Returns within
+// that region need pops, as do edges leaving it; unwind-only paths do not.
+BasicBlock *LateLowerGCFrame::FindGCFramePushBlock(State &S, SmallVectorImpl<BasicBlock *> &PopBlocks,
+        SmallVectorImpl<std::pair<BasicBlock *, BasicBlock *>> &ExitEdges)
+{
+    Function *F = S.F;
+    BasicBlock *Entry = &F->getEntryBlock();
+    auto UseEntry = [&]() {
+        PopBlocks.clear();
+        ExitEdges.clear();
+        for (auto &BB : *F)
+            if (isa<ReturnInst>(BB.getTerminator()))
+                PopBlocks.push_back(&BB);
+        return Entry;
+    };
+    // A returns-twice call hides control flow that can re-enter a popped region.
+    if (!S.ReturnsTwice.empty())
+        return UseEntry();
+    // The push loads from pgcstack, so it cannot be sunk past its definition.
+    if (auto *I = dyn_cast<Instruction>(pgcstack))
+        if (I->getParent() != Entry)
+            return UseEntry();
+    // Include safepoints with live slots and roots without liveness tracking.
+    SmallPtrSet<BasicBlock *, 16> NeedFrame;
+    bool RootsWithoutLiveness = !S.ArrayAllocas.empty() || !S.TrackedStores.empty();
+    for (auto &BB : *F) {
+        for (auto &I : BB) {
+            auto *CI = dyn_cast<CallBase>(&I);
+            Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+            if (Callee && (Callee == enter_handler_func || Callee == pop_handler_func ||
+                    Callee == pop_handler_noexcept_func))
+                return UseEntry();
+        }
+        const BBState &BBS = S.BBStates[&BB];
+        if (!BBS.HasSafepoint)
+            continue;
+        bool Need = RootsWithoutLiveness;
+        for (int Safepoint = BBS.FirstSafepoint; !Need && Safepoint >= BBS.LastSafepoint; --Safepoint)
+            Need = !S.LiveSets[Safepoint].empty();
+        if (!Need) {
+            LargeSparseBitVector LiveIn;
+            AddInPredecessorLiveOuts(&BB, LiveIn, S);
+            Need = !LiveIn.empty();
+        }
+        if (Need)
+            NeedFrame.insert(&BB);
+    }
+    // Follow derived slot addresses. PHIs need incoming blocks for dominance
+    // and their own blocks and users for lifetime coverage.
+    SmallPtrSet<Value *, 16> SeenSlotPointers;
+    SmallVector<Value *, 16> SlotPointers;
+    for (auto &AI : S.ArrayAllocas)
+        SlotPointers.push_back(AI.first);
+    while (!SlotPointers.empty()) {
+        Value *Root = SlotPointers.pop_back_val();
+        if (!SeenSlotPointers.insert(Root).second)
+            continue;
+        for (Use &U : Root->uses()) {
+            auto *I = cast<Instruction>(U.getUser());
+            if (isa<DbgInfoIntrinsic>(I))
+                continue;
+            if (auto *II = dyn_cast<IntrinsicInst>(I)) {
+                if (II->getIntrinsicID() == Intrinsic::lifetime_start ||
+                        II->getIntrinsicID() == Intrinsic::lifetime_end)
+                    continue;
+            }
+            if (auto *Phi = dyn_cast<PHINode>(I)) {
+                NeedFrame.insert(Phi->getIncomingBlock(U));
+                NeedFrame.insert(Phi->getParent());
+            }
+            else {
+                NeedFrame.insert(I->getParent());
+            }
+            if (isa<GetElementPtrInst>(I) || isa<BitCastInst>(I) ||
+                    isa<AddrSpaceCastInst>(I) || isa<PHINode>(I) ||
+                    isa<SelectInst>(I) || isa<FreezeInst>(I))
+                SlotPointers.push_back(I);
+        }
+    }
+    for (auto &Store : S.TrackedStores)
+        NeedFrame.insert(Store.first->getParent());
+    if (NeedFrame.empty())
+        return UseEntry();
+    if (!S.DT)
+        S.DT = &GetDT();
+    DominatorTree &DT = *S.DT;
+    BasicBlock *BB = nullptr;
+    for (BasicBlock *NB : NeedFrame) {
+        if (!DT.isReachableFromEntry(NB))
+            continue; // everything dominates unreachable code
+        BB = BB ? DT.findNearestCommonDominator(BB, NB) : NB;
+    }
+    if (!BB || BB == Entry)
+        return UseEntry();
+    SmallPtrSet<BasicBlock *, 16> CyclicBlocks;
+    for (auto I = scc_begin(F); !I.isAtEnd(); ++I) {
+        if (!I.hasCycle())
+            continue;
+        for (BasicBlock *CycleBB : *I)
+            CyclicBlocks.insert(CycleBB);
+    }
+    // A repeated push would self-link the shadow stack. SCCs include
+    // irreducible cycles that LoopInfo may miss.
+    while (BB != Entry) {
+        bool OK = !CyclicBlocks.contains(BB) && BB->getFirstInsertionPt() != BB->end();
+        if (OK) {
+            // Deduplicate exit edges because switch successors can repeat.
+            PopBlocks.clear();
+            ExitEdges.clear();
+            SmallSet<std::pair<BasicBlock *, BasicBlock *>, 8> SeenEdges;
+            for (auto &Cur : *F) {
+                if (!DT.isReachableFromEntry(&Cur) || !DT.dominates(BB, &Cur))
+                    continue;
+                if (isa<ReturnInst>(Cur.getTerminator()))
+                    PopBlocks.push_back(&Cur);
+                for (BasicBlock *Succ : successors(&Cur)) {
+                    if (DT.dominates(BB, Succ))
+                        continue;
+                    if (!isa<BranchInst>(Cur.getTerminator()) && !isa<SwitchInst>(Cur.getTerminator())) {
+                        // This edge type cannot be split (e.g. indirectbr or callbr).
+                        OK = false;
+                        break;
+                    }
+                    if (SeenEdges.insert({&Cur, Succ}).second)
+                        ExitEdges.push_back({&Cur, Succ});
+                }
+                if (!OK)
+                    break;
+            }
+            if (OK)
+                return BB;
+        }
+        BB = DT.getNode(BB)->getIDom()->getBlock();
+    }
+    return UseEntry();
+}
+
 void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAssignedColors, State &S,
-                                                std::map<Value *, std::pair<int, int>>) {
+                                                std::map<Value *, std::pair<int, int>>, bool *CFGModified) {
     auto F = S.F;
     auto T_int32 = Type::getInt32Ty(F->getContext());
     int MaxColor = -1;
@@ -2427,21 +2565,6 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
 
     // Insert instructions for the actual gc frame
     if (MaxColor != -1 || !S.ArrayAllocas.empty() || !S.TrackedStores.empty()) {
-        // Create and push a GC frame.
-        auto gcframe = CallInst::Create(
-            getOrDeclare(jl_intrinsics::newGCFrame),
-            {ConstantInt::get(T_int32, 0)},
-            "gcframe");
-        gcframe->insertBefore(F->getEntryBlock().begin());
-
-        auto pushGcframe = CallInst::Create(
-            getOrDeclare(jl_intrinsics::pushGCFrame),
-            {gcframe, ConstantInt::get(T_int32, 0)});
-        if (isa<Argument>(pgcstack))
-             pushGcframe->insertAfter(gcframe);
-         else
-             pushGcframe->insertAfter(cast<Instruction>(pgcstack));
-
         // we don't run memsetopt after this, so run a basic approximation of it
         // that removes any redundant memset calls in the prologue since getGCFrameSlot already includes the null store
         Instruction *toerase = nullptr;
@@ -2478,6 +2601,29 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
         if (toerase)
             toerase->eraseFromParent();
         toerase = nullptr;
+
+        // Create and push a GC frame.
+        SmallVector<BasicBlock *, 0> PopBlocks;
+        SmallVector<std::pair<BasicBlock *, BasicBlock *>, 0> ExitEdges;
+        BasicBlock *PushBB = FindGCFramePushBlock(S, PopBlocks, ExitEdges);
+        auto gcframe = CallInst::Create(
+            getOrDeclare(jl_intrinsics::newGCFrame),
+            {ConstantInt::get(T_int32, 0)},
+            "gcframe");
+        auto pushGcframe = CallInst::Create(
+            getOrDeclare(jl_intrinsics::pushGCFrame),
+            {gcframe, ConstantInt::get(T_int32, 0)});
+        if (PushBB != &F->getEntryBlock()) {
+            gcframe->insertBefore(PushBB->getFirstInsertionPt());
+            pushGcframe->insertAfter(gcframe);
+        }
+        else {
+            gcframe->insertBefore(F->getEntryBlock().begin());
+            if (isa<Argument>(pgcstack))
+                pushGcframe->insertAfter(gcframe);
+            else
+                pushGcframe->insertAfter(cast<Instruction>(pgcstack));
+        }
 
         // Replace Allocas
         unsigned AllocaSlot = 2; // first two words are metadata
@@ -2546,18 +2692,30 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
 
         // Insert GC frame stores
         PlaceGCFrameStores(S, AllocaSlot - 2, Colors, PreAssignedColors, gcframe);
-        // Insert GCFrame pops
-        for (auto &BB : *F) {
-            if (isa<ReturnInst>(BB.getTerminator())) {
-                auto popGcframe = CallInst::Create(
-                    getOrDeclare(jl_intrinsics::popGCFrame),
-                    {gcframe});
+        // Pop returns in the region and each distinct outgoing edge.
+        for (BasicBlock *BB : PopBlocks) {
+            auto popGcframe = CallInst::Create(
+                getOrDeclare(jl_intrinsics::popGCFrame),
+                {gcframe});
 #if JL_LLVM_VERSION >= 200000
-                popGcframe->insertBefore(BB.getTerminator()->getIterator());
+            popGcframe->insertBefore(BB->getTerminator()->getIterator());
 #else
-                popGcframe->insertBefore(BB.getTerminator());
+            popGcframe->insertBefore(BB->getTerminator());
 #endif
-            }
+        }
+        for (auto &Edge : ExitEdges) {
+            assert(S.DT);
+            BasicBlock *Split = SplitEdge(Edge.first, Edge.second, S.DT);
+            auto popGcframe = CallInst::Create(
+                getOrDeclare(jl_intrinsics::popGCFrame),
+                {gcframe});
+#if JL_LLVM_VERSION >= 200000
+            popGcframe->insertBefore(Split->getTerminator()->getIterator());
+#else
+            popGcframe->insertBefore(Split->getTerminator());
+#endif
+            if (CFGModified)
+                *CFGModified = true;
         }
     }
 }
@@ -2614,7 +2772,7 @@ bool LateLowerGCFrame::runOnFunction(Function &F, bool *CFGModified) {
         ComputeLiveness(S);
         auto Colors = ColorRoots(S);
         std::map<Value *, std::pair<int, int>> CallFrames; // = OptimizeCallFrames(S, Ordering);
-        PlaceRootsAndUpdateCalls(Colors.first, Colors.second, S, CallFrames);
+        PlaceRootsAndUpdateCalls(Colors.first, Colors.second, S, CallFrames, CFGModified);
       }
       CleanupIR(F, &S, CFGModified);
     }

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -31,7 +31,8 @@ JuliaPassContext::JuliaPassContext()
         pgcstack_getter(nullptr), adoptthread_func(nullptr), gcroot_flush_func(nullptr),
         gc_preserve_begin_func(nullptr), gc_preserve_end_func(nullptr),
         pointer_from_objref_func(nullptr), gc_loaded_func(nullptr), alloc_obj_func(nullptr),
-        typeof_func(nullptr), blackbox_func(nullptr), write_barrier_func(nullptr), pop_handler_noexcept_func(nullptr),
+        typeof_func(nullptr), blackbox_func(nullptr), write_barrier_func(nullptr),
+        enter_handler_func(nullptr), pop_handler_func(nullptr), pop_handler_noexcept_func(nullptr),
         call_func(nullptr), call2_func(nullptr), call3_func(nullptr), cancel_point_func(nullptr), module(nullptr)
 {
 }
@@ -58,6 +59,8 @@ void JuliaPassContext::initFunctions(Module &M)
     blackbox_func = M.getFunction("julia.blackbox");
     write_barrier_func = M.getFunction("julia.write_barrier");
     alloc_obj_func = M.getFunction("julia.gc_alloc_obj");
+    enter_handler_func = M.getFunction(XSTR(jl_enter_handler));
+    pop_handler_func = M.getFunction(XSTR(jl_pop_handler));
     pop_handler_noexcept_func = M.getFunction(XSTR(jl_pop_handler_noexcept));
     call_func = M.getFunction("julia.call");
     call2_func = M.getFunction("julia.call2");

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -31,7 +31,8 @@ JuliaPassContext::JuliaPassContext()
         pgcstack_getter(nullptr), adoptthread_func(nullptr), gcroot_flush_func(nullptr),
         gc_preserve_begin_func(nullptr), gc_preserve_end_func(nullptr),
         pointer_from_objref_func(nullptr), gc_loaded_func(nullptr), alloc_obj_func(nullptr),
-        typeof_func(nullptr), blackbox_func(nullptr), write_barrier_func(nullptr), pop_handler_noexcept_func(nullptr),
+        typeof_func(nullptr), blackbox_func(nullptr), write_barrier_func(nullptr),
+        enter_handler_func(nullptr), pop_handler_func(nullptr), pop_handler_noexcept_func(nullptr),
         call_func(nullptr), call2_func(nullptr), call3_func(nullptr), module(nullptr)
 {
 }
@@ -58,6 +59,8 @@ void JuliaPassContext::initFunctions(Module &M)
     blackbox_func = M.getFunction("julia.blackbox");
     write_barrier_func = M.getFunction("julia.write_barrier");
     alloc_obj_func = M.getFunction("julia.gc_alloc_obj");
+    enter_handler_func = M.getFunction(XSTR(jl_enter_handler));
+    pop_handler_func = M.getFunction(XSTR(jl_pop_handler));
     pop_handler_noexcept_func = M.getFunction(XSTR(jl_pop_handler_noexcept));
     call_func = M.getFunction("julia.call");
     call2_func = M.getFunction("julia.call2");

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -61,6 +61,8 @@ struct JuliaPassContext {
     llvm::Function *typeof_func;
     llvm::Function *blackbox_func;
     llvm::Function *write_barrier_func;
+    llvm::Function *enter_handler_func;
+    llvm::Function *pop_handler_func;
     llvm::Function *pop_handler_noexcept_func;
     llvm::Function *call_func;
     llvm::Function *call2_func;

--- a/test/llvmpasses/final-lower-gc.ll
+++ b/test/llvmpasses/final-lower-gc.ll
@@ -22,6 +22,7 @@ define void @gc_frame_lowering(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @gc_frame_lowering
 ; OPAQUE: %gcframe = alloca ptr addrspace(10), i32 4
+; OPAQUE-NEXT: call void @llvm.lifetime.start{{.*}}%gcframe
   %gcframe = call {} addrspace(10)** @julia.new_gc_frame(i32 2)
 ; OPAQUE: [[GCFRAME_SLOT:%.*]] = call ptr @julia.get_pgcstack()
   %pgcstack = call {}*** @julia.get_pgcstack()
@@ -47,9 +48,35 @@ top:
 ; OPAQUE-NEXT: [[PREV_GCFRAME_PTR3:%.*]] = getelementptr inbounds ptr addrspace(10), ptr %gcframe, i32 1
 ; OPAQUE-NEXT: [[PREV_GCFRAME_PTR4:%.*]] = load ptr addrspace(10), ptr [[PREV_GCFRAME_PTR3]], align 8, !tbaa !0
 ; OPAQUE-NEXT: store ptr addrspace(10) [[PREV_GCFRAME_PTR4]], ptr [[GCFRAME_SLOT]], align 8, !tbaa !0
+; OPAQUE-NEXT: call void @llvm.lifetime.end{{.*}}%gcframe
   call void @julia.pop_gc_frame({} addrspace(10)** %gcframe)
 ; CHECK-NEXT: ret void
   ret void
+}
+
+; Lowering lifetime.end must not depend on the function's block order.
+define void @gc_frame_block_order() {
+top:
+; CHECK-LABEL: @gc_frame_block_order
+; OPAQUE: %gcframe = alloca ptr addrspace(10), i32 3
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  br label %cold
+
+pop:
+; OPAQUE: pop:
+; OPAQUE: call void @llvm.lifetime.end{{.*}}%gcframe
+  call void @julia.pop_gc_frame({} addrspace(10)** %gcframe)
+  br label %exit
+
+exit:
+  ret void
+
+cold:
+; OPAQUE: cold:
+; OPAQUE: call void @llvm.lifetime.start{{.*}}%gcframe
+  %gcframe = call {} addrspace(10)** @julia.new_gc_frame(i32 1)
+  call void @julia.push_gc_frame({} addrspace(10)** %gcframe, i32 1)
+  br label %pop
 }
 
 define {} addrspace(10)* @gc_alloc_lowering() {

--- a/test/llvmpasses/final-lower-gc.ll
+++ b/test/llvmpasses/final-lower-gc.ll
@@ -1,6 +1,7 @@
 ; This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='FinalLowerGC' -S %s | FileCheck %s --check-prefixes=CHECK,OPAQUE
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='FinalLowerGC' --julia-check-gc-frame-balance -S %s | FileCheck %s --check-prefixes=BALANCE
 
 
 @tag = external addrspace(10) global {}
@@ -21,8 +22,9 @@ attributes #0 = { allocsize(1) }
 define void @gc_frame_lowering(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @gc_frame_lowering
+; BALANCE-LABEL: @gc_frame_lowering
 ; OPAQUE: %gcframe = alloca ptr addrspace(10), i32 4
-; OPAQUE-NEXT: call void @llvm.lifetime.start{{.*}}%gcframe
+; OPAQUE-NOT: call void @llvm.lifetime.start
   %gcframe = call {} addrspace(10)** @julia.new_gc_frame(i32 2)
 ; OPAQUE: [[GCFRAME_SLOT:%.*]] = call ptr @julia.get_pgcstack()
   %pgcstack = call {}*** @julia.get_pgcstack()
@@ -33,6 +35,10 @@ top:
 ; OPAQUE-DAG: [[PREV_GCFRAME:%.*]] = load ptr, ptr [[GCFRAME_SLOT]], align 8
 ; OPAQUE-DAG: store ptr [[PREV_GCFRAME]], ptr [[PREV_GCFRAME_PTR]], align 8, !tbaa !0
 ; OPAQUE-NEXT: store ptr %gcframe, ptr [[GCFRAME_SLOT]], align 8
+; BALANCE: [[PUSHTOP:%.*]] = load ptr, ptr %pgcstack
+; BALANCE-NEXT: [[SELFLINKED:%.*]] = icmp eq ptr [[PUSHTOP]], %gcframe
+; BALANCE-NEXT: [[PUSHADDR:%.*]] = select i1 [[SELFLINKED]], ptr null, ptr %gcframe
+; BALANCE-NEXT: store volatile i64 0, ptr [[PUSHADDR]]
   call void @julia.push_gc_frame({} addrspace(10)** %gcframe, i32 2)
   %aboxed = call {} addrspace(10)* @ijl_box_int64(i64 signext %a)
 ; OPAQUE: %frame_slot_1 = getelementptr inbounds ptr addrspace(10), ptr %gcframe, i32 3
@@ -48,7 +54,9 @@ top:
 ; OPAQUE-NEXT: [[PREV_GCFRAME_PTR3:%.*]] = getelementptr inbounds ptr addrspace(10), ptr %gcframe, i32 1
 ; OPAQUE-NEXT: [[PREV_GCFRAME_PTR4:%.*]] = load ptr addrspace(10), ptr [[PREV_GCFRAME_PTR3]], align 8, !tbaa !0
 ; OPAQUE-NEXT: store ptr addrspace(10) [[PREV_GCFRAME_PTR4]], ptr [[GCFRAME_SLOT]], align 8, !tbaa !0
-; OPAQUE-NEXT: call void @llvm.lifetime.end{{.*}}%gcframe
+; BALANCE: [[MISMATCH:%.*]] = icmp ne ptr [[POPTOP:%.*]], %gcframe
+; BALANCE-NEXT: [[POPADDR:%.*]] = select i1 [[MISMATCH]], ptr null, ptr %gcframe
+; BALANCE-NEXT: store volatile i64 0, ptr [[POPADDR]]
   call void @julia.pop_gc_frame({} addrspace(10)** %gcframe)
 ; CHECK-NEXT: ret void
   ret void

--- a/test/llvmpasses/final-lower-gc.ll
+++ b/test/llvmpasses/final-lower-gc.ll
@@ -35,6 +35,7 @@ top:
 ; OPAQUE-DAG: [[PREV_GCFRAME:%.*]] = load ptr, ptr [[GCFRAME_SLOT]], align 8
 ; OPAQUE-DAG: store ptr [[PREV_GCFRAME]], ptr [[PREV_GCFRAME_PTR]], align 8, !tbaa !0
 ; OPAQUE-NEXT: store ptr %gcframe, ptr [[GCFRAME_SLOT]], align 8
+; OPAQUE-NEXT: %gcframe.published = load atomic volatile i64, ptr %gcframe monotonic, align 8
 ; BALANCE: [[PUSHTOP:%.*]] = load ptr, ptr %pgcstack
 ; BALANCE-NEXT: [[SELFLINKED:%.*]] = icmp eq ptr [[PUSHTOP]], %gcframe
 ; BALANCE-NEXT: [[PUSHADDR:%.*]] = select i1 [[SELFLINKED]], ptr null, ptr %gcframe
@@ -52,7 +53,7 @@ top:
   call void @boxed_simple({} addrspace(10)* %aboxed, {} addrspace(10)* %bboxed)
 
 ; OPAQUE-NEXT: [[PREV_GCFRAME_PTR3:%.*]] = getelementptr inbounds ptr addrspace(10), ptr %gcframe, i32 1
-; OPAQUE-NEXT: [[PREV_GCFRAME_PTR4:%.*]] = load ptr addrspace(10), ptr [[PREV_GCFRAME_PTR3]], align 8, !tbaa !0
+; OPAQUE-NEXT: [[PREV_GCFRAME_PTR4:%.*]] = load atomic ptr addrspace(10), ptr [[PREV_GCFRAME_PTR3]] monotonic, align 8, !tbaa !0
 ; OPAQUE-NEXT: store ptr addrspace(10) [[PREV_GCFRAME_PTR4]], ptr [[GCFRAME_SLOT]], align 8, !tbaa !0
 ; BALANCE: [[MISMATCH:%.*]] = icmp ne ptr [[POPTOP:%.*]], %gcframe
 ; BALANCE-NEXT: [[POPADDR:%.*]] = select i1 [[MISMATCH]], ptr null, ptr %gcframe
@@ -62,17 +63,22 @@ top:
   ret void
 }
 
-; Lowering lifetime.end must not depend on the function's block order.
+; Sunk (non-entry-block) frames must not get lifetime markers either.
 define void @gc_frame_block_order() {
 top:
 ; CHECK-LABEL: @gc_frame_block_order
 ; OPAQUE: %gcframe = alloca ptr addrspace(10), i32 3
+; OPAQUE-NOT: call void @llvm.lifetime
+; OPAQUE: pop:
+; OPAQUE-NOT: call void @llvm.lifetime
+; OPAQUE: cold:
+; OPAQUE-NOT: call void @llvm.lifetime
+; OPAQUE: call void @llvm.memset{{.*}}%gcframe
+; OPAQUE-NOT: call void @llvm.lifetime
   %pgcstack = call {}*** @julia.get_pgcstack()
   br label %cold
 
 pop:
-; OPAQUE: pop:
-; OPAQUE: call void @llvm.lifetime.end{{.*}}%gcframe
   call void @julia.pop_gc_frame({} addrspace(10)** %gcframe)
   br label %exit
 
@@ -80,8 +86,6 @@ exit:
   ret void
 
 cold:
-; OPAQUE: cold:
-; OPAQUE: call void @llvm.lifetime.start{{.*}}%gcframe
   %gcframe = call {} addrspace(10)** @julia.new_gc_frame(i32 1)
   call void @julia.push_gc_frame({} addrspace(10)** %gcframe, i32 1)
   br label %pop

--- a/test/llvmpasses/image-codegen.jl
+++ b/test/llvmpasses/image-codegen.jl
@@ -1,5 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 # RUN: export JULIA_LLVM_ARGS="--print-before=loop-vectorize --print-module-scope"
+# RUN: export JULIA_OBJCACHE=0
 # RUN: rm -rf %t
 # RUN: mkdir %t
 # RUN: julia --image-codegen -t1,0 --startup-file=no %s 2> %t/output.txt

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -11,6 +11,11 @@ declare void @jl_safepoint()
 declare {} addrspace(10)* @jl_apply_generic({} addrspace(10)*, {} addrspace(10)**, i32)
 declare noalias nonnull {} addrspace(10)* @julia.gc_alloc_obj({}**, i64, {} addrspace(10)*)
 declare i32 @rooting_callee({} addrspace(12)*, {} addrspace(12)*)
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture)
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
+declare void @ijl_enter_handler(ptr, ptr)
+declare void @ijl_pop_handler(ptr, i32)
+declare void @ijl_pop_handler_noexcept(ptr, i32)
 
 define void @gc_frame_lowering(i64 %a, i64 %b) {
 top:
@@ -212,6 +217,171 @@ define swiftcc ptr addrspace(10) @insert_element(ptr swiftself "gcstack" %0) {
   ret ptr addrspace(10) null
 }
 
+
+; The gc frame setup should be sunk into the cold block when the fast path
+; needs no rooting, and the fast-path return then needs no pop.
+define i64 @sunk_gcframe(i64 %a) {
+; CHECK-LABEL: @sunk_gcframe
+top:
+; CHECK: top:
+; CHECK-NOT: @julia.new_gc_frame
+; CHECK-NOT: @julia.push_gc_frame
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  %cmp = icmp sgt i64 %a, 0
+  br i1 %cmp, label %fast, label %cold
+fast:
+; CHECK: fast:
+; CHECK-NOT: @julia.pop_gc_frame
+  %r = add i64 %a, 1
+  ret i64 %r
+cold:
+; CHECK: cold:
+; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+; CHECK-NEXT: call void @julia.push_gc_frame(ptr %gcframe, i32 1)
+; CHECK: @jl_box_int64
+  %aboxed = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+  call void @jl_safepoint()
+  call void @boxed_simple({} addrspace(10)* %aboxed, {} addrspace(10)* %aboxed)
+  unreachable
+}
+
+; A cold path that rejoins the fast path: the frame should be pushed only in
+; the cold block and popped once on the split edge back to the join block.
+define i64 @sunk_gcframe_rejoin(i64 %a) {
+; CHECK-LABEL: @sunk_gcframe_rejoin
+top:
+; CHECK: top:
+; CHECK-NOT: @julia.new_gc_frame
+; CHECK-NOT: @julia.push_gc_frame
+; CHECK-NOT: @julia.pop_gc_frame
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  %cmp = icmp sgt i64 %a, 0
+  br i1 %cmp, label %join, label %cold
+cold:
+; CHECK: cold:
+; CHECK: call ptr @julia.new_gc_frame(i32 1)
+; CHECK: call void @julia.push_gc_frame(ptr %{{.*}}, i32 1)
+; CHECK: @jl_box_int64
+  %aboxed = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+  call void @jl_safepoint()
+  call void @boxed_simple({} addrspace(10)* %aboxed, {} addrspace(10)* %aboxed)
+  br label %join
+; CHECK: call void @julia.pop_gc_frame
+; CHECK-NOT: @julia.pop_gc_frame
+join:
+; CHECK: ret i64
+  %r = add i64 %a, 1
+  ret i64 %r
+}
+
+; Ignore disposable lifetime markers when finding alloca-root users.
+define ptr addrspace(10) @sunk_gcframe_alloca_lifetime(ptr addrspace(10) %input, i64 %a) {
+; CHECK-LABEL: @sunk_gcframe_alloca_lifetime
+top:
+; CHECK: top:
+; CHECK-NOT: @julia.new_gc_frame
+; CHECK-NOT: @julia.push_gc_frame
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %root = alloca ptr addrspace(10), align 8
+  call void @llvm.lifetime.start.p0(i64 8, ptr %root)
+  %cmp = icmp sgt i64 %a, 0
+  br i1 %cmp, label %fast, label %cold
+
+fast:
+; CHECK: fast:
+; CHECK-NOT: @julia.pop_gc_frame
+; CHECK-NOT: @llvm.lifetime
+; CHECK: ret ptr addrspace(10)
+  call void @llvm.lifetime.end.p0(i64 8, ptr %root)
+  ret ptr addrspace(10) %input
+
+cold:
+; CHECK: cold:
+; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+; CHECK: call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 0)
+; CHECK: call void @julia.push_gc_frame(ptr %gcframe, i32 1)
+  store ptr addrspace(10) %input, ptr %root, align 8
+  call void @jl_safepoint()
+  %value = load ptr addrspace(10), ptr %root, align 8
+; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
+; CHECK-NOT: @llvm.lifetime
+; CHECK: ret ptr addrspace(10)
+  call void @llvm.lifetime.end.p0(i64 8, ptr %root)
+  ret ptr addrspace(10) %value
+}
+
+; Handler state restoration requires the frame to remain in the entry block.
+define void @gcframe_enter_handler(ptr %task, ptr %handler, i64 %a) {
+; CHECK-LABEL: @gcframe_enter_handler
+top:
+; CHECK: top:
+; CHECK-NEXT: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+  %pgcstack = call ptr @julia.get_pgcstack()
+  call void @ijl_enter_handler(ptr %task, ptr %handler)
+  br label %cold
+cold:
+  %boxed = call ptr addrspace(10) @jl_box_int64(i64 %a)
+  call void @jl_safepoint()
+  call void @boxed_simple(ptr addrspace(10) %boxed, ptr addrspace(10) %boxed)
+  unreachable
+}
+
+define void @gcframe_pop_handler(ptr %task, i64 %a) {
+; CHECK-LABEL: @gcframe_pop_handler
+top:
+; CHECK: top:
+; CHECK-NEXT: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+  %pgcstack = call ptr @julia.get_pgcstack()
+  call void @ijl_pop_handler(ptr %task, i32 1)
+  br label %cold
+cold:
+  %boxed = call ptr addrspace(10) @jl_box_int64(i64 %a)
+  call void @jl_safepoint()
+  call void @boxed_simple(ptr addrspace(10) %boxed, ptr addrspace(10) %boxed)
+  unreachable
+}
+
+define void @gcframe_pop_handler_noexcept(ptr %task, i64 %a) {
+; CHECK-LABEL: @gcframe_pop_handler_noexcept
+top:
+; CHECK: top:
+; CHECK-NEXT: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+  %pgcstack = call ptr @julia.get_pgcstack()
+  call void @ijl_pop_handler_noexcept(ptr %task, i32 1)
+  br label %cold
+cold:
+  %boxed = call ptr addrspace(10) @jl_box_int64(i64 %a)
+  call void @jl_safepoint()
+  call void @boxed_simple(ptr addrspace(10) %boxed, ptr addrspace(10) %boxed)
+  unreachable
+}
+
+; Keep a rooting alloca live when its derived pointer crosses a rejoin phi.
+define ptr addrspace(10) @gcframe_slot_phi(ptr addrspace(10) %input, ptr addrspace(11) %fallback, i1 %cond) {
+; CHECK-LABEL: @gcframe_slot_phi
+top:
+; CHECK: top:
+; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+  %pgcstack = call ptr @julia.get_pgcstack()
+; CHECK: call void @julia.push_gc_frame(ptr %gcframe, i32 1)
+  %root = alloca ptr addrspace(10), align 8
+  br i1 %cond, label %cold, label %merge
+
+cold:
+  store ptr addrspace(10) %input, ptr %root, align 8
+  %root.loaded = addrspacecast ptr %root to ptr addrspace(11)
+  call void @jl_safepoint()
+  br label %merge
+
+merge:
+; CHECK: merge:
+  %slot = phi ptr addrspace(11) [ %root.loaded, %cold ], [ %fallback, %top ]
+; CHECK: %value = load ptr addrspace(10), ptr addrspace(11) %slot
+  %value = load ptr addrspace(10), ptr addrspace(11) %slot
+; CHECK-NEXT: call void @julia.pop_gc_frame(ptr %gcframe)
+; CHECK-NEXT: ret ptr addrspace(10) %value
+  ret ptr addrspace(10) %value
+}
 
 !0 = !{i64 0, i64 23}
 !1 = !{!1}

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -274,6 +274,30 @@ join:
   ret i64 %r
 }
 
+; Split every parallel switch edge that leaves the rooted region.
+define i64 @sunk_gcframe_duplicate_switch(i64 %a) {
+; CHECK-LABEL: @sunk_gcframe_duplicate_switch
+top:
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  %cmp = icmp sgt i64 %a, 0
+  br i1 %cmp, label %join, label %cold
+cold:
+; CHECK: cold:
+; CHECK: call ptr @julia.new_gc_frame(i32 1)
+  %aboxed = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+  call void @jl_safepoint()
+  call void @boxed_simple({} addrspace(10)* %aboxed, {} addrspace(10)* %aboxed)
+  switch i64 %a, label %join [
+    i64 0, label %join
+    i64 1, label %inside
+  ]
+inside:
+  br label %join
+; CHECK-COUNT-3: call void @julia.pop_gc_frame
+join:
+  ret i64 %a
+}
+
 ; Ignore disposable lifetime markers when finding alloca-root users.
 define ptr addrspace(10) @sunk_gcframe_alloca_lifetime(ptr addrspace(10) %input, i64 %a) {
 ; CHECK-LABEL: @sunk_gcframe_alloca_lifetime

--- a/test/llvmpasses/names.jl
+++ b/test/llvmpasses/names.jl
@@ -149,11 +149,12 @@ emit(f5, A)
 # CHECK: %ptls_load
 # CHECK: %safepoint
 # CHECK: %"e::E.f"
-# CHECK: @"+Main.Base.RefValue
-# CHECK: %"e::E.f.tag_addr"
-# CHECK: %"e::E.f.tag"
-# CHECK: @"jl_sym#g
-# CHECK: @"jl_sym#h
+# Frame sinking may reorder these independent names.
+# CHECK-DAG: @"+Main.Base.RefValue
+# CHECK-DAG: %"e::E.f.tag_addr"
+# CHECK-DAG: %"e::E.f.tag"
+# CHECK-DAG: @"jl_sym#g
+# CHECK-DAG: @"jl_sym#h
 emit(f6, E)
 
 


### PR DESCRIPTION
Builds on #61596
@gbaraldi This came up as an idea and I started to explore it before discovering #61596
There seemed to be some merit in merging the two approaches, so I thought I'd open separately

Claude and codex:

---

Julia currently creates, clears, pushes, and pops a GC shadow-stack frame even
when rooting is needed only on a cold path. This adds avoidable work to common
fast paths and motivates many small `@noinline` throw helpers in Base.

This change lets `LateLowerGCFrame` move frame setup to the nearest common
dominator of the blocks that need it. Returns within that region pop normally;
edges leaving it are split and pop before rejoining code that does not need the
frame. Paths ending in `resume` or `unreachable` need no explicit pop because
the caller's exception handler restores `pgcstack` while unwinding, matching
the existing behavior.

`FinalLowerGC` still places the backing `alloca` in the entry block, preserving
a static stack allocation, and emits the clearing memset at the sunk setup
point. The frame alloca carries no lifetime markers. Instead, the push emits an
atomic volatile monotonic load of the frame, and the pop's `frame.prev` load is
atomic monotonic; both lower to plain loads. These keep the frame's stores
visible to the post-lowering DSE/GVN cleanup: the GC reads the frame through
the shadow stack, but LLVM cannot see those reads (safepoint callees carry
memory effects that exclude the frame alloca, and DSE treats allocas as dead at
function exit regardless of escapes). Without an in-function reader, DSE
deleted a sunk frame's nroots store and memset, and GC marking walked stale
stack words as roots — the nanosoldier segfault on earlier revisions of this
PR. Entry-block frames were protected only by accident: the prologue safepoint
poll's volatile load happened to land right after the push, and sinking moves
the push past it.

An opt-in diagnostic, `JULIA_LLVM_ARGS="--julia-check-gc-frame-balance"`,
instruments every lowered push with a self-link check and every lowered pop
with a top-of-stack check, faulting at the offending site instead of leaving a
dangling frame for a later collection to crash on.

## Example

A function that allocates only while constructing an error can now skip GC
frame setup on its successful path:

```julia
function checked_increment(x)
    x >= 0 || error("negative value: $x")
    return x + 1
end
```

## Correctness constraints

Sinking falls back to the entry block when any of these conditions is not met:

- The push block executes at most once. SCC analysis also catches irreducible
  cycles that `LoopInfo` can miss.
- The function has no `returns_twice` call or Julia EH runtime call. This avoids
  stale frames after `longjmp` and preserves handler `gcstack` balance.
- Every edge leaving the pushed region can be split safely.
- `pgcstack` is available from the entry block.

The required region includes safepoints with live roots, tracked stores, and
all semantic uses of rooting allocas. Lifetime and debug markers are ignored;
lifetime markers are removed when allocas become frame slots. Pointer-derived
slot addresses are followed through GEPs, casts, selects, and PHIs so a pop
cannot end the frame lifetime before a downstream consumer. Parallel switch edges are split individually so every path leaving the region
pops exactly once.

## Relationship to JuliaLang/julia#61596

This is an independent implementation of the same optimization proposed by
@gbaraldi in JuliaLang/julia#61596. It uses the same overall design: an
NCD-selected push block, split-edge pops, an entry-block alloca, and
conservative EH handling. Credit for that design belongs to the earlier PR.

This implementation uses SCC analysis for cycle detection, handles parallel
switch edges individually, checks the `returns_twice` attribute, and follows derived
rooting-slot pointers across the proposed pop boundary.

## Benchmarks

Fastest of 9 timed runs on Apple silicon (ns/call), each a warmed `@noinline`
callee driven from a summing loop with a GC before each timing, against
nightly `97537a10159`:

| Pattern | Nightly | This change | Relative |
|---|---:|---:|---:|
| Cold throw with string interpolation (200M calls) | 1.191 | **0.695** | **1.71×** |
| Heap allocation on every call (20M calls) | 3.38 | 3.39 | 1.00× |
| BaseBenchmarks `perf_sumrange(::ArrayLSLS{Int32,2})` (20k calls) | 1195 | 1196 | 1.00× |

The cold-throw case confirms frame setup leaves the hot path; the generated IR
shows the push sunk into the error branch. The other two confirm the
DSE-visibility loads cost nothing measurable when the frame is needed —
`perf_sumrange`, whose sunk frame is live across a hot allocating loop, is the
benchmark that crashed nanosoldier before the DSE fix, and it also survives
33M iterations / 54k collections under a 64MB heap with balance checks on.
