### PR TITLE
Expose the ABI used by CodeInstances

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -68,7 +68,7 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     uniontypes, unsafe_convert, unwrap_unionall, unwrapva, vect, widen_diagonal,
     _uncompressed_ir, datatype_min_ninitialized,
     partialstruct_init_undefs, fieldcount_noerror, _eval_import, _eval_using,
-    get_ci_mi, get_methodtable, morespecific, specializations, has_image_globalref,
+    get_ci_mi, get_ci_abi, get_methodtable, morespecific, specializations, has_image_globalref,
     rewrap_free_typevars, find_free_typevars, typeintersect_env,
     PARTITION_MASK_KIND, PARTITION_KIND_GUARD, PARTITION_FLAG_EXPORTED, PARTITION_FLAG_DEPRECATED,
     BINDING_FLAG_ANY_IMPLICIT_EDGES, is_some_implicit, IteratorSize, SizeUnknown, get_require_world, JLOptions,

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -2469,12 +2469,6 @@ function abstract_call_unionall(interp::AbstractInterpreter, argtypes::Vector{An
     return CallMeta(ret, Any, Effects(EFFECTS_TOTAL; nothrow), call.info)
 end
 
-function get_ci_abi(ci::CodeInstance)
-    def = ci.def
-    isa(def, ABIOverride) && return def.abi
-    (def::MethodInstance).specTypes
-end
-
 function abstract_invoke(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtInfo, vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
     argtypes = arginfo.argtypes
     ft′ = argtype_by_index(argtypes, 2)

--- a/Compiler/test/testgroups
+++ b/Compiler/test/testgroups
@@ -16,4 +16,5 @@ tarjan
 validation
 special_loading
 abioverride
+abi_layout
 verifytrim

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1800,6 +1800,22 @@ function get_ci_mi(codeinst::CodeInstance)
 end
 
 """
+    Base.get_ci_abi(codeinst::CodeInstance)
+
+The signature `codeinst` is compiled against, i.e. the tuple type its generated
+code takes as arguments. This is the `specTypes` of its `MethodInstance` unless a
+`Core.ABIOverride` replaces it. Mirrors the C `jl_get_ci_abi`.
+"""
+function get_ci_abi(codeinst::CodeInstance)
+    def = codeinst.def
+    if def isa Core.ABIOverride
+        return def.abi
+    else
+        return (def::MethodInstance).specTypes
+    end
+end
+
+"""
     Base.generating_output([incremental::Bool])::Bool
 
 Return `true` if the current process is being used to pre-generate a

--- a/doc/src/devdocs/callconv.md
+++ b/doc/src/devdocs/callconv.md
@@ -24,6 +24,46 @@ the "structure return" (`sret`) convention, where the caller provides a pointer 
 An argument or return value that is a homogeneous tuple is sometimes represented as an LLVM vector
 instead of an LLVM array.
 
+### Introspecting the native calling convention
+
+Out-of-tree code generators (GPUCompiler.jl, Enzyme.jl) need to know exactly how a
+signature is lowered, and re-deriving these rules is a reliable source of drift.
+`jl_get_specsig_layout` in `julia.h` answers the question directly, by running the
+same code that emits the signature:
+
+```c
+jl_abi_query_t query = { .version = JL_ABI_LAYOUT_VERSION, .ci = codeinst };
+jl_abi_layout_t layout;
+jl_abi_arginfo_t args[nargs];
+jl_get_specsig_layout(&query, &layout, args, nargs);
+```
+
+A query names either a `jl_code_instance_t` (whose ABI signature comes from
+`jl_get_ci_abi`, which follows a `Core.ABIOverride`) or an explicit
+`(sigt, rt)` pair. The answer depends on the `jl_cgparams_t` — `gcstack_arg`
+adds or removes a parameter, `prefer_specsig` decides whether the specialized
+signature is used at all — and on the target, since the alloca address space
+comes from the module's data layout. Pass both if they differ from the host's.
+
+`layout` reports how the value is returned (`jl_abi_retcc_t`, mirroring
+`jl_returninfo_t::CallingConv`), and the indices of the leading parameters,
+which appear in this order when present:
+
+  1. `sret_return` or `union_bytes_return`, the caller-provided return slot
+  2. `return_roots`, an array of the tracked pointers in that slot
+  3. `pgcstack_arg`
+
+`args[i]` then describes `jl_tparam(sigt, i)`: whether it is passed by value,
+indirectly as a pointer, boxed, or not at all (a ghost type, or a value that is
+exactly its own type — see `jl_is_typeegal`), along with its 0-based LLVM
+parameter index. An aggregate passed indirectly that contains *some* but not all
+tracked pointers additionally takes a `.roots.` shadow parameter, reported as
+`roots_idx`; forgetting it shifts every later parameter.
+
+The type-level rules that decide boxing are separately available from libjulia,
+without an LLVM context: `jl_deserves_stack`, `jl_deserves_argbox` and
+`jl_deserves_retbox`.
+
 ## JL Call Convention
 
 The JL Call convention is for builtins and generic dispatch. Hand-written functions using this

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -135,6 +135,8 @@ JL_DLLEXPORT void *jl_get_llvm_function_fallback(void *native_code, uint32_t idx
 
 JL_DLLEXPORT LLVMOrcThreadSafeModuleRef jl_get_llvm_module_fallback(void *native_code) UNAVAILABLE
 
+JL_DLLEXPORT int jl_get_specsig_layout_fallback(const jl_abi_query_t *query, jl_abi_layout_t *layout,
+        jl_abi_arginfo_t *args, int32_t args_capacity) UNAVAILABLE
 JL_DLLEXPORT void *jl_type_to_llvm_fallback(jl_value_t *jt, LLVMContextRef llvmctxt, bool_t *isboxed) UNAVAILABLE
 
 JL_DLLEXPORT void *jl_struct_to_llvm_fallback(jl_value_t *jt, LLVMContextRef llvmctxt, bool_t *isboxed) UNAVAILABLE

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1644,13 +1644,6 @@ static MDNode *best_tbaa(jl_tbaacache_t &tbaa_cache, jl_value_t *jt) {
     return jl_is_mutable(jt) ? tbaa_cache.tbaa_mutab : tbaa_cache.tbaa_immut;
 }
 
-// tracks whether codegen is currently able to simply stack-allocate this type
-// note that this includes jl_isbits, although codegen should work regardless
-static bool jl_is_concrete_immutable(jl_value_t* t)
-{
-    return jl_may_be_immutable_datatype(t) && ((jl_datatype_t*)t)->isconcretetype && !jl_is_kind(t);
-}
-
 static bool jl_is_pointerfree(jl_value_t* t)
 {
     if (!jl_is_concrete_immutable(t))
@@ -1675,20 +1668,19 @@ static unsigned get_box_tindex(jl_datatype_t *jt, jl_value_t *ut) JL_CANSAFEPOIN
 // these queries are usually related, but we split them out here
 // for convenience and clarity (and because it changes the calling convention)
 // n.b. this must include jl_is_datatype_singleton (ghostType) and primitive types
+// The definitions live in src/datatype.c so that out-of-tree code generators can
+// call them; these are just the local spellings.
 static bool deserves_stack(jl_value_t* t) JL_CANSAFEPOINT
 {
-    if (!jl_is_concrete_immutable(t))
-        return false;
-    jl_datatype_t *dt = (jl_datatype_t*)t;
-    return jl_is_datatype_singleton(dt) || jl_datatype_isinlinealloc(dt, /* (require) pointerfree */ 0);
+    return jl_deserves_stack(t);
 }
 static bool deserves_argbox(jl_value_t* t) JL_CANSAFEPOINT
 {
-    return !deserves_stack(t);
+    return jl_deserves_argbox(t);
 }
 static bool deserves_retbox(jl_value_t* t) JL_CANSAFEPOINT
 {
-    return deserves_argbox(t);
+    return jl_deserves_retbox(t);
 }
 static bool deserves_unionbox(jl_value_t* t) JL_CANSAFEPOINT
 {
@@ -8406,7 +8398,7 @@ static void gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *abi, jl_va
 }
 
 jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value *fval, StringRef name, jl_value_t *sig, jl_value_t *jlrettype, bool is_opaque_closure,
-        ArrayRef<const char*> ArgNames, unsigned nreq)
+        ArrayRef<const char*> ArgNames, unsigned nreq, jl_specsig_layout_t *layout_out)
 {
     bool gcstack_arg = out.params->gcstack_arg;
     jl_returninfo_t props = {};
@@ -8441,6 +8433,8 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
         if (props.union_bytes) {
             props.cc = jl_returninfo_t::Union;
             fsig.push_back(PointerType::getUnqual(M->getContext()));
+            if (layout_out)
+                layout_out->sret_idx = fsig.size() - 1;
             argnames.push_back("union_bytes_return");
             Type *pair[] = { T_prjlvalue, getInt8Ty(M->getContext()) };
             rt = StructType::get(M->getContext(), ArrayRef<Type*>(pair));
@@ -8472,6 +8466,8 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
             // sret is always passed from alloca
             assert(M);
             fsig.push_back(PointerType::get(M->getContext(), M->getDataLayout().getAllocaAddrSpace()));
+            if (layout_out)
+                layout_out->sret_idx = fsig.size() - 1;
             argnames.push_back("sret_return");
             srt = rt;
             rt = getVoidTy(M->getContext());
@@ -8521,6 +8517,8 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
         param.addAttribute("julia.return_roots", std::to_string(props.return_roots));
         attrs.push_back(AttributeSet::get(M->getContext(), param));
         fsig.push_back(getPointerTy(M->getContext()));
+        if (layout_out)
+            layout_out->return_roots_idx = fsig.size() - 1;
         argnames.push_back("return_roots");
     }
 
@@ -8532,6 +8530,8 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
         param.addAttribute(Attribute::NonNull);
         attrs.push_back(AttributeSet::get(M->getContext(), param));
         fsig.push_back(PointerType::get(M->getContext(), 0));
+        if (layout_out)
+            layout_out->pgcstack_idx = fsig.size() - 1;
         argnames.push_back("pgcstack_arg");
     }
 
@@ -8541,19 +8541,27 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
         bool isboxed = false;
         Type *et = nullptr;
         if (i != 0 || !is_opaque_closure) { // special token for OC argument
-            if (is_uniquerep_Type(jt))
+            if (is_uniquerep_Type(jt)) {
+                if (layout_out)
+                    layout_out->record_elided(JL_ABI_ELIDE_UNIQUEREP);
                 continue;
+            }
             isboxed = deserves_argbox(jt);
             et = isboxed ? T_prjlvalue : _julia_type_to_llvm(&out, M->getContext(), jt, nullptr, /*noboxing*/false);
-            if (type_is_ghost(et))
+            if (type_is_ghost(et)) {
+                if (layout_out)
+                    layout_out->record_elided(JL_ABI_ELIDE_GHOST);
                 continue;
+            }
         }
         AttrBuilder param(M->getContext());
         Type *ty = et;
+        uint8_t argcc = isboxed ? JL_ABI_ARG_BOXED : JL_ABI_ARG_VALUE;
         if (et == nullptr || et->isAggregateType()) { // aggregate types are passed by pointer
             addNoCaptureAttr(param);
             param.addAttribute(Attribute::ReadOnly);
             ty = PointerType::get(M->getContext(), AddressSpace::Derived);
+            argcc = JL_ABI_ARG_INDIRECT;
         }
         else if (isboxed && jl_may_be_immutable_datatype(jt) && !jl_is_abstracttype(jt)) {
             param.addAttribute(Attribute::ReadOnly);
@@ -8565,6 +8573,8 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
         }
         attrs.push_back(AttributeSet::get(M->getContext(), param));
         fsig.push_back(ty);
+        if (layout_out)
+            layout_out->record_param(fsig.size() - 1, argcc);
         size_t argno = i < nreq ? i : nreq;
         std::string genname;
         if (!ArgNames.empty()) {
@@ -8581,6 +8591,10 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
             if (tracked.count && !tracked.all) {
                 attrs.push_back(AttributeSet::get(M->getContext(), param));
                 fsig.push_back(PointerType::get(M->getContext(), M->getDataLayout().getAllocaAddrSpace()));
+                // n.b. derived from fsig, not argnames: the name is only pushed
+                // when ArgNames was supplied, but the parameter always is
+                if (layout_out)
+                    layout_out->arg_to_roots.back() = fsig.size() - 1;
                 if (!genname.empty())
                     argnames.push_back((Twine(".roots.") + genname).str());
             }
@@ -8630,6 +8644,117 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
     props.decl = FunctionCallee(ftype, fval);
     props.attrs = attributes;
     return props;
+}
+
+// The public enums must stay numerically identical to the internal ones, since
+// jl_get_specsig_layout copies jl_returninfo_t::cc straight through.
+static_assert((int)JL_ABI_RET_BOXED    == (int)jl_returninfo_t::Boxed,    "");
+static_assert((int)JL_ABI_RET_REGISTER == (int)jl_returninfo_t::Register, "");
+static_assert((int)JL_ABI_RET_SRET     == (int)jl_returninfo_t::SRet,     "");
+static_assert((int)JL_ABI_RET_UNION    == (int)jl_returninfo_t::Union,    "");
+static_assert((int)JL_ABI_RET_GHOSTS   == (int)jl_returninfo_t::Ghosts,   "");
+
+// Report the specsig ABI of a signature (or CodeInstance) without requiring the
+// caller to reimplement any of the rules above. See src/julia.h for the
+// contract; this answers by running get_specsig_function for real, so the two
+// can never disagree.
+extern "C" JL_DLLEXPORT_CODEGEN
+int jl_get_specsig_layout_impl(const jl_abi_query_t *q, jl_abi_layout_t *out,
+                               jl_abi_arginfo_t *args, int32_t args_capacity)
+{
+    if (q == NULL || out == NULL)
+        return -3;
+    if (q->version != JL_ABI_LAYOUT_VERSION) {
+        out->version = JL_ABI_LAYOUT_VERSION;
+        return -1;
+    }
+    memset(out, 0, sizeof(*out));
+    out->version = JL_ABI_LAYOUT_VERSION;
+    out->sret_idx = out->return_roots_idx = out->pgcstack_idx = -1;
+
+    jl_value_t *sigt = q->sigt;
+    jl_value_t *rt = q->rt;
+    bool is_opaque_closure = q->is_opaque_closure != 0;
+    jl_method_instance_t *mi = NULL;
+    if (q->ci != NULL) {
+        mi = jl_get_ci_mi(q->ci);
+        sigt = get_ci_abi(q->ci);
+        rt = q->ci->rettype;
+        is_opaque_closure = jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
+    }
+    if (sigt == NULL || rt == NULL || !jl_is_tuple_type(sigt))
+        return -3;
+    out->sigt = sigt;
+    out->rettype = rt;
+    out->nargs = jl_nparams(sigt);
+
+    const jl_cgparams_t *cgparams = q->cgparams ? q->cgparams : &jl_default_cgparams;
+    bool specsig, needsparams = false;
+    if (mi != NULL)
+        std::tie(specsig, needsparams) = uses_specsig(sigt, mi, rt, cgparams->prefer_specsig);
+    else
+        specsig = uses_specsig(sigt, false, rt, cgparams->prefer_specsig);
+    out->specsig = specsig;
+    out->needsparams = needsparams;
+    if (args != NULL && args_capacity < out->nargs)
+        return -2;
+    if (!specsig)
+        return 0; // the jlcall ABI applies; nothing further to report
+
+    // Declare into the caller's module if it gave us one -- its DataLayout and
+    // Triple decide the alloca address space and the calling convention, which
+    // differ for the GPU targets this interface exists to serve. Otherwise use
+    // a scratch module, which is thrown away before returning.
+    std::unique_ptr<LLVMContext> scratch_ctx;
+    std::unique_ptr<Module> scratch_mod;
+    Module *M;
+    if (q->mod != NULL) {
+        M = unwrap((LLVMModuleRef)q->mod);
+    }
+    else {
+        scratch_ctx = std::make_unique<LLVMContext>();
+        DataLayout DL = q->datalayout ? DataLayout(StringRef(q->datalayout))
+                                      : jl_ExecutionEngine->getDataLayout();
+        Triple TT = q->triple ? Triple(StringRef(q->triple))
+                              : jl_ExecutionEngine->getTargetTriple();
+        scratch_mod = jl_create_llvm_module("jl_abi_query", *scratch_ctx, DL, TT);
+        M = scratch_mod.get();
+    }
+
+    jl_codegen_output_t cgout(*M);
+    cgout.params = cgparams;
+    // n.b. temporary_roots stays null: the type conversions below check for it
+    jl_specsig_layout_t layout;
+    jl_returninfo_t props = get_specsig_function(cgout, M, NULL,
+            q->name ? StringRef(q->name) : StringRef(""), sigt, rt, is_opaque_closure,
+            {}, 0, &layout);
+
+    out->rettype_cc = (int32_t)props.cc;
+    out->return_roots = props.return_roots;
+    out->all_roots = props.all_roots;
+    out->union_bytes = props.union_bytes;
+    out->union_align = props.union_align;
+    out->union_minalign = props.union_minalign;
+    out->sret_idx = layout.sret_idx;
+    out->return_roots_idx = layout.return_roots_idx;
+    out->pgcstack_idx = layout.pgcstack_idx;
+    out->nprefix_params = (layout.sret_idx >= 0) + (layout.return_roots_idx >= 0) +
+                          (layout.pgcstack_idx >= 0);
+    out->nparams = props.decl.getFunctionType()->getNumParams();
+    assert((int32_t)layout.arg_to_param.size() == out->nargs);
+    if (args != NULL) {
+        for (int32_t i = 0; i < out->nargs; i++) {
+            args[i].typ = jl_tparam(sigt, i);
+            args[i].cc = layout.arg_cc[i];
+            args[i].param_idx = layout.arg_to_param[i];
+            args[i].roots_idx = layout.arg_to_roots[i];
+            args[i].elide_reason = layout.arg_elide[i];
+            args[i]._reserved = 0;
+        }
+    }
+    if (q->mod != NULL && q->decl_out != NULL)
+        *q->decl_out = wrap(cast<Function>(props.decl.getCallee()));
+    return 0;
 }
 
 static DISubroutineType *

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -399,6 +399,36 @@ int jl_datatype_isinlinealloc(jl_datatype_t *ty, int pointerfree)
     return 0;
 }
 
+// tracks whether codegen is currently able to simply stack-allocate this type
+// note that this includes jl_isbits, although codegen should work regardless
+JL_DLLEXPORT int jl_is_concrete_immutable(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    return jl_may_be_immutable_datatype(t) && ((jl_datatype_t*)t)->isconcretetype && !jl_is_kind(t);
+}
+
+// These queries are usually related, but we split them out here for convenience
+// and clarity (and because it changes the calling convention). They describe the
+// specsig ABI, so out-of-tree code generators need to agree with them exactly;
+// codegen forwards to these rather than keeping its own copy.
+// n.b. this must include jl_is_datatype_singleton (ghostType) and primitive types
+JL_DLLEXPORT int jl_deserves_stack(jl_value_t *t) JL_CANSAFEPOINT
+{
+    if (!jl_is_concrete_immutable(t))
+        return 0;
+    jl_datatype_t *dt = (jl_datatype_t*)t;
+    return jl_is_datatype_singleton(dt) || jl_datatype_isinlinealloc(dt, /* (require) pointerfree */ 0);
+}
+
+JL_DLLEXPORT int jl_deserves_argbox(jl_value_t *t) JL_CANSAFEPOINT
+{
+    return !jl_deserves_stack(t);
+}
+
+JL_DLLEXPORT int jl_deserves_retbox(jl_value_t *t) JL_CANSAFEPOINT
+{
+    return jl_deserves_argbox(t);
+}
+
 static unsigned union_isinlinable(jl_value_t *ty, int pointerfree, size_t *nbytes, size_t *align, int asfield) JL_CANSAFEPOINT
 {
     if (jl_is_uniontype(ty)) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -662,6 +662,17 @@ JL_DLLEXPORT int jl_is_ci_equiv(jl_code_instance_t *ci JL_PROPAGATES_ROOT, jl_co
     return 0;
 }
 
+// The signature this CodeInstance is actually compiled against. Usually the
+// specTypes of its MethodInstance, but a Core.ABIOverride replaces it. Callers
+// that care about the ABI (rather than about which method was inferred) must
+// use this instead of reaching for `jl_get_ci_mi(ci)->specTypes` directly.
+JL_DLLEXPORT jl_value_t *jl_get_ci_abi(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    if (jl_is_abioverride(ci->def))
+        return ((jl_abi_override_t*)ci->def)->abi;
+    return jl_get_ci_mi(ci)->specTypes;
+}
+
 // look for something with an egal ABI and properties that is already in the JIT for the target_world, or could be added to the JIT instead of ci to satisfy the same invoke edge with the same src.
 JL_DLLEXPORT jl_code_instance_t *jl_get_ci_equiv(jl_code_instance_t *ci JL_PROPAGATES_ROOT, size_t target_world) JL_NOTSAFEPOINT
 {

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -365,6 +365,35 @@ struct jl_returninfo_t {
     uint32_t effects = 0;  // ipo_purity_bits, applied to CallInst and Function
 };
 
+// Optional output of get_specsig_function describing where each Julia-level
+// argument ended up in the emitted LLVM parameter list. Recorded as codegen
+// builds the signature, so that it cannot drift from the signature itself.
+// This is what backs the exported jl_get_specsig_layout.
+struct jl_specsig_layout_t {
+    // one entry per jl_tparam(sig, i), in order
+    llvm::SmallVector<int32_t, 8> arg_to_param;  // LLVM param index, or -1 if elided
+    llvm::SmallVector<int32_t, 8> arg_to_roots;  // index of the `.roots.` shadow param, or -1
+    llvm::SmallVector<uint8_t, 8> arg_cc;        // jl_abi_argcc_t
+    llvm::SmallVector<uint8_t, 8> arg_elide;     // jl_abi_elide_t
+    // leading parameters, or -1 if not present
+    int32_t sret_idx = -1;          // sret_return or union_bytes_return
+    int32_t return_roots_idx = -1;
+    int32_t pgcstack_idx = -1;
+
+    void record_elided(uint8_t reason) JL_NOTSAFEPOINT {
+        arg_to_param.push_back(-1);
+        arg_to_roots.push_back(-1);
+        arg_cc.push_back(JL_ABI_ARG_ELIDED);
+        arg_elide.push_back(reason);
+    }
+    void record_param(int32_t param_idx, uint8_t cc) JL_NOTSAFEPOINT {
+        arg_to_param.push_back(param_idx);
+        arg_to_roots.push_back(-1);
+        arg_cc.push_back(cc);
+        arg_elide.push_back(JL_ABI_ELIDE_NONE);
+    }
+};
+
 struct jl_codegen_call_target_t {
     llvm::Function *decl;
     bool external_linkage; // whether codegen would like this edge to be externally-available
@@ -562,7 +591,8 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &ctx, Module *M, Value 
                                      StringRef name, jl_value_t *sig, jl_value_t *jlrettype,
                                      bool is_opaque_closure,
                                      ArrayRef<const char *> ArgNames = {},
-                                     unsigned nreq = 0) JL_CANSAFEPOINT;
+                                     unsigned nreq = 0,
+                                     jl_specsig_layout_t *layout_out = nullptr) JL_CANSAFEPOINT;
 
 void add_named_global(StringRef name, void *addr) JL_NOTSAFEPOINT;
 
@@ -585,11 +615,11 @@ static const inline char *name_from_method_instance(jl_method_instance_t *li) JL
     return jl_is_method(li->def.method) ? jl_symbol_name(li->def.method->name) : "top-level scope";
 }
 
+// n.b. the definition lives in src/gf.c as the exported jl_get_ci_abi, so that
+// out-of-tree code generators see the same answer codegen does
 static inline jl_value_t *get_ci_abi(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    if (jl_typeof(ci->def) == (jl_value_t*)jl_abioverride_type)
-        return ((jl_abi_override_t*)ci->def)->abi;
-    return jl_get_ci_mi(ci)->specTypes;
+    return jl_get_ci_abi(ci);
 }
 
 template <size_t offset = 0>

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -104,6 +104,9 @@
     XX(jl_current_exception) \
     XX(jl_debug_method_invalidation) \
     XX(jl_deprecate_binding) \
+    XX(jl_deserves_argbox) \
+    XX(jl_deserves_retbox) \
+    XX(jl_deserves_stack) \
     XX(jl_dlclose) \
     XX(jl_dlopen) \
     XX(jl_dlsym) \
@@ -199,6 +202,7 @@
     XX(jl_get_sysimage_cpu_target) \
     XX(jl_cpu_has_fma) \
     XX(jl_get_current_task) \
+    XX(jl_get_ci_abi) \
     XX(jl_get_default_sysimg_path) \
     XX(jl_get_excstack) \
     XX(jl_get_fenv_consts) \
@@ -272,6 +276,7 @@
     XX(jl_is_binding_deprecated) \
     XX(jl_is_char_signed) \
     XX(jl_is_compilable) \
+    XX(jl_is_concrete_immutable) \
     XX(jl_is_const) \
     XX(jl_is_assertsbuild) \
     XX(jl_is_debugbuild) \
@@ -534,6 +539,7 @@
     YY(jl_get_llvm_external_fns) \
     YY(jl_get_llvm_cis) \
     YY(jl_get_llvm_mi_cache_order) \
+    YY(jl_get_specsig_layout) \
     YY(jl_dump_function_asm) \
     YY(jl_LLVMCreateDisasm) \
     YY(jl_LLVMDisasmInstruction) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -2907,6 +2907,109 @@ typedef struct {
     int emit_metadata;
 } jl_emission_params_t;
 
+// specsig ABI introspection --------------------------------------------------
+// These let out-of-tree code generators (GPUCompiler.jl, Enzyme.jl) ask how a
+// signature is lowered to an LLVM function signature, rather than re-deriving
+// the rules and drifting from codegen.
+
+// The signature a CodeInstance is compiled against (see Core.ABIOverride).
+JL_DLLEXPORT jl_value_t *jl_get_ci_abi(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
+
+// Whether codegen can stack-allocate values of this type, and hence whether
+// arguments/returns of this type are passed boxed. These require no LLVM
+// context, so unlike jl_get_specsig_layout they live in libjulia proper.
+JL_DLLEXPORT int jl_is_concrete_immutable(jl_value_t *t) JL_NOTSAFEPOINT;
+// n.b. these may compute a lazy layout, and so can safepoint
+JL_DLLEXPORT int jl_deserves_stack(jl_value_t *t) JL_CANSAFEPOINT;
+JL_DLLEXPORT int jl_deserves_argbox(jl_value_t *t) JL_CANSAFEPOINT;
+JL_DLLEXPORT int jl_deserves_retbox(jl_value_t *t) JL_CANSAFEPOINT;
+
+// The full specsig layout of a signature: how the return value is passed, and
+// where each Julia argument lands in the LLVM parameter list. Answered by
+// running the same code that emits the signature, so it cannot drift.
+//
+// This interface is not covered by the usual API stability promise. Callers
+// MUST set `version` to JL_ABI_LAYOUT_VERSION; a mismatch is reported through
+// the return value rather than asserted, so that a caller built against an
+// older Julia degrades cleanly.
+#define JL_ABI_LAYOUT_VERSION 1
+
+// mirrors jl_returninfo_t::CallingConv in src/jitlayers.h; same numeric values
+typedef enum {
+    JL_ABI_RET_BOXED    = 0, // returns jl_value_t addrspace(10)*
+    JL_ABI_RET_REGISTER = 1, // returned directly (possibly `void`, for a ghost or Union{})
+    JL_ABI_RET_SRET     = 2, // returned through a leading alloca-AS sret pointer
+    JL_ABI_RET_UNION    = 3, // leading buffer pointer; returns {addrspace(10)*, i8}
+    JL_ABI_RET_GHOSTS   = 4  // returns only the i8 union selector
+} jl_abi_retcc_t;
+
+typedef enum {
+    JL_ABI_ARG_ELIDED   = 0, // not passed at all
+    JL_ABI_ARG_VALUE    = 1, // passed directly by value
+    JL_ABI_ARG_INDIRECT = 2, // aggregate: passed as ptr addrspace(11), nocapture readonly
+    JL_ABI_ARG_BOXED    = 3  // passed as jl_value_t addrspace(10)*
+} jl_abi_argcc_t;
+
+typedef enum {
+    JL_ABI_ELIDE_NONE      = 0,
+    JL_ABI_ELIDE_GHOST     = 1, // the LLVM type is empty
+    JL_ABI_ELIDE_UNIQUEREP = 2  // the value is exactly its type (see jl_is_typeegal)
+} jl_abi_elide_t;
+
+typedef struct {
+    jl_value_t *typ;      // jl_tparam(sigt, i); rooted by sigt
+    int32_t cc;           // jl_abi_argcc_t
+    int32_t param_idx;    // 0-based index into the LLVM parameter list, or -1 if elided
+    int32_t roots_idx;    // 0-based index of the extra `.roots.` shadow parameter, or -1
+    int32_t elide_reason; // jl_abi_elide_t
+    int32_t _reserved;
+} jl_abi_arginfo_t;
+
+typedef struct {
+    uint32_t version;         // in: JL_ABI_LAYOUT_VERSION
+    int32_t specsig;          // if 0, the jlcall ABI applies and the fields below are zeroed
+    int32_t needsparams;      // static parameters are required (jl_fptr_sparam)
+    jl_value_t *sigt;         // the signature used (see jl_get_ci_abi)
+    jl_value_t *rettype;
+    int32_t rettype_cc;       // jl_abi_retcc_t
+    uint32_t return_roots;
+    int32_t all_roots;
+    size_t union_bytes;
+    size_t union_align;
+    size_t union_minalign;
+    int32_t sret_idx;         // sret_return / union_bytes_return parameter, or -1
+    int32_t return_roots_idx; // return_roots parameter, or -1
+    int32_t pgcstack_idx;     // pgcstack_arg parameter, or -1
+    int32_t nprefix_params;   // how many of the three above are present
+    int32_t nargs;            // jl_nparams(sigt); the required capacity of `args`
+    int32_t nparams;          // total LLVM parameter count
+} jl_abi_layout_t;
+
+typedef struct {
+    uint32_t version;              // in: JL_ABI_LAYOUT_VERSION
+    jl_code_instance_t *ci;        // optional; supersedes sigt/rt/is_opaque_closure
+    jl_value_t *sigt;              // required if ci == NULL
+    jl_value_t *rt;                // required if ci == NULL
+    int32_t is_opaque_closure;
+    const jl_cgparams_t *cgparams; // NULL means &jl_default_cgparams
+    void *mod;                     // LLVMModuleRef to declare into, or NULL for a scratch module
+    const char *datalayout;        // only used when mod == NULL; NULL means the host JIT's
+    const char *triple;            // only used when mod == NULL; NULL means the host JIT's
+    const char *name;              // declaration name; only used when mod != NULL
+    void **decl_out;               // LLVMValueRef out-param; only used when mod != NULL
+} jl_abi_query_t;
+
+// Pass args == NULL to ask only for the layout; otherwise `args` must have room
+// for jl_nparams(sigt) entries, which the caller already knows.
+// Returns 0 on success, or:
+//   -1 version mismatch (layout->version is set to the supported version)
+//   -2 args != NULL and args_capacity < layout->nargs (layout is still filled in)
+//   -3 invalid input
+JL_DLLIMPORT int jl_get_specsig_layout(const jl_abi_query_t *query,
+                                       jl_abi_layout_t *layout,
+                                       jl_abi_arginfo_t *args,
+                                       int32_t args_capacity);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Current users are re-deriving this information instead of relying on the
actual source of truth.

https://github.com/JuliaGPU/GPUCompiler.jl/blob/7dd4056d9144e20e5a2912be9e81eda1c7d59336/src/irgen.jl#L550

Assisted-by: Claude Code (Opus 5)
