### PR TITLE
Show documentation for the latest prerelease

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -589,9 +589,9 @@ function Documenter.Writers.HTMLWriter.expand_versions(dir::String, v::Versions)
     vnums = [VersionNumber(x) for x in available_folders]
     master_version = maximum(vnums)
     filter!(x -> x.major == 1 && x.minor == master_version.minor-1, vnums)
-    rc = maximum(vnums)
-    if !isempty(rc.prerelease) && occursin(r"^rc", rc.prerelease[1])
-        src = "v$(rc)"
+    prerelease = maximum(vnums)
+    if !isempty(prerelease.prerelease)
+        src = "v$(prerelease)"
         @assert src ∈ available_folders
         push!(v.versions, src => src, pop!(v.versions))
     end


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/julia/issues/50872 in a much simpler way than the previous attempt.

I think it would be great to backport this to 1.13 to be able to test it immediately in the 1.13 release cycle.

Why does this approach work:
As previously, the maximum over all version numbers is taken, which is assumed to be the version number of the master branch. For checking for prereleases, it thus suffices to look at the previous minor release family. If the maximum of these has prerelease data, then this should be available in the version specifier of the documentation, as in this case it is an "active" prerelease. This is the case, because a version with prerelease data is always consider "less than" the same version without prerelease data.
This process always takes the latest prerelease, as the order "alpha", "beta", "rc" in increasing alphabetically, so newer prereleases will always be "greater than" previous ones.

The only "real" change here is thus dropping the requirement, that "rc" has to be part of the prerelease data.

cc @mortenpi @IanButterworth @fredrikekre @KristofferC 