### PR TITLE
[release-1.13] codegen: do not rely on method roots if `--strip-ir` is enabled (#62579)

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1485,7 +1485,7 @@ function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vec
             !applicable(argextype, farg, ci, sptypes) && continue # TODO: Why is this failing during bootstrap
             ftyp = widenconst(argextype(farg, ci, sptypes))
 
-            if ftyp === typeof(Core.finalizer) && length(stmt.args) == 3
+            if ftyp === typeof(Core.finalizer) && 3 <= length(stmt.args) <= 5
                 finalizer = argextype(stmt.args[2], ci, sptypes)
                 obj = argextype(stmt.args[3], ci, sptypes)
                 atype = argtypes_to_type(Any[finalizer, obj])

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -219,7 +219,7 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
                         end
                     end
                 elseif Core.finalizer isa ftyp
-                    if length(stmt.args) == 3
+                    if 3 <= length(stmt.args) <= 5
                         finalizer = argextype(stmt.args[2], codeinfo, sptypes)
                         obj = argextype(stmt.args[3], codeinfo, sptypes)
                         atype = argtypes_to_type(Any[finalizer, obj])
@@ -229,9 +229,8 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
                             ci = get(caches, mi, nothing)
                             ci isa CodeInstance && continue
                         end
-
-                        error = "unresolved finalizer registered"
                     end
+                    error = "unresolved finalizer registered"
                 elseif Core._apply isa ftyp
                     error = "trim verification not yet implemented for builtin `Core._apply`"
                 elseif Core._call_in_world_total isa ftyp

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -383,9 +383,14 @@ static void aot_optimize_roots(jl_codegen_params_t &params, egal_set &method_roo
         auto get_global_root = [val, &method_roots]() {
             if (jl_is_globally_rooted(val))
                 return val;
-            jl_value_t *mval = method_roots.get(val);
-            if (mval)
-                return mval;
+            // `--trim` / `--strip-ir` drop all method roots in the serializer
+            // under the assumption that they root only objects for compressed
+            // IR so any roots for codegen must be stored separately
+            if (!(jl_options.trim || jl_options.strip_ir)) {
+                jl_value_t *mval = method_roots.get(val);
+                if (mval)
+                    return mval;
+            }
             return jl_as_global_root(val, 1);
         };
         jl_value_t *mval = get_global_root();

--- a/test/trimming/trimmability.jl
+++ b/test/trimming/trimmability.jl
@@ -20,10 +20,85 @@ area(c::Circle) = pi*c.radius^2
 sum_areas(v::Vector{Shape}) = sum(area, v)
 
 mutable struct Foo; x::Int; end
+
+# To check that objects embedded in emitted code are retained (kept[] == 0): we did not lose any roots
+const kept = Base.RefValue{Int}(0)
+# To check that some objects died (dropped[] > 0): GC + finalizers fired
+const dropped = Base.RefValue{Int}(0)
+note_kept(x::Foo) = (kept[] += 1; nothing)
+note_dropped(x::Foo) = (dropped[] += 1; nothing)
+
 const storage = Foo[]
 function add_one(x::Cint)::Cint
-    push!(storage, Foo(x))
+    entry = Foo(x)
+    finalizer(note_kept, entry)
+    push!(storage, entry)
     return x + 1
+end
+
+let captured = Foo[]
+    global @noinline function add_one_captured(x::Cint)::Cint
+        entry = Foo(x)
+        finalizer(note_kept, entry)
+        push!(captured, entry)
+        return x + 1
+    end
+end
+
+const box = Base.RefValue{Any}(nothing)
+@noinline function drop_one(x::Cint)
+    entry = Foo(x)
+    finalizer(note_dropped, entry)
+    box[] = entry
+    box[] = nothing
+    return nothing
+end
+
+const fin_total = Base.RefValue{Int}(0)
+const fin_log = Int[]
+
+# Test various forms of fully de-virtualized / partially de-virtualized
+# and inlineable / non-inlineable finalizers
+fin_inline_local(x::Base.RefValue{Int}) = (fin_total[] += x[]; nothing)
+fin_inline_escaping(x::Base.RefValue{Int}) = (fin_total[] += x[]; nothing)
+@noinline fin_call_local(x::Base.RefValue{Int}) = (fin_total[] += x[]; nothing)
+@noinline fin_call_escaping(x::Base.RefValue{Int}) = (fin_total[] += x[]; nothing)
+fin_throws_escaping(x::Base.RefValue{Int}) = (push!(fin_log, x[]); nothing)
+
+@noinline function local_finalizers()
+    a = Base.RefValue{Int}(1)
+    finalizer(fin_inline_local, a)
+    b = Base.RefValue{Int}(2)
+    finalizer(fin_call_local, b)
+    return nothing
+end
+
+const escapee = Base.RefValue{Any}(nothing)
+@noinline function escaping_finalizers()
+    r = Base.RefValue{Int}(8)
+    finalizer(fin_inline_escaping, r)
+    escapee[] = r
+    finalize(r)
+    s = Base.RefValue{Int}(16)
+    finalizer(fin_call_escaping, s)
+    escapee[] = s
+    finalize(s)
+    t = Base.RefValue{Int}(32)
+    finalizer(fin_throws_escaping, t)
+    escapee[] = t
+    finalize(t)
+    escapee[] = nothing
+    return nothing
+end
+
+@noinline function finalizer_check()
+    local_finalizers()
+    escaping_finalizers()
+    total = 0
+    for x in fin_log
+        total += x
+    end
+    return (fin_total[], total)
 end
 
 function _test_cat()
@@ -116,8 +191,17 @@ function @main(args::Vector{String})::Cint
     for i = 1:10
         # https://github.com/JuliaLang/julia/issues/60846
         add_one(Cint(i))
+        add_one_captured(Cint(i))
+        drop_one(Cint(i))
         GC.gc()
     end
+    GC.gc(true)
+
+    let (counted, logged) = finalizer_check()
+        println(Core.stdout, "finalizers: ", counted, " ", logged)
+    end
+
+    println(Core.stdout, "collected: ", kept[], " kept, ", dropped[], " dropped")
 
     try
         sock = connect("localhost", 4900)

--- a/test/trimming/trimming.jl
+++ b/test/trimming/trimming.jl
@@ -24,6 +24,8 @@ let exe_suffix = splitext(Base.julia_exename())[2]
     @test parse(Float64, lines[6]) isa Float64
     @test lines[7] == "Version: 1.1.0"
     @test lines[8] == "# preferences: 0"
+    @test lines[9] == "finalizers: 27 32"
+    @test lines[10] == "collected: 0 kept, 10 dropped"
 
     basic_jll_exe = joinpath(bindir, "basic_jll" * exe_suffix)
     lines = split(readchomp(`$basic_jll_exe`), "\n")


### PR DESCRIPTION
Straightforward backport of #62579 - separate PR only because there is no backports PR currently open.