### PR TITLE
lowering: Allow `LineNumberNode` in `let` bindings

### DIFF
--- a/JuliaLowering/test/compat.jl
+++ b/JuliaLowering/test/compat.jl
@@ -501,6 +501,10 @@ test_toplevel_programs = [
             @test JL.est_to_expr(JS.parsestmt(SyntaxTree, s)) == JS.parsestmt(Expr, s)
         end
     end
+
+    # empty let block linenumbernode is accepted by lowering
+    fl_eval(test_mod, Expr(:let, Expr(:block, LineNumberNode(1)), Expr(:block, 1))) == 1
+    jl_eval(test_mod, Expr(:let, Expr(:block, LineNumberNode(1)), Expr(:block, 1))) == 1
 end
 
 @testset "non-ASCII operator handling" begin

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1318,6 +1318,7 @@
                                           (= ,(cadar binds) ,tmp)
                                           ,blk)))))))
                (else (error "invalid let syntax"))))
+             ((linenum? (car binds)) (loop (cdr binds) blk))
              (else (error "invalid let syntax")))))))))
 
 (define (valid-macro-def-name? e)


### PR DESCRIPTION
Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/176.  The first arg to
     `let` is a `block`, which usually has line number nodes.  I tried simply
     not inserting these in JuliaLowering when we're in a `let`, but it isn't
     guaranteed that the `let` node will be around when JuliaLowering converts
     the bindings block.

Still, don't remove the special case in JL so we can be nice to macros.