### PR TITLE
[JuliaLowering] include_string: Basic `mapexpr` support

### DIFF
--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -839,9 +839,28 @@ end
 
 Like `include`, except reads code from the given string rather than from a file.
 """
-function include_string(mod::Module, code::AbstractString, filename::AbstractString="string";
+function include_string(mapexpr::Function, mod::Module, code::AbstractString,
+                        filename::AbstractString;
                         expr_compat_mode=false, version::VersionNumber=VERSION)
-    eval(mod, parseall(SyntaxTree, code; filename, version); expr_compat_mode)
+    st = parseall(SyntaxTree, code; filename, version, ignore_warnings=true)
+    @jl_assert kind(st) === K"toplevel" st
+    try
+        if mapexpr !== identity
+            # TODO: Is there any way to support provenance here?
+            local last = nothing
+            for c in children(st)
+                last = eval(mod, expr_to_est(mapexpr(est_to_expr(c))); expr_compat_mode)
+            end
+            last
+        else
+            eval(mod, st; expr_compat_mode)
+        end
+    catch err
+        # @info "JL err" mod filename code st
+        rethrow(err)
+    end
 end
+include_string(mod, code, filename="string"; kws...) =
+    include_string(identity, mod, code, filename; kws...)
 
 include(path::AbstractString) = include(JuliaLowering, path)

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -844,20 +844,15 @@ function include_string(mapexpr::Function, mod::Module, code::AbstractString,
                         expr_compat_mode=false, version::VersionNumber=VERSION)
     st = parseall(SyntaxTree, code; filename, version, ignore_warnings=true)
     @jl_assert kind(st) === K"toplevel" st
-    try
-        if mapexpr !== identity
-            # TODO: Is there any way to support provenance here?
-            local last = nothing
-            for c in children(st)
-                last = eval(mod, expr_to_est(mapexpr(est_to_expr(c))); expr_compat_mode)
-            end
-            last
-        else
-            eval(mod, st; expr_compat_mode)
+    if mapexpr !== identity
+        # TODO: Is there any way to support provenance here?
+        local last = nothing
+        for c in children(st)
+            last = eval(mod, expr_to_est(mapexpr(est_to_expr(c))); expr_compat_mode)
         end
-    catch err
-        # @info "JL err" mod filename code st
-        rethrow(err)
+        last
+    else
+        eval(mod, st; expr_compat_mode)
     end
 end
 include_string(mod, code, filename="string"; kws...) =

--- a/JuliaLowering/test/hooks.jl
+++ b/JuliaLowering/test/hooks.jl
@@ -79,4 +79,76 @@
 
         @test jeval("Base.@propagate_inbounds @inline meta_double_quote_issue(x) = x") isa Function
     end
+
+    @testset "(AI) `include_string` with `mapexpr`" begin
+        seen = Any[]
+        out = JL.include_string(ex -> (push!(seen, ex); ex), Module(:MapexprSeen),
+                                "aa = 1\n\nbb = aa + 1\nbb*10", "none")
+        @test seen == [Meta.parse("aa = 1"), Meta.parse("bb = aa + 1"), Meta.parse("bb*10")]
+        @test out === 20
+
+        function mapexpr_sees(code)
+            seen = Any[]
+            JL.include_string(ex -> (push!(seen, ex); nothing), Module(:MapexprCmp),
+                              code, "none")
+            only(seen)
+        end
+        for code in ("xx += 1", "for i in 1:2; end", "function g(a); a; end",
+                     "@inline h(a) = a", "\"doc\" k(a) = a", "using Base.Threads",
+                     "const cc = 1", "a.b = 2", "x[1] = 2", "if p; q; else; r; end",
+                     "macro mmm(); end")
+            @test mapexpr_sees(code) == Meta.parse(code)
+        end
+        # FIXME: our `:module` expressions have the syntax version as an extra
+        # leading argument - `Expr(:module, v"1.14.0", true, :MMM, body)` - so
+        # they don't have the shape `mapexpr` expects
+        @test_broken mapexpr_sees("module MMM; end") == Meta.parse("module MMM; end")
+
+        out = JL.include_string(ex -> Expr(:module, true, :Renamed, ex.args[end]),
+                                Module(:MapexprModule), "module Orig; yy = 1; end", "none")
+        @test out isa Module && nameof(out) === :Renamed
+        @test Base.invokelatest(() -> isdefined(out, :yy))
+
+        # Statements are mapped and evaluated one at a time (rather than all
+        # mapped up front), so `mapexpr` may depend on earlier evaluation
+        log = Symbol[]
+        logmod = Module(:MapexprOrder)
+        Core.eval(logmod, :(const log = $log))
+        JL.include_string(ex -> (push!(log, :map); ex), logmod,
+                          "push!(log, :eval)\npush!(log, :eval)", "none")
+        @test log == [:map, :eval, :map, :eval]
+
+        # return value
+        @test JL.include_string(ex -> Expr(:call, :+, ex, 100), Module(:MapexprAdd),
+                                "1+1\n2+2", "none") === 104
+        # returning `nothing` drops a statement
+        @test JL.include_string(ex -> nothing, Module(:MapexprDrop),
+                                "error(\"not evaluated\")", "none") === nothing
+        @test JL.include_string(ex -> error("never called"), Module(:MapexprEmpty),
+                                "# just a comment\n", "none") === nothing
+
+        noop(x) = x
+        # Definitions survive the round trip (world age)
+        m = Module(:MapexprDefs)
+        @test JL.include_string(noop, m, "module Inner; zz = 5; end", "none") isa Module
+        @test Base.invokelatest(() -> isdefined(m.Inner, :zz))
+        @test JL.include_string(noop, m, "f(x) = x + 1\nf(2)", "none") === 3
+        @test JL.include_string(noop, m, "macro mm(); 7; end\n@mm", "none") === 7
+
+        # `expr_compat_mode` still applies
+        @test JL.include_string(noop, Module(:MapexprCompat),
+                                """
+                                macro plus1(ex)
+                                    :(\$(esc(ex)) + 1)
+                                end
+                                qq = 10
+                                @plus1 qq
+                                """, "none"; expr_compat_mode=true) === 11
+
+        # Errors in the included code and in `mapexpr` itself both propagate
+        @test_throws "boom" JL.include_string(noop, Module(:MapexprErr),
+                                              "error(\"boom\")", "none")
+        @test_throws "in mapexpr" JL.include_string(ex -> error("in mapexpr"),
+                                                    Module(:MapexprErr2), "1+1", "none")
+    end
 end


### PR DESCRIPTION
Dumps provenance, of course.  Tests botted.

Also supply `ignore_warnings=true` to the `parseall` function.  Parsing SparseArrays runs into some "you don't need parens here" warnings that become errors.  This might have been the source of our confusing parse failures in the pkgeval, but I didn't check.

Assisted-by: Claude Opus 5