### PR TITLE
JuliaLowering: set slot flags on the break-block result slot

### DIFF
--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -729,7 +729,9 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         end
         end_label = make_label(ctx, ex)
         need_value = needs_value || in_tail_pos
-        result_var = need_value ? new_local_binding(ctx, ex, "$(name)_result") : nothing
+        result_var = need_value ?
+            new_local_binding(ctx, ex, "$(name)_result";
+                              is_read=true, is_assigned=true, is_used_undef=true) : nothing
         outer_target = get(ctx.break_targets, name, nothing)
         ctx.break_targets[name] = JumpTarget(end_label, ctx, result_var)
         push!(ctx.break_label_stack, name)

--- a/JuliaLowering/test/loops.jl
+++ b/JuliaLowering/test/loops.jl
@@ -292,3 +292,27 @@ end
 end
 
 end
+
+@testset "break-block result slot flags" begin
+
+test_mod = Module()
+
+# The result slot of a value-position loop is assigned only on some paths
+# (a `break` jumps past the fall-through assignment), so its slot flags
+# must report it as used and maybe-undef.
+JuliaLowering.include_string(test_mod, """
+function f_loop_result_slot(c)
+    y = while true
+        c && break
+    end
+    y
+end
+""")
+let ci = Base.uncompressed_ir(only(methods(test_mod.f_loop_result_slot)))
+    i = findfirst(==(Symbol("loop-exit_result")), ci.slotnames)
+    @test i !== nothing
+    # 0x08 (SLOT_USED) | 0x20 (SLOT_USEDUNDEF)
+    @test ci.slotflags[i] == 0x28
+end
+
+end


### PR DESCRIPTION
🤖 split out from the UnifiedIR branch. Linearization materializes the result slot of a value-position break block (e.g. the `loop-exit_result` slot of a value-position `while` with a conditional `break`) after variable analysis has already run, so the slot kept the default all-false flags and the emitted CodeInfo slotflags reported 0x00. The slot genuinely has undef-sensitive reads: a `break` jumps past the fall-through assignment and reaches the `Expr(:isdefined)` guard with the slot unassigned, so the flags must report it as used and maybe-undef (SLOT_USED | SLOT_USEDUNDEF), which consumers that seed undef-ness from slotflags rely on. Create the binding with is_read/is_assigned/is_used_undef set, matching the closure-box precedent in closure conversion.