### PR TITLE
runtime: uphold Method's min-initialized invariant in jl_new_method_u…

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -1059,7 +1059,9 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
         (jl_method_t*)jl_gc_alloc(ct->ptls, sizeof(jl_method_t), jl_method_type);
     jl_atomic_store_relaxed(&m->specializations, (jl_value_t*)jl_emptysvec);
     jl_atomic_store_relaxed(&m->speckeyset, (jl_genericmemory_t*)jl_an_empty_memory_any);
-    m->sig = NULL;
+    // `sig` and `name` are inside the min-initialized prefix (ninitialized == 10),
+    // so codegen omits null checks for them; they must never be observable as NULL.
+    m->sig = jl_bottom_type;
     m->slot_syms = NULL;
     m->roots = NULL;
     m->root_blocks = NULL;
@@ -1071,7 +1073,7 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     m->debuginfo = NULL;
     jl_atomic_store_relaxed(&m->unspecialized, NULL);
     m->generator = NULL;
-    m->name = NULL;
+    m->name = jl_empty_sym;
     m->file = jl_empty_sym;
     m->line = 0;
     m->called = 0xff;

--- a/test/core.jl
+++ b/test/core.jl
@@ -9282,3 +9282,11 @@ end
     return freed[]
 end
 @test issue52533_beside(Ref(false))
+
+# `jl_new_method_uninit` must satisfy Method's min-initialized invariant:
+# fields in the initialized prefix (e.g. `sig`, `name`) are assumed non-null
+# by codegen, which omits undef checks when loading them.
+let m = ccall(:jl_new_method_uninit, Ref{Method}, (Any,), @__MODULE__)
+    @test m.sig === Union{}
+    @test m.name === Symbol("")
+end


### PR DESCRIPTION
…ninit

🤖 Method declares ninitialized == 10, so codegen, getfield_nothrow, and SROA all assume the reference fields in that prefix (`name`, `sig`, ...) are never null and omit undef checks when loading them. However, jl_new_method_uninit left `sig` and `name` NULL, so compiled code that loaded and dereferenced those fields of a not-yet-filled-in Method segfaulted where the interpreter and the getfield builtin (which always null-check) threw UndefRefError. Initialize them to inert non-null defaults (Union{} and the empty symbol) so the invariant holds from allocation; every caller overwrites them with real values immediately.