### PR TITLE
forward several whole-array functions on ReshapedArray to the parent

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -342,6 +342,12 @@ _mapreduce_dim(f, op, nt, A::AbstractArrayOrBroadcasted, dims::D) where {D} =
 _mapreduce_dim(f, op, ::_InitialValue, A::AbstractArrayOrBroadcasted, dims::D) where {D} =
     mapreducedim!(f, op, reducedim_init(f, op, A, dims), A)
 
+_mapreduce_dim(f, op, nt, R::ReshapedArray, ::Colon) =
+    _mapreduce_dim(f, op, nt, parent(R), :)
+
+_mapreduce_dim(f, op, i::_InitialValue, R::ReshapedArray, ::Colon) =
+    _mapreduce_dim(f, op, i, parent(R), :)
+
 """
     reduce(f, A::AbstractArray; dims=:, [init])
 
@@ -984,6 +990,8 @@ for (fname, _fname, op) in [(:sum,     :_sum,     :add_sum), (:prod,    :_prod, 
         # Underlying implementations using dispatch
         ($_fname)(a, ::Colon; kw...) = ($_fname)(identity, a, :; kw...)
         ($_fname)(f, a, ::Colon; kw...) = mapreduce($mapf, $op, a; kw...)
+
+        ($_fname)(R::ReshapedArray, ::Colon) = ($fname)(parent(R))
     end
 end
 

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -458,3 +458,13 @@ function merge_adjacent_dim(apsz::Dims{N}, apst::Dims{N}, n::Int = 1) where {N}
     end
     return sz, st, n
 end
+
+map(f, R::ReshapedArray) = reshape(map(f, parent(R)), size(R))
+
+iterate(R::ReshapedArray) = iterate(parent(R))
+iterate(R::ReshapedArray, state) = iterate(parent(R), state)
+
+mapfoldl_impl(f, op, nt, R::ReshapedArray) = mapfoldl_impl(f, op, nt, parent(R))
+mapfoldr_impl(f, op, nt, R::ReshapedArray) = mapfoldr_impl(f, op, nt, parent(R))
+
+in(x, R::ReshapedArray) = in(x, parent(R))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2357,3 +2357,16 @@ end
         end
     end
 end
+
+@testset "map on ReshapedArray" begin
+    R = reshape(1:4, 2, 2)
+    for T in [Float64, BigInt]
+        S = @inferred map(T, R)
+        @test S == R
+        @test eltype(S) == T
+        @test parent(S) isa AbstractRange
+    end
+    P = PermutedDimsArray(collect(reshape(1:6, 2, 3)), (2, 1))
+    @test map(identity, reshape(P, 2, 3)) isa Matrix{Int}
+    @test map(identity, reshape(P, 6)) isa Vector{Int}
+end

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -791,3 +791,17 @@ end
     end
     @test (res isa Exception) || res == (1, (2, 3))
 end
+
+@testset "reductions over ReshapedArray" begin
+    @test sum(reshape(map(UInt8, 1:9), 3, 3)) === 45
+    @test @inferred(sum(reshape(1:4, 2, 2))) === 10
+    for f in (minimum, maximum, extrema)
+        @test_throws "range must be non-empty" f(reshape(1:0, 0, 1))
+    end
+
+    P = reshape(PermutedDimsArray(collect(reshape(1:6, 2, 3)), (2, 1)), 2, 3)
+    C = collect(P)
+    @test mapreduce(string, *, P) == mapreduce(string, *, C)
+    @test foldl(-, P) == foldl(-, C) && foldr(-, P) == foldr(-, C)
+    @test [x for x in P] == C
+end


### PR DESCRIPTION
expanded from & replaces https://github.com/JuliaLang/julia/pull/40678

since `reshape` preserves ordering, a lot of functions that act on the whole array in linear order are faster to apply to `parent` rather than to the `ReshapedArray`, here that's `map`, `mapreduce`, `mapfoldl`, `mapfoldl`, `iterate`, `in`, and the reduction functions `sum`, `prod`, `minimum`, `maximum`, `extrema`

example speedups:

```julia
using BenchmarkTools
V = view(rand(1000, 1001), 1:999, 1:1000);
R = reshape(V, 999_000);
f(A) = any(x -> (x%1357 == 0), A)
@btime f($R)
    2.030 ms # master
    1.159 ms  # PR
```

or

```julia
julia> @btime map(Float64, $(reshape(1:400, 20, 20)));
  73.398 ns (3 allocations: 3.58 KiB) # master
  25.663 ns (0 allocations: 0 bytes) # PR
```

or
```julia
using BenchmarkTools
A = rand(1000, 1000);
R = reshape(PermutedDimsArray(A, (2, 1)), 10^6);
@btime mapreduce(abs2, +, $R)
  581.125 μs (0 allocations: 0 bytes) # master
  94.292 μs (0 allocations: 0 bytes) # PR
```

assisted by fable 5

fyi note that `PermutedDimsArray` does something similar at least for `mapreducedim` stuff
https://github.com/JuliaLang/julia/blob/c4dc4e24b091c934451f3a7c5dc1c1609c13cf75/base/permuteddimsarray.jl#L351-L367