### PR TITLE
Access WeakRef.value with monotonic ordering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,11 @@ Multi-threading changes
   and `@atomiconce` macros (e.g. `@atomic a[]`, `@atomic a[] = v`, `@atomic a[] += 1`), which allows
   the memory ordering to be specified explicitly and makes atomic read-modify-write operations
   syntactically clear ([#62382]).
+* The `value` field of `WeakRef` is now declared `@atomic`, since the garbage collector may replace it
+  by `nothing` at any safepoint. Reading `w.value` or writing `w.value = v` uses `:monotonic` ordering,
+  which prevents the compiler from caching a weak reference across a safepoint. Writing the field with
+  `setfield!` now requires an ordering to be given, e.g. `setfield!(w, :value, v, :monotonic)`
+  ([#62613]).
 
 Build system changes
 --------------------

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -62,6 +62,12 @@ function setproperty!(x, f::Symbol, v)
     return setfield!(x, f, val)
 end
 
+# The GC may clear `WeakRef.value` at any safepoint. `unordered`, the default
+# for an atomic field, would still let LLVM hoist the load out of a loop, so
+# read and write it with `monotonic`.
+getproperty(x::WeakRef, f::Symbol) = (@inline; getfield(x, f, :monotonic))
+setproperty!(x::WeakRef, f::Symbol, v) = (@inline; setfield!(x, f, v, :monotonic))
+
 typeof(function getproperty end).name.constprop_heuristic = or_int(Core.FORCE_CONST_PROP, Core.DISABLE_SEMI_CONCRETE_EVAL)
 typeof(function setproperty! end).name.constprop_heuristic = Core.FORCE_CONST_PROP
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -628,12 +628,14 @@ end
 
 # constructors for built-in types
 
+eval(Core, quote
 mutable struct WeakRef
-    value
-    WeakRef() = WeakRef(nothing)
-    WeakRef(@nospecialize(v)) = ccall(:jl_gc_new_weakref_th, Ref{WeakRef},
-                                      (Ptr{Cvoid}, Any), getptls(), v)
-end
+        $(Expr(:atomic, :value))
+        WeakRef() = WeakRef(nothing)
+        WeakRef(@nospecialize(v)) = ccall(:jl_gc_new_weakref_th, Ref{WeakRef},
+                                        (Ptr{Cvoid}, Any), getptls(), v)
+    end
+end)
 
 Tuple{}() = ()
 

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -9,6 +9,12 @@ to the Julia value `x`: although `w` contains a reference to `x`, it does not pr
 garbage collected. `w.value` is either `x` (if `x` has not been garbage-collected yet) or `nothing`
 (if `x` has been garbage-collected).
 
+The `value` field is declared `@atomic`, since the garbage collector may replace it by `nothing` at
+any safepoint. Reading `w.value` or writing `w.value = v` uses `:monotonic` ordering; a different
+ordering can be requested with the [`@atomic`](@ref) macro. Code that inspects the referenced value
+should read the field once into a local variable and use that, since a second read may observe
+`nothing`.
+
 ```jldoctest
 julia> x = "a string"
 "a string"

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -99,7 +99,7 @@ function setindex!(wkh::WeakKeyDict{K}, v, key) where K
             finalizer(wkh.finalizer, key)
             k = WeakRef(key)
         else
-            k.value = key
+            @atomic :monotonic k.value = key
         end
         wkh.ht[k] = v
     end

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -1043,7 +1043,7 @@ JL_DLLEXPORT size_t jl_gc_genericmemory_how(void *arg) JL_NOTSAFEPOINT
 JL_DLLEXPORT jl_weakref_t *jl_gc_new_weakref_th(jl_ptls_t ptls, jl_value_t *value)
 {
     jl_weakref_t *wr = (jl_weakref_t*)jl_gc_alloc(ptls, sizeof(void*), jl_weakref_type);
-    wr->value = value;  // NOTE: wb not needed here
+    jl_atomic_store_relaxed(&wr->value, value);  // NOTE: wb not needed here
     mmtk_add_weak_candidate(wr);
     return wr;
 }

--- a/src/gc-mmtk/mmtk_julia/src/reference_glue.rs
+++ b/src/gc-mmtk/mmtk_julia/src/reference_glue.rs
@@ -5,6 +5,7 @@ use mmtk::util::{Address, ObjectReference};
 use mmtk::vm::Finalizable;
 use mmtk::vm::ObjectTracer;
 use mmtk::vm::ReferenceGlue;
+use std::sync::atomic::{AtomicPtr, Ordering};
 
 extern "C" {
     pub static jl_nothing: *mut jl_value_t;
@@ -36,15 +37,20 @@ impl Finalizable for JuliaFinalizableObject {
 pub struct VMReferenceGlue {}
 
 impl VMReferenceGlue {
-    fn load_referent_raw(reference: ObjectReference) -> *mut jl_value_t {
+    // `jl_weakref_t::value` is `_Atomic`, so bindgen gives the field an opaque
+    // type: reach it through an `AtomicPtr` rather than reading it by value.
+    fn referent_slot(reference: ObjectReference) -> *const AtomicPtr<jl_value_t> {
         let reff = reference.to_raw_address().to_ptr::<jl_weakref_t>();
-        unsafe { (*reff).value }
+        unsafe { ::std::ptr::addr_of!((*reff).value) as *const AtomicPtr<jl_value_t> }
+    }
+
+    fn load_referent_raw(reference: ObjectReference) -> *mut jl_value_t {
+        unsafe { (*Self::referent_slot(reference)).load(Ordering::Relaxed) }
     }
 
     fn set_referent_raw(reference: ObjectReference, referent_raw: *mut jl_value_t) {
-        let reff = reference.to_raw_address().to_mut_ptr::<jl_weakref_t>();
         unsafe {
-            (*reff).value = referent_raw;
+            (*Self::referent_slot(reference)).store(referent_raw, Ordering::Relaxed);
         }
     }
 }

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -362,7 +362,8 @@ JL_DLLEXPORT jl_weakref_t *jl_gc_new_weakref_th(jl_ptls_t ptls, jl_value_t *valu
 {
     jl_weakref_t *wr = (jl_weakref_t*)jl_gc_alloc(ptls, sizeof(void*),
                                                   jl_weakref_type);
-    wr->value = value;  // NOTE: wb not needed here
+    // NOTE: wb not needed here
+    jl_atomic_store_relaxed(&wr->value, value);
     small_arraylist_push(&ptls->gc_tls_common.heap.weak_refs, wr);
     return wr;
 }
@@ -377,8 +378,9 @@ static void clear_weak_refs(void) JL_NOTSAFEPOINT
             void **lst = ptls2->gc_tls_common.heap.weak_refs.items;
             for (n = 0; n < l; n++) {
                 jl_weakref_t *wr = (jl_weakref_t*)lst[n];
-                if (!gc_marked(jl_astaggedvalue(wr->value)->bits.gc))
-                    wr->value = (jl_value_t*)jl_nothing;
+                jl_value_t *value = jl_atomic_load_relaxed(&wr->value);
+                if (!gc_marked(jl_astaggedvalue(value)->bits.gc))
+                    jl_atomic_store_relaxed(&wr->value, (jl_value_t*)jl_nothing);
             }
         }
     }

--- a/src/julia.h
+++ b/src/julia.h
@@ -761,7 +761,7 @@ typedef struct _jl_vararg_t {
 
 typedef struct _jl_weakref_t {
     JL_DATA_TYPE
-    jl_value_t *value;
+    _Atomic(jl_value_t*) value;
 } jl_weakref_t;
 
 // N.B: Needs to be synced with runtime_internals.jl

--- a/test/core.jl
+++ b/test/core.jl
@@ -3231,6 +3231,17 @@ mutable struct Obj; x; end
         @test wref[1].value === nothing
     end
     test_wr()
+
+    # `value` is `@atomic` and property access uses `:monotonic` (#62613)
+    @test Base.isfieldatomic(WeakRef, :value)
+    let x = Ref(1), w = WeakRef(x)
+        @test (@atomic w.value) === x
+        @atomic :monotonic w.value = nothing
+        @test w.value === nothing
+        w.value = x
+        @test w.value === x
+        @test_throws ConcurrencyViolationError setfield!(w, :value, nothing)
+    end
 end
 
 # issue #9947

--- a/test/llvmpasses/weakref-licm.jl
+++ b/test/llvmpasses/weakref-licm.jl
@@ -1,0 +1,42 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no %s %t && llvm-link -S %t/* -o %t/module.ll
+# RUN: cat %t/module.ll | FileCheck %s -check-prefix=CODEGEN
+# RUN: julia --startup-file=no %s %t -O && llvm-link -S %t/* -o %t/module.ll
+# RUN: cat %t/module.ll | FileCheck %s -check-prefix=FINAL
+
+## The GC may clear `WeakRef.value` at any safepoint, so the load has to be
+## `monotonic` and must stay inside the loop, even though the only call in the
+## loop is `:consistent` and `:effect_free` and therefore carries
+## `memory(argmem: read)`. See https://github.com/JuliaLang/julia/issues/62613
+##
+## - `CODEGEN`: the field is loaded with `monotonic` ordering
+## - `FINAL`: the optimization pipeline does not hoist that load out of the loop
+
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+@noinline add_weakref_value(x, y) = x + y
+@noinline make_weakref(n) = WeakRef(Base.RefValue(n))
+
+# CODEGEN-LABEL: @julia_weakref_licm
+# CODEGEN: load atomic ptr addrspace(10), ptr addrspace(11) %{{[0-9]+}} monotonic
+
+# FINAL-LABEL: @julia_weakref_licm
+# COM: an `unordered` load would be hoisted into the entry block, ahead of this branch
+# FINAL-NOT: load atomic ptr, ptr %{{[0-9]+}}
+# FINAL: br label %[[LOOP:[a-zA-Z0-9_.]+]]
+# FINAL: [[LOOP]]:
+# FINAL: load atomic ptr, ptr %{{[0-9]+}} monotonic
+# FINAL: br i1 {{.*}} label %[[LOOP]]
+function weakref_licm(n)
+    w = make_weakref(n)
+    z = 0
+    for i in 1:1000
+        y = w.value
+        if y isa Base.RefValue{Int}
+            z = add_weakref_value(z, y[])
+        end
+    end
+    return z
+end
+emit(weakref_licm, Int)


### PR DESCRIPTION
Candidate fix for #62613.  I was debating if we should use scope `single-thread` for these, but I think monotonic along should suffice.

The rust/mmtk changes need detailed review.

```quote
The garbage collector may replace the value of a weak reference by `nothing` at
any safepoint, so a load of the field must not be cached across one. Declaring
the field `@atomic` is not sufficient by itself: an access without an explicit
ordering is emitted as an `unordered` load, which LLVM is still free to hoist
out of a loop. Property access therefore uses `:monotonic`.

The stock and MMTk collectors write the field through the relaxed atomic API
rather than an implicit sequentially consistent access, and the MMTk reference
glue reaches it through an `AtomicPtr`, since bindgen gives the `_Atomic` field
an opaque type.
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
