### PR TITLE
interpreter: publish the uncompressed method source atomically

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -773,7 +773,9 @@ jl_value_t *jl_code_or_ci_for_interpreter(jl_method_instance_t *mi JL_PROPAGATES
     if (jl_is_method(mi->def.value)) {
         if (mi->def.method->source) {
             jl_method_t *m = mi->def.method;
-            src = (jl_code_info_t*)m->source;
+            // Acquire pairs with the release publish below: a reader that sees
+            // the uncompressed CodeInfo pointer must also see its contents.
+            src = (jl_code_info_t*)jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&m->source);
             if (!jl_is_code_info(src)) {
                 // Root the compressed blob across the (allocating) decode:
                 // another thread interpreting the same method concurrently can
@@ -789,7 +791,8 @@ jl_value_t *jl_code_or_ci_for_interpreter(jl_method_instance_t *mi JL_PROPAGATES
                 // access it frequently. TODO: Have some sort of usage-based
                 // cache here. (Concurrent publishes store equivalent copies;
                 // last one wins.)
-                jl_gc_write(m, m->source, jl_value_t, (jl_value_t*)src);
+                jl_gc_write_atomic(m, *(_Atomic(jl_value_t*)*)&m->source, jl_value_t,
+                                   (jl_value_t*)src, release);
             }
             ret = (jl_value_t*)src;
         }


### PR DESCRIPTION
The interpreter caches a method's uncompressed source by storing the decoded `CodeInfo` over `m->source`. The publish used a plain write while concurrent interpreters of the same method read `m->source` with a plain load, so nothing orders the contents of the new `CodeInfo` against the store of its pointer. On a weak-memory target a reader can observe the new pointer while the object it points at is still being filled in, and then interpret a partially initialized `CodeInfo`.

This publishes with a release store and reads with an acquire load. The last-one-wins design is unchanged: concurrent publishes still store equivalent copies, and a reader either sees the compressed blob (and decodes it itself) or a fully constructed `CodeInfo`.

## Evidence

ThreadSanitizer reports the pair directly. Reproduced with a TSan build (`contrib/tsan/build.sh`) running several threads that interpret the same methods for the first time simultaneously — methods loaded from the sysimage or a pkgimage have compressed source, so the first interpretation is what decodes and publishes:

```
WARNING: ThreadSanitizer: data race (pid=3305147)
  Write of size 8 at 0x7fffdb0ea0c8 by thread T33:
    #0 jl_code_or_ci_for_interpreter src/interpreter.c:903
    #1 jl_interpret_mi src/interpreter.c:967
    #2 _jl_invoke src/gf.c:4608
    #3 ijl_apply_generic src/gf.c:4852
    #4 jl_apply src/julia.h:2511
    #5 start_task src/task.c:1247

  Previous read of size 8 at 0x7fffdb0ea0c8 by thread T32:
    #0 jl_code_or_ci_for_interpreter src/interpreter.c:885
    #1 jl_interpret_mi src/interpreter.c:967
    #2 _jl_invoke src/gf.c:4608
    #3 ijl_apply_generic src/gf.c:4852
    #4 jl_apply src/julia.h:2511
    #5 start_task src/task.c:1247
```

Both frames are in `jl_code_or_ci_for_interpreter` on the same address: the write is the `jl_gc_write` publish, the read is the plain load of `m->source` at the top of the function. (Line numbers are from the revision the TSan binary was built from, which is why they do not match this diff exactly.)

There is no regression test. The defect is a missing memory ordering, so it is invisible to a functional test on x86 — TSan is the tool that observes it, and Julia's test suite does not run under TSan.

This pull request was written with the assistance of generative AI (Claude).
