### PR TITLE
runtime: wake the scheduler when arming sigint on macOS

### DIFF
--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -742,6 +742,7 @@ static void jl_try_deliver_sigint(void)
     int force = jl_check_force_sigint();
     jl_task_t *ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
     int can_throw = ct2 != NULL && ct2->eh != NULL;
+    int wake_scheduler = 0;
     if (can_throw && (force || (!ptls2->defer_signal && ptls2->io_wait))) {
         jl_safepoint_consume_sigint();
         if (force)
@@ -751,11 +752,27 @@ static void jl_try_deliver_sigint(void)
     }
     else {
         jl_wake_libuv();
+        wake_scheduler = 1;
     }
 
     ret = thread_resume(thread);
     HANDLE_MACH_ERROR("thread_resume", ret);
     pthread_mutex_unlock(&ctx_rewrite_lock);
+
+    if (wake_scheduler) {
+        // Unlike the POSIX path, mach delivery does not run a signal handler
+        // on the target thread: the armed sigint safepoint is only consumed
+        // when thread 0 executes code again. jl_wake_libuv only reaches it
+        // inside uv_run; if it is parked in the scheduler's deep sleep
+        // (uv_cond_wait on wake_signal), nothing would ever wake it and the
+        // interrupt would be swallowed, so wake that path too. This must
+        // happen after thread_resume: the thread may have been suspended
+        // while holding its own sleep_lock.
+        surprise_wakeup(ptls2);
+        uv_mutex_lock(&ptls2->sleep_lock);
+        uv_cond_signal(&ptls2->wake_signal);
+        uv_mutex_unlock(&ptls2->sleep_lock);
+    }
 }
 
 static void jl_exit_thread0_cb(int signo)


### PR DESCRIPTION
The mach and POSIX paths deliver SIGINT differently. On POSIX a signal handler runs on the target thread regardless of what that thread is doing, so arming the interrupt safepoint is always followed by the target thread executing code. Mach delivery instead suspends thread 0, arms the safepoint, and resumes it — the interrupt is only observed when thread 0 next runs code.

When thread 0 cannot throw immediately (it is not in `io_wait`, or the signal is deferred), `jl_try_deliver_sigint` arms the safepoint and calls `jl_wake_libuv`. That only reaches thread 0 if it is inside `uv_run`. A thread parked in the scheduler's deep sleep instead — `uv_cond_wait` on its own `wake_signal` — is not woken by anything, so the armed interrupt is never consumed and the SIGINT is swallowed.

This wakes the scheduler sleep path as well, after `thread_resume`, since the thread may have been suspended while holding its own `sleep_lock`. A spurious wakeup of a thread that did not need one is harmless; the scheduler already tolerates them.

## Why there is no regression test

I tried to write one and could not make it isolate this path, so I am not shipping a test rather than shipping a misleading one.

The obvious construction is to park thread 0 somewhere that is not `uv_run` and not `io_wait`, then send SIGINT. But a task blocked on a `Condition`/`Event` is not interruptible on **any** platform — I verified locally on Linux that a child running `wait(Base.Event())` ignores SIGINT at both `-t 1` and `-t 4`, so such a test fails everywhere and for a different reason. Conversely, the states that *are* interruptible (`sleep`, REPL input) put thread 0 in `io_wait` or `uv_run`, which is exactly where the existing code already works: a child running `sleep(600)` at `-t 4` is interrupted normally.

Hitting the swallowed case therefore needs thread 0 to be in the scheduler's deep sleep at the moment of delivery while the interrupt is otherwise deliverable, which is a race no test can pin down deterministically. It became reproducible in the macOS `misc.jl` SIGINT tests on the tiered-compilation branch (#61888), where background compilation widens the window in which thread 0 is parked there; on master the window is narrow but reachable.

The change itself is verifiable by inspection: on the mach path the only wake for the `else` branch is `jl_wake_libuv`, and `surprise_wakeup` plus signalling `wake_signal` is what every other wake of a deep-sleeping thread does (see `jl_wakeup_thread` in `src/scheduler.c`).

This pull request was written with the assistance of generative AI (Claude).
