### PR TITLE
Broadcast: fix `@.` with generator

### DIFF
--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -964,3 +964,18 @@ end
     @test (f = jl_eval(test_mod, ex; expr_compat_mode=false)) isa Function
     @test f(1, 'a') == (1, 'a', Int, Char)
 end
+
+# duplicated in base tests
+JuliaLowering.include_string(@__MODULE__, """
+@testset "interaction of @. with generators" begin
+   @test [(x,y,a,b) for x in 1:2, y in 3:4 for a in 5:6, b in 7:8 if true] ==
+       @. [(x,y,a,b) for x in 1:2, y in 3:4 for a in 5:6, b in 7:8 if true]
+   # + in iterspec gets dotted
+   @test [[11, 22]] == @. [x for x in [[1, 2] + [10, 20]] if true]
+   # + in body gets dotted
+   let m = @. [(x+y) for x in [[1,2],[10,20]], y in [100]]
+       @test m[1] == [101,102]
+       @test m[2] == [110,120]
+   end
+end
+""")

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1314,6 +1314,8 @@ function __dot__(x::Expr)
         Expr(:let, undot(dotargs[1]), dotargs[2])
     elseif x.head === :for # don't add dots to for x=... assignments
         Expr(:for, undot(dotargs[1]), dotargs[2])
+    elseif x.head === :generator || x.head === :filter
+        Expr(x.head, dotargs[1], map(undot, dotargs[2:end])...)
     elseif (x.head === :(=) || x.head === :function || x.head === :macro) &&
            Meta.isexpr(x.args[1], :call) # function or macro definition
         Expr(x.head, x.args[1], dotargs[2])

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1294,6 +1294,8 @@ function __dot__(x::Expr)
         Expr(:let, undot(dotargs[1]), dotargs[2])
     elseif x.head === :for # don't add dots to for x=... assignments
         Expr(:for, undot(dotargs[1]), dotargs[2])
+    elseif x.head === :generator || x.head === :filter
+        Expr(x.head, dotargs[1], map(undot, dotargs[2:end])...)
     elseif (x.head === :(=) || x.head === :function || x.head === :macro) &&
            Meta.isexpr(x.args[1], :call) # function or macro definition
         Expr(x.head, x.args[1], dotargs[2])

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -286,6 +286,18 @@ let x = [1,2,3]
     @test (x .=== 1:3 .=== [1,2,3]) == @.(x === 1:3 === [1,2,3]) == [true, true, true]
 end
 
+@testset "interaction of @. with generators" begin
+    @test [(x,y,a,b) for x in 1:2, y in 3:4 for a in 5:6, b in 7:8 if true] ==
+        @. [(x,y,a,b) for x in 1:2, y in 3:4 for a in 5:6, b in 7:8 if true]
+    # + in iterspec gets dotted
+    @test [[11, 22]] == @. [x for x in [[1, 2] + [10, 20]] if true]
+    # + in body gets dotted
+    let m = @. [(x+y) for x in [[1,2],[10,20]], y in [100]]
+        @test m[1] == [101,102]
+        @test m[2] == [110,120]
+    end
+end
+
 # PR #17510: Fused in-place assignment
 let x = [1:4;], y = x
     y .= 2:5


### PR DESCRIPTION
`=` for iteration should be excluded like it is in `for` and `let`, where `.=` is nonsense.  

NFC under flisp lowering (it doesn't check the `=`); found by lowering older versions of FrankWolfe.jl with JuliaLowering.