### PR TITLE
codegen: Fix inverted safepoint condition in `emit_gc_state_set`

### DIFF
--- a/src/llvm-codegen-shared.h
+++ b/src/llvm-codegen-shared.h
@@ -249,7 +249,7 @@ static inline llvm::Value *emit_gc_state_set(llvm::IRBuilder<> &builder, llvm::T
                 return old_state;
     BasicBlock *passBB = BasicBlock::Create(builder.getContext(), "safepoint", builder.GetInsertBlock()->getParent());
     BasicBlock *exitBB = BasicBlock::Create(builder.getContext(), "after_safepoint", builder.GetInsertBlock()->getParent());
-    builder.CreateCondBr(builder.CreateICmpEQ(old_state, state, "is_new_state"), // Safepoint whenever we do not change the GC state
+    builder.CreateCondBr(builder.CreateICmpNE(old_state, state, "is_new_state"), // Safepoint whenever we change the GC state
                          passBB, exitBB);
     builder.SetInsertPoint(passBB);
     MDNode *tbaa = get_tbaa_const(builder.getContext());


### PR DESCRIPTION
I asked Claude to review the safepoint implementation in Julia and it pointed out
that in #49933 I introduced a bug around foreign-threads and GC safepoints.

```quote
`emit_gc_state_set` emitted the safepoint poll when the GC state was
unchanged and skipped it when the state actually transitioned, the
opposite of the runtime equivalent `jl_gc_state_set`. It also
contradicted the constant-folding shortcut directly above it, which
elides the poll when the two states are statically equal.

The live consequence is at `@cfunction`/`@ccallable` entry, which
lowers through `emit_gc_unsafe_enter`: a thread entering Julia from
gc-safe state stored `JL_GC_STATE_UNSAFE` and proceeded without polling.
An adopted foreign thread is deliberately left in gc-safe state when it
returns from a callback, so every subsequent callback from that thread
took this path, as does any `gc_safe=true` `@ccall` whose callee calls
back into Julia. If a stop-the-world was in progress, such a thread
would run Julia code concurrently with the collector.

Introduced in #49933; present in 1.13 and later.
```
