### PR TITLE
Avoid misleading wording for `UnionAll` type in documentation

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1155,7 +1155,7 @@ Vector{Vector{T}} where T (alias for Array{Array{T, 1}, 1} where T)
 Type `T1` defines a 1-dimensional array of 1-dimensional arrays; each
 of the inner arrays consists of objects of the same type, but this type may vary from one inner array to the next.
 On the other hand, type `T2` defines a 1-dimensional array of 1-dimensional arrays all of whose inner arrays must have the
-same type. Note that `T2` is an abstract type, e.g., `Array{Array{Int,1},1} <: T2`, whereas `T1` is a concrete type. As a consequence, `T1` can be constructed with a zero-argument constructor `a=T1()` but `T2` cannot.
+same type. Note that `T2` is a `UnionAll` type, e.g., `Array{Array{Int,1},1} <: T2`, whereas `T1` is a `DataType`. As a consequence, `T1` can be constructed with a zero-argument constructor `a=T1()` but `T2` cannot.
 
 There is a convenient syntax for naming such types, similar to the short form of function
 definition syntax:


### PR DESCRIPTION
It is misleading to talk about the "abstract" type `const T1 = Array{Array{T, 1} where T, 1}`
when there is
```
julia> T1 |> isabstracttype
false
```