### PR TITLE
Deactivate auto insert closing bracket

### DIFF
--- a/stdlib/REPL/src/options.jl
+++ b/stdlib/REPL/src/options.jl
@@ -51,7 +51,7 @@ Options(;
         auto_indent_time_threshold = 0.005,
         auto_refresh_time_delay = 0.0, # this no longer seems beneficial
         hint_tab_completes = true,
-        auto_insert_closing_bracket = true,
+        auto_insert_closing_bracket = false,
         style_input = true,
         iocontext = Dict{Symbol,Any}()) =
             Options(hascolor, extra_keymap, tabwidth,


### PR DESCRIPTION
The setting mechanism is so horribly racy/broken that it can even happen that
`auto_insert_closing_bracket`  shows `false` although the (mis)feature is still
active. Deactivate the setting per default to fix the regression.

This will neither fix the races nor the misbehaving REPL when it is active, but then at least the people who think it is a good idea that the REPL does not do what they type can try to fix the problems.