### PR TITLE
threading: don't poll a safepoint after the GC drops the thread's roots

### DIFF
--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -121,6 +121,8 @@ void jl_init_thread_heap(struct _jl_tls_states_t *ptls) JL_NOTSAFEPOINT;
 // Deallocates any memory previously used for thread-local GC data structures.
 // Mostly used to ensure that we perform this memory cleanup for foreign threads that are
 // about to leave Julia.
+// After this call the GC may no longer scan this thread's roots; the caller
+// must be GC-unsafe and must not poll a safepoint afterwards.
 void jl_free_thread_gc_state(struct _jl_tls_states_t *ptls);
 
 // ========================================================================= //

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1412,6 +1412,7 @@ extern pthread_mutex_t in_signal_lock;
 #endif
 
 void jl_set_gc_and_wait(jl_task_t *ct) JL_CANSAFEPOINT;
+void jl_gc_safe_enter_from_nonmutator(jl_ptls_t ptls) JL_CANSAFEPOINT_LEAVE;
 
 // Query if this object is perm-allocated in an image.
 JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t* v) JL_NOTSAFEPOINT;

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -231,6 +231,18 @@ void jl_safepoint_end_gc(void)
     uv_cond_broadcast(&safepoint_cond_end);
 }
 
+// `jl_gc_safe_enter` for a thread that is no longer a mutator with a valid current task
+void jl_gc_safe_enter_from_nonmutator(jl_ptls_t ptls) JL_NO_SAFEPOINT_ANALYSIS
+{
+    // instead of loading from the safepoint page (whose trap handler requires
+    // a valid current task), perform the collector handshake directly
+    jl_atomic_store_release(&ptls->gc_state, JL_GC_STATE_SAFE);
+    uv_mutex_lock(&safepoint_lock);
+    uv_cond_broadcast(&safepoint_cond_begin);
+    uv_mutex_unlock(&safepoint_lock);
+    jl_safepoint_wait_gc(NULL);
+}
+
 void jl_set_gc_and_wait(jl_task_t *ct)
 {
     // reading own gc state doesn't need atomic ops since no one else

--- a/src/threading.c
+++ b/src/threading.c
@@ -550,7 +550,7 @@ static void jl_delete_thread(void *value)
     ptls->root_task = NULL;
     jl_free_thread_gc_state(ptls);
     // park in safe-region from here on (this may run GC again)
-    (void)jl_gc_safe_enter(ptls);
+    jl_gc_safe_enter_from_nonmutator(ptls);
     // try to free some state we do not need anymore
 #ifndef _OS_WINDOWS_
     void *signal_stack = ptls->signal_stack;

--- a/src/threading.c
+++ b/src/threading.c
@@ -548,9 +548,6 @@ static void jl_delete_thread(void *value)
     ptls->previous_exception = NULL;
     // allow the page root_task is on to be freed
     ptls->root_task = NULL;
-    jl_free_thread_gc_state(ptls);
-    // park in safe-region from here on (this may run GC again)
-    jl_gc_safe_enter_from_nonmutator(ptls);
     // try to free some state we do not need anymore
 #ifndef _OS_WINDOWS_
     void *signal_stack = ptls->signal_stack;
@@ -604,6 +601,12 @@ static void jl_delete_thread(void *value)
 #endif
     free(ptls->bt_data);
     small_arraylist_free(&ptls->locks);
+    // Nothing can reach this thread's task now that `current_task` is
+    // cleared, so drop the GC state and park. The park is obligatory: this
+    // ptls remains in `jl_all_tls_states` forever, so the thread must be
+    // left GC-safe or every future stop-the-world would wait on it.
+    jl_free_thread_gc_state(ptls);
+    jl_gc_safe_enter_from_nonmutator(ptls);
 }
 
 //// debugging hack: if we are exiting too fast for error message printing on threads,


### PR DESCRIPTION
The `jl_gc_safe_enter` here requires that we still have a valid current task object, but `jl_free_thread_gc_state` returns the thread's objects to the GC for re-collection (including its tasks).

Stock GC was unaffected only by accident: it keeps the dead thread's ptls in `jl_all_tls_states` and roots `ptls->current_task` until the end of teardown, so the same poll dereferenced a still-live task there.

Also fix a Profile ordering bug that does affect stock GC.

Found with heavy MWE drilldown assistance from Claude Fable 5 🤖 - Fix is by me