### PR TITLE
Don't abort when query for unregistered CI completes

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2054,7 +2054,7 @@ void JuliaOJIT::publishCIs(ArrayRef<jl_code_instance_t *> CIs, bool Wait)
         for (auto CI : CIs) {
             auto It = CISymbols.find(CI);
             if (It == CISymbols.end())
-                return;
+                continue;
             auto CISym = It->second;
             if (CISym.invoke)
                 Exports.add(CISym.invoke);
@@ -2077,7 +2077,22 @@ void JuliaOJIT::publishCIs(ArrayRef<jl_code_instance_t *> CIs, bool Wait)
         auto Syms = std::move(*SymsE);
         for (auto [i, CI] : llvm::enumerate(CIs)) {
             jl_codeinst_funcs_t<void *> Addrs{};
-            const auto &S = CISymbols.at(CIs[i]);
+            // If jl_jit_unregister_ci has been called for this CI before our
+            // callback fired, it's possible that we won't find anything in
+            // CISymbols.  This is ok, since the code instance is no longer
+            // needed.
+            auto It = CISymbols.find(CIs[i]);
+            if (It == CISymbols.end())
+                continue;
+            const auto &S = It->second;
+
+            // It is also possible that a new CI has been allocated with the
+            // same address in the meantime.  It is guaranteed to have a new ORC
+            // symbol, so we can close this by ignoring queries if the symbols
+            // in CISymbols don't agree with Syms.
+            if ((S.invoke && !Syms.contains(S.invoke)) ||
+                (S.specptr && !Syms.contains(S.specptr)))
+                continue;
             Addrs.invoke_api = S.invoke_api;
             if (S.invoke)
                 Addrs.invoke = (void *)Syms.at(S.invoke).getAddress().getValue();

--- a/test/jit.jl
+++ b/test/jit.jl
@@ -149,4 +149,20 @@ function test_gc_codeinst()
     true
 end
 @test test_gc_codeinst()
+
+# If we call jl_jit_unregister_ci when there are pending ORC queries for the
+# symbol, they will attempt to find the symbol in CISymbols after it has been
+# removed.  This shouldn't crash.
+function test_oneshot_publish_race()
+    @sync for i in 1:1000
+        # This will go through jl_invoke_oneshot
+        Threads.@spawn @eval begin
+            ccall(:jl_cpu_pause, Cvoid, ())
+            $i
+        end
+    end
+    true
+end
+@test test_oneshot_publish_race()
+
 sleep(5)  # Avoids problems where we don't respond to Distributed.jl fast enough


### PR DESCRIPTION
`jl_invoke_oneshot` calls `jl_jit_unregister_ci` right after the ORC query for that CI's symbols completes.  However, it's possible that another query for the same CI was in flight when the CI was unregistered, and it was possible for the callback for that query to trigger an assertion failure when it looked up the CI in `CISymbols`.

We can fix this pretty easily by skipping any CIs that we find are missing in CISymbols when the callback fires (this is what we expect to happen if our CI was unregistered before completion).

It is also necessary for us to check that the symbols we find in CISymbols match the ones we looked up in ORC, because it is possible that another CI has been allocated while our lookup was in flight.  I wasn't able to get a test to trigger this behaviour, but it should be impossible now.

This issue was found by @topolarity.

Adds a regression test written by Claude Fable 5.