### PR TITLE
MMTk: iterate TLS with `gc_n_threads` not `jl_n_threads`

### DIFF
--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -919,7 +919,7 @@ JL_DLLEXPORT void jl_gc_mmtk_sweep_stack_pools(void)
     //            if (stkbuf)
     //                push(free_stacks[sz], stkbuf)
     assert(gc_n_threads);
-    for (int i = 0; i < jl_n_threads; i++) {
+    for (int i = 0; i < gc_n_threads; i++) {
         jl_ptls_t ptls2 = gc_all_tls_states[i];
         if (ptls2 == NULL)
             continue;


### PR DESCRIPTION
This value can change concurrently during a collection, so we have to be careful to use the correct snapshot.

Spotted by inspection by Claude Fable 5 🤖 while investigating other GC issues.