### PR TITLE
make: include `clang-safety` in the `analyze-%` target

### DIFF
--- a/doc/src/devdocs/agents/skills/c-static-analysis/SKILL.md
+++ b/doc/src/devdocs/agents/skills/c-static-analysis/SKILL.md
@@ -25,7 +25,8 @@ Run static analysis checks:
   Add `--output-sync` when your `make` supports it to keep parallel output
   grouped; otherwise omit it.
 - Checks can also be rerun individually with `clang-sa-<file-stem>`,
-  `clang-sagc-<file-stem>` or `clang-tidy-<file-stem>`.
+  `clang-sagc-<file-stem>`, `clang-safety-<file-stem>` or
+  `clang-tidy-<file-stem>`.
 
 ## Fixing the GC-rooting checker (clang-sagc)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -846,6 +846,7 @@ analyzegc: $(addprefix clang-sagc-,$(filter-out $(basename $(SKIP_GC_CHECK)),$(C
 analyze: analyzesrc analyzegc tidysrc safesrc
 
 $(addprefix analyze-,$(CODEGEN_SRCS) $(SRCS)) : analyze-% : clang-sa-%
+$(addprefix analyze-,$(CODEGEN_SRCS) $(SRCS)) : analyze-% : clang-safety-%
 $(addprefix analyze-,$(CODEGEN_SRCS) $(SRCS)) : analyze-% : clang-tidy-%
 $(addprefix analyze-,$(filter-out $(basename $(SKIP_GC_CHECK)),$(CODEGEN_SRCS) $(SRCS))) : analyze-% : clang-sagc-%
 


### PR DESCRIPTION
This was throwing off Claude causing the robot to forget to run the full set of analyses we have now.