### PR TITLE
staticdata: record the GC configuration in the pkgimage header + objcache key

### DIFF
--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -913,3 +913,14 @@ void sweep_mtarraylist_buffers(void) JL_NOTSAFEPOINT
 #ifdef __cplusplus
 }
 #endif
+
+#define JL_GC_ABI_STR_(x) #x
+#define JL_GC_ABI_STR(x) JL_GC_ABI_STR_(x)
+JL_DLLEXPORT const char *jl_gc_image_abi(void)
+{
+#ifdef WITH_THIRD_PARTY_HEAP
+    return "mmtk-" MMTK_PLAN "-moving-" JL_GC_ABI_STR(MMTK_MOVING);
+#else
+    return "stock";
+#endif
+}

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1415,6 +1415,8 @@ void jl_set_gc_and_wait(jl_task_t *ct) JL_CANSAFEPOINT;
 
 // Query if this object is perm-allocated in an image.
 JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t* v) JL_NOTSAFEPOINT;
+// GC configuration baked into generated code; must match between an image and the runtime that loads it.
+JL_DLLEXPORT const char *jl_gc_image_abi(void) JL_NOTSAFEPOINT;
 
 // the first argument to jl_idtable_rehash is used to return a value
 // make sure it is rooted if it is used after the function returns

--- a/src/objcache.cpp
+++ b/src/objcache.cpp
@@ -256,6 +256,7 @@ static ObjCache::Hash hashModule(const llvm::Module &M) JL_NOTSAFEPOINT
 
     Hasher.update(LLVM_VERSION_STRING);
     Hasher.update(JL_CODEGEN_SRC_HASH);
+    Hasher.update(jl_gc_image_abi());
     Hasher.update({(uint8_t *)&ModHash[0], sizeof ModHash});
     return Hasher.final();
 }

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -713,7 +713,7 @@ static const char *jl_git_commit(void) JL_CANSAFEPOINT
 
 
 // "magic" string and version header of .ji file
-static const int JI_FORMAT_VERSION = 14;
+static const int JI_FORMAT_VERSION = 15;
 static const char JI_MAGIC[] = "\373jli\r\n\032\n"; // based on PNG signature
 static const uint16_t BOM = 0xFEFF; // byte-order marker
 
@@ -731,6 +731,8 @@ static int64_t write_header(ios_t *s, uint32_t flags) JL_CANSAFEPOINT
     ios_write(s, JL_BUILD_UNAME, strlen(JL_BUILD_UNAME)+1);
     ios_write(s, JL_BUILD_ARCH, strlen(JL_BUILD_ARCH)+1);
     ios_write(s, JULIA_VERSION_STRING, strlen(JULIA_VERSION_STRING)+1);
+    const char *gc_abi = jl_gc_image_abi();
+    ios_write(s, gc_abi, strlen(gc_abi)+1);
     write_uint32(s, flags);
     if (flags & JI_FLAG_PKGIMAGE) {
         const char *branch = jl_git_branch(), *commit = jl_git_commit();
@@ -1034,7 +1036,8 @@ JL_DLLEXPORT int jl_read_verify_header(ios_t *s, uint32_t *flags, uint32_t *chec
           read_uint8(s) == sizeof(void*) &&
           readstr_verify(s, JL_BUILD_UNAME, 1) &&
           readstr_verify(s, JL_BUILD_ARCH, 1) &&
-          readstr_verify(s, JULIA_VERSION_STRING, 1)))
+          readstr_verify(s, JULIA_VERSION_STRING, 1) &&
+          readstr_verify(s, jl_gc_image_abi(), 1)))
         return -1;
 
     *flags = read_uint32(s);


### PR DESCRIPTION
We perform GC-specific codegen so we need to include it as part of our image cache header so that it is invalidated appropriately.

Drafted by Claude Fable 5 🤖 