### PR TITLE
cancellation: Scale waiter-registry pruning with the registration count

### DIFF
--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -557,9 +557,16 @@ const _PRUNE_DEAD_THRESHOLD = UInt32(16)
 # threshold loses `_try_prune!`'s trylock to a concurrent walk, corpses that
 # walk had already passed remain counted here, and the next death must retry
 # the prune rather than let the count sail past the threshold forever.
+# The threshold scales with the (approximate) list length: a prune walk is
+# O(list), so tripping it every fixed number of deaths makes a mass fan-out
+# parking under one source - e.g. any large task tree governed by a shared
+# ambient token - quadratic in its waiter count. Requiring the dead to be a
+# constant fraction of the list amortizes each walk against the corpses it
+# collects.
 function _note_dead_registration!(src::CancellationTokenSource)
     dc = @atomic :monotonic src.dead_count += UInt32(1)
-    dc >= _PRUNE_DEAD_THRESHOLD && _try_prune!(src)
+    threshold = max(_PRUNE_DEAD_THRESHOLD, (@atomic :monotonic src.reg_count) >> 2)
+    dc >= threshold && _try_prune!(src)
     return nothing
 end
 
@@ -707,6 +714,7 @@ end
 # the caller wakes them after releasing the walk lock.
 function _walk_waiters!(node::CancellationTokenSource, sev::UInt8)
     @atomic :monotonic node.dead_count = UInt32(0)
+    nlive = UInt32(0)
     towake = nothing
     prev = nothing # the predecessor's slot for `node`, once past the head
     # seq_cst: the S-ordered counterpart of a registrant's seq_cst push -
@@ -768,10 +776,16 @@ function _walk_waiters!(node::CancellationTokenSource, sev::UInt8)
                 # a lost claim: a completion or interrupter won the race;
                 # the waiter resumes through that wake
             end
+            nlive += UInt32(1)
             prev = slot
         end
         w = wnext
     end
+    # Resync the approximate list length (see _note_dead_registration!'s
+    # scaled prune threshold) to what this walk left linked. Entries kept
+    # only because their head-unlink CAS lost count as live: conservative,
+    # and the next walk resyncs.
+    @atomic :monotonic node.reg_count = nlive
     return towake
 end
 

--- a/base/park.jl
+++ b/base/park.jl
@@ -311,6 +311,9 @@ function wait_enqueue!(x::SourceWait, w::WaitEntry, first::Bool)
                 break
             end
         end
+        # approximate list length, feeding the scaled prune threshold
+        # (resynced by every walk; see _note_dead_registration!)
+        @atomic :monotonic src.reg_count += UInt32(1)
     else
         # Sticky re-arm (already registered): upgrade this thread's
         # arm-then-recheck to the store-load ordering the race argument

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4320,26 +4320,28 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_cancel_source_type = (jl_datatype_t*)
         jl_new_datatype(jl_symbol("CancellationTokenSource"), core, jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(6,
+                        jl_perm_symsvec(7,
                                         "child_head",
                                         "waiters_head",
                                         "walk_lock",
                                         "state",
                                         "nparents",
-                                        "dead_count"),
-                        jl_svec(6,
+                                        "dead_count",
+                                        "reg_count"),
+                        jl_svec(7,
                                 jl_any_type, // Union{Nothing, CancellationTokenSource}, weak
                                 jl_any_type, // Union{Nothing, WaitEntry}, strong
                                 jl_any_type, // Union{Nothing, ReentrantLock}, strong
                                 jl_uint8_type,
                                 jl_uint16_type,
+                                jl_uint32_type,
                                 jl_uint32_type),
                         jl_emptysvec,
-                        0, 1, 6);
+                        0, 1, 7);
     // Field 5 (nparents) is const; fields 1-4 (child_head, waiters_head,
-    // walk_lock, state) and 6 (dead_count) are atomic
-    const static uint32_t cancel_source_constfields[1]  = { 0b010000 };
-    const static uint32_t cancel_source_atomicfields[1] = { 0b101111 };
+    // walk_lock, state), 6 (dead_count) and 7 (reg_count) are atomic
+    const static uint32_t cancel_source_constfields[1]  = { 0b0010000 };
+    const static uint32_t cancel_source_atomicfields[1] = { 0b1101111 };
     jl_cancel_source_type->name->constfields = cancel_source_constfields;
     jl_cancel_source_type->name->atomicfields = cancel_source_atomicfields;
     XX(cancel_source);

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -359,6 +359,11 @@ struct _jl_cancel_source_t {
     // threshold triggers a pruning walk. Approximate (relaxed); walks reset
     // it.
     _Atomic(uint32_t) dead_count;
+    // Approximate length of the waiter list: incremented per registration
+    // push, resynced to the surviving count by each walk. The pruning
+    // threshold scales with it (a fixed threshold makes a mass fan-out's
+    // prune walks quadratic in the number of parked waiters).
+    _Atomic(uint32_t) reg_count;
     // jl_cancel_parent_link_t links[nparents];  (see jl_cancel_source_links)
 };
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1633,7 +1633,7 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
             write_uint8(f, jl_atomic_load_relaxed(&cs->state));
             write_padding(f, offsetof(jl_cancel_source_t, nparents) - 3 * sizeof(void*) - sizeof(uint8_t));
             ios_write(f, (char*)&cs->nparents, sizeof(uint16_t));
-            write_padding(f, sizeof(jl_cancel_source_t) - offsetof(jl_cancel_source_t, nparents) - sizeof(uint16_t)); // incl. dead_count (transient; reset)
+            write_padding(f, sizeof(jl_cancel_source_t) - offsetof(jl_cancel_source_t, nparents) - sizeof(uint16_t)); // incl. dead_count + reg_count (transient; reset)
             jl_cancel_parent_link_t *links = jl_cancel_source_links(cs);
             for (size_t i = 0; i < cs->nparents; i++) {
                 write_pointerfield(s, (jl_value_t*)links[i].parent);

--- a/src/task.c
+++ b/src/task.c
@@ -1763,6 +1763,7 @@ JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
     jl_atomic_store_relaxed(&src->state, 0);
     src->nparents = (uint16_t)np;
     jl_atomic_store_relaxed(&src->dead_count, 0);
+    jl_atomic_store_relaxed(&src->reg_count, 0);
     // Initialize every link entry before publishing the node under *any*
     // parent: a concurrent cancellation walk that reaches the node through
     // one parent scans all of its entries.


### PR DESCRIPTION
The waiter registry collects dead registrations (retired entries, entries of completed tasks) with a pruning walk triggered every fixed number of deaths. A prune walk is O(list), so a mass fan-out parking under a single source - any large task tree governed by a shared ambient token, e.g. `Threads.@spawn` trees whose interior nodes wait on their children - made the accumulated prunes quadratic in the number of parked waiters: with cancellation fully activated, the test suite's 2M-task spawn tree spent over four minutes almost entirely in prune walks.

Track an approximate list length on the source (incremented per registration push, resynced by every walk) and require the dead to be a constant fraction of it before pruning, amortizing each walk against the corpses it collects. The 2M-task tree returns to seconds, and small sources keep the previous fixed threshold.