### PR TITLE
cancellation: Implement task abandonment

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -280,8 +280,10 @@ Returns `false` - with `t` untouched and still running - when the abandonment
 could not be performed safely: `t` was not (or no longer) running on a
 thread, was found holding runtime state that must not be discarded (runtime
 locks, an in-flight finalizer or GC transition, a signal-deferral region),
-another abandonment was already in flight for that thread, or the delivery
-could not be completed in time (e.g. the victim blocks the delivery signal).
+or another abandonment was already in flight for that thread. Blocks (in a
+scheduler-friendly wait) until the delivery settles the request one way or
+the other; a victim thread that never services signals blocks the call
+indefinitely.
 
 `next_task` must be a fresh, never-scheduled task; it takes over the
 victim's thread.
@@ -328,38 +330,21 @@ function unsafe_abandon!(t::Task, next_task::Task, @nospecialize(result))
     tid < 0 && return false
     tid = tid % Int16
     # Acquired (and, first time, created) only after the request is
-    # published with its first signal in flight: the victim may be a
-    # checkless spin blocking GC's stop-the-world, which any allocation
-    # here could otherwise join before the delivery frees it. A settle that
-    # races the condition's registration is repaired by the ticker's ping.
+    # published with its signal in flight: the victim may be a checkless
+    # spin blocking GC's stop-the-world, which any allocation here could
+    # otherwise join before the delivery frees it. The delivery bit cannot
+    # be coalesced away, so the single send suffices; a settle that races
+    # the condition's registration is caught by the poll below (poll first,
+    # then wait - the settle's ping latches on the registered handle).
     cond = _abandon_notify!()
-    # Deliveries coalesce with best-effort cancellation/preemption signals
-    # on the shared per-thread request slot, so a single send can be lost:
-    # periodically re-send - which also re-pings the wakeup condition, so
-    # the wait below never sleeps through a lost settle notification.
-    ticker = Timer(0.01; interval=0.01) do _
-        ccall(:jl_abandon_task_resend, Cvoid, (Int16,), tid)
-        ccall(:jl_abandon_notify_ping, Cvoid, ())
-    end
-    deadline = time_ns() + 2_000_000_000 # 2s: then withdraw rather than hang
     ok = false
-    try
-        while true
-            verdict = ccall(:jl_abandon_task_poll, Cint, (Int16,), tid)
-            if verdict != 0
-                ok = verdict == 1
-                break
-            end
-            if time_ns() >= deadline &&
-               ccall(:jl_abandon_task_withdraw, Cint, (Int16,), tid) == 1
-                break # fully withdrawn; no abandonment happened
-            end
-            # (a lost withdraw race means a delivery took the request - the
-            # next poll returns its verdict)
-            wait(cond; cancel=nothing)
+    while true
+        verdict = ccall(:jl_abandon_task_poll, Cint, (Int16,), tid)
+        if verdict != 0
+            ok = verdict == 1
+            break
         end
-    finally
-        close(ticker)
+        wait(cond; cancel=nothing)
     end
     if ok
         # A forcibly abandoned task never goes through the regular task

--- a/base/task.jl
+++ b/base/task.jl
@@ -301,50 +301,42 @@ victim's thread.
 unsafe_abandon!(t::Task, next_task::Task) =
     unsafe_abandon!(t, next_task, CancellationRequest(0x4)) # CANCEL_REQUEST_ABANDON_ALL
 
-# The delivery paths settle the request slot from signal context, where
-# `uv_async_send` is the one legal wakeup: a process-global AsyncCondition
-# (created lazily, registered with the runtime, kept open for the process
-# lifetime) makes the requester-side waits event-driven. Spurious wakeups
-# (another thread's abandonment settling) re-check and re-park.
-const _abandon_notify_cond = Ref{Any}(nothing) # Union{Nothing, AsyncCondition}; untyped for bootstrap order
-const _abandon_notify_lock = ReentrantLock()
-function _abandon_notify!()
-    c = _abandon_notify_cond[]
-    c === nothing || return c
-    lock(_abandon_notify_lock; cancel=nothing)
-    try
-        c = _abandon_notify_cond[]
-        if c === nothing
-            c = AsyncCondition()
-            ccall(:jl_set_abandon_notify_handle, Cvoid, (Ptr{Cvoid},), c.handle)
-            _abandon_notify_cond[] = c
-        end
-        return c
-    finally
-        unlock(_abandon_notify_lock)
-    end
-end
-
 function unsafe_abandon!(t::Task, next_task::Task, @nospecialize(result))
-    tid = ccall(:jl_abandon_task_request, Cint, (Any, Any, Any), t, next_task, result)
-    tid < 0 && return false
+    # The requester's own wakeup handle, staged with the request in the
+    # victim thread's abandon slot: the delivery paths ping it (from signal
+    # context, where uv_async_send is the one legal wakeup) when the
+    # request settles. One requester per slot means one consumer per
+    # handle, which is exactly the AsyncCondition trigger's latched,
+    # consume-once semantics - a settle that lands inside the check/park
+    # window below is caught by the latch.
+    async = AsyncCondition()
+    tid = ccall(:jl_abandon_task_request, Cint, (Any, Any, Any, Ptr{Cvoid}),
+                t, next_task, result, async.handle)
+    if tid < 0
+        close(async)
+        return false
+    end
     tid = tid % Int16
-    # Acquired (and, first time, created) only after the request is
-    # published with its signal in flight: the victim may be a checkless
-    # spin blocking GC's stop-the-world, which any allocation here could
-    # otherwise join before the delivery frees it. The delivery bit cannot
-    # be coalesced away, so the single send suffices; a settle that races
-    # the condition's registration is caught by the poll below (poll first,
-    # then wait - the settle's ping latches on the registered handle).
-    cond = _abandon_notify!()
     ok = false
-    while true
-        verdict = ccall(:jl_abandon_task_poll, Cint, (Int16,), tid)
-        if verdict != 0
-            ok = verdict == 1
-            break
+    try
+        while true
+            verdict = ccall(:jl_abandon_task_poll, Cint, (Int16,), tid)
+            if verdict == 1 || verdict == -1
+                ok = verdict == 1
+                break
+            elseif verdict == 2
+                # mid-settle: the ping was already sent (pre-terminal, so it
+                # can never race this handle's close below); the verdict is
+                # microseconds away
+                ccall(:jl_cpu_pause, Cvoid, ())
+            else
+                wait(async; cancel=nothing)
+            end
         end
-        wait(cond; cancel=nothing)
+    finally
+        # Safe only after the terminal consume: pings happen strictly
+        # before the terminal state becomes visible.
+        close(async)
     end
     if ok
         # A forcibly abandoned task never goes through the regular task

--- a/base/task.jl
+++ b/base/task.jl
@@ -149,9 +149,11 @@ end
 
 # task states
 
-const task_state_runnable = UInt8(0)
-const task_state_done     = UInt8(1)
-const task_state_failed   = UInt8(2)
+const task_state_runnable  = UInt8(0)
+const task_state_done      = UInt8(1)
+const task_state_failed    = UInt8(2)
+# like _failed, but the task was forcibly abandoned and may have leaked resources
+const task_state_abandoned = UInt8(3)
 
 @inline function getproperty(t::Task, field::Symbol)
     if field === :state
@@ -163,6 +165,8 @@ const task_state_failed   = UInt8(2)
             return :done
         elseif st === task_state_failed
             return :failed
+        elseif st === task_state_abandoned
+            return :abandoned
         else
             @assert false "unexpected state"
         end
@@ -260,7 +264,58 @@ true
 !!! compat "Julia 1.3"
     This function requires at least Julia 1.3.
 """
-istaskfailed(t::Task) = ((@atomic :acquire t._state) === task_state_failed)
+function istaskfailed(t::Task)
+    st = @atomic :acquire t._state
+    return st === task_state_failed || st === task_state_abandoned
+end
+
+"""
+    unsafe_abandon!(t::Task, next_task::Task) -> Bool
+
+Forcibly abandon task `t` and switch its thread to `next_task`, discarding
+`t`'s execution. Returns `true` if the abandonment committed: `t`'s state is
+`:abandoned` and it will never run another instruction.
+
+Returns `false` - with `t` untouched and still running - when the abandonment
+could not be performed safely: `t` was not (or no longer) current on its
+thread, the delivery found it holding *runtime* state that must not be
+discarded (runtime locks, a running finalizer or inhibited finalizers - which
+includes holding a `ReentrantLock` - or a signal-deferral region), another
+abandonment was already in flight for that thread, or delivery timed out.
+The validation happens on the target thread at the point it is actually
+stopped, so a `false` return is authoritative, not a racy guess; callers
+retry or fall back to freezing the task in place.
+
+This is used to implement `CANCEL_REQUEST_ABANDON_ALL` where a task needs to
+be stopped without waiting for it to reach a safe cancellation point.
+
+!!! warning
+    This is a dangerous operation. The abandoned task may have acquired *user*
+    locks or other resources that will be leaked, potentially causing
+    deadlocks in future code. It should only be used as a last-resort method
+    to recover a system when tasks are unable to process cancellation.
+
+!!! note
+    The task must be currently running on a thread for this to have effect;
+    use [`cancel!`](@ref) with `CANCEL_REQUEST_ABANDON_ALL` to also stop
+    parked or queued tasks.
+"""
+function unsafe_abandon!(t::Task, next_task::Task)
+    ok = ccall(:jl_abandon_task, Cint, (Any, Any), t, next_task) != 0
+    if ok
+        # An abandoned task never goes through the regular task completion
+        # path, so wake up anyone waiting on it. (The waiters observe the
+        # already-stored abandoned state; they do not touch the task's stack.
+        # The root task's donenotify may be `nothing`.)
+        donenotify = t.donenotify
+        if donenotify isa ThreadSynchronizer
+            lock(donenotify)
+            notify(donenotify)
+            unlock(donenotify)
+        end
+    end
+    return ok
+end
 
 Threads.threadid(t::Task) = Int(ccall(:jl_get_task_tid, Int16, (Any,), t)+1)
 function Threads.threadpool(t::Task)
@@ -1057,7 +1112,15 @@ const Workqueue = Workqueues[1] # default work queue is thread 1 // TODO: deprec
 workqueue_for(tid::Int) = Workqueues[tid]
 
 function enq_work(t::Task)
-    (t._state === task_state_runnable && t.queue === nothing) || error("schedule: Task not runnable")
+    state = t._state
+    if state === task_state_abandoned
+        # A task frozen by forcible abandonment leaves its waitqueue
+        # registrations behind by design; a later notify of such a stale
+        # entry lands here. The wakeup is consumed by the abandoned task -
+        # drop it silently.
+        return t
+    end
+    (state === task_state_runnable && t.queue === nothing) || error("schedule: Task not runnable")
     (@atomic :monotonic t.waiting_on) === nothing ||
         throw(ConcurrencyViolationError("schedule: Task is registered on a wait queue"))
 
@@ -1280,7 +1343,7 @@ function yieldto(t::Task, @nospecialize(x=nothing))
     # state error instead.
     if t._state === task_state_done
         return x
-    elseif t._state === task_state_failed
+    elseif t._state === task_state_failed || t._state === task_state_abandoned
         throw(t.result)
     end
     # [task] user_time -yield-> wait_time
@@ -1389,21 +1452,40 @@ function ensure_rescheduled(othertask::Task)
     nothing
 end
 
+function discard_stale_workqueue_task(t::Task)
+    # A task frozen in place by forcible abandonment is completed without
+    # ever leaving the queues it was registered with (a workqueue, or a
+    # waitqueue whose later notify re-enqueues it here); discard it. Any
+    # other non-runnable state means the task somehow got queued twice -
+    # probably broken now, but try discarding this switch and keep going.
+    # We can't throw here, because it's probably not the fault of the caller
+    # to wait, and don't want to use print() here, because that may try to
+    # incur a task switch.
+    if t._state !== task_state_abandoned
+        ccall(:jl_safe_printf, Cvoid, (Ptr{UInt8}, Int32...),
+            "\nWARNING: Workqueue inconsistency detected: popfirst!(Workqueue).state !== :runnable\n")
+    end
+    nothing
+end
+
 function trypoptask(W::StickyWorkqueue)
     while !isempty(W)
         t = popfirst!(W)
         if t._state !== task_state_runnable
-            # assume this somehow got queued twice,
-            # probably broken now, but try discarding this switch and keep going
-            # can't throw here, because it's probably not the fault of the caller to wait
-            # and don't want to use print() here, because that may try to incur a task switch
-            ccall(:jl_safe_printf, Cvoid, (Ptr{UInt8}, Int32...),
-                "\nWARNING: Workqueue inconsistency detected: popfirst!(Workqueue).state !== :runnable\n")
+            discard_stale_workqueue_task(t)
             continue
         end
         return t
     end
-    return Partr.multiq_deletemin()
+    while true
+        t = Partr.multiq_deletemin()
+        t === nothing && return nothing
+        if t._state !== task_state_runnable
+            discard_stale_workqueue_task(t)
+            continue
+        end
+        return t
+    end
 end
 
 checktaskempty = Partr.multiq_check_empty

--- a/base/task.jl
+++ b/base/task.jl
@@ -277,36 +277,95 @@ Forcibly abandon task `t` and switch its thread to `next_task`, discarding
 `:abandoned` and it will never run another instruction.
 
 Returns `false` - with `t` untouched and still running - when the abandonment
-could not be performed safely: `t` was not (or no longer) current on its
-thread, the delivery found it holding *runtime* state that must not be
-discarded (runtime locks, a running finalizer or inhibited finalizers - which
-includes holding a `ReentrantLock` - or a signal-deferral region), another
-abandonment was already in flight for that thread, or delivery timed out.
-The validation happens on the target thread at the point it is actually
-stopped, so a `false` return is authoritative, not a racy guess; callers
-retry or fall back to freezing the task in place.
+could not be performed safely: `t` was not (or no longer) running on a
+thread, was found holding runtime state that must not be discarded (runtime
+locks, an in-flight finalizer or GC transition, a signal-deferral region),
+another abandonment was already in flight for that thread, or the delivery
+could not be completed in time (e.g. the victim blocks the delivery signal).
 
-This is used to implement `CANCEL_REQUEST_ABANDON_ALL` where a task needs to
-be stopped without waiting for it to reach a safe cancellation point.
+`next_task` must be a fresh, never-scheduled task; it takes over the
+victim's thread.
 
 !!! warning
-    This is a dangerous operation. The abandoned task may have acquired *user*
-    locks or other resources that will be leaked, potentially causing
-    deadlocks in future code. It should only be used as a last-resort method
-    to recover a system when tasks are unable to process cancellation.
+    Abandonment discards the victim's execution wherever it stands. Any
+    non-runtime resource it holds (locks, buffers, connections) is leaked.
+    This is a last-resort recovery primitive.
 
 !!! note
     The task must be currently running on a thread for this to have effect;
     use [`cancel!`](@ref) with `CANCEL_REQUEST_ABANDON_ALL` to also stop
     parked or queued tasks.
 """
-function unsafe_abandon!(t::Task, next_task::Task)
-    ok = ccall(:jl_abandon_task, Cint, (Any, Any), t, next_task) != 0
+unsafe_abandon!(t::Task, next_task::Task) =
+    unsafe_abandon!(t, next_task, CancellationRequest(0x4)) # CANCEL_REQUEST_ABANDON_ALL
+
+# The delivery paths settle the request slot from signal context, where
+# `uv_async_send` is the one legal wakeup: a process-global AsyncCondition
+# (created lazily, registered with the runtime, kept open for the process
+# lifetime) makes the requester-side waits event-driven. Spurious wakeups
+# (another thread's abandonment settling) re-check and re-park.
+const _abandon_notify_cond = Ref{Any}(nothing) # Union{Nothing, AsyncCondition}; untyped for bootstrap order
+const _abandon_notify_lock = ReentrantLock()
+function _abandon_notify!()
+    c = _abandon_notify_cond[]
+    c === nothing || return c
+    lock(_abandon_notify_lock; cancel=nothing)
+    try
+        c = _abandon_notify_cond[]
+        if c === nothing
+            c = AsyncCondition()
+            ccall(:jl_set_abandon_notify_handle, Cvoid, (Ptr{Cvoid},), c.handle)
+            _abandon_notify_cond[] = c
+        end
+        return c
+    finally
+        unlock(_abandon_notify_lock)
+    end
+end
+
+function unsafe_abandon!(t::Task, next_task::Task, @nospecialize(result))
+    tid = ccall(:jl_abandon_task_request, Cint, (Any, Any, Any), t, next_task, result)
+    tid < 0 && return false
+    tid = tid % Int16
+    # Acquired (and, first time, created) only after the request is
+    # published with its first signal in flight: the victim may be a
+    # checkless spin blocking GC's stop-the-world, which any allocation
+    # here could otherwise join before the delivery frees it. A settle that
+    # races the condition's registration is repaired by the ticker's ping.
+    cond = _abandon_notify!()
+    # Deliveries coalesce with best-effort cancellation/preemption signals
+    # on the shared per-thread request slot, so a single send can be lost:
+    # periodically re-send - which also re-pings the wakeup condition, so
+    # the wait below never sleeps through a lost settle notification.
+    ticker = Timer(0.01; interval=0.01) do _
+        ccall(:jl_abandon_task_resend, Cvoid, (Int16,), tid)
+        ccall(:jl_abandon_notify_ping, Cvoid, ())
+    end
+    deadline = time_ns() + 2_000_000_000 # 2s: then withdraw rather than hang
+    ok = false
+    try
+        while true
+            verdict = ccall(:jl_abandon_task_poll, Cint, (Int16,), tid)
+            if verdict != 0
+                ok = verdict == 1
+                break
+            end
+            if time_ns() >= deadline &&
+               ccall(:jl_abandon_task_withdraw, Cint, (Int16,), tid) == 1
+                break # fully withdrawn; no abandonment happened
+            end
+            # (a lost withdraw race means a delivery took the request - the
+            # next poll returns its verdict)
+            wait(cond; cancel=nothing)
+        end
+    finally
+        close(ticker)
+    end
     if ok
-        # An abandoned task never goes through the regular task completion
-        # path, so wake up anyone waiting on it. (The waiters observe the
-        # already-stored abandoned state; they do not touch the task's stack.
-        # The root task's donenotify may be `nothing`.)
+        # A forcibly abandoned task never goes through the regular task
+        # completion path, so wake up anyone waiting on it. (The waiters
+        # observe the already-stored abandoned state; they do not touch the
+        # task's stack. The root task's donenotify may be `nothing`.)
         donenotify = t.donenotify
         if donenotify isa ThreadSynchronizer
             lock(donenotify)

--- a/src/gc-mmtk/mmtk_julia/src/scanning.rs
+++ b/src/gc-mmtk/mmtk_julia/src/scanning.rs
@@ -95,6 +95,8 @@ impl Scanning<JuliaVM> for VMScanning {
         root_scan_task(ptls.current_task as *mut _jl_task_t, true);
         root_scan_task(ptls.next_task, true);
         root_scan_task(ptls.previous_task, true);
+        root_scan_task(ptls.abandon_victim, true);
+        root_scan_task(ptls.abandon_to, true);
         if !ptls.previous_exception.is_null() {
             node_buffer.push(unsafe {
                 // unsafe: We have just checked `ptls.previous_exception` is not null.

--- a/src/gc-mmtk/mmtk_julia/src/scanning.rs
+++ b/src/gc-mmtk/mmtk_julia/src/scanning.rs
@@ -97,6 +97,14 @@ impl Scanning<JuliaVM> for VMScanning {
         root_scan_task(ptls.previous_task, true);
         root_scan_task(ptls.abandon_victim, true);
         root_scan_task(ptls.abandon_to, true);
+        if !ptls.abandon_result.is_null() {
+            node_buffer.push(unsafe {
+                // unsafe: We have just checked `ptls.abandon_result` is not null.
+                ObjectReference::from_raw_address_unchecked(Address::from_mut_ptr(
+                    ptls.abandon_result,
+                ))
+            });
+        }
         if !ptls.previous_exception.is_null() {
             node_buffer.push(unsafe {
                 // unsafe: We have just checked `ptls.previous_exception` is not null.

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3034,6 +3034,11 @@ static void gc_queue_thread_local(jl_gc_markqueue_t *mq, jl_ptls_t ptls2) JL_NOT
         gc_try_claim_and_push(mq, task, NULL);
         gc_heap_snapshot_record_root((jl_value_t*)task, "abandon target");
     }
+    jl_value_t *abandon_result = ptls2->abandon_result;
+    if (abandon_result != NULL) {
+        gc_try_claim_and_push(mq, abandon_result, NULL);
+        gc_heap_snapshot_record_root(abandon_result, "abandon result");
+    }
     task = ptls2->previous_task;
     if (task != NULL) {
         gc_try_claim_and_push(mq, task, NULL);

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3024,6 +3024,16 @@ static void gc_queue_thread_local(jl_gc_markqueue_t *mq, jl_ptls_t ptls2) JL_NOT
         gc_try_claim_and_push(mq, task, NULL);
         gc_heap_snapshot_record_root((jl_value_t*)task, "next task");
     }
+    task = ptls2->abandon_victim;
+    if (task != NULL) {
+        gc_try_claim_and_push(mq, task, NULL);
+        gc_heap_snapshot_record_root((jl_value_t*)task, "abandon victim");
+    }
+    task = ptls2->abandon_to;
+    if (task != NULL) {
+        gc_try_claim_and_push(mq, task, NULL);
+        gc_heap_snapshot_record_root((jl_value_t*)task, "abandon target");
+    }
     task = ptls2->previous_task;
     if (task != NULL) {
         gc_try_claim_and_push(mq, task, NULL);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2581,7 +2581,6 @@ JL_DLLEXPORT int jl_set_task_tid(jl_task_t *task, int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_set_task_threadpoolid(jl_task_t *task, int8_t tpid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_send_cancellation_signal(int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_send_preempt_signal(int16_t tid) JL_NOTSAFEPOINT;
-JL_DLLEXPORT int jl_abandon_task(jl_task_t *t, jl_task_t *next_task);
 JL_DLLEXPORT void jl_shootdown_cancelled_tasks(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2559,9 +2559,10 @@ struct _jl_handler_t {
     int8_t gc_state;
 };
 
-#define JL_TASK_STATE_RUNNABLE 0
-#define JL_TASK_STATE_DONE     1
-#define JL_TASK_STATE_FAILED   2
+#define JL_TASK_STATE_RUNNABLE  0
+#define JL_TASK_STATE_DONE      1
+#define JL_TASK_STATE_FAILED    2
+#define JL_TASK_STATE_ABANDONED 3
 
 JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t*, jl_value_t*, size_t) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t nparents) JL_CANSAFEPOINT;
@@ -2580,6 +2581,7 @@ JL_DLLEXPORT int jl_set_task_tid(jl_task_t *task, int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_set_task_threadpoolid(jl_task_t *task, int8_t tpid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_send_cancellation_signal(int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_send_preempt_signal(int16_t tid) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_abandon_task(jl_task_t *t, jl_task_t *next_task);
 JL_DLLEXPORT void jl_shootdown_cancelled_tasks(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1400,7 +1400,7 @@ int jl_safepoint_consume_sigint(void) JL_CANSAFEPOINT;
 void jl_wake_libuv(void) JL_NOTSAFEPOINT;
 void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT;
 int jl_abandon_try_commit(jl_ptls_t ptls) JL_NOTSAFEPOINT;
-void JL_NORETURN jl_abandon_task_cb(void);
+void JL_NORETURN jl_abandon_task_cb(void) JL_CANSAFEPOINT;
 
 void jl_set_pgcstack(jl_gcframe_t **) JL_NOTSAFEPOINT;
 #if defined(_OS_WINDOWS_)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1398,6 +1398,9 @@ void jl_safepoint_defer_sigint(void) JL_NOTSAFEPOINT;
 // to be delivered.
 int jl_safepoint_consume_sigint(void) JL_CANSAFEPOINT;
 void jl_wake_libuv(void) JL_NOTSAFEPOINT;
+void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT;
+int jl_abandon_try_commit(jl_ptls_t ptls) JL_NOTSAFEPOINT;
+void JL_NORETURN jl_abandon_task_cb(void);
 
 void jl_set_pgcstack(jl_gcframe_t **) JL_NOTSAFEPOINT;
 #if defined(_OS_WINDOWS_)

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -251,6 +251,14 @@ typedef struct _jl_tls_states_t {
     struct _jl_bt_element_t *profiling_bt_buffer;
     // Atomically set by the sender, reset by the handler.
     volatile _Atomic(sig_atomic_t) signal_request; // TODO: no actual reason for this to be _Atomic
+    // Fire-and-forget delivery requests, as a bitmask so that concurrent
+    // senders (and the suspend handshake occupying `signal_request`) can
+    // never coalesce a request away: the handler consumes and services
+    // every set bit on each delivery, so a single signal suffices.
+#define JL_SIGNAL_REQ_CANCEL  0x01
+#define JL_SIGNAL_REQ_PREEMPT 0x02
+#define JL_SIGNAL_REQ_ABANDON 0x04
+    _Atomic(uint8_t) signal_request_flags;
     // Allow the sigint to be raised asynchronously
     // this is limited to the few places we do synchronous IO
     // we can make this more general (similar to defer_signal) if necessary

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -235,6 +235,13 @@ typedef struct _jl_tls_states_t {
     // (raw - this slot carries the reference until the requester's
     // write-barrier settle) - never into a still-running task.
     struct _jl_value_t *abandon_result;
+    // Requester's wakeup handle (may be NULL for polling requesters), staged
+    // with the request and pinged by the delivery paths when the request
+    // settles. uv_async_send is async-signal-safe, and its latched
+    // trigger is consumed by exactly one waiter - the slot's single
+    // requester. The handle's lifetime is the requester's problem: it
+    // outlives the request (the slot state machine brackets every ping).
+    uv_async_t *abandon_notify;
     // Set while this thread is inside ctx_switch with the outgoing context
     // only partially saved; abandonment delivery refuses such a thread.
     volatile sig_atomic_t in_task_switch;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -213,6 +213,23 @@ typedef struct _jl_tls_states_t {
     struct _jl_task_t *next_task;
     struct _jl_task_t *previous_task;
     struct _jl_task_t *root_task;
+    // Task-abandonment handshake (see jl_abandon_task in task.c). One
+    // requester at a time owns the slot; delivery validates the victim's
+    // state at the point the thread is actually stopped and commits or
+    // refuses; a timed-out requester withdraws by CAS, arbitrating against
+    // a late delivery. `abandon_victim` and `abandon_to` are GC roots
+    // (thread scan) while the slot is active.
+#define JL_ABANDON_IDLE     0 // slot free
+#define JL_ABANDON_SETUP    1 // requester is writing the request
+#define JL_ABANDON_PENDING  2 // request published, delivery may take it
+#define JL_ABANDON_TAKEN    3 // delivery is validating
+#define JL_ABANDON_DONE     4 // committed; the callback is consuming the slot
+#define JL_ABANDON_REFUSED  5 // victim not abandonable; requester settles
+#define JL_ABANDON_FINISHED 6 // callback consumed the slot; requester settles
+    _Atomic(uint8_t) abandon_state;
+    struct _jl_task_t *abandon_victim;
+    // Target task for task abandonment
+    struct _jl_task_t *abandon_to;
     struct _jl_timing_block_t *timing_stack;
     // This is the location of our copy_stack
     void *stackbase;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -230,6 +230,14 @@ typedef struct _jl_tls_states_t {
     struct _jl_task_t *abandon_victim;
     // Target task for task abandonment
     struct _jl_task_t *abandon_to;
+    // Result value staged for the abandoned task (GC root while the slot is
+    // active): written into the victim's `result` by the delivery callback
+    // (raw - this slot carries the reference until the requester's
+    // write-barrier settle) - never into a still-running task.
+    struct _jl_value_t *abandon_result;
+    // Set while this thread is inside ctx_switch with the outgoing context
+    // only partially saved; abandonment delivery refuses such a thread.
+    volatile sig_atomic_t in_task_switch;
     struct _jl_timing_block_t *timing_stack;
     // This is the location of our copy_stack
     void *stackbase;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -820,6 +820,51 @@ static void jl_try_deliver_sigint(void)
     pthread_mutex_unlock(&ctx_rewrite_lock);
 }
 
+// Switch the target thread's current (already committed) task to
+// ptls->abandon_to (see jl_abandon_task): suspend the thread, validate the
+// pending request against its frozen state, and on commit redirect it into
+// the abandon callback. Holds the rewrite lock like every other
+// suspend-and-rewrite path (see its definition above), and the profile read
+// lock across the liveness re-check and suspension so the thread cannot
+// exit in between.
+void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT
+{
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    if (ptls2 == NULL)
+        return;
+    pthread_mutex_lock(&ctx_rewrite_lock);
+    jl_lock_profile();
+    jl_task_t *ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
+    if (ct2 == NULL) {
+        jl_unlock_profile();
+        pthread_mutex_unlock(&ctx_rewrite_lock);
+        return;
+    }
+    mach_port_t thread = pthread_mach_thread_np(ptls2->system_id);
+    kern_return_t ret = thread_suspend(thread);
+    jl_unlock_profile();
+    if (ret != KERN_SUCCESS) {
+        pthread_mutex_unlock(&ctx_rewrite_lock);
+        return;
+    }
+    // The victim thread is suspended: validate the pending request against
+    // its frozen state and, on commit, redirect it into the abandon
+    // callback (which never returns). On refusal the requester observes the
+    // verdict and withdraws; the current task continues untouched.
+    if (jl_abandon_try_commit(ptls2)) {
+        host_thread_state_t state;
+        unsigned int count = MACH_THREAD_STATE_COUNT;
+        memset(&state, 0, sizeof(state));
+        if (thread_get_state(thread, MACH_THREAD_STATE, (thread_state_t)&state, &count) == KERN_SUCCESS) {
+            jl_noreturn_call_in_state(&state, (void (*)(void))&jl_abandon_task_cb, 0, 0);
+            thread_set_state(thread, MACH_THREAD_STATE, (thread_state_t)&state, count);
+        }
+    }
+    if (thread_resume(thread) != KERN_SUCCESS)
+        jl_safe_printf("error: thread_resume failed in task abandonment\n");
+    pthread_mutex_unlock(&ctx_rewrite_lock);
+}
+
 static void jl_exit_thread0_cb(int signo)
 {
     jl_fprint_critical_error(ios_safe_stderr, signo, 0, NULL, jl_current_task);

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -847,17 +847,25 @@ void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT
         pthread_mutex_unlock(&ctx_rewrite_lock);
         return;
     }
-    // The victim thread is suspended: validate the pending request against
-    // its frozen state and, on commit, redirect it into the abandon
-    // callback (which never returns). On refusal the requester observes the
-    // verdict and withdraws; the current task continues untouched.
-    if (jl_abandon_try_commit(ptls2)) {
-        host_thread_state_t state;
-        unsigned int count = MACH_THREAD_STATE_COUNT;
-        memset(&state, 0, sizeof(state));
-        if (thread_get_state(thread, MACH_THREAD_STATE, (thread_state_t)&state, &count) == KERN_SUCCESS) {
-            jl_noreturn_call_in_state(&state, (void (*)(void))&jl_abandon_task_cb, 0, 0);
-            thread_set_state(thread, MACH_THREAD_STATE, (thread_state_t)&state, count);
+    // The victim thread is suspended: fetch its context *before* deciding
+    // anything, validate the pending request against its frozen state, and
+    // only then redirect it into the abandon callback (which never
+    // returns). A commit is rolled back to a refusal if the redirect
+    // cannot be completed - the callback is what publishes the abandoned
+    // task state, so an unredirected victim resumes untouched. On refusal
+    // the requester observes the verdict and withdraws.
+    host_thread_state_t state;
+    unsigned int count = MACH_THREAD_STATE_COUNT;
+    memset(&state, 0, sizeof(state));
+    if (thread_get_state(thread, MACH_THREAD_STATE, (thread_state_t)&state, &count) != KERN_SUCCESS) {
+        // cannot redirect; leave the request pending for a retry/withdraw
+    }
+    else if (jl_abandon_try_commit(ptls2)) {
+        jl_noreturn_call_in_state(&state, (void (*)(void))&jl_abandon_task_cb, 0, 0);
+        if (thread_set_state(thread, MACH_THREAD_STATE, (thread_state_t)&state, count) != KERN_SUCCESS) {
+            // Roll the commit back: nothing observable was published yet
+            // (the task state is written by the callback).
+            jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_REFUSED);
         }
     }
     if (thread_resume(thread) != KERN_SUCCESS)

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -821,7 +821,7 @@ static void jl_try_deliver_sigint(void)
 }
 
 // Switch the target thread's current (already committed) task to
-// ptls->abandon_to (see jl_abandon_task): suspend the thread, validate the
+// ptls->abandon_to (see jl_abandon_task_request): suspend the thread, validate the
 // pending request against its frozen state, and on commit redirect it into
 // the abandon callback. Holds the rewrite lock like every other
 // suspend-and-rewrite path (see its definition above), and the profile read

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -620,15 +620,11 @@ static int jl_thread_suspend_and_get_state(int tid, int timeout, bt_context_t *c
     }
     signals_inflight++;
     sig_atomic_t request = jl_atomic_exchange(&ptls2->signal_request, 1);
-    // A parked best-effort cancellation (5), preempt (6) or abandon (7)
-    // request may occupy the slot indefinitely - its victim may never
-    // consume it (e.g. a thread with SIGUSR2 blocked) - and all three
-    // senders tolerate a lost delivery (level-triggered recovery, a polled
-    // request byte, and a resend-until-settled loop respectively), so the
-    // suspend handshake may displace them. The handshake states 1-4/-1
-    // cannot appear here: those settle under in_signal_lock, which we hold.
-    assert(request == 0 || request == -1 || request == 5 || request == 6 ||
-           request == 7);
+    // The slot carries only suspend-handshake states: fire-and-forget
+    // requests (cancel/preempt/abandon) travel in the signal_request_flags
+    // bitmask and cannot occupy it. The handshake states 1-4 settle under
+    // in_signal_lock, which we hold, so only idle/processing can appear.
+    assert(request == 0 || request == -1);
     request = 1;
     err = pthread_kill(ptls2->system_id, SIGUSR2);
     if (err == 0) {
@@ -679,7 +675,8 @@ void jl_thread_resume(int tid)
 // available: longjmp to a compiled reset point (see usr2_handler request 5).
 static void jl_send_reset_signal(int16_t tid, int reset_code) JL_NOTSAFEPOINT
 {
-    sig_atomic_t request = reset_code == JL_RESET_CODE_PREEMPT ? 6 : 5;
+    uint8_t bit = reset_code == JL_RESET_CODE_PREEMPT ? JL_SIGNAL_REQ_PREEMPT
+                                                      : JL_SIGNAL_REQ_CANCEL;
     if (tid < 0 || tid >= jl_atomic_load_acquire(&jl_n_threads))
         return;
     jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
@@ -705,13 +702,11 @@ static void jl_send_reset_signal(int16_t tid, int reset_code) JL_NOTSAFEPOINT
         return;
     }
     // This request is best-effort and produces no acknowledgment token (see
-    // the handler): do not count it in signals_inflight, and never clobber a
-    // request that is already pending or being processed - blindly storing
-    // over an in-flight suspend handshake would lose it; our caller retries
-    // delivery anyway.
-    sig_atomic_t expected = 0;
-    if (jl_atomic_cmpswap(&ptls2->signal_request, &expected, request))
-        pthread_kill(ptls2->system_id, SIGUSR2);
+    // the handler): do not count it in signals_inflight. The request bit
+    // cannot be coalesced away - the handler consumes the whole mask on
+    // every delivery, whichever request the signal was sent for.
+    jl_atomic_fetch_or(&ptls2->signal_request_flags, bit);
+    pthread_kill(ptls2->system_id, SIGUSR2);
     pthread_mutex_unlock(&in_signal_lock);
 }
 
@@ -719,23 +714,19 @@ static void jl_send_reset_signal(int16_t tid, int reset_code) JL_NOTSAFEPOINT
 
 // Send a signal to the specified thread to abandon the current task.
 // The target task to switch to must already be published in
-// ptls2->abandon_to (state JL_ABANDON_PENDING; see jl_abandon_task).
+// ptls2->abandon_to (state JL_ABANDON_PENDING; see jl_abandon_task_request).
 void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT
 {
     jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
     if (ptls2 == NULL)
         return;
     pthread_mutex_lock(&in_signal_lock);
-    // Like the cancellation sender, this produces no acknowledgment token.
-    // Abandonment overrides a pending best-effort cancellation (5) or
-    // preempt (6) signal, but must not disturb a suspend handshake in
-    // progress (requests 1-4 / processing) - jl_abandon_task re-sends until
-    // the request settles.
-    sig_atomic_t expected = 0;
-    if (jl_atomic_cmpswap(&ptls2->signal_request, &expected, 7) ||
-        ((expected == 5 || expected == 6) &&
-         jl_atomic_cmpswap(&ptls2->signal_request, &expected, 7)))
-        pthread_kill(ptls2->system_id, SIGUSR2);
+    // Like the cancellation sender, this produces no acknowledgment token;
+    // the request bit cannot be coalesced away (see jl_send_reset_signal).
+    // The requester's verdict is the abandon slot's own settle - a single
+    // delivery either commits or refuses there.
+    jl_atomic_fetch_or(&ptls2->signal_request_flags, JL_SIGNAL_REQ_ABANDON);
+    pthread_kill(ptls2->system_id, SIGUSR2);
     pthread_mutex_unlock(&in_signal_lock);
 }
 
@@ -800,71 +791,12 @@ static void jl_exit_thread0(int signo, jl_bt_element_t *bt_data, size_t bt_size)
 //     JL_RESET_CODE_PREEMPT setjmp return and yields cooperatively. Never
 //     delivered while a handler context is published: its span (e.g. a
 //     protected allocator) must not be unwound for a mere yield request.
-void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
+// Deliver pending cancel/preempt requests (the fire-and-forget bits of
+// signal_request_flags) to the current task's published asynchronously
+// interruptible regions, if any.
+static void usr2_deliver_reset(jl_task_t *ct, jl_ptls_t ptls, uint8_t reqflags,
+                               int sig, void *ctx)
 {
-    jl_task_t *ct = jl_get_current_task();
-    if (ct == NULL)
-        return;
-    jl_ptls_t ptls = ct->ptls;
-    if (ptls == NULL)
-        return;
-    int errno_save = errno;
-    sig_atomic_t request = jl_atomic_load(&ptls->signal_request);
-    if (request == 0)
-        return;
-    if (!jl_atomic_cmpswap(&ptls->signal_request, &request, -1))
-        return;
-    if (request == 1) {
-        usr2_signal_context = jl_to_bt_context(ctx);
-        // acknowledge that we saw the signal_request and set usr2_signal_context
-        int err;
-        eventfd_t got = 1;
-        err = write(signal_caught_cond, &got, sizeof(eventfd_t));
-        if (err != sizeof(eventfd_t)) abort();
-        sig_atomic_t processing = -1;
-        jl_atomic_cmpswap(&ptls->signal_request, &processing, 0);
-        // wait for exit signal
-        do {
-            err = read(exit_signal_cond, &got, sizeof(eventfd_t));
-        } while (err == -1 && errno == EINTR);
-        if (err != sizeof(eventfd_t)) abort();
-        assert(got == 1);
-        request = jl_atomic_exchange(&ptls->signal_request, -1);
-        usr2_signal_context = NULL;
-        assert(request == 2 || request == 3 || request == 4);
-    }
-    if (request != 5 && request != 6 && request != 7) {
-        // Acknowledge the request to its synchronously waiting sender. The
-        // cancellation, preempt and abandon senders (requests 5-7) are
-        // fire-and-forget and never consume the token; writing it would
-        // poison the next suspend handshake with a stale acknowledgment.
-        int err;
-        eventfd_t got = 1;
-        err = write(signal_caught_cond, &got, sizeof(eventfd_t));
-        if (err != sizeof(eventfd_t)) abort();
-    }
-    sig_atomic_t processing = -1;
-    jl_atomic_cmpswap(&ptls->signal_request, &processing, 0);
-    if (request == 2) {
-        int force = jl_check_force_sigint();
-        jl_jmp_buf *saferestore = jl_get_safe_restore();
-        int can_throw = saferestore != NULL || ct->eh != NULL;
-        if (can_throw && (force || (!ptls->defer_signal && ptls->io_wait))) {
-            jl_safepoint_consume_sigint();
-            if (force)
-                jl_safe_printf("WARNING: Force throwing a SIGINT\n");
-            // Force a throw
-            jl_clear_force_sigint();
-            if (saferestore) // restarting jl_ or profile
-                jl_longjmp_in_ctx(sig, ctx, *saferestore, 1);
-            else
-                jl_throw_in_ctx(ct, jl_interrupt_exception, sig, ctx);
-        }
-    }
-    else if (request == 3) {
-        jl_call_in_ctx(ct->ptls, jl_exit_thread0_cb, sig, ctx);
-    }
-    else if (request == 5 || request == 6) {
         // Deliver a pending cancellation (5) or preempt (6) shootdown to
         // the published context(s) of the current task's asynchronously
         // interruptible regions, if any. N.B.: these are only ever consumed
@@ -915,10 +847,14 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
             // a foreign call reached through a reset-safe callee) may be
             // raced by a concurrent stop-the-world, and a longjmp back into
             // Julia code would break that protocol.
-            int reset_code = request == 6 ? JL_RESET_CODE_PREEMPT : JL_RESET_CODE_CANCEL;
+            // A deliverable cancellation takes precedence over a
+            // coincident preemption (the preempt request byte stays set and
+            // is consumed at the reset point's own check).
+            int reset_code = (reqflags & JL_SIGNAL_REQ_CANCEL) && bound_cancelled ?
+                JL_RESET_CODE_CANCEL : JL_RESET_CODE_PREEMPT;
             jl_reset_ctx_t *reset_ctx = jl_atomic_load_acquire(&ct->reset_ctx);
             if (reset_ctx != NULL && reset_ctx->sp != 0 &&
-                (request == 6 || bound_cancelled) &&
+                ((reqflags & JL_SIGNAL_REQ_PREEMPT) || bound_cancelled) &&
                 jl_atomic_load_relaxed(&ptls->gc_state) == JL_GC_STATE_UNSAFE) {
                 // Abandon the interrupted register state and longjmp to the
                 // reset point, whose re-executed check observes the
@@ -939,16 +875,95 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
             }
         }
     }
-    else if (request == 7) {
+
+void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
+{
+    jl_task_t *ct = jl_get_current_task();
+    if (ct == NULL)
+        return;
+    jl_ptls_t ptls = ct->ptls;
+    if (ptls == NULL)
+        return;
+    int errno_save = errno;
+    // Fire-and-forget requests (cancel/preempt/abandon) travel as bits and
+    // are consumed wholesale, first: any of the value-slot paths below may
+    // never return (a forced throw, an exit callback), and with the bits
+    // consumed here no request can be stranded without a signal to carry
+    // it. An abandonment commit does not return; the cancel/preempt bits
+    // die with the abandoned task, which is their level-triggered
+    // delivery semantics anyway.
+    uint8_t reqflags = jl_atomic_exchange(&ptls->signal_request_flags, 0);
+    if (reqflags & JL_SIGNAL_REQ_ABANDON) {
         // Task abandonment: validate the pending request against this
         // thread's actual state (we ARE the victim thread, stopped in this
         // handler, so nothing can change under the check) and, on commit,
         // redirect into the abandon callback (which must not return) to
         // switch to ptls->abandon_to. On refusal the requester observes the
         // verdict and withdraws; the current task continues untouched.
-        if (jl_abandon_try_commit(ct->ptls)) {
-            jl_call_in_ctx(ct->ptls, jl_abandon_task_cb, sig, ctx);
+        if (jl_abandon_try_commit(ptls)) {
+            jl_call_in_ctx(ptls, jl_abandon_task_cb, sig, ctx);
         }
+    }
+    if (reqflags & (JL_SIGNAL_REQ_CANCEL | JL_SIGNAL_REQ_PREEMPT)) {
+        usr2_deliver_reset(ct, ptls, reqflags, sig, ctx);
+    }
+    sig_atomic_t request = jl_atomic_load(&ptls->signal_request);
+    if (request == 0) {
+        errno = errno_save;
+        return;
+    }
+    if (!jl_atomic_cmpswap(&ptls->signal_request, &request, -1)) {
+        errno = errno_save;
+        return;
+    }
+    if (request == 1) {
+        usr2_signal_context = jl_to_bt_context(ctx);
+        // acknowledge that we saw the signal_request and set usr2_signal_context
+        int err;
+        eventfd_t got = 1;
+        err = write(signal_caught_cond, &got, sizeof(eventfd_t));
+        if (err != sizeof(eventfd_t)) abort();
+        sig_atomic_t processing = -1;
+        jl_atomic_cmpswap(&ptls->signal_request, &processing, 0);
+        // wait for exit signal
+        do {
+            err = read(exit_signal_cond, &got, sizeof(eventfd_t));
+        } while (err == -1 && errno == EINTR);
+        if (err != sizeof(eventfd_t)) abort();
+        assert(got == 1);
+        request = jl_atomic_exchange(&ptls->signal_request, -1);
+        usr2_signal_context = NULL;
+        assert(request == 2 || request == 3 || request == 4);
+    }
+    {
+        // Acknowledge the request to its synchronously waiting sender (the
+        // slot carries only the suspend handshake now; fire-and-forget
+        // requests travel in the flags bitmask consumed above).
+        int err;
+        eventfd_t got = 1;
+        err = write(signal_caught_cond, &got, sizeof(eventfd_t));
+        if (err != sizeof(eventfd_t)) abort();
+    }
+    sig_atomic_t processing = -1;
+    jl_atomic_cmpswap(&ptls->signal_request, &processing, 0);
+    if (request == 2) {
+        int force = jl_check_force_sigint();
+        jl_jmp_buf *saferestore = jl_get_safe_restore();
+        int can_throw = saferestore != NULL || ct->eh != NULL;
+        if (can_throw && (force || (!ptls->defer_signal && ptls->io_wait))) {
+            jl_safepoint_consume_sigint();
+            if (force)
+                jl_safe_printf("WARNING: Force throwing a SIGINT\n");
+            // Force a throw
+            jl_clear_force_sigint();
+            if (saferestore) // restarting jl_ or profile
+                jl_longjmp_in_ctx(sig, ctx, *saferestore, 1);
+            else
+                jl_throw_in_ctx(ct, jl_interrupt_exception, sig, ctx);
+        }
+    }
+    else if (request == 3) {
+        jl_call_in_ctx(ct->ptls, jl_exit_thread0_cb, sig, ctx);
     }
     errno = errno_save;
 }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -620,13 +620,15 @@ static int jl_thread_suspend_and_get_state(int tid, int timeout, bt_context_t *c
     }
     signals_inflight++;
     sig_atomic_t request = jl_atomic_exchange(&ptls2->signal_request, 1);
-    // A parked best-effort cancellation request (5) may occupy the slot
-    // indefinitely - its victim may never consume it (e.g. a thread with
-    // SIGUSR2 blocked) - and its sender tolerates a lost delivery (recovery
-    // is level-triggered at the task's next cancellation point), so the
-    // suspend handshake may displace it. The handshake states 1-4/-1 cannot
-    // appear here: those settle under in_signal_lock, which we hold.
-    assert(request == 0 || request == -1 || request == 5 || request == 6);
+    // A parked best-effort cancellation (5), preempt (6) or abandon (7)
+    // request may occupy the slot indefinitely - its victim may never
+    // consume it (e.g. a thread with SIGUSR2 blocked) - and all three
+    // senders tolerate a lost delivery (level-triggered recovery, a polled
+    // request byte, and a resend-until-settled loop respectively), so the
+    // suspend handshake may displace them. The handshake states 1-4/-1
+    // cannot appear here: those settle under in_signal_lock, which we hold.
+    assert(request == 0 || request == -1 || request == 5 || request == 6 ||
+           request == 7);
     request = 1;
     err = pthread_kill(ptls2->system_id, SIGUSR2);
     if (err == 0) {
@@ -714,6 +716,28 @@ static void jl_send_reset_signal(int16_t tid, int reset_code) JL_NOTSAFEPOINT
 }
 
 
+
+// Send a signal to the specified thread to abandon the current task.
+// The target task to switch to must already be published in
+// ptls2->abandon_to (state JL_ABANDON_PENDING; see jl_abandon_task).
+void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT
+{
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    if (ptls2 == NULL)
+        return;
+    pthread_mutex_lock(&in_signal_lock);
+    // Like the cancellation sender, this produces no acknowledgment token.
+    // Abandonment overrides a pending best-effort cancellation (5) or
+    // preempt (6) signal, but must not disturb a suspend handshake in
+    // progress (requests 1-4 / processing) - jl_abandon_task re-sends until
+    // the request settles.
+    sig_atomic_t expected = 0;
+    if (jl_atomic_cmpswap(&ptls2->signal_request, &expected, 7) ||
+        ((expected == 5 || expected == 6) &&
+         jl_atomic_cmpswap(&ptls2->signal_request, &expected, 7)))
+        pthread_kill(ptls2->system_id, SIGUSR2);
+    pthread_mutex_unlock(&in_signal_lock);
+}
 
 // Throw jl_interrupt_exception if the master thread is in a signal async region
 // or if SIGINT happens too often.
@@ -809,11 +833,11 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
         usr2_signal_context = NULL;
         assert(request == 2 || request == 3 || request == 4);
     }
-    if (request != 5 && request != 6) {
+    if (request != 5 && request != 6 && request != 7) {
         // Acknowledge the request to its synchronously waiting sender. The
-        // cancellation sender (request 5) is fire-and-forget and never
-        // consumes the token; writing it would poison the next suspend
-        // handshake with a stale acknowledgment.
+        // cancellation, preempt and abandon senders (requests 5-7) are
+        // fire-and-forget and never consume the token; writing it would
+        // poison the next suspend handshake with a stale acknowledgment.
         int err;
         eventfd_t got = 1;
         err = write(signal_caught_cond, &got, sizeof(eventfd_t));
@@ -913,6 +937,17 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
                 asan_unpoison_task_stack(ct, &reset_ctx->mctx);
                 jl_longjmp_in_ctx(sig, ctx, reset_ctx->mctx, reset_code);
             }
+        }
+    }
+    else if (request == 7) {
+        // Task abandonment: validate the pending request against this
+        // thread's actual state (we ARE the victim thread, stopped in this
+        // handler, so nothing can change under the check) and, on commit,
+        // redirect into the abandon callback (which must not return) to
+        // switch to ptls->abandon_to. On refusal the requester observes the
+        // verdict and withdraws; the current task continues untouched.
+        if (jl_abandon_try_commit(ct->ptls)) {
+            jl_call_in_ctx(ct->ptls, jl_abandon_task_cb, sig, ctx);
         }
     }
     errno = errno_save;

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -513,7 +513,7 @@ static void jl_try_deliver_sigint(void)
 }
 
 // Switch the target thread's current (already committed) task to
-// ptls->abandon_to (see jl_abandon_task): freeze the thread, validate the
+// ptls->abandon_to (see jl_abandon_task_request): freeze the thread, validate the
 // pending request against its frozen state, and on commit redirect it into
 // the abandon callback (which never returns). Holds the rewrite lock like
 // every other suspend-and-rewrite path; the profile read lock covers the

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -533,9 +533,11 @@ void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT
         return;
     }
     // The victim thread is frozen: validate the pending request against its
-    // state and, on commit, redirect it into the abandon callback. On
-    // refusal the requester observes the verdict and withdraws; the current
-    // task continues untouched.
+    // state and, on commit, redirect it into the abandon callback. A commit
+    // is rolled back to a refusal if the redirect cannot be completed - the
+    // callback is what publishes the abandoned task state, so an
+    // unredirected victim resumes untouched. On refusal the requester
+    // observes the verdict and withdraws.
     if (jl_abandon_try_commit(ptls2)) {
         // Redirect the thread to call jl_abandon_task_cb (which never
         // returns) on a minimal fake frame.
@@ -555,7 +557,11 @@ void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT
         ctxThread.Eip = (DWORD)&jl_abandon_task_cb;
 #endif
         ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
-        SetThreadContext(ptls2->system_id, &ctxThread);
+        if (!SetThreadContext(ptls2->system_id, &ctxThread)) {
+            // Roll the commit back: nothing observable was published yet
+            // (the task state is written by the callback).
+            jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_REFUSED);
+        }
     }
     jl_thread_resume(tid);
     ReleaseSRWLockExclusive(&ctx_rewrite_lock);

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -512,6 +512,55 @@ static void jl_try_deliver_sigint(void)
     ReleaseSRWLockExclusive(&ctx_rewrite_lock);
 }
 
+// Switch the target thread's current (already committed) task to
+// ptls->abandon_to (see jl_abandon_task): freeze the thread, validate the
+// pending request against its frozen state, and on commit redirect it into
+// the abandon callback (which never returns). Holds the rewrite lock like
+// every other suspend-and-rewrite path; the profile read lock covers the
+// suspension itself (see jl_send_reset_signal above).
+void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT
+{
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    if (ptls2 == NULL)
+        return;
+    AcquireSRWLockExclusive(&ctx_rewrite_lock);
+    CONTEXT ctxThread;
+    jl_lock_profile();
+    int suspended = jl_thread_suspend_and_get_state(tid, 0, &ctxThread);
+    jl_unlock_profile();
+    if (!suspended) {
+        ReleaseSRWLockExclusive(&ctx_rewrite_lock);
+        return;
+    }
+    // The victim thread is frozen: validate the pending request against its
+    // state and, on commit, redirect it into the abandon callback. On
+    // refusal the requester observes the verdict and withdraws; the current
+    // task continues untouched.
+    if (jl_abandon_try_commit(ptls2)) {
+        // Redirect the thread to call jl_abandon_task_cb (which never
+        // returns) on a minimal fake frame.
+#if defined(_CPU_X86_64_)
+        uintptr_t sp = (uintptr_t)ctxThread.Rsp;
+        sp = (sp - 256) & ~(uintptr_t)15; // skip resume data, realign
+        sp -= sizeof(uintptr_t); // fake return address slot
+        *(uintptr_t*)sp = 0;
+        ctxThread.Rsp = (DWORD64)sp;
+        ctxThread.Rip = (DWORD64)&jl_abandon_task_cb;
+#elif defined(_CPU_X86_)
+        uintptr_t sp = (uintptr_t)ctxThread.Esp;
+        sp = (sp - 64) & ~(uintptr_t)15;
+        sp -= sizeof(uintptr_t); // fake return address slot
+        *(uintptr_t*)sp = 0;
+        ctxThread.Esp = (DWORD)sp;
+        ctxThread.Eip = (DWORD)&jl_abandon_task_cb;
+#endif
+        ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+        SetThreadContext(ptls2->system_id, &ctxThread);
+    }
+    jl_thread_resume(tid);
+    ReleaseSRWLockExclusive(&ctx_rewrite_lock);
+}
+
 static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guarantee __stdcall
 {
     int sig;

--- a/src/task.c
+++ b/src/task.c
@@ -1691,7 +1691,10 @@ static void abandon_notify(jl_ptls_t ptls2) JL_NOTSAFEPOINT
 
 // Callback for task abandonment - the delivery redirects the victim thread
 // here (via jl_call_in_ctx / a rewritten thread context). Must not return.
-JL_NORETURN void jl_abandon_task_cb(void)
+// JL_CANSAFEPOINT: like the other context-entry callbacks, the victim
+// thread enters here in managed compute (gc_state == 0 is in the commit's
+// refusal set), holding the gc-unsafe region.
+JL_NORETURN void jl_abandon_task_cb(void) JL_CANSAFEPOINT
 {
     jl_task_t *ct = jl_current_task;
     jl_ptls_t ptls = ct->ptls;

--- a/src/task.c
+++ b/src/task.c
@@ -424,6 +424,10 @@ const char tsan_state_corruption[] = "TSAN state corrupted. Exiting HARD!\n";
 JL_NO_ASAN static void ctx_switch(jl_task_t *lastt) JL_CANSAFEPOINT
 {
     jl_ptls_t ptls = lastt->ptls;
+    // Abandonment delivery must refuse a thread whose outgoing context is
+    // only partially saved; cleared at every resumption point (the
+    // setjmp return, the common tail, and start_task for fresh tasks).
+    ptls->in_task_switch = 1;
     jl_task_t **pt = &ptls->next_task;
     jl_task_t *t = *pt;
     assert(t != lastt);
@@ -484,6 +488,7 @@ JL_NO_ASAN static void ctx_switch(jl_task_t *lastt) JL_CANSAFEPOINT
 #ifdef MIGRATE_TASKS
                 ptls = lastt->ptls;
 #endif
+                ptls->in_task_switch = 0;
                 lastt->ctx.copy_ctx = NULL;
                 sanitizer_finish_switch_fiber(&ptls->previous_task->ctx, &lastt->ctx);
                 return;
@@ -655,6 +660,7 @@ JL_NO_ASAN static void ctx_switch(jl_task_t *lastt) JL_CANSAFEPOINT
 #endif
     assert(ptls);
     assert(lastt == jl_atomic_load_relaxed(&ptls->current_task));
+    ptls->in_task_switch = 0;
     lastt->ctx.ctx = NULL;
     sanitizer_finish_switch_fiber(&ptls->previous_task->ctx, &lastt->ctx);
 }
@@ -1221,6 +1227,7 @@ CFI_NORETURN
 #endif
     ct->ctx.ctx = NULL;
     jl_ptls_t ptls = ct->ptls;
+    ptls->in_task_switch = 0;
     jl_value_t *res;
     assert(ptls->finalizers_inhibited == 0);
 
@@ -1670,63 +1677,98 @@ JL_DLLEXPORT int8_t jl_get_task_threadpoolid(jl_task_t *t)
 }
 
 
-// Callback for task abandonment - called via jl_call_in_ctx from signal handler.
-// This function must not return.
+// Global wakeup for abandonment completion: the delivery paths settle the
+// request slot from signal context (or with the victim thread suspended),
+// where uv_async_send is the one legal wakeup. Julia installs an
+// AsyncCondition handle here so requester-side waits can be event-driven.
+static _Atomic(uv_async_t*) abandon_notify_handle = NULL;
+
+JL_DLLEXPORT void jl_set_abandon_notify_handle(uv_async_t *handle) JL_NOTSAFEPOINT
+{
+    jl_atomic_store_release(&abandon_notify_handle, handle);
+}
+
+static void abandon_notify(void) JL_NOTSAFEPOINT
+{
+    uv_async_t *h = jl_atomic_load_acquire(&abandon_notify_handle);
+    if (h != NULL)
+        uv_async_send(h);
+}
+
+JL_DLLEXPORT void jl_abandon_notify_ping(void) JL_NOTSAFEPOINT
+{
+    abandon_notify();
+}
+
+// Callback for task abandonment - the delivery redirects the victim thread
+// here (via jl_call_in_ctx / a rewritten thread context). Must not return.
 JL_NORETURN void jl_abandon_task_cb(void)
 {
     jl_task_t *ct = jl_current_task;
     jl_ptls_t ptls = ct->ptls;
     jl_task_t *next_task = ptls->abandon_to;
 
-    // Consume the request. The slot stays claimed (FINISHED, not IDLE)
-    // until the requester acknowledges: DONE is transient - this callback
-    // runs within microseconds of the commit - so the requester's verdict
-    // must be a state only it retires, or it would misread the settled
-    // slot as a refusal.
-    ptls->abandon_to = NULL;
-    ptls->abandon_victim = NULL;
-    jl_atomic_store_release(&ptls->abandon_state, JL_ABANDON_FINISHED);
+    // The delivery only redirects here for a committed request with a
+    // target set; there is no return path out of this (fake) frame.
+    if (next_task == NULL)
+        abort();
+
+    // The staged result becomes the abandoned task's (exceptional) outcome.
+    // Raw store: the write barrier is not async-signal-safe - the ptls
+    // staging slot keeps the value rooted until the requester settles the
+    // verdict and issues the barrier (jl_abandon_task_poll) - and unlike
+    // the refused case, the abandoned task can never run again to observe
+    // the write.
+    ct->result = ptls->abandon_result;
+    // An exception retained from the victim's active catch would otherwise
+    // shadow the abandonment result when the failure is displayed.
+    ct->excstack = NULL;
+    jl_atomic_store_relaxed(&ct->_isexception, 1);
+    // The observable task state is published here - with the result already
+    // in place - not at commit: a failed context redirect (mach, windows)
+    // can then roll the commit back with nothing published, and a poller
+    // that sees `:abandoned` never reads a half-staged outcome.
+    jl_atomic_store_release(&ct->_state, JL_TASK_STATE_ABANDONED);
 
     // A cancellation-handler delivery in flight on this thread dies with the
     // abandoned task; disarm so future deliveries are not blocked.
     ptls->cancel_handler_armed = 0;
 
-    // The handler only invokes us for a still-current abandoned task with a
-    // target set; we cannot return from here (the fake signal frame has no
-    // return path).
-    if (next_task == NULL)
-        abort();
+    // Ordinary switch-exit bookkeeping that the redirect bypassed: the
+    // timing block on the discarded stack must be exited before that stack
+    // is released for reuse by ctx_switch below.
+    (void)jl_timing_block_task_exit(ct, ptls);
 
-    // The task state was already set to ABANDONED by the caller of jl_abandon_task.
-    // We don't attempt to notify waiters here because:
-    // 1. We're in a signal-handler-triggered context with limited safe operations
-    // 2. The donenotify lock might already be held (would cause deadlock)
-    // 3. Waiters will see the state change when they poll istaskdone()
-    // The caller of jl_abandon_task is responsible for waking up any waiters
-    // after the abandon signal has been processed.
-
-    // The root task's stack is the system stack, not a pooled buffer - it must
-    // not be released into the task-stack pool for reuse by ctx_switch below.
+    // The root task's stack is the system stack, not a pooled buffer - it
+    // must not be released into the task-stack pool by ctx_switch below.
     if (ct == ptls->root_task) {
         ct->ctx.stkbuf = NULL;
         ct->ctx.bufsz = 0;
     }
 
-    // Set the next task's thread ID to this thread before switching.
-    // This is normally done by jl_switch but we're bypassing that.
-    int16_t tid = jl_atomic_load_relaxed(&ct->tid);
-    jl_set_task_tid(next_task, tid);
+    // The target's thread affinity was claimed by the requester
+    // (jl_abandon_task_request) - which is also the validation that it is
+    // not running anywhere else.
+    assert(jl_atomic_load_relaxed(&next_task->tid) ==
+           jl_atomic_load_relaxed(&ct->tid));
 
-    // Set up the next task and switch to it
+    // Install the target as this thread's next task *before* releasing the
+    // `abandon_to` staging slot: both are GC roots, and the requester may
+    // drop its own reference to the rescue task the moment it observes
+    // FINISHED. `abandon_victim` and `abandon_result` stay staged - rooting
+    // the raw-stored result - until the requester's settle.
     ptls->next_task = next_task;
+    ptls->abandon_to = NULL;
+    jl_atomic_store_release(&ptls->abandon_state, JL_ABANDON_FINISHED);
+    abandon_notify();
 
     // Clear state that might cause issues during switch
     ptls->in_finalizer = 0;
     ptls->in_pure_callback = 0;
 
-    // Call ctx_switch directly - the task state is already set to abandoned
-    // so ctx_switch will treat it as killed and do proper cleanup
-    // (release stack, clear gcstack and eh pointers).
+    // The task state is already ABANDONED, so ctx_switch treats the victim
+    // as killed and performs the teardown (release the stack, clear gcstack
+    // and eh).
     JL_PROBE_RT_PAUSE_TASK(ct);
     ctx_switch(ct);
 
@@ -1738,11 +1780,11 @@ JL_NORETURN void jl_abandon_task_cb(void)
 // `ptls2`'s current task. The victim thread must be quiescent: this runs
 // either in its signal handler (unix) or while it is suspended (mach,
 // windows), so the state inspected here cannot change under us - unlike a
-// pre-check on the requester's thread. On commit the task is marked
-// abandoned and 1 is returned; the caller then redirects the thread into
-// jl_abandon_task_cb, which consumes `abandon_to` and settles the slot. On
-// refusal (or no pending request) 0 is returned and the requester settles.
-// Async-signal-safe: loads, stores and CAS only.
+// pre-check on the requester's thread. On commit the request slot moves to
+// DONE and 1 is returned; the caller then redirects the thread into
+// jl_abandon_task_cb, which publishes the task state and settles the slot.
+// On refusal (or no pending request) 0 is returned; the requester observes
+// REFUSED and settles. Async-signal-safe: loads, stores and CAS only.
 int jl_abandon_try_commit(jl_ptls_t ptls2) JL_NOTSAFEPOINT
 {
     uint8_t st = JL_ABANDON_PENDING;
@@ -1754,6 +1796,11 @@ int jl_abandon_try_commit(jl_ptls_t ptls2) JL_NOTSAFEPOINT
     // context would corrupt *runtime* state. Leaking user resources is the
     // documented cost of an unsafe abandon; leaking runtime state is not:
     //  - the thread already switched away (the request outlived its target);
+    //  - the thread is not in managed compute (gc_state != 0): a GC-safe
+    //    region is a foreign call or scheduler wait whose C frame owns
+    //    runtime interactions, and may be mid stop-the-world handshake;
+    //  - the thread is inside ctx_switch with the outgoing context only
+    //    partially saved;
     //  - runtime (jl_mutex_t) locks are held - including the uv loop lock,
     //    whose owner is checked explicitly since takeover paths acquire it
     //    through trylock variants;
@@ -1768,6 +1815,8 @@ int jl_abandon_try_commit(jl_ptls_t ptls2) JL_NOTSAFEPOINT
     //    and running count, so the rescue task would re-enter the
     //    scheduler with sleep bookkeeping still claimed by the victim.
     if (ct != t ||
+        jl_atomic_load_relaxed(&ptls2->gc_state) != 0 ||
+        ptls2->in_task_switch ||
         ptls2->locks.len != 0 ||
         ptls2->in_finalizer ||
         ptls2->finalizers_inhibited != 0 ||
@@ -1775,101 +1824,147 @@ int jl_abandon_try_commit(jl_ptls_t ptls2) JL_NOTSAFEPOINT
         jl_atomic_load_relaxed(&ptls2->sleep_check_state) != 0 || // 0 == not_sleeping
         jl_atomic_load_relaxed(&jl_uv_mutex.owner) == ct) {
         jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_REFUSED);
+        abandon_notify();
         return 0;
     }
-    // Commit. The result was pre-staged by the requester (the write barrier
-    // is not async-signal-safe); the exception flag and state are set here,
-    // with the victim stopped, which is what makes `:abandoned` mean "will
-    // never run another instruction".
-    jl_atomic_store_relaxed(&t->_isexception, 1);
-    jl_atomic_store_release(&t->_state, JL_TASK_STATE_ABANDONED);
+    // Commit: only the request slot here - the victim's observable task
+    // state is written by the callback (see jl_abandon_task_cb).
     jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_DONE);
     return 1;
 }
 
-// Forcibly switch the thread running `t` from `t` to `next_task`,
-// discarding `t`'s execution (CANCEL_REQUEST_ABANDON_ALL's last resort for
-// code that cannot reach a cancellation point). Returns 1 if the
-// abandonment committed. Returns 0 - with every published effect withdrawn
-// and `t` untouched and still running - when the victim was not (or no
-// longer) current on its thread, was found holding runtime state that must
-// not be discarded (see jl_abandon_try_commit), an abandonment was already
-// in flight for that thread, or delivery could not be completed in time.
-JL_DLLEXPORT int jl_abandon_task(jl_task_t *t, jl_task_t *next_task)
+// Publish an abandonment request for `t` (which must be current on some
+// thread), redirecting its thread to `next_task` and staging `result`
+// (NULL: the interned ABANDON_ALL severity byte) as the abandoned task's
+// outcome, then send one delivery signal. Returns the victim's thread id
+// on publication; -1 when no request could be published: the victim is not
+// current on a thread, the target is the victim itself or already bound to
+// a thread, or another abandonment is in flight for the victim's thread.
+// The caller owns the published request and must drive it to a verdict
+// with jl_abandon_task_poll, re-sending via jl_abandon_task_resend while
+// pending (deliveries coalesce with best-effort cancellation/preemption
+// signals on the shared per-thread slot, so a single send can be lost) and
+// optionally withdrawing via jl_abandon_task_withdraw.
+JL_DLLEXPORT int jl_abandon_task_request(jl_task_t *t, jl_task_t *next_task,
+                                         jl_value_t *result)
 {
+    if (t == next_task)
+        return -1;
     int16_t tid = jl_atomic_load_relaxed(&t->tid);
     if (tid < 0)
-        return 0; // Task not assigned to a thread
+        return -1; // task not assigned to a thread
     jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
     if (ptls2 == NULL)
-        return 0;
+        return -1;
     if (jl_atomic_load_relaxed(&ptls2->current_task) != t)
-        return 0; // Task is not currently running
+        return -1; // task is not currently running
     // Claim the request slot.
     uint8_t st = JL_ABANDON_IDLE;
     if (!jl_atomic_cmpswap(&ptls2->abandon_state, &st, JL_ABANDON_SETUP))
-        return 0; // another abandonment is in flight for this thread
-    // Pre-stage the abandonment as the task's result (off the delivery
-    // path: jl_gc_wb is not async-signal-safe). Julia-side callers set a
-    // proper CancellationRequest beforehand; the C direct-abandon path
-    // falls back to the interned severity byte. Stale on refusal is
-    // benign: normal completion overwrites result and _isexception.
-    if (t->result == jl_nothing || t->result == NULL) {
-        jl_value_t *creq = jl_box_uint8(0x4); // CANCEL_REQUEST_ABANDON_ALL
-        t->result = creq;
-        jl_gc_wb(t, creq);
+        return -1; // another abandonment is in flight for this thread
+    // Claim the target's thread affinity up front: this is what makes the
+    // callback's installation of the target sound, and it doubles as the
+    // validation that the target is not already running (or sticky-queued)
+    // on some other thread.
+    if (!jl_set_task_tid(next_task, tid)) {
+        jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
+        return -1;
     }
-    // (N.B.: _isexception is set at commit, not here: normal completion
-    // overwrites a stale result, but does not clear a stale exception flag,
-    // so a refused victim would look failed.)
+    if (result == NULL)
+        result = jl_box_uint8(0x4); // CANCEL_REQUEST_ABANDON_ALL (interned)
+    ptls2->abandon_result = result;
     ptls2->abandon_victim = t;
     ptls2->abandon_to = next_task;
     jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_PENDING);
-    // Deliver with a timeout. The unix request slot is shared with
-    // best-effort cancellation/preemption signals and deliveries coalesce,
-    // so a single send can be lost - re-send until the request settles. The
-    // deadline is wall-clock, not iteration-count: on an oversubscribed or
-    // serialized machine (CI under load, rr) every uv_sleep(1) costs a
-    // reschedule and an iteration-counted loop stretches from its nominal
-    // bound to minutes.
-    uint64_t abandon_deadline = uv_hrtime() + 2000000000ull; // 2s
-    for (;;) {
+    jl_send_abandon_signal(tid);
+    return tid;
+}
+
+// Re-send the delivery signal for a still-pending request on `tid`; a
+// no-op once the request settled.
+JL_DLLEXPORT void jl_abandon_task_resend(int16_t tid)
+{
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    if (ptls2 != NULL &&
+        jl_atomic_load_acquire(&ptls2->abandon_state) == JL_ABANDON_PENDING)
         jl_send_abandon_signal(tid);
-        for (int spin = 0; spin < 10; spin++) {
-            st = jl_atomic_load_acquire(&ptls2->abandon_state);
-            if (st != JL_ABANDON_PENDING)
-                goto settle;
-            uv_sleep(1);
-        }
-        if (uv_hrtime() >= abandon_deadline)
-            break;
-    }
-    // Timed out: withdraw the request, arbitrating against a late delivery.
-    st = JL_ABANDON_PENDING;
-    if (jl_atomic_cmpswap(&ptls2->abandon_state, &st, JL_ABANDON_SETUP)) {
-        ptls2->abandon_victim = NULL;
-        ptls2->abandon_to = NULL;
-        jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
+}
+
+// Verdict poll for the request published on thread `tid`: 0 while the
+// request is pending or mid-delivery (keep waiting), 1 once the
+// abandonment committed, -1 once it was refused. A terminal verdict
+// retires the slot and is returned exactly once.
+JL_DLLEXPORT int jl_abandon_task_poll(int16_t tid)
+{
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    uint8_t st = jl_atomic_load_acquire(&ptls2->abandon_state);
+    if (st == JL_ABANDON_PENDING || st == JL_ABANDON_TAKEN ||
+        st == JL_ABANDON_DONE)
         return 0;
-    }
-settle:
-    // A delivery took the request: wait out its (bounded) validation, and,
-    // on commit, the callback's consumption of the slot (DONE is a
-    // transient state on the way to FINISHED).
-    while ((st = jl_atomic_load_acquire(&ptls2->abandon_state)) == JL_ABANDON_TAKEN ||
-           st == JL_ABANDON_DONE)
-        uv_sleep(1);
     if (st == JL_ABANDON_FINISHED) {
-        // Committed; the callback consumed abandon_victim/abandon_to.
-        // Retire the slot.
+        // Committed; the callback consumed the target slot and raw-stored
+        // the staged result. Issue the write barrier it could not, then
+        // release the staging roots and retire the slot.
+        jl_task_t *t = ptls2->abandon_victim;
+        assert(t != NULL);
+        jl_gc_wb(t, ptls2->abandon_result);
+        ptls2->abandon_victim = NULL;
+        ptls2->abandon_result = NULL;
         jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
         return 1;
     }
-    // Refused: withdraw our published state.
+    assert(st == JL_ABANDON_REFUSED);
+    // Refused: withdraw the published state, returning the target's
+    // affinity claim (it never ran, and only this requester saw it).
+    jl_task_t *next = ptls2->abandon_to;
+    if (next != NULL)
+        jl_atomic_store_relaxed(&next->tid, -1);
     ptls2->abandon_victim = NULL;
     ptls2->abandon_to = NULL;
+    ptls2->abandon_result = NULL;
     jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
-    return 0;
+    return -1;
+}
+
+// Withdraw a still-undelivered request on `tid`: returns 1 with the
+// request fully withdrawn (no abandonment will happen), 0 when a delivery
+// already took it - the caller keeps polling for the verdict.
+JL_DLLEXPORT int jl_abandon_task_withdraw(int16_t tid)
+{
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    uint8_t st = JL_ABANDON_PENDING;
+    if (!jl_atomic_cmpswap(&ptls2->abandon_state, &st, JL_ABANDON_SETUP))
+        return 0;
+    jl_task_t *next = ptls2->abandon_to;
+    if (next != NULL)
+        jl_atomic_store_relaxed(&next->tid, -1);
+    ptls2->abandon_victim = NULL;
+    ptls2->abandon_to = NULL;
+    ptls2->abandon_result = NULL;
+    jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
+    return 1;
+}
+
+// Blocking convenience driver for callers on non-Julia threads (the signal
+// listener's direct-abandon rung), with a bounded wall-clock wait;
+// Julia-side callers compose the primitives above with scheduler-friendly
+// waits instead (see Base.unsafe_abandon!). Returns 1 if the abandonment
+// committed.
+JL_DLLEXPORT int jl_abandon_task(jl_task_t *t, jl_task_t *next_task)
+{
+    int tid = jl_abandon_task_request(t, next_task, NULL);
+    if (tid < 0)
+        return 0;
+    uint64_t deadline = uv_hrtime() + 2000000000ull; // 2s
+    for (;;) {
+        int verdict = jl_abandon_task_poll((int16_t)tid);
+        if (verdict != 0)
+            return verdict == 1;
+        if (uv_hrtime() >= deadline && jl_abandon_task_withdraw((int16_t)tid))
+            return 0;
+        jl_abandon_task_resend((int16_t)tid);
+        uv_sleep(1);
+    }
 }
 
 // cancellation token sources -----------------------------------------------

--- a/src/task.c
+++ b/src/task.c
@@ -1610,6 +1610,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     jl_atomic_store_relaxed(&ct->bound_cancel_token, jl_nothing);
     jl_atomic_store_relaxed(&ct->reset_ctx, NULL);
     jl_atomic_store_relaxed(&ct->cancel_handler_ctx, NULL);
+    ptls->abandon_to = NULL;
     ptls->root_task = ct;
     jl_atomic_store_relaxed(&ptls->current_task, ct);
     JL_GC_PROMISE_ROOTED(ct);
@@ -1668,6 +1669,208 @@ JL_DLLEXPORT int8_t jl_get_task_threadpoolid(jl_task_t *t)
     return t->threadpoolid;
 }
 
+
+// Callback for task abandonment - called via jl_call_in_ctx from signal handler.
+// This function must not return.
+JL_NORETURN void jl_abandon_task_cb(void)
+{
+    jl_task_t *ct = jl_current_task;
+    jl_ptls_t ptls = ct->ptls;
+    jl_task_t *next_task = ptls->abandon_to;
+
+    // Consume the request. The slot stays claimed (FINISHED, not IDLE)
+    // until the requester acknowledges: DONE is transient - this callback
+    // runs within microseconds of the commit - so the requester's verdict
+    // must be a state only it retires, or it would misread the settled
+    // slot as a refusal.
+    ptls->abandon_to = NULL;
+    ptls->abandon_victim = NULL;
+    jl_atomic_store_release(&ptls->abandon_state, JL_ABANDON_FINISHED);
+
+    // A cancellation-handler delivery in flight on this thread dies with the
+    // abandoned task; disarm so future deliveries are not blocked.
+    ptls->cancel_handler_armed = 0;
+
+    // The handler only invokes us for a still-current abandoned task with a
+    // target set; we cannot return from here (the fake signal frame has no
+    // return path).
+    if (next_task == NULL)
+        abort();
+
+    // The task state was already set to ABANDONED by the caller of jl_abandon_task.
+    // We don't attempt to notify waiters here because:
+    // 1. We're in a signal-handler-triggered context with limited safe operations
+    // 2. The donenotify lock might already be held (would cause deadlock)
+    // 3. Waiters will see the state change when they poll istaskdone()
+    // The caller of jl_abandon_task is responsible for waking up any waiters
+    // after the abandon signal has been processed.
+
+    // The root task's stack is the system stack, not a pooled buffer - it must
+    // not be released into the task-stack pool for reuse by ctx_switch below.
+    if (ct == ptls->root_task) {
+        ct->ctx.stkbuf = NULL;
+        ct->ctx.bufsz = 0;
+    }
+
+    // Set the next task's thread ID to this thread before switching.
+    // This is normally done by jl_switch but we're bypassing that.
+    int16_t tid = jl_atomic_load_relaxed(&ct->tid);
+    jl_set_task_tid(next_task, tid);
+
+    // Set up the next task and switch to it
+    ptls->next_task = next_task;
+
+    // Clear state that might cause issues during switch
+    ptls->in_finalizer = 0;
+    ptls->in_pure_callback = 0;
+
+    // Call ctx_switch directly - the task state is already set to abandoned
+    // so ctx_switch will treat it as killed and do proper cleanup
+    // (release stack, clear gcstack and eh pointers).
+    JL_PROBE_RT_PAUSE_TASK(ct);
+    ctx_switch(ct);
+
+    // If we somehow return, something went very wrong
+    abort();
+}
+
+// Validate and commit (or refuse) the pending abandon request for
+// `ptls2`'s current task. The victim thread must be quiescent: this runs
+// either in its signal handler (unix) or while it is suspended (mach,
+// windows), so the state inspected here cannot change under us - unlike a
+// pre-check on the requester's thread. On commit the task is marked
+// abandoned and 1 is returned; the caller then redirects the thread into
+// jl_abandon_task_cb, which consumes `abandon_to` and settles the slot. On
+// refusal (or no pending request) 0 is returned and the requester settles.
+// Async-signal-safe: loads, stores and CAS only.
+int jl_abandon_try_commit(jl_ptls_t ptls2) JL_NOTSAFEPOINT
+{
+    uint8_t st = JL_ABANDON_PENDING;
+    if (!jl_atomic_cmpswap(&ptls2->abandon_state, &st, JL_ABANDON_TAKEN))
+        return 0; // no pending request (withdrawn, already consumed, or none)
+    jl_task_t *t = ptls2->abandon_victim;
+    jl_task_t *ct = jl_atomic_load_relaxed(&ptls2->current_task);
+    // The refusal set: conditions under which discarding the current
+    // context would corrupt *runtime* state. Leaking user resources is the
+    // documented cost of an unsafe abandon; leaking runtime state is not:
+    //  - the thread already switched away (the request outlived its target);
+    //  - runtime (jl_mutex_t) locks are held - including the uv loop lock,
+    //    whose owner is checked explicitly since takeover paths acquire it
+    //    through trylock variants;
+    //  - a finalizer is running, or finalizers are inhibited (ReentrantLock
+    //    holders raise this; the counter would leak and permanently disable
+    //    finalizers on this thread);
+    //  - the victim is in a signal-deferral region (sigatomic; this also
+    //    covers the inference entry point);
+    //  - the victim is inside the scheduler's sleep transition
+    //    (sleep_check_state != not_sleeping): abandonment bypasses the
+    //    JL_CATCH in jl_task_get_next that would restore the sleep state
+    //    and running count, so the rescue task would re-enter the
+    //    scheduler with sleep bookkeeping still claimed by the victim.
+    if (ct != t ||
+        ptls2->locks.len != 0 ||
+        ptls2->in_finalizer ||
+        ptls2->finalizers_inhibited != 0 ||
+        ptls2->defer_signal != 0 ||
+        jl_atomic_load_relaxed(&ptls2->sleep_check_state) != 0 || // 0 == not_sleeping
+        jl_atomic_load_relaxed(&jl_uv_mutex.owner) == ct) {
+        jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_REFUSED);
+        return 0;
+    }
+    // Commit. The result was pre-staged by the requester (the write barrier
+    // is not async-signal-safe); the exception flag and state are set here,
+    // with the victim stopped, which is what makes `:abandoned` mean "will
+    // never run another instruction".
+    jl_atomic_store_relaxed(&t->_isexception, 1);
+    jl_atomic_store_release(&t->_state, JL_TASK_STATE_ABANDONED);
+    jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_DONE);
+    return 1;
+}
+
+// Forcibly switch the thread running `t` from `t` to `next_task`,
+// discarding `t`'s execution (CANCEL_REQUEST_ABANDON_ALL's last resort for
+// code that cannot reach a cancellation point). Returns 1 if the
+// abandonment committed. Returns 0 - with every published effect withdrawn
+// and `t` untouched and still running - when the victim was not (or no
+// longer) current on its thread, was found holding runtime state that must
+// not be discarded (see jl_abandon_try_commit), an abandonment was already
+// in flight for that thread, or delivery could not be completed in time.
+JL_DLLEXPORT int jl_abandon_task(jl_task_t *t, jl_task_t *next_task)
+{
+    int16_t tid = jl_atomic_load_relaxed(&t->tid);
+    if (tid < 0)
+        return 0; // Task not assigned to a thread
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+    if (ptls2 == NULL)
+        return 0;
+    if (jl_atomic_load_relaxed(&ptls2->current_task) != t)
+        return 0; // Task is not currently running
+    // Claim the request slot.
+    uint8_t st = JL_ABANDON_IDLE;
+    if (!jl_atomic_cmpswap(&ptls2->abandon_state, &st, JL_ABANDON_SETUP))
+        return 0; // another abandonment is in flight for this thread
+    // Pre-stage the abandonment as the task's result (off the delivery
+    // path: jl_gc_wb is not async-signal-safe). Julia-side callers set a
+    // proper CancellationRequest beforehand; the C direct-abandon path
+    // falls back to the interned severity byte. Stale on refusal is
+    // benign: normal completion overwrites result and _isexception.
+    if (t->result == jl_nothing || t->result == NULL) {
+        jl_value_t *creq = jl_box_uint8(0x4); // CANCEL_REQUEST_ABANDON_ALL
+        t->result = creq;
+        jl_gc_wb(t, creq);
+    }
+    // (N.B.: _isexception is set at commit, not here: normal completion
+    // overwrites a stale result, but does not clear a stale exception flag,
+    // so a refused victim would look failed.)
+    ptls2->abandon_victim = t;
+    ptls2->abandon_to = next_task;
+    jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_PENDING);
+    // Deliver with a timeout. The unix request slot is shared with
+    // best-effort cancellation/preemption signals and deliveries coalesce,
+    // so a single send can be lost - re-send until the request settles. The
+    // deadline is wall-clock, not iteration-count: on an oversubscribed or
+    // serialized machine (CI under load, rr) every uv_sleep(1) costs a
+    // reschedule and an iteration-counted loop stretches from its nominal
+    // bound to minutes.
+    uint64_t abandon_deadline = uv_hrtime() + 2000000000ull; // 2s
+    for (;;) {
+        jl_send_abandon_signal(tid);
+        for (int spin = 0; spin < 10; spin++) {
+            st = jl_atomic_load_acquire(&ptls2->abandon_state);
+            if (st != JL_ABANDON_PENDING)
+                goto settle;
+            uv_sleep(1);
+        }
+        if (uv_hrtime() >= abandon_deadline)
+            break;
+    }
+    // Timed out: withdraw the request, arbitrating against a late delivery.
+    st = JL_ABANDON_PENDING;
+    if (jl_atomic_cmpswap(&ptls2->abandon_state, &st, JL_ABANDON_SETUP)) {
+        ptls2->abandon_victim = NULL;
+        ptls2->abandon_to = NULL;
+        jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
+        return 0;
+    }
+settle:
+    // A delivery took the request: wait out its (bounded) validation, and,
+    // on commit, the callback's consumption of the slot (DONE is a
+    // transient state on the way to FINISHED).
+    while ((st = jl_atomic_load_acquire(&ptls2->abandon_state)) == JL_ABANDON_TAKEN ||
+           st == JL_ABANDON_DONE)
+        uv_sleep(1);
+    if (st == JL_ABANDON_FINISHED) {
+        // Committed; the callback consumed abandon_victim/abandon_to.
+        // Retire the slot.
+        jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
+        return 1;
+    }
+    // Refused: withdraw our published state.
+    ptls2->abandon_victim = NULL;
+    ptls2->abandon_to = NULL;
+    jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
+    return 0;
+}
 
 // cancellation token sources -----------------------------------------------
 

--- a/src/task.c
+++ b/src/task.c
@@ -1695,11 +1695,6 @@ static void abandon_notify(void) JL_NOTSAFEPOINT
         uv_async_send(h);
 }
 
-JL_DLLEXPORT void jl_abandon_notify_ping(void) JL_NOTSAFEPOINT
-{
-    abandon_notify();
-}
-
 // Callback for task abandonment - the delivery redirects the victim thread
 // here (via jl_call_in_ctx / a rewritten thread context). Must not return.
 JL_NORETURN void jl_abandon_task_cb(void)
@@ -1841,10 +1836,9 @@ int jl_abandon_try_commit(jl_ptls_t ptls2) JL_NOTSAFEPOINT
 // current on a thread, the target is the victim itself or already bound to
 // a thread, or another abandonment is in flight for the victim's thread.
 // The caller owns the published request and must drive it to a verdict
-// with jl_abandon_task_poll, re-sending via jl_abandon_task_resend while
-// pending (deliveries coalesce with best-effort cancellation/preemption
-// signals on the shared per-thread slot, so a single send can be lost) and
-// optionally withdrawing via jl_abandon_task_withdraw.
+// with jl_abandon_task_poll (the delivery bit cannot be coalesced away, so
+// the single send suffices), optionally withdrawing via
+// jl_abandon_task_withdraw.
 JL_DLLEXPORT int jl_abandon_task_request(jl_task_t *t, jl_task_t *next_task,
                                          jl_value_t *result)
 {
@@ -1878,16 +1872,6 @@ JL_DLLEXPORT int jl_abandon_task_request(jl_task_t *t, jl_task_t *next_task,
     jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_PENDING);
     jl_send_abandon_signal(tid);
     return tid;
-}
-
-// Re-send the delivery signal for a still-pending request on `tid`; a
-// no-op once the request settled.
-JL_DLLEXPORT void jl_abandon_task_resend(int16_t tid)
-{
-    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
-    if (ptls2 != NULL &&
-        jl_atomic_load_acquire(&ptls2->abandon_state) == JL_ABANDON_PENDING)
-        jl_send_abandon_signal(tid);
 }
 
 // Verdict poll for the request published on thread `tid`: 0 while the
@@ -1943,28 +1927,6 @@ JL_DLLEXPORT int jl_abandon_task_withdraw(int16_t tid)
     ptls2->abandon_result = NULL;
     jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
     return 1;
-}
-
-// Blocking convenience driver for callers on non-Julia threads (the signal
-// listener's direct-abandon rung), with a bounded wall-clock wait;
-// Julia-side callers compose the primitives above with scheduler-friendly
-// waits instead (see Base.unsafe_abandon!). Returns 1 if the abandonment
-// committed.
-JL_DLLEXPORT int jl_abandon_task(jl_task_t *t, jl_task_t *next_task)
-{
-    int tid = jl_abandon_task_request(t, next_task, NULL);
-    if (tid < 0)
-        return 0;
-    uint64_t deadline = uv_hrtime() + 2000000000ull; // 2s
-    for (;;) {
-        int verdict = jl_abandon_task_poll((int16_t)tid);
-        if (verdict != 0)
-            return verdict == 1;
-        if (uv_hrtime() >= deadline && jl_abandon_task_withdraw((int16_t)tid))
-            return 0;
-        jl_abandon_task_resend((int16_t)tid);
-        uv_sleep(1);
-    }
 }
 
 // cancellation token sources -----------------------------------------------

--- a/src/task.c
+++ b/src/task.c
@@ -1618,6 +1618,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     jl_atomic_store_relaxed(&ct->reset_ctx, NULL);
     jl_atomic_store_relaxed(&ct->cancel_handler_ctx, NULL);
     ptls->abandon_to = NULL;
+    ptls->abandon_notify = NULL;
     ptls->root_task = ct;
     jl_atomic_store_relaxed(&ptls->current_task, ct);
     JL_GC_PROMISE_ROOTED(ct);
@@ -1677,20 +1678,13 @@ JL_DLLEXPORT int8_t jl_get_task_threadpoolid(jl_task_t *t)
 }
 
 
-// Global wakeup for abandonment completion: the delivery paths settle the
-// request slot from signal context (or with the victim thread suspended),
-// where uv_async_send is the one legal wakeup. Julia installs an
-// AsyncCondition handle here so requester-side waits can be event-driven.
-static _Atomic(uv_async_t*) abandon_notify_handle = NULL;
-
-JL_DLLEXPORT void jl_set_abandon_notify_handle(uv_async_t *handle) JL_NOTSAFEPOINT
+// Ping the requester's staged wakeup handle (if any) after settling its
+// request. The delivery paths run in signal context (or with the victim
+// suspended), where uv_async_send is the one legal wakeup; the handle is
+// part of the request, so the slot state machine brackets every ping.
+static void abandon_notify(jl_ptls_t ptls2) JL_NOTSAFEPOINT
 {
-    jl_atomic_store_release(&abandon_notify_handle, handle);
-}
-
-static void abandon_notify(void) JL_NOTSAFEPOINT
-{
-    uv_async_t *h = jl_atomic_load_acquire(&abandon_notify_handle);
+    uv_async_t *h = ptls2->abandon_notify;
     if (h != NULL)
         uv_async_send(h);
 }
@@ -1754,8 +1748,11 @@ JL_NORETURN void jl_abandon_task_cb(void)
     // the raw-stored result - until the requester's settle.
     ptls->next_task = next_task;
     ptls->abandon_to = NULL;
+    // Pinged while still in DONE (see the refusal path's ordering comment):
+    // the requester wakes, observes the pre-terminal state, and spins the
+    // final microseconds to FINISHED.
+    abandon_notify(ptls);
     jl_atomic_store_release(&ptls->abandon_state, JL_ABANDON_FINISHED);
-    abandon_notify();
 
     // Clear state that might cause issues during switch
     ptls->in_finalizer = 0;
@@ -1818,8 +1815,13 @@ int jl_abandon_try_commit(jl_ptls_t ptls2) JL_NOTSAFEPOINT
         ptls2->defer_signal != 0 ||
         jl_atomic_load_relaxed(&ptls2->sleep_check_state) != 0 || // 0 == not_sleeping
         jl_atomic_load_relaxed(&jl_uv_mutex.owner) == ct) {
+        // Ping before the terminal store: the requester consumes (and may
+        // free its handle) the moment a terminal state is visible, so a
+        // later ping could touch a dead handle. From the requester's side a
+        // pre-terminal wakeup means "verdict imminent": it spins the last
+        // microseconds instead of re-parking (see jl_abandon_task_poll).
+        abandon_notify(ptls2);
         jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_REFUSED);
-        abandon_notify();
         return 0;
     }
     // Commit: only the request slot here - the victim's observable task
@@ -1831,7 +1833,9 @@ int jl_abandon_try_commit(jl_ptls_t ptls2) JL_NOTSAFEPOINT
 // Publish an abandonment request for `t` (which must be current on some
 // thread), redirecting its thread to `next_task` and staging `result`
 // (NULL: the interned ABANDON_ALL severity byte) as the abandoned task's
-// outcome, then send one delivery signal. Returns the victim's thread id
+// outcome, then send one delivery signal. `notify` (may be NULL for
+// polling requesters) is pinged via uv_async_send when the request
+// settles; it must outlive the request. Returns the victim's thread id
 // on publication; -1 when no request could be published: the victim is not
 // current on a thread, the target is the victim itself or already bound to
 // a thread, or another abandonment is in flight for the victim's thread.
@@ -1840,7 +1844,7 @@ int jl_abandon_try_commit(jl_ptls_t ptls2) JL_NOTSAFEPOINT
 // the single send suffices), optionally withdrawing via
 // jl_abandon_task_withdraw.
 JL_DLLEXPORT int jl_abandon_task_request(jl_task_t *t, jl_task_t *next_task,
-                                         jl_value_t *result)
+                                         jl_value_t *result, uv_async_t *notify)
 {
     if (t == next_task)
         return -1;
@@ -1867,6 +1871,7 @@ JL_DLLEXPORT int jl_abandon_task_request(jl_task_t *t, jl_task_t *next_task,
     if (result == NULL)
         result = jl_box_uint8(0x4); // CANCEL_REQUEST_ABANDON_ALL (interned)
     ptls2->abandon_result = result;
+    ptls2->abandon_notify = notify;
     ptls2->abandon_victim = t;
     ptls2->abandon_to = next_task;
     jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_PENDING);
@@ -1875,16 +1880,19 @@ JL_DLLEXPORT int jl_abandon_task_request(jl_task_t *t, jl_task_t *next_task,
 }
 
 // Verdict poll for the request published on thread `tid`: 0 while the
-// request is pending or mid-delivery (keep waiting), 1 once the
-// abandonment committed, -1 once it was refused. A terminal verdict
-// retires the slot and is returned exactly once.
+// request awaits delivery (wait for the staged handle's ping), 2 while a
+// delivery is mid-settle (the ping was already sent; the verdict is
+// microseconds away - spin, do not re-park), 1 once the abandonment
+// committed, -1 once it was refused. A terminal verdict retires the slot
+// and is returned exactly once.
 JL_DLLEXPORT int jl_abandon_task_poll(int16_t tid)
 {
     jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
     uint8_t st = jl_atomic_load_acquire(&ptls2->abandon_state);
-    if (st == JL_ABANDON_PENDING || st == JL_ABANDON_TAKEN ||
-        st == JL_ABANDON_DONE)
+    if (st == JL_ABANDON_PENDING)
         return 0;
+    if (st == JL_ABANDON_TAKEN || st == JL_ABANDON_DONE)
+        return 2;
     if (st == JL_ABANDON_FINISHED) {
         // Committed; the callback consumed the target slot and raw-stored
         // the staged result. Issue the write barrier it could not, then
@@ -1894,6 +1902,7 @@ JL_DLLEXPORT int jl_abandon_task_poll(int16_t tid)
         jl_gc_wb(t, ptls2->abandon_result);
         ptls2->abandon_victim = NULL;
         ptls2->abandon_result = NULL;
+        ptls2->abandon_notify = NULL;
         jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
         return 1;
     }
@@ -1906,6 +1915,7 @@ JL_DLLEXPORT int jl_abandon_task_poll(int16_t tid)
     ptls2->abandon_victim = NULL;
     ptls2->abandon_to = NULL;
     ptls2->abandon_result = NULL;
+    ptls2->abandon_notify = NULL;
     jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
     return -1;
 }
@@ -1925,6 +1935,7 @@ JL_DLLEXPORT int jl_abandon_task_withdraw(int16_t tid)
     ptls2->abandon_victim = NULL;
     ptls2->abandon_to = NULL;
     ptls2->abandon_result = NULL;
+    ptls2->abandon_notify = NULL;
     jl_atomic_store_release(&ptls2->abandon_state, JL_ABANDON_IDLE);
     return 1;
 }

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1802,3 +1802,114 @@ include("threads_comprehensions.jl")
 end
 
 end # main testset
+
+
+# Forcible task abandonment (unsafe_abandon!): the victim must be running
+# on a thread of its own while the driver keeps executing.
+if threadpoolsize() >= 2
+    @testset "task abandonment wakes waiters" begin
+        started = Base.Event()
+        victim = Threads.@spawn begin
+            notify(started)
+            x = Ref(1.0)
+            while true
+                x[] = x[] * 1.0000001 + 0.1
+            end
+        end
+        wait(started)
+        watcher = @async wait(victim)
+        sleep(0.5) # make sure the victim is actually spinning on its thread
+        rescue = Task(() -> (while true; wait(); end))
+        rescue.sticky = false
+        Base.unsafe_abandon!(victim, rescue)
+        @test timedwait(() -> istaskdone(victim), 5.0) == :ok
+        @test victim.state === :abandoned
+        @test istaskfailed(victim)
+        # the watcher must be woken (abandoned tasks skip the regular
+        # completion path)
+        @test timedwait(() -> istaskdone(watcher), 5.0) == :ok
+        @test_throws TaskFailedException fetch(watcher)
+    end
+
+
+    @testset "unsafe_abandon! validates at delivery and can refuse" begin
+        # A victim cycling a ReentrantLock (which inhibits finalizers while
+        # held) must never be abandoned mid-hold: the delivery-point validation
+        # refuses instead of corrupting runtime bookkeeping. Abandon spam either
+        # gets a clean refusal or commits during an unlocked window.
+        lk = ReentrantLock()
+        stop = Threads.Atomic{Bool}(false)
+        victim = Threads.@spawn begin
+            while !stop[]
+                lock(lk)
+                try
+                    x = 0
+                    for i in 1:2000
+                        x += i
+                    end
+                finally
+                    unlock(lk)
+                end
+            end
+        end
+        committed = false
+        deadline = time() + 20.0
+        while !committed && time() < deadline
+            istaskdone(victim) && break
+            rescue = Task(() -> (while true; wait(); end))
+            rescue.sticky = false
+            committed = Base.unsafe_abandon!(victim, rescue)
+            if !committed
+                # refusal must leave the victim untouched and running
+                @test !istaskdone(victim)
+            end
+            sleep(0.001)
+        end
+        @test committed
+        if committed
+            @test victim.state === :abandoned
+        else
+            # Don't leave the victim spinning (it would wedge the process): stop
+            # it and surface the failure through the @test above.
+            stop[] = true
+            @test timedwait(() -> istaskdone(victim), 10.0) === :ok
+        end
+        # runtime must be healthy afterwards (finalizers not leaked-inhibited)
+        GC.gc(false)
+    end
+
+    # Linux-only: blocks the abandon signal by number (SIGUSR2 == 12) and uses
+    # Linux's SIG_BLOCK/SIG_UNBLOCK values.
+    Sys.islinux() && @testset "unsafe_abandon! withdraws cleanly on delivery timeout" begin
+        # Block the abandon signal in the victim so delivery cannot happen: the
+        # requester must time out, withdraw every published effect, and return
+        # false with the victim still running and not marked done.
+        started = Base.Event()
+        release = Threads.Atomic{Bool}(false)
+        victim = Threads.@spawn begin
+            # block SIGUSR2 on this thread
+            sset = zeros(UInt8, 128)
+            ccall(:sigemptyset, Cint, (Ptr{UInt8},), sset)
+            ccall(:sigaddset, Cint, (Ptr{UInt8}, Cint), sset, 12) # SIGUSR2
+            ccall(:pthread_sigmask, Cint, (Cint, Ptr{UInt8}, Ptr{Cvoid}), 0 #= SIG_BLOCK =#, sset, C_NULL)
+            notify(started)
+            # spin in compute so the task stays current on its thread
+            while !release[]
+                ccall(:jl_cpu_pause, Cvoid, ())
+            end
+            ccall(:pthread_sigmask, Cint, (Cint, Ptr{UInt8}, Ptr{Cvoid}), 1 #= SIG_UNBLOCK =#, sset, C_NULL)
+            :survived
+        end
+        wait(started)
+        rescue = Task(() -> (while true; wait(); end))
+        rescue.sticky = false
+        t0 = time()
+        ok = Base.unsafe_abandon!(victim, rescue)
+        dt = time() - t0
+        @test !ok
+        @test !istaskdone(victim)         # not falsely marked :abandoned
+        @test dt < 10.0                   # bounded timeout, no hang
+        release[] = true                  # victim completes normally afterwards
+        @test fetch(victim) === :survived
+    end
+end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1889,10 +1889,11 @@ if threadpoolsize() >= 2
 
     # Linux-only: blocks the abandon signal by number (SIGUSR2 == 12) and uses
     # Linux's SIG_BLOCK/SIG_UNBLOCK values.
-    Sys.islinux() && @testset "unsafe_abandon! withdraws cleanly on delivery timeout" begin
-        # Block the abandon signal in the victim so delivery cannot happen:
-        # the requester must withdraw every published effect and return
-        # false with the victim still running and not marked done.
+    Sys.islinux() && @testset "an undelivered abandonment withdraws cleanly" begin
+        # Block the abandon signal in the victim so delivery cannot happen,
+        # and exercise the request/poll/withdraw primitives directly: the
+        # withdrawal must return every published effect, leaving the victim
+        # untouched - including its eventual completion value.
         started = Threads.Atomic{Bool}(false)
         release = Threads.Atomic{Bool}(false)
         victim = Threads.@spawn begin
@@ -1914,12 +1915,16 @@ if threadpoolsize() >= 2
         end
         rescue = Task(() -> (while true; wait(); end))
         rescue.sticky = false
-        # unsafe_abandon!'s own delivery budget bounds this call; the
-        # masked victim can never take the request, so it must withdraw.
-        ok = Base.unsafe_abandon!(victim, rescue)
-        @test !ok
+        tid = ccall(:jl_abandon_task_request, Cint, (Any, Any, Any),
+                    victim, rescue, Base.CancellationRequest(0x4))
+        @test tid >= 0
+        # undeliverable: the request stays pending
+        @test ccall(:jl_abandon_task_poll, Cint, (Int16,), tid % Int16) == 0
+        @test ccall(:jl_abandon_task_withdraw, Cint, (Int16,), tid % Int16) == 1
         @test !istaskdone(victim)         # not falsely marked :abandoned
         release[] = true                  # victim completes normally afterwards
         @test fetch(victim) === :survived
+        # the withdrawal returned the rescue task's affinity claim
+        @test Threads.threadid(rescue) == 0
     end
 end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1915,8 +1915,8 @@ if threadpoolsize() >= 2
         end
         rescue = Task(() -> (while true; wait(); end))
         rescue.sticky = false
-        tid = ccall(:jl_abandon_task_request, Cint, (Any, Any, Any),
-                    victim, rescue, Base.CancellationRequest(0x4))
+        tid = ccall(:jl_abandon_task_request, Cint, (Any, Any, Any, Ptr{Cvoid}),
+                    victim, rescue, Base.CancellationRequest(0x4), C_NULL)
         @test tid >= 0
         # undeliverable: the request stays pending
         @test ccall(:jl_abandon_task_poll, Cint, (Int16,), tid % Int16) == 0

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1808,37 +1808,49 @@ end # main testset
 # on a thread of its own while the driver keeps executing.
 if threadpoolsize() >= 2
     @testset "task abandonment wakes waiters" begin
-        started = Base.Event()
+        # Synchronize on observable state, never on timing: the spin counter
+        # proves the victim is executing its loop on a thread.
+        spins = Threads.Atomic{Int}(0)
         victim = Threads.@spawn begin
-            notify(started)
             x = Ref(1.0)
             while true
                 x[] = x[] * 1.0000001 + 0.1
+                Threads.atomic_add!(spins, 1)
             end
         end
-        wait(started)
         watcher = @async wait(victim)
-        sleep(0.5) # make sure the victim is actually spinning on its thread
-        rescue = Task(() -> (while true; wait(); end))
-        rescue.sticky = false
-        Base.unsafe_abandon!(victim, rescue)
-        @test timedwait(() -> istaskdone(victim), 5.0) == :ok
+        c0 = spins[]
+        while spins[] <= c0 + 10
+            yield()
+        end
+        rescue() = (t = Task(() -> (while true; wait(); end)); t.sticky = false; t)
+        # A refusal is transient (the victim may momentarily be inside the
+        # allocator or a runtime lock); retry until the abandonment commits.
+        while !Base.unsafe_abandon!(victim, rescue())
+            yield()
+        end
+        # unsafe_abandon! returns after the verdict settles: the states are
+        # already final.
+        @test istaskdone(victim)
         @test victim.state === :abandoned
         @test istaskfailed(victim)
+        # the staged abandonment outcome, not a value leaked mid-request
+        @test victim.result isa Base.CancellationRequest
         # the watcher must be woken (abandoned tasks skip the regular
         # completion path)
-        @test timedwait(() -> istaskdone(watcher), 5.0) == :ok
         @test_throws TaskFailedException fetch(watcher)
     end
 
-
     @testset "unsafe_abandon! validates at delivery and can refuse" begin
         # A victim cycling a ReentrantLock (which inhibits finalizers while
-        # held) must never be abandoned mid-hold: the delivery-point validation
-        # refuses instead of corrupting runtime bookkeeping. Abandon spam either
-        # gets a clean refusal or commits during an unlocked window.
+        # held) must never be abandoned mid-hold: the delivery-point
+        # validation refuses instead of corrupting runtime bookkeeping.
+        # Abandon spam either gets a clean refusal or commits during an
+        # unlocked window; on refusal the victim must be left untouched -
+        # still running, and with its eventual completion value intact.
         lk = ReentrantLock()
         stop = Threads.Atomic{Bool}(false)
+        cycles = Threads.Atomic{Int}(0)
         victim = Threads.@spawn begin
             while !stop[]
                 lock(lk)
@@ -1847,33 +1859,30 @@ if threadpoolsize() >= 2
                     for i in 1:2000
                         x += i
                     end
+                    Threads.atomic_add!(cycles, 1)
                 finally
                     unlock(lk)
                 end
             end
+            :completed
+        end
+        c0 = cycles[]
+        while cycles[] <= c0
+            yield()
         end
         committed = false
-        deadline = time() + 20.0
-        while !committed && time() < deadline
-            istaskdone(victim) && break
+        while !committed
             rescue = Task(() -> (while true; wait(); end))
             rescue.sticky = false
             committed = Base.unsafe_abandon!(victim, rescue)
             if !committed
                 # refusal must leave the victim untouched and running
                 @test !istaskdone(victim)
+                yield()
             end
-            sleep(0.001)
         end
         @test committed
-        if committed
-            @test victim.state === :abandoned
-        else
-            # Don't leave the victim spinning (it would wedge the process): stop
-            # it and surface the failure through the @test above.
-            stop[] = true
-            @test timedwait(() -> istaskdone(victim), 10.0) === :ok
-        end
+        @test victim.state === :abandoned
         # runtime must be healthy afterwards (finalizers not leaked-inhibited)
         GC.gc(false)
     end
@@ -1881,10 +1890,10 @@ if threadpoolsize() >= 2
     # Linux-only: blocks the abandon signal by number (SIGUSR2 == 12) and uses
     # Linux's SIG_BLOCK/SIG_UNBLOCK values.
     Sys.islinux() && @testset "unsafe_abandon! withdraws cleanly on delivery timeout" begin
-        # Block the abandon signal in the victim so delivery cannot happen: the
-        # requester must time out, withdraw every published effect, and return
+        # Block the abandon signal in the victim so delivery cannot happen:
+        # the requester must withdraw every published effect and return
         # false with the victim still running and not marked done.
-        started = Base.Event()
+        started = Threads.Atomic{Bool}(false)
         release = Threads.Atomic{Bool}(false)
         victim = Threads.@spawn begin
             # block SIGUSR2 on this thread
@@ -1892,7 +1901,7 @@ if threadpoolsize() >= 2
             ccall(:sigemptyset, Cint, (Ptr{UInt8},), sset)
             ccall(:sigaddset, Cint, (Ptr{UInt8}, Cint), sset, 12) # SIGUSR2
             ccall(:pthread_sigmask, Cint, (Cint, Ptr{UInt8}, Ptr{Cvoid}), 0 #= SIG_BLOCK =#, sset, C_NULL)
-            notify(started)
+            started[] = true
             # spin in compute so the task stays current on its thread
             while !release[]
                 ccall(:jl_cpu_pause, Cvoid, ())
@@ -1900,15 +1909,16 @@ if threadpoolsize() >= 2
             ccall(:pthread_sigmask, Cint, (Cint, Ptr{UInt8}, Ptr{Cvoid}), 1 #= SIG_UNBLOCK =#, sset, C_NULL)
             :survived
         end
-        wait(started)
+        while !started[]
+            yield()
+        end
         rescue = Task(() -> (while true; wait(); end))
         rescue.sticky = false
-        t0 = time()
+        # unsafe_abandon!'s own delivery budget bounds this call; the
+        # masked victim can never take the request, so it must withdraw.
         ok = Base.unsafe_abandon!(victim, rescue)
-        dt = time() - t0
         @test !ok
         @test !istaskdone(victim)         # not falsely marked :abandoned
-        @test dt < 10.0                   # bounded timeout, no hang
         release[] = true                  # victim completes normally afterwards
         @test fetch(victim) === :survived
     end


### PR DESCRIPTION
Task abandonment in an aggressive form of cancellation that forcefully rips the task from its running thread and never schedules it again. Obviously this operation is dangerous. If the task holds locks or otherwise is responsible for producing results that other tasks need, deadlocks will ensue. It is intended to be used as a "last resort" option if tasks do not have cancellation point to bring the system back to an at-least-somewhat usable state in which the user can try to save any work-in-progress, investigate what happened, etc. However, this is a deliberately unsafe operation and we do not make any promises about the behavior of the system following this operation. Note that not dropping locks is a deliberate choice. If we were to drop locks, we might cause system corruption. The current design can deadlock, but at least the mutual-exclusion guarantees of locks are preserved. Note that we do have a mechanism to refuse abandonment if doing so would put the *runtime* (as opposed to user state) in an inconsistent state. The idea being that a) the runtime is hopefully correctly implemented and will not spin indefinitely and b) the whole point of this is to get a somewhat useable system back. If the runtime is corrupted that cannot happen.