### PR TITLE
cancellation: Implement `wait(tok::CancellationToken)`

### DIFF
--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -460,6 +460,13 @@ function _cached_wait_entry(waiter::Task)
     return w
 end
 
+# A source slot's aux: the low byte is the minimum delivery severity (the
+# "floor"); the watcher bit marks a `wait(::CancellationToken)` slot, whose
+# claimed wake the walk *completes* with the request as a value instead of
+# interrupting the task - the cancellation is the event that wait is for.
+# Staged pre-arm like the floor (see below).
+const WAIT_AUX_WATCHER_BIT = UInt64(0x100)
+
 # Return the entry for a cancellable park of `waiter` governed by `src`,
 # with the minimum delivery severity staged on the source slot. Must run
 # before the arm: the cancellation walk reads the slot's aux only through
@@ -710,8 +717,11 @@ end
 # registrations of completed tasks and retired entries (the only removal in
 # the registry - a live task's registration is sticky and stays linked
 # between parks) and, when `sev` is nonzero, claim armed waiters eligible
-# at that severity. Returns the claimed tasks as a `(t, rest)` cons list;
-# the caller wakes them after releasing the walk lock.
+# at that severity. Returns the claimed tasks as a cons list of
+# `Pair{Tuple{Task, WaitEntry, UInt64}, Any}` cells (a Pair's declared
+# parameters make every cell one type - a tuple cons would mint a fresh
+# concrete tuple type per list depth); the caller wakes them after
+# releasing the walk lock.
 function _walk_waiters!(node::CancellationTokenSource, sev::UInt8)
     @atomic :monotonic node.dead_count = UInt32(0)
     nlive = UInt32(0)
@@ -768,10 +778,11 @@ function _walk_waiters!(node::CancellationTokenSource, sev::UInt8)
             # spurious below-floor wake into a teardown re-park, which
             # handles it like any interruption of its wait
             # (conservatively, e.g. by detaching the awaited request).
+            aux = slot.aux
             if sev != 0x00 && (@atomic :sequentially_consistent t.waiting_on) === w &&
-                    slot.aux % UInt8 <= sev
+                    aux % UInt8 <= sev
                 if (@atomicreplace t.waiting_on w => nothing).success
-                    towake = ((t, w), towake)
+                    towake = Pair{Tuple{Task, WaitEntry, UInt64}, Any}((t, w, aux), towake)
                 end
                 # a lost claim: a completion or interrupter won the race;
                 # the waiter resumes through that wake
@@ -815,7 +826,17 @@ function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
     # cleanup (or a later notify) lazily unlinks it.
     _unlock_walk(node)
     while towake !== nothing
-        ((t, w), towake) = towake::Tuple{Tuple{Task, WaitEntry}, Any}
+        towake = towake::Pair{Tuple{Task, WaitEntry, UInt64}, Any}
+        (t, w, aux) = towake.first
+        towake = towake.second
+        if aux & WAIT_AUX_WATCHER_BIT != 0x00
+            # A watcher (`wait(::CancellationToken)`): this cancellation is
+            # the event its wait completes on, so it is woken with the
+            # request as a *value* - a watcher observes this source but
+            # does not run under it.
+            deliver_claimed_value_wake!(t, w, creq)
+            continue
+        end
         # N.B.: an ABANDON_ALL request also delivers by interruption for
         # now (freezing the task in place is not yet implemented). The
         # delivery is claim-scoped - the claim above is the wake ticket, so

--- a/base/park.jl
+++ b/base/park.jl
@@ -303,19 +303,19 @@ end
 ## SourceWait methods (the struct and its doc live above, before the
 ## entry-acquisition contract that dispatches on it)
 
-function wait_enqueue!(x::SourceWait, w::WaitEntry, first::Bool)
-    src = x.src
+function _source_wait_enqueue!(src::CancellationTokenSource, w::WaitEntry, aux::UInt64)
     i = _find_slot(w, src)
     if i == 0
         # First registration under `src`: claim a slot (the slot's `owner`
-        # is the push ticket) and stage the floor - pre-publication, so
-        # any walk that can see the slot sees its aux - then publish with
-        # a lock-free push. seq_cst, pairing with the cancellation walk's
+        # is the push ticket) and stage the aux (the floor, plus the
+        # watcher bit for a `WatcherWait`) - pre-publication, so any walk
+        # that can see the slot sees its aux - then publish with a
+        # lock-free push. seq_cst, pairing with the cancellation walk's
         # state-write-then-head-read: if the walk's head read misses this
         # push, this push is later in the total order, so the recheck
         # below observes the raised state.
         i = _acquire_slot!(w, src)
-        _set_slot_aux!(w, i, UInt64(x.floor))
+        _set_slot_aux!(w, i, aux)
         slot = slots(w)[i]
         while true
             h = _waiters_head(src)
@@ -336,6 +336,9 @@ function wait_enqueue!(x::SourceWait, w::WaitEntry, first::Bool)
     return true
 end
 
+wait_enqueue!(x::SourceWait, w::WaitEntry, first::Bool) =
+    _source_wait_enqueue!(x.src, w, UInt64(x.floor))
+
 function wait_recheck(x::SourceWait, w::WaitEntry)
     # Post-publication recheck: either the concurrent cancellation walk
     # observes our push/arm, or we observe its state write here.
@@ -344,3 +347,77 @@ function wait_recheck(x::SourceWait, w::WaitEntry)
 end
 
 wait_dequeue!(x::SourceWait, w::WaitEntry, why::UInt8) = nothing
+
+## Watching a cancellation source (`wait(::CancellationToken)`)
+
+# `WatcherWait(src)` in a park's waitables makes the wait *complete* when
+# `src` is cancelled: its slot stages the watcher aux bit, which the
+# cancellation walk delivers value-mode - the request is the payload, at
+# any severity (see `_cancel_walk_node!`).
+# The registration and recheck follow `SourceWait`'s Dekker exactly; only
+# the staged aux and the meaning of firing (the awaited event, not a
+# refusal) differ. Watcher parks always use a fresh single-use entry:
+# neither cache slot may ever carry a registration on a source the arm is
+# not an ordinary cancellable park under (the shield/claim soundness
+# argument in the cache contract above).
+struct WatcherWait
+    src::CancellationTokenSource
+end
+
+acquire_wait_entry!(ct::Task, ws::Tuple{WatcherWait}) = WaitEntry1(ct)
+acquire_wait_entry!(ct::Task, ws::Tuple{WatcherWait, SourceWait}) = WaitEntry2(ct)
+
+wait_enqueue!(x::WatcherWait, w::WaitEntry, first::Bool) =
+    _source_wait_enqueue!(x.src, w, WAIT_AUX_WATCHER_BIT | UInt64(CANCEL_REQUEST_SAFE.request))
+
+wait_recheck(x::WatcherWait, w::WaitEntry) =
+    (@atomic :sequentially_consistent x.src.state) != 0x00
+
+wait_dequeue!(x::WatcherWait, w::WaitEntry, why::UInt8) = nothing
+
+"""
+    wait(tok::CancellationToken; cancel=...)
+
+Block until `tok`'s source is cancelled, and return the corresponding
+[`CancellationRequest`](@ref) as an ordinary value; return immediately if it
+already is. This inverts the usual delivery - cancellation of `tok` is the
+event this operation waits *for*, not an interruption of it - and is the
+building block of the watcher-task ("cancellation callback") pattern.
+
+The wait itself accepts the standard `cancel` keyword argument (defaulting
+to the scoped token) and is interrupted by that token like any other
+blocking operation. Waiting on the token that also governs the wait is
+refused with an `ArgumentError`, since completing and interrupting the wait
+would be the same event; pass `cancel = nothing` to wait for `tok`
+unconditionally.
+"""
+function wait(tok::CancellationToken; cancel::CancelTokenArg=DEFAULT_CANCEL)
+    src = tok.source
+    gov = resolve_cancel_token(cancel)
+    govsrc = gov === nothing ? nothing : gov.source
+    if govsrc === src
+        throw(ArgumentError(
+            "cannot wait for a token's cancellation under the same governing token; " *
+            "pass `cancel = nothing` to wait for it unconditionally"))
+    end
+    govsrc === nothing || checkcancel(govsrc)
+    st = @atomic :acquire src.state
+    st != 0x00 && return CancellationRequest(st)
+    ct = current_task()
+    ws = govsrc === nothing ? (WatcherWait(src),) :
+                              (WatcherWait(src), SourceWait(govsrc, CANCEL_REQUEST_SAFE.request))
+    w = acquire_wait_entry!(ct, ws)
+    if !park!(ws, w, true)
+        # Fired, and the self-claim won: either the watched source's
+        # cancellation (the awaited event, delivered as the return value)
+        # or the governing token's (the refusal) - re-inspect to tell.
+        withdraw!(ws, w, WAKE_FIRED)
+        st = @atomic :acquire src.state
+        st != 0x00 && return CancellationRequest(st)
+        checkcancel(govsrc::CancellationTokenSource) # throws the refusal
+        error("cancellation wait fired with no cancellation")
+    end
+    r = wait_safe_interrupt(ws, w)
+    withdraw!(ws, w, WAKE_VALUE)
+    return r::CancellationRequest
+end

--- a/base/task.jl
+++ b/base/task.jl
@@ -1223,6 +1223,22 @@ function deliver_claimed_wake!(t::Task, w::WaitEntry, @nospecialize(exc))
     return nothing
 end
 
+# The value-mode variant of `deliver_claimed_wake!`, with the same claim
+# contract: the parked wait *completes*, returning `val` (the cancellation
+# walk's delivery to a watcher - `wait(::CancellationToken)` - whose wait
+# the cancellation is the event for).
+function deliver_claimed_value_wake!(t::Task, w::WaitEntry, @nospecialize(val))
+    (@atomic :monotonic t.waiting_on) === nothing || return nothing
+    try_unlink_claimed!(w)
+    q = t.queue
+    q === nothing || list_deletefirst!(q::StickyWorkqueue, t)
+    t._state === task_state_runnable || return nothing
+    setfield!(t, :result, val)
+    maybe_record_enqueued!(t)
+    enq_work(t)
+    return nothing
+end
+
 """
     yield()
 

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -914,6 +914,110 @@ end
     expect_cancelled(tm)
 end
 
+# a parked watcher keeps the watched source reachable through its live
+# token reference alone (no local rooting in the caller's frame)
+@noinline function _spawn_watcher_on_child(parent)
+    child = CancellationTokenSource(CancellationToken(parent))
+    t = @async wait(CancellationToken(child); cancel=nothing)
+    @assert timedwait(() -> parked_on(t, child), 10.0) == :ok
+    return t
+end
+
+@testset "waiting for a token as an event" begin
+    # an already-cancelled token: immediate value return, no throw
+    src = CancellationTokenSource()
+    cancel!(src, CANCEL_REQUEST_ABANDON_EXTERNAL)
+    req = wait(CancellationToken(src); cancel=nothing)
+    @test req isa CancellationRequest
+    @test req.request == CANCEL_REQUEST_ABANDON_EXTERNAL.request
+
+    # a parked watcher is completed (not interrupted) by the cancellation
+    src = CancellationTokenSource()
+    t = @async wait(CancellationToken(src); cancel=nothing)
+    @test timedwait(() -> parked_on(t, src), 10.0) == :ok
+    @test !istaskdone(t)
+    cancel!(src)
+    @test timedwait(() -> istaskdone(t), 10.0) == :ok
+    @test !istaskfailed(t)
+    @test fetch(t) isa CancellationRequest
+
+    # ... including at ABANDON_ALL: a watcher observes the source but does
+    # not run under it, so the freeze never applies to it
+    src = CancellationTokenSource()
+    t = @async wait(CancellationToken(src); cancel=nothing)
+    @test timedwait(() -> parked_on(t, src), 10.0) == :ok
+    cancel!(src, CANCEL_REQUEST_ABANDON_ALL)
+    @test timedwait(() -> istaskdone(t), 10.0) == :ok
+    @test !istaskfailed(t)
+    @test fetch(t).request == CANCEL_REQUEST_ABANDON_ALL.request
+
+    # ancestor cancellation reaches a watcher on a descendant source
+    parent = CancellationTokenSource()
+    child = CancellationTokenSource(CancellationToken(parent))
+    t = @async wait(CancellationToken(child); cancel=nothing)
+    @test timedwait(() -> parked_on(t, child), 10.0) == :ok
+    cancel!(parent)
+    @test timedwait(() -> istaskdone(t), 10.0) == :ok
+    @test fetch(t) isa CancellationRequest
+
+    # ordinary cancel semantics: the governing token (inherited from the
+    # scope) interrupts the wait, leaving the watched token untouched
+    watched = CancellationTokenSource()
+    gov = CancellationTokenSource()
+    t = with(CANCEL_TOKEN => CancellationToken(gov)) do
+        @async wait(CancellationToken(watched))
+    end
+    @test timedwait(() -> parked_on(t, watched), 10.0) == :ok
+    cancel!(gov)
+    @test timedwait(() -> istaskdone(t), 10.0) == :ok
+    @test istaskfailed(t)
+    @test t.result isa CancellationRequest
+    @test !Base.iscancelled(CancellationToken(watched))
+
+    # a watcher governed by an *ancestor* of the watched source is
+    # interrupted, not completed: the ancestor's own walk claims it before
+    # descending to the watched child (this is why callback watchers shield)
+    outer = CancellationTokenSource()
+    inner = CancellationTokenSource(CancellationToken(outer))
+    t = with(CANCEL_TOKEN => CancellationToken(outer)) do
+        @async wait(CancellationToken(inner))
+    end
+    @test timedwait(() -> parked_on(t, inner), 10.0) == :ok
+    cancel!(outer)
+    @test timedwait(() -> istaskdone(t), 10.0) == :ok
+    @test istaskfailed(t)
+
+    # waiting under the same token is refused, explicitly and inherited
+    srcs = CancellationTokenSource()
+    toks = CancellationToken(srcs)
+    @test_throws ArgumentError wait(toks; cancel=toks)
+    @test_throws ArgumentError with(() -> wait(toks), CANCEL_TOKEN => toks)
+
+    # the callback pattern: a shielded watcher performs its action during
+    # the cancellation
+    src = CancellationTokenSource()
+    fired = Base.Event()
+    watcher = @async begin
+        wait(CancellationToken(src); cancel=nothing)
+        notify(fired)
+    end
+    @test timedwait(() -> parked_on(watcher, src), 10.0) == :ok
+    cancel!(src)
+    wait(fired; cancel=nothing)
+    wait(watcher)
+    @test !istaskfailed(watcher)
+
+    # a parked watcher keeps the watched source attached to the tree
+    # (observability == reachability), so an ancestor cancellation still
+    # reaches it after a GC
+    parent2 = CancellationTokenSource()
+    t2 = _spawn_watcher_on_child(parent2)
+    GC.gc()
+    cancel!(parent2)
+    @test timedwait(() -> istaskdone(t2), 10.0) == :ok
+    @test fetch(t2) isa CancellationRequest
+end
+
 @testset "cancellation of waiting tasks" begin
     # Cancellation of `sleep`
     t, src = cancellable(() -> sleep(1000))


### PR DESCRIPTION
`wait(tok::CancellationToken)` parks the calling task until `tok`'s source is cancelled and returns the delivered `CancellationRequest` as a value: the cancellation is the event the wait is *for*, not an interruption of it. This is the building block of the watcher-task ("cancellation callback") pattern - a task that shields itself (`cancel = nothing`), waits on a token it observes, and reacts to the request - superseding the interrupt-handler registry design proposed in #49541.

Watcher registrations share the source's ordinary waiter registry: the slot's aux stages a watcher bit next to the severity floor, and the cancellation walk delivers a claimed watcher wake value-mode at any severity - a watcher observes the source without running under it. The wait itself stays
cancellable under its own governing token; waiting on the token that also governs the wait is refused, since completing and interrupting the wait would be the same event.