### PR TITLE
cancellation: REPL: Cancel in-flight session work on a double ^C at the prompt

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -158,6 +158,11 @@ Standard library changes
 
 #### REPL
 
+* Pressing `^C` twice at an empty `julia>` prompt now cancels all still-running
+  work started by earlier evaluations (e.g. a runaway `@async` task spewing
+  output): each REPL evaluation runs under its own cancellation source, linked
+  under one session-level source that the repeated press cancels ([#47839]).
+
 #### Test
 
 * `@test`, `@test_throws`, and `@test_broken` now support a `context` keyword argument that provides

--- a/base/client.jl
+++ b/base/client.jl
@@ -603,6 +603,63 @@ function should_use_main_entrypoint()
     return true
 end
 
+
+## The interactive session's two-level cancellation-source tree
+#
+# An interactive driver (the REPL backend) runs every evaluation under its
+# own cancellation source, each a child of one long-lived *session* source:
+# cancelling an evaluation's source stops exactly that evaluation (and
+# everything it spawned), while cancelling the session source sweeps every
+# still-running piece of work any evaluation has started - the runaway
+# `@async` from three prompts ago included. Cancellation is monotonic, so a
+# swept session source is retired and the next evaluation starts a fresh
+# session epoch: "everything so far" always means "since the last sweep".
+
+const _session_cancel_source = Ref{Union{Nothing, CancellationTokenSource}}(nothing)
+const _session_cancel_lock = ReentrantLock()
+
+# The current session source, created on first use (and after each sweep).
+function session_cancel_source!()
+    lock(_session_cancel_lock; cancel=nothing)
+    try
+        ses = _session_cancel_source[]
+        if ses === nothing
+            ses = CancellationTokenSource()
+            _session_cancel_source[] = ses
+        end
+        return ses
+    finally
+        unlock(_session_cancel_lock)
+    end
+end
+
+# A fresh source governing one interactive evaluation, linked under the
+# session source.
+new_evaluation_cancel_source!() =
+    CancellationTokenSource(CancellationToken(session_cancel_source!()))
+
+"""
+    Base.cancel_session_work!() -> Bool
+
+Cancel every still-running piece of work started under the current
+interactive session's evaluations (see the session-source tree above) and
+start a fresh session epoch. Returns whether there was a session to sweep.
+The REPL binds this to a repeated `^C` at an empty prompt.
+"""
+function cancel_session_work!()
+    lock(_session_cancel_lock; cancel=nothing)
+    ses = try
+        s = _session_cancel_source[]
+        _session_cancel_source[] = nothing
+        s
+    finally
+        unlock(_session_cancel_lock)
+    end
+    ses === nothing && return false
+    cancel!(ses)
+    return true
+end
+
 function _start()
     empty!(ARGS)
     append!(ARGS, Core.ARGS)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2848,9 +2848,31 @@ AnyDict(
         catch
         end
         cancel_beep(s)
-        move_input_end(s)
-        refresh_line(s)
-        print(terminal(s), "^C\n\n")
+        if buffer(s).size == 0
+            # ^C at an empty prompt: nothing to clear, so the press reaches
+            # for still-running work from earlier evaluations. Two presses
+            # in a row sweep it (with an announce in between) - which also
+            # makes hammering ^C at spewing background output do what the
+            # user means, even though the prompt already returned. The arm
+            # survives exactly one keystroke (`last_action`), so any other
+            # key stands it down.
+            if s.last_action === :cancel_session_arm
+                set_action!(s, :cancel_session)
+                print(terminal(s), "^C\n")
+                if Base.cancel_session_work!()
+                    print(terminal(s), "Cancelled all in-flight work.\n\n")
+                else
+                    print(terminal(s), "\n")
+                end
+            else
+                set_action!(s, :cancel_session_arm)
+                print(terminal(s), "^C  (press ^C again to cancel all in-flight work)\n\n")
+            end
+        else
+            move_input_end(s)
+            refresh_line(s)
+            print(terminal(s), "^C\n\n")
+        end
         transition(s, :reset)
         refresh_line(s)
     end,

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2848,7 +2848,7 @@ AnyDict(
         catch
         end
         cancel_beep(s)
-        if buffer(s).size == 0
+        if buffer(s).size == 0 && !Base.generating_output()
             # ^C at an empty prompt: nothing to clear, so the press reaches
             # for still-running work from earlier evaluations. Two presses
             # in a row sweep it (with an announce in between) - which also

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -471,8 +471,15 @@ function repl_backend_loop(backend::REPLBackend, get_module::Function)
             # exit flag
             break
         end
+        # Run the evaluation in the scope of a fresh cancellation source
+        # linked under the session source (see the session tree in
+        # base/client.jl): the double-^C prompt gesture sweeps every
+        # still-running task any evaluation has spawned by cancelling the
+        # session source, without a way to name each one individually.
+        evaltok = Base.CancellationToken(Base.new_evaluation_cancel_source!())
         # Mark this task as the foreground task while running user work, so that
         # components like the precompile keyboard menu know who owns interactive stdin.
+        Base.ScopedValues.@with Base.CANCEL_TOKEN => evaltok begin
         Base.@as_foreground_task if show_value == 2 # 2 indicates a function to be called
             f = ast_or_func
             try
@@ -484,6 +491,7 @@ function repl_backend_loop(backend::REPLBackend, get_module::Function)
         else
             ast = ast_or_func
             eval_user_input(ast, backend, get_module())
+        end
         end
     end
     return nothing

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -116,21 +116,20 @@ end
 
 
 # Two ^C at an empty prompt sweep the session's in-flight work (the
-# session -> evaluation cancellation-source tree; issue #47839).
+# session -> evaluation cancellation-source tree; issue #47839). N.B.: in
+# fake_repl only *displayed results* (and LineEdit's own output) reach
+# `stdout_read` - a `println` from an evaluation goes to the process
+# stdout - so every step communicates through its result value.
 fake_repl() do stdin_write, stdout_read, repl
-    repltask = @async begin
-        REPL.run_repl(repl)
-    end
+    repltask = @async REPL.run_repl(repl)
     # start a runaway background task from an evaluation
-    write(stdin_write, "global bgc = Ref(0); global bg = @async while true; sleep(0.01); bgc[] += 1; end; println(\"BG-\", \"UP\")\n")
-    readuntil(stdout_read, "BG-UP")
-    # bg survives its evaluation completing
-    write(stdin_write, "print(\"bg-alive=\", !istaskdone(bg))\n")
-    readuntil(stdout_read, "bg-alive=true")
+    write(stdin_write, "global bg = @async while true; sleep(0.01); end; \"BG\" * \"UP\"\n")
+    readuntil(stdout_read, "BGUP")
+    readuntil(stdout_read, "julia> ")
     # first ^C at the empty prompt arms the sweep
     write(stdin_write, "\x03")
     readuntil(stdout_read, "press ^C again to cancel all in-flight work")
-    # any other key stands the arm down
+    # any other key stands the arm down: this ^C press only re-arms
     write(stdin_write, "1\n")
     readuntil(stdout_read, "julia> ")
     write(stdin_write, "\x03")
@@ -139,12 +138,12 @@ fake_repl() do stdin_write, stdout_read, repl
     write(stdin_write, "\x03")
     readuntil(stdout_read, "Cancelled all in-flight work.")
     # the runaway task was cancelled ...
-    write(stdin_write, "print(\"bg-done=\", timedwait(() -> istaskdone(bg), 30.0) === :ok)\n")
-    readuntil(stdout_read, "bg-done=true")
+    write(stdin_write, "\"done=\" * string(timedwait(() -> istaskdone(bg), 30.0) === :ok)\n")
+    readuntil(stdout_read, "done=true")
     # ... and the session still evaluates (a fresh session epoch)
-    write(stdin_write, "print(\"still-\", \"alive\")\n")
+    write(stdin_write, "\"still\" * \"-alive\"\n")
     readuntil(stdout_read, "still-alive")
-    write(stdin_write, "exit()\n")
+    write(stdin_write, '\x04') # ^D: exit the REPL loop (not the process)
     Base.wait(repltask)
 end
 

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -114,6 +114,40 @@ fake_repl() do stdin_write, stdout_read, repl
     Base.wait(repltask)
 end
 
+
+# Two ^C at an empty prompt sweep the session's in-flight work (the
+# session -> evaluation cancellation-source tree; issue #47839).
+fake_repl() do stdin_write, stdout_read, repl
+    repltask = @async begin
+        REPL.run_repl(repl)
+    end
+    # start a runaway background task from an evaluation
+    write(stdin_write, "global bgc = Ref(0); global bg = @async while true; sleep(0.01); bgc[] += 1; end; println(\"BG-\", \"UP\")\n")
+    readuntil(stdout_read, "BG-UP")
+    # bg survives its evaluation completing
+    write(stdin_write, "print(\"bg-alive=\", !istaskdone(bg))\n")
+    readuntil(stdout_read, "bg-alive=true")
+    # first ^C at the empty prompt arms the sweep
+    write(stdin_write, "\x03")
+    readuntil(stdout_read, "press ^C again to cancel all in-flight work")
+    # any other key stands the arm down
+    write(stdin_write, "1\n")
+    readuntil(stdout_read, "julia> ")
+    write(stdin_write, "\x03")
+    readuntil(stdout_read, "press ^C again to cancel all in-flight work")
+    # the second press in a row sweeps
+    write(stdin_write, "\x03")
+    readuntil(stdout_read, "Cancelled all in-flight work.")
+    # the runaway task was cancelled ...
+    write(stdin_write, "print(\"bg-done=\", timedwait(() -> istaskdone(bg), 30.0) === :ok)\n")
+    readuntil(stdout_read, "bg-done=true")
+    # ... and the session still evaluates (a fresh session epoch)
+    write(stdin_write, "print(\"still-\", \"alive\")\n")
+    readuntil(stdout_read, "still-alive")
+    write(stdin_write, "exit()\n")
+    Base.wait(repltask)
+end
+
 # These are integration tests. If you want to unit test e.g. completion, or
 # exact LineEdit behavior, put them in the appropriate test files.
 # Furthermore since we are emulating an entire terminal, there may be control characters


### PR DESCRIPTION
Very shortly `^C` will cancel the *currently* running operation when not at the REPL, but what if the thing you want to cancel was launched in a previous REPL prompt and is spewing output (as in #47839). This PR introduces a (hopefully) intuitive mechanism for cancelling previous work: Press ^C twice at an empty REPL prompt. The idea is that if something is running that you want to cancel because it's spewing output, the first ^C will dump you back at the REPL (which maybe you can't see), but if you keep spamming ^C, it'll eventually cancel everything. Requiring ^C twice is just protection against accidentally cancelling something when you're not actively panicing, as well as a way to explain how the feature works (first ^C at an empty REPL prompt will print an explanatory message).

Fixes #47839