### PR TITLE
deepcopy: Fix deepcopy(::WeakRef) producing an unregistered WeakRef

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -185,7 +185,7 @@ end
 # WeakRef must be constructed through its own constructor to register
 # the new object on the GC's per-thread weak reference list, which in turn is what
 # lets the collector null out 'value' once the referent dies, otherwise the deepcopied
-# pointer is left dangling. 
+# pointer is left dangling.
 function deepcopy_internal(x::WeakRef, stackdict::IdDict)
     if haskey(stackdict, x)
         return stackdict[x]::typeof(x)

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -182,6 +182,20 @@ function deepcopy_internal(x::GenericCondition, stackdict::IdDict)
     return y
 end
 
+# WeakRef must be constructed through its own constructor: that is what registers
+# the new object on the GC's per-thread weak reference list, which in turn is what
+# lets the collector null out `value` once the referent dies, otherwise the deepcopied
+# pointer is left dangling. The referent is deliberately not deep-copied: a weak
+# reference to a fresh object with no strong referents would be collectible at once.
+function deepcopy_internal(x::WeakRef, stackdict::IdDict)
+    if haskey(stackdict, x)
+        return stackdict[x]::typeof(x)
+    end
+    y = WeakRef(x.value)
+    stackdict[x] = y
+    return y
+end
+
 # Core.WaitEntryN has a hidden variable-length slot tail that the generic
 # path above - which allocates only the fixed datatype size - cannot
 # reproduce (the GC would then scan a nonexistent tail). Allocate through

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -182,11 +182,10 @@ function deepcopy_internal(x::GenericCondition, stackdict::IdDict)
     return y
 end
 
-# WeakRef must be constructed through its own constructor: that is what registers
+# WeakRef must be constructed through its own constructor to register
 # the new object on the GC's per-thread weak reference list, which in turn is what
-# lets the collector null out `value` once the referent dies, otherwise the deepcopied
-# pointer is left dangling. The referent is deliberately not deep-copied: a weak
-# reference to a fresh object with no strong referents would be collectible at once.
+# lets the collector null out 'value' once the referent dies, otherwise the deepcopied
+# pointer is left dangling. 
 function deepcopy_internal(x::WeakRef, stackdict::IdDict)
     if haskey(stackdict, x)
         return stackdict[x]::typeof(x)

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -274,6 +274,7 @@ end
     @inferred Base.deepcopy_internal('a', IdDict())
     @inferred Base.deepcopy_internal("abc", IdDict())
     @inferred Base.deepcopy_internal([1,2,3], IdDict())
+    @inferred Base.deepcopy_internal(WeakRef(), IdDict())
 
     # structs without custom deepcopy_internal method
     struct Immutable2; x::Int; end
@@ -307,4 +308,43 @@ end
     @test !islocked(b.lock)
     @inferred deepcopy(a)
     @inferred deepcopy(a.lock)
+end
+
+@testset "`deepcopy` a `WeakRef` (#62597)" begin
+    r  = Base.RefValue(1)
+    w  = WeakRef(r)
+    w2 = deepcopy(w)
+    @test typeof(w2) === WeakRef
+    @test w2 !== w
+    @test w2.value === r
+    a, b = deepcopy((w, w))
+    @test a === b
+    @test deepcopy(WeakRef(nothing)).value === nothing
+    @test deepcopy(WeakRef()).value === nothing
+end
+
+@testset "`deepcopy` of a `WeakRef` is GC-registered (#62597)" begin
+    @noinline function mk_wr(strong, weak)
+        x = Base.RefValue(1)
+        push!(strong, x)
+        w = WeakRef(x)
+        push!(weak, w)
+        push!(weak, deepcopy(w))
+        nothing
+    end
+    @noinline both_live(weak) = weak[1].value !== nothing && weak[2].value !== nothing
+    @noinline same_referent(weak) = weak[1].value === weak[2].value
+    function test_wr()
+        strong = []
+        weak = []
+        mk_wr(strong, weak)
+        GC.gc()
+        @test both_live(weak)
+        @test same_referent(weak)
+        empty!(strong)
+        GC.gc()
+        @test weak[1].value === nothing
+        @test weak[2].value === nothing
+    end
+    test_wr()
 end


### PR DESCRIPTION
`base/deepcopy.jl` had no method for `WeakRef`, so it fell through to the generic mutable branch of `deepcopy_internal`, which allocates with `jl_new_struct_uninit`. That skips the registration onto the GC's per-thread weak reference list performed by `jl_gc_new_weakref_th`. The original is nulled out, but the copy is left dangling causing a segfault.
```julia
julia> r = Base.RefValue(1); w = WeakRef(r)
julia> w2 = deepcopy(w);
julia> r = nothing; GC.gc()

julia> w
WeakRef(nothing)

julia> w2
WeakRef(
Exception: EXCEPTION_ACCESS_VIOLATION at 0x7ffd0ee789f6 (reading 0x69)
  -- jl_object_id__cold at src/builtins.c:535
jl_idset_get at src/idset.c:40
jl_as_global_root at src/staticdata.c:2825
inst_datatype_inner at src/jltypes.c:2553
arg_type_tuple at src/gf.c:3487
ijl_apply_generic at src/gf.c:4816
_show_default at ./show.jl:518
```
Adding a method to specifically call WeakRef's constructor fixes the issue.
```
julia> r = Base.RefValue(1)
Base.RefValue{Int64}(1)

julia> w = WeakRef(r)
WeakRef(Base.RefValue{Int64}(1))

julia> w2=deepcopy(w)
WeakRef(Base.RefValue{Int64}(1))

julia> r=nothing

julia> GC.gc()

julia> w
WeakRef(nothing)

julia> w2
WeakRef(nothing)
```
- Claude also found that `WeakKeyDict` was also affected by this one level down but while the `WeakRef` keys are now being registered, the finalizer isn't firing so collection still isn't fully clean. To be frank, I don't understand that section of the code and hence what is failing very well, but I'd be happy to read up and take it up next!
- The issue also mentions Serialization. Same bug there, untouched by this PR since `deserialize` doesn't go through `deepcopy_internal`, would have to be done separately.

Tests largely written by Opus 5

Fixes #62597 

