### PR TITLE
Stop recording edges for uninformative calls

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -122,6 +122,24 @@ end
 widen_call_result(::AbstractInterpreter, si::StmtInfo, state::CallInferenceState, ::AbsIntState) =
     call_result_unused(si) && !(state.rettype === Bottom)
 
+# Whether inference of a non-concrete call site produced no conclusion worth recording
+# edges for: `Any` return and exception types, effects no better than unknown (so the
+# call can neither be deleted nor folded on their account), and no argument refinements.
+function is_uninformative_call(state::CallInferenceState, applicable::Vector{MethodMatchTarget})
+    if !(state.rettype === Any && state.exctype === Any && state.slotrefinements === nothing)
+        return false
+    end
+    if is_better_effects(state.all_effects, EFFECTS_UNKNOWN)
+        return false
+    end
+    for i = 1:length(applicable)
+        if !isdispatchtuple(applicable[i].match.spec_types)
+            return true
+        end
+    end
+    return false
+end
+
 function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(func),
                                   arginfo::ArgInfo, si::StmtInfo, @nospecialize(atype),
                                   vtypes::Union{VarTable,Nothing}, sv::AbsIntState, max_methods::Int)
@@ -362,6 +380,13 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
             infercalls2(interp, sv) || push!(sv.tasks, infercalls2)
         end
 
+        if is_uninformative_call(state, applicable)
+            # Inference learned nothing at a non-concrete call site, so there is no
+            # conclusion for a backedge to protect. Leave the edge decision to the
+            # optimizer, which adds one only if it commits to a matched method.
+            add_remark!(interp, sv, "Deferring edges of uninformative non-concrete call site to the optimizer")
+            retinfo = UninformativeCallInfo(retinfo)
+        end
         gfresult[] = CallMeta(state.rettype, state.exctype, state.all_effects, retinfo, state.slotrefinements)
         return true
     end # function infercalls

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -813,6 +813,7 @@ function compileable_specialization(code::Union{MethodInstance,CodeInstance}, ef
         end
     end
     add_inlining_edge!(et, code) # to the code and edges
+    add_uninformative_dispatch_edge!(et.edges, mi, info)
     return InvokeCase(code, effects, info)
 end
 
@@ -838,7 +839,7 @@ function add_inlining_dispatch_edge!(edges::Vector{Any}, mi::MethodInstance,
                                      @nospecialize(info::CallInfo))
     if info isa InvokeCallInfo
         add_invoke_edge!(edges, info.atype, mi)
-    elseif info isa VirtualMethodMatchInfo
+    elseif info isa VirtualMethodMatchInfo || info isa UninformativeCallInfo
         add_inlining_dispatch_edge!(edges, mi, info.info)
     elseif info isa MethodMatchInfo || info isa UnionSplitInfo
         # A standalone `MethodInstance` edge claims `mi.specTypes` has a single
@@ -847,6 +848,17 @@ function add_inlining_dispatch_edge!(edges::Vector{Any}, mi::MethodInstance,
         _add_edges_impl(edges, info, #=mi_edge=#true)
     else
         add_one_edge!(edges, mi)
+    end
+    return nothing
+end
+
+# Inference records no edges at an uninformative call site, so every commitment the
+# optimizer makes there must certify the lookup itself: an inlined body or an `:invoke`
+# both fix which method this site calls, and a method added later can change that.
+function add_uninformative_dispatch_edge!(edges::Vector{Any}, mi::MethodInstance,
+                                          @nospecialize(info::CallInfo))
+    if info isa UninformativeCallInfo
+        add_inlining_dispatch_edge!(edges, mi, info)
     end
     return nothing
 end
@@ -872,25 +884,46 @@ function resolve_todo(mi::MethodInstance, call_result::Union{Nothing,LocalInfere
     end
 
     # The local result's proof justifies its inferred facts and retained source. The
-    # ordinary call edge remains a separate executable target.
-    add_inlining_edge!(et, target)
-    add_inference_proof!(et.edges, inference_proof(call_result), target)
+    # ordinary call edge remains a separate executable target. An uninformative site
+    # consumed no facts, so it owes the edge only if it commits to the result below;
+    # `compileable_specialization` adds its own.
+    uninformative = info isa UninformativeCallInfo
+    if !uninformative
+        add_inlining_edge!(et, target)
+        add_inference_proof!(et.edges, inference_proof(call_result), target)
+    end
     inferred_result = get_local_code(call_result)
     if inferred_result isa SomeCase
+        if uninformative
+            add_inlining_edge!(et, target)
+            add_inference_proof!(et.edges, inference_proof(call_result), target)
+            add_inlining_dispatch_edge!(et.edges, mi, info)
+        end
         return ConstantCase(inferred_result.val)
     end
     (; src, effects) = inferred_result
 
     # the duplicated check might have been done already within `analyze_method!`, but still
     # we need it here too since we may come here directly using a constant-prop' result
-    if !OptimizationParams(state.interp).inlining || is_stmt_noinline(flag)
-        return compileable_specialization(target, effects, et, info, state)
+    if !OptimizationParams(state.interp).inlining || is_stmt_noinline(flag) ||
+            !src_inlining_policy(state.interp, mi, src, info, flag)
+        item = compileable_specialization(target, effects, et, info, state)
+        if uninformative
+            if item !== nothing
+                # The `:invoke` carries the effects inferred here, so certify them; the
+                # dispatch edge came from `compileable_specialization`.
+                add_inference_proof!(et.edges, inference_proof(call_result), target)
+            end
+        end
+        return item
     end
 
-    src_inlining_policy(state.interp, mi, src, info, flag) ||
-        return compileable_specialization(target, effects, et, info, state)
-
     ir, spec_info, debuginfo = retrieve_ir_for_inlining(mi, src, true)
+    if uninformative
+        add_inlining_edge!(et, target)
+        add_inference_proof!(et.edges, inference_proof(call_result), target)
+        add_inlining_dispatch_edge!(et.edges, mi, info)
+    end
     return InliningTodo(mi, ir, spec_info, debuginfo, effects)
 end
 
@@ -1247,11 +1280,14 @@ end
 
 function extract_indirect_invoke(@nospecialize info::CallInfo)
     info isa MethodResultPure && (info = info.info)
-    info isa MethodMatchInfo || return nothing
-    length(info.edges) == length(info.results) == 1 || return nothing
-    match = info.results[1]::MethodMatch
+    # keep the uninformative tag on the returned info, so that the `:invoke` emitted by
+    # `compileable_specialization` still records this site's dispatch dependency
+    matchinfo = info isa UninformativeCallInfo ? info.info : info
+    matchinfo isa MethodMatchInfo || return nothing
+    length(matchinfo.edges) == length(matchinfo.results) == 1 || return nothing
+    match = matchinfo.results[1]::MethodMatch
     match.fully_covers || return nothing
-    edge = info.edges[1]
+    edge = matchinfo.edges[1]
     edge === nothing && return nothing
     return info, edge
 end
@@ -1449,6 +1485,12 @@ function handle_call!(todo::Vector{Pair{Int,Any}},
     cases, handled_all_cases, fully_covered, joint_effects = cases
     atype = argtypes_to_type(sig.argtypes)
     atype === Union{} && return nothing # accidentally actually unreachable
+    if info isa UninformativeCallInfo && handled_all_cases && !fully_covered
+        # Inference recorded no edges for this site, but the union split emitted below
+        # commits to the lookup being exhaustive by raising a `MethodError` past the
+        # last case, so the uncovered part of the signature must be watched.
+        add_uncovered_edges!(state.edges, info.info)
+    end
     handle_cases!(todo, ir, idx, stmt, atype, cases, handled_all_cases, fully_covered, joint_effects)
 end
 
@@ -1478,6 +1520,7 @@ function semiconcrete_result_item(result::SemiConcreteResult,
     et = InliningEdgeTracker(state)
     add_inlining_edge!(et, code)
     add_inference_proof!(et.edges, inference_proof(result), code)
+    add_uninformative_dispatch_edge!(et.edges, mi, info)
 
     if (!OptimizationParams(state.interp).inlining || is_stmt_noinline(flag) ||
         # For `NativeInterpreter`, `SemiConcreteResult` may be produced for

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -234,20 +234,20 @@ function add_method_match_proofs!(edges::Vector{Any}, info::MethodMatchInfo,
     return nothing
 end
 
-function _add_edges_impl(edges::Vector{Any}, info::MethodMatchInfo, mi_edge::Bool=false)
-    if !fully_covering(info)
-        exists = false
-        for i in 2:length(edges)
-            if edges[i] === Core.methodtable && edges[i-1] == info.atype
-                exists = true
-                break
-            end
-        end
-        if !exists
-            push!(edges, info.atype)
-            push!(edges, Core.methodtable)
+function add_uncovered_edges!(edges::Vector{Any}, info::MethodMatchInfo)
+    fully_covering(info) && return nothing
+    for i in 2:length(edges)
+        if edges[i] === Core.methodtable && edges[i-1] == info.atype
+            return nothing
         end
     end
+    push!(edges, info.atype)
+    push!(edges, Core.methodtable)
+    return nothing
+end
+
+function _add_edges_impl(edges::Vector{Any}, info::MethodMatchInfo, mi_edge::Bool=false)
+    add_uncovered_edges!(edges, info)
     nmatches = length(info.results)
     if nmatches == length(info.edges) == 1 && fully_covering(info)
         # try the optimized format for the representation, if possible and applicable
@@ -344,6 +344,8 @@ add_edges_impl(edges::Vector{Any}, info::UnionSplitInfo) =
     _add_edges_impl(edges, info)
 _add_edges_impl(edges::Vector{Any}, info::UnionSplitInfo, mi_edge::Bool=false) =
     for split in info.split; _add_edges_impl(edges, split, mi_edge); end
+add_uncovered_edges!(edges::Vector{Any}, info::UnionSplitInfo) =
+    for split in info.split; add_uncovered_edges!(edges, split); end
 nsplit_impl(info::UnionSplitInfo) = length(info.split)
 getsplit_impl(info::UnionSplitInfo, idx::Int) = getsplit(info.split[idx], 1)
 function getresult_impl(info::UnionSplitInfo, idx::Int)
@@ -709,6 +711,25 @@ nsplit_impl(info::VirtualMethodMatchInfo) = nsplit(info.info)
 getsplit_impl(info::VirtualMethodMatchInfo, idx::Int) = getsplit(info.info, idx)
 getresult_impl(info::VirtualMethodMatchInfo, idx::Int) = getresult(info.info, idx)
 getedge_impl(info::VirtualMethodMatchInfo, idx::Int) = getedge(info.info, idx)
+
+"""
+    info::UninformativeCallInfo <: CallInfo
+
+Wraps the `MethodMatchInfo`/`UnionSplitInfo` of a non-concrete call site at which
+inference learned nothing from the matched methods: `Any` return and exception types,
+no argument refinements, and effects no better than `EFFECTS_UNKNOWN`. Inference records
+no edges for such a site, since there is no conclusion for a backedge to protect. The
+inliner sees through the wrapper and adds edges itself only where it commits to a matched
+method, by inlining it or emitting an `:invoke`; a site left as a dynamic call gets none.
+"""
+struct UninformativeCallInfo <: CallInfo
+    info::Union{MethodMatchInfo,UnionSplitInfo}
+end
+add_edges_impl(::Vector{Any}, ::UninformativeCallInfo) = nothing
+nsplit_impl(info::UninformativeCallInfo) = nsplit(info.info)
+getsplit_impl(info::UninformativeCallInfo, idx::Int) = getsplit(info.info, idx)
+getresult_impl(info::UninformativeCallInfo, idx::Int) = getresult(info.info, idx)
+getedge_impl(info::UninformativeCallInfo, idx::Int) = getedge(info.info, idx)
 
 """
     info::GlobalAccessInfo <: CallInfo

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6105,6 +6105,64 @@ g_concrete_only(x) = f_concrete_only(x)
 @test only(Base.return_types(g_concrete_only, Tuple{Int})) === Int
 @test only(Base.return_types(g_concrete_only, Tuple{Integer})) === Any
 
+# Inference records no backedge at a non-concrete call site where it learned nothing
+# (`Any` result, unknown effects) and the optimizer left the call dynamic, so a later
+# method definition cannot invalidate the caller. The edge is kept where the optimizer
+# commits to the matched method by inlining or `:invoke`, and at concrete call sites.
+@noinline f_uninformative(x) = Base.inferencebarrier(identity)(x)
+@noinline f_uninformative_nsp(@nospecialize x) = Base.inferencebarrier(identity)(x)
+@inline f_uninformative_inl(x) = Base.inferencebarrier(identity)(x)
+g_uninformative(x) = f_uninformative(x)
+g_uninformative_nsp(x) = f_uninformative_nsp(x)
+g_uninformative_inl(x) = f_uninformative_inl(x)
+# Report which kinds of edge to `f` the edge list of `src` holds: a dispatch edge (a
+# standalone target, or one within an encoded lookup) watches which method this call site
+# selects, while an `invoke`-style `(signature, target)` pair only certifies the code of
+# an already selected method. A committed call site needs both.
+function uninformative_edge_kinds(src, f)
+    m = only(methods(f))
+    dispatch = invoke_style = false
+    edges = src.edges
+    unwrap(@nospecialize e) = e isa Core.CodeInstance ? Compiler.get_ci_mi(e) : e
+    matches(@nospecialize e) = (e = unwrap(e); e === m || (e isa MethodInstance && e.def === m))
+    i = 1
+    while i ≤ length(edges)
+        e = edges[i]
+        if e isa Int # encoded lookup: `nmatches, atype, matches...`
+            n = abs(e)
+            for j = i+2:i+1+n
+                if matches(edges[j])
+                    dispatch = true
+                end
+            end
+            i += 2 + n
+        elseif e isa Type # `(signature, target)` pair
+            if matches(edges[i+1])
+                invoke_style = true
+            end
+            i += 2
+        else
+            if matches(e)
+                dispatch = true
+            end
+            i += 1
+        end
+    end
+    return (; dispatch, invoke_style)
+end
+let src = code_typed1(g_uninformative, (Integer,))
+    @test count(iscall((src, f_uninformative)), src.code) == 1
+    @test uninformative_edge_kinds(src, f_uninformative) == (dispatch=false, invoke_style=false)
+    src = code_typed1(g_uninformative, (Int,))
+    @test uninformative_edge_kinds(src, f_uninformative).dispatch
+    src = code_typed1(g_uninformative_nsp, (Integer,))
+    @test count(isinvoke(:f_uninformative_nsp), src.code) == 1
+    @test uninformative_edge_kinds(src, f_uninformative_nsp).dispatch
+    src = code_typed1(g_uninformative_inl, (Integer,))
+    @test count(iscall((src, f_uninformative_inl)), src.code) == 0
+    @test uninformative_edge_kinds(src, f_uninformative_inl).dispatch
+end
+
 # Test that a module-wise `@max_methods` works as expected
 module Test43370
 using Test

--- a/Compiler/test/invalidation.jl
+++ b/Compiler/test/invalidation.jl
@@ -205,11 +205,11 @@ begin
         ci = mi.cache
         @test isdefined(ci, :next)
         @test ci.owner === InvalidationTesterToken()
-        @test_broken ci.max_world == typemax(UInt)
+        @test ci.max_world == typemax(UInt)
         ci = ci.next
         @test !isdefined(ci, :next)
         @test ci.owner === nothing
-        @test_broken ci.max_world == typemax(UInt)
+        @test ci.max_world == typemax(UInt)
     end
 
     @test isnothing(pr48932_caller(42))
@@ -304,11 +304,11 @@ begin take!(GLOBAL_BUFFER)
         ci = mi.cache
         @test isdefined(ci, :next)
         @test ci.owner === InvalidationTesterToken()
-        @test_broken ci.max_world == typemax(UInt)
+        @test ci.max_world == typemax(UInt)
         ci = ci.next
         @test !isdefined(ci, :next)
         @test ci.owner === nothing
-        @test_broken ci.max_world == typemax(UInt)
+        @test ci.max_world == typemax(UInt)
     end
     @test isnothing(pr48932_caller_unuse(42))
     @test "foo" == String(take!(GLOBAL_BUFFER))
@@ -462,4 +462,32 @@ let mi = Base.method_instance(co_caller, (COBox,))
     ci = mi.cache
     @test ci.owner === InvalidationTesterToken()
     @test ci.max_world == typemax(UInt)
+end
+
+# A call site where inference learned nothing records no edges of its own, but the
+# optimizer may still commit to the matched method, by emitting an `:invoke` for it or by
+# inlining its body. Such a site must record its dispatch dependency, so that a method
+# added later invalidates the caller.
+module UninformativeCommit
+    global CALLEE = identity
+    @noinline uninf_invoke(@nospecialize x) = CALLEE(x)
+    @inline uninf_inline(x) = CALLEE(x)
+    invoke_caller(v::Vector{Any}) = uninf_invoke(v[1])
+    inline_caller(v::Vector{Any}) = uninf_inline(v[1])
+end
+let tester_ci(f) = let ci = Base.method_instance(f, (Vector{Any},)).cache
+        @test ci.owner === InvalidationTesterToken()
+        ci
+    end
+    @test only(Base.return_types(UninformativeCommit.invoke_caller, (Vector{Any},);
+        interp=InvalidationTester())) === Any
+    @test only(Base.return_types(UninformativeCommit.inline_caller, (Vector{Any},);
+        interp=InvalidationTester())) === Any
+    @test tester_ci(UninformativeCommit.invoke_caller).max_world == typemax(UInt)
+    @test tester_ci(UninformativeCommit.inline_caller).max_world == typemax(UInt)
+
+    @eval UninformativeCommit uninf_invoke(x::Int) = "specific"
+    @eval UninformativeCommit uninf_inline(x::Int) = "specific"
+    @test tester_ci(UninformativeCommit.invoke_caller).max_world != typemax(UInt)
+    @test tester_ci(UninformativeCommit.inline_caller).max_world != typemax(UInt)
 end

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -135,7 +135,7 @@ function __init__()
         ALLOC_OVERFLOW_FUNCTION[] = true
     catch ex
         # ErrorException("ccall: could not find function...")
-        if typeof(ex) != ErrorException
+        if !(ex isa ErrorException)
             rethrow()
         end
     end

--- a/deps/jlutilities/juliac/Manifest.toml
+++ b/deps/jlutilities/juliac/Manifest.toml
@@ -77,7 +77,7 @@ version = "1.8.0"
 
 [[deps.JuliaC]]
 deps = ["LazyArtifacts", "Libdl", "Mmap", "ObjectFile", "PackageCompiler", "Patchelf_jll", "Pkg", "Preferences", "RelocatableFolders", "StructIO", "TOML"]
-git-tree-sha1 = "e20ce4ef45c1abfcded4e0a6e2d0ca6d5d4267c4"
+git-tree-sha1 = "709becea1e2ce3ce495c35681e5fc8be409a2fb8"
 repo-rev = "main"
 repo-url = "https://github.com/JuliaLang/JuliaC.jl.git"
 uuid = "acedd4c2-ced6-4a15-accc-2607eb759ba2"


### PR DESCRIPTION
Inference records backedges before optimization, so a caller gets an edge to a method even if the optimizer later decides to do a dynamic dispatch there. This changes how we record backedges such that if inference didn't learn anything from the method (e.g. Any return type, unknown effects) then we don't record a backedge for it.

Fixes these invalidations seen on nightly when loading PythonCall:
<details>
<summary>Invalidations</summary>

```julia
 inserting !=(x::Py, y::Number) @ PythonCall.Core ~/.julia/packages/PythonCall/5WGSP/src/Core/Py.jl:371 invalidated:                                                                                                                           
   backedges: 1: superseding !=(x, y) @ Base operators.jl:320 with MethodInstance for !=(::Any, ::Bool) (2 children)                                                                                                                           
              2: superseding !=(x, y) @ Base operators.jl:320 with MethodInstance for !=(::Any, ::UInt8) (3 children)                                                                                                                          
              3: superseding !=(x, y) @ Base operators.jl:320 with MethodInstance for !=(::Any, ::Int64) (38 children)                                                                                                                         

 inserting >(x::Number, y::Py) @ PythonCall.Core ~/.julia/packages/PythonCall/5WGSP/src/Core/Py.jl:384 invalidated:                                                                                                                            
   backedges: 1: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Int64, ::Any) (129 children)                                                                                                                          

 inserting >(x::Py, y::Py) @ PythonCall.Core ~/.julia/packages/PythonCall/5WGSP/src/Core/Py.jl:365 invalidated:                                                                                                                                
   backedges: 1: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Any, ::Any) (190 children)                                                                                                                            
 
 inserting !=(x::Number, y::Py) @ PythonCall.Core ~/.julia/packages/PythonCall/5WGSP/src/Core/Py.jl:380 invalidated:                                                                                                                           
   backedges: 1: superseding !=(x, y) @ Base operators.jl:320 with MethodInstance for !=(::Int64, ::Any) (327 children)                                                                                                                        
                                                                                                                                                                                                                                               
 inserting >=(x::Py, y::Number) @ PythonCall.Core ~/.julia/packages/PythonCall/5WGSP/src/Core/Py.jl:374 invalidated:                                                                                                                           
   backedges: 1: superseding >=(x, y) @ Base operators.jl:481 with MethodInstance for >=(::Any, ::UInt8) (3 children)                                                                                                                          
              2: superseding >=(x, y) @ Base operators.jl:481 with MethodInstance for >=(::Any, ::Int64) (384 children)                                                                                                                        

 inserting &(x::Py, y::Number) @ PythonCall.Core ~/.julia/packages/PythonCall/5WGSP/src/Core/Py.jl:439 invalidated:                                                                                                                            
   mt_backedges:  1: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base._thisind_str(::SubString{<:StringView}, ::Int64) (0 children)                                                                                     
                  2: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base._thisind_str(::StringView, ::Int64) (0 children)                                                                                                  
                  3: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for (::Base.var"#_nextind_continued#_nextind_str##0")(::SubString{<:StringView}, ::Int64, ::Int64, ::UInt8) (0 children)                                  
                  4: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base._thisind_str(::StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}, ::Int64) (0 children)                                                                                                                                   
                  5: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base._thisind_str(::SubString{<:StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}}, ::Int64) (0 children)                                                                                                                      
                  6: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base._thisind_str(::StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}, ::Int64) (0 children)                                                                                                                                   
                  7: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base._thisind_str(::SubString{<:StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}}, ::Int64) (0 children)                                                                                                                      
                  8: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for (::Base.var"#_nextind_continued#_nextind_str##0")(::StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}, ::Int64, ::Any, ::UInt8) (0 children)                                                                                  
                  9: signature Tuple{typeof(&), Any, Int64} triggered MethodInstance for Base._search_bloom_mask(::Any) (0 children)                                                                                                           
                 10: signature Tuple{typeof(&), Any, Int64} triggered MethodInstance for Base._search_bloom_mask(::Any) (1 children)                                                                                                           
                 11: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for Base._thisind_str(::SubString{<:StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}}, ::Int64) (4 children)                                                                                                                     
                 12: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for Base.iterate_continued(::StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}, ::Int64, ::UInt32) (6 children)                                                                                                                   
                 13: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for Base._thisind_str(::StringView, ::Int64) (8 children)                                                                                                 
                 14: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for Base.iterate_continued(::StringView, ::Int64, ::UInt32) (8 children)                                                                                  
                 15: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for Base.iterate_continued(::StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}, ::Int64, ::UInt32) (8 children)                                                                                                                   
                 16: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for Base._thisind_str(::SubString{<:StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}}, ::Int64) (8 children)                                                                                                                     
                 17: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for Base._thisind_str(::StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}, ::Int64) (9 children)                                                                                                                                  
                 18: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for Base._thisind_str(::StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}, ::Int64) (29 children)                                                                                                                                 
                 19: signature Tuple{typeof(&), Any, UInt8} triggered MethodInstance for Base._thisind_str(::SubString{<:StringView}, ::Int64) (346 children)                                                                                  

 inserting |(x::Number, y::Py) @ PythonCall.Core ~/.julia/packages/PythonCall/5WGSP/src/Core/Py.jl:426 invalidated:                                                                                                                            
   mt_backedges:  1: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Char, ::Tuple) (0 children)                                                                                                           
                  2: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Int64, ::Tuple) (0 children)                                                                                                          
                  3: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::SubString{String}, ::Tuple) (0 children)                                                                                              
                  4: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::Tuple{Char, Char}) (0 children)                                                                                                
                  5: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::NTuple{4, Char}) (0 children)                                                                                                  
                  6: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::NTuple{11, Char}) (0 children)                                                                                                 
                  7: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::Tuple{Char, Char, Char}) (0 children)                                                                                          
                  8: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::NTuple{6, Char}) (0 children)                                                                                                  
                  9: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Bool, ::Tuple) (0 children)                                                                                                           
                 10: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::UInt32, ::Tuple) (0 children)                                                                                                         
                 11: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::@NamedTuple{r::UInt8, g::UInt8, b::UInt8}, ::Tuple) (0 children)                                                                      
                 12: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::Tuple{UInt8, UInt8, UInt8}) (0 children)                                                                                       
                 13: signature Tuple{typeof(|), UInt32, Any} triggered MethodInstance for Base.iterate_continued(::StringView, ::Int64, ::UInt32) (0 children)                                                                                 
                 14: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for (::Base.var"#_nextind_continued#_nextind_str##0")(::SubString{<:StringView}, ::Int64, ::Int64, ::UInt8) (0 children)                                   
                 15: signature Tuple{typeof(|), UInt32, Any} triggered MethodInstance for Base.iterate_continued(::StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}, ::Int64, ::UInt32) (0 children)                                                                                                                  
                 16: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::Tuple{String, String, String}) (0 children)                                                                                    
                 17: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::AbstractString, ::NTuple{6, String}) (0 children)                                                                                     
                 18: signature Tuple{typeof(|), UInt32, Any} triggered MethodInstance for Base.iterate_continued(::StringView{<:Union{DenseVector{UInt8}, var"#s19"} where var"#s19"<:(SubArray{UInt8, 1, var"#s17", I, true} where {var"#s17"<:DenseVector{UInt8}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}})}, ::Int64, ::UInt32) (0 children)                                                                                                                  
                 19: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::NTuple{4, String}) (0 children)                                                                                                
                 20: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Char, ::Tuple, ::Bool) (1 children)                                                                                                   
                 21: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::UInt32, ::Tuple, ::Bool) (1 children)                                                                                                 
                 22: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::@NamedTuple{r::UInt8, g::UInt8, b::UInt8}, ::Tuple, ::Bool) (1 children)                                                              
                 23: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Int64, ::Tuple, ::Bool) (2 children)                                                                                                  
                 24: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::SubString{String}, ::Tuple, ::Bool) (2 children)                                                                                      
                 25: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Bool, ::Tuple, ::Bool) (2 children)                                                                                                   
                 26: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::NTuple{4, String}, ::Bool) (3 children)                                                                                        
                 27: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::AbstractString, ::NTuple{6, String}, ::Bool) (4 children)                                                                             
                 28: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::NTuple{11, Char}, ::Bool) (5 children)
                 29: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::NTuple{6, Char}, ::Bool) (5 children)
                 30: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::Tuple{UInt8, UInt8, UInt8}, ::Bool) (5 children)
                 31: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::Tuple{String, String, String}, ::Bool) (5 children)
                 32: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::Tuple{Char, Char, Char}, ::Bool) (8 children)
                 33: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for checkindex(::Core.TypeEgal{Bool}, ::Base.AbstractOneTo{<:Integer}, ::UnitRange{Int64}) (10 children)
                 34: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for checkindex(::Core.TypeEgal{Bool}, ::Base.AbstractOneTo{<:Integer}, ::UnitRange{Int64}) (10 children)
                 35: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::Tuple{Char, Char}, ::Bool) (12 children)
                 36: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for Base._in_tuple(::Any, ::NTuple{4, Char}, ::Bool) (18 children)
                 37: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for checkindex(::Core.TypeEgal{Bool}, ::AbstractUnitRange, ::UnitRange{Int64}) (19 children)
                 38: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for checkindex(::Core.TypeEgal{Bool}, ::AbstractUnitRange, ::UnitRange{Int64}) (22 children)
                 39: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for <=(::Any, ::VersionNumber) (514 children)

 inserting !=(x::Py, y::Py) @ PythonCall.Core ~/.julia/packages/PythonCall/5WGSP/src/Core/Py.jl:361 invalidated:
   backedges: 1: superseding !=(x, y) @ Base operators.jl:320 with MethodInstance for !=(::Any, ::Any) (838 children)

 inserting >(x::Py, y::Number) @ PythonCall.Core ~/.julia/packages/PythonCall/5WGSP/src/Core/Py.jl:375 invalidated:
   backedges: 1: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Any, ::UInt64) (5 children)
              2: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Any, ::Int64) (841 children)
```
</details>

And a ton in Static.jl. Should significantly reduce invalidations in general. Inference results are still the same, we're just more accurate about recording when invalidations are actually needed.