### PR TITLE
Pass backtrace vectors of the right type to `Test.Error`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -549,7 +549,7 @@ cd(@__DIR__) do
                     # deserialization errors or something similar.  Record this testset as Errored.
                     fake = Test.DefaultTestSet(testname)
                     @atomic fake.time_end = fake.time_start + duration
-                    Test.record(fake, Test.Error(:nontest_error, testname, nothing, Base.ExceptionStack(NamedTuple[(;exception = resp, backtrace = [])]), LineNumberNode(1), nothing))
+                    Test.record(fake, Test.Error(:nontest_error, testname, nothing, Base.ExceptionStack(NamedTuple[(;exception = resp, backtrace = Union{Ptr{Nothing},Base.InterpreterIP}[])]), LineNumberNode(1), nothing))
                     Test.@with_testset fake begin
                         Test.record(o_ts, fake)
                     end
@@ -558,7 +558,7 @@ cd(@__DIR__) do
             for test in all_tests
                 (test in completed_tests) && continue
                 fake = Test.DefaultTestSet(test)
-                Test.record(fake, Test.Error(:test_interrupted, test, nothing, Base.ExceptionStack(NamedTuple[(;exception = "skipped", backtrace = [])]), LineNumberNode(1), nothing))
+                Test.record(fake, Test.Error(:test_interrupted, test, nothing, Base.ExceptionStack(NamedTuple[(;exception = "skipped", backtrace = Union{Ptr{Nothing},Base.InterpreterIP}[])]), LineNumberNode(1), nothing))
                 Test.@with_testset fake begin
                     Test.record(o_ts, fake)
                 end


### PR DESCRIPTION
Previously `[]::Any` vectors were passed, which would cause an exception in `scrub_exc_stack()`, which type-asserts the vector to be `Vector{Union{Ptr{Nothing}, Base.InterpreterIP}}`. Tested locally by Claude using workers that called `ccall(:_exit, Cvoid, (Cint,), 1)`.

Fixes this exception seen in CI of #62658 when a worker died: https://buildkite.com/julialang/julia-pr/builds/1316/list?sid=019fdd2e-8aef-43d6-b6ad-95057d79c752&tab=output#019fdd2e-8bd8-49cb-92e1-7b52c8fab358/L2065
```julia
ERROR: LoadError: TypeError: in typeassert, expected Vector{Union{Ptr{Nothing}, Base.InterpreterIP}}, got a value of type Vector{Any}
Stacktrace:
 [1] scrub_exc_stack(stack::Base.ExceptionStack, file_ts::Nothing, file_t::Nothing)
   @ Test ~julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/tester-honeycrisp-R17H3W25T9.1/019ebd61-5b1f-428e-b08c-1b5a2111e001/untrusted/build/tester-honeycrisp-R17H3W25T9-1/julialang/julia-pr/julia-9e73faa80b/share/julia/stdlib/v1.14/Test/src/Test.jl:99 [inlined]
 [2] Test.Error(test_type::Symbol, orig_expr::AbstractString, value::Nothing, excs::Base.ExceptionStack, source::LineNumberNode, context::Nothing)
   @ Test ~julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/tester-honeycrisp-R17H3W25T9.1/019ebd61-5b1f-428e-b08c-1b5a2111e001/untrusted/build/tester-honeycrisp-R17H3W25T9-1/julialang/julia-pr/julia-9e73faa80b/share/julia/stdlib/v1.14/Test/src/Test.jl:240
 [3] macro expansion
   @ ~julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/tester-honeycrisp-R17H3W25T9.1/019ebd61-5b1f-428e-b08c-1b5a2111e001/untrusted/build/tester-honeycrisp-R17H3W25T9-1/julialang/julia-pr/julia-9e73faa80b/share/julia/test/runtests.jl:552 [inlined]
 [4] macro expansion
   @ ~julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/tester-honeycrisp-R17H3W25T9.1/019ebd61-5b1f-428e-b08c-1b5a2111e001/untrusted/build/tester-honeycrisp-R17H3W25T9-1/julialang/julia-pr/julia-9e73faa80b/share/julia/stdlib/v1.14/Test/src/Test.jl:2416 [inlined]
 [5] (::var"#35#36")()
   @ Main ~julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/tester-honeycrisp-R17H3W25T9.1/019ebd61-5b1f-428e-b08c-1b5a2111e001/untrusted/build/tester-honeycrisp-R17H3W25T9-1/julialang/julia-pr/julia-9e73faa80b/share/julia/test/runtests.jl:518
 [6] cd(f::var"#35#36", dir::String)
   @ Base.Filesystem file.jl:113
 [7] top-level scope
   @ ~julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/tester-honeycrisp-R17H3W25T9.1/019ebd61-5b1f-428e-b08c-1b5a2111e001/untrusted/build/tester-honeycrisp-R17H3W25T9-1/julialang/julia-pr/julia-9e73faa80b/share/julia/test/runtests.jl:104
```