### PR TITLE
reinterpretarray: fix elsize for padded types (#62398)

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -398,7 +398,7 @@ axes(a::NonReshapedReinterpretArray{T,0}) where {T} = ()
 has_offset_axes(a::ReinterpretArray) = has_offset_axes(a.parent)
 
 elsize(::Type{<:ReinterpretArray{T,<:Any,S,A}}) where {T,S,A} =
-    sizeof(T) == sizeof(S) ? elsize(A) : sizeof(T)
+    sizeof(S) == sizeof(T) ? elsize(A) : sizeof(T)
 cconvert(::Type{Ptr{T}}, a::ReinterpretArray{T,N,S} where N) where {T,S} = cconvert(Ptr{S}, a.parent)
 unsafe_convert(::Type{Ptr{T}}, a::ReinterpretArray{T,N,S} where N) where {T,S} = Ptr{T}(unsafe_convert(Ptr{S},a.parent))
 


### PR DESCRIPTION

- Updated `elsize` logic in `base/reinterpretarray.jl` to lean on `aligned_sizeof(T)` only when element sizes match.

- ```julia
a = zeros(Int24, 2);
b = reinterpret(AlsoInt24, a);
Base.elsize(a) # 4
Base.elsize(b) # now prints 4 as intended
```
