### PR TITLE
loading: fix undefined variable in parse_cache_buildid error paths

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2139,7 +2139,7 @@ function isrelocatable(pkg::PkgId)
     isnothing(path) && return false
     io = open(path, "r")
     try
-        isvalid_cache_header(io) === nothing && throw(ArgumentError("Incompatible header in cache file $cachefile."))
+        isvalid_cache_header(io) === nothing && throw(ArgumentError("Incompatible header in cache file $path."))
         _, (includes, includes_srcfiles, _), _... = _parse_cache_header(io, path)
         for inc in includes
             !startswith(inc.filename, "@depot") && return false
@@ -2160,8 +2160,8 @@ function parse_cache_buildid(cachepath::String)
     try
         checksum = isvalid_cache_header(f)
         checksum === nothing && throw(ArgumentError("Incompatible header in cache file $cachepath."))
-        flags = read(f, UInt8)
-        syntax_version = read(f, UInt8)
+        read(f, UInt8) # flags
+        read(f, UInt8) # syntax_version
         n = read(f, Int32)
         n == 0 && error("no module defined in $cachepath")
         skip(f, n) # module name

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2159,11 +2159,11 @@ function parse_cache_buildid(cachepath::String)
     f = open(cachepath, "r")
     try
         checksum = isvalid_cache_header(f)
-        checksum === nothing && throw(ArgumentError("Incompatible header in cache file $cachefile."))
+        checksum === nothing && throw(ArgumentError("Incompatible header in cache file $cachepath."))
         flags = read(f, UInt8)
         syntax_version = read(f, UInt8)
         n = read(f, Int32)
-        n == 0 && error("no module defined in $cachefile")
+        n == 0 && error("no module defined in $cachepath")
         skip(f, n) # module name
         uuid = UUID((read(f, UInt64), read(f, UInt64))) # pkg UUID
         build_id = (UInt128(checksum) << 64) | read(f, UInt64)


### PR DESCRIPTION
The error messages interpolate `cachefile` but the argument is named `cachepath`, so both failure paths threw `UndefVarError` instead of the intended errors (readily reachable: any cache file from a different Julia build takes the incompatible-header path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)