### PR TITLE
[1.12] Disable bf16 for avx512 due to asserting instruction selection

### DIFF
--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -1252,7 +1252,22 @@ std::pair<std::string,llvm::SmallVector<std::string, 0>> jl_get_llvm_target(cons
 {
     ensure_jit_target(cpu_target, imaging);
     flags = jit_targets[0].en.flags;
-    return get_llvm_target_vec(jit_targets[0]);
+    auto res = get_llvm_target_vec(jit_targets[0]);
+    // With avx512bf16 our LLVM marks bf16 vector types legal but cannot select
+    // them, so vectorized bf16 code aborts in ISel (#62666); fixed in LLVM 19.
+    // Adjust only the target string, not the feature bits in `jit_targets`:
+    // those also gate sysimage/pkgimage matching, so clearing the bit there
+    // makes cached images built for e.g. znver4 fail to load. `-avx512bf16`
+    // must be appended, not just `+avx512bf16` dropped, as the CPU name alone
+    // re-enables it.
+    for (auto it = res.second.begin(); it != res.second.end();) {
+        if (*it == "+avx512bf16")
+            it = res.second.erase(it);
+        else
+            ++it;
+    }
+    res.second.push_back("-avx512bf16");
+    return res;
 }
 
 const std::pair<std::string,std::string> &jl_get_llvm_disasm_target(void)


### PR DESCRIPTION
Fixes #62666 on 1.12. Targets `backports-release-1.12` because `master` is not affected — see "Why not master" below.

## Problem

LLVM's X86 backend treats bf16 vector types as legal when the target has `avx512bf16`, but has no selection patterns for them. Any vectorizable loop producing bf16 aborts the process during instruction selection:

```julia
bf(x::Int64) = Base.sitofp(Core.BFloat16, x)

println("scalar: ", bf(3))   # fine — not vectorized
x = [bf(i) for i in 1:8]     # LLVM ERROR: Cannot select: v32bf16 = insert_subvector ...
```

```
$ julia --startup-file=no bf16_isel_repro.jl
scalar: Core.BFloat16(0x4040)
LLVM ERROR: Cannot select: 0x10cb880: v32bf16 = insert_subvector ...
[SIGABRT, exit 134]
```

It takes all three of: a vectorizable loop, `avx512bf16` in the target features, and `-O2`. `--optimize=1`, `--cpu-target=generic`, and `--cpu-target=znver4,-avx512bf16` all avoid it.

Ordinary package code reaches this easily — BFloat16s.jl defines `BFloat16(::Int64)` as exactly that intrinsic (`src/bfloat16.jl:197`), so `collect(BFloat16, 1:64)` aborts on any `avx512bf16` host (AMD Zen 4/5, Cooper Lake, Sapphire Rapids). Reported previously as JuliaMath/BFloat16s.jl#107.

Worse, with LLVM.jl loaded — i.e. anyone with the GPU stack — it is not even a visible crash: LLVM.jl installs a process-global fatal-error handler that throws, the throw unwinds out of `jl_compile_codeinst_now` with the codegen lock held, and the session becomes a silent `SIGTERM`-proof hang with no message printed. That part is JuliaLLVM/LLVM.jl#581.

## Why not master

The underlying backend bug is fixed upstream in LLVM 19. Same IR, stock Ubuntu `llc`:

| llc | `-mcpu=znver4` |
|---|---|
| 17.0.6 | inconclusive (can't parse `or disjoint`) |
| 18.1.3 | `Cannot select: v32bf16 = insert_subvector` |
| 19.1.1 | clean |

End to end, 1.13.0-rc1 (LLVM 20.1.8) runs the reproducer fine. So only 1.11 (LLVM 16) and 1.12 (LLVM 18) need this, and `master` needs no change.

A companion PR for `backports-release-1.11` will follow.

## Why the target string and not the feature bits

The obvious implementation — clearing the `avx512bf16` bit in `jit_targets` — breaks image loading, because those same bits are what sysimage and pkgimage validation match against:

```
ERROR: Unable to find compatible target in cached code image.
Target 0 (znver4): Rejecting this target due to use of runtime-disabled features
```

So this adjusts only the feature vector returned by `jl_get_llvm_target`, leaving the matching bits alone. Appending `-avx512bf16` is also required rather than merely dropping `+avx512bf16`, since the CPU name alone (`znver4`) re-enables the feature inside LLVM.

## Testing

Built `release-1.12` with and without the patch on an AMD Threadripper PRO 7995WX (znver4 target), and compared:

| check | unpatched | patched |
|---|---|---|
| reproducer above | `LLVM ERROR` + SIGABRT | `vector: 8`, exit 0 |
| `collect(BFloat16, 1:64)` (BFloat16s.jl) | abort | works |
| `using InteractiveUtils` (pkgimage load) | ok | ok |
| avx512f still used (`zmm` in `code_native`) | yes | yes |
| bf16 instructions emitted | — | none |
| `-C native`, `-C znver4` | ok | ok |
| `-C generic`, `-C haswell`, `-C znver4,-avx512bf16` | error (native-only source-build sysimg) | same error |

The last row is pre-existing behaviour for a source build whose sysimg is built for `native` only; it is identical with and without the patch.

## Trade-off

This removes `avx512bf16` from JIT codegen on 1.11/1.12 even where it would have worked, including when explicitly requested via `--cpu-target=cooperlake` or `+avx512bf16`. Given the feature currently only ever aborts the process on these branches, that seemed the right default, but I am happy to restrict it to the non-explicit case if preferred.

An alternative worth considering is backporting the upstream LLVM fix into `deps/patches/` instead, which would keep bf16 codegen working rather than disabling it. I did not bisect LLVM 18→19 for the fixing commit; if that is preferred I can look into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PH4zH9zvavbXWXomJbCq3B
