### PR TITLE
Fix #62569 : Parse `⁄ `(U+2044) Unicode char as division operator(`/`)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@ New language features
   and a fresh ^C epoch is re-armed at each prompt; a script that catches a ^C
   cancellation continues under the cancelled scope unless it re-arms one itself
   (`ScopedValues.@with Base.CANCEL_TOKEN => Base.sigint_new_episode!() ...`) ([#60281]).
+  * The fraction slash character `U+2044` (`⁄`) is now treated as a valid identifier character rather than an operator, allowing it to be used inside mathematical variable names like `∂x⁄∂t` ([#62668]).
 
 Language changes
 ----------------

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -151,6 +151,8 @@ JL_DLLEXPORT int jl_id_char(uint32_t wc)
         cat == UTF8PROC_CATEGORY_NO ||
         // primes (single, double, triple, their reverses, and quadruple)
         (wc >= 0x2032 && wc <= 0x2037) || (wc == 0x2057) ||
+        // fraction slash
+        wc == 0x2044 ||
         // "Rightwards Arrow with Lower Hook"
         wc == 0x1f8b2)
         return 1;


### PR DESCRIPTION
Mapped the character to division operator, added to legacy bootstrap parser, updated in math operations and global namespace.
U+2044 behaves as division operator `/` (U+002F)now.

Example:
```julia
julia> 1 ⁄ 2
0.5

julia> ∂x = 0.0
0.0
julia> ∂t = 5.0
5.0
julia> ∂x ⁄ ∂t == 0
true
```
