### PR TITLE
TOML: support capturing comments when parsing and writing them back out

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -252,7 +252,7 @@ Standard library changes
 * The parsing functions (`TOML.parsefile`, `TOML.parse`, and their `try` variants) can now capture
   the comments of a document into a `TOML.Comments` object via the new `comments` keyword argument,
   and `TOML.print` can write them back out via its new `comments` keyword argument. This allows
-  modifying a TOML file without losing its comments ([#42697]).
+  modifying a TOML file without losing its comments ([#62672]).
 
 External dependencies
 ---------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -247,6 +247,13 @@ Standard library changes
 
 #### Dates
 
+#### TOML
+
+* The parsing functions (`TOML.parsefile`, `TOML.parse`, and their `try` variants) can now capture
+  the comments of a document into a `TOML.Comments` object via the new `comments` keyword argument,
+  and `TOML.print` can write them back out via its new `comments` keyword argument. This allows
+  modifying a TOML file without losing its comments ([#42697]).
+
 External dependencies
 ---------------------
 

--- a/base/toml/parser.jl
+++ b/base/toml/parser.jl
@@ -38,13 +38,13 @@ const CommentPath = Tuple{Vararg{String}}
 
 # The comments associated with a single item (a `key = value` entry or a table
 # header): the whole-line comments directly above the item and the comment on
-# the same line as the item ("" if none). Comment text is stored without the
-# leading '#'.
+# the same line as the item (`nothing` if none; `""` is a bare trailing `#`).
+# Comment text is stored without the leading '#'.
 mutable struct CommentBlock
     above::Vector{String}
-    inline::String
+    inline::Union{String, Nothing}
 end
-CommentBlock() = CommentBlock(String[], "")
+CommentBlock() = CommentBlock(String[], nothing)
 
 """
     Comments()

--- a/base/toml/parser.jl
+++ b/base/toml/parser.jl
@@ -27,6 +27,52 @@ const EOF_CHAR = typemax(Char)
 
 const TOMLDict  = Dict{String, Any}
 
+############
+# Comments #
+############
+
+# A path of keys identifying an item in a TOML document, e.g. `("compat", "Dep")`
+# for an entry and `("deps",)` for the table header `[deps]`. The empty tuple
+# identifies the root table.
+const CommentPath = Tuple{Vararg{String}}
+
+# The comments associated with a single item (a `key = value` entry or a table
+# header): the whole-line comments directly above the item and the comment on
+# the same line as the item ("" if none). Comment text is stored without the
+# leading '#'.
+mutable struct CommentBlock
+    above::Vector{String}
+    inline::String
+end
+CommentBlock() = CommentBlock(String[], "")
+
+"""
+    Comments()
+
+A container for comments captured while parsing a TOML document. Pass it via
+the `comments` keyword argument to the parsing functions to populate it, and
+via the `comments` keyword argument to the printing functions to write the
+comments back out. See the TOML stdlib documentation for the rules of how
+comments are associated with items of the document.
+"""
+struct Comments
+    # Comments attached to a specific item, keyed by the item's key path
+    items::Dict{CommentPath, CommentBlock}
+    # Comments not attached to any item, keyed by the path of the table they
+    # appeared in; printed at the top of that table
+    floating::Dict{CommentPath, Vector{String}}
+end
+Comments() = Comments(Dict{CommentPath, CommentBlock}(), Dict{CommentPath, Vector{String}}())
+
+Base.isempty(c::Comments) = isempty(c.items) && isempty(c.floating)
+function Base.empty!(c::Comments)
+    empty!(c.items)
+    empty!(c.floating)
+    return c
+end
+Base.:(==)(a::CommentBlock, b::CommentBlock) = a.above == b.above && a.inline == b.inline
+Base.:(==)(a::Comments, b::Comments) = a.items == b.items && a.floating == b.floating
+
 ##########
 # Parser #
 ##########
@@ -82,10 +128,28 @@ mutable struct Parser{Dates}
 
     # Filled in in case we are parsing a file to improve error messages
     filepath::Union{String, Nothing}
+
+    # If not `nothing`, comments are captured into this structure while parsing
+    comments::Union{Comments, Nothing}
+    # Scratch state for comment capture; only maintained when `comments !== nothing`:
+    # The current block of contiguous whole-line comments that has not yet been
+    # attached to an item
+    pending_comments::Vector{String}
+    # The text of the most recently skipped comment (set by `skip_comment`)
+    captured_comment::String
+    # The key path of `active_table`
+    active_table_path::Vector{String}
+    # The key path of the most recently defined item, used to attach same-line
+    # comments; `nothing` if the last item cannot take comments
+    last_item_path::Union{CommentPath, Nothing}
+    # True while the active table is (inside) an array-of-tables element, where
+    # key paths do not distinguish between elements and comments are dropped
+    in_array_table::Bool
 end
 
-function Parser{Dates}(str::String; filepath=nothing) where {Dates}
+function Parser{Dates}(str::String; filepath=nothing, comments::Union{Comments, Nothing}=nothing) where {Dates}
     root = TOMLDict()
+    comments === nothing || empty!(comments)
     l = Parser{Dates}(
             str,                  # str
             EOF_CHAR,             # current_char
@@ -102,7 +166,13 @@ function Parser{Dates}(str::String; filepath=nothing) where {Dates}
             IdSet{TOMLDict}(),    # defined_tables
             IdSet{TOMLDict}(),    # implicit_tables
             root,
-            filepath
+            filepath,
+            comments,             # comments
+            String[],             # pending_comments
+            "",                   # captured_comment
+            String[],             # active_table_path
+            nothing,              # last_item_path
+            false,                # in_array_table
         )
     startup(l)
     return l
@@ -123,7 +193,8 @@ Parser{Dates}(io::IO) where {Dates} = Parser{Dates}(read(io, String))
 
 # Parser(...) will be defined by TOML stdlib
 
-function reinit!(p::Parser, str::String; filepath::Union{Nothing, String}=nothing)
+function reinit!(p::Parser, str::String; filepath::Union{Nothing, String}=nothing,
+                 comments::Union{Comments, Nothing}=nothing)
     p.str = str
     p.current_char = EOF_CHAR
     p.pos = firstindex(str)
@@ -140,6 +211,13 @@ function reinit!(p::Parser, str::String; filepath::Union{Nothing, String}=nothin
     empty!(p.defined_tables)
     empty!(p.implicit_tables)
     p.filepath = filepath
+    comments === nothing || empty!(comments)
+    p.comments = comments
+    empty!(p.pending_comments)
+    p.captured_comment = ""
+    empty!(p.active_table_path)
+    p.last_item_path = nothing
+    p.in_array_table = false
     startup(p)
     return p
 end
@@ -414,6 +492,9 @@ function skip_ws_nl(l::Parser)::Bool
     while true
         skipped_ws = accept_batch(l, x -> iswhitespace(x) || isnewline(x))
         skipped_comment = skip_comment(l)
+        if skipped_comment && l.comments !== nothing
+            push!(l.pending_comments, l.captured_comment)
+        end
         if !skipped_ws && !skipped_comment
             break
         end
@@ -422,16 +503,106 @@ function skip_ws_nl(l::Parser)::Bool
     return skipped
 end
 
-# Returns true if a comment was skipped
+# Like `skip_ws_nl` but used between top-level items when capturing comments:
+# a blank line separating a comment block from the following item makes the
+# block "floating" (associated with the enclosing table) instead of attached
+# to the item that follows it.
+function skip_ws_nl_toplevel(l::Parser)::Bool
+    l.comments === nothing && return skip_ws_nl(l)
+    skipped = false
+    nlines = 0 # newlines seen since the last comment (or the previous item)
+    while true
+        progress = false
+        while true
+            c = peek(l)
+            if iswhitespace(c)
+                eat_char(l)
+                progress = true
+            elseif isnewline(c)
+                if c == '\n'
+                    nlines += 1
+                    nlines == 2 && flush_pending_comments!(l)
+                end
+                eat_char(l)
+                progress = true
+            else
+                break
+            end
+        end
+        if skip_comment(l)
+            push!(l.pending_comments, l.captured_comment)
+            nlines = 0
+            progress = true
+        end
+        progress || break
+        skipped = true
+    end
+    return skipped
+end
+
+# Returns true if a comment was skipped. When comment capture is enabled the
+# comment text (without the leading '#') is stored in `l.captured_comment`.
 function skip_comment(l::Parser)::Bool
     found_comment = accept(l, '#')
     if found_comment
-        accept_batch(l, !isnewline)
+        if l.comments === nothing
+            accept_batch(l, !isnewline)
+        else
+            start = l.prevpos
+            accept_batch(l, !isnewline)
+            l.captured_comment = String(SubString(l.str, start:(l.prevpos-1)))
+        end
     end
     return found_comment
 end
 
-skip_ws_comment(l::Parser) = skip_ws(l) && skip_comment(l)
+function skip_ws_comment(l::Parser)::Bool
+    skip_ws(l)
+    return skip_comment(l)
+end
+
+# Move the pending comment block to the floating comments of the active table
+function flush_pending_comments!(l::Parser)
+    isempty(l.pending_comments) && return
+    comments = l.comments
+    if comments !== nothing && !l.in_array_table
+        floating = get!(() -> String[], comments.floating, Tuple(l.active_table_path))
+        append!(floating, l.pending_comments)
+    end
+    empty!(l.pending_comments)
+    return
+end
+
+# Attach the pending comment block to the item at `path`
+function attach_pending_comments!(l::Parser, path::CommentPath)
+    isempty(l.pending_comments) && return
+    block = get!(CommentBlock, (l.comments::Comments).items, path)
+    append!(block.above, l.pending_comments)
+    empty!(l.pending_comments)
+    return
+end
+
+# Attach a comment on the same line as an item to the most recently defined item
+function attach_inline_comment!(l::Parser)
+    path = l.last_item_path
+    path === nothing && return
+    block = get!(CommentBlock, (l.comments::Comments).items, path)
+    block.inline = l.captured_comment
+    return
+end
+
+# Whether an intermediate along `keys` (starting from the root table) is an
+# array of tables, which makes the key path ambiguous between array elements
+function path_traverses_array(l::Parser, keys::AbstractVector{String})
+    d = l.root
+    for k in keys
+        v = get(d, k, nothing)
+        v isa Vector && return true
+        v isa TOMLDict || return false
+        d = v
+    end
+    return false
+end
 
 @inline set_marker!(l::Parser) = l.marker = l.prevpos
 take_substring(l::Parser) = SubString(l.str, l.marker:(l.prevpos-1))
@@ -450,7 +621,7 @@ end
 
 function tryparse(l::Parser)::Err{TOMLDict}
     while true
-        skip_ws_nl(l)
+        skip_ws_nl_toplevel(l)
         peek(l) == EOF_CHAR && break
         v = parse_toplevel(l)
         if v isa ParserError
@@ -463,6 +634,7 @@ function tryparse(l::Parser)::Err{TOMLDict}
             return v
         end
     end
+    l.comments === nothing || flush_pending_comments!(l)
     return l.root
 end
 
@@ -472,14 +644,18 @@ function parse_toplevel(l::Parser)::Err{Nothing}
     if accept(l, '[')
         l.active_table = l.root
         @try parse_table(l)
-        skip_ws_comment(l)
+        if skip_ws_comment(l) && l.comments !== nothing
+            attach_inline_comment!(l)
+        end
         if !(peek(l) == '\n' || peek(l) == '\r' || peek(l) == '#' || peek(l) == EOF_CHAR)
             eat_char(l)
             return ParserError(ErrExpectedNewLineKeyValue)
         end
     else
         @try parse_entry(l, l.active_table)
-        skip_ws_comment(l)
+        if skip_ws_comment(l) && l.comments !== nothing
+            attach_inline_comment!(l)
+        end
         # SPEC: "There must be a newline (or EOF) after a key/value pair."
         if !(peek(l) == '\n' || peek(l) == '\r' || peek(l) == '#' || peek(l) == EOF_CHAR)
             eat_char(l)
@@ -539,6 +715,19 @@ function parse_table(l)
         return ParserError(ErrDuplicatedKey)
     end
     push!(l.defined_tables, l.active_table)
+    if l.comments !== nothing
+        l.in_array_table = path_traverses_array(l, table_key)
+        empty!(l.active_table_path)
+        append!(l.active_table_path, table_key)
+        if l.in_array_table
+            empty!(l.pending_comments)
+            l.last_item_path = nothing
+        else
+            path = Tuple(table_key)
+            attach_pending_comments!(l, path)
+            l.last_item_path = path
+        end
+    end
     return
 end
 
@@ -559,15 +748,38 @@ function parse_array_table(l)::Union{Nothing, ParserError}
         return ParserError(ErrArrayTreatedAsDictionary)
     end
     d_new = TOMLDict()
+    first_element = isempty(old::Vector{Any})
     push!(old::Vector{Any}, d_new)
     push!(l.defined_tables, d_new)
     l.active_table = d_new
 
+    if l.comments !== nothing
+        # Comments cannot be attached to items inside array-of-tables elements
+        # since the key path does not distinguish between the elements. Only
+        # the comment block above the first `[[...]]` header is kept, attached
+        # to the array itself; all other comments in the array are dropped.
+        if first_element && !path_traverses_array(l, @view(table_key[1:end-1]))
+            attach_pending_comments!(l, Tuple(table_key))
+        else
+            empty!(l.pending_comments)
+        end
+        empty!(l.active_table_path)
+        append!(l.active_table_path, table_key)
+        l.last_item_path = nothing
+        l.in_array_table = true
+    end
     return
 end
 
 function parse_entry(l::Parser, d)::Union{Nothing, ParserError}
     key = @try parse_key(l)
+    # Comments attach to entries of regular tables; comments captured while
+    # parsing entries of inline tables belong to the entry that owns the
+    # outermost inline table. The path must be computed here since `key`
+    # aliases `l.dotted_keys` which keys in inline table values overwrite.
+    capture_comments = l.comments !== nothing && !(d in l.inline_tables)
+    entry_path = (capture_comments && !l.in_array_table) ?
+        (l.active_table_path..., key...) : nothing
     skip_ws(l)
     if !accept(l, '=')
         return ParserError(ErrExpectedEqualAfterKey)
@@ -593,6 +805,16 @@ function parse_entry(l::Parser, d)::Union{Nothing, ParserError}
     end
     # TODO: Performance, hashing `last_key_part` again here
     d[last_key_part] = value
+    if capture_comments
+        if entry_path === nothing
+            # Inside an array-of-tables element: drop any captured comments
+            empty!(l.pending_comments)
+            l.last_item_path = nothing
+        else
+            attach_pending_comments!(l, entry_path)
+            l.last_item_path = entry_path
+        end
+    end
     return
 end
 

--- a/base/toml/parser.jl
+++ b/base/toml/parser.jl
@@ -32,6 +32,9 @@ const TOMLDict  = Dict{String, Any}
 ############
 
 # The empty path identifies the root table.
+# TODO: Formatting choices (e.g. which tables print inline, indentation) could
+# be retained for full round-tripping the same way as comments: captured into a
+# sibling side-channel keyed by these item paths and passed back to `print`.
 const CommentPath = Tuple{Vararg{String}}
 
 # Text excludes `#`; `nothing` means no inline comment and `""` a bare `#`.

--- a/base/toml/parser.jl
+++ b/base/toml/parser.jl
@@ -31,15 +31,10 @@ const TOMLDict  = Dict{String, Any}
 # Comments #
 ############
 
-# A path of keys identifying an item in a TOML document, e.g. `("compat", "Dep")`
-# for an entry and `("deps",)` for the table header `[deps]`. The empty tuple
-# identifies the root table.
+# The empty path identifies the root table.
 const CommentPath = Tuple{Vararg{String}}
 
-# The comments associated with a single item (a `key = value` entry or a table
-# header): the whole-line comments directly above the item and the comment on
-# the same line as the item (`nothing` if none; `""` is a bare trailing `#`).
-# Comment text is stored without the leading '#'.
+# Text excludes `#`; `nothing` means no inline comment and `""` a bare `#`.
 mutable struct CommentBlock
     above::Vector{String}
     inline::Union{String, Nothing}
@@ -56,10 +51,7 @@ comments back out. See the TOML stdlib documentation for the rules of how
 comments are associated with items of the document.
 """
 struct Comments
-    # Comments attached to a specific item, keyed by the item's key path
     items::Dict{CommentPath, CommentBlock}
-    # Comments not attached to any item, keyed by the path of the table they
-    # appeared in; printed at the top of that table
     floating::Dict{CommentPath, Vector{String}}
 end
 Comments() = Comments(Dict{CommentPath, CommentBlock}(), Dict{CommentPath, Vector{String}}())
@@ -129,21 +121,12 @@ mutable struct Parser{Dates}
     # Filled in in case we are parsing a file to improve error messages
     filepath::Union{String, Nothing}
 
-    # If not `nothing`, comments are captured into this structure while parsing
     comments::Union{Comments, Nothing}
-    # Scratch state for comment capture; only maintained when `comments !== nothing`:
-    # The current block of contiguous whole-line comments that has not yet been
-    # attached to an item
     pending_comments::Vector{String}
-    # The text of the most recently skipped comment (set by `skip_comment`)
     captured_comment::String
-    # The key path of `active_table`
     active_table_path::Vector{String}
-    # The key path of the most recently defined item, used to attach same-line
-    # comments; `nothing` if the last item cannot take comments
     last_item_path::Union{CommentPath, Nothing}
-    # True while the active table is (inside) an array-of-tables element, where
-    # key paths do not distinguish between elements and comments are dropped
+    # Paths cannot distinguish array-of-tables elements, so their comments are ignored.
     in_array_table::Bool
 end
 
@@ -503,10 +486,7 @@ function skip_ws_nl(l::Parser)::Bool
     return skipped
 end
 
-# Like `skip_ws_nl` but used between top-level items when capturing comments:
-# a blank line separating a comment block from the following item makes the
-# block "floating" (associated with the enclosing table) instead of attached
-# to the item that follows it.
+# A blank line makes pending comments float rather than attach to the next item.
 function skip_ws_nl_toplevel(l::Parser)::Bool
     l.comments === nothing && return skip_ws_nl(l)
     skipped = false
@@ -540,8 +520,7 @@ function skip_ws_nl_toplevel(l::Parser)::Bool
     return skipped
 end
 
-# Returns true if a comment was skipped. When comment capture is enabled the
-# comment text (without the leading '#') is stored in `l.captured_comment`.
+# Returns true if a comment was skipped
 function skip_comment(l::Parser)::Bool
     found_comment = accept(l, '#')
     if found_comment
@@ -561,7 +540,6 @@ function skip_ws_comment(l::Parser)::Bool
     return skip_comment(l)
 end
 
-# Move the pending comment block to the floating comments of the active table
 function flush_pending_comments!(l::Parser)
     isempty(l.pending_comments) && return
     comments = l.comments
@@ -573,7 +551,6 @@ function flush_pending_comments!(l::Parser)
     return
 end
 
-# Attach the pending comment block to the item at `path`
 function attach_pending_comments!(l::Parser, path::CommentPath)
     isempty(l.pending_comments) && return
     block = get!(CommentBlock, (l.comments::Comments).items, path)
@@ -582,7 +559,6 @@ function attach_pending_comments!(l::Parser, path::CommentPath)
     return
 end
 
-# Attach a comment on the same line as an item to the most recently defined item
 function attach_inline_comment!(l::Parser)
     path = l.last_item_path
     path === nothing && return
@@ -591,8 +567,6 @@ function attach_inline_comment!(l::Parser)
     return
 end
 
-# Whether an intermediate along `keys` (starting from the root table) is an
-# array of tables, which makes the key path ambiguous between array elements
 function path_traverses_array(l::Parser, keys::AbstractVector{String})
     d = l.root
     for k in keys
@@ -754,10 +728,7 @@ function parse_array_table(l)::Union{Nothing, ParserError}
     l.active_table = d_new
 
     if l.comments !== nothing
-        # Comments cannot be attached to items inside array-of-tables elements
-        # since the key path does not distinguish between the elements. Only
-        # the comment block above the first `[[...]]` header is kept, attached
-        # to the array itself; all other comments in the array are dropped.
+        # Only the first header has an unambiguous path.
         if first_element && !path_traverses_array(l, @view(table_key[1:end-1]))
             attach_pending_comments!(l, Tuple(table_key))
         else
@@ -773,10 +744,7 @@ end
 
 function parse_entry(l::Parser, d)::Union{Nothing, ParserError}
     key = @try parse_key(l)
-    # Comments attach to entries of regular tables; comments captured while
-    # parsing entries of inline tables belong to the entry that owns the
-    # outermost inline table. The path must be computed here since `key`
-    # aliases `l.dotted_keys` which keys in inline table values overwrite.
+    # `key` aliases `dotted_keys`, which parsing an inline table may overwrite.
     capture_comments = l.comments !== nothing && !(d in l.inline_tables)
     entry_path = (capture_comments && !l.in_array_table) ?
         (l.active_table_path..., key...) : nothing
@@ -807,7 +775,6 @@ function parse_entry(l::Parser, d)::Union{Nothing, ParserError}
     d[last_key_part] = value
     if capture_comments
         if entry_path === nothing
-            # Inside an array-of-tables element: drop any captured comments
             empty!(l.pending_comments)
             l.last_item_path = nothing
         else

--- a/base/toml/printer.jl
+++ b/base/toml/printer.jl
@@ -207,9 +207,9 @@ function print_comment_inline(io::IO, comments::Comments, path::CommentPath)
     block = get(comments.items, path, nothing)
     block === nothing && return
     text = block.inline
-    isempty(text) && return
+    text === nothing && return
     Base.print(io, " #")
-    if !(first(text) == ' ' || first(text) == '\t')
+    if !(isempty(text) || first(text) == ' ' || first(text) == '\t')
         Base.print(io, ' ')
     end
     for c::AbstractChar in text
@@ -220,6 +220,13 @@ function print_comment_inline(io::IO, comments::Comments, path::CommentPath)
         end
     end
 end
+
+# Whether any comments are associated with the item or table at `path`.
+# A table header that would normally be elided (because the table only
+# contains other tables) must still be printed if it has comments, so that
+# the comments keep their anchor and round-trip to the same association.
+has_comments(comments::Comments, path::CommentPath) =
+    haskey(comments.items, path) || haskey(comments.floating, path)
 
 # Returns whether any floating comment lines were printed
 function print_comments_floating(io::IO, comments::Comments, path::CommentPath, indentstr::String)
@@ -303,6 +310,9 @@ function print_table(f::Function, io::IO, a::AbstractDict,
             push!(ks, String(key))
             _values = @invokelatest values(value)
             header = isempty(value) || !all(is_tabular(v) for v in _values)::Bool || any(v in inline_tables for v in _values)::Bool
+            if !header && comments !== nothing
+                header = has_comments(comments, Tuple(ks))
+            end
             if header
                 # print table
                 first_block || println(io)

--- a/base/toml/printer.jl
+++ b/base/toml/printer.jl
@@ -228,6 +228,35 @@ end
 has_comments(comments::Comments, path::CommentPath) =
     haskey(comments.items, path) || haskey(comments.floating, path)
 
+# Comments associated with items inside a table that is printed inline have no
+# line of their own to be printed on; hoist them above the entry that owns the
+# inline table. This matches how comments inside an inline table value are
+# associated with the owning entry when parsing, so they keep this position
+# on subsequent round trips.
+function print_hoisted_inline_comments(io::IO, comments::Comments, a::AbstractDict,
+                                       path::CommentPath, indentstr::String, sorted::Bool)
+    floating = get(comments.floating, path, nothing)
+    if floating !== nothing
+        for line in floating
+            print_comment_line(io, indentstr, line)
+        end
+    end
+    vkeys = collect(keys(a))
+    sorted && sort!(vkeys)
+    for k in vkeys
+        kpath = (path..., String(k))
+        block = get(comments.items, kpath, nothing)
+        if block !== nothing
+            for line in block.above
+                print_comment_line(io, indentstr, line)
+            end
+            block.inline === nothing || print_comment_line(io, indentstr, block.inline)
+        end
+        v = a[k]
+        v isa AbstractDict && print_hoisted_inline_comments(io, comments, v, kpath, indentstr, sorted)
+    end
+end
+
 # Returns whether any floating comment lines were printed
 function print_comments_floating(io::IO, comments::Comments, path::CommentPath, indentstr::String)
     lines = get(comments.floating, path, nothing)
@@ -288,7 +317,11 @@ function print_table(f::Function, io::IO, a::AbstractDict,
         end
 
         if comments !== nothing
-            print_comments_above(io, comments, (ks..., String(key)), entry_indentstr)
+            entry_path = (ks..., String(key))
+            print_comments_above(io, comments, entry_path, entry_indentstr)
+            if value isa AbstractDict && value in inline_tables
+                print_hoisted_inline_comments(io, comments, value, entry_path, entry_indentstr, sorted)
+            end
         end
         Base.print(io, entry_indentstr)
         printkey(io, [String(key)])

--- a/base/toml/printer.jl
+++ b/base/toml/printer.jl
@@ -173,15 +173,11 @@ end
 # Comments #
 ############
 
-# Comments are printed with every character that is not valid inside a TOML
-# comment dropped or replaced, so that emitted comment text can never alter
-# the structure of the document (e.g. a comment containing a newline followed
-# by TOML syntax).
+# Sanitize comment text so it cannot introduce TOML syntax.
 
 function print_comment_line(io::IO, indentstr::String, text::AbstractString)
     Base.print(io, indentstr, '#')
-    # Captured comments keep their original leading whitespace ("# foo" is
-    # stored as " foo"); add a space for comment text that does not have one
+    # Preserve captured whitespace, but format programmatic comments as `# text`.
     if !(isempty(text) || first(text) == ' ' || first(text) == '\t')
         Base.print(io, ' ')
     end
@@ -221,18 +217,10 @@ function print_comment_inline(io::IO, comments::Comments, path::CommentPath)
     end
 end
 
-# Whether any comments are associated with the item or table at `path`.
-# A table header that would normally be elided (because the table only
-# contains other tables) must still be printed if it has comments, so that
-# the comments keep their anchor and round-trip to the same association.
 has_comments(comments::Comments, path::CommentPath) =
     haskey(comments.items, path) || haskey(comments.floating, path)
 
-# Comments associated with items inside a table that is printed inline have no
-# line of their own to be printed on; hoist them above the entry that owns the
-# inline table. This matches how comments inside an inline table value are
-# associated with the owning entry when parsing, so they keep this position
-# on subsequent round trips.
+# Hoist nested comments to an inline table's owning entry.
 function print_hoisted_inline_comments(io::IO, comments::Comments, a::AbstractDict,
                                        path::CommentPath, indentstr::String, sorted::Bool)
     floating = get(comments.floating, path, nothing)
@@ -257,7 +245,6 @@ function print_hoisted_inline_comments(io::IO, comments::Comments, a::AbstractDi
     end
 end
 
-# Returns whether any floating comment lines were printed
 function print_comments_floating(io::IO, comments::Comments, path::CommentPath, indentstr::String)
     lines = get(comments.floating, path, nothing)
     lines === nothing && return false
@@ -295,7 +282,6 @@ function print_table(f::Function, io::IO, a::AbstractDict,
 
     entry_indentstr = ' '^4max(0, indent-1)
     if comments !== nothing
-        # Floating comments are printed at the top of the table they belong to
         if print_comments_floating(io, comments, Tuple(ks), entry_indentstr)
             println(io)
         end
@@ -344,6 +330,7 @@ function print_table(f::Function, io::IO, a::AbstractDict,
             _values = @invokelatest values(value)
             header = isempty(value) || !all(is_tabular(v) for v in _values)::Bool || any(v in inline_tables for v in _values)::Bool
             if !header && comments !== nothing
+                # Preserve headers that anchor comments.
                 header = has_comments(comments, Tuple(ks))
             end
             if header
@@ -371,8 +358,6 @@ function print_table(f::Function, io::IO, a::AbstractDict,
             first_block = false
             push!(ks, String(key))
             if comments !== nothing
-                # The comment block attached to an array of tables is printed
-                # above the first `[[...]]` header
                 print_comments_above(io, comments, Tuple(ks), ' '^4indent)
             end
             for v in value

--- a/base/toml/printer.jl
+++ b/base/toml/printer.jl
@@ -2,6 +2,7 @@
 
 import Base: @invokelatest
 import ..isvalid_barekey_char # from Parser
+import ..Comments, ..CommentBlock, ..CommentPath # from Parser
 
 function print_toml_escaped(io::IO, s::AbstractString)
     for c::AbstractChar in s
@@ -168,6 +169,68 @@ function print_inline_table(f::Function, io::IO, value::AbstractDict, sorted::Bo
 end
 
 
+############
+# Comments #
+############
+
+# Comments are printed with every character that is not valid inside a TOML
+# comment dropped or replaced, so that emitted comment text can never alter
+# the structure of the document (e.g. a comment containing a newline followed
+# by TOML syntax).
+
+function print_comment_line(io::IO, indentstr::String, text::AbstractString)
+    Base.print(io, indentstr, '#')
+    # Captured comments keep their original leading whitespace ("# foo" is
+    # stored as " foo"); add a space for comment text that does not have one
+    if !(isempty(text) || first(text) == ' ' || first(text) == '\t')
+        Base.print(io, ' ')
+    end
+    for c::AbstractChar in text
+        if c == '\n'
+            Base.print(io, '\n', indentstr, "# ")
+        elseif c == '\t' || !Base.iscntrl(c)
+            Base.print(io, c)
+        end
+    end
+    Base.print(io, '\n')
+end
+
+function print_comments_above(io::IO, comments::Comments, path::CommentPath, indentstr::String)
+    block = get(comments.items, path, nothing)
+    block === nothing && return
+    for line in block.above
+        print_comment_line(io, indentstr, line)
+    end
+end
+
+function print_comment_inline(io::IO, comments::Comments, path::CommentPath)
+    block = get(comments.items, path, nothing)
+    block === nothing && return
+    text = block.inline
+    isempty(text) && return
+    Base.print(io, " #")
+    if !(first(text) == ' ' || first(text) == '\t')
+        Base.print(io, ' ')
+    end
+    for c::AbstractChar in text
+        if c == '\t' || (c != '\n' && !Base.iscntrl(c))
+            Base.print(io, c)
+        else
+            Base.print(io, ' ')
+        end
+    end
+end
+
+# Returns whether any floating comment lines were printed
+function print_comments_floating(io::IO, comments::Comments, path::CommentPath, indentstr::String)
+    lines = get(comments.floating, path, nothing)
+    lines === nothing && return false
+    for line in lines
+        print_comment_line(io, indentstr, line)
+    end
+    return !isempty(lines)
+end
+
 ##########
 # Tables #
 ##########
@@ -186,11 +249,20 @@ function print_table(f::Function, io::IO, a::AbstractDict,
     sorted::Bool = false,
     inline_tables::IdSet,
     by::Function = identity,
+    comments::Union{Comments, Nothing} = nothing,
 )
 
     if a in inline_tables
         @invokelatest print_inline_table(f, io, a, sorted)
         return
+    end
+
+    entry_indentstr = ' '^4max(0, indent-1)
+    if comments !== nothing
+        # Floating comments are printed at the top of the table they belong to
+        if print_comments_floating(io, comments, Tuple(ks), entry_indentstr)
+            println(io)
+        end
     end
 
     akeys = keys(a)
@@ -208,10 +280,16 @@ function print_table(f::Function, io::IO, a::AbstractDict,
             continue
         end
 
-        Base.print(io, ' '^4max(0,indent-1))
+        if comments !== nothing
+            print_comments_above(io, comments, (ks..., String(key)), entry_indentstr)
+        end
+        Base.print(io, entry_indentstr)
         printkey(io, [String(key)])
         Base.print(io, " = ") # print separator
         printvalue(f, io, value, sorted)
+        if comments !== nothing
+            print_comment_inline(io, comments, (ks..., String(key)))
+        end
         Base.print(io, "\n")  # new line?
         first_block = false
     end
@@ -229,19 +307,31 @@ function print_table(f::Function, io::IO, a::AbstractDict,
                 # print table
                 first_block || println(io)
                 first_block = false
+                if comments !== nothing
+                    print_comments_above(io, comments, Tuple(ks), ' '^4indent)
+                end
                 Base.print(io, ' '^4indent)
                 Base.print(io,"[")
                 printkey(io, ks)
-                Base.print(io,"]\n")
+                Base.print(io,"]")
+                if comments !== nothing
+                    print_comment_inline(io, comments, Tuple(ks))
+                end
+                Base.print(io,"\n")
             end
             # Use runtime dispatch here since the type of value seems not to be enforced other than as AbstractDict
-            @invokelatest print_table(f, io, value, ks; indent = indent + header, first_block = header, sorted, by, inline_tables)
+            @invokelatest print_table(f, io, value, ks; indent = indent + header, first_block = header, sorted, by, inline_tables, comments)
             pop!(ks)
         elseif @invokelatest(is_array_of_tables(value))
             # print array of tables
             first_block || println(io)
             first_block = false
             push!(ks, String(key))
+            if comments !== nothing
+                # The comment block attached to an array of tables is printed
+                # above the first `[[...]]` header
+                print_comments_above(io, comments, Tuple(ks), ' '^4indent)
+            end
             for v in value
                 Base.print(io, ' '^4indent)
                 Base.print(io,"[[")
@@ -249,7 +339,7 @@ function print_table(f::Function, io::IO, a::AbstractDict,
                 Base.print(io,"]]\n")
                 # TODO, nicer error here
                 !isa(v, AbstractDict) && error("array should contain only tables")
-                @invokelatest print_table(f, io, v, ks; indent = indent + 1, sorted, by, inline_tables)
+                @invokelatest print_table(f, io, v, ks; indent = indent + 1, sorted, by, inline_tables, comments)
             end
             pop!(ks)
         end
@@ -261,11 +351,11 @@ end
 # API #
 #######
 
-print(f::Function, io::IO, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) =
-    print_table(f, io, a; sorted, by, inline_tables)
-print(f::Function, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) =
-    print(f, stdout, a; sorted, by, inline_tables)
-print(io::IO, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) =
-    print_table(identity, io, a; sorted, by, inline_tables)
-print(a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) =
-    print(identity, stdout, a; sorted, by, inline_tables)
+print(f::Function, io::IO, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}(), comments::Union{Comments, Nothing}=nothing) =
+    print_table(f, io, a; sorted, by, inline_tables, comments)
+print(f::Function, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}(), comments::Union{Comments, Nothing}=nothing) =
+    print(f, stdout, a; sorted, by, inline_tables, comments)
+print(io::IO, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}(), comments::Union{Comments, Nothing}=nothing) =
+    print_table(identity, io, a; sorted, by, inline_tables, comments)
+print(a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}(), comments::Union{Comments, Nothing}=nothing) =
+    print(identity, stdout, a; sorted, by, inline_tables, comments)

--- a/stdlib/TOML/docs/src/index.md
+++ b/stdlib/TOML/docs/src/index.md
@@ -124,6 +124,65 @@ foo = [5, "bar"]
 ```
 
 
+## Preserving comments
+
+By default, comments in a TOML document are discarded when parsing, so writing
+the data out again loses them. To preserve comments, pass a [`TOML.Comments`](@ref)
+object to the parsing functions via the `comments` keyword argument and pass it
+back to [`TOML.print`](@ref):
+
+```jldoctest
+julia> using TOML
+
+julia> comments = TOML.Comments();
+
+julia> data = TOML.parse("""
+       # A comment attached to the entry below it
+       name = "MyPkg"
+
+       [compat]
+       Dep = "~1.1" # an inline comment
+       """; comments);
+
+julia> data["compat"]["OtherDep"] = "2";
+
+julia> TOML.print(data; comments, sorted=true)
+# A comment attached to the entry below it
+name = "MyPkg"
+
+[compat]
+Dep = "~1.1" # an inline comment
+OtherDep = "2"
+```
+
+Comments are associated with the *items* of the document (`key = value` entries
+and `[table]` headers) rather than with positions in the file, so the data can
+be freely modified and reformatted (e.g. with `sorted=true`) while the comments
+follow the items they belong to. The rules are:
+
+- A block of whole-line comments with no blank line between the block and the
+  following item is *attached* to that item, like a docstring, and is printed
+  directly above it.
+- A comment on the same line as an item is attached to that item and is printed
+  on the same line, after the value.
+- Any other whole-line comment (i.e. separated from the following item by a
+  blank line, or at the end of a table or of the document) is *floating*: it is
+  associated with the table it appears in and is printed at the top of that
+  table, followed by a blank line.
+- A comment attached (or associated) to an item that is deleted from the data
+  is not printed; deleting an item deletes its comments.
+- Comments inside a value that spans multiple lines (such as a multi-line
+  array) are attached to the entry that owns the value and are printed above
+  it.
+- Comments on or inside the elements of an array of tables (`[[...]]`) are
+  *not* preserved, except for a comment block attached to the first `[[...]]`
+  header, which is printed above the first element. The key paths used to
+  associate comments with items cannot distinguish between the elements of an
+  array of tables.
+
+!!! compat "Julia 1.14"
+    Comment preservation requires Julia 1.14 or later.
+
 ## References
 ```@docs
 TOML.parse
@@ -133,4 +192,5 @@ TOML.tryparsefile
 TOML.print
 TOML.Parser
 TOML.ParserError
+TOML.Comments
 ```

--- a/stdlib/TOML/docs/src/index.md
+++ b/stdlib/TOML/docs/src/index.md
@@ -139,7 +139,6 @@ julia> comments = TOML.Comments();
 julia> data = TOML.parse("""
        # A comment attached to the entry below it
        name = "MyPkg"
-
        [compat]
        Dep = "~1.1" # an inline comment
        """; comments);

--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -11,7 +11,8 @@ using Dates
 
 module Internals
     # The parser is defined in Base
-    using Base.TOML: Parser, Printer, parse, tryparse, ParserError, reinit!
+    using Base.TOML: Parser, Printer, parse, tryparse, ParserError, reinit!,
+                     Comments, CommentBlock
     # Put the error instances in this module
     for errtype in instances(Base.TOML.ErrorType)
         @eval using Base.TOML: $(Symbol(errtype))
@@ -40,66 +41,122 @@ Parser(io::IO) = Parser(Internals.Parser{Dates}(io))
 Parser(str::String; filepath=nothing) = Parser(Internals.Parser{Dates}(str; filepath))
 
 """
-    parsefile(f::AbstractString)
-    parsefile(p::Parser, f::AbstractString)
+    Comments()
+
+A container for the comments of a TOML document. Pass an empty `Comments`
+object via the `comments` keyword argument of [`TOML.parsefile`](@ref),
+[`TOML.tryparsefile`](@ref), [`TOML.parse`](@ref) or [`TOML.tryparse`](@ref)
+to capture the comments of the parsed document into it, and pass it back via
+the `comments` keyword argument of [`TOML.print`](@ref) to write the comments
+out again. This allows modifying a TOML file without losing its comments:
+
+```julia
+comments = TOML.Comments()
+data = TOML.parsefile("Project.toml"; comments)
+# ... modify data ...
+open("Project.toml", "w") do io
+    TOML.print(io, data; comments)
+end
+```
+
+Comments are associated with the items of the document (see the TOML stdlib
+documentation for the precise rules): a block of whole-line comments directly
+above an item and a comment on the same line as an item are attached to that
+item and are printed with it (and dropped with it, if the item is removed from
+the data). Whole-line comments separated from the following item by a blank
+line are "floating": they are associated with the surrounding table and are
+printed at the top of it.
+
+!!! compat "Julia 1.14"
+    This type requires Julia 1.14 or later.
+"""
+const Comments = Internals.Comments
+
+"""
+    parsefile(f::AbstractString; comments=nothing)
+    parsefile(p::Parser, f::AbstractString; comments=nothing)
 
 Parse file `f` and return the resulting table (dictionary). Throw a
 [`ParserError`](@ref) upon failure.
 
+If a [`TOML.Comments`](@ref) object is passed via the `comments` keyword
+argument, it is emptied and the comments of the document are captured into it.
+
+!!! compat "Julia 1.14"
+    The `comments` keyword argument requires Julia 1.14 or later.
+
 See also [`TOML.tryparsefile`](@ref).
 """
-parsefile(f::AbstractString) =
-    Internals.parse(Internals.Parser{Dates}(_readstring(f); filepath=abspath(f)))
-parsefile(p::Parser, f::AbstractString) =
-    Internals.parse(Internals.reinit!(p._p, _readstring(f); filepath=abspath(f)))
+parsefile(f::AbstractString; comments::Union{Comments, Nothing}=nothing) =
+    Internals.parse(Internals.Parser{Dates}(_readstring(f); filepath=abspath(f), comments))
+parsefile(p::Parser, f::AbstractString; comments::Union{Comments, Nothing}=nothing) =
+    Internals.parse(Internals.reinit!(p._p, _readstring(f); filepath=abspath(f), comments))
 
 """
-    tryparsefile(f::AbstractString)
-    tryparsefile(p::Parser, f::AbstractString)
+    tryparsefile(f::AbstractString; comments=nothing)
+    tryparsefile(p::Parser, f::AbstractString; comments=nothing)
 
 Parse file `f` and return the resulting table (dictionary). Return a
 [`ParserError`](@ref) upon failure.
 
+If a [`TOML.Comments`](@ref) object is passed via the `comments` keyword
+argument, it is emptied and the comments of the document are captured into it.
+
+!!! compat "Julia 1.14"
+    The `comments` keyword argument requires Julia 1.14 or later.
+
 See also [`TOML.parsefile`](@ref).
 """
-tryparsefile(f::AbstractString) =
-    Internals.tryparse(Internals.Parser{Dates}(_readstring(f); filepath=abspath(f)))
-tryparsefile(p::Parser, f::AbstractString) =
-    Internals.tryparse(Internals.reinit!(p._p, _readstring(f); filepath=abspath(f)))
+tryparsefile(f::AbstractString; comments::Union{Comments, Nothing}=nothing) =
+    Internals.tryparse(Internals.Parser{Dates}(_readstring(f); filepath=abspath(f), comments))
+tryparsefile(p::Parser, f::AbstractString; comments::Union{Comments, Nothing}=nothing) =
+    Internals.tryparse(Internals.reinit!(p._p, _readstring(f); filepath=abspath(f), comments))
 
 """
-    parse(x::Union{AbstractString, IO})
-    parse(p::Parser, x::Union{AbstractString, IO})
+    parse(x::Union{AbstractString, IO}; comments=nothing)
+    parse(p::Parser, x::Union{AbstractString, IO}; comments=nothing)
 
 Parse the string or stream `x`, and return the resulting table (dictionary).
 Throw a [`ParserError`](@ref) upon failure.
 
+If a [`TOML.Comments`](@ref) object is passed via the `comments` keyword
+argument, it is emptied and the comments of the document are captured into it.
+
+!!! compat "Julia 1.14"
+    The `comments` keyword argument requires Julia 1.14 or later.
+
 See also [`TOML.tryparse`](@ref).
 """
 parse(p::Parser) = Internals.parse(p._p)
-parse(str::AbstractString) =
-    Internals.parse(Internals.Parser{Dates}(String(str)))
-parse(p::Parser, str::AbstractString) =
-    Internals.parse(Internals.reinit!(p._p, String(str)))
-parse(io::IO) = parse(read(io, String))
-parse(p::Parser, io::IO) = parse(p, read(io, String))
+parse(str::AbstractString; comments::Union{Comments, Nothing}=nothing) =
+    Internals.parse(Internals.Parser{Dates}(String(str); comments))
+parse(p::Parser, str::AbstractString; comments::Union{Comments, Nothing}=nothing) =
+    Internals.parse(Internals.reinit!(p._p, String(str); comments))
+parse(io::IO; comments::Union{Comments, Nothing}=nothing) = parse(read(io, String); comments)
+parse(p::Parser, io::IO; comments::Union{Comments, Nothing}=nothing) = parse(p, read(io, String); comments)
 
 """
-    tryparse(x::Union{AbstractString, IO})
-    tryparse(p::Parser, x::Union{AbstractString, IO})
+    tryparse(x::Union{AbstractString, IO}; comments=nothing)
+    tryparse(p::Parser, x::Union{AbstractString, IO}; comments=nothing)
 
 Parse the string or stream `x`, and return the resulting table (dictionary).
 Return a [`ParserError`](@ref) upon failure.
 
+If a [`TOML.Comments`](@ref) object is passed via the `comments` keyword
+argument, it is emptied and the comments of the document are captured into it.
+
+!!! compat "Julia 1.14"
+    The `comments` keyword argument requires Julia 1.14 or later.
+
 See also [`TOML.parse`](@ref).
 """
 tryparse(p::Parser) = Internals.tryparse(p._p)
-tryparse(str::AbstractString) =
-    Internals.tryparse(Internals.Parser{Dates}(String(str)))
-tryparse(p::Parser, str::AbstractString) =
-    Internals.tryparse(Internals.reinit!(p._p, String(str)))
-tryparse(io::IO) = tryparse(read(io, String))
-tryparse(p::Parser, io::IO) = tryparse(p, read(io, String))
+tryparse(str::AbstractString; comments::Union{Comments, Nothing}=nothing) =
+    Internals.tryparse(Internals.Parser{Dates}(String(str); comments))
+tryparse(p::Parser, str::AbstractString; comments::Union{Comments, Nothing}=nothing) =
+    Internals.tryparse(Internals.reinit!(p._p, String(str); comments))
+tryparse(io::IO; comments::Union{Comments, Nothing}=nothing) = tryparse(read(io, String); comments)
+tryparse(p::Parser, io::IO; comments::Union{Comments, Nothing}=nothing) = tryparse(p, read(io, String); comments)
 
 """
     ParserError
@@ -115,14 +172,22 @@ const ParserError = Internals.ParserError
 
 
 """
-    print([to_toml::Function], io::IO [=stdout], data::AbstractDict; sorted=false, by=identity, inline_tables::IdSet{<:AbstractDict})
+    print([to_toml::Function], io::IO [=stdout], data::AbstractDict; sorted=false, by=identity, inline_tables::IdSet{<:AbstractDict}, comments=nothing)
 
 Write `data` as TOML syntax to the stream `io`. If the keyword argument `sorted` is set to `true`,
 sort tables according to the function given by the keyword argument `by`. If the keyword argument
 `inline_tables` is given, it should be a set of tables that should be printed "inline".
 
+If a [`TOML.Comments`](@ref) object (as populated by the parsing functions) is
+passed via the `comments` keyword argument, the comments in it are printed with
+the items they are associated with. Comments associated with items that are not
+present in `data` are ignored.
+
 !!! compat "Julia 1.11"
     The `inline_tables` keyword argument is supported by Julia 1.11 or later.
+
+!!! compat "Julia 1.14"
+    The `comments` keyword argument requires Julia 1.14 or later.
 
 The following data types are supported: `AbstractDict`, `AbstractVector`, `AbstractString`, `Integer`, `AbstractFloat`, `Bool`,
 `Dates.DateTime`, `Dates.Time`, `Dates.Date`. Note that the integers and floats
@@ -132,7 +197,7 @@ supported type.
 """
 const print = Internals.Printer.print
 
-public Parser, parsefile, tryparsefile, parse, tryparse, ParserError, print
+public Parser, parsefile, tryparsefile, parse, tryparse, ParserError, print, Comments
 
 # These methods are private Base interfaces, but we do our best to support them over
 # the TOML stdlib types anyway to minimize downstream breakage.
@@ -140,8 +205,9 @@ Base.TOMLCache(p::Parser) = Base.TOMLCache(p._p, Dict{String, Base.CachedTOMLDic
 Base.TOMLCache(p::Parser, d::Base.CachedTOMLDict) = Base.TOMLCache(p._p, d)
 Base.TOMLCache(p::Parser, d::Dict{String, Dict{String, Any}}) = Base.TOMLCache(p._p, d)
 
-Internals.reinit!(p::Parser, str::String; filepath::Union{Nothing, String}=nothing) =
-    Internals.reinit!(p._p, str; filepath)
+Internals.reinit!(p::Parser, str::String; filepath::Union{Nothing, String}=nothing,
+                  comments::Union{Comments, Nothing}=nothing) =
+    Internals.reinit!(p._p, str; filepath, comments)
 Internals.parse(p::Parser) = Internals.parse(p._p)
 Internals.tryparse(p::Parser) = Internals.tryparse(p._p)
 

--- a/stdlib/TOML/test/comments.jl
+++ b/stdlib/TOML/test/comments.jl
@@ -35,7 +35,7 @@ end
     @test comments.floating[()] == [" floating root comment"]
     @test comments.items[("deps",)].above == [" attached to deps"]
     @test comments.items[("deps", "Dep")].above == [" `Dep` is used for fooing bars"]
-    @test comments.items[("deps", "Dep")].inline == ""
+    @test comments.items[("deps", "Dep")].inline === nothing
     @test comments.items[("compat", "Dep")].inline == " see issue 123 before bumping"
     @test !haskey(comments.items, ("compat", "julia"))
 end
@@ -221,6 +221,59 @@ end
     data2, comments2 = parse_with_comments(out)
     @test data2 == data
     @test comments2 == comments
+end
+
+@testset "comments force elided table headers" begin
+    # `[a]` would normally be elided since `a` only contains the table `b`;
+    # a comment associated with `a` must keep its anchor
+    str = """
+    # keep me
+    [a]
+    [a.b]
+    x = 1
+    """
+    data, comments = parse_with_comments(str)
+    @test comments.items[("a",)].above == [" keep me"]
+    out = sprint_with_comments(data, comments)
+    @test occursin("[a]", out)
+    data2, comments2 = parse_with_comments(out)
+    @test data2 == data
+    @test comments2 == comments
+    @test sprint_with_comments(data2, comments2) == out
+
+    # same for a floating comment inside the elided table
+    str = """
+    [a]
+
+    # floating in a
+
+    [a.b]
+    x = 1
+    """
+    data, comments = parse_with_comments(str)
+    @test comments.floating[("a",)] == [" floating in a"]
+    out = sprint_with_comments(data, comments)
+    data2, comments2 = parse_with_comments(out)
+    @test data2 == data
+    @test comments2 == comments
+    @test sprint_with_comments(data2, comments2) == out
+
+    # without comments the header is still elided
+    data, comments = parse_with_comments("[a.b]\nx = 1\n")
+    @test !occursin(r"^\[a\]"m, sprint_with_comments(data, comments))
+end
+
+@testset "empty inline comments are preserved" begin
+    data, comments = parse_with_comments("x = 1 #\ny = 2\n")
+    @test comments.items[("x",)].inline == ""
+    @test !haskey(comments.items, ("y",))
+    out = sprint_with_comments(data, comments)
+    @test occursin("x = 1 #\n", out)
+    @test occursin("y = 2\n", out)
+    data2, comments2 = parse_with_comments(out)
+    @test data2 == data
+    @test comments2 == comments
+    @test sprint_with_comments(data2, comments2) == out
 end
 
 @testset "Comments is emptied on reuse" begin

--- a/stdlib/TOML/test/comments.jl
+++ b/stdlib/TOML/test/comments.jl
@@ -276,6 +276,39 @@ end
     @test sprint_with_comments(data2, comments2) == out
 end
 
+@testset "comments in tables printed inline are hoisted" begin
+    # A table printed via `inline_tables` has no lines for its entries'
+    # comments; they are hoisted above the entry that owns the inline table,
+    # which is where a reparse of the output associates them
+    str = """
+    [deps]
+    Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+    # above the sources entry
+    [sources.Example]
+    # local checkout
+    path = "../Example" # trailing
+    """
+    data, comments = parse_with_comments(str)
+    inline_tables = Base.IdSet{Dict{String, Any}}()
+    push!(inline_tables, data["sources"]["Example"])
+    out = sprint_with_comments(data, comments; inline_tables, sorted = true)
+    @test occursin("# above the sources entry", out)
+    @test occursin("# local checkout", out)
+    @test occursin("# trailing", out)
+    @test occursin("Example = {path = \"../Example\"}", out)
+    data2, comments2 = parse_with_comments(out)
+    @test data2 == data
+    @test comments2.items[("sources", "Example")].above ==
+        [" above the sources entry", " local checkout", " trailing"]
+    @test !haskey(comments2.items, ("sources", "Example", "path"))
+    # stable from the second print onwards
+    inline_tables2 = Base.IdSet{Dict{String, Any}}()
+    push!(inline_tables2, data2["sources"]["Example"])
+    out2 = sprint_with_comments(data2, comments2; inline_tables = inline_tables2, sorted = true)
+    @test out2 == out
+end
+
 @testset "Comments is emptied on reuse" begin
     comments = TOML.Comments()
     TOML.parse("# hi\na = 1"; comments)

--- a/stdlib/TOML/test/comments.jl
+++ b/stdlib/TOML/test/comments.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+# Comment capture and printing.
 
 using Test
 using TOML
@@ -63,9 +64,6 @@ end
 end
 
 @testset "blank line separates attached from floating" begin
-    # From the discussion in JuliaLang/julia#42697: `1` and `2` are separated
-    # from `bar` by blank lines and float to the top of the (root) table,
-    # `3` is directly above `bar` and attaches to it.
     str = """
     foo = 123
     # 1
@@ -114,9 +112,6 @@ end
 end
 
 @testset "array of tables" begin
-    # Comments cannot be attached to items inside array-of-tables elements
-    # (key paths do not distinguish between elements): only the comment block
-    # above the first `[[...]]` header is kept, attached to the array itself.
     str = """
     # above first
     [[x]]
@@ -153,11 +148,9 @@ end
     data2, comments2 = parse_with_comments(out)
     @test comments2.floating[("a",)] == [" floats in a"]
 
-    # a comment block at EOF without a blank line before it also floats
     data, comments = parse_with_comments("x = 1\n# tail")
     @test comments.floating[()] == [" tail"]
 
-    # only-comments and empty documents
     data, comments = parse_with_comments("# just a comment\n")
     @test isempty(data)
     @test comments.floating[()] == [" just a comment"]
@@ -224,8 +217,6 @@ end
 end
 
 @testset "comments force elided table headers" begin
-    # `[a]` would normally be elided since `a` only contains the table `b`;
-    # a comment associated with `a` must keep its anchor
     str = """
     # keep me
     [a]
@@ -241,7 +232,6 @@ end
     @test comments2 == comments
     @test sprint_with_comments(data2, comments2) == out
 
-    # same for a floating comment inside the elided table
     str = """
     [a]
 
@@ -258,7 +248,6 @@ end
     @test comments2 == comments
     @test sprint_with_comments(data2, comments2) == out
 
-    # without comments the header is still elided
     data, comments = parse_with_comments("[a.b]\nx = 1\n")
     @test !occursin(r"^\[a\]"m, sprint_with_comments(data, comments))
 end
@@ -277,9 +266,6 @@ end
 end
 
 @testset "comments in tables printed inline are hoisted" begin
-    # A table printed via `inline_tables` has no lines for its entries'
-    # comments; they are hoisted above the entry that owns the inline table,
-    # which is where a reparse of the output associates them
     str = """
     [deps]
     Example = "7876af07-990d-54b4-ab0e-23690620f79a"
@@ -302,7 +288,6 @@ end
     @test comments2.items[("sources", "Example")].above ==
         [" above the sources entry", " local checkout", " trailing"]
     @test !haskey(comments2.items, ("sources", "Example", "path"))
-    # stable from the second print onwards
     inline_tables2 = Base.IdSet{Dict{String, Any}}()
     push!(inline_tables2, data2["sources"]["Example"])
     out2 = sprint_with_comments(data2, comments2; inline_tables = inline_tables2, sorted = true)
@@ -317,7 +302,6 @@ end
     @test !haskey(comments.items, ("a",))
     @test isempty(comments)
 
-    # reusing a Parser without comments does not touch a previous capture
     p = TOML.Parser()
     comments = TOML.Comments()
     TOML.parse(p, "# hi\na = 1"; comments)

--- a/stdlib/TOML/test/comments.jl
+++ b/stdlib/TOML/test/comments.jl
@@ -1,0 +1,280 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Test
+using TOML
+
+function parse_with_comments(str)
+    comments = TOML.Comments()
+    data = TOML.parse(str; comments)
+    return data, comments
+end
+
+function sprint_with_comments(data, comments; kws...)
+    io = IOBuffer()
+    TOML.print(io, data; comments, kws...)
+    return String(take!(io))
+end
+
+@testset "attached, inline and floating comments" begin
+    str = """
+    # floating root comment
+
+    name = "MyPkg"
+    # attached to deps
+    [deps]
+    Dates = "ade2ca70"
+    # `Dep` is used for fooing bars
+    Dep = "0796e94c"
+
+    [compat]
+    julia = "1"
+    Dep = "~1.1" # see issue 123 before bumping
+    """
+    data, comments = parse_with_comments(str)
+    @test data["name"] == "MyPkg"
+    @test comments.floating[()] == [" floating root comment"]
+    @test comments.items[("deps",)].above == [" attached to deps"]
+    @test comments.items[("deps", "Dep")].above == [" `Dep` is used for fooing bars"]
+    @test comments.items[("deps", "Dep")].inline == ""
+    @test comments.items[("compat", "Dep")].inline == " see issue 123 before bumping"
+    @test !haskey(comments.items, ("compat", "julia"))
+end
+
+@testset "print and reparse is a fixed point" begin
+    str = """
+    # preamble comment
+
+    name = "MyPkg"
+    # attached to deps
+    [deps] # inline on header
+    # dep comment
+    Dep = "0796e94c"
+    [compat]
+    Dep = "~1.1" # inline compat
+    """
+    data, comments = parse_with_comments(str)
+    for sorted in (false, true)
+        out = sprint_with_comments(data, comments; sorted)
+        data2, comments2 = parse_with_comments(out)
+        @test data2 == data
+        @test comments2 == comments
+        @test sprint_with_comments(data2, comments2; sorted) == out
+    end
+end
+
+@testset "blank line separates attached from floating" begin
+    # From the discussion in JuliaLang/julia#42697: `1` and `2` are separated
+    # from `bar` by blank lines and float to the top of the (root) table,
+    # `3` is directly above `bar` and attaches to it.
+    str = """
+    foo = 123
+    # 1
+
+    # 2
+
+    # 3
+    bar = 456
+    """
+    data, comments = parse_with_comments(str)
+    @test comments.floating[()] == [" 1", " 2"]
+    @test comments.items[("bar",)].above == [" 3"]
+    @test !haskey(comments.items, ("foo",))
+end
+
+@testset "comments in values attach to the owning entry" begin
+    str = """
+    # above a
+    a = [1, # one
+         # two
+         2]
+    b = { x = 1 } # inline b
+    """
+    data, comments = parse_with_comments(str)
+    @test comments.items[("a",)].above == [" above a", " one", " two"]
+    @test comments.items[("b",)].inline == " inline b"
+    @test !haskey(comments.items, ("b", "x"))
+end
+
+@testset "dotted and quoted keys" begin
+    str = """
+    # above dotted
+    a.b.c = 1
+    ["weird key"]
+    # above weird entry
+    "x.y" = 2 # inline weird
+    """
+    data, comments = parse_with_comments(str)
+    @test comments.items[("a", "b", "c")].above == [" above dotted"]
+    @test comments.items[("weird key", "x.y")].above == [" above weird entry"]
+    @test comments.items[("weird key", "x.y")].inline == " inline weird"
+    out = sprint_with_comments(data, comments)
+    data2, comments2 = parse_with_comments(out)
+    @test data2 == data
+    @test comments2 == comments
+end
+
+@testset "array of tables" begin
+    # Comments cannot be attached to items inside array-of-tables elements
+    # (key paths do not distinguish between elements): only the comment block
+    # above the first `[[...]]` header is kept, attached to the array itself.
+    str = """
+    # above first
+    [[x]]
+    a = 1 # dropped
+    # dropped too
+    [[x]]
+    b = 2
+
+    [y]
+    # in y
+    z = 1
+    """
+    data, comments = parse_with_comments(str)
+    @test comments.items[("x",)].above == [" above first"]
+    @test comments.items[("y", "z")].above == [" in y"]
+    @test length(comments.items) == 2
+    @test isempty(comments.floating)
+    out = sprint_with_comments(data, comments)
+    data2, comments2 = parse_with_comments(out)
+    @test data2 == data
+    @test comments2 == comments
+end
+
+@testset "floating comments in tables and at EOF" begin
+    str = """
+    [a]
+    x = 1
+
+    # floats in a
+    """
+    data, comments = parse_with_comments(str)
+    @test comments.floating[("a",)] == [" floats in a"]
+    out = sprint_with_comments(data, comments)
+    data2, comments2 = parse_with_comments(out)
+    @test comments2.floating[("a",)] == [" floats in a"]
+
+    # a comment block at EOF without a blank line before it also floats
+    data, comments = parse_with_comments("x = 1\n# tail")
+    @test comments.floating[()] == [" tail"]
+
+    # only-comments and empty documents
+    data, comments = parse_with_comments("# just a comment\n")
+    @test isempty(data)
+    @test comments.floating[()] == [" just a comment"]
+    data, comments = parse_with_comments("")
+    @test isempty(data)
+    @test isempty(comments)
+end
+
+@testset "comment without preceding whitespace" begin
+    data, comments = parse_with_comments("a = 1# c\n[b]# d\nx = 2\n")
+    @test comments.items[("a",)].inline == " c"
+    @test comments.items[("b",)].inline == " d"
+end
+
+@testset "crlf line endings" begin
+    str = "# above\r\na = 1\r\n\r\n# floating\r\n\r\nb = 2\r\n"
+    data, comments = parse_with_comments(str)
+    @test comments.items[("a",)].above == [" above"]
+    @test comments.floating[()] == [" floating"]
+    @test !haskey(comments.items, ("b",))
+end
+
+@testset "comments removed with their item" begin
+    str = """
+    # above a
+    a = 1
+    # above b
+    b = 2
+    """
+    data, comments = parse_with_comments(str)
+    delete!(data, "a")
+    out = sprint_with_comments(data, comments)
+    @test !occursin("above a", out)
+    @test occursin("above b", out)
+end
+
+@testset "programmatic comments are sanitized" begin
+    data = Dict{String, Any}("a" => 1)
+    comments = TOML.Comments()
+    comments.items[("a",)] = TOML.Internals.CommentBlock(["evil\nb = 2"], "inline\nevil = 3")
+    out = sprint_with_comments(data, comments)
+    data2, comments2 = parse_with_comments(out)
+    @test data2 == data
+    @test comments2.items[("a",)].above == [" evil", " b = 2"]
+end
+
+@testset "comments in nested and empty tables" begin
+    str = """
+    [a]
+    # above nested header
+    [a.b] # inline nested header
+    x = 1
+    # above empty table
+    [c]
+    """
+    data, comments = parse_with_comments(str)
+    @test comments.items[("a", "b")].above == [" above nested header"]
+    @test comments.items[("a", "b")].inline == " inline nested header"
+    @test comments.items[("c",)].above == [" above empty table"]
+    out = sprint_with_comments(data, comments)
+    data2, comments2 = parse_with_comments(out)
+    @test data2 == data
+    @test comments2 == comments
+end
+
+@testset "Comments is emptied on reuse" begin
+    comments = TOML.Comments()
+    TOML.parse("# hi\na = 1"; comments)
+    @test haskey(comments.items, ("a",))
+    TOML.parse("b = 2"; comments)
+    @test !haskey(comments.items, ("a",))
+    @test isempty(comments)
+
+    # reusing a Parser without comments does not touch a previous capture
+    p = TOML.Parser()
+    comments = TOML.Comments()
+    TOML.parse(p, "# hi\na = 1"; comments)
+    @test haskey(comments.items, ("a",))
+    @test TOML.parse(p, "b = 2") == Dict("b" => 2)
+    @test haskey(comments.items, ("a",))
+end
+
+@testset "parsefile/tryparsefile/tryparse with comments" begin
+    mktemp() do path, io
+        write(io, "# above\na = 1 # inline\n")
+        close(io)
+        for parsef in (TOML.parsefile, TOML.tryparsefile)
+            comments = TOML.Comments()
+            data = parsef(path; comments)
+            @test data == Dict("a" => 1)
+            @test comments.items[("a",)].above == [" above"]
+            @test comments.items[("a",)].inline == " inline"
+            comments = TOML.Comments()
+            data = parsef(TOML.Parser(), path; comments)
+            @test data == Dict("a" => 1)
+            @test comments.items[("a",)].inline == " inline"
+        end
+        comments = TOML.Comments()
+        @test TOML.tryparse("# c\na = 1"; comments) == Dict("a" => 1)
+        @test comments.items[("a",)].above == [" c"]
+        comments = TOML.Comments()
+        @test open(io -> TOML.parse(io; comments), path) == Dict("a" => 1)
+        @test comments.items[("a",)].inline == " inline"
+    end
+end
+
+@testset "comments do not affect sorting or inline tables" begin
+    str = """
+    # above b
+    b = 1
+    a = { x = 1 }
+    """
+    data, comments = parse_with_comments(str)
+    inline_tables = Base.IdSet{Dict{String, Any}}()
+    push!(inline_tables, data["a"])
+    out = sprint_with_comments(data, comments; sorted=true, inline_tables)
+    @test occursin("a = {x = 1}", out) || occursin("a = { x = 1 }", out)
+    lines = split(out, '\n')
+    @test lines[findfirst(==("b = 1"), lines) - 1] == "# above b"
+end

--- a/stdlib/TOML/test/runtests.jl
+++ b/stdlib/TOML/test/runtests.jl
@@ -24,6 +24,7 @@ include("invalids.jl")
 include("error_printing.jl")
 include("print.jl")
 include("parse.jl")
+include("comments.jl")
 
 @inferred TOML.parse("foo = 3")
 


### PR DESCRIPTION
Implements comment preservation for TOML documents, as discussed in #42697.
Pkg PR https://github.com/JuliaLang/Pkg.jl/pull/4746 (checked out on this PR so Pkg tests can run)


Claude:

---

The design follows the approach converged on in that issue (side-channel data structure, no concrete syntax tree): comments are captured into a `TOML.Comments` object keyed by the key path of the item they are associated with, the parsed data is an unchanged `Dict`, and the printer accepts the `Comments` object back and emits the comments next to the items they belong to. The output stays fully canonicalized (`sorted`, `by`, `inline_tables` all keep working — comments follow their item wherever it is printed).

```julia
comments = TOML.Comments()
data = TOML.parsefile("Project.toml"; comments)
# ... modify data ...
open("Project.toml", "w") do io
    TOML.print(io, data; comments)
end
```

### Association rules

- A block of whole-line comments with no blank line between the block and the following item (entry or table header) is **attached** to that item, like a docstring, and prints directly above it.
- A comment on the same line as an item is attached to it and prints inline after the value.
- Any other whole-line comment (separated from the following item by a blank line, or trailing at the end of a table/document) is **floating**: it is associated with the table it appears in and prints at the top of that table. ("Moving beats deleting" — see the discussion in #42697 about ambiguous placements.)
- Deleting an item from the data drops its comments; the printer ignores comments whose paths are not present.
- Comments inside multi-line values (arrays, TOML 1.1 multi-line inline tables) attach to the owning entry.
- Comments on/inside array-of-tables elements are **not** preserved (key paths cannot distinguish elements); only a block above the first `[[...]]` header is kept, attached to the array. This is a documented v1 limitation — Project.toml files don't use arrays of tables.

Emitted comment text is sanitized (every line is prefixed `#`, control characters are dropped/replaced) so a comment string can never alter the structure of the printed document.

### Implementation notes

- Capture is **opt-in** via a new `comments` field on `Base.TOML.Parser` (default `nothing`); the loading fast path (`Base.TOML_CACHE` with `Parser{nothing}`) is unaffected, and `reinit!` resets the new state. The Preferences hashing path (`loading.jl`) never passes `comments`.
- `skip_comment` is the single capture point; a new `skip_ws_nl_toplevel` tracks blank lines between top-level items for the attached/floating distinction. `skip_ws_comment` previously skipped a trailing comment only when preceded by whitespace (`skip_ws(l) && skip_comment(l)` — short-circuit); it now always does, so `a = 1# c` and `a = 1 # c` capture identically.
- The stdlib gains `TOML.Comments` (public) and `comments` keyword arguments on `parsefile`/`tryparsefile`/`parse`/`tryparse`/`print`; docs section with the rules and a NEWS entry included.
- Round-trip property: parse-with-comments → print → reparse gives equal data and equal comments, and a second print is byte-identical (canonical form is a fixed point). Tested in `stdlib/TOML/test/comments.jl`.

A companion Pkg.jl PR (JuliaLang/Pkg.jl#4746) uses this to make `Pkg.add`/`Pkg.rm`/`Pkg.compat` etc. preserve comments in `Project.toml`.

Closes #42697

