### PR TITLE
cancellation: Cache the scoped-default token in the task

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -197,7 +197,7 @@
 #    priority::UInt16
 #    @atomic _isexception::UInt8
 #    @atomic preempt_request::UInt8
-#    pad01::UInt8
+#    bound_cancel_default::UInt8
 #    pad02::UInt8
 #    rngState0::UInt64
 #    rngState1::UInt64
@@ -216,7 +216,7 @@
 #    cached_wait_entry::Any
 #    cached_cancel_entry::Any
 #    invoked::Any
-#    @atomic bound_cancel_token::Any
+#    @atomic bound_cancel_token::Union{Nothing, CancellationTokenSource}
 #end
 
 export

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -1039,12 +1039,45 @@ function _birth_cancel_source(t::Task)
     return (tok::CancellationToken).source
 end
 
+# The scoped-default resolution, with a per-task cache: when the task's
+# `bound_cancel_default` flag is set, `bound_cancel_token` holds the source
+# this lookup would resolve to under the task's current scope (or `nothing`),
+# placed there by the slow path below. The flag is dropped wherever a scope
+# is installed (`with` enter and its inline exit) and by cancellation points
+# publishing a different source, and travels with the token through the
+# exception-handler and finalizer save/restore brackets, so a set flag
+# always describes the current scope (see bound_cancel_default in
+# src/julia_threads.h). Reconstructing the token from the cached source is
+# exact: `CancellationToken` is an immutable wrapper, so the copy is egal to
+# the token in the scope.
 @inline function default_cancel_token()
+    ct = current_task()
+    if getfield(ct, :bound_cancel_default) !== 0x00
+        # the field's declared type (Union{Nothing, CancellationTokenSource})
+        # narrows through the `=== nothing` check without a type-tag load
+        s = @atomic :monotonic ct.bound_cancel_token
+        s === nothing && return nothing
+        return CancellationToken(s)
+    end
+    return _default_cancel_token_slow(ct)
+end
+
+@noinline function _default_cancel_token_slow(ct::Task)
+    tok = nothing
     scope = Core.current_scope()::Union{Scope, Nothing}
-    scope === nothing && return nothing
-    v = KeyValue.get(scope.values, CANCEL_TOKEN)
-    v === nothing && return nothing
-    return something(v)::Union{Nothing, CancellationToken}
+    if scope !== nothing
+        v = KeyValue.get(scope.values, CANCEL_TOKEN)
+        if v !== nothing
+            tok = something(v)::Union{Nothing, CancellationToken}
+        end
+    end
+    # Cache the resolution for the current scope. The store is an untagged
+    # unsafe point for CancellationLowering, so it cannot break a published
+    # reset region's (region, token) coherence: any live region is torn down
+    # before the store and re-established at the next cancellation point.
+    @atomic :monotonic ct.bound_cancel_token = tok === nothing ? nothing : tok.source
+    setfield!(ct, :bound_cancel_default, 0x01)
+    return tok
 end
 
 @inline function default_cancel_source()

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5526,6 +5526,7 @@ isdefined_unknown_idx:
         Value *ct = get_current_task(ctx);
         Value *src = boxed(ctx, argv[1]);
         Value *bound_ptr = emit_ptrgep(ctx, ct, offsetof(jl_task_t, bound_cancel_token), "bound_cancel_token");
+        Value *bound_default_ptr = emit_ptrgep(ctx, ct, offsetof(jl_task_t, bound_cancel_default), "bound_cancel_default");
         jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
         Value *nothing_val = track_pjlvalue(ctx, literal_pointer_val(ctx, jl_nothing));
         Type *T_int8 = getInt8Ty(ctx.builder.getContext());
@@ -5555,6 +5556,9 @@ isdefined_unknown_idx:
         StoreInst *clear_store = ctx.builder.CreateAlignedStore(nothing_val, bound_ptr, ctx.types().alignof_ptr);
         clear_store->setOrdering(AtomicOrdering::Monotonic);
         ai.decorateInst(clear_store);
+        // The binding is now an explicit `nothing`, not the scoped-default
+        // cache (the skip path above keeps a matching cache intact).
+        ai.decorateInst(ctx.builder.CreateAlignedStore(ConstantInt::get(T_int8, 0), bound_default_ptr, Align(1)));
         ctx.builder.CreateBr(point_bb);
 
         // src is a token source: publish the binding (store only on rebind,
@@ -5573,6 +5577,10 @@ isdefined_unknown_idx:
         StoreInst *bind_store = ctx.builder.CreateAlignedStore(src, bound_ptr, ctx.types().alignof_ptr);
         bind_store->setOrdering(AtomicOrdering::Release);
         ai.decorateInst(bind_store);
+        // A rebind publishes an explicit source: it may differ from the
+        // scoped default, so the cache flag must drop (the same-source skip
+        // path keeps a matching cache intact).
+        ai.decorateInst(ctx.builder.CreateAlignedStore(ConstantInt::get(T_int8, 0), bound_default_ptr, Align(1)));
         emit_write_barrier(ctx, ct, src);
         ctx.builder.CreateBr(point_bb);
 
@@ -6869,6 +6877,13 @@ static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr, int ssaval_result)
 #endif
             jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe).decorateInst(
                 ctx.builder.CreateAlignedStore(scope_to_restore, scope_ptr, ctx.types().alignof_ptr));
+            // This inline restore is the only scope swap not bracketed by the
+            // exception-handler save/restore, so it must invalidate the
+            // task's cached scoped-default cancellation token itself (see
+            // bound_cancel_default in julia_threads.h).
+            Value *bcd_ptr = emit_ptrgep(ctx, get_current_task(ctx), offsetof(jl_task_t, bound_cancel_default), "bound_cancel_default");
+            jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe).decorateInst(
+                ctx.builder.CreateAlignedStore(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0), bcd_ptr, Align(1)));
             // NOTE: post-wb not needed here, due to store to current_task (see jl_gc_wb_current_task)
         }
     }
@@ -10236,6 +10251,12 @@ static jl_llvm_functions_t
                 // NOTE: wb not needed here, due to store to current_task (see jl_gc_wb_current_task)
                 jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe).decorateInst(current_scope);
                 jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe).decorateInst(scope_store);
+                // Installing a new scope invalidates the task's cached
+                // scoped-default cancellation token (see bound_cancel_default
+                // in julia_threads.h).
+                Value *bcd_ptr = emit_ptrgep(ctx, get_current_task(ctx), offsetof(jl_task_t, bound_cancel_default), "bound_cancel_default");
+                jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe).decorateInst(
+                    ctx.builder.CreateAlignedStore(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0), bcd_ptr, Align(1)));
                 // GC preserve the current_scope, since it is not rooted in the `jl_handler_t *`,
                 // the newly entered scope is preserved through the current_task.
                 Value *scope_token = ctx.builder.CreateCall(prepare_call(gc_preserve_begin_func), {current_scope});

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -263,6 +263,7 @@ static void jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NO
     uint8_t sticky = ct->sticky;
     // Finalizers hijack the current task, so preserve its token binding.
     jl_value_t *bound_token = jl_atomic_load_relaxed(&ct->bound_cancel_token);
+    uint8_t bound_default = ct->bound_cancel_default;
     JL_GC_PUSH1(&bound_token);
     // empty out the first two entries for the GC frame
     arraylist_push(list, list->items[0]);
@@ -280,6 +281,7 @@ static void jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NO
     JL_GC_POP();
     ct->sticky = sticky;
     jl_atomic_store_relaxed(&ct->bound_cancel_token, bound_token);
+    ct->bound_cancel_default = bound_default;
     jl_gc_wb_current_task(ct, bound_token);
     JL_GC_POP(); // matches the JL_GC_PUSH1 above
 }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -695,6 +695,10 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
                 jl_value_t *new_scope = eval_value(jl_enternode_scope(stmt), s);
                 jl_gc_wb_current_task(ct, new_scope);
                 ct->scope = new_scope;
+                // Installing a new scope invalidates the cached scoped-default
+                // cancellation token (see bound_cancel_default); the handler
+                // restore brackets bring the flag back with the scope.
+                ct->bound_cancel_default = 0;
                 if (!jl_setjmp(__eh.eh_ctx, 0)) {
                     ct->eh = &__eh;
                     eval_body(stmts, s, next_ip, toplevel);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4388,7 +4388,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                         "priority",
                                         "_isexception",
                                         "preempt_request",
-                                        "pad01",
+                                        "bound_cancel_default",
                                         "pad02",
                                         "rngState0",
                                         "rngState1",
@@ -4446,6 +4446,12 @@ void jl_init_types(void) JL_GC_DISABLED
     XX(task);
     jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);
+    // Declare bound_cancel_token as Union{Nothing, CancellationTokenSource}
+    // so reads narrow with a `=== nothing` check instead of a type-tag load
+    // (the tag load is a volatile unsafe point that would tear a published
+    // reset region on every cache-hit token lookup).
+    jl_value_t *boundt = jl_new_struct(jl_uniontype_type, (jl_value_t*)jl_cancel_source_type, jl_nothing_type);
+    jl_svecset(jl_task_type->types, 31, boundt);
     // Set field 20 (metrics_enabled) as const
     // Set fields 8 (_state), 12 (preempt_request), 24-27 (metric counters),
     // 28 (waiting_on) and 32 (bound_cancel_token) as atomic

--- a/src/julia.h
+++ b/src/julia.h
@@ -2563,6 +2563,9 @@ struct _jl_handler_t {
     struct _jl_cancel_handler_ctx_t *cancel_handler_ctx;
     sig_atomic_t defer_signal;
     int8_t gc_state;
+    // Saved `bound_cancel_default` flag, restored with `bound_cancel_token`
+    // (the pair is only coherent together; see julia_threads.h).
+    uint8_t bound_cancel_default;
 };
 
 #define JL_TASK_STATE_RUNNABLE  0

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -487,7 +487,17 @@ typedef struct _jl_task_t {
     // the task's next cancellation point; a preempt shootdown sets it and
     // kicks the task out of any published reset region.
     _Atomic(uint8_t) preempt_request;
-    uint8_t pad0[2];
+    // When nonzero, `bound_cancel_token` holds the cached resolution of the
+    // scoped-default CANCEL_TOKEN lookup for the task's current `scope` (the
+    // token's source, or `nothing` for "no governing token"), placed there by
+    // the slow path of `Base.default_cancel_token`. Owner-task private (no
+    // concurrent reader consults it). Cleared wherever a new scope is
+    // installed (codegen/interpreter `:enter` with scope, codegen's inline
+    // leave restore) and by a cancellation point that publishes a different
+    // source; saved and restored alongside `bound_cancel_token` by exception
+    // handlers and the finalizer bracket.
+    uint8_t bound_cancel_default;
+    uint8_t pad0[1];
     // === 64 bytes (cache line)
     uint64_t rngState[JL_RNG_SIZE];
     // flag indicating whether or not to record timing metrics for this task
@@ -528,7 +538,9 @@ typedef struct _jl_task_t {
     // `nothing`, or a `Core.CancellationTokenSource`. Read by cancellers
     // scanning for running computations governed by a cancelled subtree; may
     // be stale between cancellation points (benign: level-triggered recovery
-    // at the next check).
+    // at the next check). When `bound_cancel_default` is set, the value is
+    // the cached scoped-default resolution for the task's current scope
+    // (still a governing source, so the scanning semantics are unchanged).
     _Atomic(jl_value_t *) bound_cancel_token;
 
 // hidden state:

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -269,6 +269,7 @@ JL_DLLEXPORT void jl_enter_handler(jl_task_t *ct, jl_handler_t *eh)
     eh->scope = ct->scope;
     eh->reset_ctx = jl_atomic_load_relaxed(&ct->reset_ctx);
     eh->bound_cancel_token = jl_atomic_load_relaxed(&ct->bound_cancel_token);
+    eh->bound_cancel_default = ct->bound_cancel_default;
     eh->cancel_handler_ctx = jl_atomic_load_relaxed(&ct->cancel_handler_ctx);
     eh->gc_state = jl_atomic_load_relaxed(&ct->ptls->gc_state);
     eh->locks_len = ct->ptls->locks.len;
@@ -301,6 +302,7 @@ JL_DLLEXPORT void jl_eh_restore_state(jl_task_t *ct, jl_handler_t *eh) JL_NO_SAF
     ct->eh = eh->prev;
     ct->gcstack = eh->gcstack;
     jl_atomic_store_relaxed(&ct->bound_cancel_token, eh->bound_cancel_token);
+    ct->bound_cancel_default = eh->bound_cancel_default;
     jl_gc_wb_current_task(ct, eh->bound_cancel_token);
     jl_atomic_store_release(&ct->reset_ctx, eh->reset_ctx);
     jl_atomic_store_release(&ct->cancel_handler_ctx, eh->cancel_handler_ctx);
@@ -348,6 +350,7 @@ JL_DLLEXPORT void jl_eh_restore_state_noexcept(jl_task_t *ct, jl_handler_t *eh)
     ct->scope = eh->scope;
     ct->eh = eh->prev;
     jl_atomic_store_relaxed(&ct->bound_cancel_token, eh->bound_cancel_token);
+    ct->bound_cancel_default = eh->bound_cancel_default;
     jl_gc_wb_current_task(ct, eh->bound_cancel_token);
     jl_atomic_store_release(&ct->reset_ctx, eh->reset_ctx);
     jl_atomic_store_release(&ct->cancel_handler_ctx, eh->cancel_handler_ctx);

--- a/src/task.c
+++ b/src/task.c
@@ -1140,6 +1140,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_fu
     jl_timing_task_init(t);
     jl_atomic_store_relaxed(&t->preempt_request, 0);
     jl_atomic_store_relaxed(&t->bound_cancel_token, jl_nothing);
+    t->bound_cancel_default = 0;
     jl_atomic_store_relaxed(&t->reset_ctx, NULL);
     jl_atomic_store_relaxed(&t->cancel_handler_ctx, NULL);
 
@@ -1616,6 +1617,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     }
     jl_atomic_store_relaxed(&ct->preempt_request, 0);
     jl_atomic_store_relaxed(&ct->bound_cancel_token, jl_nothing);
+    ct->bound_cancel_default = 0;
     jl_atomic_store_relaxed(&ct->reset_ctx, NULL);
     jl_atomic_store_relaxed(&ct->cancel_handler_ctx, NULL);
     ptls->abandon_to = NULL;

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -307,6 +307,103 @@ end
                                           CANCEL_TOKEN => CancellationToken(qchild))
 end
 
+@testset "scoped-default token cache" begin
+    # The per-task cache (Task.bound_cancel_default over bound_cancel_token)
+    # must be invisible: default_cancel_token() always resolves to what the
+    # CANCEL_TOKEN scoped lookup would return under the current scope.
+    src = CancellationTokenSource()
+    tok = CancellationToken(src)
+
+    # the ambient default outside our scopes (the test harness may itself
+    # run under a governing token, e.g. the ^C episode source)
+    ambient = Base.default_cancel_token()
+
+    # warm lookups agree with the scope, and the cache invariant holds
+    with(CANCEL_TOKEN => tok) do
+        t1 = Base.default_cancel_token()
+        t2 = Base.default_cancel_token()
+        @test t1 === tok && t2 === tok
+        ct = current_task()
+        @test getfield(ct, :bound_cancel_default) === 0x01
+        @test (@atomic :monotonic ct.bound_cancel_token) === src
+    end
+    # after the scope exits, the ambient default is back
+    @test Base.default_cancel_token() === ambient
+
+    # a cancellation point that publishes a *different* explicit source must
+    # not leave the cache claiming it as the scoped default
+    other = CancellationTokenSource()
+    with(CANCEL_TOKEN => tok) do
+        @test Base.default_cancel_token() === tok      # warm the cache
+        Base.@cancel_check CancellationToken(other)    # rebind to `other`
+        @test Base.default_cancel_token() === tok      # still the scoped one
+        Base.@cancel_check nothing                     # explicit clear
+        @test Base.default_cancel_token() === tok
+    end
+
+    # the same-source cancellation point keeps a warm cache intact
+    with(CANCEL_TOKEN => tok) do
+        @test Base.default_cancel_token() === tok
+        Base.@cancel_check
+        @test getfield(current_task(), :bound_cancel_default) === 0x01
+        @test Base.default_cancel_token() === tok
+    end
+
+    # scope changes that do not touch CANCEL_TOKEN still resolve correctly
+    sv = ScopedValue(0)
+    with(CANCEL_TOKEN => tok) do
+        @test Base.default_cancel_token() === tok
+        with(sv => 1) do
+            @test Base.default_cancel_token() === tok
+        end
+        @test Base.default_cancel_token() === tok
+    end
+
+    # nesting and shielding, with warm caches at every level
+    inner = CancellationTokenSource()
+    with(CANCEL_TOKEN => tok) do
+        @test Base.default_cancel_token() === tok
+        with(CANCEL_TOKEN => CancellationToken(inner)) do
+            @test Base.default_cancel_token() === CancellationToken(inner)
+        end
+        @test Base.default_cancel_token() === tok
+        with(CANCEL_TOKEN => nothing) do
+            @test Base.default_cancel_token() === nothing
+        end
+        @test Base.default_cancel_token() === tok
+    end
+
+    # an exceptional unwind out of an inner scope restores the outer default
+    with(CANCEL_TOKEN => tok) do
+        @test Base.default_cancel_token() === tok
+        try
+            with(CANCEL_TOKEN => CancellationToken(inner)) do
+                @test Base.default_cancel_token() === CancellationToken(inner)
+                error("unwind")
+            end
+        catch err
+            @test err == ErrorException("unwind")
+        end
+        @test Base.default_cancel_token() === tok
+    end
+
+    # a task spawned under the scope resolves its inherited default
+    with(CANCEL_TOKEN => tok) do
+        t = Threads.@spawn Base.default_cancel_token()
+        @test fetch(t) === tok
+    end
+
+    # a warm cache still observes cancellation promptly (the cache holds the
+    # source; its state is what the check reads)
+    psrc = CancellationTokenSource()
+    with(CANCEL_TOKEN => CancellationToken(psrc)) do
+        @test Base.default_cancel_token() === CancellationToken(psrc)
+        Base.@cancel_check
+        cancel!(psrc)
+        @test_throws CancellationRequest Base.@cancel_check
+    end
+end
+
 @testset "cooperative cancellation of running tasks" begin
     # a @cancel_check polling loop is stopped cross-thread by cancel!
     started = Threads.Atomic{Bool}(false)


### PR DESCRIPTION
Resolving the governing cancellation token (Base.default_cancel_token) walks the scoped-value dictionary on every call (~5ns), a cost paid by every zero-argument `@cancel_check` and by every cancel-keyword API entry. Cache the resolution in the task instead: a flag byte (Task.bound_cancel_default, carved out of an existing pad) marks that bound_cancel_token currently holds the source the scoped CANCEL_TOKEN lookup resolves to under the task's current scope, making the lookup two plain loads (~0.6ns, independent of scope depth).

The flag is dropped wherever a scope is installed (codegen and interpreter enter-with-scope, and codegen's inline leave restore - the one scope swap not bracketed by the exception-handler machinery) and by cancellation points that publish a different source; the same-source skip path keeps a warm cache intact, so a zero-argument `@cancel_check` polling loop stays cached. Exception handlers and the finalizer bracket save and restore the (token, flag) pair together. The cache fill is an untagged unsafe point for CancellationLowering, so it cannot break a published reset region's (region, token) coherence, and the field keeps holding a governing source either way, so the cross-thread scanners are unaffected.

bound_cancel_token is now declared as
Union{Nothing, CancellationTokenSource} so the cache-hit read narrows through the `=== nothing` check instead of a dynamic type check: the type-tag load is a volatile unsafe point that would otherwise tear the published reset region (and re-establish it) on every iteration of a checking loop. With it, a zero-argument `@cancel_check` loop drops from ~10ns to ~2.1ns per iteration and its reset region survives across iterations.