### PR TITLE
Fix `BoundsError` in `Printf.Format`

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -132,7 +132,8 @@ function Format(f::AbstractString)
     numarguments = 0
 
     b = 0x00
-    local last_percent_pos
+    # Initialization pleases JET.
+    last_percent_pos = 0
 
     # skip ahead to first format specifier
     while pos <= len
@@ -183,16 +184,17 @@ function Format(f::AbstractString)
         width = 0
         dynamic_width = false
         if b == UInt8('*')
+            pos > len && throw(InvalidFormatStringError("Format specifier is incomplete", f, last_percent_pos, pos-1))
             dynamic_width = true
             numarguments += 1
             b = bytes[pos]
             pos += 1
         else
             while UInt8('0') <= b <= UInt8('9')
+                pos > len && throw(InvalidFormatStringError("Format specifier is incomplete", f, last_percent_pos, pos-1))
                 width = 10 * width + (b - UInt8('0'))
                 b = bytes[pos]
                 pos += 1
-                pos > len && break
             end
         end
         # parse precision
@@ -204,20 +206,18 @@ function Format(f::AbstractString)
             parsedprecdigits = true
             b = bytes[pos]
             pos += 1
-            if pos <= len
-                if b == UInt8('*')
-                    dynamic_precision = true
-                    numarguments += 1
+            if b == UInt8('*')
+                pos > len && throw(InvalidFormatStringError("Format specifier is incomplete", f, last_percent_pos, pos-1))
+                dynamic_precision = true
+                numarguments += 1
+                b = bytes[pos]
+                pos += 1
+            else
+                while UInt8('0') <= b <= UInt8('9')
+                    pos > len && throw(InvalidFormatStringError("Format specifier is incomplete", f, last_percent_pos, pos-1))
+                    precision = 10precision + (b - UInt8('0'))
                     b = bytes[pos]
                     pos += 1
-                else
-                    precision = 0
-                    while UInt8('0') <= b <= UInt8('9')
-                        precision = 10precision + (b - UInt8('0'))
-                        b = bytes[pos]
-                        pos += 1
-                        pos > len && break
-                    end
                 end
             end
         end

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -350,6 +350,16 @@ end
     @test_throws Printf.InvalidFormatStringError Printf.Format("%+")
     @test_throws Printf.InvalidFormatStringError Printf.Format("%.")
     @test_throws Printf.InvalidFormatStringError Printf.Format("%.0")
+    @test_throws Printf.InvalidFormatStringError Printf.Format("%1")
+    @test_throws Printf.InvalidFormatStringError Printf.Format("%12")
+    @test_throws Printf.InvalidFormatStringError Printf.Format("%*")
+    @test_throws Printf.InvalidFormatStringError Printf.Format("%.1")
+    @test_throws Printf.InvalidFormatStringError Printf.Format("%.12")
+    @test_throws Printf.InvalidFormatStringError Printf.Format("%.*")
+    @test_throws Printf.InvalidFormatStringError Printf.Format("%*.*")
+    @test_throws Printf.InvalidFormatStringError Printf.Format(SubString("%1d", 1:2))
+    @test_throws Printf.InvalidFormatStringError Printf.Format(SubString("%*d", 1:2))
+    @test_throws Printf.InvalidFormatStringError Printf.Format(SubString("%.1f", 1:3))
     @test isempty(Printf.Format("%%").formats)
     @test Printf.@sprintf("%d%d", 1, 2) == "12"
     @test (Printf.@sprintf "%d%d" [1 2]...) == "12"


### PR DESCRIPTION
For invalid format strings, an access in `Printf.Format` could be out of bounds. You can see the problem with (needs --check-bounds=no)
```
julia> using Printf

julia> secret = "Qu1et"
"Qu1et"

julia> Printf.Format(SubString("%1" * secret, 1:2))
ERROR: InvalidFormatStringError: 'Q' is not a valid type specifier
```

where part of the secret (the 'Q') is revealed. This example is of course not critical at all, but it shows that memory after the provided memory range (two code units) is accessed (code unit 3) and revealed. `Printf.Format` is accepting an `AbstractString` which, according to `codeunits`' docstring, can have arbitrary width enabling the caller theoretically to reveal an arbitrary amount of memory. I wouldn't know that anyone uses such types, so this should typically be limited to up to four bytes.

Thanks to @Keno for advising how to proceed.

Could someone please add backports labels for 1.10, 1.12 and 1.13?