### PR TITLE
objcache: expose a generic key/value API for external compilation caches

### DIFF
--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -101,6 +101,24 @@ JL_DLLEXPORT const char *jl_objcache_disabled_notice_fallback(void)
     return NULL;
 }
 
+JL_DLLEXPORT jl_value_t *jl_objcache_kv_get_fallback(const char *ns, const uint8_t *key,
+                                                     size_t keylen)
+{
+    return jl_nothing;
+}
+
+JL_DLLEXPORT int jl_objcache_kv_put_fallback(const char *ns, const uint8_t *key,
+                                             size_t keylen, const uint8_t *val,
+                                             size_t vallen)
+{
+    return 0;
+}
+
+JL_DLLEXPORT int jl_objcache_kv_enabled_fallback(void)
+{
+    return 0;
+}
+
 JL_DLLEXPORT void jl_jit_register_ci_fallback(jl_code_instance_t *ci)
 {
 }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2707,6 +2707,26 @@ const char *jl_objcache_disabled_notice_impl(void) JL_CANSAFEPOINT_ENTER_LEAVE
     return jl_ExecutionEngine->objCacheDisabledNotice();
 }
 
+extern "C" JL_DLLEXPORT_CODEGEN
+jl_value_t *jl_objcache_kv_get_impl(const char *ns, const uint8_t *key,
+                                    size_t keylen) JL_CANSAFEPOINT_ENTER_LEAVE
+{
+    return jl_ExecutionEngine->objCacheKVGet(ns, key, keylen);
+}
+
+extern "C" JL_DLLEXPORT_CODEGEN
+int jl_objcache_kv_put_impl(const char *ns, const uint8_t *key, size_t keylen,
+                            const uint8_t *val, size_t vallen) JL_CANSAFEPOINT_ENTER_LEAVE
+{
+    return jl_ExecutionEngine->objCacheKVPut(ns, key, keylen, val, vallen);
+}
+
+extern "C" JL_DLLEXPORT_CODEGEN
+int jl_objcache_kv_enabled_impl(void) JL_CANSAFEPOINT_ENTER_LEAVE
+{
+    return jl_ExecutionEngine->objCacheKVEnabled();
+}
+
 // API for adding bytes to record being owned by the JIT
 void jl_jit_add_bytes(size_t bytes)
 {

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -871,6 +871,18 @@ public:
         return OCache.disabledNotice();
     }
 
+    jl_value_t *objCacheKVGet(const char *Ns, const uint8_t *Key,
+                              size_t KeyLen) JL_CANSAFEPOINT_ENTER_LEAVE {
+        return OCache.kvGet(Ns, Key, KeyLen);
+    }
+    int objCacheKVPut(const char *Ns, const uint8_t *Key, size_t KeyLen,
+                      const uint8_t *Val, size_t ValLen) JL_CANSAFEPOINT_ENTER_LEAVE {
+        return OCache.kvPut(Ns, Key, KeyLen, Val, ValLen);
+    }
+    int objCacheKVEnabled() JL_CANSAFEPOINT_ENTER_LEAVE {
+        return OCache.kvEnabled();
+    }
+
     jl_locked_stream &get_dump_emitted_mi_name_stream() JL_NOTSAFEPOINT {
         return dump_emitted_mi_name_stream;
     }

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -553,6 +553,9 @@
     YY(jl_decorate_llvm_module) \
     YY(jl_jit_total_bytes) \
     YY(jl_objcache_disabled_notice) \
+    YY(jl_objcache_kv_get) \
+    YY(jl_objcache_kv_put) \
+    YY(jl_objcache_kv_enabled) \
     YY(jl_create_native) \
     YY(jl_dump_compiles) \
     YY(jl_dump_emitted_mi_name) \

--- a/src/objcache.cpp
+++ b/src/objcache.cpp
@@ -424,7 +424,8 @@ static ObjCache::Hash hashKVKey(const char *Ns, const uint8_t *Key,
     return Hasher.final();
 }
 
-jl_value_t *ObjCache::kvGet(const char *Ns, const uint8_t *Key, size_t KeyLen)
+jl_value_t *ObjCache::kvGet(const char *Ns, const uint8_t *Key,
+                            size_t KeyLen) JL_CANSAFEPOINT_ENTER_LEAVE
 {
     if (!Initialized.load(memory_order_acquire))
         initDB();
@@ -434,7 +435,7 @@ jl_value_t *ObjCache::kvGet(const char *Ns, const uint8_t *Key, size_t KeyLen)
     auto Hash = hashKVKey(Ns, Key, KeyLen);
     auto ObjKey = toObjKey(Hash);
 
-    jl_array_t *Ret;
+    jl_array_t *Ret = nullptr;
     {
         MDBTxn Txn{Env, MDB_RDONLY};
         if (!Txn.Txn)
@@ -451,8 +452,13 @@ jl_value_t *ObjCache::kvGet(const char *Ns, const uint8_t *Key, size_t KeyLen)
         // Copy out of the memory map while the read transaction is alive.
         // The allocation can run GC, which is fine: LMDB read txns only
         // pin a snapshot, they hold no lock that Julia code can contend on.
+        JL_GC_PUSH1(&Ret);
+        jl_task_t *ct = jl_current_task;
+        int8_t gc_state = jl_gc_unsafe_enter(ct->ptls);
         Ret = jl_alloc_array_1d(jl_array_uint8_type, Data.mv_size);
         memcpy(jl_array_data(Ret, uint8_t), Data.mv_data, Data.mv_size);
+        jl_gc_unsafe_leave(ct->ptls, gc_state);
+        JL_GC_POP();
     }
     NHit.fetch_add(1, memory_order_relaxed);
     NRead.fetch_add(jl_array_len(Ret), memory_order_relaxed);
@@ -468,7 +474,7 @@ jl_value_t *ObjCache::kvGet(const char *Ns, const uint8_t *Key, size_t KeyLen)
 }
 
 int ObjCache::kvPut(const char *Ns, const uint8_t *Key, size_t KeyLen,
-                    const uint8_t *Val, size_t ValLen)
+                    const uint8_t *Val, size_t ValLen) JL_CANSAFEPOINT_ENTER_LEAVE
 {
     if (!Initialized.load(memory_order_acquire))
         initDB();
@@ -486,7 +492,7 @@ int ObjCache::kvPut(const char *Ns, const uint8_t *Key, size_t KeyLen,
     return 1;
 }
 
-int ObjCache::kvEnabled()
+int ObjCache::kvEnabled() JL_CANSAFEPOINT_ENTER_LEAVE
 {
     if (!Initialized.load(memory_order_acquire))
         initDB();

--- a/src/objcache.cpp
+++ b/src/objcache.cpp
@@ -408,6 +408,91 @@ std::unique_ptr<llvm::MemoryBuffer> ObjCache::get(llvm::Module &M, CompileFn Com
     return Buf;
 }
 
+// Domain-separate KV entries from module-hash entries: the latter hash raw
+// bitcode, the former hash a tagged (namespace, key) frame.
+static ObjCache::Hash hashKVKey(const char *Ns, const uint8_t *Key,
+                                size_t KeyLen) JL_NOTSAFEPOINT
+{
+    llvm::SHA1 Hasher;
+    Hasher.update(llvm::StringRef("JLKV\0", 5));
+    uint64_t NsLen = strlen(Ns);
+    uint8_t Len[sizeof NsLen];
+    endian::write(Len, NsLen, endianness::big);
+    Hasher.update(Len);
+    Hasher.update(llvm::StringRef(Ns, NsLen));
+    Hasher.update({Key, KeyLen});
+    return Hasher.final();
+}
+
+jl_value_t *ObjCache::kvGet(const char *Ns, const uint8_t *Key, size_t KeyLen)
+{
+    if (!Initialized.load(memory_order_acquire))
+        initDB();
+    if (!Env)
+        return jl_nothing;
+
+    auto Hash = hashKVKey(Ns, Key, KeyLen);
+    auto ObjKey = toObjKey(Hash);
+
+    jl_array_t *Ret;
+    {
+        MDBTxn Txn{Env, MDB_RDONLY};
+        if (!Txn.Txn)
+            return jl_nothing;
+
+        MDB_val Data;
+        MDB_val MKey = mdbVal(ObjKey);
+        if (int Err = mdb_get(Txn.Txn, ObjCacheDbi, &MKey, &Data)) {
+            if (Err != MDB_NOTFOUND)
+                checkMDB(Err);
+            return jl_nothing;
+        }
+
+        // Copy out of the memory map while the read transaction is alive.
+        // The allocation can run GC, which is fine: LMDB read txns only
+        // pin a snapshot, they hold no lock that Julia code can contend on.
+        Ret = jl_alloc_array_1d(jl_array_uint8_type, Data.mv_size);
+        memcpy(jl_array_data(Ret, uint8_t), Data.mv_data, Data.mv_size);
+    }
+    NHit.fetch_add(1, memory_order_relaxed);
+    NRead.fetch_add(jl_array_len(Ret), memory_order_relaxed);
+
+    // Queue an atime refresh for LRU bookkeeping.
+    {
+        std::unique_lock<std::mutex> Lock{Mutex};
+        ObjQueue.push_back({Hash, nullptr});
+    }
+    QueueCond.notify_one();
+
+    return (jl_value_t *)Ret;
+}
+
+int ObjCache::kvPut(const char *Ns, const uint8_t *Key, size_t KeyLen,
+                    const uint8_t *Val, size_t ValLen)
+{
+    if (!Initialized.load(memory_order_acquire))
+        initDB();
+    if (!Env)
+        return 0;
+
+    auto Hash = hashKVKey(Ns, Key, KeyLen);
+    auto Buf = llvm::MemoryBuffer::getMemBufferCopy(
+        llvm::StringRef((const char *)Val, ValLen));
+    {
+        std::unique_lock<std::mutex> Lock{Mutex};
+        ObjQueue.push_back({Hash, std::move(Buf)});
+    }
+    QueueCond.notify_one();
+    return 1;
+}
+
+int ObjCache::kvEnabled()
+{
+    if (!Initialized.load(memory_order_acquire))
+        initDB();
+    return Env != nullptr;
+}
+
 bool ObjCache::isEnabled() const
 {
     return Env;

--- a/src/objcache.h
+++ b/src/objcache.h
@@ -30,12 +30,30 @@ using CompileFn = llvm::unique_function<std::unique_ptr<llvm::MemoryBuffer>()>;
 
 class MDBTxn;
 
+typedef struct _jl_value_t jl_value_t;
+
 class ObjCache {
 public:
     ObjCache() = default;
     ~ObjCache() JL_NOTSAFEPOINT;
     std::unique_ptr<llvm::MemoryBuffer>
     get(llvm::Module &M, CompileFn Compile) JL_CANSAFEPOINT_ENTER_LEAVE;
+    // Generic key/value interface for other compilation caches (e.g. GPU
+    // kernels) that want to share the objcache's storage and LRU eviction.
+    // Keys are content hashes: entries are write-once and must be immutable,
+    // so `ns` (a consumer namespace, e.g. the package UUID) and `key` must
+    // cover every input of the cached computation.  kvGet returns a
+    // Vector{UInt8} with a copy of the value, or jl_nothing on a miss.
+    // kvPut queues the write (asynchronous, flushed at exit); a get in the
+    // same session may still miss right after a put.
+    jl_value_t *kvGet(const char *Ns, const uint8_t *Key,
+                      size_t KeyLen) JL_CANSAFEPOINT_ENTER_LEAVE;
+    int kvPut(const char *Ns, const uint8_t *Key, size_t KeyLen, const uint8_t *Val,
+              size_t ValLen) JL_CANSAFEPOINT_ENTER_LEAVE;
+    // Whether the cache is operational (initializes it if needed).  Lets KV
+    // consumers fall back to their own storage when the objcache is disabled
+    // (JULIA_OBJCACHE=0, network filesystem, ...).
+    int kvEnabled() JL_CANSAFEPOINT_ENTER_LEAVE;
     bool isEnabled() const JL_NOTSAFEPOINT;
     // If the cache had to be disabled for a reason the user may want to know
     // about, returns a short description of that reason (for display in the


### PR DESCRIPTION
Packages that compile through external toolchains (i.e., cuTile.jl) currently maintain their own on-disk caches, each with its own storage budget and eviction policy. Expose the objcache's storage to such consumers via three exported functions:

    jl_value_t *jl_objcache_kv_get(ns, key, keylen)
    int jl_objcache_kv_put(ns, key, keylen, val, vallen)
    int jl_objcache_kv_enabled(void)

Entries are stored in the existing databases under a domain-separated digest, `SHA1("JLKV\0" || len(ns) || ns || key)`, so puts and atime refreshes ride the writer thread and participate in the same LRU accounting and eviction as JIT objects. Keys are content hashes: entries are write-once, and ns+key must cover every input of the cached computation. Writes are asynchronous (flushed at exit); kv_enabled lets consumers fall back to their own storage when the cache is unavailable (disabled, network filesystem, pid-namespace mismatch, no codegen).