### PR TITLE
stackwalk: derive the glibc pointer guard instead of reading %fs:0x30

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2167,6 +2167,9 @@ JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) 
 JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT NOINLINE int failed_to_sample_task_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
 JL_DLLEXPORT NOINLINE int failed_to_stop_thread_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
+#ifdef _OS_LINUX_
+JL_DLLEXPORT int jl_ptr_demangle_available(void) JL_NOTSAFEPOINT;
+#endif
 int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOINT;
 
 // Values a compiled cancellation reset point's setjmp returns when a

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -39,22 +39,16 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#ifdef _OS_LINUX_
+JL_DLLEXPORT int jl_ptr_demangle_available(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uintptr_t jl_ptr_demangle(uintptr_t p) JL_NOTSAFEPOINT;
+#endif
 #ifdef _COMPILER_ASAN_ENABLED_
 #if defined(__GLIBC__) && defined(_CPU_X86_64_)
-/* TODO: This is terrible - we're reaching deep into glibc internals here.
-   We should probably just switch to our own setjmp/longjmp implementation. */
 #define JB_RSP 6
-static inline uintptr_t demangle_ptr(uintptr_t var)
-{
-    asm ("ror $17, %0\n\t"
-         "xor %%fs:0x30, %0\n\t"
-        : "=r" (var)
-        : "0" (var));
-    return var;
-}
 static inline uintptr_t jmpbuf_sp(jl_jmp_buf *buf)
 {
-    return demangle_ptr((uintptr_t)(*buf)[0].__jmpbuf[JB_RSP]);
+    return jl_ptr_demangle((uintptr_t)(*buf)[0].__jmpbuf[JB_RSP]);
 }
 #else
 #error Need to implement jmpbuf_sp for this architecture
@@ -69,9 +63,22 @@ static inline void asan_unpoison_task_stack(jl_task_t *ct, jl_jmp_buf *buf)
     /* Unpoison everything from the base of the stack allocation to the address
        that we're resetting to. The idea is to remove the poison from the frames
        that we're skipping over, since they won't be unwound. */
-    uintptr_t top = jmpbuf_sp(buf);
-    uintptr_t bottom = (uintptr_t)(ct->ctx.copy_stack ? (char*)ct->ptls->stackbase  - ct->ptls->stacksize : (char*)ct->ctx.stkbuf);
-    //uintptr_t bottom = (uintptr_t)&top;
+    uintptr_t bottom;
+    uintptr_t stacktop;
+    if (ct->ctx.copy_stack) {
+        stacktop = (uintptr_t)ct->ptls->stackbase;
+        bottom = stacktop - ct->ptls->stacksize;
+    }
+    else {
+        bottom = (uintptr_t)ct->ctx.stkbuf;
+        stacktop = bottom + ct->ctx.bufsz;
+    }
+    uintptr_t top = stacktop;
+    if (jl_ptr_demangle_available()) {
+        top = jmpbuf_sp(buf);
+        if (top < bottom || top > stacktop)
+            top = stacktop;
+    }
     __asan_unpoison_stack_memory(bottom, top - bottom);
 }
 static inline void asan_unpoison_stack_memory(uintptr_t addr, size_t size) {
@@ -2167,9 +2174,6 @@ JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) 
 JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT NOINLINE int failed_to_sample_task_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
 JL_DLLEXPORT NOINLINE int failed_to_stop_thread_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
-#ifdef _OS_LINUX_
-JL_DLLEXPORT int jl_ptr_demangle_available(void) JL_NOTSAFEPOINT;
-#endif
 int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOINT;
 
 // Values a compiled cancellation reset point's setjmp returns when a

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -1501,7 +1501,7 @@ static void jl_longjmp_in_ctx(int sig, void *_ctx, jl_jmp_buf jmpbuf, int val)
     sigemptyset(&sset);
     sigaddset(&sset, sig);
     pthread_sigmask(SIG_UNBLOCK, &sset, NULL);
-    jl_longjmp(jmpbuf, 1);
+    jl_longjmp(jmpbuf, val);
 #endif
 }
 

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -1525,6 +1525,9 @@ static void sigtrap_handler(int sig, siginfo_t *info, void *context) JL_CANSAFEP
 
 void jl_install_default_signal_handlers(void)
 {
+#ifdef _OS_LINUX_
+    (void)jl_ptr_demangle_available();
+#endif
     struct sigaction actf;
     memset(&actf, 0, sizeof(struct sigaction));
     sigemptyset(&actf.sa_mask);

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1050,7 +1050,7 @@ static int derive_longjmp_mangling(void) JL_NOTSAFEPOINT
 
 // Keep lazy initialization lock-free because the first probe may run in a
 // signal handler. Racing probes derive the same process-wide values.
-JL_UNUSED static int ptr_demangle_available(void) JL_NOTSAFEPOINT
+JL_DLLEXPORT int jl_ptr_demangle_available(void) JL_NOTSAFEPOINT
 {
 #if defined(LONG_JMP_SP_ENV_SLOT)
     int state = jl_atomic_load_acquire(&julia_longjmp_state);
@@ -1259,7 +1259,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     #error Windows is currently only supported on x86 and x86_64
     #endif
 #elif defined(_OS_LINUX_) && defined(__GLIBC__)
-    if (!ptr_demangle_available())
+    if (!jl_ptr_demangle_available())
         return 0;
     __jmp_buf *_ctx = &mctx->__jmpbuf;
     #if defined(_CPU_AARCH64_)

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -972,11 +972,13 @@ void jl_fprint_bt_entry_codeloc(ios_t *s, jl_bt_element_t *bt_entry) JL_NOTSAFEP
 // https://sourceware.org/git/?p=glibc.git;a=commit;h=78f1f0e39cd41d28ae771eb3498bc33780c85cfd
 // The probe follows the approach used by LLVM's aarch64 TSAN runtime:
 // https://github.com/llvm/llvm-project/commit/daa3ebce283a753f280c549cdb103fbb2972f08e
-#if defined(__GLIBC__) && (defined(_CPU_AARCH64_) || defined(_CPU_X86_64_) || \
-                           defined(_CPU_X86_))
+#if defined(__GLIBC__) && (defined(_CPU_AARCH64_) || defined(_CPU_ARM_) || \
+                           defined(_CPU_X86_64_) || defined(_CPU_X86_))
 // Index of the mangled SP within glibc's jmp_buf.
 #if defined(_CPU_AARCH64_)
 #define LONG_JMP_SP_ENV_SLOT 13
+#elif defined(_CPU_ARM_)
+#define LONG_JMP_SP_ENV_SLOT 0
 #elif defined(_CPU_X86_64_)
 #define LONG_JMP_SP_ENV_SLOT 6
 #else
@@ -1003,7 +1005,7 @@ static NOINLINE uintptr_t probe_mangled_sp(uintptr_t *sp) JL_NOTSAFEPOINT
 {
     jmp_buf env;
     _setjmp(env);
-#if defined(_CPU_AARCH64_)
+#if defined(_CPU_AARCH64_) || defined(_CPU_ARM_)
     asm volatile ("mov %0, sp" : "=r" (*sp));
 #elif defined(_CPU_X86_64_)
     asm volatile ("movq %%rsp, %0" : "=r" (*sp));
@@ -1070,9 +1072,6 @@ JL_DLLEXPORT uintptr_t jl_ptr_demangle(uintptr_t p) JL_NOTSAFEPOINT
     assert(jl_atomic_load_relaxed(&julia_longjmp_state) > 0);
     p = rotate_right(p, jl_atomic_load_relaxed(&julia_longjmp_rotate))
         ^ jl_atomic_load_relaxed(&julia_longjmp_xor_key);
-#elif defined(__GLIBC__) && defined(_CPU_ARM_)
-// from https://github.com/bminor/glibc/blame/master/sysdeps/unix/sysv/linux/arm/sysdep.h
-    ; // nothing to do
 #endif
     return p;
 }

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -965,54 +965,114 @@ void jl_fprint_bt_entry_codeloc(ios_t *s, jl_bt_element_t *bt_entry) JL_NOTSAFEP
 
 
 #ifdef _OS_LINUX_
-#if defined(__GLIBC__) && defined(_CPU_AARCH64_)
+// glibc mangles the pointers in jmp_buf as `rotl(p ^ key, rot)`. Neither the
+// key's location nor the rotation is stable ABI, so derive both at runtime.
+// glibc 2.44 changed both:
+// https://sourceware.org/git/?p=glibc.git;a=commit;h=a5ec880f808ee7268d985bed4f961799bdc0a4bf
+// https://sourceware.org/git/?p=glibc.git;a=commit;h=78f1f0e39cd41d28ae771eb3498bc33780c85cfd
+// The probe follows the approach used by LLVM's aarch64 TSAN runtime:
+// https://github.com/llvm/llvm-project/commit/daa3ebce283a753f280c549cdb103fbb2972f08e
+#if defined(__GLIBC__) && (defined(_CPU_AARCH64_) || defined(_CPU_X86_64_) || \
+                           defined(_CPU_X86_))
+// Index of the mangled SP within glibc's jmp_buf.
+#if defined(_CPU_AARCH64_)
 #define LONG_JMP_SP_ENV_SLOT 13
-static uintptr_t julia_longjmp_xor_key;
-// GLIBC mangles the function pointers in jmp_buf (used in {set,long}*jmp
-// functions) by XORing them with a random key.  For AArch64 it is a global
-// variable rather than a TCB one (as for x86_64/powerpc).  We obtain the key by
-// issuing a setjmp and XORing the SP pointer values to derive the key.
-static void JuliaInitializeLongjmpXorKey(void)
+#elif defined(_CPU_X86_64_)
+#define LONG_JMP_SP_ENV_SLOT 6
+#else
+#define LONG_JMP_SP_ENV_SLOT 4
+#endif
+#define PTR_MANGLE_ROTATE (2 * sizeof(uintptr_t) + 1)
+
+// -1 unusable, 0 not probed yet, 1 usable
+static _Atomic(int) julia_longjmp_state;
+static _Atomic(uintptr_t) julia_longjmp_xor_key;
+static _Atomic(unsigned) julia_longjmp_rotate;
+
+static uintptr_t rotate_right(uintptr_t p, unsigned n) JL_NOTSAFEPOINT
 {
-    // 1. Call REAL(setjmp), which stores the mangled SP in env.
+    return n == 0 ? p : (p >> n) | (p << (8 * sizeof(uintptr_t) - n));
+}
+
+static uintptr_t rotate_left(uintptr_t p, unsigned n) JL_NOTSAFEPOINT
+{
+    return n == 0 ? p : (p << n) | (p >> (8 * sizeof(uintptr_t) - n));
+}
+
+static NOINLINE uintptr_t probe_mangled_sp(uintptr_t *sp) JL_NOTSAFEPOINT
+{
     jmp_buf env;
     _setjmp(env);
+#if defined(_CPU_AARCH64_)
+    asm volatile ("mov %0, sp" : "=r" (*sp));
+#elif defined(_CPU_X86_64_)
+    asm volatile ("movq %%rsp, %0" : "=r" (*sp));
+#else
+    asm volatile ("movl %%esp, %0" : "=r" (*sp));
+#endif
+    return ((uintptr_t*)&env)[LONG_JMP_SP_ENV_SLOT];
+}
 
-    // 2. Retrieve vanilla/mangled SP.
-    uintptr_t sp;
-    asm("mov  %0, sp" : "=r" (sp));
-    uintptr_t mangled_sp = ((uintptr_t*)&env)[LONG_JMP_SP_ENV_SLOT];
+static NOINLINE uintptr_t probe_mangled_sp_deep(uintptr_t *sp) JL_NOTSAFEPOINT
+{
+    volatile char pad[512];
+    uintptr_t mangled = probe_mangled_sp(sp);
+    pad[0] = 0; // Keep the frame live and prevent a tail call.
+    (void)pad[0];
+    return mangled;
+}
 
-    // 3. xor SPs to obtain key.
-    julia_longjmp_xor_key = mangled_sp ^ sp;
+// Derive the key and rotation from two probes at different stack depths.
+// A failure disables simulated longjmp rather than resuming at a wild address.
+static int derive_longjmp_mangling(void) JL_NOTSAFEPOINT
+{
+    uintptr_t sp1, sp2;
+    uintptr_t mangled1 = probe_mangled_sp(&sp1);
+    uintptr_t mangled2 = probe_mangled_sp_deep(&sp2);
+    uintptr_t sp_delta = sp1 ^ sp2;
+    if (sp_delta == 0 || sp_delta == ~(uintptr_t)0)
+        return -1;
+    unsigned rot;
+    if ((mangled1 ^ mangled2) == sp_delta)
+        rot = 0;
+    else if (rotate_right(mangled1 ^ mangled2, PTR_MANGLE_ROTATE) == sp_delta)
+        rot = PTR_MANGLE_ROTATE;
+    else
+        return -1;
+    uintptr_t key = rotate_right(mangled1, rot) ^ sp1;
+    if (rotate_left(sp2 ^ key, rot) != mangled2)
+        return -1;
+    jl_atomic_store_relaxed(&julia_longjmp_xor_key, key);
+    jl_atomic_store_relaxed(&julia_longjmp_rotate, rot);
+    return 1;
 }
 #endif
 
+// Keep lazy initialization lock-free because the first probe may run in a
+// signal handler. Racing probes derive the same process-wide values.
+JL_UNUSED static int ptr_demangle_available(void) JL_NOTSAFEPOINT
+{
+#if defined(LONG_JMP_SP_ENV_SLOT)
+    int state = jl_atomic_load_acquire(&julia_longjmp_state);
+    if (state == 0) {
+        state = derive_longjmp_mangling();
+        jl_atomic_store_release(&julia_longjmp_state, state);
+    }
+    return state > 0;
+#else
+    return 1;
+#endif
+}
+
 JL_UNUSED static uintptr_t ptr_demangle(uintptr_t p) JL_NOTSAFEPOINT
 {
-#if defined(__GLIBC__)
-#if defined(_CPU_X86_)
-// from https://github.com/bminor/glibc/blame/master/sysdeps/unix/sysv/linux/i386/pointer_guard.h
-// last changed for GLIBC_2.6 on 2007-02-01
-    asm(" rorl $9, %0\n"
-        " xorl %%gs:0x18, %0"
-        : "=r"(p) : "0"(p) : );
-#elif defined(_CPU_X86_64_)
-// from https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/x86_64/pointer_guard.h
-    asm(" rorq $17, %0\n"
-        " xorq %%fs:0x30, %0"
-        : "=r"(p) : "0"(p) : );
-#elif defined(_CPU_AARCH64_)
-// from https://github.com/bminor/glibc/blame/master/sysdeps/unix/sysv/linux/aarch64/pointer_guard.h
-// We need to use a trick like this (from GCC/LLVM TSAN) to get access to it:
-// https://github.com/llvm/llvm-project/commit/daa3ebce283a753f280c549cdb103fbb2972f08e
-    static pthread_once_t once = PTHREAD_ONCE_INIT;
-    pthread_once(&once, &JuliaInitializeLongjmpXorKey);
-    p ^= julia_longjmp_xor_key;
-#elif defined(_CPU_ARM_)
+#if defined(LONG_JMP_SP_ENV_SLOT)
+    assert(jl_atomic_load_relaxed(&julia_longjmp_state) > 0);
+    p = rotate_right(p, jl_atomic_load_relaxed(&julia_longjmp_rotate))
+        ^ jl_atomic_load_relaxed(&julia_longjmp_xor_key);
+#elif defined(__GLIBC__) && defined(_CPU_ARM_)
 // from https://github.com/bminor/glibc/blame/master/sysdeps/unix/sysv/linux/arm/sysdep.h
     ; // nothing to do
-#endif
 #endif
     return p;
 }
@@ -1118,6 +1178,19 @@ _os_ptr_munge(uintptr_t ptr) JL_NOTSAFEPOINT
 #endif
 
 
+// Reject values that cannot be user-space longjmp targets. A wrong mangling
+// scheme otherwise turns both values into effectively random addresses.
+JL_UNUSED static int valid_longjmp_target(uintptr_t sp, uintptr_t pc) JL_NOTSAFEPOINT
+{
+    if (sp == 0 || pc == 0 || sp % sizeof(void*) != 0)
+        return 0;
+#if defined(_CPU_X86_64_) || defined(_CPU_AARCH64_) || defined(_CPU_RISCV64_)
+    if ((sp >> 47) != 0 || (pc >> 47) != 0) // outside the user-space canonical half
+        return 0;
+#endif
+    return 1;
+}
+
 // Some notes: this simulates a longjmp call occurring in context `c`, as if the
 // user was to set the PC in `c` to call longjmp and the PC in the longjmp to
 // return here. This helps work around many cases where siglongjmp out of a
@@ -1179,6 +1252,8 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     #error Windows is currently only supported on x86 and x86_64
     #endif
 #elif defined(_OS_LINUX_) && defined(__GLIBC__)
+    if (!ptr_demangle_available())
+        return 0;
     __jmp_buf *_ctx = &mctx->__jmpbuf;
     #if defined(_CPU_AARCH64_)
     // Only on aarch64-linux libunwind uses a different struct than system's one:
@@ -1211,8 +1286,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
         mc->fpregs->sw = 0;               // clear TOP and exception flags
         mc->fpregs->tag = 0xffffffffu;    // all registers empty
     }
-    assert(mc->gregs[REG_ESP] % 16 == 0);
-    return 1;
+    return valid_longjmp_target(mc->gregs[REG_ESP], mc->gregs[REG_EIP]);
     #elif defined(_CPU_X86_64_)
     // https://github.com/bminor/glibc/blame/master/sysdeps/x86_64/__longjmp.S
     // https://github.com/bminor/glibc/blame/master/sysdeps/x86_64/jmpbuf-offsets.h
@@ -1230,8 +1304,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     mc->gregs[REG_RSP] = ptr_demangle(mc->gregs[REG_RSP]);
     mc->gregs[REG_RIP] = ptr_demangle(mc->gregs[REG_RIP]);
     mc->gregs[REG_RAX] = val;
-    assert(mc->gregs[REG_RSP] % 16 == 0);
-    return 1;
+    return valid_longjmp_target(mc->gregs[REG_RSP], mc->gregs[REG_RIP]);
     #elif defined(_CPU_ARM_)
     // https://github.com/bminor/glibc/blame/master/sysdeps/arm/__longjmp.S
     // https://github.com/bminor/glibc/blame/master/sysdeps/arm/include/bits/setjmp.h
@@ -1251,8 +1324,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     mc->arm_lr = ptr_demangle(mc->arm_lr);
     mc->arm_pc = mc->arm_lr;
     mc->arm_r0 = val;
-    assert(mc->arm_sp % 16 == 0);
-    return 1;
+    return valid_longjmp_target(mc->arm_sp, mc->arm_pc);
     #elif defined(_CPU_AARCH64_)
     // https://github.com/bminor/glibc/blame/master/sysdeps/aarch64/__longjmp.S
     // https://github.com/bminor/glibc/blame/master/sysdeps/aarch64/jmpbuf-offsets.h
@@ -1286,8 +1358,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     mc->regs[30] = ptr_demangle(mc->regs[30]);
     mc->pc = mc->regs[30];
     mc->regs[0] = val;
-    assert(mc->sp % 16 == 0);
-    return 1;
+    return valid_longjmp_target(mc->sp, mc->pc);
     #elif defined(_CPU_RISCV64_)
     // https://github.com/bminor/glibc/blob/master/sysdeps/riscv/bits/setjmp.h
     // https://github.com/llvm/llvm-project/blob/7714e0317520207572168388f22012dd9e152e9e/libunwind/src/Registers.hpp -> Registers_riscv
@@ -1324,8 +1395,7 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     mc->__gregs[REG_RA] = ptr_demangle(mc->__gregs[REG_RA]);
     mc->__gregs[REG_PC] = mc->__gregs[REG_RA];
     mc->__gregs[REG_A0] = val;
-    assert(mc->__gregs[REG_SP] % 16 == 0);
-    return 1;
+    return valid_longjmp_target(mc->__gregs[REG_SP], mc->__gregs[REG_PC]);
     #else
     #pragma message("jl_record_backtrace not defined for ASM/SETJMP on unknown linux")
     (void)mc;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1064,7 +1064,7 @@ JL_DLLEXPORT int jl_ptr_demangle_available(void) JL_NOTSAFEPOINT
 #endif
 }
 
-JL_UNUSED static uintptr_t ptr_demangle(uintptr_t p) JL_NOTSAFEPOINT
+JL_DLLEXPORT uintptr_t jl_ptr_demangle(uintptr_t p) JL_NOTSAFEPOINT
 {
 #if defined(LONG_JMP_SP_ENV_SLOT)
     assert(jl_atomic_load_relaxed(&julia_longjmp_state) > 0);
@@ -1280,8 +1280,8 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     mc->gregs[REG_ESP] = (*_ctx)[4];
     mc->gregs[REG_EIP] = (*_ctx)[5];
     // ifdef PTR_DEMANGLE ?
-    mc->gregs[REG_ESP] = ptr_demangle(mc->gregs[REG_ESP]);
-    mc->gregs[REG_EIP] = ptr_demangle(mc->gregs[REG_EIP]);
+    mc->gregs[REG_ESP] = jl_ptr_demangle(mc->gregs[REG_ESP]);
+    mc->gregs[REG_EIP] = jl_ptr_demangle(mc->gregs[REG_EIP]);
     mc->gregs[REG_EAX] = val;
     // The simulated longjmp resumes code that expects the i386 ABI's
     // function-boundary FPU state (an empty x87 register stack), but the
@@ -1307,9 +1307,9 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     mc->gregs[REG_RSP] = (*_ctx)[6];
     mc->gregs[REG_RIP] = (*_ctx)[7];
     // ifdef PTR_DEMANGLE ?
-    mc->gregs[REG_RBP] = ptr_demangle(mc->gregs[REG_RBP]);
-    mc->gregs[REG_RSP] = ptr_demangle(mc->gregs[REG_RSP]);
-    mc->gregs[REG_RIP] = ptr_demangle(mc->gregs[REG_RIP]);
+    mc->gregs[REG_RBP] = jl_ptr_demangle(mc->gregs[REG_RBP]);
+    mc->gregs[REG_RSP] = jl_ptr_demangle(mc->gregs[REG_RSP]);
+    mc->gregs[REG_RIP] = jl_ptr_demangle(mc->gregs[REG_RIP]);
     mc->gregs[REG_RAX] = val;
     return valid_longjmp_target(mc->gregs[REG_RSP], mc->gregs[REG_RIP]);
     #elif defined(_CPU_ARM_)
@@ -1327,8 +1327,8 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     mc->arm_r10 = (*_ctx)[8]; // aka v7 aka sl
     mc->arm_fp = (*_ctx)[10]; // aka v8 aka r11
     // ifdef PTR_DEMANGLE ?
-    mc->arm_sp = ptr_demangle(mc->arm_sp);
-    mc->arm_lr = ptr_demangle(mc->arm_lr);
+    mc->arm_sp = jl_ptr_demangle(mc->arm_sp);
+    mc->arm_lr = jl_ptr_demangle(mc->arm_lr);
     mc->arm_pc = mc->arm_lr;
     mc->arm_r0 = val;
     return valid_longjmp_target(mc->arm_sp, mc->arm_pc);
@@ -1361,8 +1361,8 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     mcfp->vregs[13] = (*_ctx)[20]; // aka d14
     mcfp->vregs[14] = (*_ctx)[21]; // aka d15
     // ifdef PTR_DEMANGLE ?
-    mc->sp = ptr_demangle(mc->sp);
-    mc->regs[30] = ptr_demangle(mc->regs[30]);
+    mc->sp = jl_ptr_demangle(mc->sp);
+    mc->regs[30] = jl_ptr_demangle(mc->regs[30]);
     mc->pc = mc->regs[30];
     mc->regs[0] = val;
     return valid_longjmp_target(mc->sp, mc->pc);
@@ -1398,8 +1398,8 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     mc->__fpregs.__d.__f[27] = (unsigned long long) (*_ctx)->__fpregs[11]; // fs11
     #endif
     // ifdef PTR_DEMANGLE ?
-    mc->__gregs[REG_SP] = ptr_demangle(mc->__gregs[REG_SP]);
-    mc->__gregs[REG_RA] = ptr_demangle(mc->__gregs[REG_RA]);
+    mc->__gregs[REG_SP] = jl_ptr_demangle(mc->__gregs[REG_SP]);
+    mc->__gregs[REG_RA] = jl_ptr_demangle(mc->__gregs[REG_RA]);
     mc->__gregs[REG_PC] = mc->__gregs[REG_RA];
     mc->__gregs[REG_A0] = val;
     return valid_longjmp_target(mc->__gregs[REG_SP], mc->__gregs[REG_PC]);

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1180,12 +1180,19 @@ _os_ptr_munge(uintptr_t ptr) JL_NOTSAFEPOINT
 
 // Reject values that cannot be user-space longjmp targets. A wrong mangling
 // scheme otherwise turns both values into effectively random addresses.
+#if defined(_CPU_X86_64_) || defined(_CPU_RISCV64_)
+#define JL_VA_USER_BITS 47
+#elif defined(_CPU_AARCH64_)
+// AArch64 uses its full unsigned VA range, including bit 47 on 48-bit kernels,
+// and supports a 52-bit userspace range with LVA.
+#define JL_VA_USER_BITS 52
+#endif
 JL_UNUSED static int valid_longjmp_target(uintptr_t sp, uintptr_t pc) JL_NOTSAFEPOINT
 {
     if (sp == 0 || pc == 0 || sp % sizeof(void*) != 0)
         return 0;
-#if defined(_CPU_X86_64_) || defined(_CPU_AARCH64_) || defined(_CPU_RISCV64_)
-    if ((sp >> 47) != 0 || (pc >> 47) != 0) // outside the user-space canonical half
+#ifdef JL_VA_USER_BITS
+    if ((sp >> JL_VA_USER_BITS) != 0 || (pc >> JL_VA_USER_BITS) != 0)
         return 0;
 #endif
     return 1;

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -2,6 +2,12 @@
 
 import Base.StackTraces: lookup
 
+# Check that glibc's saved stack pointer can be demangled on supported targets.
+if Sys.islinux() && Sys.ARCH in (:i686, :x86_64, :armv7l, :aarch64) &&
+        Base.BinaryPlatforms.libc(Base.BinaryPlatforms.HostPlatform()) == "glibc"
+    @test ccall(:jl_ptr_demangle_available, Cint, ()) == 1
+end
+
 # Test location information for inlined code (ref issues #1334 #12544)
 module test_inline_bt
 using Test


### PR DESCRIPTION
Fixes #62683.

On current glibc, `ptr_demangle()` reads the pointer guard from the TCB slot at `%fs:0x30`, but glibc mangles with the `__pointer_chk_guard` global and leaves that slot zero. `jl_simulate_longjmp` then hands `sigreturn` a RIP/RSP of `pointer ^ guard`, so Ctrl-C and stack overflow segfault instead of throwing `InterruptException` / `StackOverflowError` (1.11 is unaffected; 1.12.6 and 1.13.0-rc1 both reproduce). Full analysis and core-dump evidence in the issue.

This derives the key at runtime from a `setjmp`, the way the AArch64 path already does, rather than hardcoding where glibc keeps it. On older glibc the derived key is exactly the value the TCB slot held, so it is not a behaviour change there.

Testing: I extracted the patched `ptr_demangle` verbatim into a standalone harness and checked it against a real glibc `jmp_buf` — it recovers the true SP at `-O0`, `-O2` and `-O3`. Separately, an `LD_PRELOAD` shim that fills in `%fs:0x30` (i.e. the same net effect) makes stock 1.12.6 throw `InterruptException` on repeated Ctrl-C and `StackOverflowError` on deep recursion again.

I have **not** built Julia with this patch, so CI is the first real build. The AArch64 path is untouched but worth a second look from someone with the hardware.
