### PR TITLE
runtime: Make exit signals safe during startup and bound the teardown

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -640,8 +640,12 @@ static NOINLINE void _finish_jl_init_(jl_image_buf_t sysimage, jl_ptls_t ptls, j
 
     if (jl_options.handle_signals == JL_OPTIONS_HANDLE_SIGNALS_ON)
         jl_install_sigint_handler();
+
+    jl_atomic_store_release(&jl_initialization_complete, 1);
 }
 
+
+JL_DLLEXPORT _Atomic(int) jl_initialization_complete = 0;
 
 JL_DLLEXPORT int jl_default_debug_info_kind;
 JL_DLLEXPORT jl_cgparams_t jl_default_cgparams = {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -366,6 +366,14 @@ extern JL_DLLEXPORT _Atomic(uint64_t) jl_cumulative_recompile_time;
 // Global *atomic* integer controlling *process-wide* task timing.
 extern JL_DLLEXPORT _Atomic(uint8_t) jl_task_metrics_enabled;
 
+// Set (release) once jl_init has fully completed (image restored, module
+// initializers run). The exit-signal paths consult it: before this point the
+// graceful teardown (running `jl_atexit_hook` on a hijacked thread 0) is
+// unsafe - the image may be half-restored and the interrupted thread may
+// hold runtime locks the teardown needs - and no Julia atexit hooks can
+// have been registered yet, so an exit signal just dies abruptly instead.
+extern JL_DLLEXPORT _Atomic(int) jl_initialization_complete;
+
 #define jl_return_address() ((uintptr_t)__builtin_return_address(0))
 
 STATIC_INLINE uint32_t jl_int32hash_fast(uint32_t a)

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -737,10 +737,38 @@ static void jl_exit_thread0_cb(void) JL_CANSAFEPOINT
     jl_raise(thread0_exit_signo);
 }
 
+// The graceful teardown hijacks thread 0 at an arbitrary point, so it can
+// deadlock: the interrupted frame may hold a lock the teardown needs (the
+// JIT/ORC session mid-compilation, the symbol table, an ios lock, ...).
+// Bound the damage with a deadline: if the process is still alive this long
+// after the exit request was dispatched, die abruptly with the original
+// signal (preserving the exit status and core-dump disposition), instead of
+// wedging as an unkillable-by-TERM process.
+#define JL_EXIT_GRACE_PERIOD_S 30
+static void *thread0_exit_watchdog(void *arg)
+{
+    int signo = (int)(uintptr_t)arg;
+    struct timespec ts = {JL_EXIT_GRACE_PERIOD_S, 0};
+    while (nanosleep(&ts, &ts) == -1 && errno == EINTR)
+        ;
+    // The graceful path did not finish in time: force the exit.
+    sigset_t sset;
+    sigemptyset(&sset);
+    sigaddset(&sset, signo);
+    pthread_sigmask(SIG_UNBLOCK, &sset, NULL);
+    signal(signo, SIG_DFL);
+    raise(signo); // very unlikely to return
+    _exit(128 + signo);
+    return NULL;
+}
+
 static void jl_exit_thread0(int signo, jl_bt_element_t *bt_data, size_t bt_size)
 {
     jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[0];
     bt_context_t signal_context;
+    pthread_t watchdog;
+    if (pthread_create(&watchdog, NULL, thread0_exit_watchdog, (void*)(uintptr_t)signo) == 0)
+        pthread_detach(watchdog);
     // This also makes sure `sleep` is aborted.
     if (jl_thread_suspend_and_get_state(0, 30, &signal_context)) {
         thread0_exit_signo = signo;
@@ -1347,7 +1375,15 @@ static void *signal_listener(void *arg) JL_NOTSAFEPOINT
             uv_tty_reset_mode();
             thread0_exit_count++;
             fflush(NULL);
-            if (thread0_exit_count > 1) {
+            // A repeat request, or a request before initialization has
+            // completed, exits abruptly: hijacking thread 0 into
+            // jl_atexit_hook against a half-restored image crashes (the
+            // teardown walks unrelocated module bindings) or deadlocks (the
+            // interrupted thread may hold runtime locks the teardown needs,
+            // e.g. symtab_lock during the restore's symbol interning), and
+            // no Julia atexit hooks can have been registered yet anyway.
+            if (thread0_exit_count > 1 ||
+                    !jl_atomic_load_acquire(&jl_initialization_complete)) {
                 raise(sig); // very unlikely to return
                 _exit(128 + sig);
             }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -520,6 +520,11 @@ static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guara
         default: sig = SIGTERM; break;
     }
     if (!jl_ignore_sigint()) {
+        // Before initialization has completed, the orderly teardown
+        // (jl_atexit_hook) is unsafe against the half-restored runtime and
+        // there are no Julia atexit hooks to honor - exit abruptly.
+        if (sig != SIGINT && !jl_atomic_load_acquire(&jl_initialization_complete))
+            _exit(128 + sig);
         if (exit_on_sigint)
             jl_exit(128 + sig); // 128 + SIGINT
         if (sig == SIGINT) {

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -2189,6 +2189,35 @@ end
 end
 
 
+Sys.isunix() && @testset "exit signals during startup" begin
+    # A termination signal delivered while the runtime is still initializing
+    # (e.g. mid sysimage restore) must kill the process cleanly. The graceful
+    # teardown used to be attempted unconditionally: hijacking thread 0 into
+    # jl_atexit_hook against the half-restored image segfaulted (walking
+    # unrelocated module bindings), or deadlocked when the interrupted thread
+    # held a runtime lock the teardown needs (symtab_lock during the
+    # restore's symbol interning) - a wedged, unkillable-by-TERM process.
+    exe = joinpath(Sys.BINDIR, Base.julia_exename())
+    for delay in (0.01, 0.05, 0.1, 0.15, 0.25, 0.4)
+        out = Pipe()
+        p = run(pipeline(`$exe --startup-file=no -e 'sleep(60)'`,
+                         stdin=devnull, stdout=out, stderr=out), wait=false)
+        close(out.in)
+        reader = @async read(out, String)
+        sleep(delay)
+        process_running(p) && kill(p) # SIGTERM
+        exited = timedwait(() -> process_exited(p), 60.0)
+        @test exited === :ok
+        exited === :ok || kill(p, Base.SIGKILL)
+        wait(p)
+        output = fetch(reader)
+        @test !occursin("Segmentation fault", output)
+        # abrupt (killed by the signal / 128+SIGTERM) and graceful exits are
+        # both fine; crashes and wedges are not
+        @test p.termsignal == Base.SIGTERM || p.exitcode == 128 + Base.SIGTERM
+    end
+end
+
 Sys.isunix() && @testset "^C" begin
     # Children run the bare executable with default flags, NOT julia_cmd():
     # inherited suite flags (e.g. --check-bounds=yes) invalidate the


### PR DESCRIPTION
🤖 A termination signal (SIGTERM/SIGQUIT/SIGHUP) delivered while the runtime is still initializing hijacked thread 0 into the graceful teardown against a half-restored system image: jl_atexit_hook either segfaulted walking unrelocated module bindings, or deadlocked on a runtime lock the interrupted frame held (symtab_lock during the restore's symbol interning), leaving a process that no further TERM or QUIT can kill. This reproduces on any recent Julia at ~35% for a SIGTERM in the first ~300ms of startup, and is what has been intermittently hanging the cancellation test suite in CI: the pty REPL children get terminated early, then either crash (the i686 job's SIGSEGV cores) or wedge until job teardown (the x86_64 cores show jl_atexit_hook blocked on the symtab_lock its own hijacked frame holds, ninety minutes after the SIGTERM).

Exit signals now exit abruptly - with the signal's default disposition, preserving the exit status and coredump behavior - when initialization has not yet completed; no Julia atexit hooks can have been registered at that point, so there is nothing for the graceful path to do. Once dispatched, the graceful teardown is additionally bounded by a watchdog thread that forces the same abrupt exit if it has not finished within 30 seconds: the hijack can also land inside a JIT compilation or a libuv iolock region whose locks the teardown then needs (both observed), and a deadlocked teardown must terminate the process rather than wedge it.

CI failures:
https://buildkite.com/julialang/julia-pr/builds/1369#019fe989-f974-4a93-a6f4-4fad2d28f0d7 https://buildkite.com/julialang/julia-ci/builds/246#019fe2ec-36d2-46c8-8302-730ea99c16aa