### PR TITLE
fix a few write barrier issues

### DIFF
--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -246,9 +246,14 @@ JL_DLLEXPORT void jl_genericmemory_copyto(jl_genericmemory_t *dest, char* destda
         destdata = (char*)dest->ptr + elsz*(size_t)destdata;
     }
     if (layout->first_ptr != -1) {
-        memmove_refs((_Atomic(void*)*)destdata, (_Atomic(void*)*)srcdata, n * elsz / sizeof(void*));
+        // The barrier has to run before the move, as the boxed path above does. A plan
+        // that must observe the overwritten references (see MMTK_SNAPSHOT_BARRIER) reads
+        // them here; run it afterwards and it sees the values just written instead, so
+        // the references copied in are never counted and the ones displaced are never
+        // released.
         jl_value_t *owner = jl_genericmemory_owner(dest);
         jl_gc_wb_genericmemory_copy_ptr(owner, src, src_p, n, dt);
+        memmove_refs((_Atomic(void*)*)destdata, (_Atomic(void*)*)srcdata, n * elsz / sizeof(void*));
     }
     else {
         memmove(destdata, srcdata, n * elsz);

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -246,11 +246,6 @@ JL_DLLEXPORT void jl_genericmemory_copyto(jl_genericmemory_t *dest, char* destda
         destdata = (char*)dest->ptr + elsz*(size_t)destdata;
     }
     if (layout->first_ptr != -1) {
-        // The barrier has to run before the move, as the boxed path above does. A plan
-        // that must observe the overwritten references (see MMTK_SNAPSHOT_BARRIER) reads
-        // them here; run it afterwards and it sees the values just written instead, so
-        // the references copied in are never counted and the ones displaced are never
-        // released.
         jl_value_t *owner = jl_genericmemory_owner(dest);
         jl_gc_wb_genericmemory_copy_ptr(owner, src, src_p, n, dt);
         memmove_refs((_Atomic(void*)*)destdata, (_Atomic(void*)*)srcdata, n * elsz / sizeof(void*));

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1846,14 +1846,12 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
                 if (jl_has_typevar(ivar->lb, old_tvar)) {
                     lb = ivar->lb;
                     lb = jl_substitute_var(lb, old_tvar, (jl_value_t*)new_tvar);
-                    ivar->lb = lb;
-                    jl_gc_wb((jl_value_t*)ivar, lb);
+                    jl_gc_write((jl_value_t*)ivar, ivar->lb, jl_value_t, lb);
                 }
                 if (jl_has_typevar(ivar->ub, old_tvar)) {
                     ub = ivar->ub;
                     ub = jl_substitute_var(ub, old_tvar, (jl_value_t*)new_tvar);
-                    ivar->ub = ub;
-                    jl_gc_wb((jl_value_t*)ivar, ub);
+                    jl_gc_write((jl_value_t*)ivar, ivar->ub, jl_value_t, ub);
                 }
                 JL_GC_POP();
             }

--- a/src/task.c
+++ b/src/task.c
@@ -2095,8 +2095,7 @@ JL_DLLEXPORT jl_value_t *jl_wait_entry_slot_owner(jl_value_t *w, size_t i) JL_NO
 
 JL_DLLEXPORT void jl_wait_entry_set_slot_owner(jl_value_t *w, size_t i, jl_value_t *v) JL_NOTSAFEPOINT
 {
-    jl_atomic_store_relaxed(&wait_entry_slot(w, i)->owner, v);
-    jl_gc_wb(w, v);
+    jl_gc_write_atomic(w, wait_entry_slot(w, i)->owner, jl_value_t, v, relaxed);
 }
 
 JL_DLLEXPORT jl_value_t *jl_wait_entry_slot_next(jl_value_t *w, size_t i) JL_NOTSAFEPOINT
@@ -2106,8 +2105,7 @@ JL_DLLEXPORT jl_value_t *jl_wait_entry_slot_next(jl_value_t *w, size_t i) JL_NOT
 
 JL_DLLEXPORT void jl_wait_entry_set_slot_next(jl_value_t *w, size_t i, jl_value_t *v) JL_NOTSAFEPOINT
 {
-    wait_entry_slot(w, i)->next = v;
-    jl_gc_wb(w, v);
+    jl_gc_write(w, wait_entry_slot(w, i)->next, jl_value_t, v);
 }
 
 JL_DLLEXPORT uint64_t jl_wait_entry_slot_aux(jl_value_t *w, size_t i) JL_NOTSAFEPOINT


### PR DESCRIPTION
`jl_genericmemory_copyto` had the write barrier after instead of before which is invalid for concurrent GC. Also, a number of manual `jl_gc_wb` were added which should have just been `jl_gc_write[_atomic]`

found by claude.