### PR TITLE
abstractarray: avoid fragile invalidation edges when iterating abstract arrays

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1239,6 +1239,8 @@ oneunit(x::AbstractMatrix{T}) where {T} = _one(oneunit(T), x)
 iterate_starting_state(A) = iterate_starting_state(A, IndexStyle(A))
 iterate_starting_state(A, ::IndexLinear) = firstindex(A)
 iterate_starting_state(A, ::IndexStyle) = (eachindex(A),)
+# avoid fragile edges from union-splitting these helpers for abstract arrays (#61667)
+typeof(iterate_starting_state).name.max_methods = UInt8(1)
 @inline iterate(A::AbstractArray, state = iterate_starting_state(A)) = _iterate_abstractarray(A, state)
 @inline function _iterate_abstractarray(A::AbstractArray, state::Tuple)
     y = iterate(state...)::Union{Nothing,Tuple}
@@ -1249,6 +1251,7 @@ end
     checkbounds(Bool, A, state) || return nothing
     A[state], state + one(state)
 end
+typeof(_iterate_abstractarray).name.max_methods = UInt8(1)
 
 isempty(a::AbstractArray) = (length(a) == 0)
 

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -664,3 +664,19 @@ let ci = method_instance(fshow61667, (Vector{ShowInval61667},)).cache
     Core.eval(Main, :(struct ShowInval61667 end))
     @test ci.max_world == typemax(UInt)
 end
+
+# issue #61667 - new array types must not invalidate abstractly-typed array iteration
+struct IterInval61667{T} <: AbstractVector{T}
+    v::Vector{T}
+end
+Base.size(A::IterInval61667) = size(A.v)
+Base.getindex(A::IterInval61667, i::Int) = A.v[i]
+absvec61667() = Base.inferencebarrier(Module[])::AbstractVector{Module}
+iter61667() = invoke(iterate, Tuple{AbstractArray}, absvec61667())
+@test precompile(iter61667, ())
+let ci = method_instance(iter61667, ()).cache
+    @test ci.max_world == typemax(UInt)
+    Base.eachindex(::IndexLinear, A::IterInval61667) = eachindex(A.v)
+    Base.iterate(A::IterInval61667, y...) = iterate(A.v, y...)
+    @test ci.max_world == typemax(UInt)
+end


### PR DESCRIPTION
Since #58635/#58793, iterating an abstractly-typed AbstractArray records edges through the union split of `iterate_starting_state`, pinning `eachindex(::IndexLinear, ::AbstractVector)` — so any package defining that method for its own array type (e.g. SparseArrays' `ReadOnly`) invalidates every poorly-inferred iteration in the sysimage (analysis: https://github.com/JuliaLang/julia/issues/61667#issuecomment-5147412586). On 1.12 these calls stayed dynamic and edge-free.

Set `max_methods = 1` on `iterate_starting_state` and `_iterate_abstractarray`: abstractly-typed iteration becomes a dynamic call with no edges, concrete arrays keep the specialized fast path (verified unchanged).

Ref #61667

This pull request was written with the assistance of generative AI.