### PR TITLE
show: don't const-fold `isvisible` to avoid fragile binding edges

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1132,7 +1132,9 @@ end
 # Check whether 'sym' (defined in module 'parent') is visible from module 'from'
 # If an object with this name exists in 'from', we need to check that it's the same binding
 # and that it's not deprecated.
-function isvisible(sym::Symbol, parent::Module, from::Module)
+# `@constprop :none` so concrete-eval doesn't bake binding edges (often on `Main.sym`)
+# into the show machinery, where any rebinding of the name would invalidate it (#61667)
+@constprop :none function isvisible(sym::Symbol, parent::Module, from::Module)
     isdeprecated(parent, sym) && return false
     isdefinedglobal(from, sym) || return false
     isdefinedglobal(parent, sym) || return false

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -653,3 +653,14 @@ struct W62022{T}; x::T; end
 @noinline foo62022(::W62022{W62022{W62022{W62022{Int}}}}) = false
 @test foo62022(W62022(1)) === false # test for invalidation
 @test foo62022(W62022(W62022(W62022(1)))) === false
+
+# issue #61667 - rebinding a name in Main must not invalidate the show machinery, which
+# concrete-evals binding queries against Main (via `isvisible`)
+struct ShowInval61667; x::Int; end
+fshow61667(v) = string(v)
+@test fshow61667([ShowInval61667(1)]) isa String
+let ci = method_instance(fshow61667, (Vector{ShowInval61667},)).cache
+    @test ci.max_world == typemax(UInt)
+    Core.eval(Main, :(struct ShowInval61667 end))
+    @test ci.max_world == typemax(UInt)
+end


### PR DESCRIPTION
Concrete evaluation of `isvisible` bakes binding edges on `Main.<name>` for every printed type/function name into the compiled show machinery, so rebinding such a name in Main invalidates the whole `string`/`print`/`show` chain up into user code (e.g. SnoopCompile traces in #61667 show this recompiling `GMT.axis`). Disable constprop so the query happens at runtime, with no edges.

Ref #61667

This pull request was written with the assistance of generative AI.