### PR TITLE
Compiler: avoid miscompiling internal _return_type calls

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3045,7 +3045,7 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         if !isconcretetype(ty)
             return Future(CallMeta(Tuple, Any, EFFECTS_UNKNOWN, NoCallInfo()))
         end
-    elseif is_return_type(f)
+    elseif is_return_type(f) && is_call_to_modeled_return_type(interp, argtypes, sv)
         return return_type_tfunc(interp, argtypes, si, sv)
     elseif la == 3 && f === Core.:(!==)
         # mark !== as exactly a negated call to ===

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1805,7 +1805,10 @@ function late_inline_special_case!(ir::IRCode, idx::Int, stmt::Expr, flag::UInt3
         unionall_call = Expr(:foreigncall, Expr(:tuple, QuoteNode(:jl_type_unionall)), Any, svec(Any, Any),
             0, QuoteNode(:ccall), stmt.args[2], stmt.args[3])
         return SomeCase(unionall_call)
-    elseif is_return_type(f)
+    elseif is_return_type(f) && has_flag(flag, IR_FLAGS_REMOVABLE)
+        # only replace the call with its constant result if it may be deleted, since a
+        # constant result may also come from ordinary inference of a `return_type` method
+        # that `return_type_tfunc` does not model (and that may have side effects)
         if isconstType(type)
             return SomeCase(quoted(type_parameter(type)))
         elseif isa(type, Const)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3412,9 +3412,8 @@ end
 # TODO: this function is a very buggy and poor model of the return_type function
 # since abstract_call_gf_by_type is a very inaccurate model of _method and of typeinf_type,
 # while this assumes that it is an absolutely precise and accurate and exact model of both
-# `return_type_tfunc` only models the public definitions of `return_type`; if a call may
-# dispatch to a more specific method, its behavior would be misrepresented by the tfunc,
-# so such calls must be inferred as ordinary generic calls instead (xref JuliaGPU/Metal.jl#908)
+
+# Only model calls that dispatch to the generic, non-overlayed definitions.
 function is_call_to_modeled_return_type(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::AbsIntState)
     2 <= length(argtypes) <= 3 || return true # the tfunc conservatively bails on those itself
     ft = widenconst(argtypes[1])
@@ -3427,7 +3426,8 @@ function is_call_to_modeled_return_type(interp::AbstractInterpreter, argtypes::V
     matches === nothing && return false
     update_valid_age!(sv, get_inference_world(interp), matches.valid_worlds)
     for match in matches
-        contains_is(modeled_sigs, (match::MethodMatch).method.sig) || return false
+        method = (match::MethodMatch).method
+        is_nonoverlayed(method) && contains_is(modeled_sigs, method.sig) || return false
     end
     return true
 end

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3412,6 +3412,26 @@ end
 # TODO: this function is a very buggy and poor model of the return_type function
 # since abstract_call_gf_by_type is a very inaccurate model of _method and of typeinf_type,
 # while this assumes that it is an absolutely precise and accurate and exact model of both
+# `return_type_tfunc` only models the public definitions of `return_type`; if a call may
+# dispatch to a more specific method, its behavior would be misrepresented by the tfunc,
+# so such calls must be inferred as ordinary generic calls instead (xref JuliaGPU/Metal.jl#908)
+function is_call_to_modeled_return_type(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::AbsIntState)
+    2 <= length(argtypes) <= 3 || return true # the tfunc conservatively bails on those itself
+    ft = widenconst(argtypes[1])
+    if length(argtypes) == 3
+        modeled_sigs = (Tuple{ft, Any, DataType}, Tuple{ft, DataType, UInt})
+    else
+        modeled_sigs = (Tuple{ft, DataType},)
+    end
+    matches = findall(argtypes_to_type(argtypes), method_table(interp))
+    matches === nothing && return false
+    update_valid_age!(sv, get_inference_world(interp), matches.valid_worlds)
+    for match in matches
+        contains_is(modeled_sigs, (match::MethodMatch).method.sig) || return false
+    end
+    return true
+end
+
 function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, si::StmtInfo, sv::AbsIntState)
     UNKNOWN = CallMeta(Type, Any, Effects(EFFECTS_THROWS; nortcall=false), NoCallInfo())
     if !(2 <= length(argtypes) <= 3)

--- a/Compiler/test/AbstractInterpreter.jl
+++ b/Compiler/test/AbstractInterpreter.jl
@@ -42,6 +42,15 @@ function Compiler.add_remark!(interp::MTOverlayInterp, ::Compiler.InferenceState
     return nothing
 end
 
+# An exact-signature overlay is not one of the methods modeled by `return_type_tfunc`.
+@MethodTable RETURN_TYPE_OVERLAY_MT
+@overlay RETURN_TYPE_OVERLAY_MT Compiler.return_type(f, t::DataType) = Float64
+@newinterp ReturnTypeOverlayInterp
+Compiler.method_table(interp::ReturnTypeOverlayInterp) =
+    Compiler.OverlayMethodTable(Compiler.get_inference_world(interp), RETURN_TYPE_OVERLAY_MT)
+return_type_overlay() = Compiler.return_type(+, Tuple{Int,Int})
+@test Base.infer_return_type(return_type_overlay; interp=ReturnTypeOverlayInterp()) == Core.TypeEgal{Float64}
+
 struct StrangeSinError end
 strangesin(x) = sin(x)
 @overlay OVERLAY_MT strangesin(x::Float64) =

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7852,12 +7852,7 @@ function splatted_task_invoke(@nospecialize(rest::Tuple))
 end
 @test Base.infer_return_type(splatted_task_invoke, (Tuple,)) === Tuple{}
 
-# return_type_tfunc must only model calls that dispatch to the generic
-# `return_type(f, tt)`/`return_type(tt)` definitions: a more specific method
-# with different behavior must not be folded using their semantics.
-# On Julia <= 1.11 the internal `_return_type(interp, sig)` entry point was
-# accidentally attached as a method of `return_type`, making inference fold
-# such calls to `Union{}` (xref JuliaGPU/Metal.jl#908).
+# More-specific `return_type` methods must be inferred as ordinary generic calls.
 struct ReturnTypeUnmodeledMethod end
 Compiler.return_type(::ReturnTypeUnmodeledMethod, t::DataType) = Float64
 let h = () -> Compiler.return_type(ReturnTypeUnmodeledMethod(), Tuple{typeof(+), Int, Int})

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7852,4 +7852,29 @@ function splatted_task_invoke(@nospecialize(rest::Tuple))
 end
 @test Base.infer_return_type(splatted_task_invoke, (Tuple,)) === Tuple{}
 
+# return_type_tfunc must only model calls that dispatch to the generic
+# `return_type(f, tt)`/`return_type(tt)` definitions: a more specific method
+# with different behavior must not be folded using their semantics.
+# On Julia <= 1.11 the internal `_return_type(interp, sig)` entry point was
+# accidentally attached as a method of `return_type`, making inference fold
+# such calls to `Union{}` (xref JuliaGPU/Metal.jl#908).
+struct ReturnTypeUnmodeledMethod end
+Compiler.return_type(::ReturnTypeUnmodeledMethod, t::DataType) = Float64
+let h = () -> Compiler.return_type(ReturnTypeUnmodeledMethod(), Tuple{typeof(+), Int, Int})
+    @test h() === Float64
+    @test only(Base.return_types(h)) == Core.TypeEgal{Float64}
+end
+# the call must not be deleted when the unmodeled method has side effects
+const return_type_unmodeled_log = Ref(0)
+struct ReturnTypeUnmodeledEffects end
+Compiler.return_type(::ReturnTypeUnmodeledEffects, t::DataType) =
+    (return_type_unmodeled_log[] += 1; Float32)
+let e = () -> Compiler.return_type(ReturnTypeUnmodeledEffects(), Tuple{typeof(+), Int, Int})
+    @test e() === Float32
+    @test return_type_unmodeled_log[] == 1
+end
+# while ordinary queries keep being folded
+@test only(Base.return_types(() -> Compiler.return_type(+, Tuple{Int, Int}))) == Core.TypeEgal{Int}
+@test only(Base.return_types(() -> Compiler.return_type(Tuple{typeof(+), Int, Int}))) == Core.TypeEgal{Int}
+
 end # module inference


### PR DESCRIPTION
On Julia 1.11, inference can incorrectly fold an internal `_return_type` call when it's passed an interpreter argument:

```julia-repl
julia> g() = Core.Compiler._return_type(
           Core.Compiler.NativeInterpreter(Base.tls_world_age()),
           Tuple{typeof(Base.add_sum), Float32, Float32})

julia> g()
Union{}
```

AFAIU that's because bootstrap ordering accidentally makes `_return_type` and `return_type` the same generic function. The `return_type` tfunc consequently models the internal `_return_type(interp, sig)` method as though it were the public `return_type(f, types)` method, producing the wrong constant.

Julia 1.12’s Compiler stdlib excision made `_return_type` a separate function, hiding this without fixing the underlying assumption. More-specific methods and overlays could still be modeled incorrectly.

This PR addresses both:

- `is_call_to_modeled_return_type` restricts the transfer function to the expected generic, non-overlayed methods. Other methods use ordinary generic-call inference.
- The `IR_FLAGS_REMOVABLE` check prevents the inliner from replacing such an ordinarily inferred call with its constant result unless the call can safely be deleted, preserving possible side effects (even though very questionable)

FWIW, I worked around this in https://github.com/JuliaGPU/Metal.jl/pull/908 by switching to `Base.infer_return_type`