### PR TITLE
build: fix regression of `DEPS_GIT` checkouts of git-external dependencies

### DIFF
--- a/deps/tools/git-external.mk
+++ b/deps/tools/git-external.mk
@@ -33,7 +33,9 @@ ifneq (,$$(filter $1 1,$$(DEPS_GIT)))
 $2_SRC_DIR := $1
 $2_SRC_FILE := $$(SRCCACHE)/$1.git
 $$($2_SRC_FILE)/HEAD: | $$(SRCCACHE)
-	git clone -q --mirror --branch $$($2_BRANCH) $$($2_GIT_URL) $$(dir $$@)
+	# this repo also backs the worktree the user edits, so it gets the remote-tracking
+	# refs of an ordinary clone, leaving refs/heads/ and `git push` to the user
+	git clone -q --bare -c remote.origin.fetch='+refs/heads/*:refs/remotes/origin/*' $$($2_GIT_URL) $$(dir $$@)
 $5/$1/.git: | $$($2_SRC_FILE)/HEAD
 	# try to update the cache, if that fails, attempt to continue anyways (the ref might already be local)
 	-cd $$($2_SRC_FILE) && git fetch -q $$($2_GIT_URL) $$($2_BRANCH):remotes/origin/$$($2_BRANCH)
@@ -41,7 +43,8 @@ $5/$1/.git: | $$($2_SRC_FILE)/HEAD
 	# build), keep it and proceed as before; otherwise add a worktree sharing the bare
 	# cache's object store instead of making a full local clone
 	-git -C $$($2_SRC_FILE) worktree prune
-	[ -e $5/$1/.git ] || git -C $$($2_SRC_FILE) worktree add --detach $5/$1 $$($2_BRANCH)
+	# the path must be absolute: git -C resolves it against the bare cache, not $$(CURDIR)
+	[ -e $5/$1/.git ] || git -C $$($2_SRC_FILE) worktree add --detach $$(abspath $5/$1) $$($2_BRANCH)
 #ifneq ($3,)
 	touch -c $5/$1/$3 # old target
 #endif


### PR DESCRIPTION
Two problems keep `DEPS_GIT=<name>` from producing a usable checkout after my recent changes to use worktrees.

1. The worktree path is handed to `git -C <cache>` as written, so a relative one (`$5`) resolved to the wrong place.

2. The cache was cloned with `--mirror --branch`, which aborts outright on repositories where two remote refs update one local ref: cloning `Distributed.jl` fails with `multiple updates for ref 'refs/tags/1.9.0-rc1' not allowed`. Clone it as a plain bare repository with the remote-tracking refspec of an ordinary clone instead. Since 30d1e68c3e3 this repository is not only a download cache but the repository backing the worktree a developer edits, and a mirror is the wrong shape for that: its `+refs/*:refs/*` refspec claims `refs/heads/`, so a plain `git fetch` in the checkout refuses to run while the branch is checked out, and `remote.origin.mirror` turns a plain `git push` there into a mirror push to the upstream repository. The branch name is not needed at all, as it only selected the clone's `HEAD` while every ref the build consumes is named explicitly afterwards.