### PR TITLE
build: exempt download-only make goals from the gfortran check

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1542,9 +1542,13 @@ endif
 endif
 
 # Warn if the user tries to build something that requires `gfortran` but they don't have it installed.
+# Goals that only download or repackage sources never run the fortran compiler and are exempt.
+FC_EXEMPT_GOALS := get getall light-source-dist full-source-dist
+ifneq (,$(filter-out $(FC_EXEMPT_GOALS),$(MAKECMDGOALS))$(if $(MAKECMDGOALS),,x))
 ifeq ($(FC_VERSION),)
 ifneq ($(USE_BINARYBUILDER_OPENBLAS)$(USE_BINARYBUILDER_LIBSUITESPARSE),11)
 $(error "Attempting to build OpenBLAS or SuiteSparse without a functioning fortran compiler!")
+endif
 endif
 endif
 

--- a/Make.inc
+++ b/Make.inc
@@ -1543,7 +1543,7 @@ endif
 
 # Warn if the user tries to build something that requires `gfortran` but they don't have it installed.
 # Goals that only download or repackage sources never run the fortran compiler and are exempt.
-FC_EXEMPT_GOALS := get getall light-source-dist full-source-dist
+FC_EXEMPT_GOALS := get getall light-source-dist full-source-dist print-%
 ifneq (,$(filter-out $(FC_EXEMPT_GOALS),$(MAKECMDGOALS))$(if $(MAKECMDGOALS),,x))
 ifeq ($(FC_VERSION),)
 ifneq ($(USE_BINARYBUILDER_OPENBLAS)$(USE_BINARYBUILDER_LIBSUITESPARSE),11)

--- a/Make.inc
+++ b/Make.inc
@@ -1544,7 +1544,7 @@ endif
 # Warn if the user tries to build something that requires `gfortran` but they don't have it installed.
 # Goals that only download or repackage sources never run the fortran compiler and are exempt.
 FC_EXEMPT_GOALS := get getall light-source-dist full-source-dist print-%
-ifneq (,$(filter-out $(FC_EXEMPT_GOALS),$(MAKECMDGOALS))$(if $(MAKECMDGOALS),,x))
+ifneq (,$(filter-out $(FC_EXEMPT_GOALS),$(or $(MAKECMDGOALS),x)))
 ifeq ($(FC_VERSION),)
 ifneq ($(USE_BINARYBUILDER_OPENBLAS)$(USE_BINARYBUILDER_LIBSUITESPARSE),11)
 $(error "Attempting to build OpenBLAS or SuiteSparse without a functioning fortran compiler!")


### PR DESCRIPTION
Make.inc errors at parse time for any `USE_BINARYBUILDER=0` make when no functioning fortran compiler is found, including invocations that never run a compiler at all: `make -C stdlib getall USE_BINARYBUILDER=0` (run by `light-source-dist` to vendor the stdlib source tarballs), `make -C deps getall`, and the source-dist targets themselves. Skip the check when every requested goal only downloads or repackages sources; a default-goal build (empty `MAKECMDGOALS`) still errors early as intended.

This surfaced in the CI source-dist step (JuliaCI/julia-buildkite#597), whose rootfs has no gfortran; with this change the `FC=gcc` workaround there can eventually be dropped.

Verified behavior without a fortran compiler (`FC=no-such-fortran`):
- `make -C stdlib getall USE_BINARYBUILDER=0`: now parses and runs (previously errored)
- `make -C deps getall USE_BINARYBUILDER=0`: now parses and runs (previously errored)
- `make USE_BINARYBUILDER=0` (default build): still errors early
- `make -C deps compile-openblas USE_BINARYBUILDER=0`: still errors early

🤖 Generated with [Claude Code](https://claude.com/claude-code)