### PR TITLE
codegen: Never let optimistic effects declassify a julia.safepoint call

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1273,6 +1273,12 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                     }
                 }
                 NoteOperandUses(S, BBS, I);
+                // Calls marked "julia.safepoint" can always reach a GC
+                // safepoint, whatever memory effects they advertise; narrow
+                // effects from add_fn_attrs_for_effects only license pre-GC
+                // optimizations and must never skip rooting here.
+                bool MarkedSafepoint = CI->hasFnAttr("julia.safepoint") ||
+                        (callee && callee->hasFnAttribute("julia.safepoint"));
                 if (!CI->canReturnTwice()) {
                     if (callee) {
                         if (callee == gc_preserve_begin_func) {
@@ -1310,8 +1316,9 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                             callee->getName() == "memcmp") {
                             continue;
                         }
-                        if (callee->getMemoryEffects().onlyReadsMemory() ||
-                            callee->getMemoryEffects().onlyAccessesArgPointees()) {
+                        if (!MarkedSafepoint &&
+                            (callee->getMemoryEffects().onlyReadsMemory() ||
+                             callee->getMemoryEffects().onlyAccessesArgPointees())) {
                             continue;
                         }
                     }
@@ -1319,7 +1326,8 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                         // Intrinsics are never safepoints.
                         continue;
                     auto effects = CI->getMemoryEffects();
-                    if (effects.onlyAccessesArgPointees() || effects.onlyReadsMemory())
+                    if (!MarkedSafepoint &&
+                        (effects.onlyAccessesArgPointees() || effects.onlyReadsMemory()))
                         // Readonly functions and functions that cannot change GC state (which is inaccessiblemem) are not safepoints
                         continue;
                 }
@@ -2586,7 +2594,10 @@ bool LateLowerGCFrame::runOnFunction(Function &F, bool *CFGModified) {
           for (auto &I : BB) {
               if (auto *CI = dyn_cast<CallInst>(&I)) {
                   Function *Callee = CI->getCalledFunction();
-                  if (!Callee || Callee->hasFnAttribute("julia.safepoint")) {
+                  // hasFnAttr covers the attribute on the call site as well
+                  // as on the callee (declarations get it copied by
+                  // add_fn_attrs_for_effects; call sites always carry it).
+                  if (!Callee || CI->hasFnAttr("julia.safepoint")) {
                       CI->setMemoryEffects(MemoryEffects::unknown());
                       for (unsigned i = 0; i < CI->arg_size(); i++) {
                           if (CI->getParamAttr(i, "gcstack").isValid())

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -213,6 +213,121 @@ define swiftcc ptr addrspace(10) @insert_element(ptr swiftself "gcstack" %0) {
 }
 
 
+; Calls marked "julia.safepoint" must stay safepoints even when optimistic
+; memory effects from `add_fn_attrs_for_effects` say they cannot write
+; memory; a tracked value live across such a call still needs a root
+; (JuliaLang/julia#62613).
+
+; Case 1: optimistic effects on the callee declaration.
+declare i64 @safepoint_decl_argmem(i64) #10
+
+define {} addrspace(10)* @root_across_safepoint_decl_argmem(i64 %a) {
+top:
+; CHECK-LABEL: @root_across_safepoint_decl_argmem
+; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+  %pgcstack = call {}*** @julia.get_pgcstack()
+; CHECK: call void @julia.push_gc_frame(ptr %gcframe, i32 1)
+  %v = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+; CHECK: [[SLOT1:%.*]] = call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 0)
+; CHECK-NEXT: store ptr addrspace(10) %v, ptr [[SLOT1]]
+; CHECK-NEXT: call i64 @safepoint_decl_argmem
+  %r = call i64 @safepoint_decl_argmem(i64 %a)
+; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
+  ret {} addrspace(10)* %v
+}
+
+; Case 2: optimistic effects only on the call site, as emitted when the
+; callee is a definition rather than a declaration (single-module AOT).
+declare i64 @safepoint_callsite_argmem(i64)
+
+define {} addrspace(10)* @root_across_safepoint_callsite_argmem(i64 %a) {
+top:
+; CHECK-LABEL: @root_across_safepoint_callsite_argmem
+; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+  %pgcstack = call {}*** @julia.get_pgcstack()
+; CHECK: call void @julia.push_gc_frame(ptr %gcframe, i32 1)
+  %v = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+; CHECK: [[SLOT2:%.*]] = call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 0)
+; CHECK-NEXT: store ptr addrspace(10) %v, ptr [[SLOT2]]
+; CHECK-NEXT: call i64 @safepoint_callsite_argmem
+  %r = call i64 @safepoint_callsite_argmem(i64 %a) #10
+; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
+  ret {} addrspace(10)* %v
+}
+
+; Case 3: memory(read) (readonly) instead of argmem-only.
+declare i64 @safepoint_decl_readonly(i64) #11
+
+define {} addrspace(10)* @root_across_safepoint_readonly(i64 %a) {
+top:
+; CHECK-LABEL: @root_across_safepoint_readonly
+; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+  %pgcstack = call {}*** @julia.get_pgcstack()
+; CHECK: call void @julia.push_gc_frame(ptr %gcframe, i32 1)
+  %v = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+; CHECK: [[SLOT3:%.*]] = call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 0)
+; CHECK-NEXT: store ptr addrspace(10) %v, ptr [[SLOT3]]
+; CHECK-NEXT: call i64 @safepoint_decl_readonly
+  %r = call i64 @safepoint_decl_readonly(i64 %a)
+; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
+  ret {} addrspace(10)* %v
+}
+
+; Case 4: indirect call carrying the attributes on the call site.
+define {} addrspace(10)* @root_across_safepoint_indirect(i64 %a, ptr %fp) {
+top:
+; CHECK-LABEL: @root_across_safepoint_indirect
+; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+  %pgcstack = call {}*** @julia.get_pgcstack()
+; CHECK: call void @julia.push_gc_frame(ptr %gcframe, i32 1)
+  %v = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+; CHECK: [[SLOT4:%.*]] = call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 0)
+; CHECK-NEXT: store ptr addrspace(10) %v, ptr [[SLOT4]]
+; CHECK-NEXT: call i64 %fp
+  %r = call i64 %fp(i64 %a) #10
+; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
+  ret {} addrspace(10)* %v
+}
+
+; Case 5: the optimistic ReadNone on the gcstack parameter must be stripped
+; so post-GC passes cannot assume the callee never reads pgcstack (the frame
+; link store must stay visible).
+declare i64 @safepoint_gcstack({}*** readnone "gcstack", i64) #10
+
+define {} addrspace(10)* @root_across_safepoint_gcstack(i64 %a) {
+top:
+; CHECK-LABEL: @root_across_safepoint_gcstack
+; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 1)
+  %pgcstack = call {}*** @julia.get_pgcstack()
+; CHECK: call void @julia.push_gc_frame(ptr %gcframe, i32 1)
+  %v = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+; CHECK: [[SLOT5:%.*]] = call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 0)
+; CHECK-NEXT: store ptr addrspace(10) %v, ptr [[SLOT5]]
+; CHECK-NEXT: call i64 @safepoint_gcstack(ptr "gcstack" %pgcstack, i64 %a)
+  %r = call i64 @safepoint_gcstack({}*** readnone "gcstack" %pgcstack, i64 %a) #10
+; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
+  ret {} addrspace(10)* %v
+}
+
+; Case 6 (negative control): a genuinely readonly helper without
+; "julia.safepoint" is not a safepoint and must not force a frame.
+declare i64 @readonly_helper(i64) #12
+
+define {} addrspace(10)* @no_root_across_readonly_helper(i64 %a) {
+top:
+; CHECK-LABEL: @no_root_across_readonly_helper
+; CHECK-NOT: @julia.new_gc_frame
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  %v = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+  %r = call i64 @readonly_helper(i64 %a)
+; CHECK: ret ptr addrspace(10) %v
+  ret {} addrspace(10)* %v
+}
+
+attributes #10 = { nounwind willreturn memory(argmem: read) "julia.safepoint" }
+attributes #11 = { nounwind willreturn memory(read) "julia.safepoint" }
+attributes #12 = { nounwind willreturn memory(argmem: read) }
+
 !0 = !{i64 0, i64 23}
 !1 = !{!1}
 !2 = !{!7} ; scope list

--- a/test/llvmpasses/safepoint-effects-rooting.jl
+++ b/test/llvmpasses/safepoint-effects-rooting.jl
@@ -1,0 +1,35 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no %s %t && llvm-link -S %t/* -o %t/module.ll
+# RUN: cat %t/module.ll | FileCheck --check-prefix=ATTR %s
+# RUN: julia --startup-file=no %s %t -O && llvm-link -S %t/* -o %t/module.ll
+# RUN: cat %t/module.ll | FileCheck --check-prefix=ROOT %s
+
+# Guards JuliaLang/julia#62613: `add_fn_attrs_for_effects` gives calls to
+# `:consistent`+`:effect_free` functions optimistic memory effects for the
+# pre-GC pipeline. The unoptimized run checks the attributes are really
+# emitted (so this test cannot silently go stale); the optimized run checks
+# that a tracked value live across such a call still gets a GC frame root
+# after the full pipeline.
+
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+@noinline pureadd(a::Int, b::Int) = a + b
+@noinline makeref(n::Int) = Ref(n)
+
+function rootacross(n::Int)
+    y = makeref(n)
+    s = pureadd(n, n)
+    return s + y[]
+end
+
+# ATTR: define {{.*}}i64 @julia_rootacross
+# ATTR: call swiftcc i64 @j_pureadd{{[^(]*}}({{[^)]*}}) [[PUREATTRS:#[0-9]+]]
+# ATTR: attributes [[PUREATTRS]] = { {{.*}}memory(argmem: read){{.*}}"julia.safepoint"{{.*}} }
+
+# ROOT: define {{.*}}i64 @julia_rootacross
+# ROOT: {{%gcframe[0-9]*}} = alloca
+# ROOT: [[Y:%.*]] = call swiftcc nonnull ptr @j_makeref
+# ROOT-NEXT: store ptr [[Y]], ptr [[SLOT:%.*]],
+# ROOT-NEXT: {{.*}}call swiftcc i64 @j_pureadd
+emit(rootacross, Int)


### PR DESCRIPTION
I saw the revert #62697 and hadn't seen #62613 until now. This seems to be a fix based on the tests?

---

**Note: everything below this line was written with generative AI (Claude).**

Since #61394, calls to `:consistent`+`:effect_free` functions carry optimistic
memory effects (e.g. `memory(argmem: read)`) so pre-GC LLVM passes can optimize
around them, relying on `LateLowerGCFrame` stripping those effects before its
safepoint analysis. That made rooting correctness depend on pass ordering
alone: had `LocalScan` ever seen the un-stripped attributes, it would have
classified those calls as non-safepoints and dropped the roots of values live
across them — the unsoundness identified in #62613.

## Changes

- `LocalScan` now refuses to treat any call carrying `"julia.safepoint"` (on
  the call site or the callee) as a non-safepoint, whatever memory effects it
  advertises. Rooting no longer depends on the strip having run first.
- The strip now also matches call-site-only attributes, as emitted when the
  callee is a definition rather than a declaration (single-module AOT), where
  the previous callee-only condition missed it.

## Tests

`test/llvmpasses/late-lower-gc.ll` gains six cases:

| Case | Guards against |
|---|---|
| `memory(argmem: read)` on the callee declaration | the `LocalScan` skip quoted in #62613 (JIT path) |
| attributes on the call site only | the AOT path missed by the old strip condition |
| `memory(read)` | the `onlyReadsMemory()` arm of both checks |
| indirect call with call-site attributes | the unknown-callee path |
| `readnone` on the gcstack argument is stripped | post-GC passes assuming the callee never reads `pgcstack` (the frame link store must stay visible) |
| negative control: readonly helper without `"julia.safepoint"` gets no frame | over-conservatism; keeps the non-safepoint whitelist effective |

`test/llvmpasses/safepoint-effects-rooting.jl` is an end-to-end test through
real codegen with two FileCheck prefixes: the unoptimized run asserts the
optimistic attributes are actually emitted (so the test cannot silently go
stale if effects inference or attribute emission changes), and the optimized
run asserts a tracked value live across such a call keeps its GC-frame root
through the full `-O2` pipeline.

Mutation-tested: disabling the `LocalScan` gate fails every positive case
(the end-to-end test fails on rooting, not on attribute emission); disabling
only the strip fails exactly the `readnone`-removal case while all rooting
cases still pass on the gate alone.

## On the other concerns raised in #62613

- **nosync**: `add_fn_attrs_for_effects` never emits `nosync`, and the JIT
  pipeline has no `PostOrderFunctionAttrs` (only `InferFunctionAttrsPass`,
  which is TLI-libfunc-only), so nothing infers it; per LangRef, `memory(...)`
  does not imply `nosync`. Atomics and fences still cannot be reordered
  across these calls.
- **WeakRef hoisting** (per the consensus in the issue thread): loading
  `.value` establishes a strong root — `LateLowerGCFrame` roots the loaded
  SSA value like any other tracked value, and since `.value` is a mutable
  field, the `isLoadFromImmut` refinement (rooted-by-parent) can never apply
  to it, so the loaded value always gets its own root.
- **Finalizers**: their ordering is unspecified and the Julia-level optimizer
  already deletes and reorders `:effect_free` calls; programs that
  synchronize with finalizers do so through locks, and lock operations are
  never `:effect_free`, so those remain full barriers.
- The optimistic attributes are only emitted for pointer-free signatures
  (the `has_user_ptr` gate), so everything LLVM may derive from them is a
  subset of what `:consistent`+`:effect_free` already permit at the Julia
  level — except GC rooting, which `LateLowerGCFrame` now guards
  unconditionally.

A follow-up worth doing regardless (relevant for a future concurrent GC):
emit `WeakRef.value` loads as atomic monotonic.

Alternative to #62697.
Fixes #62613
