### PR TITLE
support: range containment is (start, end], not [start, end)

### DIFF
--- a/src/support/eytzinger.c
+++ b/src/support/eytzinger.c
@@ -46,18 +46,19 @@ static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
         uintptr_t val = (i & 1) ? r->end : r->start;
         assert(val % 4 == 0 && "Range boundary not 4-byte aligned!");
         // Encode each boundary so that the strictly-less-than predecessor search
-        // in _eyt_obj_idx answers half-open [start, end) containment queries
-        // correctly, including for abutting ranges. All boundaries are 4-byte
-        // aligned (asserted above), so the low two bits are free; we offset a
-        // start boundary by +2 and an end boundary by +1:
+        // in _eyt_obj_idx answers (start, end] containment queries (see
+        // _eyt_addr_query for the convention), including for abutting ranges.
+        // All boundaries are 4-byte aligned (asserted above), so the low two
+        // bits are free; we offset a start boundary by +2 and an end boundary
+        // by +1:
         //   start(s) -> s + 2   (s % 4 == 0, so this is even; low bit 0)
         //   end(e)   -> e + 1   (odd; low bit 1)
         // This gives three useful properties:
         // 1. A start and an end never encode to the same value, so all boundaries
         //    are distinct (required to build the Eytzinger tree).
-        // 2. When a range ends exactly where the next one starts (abutting), the
-        //    start boundary (e + 2) sorts *after* the coincident end boundary
-        //    (e + 1), so a lookup at that address lands in the later range.
+        // 2. When a range ends exactly where the next one starts (abutting),
+        //    the shared address resolves to the *earlier* range — where a
+        //    trailing zero-size singleton's value pointer lands.
         // 3. The low bit distinguishes starts (even, in-range) from ends (odd,
         //    out-of-range), which eyt_tree_is_in_range tests directly.
         // We assume there are no 0-size ranges, which is safe since nothing could

--- a/src/support/eytzinger.h
+++ b/src/support/eytzinger.h
@@ -20,12 +20,17 @@ extern "C" {
 // `tree` has `n + 1` entries (n boundaries + 1 sentinel).
 //
 // The boundaries are encoded by rebuild_tree (see there): a start boundary `s`
-// is stored as `s + 2` and an end boundary `e` as `e + 1`. To ask whether a
-// 4-byte-aligned address `addr` is contained in a half-open range, query with
-// `q = addr + 3` (see _eyt_addr_query). Because `addr % 4 == 0`, this query is
-// `== 3 (mod 4)` and so never coincides with any boundary (which are 1 or 2 mod
-// 4), and its strictly-less-than predecessor is the range's start boundary iff
-// `start <= addr < end`.
+// is stored as `s + 2` and an end boundary `e` as `e + 1`. Querying with
+// `q = addr + 1` (see _eyt_addr_query) makes the strictly-less-than
+// predecessor the range's start boundary exactly when `start < addr <= end`.
+//
+// Containment is start-exclusive, end-inclusive because queries are object
+// pointers into heap-image blobs (the convention staticdata.c asserts as
+// `base < obj && obj <= base + size`): a blob's base is its first object's
+// *tag* word, never an object — but it can equal the one-past-tag value
+// pointer of a zero-size singleton bump-allocated just before the blob
+// (#62521). Symmetrically, a trailing zero-size singleton's value pointer
+// equals the blob's end.
 static inline size_t _eyt_obj_idx(uintptr_t q, uintptr_t *tree, size_t n,
                                   uintptr_t min_addr, uintptr_t max_addr) JL_NOTSAFEPOINT
 {
@@ -51,7 +56,7 @@ static inline size_t _eyt_obj_idx(uintptr_t q, uintptr_t *tree, size_t n,
 // the encoded tree. See _eyt_obj_idx and rebuild_tree for the encoding.
 static inline uintptr_t _eyt_addr_query(uintptr_t addr) JL_NOTSAFEPOINT
 {
-    return addr + 3;
+    return addr + 1;
 }
 
 typedef struct {
@@ -78,11 +83,12 @@ typedef struct eyt_tree_t {
 
 JL_DLLEXPORT void eyt_tree_init(eyt_tree_t *t) JL_NOTSAFEPOINT;
 
-// Add a [start, end) range with caller-defined data and rebuild the tree.
-// Thread-safe for concurrent access.
+// Add a range covering the object pointers in (start, end] with caller-defined
+// data and rebuild the tree. Thread-safe for concurrent access.
 JL_DLLEXPORT void eyt_tree_add_range(eyt_tree_t *t, uintptr_t start, uintptr_t end, void *data) JL_NOTSAFEPOINT;
 
-// Returns whether `addr` is inside any registered range.
+// Returns whether `addr` is inside any registered range (start-exclusive,
+// end-inclusive; see _eyt_addr_query).
 // Thread-safe for concurrent readers and writers.
 static inline int eyt_tree_is_in_range(eyt_tree_t *t, uintptr_t addr) JL_NOTSAFEPOINT
 {

--- a/src/support/test/eytzingertest.c
+++ b/src/support/test/eytzingertest.c
@@ -1,8 +1,10 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 // Regression tests for the Eytzinger address-range tree (see eytzinger.h).
-// Covers the half-open [start, end) semantics and abutting ranges that were
-// mishandled in https://github.com/JuliaLang/julia/issues/61385.
+// Covers the object-pointer (start, end] containment convention (a blob's
+// base is a tag word, never an object; a trailing zero-size singleton's value
+// pointer equals the blob's end — issue #62521) and the abutting ranges that
+// were mishandled in issue #61385.
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -16,7 +18,7 @@ static void *find(eyt_tree_t *t, uintptr_t a) { return eyt_tree_find_data(t, a);
 typedef struct { uintptr_t s, e; void *d; } rng_t;
 static void *ref_find(rng_t *ranges, int nr, uintptr_t a) {
     for (int i = 0; i < nr; i++)
-        if (a >= ranges[i].s && a < ranges[i].e)
+        if (a > ranges[i].s && a <= ranges[i].e)
             return ranges[i].d;
     return EYT_NOTFOUND;
 }
@@ -36,14 +38,14 @@ int main(void)
         eyt_tree_t t; eyt_tree_init(&t);
         eyt_tree_add_range(&t, 100, 200, (void*)0x10);
         assert(!in_range(&t, 96));   // before
-        assert(in_range(&t, 100));   // start (inclusive)
+        assert(!in_range(&t, 100));  // start (exclusive: blob base is a tag word)
         assert(in_range(&t, 104));
         assert(in_range(&t, 196));   // last element
-        assert(!in_range(&t, 200));  // end (exclusive)
+        assert(in_range(&t, 200));   // end (inclusive: trailing zero-size singleton)
         assert(!in_range(&t, 204));  // after
-        assert(find(&t, 100) == (void*)0x10);
+        assert(find(&t, 100) == EYT_NOTFOUND);
         assert(find(&t, 196) == (void*)0x10);
-        assert(find(&t, 200) == EYT_NOTFOUND);
+        assert(find(&t, 200) == (void*)0x10);
     }
 
     // Two disjoint ranges [100, 200) and [300, 400).
@@ -51,26 +53,30 @@ int main(void)
         eyt_tree_t t; eyt_tree_init(&t);
         eyt_tree_add_range(&t, 100, 200, (void*)0x10);
         eyt_tree_add_range(&t, 300, 400, (void*)0x20);
-        assert(in_range(&t, 100) && find(&t, 100) == (void*)0x10);
-        assert(!in_range(&t, 200));
+        assert(!in_range(&t, 100));
+        assert(in_range(&t, 104) && find(&t, 104) == (void*)0x10);
+        assert(in_range(&t, 200) && find(&t, 200) == (void*)0x10);
         assert(!in_range(&t, 252));  // gap
-        assert(in_range(&t, 300) && find(&t, 300) == (void*)0x20);
+        assert(!in_range(&t, 300));
+        assert(in_range(&t, 304) && find(&t, 304) == (void*)0x20);
         assert(in_range(&t, 396));
-        assert(!in_range(&t, 400));
+        assert(in_range(&t, 400) && find(&t, 400) == (void*)0x20);
+        assert(!in_range(&t, 404));
     }
 
-    // Abutting ranges [100, 200) and [200, 300): the shared boundary belongs
-    // to the second range.
+    // Abutting ranges (100, 200] and (200, 300]: the shared boundary belongs
+    // to the *first* range (a trailing zero-size singleton of blob 1, never an
+    // object of blob 2, whose base is its first object's tag word).
     {
         eyt_tree_t t; eyt_tree_init(&t);
         eyt_tree_add_range(&t, 100, 200, (void*)0x10);
         eyt_tree_add_range(&t, 200, 300, (void*)0x20);
-        assert(in_range(&t, 100) && find(&t, 100) == (void*)0x10);
+        assert(!in_range(&t, 100));
         assert(in_range(&t, 196) && find(&t, 196) == (void*)0x10);
-        assert(in_range(&t, 200) && find(&t, 200) == (void*)0x20);
-        for (uintptr_t a = 204; a < 300; a += 4)
+        assert(in_range(&t, 200) && find(&t, 200) == (void*)0x10);
+        for (uintptr_t a = 204; a <= 300; a += 4)
             assert(in_range(&t, a) && find(&t, a) == (void*)0x20);
-        assert(!in_range(&t, 300));
+        assert(!in_range(&t, 304));
     }
 
     // Ranges added out of address order are still handled correctly.
@@ -79,11 +85,12 @@ int main(void)
         eyt_tree_add_range(&t, 300, 400, (void*)0x20);
         eyt_tree_add_range(&t, 100, 200, (void*)0x10);
         eyt_tree_add_range(&t, 200, 300, (void*)0x30);  // abuts both neighbors
-        assert(find(&t, 100) == (void*)0x10);
-        assert(find(&t, 200) == (void*)0x30);
-        assert(find(&t, 300) == (void*)0x20);
-        assert(!in_range(&t, 400));
-        assert(!in_range(&t, 96));
+        assert(find(&t, 104) == (void*)0x10);
+        assert(find(&t, 200) == (void*)0x10);
+        assert(find(&t, 300) == (void*)0x30);
+        assert(find(&t, 400) == (void*)0x20);
+        assert(!in_range(&t, 404));
+        assert(!in_range(&t, 100));
     }
 
     // Deterministic fuzz: random non-overlapping ranges (some abutting), added


### PR DESCRIPTION
🤖 #62316 re-encoded the Eytzinger image-range tree to textbook half-open [start, end) containment, reasoning that images have padding around them so boundary queries would not occur. That assumption fails for heap-image blobs smaller than GC_PERM_POOL_LIMIT, which are carved from the same perm bump pool as runtime permobjs: a zero-size singleton's value pointer is one-past its own tag word — exactly the pool's next bump address — so a small blob loaded right after such a singleton is registered starting at the singleton's address. Under start-inclusive containment the tree then claims the heap singleton is in-image while its header bit correctly says otherwise, tripping the jl_object_in_image consistency assertion (deterministically reproducible via ArDCA's dependency stack; observed as Static.StaticInt in PkgEval, fixes #62521) — and silently corrupting serialization decisions on non-assert builds. The mirror case is equally real: a trailing zero-size singleton's value pointer equals its blob's end, which start-inclusive/end-exclusive containment reports out-of-image.

Object pointers can never equal their blob's base (a blob begins with its first object's tag word) and can equal its end, so the correct convention is start-exclusive, end-inclusive — the one staticdata.c itself asserts throughout (base < obj && obj <= base + size). Query with addr + 1 instead of addr + 3: the strict-predecessor search then answers (start, end], and at abutting ranges the shared address belongs to the earlier range, matching the trailing-singleton case.