### PR TITLE
codegen: place tbaa for array and memory under `jtbaa_value`

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3343,7 +3343,8 @@ static bool isLoadFromImmut(LoadInst *LI)
     if (LI->getMetadata(LLVMContext::MD_invariant_load))
         return true;
     MDNode *TBAA = LI->getMetadata(LLVMContext::MD_tbaa);
-    if (isTBAA(TBAA, {"jtbaa_immut", "jtbaa_const", "jtbaa_datatype", "jtbaa_memoryptr", "jtbaa_memorylen", "jtbaa_memoryown"}))
+    // n.b. jtbaa_memory* derives from jtbaa_immut; jtbaa_array* deliberately does not
+    if (isTBAA(TBAA, {"jtbaa_immut", "jtbaa_const", "jtbaa_datatype"}))
         return true;
     return false;
 }
@@ -3423,19 +3424,17 @@ static MDNode *best_field_tbaa(jl_codectx_t &ctx, const jl_cgval_t &strct, jl_da
     if (tbaa == ctx.tbaa().tbaa_datatype)
         if (byte_offset != offsetof(jl_datatype_t, types))
             return ctx.tbaa().tbaa_const;
-    if (tbaa == ctx.tbaa().tbaa_array) {
-        if (jl_is_genericmemory_type(jt)) {
-            if (idx == 0)
-                return ctx.tbaa().tbaa_memorylen;
-            if (idx == 1)
-                return ctx.tbaa().tbaa_memoryptr;
-        }
-        else if (jl_is_array_type(jt)) {
-            if (idx == 0)
-                return ctx.tbaa().tbaa_arrayptr;
-            if (idx == 1)
-                return ctx.tbaa().tbaa_arraysize;
-        }
+    if (tbaa == ctx.tbaa().tbaa_memory && jl_is_genericmemory_type(jt)) {
+        if (idx == 0)
+            return ctx.tbaa().tbaa_memorylen;
+        if (idx == 1)
+            return ctx.tbaa().tbaa_memoryptr;
+    }
+    if (tbaa == ctx.tbaa().tbaa_array && jl_is_array_type(jt)) {
+        if (idx == 0)
+            return ctx.tbaa().tbaa_arrayptr;
+        if (idx == 1)
+            return ctx.tbaa().tbaa_arraysize;
     }
     if (strct.V && jl_field_isconst(jt, idx) && isLoadFromConstGV(strct.V))
         return ctx.tbaa().tbaa_const; //TODO: it seems odd to have a field with a tbaa that doesn't alias it's containing struct's tbaa

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -134,6 +134,15 @@ static Value *data_pointer(jl_codectx_t &ctx, const jl_cgval_t &x, MDNode **tbaa
     return data;
 }
 
+// data_pointer, paired with the jl_aliasinfo_t describing the memory the
+// returned pointer refers to (see the tag caveat on data_pointer above).
+static std::pair<Value*, jl_aliasinfo_t> data_pointer_ai(jl_codectx_t &ctx, const jl_cgval_t &x) JL_CANSAFEPOINT
+{
+    MDNode *tbaa;
+    Value *data = data_pointer(ctx, x, &tbaa);
+    return std::make_pair(data, jl_aliasinfo_t::fromTBAA(ctx, tbaa));
+}
+
 AtomicOrdering get_llvm_atomic_order(enum jl_memory_order order)
 {
     switch (order) {
@@ -1223,9 +1232,7 @@ template<typename T1>
 static void emit_memcpy(jl_codectx_t &ctx, Value *dst, jl_aliasinfo_t const &dst_ai, const jl_cgval_t &src,
                         T1 &&sz, Align align_dst, Align align_src, bool is_volatile=false) JL_CANSAFEPOINT
 {
-    MDNode *src_tbaa;
-    Value *src_ptr = data_pointer(ctx, src, &src_tbaa);
-    auto src_ai = jl_aliasinfo_t::fromTBAA(ctx, src_tbaa);
+    auto [src_ptr, src_ai] = data_pointer_ai(ctx, src);
     emit_memcpy_llvm(ctx, dst, dst_ai, src_ptr, src_ai, sz, align_dst, align_src, is_volatile);
 }
 
@@ -1269,7 +1276,6 @@ static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align
     auto src_ai = jl_aliasinfo_t::fromTBAA(ctx, x.tbaa);
     Type *T_prjlvalue = ctx.types().T_prjlvalue;
     if (inline_roots_ptr == nullptr) {
-        // n.b. the caller's tag, not `jtbaa_stack`: `dst` is whatever it named
         emit_unbox_store(ctx, x, dst, dst_ai.tbaa, align_src, align_dst, isVolatileStore);
         return;
     }
@@ -1283,9 +1289,8 @@ static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align
     }
     if (x.V == nullptr && x.constant == nullptr)
         return;
-    MDNode *src_tbaa;
-    Value *src = data_pointer(ctx, value_to_pointer(ctx, x), &src_tbaa);
-    src_ai = jl_aliasinfo_t::fromTBAA(ctx, src_tbaa);
+    Value *src;
+    std::tie(src, src_ai) = data_pointer_ai(ctx, value_to_pointer(ctx, x));
     bool isstack = isa<AllocaInst>(src->stripInBoundsOffsets()) || src_ai.tbaa == ctx.tbaa().tbaa_stack;
     bool hasptr = typ->layout->first_ptr >= 0;
     size_t npointers = hasptr ? typ->layout->npointers : 0;
@@ -1341,9 +1346,8 @@ static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align
     }
     if (x.V == nullptr && x.constant == nullptr)
         return;
-    MDNode *src_tbaa;
-    Value *src = data_pointer(ctx, value_to_pointer(ctx, x), &src_tbaa);
-    src_ai = jl_aliasinfo_t::fromTBAA(ctx, src_tbaa);
+    Value *src;
+    std::tie(src, src_ai) = data_pointer_ai(ctx, value_to_pointer(ctx, x));
     bool hasptr = typ->layout->first_ptr >= 0;
     size_t npointers = hasptr ? typ->layout->npointers : 0;
     size_t shrunken_size = split_value_size(typ).first;
@@ -1401,14 +1405,15 @@ static std::tuple<Value*, jl_gc_roots_t, MDNode*> split_value(jl_codectx_t &ctx,
             return "split::" + std::string(jl_symbol_name(typ->name->name));
         });
         // Label the copy with the layout tag of what it holds, as the no-copy paths
-        // above already do. Tagging it `jtbaa_stack` instead would force the copy
-        // below to join two unrelated tags, and the join of `jtbaa_stack` with
-        // anything is the root — an access that aliases all memory, which then
-        // travels with every later load of this value. Every access to the temporary
-        // goes through the tag returned here, so they stay consistent with the copy.
-        // The temporary gives up its `Region::stack` !noalias in exchange, until tbaa
-        // and region are represented separately.
-        MDNode *tbaa_dst = x.ispointer() && x.tbaa ? x.tbaa : best_tbaa(ctx.tbaa(), x.typ);
+        // above already do: every access to the temporary goes through the tag
+        // returned here, so they stay consistent with the copy, and the join of the
+        // two sides of the copy below stays a precise tag rather than the root. The
+        // temporary forfeits its `Region::stack` !noalias in exchange, until tbaa
+        // and region are represented separately. `jtbaa_const` cannot be the tag of
+        // a written copy — it also labels caller-written argument buffers, and a
+        // const-tagged copy claims its own initializing writes cannot happen
+        // (pointsToConstantMemory) — so such a copy takes the layout tag of its type.
+        MDNode *tbaa_dst = x.tbaa && x.tbaa != ctx.tbaa().tbaa_const ? x.tbaa : best_tbaa(ctx.tbaa(), x.typ);
         auto dst_ai = jl_aliasinfo_t::fromTBAA(ctx, tbaa_dst);
         split_value_into(ctx, x, x_alignment, alloca, align_dst, dst_ai, false);
         return std::make_tuple(alloca, std::move(roots), tbaa_dst);
@@ -3344,41 +3349,6 @@ static bool emit_getfield_unknownidx(jl_codectx_t &ctx,
     return false;
 }
 
-static bool isTBAA(MDNode *TBAA, std::initializer_list<const char*> const strset)
-{
-    if (!TBAA)
-        return false;
-    while (TBAA->getNumOperands() > 1) {
-        TBAA = cast<MDNode>(TBAA->getOperand(1).get());
-        auto str = cast<MDString>(TBAA->getOperand(0))->getString();
-        for (auto str2 : strset) {
-            if (str == str2) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-// Check if this is a load from an immutable value. The easiest
-// way to do so is to look at the tbaa and see if it derives from
-// jtbaa_immut.
-static bool isLoadFromImmut(LoadInst *LI)
-{
-    if (LI->getMetadata(LLVMContext::MD_invariant_load))
-        return true;
-    MDNode *TBAA = LI->getMetadata(LLVMContext::MD_tbaa);
-    // n.b. jtbaa_memory* derives from jtbaa_immut; jtbaa_array* deliberately does not
-    if (isTBAA(TBAA, {"jtbaa_immut", "jtbaa_const", "jtbaa_datatype"}))
-        return true;
-    return false;
-}
-
-static bool isConstGV(GlobalVariable *gv)
-{
-    return gv->isConstant() || gv->getMetadata("julia.constgv");
-}
-
 // Check if this can be traced through constant loads to a constant global
 // or otherwise globally rooted value.
 // Almost all `tbaa_const` loads satisfy this with the exception of
@@ -4743,9 +4713,12 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                 if (promotion_point)
                     ctx.builder.SetInsertPoint(promotion_point);
                 if (strct) {
+                    // The alloca holds only the split data portion (`tracked.first`
+                    // bytes); any trailing pointer fields live in `inline_roots`,
+                    // already null-initialized above.
                     jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, strct_tbaa);
                     promotion_point = ai.decorateInst(ctx.builder.CreateMemSet(strct, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0),
-                                                                jl_datatype_size(ty), Align(julia_alignment(ty))));
+                                                                tracked.first, Align(julia_alignment(ty))));
                 }
             }
             if (type_is_ghost(lt))

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -103,14 +103,23 @@ static Value *mark_callee_rooted(jl_codectx_t &ctx, Value *V)
 
 static Constant *julia_const_to_llvm(jl_codectx_t &ctx, jl_value_t *e) JL_CANSAFEPOINT;
 
-static Value *data_pointer(jl_codectx_t &ctx, const jl_cgval_t &x) JL_CANSAFEPOINT
+// If `tbaa` is given, it is set to the tag describing the memory that the
+// returned pointer refers to, which is not always `x.tbaa`: a pointer-free
+// constant is copied into a private constant global, so that copy is
+// `jtbaa_const` memory no matter what the mutability of its type implies.
+static Value *data_pointer(jl_codectx_t &ctx, const jl_cgval_t &x, MDNode **tbaa=nullptr) JL_CANSAFEPOINT
 {
     assert(x.ispointer());
     Value *data;
+    if (tbaa)
+        *tbaa = x.tbaa;
     if (x.constant) {
         Constant *val = julia_const_to_llvm(ctx, x.constant);
-        if (val && !type_is_ghost(val->getType()))
+        if (val && !type_is_ghost(val->getType())) {
             data = get_pointer_to_constant(ctx.emission_context, val, Align(julia_alignment(jl_typeof(x.constant))), "_j_const", *jl_Module);
+            if (tbaa)
+                *tbaa = ctx.tbaa().tbaa_const;
+        }
         else
             data = literal_pointer_val(ctx, x.constant);
     }
@@ -1193,7 +1202,7 @@ static void emit_memcpy_llvm(jl_codectx_t &ctx, Value *dst, jl_aliasinfo_t const
     // that's done, we can expect that in most cases tbaa(src) == tbaa(dst) and the
     // above problem won't be as serious.
 
-    auto merged_ai = dst_ai.merge(src_ai);
+    auto merged_ai = dst_ai.merge(ctx, src_ai);
 #if JL_LLVM_VERSION < 210000
     ctx.builder.CreateMemCpy(dst, align_dst, src, align_src, sz, is_volatile,
                              merged_ai.tbaa, merged_ai.tbaa_struct, merged_ai.scope, merged_ai.noalias);
@@ -1214,8 +1223,10 @@ template<typename T1>
 static void emit_memcpy(jl_codectx_t &ctx, Value *dst, jl_aliasinfo_t const &dst_ai, const jl_cgval_t &src,
                         T1 &&sz, Align align_dst, Align align_src, bool is_volatile=false) JL_CANSAFEPOINT
 {
-    auto src_ai = jl_aliasinfo_t::fromTBAA(ctx, src.tbaa);
-    emit_memcpy_llvm(ctx, dst, dst_ai, data_pointer(ctx, src), src_ai, sz, align_dst, align_src, is_volatile);
+    MDNode *src_tbaa;
+    Value *src_ptr = data_pointer(ctx, src, &src_tbaa);
+    auto src_ai = jl_aliasinfo_t::fromTBAA(ctx, src_tbaa);
+    emit_memcpy_llvm(ctx, dst, dst_ai, src_ptr, src_ai, sz, align_dst, align_src, is_volatile);
 }
 
 // compute the space required by split_value_into, by simulating it
@@ -1258,7 +1269,8 @@ static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align
     auto src_ai = jl_aliasinfo_t::fromTBAA(ctx, x.tbaa);
     Type *T_prjlvalue = ctx.types().T_prjlvalue;
     if (inline_roots_ptr == nullptr) {
-        emit_unbox_store(ctx, x, dst, ctx.tbaa().tbaa_stack, align_src, align_dst, isVolatileStore);
+        // n.b. the caller's tag, not `jtbaa_stack`: `dst` is whatever it named
+        emit_unbox_store(ctx, x, dst, dst_ai.tbaa, align_src, align_dst, isVolatileStore);
         return;
     }
     if (!x.inline_roots.empty()) {
@@ -1271,7 +1283,9 @@ static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align
     }
     if (x.V == nullptr && x.constant == nullptr)
         return;
-    Value *src = data_pointer(ctx, value_to_pointer(ctx, x));
+    MDNode *src_tbaa;
+    Value *src = data_pointer(ctx, value_to_pointer(ctx, x), &src_tbaa);
+    src_ai = jl_aliasinfo_t::fromTBAA(ctx, src_tbaa);
     bool isstack = isa<AllocaInst>(src->stripInBoundsOffsets()) || src_ai.tbaa == ctx.tbaa().tbaa_stack;
     bool hasptr = typ->layout->first_ptr >= 0;
     size_t npointers = hasptr ? typ->layout->npointers : 0;
@@ -1327,7 +1341,9 @@ static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align
     }
     if (x.V == nullptr && x.constant == nullptr)
         return;
-    Value *src = data_pointer(ctx, value_to_pointer(ctx, x));
+    MDNode *src_tbaa;
+    Value *src = data_pointer(ctx, value_to_pointer(ctx, x), &src_tbaa);
+    src_ai = jl_aliasinfo_t::fromTBAA(ctx, src_tbaa);
     bool hasptr = typ->layout->first_ptr >= 0;
     size_t npointers = hasptr ? typ->layout->npointers : 0;
     size_t shrunken_size = split_value_size(typ).first;
@@ -1384,11 +1400,20 @@ static std::tuple<Value*, jl_gc_roots_t, MDNode*> split_value(jl_codectx_t &ctx,
         setName(ctx.emission_context, alloca, [&]() {
             return "split::" + std::string(jl_symbol_name(typ->name->name));
         });
-        auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);
-        split_value_into(ctx, x, x_alignment, alloca, align_dst, stack_ai, false);
-        bits = alloca;
+        // Label the copy with the layout tag of what it holds, as the no-copy paths
+        // above already do. Tagging it `jtbaa_stack` instead would force the copy
+        // below to join two unrelated tags, and the join of `jtbaa_stack` with
+        // anything is the root — an access that aliases all memory, which then
+        // travels with every later load of this value. Every access to the temporary
+        // goes through the tag returned here, so they stay consistent with the copy.
+        // The temporary gives up its `Region::stack` !noalias in exchange, until tbaa
+        // and region are represented separately.
+        MDNode *tbaa_dst = x.ispointer() && x.tbaa ? x.tbaa : best_tbaa(ctx.tbaa(), x.typ);
+        auto dst_ai = jl_aliasinfo_t::fromTBAA(ctx, tbaa_dst);
+        split_value_into(ctx, x, x_alignment, alloca, align_dst, dst_ai, false);
+        return std::make_tuple(alloca, std::move(roots), tbaa_dst);
     }
-    return std::make_tuple(bits, std::move(roots), ctx.tbaa().tbaa_stack);
+    return std::make_tuple(bits, std::move(roots), best_tbaa(ctx.tbaa(), x.typ));
 }
 
 // Return the offset values corresponding to jl_field_offset, but into the two buffers for a split value (or -1)
@@ -3601,7 +3626,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
             Value *tindex0 = ctx.builder.CreateExtractValue(obj, ArrayRef<unsigned>(ptindex));
             Value *tindex = ctx.builder.CreateNUWAdd(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 1), tindex0);
             setNameWithField(ctx.emission_context, tindex, get_objname, jt, idx, Twine(".tindex"));
-            return mark_julia_slot(lv, jfty, tindex, ctx.tbaa().tbaa_stack);
+            return mark_julia_slot(lv, jfty, tindex, best_tbaa(ctx.tbaa(), jfty));
         }
         else {
             unsigned st_idx;
@@ -4539,6 +4564,10 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                 setName(ctx.emission_context, strct, arg_typename);
             }
 
+            // The selector bytes below take this same tag: they overlap the object,
+            // so a tag unrelated to the object's would let the two be reordered.
+            MDNode *strct_tbaa = best_tbaa(ctx.tbaa(), ty);
+
             for (unsigned i = 0; i < na; i++) {
                 jl_value_t *jtype = jl_svecref(sty->types, i); // n.b. ty argument must be concrete
                 jl_cgval_t fval_info = argv[i];
@@ -4595,7 +4624,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     fval = boxed(ctx, fval_info, field_promotable);
                     if (!init_as_value) {
                         if (dest) {
-                            jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);
+                            jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, strct_tbaa);
                             ai.decorateInst(ctx.builder.CreateAlignedStore(fval, dest, Align(jl_field_align(sty, i))));
                         }
                         else {
@@ -4626,12 +4655,12 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                             assert(lt->getStructElementType(llvm_idx) == ET);
                             AllocaInst *lv = emit_static_alloca(ctx, fsz1, Align(al));
                             setName(ctx.emission_context, lv, "unioninit");
-                            emit_unionmove(ctx, lv, jtype, ctx.tbaa().tbaa_stack, fval_info, tindex, /*skip*/nullptr);
+                            emit_unionmove(ctx, lv, jtype, strct_tbaa, fval_info, tindex, /*skip*/nullptr);
                             // emit all of the align-sized words
                             unsigned i = 0;
                             for (; i < fsz1 / al; i++) {
                                 Value *fldp = emit_ptrgep(ctx, lv, i * al);
-                                jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);
+                                jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, strct_tbaa);
                                 Value *fldv = ai.decorateInst(ctx.builder.CreateAlignedLoad(ET, fldp, Align(al)));
                                 strct = ctx.builder.CreateInsertValue(strct, fldv, ArrayRef<unsigned>(llvm_idx + i));
                             }
@@ -4640,7 +4669,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                                 Value *staddr = emit_ptrgep(ctx, lv, i * al);
                                 for (; i < ptindex - llvm_idx; i++) {
                                     Value *fldp = emit_ptrgep(ctx, staddr, i);
-                                    jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);
+                                    jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, strct_tbaa);
                                     Value *fldv = ai.decorateInst(ctx.builder.CreateAlignedLoad(getInt8Ty(ctx.builder.getContext()), fldp, Align(1)));
                                     strct = ctx.builder.CreateInsertValue(strct, fldv, ArrayRef<unsigned>(llvm_idx + i));
                                 }
@@ -4653,10 +4682,10 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     }
                     else {
                         Value *ptindex = emit_ptrgep(ctx, strct, offs + fsz1);
-                        jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_unionselbyte);
+                        jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, strct_tbaa);
                         ai.decorateInst(ctx.builder.CreateAlignedStore(stindex, ptindex, Align(1)));
                         if (!rhs_union.isghost)
-                            emit_unionmove(ctx, dest, jtype, ctx.tbaa().tbaa_stack, fval_info, tindex, /*skip*/nullptr);
+                            emit_unionmove(ctx, dest, jtype, strct_tbaa, fval_info, tindex, /*skip*/nullptr);
                     }
                     assert(roots.empty());
                 }
@@ -4674,7 +4703,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     else {
                         if (!roots.empty() && fval_info.inline_roots.empty())
                             fval_info = value_to_pointer(ctx, fval_info);
-                        split_value_into(ctx, fval_info, align_src, dest, align_dst, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), false);
+                        split_value_into(ctx, fval_info, align_src, dest, align_dst, jl_aliasinfo_t::fromTBAA(ctx, strct_tbaa), false);
                         if (!roots.empty()) {
                             auto inline_roots = extract_gc_roots(ctx, fval_info, roots.size());
                             for (size_t i = 0; i < inline_roots.size(); i++)
@@ -4714,7 +4743,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                 if (promotion_point)
                     ctx.builder.SetInsertPoint(promotion_point);
                 if (strct) {
-                    jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);
+                    jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, strct_tbaa);
                     promotion_point = ai.decorateInst(ctx.builder.CreateMemSet(strct, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0),
                                                                 jl_datatype_size(ty), Align(julia_alignment(ty))));
                 }
@@ -4724,7 +4753,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
             else if (init_as_value)
                 return mark_julia_type(ctx, strct, false, ty);
             else {
-                jl_cgval_t ret = mark_julia_slot(strct, ty, NULL, ctx.tbaa().tbaa_stack, jl_gc_roots_t(std::move(inline_roots)));
+                jl_cgval_t ret = mark_julia_slot(strct, ty, NULL, strct_tbaa, jl_gc_roots_t(std::move(inline_roots)));
                 if (is_promotable && promotion_point) {
                     ret.promotion_point = promotion_point;
                     ret.promotion_ssa = promotion_ssa;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -430,10 +430,9 @@ struct jl_noaliascache_t {
         MDNode *gcframe;        // GC frame
         MDNode *stack;          // Stack slot
         MDNode *data;           // Any user data that `pointerset/ref` are allowed to alias
-        MDNode *type_metadata;  // Non-user-accessible type metadata incl. union selectors, etc.
         MDNode *constant;       // Memory that is immutable by the time LLVM can see it
 
-        jl_regions_t(): gcframe(nullptr), stack(nullptr), data(nullptr), type_metadata(nullptr), constant(nullptr) {}
+        jl_regions_t(): gcframe(nullptr), stack(nullptr), data(nullptr), constant(nullptr) {}
 
         void initialize(llvm::LLVMContext &context) {
             MDBuilder mbuilder(context);
@@ -442,7 +441,6 @@ struct jl_noaliascache_t {
             this->gcframe = mbuilder.createAliasScope("jnoalias_gcframe", domain);
             this->stack = mbuilder.createAliasScope("jnoalias_stack", domain);
             this->data = mbuilder.createAliasScope("jnoalias_data", domain);
-            this->type_metadata = mbuilder.createAliasScope("jnoalias_typemd", domain);
             this->constant = mbuilder.createAliasScope("jnoalias_const", domain);
         }
     } regions;
@@ -1736,7 +1734,7 @@ struct jl_aliasinfo_t {
                                      //                    => inst_a, inst_b do not alias.
     MDNode *noalias = nullptr;       // '!noalias': See '!alias.scope' above.
 
-    enum class Region { unknown, gcframe, stack, data, constant, type_metadata }; // See jl_regions_t
+    enum class Region { unknown, gcframe, stack, data, constant }; // See jl_regions_t
 
     explicit jl_aliasinfo_t() = default;
     explicit jl_aliasinfo_t(jl_codectx_t &ctx, Region r, MDNode *tbaa);
@@ -2188,19 +2186,16 @@ jl_aliasinfo_t::jl_aliasinfo_t(jl_codectx_t &ctx, Region r, MDNode *tbaa): tbaa(
         case Region::constant:
             alias_scope = regions.constant;
             break;
-        case Region::type_metadata:
-            alias_scope = regions.type_metadata;
-            break;
     }
 
-    MDNode *all_scopes[5] = { regions.gcframe, regions.stack, regions.data, regions.type_metadata, regions.constant };
+    MDNode *all_scopes[4] = { regions.gcframe, regions.stack, regions.data, regions.constant };
     if (alias_scope) {
         // The matching region is added to !alias.scope
         // All other regions are added to !noalias
 
         int i = 0;
         Metadata *scopes[1] = { alias_scope };
-        Metadata *noaliases[4];
+        Metadata *noaliases[3];
         for (auto const &scope: all_scopes) {
             if (scope == alias_scope) continue;
             noaliases[i++] = scope;
@@ -2232,8 +2227,7 @@ jl_aliasinfo_t jl_aliasinfo_t::fromTBAA(jl_codectx_t &ctx, MDNode *tbaa) {
     auto cache = ctx.tbaa();
 
     // Each top-level TBAA node has a corresponding !alias.scope scope.
-    // Array and memory headers descend from jtbaa_data, so they map to Region::data;
-    // nothing currently maps to Region::type_metadata.
+    // Array and memory headers descend from jtbaa_data, so they map to Region::data.
     MDNode *tbaa_srcs[4] = { cache.tbaa_gcframe, cache.tbaa_stack, cache.tbaa_data, cache.tbaa_const };
     Region regions[4] = { Region::gcframe, Region::stack, Region::data, Region::constant };
 
@@ -5796,10 +5790,13 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
             break;
         case jl_returninfo_t::SRet:
             assert(result);
+            // For all_roots, the sret buffer is a static-roots array: its zero-init
+            // and the callee's store_all_roots write it as `jtbaa_gcframe`, so reads
+            // of it must carry that same tag, not the layout tag of the return type.
             retval = mark_julia_slot(result,
                                      jlretty,
                                      NULL,
-                                     best_tbaa(ctx.tbaa(), jlretty),
+                                     returninfo.all_roots ? ctx.tbaa().tbaa_gcframe : best_tbaa(ctx.tbaa(), jlretty),
                                      make_lazy_gc_roots(return_roots, returninfo.return_roots, ctx.tbaa().tbaa_gcframe));
             break;
         case jl_returninfo_t::Union: {
@@ -6438,7 +6435,6 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r) J
                         decay_derived(ctx, ptr_phi),
                         decay_derived(ctx, phi));
                 }
-                tbaa = best_tbaa(ctx.tbaa(), phiType);
             }
             jl_cgval_t val = mark_julia_slot(ptr, phiType, Tindex_phi, tbaa, jl_gc_roots_t(ArrayRef(roots)));
             val.Vboxed = ptr_phi;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -339,7 +339,6 @@ struct jl_tbaacache_t {
     // LLVM should have enough info for alias analysis of non-gcframe stack slot
     // this is mainly a place holder for `jl_cgval_t::tbaa`
     MDNode *tbaa_stack;      // stack slot
-    MDNode *tbaa_unionselbyte;   // a selector byte in isbits Union struct fields
     MDNode *tbaa_data;       // Any user data that `pointerset/ref` are allowed to alias
     MDNode *tbaa_binding;        // jl_binding_t::value
     MDNode *tbaa_value;          // jl_value_t of statically unknown type; parent of the tags below
@@ -360,7 +359,7 @@ struct jl_tbaacache_t {
     bool initialized;
 
     jl_tbaacache_t(): tbaa_root(nullptr), tbaa_gcframe(nullptr), tbaa_stack(nullptr),
-                    tbaa_unionselbyte(nullptr), tbaa_data(nullptr), tbaa_binding(nullptr),
+                    tbaa_data(nullptr), tbaa_binding(nullptr),
                     tbaa_value(nullptr), tbaa_mutab(nullptr), tbaa_datatype(nullptr),
                     tbaa_immut(nullptr), tbaa_ptrarraybuf(nullptr), tbaa_arraybuf(nullptr),
                     tbaa_array(nullptr), tbaa_arrayptr(nullptr), tbaa_arraysize(nullptr),
@@ -384,9 +383,7 @@ struct jl_tbaacache_t {
         MDNode *jtbaa = mbuilder.createTBAARoot("jtbaa");
         tbaa_root = mbuilder.createTBAAScalarTypeNode("jtbaa", jtbaa);
         tbaa_gcframe = tbaa_make_child(mbuilder, "jtbaa_gcframe").first;
-        MDNode *tbaa_stack_scalar;
-        std::tie(tbaa_stack, tbaa_stack_scalar) = tbaa_make_child(mbuilder, "jtbaa_stack");
-        tbaa_unionselbyte = tbaa_make_child(mbuilder, "jtbaa_unionselbyte", tbaa_stack_scalar).first;
+        tbaa_stack = tbaa_make_child(mbuilder, "jtbaa_stack").first;
         MDNode *tbaa_data_scalar;
         std::tie(tbaa_data, tbaa_data_scalar) = tbaa_make_child(mbuilder, "jtbaa_data");
         tbaa_binding = tbaa_make_child(mbuilder, "jtbaa_binding", tbaa_data_scalar).first;
@@ -1774,15 +1771,9 @@ struct jl_aliasinfo_t {
         return inst;
     }
 
-    // Merge two sets of alias information.
-    jl_aliasinfo_t merge(const jl_aliasinfo_t &other) const {
-        jl_aliasinfo_t result;
-        result.tbaa = MDNode::getMostGenericTBAA(this->tbaa, other.tbaa);
-        result.tbaa_struct = nullptr;
-        result.scope = MDNode::getMostGenericAliasScope(this->scope, other.scope);
-        result.noalias = MDNode::intersect(this->noalias, other.noalias);
-        return result;
-    }
+    // Merge two sets of alias information, for an instruction (such as a memcpy)
+    // that accesses both.
+    jl_aliasinfo_t merge(jl_codectx_t &ctx, const jl_aliasinfo_t &other) const;
 
     // Create alias information based on the provided TBAA metadata.
     //
@@ -2220,6 +2211,23 @@ jl_aliasinfo_t::jl_aliasinfo_t(jl_codectx_t &ctx, Region r, MDNode *tbaa): tbaa(
     }
 }
 
+jl_aliasinfo_t jl_aliasinfo_t::merge(jl_codectx_t &ctx, const jl_aliasinfo_t &other) const {
+    jl_aliasinfo_t result;
+    // Nothing may store to `jtbaa_const` memory, so an access that also touches it
+    // is never the subject of a TBAA query whose answer could change: keep the other
+    // side's precise tag instead of climbing to their (much coarser) common parent.
+    if (this->tbaa == ctx.tbaa().tbaa_const)
+        result.tbaa = other.tbaa;
+    else if (other.tbaa == ctx.tbaa().tbaa_const)
+        result.tbaa = this->tbaa;
+    else
+        result.tbaa = MDNode::getMostGenericTBAA(this->tbaa, other.tbaa);
+    result.tbaa_struct = nullptr;
+    result.scope = MDNode::getMostGenericAliasScope(this->scope, other.scope);
+    result.noalias = MDNode::intersect(this->noalias, other.noalias);
+    return result;
+}
+
 jl_aliasinfo_t jl_aliasinfo_t::fromTBAA(jl_codectx_t &ctx, MDNode *tbaa) {
     auto cache = ctx.tbaa();
 
@@ -2519,11 +2527,13 @@ static Value *zext_struct(jl_codectx_t &ctx, Value *V);
 static inline jl_cgval_t value_to_pointer(jl_codectx_t &ctx, Value *v, jl_value_t *typ, Value *tindex) JL_CANSAFEPOINT
 {
     Value *loc;
+    MDNode *tbaa;
     v = zext_struct(ctx, v);
     Align align(julia_alignment(typ));
     if (valid_as_globalinit(v)) { // llvm can't handle all the things that could be inside a ConstantExpr
         assert(jl_is_concrete_type(typ)); // not legal to have an unboxed abstract type
         loc = get_pointer_to_constant(ctx.emission_context, cast<Constant>(v), align, "_j_const", *jl_Module);
+        tbaa = ctx.tbaa().tbaa_const; // this copy lives in a private constant global
     }
     else {
         AllocaInst *slot = emit_static_alloca(ctx, v->getType(), align);
@@ -2533,8 +2543,9 @@ static inline jl_cgval_t value_to_pointer(jl_codectx_t &ctx, Value *v, jl_value_
         });
         ctx.builder.CreateAlignedStore(v, slot, align);
         loc = slot;
+        tbaa = best_tbaa(ctx.tbaa(), typ);
     }
-    return mark_julia_slot(loc, typ, tindex, ctx.tbaa().tbaa_stack);
+    return mark_julia_slot(loc, typ, tindex, tbaa);
 }
 static inline jl_cgval_t value_to_pointer(jl_codectx_t &ctx, const jl_cgval_t &v) JL_CANSAFEPOINT
 {
@@ -2561,7 +2572,7 @@ static inline jl_cgval_t value_to_pointer(jl_codectx_t &ctx, const jl_cgval_t &v
                     Constant::getNullValue(ctx.types().T_prjlvalue), ptr_field, Align(sizeof(void *)));
             }
         }
-        auto tbaa = v.V == nullptr ? ctx.tbaa().tbaa_gcframe : ctx.tbaa().tbaa_stack;
+        auto tbaa = v.V == nullptr ? ctx.tbaa().tbaa_gcframe : best_tbaa(ctx.tbaa(), v.typ);
         auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, tbaa);
         recombine_value(ctx, v, loc, stack_ai, align, false);
         return mark_julia_slot(loc, v.typ, v.TIndex, tbaa);
@@ -3910,7 +3921,7 @@ static Value *emit_bits_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, const
                 else {
                     jl_aliasinfo_t arg1_ai = jl_aliasinfo_t::fromTBAA(ctx, parg1.tbaa);
                     jl_aliasinfo_t arg2_ai = jl_aliasinfo_t::fromTBAA(ctx, parg2.tbaa);
-                    ai = arg1_ai.merge(arg2_ai);
+                    ai = arg1_ai.merge(ctx, arg2_ai);
                 }
                 ai.decorateInst(answer);
             }
@@ -5788,7 +5799,7 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
             retval = mark_julia_slot(result,
                                      jlretty,
                                      NULL,
-                                     ctx.tbaa().tbaa_gcframe,
+                                     best_tbaa(ctx.tbaa(), jlretty),
                                      make_lazy_gc_roots(return_roots, returninfo.return_roots, ctx.tbaa().tbaa_gcframe));
             break;
         case jl_returninfo_t::Union: {
@@ -5804,13 +5815,13 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
             retval = mark_julia_slot(derived,
                                      jlretty,
                                      tindex,
-                                     ctx.tbaa().tbaa_stack,
+                                     best_tbaa(ctx.tbaa(), jlretty),
                                      make_lazy_gc_roots(return_roots, returninfo.return_roots, ctx.tbaa().tbaa_gcframe));
             retval.Vboxed = box;
             break;
         }
         case jl_returninfo_t::Ghosts:
-            retval = mark_julia_slot(NULL, jlretty, call, ctx.tbaa().tbaa_stack);
+            retval = mark_julia_slot(NULL, jlretty, call, best_tbaa(ctx.tbaa(), jlretty));
             break;
     }
     return retval;
@@ -6241,8 +6252,10 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
             // since this might be a union slot, the most convenient approach to copying
             // is to move the whole alloca chunk
             AllocaInst *ssaslot = nullptr;
+            // n.b. an all-ghost union has no bits, and so no tag of its own
+            MDNode *slot_tbaa = vi.value.tbaa ? vi.value.tbaa : best_tbaa(ctx.tbaa(), vi.value.typ);
             if (vi.value.V) {
-                auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);
+                auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, slot_tbaa);
                 AllocaInst *varslot = cast<AllocaInst>(vi.value.V);
                 Type *T = varslot->getAllocatedType();
                 assert(!varslot->isArrayAllocation() && "variables not expected to be VLA");
@@ -6262,7 +6275,7 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
             Value *tindex = NULL;
             if (vi.pTIndex)
                 tindex = ctx.builder.CreateAlignedLoad(getInt8Ty(ctx.builder.getContext()), vi.pTIndex, Align(1), vi.isVolatile);
-            v = mark_julia_slot(ssaslot, vi.value.typ, tindex, ctx.tbaa().tbaa_stack, jl_gc_roots_t());
+            v = mark_julia_slot(ssaslot, vi.value.typ, tindex, slot_tbaa, jl_gc_roots_t());
         }
         if (vi.inline_roots) {
             AllocaInst *varslot = vi.inline_roots;
@@ -6349,7 +6362,7 @@ static void emit_vi_assignment_unboxed(jl_codectx_t &ctx, jl_varinfo_t &vi, Valu
         // due to LLVM bugs.
         // This check should probably mostly catch the relevant situations.
         if (vi.value.V != nullptr ? vi.value.V != rval_info.V : vi.inline_roots != nullptr) {
-            MDNode *tbaa = ctx.tbaa().tbaa_stack; // Use vi.value.tbaa ?
+            MDNode *tbaa = vi.value.tbaa ? vi.value.tbaa : best_tbaa(ctx.tbaa(), vi.value.typ);
             auto roots_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
             if (rval_info.TIndex) {
                 if (vi.value.V)
@@ -6398,7 +6411,7 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r) J
         if (dest || allunbox || inline_roots) {
             Value *ptr = nullptr;
             PHINode *ptr_phi = nullptr;
-            auto tbaa = ctx.tbaa().tbaa_stack;
+            auto tbaa = best_tbaa(ctx.tbaa(), phiType);
             PHINode *Tindex_phi = PHINode::Create(getInt8Ty(ctx.builder.getContext()), jl_array_nrows(edges), "tindex_phi");
             Tindex_phi->insertInto(BB, InsertPt);
             if (inline_roots) {
@@ -6485,7 +6498,7 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r) J
             ctx.builder.CreateMemCpy(phi, align, dest, align, nb, false);
             ctx.builder.CreateLifetimeEnd(dest);
         }
-        slot = mark_julia_slot(phi, phiType, NULL, ctx.tbaa().tbaa_stack, jl_gc_roots_t(ArrayRef(roots)));
+        slot = mark_julia_slot(phi, phiType, NULL, best_tbaa(ctx.tbaa(), phiType), jl_gc_roots_t(ArrayRef(roots)));
     }
     else {
         value_phi = PHINode::Create(vtype, jl_array_nrows(edges), "value_phi");
@@ -7659,7 +7672,7 @@ static void emit_specsig_to_specsig(
         Value *sret = &*gf_thunk->arg_begin();
         Align align(julia_alignment(rettype));
         Value *roots = return_roots ? gf_thunk->arg_begin() + 1 : nullptr; // root1 has type [n x {}*]*
-        split_value_into(ctx, gf_retval, align, sret, align, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), roots, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe));
+        split_value_into(ctx, gf_retval, align, sret, align, jl_aliasinfo_t::fromTBAA(ctx, best_tbaa(ctx.tbaa(), rettype)), roots, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe));
         ctx.builder.CreateRetVoid();
         break;
     }
@@ -9398,7 +9411,7 @@ static jl_llvm_functions_t
             Value *lv = try_emit_union_alloca(ctx, (jl_uniontype_t*)jt, allunbox, align, nbytes, inline_roots);
             if (lv) {
                 lv->setName(jl_symbol_name(s));
-                varinfo.value = mark_julia_slot(lv, jt, NULL, ctx.tbaa().tbaa_stack);
+                varinfo.value = mark_julia_slot(lv, jt, NULL, best_tbaa(ctx.tbaa(), jt));
                 varinfo.pTIndex = emit_static_alloca(ctx, 1, Align(1));
                 setName(ctx.emission_context, varinfo.pTIndex, "tindex");
                 // TODO: attach debug metadata to this variable
@@ -9428,7 +9441,7 @@ static jl_llvm_functions_t
             AllocaInst *roots = sizes.second > 0 ? emit_static_roots(ctx, sizes.second) : nullptr;
             if (bits) bits->setName(jl_symbol_name(s));
             if (roots) roots->setName(StringRef(".roots.") + jl_symbol_name(s));
-            varinfo.value = mark_julia_slot(bits, jt, NULL, ctx.tbaa().tbaa_stack, jl_gc_roots_t());
+            varinfo.value = mark_julia_slot(bits, jt, NULL, best_tbaa(ctx.tbaa(), jt), jl_gc_roots_t());
             varinfo.inline_roots = roots;
             varinfo.inline_roots_count = sizes.second;
             alloc_def_flag(ctx, varinfo);
@@ -10094,7 +10107,7 @@ static jl_llvm_functions_t
             auto roots_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
             if (sret) {
                 if (returninfo.return_roots || !inline_roots.empty() || retvalinfo.ispointer()) {
-                    emit_unionmove(ctx, sret, jlrettype, ctx.tbaa().tbaa_stack, retvalinfo, retvalinfo.TIndex, /*skip*/isboxed_union);
+                    emit_unionmove(ctx, sret, jlrettype, best_tbaa(ctx.tbaa(), jlrettype), retvalinfo, retvalinfo.TIndex, /*skip*/isboxed_union);
                 }
                 else if (retvalinfo.V) {
                     Align align(returninfo.union_align);
@@ -10355,7 +10368,7 @@ static jl_llvm_functions_t
                         if (typedval.typ != jl_bottom_type) {
                             Align align(julia_alignment(phiType));
                             assert(typedval.typ == phiType);
-                            split_value_into(ctx, typedval, align, dest, align, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), false);
+                            split_value_into(ctx, typedval, align, dest, align, jl_aliasinfo_t::fromTBAA(ctx, best_tbaa(ctx.tbaa(), phiType)), false);
                             if (tracked) {
                                 mayberoots = extract_gc_roots(ctx, typedval, tracked);
                             }
@@ -10395,7 +10408,7 @@ static jl_llvm_functions_t
                 else if (jl_is_concrete_type(val.typ) || val.constant) {
                     size_t tindex = get_box_tindex((jl_datatype_t*)(val.constant ? jl_typeof(val.constant) : val.typ), phiType);
                     if (tindex && dest && (!VN || !val.isboxed)) {
-                        emit_unionmove(ctx, dest, phiType, ctx.tbaa().tbaa_stack, val, RTindex, nullptr);
+                        emit_unionmove(ctx, dest, phiType, best_tbaa(ctx.tbaa(), phiType), val, RTindex, nullptr);
                     }
                 }
                 else {
@@ -10411,7 +10424,7 @@ static jl_llvm_functions_t
                                 ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0));
                             skip = ctx.builder.CreateOr(isboxed, skip);
                         }
-                        emit_unionmove(ctx, dest, phiType, ctx.tbaa().tbaa_stack, val, tindex, skip);
+                        emit_unionmove(ctx, dest, phiType, best_tbaa(ctx.tbaa(), phiType), val, tindex, skip);
                     }
                 }
                 assert(new_union.inline_roots.size() <= lroots.size());

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -342,16 +342,17 @@ struct jl_tbaacache_t {
     MDNode *tbaa_unionselbyte;   // a selector byte in isbits Union struct fields
     MDNode *tbaa_data;       // Any user data that `pointerset/ref` are allowed to alias
     MDNode *tbaa_binding;        // jl_binding_t::value
-    MDNode *tbaa_value;          // jl_value_t, that is not jl_array_t or jl_genericmemory_t
+    MDNode *tbaa_value;          // jl_value_t of statically unknown type; parent of the tags below
     MDNode *tbaa_mutab;              // mutable type
     MDNode *tbaa_datatype;               // datatype
     MDNode *tbaa_immut;              // immutable type
     MDNode *tbaa_ptrarraybuf;    // Data in an array of boxed values
     MDNode *tbaa_arraybuf;       // Data in an array of POD
-    MDNode *tbaa_array;      // jl_array_t or jl_genericmemory_t
+    MDNode *tbaa_array;          // jl_array_t header, mutable: resized in place by the runtime
     MDNode *tbaa_arrayptr;       // The pointer inside a jl_array_t (to a memoryref)
     MDNode *tbaa_arraysize;      // A size in a jl_array_t
     MDNode *tbaa_arrayselbyte;   // a selector byte in a isbits Union jl_genericmemory_t
+    MDNode *tbaa_memory;         // jl_genericmemory_t header, never mutated after construction
     MDNode *tbaa_memoryptr;      // The pointer inside a jl_genericmemory_t
     MDNode *tbaa_memorylen;      // The length in a jl_genericmemory_t
     MDNode *tbaa_memoryown;      // The owner in a foreign jl_genericmemory_t
@@ -363,7 +364,8 @@ struct jl_tbaacache_t {
                     tbaa_value(nullptr), tbaa_mutab(nullptr), tbaa_datatype(nullptr),
                     tbaa_immut(nullptr), tbaa_ptrarraybuf(nullptr), tbaa_arraybuf(nullptr),
                     tbaa_array(nullptr), tbaa_arrayptr(nullptr), tbaa_arraysize(nullptr),
-                    tbaa_arrayselbyte(nullptr), tbaa_memoryptr(nullptr), tbaa_memorylen(nullptr), tbaa_memoryown(nullptr),
+                    tbaa_arrayselbyte(nullptr), tbaa_memory(nullptr),
+                    tbaa_memoryptr(nullptr), tbaa_memorylen(nullptr), tbaa_memoryown(nullptr),
                     tbaa_const(nullptr), initialized(false) {}
 
     auto tbaa_make_child(MDBuilder &mbuilder, const char *name, MDNode *parent = nullptr, bool isConstant = false) {
@@ -395,17 +397,27 @@ struct jl_tbaacache_t {
         std::tie(tbaa_mutab, tbaa_mutab_scalar) =
             tbaa_make_child(mbuilder, "jtbaa_mutab", tbaa_value_scalar);
         tbaa_datatype = tbaa_make_child(mbuilder, "jtbaa_datatype", tbaa_mutab_scalar).first;
-        tbaa_immut = tbaa_make_child(mbuilder, "jtbaa_immut", tbaa_value_scalar).first;
+        MDNode *tbaa_immut_scalar;
+        std::tie(tbaa_immut, tbaa_immut_scalar) =
+            tbaa_make_child(mbuilder, "jtbaa_immut", tbaa_value_scalar);
         tbaa_arraybuf = tbaa_make_child(mbuilder, "jtbaa_arraybuf", tbaa_data_scalar).first;
         tbaa_ptrarraybuf = tbaa_make_child(mbuilder, "jtbaa_ptrarraybuf", tbaa_data_scalar).first;
+        // The header tags must descend from jtbaa_value: an array is also reachable
+        // through a type-erased pointer (a Union or an abstract type, including Any),
+        // which `best_tbaa` tags jtbaa_value, and a disjoint subtree would make that
+        // load NoAlias against the stores that initialize the header.
         MDNode *tbaa_array_scalar;
-        std::tie(tbaa_array, tbaa_array_scalar) = tbaa_make_child(mbuilder, "jtbaa_array");
+        std::tie(tbaa_array, tbaa_array_scalar) =
+            tbaa_make_child(mbuilder, "jtbaa_array", tbaa_mutab_scalar);
         tbaa_arrayptr = tbaa_make_child(mbuilder, "jtbaa_arrayptr", tbaa_array_scalar).first;
         tbaa_arraysize = tbaa_make_child(mbuilder, "jtbaa_arraysize", tbaa_array_scalar).first;
         tbaa_arrayselbyte = tbaa_make_child(mbuilder, "jtbaa_arrayselbyte", tbaa_array_scalar).first;
-        tbaa_memoryptr = tbaa_make_child(mbuilder, "jtbaa_memoryptr", tbaa_array_scalar).first;
-        tbaa_memorylen = tbaa_make_child(mbuilder, "jtbaa_memorylen", tbaa_array_scalar).first;
-        tbaa_memoryown = tbaa_make_child(mbuilder, "jtbaa_memoryown", tbaa_array_scalar).first;
+        MDNode *tbaa_memory_scalar;
+        std::tie(tbaa_memory, tbaa_memory_scalar) =
+            tbaa_make_child(mbuilder, "jtbaa_memory", tbaa_immut_scalar);
+        tbaa_memoryptr = tbaa_make_child(mbuilder, "jtbaa_memoryptr", tbaa_memory_scalar).first;
+        tbaa_memorylen = tbaa_make_child(mbuilder, "jtbaa_memorylen", tbaa_memory_scalar).first;
+        tbaa_memoryown = tbaa_make_child(mbuilder, "jtbaa_memoryown", tbaa_memory_scalar).first;
         tbaa_const = tbaa_make_child(mbuilder, "jtbaa_const", nullptr, true).first;
     }
 };
@@ -1648,7 +1660,9 @@ static MDNode *best_tbaa(jl_tbaacache_t &tbaa_cache, jl_value_t *jt) {
         return tbaa_cache.tbaa_value;
     if (jl_is_abstracttype(jt))
         return tbaa_cache.tbaa_value;
-    if (jl_is_genericmemory_type(jt) || jl_is_array_type(jt))
+    if (jl_is_genericmemory_type(jt))
+        return tbaa_cache.tbaa_memory;
+    if (jl_is_array_type(jt))
         return tbaa_cache.tbaa_array;
     // If we're here, we know all subtypes are (im)mutable, even if we
     // don't know what the exact type is
@@ -2209,9 +2223,11 @@ jl_aliasinfo_t::jl_aliasinfo_t(jl_codectx_t &ctx, Region r, MDNode *tbaa): tbaa(
 jl_aliasinfo_t jl_aliasinfo_t::fromTBAA(jl_codectx_t &ctx, MDNode *tbaa) {
     auto cache = ctx.tbaa();
 
-    // Each top-level TBAA node has a corresponding !alias.scope scope
-    MDNode *tbaa_srcs[5] = { cache.tbaa_gcframe, cache.tbaa_stack, cache.tbaa_data, cache.tbaa_array, cache.tbaa_const };
-    Region regions[5] = { Region::gcframe, Region::stack, Region::data, Region::type_metadata, Region::constant };
+    // Each top-level TBAA node has a corresponding !alias.scope scope.
+    // Array and memory headers descend from jtbaa_data, so they map to Region::data;
+    // nothing currently maps to Region::type_metadata.
+    MDNode *tbaa_srcs[4] = { cache.tbaa_gcframe, cache.tbaa_stack, cache.tbaa_data, cache.tbaa_const };
+    Region regions[4] = { Region::gcframe, Region::stack, Region::data, Region::constant };
 
     if (tbaa != nullptr) {
         MDNode *node = cast<MDNode>(tbaa->getOperand(1));
@@ -2225,7 +2241,7 @@ jl_aliasinfo_t jl_aliasinfo_t::fromTBAA(jl_codectx_t &ctx, MDNode *tbaa) {
             }
 
             // Find the matching node's index
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < 4; i++) {
                 if (cast<MDNode>(tbaa_srcs[i]->getOperand(1)) == node)
                     return jl_aliasinfo_t(ctx, regions[i], tbaa);
             }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -489,7 +489,7 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, Maybe
             std::string type_str = jl_is_datatype(x.typ) ? jl_symbol_name(((jl_datatype_t*)x.typ)->name->name) : "<unknown type>";
             return "unbox::" + type_str;
         });
-        auto combined_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);
+        auto combined_ai = jl_aliasinfo_t::fromTBAA(ctx, best_tbaa(ctx.tbaa(), x.typ));
         recombine_value(ctx, x, combined, combined_ai, alignment, false);
         p = combined;
         ai = combined_ai;
@@ -526,8 +526,9 @@ static void emit_unbox_store(jl_codectx_t &ctx, const jl_cgval_t &x, Value *dest
         return;
     }
 
-    Value *src = data_pointer(ctx, x);
-    auto src_ai = jl_aliasinfo_t::fromTBAA(ctx, x.tbaa);
+    MDNode *src_tbaa;
+    Value *src = data_pointer(ctx, x, &src_tbaa);
+    auto src_ai = jl_aliasinfo_t::fromTBAA(ctx, src_tbaa);
     emit_memcpy(ctx, dest, dest_ai, src, src_ai, jl_datatype_size(x.typ), Align(align_dst), align_src ? *align_src : Align(julia_alignment(x.typ)), isVolatile);
 }
 
@@ -1255,7 +1256,7 @@ static jl_cgval_t emit_ifelse(jl_codectx_t &ctx, jl_cgval_t c, jl_cgval_t x, jl_
             MDNode *ifelse_tbaa;
             if (!x_ptr && !y_ptr) { // both ghost
                 ifelse_result = NULL;
-                ifelse_tbaa = ctx.tbaa().tbaa_stack;
+                ifelse_tbaa = best_tbaa(ctx.tbaa(), rt_hint);
             }
             else if (!x_ptr) {
                 ifelse_result = y_ptr;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -526,10 +526,7 @@ static void emit_unbox_store(jl_codectx_t &ctx, const jl_cgval_t &x, Value *dest
         return;
     }
 
-    MDNode *src_tbaa;
-    Value *src = data_pointer(ctx, x, &src_tbaa);
-    auto src_ai = jl_aliasinfo_t::fromTBAA(ctx, src_tbaa);
-    emit_memcpy(ctx, dest, dest_ai, src, src_ai, jl_datatype_size(x.typ), Align(align_dst), align_src ? *align_src : Align(julia_alignment(x.typ)), isVolatile);
+    emit_memcpy(ctx, dest, dest_ai, x, jl_datatype_size(x.typ), Align(align_dst), align_src ? *align_src : Align(julia_alignment(x.typ)), isVolatile);
 }
 
 static jl_datatype_t *staticeval_bitstype(const jl_cgval_t &targ)

--- a/src/llvm-codegen-shared.h
+++ b/src/llvm-codegen-shared.h
@@ -164,6 +164,44 @@ static inline llvm::Instruction *tbaa_decorate(llvm::MDNode *md, llvm::Instructi
     return inst;
 }
 
+// Whether the tag `TBAA`, or any of its ancestors up to the `jtbaa` root, has a
+// name in `strset`.
+static inline bool isTBAA(llvm::MDNode *TBAA, std::initializer_list<const char*> const strset)
+{
+    if (!TBAA)
+        return false;
+    while (TBAA->getNumOperands() > 1) {
+        TBAA = llvm::cast<llvm::MDNode>(TBAA->getOperand(1).get());
+        auto str = llvm::cast<llvm::MDString>(TBAA->getOperand(0))->getString();
+        for (auto str2 : strset) {
+            if (str == str2) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// Check if this is a load from an immutable value. The easiest way to do so is
+// to look at the tbaa and see if it derives from jtbaa_immut. This list is
+// GC-critical: codegen (isLoadFromConstGV) and LateLowerGCFrame must agree on
+// whether a load of a tracked pointer is rooted through its base.
+static inline bool isLoadFromImmut(llvm::LoadInst *LI)
+{
+    if (LI->getMetadata(llvm::LLVMContext::MD_invariant_load))
+        return true;
+    llvm::MDNode *TBAA = LI->getMetadata(llvm::LLVMContext::MD_tbaa);
+    // n.b. jtbaa_memory* derives from jtbaa_immut; jtbaa_array* deliberately does not
+    if (isTBAA(TBAA, {"jtbaa_immut", "jtbaa_const", "jtbaa_datatype"}))
+        return true;
+    return false;
+}
+
+static inline bool isConstGV(llvm::GlobalVariable *gv)
+{
+    return gv->isConstant() || gv->getMetadata("julia.constgv");
+}
+
 // Get PTLS through current task.
 static inline llvm::Value *get_current_task_from_pgcstack(llvm::IRBuilder<> &builder, llvm::Value *pgcstack)
 {

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -838,41 +838,6 @@ JL_USED_FUNC static void dumpLivenessState(Function &F, State &S) {
     }
 }
 
-static bool isTBAA(MDNode *TBAA, std::initializer_list<const char*> const strset)
-{
-    if (!TBAA)
-        return false;
-    while (TBAA->getNumOperands() > 1) {
-        TBAA = cast<MDNode>(TBAA->getOperand(1).get());
-        auto str = cast<MDString>(TBAA->getOperand(0))->getString();
-        for (auto str2 : strset) {
-            if (str == str2) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-// Check if this is a load from an immutable value. The easiest
-// way to do so is to look at the tbaa and see if it derives from
-// jtbaa_immut.
-static bool isLoadFromImmut(LoadInst *LI)
-{
-    if (LI->getMetadata(LLVMContext::MD_invariant_load))
-        return true;
-    MDNode *TBAA = LI->getMetadata(LLVMContext::MD_tbaa);
-    // n.b. jtbaa_memory* derives from jtbaa_immut; jtbaa_array* deliberately does not
-    if (isTBAA(TBAA, {"jtbaa_immut", "jtbaa_const", "jtbaa_datatype"}))
-        return true;
-    return false;
-}
-
-static bool isConstGV(GlobalVariable *gv)
-{
-    return gv->isConstant() || gv->getMetadata("julia.constgv");
-}
-
 typedef llvm::SmallPtrSet<PHINode*, 1> PhiSet;
 
 static bool isLoadFromConstGV(LoadInst *LI, bool &task_local, PhiSet *seen = nullptr);

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -862,7 +862,8 @@ static bool isLoadFromImmut(LoadInst *LI)
     if (LI->getMetadata(LLVMContext::MD_invariant_load))
         return true;
     MDNode *TBAA = LI->getMetadata(LLVMContext::MD_tbaa);
-    if (isTBAA(TBAA, {"jtbaa_immut", "jtbaa_const", "jtbaa_datatype", "jtbaa_memoryptr", "jtbaa_memorylen", "jtbaa_memoryown"}))
+    // n.b. jtbaa_memory* derives from jtbaa_immut; jtbaa_array* deliberately does not
+    if (isTBAA(TBAA, {"jtbaa_immut", "jtbaa_const", "jtbaa_datatype"}))
         return true;
     return false;
 }
@@ -1909,7 +1910,7 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                     LI->setMetadata(LLVMContext::MD_invariant_load, NULL);
             }
             if (MDNode *TBAA = I->getMetadata(LLVMContext::MD_tbaa)) {
-                if (TBAA->getNumOperands() == 4 && isTBAA(TBAA, {"jtbaa_const", "jtbaa_memoryptr", "jtbaa_memorylen", "tbaa_memoryown"})) {
+                if (TBAA->getNumOperands() == 4 && isTBAA(TBAA, {"jtbaa_const", "jtbaa_memory"})) {
                     MDNode *MutableTBAA = createMutableTBAAAccessTag(TBAA);
                     if (MutableTBAA != TBAA)
                         I->setMetadata(LLVMContext::MD_tbaa, MutableTBAA);

--- a/test/core.jl
+++ b/test/core.jl
@@ -9290,3 +9290,11 @@ let m = ccall(:jl_new_method_uninit, Ref{Method}, (Any,), @__MODULE__)
     @test m.sig === Union{}
     @test m.name === Symbol("")
 end
+
+# an array reached through a Union-typed value is tagged `jtbaa_value`, which must
+# still alias the `jtbaa_arrayptr` stores that initialize its header; otherwise DSE
+# deletes them and the reshaped array is left with a null `MemoryRef`
+mkunion_arrayheader(b::Bool) = b ? fill(1.0, 1, 1) : fill(1.0 + 0im, 1, 1)
+sum_reshaped_arrayheader(b::Bool, D::Int) = sum(reshape(mkunion_arrayheader(b)[:, end], D, D))
+@test sum_reshaped_arrayheader(true, 1) === 1.0
+@test sum_reshaped_arrayheader(false, 1) === 1.0 + 0.0im


### PR DESCRIPTION
We mis-attributed the tbaa info for array and memory metadata to be
disjoint from values. This resulted in miscompiles (incorrect DSE) in
some situations where union would `phi` with it, losing the precise type
information. Move it to the right place in the tbaa tree to preserve
correctness here. Update all our tbaa places to use the julia type to
avoid this issue potentially recurring from those sites either.

:robot:
`best_tbaa` tags any value whose static type is a `Union` or an abstract
type (including `Any`) as `jtbaa_value`, so an array's header fields can
be read back through a pointer carrying that tag. `jtbaa_array` was a
top-level sibling of `jtbaa_data`, which made such a load NoAlias
against the `jtbaa_arrayptr` stores that initialize the header — on both
the TBAA axis and the scoped-noalias axis, since `fromTBAA` derived
`Region::type_metadata` from the same node. `DSEPass` could then delete
the stores initializing an `Array`'s `MemoryRef`, leaving a header with
a null `ref`, and the first element access segfaulted.

Array headers now share `Region::data` with ordinary user data rather
than occupying a region of their own, so `Region::type_metadata` is
currently unused. The header/buffer distinction survives on the TBAA
axis, where `jtbaa_arrayptr` and `jtbaa_arraybuf` remain in disjoint
subtrees.

The constant-alias stripping in `CleanupIR` listed the memory header
tags individually and misspelled `jtbaa_memoryown` as `tbaa_memoryown`,
so owner accesses were never demoted. It now tests for the
`jtbaa_memory` parent instead, which covers the three fields and leaves
nothing to misspell.

Two places that used to get away with an imprecise tag no longer can: a
tag that is merely a common ancestor of the buffer and value tags is now
an ancestor of the header tags as well, so it aliases the header loads.
No placement in the tree avoids this, since the header tags have to
descend from what a type-erased access is given.

`emit_memcpy` must give the intrinsic one tag covering both halves of
the copy, so it joins the source and destination tags. Where one side is
`jtbaa_const` that join is pure loss: nothing may store to constant
memory, so such an access is never the subject of a query whose answer
could change, and `merge` now keeps the other side's tag. Reaching that
rule also requires labelling the memory correctly, so `data_pointer`
reports the tag of the memory it returns — a pointer-free constant is
materialized as a private constant global, which is `jtbaa_const` memory
whatever the mutability of its type implies. Without this, storing a
literal into an array aliased the surrounding `jtbaa_arrayptr` and
`jtbaa_memorylen` loads, which kept the header loads inside the loop and
kept a `Memory` written and read back within a function off the stack.

The same conflation ran through the stack temporaries generally: a slot
tagged `jtbaa_stack` describes where it lives, not what it holds, and
`jtbaa_stack` is a top-level node disjoint from the value tags — so a
slot read back through a `Union` or abstract type was NoAlias against
the stores that initialized it, the same shape as the miscompile above.
Only a value's tracked pointers are definitely stack memory, and those
live in the gc frame as `inline_roots`, so the bits of a temporary can
always be described by their type. `split_value`, `value_to_pointer`,
`emit_new_struct`, `emit_unbox`, local variable slots, phi slots and the
sret buffers now label their storage with `best_tbaa` of what it holds.
That also settles a disagreement across the sret protocol, where the
caller described its result slot as `jtbaa_gcframe` while the callee
wrote it as `jtbaa_stack`; the two are disjoint top-level nodes, so an
inlined pair had the reader NoAlias against its own writer.
`jtbaa_unionselbyte` goes away with them: it hung under `jtbaa_stack`,
so once the object holding it is described by its type the selector byte
has to take the object's tag, which is the only tag guaranteed to relate
to every access that overlaps it.

`split_value` had already been returning the source's tag on the paths
where it does not have to copy, and only forced `jtbaa_stack` on the
copy itself; `typed_load` sends every aggregate load through there, so
an `Array`'s `size` read back through such a temporary had been aliasing
the element stores around it, which kept the size loads inside the loop
and kept `zeros` from forming a memset.

The temporaries give up the `Region::stack` !noalias they used to carry,
which is only expressible today by claiming the memory is a stack
region. Once tbaa and region are represented separately they can have
both.