### PR TITLE
Proof of concept: Allow some limited arithmetic on type vars

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3435,7 +3435,7 @@ function abstract_eval_new(interp::AbstractInterpreter, e::Expr, sstate::Stateme
             local allconst = isconcretedispatch(rt)
             for i = 1:nargs
                 at = widenslotwrapper(abstract_eval_value(interp, e.args[i+1], sstate, sv))
-                ft = fieldtype(rt, i)
+                ft = widen_typearith(fieldtype(rt, i))
                 nothrow && (nothrow = ⊑(𝕃ᵢ, at, ft))
                 at = tmeet(𝕃ᵢ, at, ft)
                 at === Bottom && return RTEffects(Bottom, TypeError, EFFECTS_THROWS)
@@ -3464,7 +3464,7 @@ function abstract_eval_new(interp::AbstractInterpreter, e::Expr, sstate::Stateme
                 undefs = Union{Nothing,Bool}[false for _ in 1:nargs]
                 if nargs < fcount # fill in uninitialized fields
                     for i = (nargs+1):fcount
-                        ft = fieldtype(rt, i)
+                        ft = widen_typearith(fieldtype(rt, i))
                         push!(ats, ft)
                         if ft === Union{} # `Union{}`-typed field is never initialized
                             push!(undefs, true)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1320,7 +1320,7 @@ end
             # union together types of all fields
             t = Bottom
             for i in 1:nf
-                _ft = unwrapva(ftypes[i])
+                _ft = widen_typearith(unwrapva(ftypes[i]))
                 valid_as_lattice(_ft, true) || continue
                 setfield && isconst(s, i) && continue
                 t = tmerge(t, rewrap_unionall(_ft, s00))
@@ -1340,7 +1340,7 @@ end
         elseif setfield && isconst(s, fld)
             return Bottom
         end
-        R = ftypes[fld]
+        R = widen_typearith(ftypes[fld])
         valid_as_lattice(R, true) || return Bottom
         if isempty(s.parameters)
             return R
@@ -1698,6 +1698,11 @@ end
                 continue
             end
             exactft1 = exact || (!has_free_typevars(ft1) && u.name !== Tuple.name)
+            ft1w = widen_typearith(ft1)
+            if ft1w !== ft1
+                exactft1 = false # widened to a strict supertype
+                ft1 = ft1w
+            end
             ft1 = rewrap_unionall(ft1, s)
             if exactft1
                 # `fieldtype` returns exactly (`===`) the stored type, but only
@@ -1745,6 +1750,11 @@ end
     end
 
     exactft = exact || (!has_free_typevars(ft) && u.name !== Tuple.name)
+    ftw = widen_typearith(ft)
+    if ftw !== ft
+        exactft = false # widened to a strict supertype
+        ft = ftw
+    end
     ft = rewrap_unionall(ft, s)
     if exactft
         # only an egality-certain argument pins the stored rep (see above)

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -480,3 +480,86 @@ property when there is access to mutation-free global object.
 is_mutation_free_argtype(@nospecialize(argtype)) =
     is_mutation_free_type(widenconst(ignorelimited(argtype)))
 is_mutation_free_type(@nospecialize ty) = ismutationfree(ty)
+
+# Subtyping only evaluates TypeArith after its operands are known. Replace any
+# remaining nodes with fresh TypeVars before using a field type in inference.
+function contains_typearith(@nospecialize t)
+    if t isa DataType
+        # TypeArith always contains a free type variable.
+        has_free_typevars(t) || return false
+        for p in t.parameters
+            contains_typearith(p) && return true
+        end
+        return false
+    end
+    t isa Core.TypeArith && return true
+    if t isa UnionAll
+        return contains_typearith(t.var.lb) || contains_typearith(t.var.ub) ||
+               contains_typearith(t.body)
+    end
+    if t isa Core.TypeEq || t isa Core.TypeEgal
+        return contains_typearith(t.T)
+    end
+    t isa Union && return contains_typearith(t.a) || contains_typearith(t.b)
+    if t isa Core.TypeofVararg
+        isdefined(t, :T) && contains_typearith(t.T) && return true
+        return isdefined(t, :N) && contains_typearith(t.N)
+    end
+    return false
+end
+
+function widen_typearith(@nospecialize t)
+    contains_typearith(t) || return t
+    vars = TypeVar[]
+    t = _substitute_typearith(t, vars)
+    for i = length(vars):-1:1
+        t = UnionAll(vars[i], t)
+    end
+    return t
+end
+
+function _substitute_typearith(@nospecialize(t), vars::Vector{TypeVar})
+    if t isa Core.TypeArith
+        v = TypeVar(Symbol("#ta#"))
+        push!(vars, v)
+        return v
+    end
+    if t isa UnionAll
+        lb = _substitute_typearith(t.var.lb, vars)
+        ub = _substitute_typearith(t.var.ub, vars)
+        body = _substitute_typearith(t.body, vars)
+        if lb === t.var.lb && ub === t.var.ub
+            return body === t.body ? t : UnionAll(t.var, body)
+        end
+        # Rebind the variable after changing its bounds.
+        v = TypeVar(t.var.name, lb, ub)
+        return UnionAll(v, Core.apply_type(UnionAll(t.var, body), v))
+    end
+    if t isa Core.TypeEq
+        x = _substitute_typearith(t.T, vars)
+        return x === t.T ? t : Core.apply_type(Type, x)
+    end
+    # TypeEgal parameters cannot have free type variables.
+    if t isa Union
+        a = _substitute_typearith(t.a, vars)
+        b = _substitute_typearith(t.b, vars)
+        return (a === t.a && b === t.b) ? t : Union{a, b}
+    end
+    if t isa Core.TypeofVararg
+        isdefined(t, :T) || return t
+        T = _substitute_typearith(t.T, vars)
+        if isdefined(t, :N)
+            N = _substitute_typearith(t.N, vars)
+            return (T === t.T && N === t.N) ? t : Core.apply_type(Vararg, T, N)
+        end
+        return T === t.T ? t : Core.apply_type(Vararg, T)
+    end
+    if t isa DataType && contains_typearith(t)
+        np = Vector{Any}(undef, length(t.parameters))
+        for i = 1:length(t.parameters)
+            np[i] = _substitute_typearith(t.parameters[i], vars)
+        end
+        return Core.apply_type(t.name.wrapper, np...)
+    end
+    return t
+end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -422,6 +422,27 @@ struct TypeApp
     end
 end
 
+# Deferred integer arithmetic on type parameters. Instantiation folds a node
+# once its operands are known.
+struct TypeArith
+    op::Int              # 1:+ 2:- 3:* 4:div 5:min 6:max 7:^
+    a::Any
+    b::Any
+    function TypeArith(op::Int, @nospecialize(a), @nospecialize(b))
+        if Intrinsics.slt_int(op, 1) || Intrinsics.slt_int(7, op)
+            throw(ArgumentError("invalid TypeArith op code"))
+        end
+        (a isa Int || a isa TypeVar || a isa TypeArith) ||
+            throw(ArgumentError("TypeArith operands must be Int, TypeVar, or TypeArith"))
+        (b isa Int || b isa TypeVar || b isa TypeArith) ||
+            throw(ArgumentError("TypeArith operands must be Int, TypeVar, or TypeArith"))
+        if a isa Int && b isa Int
+            throw(ArgumentError("TypeArith over constant operands must be folded"))
+        end
+        return new(op, a, b)
+    end
+end
+
 # Check if a value contains a TypeApp anywhere in its structure
 function _contains_typeapp(@nospecialize(x))
     if x isa TypeApp

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1291,6 +1291,39 @@ has_typevar(@nospecialize(t), v::TypeVar) = ccall(:jl_has_typevar, Int32, (Any, 
 # Called by lowered code from struct definitions (both flisp and JuliaLowering).
 # Uses jl_method_def directly with type objects, avoiding type-to-expression conversion.
 
+function _contains_typearith(@nospecialize t)
+    if t isa Core.TypeArith
+        return true
+    end
+    if t isa Core.TypeEq || t isa Core.TypeEgal
+        return _contains_typearith(t.T)
+    end
+    if t isa UnionAll
+        return _contains_typearith(t.var.lb) || _contains_typearith(t.var.ub) || _contains_typearith(t.body)
+    end
+    if t isa Union
+        return _contains_typearith(t.a) || _contains_typearith(t.b)
+    end
+    if t isa Core.TypeofVararg
+        if isdefined(t, :T) && _contains_typearith(t.T)
+            return true
+        end
+        return isdefined(t, :N) && _contains_typearith(t.N)
+    end
+    if t isa DataType
+        params = t.parameters
+        i = 1
+        n = length(params)
+        while i !== n + 1
+            if _contains_typearith(params[i])
+                return true
+            end
+            i = i + 1
+        end
+    end
+    return false
+end
+
 function _defaultctors(@nospecialize(ty), functionloc)
     # Walk the UnionAll chain to collect type variables and get the DataType
     nparams = 0
@@ -1412,9 +1445,21 @@ function _defaultctors(@nospecialize(ty), functionloc)
         end
         outer_atypes = Core.svec(atypes_arr...)
         outer_tvars = Core.svec(tvars...)
-        argdata = Core.svec(outer_atypes, outer_tvars, functionloc)
-        ccall(:jl_method_def, Any, (Any, Ptr{Nothing}, Any, Any),
-              argdata, C_NULL, ci, mod)
+        # Each TypeArith operand must be bound before it appears in the signature.
+        outer_ok = true
+        i = 1
+        while i !== n + 1
+            if _contains_typearith(fts[i])
+                outer_ok = ccall(:jl_typearith_signature_valid, Int32, (Any,), outer_atypes) !== Int32(0)
+                break
+            end
+            i = i + 1
+        end
+        if outer_ok
+            argdata = Core.svec(outer_atypes, outer_tvars, functionloc)
+            ccall(:jl_method_def, Any, (Any, Ptr{Nothing}, Any, Any),
+                  argdata, C_NULL, ci, mod)
+        end
 
         # For non-parametric types where all fields are Any, outer constructor suffices
         if nparams === 0

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1557,3 +1557,13 @@ julia> [1, 2] .∉ ([2, 3],)
 ```
 """
 ∉, ∌
+
+# Operators for constructing deferred type-parameter arithmetic.
+const _TypeArithOperand = Union{TypeVar, Core.TypeArith}
+for (f, op) in ((:+, 1), (:-, 2), (:*, 3), (:div, 4), (:min, 5), (:max, 6), (:^, 7))
+    @eval begin
+        $f(a::_TypeArithOperand, b::_TypeArithOperand) = Core.TypeArith($op, a, b)
+        $f(a::_TypeArithOperand, b::Int) = Core.TypeArith($op, a, b)
+        $f(a::Int, b::_TypeArithOperand) = Core.TypeArith($op, a, b)
+    end
+end

--- a/base/show.jl
+++ b/base/show.jl
@@ -2875,6 +2875,28 @@ function show(io::IO, tv::TypeVar)
     nothing
 end
 
+function show(io::IO, ta::Core.TypeArith)
+    op = ta.op
+    if op == 5 || op == 6 # min, max
+        print(io, op == 5 ? "min(" : "max(")
+        show(io, ta.a)
+        print(io, ", ")
+        show(io, ta.b)
+        print(io, ")")
+    else
+        function show_operand(io::IO, @nospecialize(x))
+            parens = x isa Core.TypeArith && x.op != 5 && x.op != 6
+            parens && print(io, "(")
+            show(io, x)
+            parens && print(io, ")")
+        end
+        show_operand(io, ta.a)
+        print(io, op == 1 ? " + " : op == 2 ? " - " : op == 3 ? " * " : op == 4 ? " ÷ " : " ^ ")
+        show_operand(io, ta.b)
+    end
+    nothing
+end
+
 function show(io::IO, vm::Core.TypeofVararg)
     print(io, "Vararg")
     if isdefined(vm, :T)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -444,6 +444,13 @@ static uintptr_t type_object_id_(jl_value_t *v, jl_varidx_t *env) JL_NOTSAFEPOIN
         return bitmix(jl_object_id((jl_value_t*)tv),
                       type_object_id_(((jl_typeeq_t*)v)->T, env));
     }
+    if (jl_is_typearith(v)) {
+        // Hash bound variables by binder depth, as in egal_types.
+        jl_typearith_t *ta = (jl_typearith_t*)v;
+        uintptr_t h = inthash((uintptr_t)(0x7ea0 + ta->op));
+        h = bitmix(h, type_object_id_(ta->a, env));
+        return bitmix(h, type_object_id_(ta->b, env));
+    }
     if (tv == jl_unionall_type) {
         jl_unionall_t *u = (jl_unionall_t*)v;
         uintptr_t h = u->var->name->hash;
@@ -1827,9 +1834,12 @@ int jl_valid_type_param(jl_value_t *v)
         return is_nestable_type_param(jl_typeof(v));
     if (jl_is_vararg(v))
         return 0;
+    // Instantiation folds nodes with no free operands.
+    if (jl_is_typearith(v))
+        return jl_has_free_typevars(v);
     // TODO: maybe more things
-    return jl_is_type(v) || jl_is_typevar(v) || jl_is_symbol(v) || jl_isbits(jl_typeof(v)) ||
-        jl_is_module(v);
+    return jl_is_type(v) || jl_is_typevar(v) || jl_is_symbol(v) ||
+        jl_isbits(jl_typeof(v)) || jl_is_module(v);
 }
 
 JL_CALLABLE(jl_f_apply_type)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -2740,6 +2740,10 @@ static jl_datatype_t *unwrap_to_datatype(jl_value_t *v) JL_NOTSAFEPOINT
 // Throws when invalid; returns otherwise.
 void jl_check_valid_supertype(jl_value_t *super, const char *type_name)
 {
+    if (jl_has_typearith(super))
+        jl_errorf("invalid subtyping in definition of %s: computed type parameter "
+                  "expressions (e.g. `N+1`) are only supported in field types, "
+                  "not supertype declarations", type_name);
     if (jl_is_unionall(super)) {
         // delegate to the body first for a more accurate error
         // when parameterizing would not salvage the definition
@@ -2887,6 +2891,13 @@ JL_DLLEXPORT jl_value_t *jl_resolve_typegroup(jl_module_t *module, jl_svec_t *ty
                                   jl_symbol_name(tv->name),
                                   jl_symbol_name(((jl_tvar_t*)p)->name),
                                   jl_symbol_name(ref->name));
+                    if (jl_has_typearith(((jl_tvar_t*)p)->lb) ||
+                        jl_has_typearith(((jl_tvar_t*)p)->ub))
+                        jl_errorf("invalid type parameter bound in definition of %s: "
+                                  "computed type parameter expressions (e.g. `N+1`) are only "
+                                  "supported in field types, not in bounds of %s",
+                                  jl_symbol_name(tv->name),
+                                  jl_symbol_name(((jl_tvar_t*)p)->name));
                 }
             }
 

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -154,7 +154,8 @@
     XX(voidpointer_type, jl_datatype_t*) \
     XX(wait_entry_type, jl_datatype_t*) \
     XX(weakref_type, jl_datatype_t*) \
-    XX(typeapp_type, jl_datatype_t*)
+    XX(typeapp_type, jl_datatype_t*) \
+    XX(typearith_type, jl_datatype_t*)
 
 // Global constant values (jl_true, jl_false, jl_nothing)
 #define JL_CONST_GLOBAL_VARS(YY) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -400,6 +400,7 @@
     XX(jl_register_newmeth_tracer) \
     XX(jl_resolve_definition_effects_in_ir) \
     XX(jl_resolve_typegroup) \
+    XX(jl_typearith_signature_valid) \
     XX(jl_restore_excstack) \
     XX(jl_restore_incremental) \
     XX(jl_restore_package_image_from_file) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -61,7 +61,7 @@ static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_CANSAF
     while (1) {
         if (jl_is_typevar(v))
             return !typeenv_has(env, (jl_tvar_t*)v);
-        if (jl_is_typeapp(v))
+        if (jl_is_typeapp(v) || jl_is_typearith(v))
             return 1;
         while (jl_is_unionall(v)) {
             jl_unionall_t *ua = (jl_unionall_t*)v;
@@ -131,6 +131,13 @@ static int has_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
         }
         if (jl_is_typeapp(v))
             return 1;
+        if (jl_is_typearith(v)) {
+            jl_typearith_t *ta = (jl_typearith_t*)v;
+            if (has_free_typevars(ta->a, env))
+                return 1;
+            v = ta->b;
+            continue;
+        }
         while (jl_is_unionall(v)) {
             jl_unionall_t *ua = (jl_unionall_t*)v;
             if (ua->var->lb != jl_bottom_type && has_free_typevars(ua->var->lb, env))
@@ -146,7 +153,7 @@ static int has_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
         }
         // After unwrapping UnionAll, body might be TypeApp or TypeVar;
         // restart the loop so those checks at the top fire.
-        if (jl_is_typeapp(v) || jl_is_typevar(v))
+        if (jl_is_typeapp(v) || jl_is_typearith(v) || jl_is_typevar(v))
             continue;
         if (jl_is_datatype(v)) {
             int expect = ((jl_datatype_t*)v)->hasfreetypevars;
@@ -188,6 +195,56 @@ JL_DLLEXPORT int jl_has_free_typevars(jl_value_t *v) JL_NOTSAFEPOINT
     return has_free_typevars(v, NULL);
 }
 
+// Return whether v contains a TypeArith node.
+int jl_has_typearith(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    while (1) {
+        if (jl_is_typearith(v))
+            return 1;
+        if (jl_is_typevar(v)) {
+            jl_tvar_t *tv = (jl_tvar_t*)v;
+            if (jl_has_typearith(tv->lb))
+                return 1;
+            v = tv->ub;
+        }
+        else if (jl_is_unionall(v)) {
+            jl_unionall_t *ua = (jl_unionall_t*)v;
+            if (jl_has_typearith((jl_value_t*)ua->var))
+                return 1;
+            v = ua->body;
+        }
+        else if (jl_is_uniontype(v) || jl_is_intersecttype(v)) {
+            if (jl_has_typearith(((jl_uniontype_t*)v)->a))
+                return 1;
+            v = ((jl_uniontype_t*)v)->b;
+        }
+        else if (jl_is_typeeq(v) || jl_is_typeegal(v)) {
+            v = ((jl_typeeq_t*)v)->T;
+        }
+        else if (jl_is_vararg(v)) {
+            jl_vararg_t *vm = (jl_vararg_t*)v;
+            if (vm->N && jl_has_typearith(vm->N))
+                return 1;
+            if (!vm->T)
+                return 0;
+            v = vm->T;
+        }
+        else if (jl_is_datatype(v)) {
+            if (!((jl_datatype_t*)v)->hasfreetypevars)
+                return 0; // nodes always contain a free typevar
+            size_t i, np = jl_nparams(v);
+            for (i = 0; i < np; i++) {
+                if (jl_has_typearith(jl_tparam(v, i)))
+                    return 1;
+            }
+            return 0;
+        }
+        else {
+            return 0;
+        }
+    }
+}
+
 static void find_free_typevars(jl_value_t *v, jl_typeenv_t *env, jl_array_t *out) JL_CANSAFEPOINT
 {
     while (1) {
@@ -210,6 +267,12 @@ static void find_free_typevars(jl_value_t *v, jl_typeenv_t *env, jl_array_t *out
         if (jl_is_typeapp(v)) {
             jl_array_ptr_1d_push(out, v);
             return;
+        }
+        if (jl_is_typearith(v)) {
+            jl_typearith_t *ta = (jl_typearith_t*)v;
+            find_free_typevars(ta->a, env, out);
+            v = ta->b;
+            continue;
         }
         while (jl_is_unionall(v)) {
             jl_unionall_t *ua = (jl_unionall_t*)v;
@@ -279,6 +342,13 @@ int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
             v = ta->param;
             continue;
         }
+        if (jl_is_typearith(v)) {
+            jl_typearith_t *ta = (jl_typearith_t*)v;
+            if (jl_has_bound_typevars(ta->a, env))
+                return 1;
+            v = ta->b;
+            continue;
+        }
         while (jl_is_unionall(v)) {
             jl_unionall_t *ua = (jl_unionall_t*)v;
             if (ua->var->lb != jl_bottom_type && jl_has_bound_typevars(ua->var->lb, env))
@@ -299,7 +369,7 @@ int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
         }
         // After unwrapping UnionAll, body might be TypeApp or TypeVar;
         // restart the loop so those checks at the top fire.
-        if (jl_is_typeapp(v) || jl_is_typevar(v))
+        if (jl_is_typeapp(v) || jl_is_typearith(v) || jl_is_typevar(v))
             continue;
         if (jl_is_datatype(v)) {
             if (!((jl_datatype_t*)v)->hasfreetypevars)
@@ -1041,7 +1111,7 @@ JL_DLLEXPORT jl_value_t *jl_type_unionall(jl_tvar_t *v, jl_value_t *body)
         }
         else {
             assert(N_has_tv);
-            assert(vm->N == (jl_value_t*)v);
+            assert(vm->N == (jl_value_t*)v || jl_is_typearith(vm->N));
             return (jl_value_t*)jl_wrap_vararg(vm->T, NULL, 1, 0);
         }
     }
@@ -1961,6 +2031,13 @@ static unsigned type_hash(jl_value_t *kj, int *failed) JL_NOTSAFEPOINT
     }
     else if (jl_is_typeegal(uw)) {
         return typeegal_hash(jl_typeegal_T(uw), failed);
+    }
+    else if (jl_is_typearith(uw)) {
+        // Match the alpha-insensitive TypeVar hashing above.
+        jl_typearith_t *ta = (jl_typearith_t*)uw;
+        unsigned hash = bitmix(type_hash(ta->a, failed), type_hash(ta->b, failed));
+        hash = bitmix((unsigned)(0x7ea0 + ta->op), hash);
+        return hash ? hash : 1;
     }
     else {
         return jl_object_id(uw);
@@ -3013,11 +3090,102 @@ static jl_value_t *inst_tuple_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_
 // return `NULL` instead of immediately throwing an error. If `nothrow` == 2 then
 // we further assume that the imprecise instantiation for non invariant parameters
 // is acceptable, and inner error (`NULL`) would be ignored.
+// Fold or rebuild a TypeArith after substituting its operands.
+static jl_value_t *fold_typearith(jl_typearith_t *ta, jl_value_t *a, jl_value_t *b, int nothrow) JL_CANSAFEPOINT
+{
+    int afree = jl_is_typevar(a) || jl_is_typearith(a);
+    int bfree = jl_is_typevar(b) || jl_is_typearith(b);
+    if (afree || bfree) {
+        if (a == ta->a && b == ta->b)
+            return (jl_value_t*)ta;
+        if ((!afree && !jl_is_long(a)) || (!bfree && !jl_is_long(b))) {
+            if (nothrow)
+                return NULL;
+            jl_type_error_rt("TypeArith", "operand", (jl_value_t*)jl_long_type,
+                             (!afree && !jl_is_long(a)) ? a : b);
+        }
+        jl_value_t *op = jl_box_long(ta->op);
+        JL_GC_PUSH1(&op);
+        jl_value_t *r = jl_new_struct(jl_typearith_type, op, a, b);
+        JL_GC_POP();
+        return r;
+    }
+    if (!jl_is_long(a) || !jl_is_long(b)) {
+        if (nothrow)
+            return NULL;
+        jl_type_error_rt("TypeArith", "operand", (jl_value_t*)jl_long_type, jl_is_long(a) ? b : a);
+    }
+    ssize_t x = jl_unbox_long(a);
+    ssize_t y = jl_unbox_long(b);
+    ssize_t r = 0;
+    if (!jl_typearith_eval(ta->op, x, y, &r)) {
+        if (nothrow)
+            return NULL;
+        jl_errorf("arithmetic error in type parameter expression (%zd, %zd)", (ssize_t)x, (ssize_t)y);
+    }
+    return jl_box_long(r);
+}
+
+// Return 0 on arithmetic error or an unknown operation.
+int jl_typearith_eval(ssize_t op, ssize_t x, ssize_t y, ssize_t *r) JL_NOTSAFEPOINT
+{
+    switch (op) {
+    case JL_TYPEARITH_ADD: return !__builtin_add_overflow(x, y, r);
+    case JL_TYPEARITH_SUB: return !__builtin_sub_overflow(x, y, r);
+    case JL_TYPEARITH_MUL: return !__builtin_mul_overflow(x, y, r);
+    case JL_TYPEARITH_DIV:
+        if (y == 0)
+            return 0;
+        if (y == -1) // x ÷ -1 == -x; overflow-checked (typemin ÷ -1)
+            return !__builtin_sub_overflow((ssize_t)0, x, r);
+        *r = x / y;
+        return 1;
+    case JL_TYPEARITH_MIN: *r = x < y ? x : y; return 1;
+    case JL_TYPEARITH_MAX: *r = x < y ? y : x; return 1;
+    case JL_TYPEARITH_POW: {
+        if (y < 0)
+            return 0;
+        ssize_t acc = 1;
+        while (y > 0) {
+            if (y & 1) {
+                if (__builtin_mul_overflow(acc, x, &acc))
+                    return 0;
+            }
+            y >>= 1;
+            if (y && __builtin_mul_overflow(x, x, &x))
+                return 0;
+        }
+        *r = acc;
+        return 1;
+    }
+    }
+    return 0;
+}
+
 static jl_value_t *inst_type_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_t *stack, int check, int nothrow, jl_deferred_typecache_t *dcache)
 {
     size_t i;
     if (jl_is_typeapp(t))
         return t;
+    if (jl_is_typearith(t)) {
+        jl_typearith_t *ta = (jl_typearith_t*)t;
+        jl_value_t *a = NULL;
+        jl_value_t *b = NULL;
+        JL_GC_PUSH2(&a, &b);
+        // Invariant operands cannot use imprecise instantiation.
+        a = inst_type_w_(ta->a, env, stack, check, nothrow ? 1 : 0, dcache);
+        if (a != NULL)
+            b = inst_type_w_(ta->b, env, stack, check, nothrow ? 1 : 0, dcache);
+        if (a == NULL || b == NULL) {
+            assert(nothrow);
+            t = NULL;
+        }
+        else {
+            t = fold_typearith(ta, a, b, nothrow);
+        }
+        JL_GC_POP();
+        return t;
+    }
     if (jl_is_typevar(t)) {
         jl_typeenv_t *e = env;
         while (e != NULL) {
@@ -3294,7 +3462,8 @@ jl_vararg_t *jl_wrap_vararg(jl_value_t *t, jl_value_t *n, int check, int nothrow
     JL_GC_PUSH1(&t);
     if (check) {
         if (n) {
-            if (jl_is_typevar(n) || jl_is_uniontype(jl_unwrap_unionall(n))) {
+            if (jl_is_typevar(n) || (jl_is_typearith(n) && jl_has_free_typevars(n)) ||
+                jl_is_uniontype(jl_unwrap_unionall(n))) {
                 // TODO: this is disabled due to #39698; it is also inconsistent
                 // with other similar checks, where we usually only check substituted
                 // values and not the bounds of variables.
@@ -4597,6 +4766,7 @@ void post_boot_hooks(void)
 
     // Initialize TypeApp type reference for mutually recursive types
     jl_typeapp_type = (jl_datatype_t*)core("TypeApp");
+    jl_typearith_type = (jl_datatype_t*)core("TypeArith");
 
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");
     jl_vecelement_typename = ((jl_datatype_t*)jl_unwrap_unionall(core("VecElement")))->name;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1348,6 +1348,30 @@ STATIC_INLINE int jl_is_typeapp(jl_value_t *v) JL_NOTSAFEPOINT
 {
     return jl_typeapp_type != NULL && jl_typeis(v, jl_typeapp_type);
 }
+// Deferred integer arithmetic on type parameters.
+typedef struct {
+    JL_DATA_TYPE
+    ssize_t op;          // inline Int field; see jl_typearith_op
+    jl_value_t *a;       // Int, TypeVar, or nested TypeArith
+    jl_value_t *b;
+} jl_typearith_t;
+
+enum jl_typearith_op {
+    JL_TYPEARITH_ADD = 1,
+    JL_TYPEARITH_SUB = 2,
+    JL_TYPEARITH_MUL = 3,
+    JL_TYPEARITH_DIV = 4,
+    JL_TYPEARITH_MIN = 5,
+    JL_TYPEARITH_MAX = 6,
+    JL_TYPEARITH_POW = 7,
+};
+
+STATIC_INLINE int jl_is_typearith(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    return jl_typearith_type != NULL && jl_typeis(v, jl_typearith_type);
+}
+int jl_has_typearith(jl_value_t *v) JL_NOTSAFEPOINT;
+int jl_typearith_eval(ssize_t op, ssize_t x, ssize_t y, ssize_t *r) JL_NOTSAFEPOINT;
 void jl_init_tasks(void) JL_GC_DISABLED JL_NOTSAFEPOINT;
 void jl_init_stack_limits(int ismaster, void **stack_hi, void **stack_lo) JL_NOTSAFEPOINT;
 jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi) JL_CANSAFEPOINT;

--- a/src/method.c
+++ b/src/method.c
@@ -1268,6 +1268,155 @@ JL_DLLEXPORT jl_methcache_t *jl_method_get_cache(jl_method_t *method JL_PROPAGAT
     return jl_method_get_table(method)->cache;
 }
 
+// A TypeArith operand must be bound by an earlier invariant position in the
+// signature. Subtyping does not solve these expressions.
+
+static int ptrarray_contains(jl_array_t *a, jl_value_t *v) JL_NOTSAFEPOINT
+{
+    for (size_t i = 0; i < jl_array_nrows(a); i++)
+        if (jl_array_ptr_ref(a, i) == v)
+            return 1;
+    return 0;
+}
+
+static void typearith_check_operands(jl_typearith_t *ta, jl_array_t *bound,
+                                     jl_sym_t *name, jl_sym_t *file, int32_t line)
+{
+    jl_value_t *ops[2] = {ta->a, ta->b};
+    for (int i = 0; i < 2; i++) {
+        if (jl_is_typevar(ops[i])) {
+            if (!ptrarray_contains(bound, ops[i])) {
+                jl_exceptionf(jl_argumenterror_type,
+                              "method definition for %s at %s:%d: static parameter %s is used in a "
+                              "computed type parameter expression before any position that "
+                              "determines its value (computed expressions are checked in match "
+                              "order, left to right, and never solved)",
+                              jl_symbol_name(name),
+                              jl_symbol_name(file),
+                              line,
+                              jl_symbol_name(((jl_tvar_t*)ops[i])->name));
+            }
+        }
+        else if (jl_is_typearith(ops[i])) {
+            typearith_check_operands((jl_typearith_t*)ops[i], bound, name, file, line);
+        }
+    }
+}
+
+static void typearith_check_walk(jl_value_t *t, int invariant, jl_array_t *bound,
+                                 jl_sym_t *name, jl_sym_t *file, int32_t line) JL_CANSAFEPOINT
+{
+    if (jl_is_typevar(t)) {
+        if (invariant && !ptrarray_contains(bound, t))
+            jl_array_ptr_1d_push(bound, t);
+        return;
+    }
+    if (jl_is_typearith(t)) {
+        typearith_check_operands((jl_typearith_t*)t, bound, name, file, line);
+        return;
+    }
+    if (jl_is_unionall(t)) {
+        jl_unionall_t *ua = (jl_unionall_t*)t;
+        if (jl_has_typearith(ua->var->lb) || jl_has_typearith(ua->var->ub)) {
+            jl_exceptionf(jl_argumenterror_type,
+                          "method definition for %s at %s:%d: computed type parameter expressions "
+                          "are not supported in bounds of type variable %s",
+                          jl_symbol_name(name), jl_symbol_name(file), line,
+                          jl_symbol_name(ua->var->name));
+        }
+        // A variable bound by this UnionAll is local to its body.
+        int had = ptrarray_contains(bound, (jl_value_t*)ua->var);
+        typearith_check_walk(ua->body, invariant, bound, name, file, line);
+        if (!had) {
+            for (size_t i = jl_array_nrows(bound); i > 0; i--) {
+                if (jl_array_ptr_ref(bound, i - 1) == (jl_value_t*)ua->var) {
+                    size_t last = jl_array_nrows(bound) - 1;
+                    jl_array_ptr_set(bound, i - 1, jl_array_ptr_ref(bound, last));
+                    jl_array_del_end(bound, 1);
+                    break;
+                }
+            }
+        }
+        return;
+    }
+    if (jl_is_uniontype(t)) {
+        // Sharing bindings between arms can only admit methods that never match.
+        typearith_check_walk(((jl_uniontype_t*)t)->a, invariant, bound, name, file, line);
+        typearith_check_walk(((jl_uniontype_t*)t)->b, invariant, bound, name, file, line);
+        return;
+    }
+    if (jl_is_typeeq(t) || jl_is_typeegal(t)) {
+        typearith_check_walk(((jl_typeeq_t*)t)->T, 1, bound, name, file, line);
+        return;
+    }
+    if (jl_is_vararg(t)) {
+        jl_vararg_t *vm = (jl_vararg_t*)t;
+        // The element type is matched before the length.
+        if (vm->T)
+            typearith_check_walk(vm->T, invariant, bound, name, file, line);
+        if (vm->N) {
+            if (jl_is_typevar(vm->N)) {
+                if (!ptrarray_contains(bound, vm->N))
+                    jl_array_ptr_1d_push(bound, vm->N); // Vararg counts bind exactly
+            }
+            else if (jl_is_typearith(vm->N)) {
+                typearith_check_operands((jl_typearith_t*)vm->N, bound, name, file, line);
+            }
+        }
+        return;
+    }
+    if (jl_is_datatype(t)) {
+        jl_datatype_t *dt = (jl_datatype_t*)t;
+        if (!dt->hasfreetypevars)
+            return;
+        int istuple = (dt->name == jl_tuple_typename);
+        for (size_t i = 0; i < jl_nparams(dt); i++)
+            typearith_check_walk(jl_tparam(dt, i), istuple ? invariant : 1, bound, name, file, line);
+    }
+}
+
+// Used by default constructors to skip invalid outer signatures.
+JL_DLLEXPORT int jl_typearith_signature_valid(jl_svec_t *atypes) JL_CANSAFEPOINT
+{
+    int ok = 1;
+    jl_array_t *bound = NULL;
+    JL_GC_PUSH1(&bound);
+    JL_TRY {
+        bound = jl_alloc_vec_any(0);
+        size_t na = jl_svec_len(atypes);
+        for (size_t i = 0; i < na; i++)
+            typearith_check_walk(jl_svecref(atypes, i), 0, bound, jl_empty_sym, jl_empty_sym, 0);
+    }
+    JL_CATCH {
+        ok = 0;
+    }
+    JL_GC_POP();
+    return ok;
+}
+
+static void check_typearith_signature(jl_svec_t *atypes, jl_svec_t *tvars,
+                                      jl_sym_t *name, jl_sym_t *file, int32_t line) JL_CANSAFEPOINT
+{
+    for (size_t i = 0; i < jl_svec_len(tvars); i++) {
+        jl_value_t *tv = jl_svecref(tvars, i);
+        if (jl_is_typevar(tv) &&
+            (jl_has_typearith(((jl_tvar_t*)tv)->lb) || jl_has_typearith(((jl_tvar_t*)tv)->ub))) {
+            jl_exceptionf(jl_argumenterror_type,
+                          "method definition for %s at %s:%d: computed type parameter expressions "
+                          "are not supported in bounds of type variable %s",
+                          jl_symbol_name(name), jl_symbol_name(file), line,
+                          jl_symbol_name(((jl_tvar_t*)tv)->name));
+        }
+    }
+    jl_array_t *bound = NULL;
+    JL_GC_PUSH1(&bound);
+    bound = jl_alloc_vec_any(0);
+    size_t na = jl_svec_len(atypes);
+    for (size_t i = 0; i < na; i++)
+        typearith_check_walk(jl_svecref(atypes, i), 0, bound, name, file, line);
+    JL_GC_POP();
+}
+
 JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
                                         jl_methtable_t *mt,
                                         jl_code_info_t *f,
@@ -1367,6 +1516,8 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
                       jl_symbol_name(file),
                       line);
     }
+    if (jl_has_typearith(argtype))
+        check_typearith_signature(atypes, tvars, name, file, line);
     ft = jl_rewrap_unionall(ft, argtype);
     if (!external_mt && !jl_has_empty_intersection(ft, (jl_value_t*)jl_builtin_type)) // disallow adding methods to Any, Function, Builtin, and subtypes, or Unions of those
         jl_errorf("cannot add methods to builtin function `%s`", jl_symbol_name(name));

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1065,6 +1065,25 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
             n += jl_printf(out, "}");
         }
     }
+    else if (vt == jl_typearith_type) {
+        jl_typearith_t *ta = (jl_typearith_t*)v;
+        static const char *opnames[] = {"?", "+", "-", "*", "\xc3\xb7" /* ÷ */, "min", "max", "^"};
+        ssize_t op = (ta->op >= 1 && ta->op <= 7) ? ta->op : 0;
+        if (op >= 5) { // min/max as calls
+            n += jl_printf(out, "%s(", opnames[op]);
+            n += jl_static_show_x(out, ta->a, depth, ctx);
+            n += jl_printf(out, ", ");
+            n += jl_static_show_x(out, ta->b, depth, ctx);
+            n += jl_printf(out, ")");
+        }
+        else {
+            n += jl_printf(out, "(");
+            n += jl_static_show_x(out, ta->a, depth, ctx);
+            n += jl_printf(out, " %s ", opnames[op]);
+            n += jl_static_show_x(out, ta->b, depth, ctx);
+            n += jl_printf(out, ")");
+        }
+    }
     else if (vt == jl_datatype_type) {
         // typeof(v) == DataType, so v is a Type object.
         // Types are printed as a fully qualified name, with parameters, e.g.

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -49,6 +49,11 @@ int must_be_new_dt(jl_value_t *t, htable_t *news, char *image_base, size_t sizeo
         if (tv->N && must_be_new_dt(tv->N, news, image_base, sizeof_sysimg))
             return 1;
     }
+    else if (jl_is_typearith(t)) {
+        jl_typearith_t *ta = (jl_typearith_t*)t;
+        return must_be_new_dt(ta->a, news, image_base, sizeof_sysimg) ||
+               must_be_new_dt(ta->b, news, image_base, sizeof_sysimg);
+    }
     else if (jl_is_datatype(t)) {
         jl_datatype_t *dt = (jl_datatype_t*)t;
         assert(jl_astaggedvalue(dt->name)->bits.in_image && "type_in_worklist mistake?");
@@ -259,6 +264,11 @@ static int type_in_worklist(jl_value_t *v, jl_query_cache *cache) JL_NOTSAFEPOIN
         jl_vararg_t *tv = (jl_vararg_t*)v;
         result = ((tv->T && type_in_worklist(tv->T, cache)) ||
                   (tv->N && type_in_worklist(tv->N, cache)));
+    }
+    else if (jl_is_typearith(v)) {
+        jl_typearith_t *ta = (jl_typearith_t*)v;
+        result = type_in_worklist(ta->a, cache) ||
+                 type_in_worklist(ta->b, cache);
     }
     else if (jl_is_datatype(v)) {
         jl_datatype_t *dt = (jl_datatype_t*)v;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -788,6 +788,8 @@ int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity) JL_NOTSAFE
             jl_value_t *bi = jl_tparam(bd, i);
             if (jl_is_typevar(ai) || jl_is_typevar(bi))
                 continue; // it's possible that Union{} is in this intersection
+            if (jl_is_typearith(ai) || jl_is_typearith(bi))
+                continue; // checked after operand substitution
             if (jl_is_type(ai)) {
                 if (jl_is_type(bi)) {
                     if (istuple && (ai == jl_bottom_type || bi == jl_bottom_type))
@@ -1921,6 +1923,36 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
 }
 
 // check n <: (length of vararg type v)
+// Fold a TypeArith when all of its operands are fixed in e.
+static jl_value_t *fold_typearith_stenv(jl_value_t *v, jl_stenv_t *e) JL_CANSAFEPOINT
+{
+    if (jl_is_long(v))
+        return v;
+    if (jl_is_typevar(v)) {
+        jl_varbinding_t *vb = lookup(e, (jl_tvar_t*)v);
+        if (vb && vb->lb == vb->ub && jl_is_long(vb->lb))
+            return vb->lb;
+        return NULL;
+    }
+    if (jl_is_typearith(v)) {
+        jl_typearith_t *ta = (jl_typearith_t*)v;
+        jl_value_t *a = fold_typearith_stenv(ta->a, e);
+        if (a == NULL)
+            return NULL;
+        JL_GC_PUSH1(&a);
+        jl_value_t *b = fold_typearith_stenv(ta->b, e);
+        jl_value_t *r = NULL;
+        if (b != NULL) {
+            ssize_t res;
+            if (jl_typearith_eval(ta->op, jl_unbox_long(a), jl_unbox_long(b), &res))
+                r = jl_box_long(res);
+        }
+        JL_GC_POP();
+        return r;
+    }
+    return NULL;
+}
+
 static int check_vararg_length(jl_value_t *v, ssize_t n, jl_stenv_t *e) JL_CANSAFEPOINT
 {
     jl_value_t *N = jl_unwrap_vararg_num(v);
@@ -2797,6 +2829,36 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
         jl_intersecttype_t *iy = (jl_intersecttype_t*)y;
         return subtype(x, iy->a, e, param) && subtype(x, iy->b, e, param);
     }
+    if (jl_is_typearith(x) || jl_is_typearith(y)) {
+        // Fold fixed operands; otherwise compare the expression structurally.
+        jl_value_t *xf = jl_is_typearith(x) ? fold_typearith_stenv(x, e) : x;
+        jl_value_t *yf = NULL;
+        int ans;
+        JL_GC_PUSH2(&xf, &yf);
+        yf = jl_is_typearith(y) ? fold_typearith_stenv(y, e) : y;
+        if (xf == NULL || yf == NULL) {
+            if (e->Loffset == 0 && jl_is_typearith(x) && jl_is_typearith(y) &&
+                ((jl_typearith_t*)x)->op == ((jl_typearith_t*)y)->op) {
+                // Compare bound variables modulo alpha-renaming.
+                jl_typearith_t *tx = (jl_typearith_t*)x, *ty = (jl_typearith_t*)y;
+                e->invdepth++;
+                ans = forall_exists_equal(tx->a, ty->a, e) &&
+                      forall_exists_equal(tx->b, ty->b, e);
+                e->invdepth--;
+            }
+            else {
+                ans = e->Loffset == 0 && jl_egal(x, y);
+            }
+            if (!ans && e->intersection) {
+                // Failure to prove equality is not enough to prove disjointness.
+                ans = 1;
+            }
+        }
+        else
+            ans = subtype(xf, yf, e, param);
+        JL_GC_POP();
+        return ans;
+    }
     if (jl_is_typevar(x)) {
         if (jl_is_typevar(y)) {
             if (x == y) return 1;
@@ -3503,6 +3565,9 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
         return 0;
     }
     if (jl_is_intersecttype(x))
+        return 0;
+    if (jl_is_typearith(x) || jl_is_typearith(y))
+        // TypeArith needs an environment to fold its operands.
         return 0;
     if (!jl_is_type(x) || !jl_is_type(y)) {
         *subtype = jl_egal(x, y);
@@ -5186,7 +5251,27 @@ static int intersect_vararg_length(jl_value_t *v, ssize_t n, jl_stenv_t *e, int8
     return 1;
 }
 
+static jl_value_t *intersect_varargs_(jl_vararg_t *vmx, jl_vararg_t *vmy, ssize_t offset, jl_stenv_t *e, jl_param_pos_t param) JL_CANSAFEPOINT;
+
 static jl_value_t *intersect_varargs(jl_vararg_t *vmx, jl_vararg_t *vmy, ssize_t offset, jl_stenv_t *e, jl_param_pos_t param) JL_CANSAFEPOINT
+{
+    // Fold computed lengths, or drop the length if it remains unknown.
+    jl_value_t *xp2 = jl_unwrap_vararg_num(vmx), *yp2 = jl_unwrap_vararg_num(vmy);
+    if ((xp2 && jl_is_typearith(xp2)) || (yp2 && jl_is_typearith(yp2))) {
+        jl_value_t **roots;
+        JL_GC_PUSHARGS(roots, 4);
+        roots[0] = (xp2 && jl_is_typearith(xp2)) ? fold_typearith_stenv(xp2, e) : xp2;
+        roots[1] = (yp2 && jl_is_typearith(yp2)) ? fold_typearith_stenv(yp2, e) : yp2;
+        roots[2] = (jl_value_t*)jl_wrap_vararg(jl_unwrap_vararg(vmx), roots[0], 1, 0);
+        roots[3] = (jl_value_t*)jl_wrap_vararg(jl_unwrap_vararg(vmy), roots[1], 1, 0);
+        jl_value_t *ii = intersect_varargs_((jl_vararg_t*)roots[2], (jl_vararg_t*)roots[3], offset, e, param);
+        JL_GC_POP();
+        return ii;
+    }
+    return intersect_varargs_(vmx, vmy, offset, e, param);
+}
+
+static jl_value_t *intersect_varargs_(jl_vararg_t *vmx, jl_vararg_t *vmy, ssize_t offset, jl_stenv_t *e, jl_param_pos_t param)
 {
     // Vararg: covariant in first parameter, invariant in second
     jl_value_t *xp1=jl_unwrap_vararg(vmx), *xp2=jl_unwrap_vararg_num(vmx),
@@ -5663,6 +5748,51 @@ static int has_typevar_via_env(jl_value_t *x, jl_tvar_t *t, jl_stenv_t *e)
 static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t param)
 {
     if (x == y) return y;
+    if (jl_is_typearith(x) || jl_is_typearith(y)) {
+        // Fold fixed operands before intersecting TypeArith nodes.
+        jl_value_t *xf = jl_is_typearith(x) ? fold_typearith_stenv(x, e) : x;
+        jl_value_t *yf = NULL;
+        jl_value_t *ii;
+        JL_GC_PUSH2(&xf, &yf);
+        yf = jl_is_typearith(y) ? fold_typearith_stenv(y, e) : y;
+        if (xf == NULL || yf == NULL) {
+            if (e->Loffset == 0 && jl_egal(x, y)) {
+                ii = x;
+            }
+            else if (e->Loffset == 0 && jl_is_typearith(x) && jl_is_typearith(y) &&
+                     ((jl_typearith_t*)x)->op == ((jl_typearith_t*)y)->op) {
+                // Match bound variables modulo alpha-renaming.
+                jl_typearith_t *tx = (jl_typearith_t*)x, *ty = (jl_typearith_t*)y;
+                jl_value_t *ia = intersect_invariant(tx->a, ty->a, e);
+                xf = ia; // reuse root
+                jl_value_t *ib = (ia == NULL || ia == jl_bottom_type) ? NULL :
+                    intersect_invariant(tx->b, ty->b, e);
+                yf = ib; // reuse root
+                if (ia == NULL || ib == NULL || ia == jl_bottom_type || ib == jl_bottom_type)
+                    // Different operands can still evaluate to the same value.
+                    ii = x;
+                else if (ia == tx->a && ib == tx->b)
+                    ii = x;
+                else if (!(jl_is_long(ia) || jl_is_typevar(ia) || jl_is_typearith(ia)) ||
+                         !(jl_is_long(ib) || jl_is_typevar(ib) || jl_is_typearith(ib)))
+                    ii = x; // the intersection cannot be represented as TypeArith
+                else {
+                    jl_value_t *op = jl_box_long(tx->op);
+                    JL_GC_PUSH1(&op);
+                    ii = jl_new_struct(jl_typearith_type, op, ia, ib);
+                    JL_GC_POP();
+                }
+            }
+            else {
+                // Keep whichever side could be folded.
+                ii = (yf != NULL) ? yf : (xf != NULL ? xf : x);
+            }
+        }
+        else
+            ii = intersect(xf, yf, e, param);
+        JL_GC_POP();
+        return ii;
+    }
     if (jl_is_typevar(x)) {
         if (jl_is_typevar(y)) {
             int xinner = 0, yinner = 0;
@@ -6135,8 +6265,9 @@ static jl_value_t *intersect_types(jl_value_t *x, jl_value_t *y, int emptiness_o
             return x;
         else if (jl_subtype(y, x))
             return y;
-        else
+        else if (!jl_has_typearith(x) && !jl_has_typearith(y))
             return jl_bottom_type;
+        // TypeArith needs the full intersection algorithm below.
     }
     init_stenv(&e, NULL, 0);
     e.intersection = 1;
@@ -6260,8 +6391,12 @@ static int might_intersect_concrete(jl_value_t *a) JL_NOTSAFEPOINT
     if (jl_is_uniontype(a))
         return might_intersect_concrete(((jl_uniontype_t*)a)->a) ||
                might_intersect_concrete(((jl_uniontype_t*)a)->b);
-    if (jl_is_vararg(a))
+    if (jl_is_vararg(a)) {
+        jl_value_t *N = jl_unwrap_vararg_num((jl_vararg_t*)a);
+        if (N && jl_is_typearith(N))
+            return 1; // the count cannot be checked without its environment
         return might_intersect_concrete(jl_unwrap_vararg(a));
+    }
     if (jl_is_some_Type(a))
         return 1;
     if (jl_is_datatype(a)) {
@@ -6269,7 +6404,7 @@ static int might_intersect_concrete(jl_value_t *a) JL_NOTSAFEPOINT
         int i, n = jl_nparams(a);
         for (i = 0; i < n; i++) {
             jl_value_t *p = jl_tparam(a, i);
-            if (jl_is_typevar(p))
+            if (jl_is_typevar(p) || jl_is_typearith(p))
                 return 1;
             if (tpl && p == jl_bottom_type)
                 return 1;
@@ -6317,7 +6452,8 @@ jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t *
         // A dispatch tuple is a concrete leaf type, so its intersection with any other
         // type is just itself (when it is a subtype) or empty. The subtype checks above
         // having failed, the intersection must be empty.
-        if (jl_is_dispatch_tupletype(a) || jl_is_dispatch_tupletype(b))
+        if ((jl_is_dispatch_tupletype(a) || jl_is_dispatch_tupletype(b)) &&
+            !jl_has_typearith(a) && !jl_has_typearith(b))
             goto bot;
         jl_stenv_t e;
         init_stenv(&e, NULL, 0);


### PR DESCRIPTION
This is a proof of concept for allowing a limited set of arithmetic operations on type vars (ref https://github.com/JuliaLang/julia/issues/8472, https://github.com/JuliaLang/julia/issues/49187). 

As a concrete example, the Tensors.jl docs have this note (https://ferrite-fem.github.io/Tensors.jl/stable/man/storing_tensors/#Storing-tensors)

> Even though a user mostly deals with the `Tensor{order, dim, T}` parameters, the full parameter list for a tensor is actually `Tensor{order, dim, T, N}` where N is the number of independent elements in the tensor. 

 saying how you need to keep this extra type parameter around for concreteness if you want to store the type in another struct. With this PR it is no longer needed. The commit https://github.com/Ferrite-FEM/Tensors.jl/commit/34ef7aefd332595ec949f5354a09e608b312f053 ports the package to using arithmetic on type parameters to avoid the last type parameter only indicating the length of the tuple:

```diff
+ struct Tensor{order, dim, T} <: AbstractTensor{order, dim, T}
+     data::NTuple{dim^order, T}
- struct Tensor{order, dim, T, M} <: AbstractTensor{order, dim, T}
-     data::NTuple{M, T}
```

```diff
+ struct SymmetricTensor{order, dim, T} <: AbstractTensor{order, dim, T}
+     data::NTuple{div(dim*(dim+1),2)^div(order,2), T}

-struct SymmetricTensor{order, dim, T, M} <: AbstractTensor{order, dim, T}
-    data::NTuple{M, T}
```

For some minimal examples see:

```julia
julia> struct StaticMatrix{R,C,T}
           data::NTuple{R*C,T}
       end

julia> fieldtype(StaticMatrix{2,3,Float64}, 1)
NTuple{6, Float64}

julia> isbitstype(StaticMatrix{2,3,Float64}), sizeof(StaticMatrix{2,3,Float64})
(true, 48)

julia> Base.infer_return_type(m -> m.data, (StaticMatrix{2,3,Float64},))
NTuple{6, Float64}
```

```julia
julia> struct SymmetricTensor{order,dim,T}
           data::NTuple{div(dim*(dim+1),2)^div(order,2), T}
       end

julia> fieldtype(SymmetricTensor, 1)
NTuple{((dim * (dim + 1)) ÷ 2) ^ (order ÷ 2), T} where {order, dim, T}

julia> fieldtype(SymmetricTensor{4,3,Float64}, 1)   # (3·4/2)² for order 4
NTuple{36, Float64}

julia> fieldtype(StaticMatrix{2}, 1)                # partial application folds partially
NTuple{2 * C, T} where {C, T}
```

```julia
julia> f(m::StaticMatrix{R,C,T}, v::NTuple{R*C,T}) where {R,C,T} = (R, C)

julia> f(StaticMatrix{2,3,Float64}((1,2,3,4,5,6)), (1.,2.,3.,4.,5.,6.))
(2, 3)

julia> f(StaticMatrix{2,3,Float64}((1,2,3,4,5,6)), (1.,2.,3.))
ERROR: MethodError: no method matching f(::StaticMatrix{2, 3, Float64}, ::Tuple{Float64, Float64, Float64})
Closest candidates are:
  f(::StaticMatrix{R, C, T}, ::NTuple{R * C, T}) where {R, C, T}

julia> (::Type{StaticMatrix{R,C,T}})(v::Vector{T}) where {R,C,T} =
           StaticMatrix{R,C,T}(NTuple{R*C,T}(v))

julia> StaticMatrix{2,2,Float64}([1.0, 2.0, 3.0, 4.0])
StaticMatrix{2, 2, Float64}((1.0, 2.0, 3.0, 4.0))

julia> next_prefix(v::NTuple{N,Int}, w::NTuple{N+1,Int}) where {N} = N;

julia> next_prefix((1,2), (3,4,5))
2
```


*Limitations*

```julia
julia> struct Child{N} <: Abs{N+1} end
ERROR: invalid subtyping in definition of Child: computed type parameter expressions
(e.g. `N+1`) are only supported in field types, not supertype declarations

julia> struct Neg{N}; data::NTuple{N-1,Int}; end;   # fine to define...

julia> fieldtype(Neg{0}, 1)                          # ...bad arithmetic degrades
Union{}

julia> Neg{0}((1,))                                  # ...and errors at construction
ERROR: ArgumentError: cannot convert a value to Union{} for assignment

julia> g(::Val{N}, ::Val{N+N}) where N = :sum;

julia> g(::Val{N}, ::Val{2*N}) where N = :product;

julia> g(Val(3), Val(6))
ERROR: MethodError: g(::Val{3}, ::Val{6}) is ambiguous.
Candidates:
  g(::Val{N}, ::Val{2 * N}) where N
  g(::Val{N}, ::Val{N + N}) where N
```

---

This PR had AI help
