### PR TITLE
inlining: encode the lookup for optimizer-synthesized dispatch edges

### DIFF
--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -840,6 +840,11 @@ function add_inlining_dispatch_edge!(edges::Vector{Any}, mi::MethodInstance,
         add_invoke_edge!(edges, info.atype, mi)
     elseif info isa VirtualMethodMatchInfo
         add_inlining_dispatch_edge!(edges, mi, info.info)
+    elseif info isa MethodMatchInfo || info isa UnionSplitInfo
+        # A standalone `MethodInstance` edge claims `mi.specTypes` has a single
+        # fully-covering match, which is false when this call matched several methods.
+        # Encode the lookup instead; `mi_edge` keeps the invalidation target.
+        _add_edges_impl(edges, info, #=mi_edge=#true)
     else
         add_one_edge!(edges, mi)
     end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1195,6 +1195,38 @@ precompile_test_harness("precompiletools") do dir
     end
 end
 
+precompile_test_harness("dispatch edge") do dir
+    KindDispatch = :KindDispatch_0x5e0bd2a4c1f7
+    write(joinpath(dir, "$KindDispatch.jl"),
+        """
+        module $KindDispatch
+            # Inference through a kind (`Type{T}`) reaches calls that match several
+            # methods, and no cached source is available for them, so the optimizer has to
+            # synthesize the call target. The dispatch edge recorded for it must not claim
+            # that the target's signature has a single fully-covering match: nothing about
+            # dispatch changes between precompiling this and loading it, so `f` must stay
+            # valid.
+            f(v::Vector{Any}) = Base.aligned_sizeof(v[1]::Type{<:Real})
+            precompile(f, (Vector{Any},))
+        end
+        """
+    )
+    pkgid = Base.PkgId(string(KindDispatch))
+    Base.compilecache(pkgid)
+    @eval using $KindDispatch
+    M = invokelatest(getglobal, @__MODULE__, KindDispatch)
+    invokelatest() do
+        world = Base.get_world_counter()
+        mi = only(Base.specializations(only(methods(M.f))))
+        @test mi.specTypes === Tuple{typeof(M.f), Vector{Any}}
+        ci = mi.cache
+        while ci.max_world < world && isdefined(ci, :next)
+            ci = ci.next
+        end
+        @test ci.max_world == typemax(UInt)
+    end
+end
+
 precompile_test_harness("invoke") do dir
     InvokeModule = :Invoke0x030e7e97c2365aad
     CallerModule = :Caller0x030e7e97c2365aad


### PR DESCRIPTION
Claude:

---

Fixes a regression from #62359 where precompiled code is thrown away on load. Reported at #61667; that thread's 1.12 → 1.13 story is a different mechanism, this one is master-only.

`add_inlining_dispatch_edge!` records a standalone `MethodInstance` edge when the optimizer synthesizes a compileable specialization for a call. A standalone `MethodInstance` edge is verified in `Compiler/src/reinfer.jl` by re-running dispatch on `mi.specTypes` and requiring a single fully-covering match:

```julia
if edge isa MethodInstance
    sig = edge.specTypes
    min_valid2, max_valid2 = verify_call(sig, initial.callees, j, 1, world, true, matches)
```

so it is only well-formed when the call site's lookup had exactly one match. When the call matched several methods the edge asserts something that was already false when it was recorded, and it fails validation on load even though dispatch never changed.

Concretely, GMT's pkgimage holds this for `Base.DataTypeLayout(::Type{T} where T<:Tuple{Symbol, Any})`:

```
[group n=3] atype=Tuple{typeof(getproperty), Type{T} where T<:Tuple{Symbol, Any}, Symbol}
    CodeInstance for getproperty(::Type{T} where T<:Tuple{Symbol, Any}, ::Symbol)
    getproperty(x::TypeEq, s::Symbol)  @ Base deprecated.jl:632
    getproperty(x::Type, f::Symbol)    @ Base Base_compiler.jl:52
...
[standalone MethodInstance] getproperty(::Type{T} where T<:Tuple{Symbol, Any}, ::Symbol)
```

The group correctly lists all three matches and validates. The standalone edge claims a unique match, `Core.TypeEgal` being a kind means the deprecated `getproperty` methods intersect `Type{T}`, and it is rejected — taking the caller down with it. From there it cascades `DataTypeLayout` → `datatype_alignment` → `aligned_sizeof` → `unsafe_copyto!` → `_growend!`, re-inferring 2144 GMT code instances and 792 Base ones during `using GMT`.

This encodes the lookup instead, as `VirtualMethodMatchInfo` already does at `stmtinfo.jl:706`, keeping `mi_edge=true` so the `MethodInstance` stays an invalidation target.

First `plot(rand(5,2))` after `using GMT` (GMT v1.42.1, macOS aarch64, cold depot per build):

| build | elapsed | recompile_time | edge-validation events during `using GMT` |
|---|---|---|---|
| `ec06c23ce1` (#62359's base) | 0.005s | 0.0s | 2007 |
| master | 3.874s | 3.86s | 5939 |
| master + this change | 0.006s | 0.0s | 1303 |

The remaining events after the fix are the legitimate `SparseArrays.ReadOnly` `eachindex` invalidation already discussed in #61667.

Bisected over per-commit nightlies to `ec06c23ce1` (good) / `c6cd168cb9` (bad); since #62359's base commit is exactly the last good commit, `juliaup add pr62359` isolates it to that PR alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
