### PR TITLE
subtype: substitute resolved var values into inner envout entries

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1913,7 +1913,49 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
         }
         else
             e->envout[e->envidx] = val;
-        // TODO: substitute the value (if any) of this variable into previous envout entries
+        // Inner unionall frames pop (and fill their envout slots) before this
+        // one, so entries at later indices may still reference `u->var`, which
+        // is about to go out of scope. Substitute this variable's resolved
+        // value into those entries. If it has no single defined value, an
+        // entry mentioning it has no defined value either: degrade that entry
+        // to an unconstrained uncertainty marker, rewrapping the escaping var
+        // so no free typevar leaks into the environment (#57427).
+        jl_value_t *selfval = e->envout[e->envidx];
+        jl_value_t *substval = (selfval == NULL || jl_is_svec(selfval) ||
+                                jl_is_typevar(selfval) || jl_is_vararg(selfval))
+                               ? NULL : selfval;
+        jl_value_t *vi = NULL;
+        JL_GC_PUSH2(&substval, &vi);
+        // walk the top-level unionall chain alongside the envout slots to
+        // recover each slot's variable name (cosmetic, for the marker's tvar);
+        // fall back to `u->var->name` if the chain doesn't line up.
+        jl_value_t *body = u->body;
+        for (int i = e->envidx + 1; i < e->envsz; i++) {
+            jl_sym_t *vname = u->var->name;
+            if (body != NULL && jl_is_unionall(body)) {
+                vname = ((jl_unionall_t*)body)->var->name;
+                body = ((jl_unionall_t*)body)->body;
+            }
+            else {
+                body = NULL;
+            }
+            vi = e->envout[i];
+            if (vi == NULL || jl_is_svec(vi) || jl_is_vararg(vi) ||
+                !jl_has_typevar(vi, u->var))
+                continue;
+            if (substval != NULL) {
+                e->envout[i] = jl_substitute_var(vi, u->var, substval);
+            }
+            else if (jl_is_typevar(vi)) {
+                e->envout[i] = wrap_tvar_env(vi, 0);
+            }
+            else {
+                vi = jl_type_unionall(u->var, vi);
+                vi = (jl_value_t*)jl_new_typevar(vname, jl_bottom_type, vi);
+                e->envout[i] = wrap_tvar_env(vi, 0);
+            }
+        }
+        JL_GC_POP();
     }
 
     JL_GC_POP();

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -3526,3 +3526,27 @@ end
         end
     end
 end
+
+# issue #57427: an envout entry filled by an inner unionall frame may reference
+# an outer right-side var; when that outer frame resolves, its value must be
+# substituted into the already-filled entries rather than escaping the
+# environment as a free typevar (which downstream consumers treat as defined).
+struct S57427{N, Tup}
+    S57427{N, Tup}() where {N, Tuple{Vararg{Nothing, N}} <: Tup <: Tuple{Vararg{Nothing, N}}} = new{N, Tup}()
+end
+let sig = Tuple{Type{S57427{N, Tup}}} where {N, Tuple{Vararg{Nothing, N}} <: Tup <: Tuple{Vararg{Nothing, N}}}
+    @test Tuple{Type{S57427{0, Tuple{}}}} <: sig
+    let (t, e) = intersection_env(Tuple{Type{S57427{0, Tuple{}}}}, sig)
+        @test t == Tuple{Type{S57427{0, Tuple{}}}}
+        @test e == Core.svec(0, Tuple{})
+    end
+    @test S57427{0, Tuple{}}() isa S57427{0, Tuple{}}
+end
+# when the outer var stays unpinned, an entry mentioning it degrades to an
+# undefined (uncertainty-marker) binding instead of leaking the var
+let sig = Tuple{Type{Ref{Tup}}} where {N, Tup >: Tuple{Vararg{Nothing, N}}}
+    let (t, e) = intersection_env(Tuple{Type{Ref{Tuple{Vararg{Nothing}}}}}, sig)
+        @test t == Tuple{Type{Ref{Tuple{Vararg{Nothing}}}}}
+        @test all(v -> ccall(:jl_has_free_typevars, Cint, (Any,), v) == 0, e)
+    end
+end


### PR DESCRIPTION
Claude proposed this fix and explanation, not yet human reviewed. It does fix the symptom (and implements the code TODO comment), though we may need to make sure this is actually the right place and right way to fix this.

---

:robot:
When `jl_subtype_env` matches a signature such as `Tuple{Type{S{N, Tup}}} where {N, NTuple{N, Nothing} <: Tup <: NTuple{N, Nothing}}`, the inner unionall frame (`Tup`) pops and records its envout slot while the outer var `N` is still in scope, so the recorded value can reference `N`. Previously nothing revisited that slot when the outer frame later resolved `N = 0` (the long-standing TODO in `subtype_unionall`), so the environment escaped with a free typevar, e.g. `svec(0, Union{Tuple{}, NTuple{N, Nothing}})`. Since JuliaLang/julia#61645 removed the `fix_inferred_var_bound` safety net, such a value is no longer converted into an (undefined) `TypeVar` marker: it flows into `sparam_vals` looking like a defined static parameter, inference derives the non-concrete return type `S{0, Union{...}} where N`, and codegen compiles the `new` to a trap, crashing with "Unreachable reached" instead of the former `UndefVarError`.

Implement the TODO: when a right-side frame fills its envout slot, substitute its resolved value into the entries already filled by inner frames. This makes the example above dispatch correctly (`Tup` is pinned to `Tuple{}` by invariance, so the constructor now succeeds where it previously threw `UndefVarError`). If the outgoing var has no single defined value, an entry mentioning it cannot be defined either, so degrade it to an unconstrained uncertainty marker with the var rewrapped in a `UnionAll`, restoring the pre-`fix_inferred_var_bound`-removal semantics (a clean `UndefVarError`) for those cases.

Fixes #57427