### PR TITLE
Base: add `unsplat(f)`, the semantic inverse of `splat`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -139,7 +139,7 @@ New library functions
 
 * `tap(f)` creates a function that calls `f(x)` for side effects and returns `x` ([#61340]).
 * `unsplat(f)` creates a function that bundles its arguments into a tuple and passes them to `f`;
-  it is the inverse of `splat`.
+  it is the inverse of `splat` ([#62714]).
 * `Base.set_binding_visibility!` sets the declared visibility (`:none`, `:public`, or `:export`) of a name
   in a module, allowing an `export` or `public` declaration to be retracted programmatically ([#62131]).
 * `Base.generating_output()` has been made `public` (but not exported) to allow checking whether the current

--- a/NEWS.md
+++ b/NEWS.md
@@ -138,6 +138,8 @@ New library functions
 ---------------------
 
 * `tap(f)` creates a function that calls `f(x)` for side effects and returns `x` ([#61340]).
+* `unsplat(f)` creates a function that bundles its arguments into a tuple and passes them to `f`;
+  it is the inverse of `splat`.
 * `Base.set_binding_visibility!` sets the declared visibility (`:none`, `:public`, or `:export`) of a name
   in a module, allowing an `export` or `public` declaration to be retracted programmatically ([#62131]).
 * `Base.generating_output()` has been made `public` (but not exported) to allow checking whether the current

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -888,6 +888,7 @@ export
     ntuple,
     splat,
     tap,
+    unsplat,
 
 # I/O and events
     close,

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1367,6 +1367,34 @@ end
 show(io::IO, s::Splat) = (print(io, "splat("); show(io, s.f); print(io, ")"))
 
 """
+    unsplat(f)
+
+Equivalent to
+```julia
+    my_unsplat(f) = args -> f(args)
+```
+i.e. given a function that takes a single tuple argument, return a new function
+that takes multiple arguments and bundles them into a tuple to pass to the
+original function. This is the inverse of [`splat`](@ref): `unsplat(splat(f))
+=== f` and `splat(unsplat(f)) === f`.
+
+# Examples
+```jldoctest
+julia> unsplat(sum)(1, 2, 3)
+6
+
+julia> unsplat(splat(+)) === +
+true
+```
+
+!!! compat "Julia 1.14"
+    `unsplat` requires at least Julia 1.14.
+"""
+unsplat(f) = f ∘ tuple
+unsplat(s::Splat) = s.f
+splat(f::ComposedFunction{<:Any,typeof(tuple)}) = f.outer
+
+"""
     tap(f)
 
 Create a function that calls `f(x)` and returns `x`.

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1378,6 +1378,7 @@ it may use a more specialized function type (such as `f ∘ tuple` via [`∘`](@
 for improved clarity or efficiency, rather than creating a new anonymous function.
 
 `unsplat` is the inverse of [`splat`](@ref): `unsplat(splat(f)) === f` and `splat(unsplat(f)) === f`.
+This operation is also sometimes referred to as "slurp".
 
 # Examples
 ```jldoctest

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1369,14 +1369,15 @@ show(io::IO, s::Splat) = (print(io, "splat("); show(io, s.f); print(io, ")"))
 """
     unsplat(f)
 
-Equivalent to
-```julia
-my_unsplat(f) = (args...) -> f(args)
-```
-i.e. given a function that takes a single tuple argument, return a new function
-that takes multiple arguments and bundles them into a tuple to pass to the
-original function. This is the inverse of [`splat`](@ref): `unsplat(splat(f))
-=== f` and `splat(unsplat(f)) === f`.
+Given a function `f` that takes a single tuple argument, return a new function
+that takes any number of arguments and bundles them into a tuple to pass to the
+original function.
+
+That is, the return value is *effectively* equivalent to `(args...) -> f(args)`, except that
+it may use a more specialized function type (such as `f ∘ tuple` via [`∘`](@ref) and [`tuple`](@ref))
+for improved clarity or efficiency, rather than creating a new anonymous function.
+
+`unsplat` is the inverse of [`splat`](@ref): `unsplat(splat(f)) === f` and `splat(unsplat(f)) === f`.
 
 # Examples
 ```jldoctest

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1371,7 +1371,7 @@ show(io::IO, s::Splat) = (print(io, "splat("); show(io, s.f); print(io, ")"))
 
 Equivalent to
 ```julia
-    my_unsplat(f) = args -> f(args)
+    my_unsplat(f) = (args...) -> f(args)
 ```
 i.e. given a function that takes a single tuple argument, return a new function
 that takes multiple arguments and bundles them into a tuple to pass to the

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1371,7 +1371,7 @@ show(io::IO, s::Splat) = (print(io, "splat("); show(io, s.f); print(io, ")"))
 
 Equivalent to
 ```julia
-    my_unsplat(f) = (args...) -> f(args)
+my_unsplat(f) = (args...) -> f(args)
 ```
 i.e. given a function that takes a single tuple argument, return a new function
 that takes multiple arguments and bundles them into a tuple to pass to the

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -294,6 +294,7 @@ Base.:(|>)
 Base.:(∘)
 Base.ComposedFunction
 Base.splat
+Base.unsplat
 Base.Fix
 Base.Fix1
 Base.Fix2

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -376,6 +376,14 @@ end
     @test_skip Returns(illtype) == Returns{DataType}(illtype)
 end
 
+@testset "unsplat" begin
+    @test unsplat(sum)(1, 2, 3) == 6
+    @test unsplat(splat(+))(1, 2, 3) == 6
+
+    @test unsplat(splat(+)) === +
+    @test splat(unsplat(sum)) === sum
+end
+
 @testset "tap" begin
     buf = IOBuffer()
     @test (123 |> tap(Base.Fix1(print, buf))) == 123


### PR DESCRIPTION
`unsplat(f)` bundles its arguments into a single tuple and passes them
to `f`, i.e. `unsplat(f) = args -> f(args)`. This is useful for
adapting a function that expects one tuple argument (such as `sum`)
into one that accepts its arguments separately.

`unsplat` and `splat` are defined as literal inverses of one another:
`unsplat(splat(f)) === f` and `splat(unsplat(f)) === f`, via a
`Base.Splat`-specific `unsplat` method and a
`ComposedFunction{<:Any,typeof(tuple)}`-specific `splat` method.

This was discussed at
https://discourse.julialang.org/t/does-base-splat-have-an-inverse/138772

Fixes #62710
