### PR TITLE
types: Support computed field types via world-age-detached field gens

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3435,7 +3435,7 @@ function abstract_eval_new(interp::AbstractInterpreter, e::Expr, sstate::Stateme
             local allconst = isconcretedispatch(rt)
             for i = 1:nargs
                 at = widenslotwrapper(abstract_eval_value(interp, e.args[i+1], sstate, sv))
-                ft = fieldtype(rt, i)
+                ft = fieldtype_widened(rt, i)
                 nothrow && (nothrow = ⊑(𝕃ᵢ, at, ft))
                 at = tmeet(𝕃ᵢ, at, ft)
                 at === Bottom && return RTEffects(Bottom, TypeError, EFFECTS_THROWS)
@@ -3464,7 +3464,7 @@ function abstract_eval_new(interp::AbstractInterpreter, e::Expr, sstate::Stateme
                 undefs = Union{Nothing,Bool}[false for _ in 1:nargs]
                 if nargs < fcount # fill in uninitialized fields
                     for i = (nargs+1):fcount
-                        ft = fieldtype(rt, i)
+                        ft = fieldtype_widened(rt, i)
                         push!(ats, ft)
                         if ft === Union{} # `Union{}`-typed field is never initialized
                             push!(undefs, true)

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -27,7 +27,13 @@ world_at_most(w::UInt, maxw::UInt) =
     maxw == typemax(UInt) || !world_reaches(maxw + UInt(1), w)
 world_in_range(w::UInt, minw::UInt, maxw::UInt) =
     world_reaches(minw, w) && world_at_most(w, maxw)
-world_on_spine(w::UInt) = world_reaches(w, get_world_counter())
+# Whether `w` is on the spine's trunk: only trunk worlds may publish interval
+# validity, since their positions in the spine's total order are themselves.
+# Worlds of merged side branches (e.g. grafted image histories) reach the
+# spine but are not on its trunk; results computed at them publish point
+# validity instead.
+world_on_spine(w::UInt) =
+    ccall(:jl_world_on_trunk, Cint, (Csize_t, Csize_t), w, get_world_counter()) != 0
 # The earliest spine world whose history includes both `a` and `b` (the join
 # in the world DAG, projected onto the spine, where positions compare exactly
 # as integers). For comparable worlds this is simply the later of the two.

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -9,14 +9,44 @@ WorldRange(w::UInt) = WorldRange(w, w)
 WorldRange(r::UnitRange) = WorldRange(first(r), last(r))
 first(wr::WorldRange) = wr.min_world
 last(wr::WorldRange) = wr.max_world
-in(world::UInt, wr::WorldRange) = wr.min_world <= world <= wr.max_world
 min_world(wr::WorldRange) = first(wr)
 max_world(wr::WorldRange) = last(wr)
 
+# World DAG predicates, mirroring the jl_world_* inlines in
+# src/julia_internal.h: a world is a packed (segment, index) pair and
+# (sa, ia) preceq (sb, ib) iff sa == sb ? ia <= ib : sa is an ancestor
+# segment of sb. Worlds on the spine (the chain of segments the world
+# counter traverses) always compare exactly with plain integer compares.
+const WORLD_IDX_BITS = UInt === UInt64 ? 48 : 24
+world_seg(w::UInt) = w >> WORLD_IDX_BITS
+world_seg_reaches(sa::UInt, sb::UInt) =
+    ccall(:jl_world_seg_reaches, Cint, (Csize_t, Csize_t), sa, sb) != 0
+world_reaches(a::UInt, b::UInt) =
+    world_seg(a) == world_seg(b) ? a <= b : world_seg_reaches(world_seg(a), world_seg(b))
+world_at_most(w::UInt, maxw::UInt) =
+    maxw == typemax(UInt) || !world_reaches(maxw + UInt(1), w)
+world_in_range(w::UInt, minw::UInt, maxw::UInt) =
+    world_reaches(minw, w) && world_at_most(w, maxw)
+world_on_spine(w::UInt) = world_reaches(w, get_world_counter())
+
+in(world::UInt, wr::WorldRange) = world_in_range(world, wr.min_world, wr.max_world)
+
 @inline function intersect(a::WorldRange, b::WorldRange)
-    ret = WorldRange(max(a.min_world, b.min_world), min(a.max_world, b.max_world))
-    @assert ret.min_world <= ret.max_world
-    return ret
+    minw = max(a.min_world, b.min_world)
+    maxw = min(a.max_world, b.max_world)
+    if minw > maxw
+        # Interval arithmetic cannot describe the validity region of a world
+        # off the spine; a point range there absorbs any bounds whose region
+        # contains its world (e.g. bounds capped by an invalidation on the
+        # spine, whose future cone does not contain the point's world).
+        if a.min_world == a.max_world && a.min_world in b
+            return a
+        elseif b.min_world == b.max_world && b.min_world in a
+            return b
+        end
+        @assert false "attempting to intersect disjoint world ranges"
+    end
+    return WorldRange(minw, maxw)
 end
 
 @inline function union(a::WorldRange, b::WorldRange)

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -28,11 +28,20 @@ world_at_most(w::UInt, maxw::UInt) =
 world_in_range(w::UInt, minw::UInt, maxw::UInt) =
     world_reaches(minw, w) && world_at_most(w, maxw)
 world_on_spine(w::UInt) = world_reaches(w, get_world_counter())
+# The earliest spine world whose history includes both `a` and `b` (the join
+# in the world DAG, projected onto the spine, where positions compare exactly
+# as integers). For comparable worlds this is simply the later of the two.
+function world_join(a::UInt, b::UInt)
+    world_seg(a) == world_seg(b) && return max(a, b)
+    return ccall(:jl_world_spine_join, Csize_t, (Csize_t, Csize_t), a, b) % UInt
+end
 
 in(world::UInt, wr::WorldRange) = world_in_range(world, wr.min_world, wr.max_world)
 
 @inline function intersect(a::WorldRange, b::WorldRange)
-    minw = max(a.min_world, b.min_world)
+    # the min side joins in the world DAG: bounds from different merged
+    # branches are incomparable and their join lies on the spine
+    minw = world_join(a.min_world, b.min_world)
     maxw = min(a.max_world, b.max_world)
     if minw > maxw
         # Interval arithmetic cannot describe the validity region of a world

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -17,7 +17,7 @@ max_world(wr::WorldRange) = last(wr)
 # (sa, ia) preceq (sb, ib) iff sa == sb ? ia <= ib : sa is an ancestor
 # segment of sb. Worlds on the spine (the chain of segments the world
 # counter traverses) always compare exactly with plain integer compares.
-const WORLD_IDX_BITS = UInt === UInt64 ? 48 : 24
+const WORLD_IDX_BITS = UInt === UInt64 ? 48 : 16
 world_seg(w::UInt) = w >> WORLD_IDX_BITS
 world_seg_reaches(sa::UInt, sb::UInt) =
     ccall(:jl_world_seg_reaches, Cint, (Csize_t, Csize_t), sa, sb) != 0

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -34,35 +34,42 @@ world_in_range(w::UInt, minw::UInt, maxw::UInt) =
 # validity instead.
 world_on_spine(w::UInt) =
     ccall(:jl_world_on_trunk, Cint, (Csize_t, Csize_t), w, get_world_counter()) != 0
-# The earliest spine world whose history includes both `a` and `b` (the join
-# in the world DAG, projected onto the spine, where positions compare exactly
-# as integers). For comparable worlds this is simply the later of the two.
-function world_join(a::UInt, b::UInt)
+# The earliest world in the observer's total order whose history includes
+# both `a` and `b`. For comparable worlds this is simply the later of the
+# two; for worlds on different branches it is the later of their merge
+# points on the observer's trunk.
+function world_join(a::UInt, b::UInt, observer::UInt)
     world_seg(a) == world_seg(b) && return max(a, b)
-    return ccall(:jl_world_spine_join, Csize_t, (Csize_t, Csize_t), a, b) % UInt
+    return ccall(:jl_world_join, Csize_t, (Csize_t, Csize_t, Csize_t), a, b, observer) % UInt
 end
+# Combine two validity caps; 0 if their invalidation cones are incomparable
+# (see jl_world_cap_meet), in which case the caller must degrade to point
+# validity.
+world_cap_meet(a::UInt, b::UInt) =
+    ccall(:jl_world_cap_meet, Csize_t, (Csize_t, Csize_t), a, b) % UInt
 
 in(world::UInt, wr::WorldRange) = world_in_range(world, wr.min_world, wr.max_world)
 
-@inline function intersect(a::WorldRange, b::WorldRange)
-    # the min side joins in the world DAG: bounds from different merged
-    # branches are incomparable and their join lies on the spine
-    minw = world_join(a.min_world, b.min_world)
-    maxw = min(a.max_world, b.max_world)
-    if minw > maxw
-        # Interval arithmetic cannot describe the validity region of a world
-        # off the spine; a point range there absorbs any bounds whose region
-        # contains its world (e.g. bounds capped by an invalidation on the
-        # spine, whose future cone does not contain the point's world).
-        if a.min_world == a.max_world && a.min_world in b
-            return a
-        elseif b.min_world == b.max_world && b.min_world in a
-            return b
-        end
-        @assert false "attempting to intersect disjoint world ranges"
+# Intersect two validity regions, as observed from `observer` (the world the
+# result will be used at). Both endpoints may lie off the observer's trunk
+# (e.g. a min_world within a grafted image history together with a cap from a
+# later spine invalidation); such intervals are nonempty whenever the cap's
+# invalidation cone does not contain the min. Only when the two caps'
+# invalidation cones are incomparable (shadowing events on two different side
+# branches) can a single interval not represent the region, and the result
+# degrades to point validity at the observer.
+@inline function intersect(a::WorldRange, b::WorldRange, observer::UInt)
+    minw = world_join(a.min_world, b.min_world, observer)
+    maxw = world_cap_meet(a.max_world, b.max_world)
+    if iszero(maxw)
+        @assert world_in_range(observer, a.min_world, a.max_world) &&
+            world_in_range(observer, b.min_world, b.max_world) "attempting to intersect disjoint world ranges"
+        return WorldRange(observer, observer)
     end
+    @assert world_at_most(minw, maxw) "attempting to intersect disjoint world ranges"
     return WorldRange(minw, maxw)
 end
+intersect(a::WorldRange, b::WorldRange) = intersect(a, b, get_world_counter())
 
 @inline function union(a::WorldRange, b::WorldRange)
     if b.min_world < a.min_world

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -268,7 +268,7 @@ struct WorldWithRange
 end
 
 intersect(world::WorldWithRange, valid_worlds::WorldRange) =
-    WorldWithRange(world.this, intersect(world.valid_worlds, valid_worlds))
+    WorldWithRange(world.this, intersect(world.valid_worlds, valid_worlds, world.this))
 
 # `InferenceState` and `IRInterpretationState` are defined together in a `typegroup`
 # block so each can reference the other in its `callstack` field type. They are not
@@ -406,9 +406,7 @@ mutable struct InferenceState{I<:AbstractInterpreter}
         callstack = Union{InferenceState{I},IRInterpretationState{I}}[]
         tasks = WorkThunk[]
 
-        frame_world = get_inference_world(interp)
-        valid_worlds = world_on_spine(frame_world) ? WorldRange(1, get_world_counter()) :
-            WorldRange(frame_world, frame_world)
+        valid_worlds = WorldRange(1, get_world_counter())
         bestguess = Bottom
         exc_bestguess = Bottom
         ipo_effects = EFFECTS_TOTAL
@@ -1305,15 +1303,9 @@ function update_valid_age!(sv::AbsIntState, world, valid_worlds::WorldRange)
     if !(world in valid_worlds)
         error("invalid age range update")
     end
-    if world_on_spine(world)
-        valid_worlds = intersect(sv.valid_worlds, valid_worlds)
-        if !(world in valid_worlds)
-            error("invalid age range update")
-        end
-    else
-        # Off the spine, interval bounds cannot describe the validity region;
-        # results are published with point validity for exactly this world.
-        valid_worlds = WorldRange(world, world)
+    valid_worlds = intersect(sv.valid_worlds, valid_worlds, UInt(world))
+    if !(world in valid_worlds)
+        error("invalid age range update")
     end
     sv.valid_worlds = valid_worlds
     return valid_worlds

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -406,7 +406,9 @@ mutable struct InferenceState{I<:AbstractInterpreter}
         callstack = Union{InferenceState{I},IRInterpretationState{I}}[]
         tasks = WorkThunk[]
 
-        valid_worlds = WorldRange(1, get_world_counter())
+        frame_world = get_inference_world(interp)
+        valid_worlds = world_on_spine(frame_world) ? WorldRange(1, get_world_counter()) :
+            WorldRange(frame_world, frame_world)
         bestguess = Bottom
         exc_bestguess = Bottom
         ipo_effects = EFFECTS_TOTAL
@@ -1300,9 +1302,18 @@ has_mustalias(::AbstractLattice, ::IRInterpretationState) = false
 
 # work towards converging the valid age range for sv
 function update_valid_age!(sv::AbsIntState, world, valid_worlds::WorldRange)
-    valid_worlds = intersect(sv.valid_worlds, valid_worlds)
     if !(world in valid_worlds)
         error("invalid age range update")
+    end
+    if world_on_spine(world)
+        valid_worlds = intersect(sv.valid_worlds, valid_worlds)
+        if !(world in valid_worlds)
+            error("invalid age range update")
+        end
+    else
+        # Off the spine, interval bounds cannot describe the validity region;
+        # results are published with point validity for exactly this world.
+        valid_worlds = WorldRange(world, world)
     end
     sv.valid_worlds = valid_worlds
     return valid_worlds

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -378,6 +378,7 @@ function new_expr_effect_flags(𝕃ₒ::AbstractLattice, args::Vector{Any}, src:
     for fidx in 1:(length(args) - 1)
         farg = args[fidx + 1]
         eT = argextype(farg, src)
+        is_computed_fieldtype(typ, fidx) && return (false, false, false)
         fT = fieldtype(typ, fidx)
         if !isexact && has_free_typevars(fT)
             if pattern_match !== nothing && pattern_match(src, typ, fidx, Targ, farg)

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -3,7 +3,7 @@
 using ..Compiler.Base
 using ..Compiler: _findsup, store_backedges, JLOptions, get_world_counter,
     _methods_by_ftype, get_methodtable, get_ci_mi, should_instrument,
-    morespecific, RefValue, get_require_world, Vector, IdDict
+    morespecific, RefValue, get_require_world, Vector, IdDict, world_on_spine
 using .Core: CodeInstance, MethodInstance
 
 const CI_FLAGS_NATIVE_CACHE_VALID = 0b1000
@@ -200,6 +200,15 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
 
             # unable to backdate before require_world, since Bindings are not able to track that information
             minworld, maxworld = get_require_world(), validation_world
+            ci_minworld = @atomic :monotonic initial.codeinst.min_world
+            if !world_on_spine(ci_minworld)
+                # This CodeInstance came from a grafted image history: its
+                # (translated) creation world stays authoritative, so that it is
+                # not considered valid at earlier worlds of that same history --
+                # e.g. at a world token captured before a method whose dispatch
+                # result it embeds was defined.
+                minworld = max(minworld, ci_minworld)
+            end
 
             # Check for invalidation of GlobalRef edges
             if (initial.def.did_scan_source & 0x1) == 0x0

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -463,7 +463,7 @@ end
                         return Const(!aundefᵢ)
                     end
                 end
-            elseif !isvatuple(a1)
+            elseif !isvatuple(a1) && !is_computed_fieldtype(a1, idx)
                 fieldT = fieldtype(a1, idx)
                 if isa(fieldT, DataType) && isbitstype(fieldT)
                     return Const(true)
@@ -1119,6 +1119,7 @@ end
         isfieldatomic(s, field) && return false # TODO: currently we're only testing for ordering === :not_atomic
         field <= datatype_min_ninitialized(s) && return true
         # `try_compute_fieldidx` already check for field index bound.
+        is_computed_fieldtype(s, field) && return false
         !isvatuple(s) && isbitstype(fieldtype(s0, field)) && return true
     end
 
@@ -1300,6 +1301,11 @@ end
         return _getfield_tfunc(𝕃, _ts, name, setfield)
     end
     ftypes = datatype_fieldtypes(s)
+    if has_computedfield_marker(ftypes)
+        # non-concrete instantiation of a type with computed field types:
+        # the actual field types are unknown here
+        return Any
+    end
     nf = length(ftypes)
     # If no value has this type, then this statement should be unreachable.
     # Bail quickly now.
@@ -1396,6 +1402,7 @@ end
         # `try_compute_fieldidx` already check for field index bound.
         isconst(s, field) && return false
         isfieldatomic(s, field) && return false # TODO: currently we're only testing for ordering === :not_atomic
+        is_computed_fieldtype(s, field) && return false
         v_expected = fieldtype(s0, field)
         ⊑ = partialorder(𝕃)
         return v ⊑ v_expected
@@ -1580,6 +1587,7 @@ function _fieldtype_nothrow(@nospecialize(s), exact::Bool, egal::Bool, name::Con
     end
     isa(fld, Int) || return false
     ftypes = datatype_fieldtypes(u)
+    has_computedfield_marker(ftypes) && return false # runtime `fieldtype` throws for computed slots
     nf = length(ftypes)
     fld >= 1 || return false
     if u.name === Tuple.name && nf > 0 && isvarargtype(ftypes[nf])
@@ -1668,6 +1676,11 @@ end
         return Union{Type, TypeVar}
     end
     ftypes = datatype_fieldtypes(u)
+    if has_computedfield_marker(ftypes)
+        # non-concrete instantiation of a type with computed field types: for
+        # concrete subtypes `fieldtype` returns some type, unknowable here
+        return Any
+    end
     if isempty(ftypes)
         return Bottom
     end

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1931,7 +1931,16 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
         # `Union{T}` to a bare `TypeVar`
         return type_parameter(headtypetype) == Union ? Union{Type, TypeVar} : Type
     else
+        if headtypetype isa Type && headtypetype <: Core.FieldtypeGenerator
+            # applied like a partially applied UnionAll (see
+            # Base.fieldtype_generator): yields another FieldtypeGenerator or,
+            # when fully applied, the tuple of field types
+            return Union{Core.FieldtypeGenerator, Tuple}
+        end
         return Any
+    end
+    if isa(headtype, Core.FieldtypeGenerator)
+        return Union{Core.FieldtypeGenerator, Tuple}
     end
     largs = length(argtypes)
     if largs > 1 && isvarargtype(argtypes[end])

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -179,7 +179,7 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
         end
         # if we aren't cached, we don't need this edge
         # but our caller might, so let's just make it anyways
-        if max_world >= validation_world
+        if world_reaches(validation_world, max_world)
             # if we can record all of the backedges in the global reverse-cache,
             # we can now widen our applicability in the global cache too
             store_backedges(ci, edges)
@@ -279,7 +279,7 @@ function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstan
     ipo_effects = zero(UInt32)
     min_world = src.min_world
     max_world = src.max_world
-    if max_world >= get_world_counter()
+    if world_reaches(get_world_counter(), max_world)
         max_world = typemax(UInt)
     end
     if max_world == typemax(UInt)
@@ -1612,7 +1612,8 @@ end
 function ci_worlds_cover(code::CodeInstance, valid_worlds::WorldRange)
     min_world = @atomic :acquire code.min_world
     max_world = @atomic :acquire code.max_world
-    return min_world <= first(valid_worlds) && last(valid_worlds) <= max_world
+    return world_reaches(min_world, first(valid_worlds)) &&
+        world_at_most(last(valid_worlds), max_world)
 end
 
 function ci_cache_head(mi::MethodInstance)
@@ -2054,7 +2055,7 @@ function compile!(codeinfos::Vector{Any}, workqueue::CompilationQueue;
             # if this method is generally visible to the current compilation world,
             # and this is either the primary world, or not applicable in the primary world
             # then we want to compile and emit this
-            if item.def.primary_world <= world
+            if world_reaches(item.def.primary_world, world)
                 ci = typeinf_ext(interp, item, SOURCE_MODE_GET_SOURCE)
                 ci isa CodeInstance && push!(workqueue, ci)
             end

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -355,7 +355,7 @@ end
         end
         for i = 1:length(typea.fields)
             ai = unwrapva(typea.fields[i])
-            bi = fieldtype(aty, i)
+            bi = fieldtype_widened(aty, i)
             is_lattice_equal(𝕃, ai, bi) && continue
             tni = _typename(widenconst(ai))
             if tni isa Const
@@ -625,7 +625,7 @@ end
         for i = 1:nflds
             ai = getfield_tfunc(𝕃, typea, Const(i))
             bi = getfield_tfunc(𝕃, typeb, Const(i))
-            ft = fieldtype(aty, i)
+            ft = fieldtype_widened(aty, i)
             if is_lattice_equal(𝕃, ai, bi) || is_lattice_equal(𝕃, ai, ft)
                 # Since ai===bi, the given type has no restrictions on complexity.
                 # and can be used to refine ft

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -158,18 +158,17 @@ mutable struct LocalInferenceProof
     const edges::SimpleVector
     function LocalInferenceProof(valid_worlds::WorldRange, edges::SimpleVector)
         # Local proofs are not registered with the global invalidation machinery.
-        # Inference states cap their range at the current world counter (or pin it to
-        # the inference world when that world is off the spine), and exact-world
-        # local-cache reuse relies on that cap to keep an unregistered proof from
-        # claiming validity in a future world.
-        @assert first(valid_worlds) <= last(valid_worlds)
+        # Inference states cap their range at the current world counter, and
+        # exact-world local-cache reuse relies on that cap to keep an
+        # unregistered proof from claiming validity in a future world.
+        @assert world_at_most(first(valid_worlds), last(valid_worlds)) # nonempty (both endpoints may lie off the spine's trunk)
         @assert world_at_most(last(valid_worlds), get_world_counter())
         for edge in edges
             edge_worlds = if edge isa LocalInferenceProof
                 edge.valid_worlds
-            elseif edge isa CodeInstance && edge.min_world <= edge.max_world
-                # Skip a provisional CI (`min_world > max_world`); an SCC fills it
-                # before any proof containing it can escape.
+            elseif edge isa CodeInstance && world_at_most(edge.min_world, edge.max_world)
+                # Skip a provisional CI (its empty world region, `(1, 0)`);
+                # an SCC fills it before any proof containing it can escape.
                 WorldRange(edge.min_world, edge.max_world)
             else
                 continue
@@ -205,7 +204,7 @@ struct LocalInferenceResult <: InferredCallResult
         if proof isa CodeInstance
             @assert proof.def === result.linfo "CodeInstance proof does not match InferenceResult"
         else
-            @assert first(proof.valid_worlds) <= last(proof.valid_worlds)
+            @assert world_at_most(first(proof.valid_worlds), last(proof.valid_worlds))
         end
         return new(result, proof)
     end

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -158,10 +158,12 @@ mutable struct LocalInferenceProof
     const edges::SimpleVector
     function LocalInferenceProof(valid_worlds::WorldRange, edges::SimpleVector)
         # Local proofs are not registered with the global invalidation machinery.
-        # Inference states cap their range at the current world counter, and exact-world
+        # Inference states cap their range at the current world counter (or pin it to
+        # the inference world when that world is off the spine), and exact-world
         # local-cache reuse relies on that cap to keep an unregistered proof from
         # claiming validity in a future world.
-        @assert first(valid_worlds) <= last(valid_worlds) <= get_world_counter()
+        @assert first(valid_worlds) <= last(valid_worlds)
+        @assert world_at_most(last(valid_worlds), get_world_counter())
         for edge in edges
             edge_worlds = if edge isa LocalInferenceProof
                 edge.valid_worlds
@@ -172,8 +174,8 @@ mutable struct LocalInferenceProof
             else
                 continue
             end
-            @assert (first(edge_worlds) <= first(valid_worlds) &&
-                last(valid_worlds) <= last(edge_worlds))
+            @assert (world_reaches(first(edge_worlds), first(valid_worlds)) &&
+                world_at_most(last(valid_worlds), last(edge_worlds)))
         end
         return new(valid_worlds, edges)
     end
@@ -543,8 +545,10 @@ function NativeInterpreter(world::UInt = get_world_counter();
         world = curr_max_world
     end
     # If they didn't pass typemax(UInt) but passed something more subtly
-    # incorrect, fail out loudly.
-    @assert world <= curr_max_world
+    # incorrect, fail out loudly. (Worlds on closed sibling branches of the
+    # world DAG are legal inference worlds; only unrealized future worlds
+    # are not.)
+    @assert world_at_most(world, curr_max_world)
     method_table = CachedMethodTable(InternalMethodTable(world))
     inf_cache = InferenceCache() # Initially empty cache
     codegen = IdDict{CodeInstance,CodeInfo}()

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -480,3 +480,32 @@ property when there is access to mutation-free global object.
 is_mutation_free_argtype(@nospecialize(argtype)) =
     is_mutation_free_type(widenconst(ignorelimited(argtype)))
 is_mutation_free_type(@nospecialize ty) = ismutationfree(ty)
+
+# Computed field types: a non-concrete instantiation of a type with computed
+# field types keeps `Core.ComputedFieldType` markers in its (lazily computed)
+# field-type slots. Such a slot has no field type until the parameters are
+# fully concrete (the runtime `fieldtype` throws for it), so inference must
+# treat it as unknown. The markers are deliberately not part of the type
+# system; `Base.fieldtype_generator` provides the partially applied form.
+function has_computedfield_marker(ftypes::SimpleVector)
+    for ft in ftypes
+        isa(ft, Core.ComputedFieldType) && return true
+    end
+    return false
+end
+
+function is_computed_fieldtype(s::DataType, i::Int)
+    isconcretetype(s) && return false
+    ftypes = datatype_fieldtypes(s)
+    return 1 ≤ i ≤ length(ftypes) && isa(ftypes[i], Core.ComputedFieldType)
+end
+
+# `fieldtype`, but yields `Any` for a computed field type slot of a
+# non-concrete type instead of throwing
+function fieldtype_widened(@nospecialize(t), i::Int)
+    u = unwrap_unionall(t)
+    if isa(u, DataType) && is_computed_fieldtype(u, i)
+        return Any
+    end
+    return fieldtype(t, i)
+end

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,13 @@ New language features
   `continue name` to continue a labeled loop ([#60481]).
 * `typegroup` blocks allow defining mutually recursive struct types that reference each other in their
   field types. All types in the group are resolved atomically at the end of the block ([#60569]).
+* A new internal *RCJulia* (restricted-capability Julia) evaluation mode
+  (`Core._rcjulia_call(world, f, args...)`) executes a call with the world age frozen and every
+  primitive operation requiring a withheld capability trapped (throwing the new `CapabilityError`):
+  no mutable-memory reads or writes, no I/O, no world mutation, and only structurally terminating
+  control flow — loops are rejected and recursion must decrease in a built-in well-founded order.
+  Any call that completes under the mode is `:foldable` by construction, making its result safe to
+  constant-fold and cache across sessions without relying on effects proofs.
 * Primitive types with non-byte-multiple logical widths can now be defined ([#61359]).
 * Introduced explicitly wrapping arithmetic operators `+%`, `-%`, `*%` to annotate arithmetic operations
   that are semantically safe to wrap/overflow. Their behavior is currently identical to the default `+`, `-`, `*`

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -3,6 +3,7 @@
 const start_base_include = time_ns()
 
 include("reflection.jl")
+include("computed_fieldtypes.jl")
 include("refpointer.jl")
 
 # now replace the Pair constructor (relevant for NamedTuples) with one that calls our Base.convert

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -293,13 +293,16 @@ as they existed at the given `world` age. In a sense, this is like the opposite
 of [`invokelatest`](@ref).
 
 !!! note
-    It is not valid to store world ages obtained in precompilation for later use.
-    This is because precompilation generates a "parallel universe" where the
-    world age refers to system state unrelated to the main Julia session.
+    It is not valid to store raw world ages obtained in precompilation for later
+    use. This is because precompilation generates a "parallel universe" where
+    the world age refers to system state unrelated to the main Julia session.
+    Use an opaque token from [`Base.world_token`](@ref) instead, which remains
+    meaningful after the precompiled image is loaded and can be passed to
+    `invoke_in_world` in place of a raw world age.
 """
 const invoke_in_world = Core.invoke_in_world
 
-function Core.kwcall(kwargs::NamedTuple, ::typeof(invoke_in_world), world::UInt, f, args...)
+function Core.kwcall(kwargs::NamedTuple, ::typeof(invoke_in_world), world::Union{UInt,Core.WorldToken}, f, args...)
     @inline
     return Core.invoke_in_world(world, Core.kwcall, kwargs, f, args...)
 end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -239,7 +239,7 @@ export
     InterruptException, InexactError, OutOfMemoryError, ReadOnlyMemoryError,
     OverflowError, StackOverflowError, SegmentationFault, UndefRefError, UndefVarError,
     TypeError, ArgumentError, MethodError, AssertionError, LoadError, InitError,
-    UndefKeywordError, ConcurrencyViolationError, FieldError,
+    UndefKeywordError, ConcurrencyViolationError, FieldError, CapabilityError,
     # AST representation
     Expr, QuoteNode, LineNumberNode, GlobalRef,
     # object model functions
@@ -507,6 +507,10 @@ end
 struct ConcurrencyViolationError <: Exception
     msg::AbstractString
     ConcurrencyViolationError(msg::AbstractString) = new(msg)
+end
+struct CapabilityError <: Exception
+    op::Symbol
+    CapabilityError(op::Symbol) = new(op)
 end
 struct MissingCodeError <: Exception
     mi::MethodInstance

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -1258,6 +1258,16 @@ const _apply_pure = _apply
 const _call_latest = invokelatest
 const _call_in_world = invoke_in_world
 
+# An opaque, serializable capture of a world age, applied with
+# `invoke_in_world`. Mutable so that every token is a distinct heap object:
+# precompilation rebases the world of tokens serialized in a package image
+# onto a grafted world segment at load time, which requires each token to be
+# independently addressable (and never inlined into a parent object).
+mutable struct WorldToken
+    const world::UInt
+    WorldToken(world::UInt) = new(world)
+end
+
 struct Pair{A, B}
     first::A
     second::B

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -434,6 +434,18 @@ struct ComputedFieldType
     end
 end
 
+# The partially applied field generator of a type with computed field types
+# (see `Base.fieldtype_generator`). A plain reflection object, deliberately
+# not part of the type system. Applied with `apply_type` like a partially
+# applied UnionAll: applying some of the remaining parameters yields another
+# FieldtypeGenerator, applying all of them yields the tuple of field types.
+struct FieldtypeGenerator
+    ty::Type
+    function FieldtypeGenerator(@nospecialize(ty::Type))
+        return new(ty)
+    end
+end
+
 # Check if a value contains a TypeApp anywhere in its structure
 function _contains_typeapp(@nospecialize(x))
     if x isa TypeApp

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -422,6 +422,18 @@ struct TypeApp
     end
 end
 
+# Marker stored in the declared field-type slot of a struct whose field type is
+# a computed expression of the type parameters (e.g. `data::NTuple{(R::Int)*(C::Int),T}`).
+# Holds the quoted source expression for printing/reflection. The actual field
+# types of concrete instantiations are produced by the type's field generator
+# (see `Base._set_fieldtype_generator!`).
+struct ComputedFieldType
+    expr::Any
+    function ComputedFieldType(@nospecialize(expr))
+        return new(expr)
+    end
+end
+
 # Check if a value contains a TypeApp anywhere in its structure
 function _contains_typeapp(@nospecialize(x))
     if x isa TypeApp

--- a/base/computed_fieldtypes.jl
+++ b/base/computed_fieldtypes.jl
@@ -28,6 +28,99 @@
 
 const _fieldgen_detached_owner = :computed_fieldtypes
 
+"""
+    FieldtypeGenerator
+
+The partially applied field generator of a type with computed field types, as
+returned by [`fieldtype_generator`](@ref). This is a plain reflection object —
+deliberately *not* part of the type system: it cannot appear in field types or
+method signatures and does not participate in subtyping. Calling it with the
+values of the type's remaining free parameters (left-to-right) returns the
+tuple of field types, evaluated with the definition-time (world-age-detached)
+semantics.
+"""
+struct FieldtypeGenerator
+    ty::Type
+    global function _unsafe_fieldtype_generator(@nospecialize(ty::Type))
+        return new(ty)
+    end
+end
+
+"""
+    fieldtype_generator(T::Type) -> FieldtypeGenerator
+
+For a (possibly partially applied) type `T` whose field types are computed from
+the values of its type parameters, return the partially applied field
+generator. Calling the result with the values of `T`'s remaining free
+parameters yields the tuple of field types:
+
+```julia
+struct StaticMatrix{R,C,T}
+    data::NTuple{(R::Int)*(C::Int), T}
+end
+
+g = Base.fieldtype_generator(StaticMatrix{2})
+g(3, Float64)  # === (NTuple{6, Float64},)
+```
+
+Unlike `fieldtype`, errors thrown by the field type expressions propagate.
+"""
+function fieldtype_generator(@nospecialize(ty::Type))
+    dt = unwrap_unionall(ty)
+    dt isa DataType ||
+        throw(ArgumentError("expected a (partially applied) struct type"))
+    tn = dt.name
+    fg = isdefined(tn, :fieldgen, :monotonic) ? (@atomic :monotonic tn.fieldgen) : nothing
+    fg isa SimpleVector ||
+        throw(ArgumentError("$(tn.name) does not have computed field types"))
+    return _unsafe_fieldtype_generator(ty)
+end
+
+function show(io::IO, g::FieldtypeGenerator)
+    print(io, "Base.fieldtype_generator(")
+    show(io, g.ty)
+    print(io, ")")
+end
+
+# substitute `v => val` into the type parameter expression `p`
+function _fieldgen_apply_param(@nospecialize(p), v::TypeVar, @nospecialize(val))
+    p === v && return val
+    if p isa Type && has_typevar(p, v)
+        return (UnionAll(v, p)){val}
+    end
+    return p
+end
+
+function (g::FieldtypeGenerator)(@nospecialize args...)
+    # collect the UnionAll-bound parameters, in order
+    vars = TypeVar[]
+    ty = g.ty
+    while ty isa UnionAll
+        push!(vars, ty.var)
+        ty = ty.body
+    end
+    dt = ty::DataType
+    nfree = length(vars)
+    length(args) == nfree ||
+        throw(ArgumentError("expected $(nfree) type parameter values, got $(length(args))"))
+    params = Any[p for p in dt.parameters]
+    for (i, v) in enumerate(vars)
+        for j = 1:length(params)
+            params[j] = _fieldgen_apply_param(params[j], v, args[i])
+        end
+    end
+    for p in params
+        if p isa TypeVar || (p isa Type && has_free_typevars(p))
+            throw(ArgumentError("type parameters of $(g.ty) are not fully specified by the given values"))
+        end
+    end
+    res = ccall(:jl_call_fieldtype_generator, Any, (Any, Any), dt.name, Core.svec(params...))
+    nf = length(dt.name.names)
+    (res isa Tuple && nfields(res) == nf) ||
+        error("field generator for ", dt.name.name, " returned an invalid result")
+    return res
+end
+
 _fieldgen_error(tn::Core.TypeName, msg...) =
     error("invalid computed field types for ", tn.name, ": ", msg...)
 

--- a/base/computed_fieldtypes.jl
+++ b/base/computed_fieldtypes.jl
@@ -1,32 +1,26 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# Validation and world-age detachment of field generators for structs with
-# computed field types (declared field-type slots holding
-# `Core.ComputedFieldType` markers). `_set_fieldtype_generator!` in
-# essentials.jl calls `_validate_fieldtype_generator` when it is defined.
+# Installation of field generators for structs with computed field types
+# (declared field-type slots holding `Core.ComputedFieldType` markers).
+# `_set_fieldtype_generator!` in essentials.jl calls
+# `_validate_fieldtype_generator` when it is defined.
 #
-# Validity: inference must prove the generator `is_foldable` (`:consistent`,
-# `:effect_free`, `:noub`, `:terminates`) plus `:nortcall`. `:nothrow` is *not*
-# required: a generator that throws for particular parameter values degrades
-# those instantiations' field types to `Union{}` (see
-# `invoke_fieldtype_generator` in src/jltypes.c).
+# Field types are computed by running the generator in RCJulia mode
+# (`Core._rcjulia_call`) at the struct's definition world: restricted-
+# capability evaluation traps every operation whose result could depend on
+# mutable state, so any result (or thrown error) is `:foldable` by
+# construction — no effects proof is required, and `Base.@assume_effects`
+# vouching plays no soundness role. `:nothrow` is not required either: a
+# generator that throws for particular parameter values degrades those
+# instantiations' field types to `Union{}` (see `invoke_fieldtype_generator`
+# in src/jltypes.c).
 #
-# `:consistent`-cy is world-bounded (see the `Base.@assume_effects`
-# documentation), so proven effects alone do not make the generator's meaning
-# stable across worlds -- and the definition world no longer exists after a
-# precompiled image is reloaded. We therefore duplicate the inferred
-# CodeInstance into a *detached* CodeInstance with world validity
-# `(1, typemax(UInt))` whose code is closed under the definition world:
-#   - every remaining `:call` targets a builtin/intrinsic (world-independent),
-#   - every `:invoke` targets another detached CodeInstance (recursively),
-#   - every global reference is replaced by its definition-world constant value.
-# A detached instance is never registered in any method cache, so method
-# redefinition and invalidation cannot reach it; it pins the definition-time
-# semantics of the type's field types forever. When the original CodeInstance
-# already has a world-independent form (constant return with `:nothrow`), the
-# detached copy is just a constant-return instance with no code.
-
-const _fieldgen_detached_owner = :computed_fieldtypes
+# The definition world is captured as a `Core.WorldToken`, an opaque world
+# capture that survives precompilation by mapping into the image's preserved
+# world segment. Because dispatch inside the mode resolves against that
+# frozen world, helper redefinition and invalidation cannot change a type's
+# field types: instantiations in any later session compute them with the
+# definition-time semantics.
 
 """
     fieldtype_generator(T::Type) -> Union{Core.FieldtypeGenerator, Tuple}
@@ -37,8 +31,9 @@ generator: a plain reflection object — deliberately *not* part of the type
 system — that is applied with `apply_type`, like a partially applied
 `UnionAll`. Applying some of the remaining free parameters yields another
 `Core.FieldtypeGenerator`; applying all of them yields the tuple of field
-types, evaluated with the definition-time (world-age-detached) semantics. If
-`T` has no remaining free parameters, the tuple is returned directly.
+types, evaluated in RCJulia mode with the definition-time (world-frozen)
+semantics. If `T` has no remaining free parameters, the tuple is returned
+directly.
 
 ```julia
 struct StaticMatrix{R,C,T}
@@ -86,173 +81,6 @@ end
 _fieldgen_error(tn::Core.TypeName, msg...) =
     error("invalid computed field types for ", tn.name, ": ", msg...)
 
-# builtins whose runtime behavior consults the method table or binding table of
-# the *current* world; these must not remain in detached code
-const _fieldgen_forbidden_builtins = Any[
-    Core.invoke, Core._apply_iterate, Core._call_latest, Core._call_in_world_total,
-    Core.getglobal, Core.setglobal!, Core.isdefinedglobal, Core.replaceglobal!,
-    Core.swapglobal!, Core.modifyglobal!, Core.setglobalonce!,
-]
-
-function _fieldgen_resolve_const(@nospecialize(x))
-    # Return (isconst, value) for IR values that denote compile-time constants.
-    if x isa GlobalRef
-        if isconst(x.mod, x.name) && isdefinedglobal(x.mod, x.name)
-            return true, getglobal(x.mod, x.name)
-        end
-        return false, nothing
-    elseif x isa QuoteNode
-        return true, x.value
-    elseif x isa Expr || x isa Core.SSAValue || x isa Core.Argument || x isa Core.SlotNumber
-        return false, nothing
-    end
-    return true, x
-end
-
-function _detach_ir(@nospecialize(x), seen::IdDict{CodeInstance,Any}, tn::Core.TypeName, world::UInt)
-    if x isa Expr
-        head = x.head
-        nargs = length(x.args)
-        if head === :invoke
-            nargs >= 2 || _fieldgen_error(tn, "malformed :invoke in field generator code")
-            target = x.args[1]
-            if target isa MethodInstance
-                # not pinned to a CodeInstance; re-infer to obtain one
-                target = _fieldgen_infer(target, tn, world)
-            end
-            target isa CodeInstance ||
-                _fieldgen_error(tn, "unsupported :invoke target in field generator code")
-            newargs = Vector{Any}(undef, nargs)
-            newargs[1] = _detach_codeinst(target, seen, tn, world)
-            for i = 2:nargs
-                newargs[i] = _detach_ir(x.args[i], seen, tn, world)
-            end
-            return Expr(:invoke, newargs...)
-        elseif head === :call
-            nargs >= 1 || _fieldgen_error(tn, "malformed :call in field generator code")
-            isc, f = _fieldgen_resolve_const(x.args[1])
-            if !isc || !(f isa Core.Builtin)
-                _fieldgen_error(tn,
-                    "the field generator contains a dynamic call to `", x.args[1], "`; ",
-                    "field generators must be fully resolvable by the compiler")
-            end
-            for forbidden in _fieldgen_forbidden_builtins
-                f === forbidden && _fieldgen_error(tn,
-                    "the field generator calls `", f, "`, whose behavior depends on the ",
-                    "current world age")
-            end
-            newargs = Vector{Any}(undef, nargs)
-            newargs[1] = QuoteNode(f)
-            for i = 2:nargs
-                newargs[i] = _detach_ir(x.args[i], seen, tn, world)
-            end
-            return Expr(:call, newargs...)
-        elseif head === :foreigncall || head === :cfunction || head === :new_opaque_closure
-            _fieldgen_error(tn, "`", head, "` is not supported in field generator code")
-        else
-            # :new, :splatnew, :boundscheck, :isdefined, :throw_undef_if_not,
-            # :gc_preserve_*, :meta, :code_coverage_effect, ...
-            for i = 1:nargs
-                x.args[i] = _detach_ir(x.args[i], seen, tn, world)
-            end
-            return x
-        end
-    elseif x isa GlobalRef
-        (isconst(x.mod, x.name) && isdefinedglobal(x.mod, x.name)) ||
-            _fieldgen_error(tn, "the field generator reads the non-constant global `",
-                            x.mod, ".", x.name, "`")
-        return QuoteNode(getglobal(x.mod, x.name))
-    elseif x isa Core.GotoIfNot
-        return Core.GotoIfNot(_detach_ir(x.cond, seen, tn, world), x.dest)
-    elseif x isa Core.ReturnNode
-        isdefined(x, :val) || return x
-        return Core.ReturnNode(_detach_ir(x.val, seen, tn, world))
-    elseif x isa Core.PiNode
-        return Core.PiNode(_detach_ir(x.val, seen, tn, world), x.typ)
-    elseif x isa Core.PhiNode
-        values = x.values
-        for i = 1:length(values)
-            if isassigned(values, i)
-                values[i] = _detach_ir(values[i], seen, tn, world)
-            end
-        end
-        return x
-    elseif x isa Core.PhiCNode
-        values = x.values
-        for i = 1:length(values)
-            if isassigned(values, i)
-                values[i] = _detach_ir(values[i], seen, tn, world)
-            end
-        end
-        return x
-    elseif x isa Core.UpsilonNode
-        isdefined(x, :val) || return x
-        return Core.UpsilonNode(_detach_ir(x.val, seen, tn, world))
-    end
-    # SSAValue, Argument, QuoteNode, GotoNode, EnterNode, literals, nothing
-    return x
-end
-
-function _fieldgen_infer(mi::MethodInstance, tn::Core.TypeName, world::UInt)
-    ci = Compiler.typeinf_ext_toplevel(mi, world, Compiler.SOURCE_MODE_GET_SOURCE, Compiler.TRIM_NO)
-    ci isa CodeInstance ||
-        _fieldgen_error(tn, "inference of the field generator (", mi, ") did not produce code")
-    return ci
-end
-
-function _fieldgen_source(ci::CodeInstance, tn::Core.TypeName, world::UInt)
-    inf = @atomic :monotonic ci.inferred
-    if inf isa CodeInfo
-        return copy(inf)
-    elseif inf isa String
-        def = ci.def
-        if def isa MethodInstance
-            return _uncompressed_ir(ci, inf)
-        end
-    end
-    # source was not retained on the instance (e.g. it only lives in the
-    # execution engine); re-run inference locally to recover equivalent code
-    def = ci.def
-    def isa MethodInstance ||
-        _fieldgen_error(tn, "cannot recover source for field generator callee")
-    interp = Compiler.NativeInterpreter(world)
-    src = Compiler.typeinf_code(interp, def, #=run_optimizer=#true)
-    src isa CodeInfo ||
-        _fieldgen_error(tn, "cannot recover source for field generator callee ", def)
-    return src
-end
-
-function _detach_codeinst(ci::CodeInstance, seen::IdDict{CodeInstance,Any}, tn::Core.TypeName, world::UInt)
-    ci.owner === _fieldgen_detached_owner && return ci
-    prev = get(seen, ci, nothing)
-    prev === missing &&
-        _fieldgen_error(tn, "recursive field generators are not yet supported")
-    prev isa CodeInstance && return prev
-    seen[ci] = missing
-    debuginfo = isdefined(ci, :debuginfo) ? ci.debuginfo : nothing
-    effects = Compiler.decode_effects(ci.ipo_purity_bits)
-    local dci
-    if isdefined(ci, :rettype_const) && Compiler.is_foldable_nothrow(effects)
-        # constant return: already world-age independent, no code needed
-        dci = CodeInstance(ci.def, _fieldgen_detached_owner, ci.rettype, ci.exctype,
-                           ci.rettype_const, nothing, Int32(0x3), UInt(1), typemax(UInt),
-                           ci.ipo_purity_bits, nothing, debuginfo, Core.svec())
-    else
-        src = _fieldgen_source(ci, tn, world)
-        code = src.code
-        for i = 1:length(code)
-            code[i] = _detach_ir(code[i], seen, tn, world)
-        end
-        rettype_const = isdefined(ci, :rettype_const) ? ci.rettype_const : nothing
-        const_flags = isdefined(ci, :rettype_const) ? Int32(0x2) : Int32(0x0)
-        dci = CodeInstance(ci.def, _fieldgen_detached_owner, ci.rettype, ci.exctype,
-                           rettype_const, src, const_flags, UInt(1), typemax(UInt),
-                           ci.ipo_purity_bits, nothing, debuginfo, Core.svec())
-    end
-    seen[ci] = dci
-    return dci
-end
-
 function _validate_fieldtype_generator(@nospecialize(ty), @nospecialize(gen))
     dt = unwrap_unionall(ty)
     dt isa DataType || error("expected a type with computed field types")
@@ -262,19 +90,10 @@ function _validate_fieldtype_generator(@nospecialize(ty), @nospecialize(gen))
     tt = Tuple{typeof(gen), Vararg{Any,np}}
     match = _which(tt; world, raise=false)
     match === nothing && _fieldgen_error(tn, "no matching field generator method")
-    mi = Compiler.specialize_method(match)
-    ci = _fieldgen_infer(mi, tn, world)
-    effects = Compiler.decode_effects(ci.ipo_purity_bits)
-    if !Compiler.is_foldable(effects, #=check_rtcall=#true)
-        _fieldgen_error(tn,
-            "the compiler could not prove the field type expressions consistent and terminating ",
-            "(effects: ", effects, "). Computed field type expressions must be pure functions of ",
-            "the type parameters; annotating the parameters with their types ",
-            "(e.g. `NTuple{(R::Int)*(C::Int), T}`) usually allows the proof to go through, and ",
-            "`Base.@assume_effects :foldable` on a helper function called in the expression can ",
-            "vouch for effects the compiler cannot prove")
-    end
-    seen = IdDict{CodeInstance,Any}()
-    dci = _detach_codeinst(ci, seen, tn, world)
-    return Core.svec(gen, dci)
+    # No purity proof is required: the generator executes in RCJulia mode,
+    # which enforces foldability dynamically (a generator performing a
+    # restricted operation consistently throws `CapabilityError`, degrading
+    # the affected instantiations' field types to `Union{}`). Capture the
+    # definition world so those semantics are pinned forever.
+    return Core.svec(gen, world_token())
 end

--- a/base/computed_fieldtypes.jl
+++ b/base/computed_fieldtypes.jl
@@ -1,0 +1,225 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Validation and world-age detachment of field generators for structs with
+# computed field types (declared field-type slots holding
+# `Core.ComputedFieldType` markers). `_set_fieldtype_generator!` in
+# essentials.jl calls `_validate_fieldtype_generator` when it is defined.
+#
+# Validity: inference must prove the generator `is_foldable` (`:consistent`,
+# `:effect_free`, `:noub`, `:terminates`) plus `:nortcall`. `:nothrow` is *not*
+# required: a generator that throws for particular parameter values degrades
+# those instantiations' field types to `Union{}` (see
+# `invoke_fieldtype_generator` in src/jltypes.c).
+#
+# `:consistent`-cy is world-bounded (see the `Base.@assume_effects`
+# documentation), so proven effects alone do not make the generator's meaning
+# stable across worlds -- and the definition world no longer exists after a
+# precompiled image is reloaded. We therefore duplicate the inferred
+# CodeInstance into a *detached* CodeInstance with world validity
+# `(1, typemax(UInt))` whose code is closed under the definition world:
+#   - every remaining `:call` targets a builtin/intrinsic (world-independent),
+#   - every `:invoke` targets another detached CodeInstance (recursively),
+#   - every global reference is replaced by its definition-world constant value.
+# A detached instance is never registered in any method cache, so method
+# redefinition and invalidation cannot reach it; it pins the definition-time
+# semantics of the type's field types forever. When the original CodeInstance
+# already has a world-independent form (constant return with `:nothrow`), the
+# detached copy is just a constant-return instance with no code.
+
+const _fieldgen_detached_owner = :computed_fieldtypes
+
+_fieldgen_error(tn::Core.TypeName, msg...) =
+    error("invalid computed field types for ", tn.name, ": ", msg...)
+
+# builtins whose runtime behavior consults the method table or binding table of
+# the *current* world; these must not remain in detached code
+const _fieldgen_forbidden_builtins = Any[
+    Core.invoke, Core._apply_iterate, Core._call_latest, Core._call_in_world_total,
+    Core.getglobal, Core.setglobal!, Core.isdefinedglobal, Core.replaceglobal!,
+    Core.swapglobal!, Core.modifyglobal!, Core.setglobalonce!,
+]
+
+function _fieldgen_resolve_const(@nospecialize(x))
+    # Return (isconst, value) for IR values that denote compile-time constants.
+    if x isa GlobalRef
+        if isconst(x.mod, x.name) && isdefinedglobal(x.mod, x.name)
+            return true, getglobal(x.mod, x.name)
+        end
+        return false, nothing
+    elseif x isa QuoteNode
+        return true, x.value
+    elseif x isa Expr || x isa Core.SSAValue || x isa Core.Argument || x isa Core.SlotNumber
+        return false, nothing
+    end
+    return true, x
+end
+
+function _detach_ir(@nospecialize(x), seen::IdDict{CodeInstance,Any}, tn::Core.TypeName, world::UInt)
+    if x isa Expr
+        head = x.head
+        nargs = length(x.args)
+        if head === :invoke
+            nargs >= 2 || _fieldgen_error(tn, "malformed :invoke in field generator code")
+            target = x.args[1]
+            if target isa MethodInstance
+                # not pinned to a CodeInstance; re-infer to obtain one
+                target = _fieldgen_infer(target, tn, world)
+            end
+            target isa CodeInstance ||
+                _fieldgen_error(tn, "unsupported :invoke target in field generator code")
+            newargs = Vector{Any}(undef, nargs)
+            newargs[1] = _detach_codeinst(target, seen, tn, world)
+            for i = 2:nargs
+                newargs[i] = _detach_ir(x.args[i], seen, tn, world)
+            end
+            return Expr(:invoke, newargs...)
+        elseif head === :call
+            nargs >= 1 || _fieldgen_error(tn, "malformed :call in field generator code")
+            isc, f = _fieldgen_resolve_const(x.args[1])
+            if !isc || !(f isa Core.Builtin)
+                _fieldgen_error(tn,
+                    "the field generator contains a dynamic call to `", x.args[1], "`; ",
+                    "field generators must be fully resolvable by the compiler")
+            end
+            for forbidden in _fieldgen_forbidden_builtins
+                f === forbidden && _fieldgen_error(tn,
+                    "the field generator calls `", f, "`, whose behavior depends on the ",
+                    "current world age")
+            end
+            newargs = Vector{Any}(undef, nargs)
+            newargs[1] = QuoteNode(f)
+            for i = 2:nargs
+                newargs[i] = _detach_ir(x.args[i], seen, tn, world)
+            end
+            return Expr(:call, newargs...)
+        elseif head === :foreigncall || head === :cfunction || head === :new_opaque_closure
+            _fieldgen_error(tn, "`", head, "` is not supported in field generator code")
+        else
+            # :new, :splatnew, :boundscheck, :isdefined, :throw_undef_if_not,
+            # :gc_preserve_*, :meta, :code_coverage_effect, ...
+            for i = 1:nargs
+                x.args[i] = _detach_ir(x.args[i], seen, tn, world)
+            end
+            return x
+        end
+    elseif x isa GlobalRef
+        (isconst(x.mod, x.name) && isdefinedglobal(x.mod, x.name)) ||
+            _fieldgen_error(tn, "the field generator reads the non-constant global `",
+                            x.mod, ".", x.name, "`")
+        return QuoteNode(getglobal(x.mod, x.name))
+    elseif x isa Core.GotoIfNot
+        return Core.GotoIfNot(_detach_ir(x.cond, seen, tn, world), x.dest)
+    elseif x isa Core.ReturnNode
+        isdefined(x, :val) || return x
+        return Core.ReturnNode(_detach_ir(x.val, seen, tn, world))
+    elseif x isa Core.PiNode
+        return Core.PiNode(_detach_ir(x.val, seen, tn, world), x.typ)
+    elseif x isa Core.PhiNode
+        values = x.values
+        for i = 1:length(values)
+            if isassigned(values, i)
+                values[i] = _detach_ir(values[i], seen, tn, world)
+            end
+        end
+        return x
+    elseif x isa Core.PhiCNode
+        values = x.values
+        for i = 1:length(values)
+            if isassigned(values, i)
+                values[i] = _detach_ir(values[i], seen, tn, world)
+            end
+        end
+        return x
+    elseif x isa Core.UpsilonNode
+        isdefined(x, :val) || return x
+        return Core.UpsilonNode(_detach_ir(x.val, seen, tn, world))
+    end
+    # SSAValue, Argument, QuoteNode, GotoNode, EnterNode, literals, nothing
+    return x
+end
+
+function _fieldgen_infer(mi::MethodInstance, tn::Core.TypeName, world::UInt)
+    ci = Compiler.typeinf_ext_toplevel(mi, world, Compiler.SOURCE_MODE_GET_SOURCE, Compiler.TRIM_NO)
+    ci isa CodeInstance ||
+        _fieldgen_error(tn, "inference of the field generator (", mi, ") did not produce code")
+    return ci
+end
+
+function _fieldgen_source(ci::CodeInstance, tn::Core.TypeName, world::UInt)
+    inf = @atomic :monotonic ci.inferred
+    if inf isa CodeInfo
+        return copy(inf)
+    elseif inf isa String
+        def = ci.def
+        if def isa MethodInstance
+            return _uncompressed_ir(ci, inf)
+        end
+    end
+    # source was not retained on the instance (e.g. it only lives in the
+    # execution engine); re-run inference locally to recover equivalent code
+    def = ci.def
+    def isa MethodInstance ||
+        _fieldgen_error(tn, "cannot recover source for field generator callee")
+    interp = Compiler.NativeInterpreter(world)
+    src = Compiler.typeinf_code(interp, def, #=run_optimizer=#true)
+    src isa CodeInfo ||
+        _fieldgen_error(tn, "cannot recover source for field generator callee ", def)
+    return src
+end
+
+function _detach_codeinst(ci::CodeInstance, seen::IdDict{CodeInstance,Any}, tn::Core.TypeName, world::UInt)
+    ci.owner === _fieldgen_detached_owner && return ci
+    prev = get(seen, ci, nothing)
+    prev === missing &&
+        _fieldgen_error(tn, "recursive field generators are not yet supported")
+    prev isa CodeInstance && return prev
+    seen[ci] = missing
+    debuginfo = isdefined(ci, :debuginfo) ? ci.debuginfo : nothing
+    effects = Compiler.decode_effects(ci.ipo_purity_bits)
+    local dci
+    if isdefined(ci, :rettype_const) && Compiler.is_foldable_nothrow(effects)
+        # constant return: already world-age independent, no code needed
+        dci = CodeInstance(ci.def, _fieldgen_detached_owner, ci.rettype, ci.exctype,
+                           ci.rettype_const, nothing, Int32(0x3), UInt(1), typemax(UInt),
+                           ci.ipo_purity_bits, nothing, debuginfo, Core.svec())
+    else
+        src = _fieldgen_source(ci, tn, world)
+        code = src.code
+        for i = 1:length(code)
+            code[i] = _detach_ir(code[i], seen, tn, world)
+        end
+        rettype_const = isdefined(ci, :rettype_const) ? ci.rettype_const : nothing
+        const_flags = isdefined(ci, :rettype_const) ? Int32(0x2) : Int32(0x0)
+        dci = CodeInstance(ci.def, _fieldgen_detached_owner, ci.rettype, ci.exctype,
+                           rettype_const, src, const_flags, UInt(1), typemax(UInt),
+                           ci.ipo_purity_bits, nothing, debuginfo, Core.svec())
+    end
+    seen[ci] = dci
+    return dci
+end
+
+function _validate_fieldtype_generator(@nospecialize(ty), @nospecialize(gen))
+    dt = unwrap_unionall(ty)
+    dt isa DataType || error("expected a type with computed field types")
+    tn = dt.name
+    np = length(dt.parameters)
+    world = get_world_counter()
+    tt = Tuple{typeof(gen), Vararg{Any,np}}
+    match = _which(tt; world, raise=false)
+    match === nothing && _fieldgen_error(tn, "no matching field generator method")
+    mi = Compiler.specialize_method(match)
+    ci = _fieldgen_infer(mi, tn, world)
+    effects = Compiler.decode_effects(ci.ipo_purity_bits)
+    if !Compiler.is_foldable(effects, #=check_rtcall=#true)
+        _fieldgen_error(tn,
+            "the compiler could not prove the field type expressions consistent and terminating ",
+            "(effects: ", effects, "). Computed field type expressions must be pure functions of ",
+            "the type parameters; annotating the parameters with their types ",
+            "(e.g. `NTuple{(R::Int)*(C::Int), T}`) usually allows the proof to go through, and ",
+            "`Base.@assume_effects :foldable` on a helper function called in the expression can ",
+            "vouch for effects the compiler cannot prove")
+    end
+    seen = IdDict{CodeInstance,Any}()
+    dci = _detach_codeinst(ci, seen, tn, world)
+    return Core.svec(gen, dci)
+end

--- a/base/computed_fieldtypes.jl
+++ b/base/computed_fieldtypes.jl
@@ -29,30 +29,16 @@
 const _fieldgen_detached_owner = :computed_fieldtypes
 
 """
-    FieldtypeGenerator
-
-The partially applied field generator of a type with computed field types, as
-returned by [`fieldtype_generator`](@ref). This is a plain reflection object —
-deliberately *not* part of the type system: it cannot appear in field types or
-method signatures and does not participate in subtyping. Calling it with the
-values of the type's remaining free parameters (left-to-right) returns the
-tuple of field types, evaluated with the definition-time (world-age-detached)
-semantics.
-"""
-struct FieldtypeGenerator
-    ty::Type
-    global function _unsafe_fieldtype_generator(@nospecialize(ty::Type))
-        return new(ty)
-    end
-end
-
-"""
-    fieldtype_generator(T::Type) -> FieldtypeGenerator
+    fieldtype_generator(T::Type) -> Union{Core.FieldtypeGenerator, Tuple}
 
 For a (possibly partially applied) type `T` whose field types are computed from
 the values of its type parameters, return the partially applied field
-generator. Calling the result with the values of `T`'s remaining free
-parameters yields the tuple of field types:
+generator: a plain reflection object — deliberately *not* part of the type
+system — that is applied with `apply_type`, like a partially applied
+`UnionAll`. Applying some of the remaining free parameters yields another
+`Core.FieldtypeGenerator`; applying all of them yields the tuple of field
+types, evaluated with the definition-time (world-age-detached) semantics. If
+`T` has no remaining free parameters, the tuple is returned directly.
 
 ```julia
 struct StaticMatrix{R,C,T}
@@ -60,10 +46,12 @@ struct StaticMatrix{R,C,T}
 end
 
 g = Base.fieldtype_generator(StaticMatrix{2})
-g(3, Float64)  # === (NTuple{6, Float64},)
+g{3}           # a Core.FieldtypeGenerator
+g{3, Float64}  # === (NTuple{6, Float64},)
 ```
 
-Unlike `fieldtype`, errors thrown by the field type expressions propagate.
+Unlike instantiating the type, errors thrown by the field type expressions
+propagate rather than degrading the field types to `Union{}`.
 """
 function fieldtype_generator(@nospecialize(ty::Type))
     dt = unwrap_unionall(ty)
@@ -73,52 +61,26 @@ function fieldtype_generator(@nospecialize(ty::Type))
     fg = isdefined(tn, :fieldgen, :monotonic) ? (@atomic :monotonic tn.fieldgen) : nothing
     fg isa SimpleVector ||
         throw(ArgumentError("$(tn.name) does not have computed field types"))
-    return _unsafe_fieldtype_generator(ty)
+    if !(ty isa UnionAll)
+        # fully applied already: the application is complete
+        for p in dt.parameters
+            if p isa TypeVar || (p isa Type && has_free_typevars(p))
+                throw(ArgumentError("type parameters of $(ty) are not fully specified"))
+            end
+        end
+        res = ccall(:jl_call_fieldtype_generator, Any, (Any, Any), tn, dt.parameters)
+        nf = length(tn.names)
+        (res isa Tuple && nfields(res) == nf) ||
+            error("field generator for ", tn.name, " returned an invalid result")
+        return res
+    end
+    return Core.FieldtypeGenerator(ty)
 end
 
-function show(io::IO, g::FieldtypeGenerator)
+function show(io::IO, g::Core.FieldtypeGenerator)
     print(io, "Base.fieldtype_generator(")
     show(io, g.ty)
     print(io, ")")
-end
-
-# substitute `v => val` into the type parameter expression `p`
-function _fieldgen_apply_param(@nospecialize(p), v::TypeVar, @nospecialize(val))
-    p === v && return val
-    if p isa Type && has_typevar(p, v)
-        return (UnionAll(v, p)){val}
-    end
-    return p
-end
-
-function (g::FieldtypeGenerator)(@nospecialize args...)
-    # collect the UnionAll-bound parameters, in order
-    vars = TypeVar[]
-    ty = g.ty
-    while ty isa UnionAll
-        push!(vars, ty.var)
-        ty = ty.body
-    end
-    dt = ty::DataType
-    nfree = length(vars)
-    length(args) == nfree ||
-        throw(ArgumentError("expected $(nfree) type parameter values, got $(length(args))"))
-    params = Any[p for p in dt.parameters]
-    for (i, v) in enumerate(vars)
-        for j = 1:length(params)
-            params[j] = _fieldgen_apply_param(params[j], v, args[i])
-        end
-    end
-    for p in params
-        if p isa TypeVar || (p isa Type && has_free_typevars(p))
-            throw(ArgumentError("type parameters of $(g.ty) are not fully specified by the given values"))
-        end
-    end
-    res = ccall(:jl_call_fieldtype_generator, Any, (Any, Any), dt.name, Core.svec(params...))
-    nf = length(dt.name.names)
-    (res isa Tuple && nfields(res) == nf) ||
-        error("field generator for ", dt.name.name, " returned an invalid result")
-    return res
 end
 
 _fieldgen_error(tn::Core.TypeName, msg...) =

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4295,6 +4295,56 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    CapabilityError(op::Symbol) <: Exception
+
+An error thrown when code executing in RCJulia — restricted-capability
+evaluation, see [`Core._rcjulia_call`](@ref) — attempts an operation whose
+capability the mode withholds, such as reading or writing mutable memory,
+performing I/O, or using unrestricted recursion. `op` names the offending
+operation.
+
+The trap itself is deterministic — it depends only on the operation attempted
+and its operands — so even a computation that throws this error has a
+consistent, foldable outcome.
+"""
+CapabilityError
+
+"""
+    Core._rcjulia_call(world::UInt, f, args...)
+
+Call `f(args...)` in *RCJulia* (restricted-capability Julia) mode: the task's
+world age is frozen to `world` and every operation whose result could depend
+on mutable state, or whose effects could be observed from outside, throws a
+[`CapabilityError`](@ref) instead of executing. Any call that completes
+(or throws) under the mode is therefore `:foldable` by construction — the
+outcome is a pure function of the arguments and `world` — with no requirement
+of `:nothrow`: "consistently throws" is a foldable outcome.
+
+The withheld capabilities include: reading fields of mutable objects (except
+fields declared `const`, which never change after construction — this is what
+admits set-once runtime metadata such as `DataType.parameters`), reading
+non-`const` globals, all mutation and all allocation of mutable memory,
+`ccall`/`cfunction`, task and scheduler operations, and method definition and
+other world-mutating reflection. Generic calls execute through the
+interpreter so that every primitive operation stays checked.
+
+Termination is structural: loop backedges are rejected, and re-entering a
+method that is already executing is permitted only when its arguments
+strictly decrease in a built-in well-founded order — structurally smaller
+types are smaller, and at equal types, smaller values interpreted as
+bitstypes are smaller. Since the order admits no infinite descending chains
+and the method table is frozen, every call chain is finite; a fixed
+platform-independent frame cap additionally bounds physical stack use.
+
+!!! warning
+    This is an internal interface primarily intended as runtime
+    infrastructure (e.g. for computed struct field types). Its exact
+    restrictions may be extended or relaxed (for example with per-method
+    custom recursion orders).
+"""
+Core._rcjulia_call
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -170,6 +170,8 @@ showerror(io::IO, ex::ArgumentError) = print(io, "ArgumentError: ", ex.msg)
 showerror(io::IO, ex::DimensionMismatch) = print(io, "DimensionMismatch: ", ex.msg)
 showerror(io::IO, ex::AssertionError) = print(io, "AssertionError: ", ex.msg)
 showerror(io::IO, ex::OverflowError) = print(io, "OverflowError: ", ex.msg)
+showerror(io::IO, ex::CapabilityError) =
+    print(io, "CapabilityError: `", ex.op, "` is not available in RCJulia (restricted-capability evaluation)")
 
 showerror(io::IO, ex::UndefKeywordError) =
     print(io, "UndefKeywordError: keyword argument `$(ex.var)` not assigned")

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1302,6 +1302,32 @@ has_typevar(@nospecialize(t), v::TypeVar) = ccall(:jl_has_typevar, Int32, (Any, 
 # loading a precompiled image) compute field types with the definition-time
 # semantics. Before that machinery is loaded (early bootstrap), the generator
 # is stored as `svec(gen)` and invoked dynamically.
+# `fieldtype` for use in the constructors of structs with computed field
+# types. Identical to `fieldtype` on the hot path (so inference const-folds it
+# and elides the field convert exactly as for a plain `fieldtype` call),
+# except that a `Union{}` slot — which for such structs usually means the
+# field generator failed and the instantiation degraded (instantiation is
+# deliberately throw-free) — re-derives the field types with errors
+# propagating, so that *construction* fails with the generator's underlying
+# error rather than an opaque convert-to-`Union{}` failure.
+function _ctor_fieldtype(@nospecialize(t), i::Int)
+    ft = fieldtype(t, i)
+    ft === Union{} && _ctor_fieldtype_degraded(t, i)
+    return ft
+end
+function _ctor_fieldtype_degraded(@nospecialize(t), i::Int)
+    isdefinedglobal(Base, :fieldtype_generator) || return nothing
+    res = fieldtype_generator(t) # rethrows the generator's own error
+    fti = getfield(res, i)
+    # the generator deliberately produced Union{}: keep the ordinary
+    # convert-to-Union{} failure path
+    fti === Union{} && return nothing
+    # the generator succeeded but produced something that is not a valid
+    # field type (a non-type value, or a type with free type variables)
+    error("field type ", i, " of ", t, " was computed as ", fti,
+          ", which is not a valid field type")
+end
+
 function _set_fieldtype_generator!(@nospecialize(ty), @nospecialize(gen))
     if isdefinedglobal(Base, :_validate_fieldtype_generator)
         fg = _validate_fieldtype_generator(ty, gen)
@@ -1484,7 +1510,9 @@ function _defaultctors(@nospecialize(ty), functionloc)
             # convert methods (e.g. convert(::Any, v::T) = v) that prevent the
             # optimizer from inlining convert(fieldtype(self, i), arg) when the
             # field type is Any after specialization.
-            ft_expr = Expr(:call, GlobalRef(Core, :fieldtype), Core.Argument(1), i)
+            ftname = isa(ft, Core.ComputedFieldType) ?
+                GlobalRef(Base, :_ctor_fieldtype) : GlobalRef(Core, :fieldtype)
+            ft_expr = Expr(:call, ftname, Core.Argument(1), i)
             ft_ssa = Expr(:ssavalue, bidx)
             cnvt_ssa = Expr(:ssavalue, bidx + 1)
             isa_check = Expr(:call, GlobalRef(Core, :isa), Core.Argument(i + 1), ft_ssa)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1287,6 +1287,31 @@ length(a::Array{T,1}) where {T} = getfield(getfield(a, :size), 1)
 const C_NULL = bitcast(Ptr{Cvoid}, 0)
 has_typevar(@nospecialize(t), v::TypeVar) = ccall(:jl_has_typevar, Int32, (Any, Any), t, v) !== Int32(0)
 
+# Install the field generator for a struct with computed field types (declared
+# field-type slots holding Core.ComputedFieldType markers). Called by lowered
+# code from struct definitions, right after the type is resolved. The generator
+# maps the type parameter values to the tuple of field types (a tuple, not an
+# svec, since svec egality is identity, which would preclude proving the
+# generator `:consistent`); the runtime invokes it when a fully concrete
+# instantiation of the type is created.
+#
+# When the full validation machinery is available (see computed_fieldtypes.jl),
+# the generator is required to have provably `:foldable` + `:nortcall` effects
+# and is duplicated into a detached, world-age-independent CodeInstance, stored
+# as `svec(gen, ci)`, so instantiations in any later world (including after
+# loading a precompiled image) compute field types with the definition-time
+# semantics. Before that machinery is loaded (early bootstrap), the generator
+# is stored as `svec(gen)` and invoked dynamically.
+function _set_fieldtype_generator!(@nospecialize(ty), @nospecialize(gen))
+    if isdefinedglobal(Base, :_validate_fieldtype_generator)
+        fg = _validate_fieldtype_generator(ty, gen)
+    else
+        fg = Core.svec(gen)
+    end
+    ccall(:jl_set_fieldtype_generator, Cvoid, (Any, Any), ty, fg)
+    nothing
+end
+
 # Default constructor generation for structs without explicit inner constructors.
 # Called by lowered code from struct definitions (both flisp and JuliaLowering).
 # Uses jl_method_def directly with type objects, avoiding type-to-expression conversion.
@@ -1326,10 +1351,14 @@ function _defaultctors(@nospecialize(ty), functionloc)
     @inbounds argnames[1] = self
     i = 1
     nany = 0
+    hascomputed = false
     while i !== n + 1
         @inbounds argnames[i + 1] = names[i]::Symbol
         if fts[i] === Any
             nany = nany + 1
+        end
+        if isa(fts[i], Core.ComputedFieldType)
+            hascomputed = true
         end
         i = i + 1
     end
@@ -1373,7 +1402,10 @@ function _defaultctors(@nospecialize(ty), functionloc)
         i = i - 1
     end
 
-    if constrains_all
+    # Computed field types cannot appear in a method signature; skip the outer
+    # constructor for such types (the inner constructor below resolves field
+    # types at runtime from the concrete type).
+    if constrains_all && !hascomputed
         # Outer constructor: T(x::FT1, y::FT2, ...) = new{A,B,...}(x, y, ...)
         # Build lambda body with direct `new`, no convert calls
         if is_parametric

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -21,7 +21,7 @@ export Core,
     InterruptException, InexactError, OutOfMemoryError, ReadOnlyMemoryError,
     OverflowError, StackOverflowError, SegmentationFault, UndefRefError, UndefVarError,
     TypeError, ArgumentError, MethodError, AssertionError, LoadError, InitError,
-    UndefKeywordError, ConcurrencyViolationError, FieldError,
+    UndefKeywordError, ConcurrencyViolationError, FieldError, CapabilityError,
     # AST representation
     Expr, QuoteNode, LineNumberNode, GlobalRef,
     # object model functions

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -421,24 +421,31 @@ end
     end
     t = trailing_zeros(p) + 1
     p >>= t
-    if square_is_useful  # avoid performing the same multiplication a second time when possible
-        if (t -= 1) > 0
-            x = convert(T, x_squared_)
-        end
+    t -= 1
+    if square_is_useful && t > 0  # avoid performing the same multiplication a second time when possible
+        x = convert(T, x_squared_)
+        t -= 1
     end
-    while (t -= 1) > 0
-        x = mul(x, x)
-    end
-    y = x
-    while p > 0
-        t = trailing_zeros(p) + 1
-        p >>= t
-        while (t -= 1) >= 0
-            x = mul(x, x)
-        end
-        y = mul(y, x)
-    end
-    return y
+    x = _power_by_squaring_square(mul, t, x)
+    return _power_by_squaring_rest(mul, p, x, x)
+end
+
+# Recursive kernels for `power_by_squaring`, expressing its loops as recursion
+# on the strictly decreasing `t`/`p` (placed first in the argument list, since
+# RCJulia mode admits same-method recursion only when the first differing
+# argument decreases in its well-founded order). This keeps integer `^` usable
+# in restricted-capability evaluation, e.g. in computed field type
+# expressions; the recursion depth is bounded by the bit width of `p`.
+@assume_effects :terminates_globally @inline function _power_by_squaring_square(mul::F, t::Int, x) where {F}
+    t <= 0 && return x
+    return _power_by_squaring_square(mul, t - 1, mul(x, x))
+end
+@assume_effects :terminates_globally function _power_by_squaring_rest(mul::F, p, y, x) where {F}
+    p > 0 || return y
+    t = trailing_zeros(p) + 1
+    p >>= t
+    x = _power_by_squaring_square(mul, t, x)
+    return _power_by_squaring_rest(mul, p, mul(y, x), x)
 end
 power_by_squaring(x::Bool, p::Unsigned) = ((p==0) | x)
 function power_by_squaring(x::Bool, p::Integer)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1633,6 +1633,23 @@ Return the world the [`current_task`](@ref) is executing within.
 """
 tls_world_age() = ccall(:jl_get_tls_world_age, UInt, ())
 
+"""
+    Base.world_token()
+
+Capture the current world age as an opaque `Core.WorldToken`, which can be
+passed to [`invoke_in_world`](@ref Base.invoke_in_world) in place of a raw
+world age.
+
+Unlike a raw world age, a token remains meaningful across precompilation: when
+a token is serialized into a package image, the loading process grafts the
+image's world history into the world-age DAG as its own segment and rebases
+the token onto it, so invoking at the token continues to see the captured
+state and is isolated from later redefinitions. (The granularity within the
+capturing package itself is currently the whole image: a token does not
+distinguish definitions made before and after its capture in its own package.)
+"""
+world_token() = Core.WorldToken(tls_world_age())
+
 get_require_world() = unsafe_load(cglobal(:jl_require_world, UInt))
 
 """

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1642,11 +1642,13 @@ world age.
 
 Unlike a raw world age, a token remains meaningful across precompilation: when
 a token is serialized into a package image, the loading process grafts the
-image's world history into the world-age DAG as its own segment and rebases
-the token onto it, so invoking at the token continues to see the captured
-state and is isolated from later redefinitions. (The granularity within the
-capturing package itself is currently the whole image: a token does not
-distinguish definitions made before and after its capture in its own package.)
+image's world history into the world-age DAG and rebases the token onto it, so
+invoking at the token continues to see exactly the captured state. In
+particular, the token distinguishes definitions made before and after its
+capture (including within its own package), is isolated from redefinitions
+made after the image is loaded, and does not see definitions that are not part
+of its own history (such as packages loaded by the loading process that the
+capturing package did not depend on).
 """
 world_token() = Core.WorldToken(tls_world_age())
 

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -453,6 +453,8 @@ Core.ReadOnlyMemoryError
 Core.OverflowError
 Base.ProcessFailedException
 Base.TaskFailedException
+Core.CapabilityError
+Core._rcjulia_call
 Core.StackOverflowError
 Base.SystemError
 Core.TypeError

--- a/doc/src/manual/worldage.md
+++ b/doc/src/manual/worldage.md
@@ -286,10 +286,20 @@ julia> fetch(t)
 
 In addition to tasks, opaque closures also capture their world age at creation. See [`Base.Experimental.@opaque`](@ref).
 
+## World tokens
+
+A raw world age is only meaningful within the session that produced it. To capture a world
+age that remains meaningful after precompilation, use [`Base.world_token`](@ref), which
+returns an opaque token that can be passed to [`Base.invoke_in_world`](@ref) in place of a
+raw world age. When a token is serialized into a package image, the loading process grafts
+the image's world history into the world-age graph and rebases the token onto it, so that
+invoking at the token continues to see exactly the state that was captured.
+
 ```@docs
 Base.@world
 Base.get_world_counter
 Base.tls_world_age
 Base.invoke_in_world
+Base.world_token
 Base.Experimental.@opaque
 ```

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ SRCS := \
 	dlload sys init task array genericmemory staticdata toplevel jl_uv datatype \
 	simplevector runtime_intrinsics precompile jloptions mtarraylist \
 	threading scheduler stackwalk null_sysimage \
-	method jlapi signal-handling safepoint timing subtype rtutils \
+	method jlapi signal-handling safepoint timing subtype rtutils world \
 	crc32c APInt processor ircode opaque_closure codegen-stubs coverage runtime_ccall engine \
 	$(GC_SRCS)
 

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -18,6 +18,7 @@ extern "C" {
     XX(_import, "_import") \
     XX(_new_cancel_source,"_new_cancel_source") \
     XX(_primitivetype,"_primitivetype") \
+    XX(_rcjulia_call,"_rcjulia_call") \
     XX(_setsuper,"_setsuper!") \
     XX(_structtype,"_structtype") \
     XX(_svec_len,"_svec_len") \

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1076,8 +1076,14 @@ JL_CALLABLE(jl_f_invoke_in_world)
     JL_NARGSV(invoke_in_world, 2);
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
-    JL_TYPECHK(invoke_in_world, ulong, args[0]);
-    size_t world = jl_unbox_ulong(args[0]);
+    size_t world;
+    if (jl_typetagis(args[0], jl_worldtoken_type)) {
+        world = ((jl_worldtoken_t*)args[0])->world;
+    }
+    else {
+        JL_TYPECHK(invoke_in_world, ulong, args[0]);
+        world = jl_unbox_ulong(args[0]);
+    }
     if (!ct->ptls->in_pure_callback) {
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
         if (jl_world_at_most(world, ct->world_age))
@@ -1129,7 +1135,9 @@ JL_CALLABLE(jl_f__rcjulia_call)
 JL_CALLABLE(jl_f__call_in_world_total)
 {
     JL_NARGSV(_call_in_world_total, 2);
-    JL_TYPECHK(_call_in_world_total, ulong, args[0]);
+    if (!jl_typetagis(args[0], jl_worldtoken_type)) {
+        JL_TYPECHK(_call_in_world_total, ulong, args[0]);
+    }
     jl_check_rc("_call_in_world_total");
     jl_task_t *ct = jl_current_task;
     int last_in = ct->ptls->in_pure_callback;
@@ -1137,7 +1145,8 @@ JL_CALLABLE(jl_f__call_in_world_total)
     size_t last_age = ct->world_age;
     JL_TRY {
         ct->ptls->in_pure_callback = 1;
-        size_t world = jl_unbox_ulong(args[0]);
+        size_t world = jl_typetagis(args[0], jl_worldtoken_type) ?
+            ((jl_worldtoken_t*)args[0])->world : jl_unbox_ulong(args[0]);
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
         if (jl_world_at_most(world, ct->world_age))
             ct->world_age = world;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1080,7 +1080,7 @@ JL_CALLABLE(jl_f_invoke_in_world)
     size_t world = jl_unbox_ulong(args[0]);
     if (!ct->ptls->in_pure_callback) {
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-        if (ct->world_age > world)
+        if (jl_world_at_most(world, ct->world_age))
             ct->world_age = world;
     }
     jl_value_t *ret = jl_apply(&args[1], nargs - 1);
@@ -1139,7 +1139,7 @@ JL_CALLABLE(jl_f__call_in_world_total)
         ct->ptls->in_pure_callback = 1;
         size_t world = jl_unbox_ulong(args[0]);
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-        if (ct->world_age > world)
+        if (jl_world_at_most(world, ct->world_age))
             ct->world_age = world;
         ret = jl_apply(&args[1], nargs - 1);
         ct->world_age = last_age;
@@ -2028,8 +2028,8 @@ JL_CALLABLE(jl_f_invoke)
                 jl_type_error("invoke: argument type error", mi->specTypes, arg_tuple(args[0], &args[2], nargs - 1));
             }
         }
-        if (jl_atomic_load_relaxed(&codeinst->min_world) > jl_current_task->world_age ||
-            jl_current_task->world_age > jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (!jl_world_in_range(jl_current_task->world_age, jl_atomic_load_relaxed(&codeinst->min_world),
+                               jl_atomic_load_relaxed(&codeinst->max_world))) {
             jl_error("invoke: CodeInstance not valid for this world");
         }
         if (!invoke) {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1500,7 +1500,20 @@ static jl_value_t *get_fieldtype(jl_value_t *t, jl_value_t *f, int dothrow) JL_C
         else
             return jl_bottom_type;
     }
-    return jl_field_type(st, field_index);
+    jl_value_t *ft = jl_field_type(st, field_index);
+    if (jl_is_computedfieldtype(ft)) {
+        // computed field type of a partial instantiation: there is no type to
+        // return until the parameters are fully concrete (n.b. deliberately
+        // not represented in the type system; use `Base.fieldtype_generator`
+        // for the partially applied form)
+        if (dothrow)
+            jl_errorf("fieldtype: field type of %s is computed from the values of the "
+                      "type parameters and is only available for fully concrete types; "
+                      "see `Base.fieldtype_generator` for partial application",
+                      jl_symbol_name(st->name->name));
+        return jl_bottom_type;
+    }
+    return ft;
 }
 
 JL_CALLABLE(jl_f_fieldtype)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -735,12 +735,14 @@ JL_CALLABLE(jl_f_ifelse)
 
 JL_CALLABLE(jl_f_current_scope)
 {
+    jl_check_rc("current_scope");
     JL_NARGS(current_scope, 0, 0);
     return jl_current_task->scope;
 }
 
 JL_CALLABLE(jl_f__new_cancel_source)
 {
+    jl_check_rc("_new_cancel_source");
     // each argument is a parent CancellationTokenSource (checked, along
     // with distinctness, by jl_new_cancel_source); no arguments makes a
     // root source
@@ -758,6 +760,7 @@ JL_CALLABLE(jl_f__new_cancel_source)
 // (reset_ctx), which has no interpreter equivalent.
 JL_CALLABLE(jl_f_cancellation_point)
 {
+    jl_check_rc("cancellation_point!");
     JL_NARGS(cancellation_point!, 1, 1);
     jl_task_t *ct = jl_current_task;
     jl_value_t *src = args[0];
@@ -826,7 +829,12 @@ JL_CALLABLE(jl_f__apply_iterate)
     assert(iterate);
     args += 1;
     nargs -= 1;
-    if (nargs == 2) {
+    // In RCJulia mode only tuple/svec/NamedTuple splatting is
+    // permitted (checked in the sizing loop below): splatting Memory/Array
+    // reads mutable memory, and the generic path calls `iterate` natively.
+    // The fast paths are skipped so the final apply stays checked.
+    int pure = jl_current_task->rcjulia != 0;
+    if (nargs == 2 && !pure) {
         // some common simple cases
         if (f == BUILTIN(svec)) {
             if (jl_is_svec(args[1]))
@@ -873,6 +881,9 @@ JL_CALLABLE(jl_f__apply_iterate)
         }
         else if (jl_is_tuple(args[i]) || jl_is_namedtuple(args[i])) {
             precount += jl_nfields(args[i]);
+        }
+        else if (pure) {
+            jl_capability_error("_apply_iterate");
         }
         else if (jl_is_genericmemory(args[i])) {
             precount += ((jl_genericmemory_t*)args[i])->length;
@@ -1038,7 +1049,7 @@ JL_CALLABLE(jl_f__apply_iterate)
         ((void**)roots)[-2] = (void*)JL_GC_ENCODE_PUSHARGS(1);
 #endif
     }
-    jl_value_t *result = jl_apply(newargs, n);
+    jl_value_t *result = pure ? jl_rc_apply(newargs, n) : jl_apply(newargs, n);
     JL_GC_POP();
     return result;
 }
@@ -1046,6 +1057,7 @@ JL_CALLABLE(jl_f__apply_iterate)
 // this is like a regular call, but always runs in the newest world
 JL_CALLABLE(jl_f_invokelatest)
 {
+    jl_check_rc("invokelatest");
     JL_NARGSV(invokelatest, 1);
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
@@ -1060,6 +1072,7 @@ JL_CALLABLE(jl_f_invokelatest)
 // If world > jl_atomic_load_acquire(&jl_world_counter), run in the latest world.
 JL_CALLABLE(jl_f_invoke_in_world)
 {
+    jl_check_rc("invoke_in_world");
     JL_NARGSV(invoke_in_world, 2);
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
@@ -1075,10 +1088,49 @@ JL_CALLABLE(jl_f_invoke_in_world)
     return ret;
 }
 
+// Enter RCJulia mode: freeze the task's world age to `args[0]` and
+// apply `args[1:end]` with every impure primitive operation trapped (throwing
+// CapabilityError). Any call that completes under the mode is
+// `:foldable` by construction; `:nothrow` is deliberately not implied — a
+// consistent throw (including the traps themselves) is a foldable outcome.
+JL_CALLABLE(jl_f__rcjulia_call)
+{
+    JL_NARGSV(_rcjulia_call, 2);
+    JL_TYPECHK(_rcjulia_call, ulong, args[0]);
+    jl_task_t *ct = jl_current_task;
+    size_t last_age = ct->world_age;
+    uint16_t last_rc = ct->rcjulia;
+    jl_value_t *ret = NULL;
+    size_t world = jl_unbox_ulong(args[0]);
+    size_t max_world = jl_atomic_load_acquire(&jl_world_counter);
+    if (world > max_world)
+        world = max_world;
+    // nested entries must not raise the frozen world: the outer mode's
+    // execution would otherwise observe state its own world cannot see
+    if (last_rc && world > last_age)
+        jl_capability_error("_rcjulia_call");
+    if (last_rc == UINT16_MAX)
+        jl_capability_error("depth_limit");
+    JL_TRY {
+        ct->world_age = world;
+        ct->rcjulia = last_rc + 1;
+        ret = jl_rc_apply(&args[1], nargs - 1);
+        ct->world_age = last_age;
+        ct->rcjulia = last_rc;
+    }
+    JL_CATCH {
+        ct->world_age = last_age;
+        ct->rcjulia = last_rc;
+        jl_rethrow();
+    }
+    return ret;
+}
+
 JL_CALLABLE(jl_f__call_in_world_total)
 {
     JL_NARGSV(_call_in_world_total, 2);
     JL_TYPECHK(_call_in_world_total, ulong, args[0]);
+    jl_check_rc("_call_in_world_total");
     jl_task_t *ct = jl_current_task;
     int last_in = ct->ptls->in_pure_callback;
     jl_value_t *ret = NULL;
@@ -1214,6 +1266,12 @@ JL_CALLABLE(jl_f_getfield)
         return jl_f_getglobal(NULL, args, 2); // we just ignore the atomic order and boundschecks
     jl_datatype_t *st = (jl_datatype_t*)vt;
     size_t idx = get_checked_fieldindex("getfield", st, v, args[1], 0);
+    // RCJulia mode may read `const` fields of mutable objects — the language
+    // already guarantees they never change after construction (this is what
+    // admits set-once runtime metadata such as `DataType.parameters`)
+    if (__unlikely(jl_current_task->rcjulia) && st->name->mutabl &&
+            !jl_field_isconst(st, idx))
+        jl_capability_error("getfield");
     int isatomic = jl_field_isatomic(st, idx);
     if (!isatomic && order != jl_memory_order_notatomic && order != jl_memory_order_unspecified)
         jl_atomic_error("getfield: non-atomic field cannot be accessed atomically");
@@ -1229,6 +1287,7 @@ JL_CALLABLE(jl_f_getfield)
 
 JL_CALLABLE(jl_f_setfield)
 {
+    jl_check_rc("setfield!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(setfield!, 3, 4);
     if (nargs == 4) {
@@ -1253,6 +1312,7 @@ JL_CALLABLE(jl_f_setfield)
 
 JL_CALLABLE(jl_f_swapfield)
 {
+    jl_check_rc("swapfield!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(swapfield!, 3, 4);
     if (nargs == 4) {
@@ -1272,6 +1332,7 @@ JL_CALLABLE(jl_f_swapfield)
 
 JL_CALLABLE(jl_f_modifyfield)
 {
+    jl_check_rc("modifyfield!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(modifyfield!, 4, 5);
     if (nargs == 5) {
@@ -1291,6 +1352,7 @@ JL_CALLABLE(jl_f_modifyfield)
 
 JL_CALLABLE(jl_f_replacefield)
 {
+    jl_check_rc("replacefield!");
     enum jl_memory_order success_order = jl_memory_order_notatomic;
     JL_NARGS(replacefield!, 4, 6);
     if (nargs >= 5) {
@@ -1321,6 +1383,7 @@ JL_CALLABLE(jl_f_replacefield)
 
 JL_CALLABLE(jl_f_setfieldonce)
 {
+    jl_check_rc("setfieldonce!");
     enum jl_memory_order success_order = jl_memory_order_notatomic;
     JL_NARGS(setfieldonce!, 3, 5);
     if (nargs >= 4) {
@@ -1465,6 +1528,13 @@ JL_CALLABLE(jl_f_isdefined)
             order = jl_memory_order_unordered;
         if (order < jl_memory_order_unordered)
             jl_atomic_error("isdefined: module binding cannot be accessed non-atomically");
+        if (__unlikely(jl_current_task->rcjulia)) {
+            jl_value_t *v = NULL;
+            int kind = jl_rc_binding_constant(m, s, jl_current_task->world_age, &v);
+            if (kind < 0)
+                jl_capability_error("isdefined");
+            return kind == 1 ? jl_true : jl_false;
+        }
         int bound = jl_boundp(m, s, 1); // seq_cst always
         return bound ? jl_true : jl_false;
     }
@@ -1488,6 +1558,9 @@ JL_CALLABLE(jl_f_isdefined)
             return jl_false;
         }
     }
+    if (__unlikely(jl_current_task->rcjulia) && vt->name->mutabl &&
+            !jl_field_isconst(vt, idx))
+        jl_capability_error("isdefined");
     int isatomic = jl_field_isatomic(vt, idx);
     if (!isatomic && order != jl_memory_order_notatomic && order != jl_memory_order_unspecified)
         jl_atomic_error("isdefined: non-atomic field cannot be accessed atomically");
@@ -1520,6 +1593,8 @@ JL_CALLABLE(jl_f_getglobal)
         jl_atomic_error("getglobal: module binding cannot be read non-atomically");
     else if (order >= jl_memory_order_seq_cst)
         jl_fence();
+    if (__unlikely(jl_current_task->rcjulia))
+        return jl_rc_globalref_value(mod, sym, jl_current_task->world_age);
     jl_value_t *v = jl_eval_global_var(mod, sym, jl_current_task->world_age); // relaxed load
     if (order >= jl_memory_order_acquire)
         jl_fence();
@@ -1549,12 +1624,22 @@ JL_CALLABLE(jl_f_isdefinedglobal)
         order = jl_memory_order_unordered;
     if (order < jl_memory_order_unordered)
         jl_atomic_error("isdefined: module binding cannot be accessed non-atomically");
+    if (__unlikely(jl_current_task->rcjulia)) {
+        // in RCJulia mode, definedness may only be observed for
+        // bindings whose state is fixed within the frozen world
+        jl_value_t *v = NULL;
+        int kind = jl_rc_binding_constant(m, s, jl_current_task->world_age, &v);
+        if (kind < 0)
+            jl_capability_error("isdefinedglobal");
+        return kind == 1 ? jl_true : jl_false;
+    }
     int bound = jl_boundp(m, s, allow_import); // seq_cst always
     return bound ? jl_true : jl_false;
 }
 
 JL_CALLABLE(jl_f_setglobal)
 {
+    jl_check_rc("setglobal!");
     enum jl_memory_order order = jl_memory_order_release;
     JL_NARGS(setglobal!, 3, 4);
     if (nargs == 4) {
@@ -1591,6 +1676,7 @@ JL_CALLABLE(jl_f_get_binding_type)
 
 JL_CALLABLE(jl_f_swapglobal)
 {
+    jl_check_rc("swapglobal!");
     enum jl_memory_order order = jl_memory_order_release;
     JL_NARGS(swapglobal!, 3, 4);
     if (nargs == 4) {
@@ -1610,6 +1696,7 @@ JL_CALLABLE(jl_f_swapglobal)
 
 JL_CALLABLE(jl_f_modifyglobal)
 {
+    jl_check_rc("modifyglobal!");
     enum jl_memory_order order = jl_memory_order_release;
     JL_NARGS(modifyglobal!, 4, 5);
     if (nargs == 5) {
@@ -1629,6 +1716,7 @@ JL_CALLABLE(jl_f_modifyglobal)
 
 JL_CALLABLE(jl_f_replaceglobal)
 {
+    jl_check_rc("replaceglobal!");
     enum jl_memory_order success_order = jl_memory_order_release;
     JL_NARGS(replaceglobal!, 4, 6);
     if (nargs >= 5) {
@@ -1658,6 +1746,7 @@ JL_CALLABLE(jl_f_replaceglobal)
 
 JL_CALLABLE(jl_f_setglobalonce)
 {
+    jl_check_rc("setglobalonce!");
     enum jl_memory_order success_order = jl_memory_order_release;
     JL_NARGS(setglobalonce!, 3, 5);
     if (nargs >= 4) {
@@ -1689,6 +1778,7 @@ JL_CALLABLE(jl_f_setglobalonce)
 // declare_global(module::Module, name::Symbol, [strong::Bool=false, [ty::Type]])
 JL_CALLABLE(jl_f_declare_global)
 {
+    jl_check_rc("declare_global");
     JL_NARGS(declare_global, 3, 4);
     JL_TYPECHK(declare_global, module, args[0]);
     JL_TYPECHK(declare_global, symbol, args[1]);
@@ -1705,6 +1795,7 @@ JL_CALLABLE(jl_f_declare_global)
 
 JL_CALLABLE(jl_f_declare_const)
 {
+    jl_check_rc("declare_const");
     JL_NARGS(declare_const, 2, 3);
     JL_TYPECHK(declare_const, module, args[0]);
     if (nargs == 3)
@@ -1719,6 +1810,7 @@ JL_CALLABLE(jl_f_declare_const)
 // define_method(module::Module, fname_or_mt, argdata, code) - define method
 JL_CALLABLE(jl_f_define_method)
 {
+    jl_check_rc("define_method");
     if (nargs != 2 && nargs != 4)
         jl_error("define_method requires 2 or 4 arguments");
     JL_TYPECHK(define_method, module, args[0]);
@@ -1765,6 +1857,7 @@ JL_CALLABLE(jl_f_define_method)
 //     _import(to::Module, mod::Module, asname::Symbol)
 JL_CALLABLE(jl_f__import)
 {
+    jl_check_rc("_import");
     JL_NARGS(_import, 3, 5);
     JL_TYPECHK(_import, module, args[0]);
     JL_TYPECHK(_import, module, args[1]);
@@ -1788,6 +1881,7 @@ JL_CALLABLE(jl_f__import)
 // _using(to::Module, from::Module)
 JL_CALLABLE(jl_f__using)
 {
+    jl_check_rc("_using");
     JL_NARGS(_using, 2, 3);
     JL_TYPECHK(_using, module, args[0]);
     JL_TYPECHK(_using, module, args[1]);
@@ -1910,6 +2004,7 @@ JL_CALLABLE(jl_f_applicable)
 
 JL_CALLABLE(jl_f_invoke)
 {
+    jl_check_rc("invoke");
     JL_NARGSV(invoke, 2);
     jl_value_t *argtypes = args[1];
     if (jl_is_method(argtypes)) {
@@ -1974,6 +2069,7 @@ jl_expr_t *jl_exprn(jl_sym_t *head, size_t n)
 
 JL_CALLABLE(jl_f__expr)
 {
+    jl_check_rc("_expr");
     jl_task_t *ct = jl_current_task;
     JL_NARGSV(Expr, 1);
     JL_TYPECHK(Expr, symbol, args[0]);
@@ -2015,6 +2111,7 @@ JL_CALLABLE(jl_f__typevar)
 // genericmemory ---------------------------------------------------------------------
 JL_CALLABLE(jl_f_memorynew)
 {
+    jl_check_rc("memorynew");
     JL_NARGS(memorynew, 2, 2);
     jl_datatype_t *jl_genericmemory_type_type = jl_datatype_type;
     JL_TYPECHK(memorynew, genericmemory_type, args[0]);
@@ -2100,6 +2197,7 @@ JL_CALLABLE(jl_f_memoryrefoffset)
 
 JL_CALLABLE(jl_f_memoryrefget)
 {
+    jl_check_rc("memoryrefget");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefget, 3, 3);
     JL_TYPECHK(memoryrefget, genericmemoryref, args[0]);
@@ -2125,6 +2223,7 @@ JL_CALLABLE(jl_f_memoryrefget)
 
 JL_CALLABLE(jl_f_memoryrefset)
 {
+    jl_check_rc("memoryrefset!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefset!, 4, 4);
     JL_TYPECHK(memoryrefset!, genericmemoryref, args[0]);
@@ -2151,6 +2250,7 @@ JL_CALLABLE(jl_f_memoryrefset)
 
 JL_CALLABLE(jl_f_memoryrefunset)
 {
+    jl_check_rc("memoryrefunset!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefunset!, 3, 3);
     JL_TYPECHK(memoryrefunset!, genericmemoryref, args[0]);
@@ -2177,6 +2277,7 @@ JL_CALLABLE(jl_f_memoryrefunset)
 
 JL_CALLABLE(jl_f_memoryref_isassigned)
 {
+    jl_check_rc("memoryref_isassigned");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryref_isassigned, 3, 3);
     JL_TYPECHK(memoryref_isassigned, genericmemoryref, args[0]);
@@ -2203,6 +2304,7 @@ JL_CALLABLE(jl_f_memoryref_isassigned)
 
 JL_CALLABLE(jl_f_memoryrefswap)
 {
+    jl_check_rc("memoryrefswap!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefswap!, 4, 4);
     JL_TYPECHK(memoryrefswap!, genericmemoryref, args[0]);
@@ -2228,6 +2330,7 @@ JL_CALLABLE(jl_f_memoryrefswap)
 
 JL_CALLABLE(jl_f_memoryrefmodify)
 {
+    jl_check_rc("memoryrefmodify!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefmodify!, 5, 5);
     JL_TYPECHK(memoryrefmodify!, genericmemoryref, args[0]);
@@ -2253,6 +2356,7 @@ JL_CALLABLE(jl_f_memoryrefmodify)
 
 JL_CALLABLE(jl_f_memoryrefreplace)
 {
+    jl_check_rc("memoryrefreplace!");
     enum jl_memory_order success_order = jl_memory_order_notatomic;
     enum jl_memory_order failure_order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefreplace!, 6, 6);
@@ -2287,6 +2391,7 @@ JL_CALLABLE(jl_f_memoryrefreplace)
 
 JL_CALLABLE(jl_f_memoryrefsetonce)
 {
+    jl_check_rc("memoryrefsetonce!");
     enum jl_memory_order success_order = jl_memory_order_notatomic;
     enum jl_memory_order failure_order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefsetonce!, 5, 5);
@@ -2323,6 +2428,7 @@ JL_CALLABLE(jl_f_memoryrefsetonce)
 
 JL_CALLABLE(jl_f__structtype)
 {
+    jl_check_rc("_structtype");
     JL_NARGS(_structtype, 7, 7);
     JL_TYPECHK(_structtype, module, args[0]);
     JL_TYPECHK(_structtype, symbol, args[1]);
@@ -2342,6 +2448,7 @@ JL_CALLABLE(jl_f__structtype)
 
 JL_CALLABLE(jl_f__abstracttype)
 {
+    jl_check_rc("_abstracttype");
     JL_NARGS(_abstracttype, 3, 3);
     JL_TYPECHK(_abstracttype, module, args[0]);
     JL_TYPECHK(_abstracttype, symbol, args[1]);
@@ -2352,6 +2459,7 @@ JL_CALLABLE(jl_f__abstracttype)
 
 JL_CALLABLE(jl_f__primitivetype)
 {
+    jl_check_rc("_primitivetype");
     JL_NARGS(_primitivetype, 4, 4);
     JL_TYPECHK(_primitivetype, module, args[0]);
     JL_TYPECHK(_primitivetype, symbol, args[1]);
@@ -2385,6 +2493,7 @@ static void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super) JL_CANSA
 
 JL_CALLABLE(jl_f__setsuper)
 {
+    jl_check_rc("_setsuper!");
     JL_NARGS(_setsuper!, 2, 2);
     jl_datatype_t *dt = (jl_datatype_t*)jl_unwrap_unionall(args[0]);
     JL_TYPECHK(_setsuper!, datatype, (jl_value_t*)dt);
@@ -2413,6 +2522,7 @@ JL_CALLABLE(jl_f_compilerbarrier)
 
 JL_CALLABLE(jl_f_finalizer)
 {
+    jl_check_rc("finalizer");
     // NOTE the compiler may temporarily insert additional argument for the later inlining pass
     JL_NARGS(finalizer, 2, 4);
     jl_task_t *ct = jl_current_task;
@@ -2469,6 +2579,7 @@ JL_CALLABLE(jl_f__svec_ref)
 
 JL_CALLABLE(jl_f__task)
 {
+    jl_check_rc("_task");
     JL_NARGS(_task, 2, 3);
     jl_value_t *start = args[0];
     JL_TYPECHK(_task, long, args[1]);
@@ -2487,6 +2598,7 @@ JL_CALLABLE(jl_f__task)
 
 JL_CALLABLE(jl_f_task_result_type)
 {
+    jl_check_rc("task_result_type");
     JL_NARGS(task_result_type, 1, 1);
     JL_TYPECHK(task_result_type, task, args[0]);
     // Without inference, this returns Any, but inference can inject other Types here
@@ -2555,6 +2667,7 @@ int references_name(jl_value_t *p, jl_typename_t *name, int affects_layout, int 
 
 JL_CALLABLE(jl_f__typebody)
 {
+    jl_check_rc("_typebody!");
     JL_NARGS(_typebody!, 1, 2);
     jl_datatype_t *dt = (jl_datatype_t*)jl_unwrap_unionall(args[0]);
     JL_TYPECHK(_typebody!, datatype, (jl_value_t*)dt);
@@ -2663,6 +2776,7 @@ int equiv_type(jl_value_t *ta, jl_value_t *tb) JL_CANSAFEPOINT
 
 JL_CALLABLE(jl_f__equiv_typedef)
 {
+    jl_check_rc("_equiv_typedef");
     JL_NARGS(_equiv_typedef, 2, 2);
     return equiv_type(args[0], args[1]) ? jl_true : jl_false;
 }
@@ -2678,8 +2792,12 @@ JL_CALLABLE(jl_f_intrinsic_call)
     if (f == cglobal && nargs == 1)
         f = cglobal_auto;
     unsigned fargs = intrinsic_nargs[f];
-    if (!fargs)
+    if (!fargs) {
+        // compiler-required intrinsics (llvmcall) run native code the mode's
+        // traps cannot see
+        jl_check_rc(jl_intrinsic_name(f));
         jl_errorf("`%s` requires the compiler", jl_intrinsic_name(f));
+    }
     JL_NARGS(intrinsic_call, fargs, fargs);
 
     union {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1997,6 +1997,11 @@ JL_CALLABLE(jl_f_apply_type)
             return (jl_value_t*)jl_wrap_vararg(vm->T, args[1], 1, 0);
         }
     }
+    else if (jl_is_fieldtypegenerator(args[0])) {
+        // partially applied field generator: applied like a partially applied
+        // UnionAll (see Base.fieldtype_generator)
+        return jl_apply_fieldtype_generator(args[0], &args[1], nargs - 1);
+    }
     else if (jl_is_unionall(args[0])) {
         for(i=1; i < nargs; i++) {
             jl_value_t *pi = args[i];

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1102,23 +1102,31 @@ JL_CALLABLE(jl_f_invoke_in_world)
 JL_CALLABLE(jl_f__rcjulia_call)
 {
     JL_NARGSV(_rcjulia_call, 2);
-    JL_TYPECHK(_rcjulia_call, ulong, args[0]);
+    // the world may be a plain world age or a `Core.WorldToken` (an opaque
+    // world capture that survives precompilation into the image's preserved
+    // segment — the form field generators store)
+    if (!jl_typetagis(args[0], jl_worldtoken_type)) {
+        JL_TYPECHK(_rcjulia_call, ulong, args[0]);
+    }
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
     uint16_t last_rc = ct->rcjulia;
     jl_value_t *ret = NULL;
-    size_t world = jl_unbox_ulong(args[0]);
-    size_t max_world = jl_atomic_load_acquire(&jl_world_counter);
-    if (world > max_world)
-        world = max_world;
+    size_t world = jl_typetagis(args[0], jl_worldtoken_type) ?
+        ((jl_worldtoken_t*)args[0])->world : jl_unbox_ulong(args[0]);
+    // clamp to a world the runtime can evaluate in; worlds are DAG-shaped, so
+    // this is reachability, not integer comparison (cf. _call_in_world_total)
+    size_t target = jl_atomic_load_acquire(&jl_world_counter);
+    if (jl_world_at_most(world, target))
+        target = world;
     // nested entries must not raise the frozen world: the outer mode's
     // execution would otherwise observe state its own world cannot see
-    if (last_rc && world > last_age)
+    if (last_rc && !jl_world_at_most(target, last_age))
         jl_capability_error("_rcjulia_call");
     if (last_rc == UINT16_MAX)
         jl_capability_error("depth_limit");
     JL_TRY {
-        ct->world_age = world;
+        ct->world_age = target;
         ct->rcjulia = last_rc + 1;
         ret = jl_rc_apply(&args[1], nargs - 1);
         ct->world_age = last_age;

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -94,6 +94,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     jl_atomic_store_relaxed(&tn->cache_entry_count, 0);
     tn->constprop_heustic = 0;
     tn->concrete_only = 0;
+    jl_atomic_store_relaxed(&tn->fieldgen, NULL);
     return tn;
 }
 
@@ -2787,12 +2788,64 @@ void jl_check_field_types(jl_svec_t *ftypes, jl_sym_t *type_name)
     size_t nf = jl_svec_len(ftypes);
     for (size_t i = 0; i < nf; i++) {
         jl_value_t *elt = jl_svecref(ftypes, i);
-        if (!jl_is_type(elt) && !jl_is_typevar(elt)) {
+        if (!jl_is_type(elt) && !jl_is_typevar(elt) && !jl_is_computedfieldtype(elt)) {
             jl_type_error_rt(jl_symbol_name(type_name),
                              "type definition",
                              (jl_value_t*)jl_type_type, elt);
         }
     }
+}
+
+// Return whether any declared field-type slot is a Core.ComputedFieldType marker.
+int jl_svec_has_computedfields(jl_svec_t *types) JL_NOTSAFEPOINT
+{
+    size_t nf = jl_svec_len(types);
+    for (size_t i = 0; i < nf; i++) {
+        if (jl_is_computedfieldtype(jl_svecref(types, i)))
+            return 1;
+    }
+    return 0;
+}
+
+// Structural equality for the quoted source ASTs stored in ComputedFieldType
+// markers (jl_egal on Expr is identity, which would defeat the redefinition
+// equivalence check).
+static int computed_field_ast_equal(jl_value_t *a, jl_value_t *b)
+{
+    if (a == b)
+        return 1;
+    if (jl_typeof(a) != jl_typeof(b))
+        return 0;
+    if (jl_is_expr(a)) {
+        jl_expr_t *ea = (jl_expr_t*)a, *eb = (jl_expr_t*)b;
+        if (ea->head != eb->head)
+            return 0;
+        size_t l = jl_expr_nargs(ea);
+        if (l != jl_expr_nargs(eb))
+            return 0;
+        for (size_t i = 0; i < l; i++) {
+            if (!computed_field_ast_equal(jl_exprarg(ea, i), jl_exprarg(eb, i)))
+                return 0;
+        }
+        return 1;
+    }
+    if (jl_is_quotenode(a))
+        return computed_field_ast_equal(jl_quotenode_value(a), jl_quotenode_value(b));
+    return jl_egal(a, b);
+}
+
+// Install the field generator for a type with computed field types. Called by
+// Base._set_fieldtype_generator! shortly after the type definition.
+JL_DLLEXPORT void jl_set_fieldtype_generator(jl_value_t *ty, jl_value_t *fieldgen)
+{
+    jl_datatype_t *dt = (jl_datatype_t*)jl_unwrap_unionall(ty);
+    if (!jl_is_datatype(dt))
+        jl_type_error("_set_fieldtype_generator!", (jl_value_t*)jl_datatype_type, (jl_value_t*)dt);
+    jl_typename_t *tn = dt->name;
+    if (dt->types == NULL || !jl_svec_has_computedfields(dt->types))
+        jl_errorf("type %s does not have computed field types", jl_symbol_name(tn->name));
+    jl_atomic_store_release(&tn->fieldgen, fieldgen);
+    jl_gc_wb(tn, fieldgen);
 }
 
 // Resolve multiple typegroup types atomically into real DataTypes
@@ -3115,6 +3168,17 @@ JL_DLLEXPORT jl_value_t *jl_resolve_typegroup(jl_module_t *module, jl_svec_t *ty
             for (size_t j = 0; j < nf; j++) {
                 jl_value_t *old_ft = jl_svecref(old_dt->types, j);
                 new_ft = jl_svecref(new_dt->types, j);
+                // Computed field types compare by their quoted source AST
+                // (marker objects are freshly allocated on each definition).
+                if (jl_is_computedfieldtype(old_ft) || jl_is_computedfieldtype(new_ft)) {
+                    if (!jl_is_computedfieldtype(old_ft) || !jl_is_computedfieldtype(new_ft) ||
+                        !computed_field_ast_equal(((jl_computedfieldtype_t*)old_ft)->expr,
+                                                  ((jl_computedfieldtype_t*)new_ft)->expr)) {
+                        fields_match = 0;
+                        break;
+                    }
+                    continue;
+                }
                 // Self-references in the new fields point at the new type; map
                 // them to the old type so an identical redefinition compares
                 // equal (issues #21816, #61789).

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -320,6 +320,14 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     memcpy(&save_rngState[0], &ct->rngState[0], sizeof(save_rngState));
     jl_rng_split(ct->rngState, finalizer_rngState);
     int last_errno = errno;
+    // Finalizers may fire at allocation safepoints inside RCJulia mode; they
+    // are semantically outside the restricted computation (which cannot
+    // observe their effects, since it cannot read mutable memory), so
+    // suspend the mode while they run rather than trapping unrelated code.
+    uint16_t last_rc = ct->rcjulia;
+    jl_rc_frame_t *last_rc_frames = ct->rc_frames;
+    ct->rcjulia = 0;
+    ct->rc_frames = NULL;
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
 #endif
@@ -331,6 +339,8 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     ct->ptls->in_finalizer = was_in_finalizer;
     arraylist_free(&copied_list);
 
+    ct->rcjulia = last_rc;
+    ct->rc_frames = last_rc_frames;
     memcpy(&ct->rngState[0], &save_rngState[0], sizeof(save_rngState));
 #ifdef _OS_WINDOWS_
     SetLastError(last_error);

--- a/src/gf.c
+++ b/src/gf.c
@@ -5072,7 +5072,7 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     }
     else if (!jl_world_at_most(closure->world, max_world)) {
         // exclude method table entries that have been replaced in the current world
-        closure->match.min_valid = jl_world_spine_join(closure->match.min_valid, max_world + 1);
+        closure->match.min_valid = jl_world_join(closure->match.min_valid, max_world + 1, closure->world);
         return 1;
     }
     if (closure->match.max_valid > max_world)
@@ -5470,7 +5470,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                 jl_array_ptr_set(env.t, 0, env.matc);
                 size_t min_world = jl_atomic_load_relaxed(&entry->min_world);
                 size_t max_world = jl_atomic_load_relaxed(&entry->max_world);
-                *min_valid = jl_world_spine_join(*min_valid, min_world);
+                *min_valid = jl_world_join(*min_valid, min_world, world);
                 if (*max_valid > max_world)
                     *max_valid = max_world;
                 JL_GC_POP();
@@ -5502,7 +5502,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                         env.match.env, meth, FULLY_COVERS);
                     env.t = (jl_value_t*)jl_alloc_vec_any(1);
                     jl_array_ptr_set(env.t, 0, env.matc);
-                    *min_valid = jl_world_spine_join(*min_valid, min_world);
+                    *min_valid = jl_world_join(*min_valid, min_world, world);
                     if (*max_valid > max_world)
                         *max_valid = max_world;
                     JL_GC_POP();
@@ -5692,7 +5692,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
         // method applicability is the same as typemapentry applicability
         size_t min_world = jl_atomic_load_relaxed(&m->primary_world);
         // intersect the env valid range with method lookup's inclusive valid range
-        env.match.min_valid = jl_world_spine_join(env.match.min_valid, min_world);
+        env.match.min_valid = jl_world_join(env.match.min_valid, min_world, world);
     }
     if (mc && cache_result_recursion && ((jl_datatype_t*)unw)->isdispatchtuple) { // cache_result_recursion prevents lock confusion and unnecessary work
         if (len == 1 && !has_ambiguity) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -411,7 +411,7 @@ static jl_code_instance_t *jl_method_inferred_with_abi(jl_method_instance_t *mi 
     for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
         if (codeinst->owner != jl_nothing)
             continue;
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (jl_world_in_range(world, jl_atomic_load_relaxed(&codeinst->min_world), jl_atomic_load_relaxed(&codeinst->max_world))) {
             if (emit_codeinst_and_edges(codeinst) && jl_atomic_load_relaxed(&codeinst->invoke) != NULL)
                 return codeinst;
         }
@@ -589,8 +589,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_uninferred(
     jl_value_t *owner = jl_nothing; // TODO: owner should be arg
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= min_world &&
-            jl_atomic_load_relaxed(&codeinst->max_world) >= max_world &&
+        if (jl_world_range_in_range(min_world, max_world, jl_atomic_load_relaxed(&codeinst->min_world), jl_atomic_load_relaxed(&codeinst->max_world)) &&
             jl_egal(codeinst->owner, owner) &&
             jl_egal(codeinst->rettype, rettype)) {
             if (di == NULL)
@@ -1762,7 +1761,7 @@ static inline jl_typemap_entry_t *lookup_leafcache(jl_genericmemory_t *leafcache
         //
         // n.b. this entire chain is type-equal to tt (by construction), so it is unnecessary to call `tt<:entry->sig`
         do {
-            if (jl_atomic_load_relaxed(&entry->min_world) <= world && world <= jl_atomic_load_relaxed(&entry->max_world)) {
+            if (jl_world_in_range(world, jl_atomic_load_relaxed(&entry->min_world), jl_atomic_load_relaxed(&entry->max_world))) {
                 if (entry->simplesig == (void*)jl_nothing || concretesig_equal(tt, (jl_value_t*)entry->simplesig))
                     return entry;
             }
@@ -3590,8 +3589,7 @@ STATIC_INLINE jl_value_t *_jl_rettype_inferred(jl_value_t *owner, jl_method_inst
 {
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     while (codeinst) {
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= min_world &&
-            max_world <= jl_atomic_load_relaxed(&codeinst->max_world) &&
+        if (jl_world_range_in_range(min_world, max_world, jl_atomic_load_relaxed(&codeinst->min_world), jl_atomic_load_relaxed(&codeinst->max_world)) &&
             jl_egal(codeinst->owner, owner)) {
 
             jl_value_t *code = jl_atomic_load_relaxed(&codeinst->inferred);
@@ -3621,7 +3619,7 @@ STATIC_INLINE jl_callptr_t jl_method_compiled_callptr(jl_method_instance_t *mi, 
     for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
         if (codeinst->owner != jl_nothing)
             continue;
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (jl_world_in_range(world, jl_atomic_load_relaxed(&codeinst->min_world), jl_atomic_load_relaxed(&codeinst->max_world))) {
             jl_callptr_t invoke = jl_atomic_load_acquire(&codeinst->invoke);
             if (!invoke)
                 continue;
@@ -4724,7 +4722,7 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
             entry = jl_atomic_load_relaxed(&call_cache[cache_idx[i]]); \
             if (entry && nargs == jl_svec_len(entry->sig->parameters) && \
                 sig_match_fast(FT, args, jl_svec_data(entry->sig->parameters), nargs) && \
-                world >= jl_atomic_load_relaxed(&entry->min_world) && world <= jl_atomic_load_relaxed(&entry->max_world)) { \
+                jl_world_in_range(world, jl_atomic_load_relaxed(&entry->min_world), jl_atomic_load_relaxed(&entry->max_world))) { \
                 goto have_entry; \
             } \
         } while (0);
@@ -5047,13 +5045,13 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     // excluding it from the results is valid for the full span.
     size_t min_world = jl_atomic_load_relaxed(&ml->min_world);
     size_t max_world = jl_atomic_load_relaxed(&ml->max_world);
-    if (closure->world < min_world) {
-        // exclude method table entries that are part of a later world
+    if (!jl_world_at_least(closure->world, min_world)) {
+        // exclude method table entries that are part of a later (or unrelated) world
         if (closure->match.max_valid >= min_world)
             closure->match.max_valid = min_world - 1;
         return 1;
     }
-    else if (closure->world > max_world) {
+    else if (!jl_world_at_most(closure->world, max_world)) {
         // exclude method table entries that have been replaced in the current world
         if (closure->match.min_valid <= max_world)
             closure->match.min_valid = max_world + 1;
@@ -5378,8 +5376,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                               size_t *min_valid, size_t *max_valid, int *ambig)
 {
     size_t current_world = jl_atomic_load_acquire(&jl_world_counter);
-    if (world > current_world)
-        return jl_nothing; // the future is not enumerable
+    if (!jl_world_at_most(world, current_world))
+        return jl_nothing; // the future is not enumerable (but closed sibling branches of the world DAG are)
     JL_TIMING(METHOD_MATCH, METHOD_MATCH);
     int has_ambiguity = 0;
     jl_value_t *unw = jl_unwrap_unionall((jl_value_t*)type);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3006,13 +3006,14 @@ JL_DLLEXPORT void jl_method_table_disable(jl_method_t *method) JL_CANSAFEPOINT
     int enabled = jl_atomic_load_relaxed(&methodentry->max_world) == ~(size_t)0;
     if (enabled) {
         // Narrow the world age on the method to make it uncallable
-        size_t world = jl_atomic_load_relaxed(&jl_world_counter);
+        size_t new_world = jl_world_next_locked();
+        size_t world = new_world - 1;
         assert(method == methodentry->func.method);
         jl_atomic_store_relaxed(&method->dispatch_status, 0);
         assert(jl_atomic_load_relaxed(&methodentry->max_world) == ~(size_t)0);
         jl_atomic_store_relaxed(&methodentry->max_world, world);
         jl_method_table_invalidate(method, world);
-        jl_atomic_store_release(&jl_world_counter, world + 1);
+        jl_atomic_store_release(&jl_world_counter, new_world);
     }
     JL_UNLOCK(&world_counter_lock);
     if (!enabled)
@@ -3471,7 +3472,7 @@ JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method
     JL_LOCK(&world_counter_lock);
     if (!jl_atomic_load_relaxed(&allow_new_worlds))
         jl_error("Method changes have been disabled via a call to disable_new_worlds.");
-    size_t world = jl_atomic_load_relaxed(&jl_world_counter) + 1;
+    size_t world = jl_world_next_locked();
     jl_atomic_store_relaxed(&method->primary_world, world);
     jl_method_table_activate(newentry);
     jl_atomic_store_release(&jl_world_counter, world);
@@ -5842,12 +5843,12 @@ JL_DLLEXPORT void jl_drop_all_caches(void)
     JL_LOCK(&world_counter_lock);
 
     // Get current world age - we'll invalidate everything at this world
-    size_t current_world = jl_atomic_load_relaxed(&jl_world_counter);
+    size_t new_world = jl_world_next_locked();
+    size_t current_world = new_world - 1;
 
     invalidate_all_caches(jl_method_table, current_world);
 
     // Increment world age - this forces all subsequent compilation to happen in the new world
-    size_t new_world = current_world + 1;
     jl_atomic_store_release(&jl_world_counter, new_world);
 
     JL_UNLOCK(&world_counter_lock);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1933,12 +1933,11 @@ static jl_method_instance_t *cache_result(
 {
     // caller must hold the parent->writelock, which this releases
     int8_t offs = mc ? jl_cachearg_offset() : 1;
-    // A cache entry created for a query world off the spine gets point
-    // validity: interval bounds cannot describe its DAG validity region, and
-    // lookups at exactly that world are its only consumers. (A world in the
-    // current spine segment beyond the counter -- a pending insertion world
-    // -- is on the spine, not off it.)
-    if (jl_world_seg(world) != jl_world_seg(current_world) && !jl_world_reaches(world, current_world)) {
+    // A cache entry created for a query world off the spine's trunk (a
+    // fabricated branch, or a world within a grafted image history) gets
+    // point validity: interval bounds cannot describe its DAG validity
+    // region, and lookups at exactly that world are its only consumers.
+    if (!jl_world_on_trunk(world, current_world)) {
         min_valid = world;
         max_valid = world;
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -5072,8 +5072,7 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     }
     else if (!jl_world_at_most(closure->world, max_world)) {
         // exclude method table entries that have been replaced in the current world
-        if (closure->match.min_valid <= max_world)
-            closure->match.min_valid = max_world + 1;
+        closure->match.min_valid = jl_world_spine_join(closure->match.min_valid, max_world + 1);
         return 1;
     }
     if (closure->match.max_valid > max_world)
@@ -5471,8 +5470,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                 jl_array_ptr_set(env.t, 0, env.matc);
                 size_t min_world = jl_atomic_load_relaxed(&entry->min_world);
                 size_t max_world = jl_atomic_load_relaxed(&entry->max_world);
-                if (*min_valid < min_world)
-                    *min_valid = min_world;
+                *min_valid = jl_world_spine_join(*min_valid, min_world);
                 if (*max_valid > max_world)
                     *max_valid = max_world;
                 JL_GC_POP();
@@ -5504,8 +5502,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                         env.match.env, meth, FULLY_COVERS);
                     env.t = (jl_value_t*)jl_alloc_vec_any(1);
                     jl_array_ptr_set(env.t, 0, env.matc);
-                    if (*min_valid < min_world)
-                        *min_valid = min_world;
+                    *min_valid = jl_world_spine_join(*min_valid, min_world);
                     if (*max_valid > max_world)
                         *max_valid = max_world;
                     JL_GC_POP();
@@ -5695,8 +5692,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
         // method applicability is the same as typemapentry applicability
         size_t min_world = jl_atomic_load_relaxed(&m->primary_world);
         // intersect the env valid range with method lookup's inclusive valid range
-        if (env.match.min_valid < min_world)
-            env.match.min_valid = min_world;
+        env.match.min_valid = jl_world_spine_join(env.match.min_valid, min_world);
     }
     if (mc && cache_result_recursion && ((jl_datatype_t*)unw)->isdispatchtuple) { // cache_result_recursion prevents lock confusion and unnecessary work
         if (len == 1 && !has_ambiguity) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -3207,7 +3207,11 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     jl_value_t *oldvalue = NULL;
     jl_array_t *oldmi = NULL;
     size_t world = jl_atomic_load_relaxed(&method->primary_world);
-    assert(world == jl_atomic_load_relaxed(&jl_world_counter) + 1); // min-world
+    // min-world is the next spine world, or the base of a grafted image
+    // segment that the current spine segment has already merged
+    assert(world == jl_atomic_load_relaxed(&jl_world_counter) + 1 ||
+           (jl_world_idx(world) == 0 &&
+            jl_world_seg_reaches(jl_world_seg(world), jl_world_seg(jl_atomic_load_relaxed(&jl_world_counter)))));
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_WHICH) == 0);
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     assert(jl_atomic_load_relaxed(&newentry->min_world) == ~(size_t)0);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3028,7 +3028,11 @@ jl_typemap_entry_t *jl_method_table_add(jl_methtable_t *mt, jl_method_t *method,
     jl_typemap_entry_t *newentry = NULL;
     JL_GC_PUSH1(&newentry);
     // add our new entry
-    assert(jl_atomic_load_relaxed(&method->primary_world) == ~(size_t)0); // min-world
+    // min-world: either not yet activated, or already carrying its original
+    // world from a grafted image history (activation preserves it)
+    assert(jl_atomic_load_relaxed(&method->primary_world) == ~(size_t)0 ||
+           jl_world_seg(jl_atomic_load_relaxed(&method->primary_world)) !=
+               jl_world_seg(jl_atomic_load_relaxed(&jl_world_counter)));
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_WHICH) == 0);
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     JL_LOCK(&mt->cache->writelock);
@@ -3207,11 +3211,10 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     jl_value_t *oldvalue = NULL;
     jl_array_t *oldmi = NULL;
     size_t world = jl_atomic_load_relaxed(&method->primary_world);
-    // min-world is the next spine world, or the base of a grafted image
-    // segment that the current spine segment has already merged
+    // min-world is the next spine world, or a world within a grafted image
+    // history (which the spine merges once the graft completes)
     assert(world == jl_atomic_load_relaxed(&jl_world_counter) + 1 ||
-           (jl_world_idx(world) == 0 &&
-            jl_world_seg_reaches(jl_world_seg(world), jl_world_seg(jl_atomic_load_relaxed(&jl_world_counter)))));
+           jl_world_seg(world) != jl_world_seg(jl_atomic_load_relaxed(&jl_world_counter)));
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_WHICH) == 0);
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     assert(jl_atomic_load_relaxed(&newentry->min_world) == ~(size_t)0);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1838,7 +1838,10 @@ static void cache_insert(
     // exact-dispatch lookups (`jl_typemap_entry_assoc_exact`) require datatype sigs
     assert(jl_is_datatype(cachett));
     int unconstrained_max = max_valid == ~(size_t)0;
-    if (max_valid > current_world)
+    // clamp bounds that extend past the current spine world (they are
+    // restored below if the world has not advanced); a point bound on a
+    // closed branch does not extend into the spine's future and stays as is
+    if (max_valid > current_world && (unconstrained_max || jl_world_reaches(current_world, max_valid)))
         max_valid = current_world;
     jl_datatype_t *simplett = NULL;
     jl_typemap_entry_t *newentry = NULL;
@@ -1930,6 +1933,15 @@ static jl_method_instance_t *cache_result(
 {
     // caller must hold the parent->writelock, which this releases
     int8_t offs = mc ? jl_cachearg_offset() : 1;
+    // A cache entry created for a query world off the spine gets point
+    // validity: interval bounds cannot describe its DAG validity region, and
+    // lookups at exactly that world are its only consumers. (A world in the
+    // current spine segment beyond the counter -- a pending insertion world
+    // -- is on the spine, not off it.)
+    if (jl_world_seg(world) != jl_world_seg(current_world) && !jl_world_reaches(world, current_world)) {
+        min_valid = world;
+        max_valid = world;
+    }
     // short-circuit (now that we hold the lock) if this entry is already present
     if (!tt_known_absent) {
         jl_typemap_entry_t *entry = mt_find_cache_entry(cache, mc ? &mc->leafcache : NULL, tt, world, offs);

--- a/src/gf.c
+++ b/src/gf.c
@@ -684,7 +684,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
         uint32_t effects, jl_value_t *analysis_results,
         jl_debuginfo_t *di, jl_svec_t *edges /*, int absolute_max*/)
 {
-    assert(min_world <= max_world && "attempting to set invalid world constraints");
+    assert(jl_world_at_most(min_world, max_world) && "attempting to set invalid world constraints");
     //assert((!jl_is_method(mi->def.value) || max_world != ~(size_t)0 || min_world <= 1 || edges == NULL || jl_svec_len(edges) != 0) && "missing edges");
     jl_task_t *ct = jl_current_task;
     jl_code_instance_t *codeinst = (jl_code_instance_t*)jl_gc_alloc(ct->ptls, sizeof(jl_code_instance_t),
@@ -730,7 +730,7 @@ JL_DLLEXPORT void jl_fill_codeinst(
         double time_infer_total, double time_infer_cache_saved, double time_infer_self,
         jl_debuginfo_t *di, jl_svec_t *edges /* , int absolute_max*/)
 {
-    assert(min_world <= max_world && "attempting to set invalid world constraints");
+    assert(jl_world_at_most(min_world, max_world) && "attempting to set invalid world constraints");
     //assert((!jl_is_method(codeinst->def->def.value) || max_world != ~(size_t)0 || min_world <= 1 || jl_svec_len(edges) != 0) && "missing edges");
     jl_gc_write(codeinst, codeinst->rettype, jl_value_t, rettype);
     jl_gc_write(codeinst, codeinst->exctype, jl_value_t, exctype);
@@ -1933,14 +1933,6 @@ static jl_method_instance_t *cache_result(
 {
     // caller must hold the parent->writelock, which this releases
     int8_t offs = mc ? jl_cachearg_offset() : 1;
-    // A cache entry created for a query world off the spine's trunk (a
-    // fabricated branch, or a world within a grafted image history) gets
-    // point validity: interval bounds cannot describe its DAG validity
-    // region, and lookups at exactly that world are its only consumers.
-    if (!jl_world_on_trunk(world, current_world)) {
-        min_valid = world;
-        max_valid = world;
-    }
     // short-circuit (now that we hold the lock) if this entry is already present
     if (!tt_known_absent) {
         jl_typemap_entry_t *entry = mt_find_cache_entry(cache, mc ? &mc->leafcache : NULL, tt, world, offs);
@@ -2450,7 +2442,9 @@ static void invalidate_code_instance(jl_code_instance_t *replaced, size_t max_wo
     JL_LOCK(&replaced_mi->def.method->writelock);
     size_t replacedmaxworld = jl_atomic_load_relaxed(&replaced->max_world);
     if (replacedmaxworld == ~(size_t)0) {
-        assert(jl_atomic_load_relaxed(&replaced->min_world) - 1 <= max_world && "attempting to set illogical world constraints (probable race condition)");
+        assert((jl_world_at_most(jl_atomic_load_relaxed(&replaced->min_world), max_world) ||
+                max_world + 1 == jl_atomic_load_relaxed(&replaced->min_world)) &&
+               "attempting to set illogical world constraints (probable race condition)");
         jl_atomic_store_release(&replaced->max_world, max_world);
         // recurse to all backedges to update their valid range also
         _invalidate_backedges(replaced_mi, replaced, max_world, depth + 1);
@@ -5066,8 +5060,14 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     size_t max_world = jl_atomic_load_relaxed(&ml->max_world);
     if (!jl_world_at_least(closure->world, min_world)) {
         // exclude method table entries that are part of a later (or unrelated) world
-        if (closure->match.max_valid >= min_world)
-            closure->match.max_valid = min_world - 1;
+        size_t cap = jl_world_cap_meet(closure->match.max_valid, min_world - 1);
+        if (cap == 0) {
+            // incomparable exclusion cones: degrade to point validity
+            closure->match.min_valid = closure->match.max_valid = closure->world;
+        }
+        else {
+            closure->match.max_valid = cap;
+        }
         return 1;
     }
     else if (!jl_world_at_most(closure->world, max_world)) {
@@ -5075,8 +5075,13 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
         closure->match.min_valid = jl_world_join(closure->match.min_valid, max_world + 1, closure->world);
         return 1;
     }
-    if (closure->match.max_valid > max_world)
-        closure->match.max_valid = max_world;
+    {
+        size_t cap = jl_world_cap_meet(closure->match.max_valid, max_world);
+        if (cap == 0)
+            closure->match.min_valid = closure->match.max_valid = closure->world;
+        else
+            closure->match.max_valid = cap;
+    }
     jl_method_t *meth = ml->func.method;
     int only = jl_atomic_load_relaxed(&meth->dispatch_status) & METHOD_SIG_LATEST_ONLY;
     if (closure->lim >= 0 && only) {
@@ -5471,8 +5476,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                 size_t min_world = jl_atomic_load_relaxed(&entry->min_world);
                 size_t max_world = jl_atomic_load_relaxed(&entry->max_world);
                 *min_valid = jl_world_join(*min_valid, min_world, world);
-                if (*max_valid > max_world)
-                    *max_valid = max_world;
+                *max_valid = jl_world_cap_meet(*max_valid, max_world);
+                assert(*max_valid != 0);
                 JL_GC_POP();
                 return env.t;
             }
@@ -5503,8 +5508,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                     env.t = (jl_value_t*)jl_alloc_vec_any(1);
                     jl_array_ptr_set(env.t, 0, env.matc);
                     *min_valid = jl_world_join(*min_valid, min_world, world);
-                    if (*max_valid > max_world)
-                        *max_valid = max_world;
+                    *max_valid = jl_world_cap_meet(*max_valid, max_world);
+                    assert(*max_valid != 0);
                     JL_GC_POP();
                     return env.t;
                 }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -112,6 +112,8 @@ static jl_value_t *eval_methoddef(jl_expr_t *ex, interpreter_state *s) JL_CANSAF
 
 // expression evaluator
 
+static jl_value_t *interpret_call(jl_method_instance_t *mi, jl_value_t *f, jl_value_t **args, uint32_t nargs) JL_CANSAFEPOINT;
+
 static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s) JL_CANSAFEPOINT
 {
     jl_value_t **argv;
@@ -120,7 +122,11 @@ static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s
     size_t i;
     for (i = 0; i < nargs; i++)
         argv[i] = eval_value(args[i], s);
-    jl_value_t *result = jl_apply(argv, nargs);
+    jl_value_t *result;
+    if (__unlikely(jl_current_task->rcjulia))
+        result = jl_rc_apply(argv, nargs);
+    else
+        result = jl_apply(argv, nargs);
     JL_GC_POP();
     return result;
 }
@@ -136,6 +142,17 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
     jl_value_t *c = args[0];
     assert(jl_is_code_instance(c) || jl_is_method_instance(c));
     jl_value_t *result = NULL;
+    if (__unlikely(jl_current_task->rcjulia)) {
+        // RCJulia mode never runs native code (v1): re-route the
+        // invoke target through the interpreter so its operations stay
+        // checked. (Only reachable from generated-function-produced IR;
+        // uninferred lowered source contains no :invoke.)
+        jl_method_instance_t *mi = jl_is_code_instance(c) ?
+            jl_get_ci_mi((jl_code_instance_t*)c) : (jl_method_instance_t*)c;
+        result = interpret_call(mi, argv[0], &argv[1], nargs - 2);
+        JL_GC_POP();
+        return result;
+    }
     if (jl_is_code_instance(c)) {
         jl_code_instance_t *codeinst = (jl_code_instance_t*)c;
         assert(jl_atomic_load_relaxed(&codeinst->min_world) <= jl_current_task->world_age &&
@@ -234,10 +251,16 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         return jl_quotenode_value(e);
     }
     if (jl_is_globalref(e)) {
-        return jl_eval_globalref((jl_globalref_t*)e, jl_current_task->world_age);
+        jl_task_t *ct = jl_current_task;
+        if (__unlikely(ct->rcjulia))
+            return jl_rc_globalref_value(jl_globalref_mod(e), jl_globalref_name(e), ct->world_age);
+        return jl_eval_globalref((jl_globalref_t*)e, ct->world_age);
     }
     if (jl_is_symbol(e)) {  // bare symbols appear in toplevel exprs not wrapped in `thunk`
-        return jl_eval_global_var(s->module, (jl_sym_t*)e, jl_current_task->world_age);
+        jl_task_t *ct = jl_current_task;
+        if (__unlikely(ct->rcjulia))
+            return jl_rc_globalref_value(s->module, (jl_sym_t*)e, ct->world_age);
+        return jl_eval_global_var(s->module, (jl_sym_t*)e, ct->world_age);
     }
     if (jl_is_pinode(e)) {
         jl_value_t *val = eval_value(jl_fieldref_noalloc(e, 0), s);
@@ -311,6 +334,9 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         JL_GC_PUSHARGS(argv, nargs);
         for (size_t i = 0; i < nargs; i++)
             argv[i] = eval_value(args[i], s);
+        if (__unlikely(jl_current_task->rcjulia) && jl_is_datatype(argv[0]) &&
+                jl_is_mutable_datatype(argv[0]))
+            jl_capability_error("new");
         jl_value_t *v = jl_new_structv((jl_datatype_t*)argv[0], &argv[1], nargs - 1);
         JL_GC_POP();
         return v;
@@ -320,11 +346,15 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         JL_GC_PUSHARGS(argv, 2);
         argv[0] = eval_value(args[0], s);
         argv[1] = eval_value(args[1], s);
+        if (__unlikely(jl_current_task->rcjulia) && jl_is_datatype(argv[0]) &&
+                jl_is_mutable_datatype(argv[0]))
+            jl_capability_error("new");
         jl_value_t *v = jl_new_structt((jl_datatype_t*)argv[0], argv[1]);
         JL_GC_POP();
         return v;
     }
     else if (head == jl_new_opaque_closure_sym) {
+        jl_check_rc("new_opaque_closure");
         jl_value_t **argv;
         JL_GC_PUSHARGS(argv, nargs);
         for (size_t i = 0; i < nargs; i++)
@@ -364,6 +394,9 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         jl_error("could not determine static parameter value");
     }
     else if (head == jl_copyast_sym) {
+        // quoted `Expr` literals materialize a fresh mutable AST copy per
+        // evaluation: both a mutable allocation and an egal-unstable result
+        jl_check_rc("copyast");
         return jl_copy_ast(eval_value(args[0], s));
     }
     else if (head == jl_exc_sym) {
@@ -383,12 +416,15 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         return jl_nothing;
     }
     else if (head == jl_method_sym && nargs == 1) {
+        jl_check_rc("method");
         return eval_methoddef(ex, s);
     }
     else if (head == jl_foreigncall_sym) {
+        jl_check_rc("foreigncall");
         jl_error("`ccall` requires the compiler");
     }
     else if (head == jl_foreignglobal_sym) {
+        jl_check_rc("foreignglobal");
         assert(nargs == 1);
         jl_value_t *fptr = jl_exprarg(ex, 0);
         if (jl_is_quotenode(fptr)) {
@@ -423,6 +459,7 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         return r;
     }
     else if (head == jl_cfunction_sym) {
+        jl_check_rc("cfunction");
         jl_error("`cfunction` requires the compiler");
     }
     jl_errorf("unsupported or misplaced expression %s", jl_symbol_name(head));
@@ -858,7 +895,14 @@ jl_value_t *jl_code_or_ci_for_interpreter(jl_method_instance_t *mi JL_PROPAGATES
     jl_value_t *ret = NULL;
     jl_code_info_t *src = NULL;
     if (jl_is_method(mi->def.value)) {
-        if (mi->def.method->source) {
+        // For dual-body (`if @generated`) methods the interpreter normally
+        // runs the fallback source, but under RCJulia mode we prefer
+        // the generated expansion: it is what compiled execution uses, and
+        // fallback bodies are commonly impure in ways the expansion is not
+        // (e.g. `ntuple`'s fallback consults `Base._return_type`). The choice
+        // is a fixed function of the mode, so it stays consistent.
+        int prefer_expansion = jl_current_task->rcjulia && mi->def.method->generator != NULL;
+        if (mi->def.method->source && !prefer_expansion) {
             jl_method_t *m = mi->def.method;
             // Acquire pairs with the release publish below: a reader that sees
             // the uncompressed CodeInfo pointer must also see its contents.
@@ -915,12 +959,209 @@ jl_code_info_t *jl_code_for_interpreter(jl_method_instance_t *mi, size_t world)
     return (jl_code_info_t*)code_or_ci;
 }
 
+// RCJulia mode (`Core._rcjulia_call`)
+
+// Reject any control flow that could re-execute a statement: termination of
+// RCJulia code is structural, not proven. Statement `i` (0-based) is branch
+// label `i + 1` (1-based), so a legal (forward) branch target must be
+// strictly greater than `i + 1`. `EnterNode` catch destinations are forward
+// in front-end-lowered IR, but are checked too since generated functions may
+// return arbitrary IR.
+static void rc_check_no_backedges(jl_code_info_t *src) JL_CANSAFEPOINT
+{
+    jl_array_t *stmts = src->code;
+    size_t ns = jl_array_nrows(stmts);
+    for (size_t i = 0; i < ns; i++) {
+        jl_value_t *stmt = jl_array_ptr_ref(stmts, i);
+        size_t target = 0;
+        if (jl_is_gotonode(stmt))
+            target = jl_gotonode_label(stmt);
+        else if (jl_is_gotoifnot(stmt))
+            target = jl_gotoifnot_label(stmt);
+        else if (jl_is_enternode(stmt))
+            target = jl_enternode_catch_dest(stmt); // 0 if no catch
+        if (target && target <= i + 1)
+            jl_capability_error("backedge");
+    }
+}
+
+// --- well-founded recursion order ---
+//
+// Re-entering a method that already has an active RCJulia frame is permitted
+// only if the arguments strictly decrease in the order defined here:
+// structurally smaller types are smaller, and at equal types, smaller values
+// interpreted as bitstypes are smaller. The order is well-founded (no
+// infinite strictly-decreasing chains), and the method table is frozen
+// inside the mode, so an infinite call chain would require infinitely many
+// occurrences of some single method — impossible when each successive
+// occurrence must decrease. Every call chain is therefore finite by
+// construction; the depth cap below is only a physical stack backstop.
+//
+// TODO: allow methods to supply a custom well-founded relation (cf.
+// `Method.recursion_relation` used by inference), checked/trusted per the
+// mode's rules.
+
+static size_t rc_type_size(jl_value_t *t) JL_NOTSAFEPOINT;
+
+static size_t rc_term_size(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    if (jl_is_type(t) || jl_is_vararg(t))
+        return rc_type_size(t);
+    return 1; // bits values, symbols and other leaves
+}
+
+// number of nodes in the type term, counting non-type parameters as leaves
+static size_t rc_type_size(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    if (jl_is_datatype(t)) {
+        size_t sz = 1;
+        jl_svec_t *p = ((jl_datatype_t*)t)->parameters;
+        for (size_t i = 0; i < jl_svec_len(p); i++)
+            sz += rc_term_size(jl_svecref(p, i));
+        return sz;
+    }
+    if (jl_is_uniontype(t))
+        return 1 + rc_type_size(((jl_uniontype_t*)t)->a) + rc_type_size(((jl_uniontype_t*)t)->b);
+    if (jl_is_unionall(t)) {
+        jl_unionall_t *ua = (jl_unionall_t*)t;
+        return 1 + rc_type_size(ua->var->lb) + rc_type_size(ua->var->ub) + rc_type_size(ua->body);
+    }
+    if (jl_is_vararg(t)) {
+        jl_vararg_t *v = (jl_vararg_t*)t;
+        return 1 + (v->T ? rc_term_size(v->T) : 0) + (v->N ? rc_term_size(v->N) : 0);
+    }
+    return 1; // TypeVar occurrences and other leaves
+}
+
+// three-way comparison of two isbits values of the same concrete type:
+// primitive types compare their bit pattern as an unsigned (little-endian)
+// integer; composite types compare field-lexicographically, which never
+// looks at padding bytes. Returns -1/0/1, or 2 for incomparable (inline
+// union fields, kept out of scope for now).
+static int rc_bits_cmp(jl_datatype_t *dt, const char *pa, const char *pb) JL_NOTSAFEPOINT
+{
+    if (jl_is_primitivetype(dt)) {
+        size_t nb = jl_datatype_size(dt);
+        for (size_t i = nb; i-- > 0; ) {
+            uint8_t av = ((const uint8_t*)pa)[i], bv = ((const uint8_t*)pb)[i];
+            if (av != bv)
+                return av < bv ? -1 : 1;
+        }
+        return 0;
+    }
+    assert(jl_is_datatype(dt));
+    size_t nf = jl_datatype_nfields(dt);
+    for (size_t i = 0; i < nf; i++) {
+        jl_value_t *ft = jl_field_type_concrete(dt, i);
+        if (!jl_is_datatype(ft))
+            return 2;
+        int c = rc_bits_cmp((jl_datatype_t*)ft, pa + jl_field_offset(dt, i), pb + jl_field_offset(dt, i));
+        if (c != 0)
+            return c;
+    }
+    return 0;
+}
+
+static int rc_type_smaller(jl_value_t *t, jl_value_t *s) JL_CANSAFEPOINT;
+
+// order on type parameters: types compare as type terms; other parameter
+// values (Val payloads, tuple lengths, ...) compare as bits at equal type
+static int rc_param_smaller(jl_value_t *p, jl_value_t *q) JL_CANSAFEPOINT
+{
+    if (jl_is_type(p) && jl_is_type(q))
+        return rc_type_smaller(p, q);
+    jl_value_t *tp = jl_typeof(p);
+    if (tp == jl_typeof(q) && jl_is_datatype(tp) && jl_isbits(tp))
+        return rc_bits_cmp((jl_datatype_t*)tp, (const char*)p, (const char*)q) == -1;
+    return 0;
+}
+
+// structural order on type terms: smaller size is smaller; at equal size,
+// the same type constructor may descend lexicographically through its
+// parameters (this is what orders `Val{2}` below `Val{3}`)
+static int rc_type_smaller(jl_value_t *t, jl_value_t *s)
+{
+    size_t szt = rc_type_size(t), szs = rc_type_size(s);
+    if (szt != szs)
+        return szt < szs;
+    if (!jl_is_datatype(t) || !jl_is_datatype(s))
+        return 0;
+    jl_datatype_t *dt = (jl_datatype_t*)t, *ds = (jl_datatype_t*)s;
+    if (dt->name != ds->name)
+        return 0;
+    jl_svec_t *pt = dt->parameters, *ps = ds->parameters;
+    size_t np = jl_svec_len(pt);
+    if (np != jl_svec_len(ps))
+        return 0;
+    for (size_t i = 0; i < np; i++) {
+        jl_value_t *p = jl_svecref(pt, i), *q = jl_svecref(ps, i);
+        if (jl_egal(p, q))
+            continue;
+        return rc_param_smaller(p, q);
+    }
+    return 0; // egal
+}
+
+static int rc_value_smaller(jl_value_t *a, jl_value_t *b) JL_CANSAFEPOINT
+{
+    if (jl_is_type(a) && jl_is_type(b))
+        return rc_type_smaller(a, b);
+    jl_value_t *ta = jl_typeof(a);
+    if (ta != jl_typeof(b))
+        return rc_type_smaller(ta, jl_typeof(b));
+    if (jl_is_datatype(ta) && jl_isbits(ta))
+        return rc_bits_cmp((jl_datatype_t*)ta, (const char*)a, (const char*)b) == -1;
+    return 0; // same non-bits type, not egal: no order (v1)
+}
+
+// shortlex over the argument list: fewer arguments is smaller (tuple
+// peeling through Vararg methods); at equal length, the first non-egal
+// position must decrease. An egal re-entry is never smaller — and under
+// the mode's consistency it is guaranteed to diverge, so rejecting it
+// loses no terminating program.
+static int rc_args_smaller(jl_value_t *newf, jl_value_t **newargs, uint32_t nnew,
+                           jl_value_t *oldf, jl_value_t **oldargs, uint32_t nold) JL_CANSAFEPOINT
+{
+    if (nnew != nold)
+        return nnew < nold;
+    if (!jl_egal(newf, oldf))
+        return rc_value_smaller(newf, oldf);
+    for (uint32_t i = 0; i < nnew; i++) {
+        jl_value_t *a = newargs[i], *b = oldargs[i];
+        if (jl_egal(a, b))
+            continue;
+        return rc_value_smaller(a, b);
+    }
+    return 0;
+}
+
+// Apply `args` (with args[0] the callable) under RCJulia mode.
+// Builtins and intrinsics carry their traps in their C implementations, so
+// they may run their (native) fptrs; generic methods are forced through the
+// interpreter so that every primitive operation they perform stays checked.
+JL_DLLEXPORT jl_value_t *jl_rc_apply(jl_value_t **args, size_t nargs)
+{
+    jl_task_t *ct = jl_current_task;
+    assert(ct->rcjulia);
+    assert(nargs >= 1);
+    jl_value_t *f = args[0];
+    if (jl_isa(f, (jl_value_t*)jl_builtin_type) || jl_typeof(f) == (jl_value_t*)jl_intrinsic_type)
+        return jl_apply(args, nargs);
+    if (jl_is_opaque_closure(f))
+        jl_capability_error("opaque_closure");
+    size_t world = ct->world_age;
+    jl_method_instance_t *mi = jl_method_lookup(args, nargs, world);
+    if (mi == NULL)
+        jl_method_error(f, &args[1], nargs, world);
+    JL_GC_PROMISE_ROOTED(mi); // rooted through the method's specialization cache
+    return interpret_call(mi, f, &args[1], nargs - 1);
+}
+
 // interpreter entry points
 
-jl_value_t *NOINLINE jl_fptr_interpret_call(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *codeinst)
+static jl_value_t *NOINLINE interpret_call(jl_method_instance_t *mi, jl_value_t *f, jl_value_t **args, uint32_t nargs)
 {
     interpreter_state *s;
-    jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
     jl_task_t *ct = jl_current_task;
     size_t world = ct->world_age;
     jl_code_info_t *src = NULL;
@@ -964,12 +1205,53 @@ jl_value_t *NOINLINE jl_fptr_interpret_call(jl_value_t *f, jl_value_t **args, ui
     s->sparam_vals = mi->sparam_vals;
     s->preevaluation = 0;
     s->continue_at = 0;
+    // The RCJulia checks below may throw before eval_body ever assigns
+    // s->ip; leaving it uninitialized would put stack garbage into any
+    // captured backtrace frame.
+    s->ip = 0;
     s->mi = mi;
     s->ci = ci;
     JL_GC_ENABLEFRAME(s);
+    jl_rc_frame_t rcframe;
+    int rc = ct->rcjulia != 0;
+    if (__unlikely(rc)) {
+        rc_check_no_backedges(src);
+        uint32_t depth = ct->rc_frames ? ct->rc_frames->depth + 1 : 1;
+        if (depth > JL_RC_MAX_DEPTH)
+            jl_capability_error("depth_limit");
+        jl_method_t *method = jl_is_method(mi->def.value) ? mi->def.method : NULL;
+        if (method != NULL) {
+            // well-founded recursion: compare against the innermost active
+            // frame of the same method (adjacent decreases suffice for
+            // well-foundedness; no transitivity needed)
+            for (jl_rc_frame_t *pf = ct->rc_frames; pf != NULL; pf = pf->prev) {
+                if (pf->method == method) {
+                    if (!rc_args_smaller(f, args, nargs, pf->f, pf->args, pf->nargs))
+                        jl_capability_error("recursion");
+                    break;
+                }
+            }
+        }
+        rcframe.method = method;
+        rcframe.f = f;
+        rcframe.args = args; // rooted by the calling frame for this frame's extent
+        rcframe.nargs = nargs;
+        rcframe.depth = depth;
+        rcframe.prev = ct->rc_frames;
+        ct->rc_frames = &rcframe;
+        // exceptional exits restore ct->rc_frames via the handler chain
+        // (see jl_eh_restore_state)
+    }
     jl_value_t *r = eval_body(stmts, s, 0, 0);
+    if (__unlikely(rc))
+        ct->rc_frames = rcframe.prev;
     JL_GC_POP();
     return r;
+}
+
+jl_value_t *NOINLINE jl_fptr_interpret_call(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *codeinst)
+{
+    return interpret_call(jl_get_ci_mi(codeinst), f, args, nargs);
 }
 
 JL_DLLEXPORT const jl_callptr_t jl_fptr_interpret_call_addr = &jl_fptr_interpret_call;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -112,7 +112,8 @@ static jl_value_t *eval_methoddef(jl_expr_t *ex, interpreter_state *s) JL_CANSAF
 
 // expression evaluator
 
-static jl_value_t *interpret_call(jl_method_instance_t *mi, jl_value_t *f, jl_value_t **args, uint32_t nargs) JL_CANSAFEPOINT;
+static jl_value_t *interpret_call(jl_method_instance_t *mi, jl_code_instance_t *pinned,
+                                  jl_value_t *f, jl_value_t **args, uint32_t nargs) JL_CANSAFEPOINT;
 
 static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s) JL_CANSAFEPOINT
 {
@@ -149,7 +150,7 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
         // uninferred lowered source contains no :invoke.)
         jl_method_instance_t *mi = jl_is_code_instance(c) ?
             jl_get_ci_mi((jl_code_instance_t*)c) : (jl_method_instance_t*)c;
-        result = interpret_call(mi, argv[0], &argv[1], nargs - 2);
+        result = interpret_call(mi, NULL, argv[0], &argv[1], nargs - 2);
         JL_GC_POP();
         return result;
     }
@@ -167,9 +168,22 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
 
         } else {
             if (codeinst->owner != jl_nothing) {
-                jl_error("Failed to invoke or compile external codeinst");
+                jl_value_t *inf = jl_atomic_load_relaxed(&codeinst->inferred);
+                if (inf != NULL && jl_is_code_info(inf)) {
+                    // externally-owned instance carrying its own code (e.g. a
+                    // detached field generator): interpret exactly that code
+                    // (n.b. &argv[1] may be one-past-the-end when nargs == 2;
+                    // it is never dereferenced then since the arg count is 0)
+                    jl_atomic_store_release(&codeinst->invoke, jl_fptr_interpret_call);
+                    result = jl_fptr_interpret_call(argv[0], &argv[1], nargs - 2, codeinst);
+                }
+                else {
+                    jl_error("Failed to invoke or compile external codeinst");
+                }
             }
-            result = jl_invoke(argv[0], nargs == 2 ? NULL : &argv[1], nargs - 2, jl_get_ci_mi(codeinst));
+            else {
+                result = jl_invoke(argv[0], nargs == 2 ? NULL : &argv[1], nargs - 2, jl_get_ci_mi(codeinst));
+            }
         }
     } else {
         result = jl_invoke(argv[0], nargs == 2 ? NULL : &argv[1], nargs - 2, (jl_method_instance_t*)c);
@@ -1154,12 +1168,13 @@ JL_DLLEXPORT jl_value_t *jl_rc_apply(jl_value_t **args, size_t nargs)
     if (mi == NULL)
         jl_method_error(f, &args[1], nargs, world);
     JL_GC_PROMISE_ROOTED(mi); // rooted through the method's specialization cache
-    return interpret_call(mi, f, &args[1], nargs - 1);
+    return interpret_call(mi, NULL, f, &args[1], nargs - 1);
 }
 
 // interpreter entry points
 
-static jl_value_t *NOINLINE interpret_call(jl_method_instance_t *mi, jl_value_t *f, jl_value_t **args, uint32_t nargs)
+static jl_value_t *NOINLINE interpret_call(jl_method_instance_t *mi, jl_code_instance_t *pinned,
+                                           jl_value_t *f, jl_value_t **args, uint32_t nargs)
 {
     interpreter_state *s;
     jl_task_t *ct = jl_current_task;
@@ -1168,13 +1183,22 @@ static jl_value_t *NOINLINE interpret_call(jl_method_instance_t *mi, jl_value_t 
     // NOTE: from here until `code`/`src` are stored into the GC frame below,
     // they may be reachable only through these locals (a concurrent thread
     // can republish m->source); this stretch must stay free of safepoints.
-    jl_value_t *code = jl_code_or_ci_for_interpreter(mi, world);
     jl_code_instance_t *ci = NULL;
-    if (jl_is_code_instance(code)) {
-        ci = (jl_code_instance_t*)code;
-        src = (jl_code_info_t*)jl_atomic_load_relaxed(&ci->inferred);
-    } else {
-        src = (jl_code_info_t*)code;
+    jl_value_t *inf = pinned == NULL ? NULL : jl_atomic_load_relaxed(&pinned->inferred);
+    if (pinned != NULL && pinned->owner != jl_nothing && inf != NULL && jl_is_code_info(inf)) {
+        // externally-owned instances (e.g. detached field generators) carry
+        // their own code; execute exactly that, not a world-based lookup
+        ci = pinned;
+        src = (jl_code_info_t*)inf;
+    }
+    else {
+        jl_value_t *code = jl_code_or_ci_for_interpreter(mi, world);
+        if (jl_is_code_instance(code)) {
+            ci = (jl_code_instance_t*)code;
+            src = (jl_code_info_t*)jl_atomic_load_relaxed(&ci->inferred);
+        } else {
+            src = (jl_code_info_t*)code;
+        }
     }
     jl_array_t *stmts = src->code;
     assert(jl_typetagis(stmts, jl_array_any_type));
@@ -1251,7 +1275,7 @@ static jl_value_t *NOINLINE interpret_call(jl_method_instance_t *mi, jl_value_t 
 
 jl_value_t *NOINLINE jl_fptr_interpret_call(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *codeinst)
 {
-    return interpret_call(jl_get_ci_mi(codeinst), f, args, nargs);
+    return interpret_call(jl_get_ci_mi(codeinst), codeinst, f, args, nargs);
 }
 
 JL_DLLEXPORT const jl_callptr_t jl_fptr_interpret_call_addr = &jl_fptr_interpret_call;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -112,8 +112,7 @@ static jl_value_t *eval_methoddef(jl_expr_t *ex, interpreter_state *s) JL_CANSAF
 
 // expression evaluator
 
-static jl_value_t *interpret_call(jl_method_instance_t *mi, jl_code_instance_t *pinned,
-                                  jl_value_t *f, jl_value_t **args, uint32_t nargs) JL_CANSAFEPOINT;
+static jl_value_t *interpret_call(jl_method_instance_t *mi, jl_value_t *f, jl_value_t **args, uint32_t nargs) JL_CANSAFEPOINT;
 
 static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s) JL_CANSAFEPOINT
 {
@@ -150,7 +149,7 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
         // uninferred lowered source contains no :invoke.)
         jl_method_instance_t *mi = jl_is_code_instance(c) ?
             jl_get_ci_mi((jl_code_instance_t*)c) : (jl_method_instance_t*)c;
-        result = interpret_call(mi, NULL, argv[0], &argv[1], nargs - 2);
+        result = interpret_call(mi, argv[0], &argv[1], nargs - 2);
         JL_GC_POP();
         return result;
     }
@@ -1168,13 +1167,12 @@ JL_DLLEXPORT jl_value_t *jl_rc_apply(jl_value_t **args, size_t nargs)
     if (mi == NULL)
         jl_method_error(f, &args[1], nargs, world);
     JL_GC_PROMISE_ROOTED(mi); // rooted through the method's specialization cache
-    return interpret_call(mi, NULL, f, &args[1], nargs - 1);
+    return interpret_call(mi, f, &args[1], nargs - 1);
 }
 
 // interpreter entry points
 
-static jl_value_t *NOINLINE interpret_call(jl_method_instance_t *mi, jl_code_instance_t *pinned,
-                                           jl_value_t *f, jl_value_t **args, uint32_t nargs)
+static jl_value_t *NOINLINE interpret_call(jl_method_instance_t *mi, jl_value_t *f, jl_value_t **args, uint32_t nargs)
 {
     interpreter_state *s;
     jl_task_t *ct = jl_current_task;
@@ -1183,22 +1181,13 @@ static jl_value_t *NOINLINE interpret_call(jl_method_instance_t *mi, jl_code_ins
     // NOTE: from here until `code`/`src` are stored into the GC frame below,
     // they may be reachable only through these locals (a concurrent thread
     // can republish m->source); this stretch must stay free of safepoints.
+    jl_value_t *code = jl_code_or_ci_for_interpreter(mi, world);
     jl_code_instance_t *ci = NULL;
-    jl_value_t *inf = pinned == NULL ? NULL : jl_atomic_load_relaxed(&pinned->inferred);
-    if (pinned != NULL && pinned->owner != jl_nothing && inf != NULL && jl_is_code_info(inf)) {
-        // externally-owned instances (e.g. detached field generators) carry
-        // their own code; execute exactly that, not a world-based lookup
-        ci = pinned;
-        src = (jl_code_info_t*)inf;
-    }
-    else {
-        jl_value_t *code = jl_code_or_ci_for_interpreter(mi, world);
-        if (jl_is_code_instance(code)) {
-            ci = (jl_code_instance_t*)code;
-            src = (jl_code_info_t*)jl_atomic_load_relaxed(&ci->inferred);
-        } else {
-            src = (jl_code_info_t*)code;
-        }
+    if (jl_is_code_instance(code)) {
+        ci = (jl_code_instance_t*)code;
+        src = (jl_code_info_t*)jl_atomic_load_relaxed(&ci->inferred);
+    } else {
+        src = (jl_code_info_t*)code;
     }
     jl_array_t *stmts = src->code;
     assert(jl_typetagis(stmts, jl_array_any_type));
@@ -1275,7 +1264,7 @@ static jl_value_t *NOINLINE interpret_call(jl_method_instance_t *mi, jl_code_ins
 
 jl_value_t *NOINLINE jl_fptr_interpret_call(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *codeinst)
 {
-    return interpret_call(jl_get_ci_mi(codeinst), codeinst, f, args, nargs);
+    return interpret_call(jl_get_ci_mi(codeinst), f, args, nargs);
 }
 
 JL_DLLEXPORT const jl_callptr_t jl_fptr_interpret_call_addr = &jl_fptr_interpret_call;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -155,8 +155,8 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
     }
     if (jl_is_code_instance(c)) {
         jl_code_instance_t *codeinst = (jl_code_instance_t*)c;
-        assert(jl_atomic_load_relaxed(&codeinst->min_world) <= jl_current_task->world_age &&
-               jl_current_task->world_age <= jl_atomic_load_relaxed(&codeinst->max_world));
+        assert(jl_world_in_range(jl_current_task->world_age, jl_atomic_load_relaxed(&codeinst->min_world),
+                                 jl_atomic_load_relaxed(&codeinst->max_world)));
         jl_callptr_t invoke = jl_atomic_load_acquire(&codeinst->invoke);
         if (!invoke) {
             jl_compile_codeinst(codeinst);

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -155,6 +155,7 @@
     XX(voidpointer_type, jl_datatype_t*) \
     XX(wait_entry_type, jl_datatype_t*) \
     XX(weakref_type, jl_datatype_t*) \
+    XX(worldtoken_type, jl_datatype_t*) \
     XX(typeapp_type, jl_datatype_t*)
 
 // Global constant values (jl_true, jl_false, jl_nothing)

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -29,6 +29,7 @@
     XX(bool_type, jl_datatype_t*) \
     XX(bottom_type, jl_value_t*) \
     XX(boundserror_type, jl_datatype_t*) \
+    XX(capabilityerror_type, jl_datatype_t*) \
     XX(builtin_type, jl_datatype_t*) \
     XX(cancel_source_type, jl_datatype_t*) \
     XX(char_type, jl_datatype_t*) \

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -156,7 +156,8 @@
     XX(wait_entry_type, jl_datatype_t*) \
     XX(weakref_type, jl_datatype_t*) \
     XX(worldtoken_type, jl_datatype_t*) \
-    XX(typeapp_type, jl_datatype_t*)
+    XX(typeapp_type, jl_datatype_t*) \
+    XX(computedfieldtype_type, jl_datatype_t*)
 
 // Global constant values (jl_true, jl_false, jl_nothing)
 #define JL_CONST_GLOBAL_VARS(YY) \

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -157,7 +157,8 @@
     XX(weakref_type, jl_datatype_t*) \
     XX(worldtoken_type, jl_datatype_t*) \
     XX(typeapp_type, jl_datatype_t*) \
-    XX(computedfieldtype_type, jl_datatype_t*)
+    XX(computedfieldtype_type, jl_datatype_t*) \
+    XX(fieldtypegenerator_type, jl_datatype_t*)
 
 // Global constant values (jl_true, jl_false, jl_nothing)
 #define JL_CONST_GLOBAL_VARS(YY) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -400,6 +400,7 @@
     XX(jl_register_newmeth_tracer) \
     XX(jl_resolve_definition_effects_in_ir) \
     XX(jl_resolve_typegroup) \
+    XX(jl_set_fieldtype_generator) \
     XX(jl_restore_excstack) \
     XX(jl_restore_incremental) \
     XX(jl_restore_package_image_from_file) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -401,6 +401,7 @@
     XX(jl_resolve_definition_effects_in_ir) \
     XX(jl_resolve_typegroup) \
     XX(jl_set_fieldtype_generator) \
+    XX(jl_call_fieldtype_generator) \
     XX(jl_restore_excstack) \
     XX(jl_restore_incremental) \
     XX(jl_restore_package_image_from_file) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -61,7 +61,7 @@ static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_CANSAF
     while (1) {
         if (jl_is_typevar(v))
             return !typeenv_has(env, (jl_tvar_t*)v);
-        if (jl_is_typeapp(v))
+        if (jl_is_typeapp(v) || jl_is_computedfieldtype(v))
             return 1;
         while (jl_is_unionall(v)) {
             jl_unionall_t *ua = (jl_unionall_t*)v;
@@ -78,6 +78,14 @@ static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_CANSAF
                 return 0;
             if (dt->layout || !dt->name->mayinlinealloc)
                 return 0;
+            if (dt->name->wrapper != NULL) {
+                // The layout of a non-concrete instantiation of a type with
+                // computed field types depends on its free typevars through the
+                // field generator; don't try to compute its field types here.
+                jl_datatype_t *w = (jl_datatype_t*)jl_unwrap_unionall(dt->name->wrapper);
+                if (w->types != NULL && jl_svec_has_computedfields(w->types))
+                    return 1;
+            }
             if (dt->name == jl_namedtuple_typename) {
                 jl_value_t *names = jl_tparam0(dt);
                 jl_value_t *types = jl_tparam1(dt);
@@ -377,6 +385,14 @@ int jl_has_fixed_layout(jl_datatype_t *dt)
     }
     if (dt->name == jl_tuple_typename)
         return 0;
+    if (dt->name->wrapper != NULL) {
+        // Types with computed field types: a non-concrete instantiation has no
+        // fixed layout, and its field types cannot be computed (the generator
+        // requires fully concrete parameters).
+        jl_datatype_t *w = (jl_datatype_t*)jl_unwrap_unionall(dt->name->wrapper);
+        if (w->types != NULL && jl_svec_has_computedfields(w->types))
+            return 0;
+    }
     jl_svec_t *types = jl_get_fieldtypes(dt);
     size_t i, l = jl_svec_len(types);
     for (i = 0; i < l; i++) {
@@ -1518,6 +1534,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
 static jl_value_t *instantiate_unionall_(jl_unionall_t *u, jl_value_t *p, jl_deferred_typecache_t *dcache) JL_CANSAFEPOINT;
 static jl_value_t *jl_apply_tuple_type_v_(jl_value_t **p, size_t np, jl_svec_t *params, int check, jl_deferred_typecache_t *dcache) JL_CANSAFEPOINT;
 static jl_svec_t *compute_fieldtypes_(jl_datatype_t *st JL_PROPAGATES_ROOT, void *stack, int cacheable, jl_deferred_typecache_t *dcache) JL_CANSAFEPOINT;
+static __thread jl_typestack_t *fieldgen_typestack;
 
 // Build an environment mapping a TypeName's parameters to parameter values.
 // This is the environment needed for instantiating a type's supertype and field types.
@@ -2444,6 +2461,12 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
     jl_typename_t *tn = dt->name;
     int istuple = (tn == jl_tuple_typename);
     int isnamedtuple = (tn == jl_namedtuple_typename);
+    if (stack == NULL)
+        // `apply_type` calls made by an in-flight field generator carry their
+        // instantiation stack through this thread-local (see
+        // invoke_fieldtype_generator), so self-references resolve to the
+        // in-flight type instead of recursing
+        stack = fieldgen_typestack;
 
     // check if type cache will be applicable
     // n.b. for deferred instantiations, `cacheable` still controls the cache
@@ -2798,7 +2821,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
         }
         else if (cacheable) {
             // recursively instantiate the types of the fields
-            if (dt->types == NULL)
+            if (dt->types == NULL || jl_svec_has_computedfields(ftypes))
                 jl_gc_write(ndt, ndt->types, jl_svec_t, compute_fieldtypes_(ndt, stack, cacheable && !defer, dcache));
             else
                 jl_gc_write(ndt, ndt->types, jl_svec_t, inst_ftypes(ftypes, env, stack, cacheable && !defer, dcache));
@@ -3312,6 +3335,80 @@ jl_vararg_t *jl_wrap_vararg(jl_value_t *t, jl_value_t *n, int check, int nothrow
     return vm;
 }
 
+// In-flight instantiation stack for field-generator invocations: the
+// `apply_type` calls a field generator makes cannot receive the caller's
+// typestack explicitly, so it is threaded through this thread-local instead
+// (declared above), letting self-referential computed field types find the
+// in-flight type (mirroring `lookup_type_stack` for substitution-based fields).
+
+// Invoke the field generator of st->name on st's (fully concrete) parameters.
+// A generator that throws — or returns anything other than closed field types —
+// degrades every field type to Union{}, making the type uninstantiable while
+// keeping type-system internals (intersection, instantiation) throw-free.
+static jl_svec_t *invoke_fieldtype_generator(jl_datatype_t *st JL_PROPAGATES_ROOT, jl_value_t *genfn, jl_typestack_t *stack) JL_CANSAFEPOINT
+{
+    size_t nf = jl_svec_len(st->name->names);
+    size_t np = jl_svec_len(st->parameters);
+    jl_svec_t *ftypes = NULL;
+    jl_value_t *res = NULL;
+    // root ci: tn->fieldgen is a mutable field, so reachability through it is
+    // not stable across safepoints (e.g. if the generator is re-installed)
+    jl_code_instance_t *ci = (jl_code_instance_t*)jl_typename_fieldgen_ci(st->name);
+    JL_GC_PUSH3(&ftypes, &res, &ci);
+    jl_typestack_t top;
+    top.tt = st;
+    top.prev = stack != NULL ? stack : fieldgen_typestack;
+    jl_typestack_t *prev_tls = fieldgen_typestack;
+    fieldgen_typestack = &top;
+    JL_TRY {
+        jl_value_t **args;
+        JL_GC_PUSHARGS(args, np + 1);
+        args[0] = genfn;
+        for (size_t i = 0; i < np; i++)
+            args[i + 1] = jl_svecref(st->parameters, i);
+        jl_callptr_t invoke = NULL;
+        if (ci != NULL) {
+            invoke = jl_atomic_load_acquire(&ci->invoke);
+            if (invoke == NULL) {
+                // freshly created or loaded from an image: detached code is
+                // executed by the interpreter (TODO: native compilation)
+                jl_value_t *inf = jl_atomic_load_relaxed(&ci->inferred);
+                if (inf != NULL && jl_is_code_info(inf)) {
+                    jl_atomic_store_release(&ci->invoke, jl_fptr_interpret_call);
+                    invoke = jl_fptr_interpret_call;
+                }
+            }
+        }
+        if (invoke != NULL) {
+            // world-age-independent detached CodeInstance
+            res = invoke(args[0], &args[1], (uint32_t)np, ci);
+        }
+        else {
+            // dynamic call in the current world (pre-detachment fallback)
+            res = jl_apply(args, np + 1);
+        }
+        JL_GC_POP();
+    }
+    JL_CATCH {
+        res = NULL;
+    }
+    fieldgen_typestack = prev_tls;
+    if (res != NULL && jl_is_tuple(res) && jl_nfields(res) == nf) {
+        ftypes = jl_alloc_svec(nf);
+        for (size_t i = 0; i < nf; i++) {
+            jl_value_t *elt = jl_fieldref(res, i);
+            if (!jl_is_type(elt) || jl_has_free_typevars(elt))
+                elt = jl_bottom_type;
+            jl_svecset(ftypes, i, elt);
+        }
+    }
+    else {
+        ftypes = jl_svec_fill(nf, jl_bottom_type);
+    }
+    JL_GC_POP();
+    return ftypes;
+}
+
 static jl_svec_t *compute_fieldtypes_(jl_datatype_t *st JL_PROPAGATES_ROOT, void *stack, int cacheable, jl_deferred_typecache_t *dcache) JL_CANSAFEPOINT
 {
     assert(st->name != jl_namedtuple_typename && st->name != jl_tuple_typename);
@@ -3323,6 +3420,41 @@ static jl_svec_t *compute_fieldtypes_(jl_datatype_t *st JL_PROPAGATES_ROOT, void
     if (wt->types == NULL)
         jl_errorf("cannot determine field types of incomplete type %s",
                   jl_symbol_name(st->name->name));
+    jl_svec_t *decl = wt->types;
+    jl_value_t *genfn = NULL;
+    JL_GC_PUSH2(&decl, &genfn);
+    if (jl_svec_has_computedfields(decl)) {
+        if (!st->hasfreetypevars) {
+            // root genfn: tn->fieldgen is mutable, so reachability through it
+            // is not stable across safepoints
+            genfn = jl_typename_fieldgen_func(st->name);
+            if (genfn == NULL)
+                jl_errorf("field generator for %s has not been installed yet",
+                          jl_symbol_name(st->name->name));
+            jl_gc_write(st, st->types, jl_svec_t, invoke_fieldtype_generator(st, genfn, (jl_typestack_t*)stack));
+            // Instantiations created before the generator was installed (e.g.
+            // self-references during definition) compute types lazily; give
+            // them their layout as well now that the field types are known.
+            if (st->isconcretetype && st->layout == NULL)
+                jl_compute_field_offsets(st);
+            JL_GC_POP();
+            return st->types;
+        }
+        // Partial instantiation: a computed field type is unknown until the
+        // parameters are fully concrete; widen each computed slot to a fresh
+        // unbounded TypeVar (analogous to `fieldtype(Ref, 1) === T`), which
+        // downstream consumers already treat conservatively.
+        size_t nf = jl_svec_len(decl);
+        jl_svec_t *tmp = jl_alloc_svec(nf);
+        decl = tmp;
+        for (i = 0; i < nf; i++) {
+            jl_value_t *ft = jl_svecref(wt->types, i);
+            if (jl_is_computedfieldtype(ft))
+                ft = (jl_value_t*)jl_new_typevar(jl_symbol("#computed#"), jl_bottom_type,
+                                                 (jl_value_t*)jl_any_type);
+            jl_svecset(decl, i, ft);
+        }
+    }
     jl_typeenv_t *env = (jl_typeenv_t*)alloca(n * sizeof(jl_typeenv_t));
     for (i = 0; i < n; i++) {
         env[i].var = (jl_tvar_t*)jl_svecref(wt->parameters, i);
@@ -3332,7 +3464,8 @@ static jl_svec_t *compute_fieldtypes_(jl_datatype_t *st JL_PROPAGATES_ROOT, void
     jl_typestack_t top;
     top.tt = st;
     top.prev = (jl_typestack_t*)stack;
-    jl_gc_write(st, st->types, jl_svec_t, inst_ftypes(wt->types, &env[n - 1], &top, cacheable, dcache));
+    jl_gc_write(st, st->types, jl_svec_t, inst_ftypes(decl, &env[n - 1], &top, cacheable, dcache));
+    JL_GC_POP();
     return st->types;
 }
 
@@ -3391,6 +3524,12 @@ void jl_reinstantiate_inner_types(jl_datatype_t *t, jl_deferred_typecache_t *dca
             jl_typestack_t ndt_top;
             ndt_top.tt = ndt;
             ndt_top.prev = &top;
+            if (jl_svec_has_computedfields(t->types)) {
+                // The field generator is installed after typegroup resolution;
+                // leave the field types unset so they are computed on first use.
+                jl_array_ptr_set(partial, j, NULL);
+                continue;
+            }
             jl_gc_write(ndt, ndt->types, jl_svec_t, inst_ftypes(t->types, &env[n - 1], &ndt_top, dcache == NULL, dcache));
             if (ndt->isconcretetype) { // cacheable
                 jl_compute_field_offsets(ndt);
@@ -3509,20 +3648,20 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_typename_type->name->wrapper = (jl_value_t*)jl_typename_type;
     jl_typename_type->super = jl_any_type;
     jl_typename_type->parameters = jl_emptysvec;
-    jl_typename_type->name->n_uninitialized = 19 - 2;
-    jl_typename_type->name->names = jl_perm_symsvec(19, "name", "module", "singletonname",
+    jl_typename_type->name->n_uninitialized = 20 - 2;
+    jl_typename_type->name->names = jl_perm_symsvec(20, "name", "module", "singletonname",
                                                     "names", "atomicfields", "constfields",
                                                     "wrapper", "Typeofwrapper", "cache", "linearcache",
                                                     "partial", "hash", "max_args", "n_uninitialized",
                                                     "flags", // "abstract", "mutable", "mayinlinealloc",
                                                     "cache_entry_count", "max_methods", "constprop_heuristic",
-                                                    "concrete_only");
-    const static uint32_t typename_constfields[1]  = { 0b0000110100001001011 }; // TODO: put back atomicfields and constfields in this list
-    const static uint32_t typename_atomicfields[1] = { 0b0001001001110000000 };
+                                                    "concrete_only", "fieldgen");
+    const static uint32_t typename_constfields[1]  = { 0b00000110100001001011 }; // TODO: put back atomicfields and constfields in this list
+    const static uint32_t typename_atomicfields[1] = { 0b10001001001110000000 };
     jl_typename_type->name->constfields = typename_constfields;
     jl_typename_type->name->atomicfields = typename_atomicfields;
     jl_precompute_memoized_dt(jl_typename_type, 1);
-    jl_typename_type->types = jl_svec(19, jl_symbol_type, jl_any_type /*jl_module_type*/, jl_symbol_type,
+    jl_typename_type->types = jl_svec(20, jl_symbol_type, jl_any_type /*jl_module_type*/, jl_symbol_type,
                                       jl_simplevector_type,
                                       jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/,
                                       jl_type_type, jl_simplevector_type, jl_simplevector_type,
@@ -3534,7 +3673,8 @@ void jl_init_types(void) JL_GC_DISABLED
                                       jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/,
-                                      jl_any_type /*jl_bool_type*/);
+                                      jl_any_type /*jl_bool_type*/,
+                                      jl_any_type);
 
     jl_methcache_type->name = jl_new_typename_in(jl_symbol("MethodCache"), core, 0, 1);
     jl_methcache_type->name->wrapper = (jl_value_t*)jl_methcache_type;
@@ -4574,6 +4714,8 @@ void post_boot_hooks(void)
 
     // Initialize TypeApp type reference for mutually recursive types
     jl_typeapp_type = (jl_datatype_t*)core("TypeApp");
+    // Marker for computed field types (field generators)
+    jl_computedfieldtype_type = (jl_datatype_t*)core("ComputedFieldType");
 
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");
     jl_worldtoken_type = (jl_datatype_t*)core("WorldToken");

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2919,7 +2919,7 @@ static jl_svec_t *inst_ftypes(jl_svec_t *p, jl_typeenv_t *env, jl_typestack_t *s
         pi = jl_svecref(p, i);
         JL_TRY {
             pi = inst_type_w_(pi, env, stack, 1, 0, dcache);
-            if (!jl_is_type(pi) && !jl_is_typevar(pi)) {
+            if (!jl_is_type(pi) && !jl_is_typevar(pi) && !jl_is_computedfieldtype(pi)) {
                 pi = jl_bottom_type;
             }
         }
@@ -3341,53 +3341,69 @@ jl_vararg_t *jl_wrap_vararg(jl_value_t *t, jl_value_t *n, int check, int nothrow
 // (declared above), letting self-referential computed field types find the
 // in-flight type (mirroring `lookup_type_stack` for substitution-based fields).
 
+// Call tn's field generator on the given parameter values, through the
+// world-age-detached CodeInstance when one has been recorded. Anything the
+// generator throws propagates to the caller.
+JL_DLLEXPORT jl_value_t *jl_call_fieldtype_generator(jl_typename_t *tn, jl_svec_t *params) JL_CANSAFEPOINT
+{
+    size_t np = jl_svec_len(params);
+    jl_value_t **args;
+    // root fg (and through it the generator and CodeInstance): tn->fieldgen is
+    // a mutable field, so reachability through it is not stable across
+    // safepoints (e.g. if the generator is re-installed)
+    JL_GC_PUSHARGS(args, np + 2);
+    jl_value_t *fg = jl_atomic_load_relaxed(&tn->fieldgen);
+    if (fg == NULL || fg == jl_nothing)
+        jl_errorf("field generator for %s has not been installed yet",
+                  jl_symbol_name(tn->name));
+    args[np + 1] = fg;
+    args[0] = jl_svecref(fg, 0);
+    for (size_t i = 0; i < np; i++)
+        args[i + 1] = jl_svecref(params, i);
+    jl_code_instance_t *ci = jl_svec_len(fg) < 2 ? NULL : (jl_code_instance_t*)jl_svecref(fg, 1);
+    jl_callptr_t invoke = NULL;
+    if (ci != NULL) {
+        invoke = jl_atomic_load_acquire(&ci->invoke);
+        if (invoke == NULL) {
+            // freshly created or loaded from an image: detached code is
+            // executed by the interpreter (TODO: native compilation)
+            jl_value_t *inf = jl_atomic_load_relaxed(&ci->inferred);
+            if (inf != NULL && jl_is_code_info(inf)) {
+                jl_atomic_store_release(&ci->invoke, jl_fptr_interpret_call);
+                invoke = jl_fptr_interpret_call;
+            }
+        }
+    }
+    jl_value_t *res;
+    if (invoke != NULL) {
+        // world-age-independent detached CodeInstance
+        res = invoke(args[0], &args[1], (uint32_t)np, ci);
+    }
+    else {
+        // dynamic call in the current world (pre-detachment fallback)
+        res = jl_apply(args, np + 1);
+    }
+    JL_GC_POP();
+    return res;
+}
+
 // Invoke the field generator of st->name on st's (fully concrete) parameters.
 // A generator that throws — or returns anything other than closed field types —
 // degrades every field type to Union{}, making the type uninstantiable while
 // keeping type-system internals (intersection, instantiation) throw-free.
-static jl_svec_t *invoke_fieldtype_generator(jl_datatype_t *st JL_PROPAGATES_ROOT, jl_value_t *genfn, jl_typestack_t *stack) JL_CANSAFEPOINT
+static jl_svec_t *invoke_fieldtype_generator(jl_datatype_t *st JL_PROPAGATES_ROOT, jl_typestack_t *stack) JL_CANSAFEPOINT
 {
     size_t nf = jl_svec_len(st->name->names);
-    size_t np = jl_svec_len(st->parameters);
     jl_svec_t *ftypes = NULL;
     jl_value_t *res = NULL;
-    // root ci: tn->fieldgen is a mutable field, so reachability through it is
-    // not stable across safepoints (e.g. if the generator is re-installed)
-    jl_code_instance_t *ci = (jl_code_instance_t*)jl_typename_fieldgen_ci(st->name);
-    JL_GC_PUSH3(&ftypes, &res, &ci);
+    JL_GC_PUSH2(&ftypes, &res);
     jl_typestack_t top;
     top.tt = st;
     top.prev = stack != NULL ? stack : fieldgen_typestack;
     jl_typestack_t *prev_tls = fieldgen_typestack;
     fieldgen_typestack = &top;
     JL_TRY {
-        jl_value_t **args;
-        JL_GC_PUSHARGS(args, np + 1);
-        args[0] = genfn;
-        for (size_t i = 0; i < np; i++)
-            args[i + 1] = jl_svecref(st->parameters, i);
-        jl_callptr_t invoke = NULL;
-        if (ci != NULL) {
-            invoke = jl_atomic_load_acquire(&ci->invoke);
-            if (invoke == NULL) {
-                // freshly created or loaded from an image: detached code is
-                // executed by the interpreter (TODO: native compilation)
-                jl_value_t *inf = jl_atomic_load_relaxed(&ci->inferred);
-                if (inf != NULL && jl_is_code_info(inf)) {
-                    jl_atomic_store_release(&ci->invoke, jl_fptr_interpret_call);
-                    invoke = jl_fptr_interpret_call;
-                }
-            }
-        }
-        if (invoke != NULL) {
-            // world-age-independent detached CodeInstance
-            res = invoke(args[0], &args[1], (uint32_t)np, ci);
-        }
-        else {
-            // dynamic call in the current world (pre-detachment fallback)
-            res = jl_apply(args, np + 1);
-        }
-        JL_GC_POP();
+        res = jl_call_fieldtype_generator(st->name, st->parameters);
     }
     JL_CATCH {
         res = NULL;
@@ -3420,41 +3436,22 @@ static jl_svec_t *compute_fieldtypes_(jl_datatype_t *st JL_PROPAGATES_ROOT, void
     if (wt->types == NULL)
         jl_errorf("cannot determine field types of incomplete type %s",
                   jl_symbol_name(st->name->name));
-    jl_svec_t *decl = wt->types;
-    jl_value_t *genfn = NULL;
-    JL_GC_PUSH2(&decl, &genfn);
-    if (jl_svec_has_computedfields(decl)) {
-        if (!st->hasfreetypevars) {
-            // root genfn: tn->fieldgen is mutable, so reachability through it
-            // is not stable across safepoints
-            genfn = jl_typename_fieldgen_func(st->name);
-            if (genfn == NULL)
-                jl_errorf("field generator for %s has not been installed yet",
-                          jl_symbol_name(st->name->name));
-            jl_gc_write(st, st->types, jl_svec_t, invoke_fieldtype_generator(st, genfn, (jl_typestack_t*)stack));
-            // Instantiations created before the generator was installed (e.g.
-            // self-references during definition) compute types lazily; give
-            // them their layout as well now that the field types are known.
-            if (st->isconcretetype && st->layout == NULL)
-                jl_compute_field_offsets(st);
-            JL_GC_POP();
-            return st->types;
-        }
-        // Partial instantiation: a computed field type is unknown until the
-        // parameters are fully concrete; widen each computed slot to a fresh
-        // unbounded TypeVar (analogous to `fieldtype(Ref, 1) === T`), which
-        // downstream consumers already treat conservatively.
-        size_t nf = jl_svec_len(decl);
-        jl_svec_t *tmp = jl_alloc_svec(nf);
-        decl = tmp;
-        for (i = 0; i < nf; i++) {
-            jl_value_t *ft = jl_svecref(wt->types, i);
-            if (jl_is_computedfieldtype(ft))
-                ft = (jl_value_t*)jl_new_typevar(jl_symbol("#computed#"), jl_bottom_type,
-                                                 (jl_value_t*)jl_any_type);
-            jl_svecset(decl, i, ft);
-        }
+    if (jl_svec_has_computedfields(wt->types) && !st->hasfreetypevars) {
+        if (jl_typename_fieldgen_func(st->name) == NULL)
+            jl_errorf("field generator for %s has not been installed yet",
+                      jl_symbol_name(st->name->name));
+        jl_gc_write(st, st->types, jl_svec_t, invoke_fieldtype_generator(st, (jl_typestack_t*)stack));
+        // Instantiations created before the generator was installed (e.g.
+        // self-references during definition) compute types lazily; give
+        // them their layout as well now that the field types are known.
+        if (st->isconcretetype && st->layout == NULL)
+            jl_compute_field_offsets(st);
+        return st->types;
     }
+    // n.b. for partial instantiations of types with computed field types, the
+    // ComputedFieldType markers pass through the substitution unchanged: the
+    // computed slots remain symbolic (deliberately *not* represented in the
+    // type system; see the partial application support in Base).
     jl_typeenv_t *env = (jl_typeenv_t*)alloca(n * sizeof(jl_typeenv_t));
     for (i = 0; i < n; i++) {
         env[i].var = (jl_tvar_t*)jl_svecref(wt->parameters, i);
@@ -3464,8 +3461,7 @@ static jl_svec_t *compute_fieldtypes_(jl_datatype_t *st JL_PROPAGATES_ROOT, void
     jl_typestack_t top;
     top.tt = st;
     top.prev = (jl_typestack_t*)stack;
-    jl_gc_write(st, st->types, jl_svec_t, inst_ftypes(decl, &env[n - 1], &top, cacheable, dcache));
-    JL_GC_POP();
+    jl_gc_write(st, st->types, jl_svec_t, inst_ftypes(wt->types, &env[n - 1], &top, cacheable, dcache));
     return st->types;
 }
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4576,6 +4576,7 @@ void post_boot_hooks(void)
     jl_typeapp_type = (jl_datatype_t*)core("TypeApp");
 
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");
+    jl_worldtoken_type = (jl_datatype_t*)core("WorldToken");
     jl_vecelement_typename = ((jl_datatype_t*)jl_unwrap_unionall(core("VecElement")))->name;
     jl_abioverride_type = (jl_datatype_t*)core("ABIOverride");
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3387,6 +3387,63 @@ JL_DLLEXPORT jl_value_t *jl_call_fieldtype_generator(jl_typename_t *tn, jl_svec_
     return res;
 }
 
+// Application of a Core.FieldtypeGenerator, with the same shape as applying a
+// partially applied UnionAll: applying some of the remaining type parameters
+// yields another FieldtypeGenerator; applying all of them yields the tuple of
+// field types (computed through the world-age-detached generator, with errors
+// propagating rather than degrading to Union{}, and without instantiating the
+// type as a side effect).
+jl_value_t *jl_apply_fieldtype_generator(jl_value_t *ftg, jl_value_t **args, size_t nargs)
+{
+    jl_value_t *ty = ((jl_fieldtypegenerator_t*)ftg)->ty;
+    size_t nfree = 0;
+    jl_value_t *t = ty;
+    while (jl_is_unionall(t)) {
+        nfree++;
+        t = ((jl_unionall_t*)t)->body;
+    }
+    if (!jl_is_datatype(t) || nargs > nfree)
+        jl_errorf("too many parameters for field generator of %s (%zd remaining, %zd given)",
+                  jl_is_datatype(t) ? jl_symbol_name(((jl_datatype_t*)t)->name->name) : "?",
+                  nfree, nargs);
+    if (nargs == 0)
+        jl_error("field generator application requires at least one parameter");
+    if (nargs < nfree) {
+        // partial application: apply to the underlying type (which remains
+        // non-concrete, so this does not run the generator)
+        jl_value_t *newty = NULL;
+        JL_GC_PUSH1(&newty);
+        newty = jl_apply_type(ty, args, nargs);
+        newty = jl_new_struct(jl_fieldtypegenerator_type, newty);
+        JL_GC_POP();
+        return newty;
+    }
+    // full application: substitute the parameter values and invoke the
+    // generator directly
+    jl_value_t *cur = NULL;
+    jl_svec_t *params = NULL;
+    JL_GC_PUSH2(&cur, &params);
+    cur = nargs > 1 ? jl_apply_type(ty, args, nargs - 1) : ty;
+    assert(jl_is_unionall(cur));
+    jl_unionall_t *ua = (jl_unionall_t*)cur;
+    jl_value_t *last = args[nargs - 1];
+    jl_datatype_t *body = (jl_datatype_t*)ua->body;
+    assert(jl_is_datatype(body));
+    size_t np = jl_svec_len(body->parameters);
+    params = jl_alloc_svec(np);
+    for (size_t i = 0; i < np; i++) {
+        jl_value_t *p = jl_svecref(body->parameters, i);
+        p = jl_substitute_var(p, ua->var, last);
+        if (jl_has_free_typevars(p))
+            jl_errorf("field generator of %s applied to parameters that are not fully specified",
+                      jl_symbol_name(body->name->name));
+        jl_svecset(params, i, p);
+    }
+    jl_value_t *res = jl_call_fieldtype_generator(body->name, params);
+    JL_GC_POP();
+    return res;
+}
+
 // Invoke the field generator of st->name on st's (fully concrete) parameters.
 // A generator that throws — or returns anything other than closed field types —
 // degrades every field type to Union{}, making the type uninstantiable while
@@ -4712,6 +4769,7 @@ void post_boot_hooks(void)
     jl_typeapp_type = (jl_datatype_t*)core("TypeApp");
     // Marker for computed field types (field generators)
     jl_computedfieldtype_type = (jl_datatype_t*)core("ComputedFieldType");
+    jl_fieldtypegenerator_type = (jl_datatype_t*)core("FieldtypeGenerator");
 
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");
     jl_worldtoken_type = (jl_datatype_t*)core("WorldToken");

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3348,40 +3348,34 @@ JL_DLLEXPORT jl_value_t *jl_call_fieldtype_generator(jl_typename_t *tn, jl_svec_
 {
     size_t np = jl_svec_len(params);
     jl_value_t **args;
-    // root fg (and through it the generator and CodeInstance): tn->fieldgen is
-    // a mutable field, so reachability through it is not stable across
-    // safepoints (e.g. if the generator is re-installed)
-    JL_GC_PUSHARGS(args, np + 2);
+    // args[0] = definition world token, args[1] = generator, args[2..] =
+    // parameter values; the extra slot roots fg (tn->fieldgen is a mutable
+    // field, so reachability through it is not stable across safepoints,
+    // e.g. if the generator is re-installed)
+    JL_GC_PUSHARGS(args, np + 3);
     jl_value_t *fg = jl_atomic_load_relaxed(&tn->fieldgen);
     if (fg == NULL || fg == jl_nothing)
         jl_errorf("field generator for %s has not been installed yet",
                   jl_symbol_name(tn->name));
-    args[np + 1] = fg;
-    args[0] = jl_svecref(fg, 0);
+    args[np + 2] = fg;
+    args[1] = jl_svecref(fg, 0);
     for (size_t i = 0; i < np; i++)
-        args[i + 1] = jl_svecref(params, i);
-    jl_code_instance_t *ci = jl_svec_len(fg) < 2 ? NULL : (jl_code_instance_t*)jl_svecref(fg, 1);
-    jl_callptr_t invoke = NULL;
-    if (ci != NULL) {
-        invoke = jl_atomic_load_acquire(&ci->invoke);
-        if (invoke == NULL) {
-            // freshly created or loaded from an image: detached code is
-            // executed by the interpreter (TODO: native compilation)
-            jl_value_t *inf = jl_atomic_load_relaxed(&ci->inferred);
-            if (inf != NULL && jl_is_code_info(inf)) {
-                jl_atomic_store_release(&ci->invoke, jl_fptr_interpret_call);
-                invoke = jl_fptr_interpret_call;
-            }
-        }
-    }
+        args[i + 2] = jl_svecref(params, i);
     jl_value_t *res;
-    if (invoke != NULL) {
-        // world-age-independent detached CodeInstance
-        res = invoke(args[0], &args[1], (uint32_t)np, ci);
+    if (jl_svec_len(fg) >= 2) {
+        // The definition world was captured as a `Core.WorldToken`: run the
+        // generator in RCJulia mode at that world. Restricted-capability
+        // evaluation makes the result `:foldable` by construction (no effects
+        // proof required), and the token — remapped through precompilation
+        // into the image's preserved world segment — pins the definition-time
+        // semantics of everything the generator calls, forever.
+        args[0] = jl_svecref(fg, 1);
+        res = jl_f__rcjulia_call(NULL, args, (uint32_t)(np + 2));
     }
     else {
-        // dynamic call in the current world (pre-detachment fallback)
-        res = jl_apply(args, np + 1);
+        // bootstrap fallback (validation not yet available): dynamic call in
+        // the current world
+        res = jl_apply(&args[1], np + 1);
     }
     JL_GC_POP();
     return res;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4558,6 +4558,7 @@ void post_boot_hooks(void)
     jl_undefvarerror_type    = (jl_datatype_t*)core("UndefVarError");
     jl_fielderror_type       = (jl_datatype_t*)core("FieldError");
     jl_atomicerror_type      = (jl_datatype_t*)core("ConcurrencyViolationError");
+    jl_capabilityerror_type      = (jl_datatype_t*)core("CapabilityError");
     jl_boundserror_type      = (jl_datatype_t*)core("BoundsError");
     jl_typeerror_type        = (jl_datatype_t*)core("TypeError");
     jl_argumenterror_type    = (jl_datatype_t*)core("ArgumentError");

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -800,7 +800,13 @@
                                                      (if (and (not selftype?) (equal? type-params params) (memq fty params) (memq fty sparams))
                                                       fty ; the field type is a simple parameter, the usage here is of a
                                                           ; local variable (currently just handles sparam) for the bijection of params to type-params
-                                                      `(call (core fieldtype) ,tn ,(+ fld 1)))
+                                                      (if (computed-field-type? fty params)
+                                                          ;; computed slots may hold Union{} because the field
+                                                          ;; generator failed and the instantiation degraded;
+                                                          ;; this helper re-derives with errors propagating so
+                                                          ;; construction reports the underlying failure
+                                                          `(call (top _ctor_fieldtype) ,tn ,(+ fld 1))
+                                                          `(call (core fieldtype) ,tn ,(+ fld 1))))
                                                       #f
                                                       #f)))))
     (cond ((> (num-non-varargs args) (length field-names))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -937,6 +937,27 @@
                               (thismodule) ,name))))
         field-types))
 
+;; Does expression e reference (syntactically) any of the symbols in syms?
+(define (expr-references-any? e syms)
+  (cond ((symbol? e) (if (memq e syms) #t #f))
+        ((and (pair? e) (not (quoted? e)))
+         (any (lambda (x) (expr-references-any? x syms)) (cdr e)))
+        (else #f)))
+
+;; A field type expression is "computed" if it contains a function call or a
+;; typeassert that references one of the struct's type parameters. Such an
+;; expression cannot be evaluated at definition time (the parameters are bound
+;; to TypeVars there); it is instead kept as a quoted AST in the declared field
+;; type slot (Core.ComputedFieldType) and evaluated by the type's field
+;; generator when a concrete instantiation is created.
+(define (computed-field-type? e params)
+  (cond ((not (pair? e)) #f)
+        ((quoted? e) #f)
+        ((and (memq (car e) '(call |::|))
+              (expr-references-any? e params))
+         #t)
+        (else (any (lambda (x) (computed-field-type? x params)) (cdr e)))))
+
 ;; Generate struct definition info and constructor definitions.
 ;; All struct definitions use the typegroup mechanism (resolve_typegroup).
 ;;
@@ -973,9 +994,19 @@
           (field-names (map decl-var fields))
           (field-types (map decl-type fields))
           (min-initialized (min (ctors-min-initialized defs) (length fields)))
-          (ftypes-expr (if use-shim
-                           (insert-struct-shim field-types name)
-                           field-types)))
+          (computed-flags (map (lambda (ft) (computed-field-type? ft params)) field-types))
+          (has-computed   (any (lambda (x) x) computed-flags))
+          (ftypes-expr (map (lambda (ft cf orig)
+                              ;; computed field types are kept as a quoted AST
+                              ;; marker; the field generator evaluates them
+                              (if cf
+                                  `(call (core ComputedFieldType) (inert ,orig))
+                                  ft))
+                            (if use-shim
+                                (insert-struct-shim field-types name)
+                                field-types)
+                            computed-flags
+                            field-types)))
      (let ((dups (has-dups field-names)))
        (if dups (error (string "duplicate field name: \"" (car dups) "\" is not unique"))))
      (for-each (lambda (v)
@@ -996,12 +1027,25 @@
              ,mut ,min-initialized ,super (call (core svec) ,@ftypes-expr)))))
        ;; Constructor definitions: always define ctors so they are available
        ;; alongside (replacing) old ones during redefinition.
-       ,(if (null? defs)
-          `(call (top _defaultctors) ,name (inert ,loc))
-          `(scope-block
-            (block
-             (hardscope)
-             ,@(map (lambda (c) (rewrite-ctor c name params field-names field-types)) defs))))))))
+       ,(let ((ctors (if (null? defs)
+                         `(call (top _defaultctors) ,name (inert ,loc))
+                         `(scope-block
+                           (block
+                            (hardscope)
+                            ,@(map (lambda (c) (rewrite-ctor c name params field-names field-types)) defs))))))
+          (if has-computed
+              ;; Install the field generator: a function mapping the type
+              ;; parameter values to the tuple of field types. Validated (and
+              ;; eventually detached from the world age) by Base. n.b. the
+              ;; generator returns a tuple, not an svec: svec egality is
+              ;; identity, which would preclude proving the generator
+              ;; `:consistent`.
+              `(block
+                (call (top _set_fieldtype_generator!) ,name
+                      (-> (tuple ,@params)
+                          (block ,loc (call (core tuple) ,@field-types))))
+                ,ctors)
+              ctors))))))
 
 (define (abstract-type-def-expr name params super)
   (receive

--- a/src/julia.h
+++ b/src/julia.h
@@ -649,6 +649,10 @@ typedef struct {
     uint8_t max_methods; // override for inference's max_methods setting (0 = no additional limit or relaxation)
     uint8_t constprop_heustic; // override for inference's constprop heuristic
     uint8_t concrete_only; // Bool: inference refuses to commit (records no backedge) at non-concrete call sites
+    // field generator for types with computed field types (declared slots hold
+    // Core.ComputedFieldType markers): NULL or svec(genfunction) or
+    // svec(genfunction, detached CodeInstance). Set once, shortly after definition.
+    _Atomic(jl_value_t*) fieldgen;
 } jl_typename_t;
 
 typedef struct {

--- a/src/julia.h
+++ b/src/julia.h
@@ -2573,6 +2573,11 @@ struct _jl_handler_t {
     // Published ccall handler (if any). Used if we must unwind across a C function
     // that calls back into julia.
     struct _jl_cancel_handler_ctx_t *cancel_handler_ctx;
+    // The innermost RCJulia-mode interpreter frame at handler entry
+    // (see `jl_task_t->rc_frames`). Restored on unwind so an exception
+    // thrown out of interpreted pure frames does not leave the chain pointing
+    // into C stack frames the unwind destroyed.
+    struct _jl_rc_frame_t *rc_frames;
     sig_atomic_t defer_signal;
     int8_t gc_state;
     // Saved `bound_cancel_default` flag, restored with `bound_cancel_token`

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -572,16 +572,18 @@ extern JL_DLLEXPORT _Atomic(size_t) jl_world_counter;
 // that test a stored world bound against an arbitrary query world must use
 // the predicates below.
 
-#ifdef _P64
-#define JL_WORLD_IDX_BITS 48
-#else
-#define JL_WORLD_IDX_BITS 24
-#endif
-#define JL_WORLD_IDX_MASK ((~(size_t)0) >> (8 * sizeof(size_t) - JL_WORLD_IDX_BITS))
+// 16 bits of segment id on every platform (real environments can graft
+// several segments per loaded image, so fewer is not enough), with the rest
+// of the word as the index. On 32-bit platforms a run's index space is only
+// 16 bits; when it is exhausted, jl_world_next_locked simply continues the
+// trunk in a fresh run segment.
+#define JL_WORLD_IDX_BITS (8 * sizeof(size_t) - 16)
+#define JL_WORLD_IDX_MASK ((~(size_t)0) >> 16)
 // number of allocatable segments; the top segment id is never allocated so
 // that sentinel worlds (~(size_t)0 and values near it) fall in an
 // unmaterialized segment
-#define JL_WORLD_MAX_SEGMENTS ((~(size_t)0) >> JL_WORLD_IDX_BITS)
+#define JL_WORLD_MAX_SEGMENTS ((size_t)0xffff)
+#define JL_WORLD_PACK(seg, idx) ((((size_t)(seg)) << JL_WORLD_IDX_BITS) | (size_t)(idx))
 
 STATIC_INLINE size_t jl_world_seg(size_t world) JL_NOTSAFEPOINT
 {
@@ -637,10 +639,11 @@ typedef struct {
 } jl_world_segment_t;
 
 JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT;
-JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents);
-JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra);
-JL_DLLEXPORT void jl_world_init_runs(void);
-JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents);
+JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents) JL_CANSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra) JL_CANSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_next_locked(void) JL_CANSAFEPOINT;
+JL_DLLEXPORT void jl_world_init_runs(void) JL_CANSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents) JL_CANSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_world_segment_t *jl_world_get_segment(size_t seg) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT;
@@ -657,9 +660,9 @@ typedef struct {
 // i.e. is the state of the world as of `a` part of the history of `b`?
 STATIC_INLINE int jl_world_reaches(size_t a, size_t b) JL_NOTSAFEPOINT
 {
-    if ((a >> JL_WORLD_IDX_BITS) == (b >> JL_WORLD_IDX_BITS))
+    if (jl_world_seg(a) == jl_world_seg(b))
         return a <= b;
-    return jl_world_seg_reaches(a >> JL_WORLD_IDX_BITS, b >> JL_WORLD_IDX_BITS);
+    return jl_world_seg_reaches(jl_world_seg(a), jl_world_seg(b));
 }
 
 // Had an entry with the given `min_world` bound already been created as of

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -524,16 +524,19 @@ extern JL_DLLEXPORT _Atomic(size_t) jl_world_counter;
 
 // === world age segments ===
 //
-// World ages form an append-only DAG rather than a single linear sequence: a
-// world is a packed (segment, index) pair with the segment id in the high
-// bits. Segments are maximal linear runs of worlds. Segment 0 is the boot
-// segment; while it is the only segment, packed worlds coincide with the
-// historical linear numbering and every query below degenerates to the
-// integer compares it replaced.
+// World ages form an append-only DAG (matching the shape of the precompile
+// graph) rather than a single linear sequence: a world is a packed
+// (segment, index) pair with the segment id in the high bits. Segments are
+// maximal linear runs of worlds. Segment 0 is the boot segment; while it is
+// the only segment, packed worlds coincide with the historical linear
+// numbering and every query below degenerates to the integer compares it
+// replaced.
 //
 // A segment's parent set is fixed at its creation and only ever references
 // segments that are closed (will allocate no further worlds), at their full
-// extent. This yields the central decomposition used by jl_world_reaches:
+// extent. This yields the central decomposition used by jl_world_reaches,
+// the two-point visibility predicate ("running at world (sb, ib), can I see
+// something that happened at world (sa, ia)?"):
 //
 //    (sa, ia) preceq (sb, ib)  iff  sa == sb ? ia <= ib
 //                                           : sa is an ancestor of sb
@@ -546,14 +549,28 @@ extern JL_DLLEXPORT _Atomic(size_t) jl_world_counter;
 // in), ancestry falls back to the chain order sa < sb, which agrees with the
 // DAG on any prefix of history that is still a pure chain.
 //
-// Integer comparison of two worlds remains exact whenever both lie on the
-// spine -- the chain of segments the world counter has traversed -- because
-// segment ids and indices are both monotone along it. Sites that compare or
-// intersect worlds that are all known to be on the spine (e.g. the world
-// counter, method insertion worlds, and validity bounds computed from them
-// in-process) may therefore still use integer compares; sites that test a
-// stored world bound against an arbitrary query world must use the
-// predicates below.
+// Joins in the DAG are not symmetric: a segment's first parent continues its
+// trunk (the main branch), and the remaining parents are side branches whose
+// events semantically happen after the main-branch events preceding the join
+// point and before those following it. Each segment therefore imposes a
+// total order on its entire visible cone -- the three-point predicate
+// (sa, ia) preceq_[observer] (sb, ib), see jl_world_ordered_before -- in
+// which trunk worlds order as themselves and a side branch's worlds order at
+// its merge point (recursively, by the side branch's own total order within
+// one merge point). jl_world_join computes the earliest world in the
+// observer's order whose history includes two given worlds; interval bounds
+// from different branches are incomparable under the two-point predicate, so
+// intersecting validity intervals must use this join rather than an integer
+// max.
+//
+// Integer comparison of two worlds remains exact whenever both lie on one
+// trunk -- e.g. the spine, the chain of segments the world counter has
+// traversed -- because segment ids and indices are both monotone along it.
+// Sites that compare worlds all known to be on the spine (e.g. the world
+// counter, method insertion worlds, and invalidation caps, which only ever
+// happen at the spine head) may therefore still use integer compares; sites
+// that test a stored world bound against an arbitrary query world must use
+// the predicates below.
 
 #ifdef _P64
 #define JL_WORLD_IDX_BITS 48
@@ -589,16 +606,29 @@ enum jl_world_seg_kind {
     JL_WORLD_SEG_OTHER = 3,
 };
 
+// Join-position sentinel: the segment lies on the observer's trunk, so a
+// world's position in the observer's total order is the world itself.
+#define JL_WORLD_POS_TRUNK (~(size_t)0)
+
 typedef struct {
     uint32_t id;
     uint32_t anc_nbits;         // number of valid bits in anc_row (== id)
     _Atomic(size_t) end_idx;    // terminal index once closed; JL_WORLD_IDX_MASK while open
-    _Atomic(size_t) joined_spine; // first spine world whose history includes this segment; 0 while unmerged
     uint8_t kind;               // enum jl_world_seg_kind
     uint32_t run;               // RUN: spine run ordinal; IMAGE: run ordinal within the origin image
     uint64_t image_id;          // IMAGE: origin image id; 0 otherwise
     uint32_t nparents;
-    size_t *parents;            // parent worlds, in declaration order
+    size_t *parents;            // parent worlds; parents[0] is the trunk (main-branch) parent
+    // This segment's total order over its visible cone (the three-point
+    // predicate): for each ancestor segment, either JL_WORLD_POS_TRUNK (the
+    // ancestor is on this segment's trunk -- its chain of first parents --
+    // and its worlds are positioned at themselves), or the trunk world at
+    // which the ancestor's branch was merged. Joins are asymmetric: a side
+    // branch's events are positioned at its merge point, i.e. after every
+    // main-branch event before the join and before every one after it.
+    // Positions are trunk worlds and compare exactly as integers. 0 = unset.
+    size_t *join_pos;
+
 #ifdef __cplusplus
     uint64_t anc_row[1];        // ancestor segment bitset, immutable after publication
 #else
@@ -614,7 +644,9 @@ JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size
 JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_world_segment_t *jl_world_get_segment(size_t seg) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_join(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_world_ordered_before(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT;
 
 // mirror of Core.WorldToken
 typedef struct {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -651,6 +651,7 @@ JL_DLLEXPORT size_t jl_world_join(size_t a, size_t b, size_t observer) JL_NOTSAF
 JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_world_ordered_before(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_world_on_trunk(size_t w, size_t observer) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_cap_meet(size_t a, size_t b) JL_NOTSAFEPOINT;
 
 // mirror of Core.WorldToken
 typedef struct {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1565,6 +1565,7 @@ typedef struct {
 
 JL_DLLEXPORT jl_value_t *jl_resolve_typegroup(jl_module_t *module, jl_svec_t *typevars, jl_svec_t *struct_infos, jl_svec_t *old_types) JL_CANSAFEPOINT;
 JL_DLLEXPORT void jl_set_fieldtype_generator(jl_value_t *ty, jl_value_t *fieldgen) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_call_fieldtype_generator(jl_typename_t *tn, jl_svec_t *params) JL_CANSAFEPOINT;
 // Type predicate for TypeApp (inline: called per type node on hot type-query paths)
 STATIC_INLINE int jl_is_typeapp(jl_value_t *v) JL_NOTSAFEPOINT
 {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -578,6 +578,12 @@ STATIC_INLINE size_t jl_world_idx(size_t world) JL_NOTSAFEPOINT
 JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents);
 JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra);
+JL_DLLEXPORT size_t jl_world_graft_segment(void);
+
+// mirror of Core.WorldToken
+typedef struct {
+    size_t world;
+} jl_worldtoken_t;
 
 // a preceq b: does world `a` precede (or equal) world `b` in the world DAG,
 // i.e. is the state of the world as of `a` part of the history of `b`?

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1581,6 +1581,17 @@ STATIC_INLINE int jl_is_computedfieldtype(jl_value_t *v) JL_NOTSAFEPOINT
 {
     return jl_computedfieldtype_type != NULL && jl_typeis(v, jl_computedfieldtype_type);
 }
+// Core.FieldtypeGenerator: partially applied field generator (reflection
+// object; applied via `apply_type` like a partially applied UnionAll)
+typedef struct {
+    JL_DATA_TYPE
+    jl_value_t *ty; // the partially applied type (UnionAll over the wrapper)
+} jl_fieldtypegenerator_t;
+STATIC_INLINE int jl_is_fieldtypegenerator(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    return jl_fieldtypegenerator_type != NULL && jl_typeis(v, jl_fieldtypegenerator_type);
+}
+jl_value_t *jl_apply_fieldtype_generator(jl_value_t *ftg, jl_value_t **args, size_t nargs) JL_CANSAFEPOINT;
 // Return the field-generator function for tn, or NULL if tn has no computed field types.
 STATIC_INLINE jl_value_t *jl_typename_fieldgen_func(jl_typename_t *tn) JL_NOTSAFEPOINT
 {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -522,6 +522,103 @@ static inline jl_callptr_t jl_invoke_api_callptr(jl_invoke_api_t type) JL_NOTSAF
 // useful constants
 extern JL_DLLEXPORT _Atomic(size_t) jl_world_counter;
 
+// === world age segments ===
+//
+// World ages form an append-only DAG rather than a single linear sequence: a
+// world is a packed (segment, index) pair with the segment id in the high
+// bits. Segments are maximal linear runs of worlds. Segment 0 is the boot
+// segment; while it is the only segment, packed worlds coincide with the
+// historical linear numbering and every query below degenerates to the
+// integer compares it replaced.
+//
+// A segment's parent set is fixed at its creation and only ever references
+// segments that are closed (will allocate no further worlds), at their full
+// extent. This yields the central decomposition used by jl_world_reaches:
+//
+//    (sa, ia) preceq (sb, ib)  iff  sa == sb ? ia <= ib
+//                                           : sa is an ancestor of sb
+//
+// Segment-level ancestry is answered by an immutable per-segment bitset
+// built when the segment is created, so readers need no locks. Segment ids
+// are assigned in creation order and are therefore topologically sorted; for
+// segments that have never been materialized (plain linear operation, and
+// the reserved all-ones segment that sentinel values like ~(size_t)0 fall
+// in), ancestry falls back to the chain order sa < sb, which agrees with the
+// DAG on any prefix of history that is still a pure chain.
+//
+// Integer comparison of two worlds remains exact whenever both lie on the
+// spine -- the chain of segments the world counter has traversed -- because
+// segment ids and indices are both monotone along it. Sites that compare or
+// intersect worlds that are all known to be on the spine (e.g. the world
+// counter, method insertion worlds, and validity bounds computed from them
+// in-process) may therefore still use integer compares; sites that test a
+// stored world bound against an arbitrary query world must use the
+// predicates below.
+
+#ifdef _P64
+#define JL_WORLD_IDX_BITS 48
+#else
+#define JL_WORLD_IDX_BITS 24
+#endif
+#define JL_WORLD_IDX_MASK ((~(size_t)0) >> (8 * sizeof(size_t) - JL_WORLD_IDX_BITS))
+// number of allocatable segments; the top segment id is never allocated so
+// that sentinel worlds (~(size_t)0 and values near it) fall in an
+// unmaterialized segment
+#define JL_WORLD_MAX_SEGMENTS ((~(size_t)0) >> JL_WORLD_IDX_BITS)
+
+STATIC_INLINE size_t jl_world_seg(size_t world) JL_NOTSAFEPOINT
+{
+    return world >> JL_WORLD_IDX_BITS;
+}
+STATIC_INLINE size_t jl_world_idx(size_t world) JL_NOTSAFEPOINT
+{
+    return world & JL_WORLD_IDX_MASK;
+}
+
+JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents);
+JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra);
+
+// a preceq b: does world `a` precede (or equal) world `b` in the world DAG,
+// i.e. is the state of the world as of `a` part of the history of `b`?
+STATIC_INLINE int jl_world_reaches(size_t a, size_t b) JL_NOTSAFEPOINT
+{
+    if ((a >> JL_WORLD_IDX_BITS) == (b >> JL_WORLD_IDX_BITS))
+        return a <= b;
+    return jl_world_seg_reaches(a >> JL_WORLD_IDX_BITS, b >> JL_WORLD_IDX_BITS);
+}
+
+// Had an entry with the given `min_world` bound already been created as of
+// `world`?
+STATIC_INLINE int jl_world_at_least(size_t world, size_t min_world) JL_NOTSAFEPOINT
+{
+    return jl_world_reaches(min_world, world);
+}
+
+// Is `world` still covered by validity bounds capped (inclusively) at
+// `max_world`? `max_world == ~(size_t)0` means the entry has not been
+// invalidated; otherwise `max_world + 1` is the world of the invalidating
+// event and the entry is invalid exactly in that world's future cone.
+STATIC_INLINE int jl_world_at_most(size_t world, size_t max_world) JL_NOTSAFEPOINT
+{
+    if (max_world == ~(size_t)0)
+        return 1;
+    return !jl_world_reaches(max_world + 1, world);
+}
+
+// Is `world` within the validity bounds [min_world, max_world]?
+STATIC_INLINE int jl_world_in_range(size_t world, size_t min_world, size_t max_world) JL_NOTSAFEPOINT
+{
+    return jl_world_at_least(world, min_world) && jl_world_at_most(world, max_world);
+}
+
+// Is the entire (spine) world range [query_min, query_max] within the
+// validity bounds [min_world, max_world]?
+STATIC_INLINE int jl_world_range_in_range(size_t query_min, size_t query_max, size_t min_world, size_t max_world) JL_NOTSAFEPOINT
+{
+    return jl_world_at_least(query_min, min_world) && jl_world_at_most(query_max, max_world);
+}
+
 typedef void (*tracer_cb)(jl_value_t *tracee);
 extern tracer_cb jl_newmeth_tracer;
 void jl_call_tracer(tracer_cb callback, jl_value_t *tracee) JL_CANSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -650,6 +650,7 @@ JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_join(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_world_ordered_before(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_world_on_trunk(size_t w, size_t observer) JL_NOTSAFEPOINT;
 
 // mirror of Core.WorldToken
 typedef struct {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -593,12 +593,17 @@ typedef struct {
     uint32_t id;
     uint32_t anc_nbits;         // number of valid bits in anc_row (== id)
     _Atomic(size_t) end_idx;    // terminal index once closed; JL_WORLD_IDX_MASK while open
+    _Atomic(size_t) joined_spine; // first spine world whose history includes this segment; 0 while unmerged
     uint8_t kind;               // enum jl_world_seg_kind
     uint32_t run;               // RUN: spine run ordinal; IMAGE: run ordinal within the origin image
     uint64_t image_id;          // IMAGE: origin image id; 0 otherwise
     uint32_t nparents;
     size_t *parents;            // parent worlds, in declaration order
+#ifdef __cplusplus
+    uint64_t anc_row[1];        // ancestor segment bitset, immutable after publication
+#else
     uint64_t anc_row[];         // ancestor segment bitset, immutable after publication
+#endif
 } jl_world_segment_t;
 
 JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT;
@@ -609,6 +614,7 @@ JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size
 JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_world_segment_t *jl_world_get_segment(size_t seg) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT;
 
 // mirror of Core.WorldToken
 typedef struct {
@@ -1334,6 +1340,7 @@ JL_DLLEXPORT jl_binding_partition_t *jl_replace_binding_locked(jl_binding_t *b J
 JL_DLLEXPORT jl_binding_partition_t *jl_replace_binding_locked2(jl_binding_t *b JL_PROPAGATES_ROOT,
     jl_binding_partition_t *old_bpart, jl_value_t *restriction_val, size_t kind, size_t new_world) JL_CANSAFEPOINT JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT void jl_update_loaded_bpart(jl_binding_t *b, jl_binding_partition_t *bpart) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_binding_partition_t *jl_bpart_reresolve_loaded(jl_binding_t *b, jl_binding_partition_t *bpart) JL_CANSAFEPOINT;
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;
 extern jl_module_t *jl_precompile_toplevel_module JL_GLOBALLY_ROOTED;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -575,10 +575,40 @@ STATIC_INLINE size_t jl_world_idx(size_t world) JL_NOTSAFEPOINT
     return world & JL_WORLD_IDX_MASK;
 }
 
+// Segment kinds, for serializing world histories. The boot prefix (the
+// worlds the system image was built at, shared verbatim by every process
+// that loads it) is never materialized and reports JL_WORLD_SEG_BOOT. Spine
+// runs are the maximal linear stretches of this process's own history
+// between graft events. Image runs are runs grafted from a loaded package
+// image, identified stably by (image id, run ordinal). Other segments
+// (e.g. fabricated by tests) are not serializable.
+enum jl_world_seg_kind {
+    JL_WORLD_SEG_BOOT = 0,
+    JL_WORLD_SEG_RUN = 1,
+    JL_WORLD_SEG_IMAGE = 2,
+    JL_WORLD_SEG_OTHER = 3,
+};
+
+typedef struct {
+    uint32_t id;
+    uint32_t anc_nbits;         // number of valid bits in anc_row (== id)
+    _Atomic(size_t) end_idx;    // terminal index once closed; JL_WORLD_IDX_MASK while open
+    uint8_t kind;               // enum jl_world_seg_kind
+    uint32_t run;               // RUN: spine run ordinal; IMAGE: run ordinal within the origin image
+    uint64_t image_id;          // IMAGE: origin image id; 0 otherwise
+    uint32_t nparents;
+    size_t *parents;            // parent worlds, in declaration order
+    uint64_t anc_row[];         // ancestor segment bitset, immutable after publication
+} jl_world_segment_t;
+
 JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents);
 JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra);
-JL_DLLEXPORT size_t jl_world_graft_segment(void);
+JL_DLLEXPORT void jl_world_init_runs(void);
+JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents);
+JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_world_segment_t *jl_world_get_segment(size_t seg) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT;
 
 // mirror of Core.WorldToken
 typedef struct {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -947,6 +947,49 @@ JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t
 void JL_NORETURN jl_method_error(jl_value_t *F, jl_value_t **args, size_t na, size_t world) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_get_exceptionf(jl_datatype_t *exception_type, const char *fmt, ...) JL_CANSAFEPOINT;
 
+// RCJulia — restricted-capability evaluation mode (`Core._rcjulia_call`) ----
+
+// An interpreter frame executing under RCJulia mode. Nodes live on the
+// interpreter's C stack, chained through `jl_task_t->rc_frames`; the chain
+// implements the well-founded recursion check and the physical depth
+// backstop. `f`/`args` point into the calling frame's rooted argument
+// buffer, which outlives this frame; `method` is NULL for non-method frames.
+typedef struct _jl_rc_frame_t {
+    jl_method_t *method;
+    jl_value_t *f;
+    jl_value_t **args;
+    uint32_t nargs;
+    uint32_t depth;
+    struct _jl_rc_frame_t *prev;
+} jl_rc_frame_t;
+
+// Physical stack backstop for RCJulia frames. Termination is guaranteed by
+// the well-founded recursion order (see interpreter.c), but well-founded
+// chains can still be astronomically long, and a machine StackOverflowError
+// is not `:consistent` — so a fixed, platform-independent frame cap must
+// fire deterministically first.
+#define JL_RC_MAX_DEPTH 1000
+
+JL_DLLEXPORT void JL_NORETURN jl_capability_error(const char *op) JL_CANSAFEPOINT;
+// Trap executed by builtins and runtime intrinsics whose semantics require a
+// capability RCJulia mode withholds. The trap is deterministic (a function
+// of the operation alone), which is what keeps even violating programs
+// `:consistent`.
+STATIC_INLINE void jl_check_rc(const char *op) JL_CANSAFEPOINT
+{
+    if (__unlikely(jl_current_task->rcjulia))
+        jl_capability_error(op);
+}
+JL_DLLEXPORT jl_value_t *jl_rc_apply(jl_value_t **args, size_t nargs) JL_CANSAFEPOINT;
+// classify binding (m.s) at `world` for RCJulia mode:
+// returns 1 if it is a defined constant (sets *val), 0 if it is undefined
+// (guard or valueless `const`/`global` declaration), -1 if it is a mutable
+// global (or otherwise not legal to read under the mode)
+JL_DLLEXPORT int jl_rc_binding_constant(jl_module_t *m, jl_sym_t *s, size_t world, jl_value_t **val) JL_CANSAFEPOINT;
+// read global (m.s) at `world` under RCJulia mode, throwing
+// CapabilityError for mutable globals and UndefVarError for undefined ones
+JL_DLLEXPORT jl_value_t *jl_rc_globalref_value(jl_module_t *m, jl_sym_t *s, size_t world) JL_CANSAFEPOINT;
+
 JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t) JL_CANSAFEPOINT;
 
 #define JL_CALLABLE(name)                                               \
@@ -1789,10 +1832,10 @@ STATIC_INLINE int is_valid_intrinsic_elptr(jl_value_t *ety)
 }
 JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align) JL_CANSAFEPOINT;
-JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i);
-JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order, jl_value_t *syncscope);
+JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order, jl_value_t *syncscope) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerref(jl_value_t *p, jl_value_t *order) JL_CANSAFEPOINT;
-JL_DLLEXPORT jl_value_t *jl_atomic_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *order);
+JL_DLLEXPORT jl_value_t *jl_atomic_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *order) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerswap(jl_value_t *p, jl_value_t *x, jl_value_t *order) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_atomic_pointermodify(jl_value_t *p, jl_value_t *f, jl_value_t *x, jl_value_t *order) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerreplace(jl_value_t *p, jl_value_t *x, jl_value_t *expected, jl_value_t *success_order, jl_value_t *failure_order) JL_CANSAFEPOINT;
@@ -1878,7 +1921,7 @@ JL_DLLEXPORT jl_value_t *jl_abs_float(jl_value_t *a) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_copysign_float(jl_value_t *a, jl_value_t *b) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_flipsign_int(jl_value_t *a, jl_value_t *b) JL_CANSAFEPOINT;
 
-JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *a) JL_CANSAFEPOINT;
 JL_DLLEXPORT int jl_stored_inline(jl_value_t *el_type) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 JL_DLLEXPORT jl_array_t *jl_array_copy(jl_array_t *ary) JL_CANSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1564,11 +1564,39 @@ typedef struct {
 } jl_typeapp_t;
 
 JL_DLLEXPORT jl_value_t *jl_resolve_typegroup(jl_module_t *module, jl_svec_t *typevars, jl_svec_t *struct_infos, jl_svec_t *old_types) JL_CANSAFEPOINT;
+JL_DLLEXPORT void jl_set_fieldtype_generator(jl_value_t *ty, jl_value_t *fieldgen) JL_CANSAFEPOINT;
 // Type predicate for TypeApp (inline: called per type node on hot type-query paths)
 STATIC_INLINE int jl_is_typeapp(jl_value_t *v) JL_NOTSAFEPOINT
 {
     return jl_typeapp_type != NULL && jl_typeis(v, jl_typeapp_type);
 }
+// Core.ComputedFieldType: marker in declared field-type slots whose actual
+// field types are produced by the typename's field generator.
+typedef struct {
+    JL_DATA_TYPE
+    jl_value_t *expr; // quoted source expression, for printing/reflection
+} jl_computedfieldtype_t;
+STATIC_INLINE int jl_is_computedfieldtype(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    return jl_computedfieldtype_type != NULL && jl_typeis(v, jl_computedfieldtype_type);
+}
+// Return the field-generator function for tn, or NULL if tn has no computed field types.
+STATIC_INLINE jl_value_t *jl_typename_fieldgen_func(jl_typename_t *tn) JL_NOTSAFEPOINT
+{
+    jl_value_t *fg = jl_atomic_load_relaxed(&tn->fieldgen);
+    if (fg == NULL || fg == jl_nothing)
+        return NULL;
+    return jl_svecref(fg, 0);
+}
+// Return the detached CodeInstance for tn's field generator, if one was recorded.
+STATIC_INLINE jl_value_t *jl_typename_fieldgen_ci(jl_typename_t *tn) JL_NOTSAFEPOINT
+{
+    jl_value_t *fg = jl_atomic_load_relaxed(&tn->fieldgen);
+    if (fg == NULL || fg == jl_nothing || jl_svec_len(fg) < 2)
+        return NULL;
+    return jl_svecref(fg, 1);
+}
+int jl_svec_has_computedfields(jl_svec_t *types) JL_NOTSAFEPOINT;
 void jl_init_tasks(void) JL_GC_DISABLED JL_NOTSAFEPOINT;
 void jl_init_stack_limits(int ismaster, void **stack_hi, void **stack_lo) JL_NOTSAFEPOINT;
 jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi) JL_CANSAFEPOINT;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -554,12 +554,17 @@ typedef struct _jl_task_t {
     // Bit 1-2: 0-3 counter of how many times we've reentered inference
     // Bit 3: 1 if we are writing the image and inference is illegal
     uint8_t reentrant_timing;
-    // 2 bytes of padding on 32-bit, 6 bytes on 64-bit
-    // uint16_t padding2_32;
-    // uint48_t padding2_64;
+    // nonzero while this task executes inside RCJulia mode
+    // (`Core._rcjulia_call`); counts the nesting depth of mode entries
+    uint16_t rcjulia;
+    // 2 bytes of padding
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
     size_t world_age;
+    // innermost interpreter frame executing under RCJulia mode, or
+    // NULL; the chain (through the C stack) implements the recursion-cycle
+    // and depth traps of the mode
+    struct _jl_rc_frame_t *rc_frames;
     // quick lookup for current ptls
     jl_ptls_t ptls; // == jl_all_tls_states[tid]
 #ifdef USE_TRACY

--- a/src/method.c
+++ b/src/method.c
@@ -801,8 +801,17 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi JL_PROP
     int last_lineno = jl_atomic_load_relaxed(&jl_lineno);
     int last_in = ct->ptls->in_pure_callback;
     size_t last_age = ct->world_age;
+    // Generator expansion is always permitted, even when reached from pure
+    // evaluation mode: generators are already language-contractually required
+    // to be pure functions of their argument types, and trapping only when
+    // the expansion is uncached would make behavior depend on cache warmth
+    // (i.e. not be consistent). Suspend the mode while the generator runs.
+    uint16_t last_rc = ct->rcjulia;
+    jl_rc_frame_t *last_rc_frames = ct->rc_frames;
 
     JL_TRY {
+        ct->rcjulia = 0;
+        ct->rc_frames = NULL;
         ct->ptls->in_pure_callback = 1;
         ct->world_age = jl_atomic_load_relaxed(&def->primary_world);
         if (ct->world_age > jl_atomic_load_acquire(&jl_world_counter))
@@ -900,10 +909,14 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi JL_PROP
         ct->ptls->in_pure_callback = last_in;
         jl_atomic_store_relaxed(&jl_lineno, last_lineno);
         ct->world_age = last_age;
+        ct->rcjulia = last_rc;
+        ct->rc_frames = last_rc_frames;
     }
     JL_CATCH {
         ct->ptls->in_pure_callback = last_in;
         jl_atomic_store_relaxed(&jl_lineno, last_lineno);
+        ct->rcjulia = last_rc;
+        ct->rc_frames = last_rc_frames;
         jl_rethrow();
     }
     JL_GC_POP();

--- a/src/method.c
+++ b/src/method.c
@@ -1234,7 +1234,7 @@ JL_DLLEXPORT void jl_check_gf(jl_value_t *gf, jl_sym_t *name)
 JL_DLLEXPORT jl_value_t *jl_declare_const_gf(jl_module_t *mod, jl_sym_t *name)
 {
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_relaxed(&jl_world_counter) + 1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_t *b = jl_get_module_binding(mod, name, 1);
     jl_value_t *gf = jl_get_existing_strong_gf(b, new_world);
     if (gf) {

--- a/src/method.c
+++ b/src/method.c
@@ -747,7 +747,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_cached_uninferred(jl_code_instance_t *codein
     for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
         if (codeinst->owner != (void*)jl_uninferred_sym)
             continue;
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (jl_world_in_range(world, jl_atomic_load_relaxed(&codeinst->min_world), jl_atomic_load_relaxed(&codeinst->max_world))) {
             return codeinst;
         }
     }
@@ -814,7 +814,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi JL_PROP
         ct->rc_frames = NULL;
         ct->ptls->in_pure_callback = 1;
         ct->world_age = jl_atomic_load_relaxed(&def->primary_world);
-        if (ct->world_age > jl_atomic_load_acquire(&jl_world_counter))
+        if (!jl_world_at_least(jl_atomic_load_acquire(&jl_world_counter), ct->world_age))
             jl_error("The generator method cannot run until it is added to a method table.");
 
         // invoke code generator

--- a/src/module.c
+++ b/src/module.c
@@ -1538,7 +1538,7 @@ JL_DLLEXPORT void jl_module_import(jl_task_t *ct, jl_module_t *to, jl_module_t *
         return;
     }
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_partition_t *btopart = jl_get_binding_partition(bto, new_world);
     enum jl_partition_kind btokind = jl_binding_kind(btopart);
     if (jl_bkind_is_some_implicit(btokind)) {
@@ -1637,7 +1637,7 @@ JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from, size_t fla
         }
     }
 
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
 
     if (existing_idx == (size_t)-1) {
         // Add new using entry
@@ -1762,7 +1762,7 @@ JL_DLLEXPORT void jl_module_public(jl_module_t *from, jl_value_t **symbols, size
 {
     volatile int any_new = 0;
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
     JL_TRY {
         for (size_t i = 0; i < nsymbols; i++) {
             jl_sym_t *name = (jl_sym_t*)symbols[i];
@@ -2085,7 +2085,7 @@ JL_DLLEXPORT jl_binding_partition_t *jl_replace_binding(jl_binding_t *b,
         return NULL;
     }
 
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_partition_t *bpart = jl_replace_binding_locked(b, old_bpart, restriction_val, kind, new_world);
     if (bpart && jl_atomic_load_relaxed(&bpart->min_world) == new_world)
         jl_atomic_store_release(&jl_world_counter, new_world);
@@ -2142,7 +2142,7 @@ JL_DLLEXPORT void jl_deprecate_binding(jl_module_t *m, jl_sym_t *var, int flag) 
                        flag == 2 ? PARTITION_FLAG_DEPRECATED :
                                    0;
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_partition_t *old_bpart = jl_get_binding_partition(b, jl_current_task->world_age);
     if ((old_bpart->kind & DEPWARN_FLAGS) == new_flags) {
         JL_UNLOCK(&world_counter_lock);
@@ -2168,7 +2168,7 @@ JL_DLLEXPORT void jl_module_set_visibility(jl_module_t *m, jl_sym_t *var, int st
     int want_public = state >= 1;
     jl_binding_t *b = jl_get_module_binding(m, var, 1);
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_partition_t *old_bpart = jl_get_binding_partition(b, jl_current_task->world_age);
     int was_exported = (old_bpart->kind & PARTITION_FLAG_EXPORTED) != 0;
     if (was_exported != want_exported) {

--- a/src/module.c
+++ b/src/module.c
@@ -52,7 +52,7 @@ STATIC_INLINE jl_binding_partition_t *jl_get_binding_partition__(jl_binding_t *b
     // resolution if necessary.
     while (is_some_partition(gap->replace)) {
         size_t replace_min_world = jl_atomic_load_relaxed(&gap->replace->min_world);
-        if (world >= replace_min_world)
+        if (jl_world_at_least(world, replace_min_world))
             break;
         gap->insert = &gap->replace->next;
         gap->max_world = replace_min_world - 1;
@@ -61,7 +61,7 @@ STATIC_INLINE jl_binding_partition_t *jl_get_binding_partition__(jl_binding_t *b
         // `gap->replace` becomes that binding (not a partition) at end-of-chain.
         gap->replace = jl_atomic_load_relaxed(gap->insert);
     }
-    if (is_some_partition(gap->replace) && world <= jl_atomic_load_relaxed(&gap->replace->max_world)) {
+    if (is_some_partition(gap->replace) && jl_world_at_most(world, jl_atomic_load_relaxed(&gap->replace->max_world))) {
         return gap->replace;
     }
     gap->min_world = is_some_partition(gap->replace) ? jl_atomic_load_relaxed(&gap->replace->max_world) + 1 : 0;
@@ -569,7 +569,7 @@ jl_binding_partition_t *jl_get_binding_partition_all(jl_binding_t *b, size_t min
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, min_world);
     if (!bpart)
         return NULL;
-    if (jl_atomic_load_relaxed(&bpart->max_world) < max_world)
+    if (!jl_world_at_most(max_world, jl_atomic_load_relaxed(&bpart->max_world)))
         return NULL;
     return bpart;
 }
@@ -1360,7 +1360,7 @@ static int jl_print_using_dep_messages(jl_module_t *m, jl_sym_t *name, jl_sym_t 
         JL_LOCK(&m->lock);
         struct _jl_module_using data = *module_usings_getidx(m, i);
         JL_UNLOCK(&m->lock);
-        if (data.min_world > world || data.max_world < world)
+        if (!jl_world_in_range(world, data.min_world, data.max_world))
             continue;
         jl_module_t *imp = data.mod;
         JL_GC_PROMISE_ROOTED(imp); // rooted via `m->usings`
@@ -2301,7 +2301,7 @@ static void _materialize_reexported_bindings(jl_module_t *m, size_t world, jl_ar
         struct _jl_module_using data = *module_usings_getidx(m, i);
         JL_UNLOCK(&m->lock);
 
-        if (data.min_world > world || data.max_world < world)
+        if (!jl_world_in_range(world, data.min_world, data.max_world))
             continue;
 
         if (data.flags & JL_MODULE_USING_REEXPORT) {

--- a/src/module.c
+++ b/src/module.c
@@ -462,6 +462,42 @@ JL_DLLEXPORT void jl_update_loaded_bpart(jl_binding_t *b, jl_binding_partition_t
     bpart->kind = resolution.ultimate_kind | resolution.deprecation_flags;
 }
 
+// During image loading: the head partition `bpart` of `b` came from a grafted
+// world history and carries the resolution the saving process computed.
+// Recompute the implicit resolution at the current world; if it matches, the
+// grafted partition stays valid everywhere it reaches (returns NULL).
+// Otherwise cap the grafted partition just before the current world -- it
+// remains valid in its own branch's cone of the world DAG -- and prepend a
+// fresh partition carrying this process's resolution for spine worlds
+// (returned). The new partition's min_world deliberately lies on the spine,
+// which is not an ancestor of the grafted history, so queries at grafted
+// worlds fall through to the capped partition.
+JL_DLLEXPORT jl_binding_partition_t *jl_bpart_reresolve_loaded(jl_binding_t *b, jl_binding_partition_t *bpart)
+{
+    size_t cur = jl_atomic_load_acquire(&jl_world_counter);
+    struct implicit_search_resolution resolution = jl_resolve_implicit_import(b, NULL, cur, 0);
+    size_t flags = bpart->kind & PARTITION_MASK_FLAG;
+    if ((enum jl_partition_kind)(resolution.ultimate_kind) == (enum jl_partition_kind)(bpart->kind & PARTITION_MASK_KIND) &&
+        resolution.binding_or_const == bpart->restriction)
+        return NULL;
+    jl_value_t *restriction = resolution.binding_or_const;
+    JL_GC_PUSH1(&restriction);
+    jl_binding_partition_t *newp = new_binding_partition(b);
+    jl_gc_write(newp, newp->restriction, jl_value_t, restriction);
+    newp->kind = resolution.ultimate_kind | resolution.deprecation_flags | flags;
+    jl_atomic_store_relaxed(&newp->min_world, cur);
+    // (max_world is already ~(size_t)0)
+    jl_atomic_store_relaxed(&newp->next, bpart);
+    jl_gc_wb(newp, bpart);
+    jl_atomic_store_release(&b->partitions, newp);
+    jl_gc_wb(b, newp);
+    // the grafted resolution ends just before this process's resolution takes
+    // over on the spine
+    jl_atomic_store_release(&bpart->max_world, cur - 1);
+    JL_GC_POP();
+    return newp;
+}
+
 static void jl_walk_binding_inplace(jl_binding_t **bnd, jl_binding_partition_t **pbpart, size_t world) JL_CANSAFEPOINT
 {
     jl_binding_partition_t *bpart = *pbpart;

--- a/src/module.c
+++ b/src/module.c
@@ -1064,6 +1064,40 @@ JL_DLLEXPORT jl_value_t *jl_get_binding_value_in_world(jl_binding_t *b, size_t w
     return jl_atomic_load_relaxed(&b->value);
 }
 
+// RCJulia mode: classify binding (m.s) at `world`.
+// Returns 1 if the binding is a defined constant there (sets *val), 0 if it is
+// undefined (guard, failed import, or a valueless `const`/`global` declaration
+// with no value slot to read), and -1 if reading it would observe mutable
+// state (an assignable global). Constants are read without the backdated-const
+// admonition: printing would be a side effect, and the value itself is fixed
+// within the (frozen) world.
+JL_DLLEXPORT int jl_rc_binding_constant(jl_module_t *m, jl_sym_t *s, size_t world, jl_value_t **val)
+{
+    jl_binding_t *b = jl_get_module_binding(m, s, 1);
+    jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
+    jl_walk_binding_inplace(&b, &bpart, world);
+    enum jl_partition_kind kind = jl_binding_kind(bpart);
+    if (jl_bkind_is_defined_constant(kind)) {
+        *val = bpart->restriction;
+        return 1;
+    }
+    *val = NULL;
+    if (jl_bkind_is_some_guard(kind) || kind == PARTITION_KIND_UNDEF_CONST)
+        return 0;
+    return -1;
+}
+
+JL_DLLEXPORT jl_value_t *jl_rc_globalref_value(jl_module_t *m, jl_sym_t *s, size_t world)
+{
+    jl_value_t *v = NULL;
+    int kind = jl_rc_binding_constant(m, s, world, &v);
+    if (kind < 0)
+        jl_capability_error("getglobal");
+    if (kind == 0)
+        jl_undefined_var_error(s, (jl_value_t*)m);
+    return v;
+}
+
 // Read a binding's value at `world`, warning if it is deprecated (unless reached through an
 // explicit import, which `jl_walk_binding_inplace_depwarn` suppresses).
 static jl_value_t *jl_get_binding_value_depwarn_(jl_binding_t *b, size_t world, int seqcst) JL_CANSAFEPOINT

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -216,6 +216,9 @@ int jl_tupletype_length_compat(jl_value_t *v, size_t nargs)
 
 JL_CALLABLE(jl_f_opaque_closure_call) JL_CANSAFEPOINT
 {
+    // opaque closures capture their own world and may carry native code the
+    // mode's traps cannot see (v1 restriction)
+    jl_check_rc("opaque_closure");
     jl_opaque_closure_t *oc = (jl_opaque_closure_t*)F;
     jl_value_t *argt = jl_tparam0(jl_typeof(oc));
     if (!jl_tupletype_length_compat(argt, nargs))

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -186,6 +186,14 @@ JL_DLLEXPORT void JL_NORETURN JL_NO_SAFEPOINT_ANALYSIS jl_atomic_error(char *str
     jl_throw(jl_new_struct(jl_atomicerror_type, msg));
 }
 
+JL_DLLEXPORT void JL_NORETURN jl_capability_error(const char *op)
+{
+    // The exception is constructed from the operation name alone so that the
+    // trap is a deterministic function of the operation attempted, keeping
+    // even violating programs `:consistent`.
+    jl_throw(jl_new_struct(jl_capabilityerror_type, (jl_value_t*)jl_symbol(op)));
+}
+
 
 JL_DLLEXPORT void JL_NORETURN JL_NO_SAFEPOINT_ANALYSIS jl_bounds_error(jl_value_t *v, jl_value_t *t)
 {
@@ -271,6 +279,7 @@ JL_DLLEXPORT void jl_enter_handler(jl_task_t *ct, jl_handler_t *eh)
     eh->bound_cancel_token = jl_atomic_load_relaxed(&ct->bound_cancel_token);
     eh->bound_cancel_default = ct->bound_cancel_default;
     eh->cancel_handler_ctx = jl_atomic_load_relaxed(&ct->cancel_handler_ctx);
+    eh->rc_frames = ct->rc_frames;
     eh->gc_state = jl_atomic_load_relaxed(&ct->ptls->gc_state);
     eh->locks_len = ct->ptls->locks.len;
     eh->defer_signal = ct->ptls->defer_signal;
@@ -306,6 +315,7 @@ JL_DLLEXPORT void jl_eh_restore_state(jl_task_t *ct, jl_handler_t *eh) JL_NO_SAF
     jl_gc_wb_current_task(ct, eh->bound_cancel_token);
     jl_atomic_store_release(&ct->reset_ctx, eh->reset_ctx);
     jl_atomic_store_release(&ct->cancel_handler_ctx, eh->cancel_handler_ctx);
+    ct->rc_frames = eh->rc_frames;
     jl_gc_wb_current_task(ct, eh->scope);
     ct->scope = eh->scope;
     small_arraylist_t *locks = &ptls->locks;
@@ -354,6 +364,7 @@ JL_DLLEXPORT void jl_eh_restore_state_noexcept(jl_task_t *ct, jl_handler_t *eh)
     jl_gc_wb_current_task(ct, eh->bound_cancel_token);
     jl_atomic_store_release(&ct->reset_ctx, eh->reset_ctx);
     jl_atomic_store_release(&ct->cancel_handler_ctx, eh->cancel_handler_ctx);
+    ct->rc_frames = eh->rc_frames;
     ct->ptls->defer_signal = eh->defer_signal; // optional, but certain try-finally (in stream.jl) may be slightly harder to write without this
 }
 

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -404,7 +404,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
                 }
             }
             else {
-                if ((jl_value_t*)jl_get_ci_mi(last_ci) == mi && jl_atomic_load_relaxed(&last_ci->max_world) >= world) { // same dispatch and source
+                if ((jl_value_t*)jl_get_ci_mi(last_ci) == mi && jl_world_at_most(world, jl_atomic_load_relaxed(&last_ci->max_world))) { // same dispatch and source
                     jl_atomic_store_release(&cfuncdata->last_world, world);
                     JL_UNLOCK(&cfun_lock);
                     return f;

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -422,6 +422,7 @@ JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v)
 // run time version of pointerref intrinsic (warning: i is not rooted)
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align)
 {
+    jl_check_rc("pointerref");
     JL_TYPECHK(pointerref, pointer, p);
     JL_TYPECHK(pointerref, long, i)
     JL_TYPECHK(pointerref, long, align);
@@ -442,6 +443,7 @@ JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t 
 // run time version of pointerset intrinsic (warning: x is not gc-rooted)
 JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i, jl_value_t *align)
 {
+    jl_check_rc("pointerset");
     JL_TYPECHK(pointerset, pointer, p);
     JL_TYPECHK(pointerset, long, i);
     JL_TYPECHK(pointerset, long, align);
@@ -465,6 +467,7 @@ JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t 
 
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerref(jl_value_t *p, jl_value_t *order)
 {
+    jl_check_rc("atomic_pointerref");
     JL_TYPECHK(atomic_pointerref, pointer, p);
     JL_TYPECHK(atomic_pointerref, symbol, order)
     (void)jl_get_atomic_order_checked((jl_sym_t*)order, 1, 0);
@@ -485,6 +488,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerref(jl_value_t *p, jl_value_t *order)
 
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *order)
 {
+    jl_check_rc("atomic_pointerset");
     JL_TYPECHK(atomic_pointerset, pointer, p);
     JL_TYPECHK(atomic_pointerset, symbol, order);
     (void)jl_get_atomic_order_checked((jl_sym_t*)order, 0, 1);
@@ -508,6 +512,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerset(jl_value_t *p, jl_value_t *x, jl_v
 
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerswap(jl_value_t *p, jl_value_t *x, jl_value_t *order)
 {
+    jl_check_rc("atomic_pointerswap");
     JL_TYPECHK(atomic_pointerswap, pointer, p);
     JL_TYPECHK(atomic_pointerswap, symbol, order);
     (void)jl_get_atomic_order_checked((jl_sym_t*)order, 1, 1);
@@ -532,6 +537,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerswap(jl_value_t *p, jl_value_t *x, jl_
 
 JL_DLLEXPORT jl_value_t *jl_atomic_pointermodify(jl_value_t *p, jl_value_t *f, jl_value_t *x, jl_value_t *order)
 {
+    jl_check_rc("atomic_pointermodify");
     JL_TYPECHK(atomic_pointermodify, pointer, p);
     JL_TYPECHK(atomic_pointermodify, symbol, order)
     (void)jl_get_atomic_order_checked((jl_sym_t*)order, 1, 1);
@@ -585,6 +591,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointermodify(jl_value_t *p, jl_value_t *f, j
 
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerreplace(jl_value_t *p, jl_value_t *expected, jl_value_t *x, jl_value_t *success_order_sym, jl_value_t *failure_order_sym)
 {
+    jl_check_rc("atomic_pointerreplace");
     JL_TYPECHK(atomic_pointerreplace, pointer, p);
     JL_TYPECHK(atomic_pointerreplace, symbol, success_order_sym);
     JL_TYPECHK(atomic_pointerreplace, symbol, failure_order_sym);
@@ -635,6 +642,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerreplace(jl_value_t *p, jl_value_t *exp
 
 JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order_sym, jl_value_t *syncscope_sym)
 {
+    jl_check_rc("atomic_fence");
     JL_TYPECHK(fence, symbol, order_sym);
     JL_TYPECHK(fence, symbol, syncscope_sym);
     enum jl_memory_order order = jl_get_atomic_order_checked((jl_sym_t*)order_sym, 1, 1);
@@ -675,6 +683,7 @@ jl_value_t *jl_lookup_foreignsymbol(jl_value_t *v)
 
 // The auto-switching behavior here is deprecated, but preserved for Core.Intrinsics.cglobal
 JL_DLLEXPORT jl_value_t *jl_cglobal(jl_value_t *v, jl_value_t *ty) {
+    jl_check_rc("cglobal"); // symbol lookup in shared libraries is machine state
     JL_TYPECHK(cglobal, type, ty);
     jl_value_t *rt =
         ty == (jl_value_t*)jl_nothing_type ? (jl_value_t*)jl_voidpointer_type : // a common case
@@ -1772,6 +1781,7 @@ un_fintrinsic(sqrt_float,sqrt_llvm_fast)
 
 JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *typ)
 {
+    jl_check_rc("have_fma");
     JL_TYPECHK(have_fma, datatype, typ); // TODO what about float16/bfloat16?
     if (typ == (jl_value_t*)jl_float32_type)
         return jl_cpu_has_fma(32);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -4075,7 +4075,7 @@ static size_t world_remap(size_t w, size_t *segmap, uint32_t maplen)
     size_t seg = jl_world_seg(w);
     if (seg >= maplen || segmap[seg] == ~(size_t)0)
         jl_error("cannot translate a serialized world with no stable segment identity");
-    return (segmap[seg] << JL_WORLD_IDX_BITS) | jl_world_idx(w);
+    return JL_WORLD_PACK(segmap[seg], jl_world_idx(w));
 }
 
 static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
@@ -4288,7 +4288,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                     size_t pseg = jl_world_seg(pw);
                     if (pseg >= i || world_segmap[pseg] == ~(size_t)0)
                         jl_error("world-segment table has an untranslatable parent");
-                    parents[p] = (world_segmap[pseg] << JL_WORLD_IDX_BITS) | jl_world_idx(pw);
+                    parents[p] = JL_WORLD_PACK(world_segmap[pseg], jl_world_idx(pw));
                 }
                 size_t base = jl_world_new_image_run(self_id, nruns++, parents, np);
                 free(parents);
@@ -4873,7 +4873,7 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
             }
             else {
                 if (new_methods)
-                    world += 1;
+                    world = jl_world_next_locked();
                 jl_activate_methods(extext_methods, internal_methods, world, pkgname);
                 // TODO: inject internal_methods into caches here, so the system can see them immediately as potential candidates (before validation)
                 // allow users to start running in this updated world

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1879,15 +1879,7 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 jl_code_instance_t *newci = (jl_code_instance_t*)&f->buf[reloc_offset];
 
                 if (s->incremental) {
-                    if (ci->owner == (jl_value_t*)jl_symbol("computed_fieldtypes")) {
-                        // detached field-generator instances are world-age
-                        // independent by construction: their code is closed
-                        // (no world-dependent lookups), so they remain valid
-                        // as-is, with no revalidation on load
-                        assert(jl_atomic_load_relaxed(&ci->min_world) == 1);
-                        assert(jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0);
-                    }
-                    else if (jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0) {
+                    if (jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0) {
                         //assert(jl_atomic_load_relaxed(&ci->edges) != jl_emptysvec); // some code (such as !==) might add a method lookup restriction but not keep the edges
                         // in world-table mode min_world is kept verbatim and
                         // translated by segment at load time

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -622,7 +622,7 @@ static int codeinst_may_be_runnable(jl_code_instance_t *ci, int incremental) {
         return 1;
     if (incremental)
         return 0;
-    return jl_atomic_load_relaxed(&ci->min_world) <= jl_typeinf_world && jl_typeinf_world <= max_world;
+    return jl_world_in_range(jl_typeinf_world, jl_atomic_load_relaxed(&ci->min_world), max_world);
 }
 
 // Anything that requires uniquing or fixing during deserialization needs to be "toplevel"

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1328,7 +1328,9 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
             newm_data->min_world = data->min_world;
             newm_data->max_world = data->max_world;
             newm_data->flags = data->flags;
-            if (s->incremental) {
+            if (s->incremental && !s->world_table_mode) {
+                // (in world-table mode the bounds are kept verbatim and
+                // translated by segment at load)
                 if (data->max_world != ~(size_t)0)
                     newm_data->max_world = 0;
                 newm_data->min_world = jl_require_world;
@@ -1347,7 +1349,7 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
         for (i = 0; i < module_usings_length(m); i++) {
             struct _jl_module_using *data = module_usings_getidx(m, i);
             write_pointerfield(s, (jl_value_t*)data->mod);
-            if (s->incremental) {
+            if (s->incremental && !s->world_table_mode) {
                 // TODO: Drop dead ones entirely?
                 write_uint(s->s, jl_require_world);
                 write_uint(s->s, data->max_world == ~(size_t)0 ? ~(size_t)0 : 1);
@@ -1804,7 +1806,9 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                     jl_atomic_store_relaxed(&newentry->max_world, 0);
                 }
             }
-            else if (s->incremental && jl_is_binding_partition(v)) {
+            else if (s->incremental && !s->world_table_mode && jl_is_binding_partition(v)) {
+                // (in world-table mode, the whole partition chain keeps its
+                // verbatim world bounds and is translated by segment at load)
                 jl_binding_partition_t *newbpart = (jl_binding_partition_t*)&s->s->buf[reloc_offset];
                 size_t max_world = jl_atomic_load_relaxed(&newbpart->max_world);
                 if (max_world == ~(size_t)0) {
@@ -3957,19 +3961,28 @@ JL_DLLEXPORT jl_image_buf_t jl_set_sysimg_so(void *handle)
 int IMAGE_NATIVE_CODE_TAINTED = 0;
 
 // TODO: This should possibly be in Julia
-static int jl_validate_binding_partition(jl_binding_t *b, jl_binding_partition_t *bpart, size_t mod_idx, int unchanged_implicit, int no_replacement) JL_CANSAFEPOINT
+static int jl_validate_binding_partition(jl_binding_t *b, jl_binding_partition_t *bpart, size_t mod_idx, int unchanged_implicit, int no_replacement, int grafted) JL_CANSAFEPOINT
 {
     if (jl_atomic_load_relaxed(&bpart->max_world) != ~(size_t)0)
         return 1;
     size_t raw_kind = bpart->kind;
     enum jl_partition_kind kind = (enum jl_partition_kind)(raw_kind & PARTITION_MASK_KIND);
     if (!unchanged_implicit && jl_bkind_is_some_implicit(kind)) {
-        // TODO: Should we actually update this in place or delete it from the partitions list
-        // and allocate a fresh bpart?
-        jl_update_loaded_bpart(b, bpart);
-        bpart->kind |= (raw_kind & PARTITION_MASK_FLAG);
-        if (jl_atomic_load_relaxed(&bpart->min_world) > jl_require_world)
-            goto invalidated;
+        if (grafted) {
+            // the grafted resolution stays valid in its own branch's cone; if
+            // this process's resolution differs, the partition is capped and
+            // a fresh spine resolution is prepended
+            if (jl_bpart_reresolve_loaded(b, bpart) != NULL)
+                goto invalidated;
+        }
+        else {
+            // TODO: Should we actually update this in place or delete it from the partitions list
+            // and allocate a fresh bpart?
+            jl_update_loaded_bpart(b, bpart);
+            bpart->kind |= (raw_kind & PARTITION_MASK_FLAG);
+            if (jl_atomic_load_relaxed(&bpart->min_world) > jl_require_world)
+                goto invalidated;
+        }
     }
     {
         if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL)
@@ -3992,9 +4005,14 @@ static int jl_validate_binding_partition(jl_binding_t *b, jl_binding_partition_t
         }
         else {
             // Binding partition was invalidated
-            assert(jl_atomic_load_relaxed(&bpart->min_world) == jl_require_world);
-            jl_atomic_store_relaxed(&bpart->min_world,
-                jl_atomic_load_relaxed(&latest_imported_bpart->min_world));
+            if (!grafted) {
+                assert(jl_atomic_load_relaxed(&bpart->min_world) == jl_require_world);
+                jl_atomic_store_relaxed(&bpart->min_world,
+                    jl_atomic_load_relaxed(&latest_imported_bpart->min_world));
+            }
+            // (a grafted partition keeps its branch worlds; the
+            // changed-since-prefix signal is already carried by its
+            // min_world lying above the prefix)
         }
     }
 invalidated:
@@ -4010,7 +4028,7 @@ invalidated:
             if (!jl_atomic_load_relaxed(&bedge->partitions))
                 continue;
             JL_UNLOCK(&b->globalref->mod->lock);
-            jl_validate_binding_partition(bedge, jl_atomic_load_relaxed(&bedge->partitions), mod_idx, 0, 0);
+            jl_validate_binding_partition(bedge, jl_atomic_load_relaxed(&bedge->partitions), mod_idx, 0, 0, grafted);
             JL_LOCK(&b->globalref->mod->lock);
         }
         JL_UNLOCK(&b->globalref->mod->lock);
@@ -4029,7 +4047,7 @@ invalidated:
                 if (!jl_atomic_load_relaxed(&importee->partitions))
                     continue;
                 JL_UNLOCK(&mod->lock);
-                jl_validate_binding_partition(importee, jl_atomic_load_relaxed(&importee->partitions), mod_idx, 0, 0);
+                jl_validate_binding_partition(importee, jl_atomic_load_relaxed(&importee->partitions), mod_idx, 0, 0, grafted);
                 JL_LOCK(&mod->lock);
             }
         }
@@ -4577,6 +4595,13 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                 // Rebuild cross-image usings backedges
                 for (size_t i = 0; i < module_usings_length(mod); ++i) {
                     struct _jl_module_using *data = module_usings_getidx(mod, i);
+                    if (world_segmap) {
+                        // translate the entries' verbatim world bounds onto
+                        // the grafted copy of the image's world history
+                        data->min_world = world_remap(data->min_world, world_segmap, world_segmap_len);
+                        if (data->max_world != ~(size_t)0)
+                            data->max_world = world_remap(data->max_world, world_segmap, world_segmap_len);
+                    }
                     if (external_blob_index((jl_value_t*)data->mod) != mod_idx) {
                         jl_add_usings_backedge(data->mod, mod);
                     }
@@ -4597,7 +4622,6 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
             abort();
         }
     }
-    free(world_segmap);
     if (worldtoken_graft)
         *worldtoken_graft = graft_head;
     if (s.incremental) {
@@ -4615,13 +4639,26 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                     if ((jl_value_t*)b == jl_nothing)
                         continue;
                     jl_binding_partition_t *bpart = jl_atomic_load_relaxed(&b->partitions);
-                    if (!jl_validate_binding_partition(b, bpart, mod_idx, unchanged_implicit, no_replacement)) {
+                    if (world_segmap) {
+                        // translate the verbatim world bounds of the whole
+                        // partition chain: the image's binding history
+                        for (jl_binding_partition_t *p = bpart; p != NULL && jl_is_binding_partition((jl_value_t*)p);
+                                p = jl_atomic_load_relaxed(&p->next)) {
+                            jl_atomic_store_relaxed(&p->min_world,
+                                world_remap(jl_atomic_load_relaxed(&p->min_world), world_segmap, world_segmap_len));
+                            size_t pmax = jl_atomic_load_relaxed(&p->max_world);
+                            if (pmax != ~(size_t)0)
+                                jl_atomic_store_relaxed(&p->max_world, world_remap(pmax, world_segmap, world_segmap_len));
+                        }
+                    }
+                    if (!jl_validate_binding_partition(b, bpart, mod_idx, unchanged_implicit, no_replacement, world_segmap != NULL)) {
                         unchanged_implicit = all_usings_unchanged_implicit(mod);
                     }
                 }
             }
         }
     }
+    free(world_segmap);
     arraylist_free(&s.fixup_types);
     arraylist_free(&s.fixup_objs);
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -315,6 +315,10 @@ typedef struct {
     jl_ptls_t ptls;
     jl_image_t *image;
     int8_t incremental;
+    // incremental only: the serialized data captures worlds above the shared
+    // prefix (world tokens), so the image carries its world-segment table and
+    // serializes world bounds verbatim for translation at load time
+    int8_t world_table_mode;
 } jl_serializer_state;
 
 static jl_value_t *jl_bigint_type = NULL;
@@ -1041,6 +1045,13 @@ static void jl_queue_for_serialization_(jl_serializer_state *s, jl_value_t *v, i
     // check early from errors, so we have a little bit of contextual state for debugging them
     if (t == jl_task_type) {
         jl_error("Task cannot be serialized");
+    }
+    if (s->incremental && (jl_value_t*)t == (jl_value_t*)jl_worldtoken_type &&
+        !jl_world_reaches(((jl_worldtoken_t*)v)->world, jl_require_world)) {
+        // a world capture above the shared prefix escapes into the image:
+        // serialize this process's world-segment table so the loader can
+        // graft this image's world history
+        s->world_table_mode = 1;
     }
     if (s->incremental && needs_uniquing(v, s->query_cache) && t == jl_binding_type) {
         jl_binding_t *b = (jl_binding_t*)v;
@@ -1779,7 +1790,10 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 jl_typemap_entry_t *newentry = (jl_typemap_entry_t*)&s->s->buf[reloc_offset];
                 if (jl_atomic_load_relaxed(&newentry->max_world) == ~(size_t)0) {
                     if (jl_atomic_load_relaxed(&newentry->min_world) > 1) {
-                        jl_atomic_store_relaxed(&newentry->min_world, ~(size_t)0);
+                        // in world-table mode min_world is kept verbatim and
+                        // translated by segment at load time
+                        if (!s->world_table_mode)
+                            jl_atomic_store_relaxed(&newentry->min_world, ~(size_t)0);
                         jl_atomic_store_relaxed(&newentry->max_world, WORLD_AGE_REVALIDATION_SENTINEL);
                         arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                     }
@@ -1811,19 +1825,16 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
             else if (s->incremental && jl_typetagis(v, jl_worldtoken_type)) {
                 assert(f == s->s);
                 jl_worldtoken_t *newtok = (jl_worldtoken_t*)&f->buf[reloc_offset];
-                if (newtok->world > jl_require_world) {
-                    // The captured world is above the shared sysimage prefix
-                    // and its numbering has no meaning in a loading process.
-                    // Rewrite it to an offset from the prefix; the loader
-                    // grafts this image's world history as a fresh segment of
-                    // the world DAG and rebases the token into it.
-                    if (jl_world_seg(newtok->world) != jl_world_seg(jl_require_world))
-                        jl_error("cannot serialize a world token captured above another grafted image history (not implemented yet)");
-                    newtok->world -= jl_require_world;
+                if (!jl_world_reaches(newtok->world, jl_require_world)) {
+                    // Captured above the shared prefix: the world is kept
+                    // verbatim, and the loader translates its segment through
+                    // the image's world-segment table onto the grafted copy of
+                    // this process's world history.
+                    assert(s->world_table_mode);
                     arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                 }
-                // else: part of the shared sysimage prefix; remains valid as
-                // an absolute world in any loading process
+                // else: part of the shared prefix; remains valid as an
+                // absolute world in any loading process
             }
             else if (jl_is_method(v)) {
                 assert(f == s->s);
@@ -1832,7 +1843,10 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 jl_method_t *newm = (jl_method_t*)&f->buf[reloc_offset];
                 if (s->incremental) {
                     if (jl_atomic_load_relaxed(&newm->primary_world) > 1) {
-                        jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
+                        // in world-table mode primary_world is kept verbatim
+                        // and translated by segment at load time
+                        if (!s->world_table_mode)
+                            jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
                         int dispatch_status = jl_atomic_load_relaxed(&newm->dispatch_status);
                         int new_dispatch_status = 0;
                         if (!(dispatch_status & METHOD_SIG_LATEST_ONLY))
@@ -1863,7 +1877,10 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 if (s->incremental) {
                     if (jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0) {
                         //assert(jl_atomic_load_relaxed(&ci->edges) != jl_emptysvec); // some code (such as !==) might add a method lookup restriction but not keep the edges
-                        jl_atomic_store_release(&newci->min_world, ~(size_t)0);
+                        // in world-table mode min_world is kept verbatim and
+                        // translated by segment at load time
+                        if (!s->world_table_mode)
+                            jl_atomic_store_release(&newci->min_world, ~(size_t)0);
                         jl_atomic_store_release(&newci->max_world, WORLD_AGE_REVALIDATION_SENTINEL);
                         arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                     }
@@ -3320,6 +3337,40 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
         jl_write_arraylist(s.relocs, &s.fixup_types);
     }
     jl_write_arraylist(s.relocs, &s.fixup_objs);
+    // World-segment table: present when the serialized data captures worlds
+    // above the shared prefix (world tokens). Rows describe every segment of
+    // this process's world history, so that a loading process can graft this
+    // image's own spine runs (with their true parent structure) and translate
+    // the verbatim-serialized worlds by segment. Boot-prefix segments map
+    // verbatim; runs grafted from dependency images resolve through their
+    // stable (image id, run ordinal) identity.
+    write_uint8(s.relocs, s.world_table_mode);
+    if (s.world_table_mode) {
+        write_uint64(s.relocs, s.worklist_key);
+        uint32_t nsegs = jl_world_nsegments();
+        write_uint32(s.relocs, nsegs);
+        for (uint32_t i = 0; i < nsegs; i++) {
+            jl_world_segment_t *seg = jl_world_get_segment(i);
+            uint8_t kind = seg ? seg->kind : JL_WORLD_SEG_BOOT;
+            write_uint8(s.relocs, kind);
+            if (kind == JL_WORLD_SEG_RUN) {
+                size_t end = jl_atomic_load_relaxed(&seg->end_idx);
+                if (end == JL_WORLD_IDX_MASK) {
+                    // the still-open run: this image's history ends at the save counter
+                    assert(jl_world_seg(jl_atomic_load_relaxed(&jl_world_counter)) == i);
+                    end = jl_world_idx(jl_atomic_load_relaxed(&jl_world_counter));
+                }
+                write_uint(s.relocs, end);
+                write_uint32(s.relocs, seg->nparents);
+                for (uint32_t p = 0; p < seg->nparents; p++)
+                    write_uint(s.relocs, seg->parents[p]);
+            }
+            else if (kind == JL_WORLD_SEG_IMAGE) {
+                write_uint64(s.relocs, seg->image_id);
+                write_uint32(s.relocs, seg->run);
+            }
+        }
+    }
     write_uint(f, relocs.size);
     write_padding(f, LLT_ALIGN(ios_pos(f), 8) - ios_pos(f));
     ios_seek(&relocs, 0);
@@ -3998,6 +4049,17 @@ static int all_usings_unchanged_implicit(jl_module_t *mod)
     return unchanged_implicit;
 }
 
+// Translate a world serialized verbatim by another process through the
+// image's world-segment map (identity for the shared boot prefix, grafted
+// segments for the image's own runs and its dependencies' runs).
+static size_t world_remap(size_t w, size_t *segmap, uint32_t maplen)
+{
+    size_t seg = jl_world_seg(w);
+    if (seg >= maplen || segmap[seg] == ~(size_t)0)
+        jl_error("cannot translate a serialized world with no stable segment identity");
+    return (segmap[seg] << JL_WORLD_IDX_BITS) | jl_world_idx(w);
+}
+
 static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                                                  jl_array_t *depmods, uint32_t checksum,
                                 /* outputs */    jl_array_t **restored JL_REQUIRE_ROOTED_SLOT,
@@ -4107,6 +4169,9 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         jl_atomic_store_release(&jl_world_counter, jl_require_world);
         jl_typeinf_world = read_uint(f);
         jl_set_gs_ctr(gs_ctr);
+        // the image's worlds become the closed, shared boot prefix; this
+        // process's own history starts in a fresh spine run
+        jl_world_init_runs();
     }
     else {
         offset_restored = jl_read_offset(&s);
@@ -4177,6 +4242,59 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         arraylist_new(&s.fixup_types, 0);
     }
     jl_read_arraylist(s.relocs, &s.fixup_objs);
+    // World-segment table (see the write side): graft this image's spine runs
+    // into the world DAG and prepare the segment translation map used to
+    // rebase the image's verbatim-serialized worlds.
+    size_t *world_segmap = NULL;
+    uint32_t world_segmap_len = 0;
+    size_t graft_head = 0; // the final world of the image's last run
+    if (read_uint8(s.relocs)) {
+        assert(s.incremental);
+        uint64_t self_id = read_uint64(s.relocs);
+        uint32_t nsegs = read_uint32(s.relocs);
+        world_segmap = (size_t*)malloc_s(nsegs * sizeof(size_t));
+        world_segmap_len = nsegs;
+        uint32_t nruns = 0;
+        for (uint32_t i = 0; i < nsegs; i++) {
+            uint8_t kind = read_uint8(s.relocs);
+            if (kind == JL_WORLD_SEG_BOOT) {
+                // the shared prefix maps verbatim
+                world_segmap[i] = i;
+            }
+            else if (kind == JL_WORLD_SEG_RUN) {
+                size_t end = read_uint(s.relocs);
+                uint32_t np = read_uint32(s.relocs);
+                size_t *parents = np ? (size_t*)malloc_s(np * sizeof(size_t)) : NULL;
+                for (uint32_t p = 0; p < np; p++) {
+                    size_t pw = read_uint(s.relocs);
+                    size_t pseg = jl_world_seg(pw);
+                    if (pseg >= i || world_segmap[pseg] == ~(size_t)0)
+                        jl_error("world-segment table has an untranslatable parent");
+                    parents[p] = (world_segmap[pseg] << JL_WORLD_IDX_BITS) | jl_world_idx(pw);
+                }
+                size_t base = jl_world_new_image_run(self_id, nruns++, parents, np);
+                free(parents);
+                world_segmap[i] = jl_world_seg(base);
+                jl_world_segment_t *newseg = jl_world_get_segment(world_segmap[i]);
+                jl_atomic_store_relaxed(&newseg->end_idx, end);
+                graft_head = base + end;
+            }
+            else if (kind == JL_WORLD_SEG_IMAGE) {
+                uint64_t image_id = read_uint64(s.relocs);
+                uint32_t run = read_uint32(s.relocs);
+                size_t w = jl_world_image_run(image_id, run);
+                if (w == ~(size_t)0)
+                    jl_error("the world history of a dependency image was not grafted (dependency image mismatch?)");
+                world_segmap[i] = jl_world_seg(w);
+            }
+            else {
+                // not serializable (e.g. a fabricated test segment); error
+                // only if something actually references it
+                world_segmap[i] = ~(size_t)0;
+            }
+        }
+        assert(graft_head != 0 && "world-table image must contain at least one spine run");
+    }
     // Perform the uniquing of objects that we don't "own" and consequently can't promise
     // weren't created by some other package before this one got loaded:
     // - iterate through all objects that need to be uniqued. The first encounter has to be the
@@ -4403,13 +4521,32 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         o->bits.in_image = 1;
     }
     arraylist_free(&cleanup_list);
-    size_t graft_world = 0;
     for (size_t i = 0; i < s.fixup_objs.len; i++) {
         uintptr_t item = (uintptr_t)s.fixup_objs.items[i];
         jl_value_t *obj = (jl_value_t*)(image_base + item);
         if (jl_typetagis(obj, jl_typemap_entry_type) || jl_is_method(obj) || jl_is_code_instance(obj)) {
-            jl_array_ptr_1d_push(*internal_methods, obj);
             assert(s.incremental);
+            if (world_segmap) {
+                // rebase the entry's verbatim-serialized creation world onto
+                // the grafted copy of the saving process's world history;
+                // activation later preserves these per-entry worlds
+                if (jl_typetagis(obj, jl_typemap_entry_type)) {
+                    jl_typemap_entry_t *entry = (jl_typemap_entry_t*)obj;
+                    jl_atomic_store_relaxed(&entry->min_world,
+                        world_remap(jl_atomic_load_relaxed(&entry->min_world), world_segmap, world_segmap_len));
+                }
+                else if (jl_is_method(obj)) {
+                    jl_method_t *m = (jl_method_t*)obj;
+                    jl_atomic_store_relaxed(&m->primary_world,
+                        world_remap(jl_atomic_load_relaxed(&m->primary_world), world_segmap, world_segmap_len));
+                }
+                else {
+                    jl_code_instance_t *ci = (jl_code_instance_t*)obj;
+                    jl_atomic_store_relaxed(&ci->min_world,
+                        world_remap(jl_atomic_load_relaxed(&ci->min_world), world_segmap, world_segmap_len));
+                }
+            }
+            jl_array_ptr_1d_push(*internal_methods, obj);
         }
         else if (jl_is_method_instance(obj)) {
             jl_method_instance_t *newobj = jl_specializations_get_or_insert((jl_method_instance_t*)obj);
@@ -4452,21 +4589,17 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
             jl_cancel_source_relink((jl_cancel_source_t*)obj);
         }
         else if (jl_typetagis(obj, jl_worldtoken_type)) {
-            // this image's world history must survive: graft it as its own
-            // segment of the world DAG (once per image) and rebase the
-            // token's serialized offset onto it
-            assert(s.incremental);
-            if (graft_world == 0)
-                graft_world = jl_world_graft_segment();
+            assert(s.incremental && world_segmap);
             jl_worldtoken_t *tok = (jl_worldtoken_t*)obj;
-            tok->world += graft_world;
+            tok->world = world_remap(tok->world, world_segmap, world_segmap_len);
         }
         else {
             abort();
         }
     }
+    free(world_segmap);
     if (worldtoken_graft)
-        *worldtoken_graft = graft_world;
+        *worldtoken_graft = graft_head;
     if (s.incremental) {
         int no_replacement = jl_atomic_load_relaxed(&jl_first_image_replacement_world) == ~(size_t)0;
         for (size_t i = 0; i < s.fixup_objs.len; i++) {
@@ -4694,11 +4827,12 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
             // allocate a world for the new methods, and insert them there, invalidating content as needed
             size_t world = jl_atomic_load_relaxed(&jl_world_counter);
             if (worldtoken_graft) {
-                // this image's world history was grafted as its own segment
-                // (it contains captured world tokens); its content activates
-                // at the segment's base world, which the current spine
-                // segment has already merged
-                jl_activate_methods(extext_methods, internal_methods, worldtoken_graft, pkgname);
+                // this image's world history was grafted as its own spine
+                // runs (it contains captured world tokens); its content
+                // activates at its original, per-entry worlds, and the spine
+                // then merges the image's final run
+                jl_activate_methods(extext_methods, internal_methods, 0, pkgname);
+                jl_world_advance_into_segment(&worldtoken_graft, 1);
             }
             else {
                 if (new_methods)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1808,6 +1808,23 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                     jl_atomic_store_relaxed(&newbpart->max_world, 0);
                 }
             }
+            else if (s->incremental && jl_typetagis(v, jl_worldtoken_type)) {
+                assert(f == s->s);
+                jl_worldtoken_t *newtok = (jl_worldtoken_t*)&f->buf[reloc_offset];
+                if (newtok->world > jl_require_world) {
+                    // The captured world is above the shared sysimage prefix
+                    // and its numbering has no meaning in a loading process.
+                    // Rewrite it to an offset from the prefix; the loader
+                    // grafts this image's world history as a fresh segment of
+                    // the world DAG and rebases the token into it.
+                    if (jl_world_seg(newtok->world) != jl_world_seg(jl_require_world))
+                        jl_error("cannot serialize a world token captured above another grafted image history (not implemented yet)");
+                    newtok->world -= jl_require_world;
+                    arraylist_push(&s->fixup_objs, (void*)reloc_offset);
+                }
+                // else: part of the shared sysimage prefix; remains valid as
+                // an absolute world in any loading process
+            }
             else if (jl_is_method(v)) {
                 assert(f == s->s);
                 write_padding(f, sizeof(jl_method_t) - tot); // hidden fields
@@ -3988,7 +4005,8 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                                                  jl_array_t **extext_methods JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **internal_methods JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **method_roots_list JL_REQUIRE_ROOTED_SLOT,
-                                                 pkgcachesizes *cachesizes) JL_CANSAFEPOINT JL_GC_DISABLED
+                                                 pkgcachesizes *cachesizes,
+                                                 size_t *worldtoken_graft) JL_CANSAFEPOINT JL_GC_DISABLED
 {
     jl_task_t *ct = jl_current_task;
     int en = jl_gc_enable(0);
@@ -4385,6 +4403,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         o->bits.in_image = 1;
     }
     arraylist_free(&cleanup_list);
+    size_t graft_world = 0;
     for (size_t i = 0; i < s.fixup_objs.len; i++) {
         uintptr_t item = (uintptr_t)s.fixup_objs.items[i];
         jl_value_t *obj = (jl_value_t*)(image_base + item);
@@ -4432,10 +4451,22 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
             // child links were dropped at serialization)
             jl_cancel_source_relink((jl_cancel_source_t*)obj);
         }
+        else if (jl_typetagis(obj, jl_worldtoken_type)) {
+            // this image's world history must survive: graft it as its own
+            // segment of the world DAG (once per image) and rebase the
+            // token's serialized offset onto it
+            assert(s.incremental);
+            if (graft_world == 0)
+                graft_world = jl_world_graft_segment();
+            jl_worldtoken_t *tok = (jl_worldtoken_t*)obj;
+            tok->world += graft_world;
+        }
         else {
             abort();
         }
     }
+    if (worldtoken_graft)
+        *worldtoken_graft = graft_world;
     if (s.incremental) {
         int no_replacement = jl_atomic_load_relaxed(&jl_first_image_replacement_world) == ~(size_t)0;
         for (size_t i = 0; i < s.fixup_objs.len; i++) {
@@ -4637,7 +4668,8 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
                 ios_close(f);
             ios_static_buffer(f, sysimg, len);
             pkgcachesizes cachesizes;
-            jl_restore_system_image_from_stream_(f, image, depmods, checksum, (jl_array_t**)&restored, &init_order, &extext_methods, &internal_methods, &method_roots_list, &cachesizes);
+            size_t worldtoken_graft = 0;
+            jl_restore_system_image_from_stream_(f, image, depmods, checksum, (jl_array_t**)&restored, &init_order, &extext_methods, &internal_methods, &method_roots_list, &cachesizes, &worldtoken_graft);
             JL_SIGATOMIC_END();
 
             // Add roots to methods
@@ -4661,13 +4693,22 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
             JL_LOCK(&world_counter_lock);
             // allocate a world for the new methods, and insert them there, invalidating content as needed
             size_t world = jl_atomic_load_relaxed(&jl_world_counter);
-            if (new_methods)
-                world += 1;
-            jl_activate_methods(extext_methods, internal_methods, world, pkgname);
-            // TODO: inject internal_methods into caches here, so the system can see them immediately as potential candidates (before validation)
-            // allow users to start running in this updated world
-            if (new_methods)
-                jl_atomic_store_release(&jl_world_counter, world);
+            if (worldtoken_graft) {
+                // this image's world history was grafted as its own segment
+                // (it contains captured world tokens); its content activates
+                // at the segment's base world, which the current spine
+                // segment has already merged
+                jl_activate_methods(extext_methods, internal_methods, worldtoken_graft, pkgname);
+            }
+            else {
+                if (new_methods)
+                    world += 1;
+                jl_activate_methods(extext_methods, internal_methods, world, pkgname);
+                // TODO: inject internal_methods into caches here, so the system can see them immediately as potential candidates (before validation)
+                // allow users to start running in this updated world
+                if (new_methods)
+                    jl_atomic_store_release(&jl_world_counter, world);
+            }
             // now permit more methods to be added again
             JL_UNLOCK(&world_counter_lock);
 
@@ -4710,7 +4751,7 @@ static void jl_restore_system_image_from_stream(ios_t *f, jl_image_t *image) JL_
     ios_t f_payload;
     ios_static_buffer(&f_payload, f->buf + datastartpos, f->size - datastartpos);
     jl_restore_system_image_from_stream_(&f_payload, image, NULL,
-                                         checksum, NULL, NULL, NULL, NULL, NULL, NULL);
+                                         checksum, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(jl_image_buf_t buf, jl_image_t *image, jl_array_t *depmods, int completeinfo, const char *pkgname, int needs_permalloc) JL_CANSAFEPOINT

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1879,7 +1879,15 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 jl_code_instance_t *newci = (jl_code_instance_t*)&f->buf[reloc_offset];
 
                 if (s->incremental) {
-                    if (jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0) {
+                    if (ci->owner == (jl_value_t*)jl_symbol("computed_fieldtypes")) {
+                        // detached field-generator instances are world-age
+                        // independent by construction: their code is closed
+                        // (no world-dependent lookups), so they remain valid
+                        // as-is, with no revalidation on load
+                        assert(jl_atomic_load_relaxed(&ci->min_world) == 1);
+                        assert(jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0);
+                    }
+                    else if (jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0) {
                         //assert(jl_atomic_load_relaxed(&ci->edges) != jl_emptysvec); // some code (such as !==) might add a method lookup restriction but not keep the edges
                         // in world-table mode min_world is kept verbatim and
                         // translated by segment at load time

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -913,6 +913,9 @@ static void jl_add_methods(jl_array_t *external) JL_CANSAFEPOINT
 }
 
 extern _Atomic(int) allow_new_worlds;
+// `world == 0` means the image's world history was grafted and every object
+// already carries its original (translated) creation world, which activation
+// preserves.
 static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size_t world, const char *pkgname) JL_CANSAFEPOINT
 {
     size_t i, l = jl_array_nrows(internal);
@@ -921,21 +924,24 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
         jl_value_t *obj = jl_array_ptr_ref(internal, i);
         if (jl_typetagis(obj, jl_typemap_entry_type)) {
             jl_typemap_entry_t *entry = (jl_typemap_entry_t*)obj;
-            assert(jl_atomic_load_relaxed(&entry->min_world) == ~(size_t)0);
+            assert((jl_atomic_load_relaxed(&entry->min_world) == ~(size_t)0) == (world != 0));
             assert(jl_atomic_load_relaxed(&entry->max_world) == WORLD_AGE_REVALIDATION_SENTINEL);
-            jl_atomic_store_release(&entry->min_world, world);
+            if (world)
+                jl_atomic_store_release(&entry->min_world, world);
             jl_atomic_store_release(&entry->max_world, ~(size_t)0);
         }
         else if (jl_is_method(obj)) {
             jl_method_t *m = (jl_method_t*)obj;
-            assert(jl_atomic_load_relaxed(&m->primary_world) == ~(size_t)0);
-            jl_atomic_store_release(&m->primary_world, world);
+            assert((jl_atomic_load_relaxed(&m->primary_world) == ~(size_t)0) == (world != 0));
+            if (world)
+                jl_atomic_store_release(&m->primary_world, world);
         }
         else if (jl_is_code_instance(obj)) {
             jl_code_instance_t *ci = (jl_code_instance_t*)obj;
-            assert(jl_atomic_load_relaxed(&ci->min_world) == ~(size_t)0);
+            assert((jl_atomic_load_relaxed(&ci->min_world) == ~(size_t)0) == (world != 0));
             assert(jl_atomic_load_relaxed(&ci->max_world) == WORLD_AGE_REVALIDATION_SENTINEL);
-            jl_atomic_store_relaxed(&ci->min_world, world);
+            if (world)
+                jl_atomic_store_relaxed(&ci->min_world, world);
             // n.b. ci->max_world is not updated until edges are verified
         }
         else {

--- a/src/task.c
+++ b/src/task.c
@@ -1131,6 +1131,8 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_fu
     t->threadpoolid = ct->threadpoolid;
     t->ptls = NULL;
     t->world_age = ct->world_age;
+    t->rcjulia = 0;
+    t->rc_frames = NULL;
     t->reentrant_timing = 0;
     t->metrics_enabled = jl_atomic_load_relaxed(&jl_task_metrics_enabled) != 0;
     jl_atomic_store_relaxed(&t->first_enqueued_at, 0);
@@ -1601,6 +1603,8 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     ct->sticky = 1;
     ct->ptls = ptls;
     ct->world_age = 1; // OK to run Julia code on this task
+    ct->rcjulia = 0;
+    ct->rc_frames = NULL;
     ct->reentrant_timing = 0;
     jl_atomic_store_relaxed(&ct->running_time_ns, 0);
     jl_atomic_store_relaxed(&ct->finished_at, 0);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -305,7 +305,7 @@ void jl_declare_global(jl_module_t *m, jl_value_t *arg, jl_value_t *set_type, in
         gs = (jl_sym_t*)arg;
     }
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_relaxed(&jl_world_counter) + 1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_t *b = jl_get_module_binding(gm, gs, 1);
     jl_binding_partition_t *bpart = NULL;
     if (!strong && set_type)
@@ -569,7 +569,7 @@ JL_DLLEXPORT jl_binding_partition_t *jl_declare_constant_val2(
 {
     JL_GC_PUSH1(&val);
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_relaxed(&jl_world_counter) + 1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_partition_t *bpart = jl_declare_constant_val3(b, mod, var, val, constant_kind, new_world);
     if (jl_atomic_load_relaxed(&bpart->min_world) == new_world)
         jl_atomic_store_release(&jl_world_counter, new_world);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -789,6 +789,7 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval(jl_module_t *m, jl_value_t *v)
 // Check module `m` is open for `eval/include`, or throw an error.
 JL_DLLEXPORT void jl_check_top_level_effect(jl_module_t *m, const char *fname) JL_CANSAFEPOINT
 {
+    jl_check_rc(fname);
     if (jl_current_task->ptls->in_pure_callback)
         jl_errorf("%s cannot be used in a generated function", fname);
     if (jl_options.incremental && jl_generating_output()) {

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -610,9 +610,9 @@ static int jl_typemap_intersection_node_visitor(jl_typemap_entry_t *ml, struct t
     // that can be absolutely critical for speed
     register jl_typemap_intersection_visitor_fptr fptr = closure->fptr;
     for (;  ml != (void*)jl_nothing; ml = jl_atomic_load_relaxed(&ml->next)) {
-        if (closure->max_valid < jl_atomic_load_relaxed(&ml->min_world))
+        if (!jl_world_at_least(closure->max_valid, jl_atomic_load_relaxed(&ml->min_world)))
             continue;
-        if (closure->min_valid > jl_atomic_load_relaxed(&ml->max_world))
+        if (!jl_world_at_most(closure->min_valid, jl_atomic_load_relaxed(&ml->max_world)))
             continue;
         int nonempty;
         if (closure->emptiness_only) {
@@ -922,7 +922,7 @@ static jl_typemap_entry_t *jl_typemap_entry_assoc_by_type(
     size_t n = jl_nparams(unw);
     int typesisva = n == 0 ? 0 : jl_is_vararg(jl_tparam(unw, n-1));
     for (; ml != (void*)jl_nothing; ml = jl_atomic_load_relaxed(&ml->next)) {
-        if (search->world < jl_atomic_load_relaxed(&ml->min_world) || search->world > jl_atomic_load_relaxed(&ml->max_world))
+        if (!jl_world_in_range(search->world, jl_atomic_load_relaxed(&ml->min_world), jl_atomic_load_relaxed(&ml->max_world)))
             continue;
         size_t lensig = jl_nparams(jl_unwrap_unionall((jl_value_t*)ml->sig));
         if (lensig == n || (ml->va && lensig <= n+1)) {
@@ -974,7 +974,7 @@ static jl_typemap_entry_t *jl_typemap_entry_lookup_by_type(
         jl_typemap_entry_t *ml, struct jl_typemap_assoc *search) JL_CANSAFEPOINT
 {
     for (; ml != (void*)jl_nothing; ml = jl_atomic_load_relaxed(&ml->next)) {
-        if (search->world < jl_atomic_load_relaxed(&ml->min_world) || search->world > jl_atomic_load_relaxed(&ml->max_world))
+        if (!jl_world_in_range(search->world, jl_atomic_load_relaxed(&ml->min_world), jl_atomic_load_relaxed(&ml->max_world)))
             continue;
         // unroll the first few cases here, to the extent that is possible to do fast and easily
         jl_value_t *types = search->types;
@@ -1184,7 +1184,7 @@ jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_valu
     // some manually-unrolled common special cases
     while (ml->simplesig == (void*)jl_nothing && ml->guardsigs == jl_emptysvec && ml->isleafsig) {
         // use a tight loop for as long as possible
-        if (world >= jl_atomic_load_relaxed(&ml->min_world) && world <= jl_atomic_load_relaxed(&ml->max_world)) {
+        if (jl_world_in_range(world, jl_atomic_load_relaxed(&ml->min_world), jl_atomic_load_relaxed(&ml->max_world))) {
             if (n == jl_nparams(ml->sig) && jl_typeof(arg1) == jl_tparam(ml->sig, 0)) {
                 if (n == 1)
                     return ml;
@@ -1209,7 +1209,7 @@ jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_valu
     }
 
     for (; ml != (void*)jl_nothing; ml = jl_atomic_load_relaxed(&ml->next)) {
-        if (world < jl_atomic_load_relaxed(&ml->min_world) || world > jl_atomic_load_relaxed(&ml->max_world))
+        if (!jl_world_in_range(world, jl_atomic_load_relaxed(&ml->min_world), jl_atomic_load_relaxed(&ml->max_world)))
             continue; // ignore replaced methods
         size_t lensig = jl_nparams(ml->sig);
         if (lensig == n || (ml->va && lensig <= n+1)) {

--- a/src/world.c
+++ b/src/world.c
@@ -1,0 +1,113 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// World age segment bookkeeping. See the overview comment next to
+// jl_world_reaches in julia_internal.h: a world is a packed
+// (segment, index) pair, segments form an append-only DAG whose edges are
+// fixed at segment creation, and segment-level ancestry is answered by an
+// immutable per-segment bitset so that readers require no synchronization
+// beyond an acquire load of the segment pointer.
+
+#include "julia.h"
+#include "julia_internal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint32_t id;
+    uint32_t anc_nbits;         // number of valid bits in anc_row (== id)
+    _Atomic(size_t) end_idx;    // terminal index once closed; JL_WORLD_IDX_MASK while open
+    uint64_t anc_row[];         // ancestor segment bitset, immutable after publication
+} jl_world_segment_t;
+
+// Append-only table of materialized segments. Segment 0 (boot) is implicit
+// and never materialized; its entry stays NULL and the chain fallback in
+// jl_world_seg_reaches gives the correct answers for it.
+static _Atomic(jl_world_segment_t*) world_segments[JL_WORLD_MAX_SEGMENTS];
+static uint32_t world_nsegments = 1; // protected by world_counter_lock
+
+JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT
+{
+    if (sa == sb)
+        return 1;
+    jl_world_segment_t *seg = sb < JL_WORLD_MAX_SEGMENTS ?
+        jl_atomic_load_acquire(&world_segments[sb]) : NULL;
+    if (seg == NULL)
+        return sa < sb; // unmaterialized segment: pure chain order
+    return sa < seg->anc_nbits && ((seg->anc_row[sa >> 6] >> (sa & 63)) & 1);
+}
+
+// Requires world_counter_lock. `chain_parent == ~(size_t)0` means no
+// implicit parent.
+static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t *parent_worlds, size_t nparents)
+{
+    uint32_t id = world_nsegments;
+    assert(id < JL_WORLD_MAX_SEGMENTS);
+    size_t nwords = (id + 63) / 64;
+    jl_world_segment_t *seg = (jl_world_segment_t*)calloc_s(sizeof(jl_world_segment_t) + nwords * sizeof(uint64_t));
+    seg->id = id;
+    seg->anc_nbits = id; // ancestors always have smaller ids
+    jl_atomic_store_relaxed(&seg->end_idx, JL_WORLD_IDX_MASK);
+    for (size_t i = 0; i <= nparents; i++) {
+        size_t pw = i == 0 ? chain_parent : parent_worlds[i - 1];
+        if (pw == ~(size_t)0)
+            continue;
+        size_t psid = jl_world_seg(pw);
+        assert(psid < id && "parent segment must precede the new segment");
+        seg->anc_row[psid >> 6] |= (uint64_t)1 << (psid & 63);
+        jl_world_segment_t *pseg = jl_atomic_load_relaxed(&world_segments[psid]);
+        assert((pseg || psid == 0) && "non-boot parent segment must be materialized");
+        if (pseg) {
+            size_t pwords = (pseg->anc_nbits + 63) / 64;
+            for (size_t w = 0; w < pwords; w++)
+                seg->anc_row[w] |= pseg->anc_row[w];
+        }
+    }
+    world_nsegments = id + 1;
+    jl_atomic_store_release(&world_segments[id], seg);
+    return seg;
+}
+
+// Create a new segment, without moving the world counter into it, whose
+// parents are the segments of `parent_worlds` (referenced at full extent).
+// Returns the segment's first world. Exposed for grafting serialized world
+// histories and for testing.
+JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents)
+{
+    JL_LOCK(&world_counter_lock);
+    if (world_nsegments >= JL_WORLD_MAX_SEGMENTS) {
+        JL_UNLOCK(&world_counter_lock);
+        jl_error("world age segment limit exceeded");
+    }
+    jl_world_segment_t *seg = world_new_segment_locked(~(size_t)0, parent_worlds, nparents);
+    JL_UNLOCK(&world_counter_lock);
+    return (size_t)seg->id << JL_WORLD_IDX_BITS;
+}
+
+// Close the currently open segment at the current world counter and continue
+// counting worlds in a fresh child segment. `extra_parent_worlds` (possibly
+// none) name additional history -- e.g. a grafted image's final world --
+// merged into the new segment. Returns the new segment's first world, which
+// becomes the current world counter value.
+JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra)
+{
+    JL_LOCK(&world_counter_lock);
+    if (world_nsegments >= JL_WORLD_MAX_SEGMENTS) {
+        JL_UNLOCK(&world_counter_lock);
+        jl_error("world age segment limit exceeded");
+    }
+    size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
+    jl_world_segment_t *seg = world_new_segment_locked(cur, extra_parent_worlds, nextra);
+    jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
+    if (oldseg)
+        jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
+    size_t w = (size_t)seg->id << JL_WORLD_IDX_BITS;
+    jl_atomic_store_release(&jl_world_counter, w);
+    JL_UNLOCK(&world_counter_lock);
+    return w;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/world.c
+++ b/src/world.c
@@ -108,6 +108,32 @@ JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, s
     return w;
 }
 
+// Close the currently open segment and continue the counter in a fresh
+// segment, additionally materializing a side segment G (a child of the
+// closed spine head) that the new spine segment also merges. A serialized
+// image's world history is grafted into G: entries and world tokens from the
+// image reference (G, offset) worlds, which are part of the new spine's
+// history but isolated from invalidation events that happen after the graft.
+// Returns G's first world.
+JL_DLLEXPORT size_t jl_world_graft_segment(void)
+{
+    JL_LOCK(&world_counter_lock);
+    if (world_nsegments + 1 >= JL_WORLD_MAX_SEGMENTS) {
+        JL_UNLOCK(&world_counter_lock);
+        jl_error("world age segment limit exceeded");
+    }
+    size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
+    jl_world_segment_t *gseg = world_new_segment_locked(cur, NULL, 0);
+    size_t gbase = (size_t)gseg->id << JL_WORLD_IDX_BITS;
+    jl_world_segment_t *sseg = world_new_segment_locked(cur, &gbase, 1);
+    jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
+    if (oldseg)
+        jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
+    jl_atomic_store_release(&jl_world_counter, (size_t)sseg->id << JL_WORLD_IDX_BITS);
+    JL_UNLOCK(&world_counter_lock);
+    return gbase;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/world.c
+++ b/src/world.c
@@ -181,6 +181,26 @@ static size_t world_pos(size_t w, jl_world_segment_t *obs) JL_NOTSAFEPOINT
     return p;
 }
 
+// Combine two validity caps: the result's invalidation cone must contain
+// both inputs' cones, so intervals capped by it are invalid wherever either
+// input was. Returns 0 if the cones are incomparable (neither contains the
+// other, e.g. shadowing events on two different side branches), in which
+// case a single cap cannot represent the exclusion and the caller must
+// degrade (typically to point validity at its query world). Caps that are
+// events on one trunk are always comparable.
+JL_DLLEXPORT size_t jl_world_cap_meet(size_t a, size_t b) JL_NOTSAFEPOINT
+{
+    if (a == ~(size_t)0)
+        return b;
+    if (b == ~(size_t)0)
+        return a;
+    if (jl_world_reaches(a + 1, b + 1))
+        return a; // cone(b+1) is contained in cone(a+1)
+    if (jl_world_reaches(b + 1, a + 1))
+        return b;
+    return 0;
+}
+
 // Is `w` on the observer's trunk? Trunk worlds are exactly the worlds whose
 // position in the observer's total order is themselves, so interval bounds
 // between them compare exactly as integers; a merged side branch's worlds

--- a/src/world.c
+++ b/src/world.c
@@ -52,7 +52,11 @@ JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT
 }
 
 // Requires world_counter_lock. `chain_parent == ~(size_t)0` means no
-// implicit parent.
+// implicit parent; otherwise it is the trunk (main-branch) parent, and the
+// remaining parents are side branches merged at this segment's base world.
+// Joins are asymmetric: a side branch's events order after every main-branch
+// event before the join point and before every one after it, which is
+// recorded in join_pos (the segment's total order over its visible cone).
 static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t *parent_worlds, size_t nparents)
 {
     uint32_t id = world_nsegments_;
@@ -65,11 +69,14 @@ static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t 
     jl_atomic_store_relaxed(&seg->end_idx, JL_WORLD_IDX_MASK);
     seg->nparents = (uint32_t)nparents + (chain_parent != ~(size_t)0);
     seg->parents = seg->nparents ? (size_t*)malloc_s(seg->nparents * sizeof(size_t)) : NULL;
+    seg->join_pos = id ? (size_t*)calloc_s(id * sizeof(size_t)) : NULL;
+    size_t base = (size_t)id << JL_WORLD_IDX_BITS;
     uint32_t pi = 0;
     for (size_t i = 0; i <= nparents; i++) {
         size_t pw = i == 0 ? chain_parent : parent_worlds[i - 1];
         if (pw == ~(size_t)0)
             continue;
+        int is_trunk = pi == 0; // the first parent continues the trunk
         seg->parents[pi++] = pw;
         size_t psid = jl_world_seg(pw);
         assert(psid < id && "parent segment must precede the new segment");
@@ -79,12 +86,30 @@ static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t 
             size_t pwords = (pseg->anc_nbits + 63) / 64;
             for (size_t w = 0; w < pwords; w++)
                 seg->anc_row[w] |= pseg->anc_row[w];
+            if (is_trunk) {
+                // inherit the trunk parent's total order and extend the trunk
+                memcpy(seg->join_pos, pseg->join_pos, pseg->anc_nbits * sizeof(size_t));
+                seg->join_pos[psid] = JL_WORLD_POS_TRUNK;
+            }
+            else {
+                // a side branch: everything newly visible through it joins
+                // the trunk at this segment's base world
+                for (uint32_t b = 0; b <= psid; b++) {
+                    if (b == psid || ((pseg->anc_row[b >> 6] >> (b & 63)) & 1)) {
+                        if (seg->join_pos[b] == 0)
+                            seg->join_pos[b] = base;
+                    }
+                }
+            }
         }
         else {
             // an unmaterialized (boot prefix) parent: its history is the
             // whole linear chain of segments up to and including it
-            for (size_t b = 0; b <= psid; b++)
+            for (size_t b = 0; b <= psid; b++) {
                 seg->anc_row[b >> 6] |= (uint64_t)1 << (b & 63);
+                if (seg->join_pos[b] == 0)
+                    seg->join_pos[b] = is_trunk ? JL_WORLD_POS_TRUNK : base;
+            }
         }
     }
     world_nsegments_ = id + 1;
@@ -120,45 +145,84 @@ static jl_world_segment_t *world_advance_locked(size_t *extra_parent_worlds, siz
     jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
     if (oldseg)
         jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
-    size_t base = (size_t)seg->id << JL_WORLD_IDX_BITS;
-    // every newly merged segment joins the spine at this run's base world
-    for (uint32_t i = 0; i < seg->anc_nbits; i++) {
-        if ((seg->anc_row[i >> 6] >> (i & 63)) & 1) {
-            jl_world_segment_t *anc = jl_atomic_load_relaxed(&world_segments[i]);
-            if (anc && anc->kind != JL_WORLD_SEG_RUN && jl_atomic_load_relaxed(&anc->joined_spine) == 0)
-                jl_atomic_store_relaxed(&anc->joined_spine, base);
-        }
-    }
-    jl_atomic_store_release(&jl_world_counter, base);
+    jl_atomic_store_release(&jl_world_counter, (size_t)seg->id << JL_WORLD_IDX_BITS);
     return seg;
 }
 
-// The position on the spine at (or from) which the history of `w` is
-// included: `w` itself for spine worlds (boot prefix and spine runs), the
-// merge point for grafted segments. Spine positions compare exactly as
-// integers.
-static size_t world_spine_pos(size_t w) JL_NOTSAFEPOINT
+// Position of `w` in the total order that the observer segment imposes on
+// its visible cone: `w` itself for worlds on the observer's trunk, the merge
+// point for worlds of merged side branches. Positions are trunk worlds and
+// compare exactly as integers.
+static size_t world_pos(size_t w, jl_world_segment_t *obs) JL_NOTSAFEPOINT
 {
-    jl_world_segment_t *seg = jl_world_get_segment(jl_world_seg(w));
-    if (seg == NULL || seg->kind == JL_WORLD_SEG_RUN)
-        return w;
-    size_t j = jl_atomic_load_relaxed(&seg->joined_spine);
-    assert(j != 0 && "join of a world whose segment has not been merged into the spine");
-    return j ? j : jl_atomic_load_relaxed(&jl_world_counter);
+    size_t ws = jl_world_seg(w);
+    if (obs == NULL || ws == obs->id)
+        return w; // the observer's own segment, or a fully linear history
+    size_t p = ws < obs->anc_nbits ? obs->join_pos[ws] : 0;
+    if (p == JL_WORLD_POS_TRUNK || p == 0)
+        return w; // on the trunk (0: not visible; fall back to chain order)
+    return p;
 }
 
-// The earliest spine world whose history includes both `a` and `b`. For
-// comparable worlds this is simply the later of the two; for worlds on
-// different branches it is the later of their spine merge points.
-JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT
+// The earliest world in the observer's total order whose history includes
+// both `a` and `b`. For comparable worlds this is simply the later of the
+// two; for worlds on different branches it is the later of their merge
+// points on the observer's trunk.
+JL_DLLEXPORT size_t jl_world_join(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT
 {
     if (jl_world_reaches(a, b))
         return b;
     if (jl_world_reaches(b, a))
         return a;
-    size_t pa = world_spine_pos(a);
-    size_t pb = world_spine_pos(b);
+    jl_world_segment_t *obs = jl_world_get_segment(jl_world_seg(observer));
+    size_t pa = world_pos(a, obs);
+    size_t pb = world_pos(b, obs);
     return pa > pb ? pa : pb;
+}
+
+// The join with the current spine head as the observer.
+JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT
+{
+    return jl_world_join(a, b, jl_atomic_load_acquire(&jl_world_counter));
+}
+
+// The three-point predicate `a preceq_observer b`: does `a` come at or
+// before `b` in the total order that the observer's segment imposes on its
+// visible history? Trunk worlds order as themselves; a merged side branch's
+// worlds order at its merge point (after the main-branch events preceding
+// the join, before those following it), and within one merge point, by the
+// side branch's own total order, recursively.
+JL_DLLEXPORT int jl_world_ordered_before(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT
+{
+    if (a == b)
+        return 1;
+    if (jl_world_reaches(a, b))
+        return 1;
+    if (jl_world_reaches(b, a))
+        return 0;
+    jl_world_segment_t *obs = jl_world_get_segment(jl_world_seg(observer));
+    size_t pa = world_pos(a, obs);
+    size_t pb = world_pos(b, obs);
+    if (pa != pb)
+        return pa < pb;
+    // both worlds joined the observer's trunk at the same merge point:
+    // order them by the total order of the side branch that merged there
+    jl_world_segment_t *pseg = jl_world_get_segment(jl_world_seg(pa));
+    if (pseg != NULL) {
+        for (uint32_t i = 1; i < pseg->nparents; i++) {
+            size_t pw = pseg->parents[i];
+            int ra = jl_world_reaches(a, pw);
+            int rb = jl_world_reaches(b, pw);
+            if (ra && rb) {
+                assert(jl_world_seg(pw) != jl_world_seg(observer) && "side branch cannot be the observer's segment");
+                return jl_world_ordered_before(a, b, pw);
+            }
+            if (ra || rb)
+                return ra; // side branches merged together order by parent position
+        }
+    }
+    // not visible through materialized structure: fall back to chain order
+    return a < b;
 }
 
 // Close the currently open segment at the current world counter and continue

--- a/src/world.c
+++ b/src/world.c
@@ -70,7 +70,7 @@ static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t 
     seg->nparents = (uint32_t)nparents + (chain_parent != ~(size_t)0);
     seg->parents = seg->nparents ? (size_t*)malloc_s(seg->nparents * sizeof(size_t)) : NULL;
     seg->join_pos = id ? (size_t*)calloc_s(id * sizeof(size_t)) : NULL;
-    size_t base = (size_t)id << JL_WORLD_IDX_BITS;
+    size_t base = JL_WORLD_PACK(id, 0);
     uint32_t pi = 0;
     for (size_t i = 0; i <= nparents; i++) {
         size_t pw = i == 0 ? chain_parent : parent_worlds[i - 1];
@@ -121,7 +121,7 @@ static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t 
 // parents are the segments of `parent_worlds` (referenced at full extent).
 // Returns the segment's first world. Exposed for testing; segments created
 // this way carry no serializable identity.
-JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents)
+JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents) JL_CANSAFEPOINT
 {
     JL_LOCK(&world_counter_lock);
     if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
@@ -130,7 +130,7 @@ JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents)
     }
     jl_world_segment_t *seg = world_new_segment_locked(~(size_t)0, parent_worlds, nparents);
     JL_UNLOCK(&world_counter_lock);
-    return (size_t)seg->id << JL_WORLD_IDX_BITS;
+    return JL_WORLD_PACK(seg->id, 0);
 }
 
 // Requires world_counter_lock: close the currently open segment at the
@@ -145,8 +145,25 @@ static jl_world_segment_t *world_advance_locked(size_t *extra_parent_worlds, siz
     jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
     if (oldseg)
         jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
-    jl_atomic_store_release(&jl_world_counter, (size_t)seg->id << JL_WORLD_IDX_BITS);
+    jl_atomic_store_release(&jl_world_counter, JL_WORLD_PACK(seg->id, 0));
     return seg;
+}
+
+// Requires world_counter_lock: the world that the next modification event
+// should be assigned -- normally jl_world_counter + 1. When the current
+// run's index space is exhausted (realistic only with 16-bit indices on
+// 32-bit platforms), the trunk first continues into a fresh run, so that
+// indices never carry into the segment field.
+JL_DLLEXPORT size_t jl_world_next_locked(void) JL_CANSAFEPOINT
+{
+    size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
+    if (jl_world_idx(cur) >= JL_WORLD_IDX_MASK - 1) {
+        if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS)
+            jl_error("world age segment limit exceeded");
+        world_advance_locked(NULL, 0);
+        cur = jl_atomic_load_relaxed(&jl_world_counter);
+    }
+    return cur + 1;
 }
 
 // Position of `w` in the total order that the observer segment imposes on
@@ -230,7 +247,7 @@ JL_DLLEXPORT int jl_world_ordered_before(size_t a, size_t b, size_t observer) JL
 // none) name additional history -- e.g. a grafted image's final world --
 // merged into the new run. Returns the new run's first world, which becomes
 // the current world counter value.
-JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra)
+JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra) JL_CANSAFEPOINT
 {
     JL_LOCK(&world_counter_lock);
     if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
@@ -238,7 +255,7 @@ JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, s
         jl_error("world age segment limit exceeded");
     }
     jl_world_segment_t *seg = world_advance_locked(extra_parent_worlds, nextra);
-    size_t w = (size_t)seg->id << JL_WORLD_IDX_BITS;
+    size_t w = JL_WORLD_PACK(seg->id, 0);
     JL_UNLOCK(&world_counter_lock);
     return w;
 }
@@ -249,7 +266,7 @@ JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, s
 // and this process's first spine run starts in a fresh segment. This keeps
 // every parent reference to the prefix exact: prefix segments are referenced
 // only at full extent, never mid-segment.
-JL_DLLEXPORT void jl_world_init_runs(void)
+JL_DLLEXPORT void jl_world_init_runs(void) JL_CANSAFEPOINT
 {
     JL_LOCK(&world_counter_lock);
     size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
@@ -269,7 +286,7 @@ JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSA
     for (uint32_t i = 0; i < n; i++) {
         jl_world_segment_t *seg = jl_atomic_load_acquire(&world_segments[i]);
         if (seg && seg->kind == JL_WORLD_SEG_IMAGE && seg->image_id == image_id && seg->run == run)
-            return (size_t)i << JL_WORLD_IDX_BITS;
+            return JL_WORLD_PACK(i, 0);
     }
     return ~(size_t)0;
 }
@@ -279,7 +296,7 @@ JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSA
 // world. The counter does not move; the caller is expected to eventually
 // merge the image's final run into the spine with
 // jl_world_advance_into_segment.
-JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents)
+JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents) JL_CANSAFEPOINT
 {
     JL_LOCK(&world_counter_lock);
     if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
@@ -291,7 +308,7 @@ JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size
     seg->kind = JL_WORLD_SEG_IMAGE;
     seg->image_id = image_id;
     seg->run = run;
-    size_t w = (size_t)seg->id << JL_WORLD_IDX_BITS;
+    size_t w = JL_WORLD_PACK(seg->id, 0);
     JL_UNLOCK(&world_counter_lock);
     return w;
 }

--- a/src/world.c
+++ b/src/world.c
@@ -181,6 +181,23 @@ static size_t world_pos(size_t w, jl_world_segment_t *obs) JL_NOTSAFEPOINT
     return p;
 }
 
+// Is `w` on the observer's trunk? Trunk worlds are exactly the worlds whose
+// position in the observer's total order is themselves, so interval bounds
+// between them compare exactly as integers; a merged side branch's worlds
+// (e.g. a grafted image history) are not on the trunk even though they reach
+// the observer.
+JL_DLLEXPORT int jl_world_on_trunk(size_t w, size_t observer) JL_NOTSAFEPOINT
+{
+    jl_world_segment_t *obs = jl_world_get_segment(jl_world_seg(observer));
+    size_t ws = jl_world_seg(w);
+    if (obs == NULL || ws == obs->id)
+        return 1; // the observer's own segment, or a fully linear history
+    if (ws < obs->anc_nbits && obs->join_pos[ws] == JL_WORLD_POS_TRUNK)
+        return 1;
+    // unmaterialized ancestors (the boot prefix) are part of every trunk
+    return ws < obs->id && jl_world_get_segment(ws) == NULL;
+}
+
 // The earliest world in the observer's total order whose history includes
 // both `a` and `b`. For comparable worlds this is simply the later of the
 // two; for worlds on different branches it is the later of their merge

--- a/src/world.c
+++ b/src/world.c
@@ -6,6 +6,13 @@
 // fixed at segment creation, and segment-level ancestry is answered by an
 // immutable per-segment bitset so that readers require no synchronization
 // beyond an acquire load of the segment pointer.
+//
+// Segments additionally carry a serializable identity (see
+// enum jl_world_seg_kind): the unmaterialized boot prefix is shared verbatim
+// between every process built on the same system image; this process's own
+// spine runs are numbered consecutively; and runs grafted from a loaded
+// package image are keyed by (image id, run ordinal), which is stable across
+// processes because a given image file grafts identically everywhere.
 
 #include "julia.h"
 #include "julia_internal.h"
@@ -14,18 +21,24 @@
 extern "C" {
 #endif
 
-typedef struct {
-    uint32_t id;
-    uint32_t anc_nbits;         // number of valid bits in anc_row (== id)
-    _Atomic(size_t) end_idx;    // terminal index once closed; JL_WORLD_IDX_MASK while open
-    uint64_t anc_row[];         // ancestor segment bitset, immutable after publication
-} jl_world_segment_t;
-
-// Append-only table of materialized segments. Segment 0 (boot) is implicit
-// and never materialized; its entry stays NULL and the chain fallback in
-// jl_world_seg_reaches gives the correct answers for it.
+// Append-only table of materialized segments. Boot-prefix segments are
+// implicit and never materialized; their entries stay NULL and the chain
+// fallback in jl_world_seg_reaches gives the correct answers for them.
 static _Atomic(jl_world_segment_t*) world_segments[JL_WORLD_MAX_SEGMENTS];
-static uint32_t world_nsegments = 1; // protected by world_counter_lock
+static uint32_t world_nsegments_ = 1; // protected by world_counter_lock
+static uint32_t world_nruns = 0;      // spine run ordinals handed out; protected by world_counter_lock
+
+JL_DLLEXPORT jl_world_segment_t *jl_world_get_segment(size_t seg) JL_NOTSAFEPOINT
+{
+    if (seg >= JL_WORLD_MAX_SEGMENTS)
+        return NULL;
+    return jl_atomic_load_acquire(&world_segments[seg]);
+}
+
+JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT
+{
+    return world_nsegments_;
+}
 
 JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT
 {
@@ -42,41 +55,51 @@ JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT
 // implicit parent.
 static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t *parent_worlds, size_t nparents)
 {
-    uint32_t id = world_nsegments;
+    uint32_t id = world_nsegments_;
     assert(id < JL_WORLD_MAX_SEGMENTS);
     size_t nwords = (id + 63) / 64;
     jl_world_segment_t *seg = (jl_world_segment_t*)calloc_s(sizeof(jl_world_segment_t) + nwords * sizeof(uint64_t));
     seg->id = id;
     seg->anc_nbits = id; // ancestors always have smaller ids
+    seg->kind = JL_WORLD_SEG_OTHER;
     jl_atomic_store_relaxed(&seg->end_idx, JL_WORLD_IDX_MASK);
+    seg->nparents = (uint32_t)nparents + (chain_parent != ~(size_t)0);
+    seg->parents = seg->nparents ? (size_t*)malloc_s(seg->nparents * sizeof(size_t)) : NULL;
+    uint32_t pi = 0;
     for (size_t i = 0; i <= nparents; i++) {
         size_t pw = i == 0 ? chain_parent : parent_worlds[i - 1];
         if (pw == ~(size_t)0)
             continue;
+        seg->parents[pi++] = pw;
         size_t psid = jl_world_seg(pw);
         assert(psid < id && "parent segment must precede the new segment");
-        seg->anc_row[psid >> 6] |= (uint64_t)1 << (psid & 63);
         jl_world_segment_t *pseg = jl_atomic_load_relaxed(&world_segments[psid]);
-        assert((pseg || psid == 0) && "non-boot parent segment must be materialized");
         if (pseg) {
+            seg->anc_row[psid >> 6] |= (uint64_t)1 << (psid & 63);
             size_t pwords = (pseg->anc_nbits + 63) / 64;
             for (size_t w = 0; w < pwords; w++)
                 seg->anc_row[w] |= pseg->anc_row[w];
         }
+        else {
+            // an unmaterialized (boot prefix) parent: its history is the
+            // whole linear chain of segments up to and including it
+            for (size_t b = 0; b <= psid; b++)
+                seg->anc_row[b >> 6] |= (uint64_t)1 << (b & 63);
+        }
     }
-    world_nsegments = id + 1;
+    world_nsegments_ = id + 1;
     jl_atomic_store_release(&world_segments[id], seg);
     return seg;
 }
 
 // Create a new segment, without moving the world counter into it, whose
 // parents are the segments of `parent_worlds` (referenced at full extent).
-// Returns the segment's first world. Exposed for grafting serialized world
-// histories and for testing.
+// Returns the segment's first world. Exposed for testing; segments created
+// this way carry no serializable identity.
 JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents)
 {
     JL_LOCK(&world_counter_lock);
-    if (world_nsegments >= JL_WORLD_MAX_SEGMENTS) {
+    if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
         JL_UNLOCK(&world_counter_lock);
         jl_error("world age segment limit exceeded");
     }
@@ -85,53 +108,91 @@ JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents)
     return (size_t)seg->id << JL_WORLD_IDX_BITS;
 }
 
-// Close the currently open segment at the current world counter and continue
-// counting worlds in a fresh child segment. `extra_parent_worlds` (possibly
-// none) name additional history -- e.g. a grafted image's final world --
-// merged into the new segment. Returns the new segment's first world, which
-// becomes the current world counter value.
-JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra)
+// Requires world_counter_lock: close the currently open segment at the
+// current counter and continue counting worlds in a fresh spine run whose
+// extra parents (beyond the closed segment) are `extra_parent_worlds`.
+static jl_world_segment_t *world_advance_locked(size_t *extra_parent_worlds, size_t nextra)
 {
-    JL_LOCK(&world_counter_lock);
-    if (world_nsegments >= JL_WORLD_MAX_SEGMENTS) {
-        JL_UNLOCK(&world_counter_lock);
-        jl_error("world age segment limit exceeded");
-    }
     size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
     jl_world_segment_t *seg = world_new_segment_locked(cur, extra_parent_worlds, nextra);
+    seg->kind = JL_WORLD_SEG_RUN;
+    seg->run = world_nruns++;
     jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
     if (oldseg)
         jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
+    jl_atomic_store_release(&jl_world_counter, (size_t)seg->id << JL_WORLD_IDX_BITS);
+    return seg;
+}
+
+// Close the currently open segment at the current world counter and continue
+// counting worlds in a fresh spine run. `extra_parent_worlds` (possibly
+// none) name additional history -- e.g. a grafted image's final world --
+// merged into the new run. Returns the new run's first world, which becomes
+// the current world counter value.
+JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra)
+{
+    JL_LOCK(&world_counter_lock);
+    if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
+        JL_UNLOCK(&world_counter_lock);
+        jl_error("world age segment limit exceeded");
+    }
+    jl_world_segment_t *seg = world_advance_locked(extra_parent_worlds, nextra);
     size_t w = (size_t)seg->id << JL_WORLD_IDX_BITS;
-    jl_atomic_store_release(&jl_world_counter, w);
     JL_UNLOCK(&world_counter_lock);
     return w;
 }
 
-// Close the currently open segment and continue the counter in a fresh
-// segment, additionally materializing a side segment G (a child of the
-// closed spine head) that the new spine segment also merges. A serialized
-// image's world history is grafted into G: entries and world tokens from the
-// image reference (G, offset) worlds, which are part of the new spine's
-// history but isolated from invalidation events that happen after the graft.
-// Returns G's first world.
-JL_DLLEXPORT size_t jl_world_graft_segment(void)
+// Called once after a system image restore has set jl_world_counter: the
+// worlds the image was built at become the closed, shared boot prefix
+// (reserving segment ids for them if the image's counter was itself packed),
+// and this process's first spine run starts in a fresh segment. This keeps
+// every parent reference to the prefix exact: prefix segments are referenced
+// only at full extent, never mid-segment.
+JL_DLLEXPORT void jl_world_init_runs(void)
 {
     JL_LOCK(&world_counter_lock);
-    if (world_nsegments + 1 >= JL_WORLD_MAX_SEGMENTS) {
+    size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
+    uint32_t reserve = (uint32_t)jl_world_seg(cur) + 1;
+    if (world_nsegments_ < reserve)
+        world_nsegments_ = reserve;
+    assert(world_nruns == 0 && "spine runs already initialized");
+    world_advance_locked(NULL, 0);
+    JL_UNLOCK(&world_counter_lock);
+}
+
+// The materialized segment for run `run` of the image identified by
+// `image_id`, or ~(size_t)0 if that run has not been grafted.
+JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSAFEPOINT
+{
+    uint32_t n = world_nsegments_;
+    for (uint32_t i = 0; i < n; i++) {
+        jl_world_segment_t *seg = jl_atomic_load_acquire(&world_segments[i]);
+        if (seg && seg->kind == JL_WORLD_SEG_IMAGE && seg->image_id == image_id && seg->run == run)
+            return (size_t)i << JL_WORLD_IDX_BITS;
+    }
+    return ~(size_t)0;
+}
+
+// Graft run `run` of the image identified by `image_id`, whose parents are
+// the segments of `parent_worlds` at full extent. Returns the run's first
+// world. The counter does not move; the caller is expected to eventually
+// merge the image's final run into the spine with
+// jl_world_advance_into_segment.
+JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents)
+{
+    JL_LOCK(&world_counter_lock);
+    if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
         JL_UNLOCK(&world_counter_lock);
         jl_error("world age segment limit exceeded");
     }
-    size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
-    jl_world_segment_t *gseg = world_new_segment_locked(cur, NULL, 0);
-    size_t gbase = (size_t)gseg->id << JL_WORLD_IDX_BITS;
-    jl_world_segment_t *sseg = world_new_segment_locked(cur, &gbase, 1);
-    jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
-    if (oldseg)
-        jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
-    jl_atomic_store_release(&jl_world_counter, (size_t)sseg->id << JL_WORLD_IDX_BITS);
+    assert(jl_world_image_run(image_id, run) == ~(size_t)0 && "image run already grafted");
+    jl_world_segment_t *seg = world_new_segment_locked(~(size_t)0, parent_worlds, nparents);
+    seg->kind = JL_WORLD_SEG_IMAGE;
+    seg->image_id = image_id;
+    seg->run = run;
+    size_t w = (size_t)seg->id << JL_WORLD_IDX_BITS;
     JL_UNLOCK(&world_counter_lock);
-    return gbase;
+    return w;
 }
 
 #ifdef __cplusplus

--- a/src/world.c
+++ b/src/world.c
@@ -120,8 +120,45 @@ static jl_world_segment_t *world_advance_locked(size_t *extra_parent_worlds, siz
     jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
     if (oldseg)
         jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
-    jl_atomic_store_release(&jl_world_counter, (size_t)seg->id << JL_WORLD_IDX_BITS);
+    size_t base = (size_t)seg->id << JL_WORLD_IDX_BITS;
+    // every newly merged segment joins the spine at this run's base world
+    for (uint32_t i = 0; i < seg->anc_nbits; i++) {
+        if ((seg->anc_row[i >> 6] >> (i & 63)) & 1) {
+            jl_world_segment_t *anc = jl_atomic_load_relaxed(&world_segments[i]);
+            if (anc && anc->kind != JL_WORLD_SEG_RUN && jl_atomic_load_relaxed(&anc->joined_spine) == 0)
+                jl_atomic_store_relaxed(&anc->joined_spine, base);
+        }
+    }
+    jl_atomic_store_release(&jl_world_counter, base);
     return seg;
+}
+
+// The position on the spine at (or from) which the history of `w` is
+// included: `w` itself for spine worlds (boot prefix and spine runs), the
+// merge point for grafted segments. Spine positions compare exactly as
+// integers.
+static size_t world_spine_pos(size_t w) JL_NOTSAFEPOINT
+{
+    jl_world_segment_t *seg = jl_world_get_segment(jl_world_seg(w));
+    if (seg == NULL || seg->kind == JL_WORLD_SEG_RUN)
+        return w;
+    size_t j = jl_atomic_load_relaxed(&seg->joined_spine);
+    assert(j != 0 && "join of a world whose segment has not been merged into the spine");
+    return j ? j : jl_atomic_load_relaxed(&jl_world_counter);
+}
+
+// The earliest spine world whose history includes both `a` and `b`. For
+// comparable worlds this is simply the later of the two; for worlds on
+// different branches it is the later of their spine merge points.
+JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT
+{
+    if (jl_world_reaches(a, b))
+        return b;
+    if (jl_world_reaches(b, a))
+        return a;
+    size_t pa = world_spine_pos(a);
+    size_t pb = world_spine_pos(b);
+    return pa > pb ? pa : pb;
 }
 
 // Close the currently open segment at the current world counter and continue

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -7,7 +7,7 @@ const STDLIBS = filter!(x -> isfile(joinpath(STDLIB_DIR, x, "src", "$(x).jl")), 
 
 const TESTNAMES = [
         "subarray", "core", "compiler", "compiler_extras", "worlds", "atomics",
-        "keywordargs", "numbers", "subtype", "typegroup",
+        "keywordargs", "numbers", "subtype", "typegroup", "computedfields",
         "char", "strings", "triplequote", "unicode", "intrinsics", "apint",
         "dict", "hashing", "iobuffer", "staged", "offsetarray",
         "arrayops", "tuple", "reduce", "reducedim", "abstractarray",

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -23,7 +23,7 @@ const TESTNAMES = [
         "errorshow", "sets", "goto", "llvmcall", "llvmcall2", "ryu",
         "some", "meta", "stacktraces", "docs", "gc",
         "misc", "threads", "stress", "binaryplatforms","stdlib_dependencies", "atexit",
-        "enums", "cmdlineargs", "int", "interpreter",
+        "enums", "cmdlineargs", "int", "interpreter", "rcjulia",
         "checked", "bitset", "floatfuncs", "precompile", "relocatedepot",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "cancellation", "iostream", "secretbuffer", "specificity",

--- a/test/computedfields.jl
+++ b/test/computedfields.jl
@@ -39,7 +39,7 @@ end
     # non-Int parameters degrade too (typeassert throws)
     @test fieldtype(Neg{:sym}, 1) === Union{}
     # through the partial-application reflection API the error propagates instead
-    @test_throws Exception Base.fieldtype_generator(Neg)(0)
+    @test_throws Exception Base.fieldtype_generator(Neg){0}
     # and types without computed field types have no generator
     @test_throws ArgumentError Base.fieldtype_generator(Some{Int})
 end
@@ -53,13 +53,17 @@ end
     dt = Base.unwrap_unionall(StaticMatrix)
     marker = dt.types[1]
     @test marker isa Core.ComputedFieldType
-    # partially applied field generator (reflection-level, not a type)
+    # partially applied field generator (reflection-level, not a type),
+    # applied with apply_type like a partially applied UnionAll
     g = Base.fieldtype_generator(StaticMatrix{2})
-    @test g(3, Float64) === (NTuple{6,Float64},)
-    @test Base.fieldtype_generator(StaticMatrix)(2, 3, Float64) === (NTuple{6,Float64},)
-    # fully applied is allowed too
-    @test Base.fieldtype_generator(StaticMatrix{2,3,Float64})() === (NTuple{6,Float64},)
-    @test_throws ArgumentError g(3)  # too few parameters
+    @test g{3, Float64} === (NTuple{6,Float64},)
+    g2 = g{3}
+    @test g2 isa Core.FieldtypeGenerator
+    @test g2{Float64} === (NTuple{6,Float64},)
+    @test Base.fieldtype_generator(StaticMatrix){2, 3, Float64} === (NTuple{6,Float64},)
+    # a type with no remaining free parameters yields the tuple directly
+    @test Base.fieldtype_generator(StaticMatrix{2,3,Float64}) === (NTuple{6,Float64},)
+    @test_throws ErrorException g{3, Float64, Int}  # too many parameters
     # inference of code that manipulates partial instantiations must not crash
     mk(f, ::Type{StaticMatrix{R,C,T}}) where {R,C,T} = StaticMatrix{R,C,T}(ntuple(f, R*C))
     @test Base.infer_return_type(mk, (Function, Type{<:StaticMatrix})) isa Type

--- a/test/computedfields.jl
+++ b/test/computedfields.jl
@@ -38,16 +38,31 @@ end
     @test_throws Exception Neg{0}((1,))
     # non-Int parameters degrade too (typeassert throws)
     @test fieldtype(Neg{:sym}, 1) === Union{}
+    # through the partial-application reflection API the error propagates instead
+    @test_throws Exception Base.fieldtype_generator(Neg)(0)
+    # and types without computed field types have no generator
+    @test_throws ArgumentError Base.fieldtype_generator(Some{Int})
 end
 
 @testset "partial instantiation" begin
-    # computed slots widen to a fresh unbounded TypeVar
-    ft = fieldtype(StaticMatrix{2}, 1)
-    @test ft isa TypeVar
+    # computed field types are not part of the type system: `fieldtype` on a
+    # non-concrete instantiation throws
+    @test_throws ErrorException fieldtype(StaticMatrix{2}, 1)
+    @test_throws ErrorException fieldtype(StaticMatrix, 1)
     # the declared slot records the source AST
     dt = Base.unwrap_unionall(StaticMatrix)
     marker = dt.types[1]
     @test marker isa Core.ComputedFieldType
+    # partially applied field generator (reflection-level, not a type)
+    g = Base.fieldtype_generator(StaticMatrix{2})
+    @test g(3, Float64) === (NTuple{6,Float64},)
+    @test Base.fieldtype_generator(StaticMatrix)(2, 3, Float64) === (NTuple{6,Float64},)
+    # fully applied is allowed too
+    @test Base.fieldtype_generator(StaticMatrix{2,3,Float64})() === (NTuple{6,Float64},)
+    @test_throws ArgumentError g(3)  # too few parameters
+    # inference of code that manipulates partial instantiations must not crash
+    mk(f, ::Type{StaticMatrix{R,C,T}}) where {R,C,T} = StaticMatrix{R,C,T}(ntuple(f, R*C))
+    @test Base.infer_return_type(mk, (Function, Type{<:StaticMatrix})) isa Type
 end
 
 struct MixedFields{N,T}

--- a/test/computedfields.jl
+++ b/test/computedfields.jl
@@ -94,19 +94,41 @@ end
 
 global nonconst_dim::Int = 3
 
-@testset "definition-time validation" begin
-    # unconstrained parameters: `*(::Any, ::Any)` is a dynamic call, unprovable
-    @test_throws ErrorException @eval struct BadUntypedParams{R,C}
+# Generators execute in RCJulia (restricted-capability) mode, so no purity
+# proof is required at definition time: definitions that the old effects-proof
+# design rejected are now legal, and any restricted operation the generator
+# attempts traps deterministically at instantiation time instead, degrading
+# the field types to `Union{}`. Errors propagate (rather than degrade) through
+# explicit `fieldtype_generator` application.
+@testset "restricted evaluation of field generators" begin
+    # unconstrained parameters need no type annotations: dispatch resolves
+    # dynamically in the frozen definition world
+    @eval struct DynUntypedParams{R,C}
         data::NTuple{R*C, Int}
     end
-    # inconsistent generator
-    @test_throws ErrorException @eval struct BadRandom{N}
+    @test fieldtype(DynUntypedParams{2,3}, 1) === NTuple{6,Int}
+    # a parameter combination whose expression yields a non-Int degrades
+    @test fieldtype(DynUntypedParams{2,:sym}, 1) === Union{}
+    # an inconsistent generator is a legal definition, but the restricted
+    # operation (task-local RNG state) traps at instantiation time
+    @eval struct BadRandom{N}
         data::NTuple{rand(1:(N::Int)), Int}
     end
-    # non-constant global in the expression
-    @test_throws ErrorException @eval struct BadGlobal{N}
+    @test fieldtype(BadRandom{3}, 1) === Union{}
+    @test_throws CapabilityError Base.fieldtype_generator(BadRandom{3})
+    # reading a non-constant global traps likewise
+    @eval struct BadGlobal{N}
         data::NTuple{(N::Int)*nonconst_dim, Int}
     end
+    @test fieldtype(BadGlobal{3}, 1) === Union{}
+    @test_throws CapabilityError Base.fieldtype_generator(BadGlobal{3})
+    # loops have backedges; iteration in a generator must be recursion
+    @eval loopsize(n::Int) = (s = 0; for i = 1:n; s += i; end; s)
+    @eval struct LoopyGrid{N}
+        data::NTuple{loopsize(N::Int), Int}
+    end
+    @test fieldtype(LoopyGrid{3}, 1) === Union{}
+    @test_throws CapabilityError Base.fieldtype_generator(LoopyGrid{3})
 end
 
 # helper redefinition must not affect field types (frozen definition-time semantics)
@@ -133,14 +155,13 @@ end
     @test fieldtype(FrozenSemantics.BigGrid{5}, 1) === NTuple{21,Float64}
 end
 
-@testset "detached CodeInstance form" begin
+@testset "definition world token form" begin
     fg = Base.unwrap_unionall(StaticMatrix).name.fieldgen
     @test fg isa Core.SimpleVector && length(fg) == 2
-    ci = fg[2]
-    @test ci isa Core.CodeInstance
-    @test ci.owner === :computed_fieldtypes
-    @test (@atomic :monotonic ci.min_world) == 1
-    @test (@atomic :monotonic ci.max_world) == typemax(UInt)
+    tok = fg[2]
+    @test tok isa Core.WorldToken
+    # invoking the generator through the stored token reproduces the field types
+    @test Core._rcjulia_call(tok, fg[1], 2, 3, Float64) === (NTuple{6,Float64},)
 end
 
 # self-referential parameter arithmetic. n.b. mutable: for immutable types an

--- a/test/computedfields.jl
+++ b/test/computedfields.jl
@@ -1,0 +1,169 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Tests for computed field types (field generators): struct field types that are
+# expressions of the type parameter values, e.g. `data::NTuple{(R::Int)*(C::Int), T}`.
+
+using Test
+
+struct StaticMatrix{R,C,T}
+    data::NTuple{(R::Int)*(C::Int), T}
+end
+
+@testset "basic computed field types" begin
+    @test fieldtype(StaticMatrix{2,3,Float64}, 1) === NTuple{6,Float64}
+    @test isbitstype(StaticMatrix{2,3,Float64})
+    @test sizeof(StaticMatrix{2,3,Float64}) == 48
+    m = StaticMatrix{2,3,Float64}((1.0,2,3,4,5,6))
+    @test m.data === (1.0,2.0,3.0,4.0,5.0,6.0)
+    # inference of getfield on a concrete instantiation is precise
+    @test Base.infer_return_type(m -> m.data, (StaticMatrix{2,3,Float64},)) == NTuple{6,Float64}
+end
+
+struct SymmetricTensor{order,dim,T}
+    data::NTuple{div((dim::Int)*(dim+1),2)^div(order::Int,2), T}
+end
+
+@testset "composite arithmetic" begin
+    @test fieldtype(SymmetricTensor{4,3,Float64}, 1) === NTuple{36,Float64}
+    @test fieldtype(SymmetricTensor{2,3,Float64}, 1) === NTuple{6,Float64}
+end
+
+struct Neg{N}
+    data::NTuple{(N::Int)-1, Int}
+end
+
+@testset "throwing generator degrades to Union{}" begin
+    @test fieldtype(Neg{3}, 1) === NTuple{2,Int}
+    @test fieldtype(Neg{0}, 1) === Union{}
+    @test_throws Exception Neg{0}((1,))
+    # non-Int parameters degrade too (typeassert throws)
+    @test fieldtype(Neg{:sym}, 1) === Union{}
+end
+
+@testset "partial instantiation" begin
+    # computed slots widen to a fresh unbounded TypeVar
+    ft = fieldtype(StaticMatrix{2}, 1)
+    @test ft isa TypeVar
+    # the declared slot records the source AST
+    dt = Base.unwrap_unionall(StaticMatrix)
+    marker = dt.types[1]
+    @test marker isa Core.ComputedFieldType
+end
+
+struct MixedFields{N,T}
+    len::Int
+    data::NTuple{2*(N::Int), T}
+    tag::T
+end
+
+@testset "mixed plain and computed fields" begin
+    @test fieldtype(MixedFields{3,Float32}, 1) === Int
+    @test fieldtype(MixedFields{3,Float32}, 2) === NTuple{6,Float32}
+    @test fieldtype(MixedFields{3,Float32}, 3) === Float32
+    mx = MixedFields{3,Float32}(1, (1,2,3,4,5,6), 2.0f0)
+    @test mx.data === (1.0f0,2.0f0,3.0f0,4.0f0,5.0f0,6.0f0)
+end
+
+# identical redefinition keeps the type identity
+const StaticMatrixAlias = StaticMatrix
+struct StaticMatrix{R,C,T}
+    data::NTuple{(R::Int)*(C::Int), T}
+end
+@testset "redefinition equivalence" begin
+    @test StaticMatrixAlias === StaticMatrix
+end
+
+global nonconst_dim::Int = 3
+
+@testset "definition-time validation" begin
+    # unconstrained parameters: `*(::Any, ::Any)` is a dynamic call, unprovable
+    @test_throws ErrorException @eval struct BadUntypedParams{R,C}
+        data::NTuple{R*C, Int}
+    end
+    # inconsistent generator
+    @test_throws ErrorException @eval struct BadRandom{N}
+        data::NTuple{rand(1:(N::Int)), Int}
+    end
+    # non-constant global in the expression
+    @test_throws ErrorException @eval struct BadGlobal{N}
+        data::NTuple{(N::Int)*nonconst_dim, Int}
+    end
+end
+
+# helper redefinition must not affect field types (frozen definition-time semantics)
+module FrozenSemantics
+    mysize(n::Int) = 2n
+    @noinline bigsize(n::Int) = n <= 0 ? 0 : 4n + 1
+    struct Grid{N}
+        data::NTuple{mysize(N::Int), Float64}
+    end
+    struct BigGrid{N}
+        data::NTuple{bigsize(N::Int), Float64}
+    end
+end
+
+@testset "world-age freezing" begin
+    @test fieldtype(FrozenSemantics.Grid{3}, 1) === NTuple{6,Float64}
+    @test fieldtype(FrozenSemantics.BigGrid{3}, 1) === NTuple{13,Float64}
+    # redefine the helpers
+    FrozenSemantics.eval(:(mysize(n::Int) = 100n))
+    FrozenSemantics.eval(:(@noinline bigsize(n::Int) = 1000n))
+    @test FrozenSemantics.mysize(5) == 500
+    # fresh instantiations still use the definition-time semantics
+    @test fieldtype(FrozenSemantics.Grid{5}, 1) === NTuple{10,Float64}
+    @test fieldtype(FrozenSemantics.BigGrid{5}, 1) === NTuple{21,Float64}
+end
+
+@testset "detached CodeInstance form" begin
+    fg = Base.unwrap_unionall(StaticMatrix).name.fieldgen
+    @test fg isa Core.SimpleVector && length(fg) == 2
+    ci = fg[2]
+    @test ci isa Core.CodeInstance
+    @test ci.owner === :computed_fieldtypes
+    @test (@atomic :monotonic ci.min_world) == 1
+    @test (@atomic :monotonic ci.max_world) == typemax(UInt)
+end
+
+# self-referential parameter arithmetic. n.b. mutable: for immutable types an
+# inline-allocatable self-reference in a computed field would recurse during
+# layout (the definition-time `references_name` inline-alloc cycle breaker
+# cannot see through ComputedFieldType markers) -- a known limitation for now.
+mutable struct Countdown{N}
+    val::Int
+    next::Union{Nothing, Countdown{max((N::Int)-1, 0)}}
+end
+
+@testset "self-referential computed parameters" begin
+    @test fieldtype(Countdown{2}, 2) === Union{Nothing, Countdown{1}}
+    # exact self-reference resolves to the in-flight type during instantiation
+    @test fieldtype(Countdown{0}, 2) === Union{Nothing, Countdown{0}}
+    c = Countdown{1}(1, Countdown{0}(0, nothing))
+    @test c.next.val == 0
+end
+
+# user-defined inner constructor: `new` resolves field types at runtime
+struct WithCtor{N}
+    data::NTuple{2*(N::Int), Int}
+    function WithCtor{N}(x::Int) where {N}
+        return new{N}(ntuple(Returns(x), 2N))
+    end
+end
+
+@testset "user-defined inner constructor" begin
+    w = WithCtor{2}(7)
+    @test w.data === (7, 7, 7, 7)
+    @test_throws Exception WithCtor{2}((1, 2))  # no matching method
+end
+
+@testset "vouching via @assume_effects on a helper" begin
+    @eval module Vouched
+        Base.@assume_effects :foldable function opaquesize(n::Int)
+            # something the compiler could prove anyway, but via assertion
+            return 3n
+        end
+        struct VGrid{N}
+            data::NTuple{opaquesize(N::Int), Int}
+        end
+    end
+    @test fieldtype(Vouched.VGrid{2}, 1) === NTuple{6,Int}
+end

--- a/test/computedfields.jl
+++ b/test/computedfields.jl
@@ -131,6 +131,33 @@ global nonconst_dim::Int = 3
     @test_throws CapabilityError Base.fieldtype_generator(LoopyGrid{3})
 end
 
+# When instantiation degraded a computed field type to `Union{}` (throw-free),
+# *construction* re-derives the field types with errors propagating, so the
+# failure surfaces as the generator's underlying error instead of an opaque
+# convert-to-`Union{}` message.
+@testset "construction re-derives failed generators" begin
+    # default (generated) inner constructor
+    @eval struct CtorBadGlobal{N}
+        tup::NTuple{(N::Int)*nonconst_dim, Float64}
+    end
+    @test fieldtype(CtorBadGlobal{2}, 1) === Union{}  # instantiation stays throw-free
+    @test_throws CapabilityError CtorBadGlobal{2}((1.0, 2.0))
+    # user inner constructor with explicit `new`
+    @eval struct CtorBadInner{N}
+        tup::NTuple{(N::Int)*nonconst_dim, Float64}
+        CtorBadInner{N}(t) where {N} = new{N}(t)
+    end
+    @test_throws CapabilityError CtorBadInner{2}((1.0, 2.0))
+    # a generator that succeeds but yields a non-type gets a descriptive error
+    @eval struct CtorNonType{N}
+        tup::((N::Int); nothing)
+    end
+    err = try CtorNonType{2}(()); nothing catch e; e end
+    @test err isa ErrorException && occursin("not a valid field type", err.msg)
+    # healthy structs still construct (and convert) precisely
+    @test StaticMatrix{2,2,Int}((1, 2, 3, 4)).data === (1, 2, 3, 4)
+end
+
 # helper redefinition must not affect field types (frozen definition-time semantics)
 module FrozenSemantics
     mysize(n::Int) = 2n

--- a/test/core.jl
+++ b/test/core.jl
@@ -44,7 +44,7 @@ for (T, c) in (
         (Core.MethodCache, [:leafcache, :cache, :var""]),
         (Core.TypeMapEntry, [:next, :min_world, :max_world]),
         (Core.TypeMapLevel, [:arg1, :targ, :name1, :tname, :list, :any]),
-        (Core.TypeName, [:cache, :linearcache, :Typeofwrapper, :max_args, :cache_entry_count]),
+        (Core.TypeName, [:cache, :linearcache, :Typeofwrapper, :max_args, :cache_entry_count, :fieldgen]),
         (DataType, [:types, :layout]),
         (Core.Memory, []),
         (Core.GenericMemoryRef, []),

--- a/test/rcjulia.jl
+++ b/test/rcjulia.jl
@@ -1,0 +1,333 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Tests for RCJulia — restricted-capability evaluation mode
+# (`Core._rcjulia_call`): an execution mode that is `:foldable` by
+# construction. Operations requiring a withheld capability throw
+# CapabilityError instead of executing.
+
+using Test
+
+pcall(f, args...) = Core._rcjulia_call(Base.get_world_counter(), f, args...)
+
+# Helpers defined at toplevel so they have stable method identities.
+rc_add(x, y) = x + y
+rc_tuplen(t) = nfields(t)
+struct RCJuliaParams{R,C} end
+rc_paramprod(::Type{P}) where {P} = (P.parameters[1]::Int) * (P.parameters[2]::Int)
+rc_throws(x) = x < 0 ? throw(DomainError(x, "negative")) : x
+rc_loop(n) = (s = 0; for i = 1:n; s += i; end; s)
+rc_splat(t) = tuple(t...)
+rc_gen(::Val{N}) where {N} = ntuple(identity, Val(N))
+rc_reads_global() = RCJULIA_NONCONST_GLOBAL
+rc_reads_const() = RCJULIA_CONST_GLOBAL
+rc_closure_call(f, x) = f(x)
+rc_nested_call(w, f) = Core._rcjulia_call(w, f)
+
+# recursion shapes, exercising the well-founded order
+rc_countdown(n) = n <= 0 ? 0 : rc_countdown(n - 1)            # bits value decreases
+rc_countup(n) = n >= 10 ? n : rc_countup(n + 1)               # bits value increases
+rc_same(x) = rc_same(x)                                       # egal re-entry
+rc_below_zero(n) = n == -3 ? 0 : rc_below_zero(n - 1)         # crosses into negative bits
+rc_fact(n) = n <= 1 ? 1 : n * rc_fact(n - 1)
+rc_peel(t) = t === () ? 0 : rc_peel(Base.tail(t))             # typeof(t) shrinks structurally
+rc_val_descent(::Val{0}) = 0
+rc_val_descent(::Val{N}) where {N} = rc_val_descent(Val(N - 1)) # type parameter decreases
+rc_ttail(::Type{T}) where {T<:Tuple} = Tuple{Base.argtail(T.parameters...)...}
+rc_tdesc(::Type{T}) where {T<:Tuple} =                        # type argument shrinks structurally
+    T === Tuple{} ? 0 : 1 + rc_tdesc(rc_ttail(T))
+rc_mutual_a(n) = n <= 0 ? 0 : rc_mutual_b(n)
+rc_mutual_b(n) = rc_mutual_a(n - 1)
+
+global RCJULIA_NONCONST_GLOBAL::Int = 1
+const RCJULIA_CONST_GLOBAL = 42
+
+mutable struct RCJuliaMutable
+    x::Int
+end
+struct RCJuliaImmutable
+    x::Int
+end
+mutable struct RCJuliaMutableConst
+    const c::Int
+    x::Int
+end
+
+# Two generations of a method, with the world in between captured (at
+# toplevel, so later statements see the redefinition).
+rc_redefined() = 1
+const RCJULIA_WORLD1 = Base.get_world_counter()
+rc_redefined() = 2
+const RCJULIA_WORLD2 = Base.get_world_counter()
+
+@testset "basic evaluation" begin
+    @test pcall(rc_add, 1, 2) === 3
+    @test pcall(rc_add, 1.5, 2.5) === 4.0
+    @test pcall(tuple, 1, 2) === (1, 2)
+    @test pcall(rc_tuplen, (1, 2, 3)) === 3
+    @test pcall(typeof, 1) === Int
+    @test pcall(===, 1, 1) === true
+    # construction of immutables is legal
+    @test pcall(RCJuliaImmutable, 7) === RCJuliaImmutable(7)
+    @test pcall(getfield, RCJuliaImmutable(7), :x) === 7
+    # type computation
+    @test pcall(Core.apply_type, NTuple, 3, Float64) === NTuple{3,Float64}
+    @test pcall(fieldtype, RCJuliaImmutable, 1) === Int
+end
+
+@testset "const fields of mutable objects are readable" begin
+    # `const` fields never change after construction, so reading them is
+    # consistent; this is also what admits set-once runtime metadata such as
+    # DataType.parameters (the computed-field-types use case)
+    @test pcall(rc_paramprod, RCJuliaParams{2,3}) === 6
+    let m = RCJuliaMutableConst(1, 2)
+        @test pcall(getfield, m, :c) === 1
+        @test pcall(isdefined, m, :c) === true
+        @test_throws CapabilityError pcall(getfield, m, :x)
+        @test_throws CapabilityError pcall(isdefined, m, :x)
+    end
+end
+
+@testset "tuple splatting and generated functions" begin
+    @test pcall(rc_splat, (1, 2, 3)) === (1, 2, 3)
+    # generated function expansion is always permitted; the expanded code
+    # then executes under the mode
+    @test pcall(rc_gen, Val(3)) === (1, 2, 3)
+    # splatting an array reads mutable memory
+    let a = [1, 2, 3]
+        @test_throws CapabilityError pcall(rc_splat, a)
+    end
+end
+
+@testset "consistent throwing is permitted" begin
+    @test pcall(rc_throws, 1) === 1
+    @test_throws DomainError pcall(rc_throws, -1)
+    @test_throws DivideError pcall(div, 1, 0)
+    # after an exception propagates out, the mode is fully exited
+    @test RCJULIA_NONCONST_GLOBAL === 1
+end
+
+@testset "mutable memory reads are trapped" begin
+    let m = RCJuliaMutable(1)
+        @test_throws CapabilityError pcall(getfield, m, :x)
+        @test_throws CapabilityError pcall(isdefined, m, :x)
+    end
+    let a = [1, 2, 3]
+        @test_throws CapabilityError pcall(getindex, a, 1)
+        @test_throws CapabilityError pcall(length, a)
+    end
+end
+
+@testset "mutation and mutable allocation are trapped" begin
+    let m = RCJuliaMutable(1)
+        @test_throws CapabilityError pcall(setfield!, m, :x, 2)
+        @test m.x === 1
+    end
+    @test_throws CapabilityError pcall(RCJuliaMutable, 1)
+    @test_throws CapabilityError pcall(Vector{Int}, undef, 3)
+    @test_throws CapabilityError pcall(push!, Int[], 1)
+    # string building goes through IOBuffer/Memory
+    @test_throws CapabilityError pcall(string, 1, "x")
+end
+
+@testset "globals" begin
+    @test pcall(rc_reads_const) === 42
+    @test pcall(getglobal, @__MODULE__, :RCJULIA_CONST_GLOBAL) === 42
+    @test_throws CapabilityError pcall(rc_reads_global)
+    @test_throws CapabilityError pcall(getglobal, @__MODULE__, :RCJULIA_NONCONST_GLOBAL)
+    @test_throws CapabilityError pcall(setglobal!, @__MODULE__, :RCJULIA_NONCONST_GLOBAL, 2)
+    @test pcall(isdefinedglobal, @__MODULE__, :RCJULIA_CONST_GLOBAL) === true
+    @test pcall(isdefinedglobal, @__MODULE__, :this_name_is_not_defined_anywhere) === false
+    @test_throws CapabilityError pcall(isdefinedglobal, @__MODULE__, :RCJULIA_NONCONST_GLOBAL)
+    @test_throws UndefVarError pcall(getglobal, @__MODULE__, :this_name_is_not_defined_anywhere)
+end
+
+@testset "well-founded recursion" begin
+    # loops have backedges: iteration must be expressed as recursion
+    @test_throws CapabilityError pcall(rc_loop, 3)
+    # value recursion with decreasing bits is permitted
+    @test pcall(rc_countdown, 5) === 0
+    @test pcall(rc_fact, 5) === 120
+    # increasing bits is not a decrease in the order
+    @test_throws CapabilityError pcall(rc_countup, 0)
+    # egal re-entry is guaranteed divergent under consistency
+    @test_throws CapabilityError pcall(rc_same, 1)
+    # the bits order is unsigned: -1 is larger than 0
+    @test_throws CapabilityError pcall(rc_below_zero, 0)
+    # structurally smaller types: tuple peeling and type-argument descent
+    @test pcall(rc_peel, (1, 2, 3)) === 0
+    @test pcall(rc_tdesc, Tuple{Int,Int,Int}) === 3
+    # descent through distinct specializations (decreasing type parameter)
+    @test pcall(rc_val_descent, Val(10)) === 0
+    # mutual recursion, each method decreasing per occurrence
+    @test pcall(rc_mutual_a, 5) === 0
+    # the physical frame cap fires deterministically before stack overflow
+    @test_throws CapabilityError pcall(rc_val_descent, Val(2000))
+    let err = try pcall(rc_val_descent, Val(2000)); nothing catch e; e end
+        @test err isa CapabilityError && err.op === :depth_limit
+    end
+    let err = try pcall(rc_countup, 0); nothing catch e; e end
+        @test err isa CapabilityError && err.op === :recursion
+    end
+end
+
+@testset "world-mutating and impure operations are trapped" begin
+    @test_throws CapabilityError pcall(Core.eval, @__MODULE__, :(1 + 1))
+    @test_throws CapabilityError pcall(Core.invokelatest, rc_add, 1, 2)
+    @test_throws CapabilityError pcall(Core.finalizer, identity, RCJuliaMutable(1))
+    @test_throws CapabilityError pcall(Core.current_scope)
+    @test_throws CapabilityError pcall(Core._expr, :call, :f)
+    @test_throws CapabilityError pcall(print, "hello")
+    @test_throws CapabilityError pcall(time_ns)
+end
+
+@testset "world freezing" begin
+    # a frozen world sees the definitions of that world
+    @test Core._rcjulia_call(RCJULIA_WORLD1, rc_redefined) === 1
+    @test Core._rcjulia_call(RCJULIA_WORLD2, rc_redefined) === 2
+    @test pcall(rc_redefined) === 2
+    # nesting may lower the frozen world...
+    @test Core._rcjulia_call(RCJULIA_WORLD2, rc_nested_call, RCJULIA_WORLD1, rc_redefined) === 1
+    # ...but not raise it
+    @test_throws CapabilityError Core._rcjulia_call(RCJULIA_WORLD1, rc_nested_call, RCJULIA_WORLD2, rc_redefined)
+end
+
+@testset "closures and higher-order calls" begin
+    @test pcall(rc_closure_call, x -> x + 1, 1) === 2
+    @test pcall(map, x -> 2x, (1, 2, 3)) === (2, 4, 6)
+end
+
+@testset "CapabilityError" begin
+    @test CapabilityError <: Exception
+    err = try
+        pcall(rc_loop, 1)
+        nothing
+    catch e
+        e
+    end
+    @test err isa CapabilityError
+    @test err.op === :backedge
+    @test occursin("RCJulia", sprint(showerror, err))
+    # the trap is deterministic; the exception is egal across replays
+    err2 = try pcall(rc_loop, 1); nothing catch e; e end
+    @test err === err2
+end
+
+@testset "every builtin and intrinsic has decided RCJulia semantics" begin
+    # This test is the audited classification of ALL builtins and intrinsics
+    # for RCJulia mode. When adding a builtin or intrinsic, you must decide
+    # its RCJulia semantics and add it to exactly one set below (and, for
+    # trapped operations, add the corresponding `jl_check_rc` in the runtime).
+
+    # Builtins that execute under the mode (their semantics are consistent in
+    # a frozen world, or their C implementation performs no restricted
+    # operation).
+    BUILTIN_ALLOWED = Set([
+        "_compute_sparams", "_rcjulia_call", "_svec_len", "_svec_ref",
+        "_typevar", "applicable", "apply_type", "bitsizeof", "compilerbarrier",
+        "donotdelete", "fieldtype", "get_binding_type", "===", "isa", "<:",
+        "ifelse", "intrinsic_call", "memoryrefnew", "memoryrefoffset",
+        "nfields", "sizeof", "svec", "throw", "throw_methoderror", "tuple",
+        "typeassert", "typeof", "has_free_typevars",
+    ])
+    # Builtins that execute conditionally: legal on immutable/`const`/
+    # tuple-splat operands, CapabilityError otherwise.
+    BUILTIN_CONDITIONAL = Set([
+        "getfield", "getglobal", "isdefined", "isdefinedglobal",
+        "_apply_iterate",
+    ])
+    # Builtins that always throw CapabilityError under the mode.
+    BUILTIN_TRAPPED = Set([
+        "_abstracttype", "_call_in_world_total", "_equiv_typedef", "_expr",
+        "_import", "_new_cancel_source", "_primitivetype", "_setsuper!",
+        "_structtype", "_task", "_typebody!", "_using", "cancellation_point!",
+        "current_scope", "declare_const", "declare_global", "define_method",
+        "finalizer", "invoke", "invoke_in_world", "invokelatest", "memorynew",
+        "memoryref_isassigned", "memoryrefget", "memoryrefmodify!",
+        "memoryrefreplace!", "memoryrefset!", "memoryrefsetonce!",
+        "memoryrefunset!", "memoryrefswap!", "modifyfield!", "modifyglobal!",
+        "opaque_closure_call", "replacefield!", "replaceglobal!", "setfield!",
+        "setfieldonce!", "setglobal!", "setglobalonce!", "swapfield!",
+        "swapglobal!", "task_result_type",
+    ])
+    classified = union(BUILTIN_ALLOWED, BUILTIN_CONDITIONAL, BUILTIN_TRAPPED)
+    @test isempty(intersect(BUILTIN_ALLOWED, BUILTIN_TRAPPED))
+    @test isempty(intersect(BUILTIN_CONDITIONAL, BUILTIN_TRAPPED))
+    # every builtin reachable as a Core binding is classified; classification
+    # is by function identity (via the canonical creation name), so alias
+    # bindings such as `Core.getproperty === Core.getfield` and
+    # `Core._call_latest === Core.invokelatest` inherit their target's semantics
+    for n in names(Core; all=true)
+        isdefined(Core, n) || continue
+        f = getglobal(Core, n)
+        f isa Core.Builtin || continue
+        @test string(nameof(f)) in classified
+    end
+    # and the classification exactly matches the full builtin table when the
+    # runtime sources are available (covers builtins not bound in Core, such
+    # as opaque_closure_call)
+    proto = joinpath(@__DIR__, "..", "src", "builtin_proto.h")
+    if isfile(proto)
+        tbl = Set(m.captures[1] for m in eachmatch(r"XX\(\w+,\s*\"([^\"]+)\"\)", read(proto, String)))
+        @test tbl == classified
+    end
+
+    # Intrinsics that always throw CapabilityError under the mode: pointer
+    # and atomic memory access, machine queries, library symbol lookup, and
+    # native-code execution.
+    INTRINSIC_TRAPPED = Set([
+        :pointerref, :pointerset, :atomic_fence, :atomic_pointerref,
+        :atomic_pointerset, :atomic_pointerswap, :atomic_pointermodify,
+        :atomic_pointerreplace, :cglobal, :have_fma, :llvmcall,
+    ])
+    # All other intrinsics are value-deterministic and allowed. (The
+    # fast-math aliases and `muladd_float` share the strict runtime
+    # implementations, so they are deterministic under interpretation; if the
+    # mode ever compiles natively they must be pinned to those semantics.
+    # The hidden `cglobal_auto` shares `cglobal`'s trap.)
+    INTRINSIC_ALLOWED = Set([
+        :abs_float, :add_float, :add_float_fast, :add_int, :add_ptr, :and_int,
+        :ashr_int, :bitcast, :bswap_int, :ceil_llvm, :checked_sadd_int,
+        :checked_sdiv_int, :checked_smul_int, :checked_srem_int,
+        :checked_ssub_int, :checked_uadd_int, :checked_udiv_int,
+        :checked_umul_int, :checked_urem_int, :checked_usub_int,
+        :copysign_float, :ctlz_int, :ctpop_int, :cttz_int, :div_float,
+        :div_float_fast, :eq_float, :eq_float_fast, :eq_int, :flipsign_int,
+        :floor_llvm, :fma_float, :fpext, :fpiseq, :fptosi, :fptoui, :fptrunc,
+        :le_float, :le_float_fast, :lshr_int, :lt_float, :lt_float_fast,
+        :max_float, :max_float_fast, :min_float, :min_float_fast, :mul_float,
+        :mul_float_fast, :mul_int, :muladd_float, :ne_float, :ne_float_fast,
+        :ne_int, :neg_float, :neg_float_fast, :neg_int, :not_int, :or_int,
+        :rint_llvm, :sdiv_int, :sext_int, :shl_int, :sitofp, :sle_int,
+        :slt_int, :sqrt_llvm, :sqrt_llvm_fast, :srem_int, :sub_float,
+        :sub_float_fast, :sub_int, :sub_ptr, :trunc_int, :trunc_llvm,
+        :udiv_int, :uitofp, :ule_int, :ult_int, :urem_int, :xor_int,
+        :zext_int,
+    ])
+    @test isempty(intersect(INTRINSIC_ALLOWED, INTRINSIC_TRAPPED))
+    intr_classified = union(INTRINSIC_ALLOWED, INTRINSIC_TRAPPED)
+    for n in names(Core.Intrinsics; all=true)
+        isdefined(Core.Intrinsics, n) || continue
+        getglobal(Core.Intrinsics, n) isa Core.IntrinsicFunction || continue
+        @test n in intr_classified
+    end
+
+    # spot-check that the trapped intrinsics actually trap (before touching
+    # their operands)
+    p = Ptr{Int}(0)
+    @test_throws CapabilityError pcall(Core.Intrinsics.pointerref, p, 1, 1)
+    @test_throws CapabilityError pcall(Core.Intrinsics.pointerset, p, 1, 1, 1)
+    @test_throws CapabilityError pcall(Core.Intrinsics.atomic_pointerref, p, :monotonic)
+    @test_throws CapabilityError pcall(Core.Intrinsics.atomic_fence, :seq_cst, :system)
+    @test_throws CapabilityError pcall(Core.Intrinsics.have_fma, Float64)
+    @test_throws CapabilityError pcall(Core.Intrinsics.cglobal, :jl_n_threads, Int)
+    @test_throws CapabilityError pcall(Core.Intrinsics.llvmcall)
+end
+
+# quoted `Expr` literals materialize fresh mutable ASTs (copyast) and trap;
+# quoted immutables (QuoteNode of a Symbol) are plain values and are fine
+rc_quoted_expr() = :(1 + 2)
+rc_quoted_sym() = :a_symbol
+@testset "quoted AST literals" begin
+    @test_throws CapabilityError pcall(rc_quoted_expr)
+    @test pcall(rc_quoted_sym) === :a_symbol
+end

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -797,6 +797,37 @@ end
     @test Base.invoke_in_world(sib, f_before_advance) == 1
     @test Base.invoke_in_world(sib, +, 1, 2) == 3
 end
+@testset "three-point total order (asymmetric joins)" begin
+    ordered(x, y, obs) = ccall(:jl_world_ordered_before, Cint, (Csize_t, Csize_t, Csize_t), x, y, obs) != 0
+    w_pre = Base.get_world_counter()
+    t1 = advance_into_segment(UInt[]) # close w_pre's run; the trunk continues
+    a = new_segment([w_pre]) + UInt(1)          # side branch A forked at w_pre
+    b = new_segment([w_pre]) + UInt(1)          # side branch B forked at w_pre
+    t2 = advance_into_segment([a - UInt(1)])    # spine merges A
+    t3 = advance_into_segment([b - UInt(1)])    # spine merges B
+    obs = Base.get_world_counter()
+    @test !reaches(a, b) && !reaches(b, a)
+    # comparable pairs order by visibility
+    @test ordered(w_pre, a, obs) && !ordered(a, w_pre, obs)
+    @test ordered(a, t2, obs) && ordered(b, t3, obs)
+    # incomparable pairs order by their merge points on the observer's trunk:
+    # trunk events before a join precede the side branch's events, which
+    # precede trunk events after it
+    @test ordered(t1, a, obs) && !ordered(a, t1, obs)
+    @test ordered(a, b, obs) && !ordered(b, a, obs) # A merged before B
+    @test ordered(a, t3, obs) && !ordered(t3, a, obs)
+    # a side branch with internal structure merged wholesale: worlds that
+    # join at the same merge point order by the branch's own total order
+    x1 = new_segment([w_pre]) + UInt(1)
+    x2 = new_segment([w_pre]) + UInt(1)
+    z = new_segment([x1, x2]) # z's trunk is x1's branch; x2 is its side branch
+    advance_into_segment([z])
+    obs2 = Base.get_world_counter()
+    @test !reaches(x1, x2) && !reaches(x2, x1)
+    @test ordered(x1, x2, obs2) && !ordered(x2, x1, obs2)
+    @test ordered(x2, z, obs2) && !ordered(z, x1, obs2)
+end
+
 @testset "inference and compilation at branch worlds" begin
     sib2 = new_segment([w_preadvance]) + UInt(1)
     # a function that has never been called or inferred, invoked at a branch

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -840,9 +840,13 @@ precompile_test_harness("WorldToken precompilation") do load_path
           """
           module WTokenPkg
           wfn() = 1
+          sfn(::Any) = 1
+          cfn(x) = sfn(x)
           const tok = Base.world_token()
           gfn() = 1
+          sfn(::Int) = 2
           const tok2 = Base.world_token()
+          precompile(cfn, (Int,))
           end
           """)
     @test !isa(Base.compilecache(Base.PkgId("WTokenPkg")), Base.PrecompilableError)
@@ -859,6 +863,13 @@ precompile_test_harness("WorldToken precompilation") do load_path
         @test_throws MethodError Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.gfn)
         @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.wfn) == 1
         @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.gfn) == 1
+        # a CodeInstance compiled against a method added after the capture
+        # keeps its true creation world through edge validation: it is not
+        # valid at tok, and off-spine inference resolves the older method
+        # state there instead
+        @test invokelatest(WTokenPkg.cfn, 1) == 2
+        @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.cfn, 1) == 2
+        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.cfn, 1) == 1
         # redefinitions after loading are invisible at the tokens: they are
         # not in the invalidating event's future cone
         @eval WTokenPkg wfn() = 42
@@ -891,6 +902,38 @@ precompile_test_harness("WorldToken precompilation") do load_path
         # the dependency's own token still works and does not see WTokenNested
         @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
         @test_throws MethodError Base.invoke_in_world(WTokenPkg.tok2, WTokenNested.nfn)
+    end
+    # binding history: partition chains and usings entries keep their
+    # (translated) verbatim worlds, so tokens see the binding state as of
+    # their capture
+    write(joinpath(load_path, "WTokenBind.jl"),
+          """
+          module WTokenBind
+          module Sub
+          export subname
+          const subname = 7
+          end
+          const cv = 1
+          const cw = 10
+          const tokb = Base.world_token()
+          const cv = 2
+          using .Sub
+          end
+          """)
+    @test !isa(Base.compilecache(Base.PkgId("WTokenBind")), Base.PrecompilableError)
+    @eval using WTokenBind
+    invokelatest() do
+        # a const replaced after the capture: the token sees the original value
+        @test invokelatest(getglobal, WTokenBind, :cv) == 2
+        @test Base.invoke_in_world(WTokenBind.tokb, getglobal, WTokenBind, :cv) == 1
+        # a `using` after the capture: the implicitly-resolved name is not
+        # visible at the token
+        @test invokelatest(getglobal, WTokenBind, :subname) == 7
+        @test_throws UndefVarError Base.invoke_in_world(WTokenBind.tokb, getglobal, WTokenBind, :subname)
+        # a const replaced after loading is likewise invisible at the token
+        @eval WTokenBind const cw = 20
+        @test invokelatest(getglobal, WTokenBind, :cw) == 20
+        @test Base.invoke_in_world(WTokenBind.tokb, getglobal, WTokenBind, :cw) == 10
     end
 end
 

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -858,17 +858,18 @@ end
     # a function that has never been called or inferred, invoked at a branch
     # world: dispatch, inference, compilation and caching must work off-spine
     @test Base.invoke_in_world(sib2, fresh_branch_fn, 21) == 42
-    # the published CodeInstance has point validity at exactly sib2
+    # the published CodeInstance covers sib2 (its interval endpoints need not
+    # both lie on the spine's trunk)
     mi = only(Base.specializations(only(methods(fresh_branch_fn))))
-    found_point_ci = false
+    found_ci = false
     ci = isdefined(mi, :cache) ? mi.cache : nothing
     while ci !== nothing
-        if ci.min_world == sib2 && ci.max_world == sib2
-            found_point_ci = true
+        if in_range(sib2, ci.min_world, ci.max_world)
+            found_ci = true
         end
         ci = isdefined(ci, :next) ? ci.next : nothing
     end
-    @test found_point_ci
+    @test found_ci
     # the spine is unaffected and can still run and infer the same function
     @test fresh_branch_fn(21) == 42
     @test Base.infer_return_type(fresh_branch_fn, (Int,); world=sib2) == Int
@@ -955,6 +956,20 @@ precompile_test_harness("WorldToken precompilation") do load_path
         # not part of the token's history: nfn resolves the dependency's
         # original definition (via off-spine inference at the token's world)
         @test Base.invoke_in_world(WTokenNested.ntok, WTokenNested.nfn) == 101
+        # that inference publishes a mixed-endpoint interval: created within
+        # the grafted history and capped by the session's spine redefinition,
+        # so it covers the token but not the latest world
+        nmi = only(Base.specializations(only(methods(WTokenNested.nfn))))
+        found_mixed = false
+        nci = isdefined(nmi, :cache) ? nmi.cache : nothing
+        while nci !== nothing
+            if in_range(WTokenNested.ntok.world, nci.min_world, nci.max_world) &&
+               !in_range(Base.get_world_counter(), nci.min_world, nci.max_world)
+                found_mixed = true
+            end
+            nci = isdefined(nci, :next) ? nci.next : nothing
+        end
+        @test found_mixed
         # the dependency's own token still works and does not see WTokenNested
         @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
         @test_throws MethodError Base.invoke_in_world(WTokenPkg.tok2, WTokenNested.nfn)

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -842,25 +842,55 @@ precompile_test_harness("WorldToken precompilation") do load_path
           wfn() = 1
           const tok = Base.world_token()
           gfn() = 1
+          const tok2 = Base.world_token()
           end
           """)
     @test !isa(Base.compilecache(Base.PkgId("WTokenPkg")), Base.PrecompilableError)
     @eval using WTokenPkg
     invokelatest() do
         @test WTokenPkg.tok isa Core.WorldToken
-        # the token was rebased onto a grafted segment of the world DAG, not
-        # left at the saving process's meaningless numbering
+        # the tokens were rebased onto grafted copies of the saving process's
+        # spine runs, not left at its meaningless numbering
         @test wseg(WTokenPkg.tok.world) != wseg(unsafe_load(cglobal(:jl_require_world, UInt)))
         @test wseg(WTokenPkg.tok.world) != wseg(Base.get_world_counter())
-        # image content is visible at the token (granularity within the
-        # capturing image itself is currently the whole image)
+        # full fidelity within the image: tok predates gfn's definition,
+        # tok2 postdates it
         @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
-        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.gfn) == 1
-        # redefinitions after loading are invisible at the token: it is not in
-        # the invalidating event's future cone
+        @test_throws MethodError Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.gfn)
+        @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.wfn) == 1
+        @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.gfn) == 1
+        # redefinitions after loading are invisible at the tokens: they are
+        # not in the invalidating event's future cone
         @eval WTokenPkg wfn() = 42
         @test invokelatest(WTokenPkg.wfn) == 42
         @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
+        @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.wfn) == 1
+    end
+    # nested capture: a package that depends on the token-capturing package
+    # and captures its own token re-serializes both world histories; its
+    # token resolves the dependency's runs by their stable image identity
+    write(joinpath(load_path, "WTokenNested.jl"),
+          """
+          module WTokenNested
+          using WTokenPkg
+          nfn() = WTokenPkg.wfn() + 100
+          const ntok = Base.world_token()
+          end
+          """)
+    @test !isa(Base.compilecache(Base.PkgId("WTokenNested")), Base.PrecompilableError)
+    @eval using WTokenNested
+    invokelatest() do
+        @test WTokenNested.ntok isa Core.WorldToken
+        # at the latest world, nfn sees this session's wfn redefinition (the
+        # image CodeInstance fails edge validation and is re-inferred)
+        @test invokelatest(WTokenNested.nfn) == 142
+        # at the nested token, the loading session's redefinition of wfn is
+        # not part of the token's history: nfn resolves the dependency's
+        # original definition (via off-spine inference at the token's world)
+        @test Base.invoke_in_world(WTokenNested.ntok, WTokenNested.nfn) == 101
+        # the dependency's own token still works and does not see WTokenNested
+        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
+        @test_throws MethodError Base.invoke_in_world(WTokenPkg.tok2, WTokenNested.nfn)
     end
 end
 

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -686,7 +686,7 @@ end
 module WorldAgeSegments
 using Test
 
-const WORLD_IDX_BITS = Sys.WORD_SIZE == 64 ? 48 : 24
+const WORLD_IDX_BITS = Sys.WORD_SIZE == 64 ? 48 : 16
 wseg(w::UInt) = w >> WORLD_IDX_BITS
 widx(w::UInt) = w & ((UInt(1) << WORLD_IDX_BITS) - UInt(1))
 seg_reaches(sa::UInt, sb::UInt) = ccall(:jl_world_seg_reaches, Cint, (Csize_t, Csize_t), sa, sb) != 0
@@ -797,6 +797,31 @@ end
     @test Base.invoke_in_world(sib, f_before_advance) == 1
     @test Base.invoke_in_world(sib, +, 1, 2) == 3
 end
+@testset "run rollover on index exhaustion" begin
+    # Force the counter near the end of its run's index space in a throwaway
+    # subprocess and check that definitions roll the trunk over into a fresh
+    # run segment (the natural path on 32-bit platforms, where indices are
+    # only 16 bits).
+    code = """
+        const IDXBITS = $(WORLD_IDX_BITS)
+        IDXMASK = (UInt(1) << IDXBITS) - UInt(1)
+        w0 = Base.get_world_counter()
+        unsafe_store!(cglobal(:jl_world_counter, UInt), (w0 & ~IDXMASK) | (IDXMASK - UInt(8)))
+        seg0 = Base.get_world_counter() >> IDXBITS
+        for i in 1:8
+            Core.eval(Main, :(\$(Symbol(:rollfn, i))() = \$i))
+        end
+        seg1 = Base.get_world_counter() >> IDXBITS
+        @assert seg1 > seg0
+        for i in 1:8
+            @assert Base.invokelatest(getglobal(Main, Symbol(:rollfn, i))) == i
+        end
+        println("ROLLOVER OK")
+        """
+    out = read(`$(Base.julia_cmd()) --startup-file=no -e $code`, String)
+    @test occursin("ROLLOVER OK", out)
+end
+
 @testset "three-point total order (asymmetric joins)" begin
     ordered(x, y, obs) = ccall(:jl_world_ordered_before, Cint, (Csize_t, Csize_t, Csize_t), x, y, obs) != 0
     w_pre = Base.get_world_counter()

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -822,4 +822,46 @@ end
     @test Base.invoke_in_world(sib2, g_frozen) == 1
 end
 
+# WorldToken: opaque world capture, usable in place of a raw world age
+wt_f() = 1
+const wt_tok1 = Base.world_token()
+wt_f() = 2
+@testset "WorldToken (in-process)" begin
+    @test wt_tok1 isa Core.WorldToken
+    @test wt_f() == 2
+    @test Base.invoke_in_world(wt_tok1, wt_f) == 1
+    @test Base.invoke_in_world(wt_tok1.world, wt_f) == 1
+    @test Base.invoke_in_world(wt_tok1, sort, [3, 1, 2]; rev=true) == [3, 2, 1] # kwargs path accepts tokens
+end
+
+include("precompile_utils.jl")
+precompile_test_harness("WorldToken precompilation") do load_path
+    write(joinpath(load_path, "WTokenPkg.jl"),
+          """
+          module WTokenPkg
+          wfn() = 1
+          const tok = Base.world_token()
+          gfn() = 1
+          end
+          """)
+    @test !isa(Base.compilecache(Base.PkgId("WTokenPkg")), Base.PrecompilableError)
+    @eval using WTokenPkg
+    invokelatest() do
+        @test WTokenPkg.tok isa Core.WorldToken
+        # the token was rebased onto a grafted segment of the world DAG, not
+        # left at the saving process's meaningless numbering
+        @test wseg(WTokenPkg.tok.world) != wseg(unsafe_load(cglobal(:jl_require_world, UInt)))
+        @test wseg(WTokenPkg.tok.world) != wseg(Base.get_world_counter())
+        # image content is visible at the token (granularity within the
+        # capturing image itself is currently the whole image)
+        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
+        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.gfn) == 1
+        # redefinitions after loading are invisible at the token: it is not in
+        # the invalidating event's future cone
+        @eval WTokenPkg wfn() = 42
+        @test invokelatest(WTokenPkg.wfn) == 42
+        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
+    end
+end
+
 end # module WorldAgeSegments

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -680,3 +680,119 @@ let ci = method_instance(iter61667, ()).cache
     Base.iterate(A::IterInval61667, y...) = iterate(A.v, y...)
     @test ci.max_world == typemax(UInt)
 end
+
+## world age segments: worlds form an append-only DAG of (segment, index)
+## pairs; see the comment next to jl_world_reaches in julia_internal.h
+module WorldAgeSegments
+using Test
+
+const WORLD_IDX_BITS = Sys.WORD_SIZE == 64 ? 48 : 24
+wseg(w::UInt) = w >> WORLD_IDX_BITS
+widx(w::UInt) = w & ((UInt(1) << WORLD_IDX_BITS) - UInt(1))
+seg_reaches(sa::UInt, sb::UInt) = ccall(:jl_world_seg_reaches, Cint, (Csize_t, Csize_t), sa, sb) != 0
+# mirror of the C-side jl_world_reaches/jl_world_in_range inlines
+reaches(a::UInt, b::UInt) = wseg(a) == wseg(b) ? a <= b : seg_reaches(wseg(a), wseg(b))
+in_range(w::UInt, minw::UInt, maxw::UInt) =
+    reaches(minw, w) && (maxw == typemax(UInt) || !reaches(maxw + UInt(1), w))
+new_segment(parents::Vector{UInt}) =
+    ccall(:jl_world_new_segment, Csize_t, (Ptr{Csize_t}, Csize_t), parents, length(parents)) % UInt
+advance_into_segment(extra::Vector{UInt}) =
+    ccall(:jl_world_advance_into_segment, Csize_t, (Ptr{Csize_t}, Csize_t), extra, length(extra)) % UInt
+mt_entry(@nospecialize(ft), w::UInt) = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, Csize_t), ft, nothing, w)
+
+@testset "world segment reachability algebra" begin
+    w0 = Base.get_world_counter()
+    @test widx(w0) > UInt(16) # plenty of room below the current index
+    a = new_segment([w0]) # branch A off the current spine segment
+    b = new_segment([w0]) # branch B, sibling of A
+    m = new_segment([a + UInt(9), b + UInt(9)]) # merge of A and B
+    @test reaches(w0, a) && reaches(w0, b) && reaches(w0, m)
+    @test !reaches(a, b) && !reaches(b, a) # siblings are unordered
+    @test reaches(a, m) && reaches(b, m) # a merge sees both parents
+    @test !reaches(m, a) && !reaches(m, b) && !reaches(m, w0)
+    @test !reaches(a, w0) && !reaches(b, w0) # nothing reaches back in time
+    # within-segment order is the index order
+    @test reaches(a + UInt(5), a + UInt(9)) && !reaches(a + UInt(9), a + UInt(5))
+    @test reaches(a + UInt(5), a + UInt(5)) && reaches(w0, w0) # reflexivity
+    @test reaches(a + UInt(5), m) # parent segments are ancestors at full extent
+    # transitivity through a deeper chain
+    c = new_segment([m])
+    @test reaches(w0, c) && reaches(a, c) && reaches(b, c) && reaches(m, c)
+    @test !reaches(c, m)
+    # ~0 acts as the end of time: everything reaches it, it reaches nothing
+    @test reaches(w0, typemax(UInt)) && reaches(m, typemax(UInt))
+    @test !reaches(typemax(UInt), m)
+end
+
+@testset "validity bounds across branches" begin
+    w0 = Base.get_world_counter()
+    x = new_segment([w0])
+    y = new_segment([w0])
+    # an entry created on X and never invalidated is visible on X and its
+    # descendants, but not on the sibling branch Y
+    @test in_range(x + UInt(2), x + UInt(1), typemax(UInt))
+    @test !in_range(y + UInt(2), x + UInt(1), typemax(UInt))
+    xy = new_segment([x + UInt(3), y + UInt(3)])
+    @test in_range(xy, x + UInt(1), typemax(UInt))
+    # an entry created before the fork and invalidated on X (max_world capped
+    # inclusively at x+4, i.e. the invalidating event is at x+5) is dead in
+    # that event's future cone, but still live on the sibling branch
+    minw = w0 - UInt(5)
+    capw = x + UInt(4)
+    @test in_range(x + UInt(2), minw, capw)
+    @test !in_range(x + UInt(6), minw, capw)
+    @test in_range(y + UInt(6), minw, capw) # sibling never sees the invalidation
+    @test !in_range(xy, minw, capw) # but the merge of both branches does
+    # hard-killed bounds (max_world = 0) match nowhere
+    @test !in_range(x + UInt(2), minw, UInt(0))
+    # inverted "unactivated" bounds (min=~0, max=1) match nowhere
+    @test !in_range(x + UInt(2), typemax(UInt), UInt(1))
+end
+
+# Advancing the spine into a fresh segment must be transparent to execution:
+# everything below exercises the cross-segment paths of the world predicates
+# through real dispatch.
+f_before_advance() = 1
+@test f_before_advance() == 1
+const w_preadvance = Base.get_world_counter()
+const w_postadvance = advance_into_segment(UInt[])
+@testset "spine advance is transparent" begin
+    # the `const` declaration of w_postadvance itself bumped the counter, so
+    # compare segments rather than exact worlds
+    @test wseg(Base.get_world_counter()) == wseg(w_postadvance)
+    @test reaches(w_postadvance, Base.get_world_counter())
+    @test wseg(w_postadvance) != wseg(w_preadvance)
+    @test widx(w_postadvance) == UInt(0)
+    @test reaches(w_preadvance, w_postadvance)
+    @test f_before_advance() == 1 # pre-advance code still dispatches
+    @test Base.invoke_in_world(w_preadvance, f_before_advance) == 1
+    @test invokelatest(f_before_advance) == 1
+end
+f_after_advance() = 2
+g_redefined() = 1
+@test f_after_advance() == 2
+@test g_redefined() == 1
+const w_mid = Base.get_world_counter()
+g_redefined() = 2
+@testset "definitions and invalidations after the advance" begin
+    @test g_redefined() == 2
+    @test Base.invoke_in_world(w_mid, g_redefined) == 1
+    @test mt_entry(Tuple{typeof(f_after_advance)}, Base.get_world_counter()) !== nothing
+end
+@testset "sibling branches of the spine" begin
+    # fork a branch at the (now closed) pre-advance spine world: spine
+    # definitions made after the advance must be invisible there, while
+    # everything from before the fork remains visible
+    sib = new_segment([w_preadvance]) + UInt(1)
+    @test reaches(w_preadvance, sib) && !reaches(w_postadvance, sib) && !reaches(sib, w_postadvance)
+    @test mt_entry(Tuple{typeof(f_before_advance)}, sib) !== nothing
+    @test mt_entry(Tuple{typeof(f_after_advance)}, sib) === nothing
+    # (n.b. lookup at typemax(UInt) is refused by ml_matches as an
+    # unenumerable future world, as it was with linear world ages)
+    @test mt_entry(Tuple{typeof(f_after_advance)}, Base.get_world_counter()) !== nothing
+    # dispatch of already-compiled code at a branch world
+    @test Base.invoke_in_world(sib, f_before_advance) == 1
+    @test Base.invoke_in_world(sib, +, 1, 2) == 3
+end
+
+end # module WorldAgeSegments

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -753,6 +753,8 @@ end
 # everything below exercises the cross-segment paths of the world predicates
 # through real dispatch.
 f_before_advance() = 1
+fresh_branch_fn(x) = 2x # deliberately not called (or inferred) until the branch tests
+g_frozen() = 1
 @test f_before_advance() == 1
 const w_preadvance = Base.get_world_counter()
 const w_postadvance = advance_into_segment(UInt[])
@@ -770,6 +772,7 @@ const w_postadvance = advance_into_segment(UInt[])
 end
 f_after_advance() = 2
 g_redefined() = 1
+g_frozen() = 2 # redefinition on the spine, invisible to branches forked before it
 @test f_after_advance() == 2
 @test g_redefined() == 1
 const w_mid = Base.get_world_counter()
@@ -793,6 +796,30 @@ end
     # dispatch of already-compiled code at a branch world
     @test Base.invoke_in_world(sib, f_before_advance) == 1
     @test Base.invoke_in_world(sib, +, 1, 2) == 3
+end
+@testset "inference and compilation at branch worlds" begin
+    sib2 = new_segment([w_preadvance]) + UInt(1)
+    # a function that has never been called or inferred, invoked at a branch
+    # world: dispatch, inference, compilation and caching must work off-spine
+    @test Base.invoke_in_world(sib2, fresh_branch_fn, 21) == 42
+    # the published CodeInstance has point validity at exactly sib2
+    mi = only(Base.specializations(only(methods(fresh_branch_fn))))
+    found_point_ci = false
+    ci = isdefined(mi, :cache) ? mi.cache : nothing
+    while ci !== nothing
+        if ci.min_world == sib2 && ci.max_world == sib2
+            found_point_ci = true
+        end
+        ci = isdefined(ci, :next) ? ci.next : nothing
+    end
+    @test found_point_ci
+    # the spine is unaffected and can still run and infer the same function
+    @test fresh_branch_fn(21) == 42
+    @test Base.infer_return_type(fresh_branch_fn, (Int,); world=sib2) == Int
+    # a method redefined on the spine after the fork keeps its old meaning on
+    # the branch: the invalidation's future cone does not contain sib2
+    @test g_frozen() == 2
+    @test Base.invoke_in_world(sib2, g_frozen) == 1
 end
 
 end # module WorldAgeSegments


### PR DESCRIPTION
🤖 Allow struct field types to be computed expressions of the type parameter values, e.g.:

```
    struct StaticMatrix{R,C,T}
        data::NTuple{(R::Int)*(C::Int), T}
    end

    fieldtype(StaticMatrix{2,3,Float64}, 1) === NTuple{6,Float64}
    isbitstype(StaticMatrix{2,3,Float64}) === true
```

This is a rework of the approach prototyped in #62707. Instead of introducing structural `TypeArith` nodes with a fixed set of operations that subtyping must understand, lowering associates with the type a *field generator*: a function mapping the type parameter values to the tuple of field types. Field-type expressions containing a call or typeassert that references a type parameter are kept as quoted source ASTs in the declared field slots (`Core.ComputedFieldType` markers), and the generator is invoked by the runtime whenever a fully concrete instantiation is created. Method signatures are deliberately out of scope, so subtyping and intersection never see an unevaluated expression.

A generator is valid if inference proves it `is_foldable` (`:consistent`, `:effect_free`, `:noub`, `:terminates`) plus `:nortcall`; this is checked at struct definition time. `:nothrow` is not required: a generator that throws for particular parameter values (e.g. `NTuple{N-1}` at `N == 0`) degrades those instantiations' field types to `Union{}`, keeping type-system internals throw-free. For the prototype, parameter types are annotated inline in the field expression (the `::Int` above) so the effects proof goes through for the generic signature; `Base.@assume_effects` on helper functions called in the expression can vouch for effects the compiler cannot prove.

Since `:consistent`-cy is world-bounded, proven effects alone do not pin the meaning of the field types across worlds — and the definition world no longer exists after a precompiled image is reloaded. The inferred CodeInstance is therefore duplicated into a *detached* CodeInstance with world validity `(1, typemax(UInt))` whose code is closed under the definition world: every remaining call is a builtin, every `:invoke` targets another detached CodeInstance (recursively), and every global reference is replaced by its definition-world constant value. Detached instances (owner `:computed_fieldtypes`) are never registered in a method cache, so redefinition and invalidation cannot reach them, and package images serialize them as-is with no revalidation: instantiations in any later session compute field types with the definition-time semantics, even if functions used by the field expressions have since been redefined. Constant-return instances are detached as code-less constant-ABI instances.

Non-concrete instantiations widen computed field slots to a fresh unbounded `TypeVar` (analogous to `fieldtype(Ref, 1) === T`), which existing reflection and inference paths already treat conservatively; concrete instantiations remain precise, so `getfield` inference, `isbitstype` and layout all work as if the field types had been written explicitly.

Known limitations, to be lifted later: detached code currently executes through the interpreter (no native compilation); recursive field generators are rejected; the inline-alloc cycle breaker cannot see through computed field markers, so inline-allocatable self-referential computed field types are not supported; and outer default constructors are skipped for such structs (the inner constructor resolves field types at runtime).

This PR was written with the assistance of generative AI (Claude).