### PR TITLE
docs: fix 16 dangling @ref targets

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1629,7 +1629,7 @@ get_world_counter() = ccall(:jl_get_world_counter, UInt, ())
 """
     tls_world_age()
 
-Return the world the [current_task()](@ref) is executing within.
+Return the world the [`current_task`](@ref) is executing within.
 """
 tls_world_age() = ccall(:jl_get_tls_world_age, UInt, ())
 

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1746,7 +1746,7 @@ end
 
 Variant of [`sort!`](@ref) that returns a sorted copy of `v` leaving `v` itself unmodified.
 
-When calling `sort` on the [`keys`](@ref) or [`values](@ref) of a dictionary, `v` is
+When calling `sort` on the [`keys`](@ref) or [`values`](@ref) of a dictionary, `v` is
 collected and then sorted.
 
 !!! compat "Julia 1.12"

--- a/doc/src/devdocs/gc-debug.md
+++ b/doc/src/devdocs/gc-debug.md
@@ -15,7 +15,7 @@ WITH_GC_DEBUG_ENV=1
 
 This sets the C preprocessor define `GC_DEBUG_ENV`, which enables several
 debugging features described below. It also automatically enables `GC_VERIFY`
-(see [GC Verification](@ref)).
+(see [GC Verification](@ref GC_VERIFY)).
 
 To rebuild Julia after changing `Make.user`:
 
@@ -107,7 +107,7 @@ a fixed interval:
 JULIA_GC_ALLOC_POOL=r1:1 JULIA_GC_ALLOC_OTHER=r1:1 ./julia myscript.jl
 ```
 
-## GC Verification (`GC_VERIFY`) {#GCVerify}
+## [GC Verification (`GC_VERIFY`)](@id GC_VERIFY)
 
 `WITH_GC_DEBUG_ENV=1` automatically enables `GC_VERIFY`. After every minor
 (quick) GC, a full second GC pass is run that:

--- a/doc/src/devdocs/sysimg.md
+++ b/doc/src/devdocs/sysimg.md
@@ -175,7 +175,7 @@ debug info, respectively, and so will make debugging more difficult.
 - Use tools like [JET.jl](https://github.com/aviatesk/JET.jl),
   [Cthulhu.jl](https://github.com/JuliaDebug/Cthulhu.jl), and/or
   [SnoopCompile](https://github.com/timholy/SnoopCompile.jl)
-  to identify failures of type-inference, and follow our [Performance Tips](@ref) to fix them.
+  to identify failures of type-inference, and follow our [Performance Tips](@ref man-performance-tips) to fix them.
 
 ### Compatibility concerns
 

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -64,7 +64,7 @@ and [Ruby](https://en.wikipedia.org/wiki/Ruby_(programming_language)).
 
 The most significant departures of Julia from typical dynamic languages are:
 
-  * The core language imposes very little; [Julia Base and the standard library](@ref man-core-base-and-stdlib) are written in Julia itself, including
+  * The core language imposes very little; [Julia Base and the standard library](@ref standard-modules) are written in Julia itself, including
     primitive operations like integer arithmetic
   * A rich language of types for constructing and describing objects, that can also optionally be
     used to make type declarations

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -1121,7 +1121,7 @@ loops cannot be merged because of the intervening `sort` function.
 
 Finally, the maximum efficiency is typically achieved when the output array of a vectorized operation
 is *pre-allocated*, so that repeated calls do not allocate new arrays over and over again for
-the results (see [Pre-allocating outputs](@ref)). A convenient syntax for this is `X .= ...`, which
+the results (see [Pre-allocate outputs](@ref)). A convenient syntax for this is `X .= ...`, which
 is equivalent to `broadcast!(identity, X, ...)` except that, as above, the `broadcast!` loop is
 fused with any nested "dot" calls. For example, `X .= sin.(Y)` is equivalent to `broadcast!(sin, X, Y)`,
 overwriting `X` with `sin.(Y)` in-place. If the left-hand side is an array-indexing expression,

--- a/doc/src/manual/memory-management.md
+++ b/doc/src/manual/memory-management.md
@@ -142,7 +142,7 @@ The best way to minimize GC impact is to reduce unnecessary allocations:
 
 ### Profiling Memory Usage
 
-For detailed guidance on profiling memory allocations and identifying performance bottlenecks, see the [Profiling](@ref man-profiling) section.
+For detailed guidance on profiling memory allocations and identifying performance bottlenecks, see the [Profiling](@ref lib-profiling) section.
 
 ## [Advanced Configuration](@id man-gc-advanced)
 

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -391,7 +391,7 @@ WARNING: import of M1.x into Main conflicts with an existing identifier; ignored
 ```
 
 The resolution of an implicit binding depends on the set of all `using`'d modules visible
-in the current world age. See [the manual chapter on world age](@ref man-worldage) for more
+in the current world age. See [the manual chapter on world age](@ref man-world-age) for more
 details.
 
 ### Default top-level definitions and bare modules

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -156,7 +156,7 @@ julia> time_sum(x)
 In some situations, your function may need to allocate memory as part of its operation, and this
 can complicate the simple picture above. In such cases, consider using one of the [tools](@ref tools)
 below to diagnose problems, or write a version of your function that separates allocation from
-its algorithmic aspects (see [Pre-allocating outputs](@ref)).
+its algorithmic aspects (see [Pre-allocate outputs](@ref)).
 
 !!! note
     For more serious benchmarking, consider the [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl)
@@ -1499,7 +1499,7 @@ may be the case during development of a package.
 Keeping the time taken to load the package down is usually helpful.
 General good practice for package developers includes:
 
-1. Reduce your dependencies to those you really need. Consider using [package extensions](@ref) to support interoperability with other packages without bloating your essential dependencies.
+1. Reduce your dependencies to those you really need. Consider using [package extensions](@ref man-extensions) to support interoperability with other packages without bloating your essential dependencies.
 3. Avoid use of [`__init__()`](@ref) functions unless there is no alternative, especially those which might trigger a lot
    of compilation, or just take a long time to execute.
 4. Where possible, fix [invalidations](https://julialang.org/blog/2020/08/invalidations/) among your dependencies and from your package code.

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/docs/src/index.md"
 ```
 
-# REPL
+# [REPL](@id The-Julia-REPL)
 
 Julia comes with a full-featured interactive command-line REPL (read-eval-print loop) built into
 the `julia` executable. In addition to allowing quick and easy evaluation of Julia statements,

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Random/docs/src/index.md"
 ```
 
-# Random
+# [Random](@id Random-Numbers)
 
 ```@meta
 DocTestSetup = :(using Random)


### PR DESCRIPTION
Found while investigating why Documenter's regression suite is red on the Julia manual job. `doc/make.jl` passes no `warnonly`, so these should have been fatal; some have been broken for a year.

#61370 renamed six stdlib page headers; three carried no `@id` and lost their anchor. Random and REPL get `@id Random-Numbers` / `@id The-Julia-REPL`, restoring the old anchors instead of rewriting call sites — which also fixes the refs in vendored `stdlib/SparseArrays-<sha>`. Nothing in-tree uses the old Libdl, Mmap, SharedArrays or Test titles, but external packages might.

The rest are stale ids and typos:

- `man-core-base-and-stdlib` → `standard-modules` (the section #55311 named was later removed)
- `man-worldage` → `man-world-age`; `man-profiling` → `lib-profiling`
- `[Performance Tips](@ref)` → `(@ref man-performance-tips)`; `[package extensions](@ref)` → `(@ref man-extensions)`
- `[Pre-allocating outputs]` → `[Pre-allocate outputs]`
- unbalanced backtick in a `values` ref; `[current_task()](@ref)` → backticked
- `{#GCVerify}` is not Documenter syntax and rendered literally; that section gets a real `@id`

Verified with a full `make -C doc html`: clean under Documenter 1.17.0.

Not included: `` [`JULIA_CPU_TARGET`](@ref) `` and `` [`JULIA_EDITOR`](@ref) ``. Those are correct here and fail only on Documenter master — JuliaDocs/Documenter.jl#2960.
