### PR TITLE
coverage: Fix compiler failures and nested output

### DIFF
--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -1161,10 +1161,10 @@ function changed_lineinfo(di::DebugInfo, codeloc::Int, prevloc::Int)
         edge === prev[2] || return true # change to this edge
         linetable = di.linetable
         # check for change to line number here
-        if linetable === nothing || line == 0
+        if !(linetable isa DebugInfo) || line == 0
             line == prevline || return true
         else
-            changed_lineinfo(linetable::DebugInfo, Int(line), Int(prevline)) && return true
+            changed_lineinfo(linetable, Int(line), Int(prevline)) && return true
         end
         # check for change to edge here
         edge == 0 && return false # no edge here

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -863,6 +863,23 @@ let cl = Int32[0,0,0,255,0,0,256,0,0,257,0,0]
     @test roundtrip_di(cl, 33, 4) == cl
 end
 
+# Test line comparisons with byte-precise debuginfo.
+let sbt = String(UInt8[
+        1, 0, 0, 0, # byte offset
+        1, 0, 0, 0, # line offset
+        2, 0, 0, 0, # number of locations
+        1, 1,       # byte and span encoding lengths
+        0, 1, 2, 1, # byte spans
+        0, 2,       # line starts
+    ])
+    codelocs = Int32[1, 0, 0, 2, 0, 0]
+    str = ccall(:jl_compress_codelocs,
+                Any, (Int32, Any, Int), Int32(-1), codelocs, 2)::String
+    di = Core.DebugInfo(:foo, sbt, Core.svec(), str)
+    @test !Compiler.changed_lineinfo(di, 1, 1)
+    @test Compiler.changed_lineinfo(di, 2, 1)
+end
+
 @test_throws ErrorException Base.code_ircode(+, (Float64, Float64); optimize_until = "nonexisting pass name")
 @test_throws ErrorException Base.code_ircode(+, (Float64, Float64); optimize_until = typemax(Int))
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -253,7 +253,7 @@ static Constant *julia_const_to_llvm(jl_codectx_t &ctx, const void *ptr, jl_data
             (void)jl_islayout_inline(ft, &fsz, &al); // compute al
             fsz = jl_field_size(bt, i); // get LLT_ALIGN(fsz+1,al)
             uint8_t sel = ((const uint8_t*)ptr)[offs + fsz - 1];
-            jl_value_t *active_ty = jl_nth_union_component(ft, sel);
+            jl_value_t *active_ty = normalize_typeofbottom_layout_alias(jl_nth_union_component(ft, sel));
             size_t active_sz = jl_datatype_size(active_ty);
             Type *AlignmentType = IntegerType::get(ctx.builder.getContext(), 8 * al);
             unsigned NumATy = (fsz - 1) / al;

--- a/test/core.jl
+++ b/test/core.jl
@@ -8959,6 +8959,14 @@ end
 
 @test sizeof(Pair{Union{typeof(Union{}),Nothing}, Union{Type{Union{}},Nothing}}(Union{}, Union{})) == 2
 
+# Codegen of a Type{Union{}} isbits-union component.
+typeofbottom_union_constant() =
+    Pair{Union{typeof(Union{}),Nothing}, Union{Type{Union{}},Nothing}}(Union{}, Union{})
+code_llvm(devnull, typeofbottom_union_constant, Tuple{})
+let p = typeofbottom_union_constant()
+    @test p.first === Union{} && p.second === Union{}
+end
+
 # Make sure that Core.Compiler has enough NamedTuple infrastructure
 # to properly give error messages for basic kwargs...
 Core.eval(Core.Compiler, quote issue50174(;a=1) = a end)

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1771,6 +1771,8 @@ end
     mkdepottempdir() do depot
         cov_test_dir = joinpath(@__DIR__, "project", "deps", "CovTest.jl")
         cov_cache_dir = joinpath(depot, "compiled", "v$(VERSION.major).$(VERSION.minor)", "CovTest")
+        # Do not let an outer tracefile redirect .cov output.
+        cov_exename = Base.julia_cmd()[1]
         function rm_cov_files()
             for cov_file in filter(endswith(".cov"), readdir(joinpath(cov_test_dir, "src"), join=true))
                 rm(cov_file)
@@ -1785,7 +1787,7 @@ end
         cd(cov_test_dir) do
             # In our depot, precompile CovTest.jl with coverage on
             @test success(addenv(
-                `$(Base.julia_cmd()) --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; exit(0)'`,
+                `$cov_exename --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; exit(0)'`,
                 "JULIA_DEPOT_PATH" => depot,
             ))
             @test !isempty(filter(!endswith(".ji"), readdir(cov_cache_dir))) # check that object cache file(s) exists
@@ -1794,7 +1796,7 @@ end
 
             # same again but call foo(), which is in the pkgimage, and should generate coverage
             @test success(addenv(
-                `$(Base.julia_cmd()) --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; foo(); exit(0)'`,
+                `$cov_exename --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; foo(); exit(0)'`,
                 "JULIA_DEPOT_PATH" => depot,
             ))
             @test cov_exists()
@@ -1802,7 +1804,7 @@ end
 
             # same again but call bar(), which is NOT in the pkgimage, and should generate coverage
             @test success(addenv(
-                `$(Base.julia_cmd()) --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; bar(); exit(0)'`,
+                `$cov_exename --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; bar(); exit(0)'`,
                 "JULIA_DEPOT_PATH" => depot,
             ))
             @test cov_exists()


### PR DESCRIPTION
Issues found during analysis of the coverage run; fixed by Claude/GPT:

- Byte-precise source locations use a compressed line table. Coverage instrumentation treated it as nested DebugInfo, causing inference failures in JuliaLowering. Compare the decoded line numbers directly instead.
- Constant emission queried the layout of Type{Union{}} without first resolving its existing layout alias, causing a codegen crash.
- Coverage tests in loading.jl inherited the parent process’s lcov option, redirecting output away from the expected .cov files. Start those subprocesses without inherited command-line options.

I'd be fine extracting these into separate PRs if wanted, but they're all pretty small fixes.