### PR TITLE
cancellation: Defer reset delivery until finalizer cleanup

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -114,12 +114,9 @@ function __init__()
             bits_per_limb() != BITS_PER_LIMB ? @error(msg) : @warn(msg)
         end
 
-        # The jl_gmp_counted_* hooks are the jl_gc_counted_* allocators with a
-        # cancellation-handler region published across them: GMP computations
-        # run under a reset region (see the `reset_safe` annotations in MPZ),
-        # and the hooks are exactly where an asynchronous unwind must not
-        # land - a cancellation delivered inside them is deferred and chained
-        # into the reset on exit instead.
+        # GMP calls may run under a reset region and re-enter the runtime
+        # through these allocation hooks. The hooks unpublish the region
+        # around the allocator.
         ccall((:__gmp_set_memory_functions, libgmp), Cvoid,
               (Ptr{Cvoid},Ptr{Cvoid},Ptr{Cvoid}),
               cglobal(:jl_gmp_counted_malloc),

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -166,10 +166,6 @@ void schedule_finalization(void *o, void *f) JL_NOTSAFEPOINT
     jl_atomic_store_relaxed(&jl_gc_have_pending_finalizers, 1);
 }
 
-// see their definitions in the reset-safe allocation section below
-STATIC_INLINE jl_reset_ctx_t *reset_region_unpublish(jl_task_t *ct) JL_NOTSAFEPOINT;
-STATIC_INLINE void reset_region_republish(jl_task_t *ct, jl_reset_ctx_t *reset_ctx);
-
 void run_finalizer(jl_task_t *ct, void *o, void *ff)
 {
     int ptr_finalizer = gc_ptr_tag(o, GC_FIN_CFUNC_TAG);
@@ -256,19 +252,16 @@ static void jl_gc_push_arraylist(jl_task_t *ct, arraylist_t *list) JL_NOTSAFEPOI
 
 // Same assumption as `jl_gc_push_arraylist`. Requires the finalizers lock
 // to be held for the current thread and will release the lock when the
-// function returns. The caller must republish the returned reset context
-// after restoring any state saved around the finalizer run.
-static jl_reset_ctx_t *jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NOTSAFEPOINT_LEAVE_WITH_CANSAFEPOINT
+// function returns.
+static void jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NOTSAFEPOINT_LEAVE_WITH_CANSAFEPOINT
 {
+    // Finalizer bookkeeping is not reset-safe. Allocation entry points that
+    // can preserve a reset region must unpublish it before reaching here.
+    assert(jl_atomic_load_relaxed(&ct->reset_ctx) == NULL);
     // Avoid marking `ct` as non-migratable via an `@async` task (as noted in the docstring
     // of `finalizer`) in a finalizer:
     uint8_t sticky = ct->sticky;
-    // Finalizers hijack the current task, so like `sticky` and the RNG its
-    // cancellation state is bracketed: unpublish the reset region (finalizer
-    // frames must not be abandoned into it) and stash the token binding,
-    // which the finalizers' own cancellation points may rebind. Both are
-    // restored below.
-    jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
+    // Finalizers hijack the current task, so preserve its token binding.
     jl_value_t *bound_token = jl_atomic_load_relaxed(&ct->bound_cancel_token);
     JL_GC_PUSH1(&bound_token);
     // empty out the first two entries for the GC frame
@@ -289,7 +282,6 @@ static jl_reset_ctx_t *jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *
     jl_atomic_store_relaxed(&ct->bound_cancel_token, bound_token);
     jl_gc_wb_current_task(ct, bound_token);
     JL_GC_POP(); // matches the JL_GC_PUSH1 above
-    return reset_ctx;
 }
 
 static uint64_t finalizer_rngState[JL_RNG_SIZE];
@@ -333,7 +325,7 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     // This releases the finalizers lock.
     int8_t was_in_finalizer = ct->ptls->in_finalizer;
     ct->ptls->in_finalizer = !finalizers_thread;
-    jl_reset_ctx_t *reset_ctx = jl_gc_run_finalizers_in_list(ct, &copied_list);
+    jl_gc_run_finalizers_in_list(ct, &copied_list);
     ct->ptls->in_finalizer = was_in_finalizer;
     arraylist_free(&copied_list);
 
@@ -342,7 +334,6 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     SetLastError(last_error);
 #endif
     errno = last_errno;
-    reset_region_republish(ct, reset_ctx);
 }
 
 JL_DLLEXPORT void jl_gc_run_pending_finalizers(jl_task_t *ct)
@@ -524,14 +515,12 @@ JL_DLLEXPORT void jl_finalize_th(jl_task_t *ct, jl_value_t *o)
     finalize_object(&finalizer_list_marked, o, &copied_list, 0);
     if (copied_list.len > 0) {
         // This releases the finalizers lock.
-        jl_reset_ctx_t *reset_ctx = jl_gc_run_finalizers_in_list(ct, &copied_list);
-        arraylist_free(&copied_list);
-        reset_region_republish(ct, reset_ctx);
+        jl_gc_run_finalizers_in_list(ct, &copied_list);
     }
     else {
         JL_UNLOCK_NOGC(&finalizers_lock);
-        arraylist_free(&copied_list);
     }
+    arraylist_free(&copied_list);
 }
 
 JL_DLLEXPORT void jl_finalize(jl_value_t *o)
@@ -666,60 +655,18 @@ JL_DLLEXPORT void *jl_malloc(size_t sz) JL_CANSAFEPOINT
 }
 
 // === GMP allocation hooks ===================================================
-// These are special reset-safe versions of GMP's allocations functions. GMP is
-// generally reset-safe, but our allocators are not, so we must protect ourselves
-// from a stray reset inside the allocator.
-
-static void jl_gmp_defer_note(void *state, uint8_t sev)
-{
-    (void)sev;
-    *(volatile sig_atomic_t*)state = 1;
-}
-
-// These guards NEST: an allocation hook may trigger a collection whose
-// finalizers run __gmpz_clear, re-entering the free hook inside the outer
-// guard. Enter therefore saves the previously published context and leave
-// restores it (never bare NULL - clearing would strip the outer hook's
-// protection for the remainder of its libc call, letting a reset longjmp
-// land mid-malloc with the arena lock held).
-STATIC_INLINE jl_cancel_handler_ctx_t *jl_gmp_guard_enter(jl_task_t *ct,
-                                                          jl_cancel_handler_ctx_t *hctx,
-                                                          volatile sig_atomic_t *deferred) JL_NOTSAFEPOINT
-{
-    jl_cancel_handler_ctx_t *prev = jl_atomic_load_relaxed(&ct->cancel_handler_ctx);
-    hctx->fn = &jl_gmp_defer_note;
-    hctx->state = (void*)deferred;
-    jl_signal_fence(); // contents before publication (same-thread signal)
-    jl_atomic_store_release(&ct->cancel_handler_ctx, hctx);
-    jl_signal_fence();
-    return prev;
-}
-
-STATIC_INLINE void jl_gmp_guard_leave(jl_task_t *ct, volatile sig_atomic_t *deferred,
-                                      jl_cancel_handler_ctx_t *prev)
-{
-    jl_signal_fence();
-    jl_atomic_store_release(&ct->cancel_handler_ctx, prev);
-    jl_signal_fence();
-    if (*deferred && prev == NULL && !ct->ptls->in_finalizer) {
-        // A reset was requested while we were inside the critical region,
-        // deliver it now.
-        reset_region_deliver_pending(ct);
-    }
-}
+// These are special reset-safe versions of GMP's allocation functions. GMP is
+// generally reset-safe, but our allocators are not, so unpublish the reset
+// region around them as the *_reset_safe entry points above do.
 
 JL_DLLEXPORT void *jl_gmp_counted_malloc(size_t sz)
 {
     jl_task_t *ct = jl_get_current_task();
     if (ct == NULL || ct->ptls == NULL)
         return jl_gc_counted_malloc(sz);
-    volatile sig_atomic_t deferred = 0;
-    jl_cancel_handler_ctx_t hctx;
-    jl_cancel_handler_ctx_t *prev = jl_gmp_guard_enter(ct, &hctx, &deferred);
+    jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
     void *data = jl_gc_counted_malloc(sz);
-    // may longjmp; `data` then leaks, like the aborted operation's other
-    // in-flight temporaries (its output is discarded by the unwind anyway)
-    jl_gmp_guard_leave(ct, &deferred, prev);
+    reset_region_republish(ct, reset_ctx); // may longjmp
     return data;
 }
 
@@ -728,11 +675,9 @@ JL_DLLEXPORT void *jl_gmp_counted_realloc_with_old_size(void *p, size_t old, siz
     jl_task_t *ct = jl_get_current_task();
     if (ct == NULL || ct->ptls == NULL)
         return jl_gc_counted_realloc_with_old_size(p, old, sz);
-    volatile sig_atomic_t deferred = 0;
-    jl_cancel_handler_ctx_t hctx;
-    jl_cancel_handler_ctx_t *prev = jl_gmp_guard_enter(ct, &hctx, &deferred);
+    jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
     void *data = jl_gc_counted_realloc_with_old_size(p, old, sz);
-    jl_gmp_guard_leave(ct, &deferred, prev);
+    reset_region_republish(ct, reset_ctx); // may longjmp
     return data;
 }
 
@@ -743,11 +688,9 @@ JL_DLLEXPORT void jl_gmp_counted_free_with_size(void *p, size_t sz)
         jl_gc_counted_free_with_size(p, sz);
         return;
     }
-    volatile sig_atomic_t deferred = 0;
-    jl_cancel_handler_ctx_t hctx;
-    jl_cancel_handler_ctx_t *prev = jl_gmp_guard_enter(ct, &hctx, &deferred);
+    jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
     jl_gc_counted_free_with_size(p, sz);
-    jl_gmp_guard_leave(ct, &deferred, prev);
+    reset_region_republish(ct, reset_ctx); // may longjmp
 }
 
 //_unchecked_calloc does not check for potential overflow of nm*sz

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -256,8 +256,9 @@ static void jl_gc_push_arraylist(jl_task_t *ct, arraylist_t *list) JL_NOTSAFEPOI
 
 // Same assumption as `jl_gc_push_arraylist`. Requires the finalizers lock
 // to be held for the current thread and will release the lock when the
-// function returns.
-static void jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NOTSAFEPOINT_LEAVE_WITH_CANSAFEPOINT
+// function returns. The caller must republish the returned reset context
+// after restoring any state saved around the finalizer run.
+static jl_reset_ctx_t *jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NOTSAFEPOINT_LEAVE_WITH_CANSAFEPOINT
 {
     // Avoid marking `ct` as non-migratable via an `@async` task (as noted in the docstring
     // of `finalizer`) in a finalizer:
@@ -266,8 +267,7 @@ static void jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NO
     // cancellation state is bracketed: unpublish the reset region (finalizer
     // frames must not be abandoned into it) and stash the token binding,
     // which the finalizers' own cancellation points may rebind. Both are
-    // restored below; the republish performs any delivery that was missed
-    // while the region was unpublished.
+    // restored below.
     jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
     jl_value_t *bound_token = jl_atomic_load_relaxed(&ct->bound_cancel_token);
     JL_GC_PUSH1(&bound_token);
@@ -289,7 +289,7 @@ static void jl_gc_run_finalizers_in_list(jl_task_t *ct, arraylist_t *list) JL_NO
     jl_atomic_store_relaxed(&ct->bound_cancel_token, bound_token);
     jl_gc_wb_current_task(ct, bound_token);
     JL_GC_POP(); // matches the JL_GC_PUSH1 above
-    reset_region_republish(ct, reset_ctx);
+    return reset_ctx;
 }
 
 static uint64_t finalizer_rngState[JL_RNG_SIZE];
@@ -333,7 +333,7 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     // This releases the finalizers lock.
     int8_t was_in_finalizer = ct->ptls->in_finalizer;
     ct->ptls->in_finalizer = !finalizers_thread;
-    jl_gc_run_finalizers_in_list(ct, &copied_list);
+    jl_reset_ctx_t *reset_ctx = jl_gc_run_finalizers_in_list(ct, &copied_list);
     ct->ptls->in_finalizer = was_in_finalizer;
     arraylist_free(&copied_list);
 
@@ -342,6 +342,7 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     SetLastError(last_error);
 #endif
     errno = last_errno;
+    reset_region_republish(ct, reset_ctx);
 }
 
 JL_DLLEXPORT void jl_gc_run_pending_finalizers(jl_task_t *ct)
@@ -523,12 +524,14 @@ JL_DLLEXPORT void jl_finalize_th(jl_task_t *ct, jl_value_t *o)
     finalize_object(&finalizer_list_marked, o, &copied_list, 0);
     if (copied_list.len > 0) {
         // This releases the finalizers lock.
-        jl_gc_run_finalizers_in_list(ct, &copied_list);
+        jl_reset_ctx_t *reset_ctx = jl_gc_run_finalizers_in_list(ct, &copied_list);
+        arraylist_free(&copied_list);
+        reset_region_republish(ct, reset_ctx);
     }
     else {
         JL_UNLOCK_NOGC(&finalizers_lock);
+        arraylist_free(&copied_list);
     }
-    arraylist_free(&copied_list);
 }
 
 JL_DLLEXPORT void jl_finalize(jl_value_t *o)
@@ -583,6 +586,9 @@ STATIC_INLINE void reset_region_deliver_pending(jl_task_t *ct)
     jl_value_t *bound = jl_atomic_load_relaxed(&ct->bound_cancel_token);
     if (bound == NULL || bound == jl_nothing ||
         jl_atomic_load_relaxed(&((jl_cancel_source_t*)bound)->state) == 0)
+        return;
+    // Protected foreign calls defer reset delivery until their guard exits.
+    if (jl_atomic_load_acquire(&ct->cancel_handler_ctx) != NULL)
         return;
     jl_reset_ctx_t *reset_ctx = jl_atomic_exchange(&ct->reset_ctx, NULL);
     if (reset_ctx == NULL || reset_ctx->sp == 0)

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -126,9 +126,8 @@ typedef struct {
 //
 // Delivery is gated on the cancellation of the task's bound token source
 // (`jl_task_t.bound_cancel_token`), which is coherent with the published
-// region by construction: everything that temporarily takes over the task
-// and may rebind it - exception handlers, the finalizer bracket in
-// gc-common.c - saves and restores the (region, token) pair together.
+// region by construction: exception handlers save and restore the (region,
+// token) pair together, and finalizers only run with the region unpublished.
 typedef struct _jl_reset_ctx_t {
     uintptr_t sp;
     struct _jl_gcframe_t *gcstack;

--- a/src/llvm-cancellation-lowering.cpp
+++ b/src/llvm-cancellation-lowering.cpp
@@ -305,8 +305,8 @@ bool CancellationLowering::runOnFunction(Function &F) {
         // stores are untagged - unsafe points whose pass-inserted clear
         // tears the region - so a region that is still live here was
         // established under the very token this point just verified as
-        // bound (the non-local rebinders, exception-handler restore and the
-        // finalizer bracket, restore the (region, token) pair together).
+        // bound (exception handlers restore the pair together, and finalizers
+        // only run with the region unpublished).
         // The load is
         // exact ground truth - the region survived if and only if no unsafe
         // point (whose pass-inserted clear nulls reset_ctx) ran since the

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -690,8 +690,8 @@ static void jl_send_reset_signal(int16_t tid, int reset_code) JL_NOTSAFEPOINT
     // Re-check now that the thread cannot run: the current task may have
     // switched before the freeze. Delivery is gated on an actual
     // cancellation of the task's bound token source, kept coherent with the
-    // published regions by the exception-handler and finalizer save/restore
-    // discipline.
+    // published regions: exception handlers restore the pair together, and
+    // finalizers only run with the region unpublished.
     ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
     bound = ct2 == NULL ? NULL :
         jl_atomic_load_relaxed(&ct2->bound_cancel_token);

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -816,9 +816,9 @@ static void usr2_deliver_reset(jl_task_t *ct, jl_ptls_t ptls, uint8_t reqflags,
         // task's bound token source: level-triggered, so a request racing a
         // region's teardown is simply dropped and recovered at the task's
         // next cancellation point. bound_cancel_token is coherent with the
-        // published regions: everything that may rebind it while a region
-        // is live (exception handlers, the finalizer bracket) saves and
-        // restores the pair together. A preempt shootdown checks no source:
+        // published regions: exception handlers restore the pair together,
+        // and finalizers only run with the region unpublished. A preempt
+        // shootdown checks no source:
         // the reset point's re-execution observes the setjmp return code
         // and yields.
         jl_value_t *bound = jl_atomic_load_relaxed(&ct->bound_cancel_token);

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -369,9 +369,8 @@ static void jl_send_reset_signal(int16_t tid, int reset_code) JL_NOTSAFEPOINT
     // Re-check now that the thread cannot run (the current task may have
     // switched before the freeze). Delivery is gated on an actual
     // cancellation of the task's bound token source - coherent with the
-    // published regions, since everything that may rebind it while a region
-    // is live (exception handlers, the finalizer bracket) restores the pair
-    // together.
+    // published regions: exception handlers restore the pair together, and
+    // finalizers only run with the region unpublished.
     ct2 = jl_atomic_load_relaxed(&ptls2->current_task);
     if (ct2 == NULL)
         goto resume;

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -1838,8 +1838,7 @@ end
     # it through the annotated MPZ entry points - either their own
     # cancellation point, an asynchronous reset landing inside audited
     # libgmp compute (the reset region stays published across the annotated
-    # call), or the deferring allocation hooks chaining into the reset on
-    # exit.
+    # call), or the allocation hooks republishing the region on exit.
     function bigmul_loop(nbits)
         b = big(3)^(nbits ÷ 2)
         m = big(10)^(nbits ÷ 8)
@@ -1859,10 +1858,10 @@ end
         @test string(big(2)^128) == "340282366920938463463374607431768211456"
 
         # Allocation-churn storm: small, allocation-dominated BigInt work
-        # hammered by cancellation. Deliveries frequently land inside the
-        # deferring jl_gmp_counted_* hooks (the handler region), exercising
-        # the defer-and-chain path; correctness is "no crash, no corruption,
-        # clean arithmetic afterwards".
+        # hammered by cancellation. Deliveries frequently race the
+        # jl_gmp_counted_* hooks, exercising their unpublish/republish path;
+        # correctness is "no crash, no corruption, clean arithmetic
+        # afterwards".
         deadline = time() + 8
         rounds = 0
         while time() < deadline
@@ -2590,9 +2589,9 @@ Sys.isunix() && @testset "^C in the REPL (pty)" begin
     # delivery could (corrupting the heap - issue #56545): the loop is
     # deliberately checkless, so delivery lands on an MPZ entry point's own
     # cancellation point, inside audited libgmp compute (unwound via the
-    # published reset region), or inside the allocation hooks (deferred and
-    # chained into the reset on exit) - and BigInt arithmetic in the
-    # session works correctly afterwards
+    # published reset region), or when an allocation hook republishes the
+    # region on exit - and BigInt arithmetic in the session works correctly
+    # afterwards
     sendline("println(\"EVAL-6\"); let b = big(3); while true; b = b*b % (big(10)^200); end; end")
     expect("EVAL-6")
     sleep(0.5)


### PR DESCRIPTION
Fix an intermittent CI failure that's been happening since 2026-08-06:

```
cancellation                                                (5) |         failed at 2026-08-13T04:07:56.705
Test Failed at /usr/home/julia/.buildkite-agent/builds/freebsd13-tester-amdci6-2/julialang/julia-ci/julia-bb79ec882e/share/julia/test/cancellation.jl:2524
  Expression: status == :ok
   Evaluated: :timed_out == :ok
Test Failed at /usr/home/julia/.buildkite-agent/builds/freebsd13-tester-amdci6-2/julialang/julia-ci/julia-bb79ec882e/share/julia/test/cancellation.jl:2524
  Expression: status == :ok
   Evaluated: :timed_out == :ok
Test Failed at /usr/home/julia/.buildkite-agent/builds/freebsd13-tester-amdci6-2/julialang/julia-ci/julia-bb79ec882e/share/julia/test/cancellation.jl:2524
  Expression: status == :ok
   Evaluated: :timed_out == :ok
Test Failed at /usr/home/julia/.buildkite-agent/builds/freebsd13-tester-amdci6-2/julialang/julia-ci/julia-bb79ec882e/share/julia/test/cancellation.jl:2611
  Expression: success(p)
```

I'm not familiar with this code, so this needs review. The fix is verified to work on a stress test that reproduced the issue locally.

Description by GPT:

---

Finalizer execution temporarily unpublishes the current task's reset context. Republish it only after callers restore finalizer state and release temporary storage. Otherwise a pending cancellation can jump past the cleanup and leave `in_finalizer` set.

Republishing can still happen inside a protected foreign call. Leave the reset pending while its cancellation-handler guard is active rather than bypassing that protection.