### PR TITLE
Make ScopedValues scope updates statically resolvable

### DIFF
--- a/Compiler/test/verifytrim.jl
+++ b/Compiler/test/verifytrim.jl
@@ -18,6 +18,29 @@ let infos = Any[]
     @test isempty(parents)
 end
 
+struct ScopedTrimEnv
+    value::Int
+end
+
+const scoped_trim_env = Base.ScopedValues.ScopedValue(ScopedTrimEnv(1))
+
+# Scope updates must keep the abstract-key HAMT traversal statically resolvable.
+function scoped_trim_read()
+    return Base.ScopedValues.with(scoped_trim_env => ScopedTrimEnv(2)) do
+        scoped_trim_env[].value
+    end
+end
+
+let infos = typeinf_ext_toplevel(
+    Any[Base.method_instance(scoped_trim_read, ())],
+    [Base.get_world_counter()],
+    TRIM_UNSAFE,
+)[1]
+    errors, _ = get_verify_typeinf_trim(infos)
+    @test scoped_trim_read() == 2
+    @test isempty(errors)
+end
+
 finalizer(@nospecialize(f), @nospecialize(o)) = Core.finalizer(f, o)
 
 let infos = typeinf_ext_toplevel(Any[Core.svec(Nothing, Tuple{typeof(finalizer), typeof(identity), Any})], [Base.get_world_counter()], TRIM_UNSAFE)[1]

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -905,7 +905,11 @@ struct PersistentDict{K,V} <: AbstractDict{K,V}
         dict::PersistentDict{K, V}, key, val) where {K, V} = @inline _keyvalueset(dict, key, val)
     @noinline Base.@assume_effects :nothrow :effect_free :terminates_globally KeyValue.set(
         dict::PersistentDict{K, V}, key::K, val::V) where {K, V} = @inline _keyvalueset(dict, key, val)
-    global function _keyvalueset(dict::PersistentDict{K, V}, key, val) where {K, V}
+    # `@nospecialize(val)`: scoped-value scope construction stores `Any`-typed
+    # values; a val-specializing MethodInstance turns every such insert into a
+    # runtime dispatch — unresolvable under static compilation (`juliac
+    # --trim`). The key stays specialized: `HashState(key)` needs its concrete type.
+    global function _keyvalueset(dict::PersistentDict{K, V}, key, @nospecialize(val)) where {K, V}
         trie = dict.trie
         h = HAMT.HashState(key)
         found, present, trie, i, bi, top, hs = HAMT.path(trie, h, #=persistent=#true)

--- a/base/hamt.jl
+++ b/base/hamt.jl
@@ -91,16 +91,21 @@ struct HashState{K}
     shift::Int
 end
 HashState(key) = HashState(key, objectid(key), 0, 0)
-# Reconstruct
-Base.@assume_effects :terminates_locally function HashState(other::HashState, key)
-    h = HashState(key)
+# Reconstruct with an explicitly pinned key type. `key` can come from a trie Leaf
+# whose K is abstract (e.g. the ScopedValues scope HAMT keys); letting the implicit
+# constructor re-infer the parameter per call produces UnionAll-typed HashStates and
+# dynamic dispatch on every hop — unresolvable under static compilation
+# (`juliac --trim`). Pinning K keeps everything one concrete wrapper type.
+Base.@assume_effects :terminates_locally function HashState{K}(@nospecialize(other::HashState), @nospecialize(key)) where {K}
+    h = HashState{K}(key, objectid(key), 0, 0)
     while h.depth !== other.depth
         h = next(h)
     end
     return h
 end
+Base.@assume_effects :terminates_locally HashState(other::HashState, key) = HashState{typeof(key)}(other, key)
 
-function next(h::HashState)
+function next(h::HashState{K}) where {K}
     depth = h.depth + 1
     shift = h.shift + BITS_PER_LEVEL
     # Assert disabled for effect precision
@@ -113,7 +118,7 @@ function next(h::HashState)
     else
         h_hash = h.hash
     end
-    return HashState(h.key, h_hash, depth, shift)
+    return HashState{K}(h.key, h_hash, depth, shift)
 end
 
 struct BitmapIndex
@@ -202,7 +207,7 @@ or grows the HAMT by inserting a new trie instead.
         @assert present "!found && !present"
         # collision -> grow
         leaf = @inbounds trie.data[i]::Leaf{K,V}
-        leaf_h = HashState(h, leaf.key)
+        leaf_h = HashState{K}(h, leaf.key)
         if leaf_h.hash == h.hash
             error("Perfect hash collision")
         end


### PR DESCRIPTION
Fixes #61641.

Setting a scoped value builds a new `Scope` by inserting into the `PersistentDict{AbstractScopedValue, Any}`-backed HAMT. Two spots in that path defeat static resolution and produce the type instability reported in #61641:

1. **`HashState` reconstruction re-infers its type parameter** from a trie `Leaf` key that inference only knows abstractly (the scope HAMT's keys are `AbstractScopedValue`), so every hop of the trie walk constructs a UnionAll-typed `HashState` and dispatches dynamically. This PR pins reconstruction to the trie's own key type — `HashState{K}(other, key)` — matching @vchuravy's suggestion in #61641 ("HashState should be `HashState{ScopedValue}`…"): everything stays one concrete wrapper type.

2. **`_keyvalueset`'s untyped `val` parameter** makes each insert of an `Any`-typed value a runtime-specializing dispatch. `@nospecialize(val)` — the value is only stored, never dispatched on. The key stays specialized (`HashState(key)` needs its concrete type). The sibling `KeyValue.set(::Type{PersistentDict{K,V}}, ::Nothing, key, val)` root constructor already behaves this way in practice.

Motivation beyond the instability: under `juliac --trim=safe`, these two spots account for every ScopedValues verify failure in a real trim-compiled HTTP server (Servo/Soleil, JuliaCon 2026 workshop material). With this change, `@with`/`Scope` construction verifies statically. We have been carrying exactly this diff as a source patch in that project's Docker builds against master (`98b8616` and predecessors) for several weeks of daily use; semantics are unchanged and the full test suite passes there.

[work by claude fable; reviewed by quinnj]

🤖 Generated with [Claude Code](https://claude.com/claude-code)