### PR TITLE
Fix: segfault in precompile when passed a UnionAll type #62692

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -4342,6 +4342,8 @@ jl_value_t *jl_get_specialization1(jl_tupletype_t *types, size_t world)
 // stays: the bottom object is the unique instance of its `Type`.
 static jl_tupletype_t *egal_normalize_hint_types(jl_tupletype_t *types JL_PROPAGATES_ROOT) JL_CANSAFEPOINT
 {
+    if (!jl_is_datatype(types))
+        return types;
     jl_svec_t *newparams = NULL;
     JL_GC_PUSH1(&newparams);
     size_t i, np = jl_nparams(types);


### PR DESCRIPTION
Calling `precompile` on an unbound generic signature (e.g., precompile(Tuple{typeof(identity), T} where T)) resulted in a `signal 11` (Segmentation fault) null-pointer dereference. #62692

Updated `egal_normalize_hint_types` to properly unpack the memory layout.
Safely unwrap `UnionAll` types using `jl_unwrap_unionall` prior to parameter extraction.

FIxed:
```julia
julia> precompile(Tuple{typeof(identity), T} where T)
false
```
Additionally tested the following:
```julia
# Nested UnionAll
precompile(Tuple{typeof(identity), T, U} where T<:Real where U<:AbstractString) # false

# Raw Unions
precompile(Union{Tuple{typeof(identity), Int}, Tuple{typeof(identity), Float64}}) # false

# Vararg inside generics
precompile(Tuple{typeof(identity), Vararg{T}} where T) # true

# TypeEgal normalization boundary
precompile(Tuple{typeof(identity), Type{T}} where T) # false

# Bottom type memory representation
precompile(Tuple{typeof(identity), Union{}}) # throws expected Julia ERROR: Tuple field type cannot be Union{}
```