### PR TITLE
Enable AggregateToVector for SROA in vector pipeline

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -559,7 +559,8 @@ static void buildVectorPipeline(FunctionPassManager &FPM, PassBuilder *PB, Optim
         FPM.addPass(VectorCombinePass());
         invokeVectorizerCallbacks(FPM, PB, O);
         FPM.addPass(LoopUnrollPass(LoopUnrollOptions(O.getSpeedupLevel(), /*OnlyWhenForced = */ false, /*ForgetSCEV = */false)));
-        FPM.addPass(SROAPass(SROAOptions::PreserveCFG));
+        FPM.addPass(SROAPass(SROAOptions(
+            SROAOptions::PreserveCFG, /*AggregateToVector=*/true)));
         FPM.addPass(InstSimplifyPass());
         FPM.addPass(AfterVectorizationMarkerPass());
     }


### PR DESCRIPTION
It's beneficial to enable AggregateToVector for SROA after memcpyopt. See https://github.com/llvm/llvm-project/pull/165159. This will fix https://github.com/llvm/llvm-project/issues/164308 because we can promote the `[2 x float]` alloca to a `<2 x float>` vector.

The fix depends on https://github.com/llvm/llvm-project/pull/216456 landing, but in any case the struct to vector canonicalization is still useful and a lightweight optimization, so there's no harm in enabling this earlier.