### PR TITLE
JuliaLowering: propagate method metadata to keyword/optional wrappers

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -454,9 +454,6 @@ function apply_32026_hack(st, orig)
     _apply_32026_hack(st, orig.context::SyntaxContext)
 end
 
-# Collect leading function-body metadata. Argument metadata is absorbed into
-# the argument list; method metadata is copied to wrappers, matching flisp's
-# `propagate-method-meta`.
 function collect_body_meta(st)
     argmeta_all = nothing
     argmeta = nothing
@@ -475,27 +472,25 @@ function collect_body_meta(st)
                     kind(id) === K"Identifier" && (argmeta[syntax_name(id)] = meta)
                 end
             end
-            continue
-        end
-        for m in children(c)
-            km = kind(m)
-            if km === K"purity"
+        else
+            for m in children(c)
                 isnothing(mmetas) && (mmetas = SyntaxList())
-                push!(mmetas, m)
-            elseif (km === K"Identifier" || km === K"Symbol") &&
-                    syntax_name(m) in ("inline", "noinline",
-                        "propagate_inbounds", "aggressive_constprop",
-                        "no_constprop")
-                isnothing(mmetas) && (mmetas = SyntaxList())
-                push!(mmetas, km === K"Symbol" ? m :
-                    @mknode(m; kind=K"Symbol"))
+                km = kind(m)
+                if km === K"purity"
+                    push!(mmetas, m)
+                elseif syntax_name(m) in (
+                    "inline", "noinline", "propagate_inbounds",
+                    "nospecializeinfer", "aggressive_constprop", "no_constprop")
+                    push!(mmetas, @mknode(m; kind=K"Symbol"))
+                end
             end
         end
     end
     (isnothing(argmeta_all) ? argmeta : argmeta_all), mmetas
 end
 
-# Convert a function body and retain metadata for wrapper generation.
+# Absorb `meta` nodes from arguments and the function body into syntax `.meta`
+# for easier desugaring.
 function _dst_function_body(st, r, method_metas)
     r2 = if has_if_generated(r)
         gen, nongen = split_generated(r, true), split_generated(r, false)

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -454,27 +454,56 @@ function apply_32026_hack(st, orig)
     _apply_32026_hack(st, orig.context::SyntaxContext)
 end
 
-# nothing if not found, or symbol if 0-arg [no]specialize, or dict arg->meta
-function collect_body_arg_meta(st)
-    out = nothing
+# Collect leading function-body metadata. Argument metadata is absorbed into
+# the argument list; method metadata is copied to wrappers, matching flisp's
+# `propagate-method-meta`.
+function collect_body_meta(st)
+    argmeta_all = nothing
+    argmeta = nothing
+    mmetas = nothing
     for c in children(st)
-        k = kind(c)
-        @stm c begin
-            [K"meta" [K"Identifier"] idents...] -> begin
-                meta = Symbol(syntax_name(c[1]))
-                meta in (:specialize, :nospecialize) || continue
-                length(idents) == 0 && return meta
-                isnothing(out) && (out = Dict{String, Symbol}())
-                for id in idents
-                    kind(id) === K"Identifier" && (out[syntax_name(id)] = meta)
+        kind(c) === K"meta" || break
+        spec = numchildren(c) >= 1 && kind(c[1]) === K"Identifier" ?
+            syntax_name(c[1]) : ""
+        if spec in ("specialize", "nospecialize")
+            meta = Symbol(spec)
+            if numchildren(c) == 1
+                isnothing(argmeta_all) && (argmeta_all = meta)
+            else
+                isnothing(argmeta) && (argmeta = Dict{String, Symbol}())
+                for id in c[2:end]
+                    kind(id) === K"Identifier" && (argmeta[syntax_name(id)] = meta)
                 end
             end
-            # Only leading meta statements are recognized in lowering.  Ideally
-            # meta after non-meta statements would be an error.
-            _ -> break
+            continue
+        end
+        for m in children(c)
+            km = kind(m)
+            if km === K"purity"
+                isnothing(mmetas) && (mmetas = SyntaxList())
+                push!(mmetas, m)
+            elseif (km === K"Identifier" || km === K"Symbol") &&
+                    syntax_name(m) in ("inline", "noinline",
+                        "propagate_inbounds", "aggressive_constprop",
+                        "no_constprop")
+                isnothing(mmetas) && (mmetas = SyntaxList())
+                push!(mmetas, km === K"Symbol" ? m :
+                    @mknode(m; kind=K"Symbol"))
+            end
         end
     end
-    out
+    (isnothing(argmeta_all) ? argmeta : argmeta_all), mmetas
+end
+
+# Convert a function body and retain metadata for wrapper generation.
+function _dst_function_body(st, r, method_metas)
+    r2 = if has_if_generated(r)
+        gen, nongen = split_generated(r, true), split_generated(r, false)
+        @ast _ st [K"_generated_body" [K"syntaxquote" gen] est_to_dst(nongen)]
+    else
+        est_to_dst(r)
+    end
+    isnothing(method_metas) ? r2 : setmeta(r2, :method_metas, method_metas)
 end
 
 """
@@ -610,45 +639,37 @@ function est_to_dst(st::SyntaxTree)
             @ast _ st [K"generator" rec(body) _dst_iterspec(st, iters)]
         ([K"=" l r], when=(is_eventually_call(l))) -> let
             # no fix_arglist needed, since this func can't be anonymous
-            l = apply_arglist_meta(l, collect_body_arg_meta(r))
-            l = force_readable_sparams(l)
+            arg_meta, method_metas = collect_body_meta(r)
+            l = force_readable_sparams(apply_arglist_meta(l, arg_meta))
             l = apply_32026_hack(l, st)
-            if has_if_generated(r)
-                gen, nongen = split_generated(r, true), split_generated(r, false)
-                r2 = @ast _ st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]
-            else
-                r2 = rec(r)
-            end
-            @ast _ st [K"function" rec(l) r2]
+            @ast _ st [K"function"
+                rec(l)
+                _dst_function_body(st, r, method_metas)]
         end
         [K"function" [K"Identifier"]] ->
             @ast _ st [K"function" apply_32026_hack(st[1], st)]
         [K"function" l r] -> let
-            l = apply_arglist_meta(_dst_fix_arglist(l), collect_body_arg_meta(r))
-            l = force_readable_sparams(l)
+            arg_meta, method_metas = collect_body_meta(r)
+            l = force_readable_sparams(
+                apply_arglist_meta(_dst_fix_arglist(l), arg_meta))
             l = apply_32026_hack(l, st)
-            if has_if_generated(r)
-                gen, nongen = split_generated(r, true), split_generated(r, false)
-                r2 = @ast _ st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]
-            else
-                r2 = rec(r)
-            end
-            @ast _ st [K"function" rec(l) r2]
+            @ast _ st [K"function"
+                rec(l)
+                _dst_function_body(st, r, method_metas)]
         end
         [K"->" l r] -> let
-            l = apply_arglist_meta(_dst_fix_arglist(l), collect_body_arg_meta(r))
-            l = force_readable_sparams(l)
-            if has_if_generated(r)
-                gen, nongen = split_generated(r, true), split_generated(r, false)
-                r2 = @ast _ st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]
-            else
-                r2 = rec(r)
-            end
-            @ast _ st [K"->" rec(l) r2]
+            arg_meta, method_metas = collect_body_meta(r)
+            l = force_readable_sparams(
+                apply_arglist_meta(_dst_fix_arglist(l), arg_meta))
+            @ast _ st [K"->"
+                rec(l)
+                _dst_function_body(st, r, method_metas)]
         end
         [K"macro" l r] -> let
-            l = apply_arglist_meta(l, collect_body_arg_meta(r))
-            @ast _ st [K"macro" rec(l) rec(r)]
+            arg_meta, method_metas = collect_body_meta(r)
+            r2 = rec(r)
+            isnothing(method_metas) || (r2 = setmeta(r2, :method_metas, method_metas))
+            @ast _ st [K"macro" rec(apply_arglist_meta(l, arg_meta)) r2]
         end
         [K"do" [K"call" f args...] lam] -> let
             @ast _ st [K"call" rec(f) rec(lam) _dst_sink_parameters(args)...]

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2438,7 +2438,7 @@ end
 # desugarable AST to macro AST.  Fortunately there are only two places (meta
 # nkw, and destructuring arg assignments) we do this, so handle them manually.
 function prepend_function_body(ctx, body, ex)
-    @stm body begin
+    out = @stm body begin
         [K"_generated_body" [K"syntaxquote" gen] nongen] -> begin
             ex_est = @stm ex begin
                 [K"meta" [K"Symbol"] n] ->
@@ -2453,6 +2453,21 @@ function prepend_function_body(ctx, body, ex)
         end
         _ -> @ast ctx body [K"block" ex body]
     end
+    # Preserve metadata needed if this body later produces wrappers.
+    mm = getmeta(body, :method_metas, nothing)
+    isnothing(mm) || setmeta!(out, :method_metas, mm)
+    out
+end
+
+# Prepend method metadata and retain it through recursive wrapper generation.
+function prepend_method_metas(ctx, src, body, method_metas)
+    isnothing(method_metas) && return body
+    out = @stm body begin
+        [K"block" stmts...] ->
+            @ast ctx src [K"block" [K"meta" method_metas...] stmts...]
+        _ -> @ast ctx src [K"block" [K"meta" method_metas...] body]
+    end
+    setmeta(out, :method_metas, method_metas)
 end
 
 # Produce all `method` exprs for the given `argl`
@@ -2598,6 +2613,7 @@ function optional_positional_defs(ctx, src, mtable, sparams, argl, body, rett)
     end
     req = pos_req_args(argl)
     passed = copy(req)
+    prop_metas = getmeta(body, :method_metas, nothing)
     methods = SyntaxList()
     for i in eachindex(opt)
         @jl_assert i == length(passed)-length(req)+1 src
@@ -2605,15 +2621,17 @@ function optional_positional_defs(ctx, src, mtable, sparams, argl, body, rett)
             # fill-all-defaults case.  note that the final default may be a
             # splat, and doesn't have further args referring to it by name, so
             # we put it directly in the call (see #50563 for some notes)
-            scope_nest(
-                ctx,
-                make_assigns(ctx, opt_names[i:end-1], opt_defaults[i:end-1]),
-                @ast ctx src [K"call" mapindex(passed, 1)...
-                    opt_names[i:end-1]... opt_defaults[end]])
+            @ast ctx src [K"block"
+                scope_nest(
+                    ctx,
+                    make_assigns(ctx, opt_names[i:end-1], opt_defaults[i:end-1]),
+                    @ast ctx src [K"call" mapindex(passed, 1)...
+                        opt_names[i:end-1]... opt_defaults[end]])]
         else
             @ast ctx src [K"block"
                 [K"call" mapindex(passed, 1)... opt_defaults[i]]]
         end
+        wrapper_body = prepend_method_metas(ctx, src, wrapper_body, prop_metas)
         # this function and method_def_expr need sp bounds because of this
         push!(methods, method_def_expr(
             ctx, src, mtable, used_typevars(passed, sparams),
@@ -2694,6 +2712,8 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett)
     (kw_decls, kw_names, kw_syms, kw_defaults, restkw) = expand_kw_args(ctx, kws)
     ordered_defaults = any(val->contains_identifier(val, kw_names), kw_defaults)
     pos_sparams = used_typevars(pargl, sparams)
+    # Sorter bodies may recursively produce optional-argument wrappers.
+    prop_metas = getmeta(body, :method_metas, nothing)
 
     m1_name = let n = kind(mtable) === K"nothing" ? "_" : syntax_name(mtable),
         mangled = reserve_module_binding_i(
@@ -2727,9 +2747,10 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett)
             scope_nest(ctx, make_assigns(ctx, kw_names, kw_defaults),
                 @ast ctx src [K"call" m1_name kw_names... rkw forward_pargl...])
         end
+        nokw_body = prepend_method_metas(
+            ctx, src, @ast(ctx, src, [K"block" [K"return" body2]]), prop_metas)
         method_def_expr(
-            ctx, src, mtable, pos_sparams, pargl,
-            @ast(ctx, src, [K"block" [K"return" body2]]))
+            ctx, src, mtable, pos_sparams, pargl, nokw_body)
     end
     # (3) Core.kwcall(arg2::NamedTuple, pargl...) methods (one per optarg).
     # - for each kwarg:
@@ -2807,6 +2828,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett)
             scope_nest(ctx, kw_assigns,
                        @ast ctx src [K"block" handle_excess final_call])
         end
+        kwcall_body = prepend_method_metas(ctx, src, kwcall_body, prop_metas)
         # Core.kwcall method has its own first argument.  Ensure closure
         # conversion knows not to put the closure there.
         let arg1_name = setmeta!(

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2453,7 +2453,6 @@ function prepend_function_body(ctx, body, ex)
         end
         _ -> @ast ctx body [K"block" ex body]
     end
-    # Preserve metadata needed if this body later produces wrappers.
     mm = getmeta(body, :method_metas, nothing)
     isnothing(mm) || setmeta!(out, :method_metas, mm)
     out
@@ -2621,12 +2620,11 @@ function optional_positional_defs(ctx, src, mtable, sparams, argl, body, rett)
             # fill-all-defaults case.  note that the final default may be a
             # splat, and doesn't have further args referring to it by name, so
             # we put it directly in the call (see #50563 for some notes)
-            @ast ctx src [K"block"
-                scope_nest(
-                    ctx,
-                    make_assigns(ctx, opt_names[i:end-1], opt_defaults[i:end-1]),
-                    @ast ctx src [K"call" mapindex(passed, 1)...
-                        opt_names[i:end-1]... opt_defaults[end]])]
+            scope_nest(
+                ctx,
+                make_assigns(ctx, opt_names[i:end-1], opt_defaults[i:end-1]),
+                @ast ctx src [K"call" mapindex(passed, 1)...
+                    opt_names[i:end-1]... opt_defaults[end]])
         else
             @ast ctx src [K"block"
                 [K"call" mapindex(passed, 1)... opt_defaults[i]]]
@@ -2712,7 +2710,6 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett)
     (kw_decls, kw_names, kw_syms, kw_defaults, restkw) = expand_kw_args(ctx, kws)
     ordered_defaults = any(val->contains_identifier(val, kw_names), kw_defaults)
     pos_sparams = used_typevars(pargl, sparams)
-    # Sorter bodies may recursively produce optional-argument wrappers.
     prop_metas = getmeta(body, :method_metas, nothing)
 
     m1_name = let n = kind(mtable) === K"nothing" ? "_" : syntax_name(mtable),

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -546,6 +546,19 @@ end
     # 0-arg @nospecialize sets all bits (-1 == typemax(Int32) for nospecialize)
     @test only(methods(test_mod.f_nospecialize_zero_body)).nospecialize == -1
 
+    # @nospecialize with exceptions: what should this do?
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_nospecialize_body_exceptions(a, @specialize(b), c)
+            @nospecialize
+            @specialize c
+            (a,b,c)
+        end
+        f_nospecialize_body_exceptions(1, 2, 3)
+    end
+    """) == (1, 2, 3)
+    @test_broken only(methods(test_mod.f_nospecialize_body_exceptions)).nospecialize == 0b100
+
     # @nospecialize with default value in signature
     @test JuliaLowering.include_string(test_mod, """
     begin

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -1897,3 +1897,32 @@ end
     @test !isdefined(test_mod, :a)
     @test !isdefined(macro_mod, :a)
 end
+
+# Method annotations propagate from the body to positional-default wrappers
+# and the `Core.kwcall` sorter (matching flisp's `propagate-method-meta`).
+@testset "method meta propagation" begin
+    JuliaLowering.include_string(test_mod, raw"""
+    @inline function _test_opts_kw(x::Int, y::Int=1; k::Int=2)
+        x + y + k
+    end
+    """)
+    fkw = test_mod._test_opts_kw
+    @test fkw(1) == 4
+    for m in (which(fkw, (Int,)), which(fkw, (Int, Int)),
+              which(Core.kwcall, (NamedTuple{(:k,), Tuple{Int}}, typeof(fkw), Int)))
+        @test Base.uncompressed_ast(m).inlining == 0x01
+    end
+
+    # Destructuring prepends assignments but must retain the metadata.
+    JuliaLowering.include_string(test_mod, raw"""
+    @inline function _test_opts_destr((a, b)::Tuple{Int,Int}, y::Int=1; k::Int=2)
+        a + b + y + k
+    end
+    """)
+    fd = test_mod._test_opts_destr
+    @test fd((1, 2)) == 6
+    for m in (which(fd, (Tuple{Int,Int},)), which(fd, (Tuple{Int,Int}, Int)),
+              which(Core.kwcall, (NamedTuple{(:k,), Tuple{Int}}, typeof(fd), Tuple{Int,Int})))
+        @test Base.uncompressed_ast(m).inlining == 0x01
+    end
+end

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -1334,6 +1334,16 @@ end
         ref_ci = find_method_ci(Meta.lower(test_mod, Meta.parse(prog_def)))
         our_ci = find_method_ci(jlower_e(prog_def))
         @test ref_ci.purity === our_ci.purity
+
+        prog = """
+        Base.@assume_effects :total function f_assume_nospecialize(x)
+            @nospecialize x
+            x
+        end
+        """
+        ref_ci = find_method_ci(fl_lower(test_mod, Meta.parse(prog)))
+        our_ci = find_method_ci(jlower_e(prog_def))
+        @test ref_ci.purity === our_ci.purity
     end
 end
 
@@ -1925,4 +1935,21 @@ end
               which(Core.kwcall, (NamedTuple{(:k,), Tuple{Int}}, typeof(fd), Tuple{Int,Int})))
         @test Base.uncompressed_ast(m).inlining == 0x01
     end
+
+    # @nospecializeinfer
+    local f = JuliaLowering.include_string(@newmod(), raw"""
+    Base.@nospecializeinfer function f(@nospecialize(x), y::Int=1)
+        (x, y)
+    end
+    """)
+    @test which(f, (Any, Int)).nospecializeinfer == true
+    @test which(f, (Any,)).nospecializeinfer == true
+
+    local f = JuliaLowering.include_string(@newmod(), raw"""
+    Base.@nospecializeinfer function f(@nospecialize(x); k::Int=1)
+        (x, k)
+    end
+    """)
+    local sorter = x->which(Core.kwcall, (NamedTuple{(:k,), Tuple{Int}}, typeof(x), Any))
+    @test sorter(f).nospecializeinfer == true
 end

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -1342,7 +1342,7 @@ end
         end
         """
         ref_ci = find_method_ci(fl_lower(test_mod, Meta.parse(prog)))
-        our_ci = find_method_ci(jlower_e(prog_def))
+        our_ci = find_method_ci(jlower_e(prog))
         @test ref_ci.purity === our_ci.purity
     end
 end


### PR DESCRIPTION
Match flisp's `propagate-method-meta`: inlining and constprop
annotations and effects overrides from the function body are now copied
onto positional-default wrapper methods and the `Core.kwcall` sorter.
Previously these were silently dropped (e.g. `@inline` on a function
with keyword arguments only applied to the body method).

Cherry-picked from kc/compiler_options_method (98b5596565); the
per-method compiler options (`optlevel`/`compile`/`infer`) parts were
dropped since that feature is not on this branch.

Fixes https://github.com/JuliaLang/julia/issues/62461

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
