### PR TITLE
Markdown: restore the code face on rendered code blocks

### DIFF
--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -158,9 +158,12 @@ end
 
 function term(io::IO, md::Code, columns)
     code = if md.language == "julia"
-        highlight(md.code)
+        hl = AnnotatedString(md.code)
+        StyledStrings.face!(hl, :markdown_code)
+        highlight!(hl)
     elseif md.language == "julia-repl" || Base.startswith(md.language, "jldoctest")
         hl = AnnotatedString(md.code)
+        StyledStrings.face!(hl, :markdown_code)
         for (; match) in eachmatch(r"(?:^|\n)julia>", hl)
             StyledStrings.face!(match, :markdown_julia_prompt)
             afterprompt = match.offset + ncodeunits(match) + 1

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1283,6 +1283,28 @@ end
     @test !occursin(Base.text_colors[:underline], lines[end])
 end
 
+@testset "code blocks are faced as code #61456" begin
+    function codefaces(md)
+        buf = Base.AnnotatedIOBuffer()
+        show(buf, MIME("text/plain"), md)
+        str = read(seekstart(buf), Base.AnnotatedString)
+        [(String(str[a.region]), a.value) for a in Base.annotations(str) if a.label === :face]
+    end
+    # Syntax highlighting is conservative, so a lone identifier picks up no
+    # highlighting of its own; it must still be faced as code.
+    for lang in ("", "julia", "julia-repl", "jldoctest", "text")
+        @test codefaces(Markdown.MD(Markdown.Code(lang, "VERSION"))) ==
+            [("VERSION", :markdown_code)]
+    end
+    # Highlighting is layered over the code face rather than replacing it.
+    let faces = codefaces(Markdown.MD(Markdown.Code("julia", "f() = 1 # c")))
+        @test ("f() = 1 # c", :markdown_code) ∈ faces
+        @test ("# c", :julia_comment) ∈ faces
+    end
+    @test ("julia>", :markdown_julia_prompt) ∈
+        codefaces(Markdown.MD(Markdown.Code("julia-repl", "julia> x")))
+end
+
 @testset "table rendering with term #25213" begin
     t = """
         a   |   b


### PR DESCRIPTION
Terminal rendering of a `julia` code block relied on syntax highlighting alone to style its contents. Since the highlighting scheme was made conservative, tokens such as a bare identifier receive no styling of their own, so a code block holding only a signature line rendered as plain text. Paint the code face over the whole block again and layer highlighting on top of it, as the 1.12 release branch already does.

Fixes #61456

Done by Claude
