### PR TITLE
codegen: give RMW fields a slot when splitting an allocation

### DIFF
--- a/src/llvm-alloc-helpers.cpp
+++ b/src/llvm-alloc-helpers.cpp
@@ -80,7 +80,7 @@ AllocUseInfo::getField(uint32_t offset, uint32_t size, Type *elty)
 }
 
 bool AllocUseInfo::addMemOp(Instruction *inst, unsigned opno, uint32_t offset,
-                                       Type *elty, bool isstore, const DataLayout &DL)
+                                       Type *elty, bool isload, bool isstore, const DataLayout &DL)
 {
     MemOp memop(inst, opno);
     memop.offset = offset;
@@ -93,15 +93,13 @@ bool AllocUseInfo::addMemOp(Instruction *inst, unsigned opno, uint32_t offset,
 
     if (!field.second.accesses.empty() && field.second.hasobjref != memop.isobjref)
         field.second.multiloc = true; // can't split this field, since it contains a mix of references and bits
-    if (!isstore)
+    if (isload)
         field.second.hasload = true;
     if (memop.isobjref) {
-        if (isstore) {
+        if (isstore)
             refstore = true;
-        }
-        else {
+        if (isload)
             refload = true;
-        }
         if (memop.isaggr)
             field.second.hasaggr = true;
         field.second.hasobjref = true;
@@ -209,7 +207,7 @@ void jl_alloc::runEscapeAnalysis(llvm::CallInst *I, EscapeAnalysisRequiredArgs r
                 required.use_info.hasunknownmem = true;
             } else if (!required.use_info.addMemOp(inst, 0, cur.offset,
                                                                inst->getType(),
-                                                               false, required.DL))
+                                                               true, false, required.DL))
                 required.use_info.hasunknownmem = true;
             return true;
         }
@@ -313,7 +311,7 @@ void jl_alloc::runEscapeAnalysis(llvm::CallInst *I, EscapeAnalysisRequiredArgs r
                 required.use_info.hasunknownmem = true;
             } else if (!required.use_info.addMemOp(inst, use->getOperandNo(),
                                                                cur.offset, storev->getType(),
-                                                               true, required.DL))
+                                                               false, true, required.DL))
                 required.use_info.hasunknownmem = true;
             return true;
         }
@@ -335,9 +333,10 @@ void jl_alloc::runEscapeAnalysis(llvm::CallInst *I, EscapeAnalysisRequiredArgs r
             required.use_info.hasload = true;
             auto storev = isa<AtomicCmpXchgInst>(inst) ? cast<AtomicCmpXchgInst>(inst)->getNewValOperand() : cast<AtomicRMWInst>(inst)->getValOperand();
             Type *elty = storev->getType();
+            // read-modify-write: this both loads and stores the field
             if (cur.offset == UINT32_MAX || !required.use_info.addMemOp(inst, use->getOperandNo(),
                                                                cur.offset, elty,
-                                                               true, required.DL)) {
+                                                               true, true, required.DL)) {
                 LLVM_DEBUG(dbgs() << "Atomic inst has unknown offset\n");
                 required.use_info.has_unknown_objref |= hasObjref(elty);
                 required.use_info.has_unknown_objrefaggr |= hasObjref(elty) && !isa<PointerType>(elty);

--- a/src/llvm-alloc-helpers.h
+++ b/src/llvm-alloc-helpers.h
@@ -124,7 +124,7 @@ namespace jl_alloc {
         void dump(llvm::raw_ostream &OS);
         void dump();
         bool addMemOp(llvm::Instruction *inst, unsigned opno, uint32_t offset, llvm::Type *elty,
-                      bool isstore, const llvm::DataLayout &DL);
+                      bool isload, bool isstore, const llvm::DataLayout &DL);
         std::pair<const uint32_t,Field> &getField(uint32_t offset, uint32_t size, llvm::Type *elty);
         std::map<uint32_t,Field>::iterator findLowerField(uint32_t offset)
         {

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -1381,6 +1381,25 @@ end
 
 @test add_one57190!() == 1
 
+# A field reached only by a read-modify-write gets a stack slot when `AllocOpt` splits
+# the non-escaping allocation
+mutable struct Atomic52575
+    @atomic x::Int
+    y::Int
+end
+replace52575!() = (r = Atomic52575(1, 2); @atomicreplace r.x 1 => 2)
+@test replace52575!() === (old = 1, success = true)
+modify52575!() = (r = Atomic52575(1, 2); @atomic r.x += 10)
+@test modify52575!() === 11
+swap52575!() = (r = Atomic52575(1, 2); @atomicswap r.x = 5)
+@test swap52575!() === 1
+mutable struct AtomicAny52575
+    @atomic x::Any
+    y::Any
+end
+replaceany52575!() = (r = AtomicAny52575(1, 2); @atomicreplace r.x 1 => 2)
+@test replaceany52575!() == (old = 1, success = true)
+
 # Test atomic Float16 operations at all optimization levels (GlobalISel miscompile on AArch64)
 # See https://github.com/JuliaLang/julia/pull/54140#issuecomment-2855794363
 for opt in 0:3


### PR DESCRIPTION
Fix the recorded effects for RMW operations in alloc-opt:

`AllocOpt`'s escape analysis recorded `cmpxchg` and `atomicrmw` as pure stores of their new-value operand, so the field they touch was left with `hasload == false`. `splitOnStack` skips allocating a stack slot for such a field, and then indexes the empty slot vector while rewriting the atomic, reading whatever happened to be on the stack. With assertions this trips `SmallVector::operator[]`; without them it produces a bogus pointer operand and crashes further down the pass pipeline.

`addMemOp` now takes separate `isload` and `isstore` flags, and the atomics set both, which keeps `refstore` set for the write-barrier check in `JuliaLICM` while also marking the field as read.

Fixes #52575

Disclaimer: Claude did the debugging here, so I didn't verify the bug, but the change seems right regardless and the test seems okay to show it now works on this example.