### PR TITLE
GC: never safepoint in the GMP/MPFR allocation hooks

### DIFF
--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -659,13 +659,18 @@ JL_DLLEXPORT void *jl_malloc(size_t sz) JL_CANSAFEPOINT
 // generally reset-safe, but our allocators are not, so unpublish the reset
 // region around them as the *_reset_safe entry points above do.
 
+// These hooks must not safepoint: GMP/MPFR call them while holding internal
+// library locks (e.g. MPFR's shared constant cache lock) that other threads
+// wait on inside GC-unsafe ccall regions, so triggering or joining a
+// collection here deadlocks the stop-the-world (#62753). The allocation is
+// still counted; the GC picks up the pressure at the next safepoint.
 JL_DLLEXPORT void *jl_gmp_counted_malloc(size_t sz)
 {
     jl_task_t *ct = jl_get_current_task();
     if (ct == NULL || ct->ptls == NULL)
-        return jl_gc_counted_malloc(sz);
+        return jl_gc_counted_malloc_nosafepoint(sz);
     jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
-    void *data = jl_gc_counted_malloc(sz);
+    void *data = jl_gc_counted_malloc_nosafepoint(sz);
     reset_region_republish(ct, reset_ctx); // may longjmp
     return data;
 }
@@ -674,9 +679,9 @@ JL_DLLEXPORT void *jl_gmp_counted_realloc_with_old_size(void *p, size_t old, siz
 {
     jl_task_t *ct = jl_get_current_task();
     if (ct == NULL || ct->ptls == NULL)
-        return jl_gc_counted_realloc_with_old_size(p, old, sz);
+        return jl_gc_counted_realloc_with_old_size_nosafepoint(p, old, sz);
     jl_reset_ctx_t *reset_ctx = reset_region_unpublish(ct);
-    void *data = jl_gc_counted_realloc_with_old_size(p, old, sz);
+    void *data = jl_gc_counted_realloc_with_old_size_nosafepoint(p, old, sz);
     reset_region_republish(ct, reset_ctx); // may longjmp
     return data;
 }

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -249,6 +249,10 @@ JL_DLLEXPORT void *jl_gc_counted_calloc(size_t nm, size_t sz) JL_CANSAFEPOINT;
 JL_DLLEXPORT void jl_gc_counted_free_with_size(void *p, size_t sz);
 // Wrapper around Libc realloc that updates Julia allocation counters.
 JL_DLLEXPORT void *jl_gc_counted_realloc_with_old_size(void *p, size_t old, size_t sz) JL_CANSAFEPOINT;
+// Counted malloc/realloc variants that never safepoint, for callers holding
+// locks the runtime knows nothing about (the GMP hooks).
+JL_DLLEXPORT void *jl_gc_counted_malloc_nosafepoint(size_t sz);
+JL_DLLEXPORT void *jl_gc_counted_realloc_with_old_size_nosafepoint(void *p, size_t old, size_t sz);
 // Special reset-safe variants of the above functions for use by GMP.
 JL_DLLEXPORT void *jl_gmp_counted_malloc(size_t sz) JL_CANSAFEPOINT;
 JL_DLLEXPORT void *jl_gmp_counted_realloc_with_old_size(void *p, size_t old, size_t sz) JL_CANSAFEPOINT;

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -1265,6 +1265,19 @@ JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
     return data;
 }
 
+// Accounts for the allocation without ever safepointing; see the GMP hooks
+// in gc-common.c for why.
+JL_DLLEXPORT void *jl_gc_counted_malloc_nosafepoint(size_t sz)
+{
+    jl_gcframe_t **pgcstack = jl_get_pgcstack();
+    jl_task_t *ct = jl_current_task;
+    void *data = malloc(sz);
+    if (data != NULL && pgcstack != NULL && ct->world_age) {
+        jl_atomic_fetch_add_relaxed(&JULIA_MALLOC_BYTES, sz);
+    }
+    return data;
+}
+
 JL_DLLEXPORT void *jl_gc_counted_calloc(size_t nm, size_t sz)
 {
     jl_gcframe_t **pgcstack = jl_get_pgcstack();
@@ -1295,6 +1308,20 @@ JL_DLLEXPORT void *jl_gc_counted_realloc_with_old_size(void *p, size_t old, size
     if (pgcstack && ct->world_age) {
         jl_ptls_t ptls = ct->ptls;
         malloc_maybe_collect(ptls, sz);
+        if (sz < old)
+            jl_atomic_fetch_add_relaxed(&JULIA_MALLOC_BYTES, old - sz);
+        else
+            jl_atomic_fetch_add_relaxed(&JULIA_MALLOC_BYTES, sz - old);
+    }
+    return realloc(p, sz);
+}
+
+// see jl_gc_counted_malloc_nosafepoint
+JL_DLLEXPORT void *jl_gc_counted_realloc_with_old_size_nosafepoint(void *p, size_t old, size_t sz)
+{
+    jl_gcframe_t **pgcstack = jl_get_pgcstack();
+    jl_task_t *ct = jl_current_task;
+    if (pgcstack && ct->world_age) {
         if (sz < old)
             jl_atomic_fetch_add_relaxed(&JULIA_MALLOC_BYTES, old - sz);
         else

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -4133,14 +4133,15 @@ JL_DLLEXPORT uint64_t jl_gc_get_max_memory(void)
 
 // allocation wrappers that add to gc pressure
 
-JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
+STATIC_INLINE void *gc_counted_malloc_(size_t sz, int maysafepoint) JL_CANSAFEPOINT
 {
     void *data = malloc(sz);
     jl_task_t *ct = jl_get_current_task();
     if (data != NULL && ct != NULL) {
         sz = memory_block_usable_size(data, 0);
         jl_ptls_t ptls = ct->ptls;
-        maybe_collect(ptls);
+        if (maysafepoint)
+            maybe_collect(ptls);
         jl_atomic_store_relaxed(&ptls->gc_tls_common.gc_num.allocd,
             jl_atomic_load_relaxed(&ptls->gc_tls_common.gc_num.allocd) + sz);
         jl_atomic_store_relaxed(&ptls->gc_tls_common.gc_num.malloc,
@@ -4148,6 +4149,18 @@ JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
         jl_batch_accum_heap_size(ptls, sz);
     }
     return data;
+}
+
+JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
+{
+    return gc_counted_malloc_(sz, 1);
+}
+
+// Accounts for the allocation without ever safepointing; see the GMP hooks
+// in gc-common.c for why.
+JL_DLLEXPORT void *jl_gc_counted_malloc_nosafepoint(size_t sz) JL_NO_SAFEPOINT_ANALYSIS
+{
+    return gc_counted_malloc_(sz, 0);
 }
 
 JL_DLLEXPORT void *jl_gc_counted_calloc(size_t nm, size_t sz)
@@ -4175,14 +4188,15 @@ JL_DLLEXPORT void jl_gc_counted_free_with_size(void *p, size_t sz)
         jl_batch_accum_free_size(ct->ptls, sz);
 }
 
-JL_DLLEXPORT void *jl_gc_counted_realloc_with_old_size(void *p, size_t old, size_t sz)
+STATIC_INLINE void *gc_counted_realloc_with_old_size_(void *p, size_t old, size_t sz, int maysafepoint) JL_CANSAFEPOINT
 {
     void *data = realloc(p, sz);
     jl_task_t *ct = jl_get_current_task();
     if (data != NULL && ct != NULL) {
         sz = memory_block_usable_size(data, 0);
         jl_ptls_t ptls = ct->ptls;
-        maybe_collect(ptls);
+        if (maysafepoint)
+            maybe_collect(ptls);
         if (!(sz < old))
             jl_atomic_store_relaxed(&ptls->gc_tls_common.gc_num.allocd,
                 jl_atomic_load_relaxed(&ptls->gc_tls_common.gc_num.allocd) + (sz - old));
@@ -4197,6 +4211,17 @@ JL_DLLEXPORT void *jl_gc_counted_realloc_with_old_size(void *p, size_t old, size
         }
     }
     return data;
+}
+
+JL_DLLEXPORT void *jl_gc_counted_realloc_with_old_size(void *p, size_t old, size_t sz)
+{
+    return gc_counted_realloc_with_old_size_(p, old, sz, 1);
+}
+
+// see jl_gc_counted_malloc_nosafepoint
+JL_DLLEXPORT void *jl_gc_counted_realloc_with_old_size_nosafepoint(void *p, size_t old, size_t sz) JL_NO_SAFEPOINT_ANALYSIS
+{
+    return gc_counted_realloc_with_old_size_(p, old, sz, 0);
 }
 
 // allocating blocks for Arrays and Strings

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -651,6 +651,39 @@ close(proc.in)
     end
 end
 
+# https://github.com/JuliaLang/julia/issues/62753
+@testset "no deadlock between GC and MPFR's shared constant cache" begin
+    script = "threads_mpfr_gc_exec.jl"
+    cmd = `$(Base.julia_cmd()) --depwarn=error --rr-detach --startup-file=no -t8 $script`
+    cmd = ignorestatus(setenv(cmd; dir = @__DIR__))
+    cmd = pipeline(cmd; stdout = stderr, stderr)
+    proc = run(cmd; wait = false)
+    # a passing run takes a few seconds; the timeout only fires on deadlock
+    timeout = false
+    timer = Timer(120) do t
+        timeout = true
+        # SIGTERM is not honored when deadlocked in the GC, go straight to
+        # the backtrace-dumping and then killing signals
+        for sig in (Base.SIGQUIT, Base.SIGKILL)
+            for _ in 1:3
+                process_running(proc) || return
+                kill(proc, sig)
+                sleep(1)
+            end
+        end
+    end
+    try
+        wait(proc)
+    finally
+        close(timer)
+    end
+    if !success(proc) || timeout
+        @error "The MPFR/GC deadlock test failed" proc.exitcode proc.termsignal timeout
+    end
+    @test success(proc)
+    @test !timeout
+end
+
 @testset "bad arguments to @threads" begin
     @test_throws ArgumentError @macroexpand(@threads 1 2) # wrong number of args
     @test_throws ArgumentError @macroexpand(@threads 1) # arg isn't an Expr

--- a/test/threads_mpfr_gc_exec.jl
+++ b/test/threads_mpfr_gc_exec.jl
@@ -1,0 +1,36 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Regression test for #62753: recomputing MPFR's shared constant cache
+# allocates through the GMP hooks while holding the cache lock; if that
+# allocation safepoints while other threads wait on the lock in GC-unsafe
+# ccall regions, the collection can never start. Here a task spamming GC.gc
+# keeps stop-the-world windows open while workers call mpfr_acos at
+# ever-rising precision, forcing recomputation under the cache's write lock;
+# unfixed builds hang within a few iterations.
+
+using Base.MPFR: libmpfr, MPFRRoundingMode as RM, MPFRRoundNearest as RNDN
+
+function acos_at(prec::Int)
+    x = BigFloat(1 - 1e-9, precision=prec)
+    z = BigFloat(precision=prec)
+    ccall((:mpfr_acos, libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, RM), z, x, RNDN)
+    return z
+end
+
+function main(iters)
+    done = Threads.Atomic{Bool}(false)
+    gcspam = Threads.@spawn while !done[]
+        GC.gc(false)
+        yield()
+    end
+    nworkers = max(2, Threads.nthreads() - 1)
+    for i in 1:iters
+        prec = 256 + 32 * i
+        tasks = [Threads.@spawn acos_at(prec) for _ in 1:nworkers]
+        foreach(wait, tasks)
+    end
+    done[] = true
+    wait(gcspam)
+end
+
+main(parse(Int, get(ENV, "MPFR_GC_ITERS", "150")))


### PR DESCRIPTION
Fixes #62753

cc. @mmikaitis @giordano 

Claude:

---

MPFR is built with a shared constant cache (`--enable-shared-cache`), so a thread that recomputes a cached constant (e.g. pi for `mpfr_acos` at a new precision) allocates through the GMP hooks while holding MPFR's internal cache lock. Those hooks called `jl_gc_counted_malloc`/`_realloc`, which can reach a safepoint via `maybe_collect`. The lock holder could therefore end up waiting for a stop-the-world while other threads sat on the same rwlock inside GC-unsafe ccall regions, unable to ever reach a safepoint: the collection never starts and the process deadlocks. Backtraces of a hung process on a 32-core Linux machine (96 Julia threads) show exactly this cycle: one thread in `jl_gc_wait_for_the_world`, one blocked on the cache rwlock inside `mpfr_acos`, and the cache-lock holder in `jl_safepoint_wait_gc` under `mpfr_cache` → `jl_gmp_counted_malloc` → `maybe_collect`.

This PR gives the counted malloc/realloc wrappers `_nosafepoint` variants (for both the stock GC and MMTk) that still record the allocation, so the GC picks up the pressure at the caller's next safepoint, and uses them in the `jl_gmp_counted_*` hooks. That removes the only edge of the cycle the runtime controls: a thread can no longer block on the GC while holding a library-internal lock the runtime knows nothing about. It also covers system MPFR builds whose configure flags we don't choose.

The regression test keeps stop-the-world windows open with a GC-spamming task while workers force cache recomputation at ever-rising precision. On unfixed builds it deadlocks within seconds with only 8 threads, on both Linux and macOS (the issue's original reproducer never hung on macOS; the missing ingredient was sustained GC pressure). On a fixed build it passes in ~3 seconds. Verified on a 32-core Linux machine: unfixed master hangs the issue's 96-thread reproducer before round 1, while with this change 2/2 full reproducer runs and 5/5 stress runs complete.

---

*This pull request was written with the assistance of generative AI (Claude).*
