### PR TITLE
`CONTRIBUTING.md`: Remove reference to non-existent PR template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Similarly to other types of contribution, AI-assisted review is allowed so long 
 
 * Review discussions on the [Julia Discourse forum](https://discourse.julialang.org).
 
-* If your pull request contains substantive contributions from a generative AI tool, please disclose so with details, and review all changes before opening. The "Tool assistance" section of the pull request template has checkboxes for this. Open the pull request yourself once you have reviewed it, rather than having a tool open it on your behalf.
+* If your pull request contains substantive contributions from a generative AI tool, please disclose so with details, and review all changes before opening. Open the pull request yourself once you have reviewed it, rather than having a tool open it on your behalf.
 
 * Relax and have fun!
 


### PR DESCRIPTION
This is a follow-up to https://github.com/JuliaLang/julia/pull/62685 ("RFC: clarify our AGENTS to align with our current policies").

An earlier iteration of #62685 included a PR template. After discussion and feedback, the PR template was removed from #62685, and was not included in the final version of #62685 that was merged.

Currently, `CONTRIBUTING.md` has one sentence that references the non-existent PR template, so we should remove that sentence.