### PR TITLE
[1.12] docs: fix dangling @ref targets (manual backport to 1.12)

### DIFF
--- a/doc/src/devdocs/sysimg.md
+++ b/doc/src/devdocs/sysimg.md
@@ -169,7 +169,7 @@ debug info, respectively, and so will make debugging more difficult.
 - Use tools like [JET.jl](https://github.com/aviatesk/JET.jl),
   [Cthulhu.jl](https://github.com/JuliaDebug/Cthulhu.jl), and/or
   [SnoopCompile](https://github.com/timholy/SnoopCompile.jl)
-  to identify failures of type-inference, and follow our [Performance Tips](@ref) to fix them.
+  to identify failures of type-inference, and follow our [Performance Tips](@ref man-performance-tips) to fix them.
 
 ### Compatibility concerns
 

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -64,7 +64,7 @@ and [Ruby](https://en.wikipedia.org/wiki/Ruby_(programming_language)).
 
 The most significant departures of Julia from typical dynamic languages are:
 
-  * The core language imposes very little; [Julia Base and the standard library](@ref man-core-base-and-stdlib) are written in Julia itself, including
+  * The core language imposes very little; [Julia Base and the standard library](@ref standard-modules) are written in Julia itself, including
     primitive operations like integer arithmetic
   * A rich language of types for constructing and describing objects, that can also optionally be
     used to make type declarations

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -1112,7 +1112,7 @@ loops cannot be merged because of the intervening `sort` function.
 
 Finally, the maximum efficiency is typically achieved when the output array of a vectorized operation
 is *pre-allocated*, so that repeated calls do not allocate new arrays over and over again for
-the results (see [Pre-allocating outputs](@ref)). A convenient syntax for this is `X .= ...`, which
+the results (see [Pre-allocate outputs](@ref)). A convenient syntax for this is `X .= ...`, which
 is equivalent to `broadcast!(identity, X, ...)` except that, as above, the `broadcast!` loop is
 fused with any nested "dot" calls. For example, `X .= sin.(Y)` is equivalent to `broadcast!(sin, X, Y)`,
 overwriting `X` with `sin.(Y)` in-place. If the left-hand side is an array-indexing expression,

--- a/doc/src/manual/memory-management.md
+++ b/doc/src/manual/memory-management.md
@@ -142,7 +142,7 @@ The best way to minimize GC impact is to reduce unnecessary allocations:
 
 ### Profiling Memory Usage
 
-For detailed guidance on profiling memory allocations and identifying performance bottlenecks, see the [Profiling](@ref man-profiling) section.
+For detailed guidance on profiling memory allocations and identifying performance bottlenecks, see the [Profiling](@ref lib-profiling) section.
 
 ## [Advanced Configuration](@id man-gc-advanced)
 

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -578,7 +578,7 @@ However, future calls to `tryeval` will continue to see the definition of `newfu
 
 You may want to try this for yourself to see how it works.
 
-The implementation of this behavior is a "world age counter", which is further described in the [Worldage](@ref man-worldage)
+The implementation of this behavior is a "world age counter", which is further described in the [Worldage](@ref "The World Age mechanism")
 manual chapter.
 
 ## Design Patterns with Parametric Methods

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -375,7 +375,7 @@ WARNING: import of M1.x into Main conflicts with an existing identifier; ignored
 ```
 
 The resolution of an implicit binding depends on the set of all `using`'d modules visible
-in the current world age. See [the manual chapter on world age](@ref man-worldage) for more
+in the current world age. See [the manual chapter on world age](@ref "The World Age mechanism") for more
 details.
 
 ### Default top-level definitions and bare modules

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -154,7 +154,7 @@ julia> time_sum(x)
 In some situations, your function may need to allocate memory as part of its operation, and this
 can complicate the simple picture above. In such cases, consider using one of the [tools](@ref tools)
 below to diagnose problems, or write a version of your function that separates allocation from
-its algorithmic aspects (see [Pre-allocating outputs](@ref)).
+its algorithmic aspects (see [Pre-allocate outputs](@ref)).
 
 !!! note
     For more serious benchmarking, consider the [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl)
@@ -1440,7 +1440,7 @@ may be the case during development of a package.
 Keeping the time taken to load the package down is usually helpful.
 General good practice for package developers includes:
 
-1. Reduce your dependencies to those you really need. Consider using [package extensions](@ref) to support interoperability with other packages without bloating your essential dependencies.
+1. Reduce your dependencies to those you really need. Consider using [package extensions](@ref man-extensions) to support interoperability with other packages without bloating your essential dependencies.
 3. Avoid use of [`__init__()`](@ref) functions unless there is no alternative, especially those which might trigger a lot
    of compilation, or just take a long time to execute.
 4. Where possible, fix [invalidations](https://julialang.org/blog/2020/08/invalidations/) among your dependencies and from your package code.


### PR DESCRIPTION
Found by building the manual against a Documenter that reports unmatched references instead of parsing the slug as an expression, which resolved them to the docstring of `-`. Same fix as #62718 on master, minus the parts that only apply there.