### PR TITLE
scopedvalues: Fold reads from enclosing scopes

### DIFF
--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -567,6 +567,13 @@ function lift_comparison!(::typeof(===), compact::IncrementalCompact,
     lhs, rhs = args[2], args[3]
     vl = argextype(lhs, compact)
     vr = argextype(rhs, compact)
+    result = egal_tfunc(𝕃ₒ, vl, vr)
+    if isa(result, Const)
+        compact[idx] = result.val
+        compact[SSAValue(idx)][:type] = result
+        add_flag!(compact[SSAValue(idx)], IR_FLAG_REFINED)
+        return
+    end
     if isa(vl, Const)
         isa(vr, Const) && return
         val = rhs
@@ -1098,9 +1105,11 @@ function lift_keyvalue_get!(compact::IncrementalCompact, idx::Int, stmt::Expr, �
         KeyValueWalker(compact))
 
     if lifted_val !== nothing
-        compact[idx] = Expr(:new, wrapper_typ, lifted_val.val)
+        newexpr = Expr(:new, wrapper_typ, lifted_val.val)
+        compact[idx] = newexpr
         compact[SSAValue(idx)][:type] = wrapper_typ
         add_flag!(compact[SSAValue(idx)], IR_FLAG_REFINED)
+        refine_new_effects!(𝕃ₒ, compact, idx, newexpr)
     else
         compact[idx] = nothing
     end
@@ -1558,6 +1567,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
         line = compact[SSAValue(idx)][:line]
         if lifted_val !== nothing && !⊑(𝕃ₒ, compact[SSAValue(idx)][:type], result_t)
             compact[idx] = lifted_val.val
+            compact[SSAValue(idx)][:type] = result_t
             add_flag!(compact[SSAValue(idx)], IR_FLAG_REFINED)
         elseif lifted_val === nothing || isa(lifted_val.val, AnySSAValue)
             # Save some work in a later compaction, by inserting this into the renamer now,

--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -1576,7 +1576,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
             compact.ssa_rename[old_idx] = lifted_val === nothing ? nothing : lifted_val.val::AnySSAValue
             should_delete_node = true
         else
-            compact[idx] = lifted_val === nothing ? nothing : lifted_val.val
+            compact[idx] = lifted_val.val
         end
 
         finish_phi_nest!(compact, nest)

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -2174,6 +2174,22 @@ let src = code_typed1(foosvalconstprop, ())
     @test count(is_constfield_load, src.code) == 0
 end
 
+# JuliaLang/julia#58330: fold scoped value reads after setting the same key
+const sval58330 = ScopedValue(1)
+let (ir, _) = only(Base.code_ircode(()) do
+        @with sval58330 => 2 sval58330[]
+    end)
+    ret = only(filter(isreturn, ir.stmts.stmt))
+    @test singleton_type(Compiler.argextype(ret.val, ir)) === 2
+end
+let (ir, _) = only(Base.code_ircode(()) do
+        with(sval58330 => 2) do
+            sval58330[]
+        end
+    end)
+    ret = only(filter(isreturn, ir.stmts.stmt))
+    @test singleton_type(Compiler.argextype(ret.val, ir)) === 2
+end
 # JuliaLang/julia #59548
 # Rewrite `Core._apply_iterate` to use `Core.svec` instead of `tuple` to better match
 # the codegen ABI

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -2174,21 +2174,42 @@ let src = code_typed1(foosvalconstprop, ())
     @test count(is_constfield_load, src.code) == 0
 end
 
-# JuliaLang/julia#58330: fold scoped value reads after setting the same key
+# JuliaLang/julia#58330: propagate SROA type refinements through scoped value reads and comparisons
 const sval58330 = ScopedValue(1)
-let (ir, _) = only(Base.code_ircode(()) do
-        @with sval58330 => 2 sval58330[]
-    end)
-    ret = only(filter(isreturn, ir.stmts.stmt))
-    @test singleton_type(Compiler.argextype(ret.val, ir)) === 2
+struct SROAEgalNonConst
+    x::Any
 end
-let (ir, _) = only(Base.code_ircode(()) do
-        with(sval58330 => 2) do
-            sval58330[]
-        end
-    end)
-    ret = only(filter(isreturn, ir.stmts.stmt))
-    @test singleton_type(Compiler.argextype(ret.val, ir)) === 2
+
+@testset "SROA type refinement propagation" begin
+    let (ir, _) = only(Base.code_ircode(()) do
+            @with sval58330 => 2 sval58330[]
+        end)
+        ret = only(filter(isreturn, ir.stmts.stmt))
+        @test singleton_type(Compiler.argextype(ret.val, ir)) === 2
+    end
+
+    let (ir, _) = only(Base.code_ircode(()) do
+            with(sval58330 => 2) do
+                sval58330[]
+            end
+        end)
+        ret = only(filter(isreturn, ir.stmts.stmt))
+        @test singleton_type(Compiler.argextype(ret.val, ir)) === 2
+    end
+
+    let (ir, _) = only(Base.code_ircode(
+            (Bool, Int, Float64, String); optimize_until="CC: SROA") do b, x, y, z
+            local val
+            if b
+                val = SROAEgalNonConst(x)
+            else
+                val = SROAEgalNonConst(y)
+            end
+            val.x === z
+        end)
+        ret = only(filter(isreturn, ir.stmts.stmt))
+        @test singleton_type(Compiler.argextype(ret.val, ir)) === false
+    end
 end
 # JuliaLang/julia #59548
 # Rewrite `Core._apply_iterate` to use `Core.svec` instead of `tuple` to better match

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -282,7 +282,7 @@ julia> with(() -> a[] * b[], a=>3, b=>4)
 12
 ```
 """
-function with(f, pair::Pair{<:AbstractScopedValue}, rest::Pair{<:AbstractScopedValue}...)
+@inline function with(f, pair::Pair{<:AbstractScopedValue}, rest::Pair{<:AbstractScopedValue}...)
     @with(pair, rest..., f())
 end
 with(@nospecialize(f)) = f()


### PR DESCRIPTION
mostly one-shot by codex 5.6 Sol xhigh. but as far as I can tell the fix seems reasonable and I verified that it solves the performance issue:


🤖-----------------
Make `ScopedValues.with` inlineable so call-site constants reach the optimizer. Propagate SROA type refinements immediately, fold identity comparisons using refined types, and recompute effects after replacing `KeyValue.get`.

Fixes JuliaLang/julia#58330