### PR TITLE
Fix: unsplat(f) inverse to splat(f)

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1344,6 +1344,7 @@ julia> my_add((1,2,3))
 ```
 """
 splat(f) = Splat(f)
+unsplat(f) = args -> f(args...)
 
 """
     Base.Splat{F} <: Function

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -294,6 +294,7 @@ Base.:(|>)
 Base.:(∘)
 Base.ComposedFunction
 Base.splat
+Base.unsplat
 Base.Fix
 Base.Fix1
 Base.Fix2


### PR DESCRIPTION
This PR addresses #62710.

unsplat(f) inverse to splat(f)

Generated with AI assistance and validated against the original
file before submission (syntax check + change-scope check).
Please review carefully — happy to adjust based on feedback.
