### PR TITLE
codegen: link emitted CI modules deterministically

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -6,6 +6,7 @@
 // target support
 #include <llvm/TargetParser/Triple.h>
 #include "llvm/Support/CodeGen.h"
+#include <llvm/ADT/MapVector.h>
 #include <llvm/ADT/Statistic.h>
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
@@ -352,7 +353,7 @@ struct jl_compiled_function_t {
    orc::ThreadSafeModule TSM;
    jl_llvm_functions_t decls;
 };
-typedef DenseMap<jl_code_instance_t*, jl_compiled_function_t> jl_compiled_functions_t;
+typedef MapVector<jl_code_instance_t*, jl_compiled_function_t> jl_compiled_functions_t;
 
 static void record_method_roots(egal_set &method_roots, jl_method_instance_t *mi)
 {

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -335,6 +335,8 @@ public:
     egal_set() = default;
     void insert(jl_value_t *val)
     {
+        JL_GC_PROMISE_ROOTED(list);
+        JL_GC_PROMISE_ROOTED(keyset);
         jl_value_t *rval = jl_idset_get(list, keyset, val);
         if (rval == NULL) {
             ssize_t idx;
@@ -614,8 +616,8 @@ static void generate_cfunc_thunks(jl_codegen_params_t &params, jl_compiled_funct
             auto it = compiled_mi.find(mi);
             if (it != compiled_mi.end()) {
                 codeinst = it->second;
-                JL_GC_PROMISE_ROOTED(codeinst);
                 auto defs = compiled_functions.find(codeinst);
+                JL_GC_PROMISE_ROOTED(codeinst);
                 defM = defs->second.TSM.getModuleUnlocked();
                 const jl_llvm_functions_t &decls = defs->second.decls;
                 func = decls.functionObject;
@@ -821,6 +823,7 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
             assert(jl_is_code_info(src));
             if (compiled_functions.count(codeinst))
                 continue; // skip any duplicates that accidentally made there way in here (or make this an error?)
+            JL_GC_PROMISE_ROOTED(codeinst);
             if (jl_ir_inlining_cost((jl_value_t*)src) < UINT16_MAX)
                 params.safepoint_on_entry = false; // ensure we don't block ExpandAtomicModifyPass from inlining this code if applicable
             orc::ThreadSafeModule result_m =


### PR DESCRIPTION
The per-CodeInstance modules created by jl_emit_native / jl_create_native are merged into the output by iterating a DenseMap keyed on CodeInstance pointers, so the merged module's layout (function order, metadata numbering) depends on session heap addresses whenever a compilation spans multiple CodeInstances. That defeats consumers that content-key on the emitted code (e.g. Metal.jl's machine-code cache, keyed on the metallib bytes GPUCompiler.jl gets out of jl_emit_native, misses randomly across sessions) and is an obstacle to reproducible image builds.

Use an insertion-ordered MapVector instead, so the link loop, root optimization, and cfunc thunk generation all follow emission order.

Not needed on 1.14+: since #60031 codegen emits directly into a single module in codeinfos order, so there is no pointer-ordered merge step.