### PR TITLE
contrib/asan: reduce sanitizer overhead

### DIFF
--- a/contrib/asan/Make.user.asan
+++ b/contrib/asan/Make.user.asan
@@ -13,8 +13,8 @@ USE_BINARYBUILDER_LLVM=1
 override SANITIZE=1
 override SANITIZE_ADDRESS=1
 
-# make the GC use regular malloc/frees, which are hooked by ASAN
-override WITH_GC_DEBUG_ENV=1
+# Limit allocation stack traces to reduce ASAN memory and runtime overhead.
+export ASAN_OPTIONS=allow_user_segv_handler=1:detect_leaks=0:malloc_context_size=2
 
 # Enable Julia assertions and LLVM assertions
 FORCE_ASSERTIONS=1

--- a/contrib/asan/build.sh
+++ b/contrib/asan/build.sh
@@ -5,10 +5,9 @@
 # Usage:
 #     contrib/asan/build.sh <path> [<make_targets>...]
 #
-# Build ASAN-enabled julia.  Given a workspace directory <path>, build
-# ASAN-enabled julia in <path>/asan.  Required toolss are install under
-# <path>/toolchain.  This scripts also takes optional <make_targets> arguments
-# which are passed to `make`.  The default make target is `debug`.
+# Build ASAN-enabled julia in <path>/asan. Required tools are installed under
+# <path>/toolchain. Optional <make_targets> are passed to `make`; the default
+# target is `release`.
 
 set -ue
 


### PR DESCRIPTION
Limit allocation backtraces to two frames, avoiding deep stack unwinding on every malloc and free. Remove `WITH_GC_DEBUG_ENV` because it enables full-heap verification and stack scrubbing rather than malloc-backed GC allocations as its comment claimed. Together these changes reduced the local compiler bootstrap from 1692 to 1303 seconds.

Together with https://github.com/JuliaCI/julia-buildkite/pull/613 this hopefully reduces the risk of the ASAN job timing out, as has been happening recently.