### PR TITLE
Markdown: Restore note admonition color

### DIFF
--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -45,7 +45,9 @@ end
 function term(io::IO, md::Admonition, columns)
     accent = if md.category == "danger"
         :error
-    elseif md.category in ("warning", "info", "note", "tip")
+    elseif md.category in ("info", "note")
+        :info
+    elseif md.category in ("warning", "tip")
         Symbol(md.category)
     elseif md.category == "compat"
         :bright_cyan


### PR DESCRIPTION
Render note admonitions with the info face, restoring the informational terminal color used before the StyledStrings migration.

Fixes #61513

Assisted-by: Codex (GPT-5)