### PR TITLE
Avoid recursive tuple splatting in Base.front

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -372,6 +372,11 @@ const All32{T,N} = Tuple{T,T,T,T,T,T,T,T,
                          T,T,T,T,T,T,T,T,
                          Vararg{T,N}}
 
+function front(t::NTuple{32, Any})
+    @inline
+    _front(t...)
+end
+
 function front(t::Any32)
     n = length(t) - 1
     r = ntuple(i -> getfield(t, i), n)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -341,12 +341,15 @@ julia> Base.front(())
 ERROR: ArgumentError: Cannot call front on an empty tuple.
 ```
 """
-front(::Tuple{}) = throw(ArgumentError("Cannot call front on an empty tuple."))
-
-function front(t::Tuple{Any,Vararg{Any,N}}) where {N}
+function front(t::Tuple)
     @inline
-    r = ntuple(i -> getfield(t, i), Val(N))
-    return r::Tuple{Vararg{eltype(typeof(t))}}
+    _front(t...)
+end
+_front() = throw(ArgumentError("Cannot call front on an empty tuple."))
+_front(v) = ()
+function _front(v, t...)
+    @inline
+    (v, _front(t...)...)
 end
 
 ## mapping ##
@@ -368,6 +371,13 @@ const All32{T,N} = Tuple{T,T,T,T,T,T,T,T,
                          T,T,T,T,T,T,T,T,
                          T,T,T,T,T,T,T,T,
                          Vararg{T,N}}
+
+function front(t::Any32)
+    n = length(t) - 1
+    r = ntuple(i -> getfield(t, i), n)
+    return r::Tuple{Vararg{eltype(typeof(t))}}
+end
+
 function map(f, t::Any32)
     n = length(t)
     A = Vector{Any}(undef, n)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -341,15 +341,12 @@ julia> Base.front(())
 ERROR: ArgumentError: Cannot call front on an empty tuple.
 ```
 """
-function front(t::Tuple)
+front(::Tuple{}) = throw(ArgumentError("Cannot call front on an empty tuple."))
+
+function front(t::Tuple{Any,Vararg{Any,N}}) where {N}
     @inline
-    _front(t...)
-end
-_front() = throw(ArgumentError("Cannot call front on an empty tuple."))
-_front(v) = ()
-function _front(v, t...)
-    @inline
-    (v, _front(t...)...)
+    r = ntuple(i -> getfield(t, i), Val(N))
+    return r::Tuple{Vararg{eltype(typeof(t))}}
 end
 
 ## mapping ##

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -160,6 +160,14 @@ end
     # @test_throws ArgumentError size((), 2)
     # @test_throws ArgumentError size((1,), 2)
     # @test_throws ArgumentError size((1,2), 2)
+    @test_throws ArgumentError Base.front(())
+    @test Base.front((1,)) === ()
+    @test Base.front((1, 2, 3)) === (1, 2)
+    @test Base.front((1, 2.0, "three", :four)) === (1, 2.0, "three")
+
+    let t = ntuple(identity, Val(40))
+        @test @inferred(Base.front(t)) === ntuple(identity, Val(39))
+    end
 end
 
 @testset "indexing" begin

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -166,7 +166,7 @@ end
     @test Base.front((1, 2.0, "three", :four)) === (1, 2.0, "three")
 
     let t = ntuple(identity, Val(40))
-        @test @inferred(Base.front(t)) === ntuple(identity, Val(39))
+        @test Base.front(t) === ntuple(identity, Val(39))
     end
 end
 


### PR DESCRIPTION
Fixes #62748.


`Base.front` currently recursively splats a shrinking tuple through `_front`, which leads to quadratic behavior for large tuples.

This PR keeps the existing recursive implementation through input length 32 and uses a generic runtime-length `ntuple` path for longer tuples. This avoids specializing on the long tuple length while preserving the existing inference behavior for variable-length homogeneous tuples.

The benchmarks below compare two local Julia builds:

```text
master: 1c0ffe69a0ef692e6d7c9cc78aa9acd89a35a5a7
PR: 966468dfd51c89782b1014928424a44c424cc674
```
### Steady-state

N | master | PR | speedup | master allocations | PR allocations
-- | -- | -- | -- | -- | --
4 | 1.608 ns | 1.807 ns | 0.89× | 0 | 0
32 | 2.943 ns | 2.833 ns | 1.04× | 0 | 0
33 | 18.173 μs | 893.261 ns | 20.3× | 594 | 35
64 | 63.599 μs | 1.668 μs | 38.1× | 2,144 | 66
128 | 244.906 μs | 3.274 μs | 74.8× | 8,384 | 130
256 | 959.200 μs | 6.556 μs | 146.3× | 33,152 | 259
1024 | 15.910 ms | 25.716 μs | 618.7× | 526,337 | 1,028
4096 | 259.833 ms | 102.160 μs | 2,543.4× | 8,398,337 | 4,100

The existing specialized path is retained through `N = 32`; the generic runtime-length path starts at `N = 33`.

For `N = 4096`, steady-state time decreases from about 260 ms to 102 μs, while allocations decrease from about 8.4 million to 4,100.

### First call (includes compilation)
Each measurement was performed in a fresh Julia process.

N | master | PR | speedup | master allocated | PR allocated
-- | -- | -- | -- | -- | --
4 | 0.772 ms | 1.533 ms | 0.50× | 176.328 KiB | 176.328 KiB
33 | 15.434 ms | 22.384 ms | 0.69× | 3.560 MiB | 3.568 MiB
128 | 35.203 ms | 23.101 ms | 1.52× | 14.037 MiB | 3.571 MiB
1024 | 1.626 s | 23.848 ms | 68.2× | 545.071 MiB | 3.617 MiB
4096 | 29.649 s | 24.850 ms | 1,193.1× | 9.198 GiB | 3.782 MiB

For the tested long tuple sizes, the PR first-call cost remains nearly constant as the tuple length increases. At `N = 4096`, first-call time decreases from about 29.6 s to 24.9 ms, while allocated memory decreases from 9.20 GiB to 3.78 MiB.

### Optimized IR size
The specialized path is retained through `N = 32`, while the runtime-`n` implementation keeps the optimized IR bounded starting at `N = 33`:

```julia
julia> for N in (31, 32, 33, 34, 128, 1024, 4096)
           t = ntuple(Float64, N)

           ci, rt = only(code_typed(
               Base.front,
               Tuple{typeof(t)};
               optimize=true,
           ))

           println(
               "N = ", N,
               " | IR statements = ", length(ci.code),
               " | return type = ", rt,
           )
       end
N = 31 | IR statements = 32 | return type = NTuple{30, Float64}
N = 32 | IR statements = 33 | return type = NTuple{31, Float64}
N = 33 | IR statements = 3 | return type = Tuple{Vararg{Float64}}
N = 34 | IR statements = 3 | return type = Tuple{Vararg{Float64}}
N = 128 | IR statements = 3 | return type = Tuple{Vararg{Float64}}
N = 1024 | IR statements = 3 | return type = Tuple{Vararg{Float64}}
N = 4096 | IR statements = 3 | return type = Tuple{Vararg{Float64}}
```

### Tests

- `./julia test/runtests.jl tuple` — passed
- `./julia test/runtests.jl core` — passed
- `Compiler/AbstractInterpreter` — passed

**Note:** `make testall` encountered an unrelated `Statistics` failure that was reproduced on an unmodified build of the same master revision.

### AI assistance
OpenAI ChatGPT was used to help discuss the implementation, benchmark and testing strategy, and wording of this pull request. I reviewed the proposed changes and built and tested the implementation locally.
