### PR TITLE
Compiler: Handle byte-precise coverage locations

### DIFF
--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -679,7 +679,9 @@ _should_instrument(::Module) = false
 _should_instrument(::Nothing) = false
 function _should_instrument(info::DebugInfo)
     linetable = info.linetable
-    linetable === nothing || (_should_instrument(linetable) && return true)
+    # a byte-precise linetable is a compressed `String` that carries no file
+    # information of its own; only recurse into nested `DebugInfo`
+    linetable isa DebugInfo && _should_instrument(linetable) && return true
     _should_instrument(info.def) && return true
     return false
 end

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -1161,10 +1161,10 @@ function changed_lineinfo(di::DebugInfo, codeloc::Int, prevloc::Int)
         edge === prev[2] || return true # change to this edge
         linetable = di.linetable
         # check for change to line number here
-        if linetable === nothing || line == 0
+        if !(linetable isa DebugInfo) || line == 0
             line == prevline || return true
         else
-            changed_lineinfo(linetable::DebugInfo, Int(line), Int(prevline)) && return true
+            changed_lineinfo(linetable, Int(line), Int(prevline)) && return true
         end
         # check for change to edge here
         edge == 0 && return false # no edge here

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -863,6 +863,24 @@ let cl = Int32[0,0,0,255,0,0,256,0,0,257,0,0]
     @test roundtrip_di(cl, 33, 4) == cl
 end
 
+# Test line comparisons with byte-precise debuginfo.
+let sbt = String(UInt8[
+        1, 0, 0, 0, # byte offset
+        1, 0, 0, 0, # line offset
+        2, 0, 0, 0, # number of locations
+        1, 1,       # byte and span encoding lengths
+        0, 1, 2, 1, # byte spans
+        0, 2,       # line starts
+    ])
+    codelocs = Int32[1, 0, 0, 2, 0, 0]
+    str = ccall(:jl_compress_codelocs,
+                Any, (Int32, Any, Int), Int32(-1), codelocs, 2)::String
+    di = Core.DebugInfo(:foo, sbt, Core.svec(), str)
+    @test !Compiler.changed_lineinfo(di, 1, 1)
+    @test Compiler.changed_lineinfo(di, 2, 1)
+    @test !Compiler._should_instrument(di)
+end
+
 @test_throws ErrorException Base.code_ircode(+, (Float64, Float64); optimize_until = "nonexisting pass name")
 @test_throws ErrorException Base.code_ircode(+, (Float64, Float64); optimize_until = typemax(Int))
 


### PR DESCRIPTION
JuliaLowering's byte-precise debug info stores its linetable as a compressed `String`, but the coverage machinery in the compiler assumed `DebugInfo.linetable` is either `nothing` or a nested `DebugInfo`, in two places:

- `changed_lineinfo` (called from `convert_to_ircode!` to decide where to insert coverage counters, only when `sv.insert_coverage` is set): the `linetable::DebugInfo` typeassert throws. Hit by any coverage mode.
- `_should_instrument` (called from `should_insert_coverage` when deciding whether a method falls in a tracked file): recurses into the linetable and hits a `MethodError: no method matching _should_instrument(::String)`. Only reached in path-specific mode (`--code-coverage=@<path>`), which is why the `all`-mode coverage CI only surfaced the first failure.

JuliaLowering-lowered code carrying byte-precise debug info can therefore fail inference under `--code-coverage`:

```
Internal error: during type inference of
Tuple{}
Encountered unexpected error in runtime:
TypeError(func=:typeassert, context="", expected=Core.DebugInfo, got="\x01\0\0\0\x01\0\0\0\f\0\0\0...")
ijl_type_error_rt at src/rtutils.c:121:5
changed_lineinfo at Compiler/src/optimize.jl:1167:0
convert_to_ircode! at Compiler/src/optimize.jl:1252:0
...
```

This failed the JuliaLowering test suite in the scheduled coverage run (the error above is from the [Linux coverage job of julia-ci build 285](https://buildkite.com/julialang/julia-ci/builds/285#01a00101-1e50-4ded-80a1-cacd0fcafd90), while running `JuliaLowering/test/branching.jl`).

The fix compares decoded locations directly for a non-`DebugInfo` linetable; nested lookup remains unchanged for `DebugInfo` linetables. It also makes `_should_instrument` recurse only into nested `DebugInfo`. File information for a byte-precise linetable remains available through the outer debug info's `def`, which is still checked.

Assisted by: Fable & Sol