### PR TITLE
codegen: Normalize isbits-union constant layouts

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -253,7 +253,7 @@ static Constant *julia_const_to_llvm(jl_codectx_t &ctx, const void *ptr, jl_data
             (void)jl_islayout_inline(ft, &fsz, &al); // compute al
             fsz = jl_field_size(bt, i); // get LLT_ALIGN(fsz+1,al)
             uint8_t sel = ((const uint8_t*)ptr)[offs + fsz - 1];
-            jl_value_t *active_ty = jl_nth_union_component(ft, sel);
+            jl_value_t *active_ty = normalize_typeofbottom_layout_alias(jl_nth_union_component(ft, sel));
             size_t active_sz = jl_datatype_size(active_ty);
             Type *AlignmentType = IntegerType::get(ctx.builder.getContext(), 8 * al);
             unsigned NumATy = (fsz - 1) / al;

--- a/test/core.jl
+++ b/test/core.jl
@@ -8959,6 +8959,14 @@ end
 
 @test sizeof(Pair{Union{typeof(Union{}),Nothing}, Union{Type{Union{}},Nothing}}(Union{}, Union{})) == 2
 
+# Codegen of a Type{Union{}} isbits-union component.
+typeofbottom_union_constant() =
+    Pair{Union{typeof(Union{}),Nothing}, Union{Type{Union{}},Nothing}}(Union{}, Union{})
+code_llvm(devnull, typeofbottom_union_constant, Tuple{})
+let p = typeofbottom_union_constant()
+    @test p.first === Union{} && p.second === Union{}
+end
+
 # Make sure that Core.Compiler has enough NamedTuple infrastructure
 # to properly give error messages for basic kwargs...
 Core.eval(Core.Compiler, quote issue50174(;a=1) = a end)


### PR DESCRIPTION
When emitting a compile-time constant containing an isbits-union field, `julia_const_to_llvm` queries `jl_datatype_size` on the active union component. `Type{Union{}}` is a layout alias: it has no layout of its own and must be normalized to `typeof(Union{})` first, as `staticdata.c` and `genericmemory.c` already do. Without the normalization, codegen dereferences a null layout and segfaults:

```julia
using InteractiveUtils
typeofbottom_union_constant() = Pair{Union{typeof(Union{}),Nothing}, Union{Type{Union{}},Nothing}}(Union{}, Union{})
code_llvm(devnull, typeofbottom_union_constant, Tuple{})
```

```
Fault at memory address: 0x9b
[...] signal 11 (1): Segmentation fault
jl_is_layout_opaque at src/julia.h:1569:28 [inlined]
jl_datatype_layout at src/julia.h:1577:49
julia_const_to_llvm at src/intrinsics.cpp:257:32
emit_unbox at src/intrinsics.cpp:455:51
emit_function at src/codegen.cpp:10062:40
```

Coverage compilation exposed this while compiling a `test/core.jl` top-level thunk containing a `Type{Union{}}`-valued union field, killing the `core` test worker with the same backtrace in the [Linux coverage job of julia-ci build 285](https://buildkite.com/julialang/julia-ci/builds/285#01a00101-1e50-4ded-80a1-cacd0fcafd90) (`in expression starting at test/core.jl:768`). The reproducer shows that the crash itself is not coverage-specific.

Assisted by: Fable & Sol