### PR TITLE
tests: Isolate nested coverage output

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1771,6 +1771,8 @@ end
     mkdepottempdir() do depot
         cov_test_dir = joinpath(@__DIR__, "project", "deps", "CovTest.jl")
         cov_cache_dir = joinpath(depot, "compiled", "v$(VERSION.major).$(VERSION.minor)", "CovTest")
+        # Do not let an outer tracefile redirect .cov output.
+        cov_exename = Base.julia_cmd()[1]
         function rm_cov_files()
             for cov_file in filter(endswith(".cov"), readdir(joinpath(cov_test_dir, "src"), join=true))
                 rm(cov_file)
@@ -1785,7 +1787,7 @@ end
         cd(cov_test_dir) do
             # In our depot, precompile CovTest.jl with coverage on
             @test success(addenv(
-                `$(Base.julia_cmd()) --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; exit(0)'`,
+                `$cov_exename --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; exit(0)'`,
                 "JULIA_DEPOT_PATH" => depot,
             ))
             @test !isempty(filter(!endswith(".ji"), readdir(cov_cache_dir))) # check that object cache file(s) exists
@@ -1794,7 +1796,7 @@ end
 
             # same again but call foo(), which is in the pkgimage, and should generate coverage
             @test success(addenv(
-                `$(Base.julia_cmd()) --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; foo(); exit(0)'`,
+                `$cov_exename --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; foo(); exit(0)'`,
                 "JULIA_DEPOT_PATH" => depot,
             ))
             @test cov_exists()
@@ -1802,7 +1804,7 @@ end
 
             # same again but call bar(), which is NOT in the pkgimage, and should generate coverage
             @test success(addenv(
-                `$(Base.julia_cmd()) --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; bar(); exit(0)'`,
+                `$cov_exename --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; bar(); exit(0)'`,
                 "JULIA_DEPOT_PATH" => depot,
             ))
             @test cov_exists()


### PR DESCRIPTION
The coverage CI runs the test suite with `--code-coverage=all --code-coverage=lcov-%p.info`. The CovTest tests in `test/loading.jl` spawn subprocesses via `Base.julia_cmd()` with an explicit `--code-coverage=@`, expecting per-file `.cov` output. However:

- `Base.julia_cmd()` forwards the outer coverage options, including the `lcov-%p.info` tracefile (it forwards tracefiles whenever they contain `%p`), so the child sees `--code-coverage=lcov-%p.info --code-coverage=@`.
- In `jloptions.c`, a later `--code-coverage=@...` updates the coverage mode but does not clear an existing `output_code_coverage` tracefile.

The child therefore writes to `lcov-<pid>.info` instead of `.cov` files, and the test's `cov_exists()` assertions fail when the outer test run uses an lcov tracefile. The [Linux coverage job of julia-ci build 285](https://buildkite.com/julialang/julia-ci/builds/285#01a00101-1e50-4ded-80a1-cacd0fcafd90) reported two such failures.

Assisted by: Fable & Sol