### PR TITLE
jit: Clear stale CodeInstance symbol mappings

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2106,10 +2106,8 @@ void JuliaOJIT::publishCIs(ArrayRef<jl_code_instance_t *> CIs, bool Wait)
 
 void JuliaOJIT::registerCI(jl_code_instance_t *CI)
 {
-#ifndef JL_NDEBUG
     std::unique_lock Lock{LinkerMutex};
-    assert(!CISymbols.contains(CI));
-#endif
+    CISymbols.erase(CI);
 }
 
 void JuliaOJIT::unregisterCI(jl_code_instance_t *CI)

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -845,10 +845,9 @@ public:
 
     void publishCIs(ArrayRef<jl_code_instance_t *> CIs, bool Wait=false) JL_CANSAFEPOINT;
 
+    // Remove any mapping left at a newly allocated CodeInstance's address.
     void registerCI(jl_code_instance_t *CI) JL_NOTSAFEPOINT;
-    // When a CodeInstance is garbage collected, we must remove any existing
-    // entries in CISymbols, to prevent invokes to a new CodeInstance with the
-    // same address from being linked to old symbol.
+    // Remove a mapping before a CodeInstance becomes unreachable.
     void unregisterCI(jl_code_instance_t *CI) JL_NOTSAFEPOINT;
 
     orc::ThreadSafeContext makeContext() JL_NOTSAFEPOINT;
@@ -945,9 +944,7 @@ private:
 
     // LinkerMutex protects CISymbols, Names
     std::mutex LinkerMutex;
-    // CISymbols maps CodeInstance pointers to their ORC symbols.  If a
-    // CodeInstance is eligible for garbage collection, it must be removed from
-    // this map first, with unregisterCI.
+    // Maps CodeInstance pointers to their ORC symbols.
     CISymbolMap CISymbols;
     jl_name_counter_t Names;
 


### PR DESCRIPTION
`JuliaOJIT::CISymbols` (from #60031) maps `jl_code_instance_t*` to ORC symbols for CodeInstances added to the JIT. The only `unregisterCI` caller is `jl_invoke_oneshot` for top-level thunks; there is no GC hook. Since #62359, ephemeral-cache interpreters (`@newinterp ... true` with a `codegen_cache`) can produce JIT-compiled CodeInstances that are not in `mi->cache`. When such a CodeInstance is collected, its `CISymbols` entry dangles, and a later `jl_new_codeinst` that reuses the same pool address trips the assertion in assert builds:

```
julia: src/jitlayers.cpp:2111: void JuliaOJIT::registerCI(jl_code_instance_t*):
Assertion `!CISymbols.contains(CI)' failed.
```

In release builds, `registerCI` was compiled out. A recycled address can therefore inherit the dead CodeInstance's symbols, or abort in `makeUniqueCIName` when the new CodeInstance is compiled.

This aborted the `Compiler/AbstractInterpreter` test (`OverlayCacheInterp`) in the coverage PR's [x86_64-linux-gnuassertrr job](https://buildkite.com/julialang/julia-pr/builds/1472#01a00061-de94-49ba-9523-83b1846b8e8a).

Assisted by: Fable & Sol