### PR TITLE
test: Do not assume threaded completion order

### DIFF
--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1136,8 +1136,6 @@ end
 
     unordered_fair = collect(jitter_channel(sin, k, delay, 10, Threads.FairSchedule()))
     unordered_static = collect(jitter_channel(sin, k, delay, 10, Threads.StaticSchedule()))
-    @test expected != unordered_fair
-    @test expected != unordered_static
     @test Set(expected) == Set(unordered_fair)
     @test Set(expected) == Set(unordered_static)
 


### PR DESCRIPTION
The `Threads.foreach(f, ::Channel)` testset in `test/threads_exec.jl` asserts that with `ntasks=10` the results come back in a different order from the input (`@test expected != unordered_fair` / `!= unordered_static`). That is a statement about scheduling luck, not `Threads.foreach` semantics: nothing guarantees that multiple tasks complete items out of order.

The retry of the coverage PR's [x86_64-linux-gnuassertrr job](https://buildkite.com/julialang/julia-pr/builds/1472#01a00201-1630-466d-b4ad-8f2cb0ce31e5) failed in the `JULIA_NUM_THREADS=1,1` pass when the fair schedule happened to preserve input order:

```
Test Failed at test/threads_exec.jl:1139
  Expression: expected != unordered_fair
```

Remove the two scheduling-sensitive checks. The single-worker ordering checks (`ntasks=1` must preserve order) and multiset-equality checks remain.

Assisted by: Fable & Sol