### PR TITLE
tests: Reduce noise in passing CI logs

### DIFF
--- a/Compiler/extras/CompilerDevTools/test/testpkg.jl
+++ b/Compiler/extras/CompilerDevTools/test/testpkg.jl
@@ -1,6 +1,19 @@
 using Pkg
 
+function with_output_on_failure(f)
+    output = IOBuffer()
+    try
+        return f(output)
+    catch
+        seekstart(output)
+        write(stderr, read(output))
+        rethrow()
+    end
+end
+
 Pkg.activate(dirname(@__DIR__)) do
-    Pkg.instantiate()
+    with_output_on_failure() do output
+        Pkg.instantiate(; io=output)
+    end
     include("runtests.jl")
 end

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -1218,7 +1218,7 @@ end
 # global scope (typevars are only visible in the same lambda).  However, it
 # would probably make more sense to keep the sparam in both methods, and have
 # the inner lambda's sig refer to the sparam instead of the global.
-@test JuliaLowering.include_string(test_mod, """
+@test_warn r"declares type variable g_shadowed_by_sparam but does not use it" @test JuliaLowering.include_string(test_mod, """
 global g_shadowed_by_sparam = Int
 function f_sp_in_sig_in_lam_in_optarg(
         x, y=((z::g_shadowed_by_sparam)->z)) where g_shadowed_by_sparam
@@ -1268,7 +1268,7 @@ end
     """) == (1,2)
 
     # Inner methods in control flow are known to be buggy/discouraged
-    @test JuliaLowering.include_string(test_mod, """
+    @test_warn r"Method definition f_if_redefines_inner\(\).*overwritten" @test JuliaLowering.include_string(test_mod, """
     begin
         function f_if_redefines_inner(cond)
             function inner(); 1; end
@@ -1281,7 +1281,7 @@ end
     end
     """) == (2,2)
 
-    @test JuliaLowering.include_string(test_mod, """
+    @test_warn r"Method definition f_let_redefines_inner\(\).*overwritten" @test JuliaLowering.include_string(test_mod, """
     begin
         function f_let_redefines_inner()
             local a,b

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -1530,7 +1530,8 @@ end
     @test JL.include_string(test_mod,
         "f_kwdef_sp(y::T; k=T) where T = (y, k); f_kwdef_sp(1)") == (1, Int)
     # ... but an sparam unused in the signature is undetermined at dispatch
-    JL.include_string(test_mod, "f_kwdef_sp_undet(y; k=T) where T = (y, k)")
+    @test_warn r"declares type variable T but does not use it" JL.include_string(
+        test_mod, "f_kwdef_sp_undet(y; k=T) where T = (y, k)")
     @test_throws UndefVarError test_mod.f_kwdef_sp_undet(1)
 end
 

--- a/JuliaLowering/test/runtests_vendored.jl
+++ b/JuliaLowering/test/runtests_vendored.jl
@@ -1,5 +1,16 @@
 using Pkg
 
+function with_output_on_failure(f)
+    output = IOBuffer()
+    try
+        return f(output)
+    catch
+        seekstart(output)
+        write(stderr, read(output))
+        rethrow()
+    end
+end
+
 let old_active_project = Base.active_project()
     try
         # test local (dev) copy of JuliaLowering, not yet vendored into Base
@@ -11,7 +22,9 @@ let old_active_project = Base.active_project()
         # picks up that dev copy without needing a committed manifest. Skip the
         # registry update: the only dependencies are path-based / stdlib, so no
         # network access is required (and tests may run with networking disabled).
-        Pkg.instantiate(; update_registry=false)
+        with_output_on_failure() do output
+            Pkg.instantiate(; update_registry=false, io=output)
+        end
 
         # restore error hints (emptied by `testdefs.jl`) so that errors print as
         # JuliaLowering expects them to

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -254,12 +254,15 @@ end
         ver = read(buf, String)
         @test startswith(ver, "Julia Version $VERSION")
         @test occursin("Environment:", ver)
-    end
-    let exename = `$(Base.julia_cmd()) --startup-file=no`
-        @test !occursin("Environment:", read(setenv(`$exename -e 'using InteractiveUtils; versioninfo()'`,
-                                                    String[]), String))
-        @test  occursin("Environment:", read(setenv(`$exename -e 'using InteractiveUtils; versioninfo()'`,
-                                                    String["JULIA_CPU_THREADS=1"]), String))
+
+        let exename = `$(Base.julia_cmd()) --startup-file=no`,
+            home = Sys.iswindows() ? "USERPROFILE=$dir" : "HOME=$dir"
+            @test !occursin("Environment:", read(setenv(
+                `$exename -e 'using InteractiveUtils; versioninfo()'`, [home]), String))
+            @test occursin("Environment:", read(setenv(
+                `$exename -e 'using InteractiveUtils; versioninfo()'`,
+                [home, "JULIA_CPU_THREADS=1"]), String))
+        end
     end
 end
 

--- a/stdlib/LibGit2/test/libgit2-tests.jl
+++ b/stdlib/LibGit2/test/libgit2-tests.jl
@@ -17,6 +17,18 @@ challenge_prompt(cmd::Cmd, challenges) = basic_challenge_prompt(cmd, challenges)
 const LIBGIT2_MIN_VER = v"1.0.0"
 const LIBGIT2_HELPER_PATH = joinpath(@__DIR__, "libgit2-helpers.jl")
 
+function with_output_on_failure(f)
+    mktemp() do _, child_stderr
+        try
+            return f(child_stderr)
+        catch
+            seekstart(child_stderr)
+            write(stderr, read(child_stderr))
+            rethrow()
+        end
+    end
+end
+
 const KEY_DIR = joinpath(@__DIR__, "keys")
 const HOME = Sys.iswindows() ? "USERPROFILE" : "HOME"  # Environment variable name for home
 const GIT_INSTALLED = try
@@ -3249,7 +3261,9 @@ mktempdir() do dir
 
                     try
                         # The generated certificate is normally invalid
-                        run(cmd)
+                        with_output_on_failure() do child_stderr
+                            run(pipeline(cmd; stderr=child_stderr))
+                        end
                         err = open(errfile, "r") do f
                             deserialize(f)
                         end

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -3,6 +3,18 @@
 using Test, Profile, Serialization, Logging
 using Base.StackTraces: StackFrame
 
+function with_output_on_failure(f)
+    mktemp() do _, child_stderr
+        try
+            return f(child_stderr)
+        catch
+            seekstart(child_stderr)
+            write(stderr, read(child_stderr))
+            rethrow()
+        end
+    end
+end
+
 @test isempty(Test.detect_closure_boxes(Profile))
 
 @test_throws "The profiling data buffer is not initialized. A profile has not been requested this session." Profile.print()
@@ -496,7 +508,10 @@ end
                     fname = cd(tmpdir) do
                         chmod(tmpdir, 0o555)
                         try
-                            read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; print(Profile.take_heap_snapshot())"`, String)
+                            cmd = `$(Base.julia_cmd()) --startup-file=no -e "using Profile; print(Profile.take_heap_snapshot())"`
+                            with_output_on_failure() do child_stderr
+                                read(pipeline(cmd; stderr=child_stderr), String)
+                            end
                         finally
                             chmod(tmpdir, 0o777)
                         end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -276,7 +276,6 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true,style_input=fa
         @test occursin("shell> ", s) # check for the echo of the prompt
         @test occursin("'", s) # check for the echo of the input
         s = readuntil(stdout_read, "\n\n")
-        @info repr(s)
         @test(startswith(s, "\e[0mERROR: unterminated single quote\nStacktrace:\n [1] ") ||
             startswith(s, "\e[0m\e[1m\e[91mERROR: \e[39m\e[22m\e[91munterminated single quote\e[39m\nStacktrace:\n [1] "),
             skip = Sys.iswindows() && Sys.WORD_SIZE == 32)
@@ -1713,6 +1712,8 @@ fake_repl() do stdin_write, stdout_read, repl
     end
     LineEdit.edit_input(s, input_f)
     @test buffercontents(LineEdit.buffer(s)) == "1234αβ56γ"
+    write(stdin_write, '\x04')
+    wait(repltask)
 end
 
 # Test that numbered prompts start at one with initialized session history.

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -264,8 +264,10 @@ end
     end
 
     # @test_nowarn with broken=true when test fails (has warning) should be Broken
-    let results = @testset NoThrowTestSet begin
-            @test_nowarn (println(stderr, "oops"); 1) broken=true
+    let results = redirect_stderr(devnull) do
+            @testset NoThrowTestSet begin
+                @test_nowarn (println(stderr, "oops"); 1) broken=true
+            end
         end
         @test length(results) == 1
         @test results[1] isa Test.Broken
@@ -348,8 +350,10 @@ end
     end
 
     # @test_nowarn failure shows expected "" and captured stderr
-    let results = @testset NoThrowTestSet begin
-            @test_nowarn println(stderr, "oops")
+    let results = redirect_stderr(devnull) do
+            @testset NoThrowTestSet begin
+                @test_nowarn println(stderr, "oops")
+            end
         end
         @test length(results) == 1
         fail = results[1]

--- a/test/JuliaLowering_stdlibs.jl
+++ b/test/JuliaLowering_stdlibs.jl
@@ -8,6 +8,18 @@ const JULIA_CPU_TARGET = get(ENV, "JULIA_CPU_TARGET", Base.unsafe_string(Base.JL
 const debug = get(ENV, "JULIA_BUILD_MODE", "release") == "debug" ? "-debug" : ""
 const JL_sysimage = joinpath(dirname(unsafe_string(Base.JLOptions().image_file)), "sys-JL$(debug).$(Libdl.dlext)")
 
+function run_quietly(cmd)
+    mktemp() do _, output
+        ok = success(pipeline(cmd; stdout=output, stderr=output))
+        if !ok
+            seekstart(output)
+            write(stderr, read(output))
+            error("command failed: $cmd")
+        end
+    end
+    return nothing
+end
+
 function compile_JL_sysimage(output_filepath)
     sysimage = unsafe_string(Base.JLOptions().image_file)
     output_sysimage = abspath(output_filepath)
@@ -25,11 +37,10 @@ function compile_JL_sysimage(output_filepath)
         "JULIA_DEPOT_PATH" => ":",
         "JULIA_NUM_THREADS" => "1",
     )
-    println("Compiling incremental sysimage with JuliaLowering...")
-    success(run(cmd))
+    run_quietly(cmd)
 
     cmd = Base.Linking.link_image_cmd(output_object, output_sysimage)
-    success(run(cmd))
+    run_quietly(cmd)
 
     return nothing
 end
@@ -37,7 +48,7 @@ end
 # ensure JL-inclusive sysimage is built / available
 if "BUILDROOT" in keys(ENV)
     # Running via Makefile, use sysimage.mk with its built-in caching / file tracking
-    run(`$(ENV["MAKE"]) -C $(ENV["BUILDROOT"]) -f sysimage.mk sysimg-JL-$(ENV["JULIA_BUILD_MODE"])`)
+    run_quietly(`$(ENV["MAKE"]) -C $(ENV["BUILDROOT"]) -f sysimage.mk sysimg-JL-$(ENV["JULIA_BUILD_MODE"])`)
 else
     # Standalone test run (CI), compile every time
     compile_JL_sysimage(JL_sysimage)
@@ -62,7 +73,7 @@ mktempdir() do tmp_depot
         `$(JULIA_EXECUTABLE) --startup-file=no --project=$env_dir -e $setupproject_command`,
         ; inherit = true
     )
-    success(run(cmd))
+    run_quietly(cmd)
 
     # now actually perform the precompilation
     cmd = addenv(
@@ -74,5 +85,5 @@ mktempdir() do tmp_depot
         "JULIA_DEPOT_PATH" => tmp_depot,
         ; inherit = true
     )
-    success(run(cmd))
+    run_quietly(cmd)
 end

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -2,14 +2,26 @@
 
 # run boundscheck tests on separate workers launched with --check-bounds={default,yes,no}
 
+function run_boundscheck(cmd)
+    mktemp() do _, output
+        ok = success(pipeline(cmd; stdout=output, stderr=output))
+        if !ok
+            seekstart(output)
+            write(stderr, read(output))
+            error("boundscheck test failed, cmd : $cmd")
+        end
+    end
+    return nothing
+end
+
 let cmd = `$(Base.julia_cmd()) --check-bounds=auto --depwarn=error --startup-file=no boundscheck_exec.jl`
-    success(pipeline(cmd; stdout=stdout, stderr=stderr)) || error("boundscheck test failed, cmd : $cmd")
+    run_boundscheck(cmd)
 end
 
 let cmd = `$(Base.julia_cmd()) --check-bounds=yes --startup-file=no --depwarn=error boundscheck_exec.jl`
-    success(pipeline(cmd; stdout=stdout, stderr=stderr)) || error("boundscheck test failed, cmd : $cmd")
+    run_boundscheck(cmd)
 end
 
 let cmd = `$(Base.julia_cmd()) --check-bounds=no --startup-file=no --depwarn=error boundscheck_exec.jl`
-    success(pipeline(cmd; stdout=stdout, stderr=stderr)) || error("boundscheck test failed, cmd : $cmd")
+    run_boundscheck(cmd)
 end

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -206,29 +206,41 @@ end
     end
 end
 
-let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
+let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`,
+    pathsep = Sys.iswindows() ? ";" : ":"
     # tests for handling of ENV errors
-    let
-        io = IOBuffer()
-        v = writereadpipeline(
-            "println(\"REPL: \", @which(less), @isdefined(InteractiveUtils))",
-            setenv(`$exename -i -E '@assert isempty(LOAD_PATH); push!(LOAD_PATH, "@stdlib"); @isdefined InteractiveUtils'`,
-                    "JULIA_LOAD_PATH" => "",
-                    "JULIA_DEPOT_PATH" => ";:",
-                    "HOME" => homedir());
-            stderr=io)
-        # @which is undefined
-        @test_broken v == ("false\nREPL: InteractiveUtilstrue\n", true)
-        stderr = String(take!(io))
-        @test_broken isempty(stderr)
-    end
-    let v = writereadpipeline("println(\"REPL: \", InteractiveUtils)",
-                setenv(`$exename -i -e 'const InteractiveUtils = 3'`,
-                    "JULIA_LOAD_PATH" => ";;;:::",
-                    "JULIA_DEPOT_PATH" => ";;;:::",
-                    "HOME" => homedir()))
-        # TODO: ideally, `@which`, etc. would still work, but Julia can't handle `using $InteractiveUtils`
-        @test v == ("REPL: 3\n", true)
+    mktempdir() do child_cwd
+        let
+            io = IOBuffer()
+            cmd = setenv(
+                `$exename -i -E '@assert isempty(LOAD_PATH); push!(LOAD_PATH, "@stdlib"); @isdefined InteractiveUtils'`,
+                "JULIA_LOAD_PATH" => "",
+                "JULIA_DEPOT_PATH" => pathsep,
+                "HOME" => homedir(),
+            )
+            v = writereadpipeline(
+                "println(\"REPL: \", @which(less), @isdefined(InteractiveUtils))",
+                Cmd(cmd; dir=child_cwd);
+                stderr=io,
+            )
+            # @which is undefined
+            @test_broken v == ("false\nREPL: InteractiveUtilstrue\n", true)
+            stderr = String(take!(io))
+            @test_broken isempty(stderr)
+        end
+        let
+            cmd = setenv(
+                `$exename -i -e 'const InteractiveUtils = 3'`,
+                "JULIA_LOAD_PATH" => pathsep^3,
+                "JULIA_DEPOT_PATH" => pathsep^3,
+                "HOME" => homedir(),
+            )
+            v = writereadpipeline(
+                "println(\"REPL: \", InteractiveUtils)", Cmd(cmd; dir=child_cwd))
+            # TODO: ideally, `@which`, etc. would still work, but Julia can't handle `using $InteractiveUtils`
+            @test v == ("REPL: 3\n", true)
+        end
+        @test isempty(readdir(child_cwd))
     end
     @testset let v = readchomperrors(`$exename -i -e '
             empty!(LOAD_PATH)
@@ -484,19 +496,19 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             read(`$exename -t auto -e $code`, String)
         for nt in (nothing, "1")
             withenv("JULIA_NUM_GC_THREADS" => nt) do
-                @test read(`$exename --gcthreads=2 -e $code`, String) == "2"
+                @test test_read_success(`$exename --gcthreads=2 -e $code`) == "2"
             end
             withenv("JULIA_NUM_GC_THREADS" => nt) do
-                @test read(`$exename --gcthreads=2,1 -e $code`, String) == "3"
+                @test test_read_success(`$exename --gcthreads=2,1 -e $code`) == "3"
             end
         end
 
         withenv("JULIA_NUM_GC_THREADS" => 2) do
-            @test read(`$exename -e $code`, String) == "2"
+            @test test_read_success(`$exename -e $code`) == "2"
         end
 
         withenv("JULIA_NUM_GC_THREADS" => "2,1") do
-            @test read(`$exename -e $code`, String) == "3"
+            @test test_read_success(`$exename -e $code`) == "3"
         end
 
         # invalid JULIA_NUM_GC_THREADS values must be rejected at startup

--- a/test/compileall.jl
+++ b/test/compileall.jl
@@ -4,6 +4,17 @@
 
 include("tempdepot.jl")
 
+function compileall_test_success(cmd)
+    mktemp() do _, output
+        ok = success(pipeline(cmd; stdout=output, stderr=output))
+        if !ok
+            seekstart(output)
+            write(stderr, read(output))
+        end
+        return ok
+    end
+end
+
 function precompile_test_harness(@nospecialize(f))
     load_path = mkdepottempdir()
     try
@@ -51,10 +62,15 @@ precompile_test_harness() do dir
     OncePerFoo.f() # fire init during compilation time
 
     """)
-    Base.compilecache(Base.PkgId("OncePerFoo"))
+    redirect_stdout(devnull) do
+        Base.compilecache(Base.PkgId("OncePerFoo"))
+    end
     new_env = Dict(["JULIA_DEPOT_PATH" => join(DEPOT_PATH, Sys.iswindows() ? ';' : ':'),
                "JULIA_LOAD_PATH" => join(LOAD_PATH, Sys.iswindows() ? ';' : ':')])
-    @test success(pipeline(addenv(`$(Base.julia_cmd()) --compile=all -t1,0 --strip-ir --output-o $(dir)/sys.o.a $(image_file) `, new_env), stderr=stderr, stdout=stdout)) skip=(Sys.WORD_SIZE == 32)
+    @test compileall_test_success(addenv(
+        `$(Base.julia_cmd()) --compile=all -t1,0 --strip-ir --output-o $(dir)/sys.o.a $(image_file)`,
+        new_env,
+    )) skip=(Sys.WORD_SIZE == 32)
     if isfile(joinpath(dir, "sys.o.a"))
         Base.Linking.link_image(joinpath(dir, "sys.o.a"), joinpath(dir, "sys.so"))
         str = readchomp(`$(Base.julia_cmd()) -t1,0 -J  $(dir)/sys.so -e 'Base.scrub_repl_backtrace(nothing); println("loaded"); main()'`)

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1338,19 +1338,25 @@ let err = nothing
     end
 end
 
+# expands inline, without the `do`-block forms of `mktemp`/`redirect_stderr`: a
+# StackOverflowError is only reliably catchable from the interpreted top-level
+# `@testset` body, not from within a compiled closure
 macro capture_stack_overflow(ex)
     return quote
-        mktemp() do _, warning_output
-            bt = redirect_stderr(warning_output) do
-                try
-                    $(esc(ex))
-                catch
-                    catch_backtrace()
-                end
-            end
-            seekstart(warning_output)
-            return bt, read(warning_output, String)
+        local path, warning_output = mktemp()
+        local prev_stderr = stderr
+        redirect_stderr(warning_output)
+        local bt = try
+            $(esc(ex))
+        catch
+            catch_backtrace()
+        finally
+            redirect_stderr(prev_stderr)
+            close(warning_output)
         end
+        local warning = read(path, String)
+        rm(path)
+        bt, warning
     end
 end
 

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1338,6 +1338,22 @@ let err = nothing
     end
 end
 
+macro capture_stack_overflow(ex)
+    return quote
+        mktemp() do _, warning_output
+            bt = redirect_stderr(warning_output) do
+                try
+                    $(esc(ex))
+                catch
+                    catch_backtrace()
+                end
+            end
+            seekstart(warning_output)
+            return bt, read(warning_output, String)
+        end
+    end
+end
+
 # issue #37587
 # TODO: enable on more platforms
 if (Sys.isapple() || Sys.islinux()) && Sys.ARCH === :x86_64
@@ -1346,20 +1362,14 @@ if (Sys.isapple() || Sys.islinux()) && Sys.ARCH === :x86_64
     pair_repeater_b() = pair_repeater_a()
 
     @testset "repeated stack frames" begin
-        let bt = try
-                single_repeater()
-            catch
-                catch_backtrace()
-            end
+        let (bt, warning) = @capture_stack_overflow(single_repeater())
+            @test occursin("Warning: detected a stack overflow", warning)
             bt_str = sprint(Base.show_backtrace, bt)
             @test occursin(r"repeated \d+ times", bt_str)
         end
 
-        let bt = try
-                pair_repeater_a()
-            catch
-                catch_backtrace()
-            end
+        let (bt, warning) = @capture_stack_overflow(pair_repeater_a())
+            @test occursin("Warning: detected a stack overflow", warning)
             bt_str = sprint(Base.show_backtrace, bt)
             @test occursin(r"repeated \d+ times", bt_str)
         end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1678,6 +1678,17 @@ end
 end
 
 @testset "relocatable upgrades #51989" begin
+    function loading_test_success(cmd)
+        mktemp() do _, output
+            ok = success(pipeline(cmd; stdout=output, stderr=output))
+            if !ok
+                seekstart(output)
+                write(stderr, read(output))
+            end
+            return ok
+        end
+    end
+
     mkdepottempdir() do depot
         # realpath is needed because Pkg is used for one of the precompile paths below, and Pkg calls realpath on the
         # project path so the cache file slug will be different if the tempdir is given as a symlink
@@ -1712,10 +1723,10 @@ end
             """)
 
         # In our depot, `precompile` this `Foo` package.
-        @test success(pipeline(addenv(
+        @test loading_test_success(addenv(
             `$(Base.julia_cmd()) --project=$foo_path --startup-file=no -e 'Base.Precompilation.precompilepkgs(["Foo51989"]); exit(0)'`,
             "JULIA_DEPOT_PATH" => depot,
-        ); stdout, stderr))
+        ))
 
         # Get the size of the generated `.ji` file so that we can ensure that it gets altered
         foo_compiled_path = joinpath(depot, "compiled", "v$(VERSION.major).$(VERSION.minor)", "Foo51989")
@@ -1733,10 +1744,10 @@ end
         end
 
         # Try to load `Foo`; this should trigger recompilation, not an error!
-        @test success(pipeline(addenv(
+        @test loading_test_success(addenv(
             `$(Base.julia_cmd()) --project=$foo_path --startup-file=no -e 'using Foo51989; exit(0)'`,
             "JULIA_DEPOT_PATH" => depot,
-        ); stdout, stderr))
+        ))
 
         # Ensure that there is still only one `.ji` file (it got replaced
         # and the file size changed).

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -697,7 +697,9 @@ precompile_test_harness(false) do dir
           error("break me")
           end
           """)
-    @test_throws Base.Precompilation.PkgPrecompileError Base.require(Main, :FooBar2)
+    redirect_stderr(devnull) do
+        @test_throws Base.Precompilation.PkgPrecompileError Base.require(Main, :FooBar2)
+    end
 
     # Test that trying to eval into closed modules during precompilation is an error
     FooBar3_file = joinpath(dir, "FooBar3.jl")
@@ -711,7 +713,9 @@ precompile_test_harness(false) do dir
         $code
         end
         """)
-        @test_throws Base.Precompilation.PkgPrecompileError Base.require(Main, :FooBar3)
+        redirect_stderr(devnull) do
+            @test_throws Base.Precompilation.PkgPrecompileError Base.require(Main, :FooBar3)
+        end
     end
 
     # Declaring an already-existing generic function of a closed module is a

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -4,6 +4,18 @@ using Test
 
 using Base.Threads
 
+function with_output_on_failure(f)
+    mktemp() do _, output
+        try
+            return f(output)
+        catch
+            seekstart(output)
+            write(stderr, read(output))
+            rethrow()
+        end
+    end
+end
+
 include("print_process_affinity.jl") # import `uv_thread_getaffinity`
 
 # whether `t` currently has an armed wait registration on `waitee`
@@ -404,8 +416,11 @@ let cmd1 = `$(Base.julia_cmd()) --depwarn=error --rr-detach --startup-file=no th
             (4, 0)) # try a couple times to trigger bad races
         new_env = copy(ENV)
         new_env["JULIA_NUM_THREADS"] = string(test_nthreads, ",", test_nthreadsi)
-        run(pipeline(setenv(cmd1, new_env), stdout = stdout, stderr = stderr))
         threads_config = "$test_nthreads,$test_nthreadsi"
+        with_output_on_failure() do output
+            run(pipeline(setenv(cmd1, new_env); stdout=output, stderr=output))
+        end
+        println("threads_exec.jl with JULIA_NUM_THREADS == $threads_config passed")
         # threads set via env var
         @test chomp(read(setenv(cmd2, new_env), String)) == threads_config
         # threads set via -t

--- a/test/typegroup.jl
+++ b/test/typegroup.jl
@@ -681,7 +681,9 @@ using Test
                 end
                 end
                 """)
-                @test_throws Exception Base.require(Main, :TG_PrecompIncomplete)
+                redirect_stderr(devnull) do
+                    @test_throws Exception Base.require(Main, :TG_PrecompIncomplete)
+                end
             finally
                 filter!((≠)(dir), LOAD_PATH)
                 filter!((≠)(depot), DEPOT_PATH)


### PR DESCRIPTION
🤖 :

Capture output from tests that intentionally exercise errors and warnings, and buffer noisy child-process logs until a command fails. Successful runs retain the test runner's start and final summary lines, while the long threads test retains one concise heartbeat per configuration. Also shut down the REPL fixture task cleanly and keep separator-only depot tests from writing relative cache directories into the source tree.

Representative excerpts from a passing Buildkite job before this change: https://buildkite.com/julialang/julia-pr/builds/1503#01a004cb-25ef-45d6-9a5a-fd37fe021b7e

Expected precompile failures are now silent between the runner lines:

```diff
 precompile  (1) | started
-ERROR: LoadError: break me
-Stacktrace:
- [1] error(s::String)
-   @ Base error.jl:56
-...
-1 dependency had output during precompilation:
-┌ FooBar2
-│  [Output was shown above]
-└
 precompile  (1) | finished
```

Expected warnings and deliberately printed errors are captured or asserted:

```diff
-Warning: detected a stack overflow; program state may be corrupted...
-oops
-[ Info: "ERROR: unterminated single quote ..."
-Unhandled Task ERROR: IOError: stream is closed or unusable
-Warning: Cannot write to current directory ... saving heap snapshot ...
-TLS host verification: the identity of the server `localhost` could not be verified.
-WARNING: method definition ... declares type variable ... but does not use it.
```

Passing child-process progress is buffered and replayed only on failure:

```diff
 JuliaLowering_stdlibs  (2) | started
-Resolving package versions...
-Installed Statistics v1.11.1
-Updating `.../Project.toml`
-Precompiling project...
-  1.5 s  ✓ Statistics
-  ...
 JuliaLowering_stdlibs  (2) | finished
```

The long threads test keeps progress without nested test tables:

```diff
-Test Summary:                                 |   Pass  Broken   Total     Time
-threads_exec.jl with JULIA_NUM_THREADS == 1,0 | 141047       8  141055  3m45.7s
+threads_exec.jl with JULIA_NUM_THREADS == 1,0 passed
```

Assisted-by: Codex (GPT-5)
Fixes #62577