### PR TITLE
base: Guard allocation arithmetic from overflow

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -953,7 +953,10 @@ end
 function copyto!(dest::AbstractArray, dstart::Integer, src)
     i = Int(dstart)
     if haslength(src) && length(dest) > 0
-        @boundscheck checkbounds(dest, i:(i + length(src) - 1))
+        n = length(src)
+        n == 0 && return dest
+        @boundscheck checkbounds(dest, i)
+        @boundscheck n <= lastindex(dest) - i + 1 || throw(BoundsError(dest, i))
         for x in src
             @inbounds dest[i] = x
             i += 1
@@ -1001,13 +1004,13 @@ function copyto!(dest::AbstractArray, dstart::Integer, src, sstart::Integer, n::
     n < 0 && throw(ArgumentError(LazyString("tried to copy n=",n,
         ", elements, but n should be non-negative")))
     n == 0 && return dest
-    dmax = dstart + n - 1
     inds = LinearIndices(dest)
-    if (dstart ∉ inds || dmax ∉ inds) | (sstart < 1)
-        sstart < 1 && throw(ArgumentError(LazyString("source start offset (",
-            sstart,") is < 1")))
-        throw(BoundsError(dest, dstart:dmax))
-    end
+    sstart < 1 && throw(ArgumentError(LazyString("source start offset (",
+        sstart,") is < 1")))
+    (dstart ∈ inds && n <= last(inds) - dstart + 1) || throw(BoundsError(dest, dstart))
+    dstart = Int(dstart)
+    n = Int(n)
+    dmax = dstart + n - 1
     y = iterate(src)
     for j = 1:(sstart-1)
         if y === nothing
@@ -1023,7 +1026,7 @@ function copyto!(dest::AbstractArray, dstart::Integer, src, sstart::Integer, n::
             "expected at least ",sstart," got ", sstart-1)))
     end
     val, st = y
-    i = Int(dstart)
+    i = dstart
     @inbounds dest[i] = val
     for val in Iterators.take(Iterators.rest(src, st), n-1)
         i += 1
@@ -1136,8 +1139,11 @@ function copyto!(dest::AbstractArray, dstart::Integer,
     n < 0 && throw(ArgumentError(LazyString("tried to copy n=",
         n," elements, but n should be non-negative")))
     destinds, srcinds = LinearIndices(dest), LinearIndices(src)
-    (checkbounds(Bool, destinds, dstart) && checkbounds(Bool, destinds, dstart+n-1)) || throw(BoundsError(dest, dstart:dstart+n-1))
-    (checkbounds(Bool, srcinds, sstart)  && checkbounds(Bool, srcinds, sstart+n-1))  || throw(BoundsError(src,  sstart:sstart+n-1))
+    (checkbounds(Bool, destinds, dstart) && n <= last(destinds) - dstart + 1) || throw(BoundsError(dest, dstart))
+    (checkbounds(Bool, srcinds, sstart)  && n <= last(srcinds) - sstart + 1)  || throw(BoundsError(src, sstart))
+    dstart = Int(dstart)
+    sstart = Int(sstart)
+    n = Int(n)
     src′ = unalias(dest, src)
     @inbounds for i = 0:n-1
         dest[dstart+i] = src′[sstart+i]
@@ -2661,7 +2667,7 @@ function _typed_hvncat_dims(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as
     # discover number of rows or columns
     # d1 dimension is increased by 1 to appropriately handle 0-length arrays
     for i ∈ 1:dims[d1]
-        outdims[d1] += cat_size(as[i], d1)
+        outdims[d1] = checked_add(outdims[d1], cat_size(as[i], d1))
     end
 
     # adjustment to handle 0-length arrays
@@ -2674,12 +2680,12 @@ function _typed_hvncat_dims(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as
     blockcount = 0
     elementcount = 0
     for i ∈ eachindex(as)
-        elementcount += cat_length(as[i])
-        currentdims[d1] += first_dim_zero ? 1 : cat_size(as[i], d1)
+        elementcount = checked_add(elementcount, cat_length(as[i]))
+        currentdims[d1] = checked_add(currentdims[d1], first_dim_zero ? 1 : cat_size(as[i], d1))
         if currentdims[d1] == outdims[d1]
             currentdims[d1] = 0
             for d ∈ (d2, 3:N...)
-                currentdims[d] += cat_size(as[i], d)
+                currentdims[d] = checked_add(currentdims[d], cat_size(as[i], d))
                 if outdims[d] == 0 # unfixed dimension
                     blockcount += 1
                     if blockcount == dims[d]
@@ -2708,7 +2714,7 @@ function _typed_hvncat_dims(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as
         outdims[d1] = 0
     end
 
-    outlen = prod(outdims)
+    outlen = Core.checked_dims(outdims...)
     elementcount == outlen ||
         throw(DimensionMismatch("mismatched number of elements; expected $(outlen), got $(elementcount)"))
 
@@ -2761,7 +2767,7 @@ function _typed_hvncat_shape(::Type{T}, shape::NTuple{N, Tuple}, row_first, as::
 
     elementcount = 0
     for i ∈ eachindex(as)
-        elementcount += cat_length(as[i])
+        elementcount = checked_add(elementcount, cat_length(as[i]))
         wasstartblock = false
         for d ∈ 1:N
             ad = (d < 3 && row_first) ? (d == 1 ? 2 : 1) : d
@@ -2769,7 +2775,7 @@ function _typed_hvncat_shape(::Type{T}, shape::NTuple{N, Tuple}, row_first, as::
             blockcounts[d] += 1
 
             if d == 1 || i == 1 || wasstartblock
-                currentdims[d] += dsize
+                currentdims[d] = checked_add(currentdims[d], dsize)
             elseif dsize != cat_size(as[i - 1], ad)
                 throw(DimensionMismatch("argument $i has a mismatched number of elements along axis $ad; \
                                          expected $(cat_size(as[i - 1], ad)), got $dsize"))
@@ -2795,7 +2801,7 @@ function _typed_hvncat_shape(::Type{T}, shape::NTuple{N, Tuple}, row_first, as::
         end
     end
 
-    outlen = prod(outdims)
+    outlen = Core.checked_dims(outdims...)
     elementcount == outlen ||
         throw(ArgumentError("mismatched number of elements; expected $(outlen), got $(elementcount)"))
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2714,7 +2714,7 @@ function _typed_hvncat_dims(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as
         outdims[d1] = 0
     end
 
-    outlen = Core.checked_dims(outdims...)
+    outlen = Core.checked_dims(ntuple(i -> outdims[i], Val(N))...)
     elementcount == outlen ||
         throw(DimensionMismatch("mismatched number of elements; expected $(outlen), got $(elementcount)"))
 
@@ -2801,7 +2801,7 @@ function _typed_hvncat_shape(::Type{T}, shape::NTuple{N, Tuple}, row_first, as::
         end
     end
 
-    outlen = Core.checked_dims(outdims...)
+    outlen = Core.checked_dims(ntuple(i -> outdims[i], Val(N))...)
     elementcount == outlen ||
         throw(ArgumentError("mismatched number of elements; expected $(outlen), got $(elementcount)"))
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -558,7 +558,7 @@ repeat_inner_outer(arr, inner, outer) = repeat_outer(repeat_inner(arr, inner), o
 
 function repeat_outer(a::AbstractMatrix, (m,n)::NTuple{2, Any})
     o, p = size(a,1), size(a,2)
-    b = similar(a, o*m, p*n)
+    b = similar(a, Base.checked_mul(o, m), Base.checked_mul(p, n))
     for j=1:n
         d = (j-1)*p+1
         R = d:d+p-1
@@ -572,7 +572,7 @@ end
 
 function repeat_outer(a::AbstractVector, (m,)::Tuple{Any})
     o = length(a)
-    b = similar(a, o*m)
+    b = similar(a, Base.checked_mul(o, m))
     for i=1:m
         c = (i-1)*o+1
         @inbounds b[c:c+o-1] = a
@@ -582,7 +582,7 @@ end
 
 function repeat_outer(arr::AbstractArray{<:Any,N}, dims::NTuple{N,Any}) where {N}
     insize  = size(arr)
-    outsize = map(*, insize, dims)
+    outsize = map(Base.checked_mul, insize, dims)
     out = similar(arr, outsize)
     for I in CartesianIndices(arr)
         for J in CartesianIndices(dims)
@@ -597,7 +597,7 @@ function repeat_outer(arr::AbstractArray{<:Any,N}, dims::NTuple{N,Any}) where {N
 end
 
 function repeat_inner(arr, inner)
-    outsize = map(*, size(arr), inner)
+    outsize = map(Base.checked_mul, size(arr), inner)
     out = similar(arr, outsize)
     for I in CartesianIndices(arr)
         for J in CartesianIndices(inner)

--- a/base/array.jl
+++ b/base/array.jl
@@ -299,8 +299,13 @@ function _copyto_impl!(dest::Union{Array,Memory}, doffs::Integer, src::Union{Arr
     @inline
     n == 0 && return dest
     n > 0 || _throw_argerror("Number of elements to copy must be non-negative.")
-    @boundscheck checkbounds(dest, doffs:doffs+n-1)
-    @boundscheck checkbounds(src, soffs:soffs+n-1)
+    @boundscheck checkbounds(dest, doffs)
+    @boundscheck n <= length(dest) - doffs + 1 || throw(BoundsError(dest, length(dest) + 1))
+    @boundscheck checkbounds(src, soffs)
+    @boundscheck n <= length(src) - soffs + 1 || throw(BoundsError(src, length(src) + 1))
+    doffs = Int(doffs)
+    soffs = Int(soffs)
+    n = Int(n)
     @inbounds let dest = memoryref(dest isa Array ? getfield(dest, :ref) : dest, doffs),
                   src = memoryref(src isa Array ? getfield(src, :ref) : src, soffs)
         unsafe_copyto!(dest, src, n)
@@ -1115,7 +1120,7 @@ end
 # TODO: This should know about the size of our GC pools
 # Specifically we are wasting ~10% of memory for small arrays
 # by not picking memory sizes that max out a GC pool
-function overallocation(maxsize)
+function overallocation(maxsize::Int)
     # compute maxsize = maxsize + 3*maxsize^(7/8) + maxsize/8
     # for small n, we grow faster than O(n)
     # for large n, we grow at O(n/8)
@@ -1123,8 +1128,8 @@ function overallocation(maxsize)
     # this means we end by adding about 10% of memory each time
     # most commonly, this will take steps of 0-3-9-34 or 1-4-16-66 or 2-8-33
     exp2 = sizeof(maxsize) * 8 - Core.Intrinsics.ctlz_int(maxsize)
-    maxsize += (1 << div(exp2 * 7, 8)) * 3 + div(maxsize, 8)
-    return maxsize
+    extra = (1 << div(exp2 * 7, 8)) * 3 + div(maxsize, 8)
+    return maxsize > typemax(Int) - extra ? typemax(Int) : maxsize + extra
 end
 
 array_new_memory(mem::Memory, newlen::Int) = typeof(mem)(undef, newlen) # when implemented, this should attempt to first expand mem
@@ -1134,20 +1139,20 @@ function _growbeg_internal!(a::Vector, delta::Int, len::Int)
     ref = a.ref
     mem = ref.mem
     offset = memoryrefoffset(ref)
-    newlen = len + delta
+    newlen = checked_add(len, delta)
     memlen = length(mem)
-    if offset + len - 1 > memlen || offset < 1
+    if offset < 1 || offset - 1 > memlen || len > memlen - (offset - 1)
         throw(ConcurrencyViolationError("Vector has invalid state. Don't modify internal fields incorrectly, or resize without correct locks"))
     end
     # since we will allocate the array in the middle of the memory we need at least 2*delta extra space
     # the +1 is because I didn't want to have an off by 1 error.
-    newmemlen = max(overallocation(len), len + 2 * delta + 1)
+    newmemlen = max(overallocation(len), checked_add(len, checked_mul(2, delta), 1))
     newoffset = div(newmemlen - newlen, 2) + 1
     # If there is extra data after the end of the array we can use that space so long as there is enough
     # space at the end that there won't be quadratic behavior with a mix of growth from both ends.
     # Specifically, we want to ensure that we will only do this operation once before
     # increasing the size of the array, and that we leave enough space at both the beginning and the end.
-    if newoffset + newlen < memlen
+    if newlen < memlen && newoffset < memlen - newlen
         newoffset = div(memlen - newlen, 2) + 1
         newmem = mem
         unsafe_copyto!(newmem, newoffset + delta, mem, offset, len)
@@ -1172,7 +1177,7 @@ function _growbeg!(a::Vector, delta::Integer)
     ref = a.ref
     len = length(a)
     offset = memoryrefoffset(ref)
-    newlen = len + delta
+    newlen = checked_add(len, delta)
     # if offset is far enough advanced to fit data in existing memory without copying
     if delta <= offset - 1
         setfield!(a, :ref, @inbounds memoryref(ref, 1 - delta))
@@ -1188,14 +1193,14 @@ function _growend_internal!(a::Vector, delta::Int, len::Int)
     ref = a.ref
     mem = ref.mem
     memlen = length(mem)
-    newlen = len + delta
+    newlen = checked_add(len, delta)
     offset = memoryrefoffset(ref)
-    newmemlen = offset + newlen - 1
-    if offset + len - 1 > memlen || offset < 1
+    if offset < 1 || offset - 1 > memlen || len > memlen - (offset - 1)
         throw(ConcurrencyViolationError("Vector has invalid state. Don't modify internal fields incorrectly, or resize without correct locks"))
     end
+    newmemlen = checked_add(offset - 1, newlen)
 
-    if offset - 1 > div(5 * newlen, 4)
+    if offset - 1 > newlen && offset - 1 - newlen > div(newlen, 4)
         # If the offset is far enough that we can copy without resizing
         # while maintaining proportional spacing on both ends of the array
         # note that this branch prevents infinite growth when doing combinations
@@ -1227,9 +1232,9 @@ function _growend!(a::Vector, delta::Integer)
     mem = ref.mem
     memlen = length(mem)
     len = length(a)
-    newlen = len + delta
+    newlen = checked_add(len, delta)
     offset = memoryrefoffset(ref)
-    newmemlen = offset + newlen - 1
+    newmemlen = checked_add(offset - 1, newlen)
     if memlen < newmemlen
         @noinline _growend_internal!(a, delta, len)
     end
@@ -1243,15 +1248,15 @@ function _growat!(a::Vector, i::Integer, delta::Integer)
     i = Int(i)
     i == 1 && return _growbeg!(a, delta)
     len = length(a)
-    i == len + 1 && return _growend!(a, delta)
+    len < typemax(Int) && i == len + 1 && return _growend!(a, delta)
     delta >= 0 || throw(ArgumentError("grow requires delta >= 0"))
     1 < i <= len || throw(BoundsError(a, i))
     ref = a.ref
     mem = ref.mem
     memlen = length(mem)
-    newlen = len + delta
+    newlen = checked_add(len, delta)
     offset = memoryrefoffset(ref)
-    newmemlen = offset + newlen - 1
+    newmemlen = checked_add(offset - 1, newlen)
 
     # which side would we rather grow into?
     prefer_start = i <= div(len, 2)
@@ -1273,7 +1278,7 @@ function _growat!(a::Vector, i::Integer, delta::Integer)
     else
         # since we will allocate the array in the middle of the memory we need at least 2*delta extra space
         # the +1 is because I didn't want to have an off by 1 error.
-        newmemlen = max(overallocation(memlen), len+2*delta+1)
+        newmemlen = max(overallocation(memlen), checked_add(len, checked_mul(2, delta), 1))
         newoffset = (newmemlen - newlen) ÷ 2 + 1
         newmem = array_new_memory(mem, newmemlen)
         newref = @inbounds memoryref(newmem, newoffset)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -26,13 +26,12 @@ mutable struct BitArray{N} <: AbstractArray{Bool, N}
     len::Int
     dims::NTuple{N,Int}
     function BitArray{N}(::UndefInitializer, dims::Vararg{Int,N}) where N
-        n = 1
         i = 1
         for d in dims
             d >= 0 || throw(ArgumentError("dimension size must be ≥ 0, got $d for dimension $i"))
-            n *= d
             i += 1
         end
+        n = Core.checked_dims(dims...)
         nc = num_bit_chunks(n)
         chunks = Vector{UInt64}(undef, nc)
         nc > 0 && (chunks[end] = UInt64(0))
@@ -116,7 +115,7 @@ const _msk64 = ~UInt64(0)
 @inline _blsr(x)= x & (x-1) #zeros the last set bit. Has native instruction on many archs. needed in multidimensional.jl
 @inline _msk_end(l::Int) = _msk64 >>> _mod64(-l)
 @inline _msk_end(B::BitArray) = _msk_end(length(B))
-num_bit_chunks(n::Int) = _div64(n+63)
+num_bit_chunks(n::Int) = _div64(n) + !iszero(_mod64(n))
 
 @inline get_chunks_id(i::Int) = _div64(i-1)+1, _mod64(i-1)
 
@@ -457,8 +456,8 @@ function _copyto_int!(dest::BitArray, doffs::Int, src::Union{BitArray,Array}, so
     n < 0 && throw(ArgumentError("Number of elements to copy must be non-negative."))
     soffs < 1 && throw(BoundsError(src, soffs))
     doffs < 1 && throw(BoundsError(dest, doffs))
-    soffs+n-1 > length(src) && throw(BoundsError(src, length(src)+1))
-    doffs+n-1 > length(dest) && throw(BoundsError(dest, length(dest)+1))
+    n > length(src) - soffs + 1 && throw(BoundsError(src, length(src)+1))
+    n > length(dest) - doffs + 1 && throw(BoundsError(dest, length(dest)+1))
     return unsafe_copyto!(dest, doffs, src, soffs, n)
 end
 
@@ -473,11 +472,12 @@ function reshape(B::BitArray{N}, dims::NTuple{N,Int}) where N
 end
 reshape(B::BitArray, dims::Tuple{Vararg{Int}}) = _bitreshape(B, dims)
 function _bitreshape(B::BitArray, dims::NTuple{N,Int}) where N
-    prod(dims) == length(B) ||
+    len = Core.checked_dims(dims...)
+    len == length(B) ||
         throw(DimensionMismatch("new dimensions $(dims) must be consistent with array length $(length(B))"))
     Br = BitArray{N}(undef, ntuple(i->0,Val(N))...)
     Br.chunks = B.chunks
-    Br.len = prod(dims)
+    Br.len = len
     N != 1 && (Br.dims = dims)
     return Br
 end
@@ -756,14 +756,15 @@ function append!(B::BitVector, items::BitVector)
     n0 = length(B)
     n1 = length(items)
     n1 == 0 && return B
+    n = checked_add(n0, n1)
     Bc = B.chunks
     k0 = length(Bc)
-    k1 = num_bit_chunks(n0 + n1)
+    k1 = num_bit_chunks(n)
     if k1 > k0
         _growend!(Bc, k1 - k0)
         Bc[end] = UInt64(0)
     end
-    B.len += n1
+    B.len = n
     copy_chunks!(Bc, n0+1, items.chunks, 1, n1)
     return B
 end
@@ -775,14 +776,15 @@ function prepend!(B::BitVector, items::BitVector)
     n0 = length(B)
     n1 = length(items)
     n1 == 0 && return B
+    n = checked_add(n0, n1)
     Bc = B.chunks
     k0 = length(Bc)
-    k1 = num_bit_chunks(n0 + n1)
+    k1 = num_bit_chunks(n)
     if k1 > k0
         _growend!(Bc, k1 - k0)
         Bc[end] = UInt64(0)
     end
-    B.len += n1
+    B.len = n
     copy_chunks!(Bc, 1 + n1, Bc, 1, n0)
     copy_chunks!(Bc, 1, items.chunks, 1, n1)
     return B

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1302,7 +1302,7 @@ IteratorSize(::Type{Flatten{I}}) where {I} = _flatten_iteratorsize(IteratorSize(
 
 flatten_length(f, T::Type{Union{}}, slurp...) = 0
 function flatten_length(f, T::Type{<:NTuple{N,Any}}) where {N}
-    return N * length(f.it)
+    return checked_mul(N, length(f.it))
 end
 flatten_length(f, ::Type{<:Number}) = length(f.it)
 flatten_length(f, T) = throw(ArgumentError(

--- a/base/range.jl
+++ b/base/range.jl
@@ -1405,7 +1405,7 @@ promote_rule(::Type{LinRange{A,L}}, b::Type{StepRangeLen{T2,R2,S2,L2}}) where {A
 function vcat(rs::AbstractRange{T}...) where T
     n::Int = 0
     for ra in rs
-        n += length(ra)
+        n = checked_add(n, length(ra))
     end
     a = Vector{T}(undef, n)
     i = 1

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -220,7 +220,7 @@ end
 # General reshape
 function _reshape(parent::AbstractArray, dims::Dims)
     n = length(parent)
-    prod(dims) == n || _throw_dmrs(n, "size", dims)
+    Core.checked_dims(dims...) == n || _throw_dmrs(n, "size", dims)
     __reshape((parent, IndexStyle(parent)), dims)
 end
 

--- a/base/ryu/Ryu.jl
+++ b/base/ryu/Ryu.jl
@@ -65,7 +65,7 @@ end
 
 """
     Ryu.writefixed(x, precision, plus=false, space=false, hash=false, decchar=UInt8('.'), trimtrailingzeros=false)
-    Ryu.writefixed(buf::AbstractVector{UInt8}, pos::Int, x, args...)
+    Ryu.writefixed(buf::AbstractVector{UInt8}, pos::Int, x, precision, args...)
 
 Convert a float value `x` into a "fixed" size decimal string of the provided precision.
 This function allows achieving the `%f` printf format.
@@ -95,7 +95,7 @@ end
 
 """
     Ryu.writeexp(x, precision, plus=false, space=false, hash=false, expchar=UInt8('e'), decchar=UInt8('.'), trimtrailingzeros=false)
-    Ryu.writeexp(buf::AbstractVector{UInt8}, pos::Int, x, args...)
+    Ryu.writeexp(buf::AbstractVector{UInt8}, pos::Int, x, precision, args...)
 
 Convert a float value `x` into a scientific notation decimal string.
 This function allows achieving the `%e` printf format.

--- a/base/ryu/Ryu.jl
+++ b/base/ryu/Ryu.jl
@@ -55,7 +55,10 @@ function writeshortest(x::T,
         decchar::UInt8=UInt8('.'),
         typed::Bool=false,
         compact::Bool=false) where {T <: Base.IEEEFloat}
-    buf = Base.StringVector(neededdigits(T))
+    precision = Int(precision)
+    precision >= -1 || throw(ArgumentError("precision must be at least -1"))
+    bufsize = precision < 0 ? neededdigits(T) : Base.checked_add(precision, neededdigits(T))
+    buf = Base.StringVector(bufsize)
     pos = writeshortest(buf, 1, x, plus, space, hash, precision, expchar, padexp, decchar, typed, compact)
     return String(resize!(buf, pos - 1))
 end
@@ -83,7 +86,9 @@ function writefixed(x::T,
     hash::Bool=false,
     decchar::UInt8=UInt8('.'),
     trimtrailingzeros::Bool=false) where {T <: Base.IEEEFloat}
-    buf = Base.StringVector(precision + neededdigits(T))
+    precision = Int(precision)
+    precision >= 0 || throw(ArgumentError("precision must be non-negative"))
+    buf = Base.StringVector(Base.checked_add(precision, neededdigits(T)))
     pos = writefixed(buf, 1, x, precision, plus, space, hash, decchar, trimtrailingzeros)
     return String(resize!(buf, pos - 1))
 end
@@ -113,7 +118,9 @@ function writeexp(x::T,
     expchar::UInt8=UInt8('e'),
     decchar::UInt8=UInt8('.'),
     trimtrailingzeros::Bool=false) where {T <: Base.IEEEFloat}
-    buf = Base.StringVector(precision + neededdigits(T))
+    precision = Int(precision)
+    precision >= 0 || throw(ArgumentError("precision must be non-negative"))
+    buf = Base.StringVector(Base.checked_add(precision, neededdigits(T)))
     pos = writeexp(buf, 1, x, precision, plus, space, hash, expchar, decchar, trimtrailingzeros)
     return String(resize!(buf, pos - 1))
 end

--- a/base/ryu/exp.jl
+++ b/base/ryu/exp.jl
@@ -1,6 +1,9 @@
 function writeexp(buf, pos, v::T,
-    precision=-1, plus=false, space=false, hash=false,
+    precision=0, plus=false, space=false, hash=false,
     expchar=UInt8('e'), decchar=UInt8('.'), trimtrailingzeros=false) where {T <: Base.IEEEFloat}
+    pos = Int(pos)
+    precision = Int(precision)
+    precision >= 0 || throw(ArgumentError("precision must be non-negative"))
     @assert 0 < pos <= length(buf) "invalid pos"
     startpos = pos
     x = Float64(v)

--- a/base/ryu/exp.jl
+++ b/base/ryu/exp.jl
@@ -1,5 +1,5 @@
 function writeexp(buf, pos, v::T,
-    precision=0, plus=false, space=false, hash=false,
+    precision, plus=false, space=false, hash=false,
     expchar=UInt8('e'), decchar=UInt8('.'), trimtrailingzeros=false) where {T <: Base.IEEEFloat}
     pos = Int(pos)
     precision = Int(precision)

--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -1,6 +1,9 @@
 function writefixed(buf, pos, v::T,
-    precision=-1, plus=false, space=false, hash=false,
+    precision=0, plus=false, space=false, hash=false,
     decchar=UInt8('.'), trimtrailingzeros=false) where {T <: Base.IEEEFloat}
+    pos = Int(pos)
+    precision = Int(precision)
+    precision >= 0 || throw(ArgumentError("precision must be non-negative"))
     @assert 0 < pos <= length(buf) "invalid pos"
     startpos = pos
     x = Float64(v)

--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -1,5 +1,5 @@
 function writefixed(buf, pos, v::T,
-    precision=0, plus=false, space=false, hash=false,
+    precision, plus=false, space=false, hash=false,
     decchar=UInt8('.'), trimtrailingzeros=false) where {T <: Base.IEEEFloat}
     pos = Int(pos)
     precision = Int(precision)

--- a/base/ryu/shortest.jl
+++ b/base/ryu/shortest.jl
@@ -229,6 +229,9 @@ function writeshortest(buf::AbstractVector{UInt8}, pos, x::T,
                        plus=false, space=false, hash=true,
                        precision=-1, expchar=UInt8('e'), padexp=false, decchar=UInt8('.'),
                        typed=false, compact=false) where {T}
+    pos = Int(pos)
+    precision = Int(precision)
+    precision >= -1 || throw(ArgumentError("precision must be at least -1"))
     @assert 0 < pos <= length(buf) "invalid pos"
     # special cases
     if x == 0
@@ -381,7 +384,7 @@ function writeshortest(buf::AbstractVector{UInt8}, pos, x::T,
             buf_cconv = Base.cconvert(Ptr{UInt8}, buf)
             GC.@preserve buf_cconv begin
                 ptr = Base.unsafe_convert(Ptr{UInt8}, buf_cconv)
-                memmove(ptr + pos + pointoff, ptr + pos + pointoff - 1, (olength - pointoff + 1)%Csize_t)
+                memmove(ptr + pos + pointoff, ptr + pos + pointoff - 1, (olength - pointoff)%Csize_t)
             end
             @inbounds buf[pos + pointoff] = decchar
             pos += olength + 1

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -686,6 +686,7 @@ function repeat(c::AbstractChar, r::Integer)
     r == 0 && return ""
     u = bswap(reinterpret(UInt32, c))
     n = 4 - (leading_zeros(u | 0xff) >> 3)
+    r > typemax(UInt) ÷ UInt(n) && throw(OutOfMemoryError())
     s = _string_n(n*r)
     p = pointer(s)
     GC.@preserve s if n == 1

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -292,6 +292,8 @@ function repeat(s::Union{String, SubString{String}}, r::Integer)
     r == 0 && return ""
     r == 1 && return String(s)
     n = sizeof(s)
+    n == 0 && return ""
+    r > typemax(UInt) ÷ UInt(n) && throw(OutOfMemoryError())
     out = _string_n(n*r)
     if n == 1 # common case: repeating a single-byte string
         @inbounds b = codeunit(s, 1)

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -80,8 +80,11 @@ JL_DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n)
 {
     jl_task_t *ct = jl_current_task;
     if (n == 0) return jl_emptysvec;
-    jl_svec_t *jv = (jl_svec_t*)jl_gc_alloc(ct->ptls, (n + 1) * sizeof(void*),
-                                            jl_simplevector_type);
+    size_t allocsz;
+    if (__builtin_add_overflow(n, (size_t)1, &allocsz) ||
+        __builtin_mul_overflow(allocsz, sizeof(void *), &allocsz))
+        jl_throw(jl_memory_exception);
+    jl_svec_t *jv = (jl_svec_t*)jl_gc_alloc(ct->ptls, allocsz, jl_simplevector_type);
     jl_set_typetagof(jv, jl_simplevector_tag, 0);
     jl_svec_set_len_unsafe(jv, n);
     return jv;

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -548,7 +548,8 @@ This creates a 25-by-30000 `BitArray`, linked to the file associated with stream
 """
 function mmap(io::IO, ::Type{<:BitArray}, dims::NTuple{N,Integer},
               offset::Integer=position(io); grow::Bool=true, shared::Bool=true) where N
-    n = prod(dims)
+    dims = map(Int, dims)
+    n = Core.checked_dims(dims...)
     nc = Base.num_bit_chunks(n)
     chunks = mmap(io, Vector{UInt64}, (nc,), offset; grow=grow, shared=shared)
     if !isreadonly(io)
@@ -584,8 +585,10 @@ function mmap(::Type{Array{T, N}}, dims::NTuple{N, Integer}; kwargs...) where {T
     open(io -> mmap(io, Array{T, N}, dims; kwargs...), SharedMemory, "", size; readonly = false, create = true)
 end
 function mmap(::Type{BitArray{N}}, dims::NTuple{N, Integer}; kwargs...) where {N}
-    prod(dims) == 0 && return BitArray{N}(undef, dims)
-    size = checked_bytesize((Base.num_bit_chunks(prod(dims)),), sizeof(UInt64))
+    dims = map(Int, dims)
+    n = Core.checked_dims(dims...)
+    n == 0 && return BitArray{N}(undef, dims)
+    size = checked_bytesize((Base.num_bit_chunks(n),), sizeof(UInt64))
     open(io -> mmap(io, BitArray{N}, dims; kwargs...), SharedMemory, "", size; readonly = false, create = true)
 end
 

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -211,6 +211,11 @@ b = @inferred mmap(s, BitArray, (17,13))
 @test Test._check_bitarray_consistency(b)
 @test b == trues(17,13)
 @test_throws ArgumentError mmap(s, BitArray, (7,3))
+
+# Memory-mapped BitArray dimensions must be checked before computing the mapped size.
+overflow_dim = Int(typemax(UInt) ÷ 3 + 1)
+@test_throws ArgumentError mmap(IOBuffer(), BitArray, (3, overflow_dim))
+@test_throws ArgumentError mmap(BitMatrix, (3, overflow_dim))
 close(s)
 s = open(file, "r+")
 b = mmap(s, BitArray, (17,19))

--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -872,7 +872,7 @@ end
 function plength(f::Spec{T}, x) where {T <: Chars}
     c = Char(first(x))
     w = textwidth(c)
-    return max(f.width, w) + (ncodeunits(c) - w)
+    return Base.checked_add(max(f.width, w), ncodeunits(c) - w)
 end
 
 plength(f::Spec{Pointer}, x) = max(f.width, 2 * sizeof(x) + 2)
@@ -880,22 +880,22 @@ plength(f::Spec{Pointer}, x) = max(f.width, 2 * sizeof(x) + 2)
 function plength(f::Spec{T}, x) where {T <: Strings}
     str = string(x)
     sw = textwidth(str)
-    p = f.precision == -1 ? (sw + (f.hash ? (x isa Symbol ? 1 : 2) : 0)) : f.precision
-    return max(f.width, p) + (sizeof(str) - sw)
+    p = f.precision == -1 ? Base.checked_add(sw, f.hash ? (x isa Symbol ? 1 : 2) : 0) : f.precision
+    return Base.checked_add(max(f.width, p), sizeof(str) - sw)
 end
 
 function plength(f::Spec{T}, x) where {T <: Ints}
     x2 = toint(x)
     return max(
         f.width,
-        f.precision + ndigits(x2, base=base(T), pad=1) + MAX_FMT_CHARS_WIDTH
+        Base.checked_add(f.precision, ndigits(x2, base=base(T), pad=1), MAX_FMT_CHARS_WIDTH)
     )
 end
 
 plength(f::Spec{T}, x::AbstractFloat) where {T <: Ints} =
-    max(f.width, f.hash + MAX_INTEGER_PART_WIDTH + 0 + MAX_FMT_CHARS_WIDTH)
+    max(f.width, Base.checked_add(Int(f.hash), MAX_INTEGER_PART_WIDTH, MAX_FMT_CHARS_WIDTH))
 plength(f::Spec{T}, x) where {T <: Floats} =
-    max(f.width, f.hash + MAX_INTEGER_PART_WIDTH + f.precision + MAX_FMT_CHARS_WIDTH)
+    max(f.width, Base.checked_add(Int(f.hash), MAX_INTEGER_PART_WIDTH, f.precision, MAX_FMT_CHARS_WIDTH))
 plength(::Spec{PositionCounter}, x) = 0
 
 @inline function computelen(substringranges, formats, args)
@@ -906,13 +906,13 @@ plength(::Spec{PositionCounter}, x) = 0
     Base.@nexprs 16 i -> begin
         if N >= i
             l, argp = plength(formats[i], args, argp)
-            len += l
+            len = Base.checked_add(len, l)
         end
     end
     if N > 16
         for i = 17:length(formats)
             l, argp = plength(formats[i], args, argp)
-            len += l
+            len = Base.checked_add(len, l)
         end
     end
     return len

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -1147,6 +1147,18 @@ end
 
 end
 
+# Format buffer estimates must not wrap before direct writers fill the buffer.
+@testset "format length overflow" begin
+    for conversion in ('e', 'f', 'g')
+        fmt = Printf.Format("%1.$(typemax(Int))$conversion")
+        @test_throws OverflowError Printf.format(fmt, 0.0)
+    end
+    @test_throws OverflowError Printf.format(Printf.Format("%.$(typemax(Int))d"), 1)
+    @test_throws OverflowError Printf.format(Printf.Format("%$(typemax(Int))s"), "α")
+    @test_throws OverflowError Printf.format(
+        Printf.Format("%$(typemax(Int))s%1s"), "", "")
+end
+
 @testset "length modifiers" begin
     @test_throws Printf.InvalidFormatStringError Printf.Format("%h")
     @test_throws Printf.InvalidFormatStringError Printf.Format("%hh")

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1520,6 +1520,13 @@ end
 
 using Base: typed_hvncat
 @testset "hvncat" begin
+    # Concatenation dimensions must not wrap before allocating and filling the result.
+    overflow_dim = Int(typemax(UInt) ÷ 3 + 1)
+    overflow_array = reshape(1:overflow_dim, 1, overflow_dim)
+    @test_throws OverflowError hvncat((1, 3), false, overflow_array, overflow_array, overflow_array)
+    @test_throws OverflowError hvncat(((1, 1, 1), (3,)), false,
+                                      overflow_array, overflow_array, overflow_array)
+
     a = fill(1, (2,3,2,4,5))
     b = fill(2, (1,1,2,4,5))
     c = fill(3, (1,2,2,4,5))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -93,6 +93,10 @@ using Dates
 
     @test_throws DimensionMismatch reshape(1:3, 4)
 
+    # Generic reshape must reject dimensions whose product overflows.
+    overflow_dim = Int(typemax(UInt) ÷ 3 + 1)
+    @test_throws ArgumentError reshape(view([1, 2], :), 3, overflow_dim)
+
     # issue #23107
     a = [1,2,3]
     @test typeof(a)(a) !== a
@@ -933,6 +937,12 @@ end
     @test isequal(cumsum(A,dims=3),A3)
     @test repeat([1,2,3,4], UInt32(1)) == [1,2,3,4]
     @test repeat([1 2], UInt32(2)) == repeat([1 2], UInt32(2), UInt32(1))
+
+    # Repeated array dimensions must be checked before allocating and filling the result.
+    overflow_count = Int(typemax(UInt) ÷ 3 + 1)
+    @test_throws OverflowError repeat([1, 2, 3], overflow_count)
+    @test_throws OverflowError repeat([1, 2, 3], inner=overflow_count)
+    @test_throws OverflowError repeat(reshape(1:9, 3, 3), overflow_count, 1)
 
     # issue 20564
     @test_throws MethodError repeat(1, 2, 3)
@@ -2364,6 +2374,12 @@ end
     @test_throws BoundsError copyto!(a,b)
     @test_throws ArgumentError copyto!(a,2:3,1:3,b,1:5,2:7)
     @test_throws ArgumentError LinearAlgebra.copy_transpose!(a,2:3,1:3,b,1:5,2:7)
+
+    # Copy bounds must be validated without overflowing their end indices.
+    @test_throws BoundsError copyto!(zeros(UInt8, 2), Int8(2), ones(UInt8, 2), Int8(2), typemax(Int8))
+    @test_throws BoundsError copyto!(view(zeros(Int, 2), :), 2, Iterators.repeated(1, typemax(Int)))
+    @test_throws BoundsError copyto!(view(zeros(Int, 2), :), Int8(2), Iterators.repeated(1), 1, typemax(Int8))
+    @test_throws BoundsError copyto!(view(zeros(Int, 2), :), Int8(2), view(ones(Int, 2), :), Int8(2), typemax(Int8))
 end
 
 @testset "empty copyto!" begin

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -209,9 +209,6 @@ timesofar("promotions")
 
         # Chunk rounding and reshape products must remain valid at the Int limit.
         @test Base.num_bit_chunks(typemax(Int)) == div(typemax(Int), 64) + 1
-        maxbits = trues(1)
-        @test_throws OutOfMemoryError resize!(maxbits, typemax(Int))
-        @test maxbits == trues(1)
         overflow_dim = Int(typemax(UInt) ÷ 3 + 1)
         @test_throws ArgumentError reshape(trues(2), 3, overflow_dim)
     end

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -158,6 +158,8 @@ timesofar("promotions")
     end
 
     @testset "copyto!" begin
+        # BitArray copy bounds must not wrap their computed end indices.
+        @test_throws BoundsError copyto!(falses(2), Int8(2), trues(2), Int8(2), typemax(Int8))
         let b1 = trues(1)
             @test all(copyto!(b1, []))
         end
@@ -204,6 +206,14 @@ timesofar("promotions")
         @check_bit_operation resize!(b1, v1 ÷ 2) BitVector
         gr(b) = (resize!(b, v1)[(v1÷2):end] .= 1; b)
         @check_bit_operation gr(b1) BitVector
+
+        # Chunk rounding and reshape products must remain valid at the Int limit.
+        @test Base.num_bit_chunks(typemax(Int)) == div(typemax(Int), 64) + 1
+        maxbits = trues(1)
+        @test_throws OutOfMemoryError resize!(maxbits, typemax(Int))
+        @test maxbits == trues(1)
+        overflow_dim = Int(typemax(UInt) ÷ 3 + 1)
+        @test_throws ArgumentError reshape(trues(2), 3, overflow_dim)
     end
 
     @testset "sizeof (issue #7515)" begin
@@ -226,6 +236,10 @@ timesofar("utils")
             @test b1 == b2
         end
     end
+
+    # BitArray constructors must reject dimensions whose product overflows.
+    overflow_dim = Int(typemax(UInt) ÷ 3 + 1)
+    @test_throws ArgumentError BitMatrix(undef, 3, overflow_dim)
 
     @testset "constructors from iterables" begin
         for g in ((x%7==3 for x = 1:v1),

--- a/test/core.jl
+++ b/test/core.jl
@@ -6981,6 +6981,23 @@ for U in unboxedunions
     end
 end
 
+# Vector growth sizes must not wrap and leave logical length larger than backing storage.
+@testset "array growth overflow" begin
+    A = [1, 2]
+    popfirst!(A)
+    @test_throws OverflowError resize!(A, typemax(Int))
+    @test A == [2]
+    @test length(A.ref.mem) == 2
+
+    for (f, A) in ((A -> Base._growbeg!(A, typemax(Int)), [1]),
+                   (A -> Base._growend!(A, typemax(Int)), [1]),
+                   (A -> Base._growat!(A, 2, typemax(Int)), [1, 2]))
+        old = copy(A)
+        @test_throws OverflowError f(A)
+        @test A == old
+    end
+end
+
 @testset "array _growatend!" begin
 
 # start w/ array, set & check elements, grow it, check that elements stayed correct, set & check elements
@@ -8505,6 +8522,14 @@ end
     a, b... = x
     @test a == 1
     @test b == Core.svec(2, 3)
+end
+
+# SimpleVector allocation must reject pointer-byte size overflow before its fill loops.
+@testset "svec allocation overflow" begin
+    n = Int(typemax(UInt) ÷ UInt(sizeof(Ptr{Cvoid})) + 1)
+    @test_throws OutOfMemoryError Tuple{Vararg{Nothing,n}}
+    mem = Memory{Nothing}(undef, n)
+    @test_throws OutOfMemoryError Core.svec(mem...)
 end
 
 @testset "setproperty! on modules" begin

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -552,6 +552,11 @@ end
 @test_throws ArgumentError length(flatten(NTuple[(1,), ()])) # #16680
 @test_throws ArgumentError length(flatten([[1], [1]]))
 
+# Flattened iterator lengths must not wrap before comprehension allocation.
+overflow_length = Int(typemax(UInt) ÷ 3 + 1)
+overflow_flatten = flatten(Iterators.repeated((1, 2, 3), overflow_length))
+@test_throws OverflowError collect(identity(x) for x in overflow_flatten)
+
 @testset "IteratorSize trait for flatten" begin
     @test (@inferred Base.IteratorSize(Base.Flatten((i for i=1:2) for j=1:1))) == Base.SizeUnknown()
     @test (@inferred Base.IteratorSize(Base.Flatten((1,2)))) == Base.HasLength()

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2669,6 +2669,11 @@ end
 end
 
 @testset "collect with specialized vcat" begin
+    # Specialized range concatenation must check its aggregate allocation length.
+    overflow_dim = Int(typemax(UInt) ÷ 3 + 1)
+    overflow_range = 1:overflow_dim
+    @test_throws OverflowError vcat(overflow_range, overflow_range, overflow_range)
+
     struct OneToThree <: AbstractUnitRange{Int} end
     Base.size(r::OneToThree) = (3,)
     Base.first(r::OneToThree) = 1

--- a/test/ryu.jl
+++ b/test/ryu.jl
@@ -7,6 +7,38 @@ todouble(sign, exp, mant) = Core.bitcast(Float64, (UInt64(sign) << 63) | (UInt64
 
 @testset "Ryu" begin
 
+# Ryu wrapper buffers must account for requested precision without size overflow.
+@testset "precision buffer sizing" begin
+    @test Ryu.writeshortest(1.0, false, false, true, 400) == "1." * repeat("0", 399)
+    @test Ryu.writeshortest(1.0, false, false, true, UInt(0)) ==
+        Ryu.writeshortest(1.0, false, false, true, 0)
+    @test Ryu.writefixed(1.25, UInt(2)) == "1.25"
+    @test Ryu.writeexp(1.25, big(2)) == "1.25e+00"
+
+    overflow_precision = typemax(Int)
+    @test_throws OverflowError Ryu.writeshortest(1.0, false, false, true, overflow_precision)
+    @test_throws OverflowError Ryu.writefixed(0.0, overflow_precision)
+    @test_throws OverflowError Ryu.writeexp(0.0, overflow_precision)
+
+    @test_throws ArgumentError Ryu.writeshortest(1.0, false, false, true, -2)
+    @test_throws ArgumentError Ryu.writefixed(floatmax(Float64), -1)
+    @test_throws ArgumentError Ryu.writeexp(floatmax(Float64), -1)
+
+    buf = fill(UInt8(0), Ryu.neededdigits(Float64))
+    @test_throws InexactError Ryu.writeshortest(buf, 1, 1.0, false, false, true, typemax(UInt))
+    @test_throws ArgumentError Ryu.writefixed(buf, 1, 1.0, -1)
+    @test_throws ArgumentError Ryu.writeexp(buf, 1, 1.0, -1)
+
+    for exactbuf in (zeros(UInt8, 4), Memory{UInt8}(undef, 4))
+        @test Ryu.writeshortest(exactbuf, 1, 1.25) == 5
+        @test String(Vector(exactbuf)) == "1.25"
+    end
+    canarybuf = fill(0xa5, 5)
+    canarybuf[5] = 0x5a
+    @test Ryu.writeshortest(canarybuf, 1, 1.25) == 5
+    @test canarybuf[5] == 0x5a
+end
+
 @testset "Float64" begin
 
 @testset "Basic" begin

--- a/test/ryu.jl
+++ b/test/ryu.jl
@@ -26,6 +26,8 @@ todouble(sign, exp, mant) = Core.bitcast(Float64, (UInt64(sign) << 63) | (UInt64
 
     buf = fill(UInt8(0), Ryu.neededdigits(Float64))
     @test_throws InexactError Ryu.writeshortest(buf, 1, 1.0, false, false, true, typemax(UInt))
+    @test_throws MethodError Ryu.writefixed(buf, 1, 1.0)
+    @test_throws MethodError Ryu.writeexp(buf, 1, 1.0)
     @test_throws ArgumentError Ryu.writefixed(buf, 1, 1.0, -1)
     @test_throws ArgumentError Ryu.writeexp(buf, 1, 1.0, -1)
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -788,6 +788,17 @@ end
             @test repeat(S, T(3)) === S*S*S
         end
     end
+    # Repetition byte counts must not wrap before allocation.
+    @test repeat("", typemax(Csize_t)) === ""
+    for c in ('α', '∀', '🍕')
+        s = string(c)
+        n = Csize_t(ncodeunits(c))
+        r = typemax(Csize_t) ÷ n + one(Csize_t)
+        @test_throws OutOfMemoryError repeat(c, r)
+        @test_throws OutOfMemoryError repeat(s, r)
+        @test_throws OutOfMemoryError repeat(SubString(s, 1), r)
+        @test_throws OutOfMemoryError repeat(GenericString(s), r)
+    end
     # Issue #32160 (string allocation unsigned overflow)
     @test_throws OutOfMemoryError repeat('x', typemax(Csize_t))
 end


### PR DESCRIPTION
Reject overflowing repetition byte counts before allocating strings and characters. Apply checked allocation and bounds arithmetic to analogous array, iterator, formatting, mmap, and SimpleVector paths so wrapped metadata cannot reach unchecked fills. Reported to security@julialang.org by the Kimi Security team.

Example issue:
```
julia> repeat("abcd", 2^62+2)

[75959] signal 11 (2): Segmentation fault
in expression starting at REPL[1]:1
jl_gc_small_alloc_inner at /Users/keno/julia/src/gc-stock.c:746:23 [inlined]
jl_gc_small_alloc_noinline at /Users/keno/julia/src/gc-stock.c:787:12 [inlined]
jl_gc_alloc_ at /Users/keno/julia/src/gc-stock.c:801:13
```

Assisted-by: Codex (GPT-5)