### PR TITLE
jitlayers: root JIT-emitted CodeInstances that are not cache-rooted

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -475,6 +475,21 @@ jl_emit_codeinsts_to_jit_impl(jl_code_instance_t **codeinsts, jl_code_info_t **s
         if (jl_atomic_load_relaxed(&codeinst->invoke))
             continue;
 
+        // The JIT retains raw pointers to every CodeInstance whose body it
+        // emits (CISymbols, pending linker info, the debuginfo address map),
+        // so such a CodeInstance must remain rooted for the lifetime of the
+        // process. That is normally guaranteed by its presence in the native
+        // `mi.cache` chain, but an AbstractInterpreter whose executable cache
+        // is not the integrated `InternalCodeCache` can request ABI
+        // compilation of a CodeInstance that is only reachable through
+        // GC-managed interpreter state. Pin those here, mirroring the
+        // opaque-closure promotion in jl_register_jit_object. Top-level
+        // thunks (whose `def` is a Module) stay unpinned: they are expected
+        // to be collected and jl_invoke_oneshot unregisters them explicitly.
+        if (jl_is_method(mi->def.value) && !mi->def.method->is_for_opaque_closure &&
+            !jl_mi_cache_has_ci(mi, codeinst))
+            jl_as_global_root((jl_value_t*)codeinst, 1);
+
         out.temporary_roots = jl_alloc_array_1d(jl_array_any_type, 0);
         out.temporary_roots_set.clear();
         if (!jl_emit_codeinst(out, codeinst, src)) { // contains safepoints


### PR DESCRIPTION
My robot prefers this over #62794 

🤖 The JIT retains raw pointers to every CodeInstance whose body it emits: as keys in the CISymbols ORC symbol map, in pending MaterializationUnit linker info, and in the debuginfo address map used for backtraces and profiling. This is safe because such a CodeInstance is normally rooted for the lifetime of the process by its presence in the native `mi.cache` chain, with the known exceptions handled explicitly (opaque-closure CodeInstances are promoted to global roots in jl_register_jit_object; top-level thunks are unregistered by jl_invoke_oneshot before they become collectible).

An AbstractInterpreter whose executable cache is not the integrated InternalCodeCache breaks that assumption: `add_codeinsts_to_jit!` verifies rooting with `jl_mi_cache_has_ci` but re-establishes it through the interpreter's cache abstraction, which for a custom cache roots the CodeInstance only in GC-managed interpreter state. Since #62359, the SOURCE_MODE_ABI path can select an existing equivalent winner from such a cache and compile it from local source. A sourceless winner has empty edges, so it is not even incidentally kept alive through callee backedge lists; once the interpreter is dropped, the CodeInstance is collected while its CISymbols entry remains, and a later CodeInstance allocated at the same address trips the `!CISymbols.contains(CI)` assertion in JuliaOJIT::registerCI (in release builds it could instead be linked to the dead CodeInstance's symbols). This is what intermittently killed Compiler/test/AbstractInterpreter.jl on CI, where the ephemeral-cache test's winner died during the subsequent OverlayCacheInterp inference: https://buildkite.com/organizations/julialang/pipelines/julia-ci/builds/224/jobs/019fd02f-6157-415d-89ce-b63474f47073/log

Enforce the lifetime requirement at the emission chokepoint: before emitting a body for a CodeInstance that is a method specialization but absent from its native `mi.cache` chain, promote it to a global root, mirroring the existing opaque-closure promotion. Thunks (whose def is a Module) stay unpinned so the oneshot flow still allows them to be collected, and the common native flow always caches first, so the pin fires only for custom-cache ABI compilations, whose jitted code is process-permanent anyway.