### PR TITLE
implement the `BUILD_PATH_PREFIX_MAP` spec for julia for more reproducible builds and control over build paths

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -2073,6 +2073,20 @@ endif # VERBOSE
 print-%:
 	@printf "%s\n" $(call shell_escape,$*)=$(call shell_escape,$(subst $(newline),\n,$($*)))
 
+# DO NOT MERGE: build with BUILD_PATH_PREFIX_MAP on CI. The source prefix must
+# be %-encoded (the Windows drive colon) and must use the native Windows path
+# spelling: MSYS make's JULIAHOME is the /c/... POSIX form, which never matches
+# the C:... paths julia and gcc see.
+ifeq ($(OS), WINNT)
+BUILD_PATH_PREFIX_MAP_SRC := $(subst \,/,$(shell echo $(call cygpath_w,$(JULIAHOME))))
+else
+BUILD_PATH_PREFIX_MAP_SRC := $(JULIAHOME)
+endif
+export BUILD_PATH_PREFIX_MAP := /julia=$(subst :,%.,$(subst =,%+,$(subst %,%\#,$(BUILD_PATH_PREFIX_MAP_SRC))))
+# MSYS2 path-converts env values that look like POSIX paths when spawning native
+# binaries, which would corrupt the value; exempt it
+export MSYS2_ENV_CONV_EXCL := BUILD_PATH_PREFIX_MAP
+
 # Also apply BUILD_PATH_PREFIX_MAP to C/C++ debug info and __FILE__, so native
 # frames use the same mapped paths as the runtime. Each dst=src pair in the map
 # becomes -ffile-prefix-map=src=dst. (This sits at the end of Make.inc so a map

--- a/Make.inc
+++ b/Make.inc
@@ -2072,3 +2072,14 @@ endif # VERBOSE
 # (hardened against any special characters appearing in the output)
 print-%:
 	@printf "%s\n" $(call shell_escape,$*)=$(call shell_escape,$(subst $(newline),\n,$($*)))
+
+# Also apply BUILD_PATH_PREFIX_MAP to C/C++ debug info and __FILE__, so native
+# frames use the same mapped paths as the runtime. Each dst=src pair in the map
+# becomes -ffile-prefix-map=src=dst. (This sits at the end of Make.inc so a map
+# constructed within this file, e.g. via cygpath_w, is visible; the JCFLAGS
+# variables are recursively expanded, so the late += still lands everywhere.)
+ifneq ($(BUILD_PATH_PREFIX_MAP),)
+BUILD_PATH_PREFIX_MAP_FLAGS := $(shell printf '%s' '$(BUILD_PATH_PREFIX_MAP)' | awk 'BEGIN { RS=":" } { i = index($$0, "="); if (i == 0) next; dst = substr($$0, 1, i-1); src = substr($$0, i+1); gsub(/%\./, ":", dst); gsub(/%\+/, "=", dst); gsub(/%\#/, "%", dst); gsub(/%\./, ":", src); gsub(/%\+/, "=", src); gsub(/%\#/, "%", src); printf " -ffile-prefix-map=%s=%s", src, dst }')
+JCFLAGS_COMMON += $(BUILD_PATH_PREFIX_MAP_FLAGS)
+JCXXFLAGS_COMMON += $(BUILD_PATH_PREFIX_MAP_FLAGS)
+endif

--- a/NEWS.md
+++ b/NEWS.md
@@ -134,6 +134,16 @@ Multi-threading changes
 Build system changes
 --------------------
 
+* Image generation now honors the
+  [`BUILD_PATH_PREFIX_MAP`](https://reproducible-builds.org/specs/build-path-prefix-map/)
+  environment variable: serialized source locations (method and module files, debug info,
+  native code debug info (DWARF), cache dependency lists, docstring locations, and
+  source-location literals in method bodies — including quoted expressions and
+  `__source__`-derived strings from macros like `@warn`) have their build directory
+  prefix replaced with the given stable prefix. Values a program computes from source
+  paths at parse time and stores in ordinary data (e.g. a global holding `@__FILE__`)
+  are not rewritten ([#32763]).
+
 New library functions
 ---------------------
 
@@ -156,6 +166,9 @@ New library functions
 New library features
 --------------------
 
+* `@assert` failure messages no longer include a `#= file:line =#` comment when the asserted
+  condition contains a macro call; the location is available from the stacktrace as usual
+  ([#32763]).
 * `IOContext` supports a new boolean `hexunsigned` option that allows for printing unsigned integers in
   decimal instead of hexadecimal ([#60267]).
 * `lazy"..."` strings now support a flag `lazy"..."c` that adds `compact` and `limit` flags to the

--- a/base/Makefile
+++ b/base/Makefile
@@ -76,7 +76,7 @@ endif
 	@printf "%s\n" "const PRIVATE_LIBDIR = "$(call shell_escape,$(call julia_escape,$(call normalize_path,$(private_libdir_rel)))) >> $@
 	@printf "%s\n" "const PRIVATE_LIBEXECDIR = "$(call shell_escape,$(call julia_escape,$(call normalize_path,$(private_libexecdir_rel)))) >> $@
 	@printf "%s\n" "const INCLUDEDIR = "$(call shell_escape,$(call julia_escape,$(call normalize_path,$(includedir_rel)))) >> $@
-	@printf "%s\n" "const SOURCEDIR = "$(call shell_escape,$(call julia_escape,$(call normalize_path,$(shell echo $(call cygpath_w,$(JULIAHOME)))))) >> $@
+	@printf "%s\n" "const SOURCEDIR = ccall(:jl_map_build_path, Any, (Any,), "$(call shell_escape,$(call julia_escape,$(call normalize_path,$(shell echo $(call cygpath_w,$(JULIAHOME))))))")::String" >> $@
 ifeq ($(DARWIN_FRAMEWORK), 1)
 	@printf "%s\n" "const DARWIN_FRAMEWORK = true" >> $@
 	@printf "%s\n" "const DARWIN_FRAMEWORK_NAME = \"$(FRAMEWORK_NAME)\"" >> $@

--- a/base/error.jl
+++ b/base/error.jl
@@ -205,6 +205,18 @@ windowserror(p, code::UInt32=Libc.GetLastError(); extrainfo=nothing) = throw(Mai
 
 ## assertion macro ##
 
+# return a copy of `ex` without the location metadata of any inner macro calls,
+# which `string` would render as an absolute-path `#= file:line =#` comment
+function _strip_macrocall_linenums(@nospecialize ex)
+    isa(ex, Expr) || return ex
+    args = Any[_strip_macrocall_linenums(a) for a in ex.args]
+    if ex.head === :macrocall
+        for i in eachindex(args)
+            isa(args[i], LineNumberNode) && (args[i] = nothing)
+        end
+    end
+    return Expr(ex.head, args...)
+end
 
 """
     @assert cond [text]
@@ -237,10 +249,10 @@ macro assert(ex, msgs...)
         # message is an expression needing evaluating
         msg = :($_assert_tostring($(esc(msg))))
     elseif isdefined(Main, :Base) && isdefined(Main.Base, :string) && applicable(Main.Base.string, msg)
-        msg = Main.Base.string(msg)
+        msg = Main.Base.string(_strip_macrocall_linenums(msg))
     else
         # string() might not be defined during bootstrap
-        msg = :($_assert_tostring($(Expr(:quote,msg))))
+        msg = :($_assert_tostring($(Expr(:quote, _strip_macrocall_linenums(msg)))))
     end
     return :($(esc(ex)) ? $(nothing) : throw(AssertionError($msg)))
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3461,6 +3461,18 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
     # in the output. We removed it above to avoid including any code we may
     # have compiled for error handling and validation.
     ccall(:jl_set_newly_inferred, Cvoid, (Any,), newly_inferred)
+
+    # remap docstring source paths for BUILD_PATH_PREFIX_MAP
+    for mod in Docs.modules
+        moduleroot(mod) === m || continue
+        for multidoc in values(Docs.meta(mod))
+            for docstr in values(multidoc.docs)
+                path = get(docstr.data, :path, nothing)
+                path isa String && (docstr.data[:path] = ccall(:jl_map_build_path, Any, (Any,), path)::String)
+            end
+        end
+    end
+
     @lock require_lock end_loading(pkg, m)
     # insert_extension_triggers(pkg)
     # run_package_callbacks(pkg)

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -154,10 +154,17 @@ function fixup_stdlib_path(path::String)
     # this function is valid even in this intermediary state
     if isdefined(@__MODULE__, :Sys)
         if Sys.BUILD_STDLIB_PATH != Sys.STDLIB
-            # BUILD_STDLIB_PATH gets defined in sysinfo.jl
+            # BUILD_STDLIB_PATH gets defined in sysinfo.jl.
+            # Under BUILD_PATH_PREFIX_MAP this can be a short relative prefix, so
+            # only replace it anchored at the start and on a component boundary.
             npath = normpath(path)
-            npath′ = replace(npath, normpath(Sys.BUILD_STDLIB_PATH) => normpath(Sys.STDLIB))
-            path = npath == npath′ ? path : npath′
+            nbase = normpath(Sys.BUILD_STDLIB_PATH)
+            if startswith(npath, nbase)
+                rest = SubString(npath, ncodeunits(nbase) + 1)
+                if isempty(rest) || rest[1] == '/' || rest[1] == '\\'
+                    path = string(normpath(Sys.STDLIB), rest)
+                end
+            end
         end
         if isdefined(@__MODULE__, :Core) && isdefined(Core, :Compiler)
             compiler_folder = dirname(String(Base.moduleloc(Core.Compiler).file))

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -150,6 +150,26 @@ let
     empty!(DEPOT_PATH)
 end
 
+# Remap the paths in pkgorigins, _included_files, and docstring metadata,
+# which would otherwise bake the build directory into the sysimage.
+let remap = p -> ccall(:jl_map_build_path, Any, (Any,), p)::String
+    for origin in values(Base.pkgorigins)
+        origin.path === nothing || (origin.path = remap(origin.path))
+        origin.cachepath === nothing || (origin.cachepath = remap(origin.cachepath))
+    end
+    for (i, (mod, file)) in enumerate(Base._included_files)
+        Base._included_files[i] = (mod, remap(file))
+    end
+    for mod in Base.Docs.modules
+        for multidoc in values(Base.Docs.meta(mod))
+            for docstr in values(multidoc.docs)
+                path = get(docstr.data, :path, nothing)
+                path isa String && (docstr.data[:path] = remap(path))
+            end
+        end
+    end
+end
+
 empty!(Base.TOML_CACHE.d)
 Base.TOML.reinit!(Base.TOML_CACHE.p, "")
 @eval Base BUILDROOT = ""

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -47,8 +47,8 @@ A string containing the full path to the directory containing the `stdlib` packa
 """
 global STDLIB::String = "$BINDIR/$DATAROOTDIR/julia/stdlib/v$(VERSION.major).$(VERSION.minor)" # for bootstrap
 # In case STDLIB change after julia is built, the variable below can be used
-# to update cached method locations to updated ones.
-const BUILD_STDLIB_PATH = STDLIB
+# to update cached method locations to updated ones (subject to BUILD_PATH_PREFIX_MAP).
+const BUILD_STDLIB_PATH = ccall(:jl_map_build_path, Any, (Any,), STDLIB)::String
 
 # helper to avoid triggering precompile warnings
 

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -353,7 +353,7 @@ function generate_precompile_statements()
                 occursin("InterruptException", output) ||
                     error("unexpected output from the pty-attached process:\n$output")
             catch ex
-                @warn "Failed to collect precompile statements from the pty-attached process" exception=(ex, catch_backtrace())
+                @warn "Failed to collect precompile statements from the pty-attached process" exception=(ex, catch_backtrace()) _module=nothing _file=nothing _line=0
             end
         end
         for (name, f) in (("package precompilation", tmp_prec), ("script", tmp_proc))
@@ -362,7 +362,7 @@ function generate_precompile_statements()
                 # in a real sysimage build (bare sysimage) both processes trace plenty;
                 # when run standalone against a finished sysimage they may trace nothing
                 msg = "no precompile statements were traced from the $name process"
-                Base.get_bool_env("CI", false) ? error(msg) : @warn(msg)
+                Base.get_bool_env("CI", false) ? error(msg) : @warn(msg, _module=nothing, _file=nothing, _line=0)
             end
             n > 0 && append!(statements, eachline(f))
         end

--- a/contrib/write_base_cache.jl
+++ b/contrib/write_base_cache.jl
@@ -1,8 +1,11 @@
 # Write the sys source cache in format readable by Base._read_dependency_src
 cachefile = ARGS[1]
+
+srcroot = dirname(@__DIR__)
+
 open(cachefile, "w") do io
     for (_, filename) in Base._included_files
-        src = read(filename, String)
+        src = read(joinpath(srcroot, relpath(filename, Base.SOURCEDIR)), String)
         write(io, Int32(sizeof(filename)))
         write(io, filename)
         write(io, UInt64(sizeof(src)))

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -197,6 +197,23 @@ Sets the maximum number of different instances of a single package that are to b
 
 If set to true, linker commands will be displayed during precompilation.
 
+### [`BUILD_PATH_PREFIX_MAP`](@id BUILD_PATH_PREFIX_MAP)
+
+Colon-separated `target=source` path prefix pairs, following the
+[reproducible builds specification](https://reproducible-builds.org/specs/build-path-prefix-map/).
+When set while Julia generates a system or package image, serialized source paths
+starting with `source` have that prefix replaced by `target`, keeping build directories
+out of the produced images. For example:
+
+```
+BUILD_PATH_PREFIX_MAP="julia=$(pwd)"
+```
+
+On Windows, escape drive-letter colons as `%.` (e.g. `julia=C%.\b\julia`).
+
+!!! compat "Julia 1.14"
+    Support for `BUILD_PATH_PREFIX_MAP` requires at least Julia 1.14.
+
 ## Pkg.jl
 
 ### [`JULIA_CI`](@id JULIA_CI)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8873,6 +8873,16 @@ static jl_datatype_t *compute_va_type(jl_value_t *sig, size_t nreq) JL_CANSAFEPO
     return (jl_datatype_t*)typ;
 }
 
+// create a DIFile with BUILD_PATH_PREFIX_MAP applied to the path
+static DIFile *mk_difile(DIBuilder &dbuilder, StringRef file)
+{
+    size_t maplen;
+    char *mapped = jl_maybe_map_build_path_cstr(file.data(), file.size(), &maplen);
+    DIFile *difile = dbuilder.createFile(mapped ? StringRef(mapped, maplen) : file, ".");
+    free(mapped);
+    return difile;
+}
+
 // Compile to LLVM IR, using a specialized signature if applicable.
 static jl_llvm_functions_t
     emit_function(
@@ -9236,7 +9246,7 @@ static jl_llvm_functions_t
     DISubprogram *SP = NULL;
     DebugLoc noDbg, topdebugloc;
     if (debug_enabled) {
-        topfile = dbuilder.createFile(ctx.file, ".");
+        topfile = mk_difile(dbuilder, ctx.file);
         DISubroutineType *subrty;
         if (ctx.emission_context.params->debug_info_level <= 1)
             subrty = debugcache.jl_di_func_null_sig;
@@ -9809,7 +9819,7 @@ static jl_llvm_functions_t
                             DebugLoc inl_loc = new_lineinfo.empty() ? DebugLoc(DILocation::get(ctx.builder.getContext(), 0, 0, SP, NULL)) : new_lineinfo.back().loc;
                             DISubprogram *&inl_SP = subprograms[std::make_tuple(fname, info.file)];
                             if (inl_SP == NULL) {
-                                DIFile *difile = dbuilder.createFile(info.file, ".");
+                                DIFile *difile = mk_difile(dbuilder, info.file);
                                 inl_SP = dbuilder.createFunction(difile
                                                              ,std::string(fname) + ";" // Name
                                                              ,fname            // LinkageName

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1343,6 +1343,11 @@ void jl_init_runtime_ccall(void) JL_NOTSAFEPOINT;
 void jl_init_intrinsic_functions(void) JL_CANSAFEPOINT JL_GC_DISABLED;
 void jl_init_intrinsic_properties(void) JL_GC_DISABLED JL_NOTSAFEPOINT;
 void jl_init_staticdata(void) JL_NOTSAFEPOINT;
+// BUILD_PATH_PREFIX_MAP remapping of serialized source paths (staticdata_utils.c)
+jl_value_t *jl_maybe_map_build_path_jlstr(jl_value_t *str) JL_CANSAFEPOINT;
+JL_DLLEXPORT char *jl_maybe_map_build_path_cstr(const char *path, size_t len, size_t *outlen) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_map_build_path(jl_value_t *str) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_test_map_build_path(jl_value_t *map, jl_value_t *path) JL_CANSAFEPOINT;
 // TypeApp: immutable struct with head::Any, param::Any
 // Represents a single lazy type application step (like UnionAll for where bindings).
 typedef struct {

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -41,10 +41,11 @@ static void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) JL_CA
         jl_value_t *normalize_depots_func = NULL;
         jl_value_t *deptuple = NULL;
         jl_value_t *depots = NULL;
+        jl_value_t *depalias = NULL;
         jl_task_t *ct = jl_current_task;
         size_t last_age = ct->world_age;
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-        JL_GC_PUSH4(&deptuple, &depots, &replace_depot_func, &normalize_depots_func);
+        JL_GC_PUSH5(&deptuple, &depots, &replace_depot_func, &normalize_depots_func, &depalias);
         replace_depot_func = jl_eval_global_var(jl_base_module, jl_symbol("replace_depot_path"), jl_current_task->world_age);
         normalize_depots_func = jl_eval_global_var(jl_base_module, jl_symbol("normalize_depots_for_relocation"), jl_current_task->world_age);
         depots = jl_apply(&normalize_depots_func, 1);
@@ -74,7 +75,8 @@ static void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) JL_CA
                 replace_depot_args[0] = replace_depot_func;
                 replace_depot_args[1] = abspath;
                 replace_depot_args[2] = depots;
-                jl_value_t *depalias = (jl_value_t*)jl_apply(replace_depot_args, 3);
+                depalias = (jl_value_t*)jl_apply(replace_depot_args, 3);
+                depalias = jl_maybe_map_build_path_jlstr(depalias);
 
                 size_t slen = jl_string_len(depalias);
                 write_int32(f, slen);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -573,8 +573,12 @@ static void jl_queue_module_for_serialization(jl_serializer_state *s, jl_module_
 {
     jl_queue_for_serialization(s, m->name);
     jl_queue_for_serialization(s, m->parent);
-    if (!jl_options.strip_metadata)
-        jl_queue_for_serialization(s, m->file);
+    if (!jl_options.strip_metadata) {
+        jl_sym_t *file = jl_maybe_map_build_path_sym(m->file);
+        if (file != m->file)
+            record_field_change((jl_value_t**)&m->file, (jl_value_t*)file);
+        jl_queue_for_serialization(s, file);
+    }
     jl_queue_for_serialization(s, jl_atomic_load_relaxed(&m->bindingkeyset));
     if (jl_options.trim) {
         jl_queue_for_serialization_(s, (jl_value_t*)jl_atomic_load_relaxed(&m->bindings), 0, 1);
@@ -638,6 +642,46 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
     jl_datatype_t *t = (jl_datatype_t*)jl_typeof(v);
     jl_queue_for_serialization_(s, (jl_value_t*)t, 1, immediate);
     const jl_datatype_layout_t *layout = t->layout;
+
+    // remap source paths per BUILD_PATH_PREFIX_MAP; not under strip-metadata,
+    // which registers its own replacements for these fields
+    if (!jl_options.strip_metadata) {
+        if (jl_is_method(v)) {
+            jl_method_t *m = (jl_method_t*)v;
+            jl_sym_t *file = jl_maybe_map_build_path_sym(m->file);
+            if (file != m->file) {
+                record_field_change((jl_value_t**)&m->file, (jl_value_t*)file);
+                jl_queue_for_serialization(s, file);
+            }
+        }
+        else if (jl_is_debuginfo(v)) {
+            jl_debuginfo_t *di = (jl_debuginfo_t*)v;
+            if (jl_is_symbol(di->def)) {
+                jl_sym_t *def = jl_maybe_map_build_path_sym((jl_sym_t*)di->def);
+                if ((jl_value_t*)def != di->def) {
+                    record_field_change(&di->def, (jl_value_t*)def);
+                    jl_queue_for_serialization(s, def);
+                }
+            }
+        }
+    }
+    // remap quoted-AST literals in method roots. Substituting the slots in place
+    // keeps root indices valid for compressed IR. Roots survive strip-metadata,
+    // so map them regardless, but respect a NULL replacement from strip-ir.
+    if (prefix_map_state == PREFIX_MAP_ACTIVE && jl_is_method(v)) {
+        jl_method_t *m = (jl_method_t*)v;
+        jl_array_t *mroots = (jl_array_t*)get_replaceable_field((jl_value_t**)&m->roots, 0);
+        if (mroots) {
+            jl_value_t **roots = jl_array_data(mroots, jl_value_t*);
+            for (size_t i = 0, n = jl_array_nrows(mroots); i < n; i++) {
+                jl_value_t *mapped = maybe_map_build_path_in_ast(roots[i], 0);
+                if (mapped) {
+                    record_field_change(&roots[i], mapped);
+                    jl_queue_for_serialization(s, mapped);
+                }
+            }
+        }
+    }
 
     if (!recursive)
         goto done_fields;
@@ -875,6 +919,13 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
                                 while (rle_iter_increment(&rootiter, nroots, rletable, nblocks2)) {
                                     if (rootiter.key == s->worklist_key) {
                                         jl_value_t *newroot = jl_array_ptr_ref(def->roots, rootiter.i);
+                                        // in-image methods never reach the roots remap in
+                                        // jl_insert_into_serialization_queue, so map here
+                                        if (prefix_map_state == PREFIX_MAP_ACTIVE) {
+                                            jl_value_t *mapped = maybe_map_build_path_in_ast(newroot, 0);
+                                            if (mapped)
+                                                newroot = mapped;
+                                        }
                                         jl_queue_for_serialization(s, newroot);
                                         jl_array_ptr_set(newroots, k++, newroot);
                                     }
@@ -1288,7 +1339,7 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
     arraylist_push(&s->relocs_list, (void*)backref_id(s, jl_atomic_load_relaxed(&m->bindingkeyset), s->link_ids_relocs));
     newm->file = NULL;
     arraylist_push(&s->relocs_list, (void*)(reloc_offset + offsetof(jl_module_t, file)));
-    arraylist_push(&s->relocs_list, (void*)backref_id(s, jl_options.strip_metadata ? jl_empty_sym : m->file , s->link_ids_relocs));
+    arraylist_push(&s->relocs_list, (void*)backref_id(s, jl_options.strip_metadata ? (jl_value_t*)jl_empty_sym : get_replaceable_field((jl_value_t**)&m->file, 0), s->link_ids_relocs));
     if (jl_options.strip_metadata)
         newm->line = 0;
     newm->usings_backedges = NULL;
@@ -3037,6 +3088,20 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
         jl_get_llvm_gv_inits(native_functions, &num_gvars, NULL);
         arraylist_grow(&gvars, num_gvars);
         jl_get_llvm_gv_inits(native_functions, &num_gvars, gvars.items);
+        // native code references its literals through these gvar slots, bypassing
+        // the method roots hook above, so remap them here too — except plain String
+        // literals (`@__DIR__`/`@__FILE__` results), which code uses for runtime file
+        // access (e.g. Documenter locating its assets) and have no reverse mapping
+        if (prefix_map_state == PREFIX_MAP_ACTIVE) {
+            for (size_t gi = 0; gi < num_gvars; gi++) {
+                jl_value_t *v = (jl_value_t*)gvars.items[gi];
+                if (jl_is_string(v))
+                    continue;
+                jl_value_t *mapped = maybe_map_build_path_in_ast(v, 0);
+                if (mapped)
+                    gvars.items[gi] = mapped;
+            }
+        }
         jl_get_llvm_external_fns(native_functions, &num_external_fns, NULL);
         arraylist_grow(&external_fns, num_external_fns);
         jl_get_llvm_external_fns(native_functions, &num_external_fns,
@@ -3446,6 +3511,8 @@ JL_DLLEXPORT uint32_t jl_create_system_image(void **_native_data, jl_array_t *wo
                                              jl_array_t *module_init_order)
 {
     JL_TIMING(SYSIMG_DUMP, SYSIMG_DUMP);
+
+    prefix_map_active(); // parse BUILD_PATH_PREFIX_MAP now; a malformed map fails the build
 
     jl_task_t *ct = jl_current_task;
     ios_t *f = (ios_t*)malloc_s(sizeof(ios_t));

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -11,6 +11,307 @@ static void write_float64(ios_t *s, double x) JL_NOTSAFEPOINT
     write_uint64(s, *((uint64_t*)&x));
 }
 
+// BUILD_PATH_PREFIX_MAP (https://reproducible-builds.org/specs/build-path-prefix-map/):
+// remap source path prefixes when writing images.
+
+typedef struct {
+    char *target;
+    size_t target_len;
+    char *source;
+    size_t source_len;
+} prefix_map_pair_t;
+
+static prefix_map_pair_t *prefix_map_pairs = NULL;
+static size_t prefix_map_npairs = 0;
+static enum {
+    PREFIX_MAP_UNPARSED = -1,
+    PREFIX_MAP_INACTIVE = 0,
+    PREFIX_MAP_ACTIVE = 1,
+    PREFIX_MAP_MALFORMED = 2,
+} prefix_map_state = PREFIX_MAP_UNPARSED;
+
+// decode `%.` `%+` `%#` escapes; NULL if invalid
+static char *prefix_map_unescape(const char *s, size_t len, size_t *outlen) JL_NOTSAFEPOINT
+{
+    char *out = (char*)malloc_s(len + 1);
+    size_t j = 0;
+    for (size_t i = 0; i < len; i++) {
+        char c = s[i];
+        if (c == '%') {
+            char e = i + 1 < len ? s[i + 1] : '\0';
+            c = e == '.' ? ':' : e == '+' ? '=' : e == '#' ? '%' : '\0';
+            if (c == '\0') {
+                free(out);
+                return NULL;
+            }
+            i++;
+        }
+        else if (c == '=' || c == ':') {
+            free(out);
+            return NULL;
+        }
+        out[j++] = c;
+    }
+    out[j] = '\0';
+    *outlen = j;
+    return out;
+}
+
+static void prefix_map_free(prefix_map_pair_t *pairs, size_t npairs) JL_NOTSAFEPOINT
+{
+    for (size_t i = 0; i < npairs; i++) {
+        free(pairs[i].target);
+        free(pairs[i].source);
+    }
+    free(pairs);
+}
+
+// returns 0 if malformed, which invalidates the whole map
+static int prefix_map_parse(const char *spec, prefix_map_pair_t **out_pairs, size_t *out_npairs) JL_NOTSAFEPOINT
+{
+    prefix_map_pair_t *pairs = NULL;
+    size_t n = 0, cap = 0;
+    const char *p = spec;
+    while (1) {
+        const char *end = strchr(p, ':');
+        size_t len = end ? (size_t)(end - p) : strlen(p);
+        if (len > 0) { // empty subsequences between ':' are ignored
+            const char *eq = (const char*)memchr(p, '=', len);
+            char *target = NULL, *source = NULL;
+            size_t tlen = 0, slen = 0;
+            if (eq) {
+                target = prefix_map_unescape(p, eq - p, &tlen);
+                if (target)
+                    source = prefix_map_unescape(eq + 1, p + len - (eq + 1), &slen);
+            }
+            // reject '@'-prefixed targets, which would collide with the loader's @depot aliases
+            if (!source || (target[0] == '@')) {
+                free(target);
+                free(source);
+                prefix_map_free(pairs, n);
+                return 0;
+            }
+            if (n == cap) {
+                cap = cap ? 2 * cap : 4;
+                pairs = (prefix_map_pair_t*)realloc_s(pairs, cap * sizeof(prefix_map_pair_t));
+            }
+            pairs[n].target = target;
+            pairs[n].target_len = tlen;
+            pairs[n].source = source;
+            pairs[n].source_len = slen;
+            n++;
+        }
+        if (!end)
+            break;
+        p = end + 1;
+    }
+    *out_pairs = pairs;
+    *out_npairs = n;
+    return 1;
+}
+
+static int is_path_sep(char c) JL_NOTSAFEPOINT
+{
+#ifdef _OS_WINDOWS_
+    if (c == '\\')
+        return 1;
+#endif
+    return c == '/';
+}
+
+// bytewise comparison, except on Windows '/' and '\\' count as equal
+static int prefix_bytes_eq(const char *path, const char *source, size_t n) JL_NOTSAFEPOINT
+{
+    for (size_t i = 0; i < n; i++) {
+        if (path[i] != source[i] && !(is_path_sep(path[i]) && is_path_sep(source[i])))
+            return 0;
+    }
+    return 1;
+}
+
+// replace a matching source prefix in `path` with its target; the rightmost pair
+// wins and the match must end on a path component boundary. Returns a malloc'd
+// string, or NULL when no pair matches.
+static char *prefix_map_apply(prefix_map_pair_t *pairs, size_t npairs,
+                              const char *path, size_t len, size_t *outlen) JL_NOTSAFEPOINT
+{
+    if (len == 0)
+        return NULL;
+    for (size_t i = npairs; i-- > 0; ) {
+        const char *source = pairs[i].source;
+        size_t slen = pairs[i].source_len;
+        while (slen > 1 && is_path_sep(source[slen - 1]))
+            slen--;
+        if (len < slen || !prefix_bytes_eq(path, source, slen))
+            continue;
+        // component-boundary check: /path/to/a must not match /path/to/aa/b
+        if (len > slen && !is_path_sep(path[slen]) && !(slen > 0 && is_path_sep(source[slen - 1])))
+            continue;
+        size_t tlen = pairs[i].target_len;
+        size_t rest = len - slen;
+        char *out = (char*)malloc_s(tlen + rest + 1);
+        memcpy(out, pairs[i].target, tlen);
+        memcpy(out + tlen, path + slen, rest);
+        out[tlen + rest] = '\0';
+        *outlen = tlen + rest;
+        return out;
+    }
+    return NULL;
+}
+
+static void prefix_map_init(void) JL_NOTSAFEPOINT
+{
+    if (prefix_map_state != PREFIX_MAP_UNPARSED)
+        return;
+    // uv_os_getenv reads the wide environment on Windows and converts to WTF-8,
+    // matching the encoding of the paths being mapped
+    size_t size = 256;
+    char *spec = (char*)malloc_s(size);
+    int r = uv_os_getenv("BUILD_PATH_PREFIX_MAP", spec, &size);
+    if (r == UV_ENOBUFS) {
+        spec = (char*)realloc_s(spec, size);
+        r = uv_os_getenv("BUILD_PATH_PREFIX_MAP", spec, &size);
+    }
+    if (r != 0 || !spec[0]) {
+        free(spec);
+        prefix_map_state = PREFIX_MAP_INACTIVE;
+        return;
+    }
+    prefix_map_state = prefix_map_parse(spec, &prefix_map_pairs, &prefix_map_npairs) ?
+        PREFIX_MAP_ACTIVE : PREFIX_MAP_MALFORMED;
+    free(spec);
+}
+
+// error on a malformed map instead of silently writing unmapped output; called
+// up front since the mapping functions themselves cannot throw
+static int prefix_map_active(void)
+{
+    prefix_map_init();
+    if (prefix_map_state == PREFIX_MAP_MALFORMED)
+        jl_error("malformed BUILD_PATH_PREFIX_MAP value");
+    return prefix_map_state == PREFIX_MAP_ACTIVE;
+}
+
+static char *maybe_map_build_path(const char *path, size_t len, size_t *outlen) JL_NOTSAFEPOINT
+{
+    if (prefix_map_state != PREFIX_MAP_ACTIVE || !jl_generating_output())
+        return NULL;
+    return prefix_map_apply(prefix_map_pairs, prefix_map_npairs, path, len, outlen);
+}
+
+// C-string variant for codegen debug info, which runs before prefix_map_active
+// has validated the map; a malformed map is simply inactive here
+JL_DLLEXPORT char *jl_maybe_map_build_path_cstr(const char *path, size_t len, size_t *outlen) JL_NOTSAFEPOINT
+{
+    prefix_map_init();
+    return maybe_map_build_path(path, len, outlen);
+}
+
+static jl_sym_t *jl_maybe_map_build_path_sym(jl_sym_t *s) JL_NOTSAFEPOINT
+{
+    if (s == NULL)
+        return s;
+    const char *name = jl_symbol_name(s);
+    size_t outlen;
+    char *mapped = maybe_map_build_path(name, strlen(name), &outlen);
+    if (!mapped)
+        return s;
+    jl_sym_t *r = jl_symbol_n(mapped, outlen);
+    free(mapped);
+    return r;
+}
+
+jl_value_t *jl_maybe_map_build_path_jlstr(jl_value_t *str) JL_CANSAFEPOINT
+{
+    size_t len = jl_string_len(str);
+    const char *data = jl_string_data(str);
+    // skip binary-packed `require` records (leading NUL) and @depot aliases
+    if (len == 0 || data[0] == '\0' || (len >= 6 && !memcmp(data, "@depot", 6)))
+        return str;
+    size_t outlen;
+    char *mapped = maybe_map_build_path(data, len, &outlen);
+    if (!mapped)
+        return str;
+    jl_value_t *r = jl_pchar_to_string(mapped, outlen);
+    free(mapped);
+    return r;
+}
+
+// remap path symbols, strings, and LineNumberNode files inside an AST literal;
+// returns NULL when nothing changed. Allocates without rooting, so the GC must
+// be disabled.
+static jl_value_t *maybe_map_build_path_in_ast(jl_value_t *v, int depth) JL_CANSAFEPOINT JL_GC_DISABLED
+{
+    if (v == NULL || depth > 100)
+        return NULL;
+    if (jl_is_symbol(v)) {
+        jl_sym_t *mapped = jl_maybe_map_build_path_sym((jl_sym_t*)v);
+        return mapped == (jl_sym_t*)v ? NULL : (jl_value_t*)mapped;
+    }
+    if (jl_is_string(v)) {
+        jl_value_t *mapped = jl_maybe_map_build_path_jlstr(v);
+        return mapped == v ? NULL : mapped;
+    }
+    if (jl_is_linenode(v)) {
+        jl_value_t *file = maybe_map_build_path_in_ast(jl_linenode_file(v), depth + 1);
+        if (file == NULL)
+            return NULL;
+        return jl_new_struct(jl_linenumbernode_type, jl_box_long(jl_linenode_line(v)), file);
+    }
+    if (jl_is_quotenode(v)) {
+        jl_value_t *val = maybe_map_build_path_in_ast(jl_quotenode_value(v), depth + 1);
+        if (val == NULL)
+            return NULL;
+        return jl_new_struct(jl_quotenode_type, val);
+    }
+    if (jl_is_expr(v)) {
+        jl_expr_t *e = (jl_expr_t*)v;
+        size_t i, n = jl_expr_nargs(e);
+        jl_expr_t *ne = NULL;
+        for (i = 0; i < n; i++) {
+            jl_value_t *mapped = maybe_map_build_path_in_ast(jl_exprarg(e, i), depth + 1);
+            if (mapped) {
+                if (ne == NULL) {
+                    ne = jl_exprn(e->head, n);
+                    for (size_t j = 0; j < n; j++)
+                        jl_exprargset(ne, j, jl_exprarg(e, j));
+                }
+                jl_exprargset(ne, i, mapped);
+            }
+        }
+        return (jl_value_t*)ne;
+    }
+    return NULL;
+}
+
+JL_DLLEXPORT jl_value_t *jl_map_build_path(jl_value_t *str) JL_CANSAFEPOINT
+{
+    JL_TYPECHK(map_build_path, string, str);
+    if (!prefix_map_active())
+        return str;
+    return jl_maybe_map_build_path_jlstr(str);
+}
+
+// test entry point that parses `map` fresh on every call, since the
+// environment value is cached per-process
+JL_DLLEXPORT jl_value_t *jl_test_map_build_path(jl_value_t *map, jl_value_t *path) JL_CANSAFEPOINT
+{
+    JL_TYPECHK(test_map_build_path, string, map);
+    JL_TYPECHK(test_map_build_path, string, path);
+    prefix_map_pair_t *pairs = NULL;
+    size_t npairs = 0;
+    if (!prefix_map_parse(jl_string_data(map), &pairs, &npairs))
+        jl_error("malformed BUILD_PATH_PREFIX_MAP value");
+    size_t outlen;
+    char *mapped = prefix_map_apply(pairs, npairs, jl_string_data(path), jl_string_len(path), &outlen);
+    prefix_map_free(pairs, npairs);
+    if (!mapped)
+        return path;
+    jl_value_t *r = jl_pchar_to_string(mapped, outlen);
+    free(mapped);
+    return r;
+}
+
 // Decide if `t` must be new, because it points to something new.
 // If it is new, the object (in particular, the super field) might not be entirely
 // valid for the cache, so we want to finish transforming it before attempting
@@ -795,7 +1096,8 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     jl_value_t *unique_func = NULL;
     jl_value_t *replace_depot_func = NULL;
     jl_value_t *normalize_depots_func = NULL;
-    JL_GC_PUSH5(&depots, &prefs_blob, &unique_func, &replace_depot_func, &normalize_depots_func);
+    jl_value_t *deppath = NULL;
+    JL_GC_PUSH6(&depots, &prefs_blob, &unique_func, &replace_depot_func, &normalize_depots_func, &deppath);
 
     jl_array_t *udeps = (jl_array_t*)jl_get_global_value(jl_base_module, jl_symbol("_require_dependencies"), ct->world_age);
     *udepsp = udeps;
@@ -828,7 +1130,7 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     for (i = 0; i < l; i++) {
         jl_value_t *deptuple = jl_array_ptr_ref(udeps, i);
         JL_TYPECHK(write_dependency_list, deptuple, deptuple);
-        jl_value_t *deppath = jl_fieldref_noalloc(deptuple, 1);
+        deppath = jl_fieldref_noalloc(deptuple, 1);
 
         if (replace_depot_func) {
             jl_value_t *replace_depot_args[3];
@@ -838,6 +1140,7 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
             deppath = (jl_value_t*)jl_apply(replace_depot_args, 3);
             JL_TYPECHK(write_dependency_list, string, deppath);
         }
+        deppath = jl_maybe_map_build_path_jlstr(deppath);
 
         size_t slen = jl_string_len(deppath);
         write_int32(s, slen);

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -45,6 +45,11 @@ end
 #-----------------------------------------------------------------------
 
 # Backtrace utility functions
+
+# the path of this file as it appears in compiled frames, which is not
+# necessarily `@__FILE__` (BUILD_PATH_PREFIX_MAP can rewrite it)
+this_file() = String(Base.moduleloc(@__MODULE__).file)
+
 function ip_has_file_and_func(ip, file, funcs)
     return any(fr -> (in_file(fr, file) && fr.func in funcs), StackTraces.lookup(ip))
 end
@@ -52,7 +57,7 @@ in_file(frame, file) = string(frame.file) == file
 
 function test_location(bt, file_ts, file_t)
     if (isnothing(file_ts) || isnothing(file_t))
-        return macrocall_location(bt, something(file_ts, @__FILE__))
+        return macrocall_location(bt, something(file_ts, this_file()))
     else
         return test_callsite(bt, file_ts, file_t)
     end
@@ -63,7 +68,7 @@ function test_callsite(bt, file_ts, file_t)
     # For that, we retrieve locations from lower to higher stack elements
     # and only traverse parts of the backtrace which we haven't traversed before.
     # The order will always be <internal functions> -> `@test` -> `@testset`.
-    internal = @something(macrocall_location(bt, @__FILE__), return nothing)
+    internal = @something(macrocall_location(bt, this_file()), return nothing)
     test = internal - 1 + @something(findfirst(ip -> any(frame -> in_file(frame, file_t), StackTraces.lookup(ip)), @view bt[internal:end]), return nothing)
     testset = test - 1 + @something(macrocall_location(@view(bt[test:end]), file_ts), return nothing)
 
@@ -86,7 +91,8 @@ end
 macrocall_location(bt, file) = findfirst(ip -> ip_has_file_and_func(ip, file, (Symbol("macro expansion"),)), bt)
 
 function scrub_backtrace(bt, file_ts, file_t)
-    do_test_ind = findfirst(ip -> ip_has_file_and_func(ip, @__FILE__, (:do_test, :do_test_throws)), bt)
+    file = this_file()
+    do_test_ind = findfirst(ip -> ip_has_file_and_func(ip, file, (:do_test, :do_test_throws)), bt)
     if do_test_ind !== nothing && length(bt) > do_test_ind
         bt = bt[do_test_ind + 1:end]
     end

--- a/test/buildpathmap.jl
+++ b/test/buildpathmap.jl
@@ -1,0 +1,183 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Tests for BUILD_PATH_PREFIX_MAP support in image serialization
+# (https://reproducible-builds.org/specs/build-path-prefix-map/)
+
+using Test
+
+# parses the given map fresh on every call (the env value is cached per-process)
+mapbp(map, path) = ccall(:jl_test_map_build_path, Any, (Any, Any), map, path)::String
+
+@testset "basic mapping" begin
+    @test mapbp("julia=/build/dir", "/build/dir/base/foo.jl") == "julia/base/foo.jl"
+    @test mapbp("julia=/build/dir", "/build/dir") == "julia"
+    @test mapbp("julia=/build/dir", "/other/dir/foo.jl") == "/other/dir/foo.jl" # no match
+    @test mapbp("", "/build/dir/foo.jl") == "/build/dir/foo.jl" # empty map
+end
+
+@testset "component-boundary matching" begin
+    @test mapbp("a=/path/to/a", "/path/to/aa/b") == "/path/to/aa/b" # must not match
+    @test mapbp("a=/path/to/a", "/path/to/a/b") == "a/b"
+    @test mapbp("a=/path/to/a/", "/path/to/a/b") == "a/b" # trailing sep on source
+    @test mapbp("root=/", "/b") == "rootb" # source is fs root; spec: target + remainder
+end
+
+@testset "rightmost priority" begin
+    @test mapbp("first=/build:second=/build", "/build/x") == "second/x"
+    @test mapbp("outer=/build:inner=/build/sub", "/build/sub/x") == "inner/x"
+    @test mapbp("inner=/build/sub:outer=/build", "/build/sub/x") == "outer/sub/x"
+end
+
+@testset "escaping" begin
+    @test mapbp("t%.arget=/pa%.th", "/pa:th/x") == "t:arget/x"   # %. => :
+    @test mapbp("t%+arget=/pa%+th", "/pa=th/x") == "t=arget/x"   # %+ => =
+    @test mapbp("t%#arget=/pa%#th", "/pa%th/x") == "t%arget/x"   # %# => %
+end
+
+@testset "empty segments and empty prefixes" begin
+    @test mapbp(":julia=/build::", "/build/x") == "julia/x" # empty subsequences ignored
+    # an empty source prefix matches at the root component boundary, i.e. absolute
+    # paths only: mapping relative paths would corrupt Base's relative method files
+    @test mapbp("rel=", "/abs/x") == "rel/abs/x"
+    @test mapbp("rel=", "relative/x") == "relative/x"
+    @test mapbp("=/build", "/build/x") == "/x" # empty target strips the prefix
+end
+
+@static if Sys.iswindows()
+@testset "windows separators and drive letters" begin
+    # drive-letter colons are escaped as %. per the spec
+    @test mapbp("julia=C%.\\build\\julia", "C:\\build\\julia\\base\\foo.jl") == "julia\\base\\foo.jl"
+    @test mapbp("julia=C%.\\build\\julia", "C:\\build\\juliax\\foo.jl") == "C:\\build\\juliax\\foo.jl"
+    @test mapbp("julia=C%./build/julia", "C:/build/julia/base/foo.jl") == "julia/base/foo.jl"
+    # separators in the source prefix match either spelling
+    @test mapbp("julia=C%./build/julia", "C:\\build\\julia\\base\\foo.jl") == "julia\\base\\foo.jl"
+    @test mapbp("julia=C%.\\build\\julia", "C:/build/julia/base/foo.jl") == "julia/base/foo.jl"
+    # matching is byte-exact: no case folding
+    @test mapbp("julia=C%.\\Build", "C:\\build\\x") == "C:\\build\\x"
+end
+end
+
+@testset "malformed maps invalidate the whole variable" begin
+    @test_throws ErrorException mapbp("nopair", "/x")               # no '='
+    @test_throws ErrorException mapbp("a=/ok:nopair", "/x")         # one bad pair poisons all
+    @test_throws ErrorException mapbp("a=b=c", "/x")                # unescaped '=' in source
+    @test_throws ErrorException mapbp("a%zb=/x", "/x")              # invalid escape
+    @test_throws ErrorException mapbp("a%=/x", "/x")                # trailing '%'
+    # '@'-prefixed targets are reserved for the loader's internal aliases (@depot)
+    @test_throws ErrorException mapbp("@depot/stable=/build", "/build/x")
+    @test_throws ErrorException mapbp("@foo=/build", "/build/x")
+end
+
+if !Sys.iswindows() # symlink-based; the parser/matcher tests above cover Windows
+@testset "pkgimage integration" begin
+    mktempdir() do tmp
+        tmp = realpath(tmp)
+        real = joinpath(tmp, "real")
+        mapped = joinpath(tmp, "mapped")
+        pkgsrc = joinpath(real, "TestPkgMap", "src")
+        mkpath(pkgsrc)
+        symlink(real, mapped)
+
+        write(joinpath(real, "TestPkgMap", "Project.toml"), """
+        name = "TestPkgMap"
+        uuid = "d31f4c31-b3ea-4e4e-bd7c-90d8bbd0d165"
+        version = "0.1.0"
+
+        [deps]
+        InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+        """)
+        write(joinpath(pkgsrc, "TestPkgMap.jl"), """
+        module TestPkgMap
+        using InteractiveUtils
+        const BUILT_FILE = @__FILE__   # parse-time value: must NOT be remapped
+        "adds one"
+        f(x) = x + 1
+        f(1)
+        # native code debug info (DIFile) is mapped too; capture IR emitted while
+        # generating output, where the map is active
+        const LLVM_IR = sprint(io -> code_llvm(io, f, (Int,); dump_module=true, debuginfo=:source))
+        # a quote body puts this file's path into the macro method's roots as
+        # LineNumberNode file symbols
+        macro qm()
+            quote
+                1 + 1
+            end
+        end
+        # logging macros bake String(__source__.file) literals into the caller's roots
+        logs_one(x) = (@warn "boom" maxlog=1; x)
+        # function-body @__DIR__ literals are used for runtime file access (e.g.
+        # Documenter locating assets); pkgimage native code must keep them unmapped
+        srcdir() = @__DIR__
+        srcdir()
+        end
+        """)
+
+        depot = joinpath(tmp, "depot")
+        env = ["JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+               "JULIA_LOAD_PATH" => real * Base.Filesystem.pathsep()]
+
+        # precompile with the map active
+        cmd = addenv(`$(Base.julia_cmd()) --startup-file=no -e 'using TestPkgMap'`,
+                     env..., "BUILD_PATH_PREFIX_MAP" => "$mapped=$real")
+        @test success(pipeline(cmd; stdout, stderr))
+
+        # fresh process without the variable: load and inspect what was serialized
+        code = """
+        using TestPkgMap
+        mapped = raw"$mapped"
+        real = raw"$real"
+        m = first(methods(TestPkgMap.f))
+        startswith(String(m.file), mapped) || error("method file not mapped: ", m.file)
+        startswith(String(Base.moduleloc(TestPkgMap).file), mapped) || error("module file not mapped")
+        function check_di(di, bad)
+            di isa Core.DebugInfo || return true
+            d = di.def
+            d isa Symbol && startswith(String(d), bad) && return false
+            check_di(di.linetable, bad) || return false
+            all(check_di(e, bad) for e in di.edges)
+        end
+        mi = m.specializations isa Core.MethodInstance ? m.specializations :
+             first(x for x in m.specializations if x !== nothing)
+        check_di(mi.cache.debuginfo, real) || error("debuginfo contains unmapped path")
+        startswith(TestPkgMap.BUILT_FILE, real) || error("parse-time @__FILE__ was remapped")
+        TestPkgMap.srcdir() == joinpath(real, "TestPkgMap", "src") ||
+            error("function-body @__DIR__ was remapped: ", TestPkgMap.srcdir())
+        isfile(String(m.file)) || error("mapped path does not resolve")
+        Base.isprecompiled(Base.identify_package("TestPkgMap")) || error("cache considered stale")
+        cachefile = first(Base.find_all_in_cache_path(Base.identify_package("TestPkgMap")))
+        includes = Base.parse_cache_header(cachefile)[2][1]
+        any(inc -> startswith(inc.filename, mapped), includes) || error("header deps not mapped")
+        any(inc -> startswith(inc.filename, real), includes) && error("header deps leak real path")
+        docpath = first(values(first(values(Base.Docs.meta(TestPkgMap))).docs)).data[:path]
+        startswith(docpath, mapped) || error("docstring path not mapped: ", docpath)
+        difile = joinpath(mapped, "TestPkgMap", "src", "TestPkgMap.jl")
+        contains(TestPkgMap.LLVM_IR, difile) || error("native debug info (DIFile) not mapped")
+        contains(TestPkgMap.LLVM_IR, real) && error("native debug info leaks real path")
+        # path-like values in a method's roots, including LineNumberNode files
+        # inside quoted Expr roots
+        function roots_paths(m)
+            out = String[]
+            walk(r) = r isa Symbol ? push!(out, String(r)) :
+                      r isa String ? push!(out, r) :
+                      r isa LineNumberNode ? (r.file isa Symbol ? push!(out, String(r.file)) : out) :
+                      r isa Expr ? foreach(walk, r.args) :
+                      r isa QuoteNode ? walk(r.value) : nothing
+            foreach(walk, m.roots)
+            return out
+        end
+        mac_paths = roots_paths(first(methods(getglobal(TestPkgMap, Symbol("@qm")))))
+        any(p -> startswith(p, mapped), mac_paths) ||
+            error("quoted LineNumberNode file not mapped in macro roots")
+        mw_paths = roots_paths(first(methods(TestPkgMap.logs_one)))
+        any(p -> startswith(p, mapped), mw_paths) ||
+            error("logging __source__ file literal not mapped in roots")
+        for p in [mac_paths; mw_paths]
+            startswith(p, real) && error("method roots leak real path: ", p)
+        end
+        println("ok")
+        """
+        cmd = addenv(`$(Base.julia_cmd()) --startup-file=no -e $code`, env...)
+        @test read(pipeline(cmd; stderr), String) == "ok\n"
+    end
+end
+end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -24,7 +24,7 @@ const TESTNAMES = [
         "some", "meta", "stacktraces", "docs", "gc",
         "misc", "threads", "stress", "binaryplatforms","stdlib_dependencies", "atexit",
         "enums", "cmdlineargs", "int", "interpreter",
-        "checked", "bitset", "floatfuncs", "precompile", "relocatedepot",
+        "checked", "bitset", "floatfuncs", "precompile", "relocatedepot", "buildpathmap",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "cancellation", "iostream", "secretbuffer", "specificity",
         "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -23,6 +23,16 @@ let
         @test occursin("1 == 2", ex.msg)
     end
 end
+# a macro call in the condition must not embed its `#= file:line =#` location in the message
+let
+    try
+        @assert @isdefined(never_defined_misc_jl)
+        error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test ex.msg == "@isdefined never_defined_misc_jl"
+    end
+end
 # test @assert message
 let
     try


### PR DESCRIPTION
This PR implements the `BUILD_PATH_PREFIX_MAP` spec as given in https://reproducible-builds.org/specs/build-path-prefix-map/
to be used as a build option to avoid the build environment's path leaking into the finished product.
This is useful for reproducible builds and also as a way to avoid the very long paths we get on our builds on buildkite, for example:

```
julia> using SHA

julia> (@which SHA.sha2_224("foo")).file
Symbol("/Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/builder-honeycrisp-P2C257CXGN.1/019ebd63-635e-4155-b60a-9d2815900786/trusted/build/builder-honeycrisp-P2C257CXGN-1/julialang/julia-ci/usr/share/julia/stdlib/v1.14/SHA/src/SHA.jl")
```

We are quite good at rewriting these paths before showing them to users (`fixup_stdlib_path`) but they sometimes leak through.

With this PR, the julia sysimage has 0 occurrences of the build path environment (using `strings` to test). Things that are rewritten:

The serialized heap:
```
┌─────┬──────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────┐
│  #  │                             What                             │                                         Where                                          │
├─────┼──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ 1   │ Method.file                                                  │ jl_insert_into_serialization_queue, src/staticdata.c (via record_field_change)         │
├─────┼──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ 2   │ Module.file                                                  │ jl_queue_module_for_serialization + the get_replaceable_field read in jl_write_module, │
│     │                                                              │  src/staticdata.c                                                                      │
├─────┼──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ 3   │ DebugInfo.def (file Symbols, incl. nested linetable/edges)   │ same queue hook, src/staticdata.c                                                      │
├─────┼──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ 4   │ Method.roots literals — path Symbols/Strings, LineNumberNode │ queue hook + maybe_map_build_path_in_ast (src/staticdata_utils.c); slot substitution   │
│     │  files inside Expr/QuoteNode trees                           │ so all compressed blobs stay index-valid                                               │
├─────┼──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ 5   │ Roots newly appended to in-image methods by a pkgimage       │ the method_roots_list copy loop, src/staticdata.c                                      │
├─────┼──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ 6   │ .ji header dependency paths                                  │ write_dependency_list, src/staticdata_utils.c (after @depot replacement)               │
├─────┼──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ 7   │ .ji srctext filenames                                        │ write_srctext, src/precompile.c                                                        │
├─────┼──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ 8   │ Native debug info (DWARF DIFiles, top-level + inlined        │ mk_difile, src/codegen.cpp (your change)                                               │
│     │ frames)                                                      │                                                                                        │
└─────┴──────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────┘
```


Julia-level state baked into the sysimage:
```
┌─────┬───────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────┐
│  #  │               What                │                                          Where                                          │
├─────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┤
│ 9   │ Sys.BUILD_STDLIB_PATH             │ base/sysinfo.jl (ccall at definition)                                                   │
├─────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┤
│ 10  │ Base.SOURCEDIR                    │ base/Makefile → generated build_h.jl (ccall at definition)                              │
├─────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┤
│ 11  │ Base.pkgorigins (path, cachepath) │ end of base/sysimg.jl                                                                   │
├─────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┤
│ 12  │ Base._included_files              │ end of base/sysimg.jl                                                                   │
├─────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┤
│ 13  │ Docstring DocStr.data[:path]      │ sysimage: base/sysimg.jl; pkgimages: end of include_package_for_output, base/loading.jl │
└─────┴───────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────┘
```

Some other things that were done to not leak strings:

- `@assert` no longer embeds `#= abspath:line =#` in messages (`_strip_macrocall_linenums`, `base/error.jl`)
- `contrib/generate_precompile.jl`'s workload `@warns` use `_file=nothing` (path would otherwise survive via native-code global roots)


A demo script to test this out is given below 

<details><summary>`demo.jl`</summary>

```julia
# Demo of every BUILD_PATH_PREFIX_MAP rewrite site, meant to be run against a build
# made with e.g. BUILD_PATH_PREFIX_MAP="🍌/monkeybusiness=$(pwd)":
#
#     ./usr/bin/julia --startup-file=no buildpathmap_demo.jl
#
# Each section prints the raw serialized value (mapped prefix) and, where the runtime
# translates it back, the translated value.

using SHA, Logging, LinearAlgebra, InteractiveUtils

const PREFIX = split(Sys.BUILD_STDLIB_PATH, "/usr/")[1] # the mapped target, e.g. "🍌/monkeybusiness"
banner(n, title) = println("\n── $n. $title ", "─"^max(0, 60 - length(title)))
show_kv(k, v) = println(rpad(k, 22), " = ", v)

println("mapped build prefix: ", repr(PREFIX))

banner(1, "Method.file")
m = first(methods(SHA.sha256))
show_kv("raw", m.file)
show_kv("functionloc", functionloc(m)[1])

banner(2, "Module.file")
show_kv("raw", Base.moduleloc(SHA).file)

banner(3, "DebugInfo.def (inlined-frame file symbols)")
function find_di_path(di, out=String[])
    di isa Core.DebugInfo || return out
    di.def isa Symbol && startswith(String(di.def), PREFIX) && push!(out, String(di.def))
    find_di_path(di.linetable, out)
    foreach(e -> find_di_path(e, out), di.edges)
    return out
end
found = String[]
for f in (LinearAlgebra.generic_matmatmul!, LinearAlgebra.mul!, SHA.digest!, sha256, lu),
        mth in methods(f)
    spec = mth.specializations
    for mi in (spec isa Core.MethodInstance ? (spec,) : spec)
        mi === nothing && continue
        ci = isdefined(mi, :cache) ? mi.cache : nothing
        while ci isa Core.CodeInstance
            isdefined(ci, :debuginfo) && append!(found, find_di_path(ci.debuginfo))
            ci = isdefined(ci, :next) ? ci.next : nothing
        end
    end
    isempty(found) || break
end
show_kv("example", isempty(found) ? "(no cached specialization found)" : first(found))

banner(4, "Method.roots literals")
# 4a. LineNumberNode file symbols from a macro's quote body
macroots = first(methods(getglobal(SHA, Symbol("@R1_16")))).roots
show_kv("macro quote LNN", first(r for r in macroots if r isa Symbol && startswith(String(r), PREFIX)))
# 4b. String(__source__.file) literals baked by logging macros
warnroots = first(methods(LinearAlgebra.LAPACK.gesvx!)).roots
show_kv("@warn _file literal", first(r for r in warnroots if r isa String && startswith(r, PREFIX)))

banner(5, "roots appended to in-image methods by pkgimages")
println("(not directly observable here; exercised by the serializer path in")
println(" staticdata.c's method_roots_list copy and covered by review)")

banner(6, ".ji header dependency paths (stdlib pkgimage)")
cachefile = first(Base.find_all_in_cache_path(Base.identify_package("Logging")))
show_kv("raw bytes contain", string(repr(PREFIX), " => ", contains(read(cachefile, String), PREFIX)))
includes = Base.parse_cache_header(cachefile)[2][1]
show_kv("parsed (translated)", first(includes).filename)
show_kv("cache accepted", Base.isprecompiled(Base.identify_package("Logging")))

banner(7, "srctext keys (base.cache, written via the inverse map)")
basecache = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "base.cache")
mappedfile = first(f for (_, f) in Base._included_files if endswith(f, "sysimg.jl"))
src = open(io -> Base._read_dependency_src(io, mappedfile), basecache)
show_kv("key", mappedfile)
show_kv("source found", startswith(src, "# This file is a part of Julia"))

banner(8, "codegen source locations (feed DIFile/DWARF during image emission)")
ir = sprint(io -> code_llvm(io, SHA.sha256, (Vector{UInt8},); dump_module=true, debuginfo=:source))
show_kv("IR annotation", first(strip(first(l for l in eachline(IOBuffer(ir)) if contains(l, PREFIX))), 80))
println("(the actual !DIFile remap at image-emission time is asserted in test/buildpathmap.jl)")

banner(9, "Sys.BUILD_STDLIB_PATH")
show_kv("raw", Sys.BUILD_STDLIB_PATH)
show_kv("runtime Sys.STDLIB", Sys.STDLIB)

banner(10, "Base.SOURCEDIR")
show_kv("raw", Base.SOURCEDIR)

banner(11, "Base.pkgorigins")
origin = Base.pkgorigins[Base.identify_package("SHA")]
show_kv("raw path", origin.path)
show_kv("pathof (translated)", pathof(SHA))

banner(12, "Base._included_files")
show_kv("example", first(f for (_, f) in Base._included_files if startswith(f, PREFIX)))

banner(13, "docstring :path metadata")
docstr = first(values(first(values(Base.Docs.meta(SHA))).docs))
show_kv("raw", docstr.data[:path])

banner(14, "bonus: @assert no longer embeds #= file:line =#")
msg = try; @assert @isdefined(surely_not_defined); catch e; e.msg; end
show_kv("message", repr(msg))

banner(15, "bonus: stack trace display translation")
st = try; error("x"); catch; stacktrace(catch_backtrace()); end
fr = first(f for f in st if contains(String(f.file), "error.jl"))
show_kv("displayed frame", string(fr.file, ":", fr.line))

println("display/lookup paths are translated to the installed location.")
```
</details>


Running this demo with `BUILD_PATH_PREFIX_MAP=🍌/monkeybusiness` gives

<details><summary>results</summary>

```
❯ ./julia buildpathmap_demo.jl
mapped build prefix: "🍌/monkeybusiness"

── 1. Method.file ─────────────────────────────────────────────────
raw                    = 🍌/monkeybusiness/usr/share/julia/stdlib/v1.14/SHA/src/SHA.jl
functionloc            = /Users/kc/julia/usr/share/julia/stdlib/v1.14/SHA/src/SHA.jl

── 2. Module.file ─────────────────────────────────────────────────
raw                    = 🍌/monkeybusiness/usr/share/julia/stdlib/v1.14/SHA/src/SHA.jl

── 3. DebugInfo.def (inlined-frame file symbols) ──────────────────
example                = 🍌/monkeybusiness/usr/share/julia/stdlib/v1.14/LinearAlgebra/src/matmul.jl

── 4. Method.roots literals ───────────────────────────────────────
macro quote LNN        = 🍌/monkeybusiness/usr/share/julia/stdlib/v1.14/SHA/src/sha2.jl
@warn _file literal    = 🍌/monkeybusiness/usr/share/julia/stdlib/v1.14/LinearAlgebra/src/lapack.jl

── 5. roots appended to in-image methods by pkgimages ─────────────
(not directly observable here; exercised by the serializer path in
 staticdata.c's method_roots_list copy and covered by review)

── 6. .ji header dependency paths (stdlib pkgimage) ───────────────
raw bytes contain      = "🍌/monkeybusiness" => true
parsed (translated)    = /Users/kc/julia/usr/share/julia/stdlib/v1.14/Logging/src/Logging.jl
cache accepted         = true

── 7. srctext keys (base.cache, written via the inverse map) ──────
key                    = 🍌/monkeybusiness/base/sysimg.jl
source found           = true

── 8. codegen source locations (feed DIFile/DWARF during image emission) 
IR annotation          = ;  @ 🍌/monkeybusiness/usr/share/julia/stdlib/v1.14/SHA/src/SHA.jl:95 within `sha
(the actual !DIFile remap at image-emission time is asserted in test/buildpathmap.jl)

── 9. Sys.BUILD_STDLIB_PATH ───────────────────────────────────────
raw                    = 🍌/monkeybusiness/usr/bin/../share/julia/stdlib/v1.14
runtime Sys.STDLIB     = /Users/kc/julia/usr/share/julia/stdlib/v1.14

── 10. Base.SOURCEDIR ──────────────────────────────────────────────
raw                    = 🍌/monkeybusiness

── 11. Base.pkgorigins ─────────────────────────────────────────────
raw path               = 🍌/monkeybusiness/usr/share/julia/stdlib/v1.14/SHA/src/SHA.jl
pathof (translated)    = /Users/kc/julia/usr/share/julia/stdlib/v1.14/SHA/src/SHA.jl

── 12. Base._included_files ────────────────────────────────────────
example                = 🍌/monkeybusiness/base/sysimg.jl

── 13. docstring :path metadata ────────────────────────────────────
raw                    = 🍌/monkeybusiness/usr/share/julia/stdlib/v1.14/SHA/src/types.jl

── 14. bonus: @assert no longer embeds #= file:line =# ─────────────
message                = "@isdefined surely_not_defined"

── 15. bonus: stack trace display translation ──────────────────────
displayed frame        = error.jl:56
```

</details>
