### PR TITLE
[backports-release-1.13] cfunction: fix and restore the no-JIT `jl_jit_abi_converter` fallback

### DIFF
--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -268,7 +268,7 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
             atype = argtypes_to_type(argtypes)
 
             mi = compileable_specialization_for_call(interp, atype)
-            if mi !== nothing
+            if mi !== nothing && atype <: (mi.def::Method).sig
                 # n.b.: Codegen may choose unpredictably to emit this `@cfunction` as a dynamic invoke or a full
                 # dynamic call, but in either case it guarantees that the required adapter(s) are emitted. All
                 # that we are required to verify here is that the callee CodeInstance is covered.
@@ -336,8 +336,11 @@ function get_verify_typeinf_trim(codeinfos::Vector{Any})
                         (Any, Csize_t, Cint),
                         sig, this_world, #= mt_cache =# 0)
             asrt = Any
-            valid = if mi !== nothing
-                mi = mi::MethodInstance
+            # We intentionally reject partially-covering methods. These have a unique target
+            # CI but check for the MethodError by lowering to a dynamic dispatch. These could
+            # be supported but it would mean silently emitting a degraded ABI, so it's better
+            # to point this out to the user via an error.
+            valid = if mi isa MethodInstance && sig <: (mi.def::Method).sig
                 ci = get(caches, mi, nothing)
                 if ci isa CodeInstance
                     # TODO: should we find a way to indicate to the user that this gets called via ccallable?

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -122,6 +122,41 @@ static void *load_library(const char * rel_path, const char * src_dir, int allow
     return handle;
 }
 
+// case-insensitive strcmp
+static int istrcmp(const char *val, const char *token) {
+    for (; *token; val++, token++) {
+        char c = *val;
+        if (c >= 'A' && c <= 'Z')
+            c += 'a' - 'A';
+        if (c != *token)
+            return 0;
+    }
+    return *val == '\0';
+}
+
+// intended to match Base.get_bool_env
+static int env_var_bool(const char *name, int *value) {
+#if defined(_OS_WINDOWS_)
+    char val[8];
+    DWORD val_len = GetEnvironmentVariableA(name, val, sizeof(val));
+    if (val_len == 0 || val_len >= sizeof(val)) /* unset, or too long to be a token */
+        return 0;
+#else
+    const char *val = getenv(name);
+    if (val == NULL)
+        return 0;
+#endif
+    if (istrcmp(val, "t") || istrcmp(val, "true") || istrcmp(val, "y") || istrcmp(val, "yes") || istrcmp(val, "1")) {
+        *value = 1;
+        return 1;
+    }
+    if (istrcmp(val, "f") || istrcmp(val, "false") || istrcmp(val, "n") || istrcmp(val, "no") || istrcmp(val, "0")) {
+        *value = 0;
+        return 1;
+    }
+    return 0;
+}
+
 static void * lookup_symbol(const void * lib_handle, const char * symbol_name) {
 #ifdef _OS_WINDOWS_
     return GetProcAddress((HMODULE) lib_handle, symbol_name);
@@ -328,13 +363,7 @@ __attribute__((constructor)) void jl_load_libjulia_internal(void) {
                 int probe_successful = 0;
 
                 // Check to see if the user has disabled libstdc++ probing
-                char *probevar = getenv("JULIA_PROBE_LIBSTDCXX");
-                if (probevar) {
-                    if (strcmp(probevar, "1") == 0 || strcmp(probevar, "yes") == 0)
-                        do_probe = 1;
-                    else if (strcmp(probevar, "0") == 0 || strcmp(probevar, "no") == 0)
-                        do_probe = 0;
-                }
+                env_var_bool("JULIA_PROBE_LIBSTDCXX", &do_probe);
                 if (do_probe) {
                     const char *cxxpath = libstdcxxprobe();
                     if (cxxpath) {
@@ -367,7 +396,10 @@ __attribute__((constructor)) void jl_load_libjulia_internal(void) {
                 libjulia_internal = load_library(curr_dep, lib_dir, /* allow_basename */ 0, /* err */ 1);
             } else if (special_idx == 2) {
                 // This special library is `libjulia-codegen`
-                libjulia_codegen = load_library(curr_dep, lib_dir, /* allow_basename */ 0, /* err */ 0);
+                int load_codegen = 1;
+                env_var_bool("JULIA_LOAD_CODEGEN_LIB", &load_codegen);
+                if (load_codegen)
+                    libjulia_codegen = load_library(curr_dep, lib_dir, /* allow_basename */ 0, /* err */ 0);
             }
             special_idx++;
         } else {

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -597,3 +597,11 @@ Arguments to be passed to the LLVM backend.
 ### `JULIA_FALLBACK_REPL`
 
 Forces the fallback repl instead of REPL.jl.
+
+### `JULIA_LOAD_CODEGEN_LIB`
+
+If set to a false value (`0`, `f`, `false`, `n`, or `no`, case-insensitive),
+the loader does not load `libjulia-codegen`, and the fallback
+(interpreter-only) implementations in `libjulia-internal` are used instead —
+exactly as if the library were absent from the installation. Intended for
+testing and debugging the no-codegen configuration.

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -612,6 +612,8 @@ static void generate_cfunc_thunks(jl_codegen_params_t &params, jl_compiled_funct
         Module *defM = nullptr;
         StringRef func;
         jl_method_instance_t *mi = (jl_method_instance_t*)jl_get_specialization1((jl_tupletype_t*)sigt, latestworld, 0);
+        if ((jl_value_t*)mi != jl_nothing && !jl_subtype(sigt, mi->def.method->sig))
+            mi = (jl_method_instance_t*)jl_nothing; // partially-covered: not a guaranteed dispatch
         if ((jl_value_t*)mi != jl_nothing) {
             auto it = compiled_mi.find(mi);
             if (it != compiled_mi.end()) {
@@ -2537,6 +2539,8 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t *dump, jl_method_instance_t *mi, jl_
                 jl_value_t *mi = jl_get_specialization1((jl_tupletype_t*)sigt, latestworld, 0);
                 if (mi == jl_nothing)
                     continue;
+                if (!jl_subtype(sigt, ((jl_method_instance_t*)mi)->def.method->sig))
+                    continue; // partially-covered: not a guaranteed dispatch
                 jl_code_instance_t *codeinst = jl_type_infer((jl_method_instance_t*)mi, latestworld, SOURCE_MODE_NOT_REQUIRED, jl_options.trim);
                 if (codeinst == nullptr || compiled_functions.count(codeinst))
                     continue;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -270,7 +270,6 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
     jl_callptr_t invoke = nullptr;
     if (codeinst != nullptr) {
         uint8_t specsigflags;
-        jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
         void *specptr = nullptr;
         jl_read_codeinst_invoke(codeinst, &specsigflags, &invoke, &specptr, /* waitcompile */ 1);
         if (invoke != nullptr) {
@@ -280,7 +279,7 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
             }
             else if (invoke == jl_fptr_args_addr) {
                 assert(specptr != nullptr);
-                if (!from_abi.specsig && jl_subtype(codeinst->rettype, from_abi.rt))
+                if (jl_specptr_matches_abi(from_abi, codeinst, specsigflags, invoke))
                     return specptr; // no adapter required
 
                 target = specptr;
@@ -288,7 +287,7 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
             }
             else if (specsigflags & JL_CI_FLAGS_SPECPTR_SPECIALIZED) {
                 assert(specptr != nullptr);
-                if (from_abi.specsig && jl_egal(mi->specTypes, from_abi.sigt) && jl_egal(codeinst->rettype, from_abi.rt))
+                if (jl_specptr_matches_abi(from_abi, codeinst, specsigflags, invoke))
                     return specptr; // no adapter required
 
                 target = specptr;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -754,6 +754,18 @@ STATIC_INLINE jl_method_instance_t *jl_get_ci_mi(jl_code_instance_t *ci JL_PROPA
     return (jl_method_instance_t*)def;
 }
 
+// Returns true if the specptr of `codeinst` can safely be invoked using `from_abi` ABI
+STATIC_INLINE int jl_specptr_matches_abi(jl_abi_t from_abi, jl_code_instance_t *codeinst,
+                                         uint8_t specsigflags, jl_callptr_t invoke)
+{
+    if (invoke == jl_fptr_args_addr)
+        return !from_abi.specsig && jl_subtype(codeinst->rettype, from_abi.rt);
+    if (specsigflags & JL_CI_FLAGS_SPECPTR_SPECIALIZED)
+        return from_abi.specsig && jl_egal(jl_get_ci_mi(codeinst)->specTypes, from_abi.sigt) &&
+               jl_egal(codeinst->rettype, from_abi.rt);
+    return 0;
+}
+
 JL_DLLEXPORT const char *jl_debuginfo_file(jl_debuginfo_t *debuginfo) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_debuginfo_file1(jl_debuginfo_t *debuginfo) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_module_t *jl_debuginfo_module1(jl_value_t *debuginfo_def) JL_NOTSAFEPOINT;

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -405,6 +405,8 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
             return f;
         }
         mi = jl_get_specialization1((jl_tupletype_t*)sigt, world, 0);
+        if (mi != jl_nothing && !jl_subtype(sigt, ((jl_method_instance_t*)mi)->def.method->sig))
+            mi = jl_nothing; // partially-covered: not a guaranteed dispatch
         if (f != nullptr) {
             if (last_ci == nullptr) {
                 if (mi == jl_nothing) {

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -352,12 +352,17 @@ struct cfuncdata_t {
 };
 
 extern "C" JL_DLLEXPORT
-void *jl_jit_abi_converter_fallback(jl_task_t *ct, void *unspecialized, jl_value_t *declrt, jl_value_t *sigt, size_t nargs, int specsig,
-                                    jl_code_instance_t *codeinst, jl_callptr_t invoke, void *target, int target_specsig)
+void *jl_jit_abi_converter_fallback(jl_task_t *ct, jl_abi_t from_abi, jl_code_instance_t *codeinst)
 {
-    if (unspecialized)
-        return unspecialized;
-    jl_errorf("cfunction not available in this build of Julia");
+    if (codeinst == nullptr)
+        return nullptr;
+    uint8_t specsigflags;
+    jl_callptr_t invoke = nullptr;
+    void *specptr = nullptr;
+    jl_read_codeinst_invoke(codeinst, &specsigflags, &invoke, &specptr, /* waitcompile */ 1);
+    if (specptr != nullptr && jl_specptr_matches_abi(from_abi, codeinst, specsigflags, invoke))
+        return specptr; // no adapter required
+    return nullptr;
 }
 
 static const inline char *name_from_method_instance(jl_method_instance_t *mi) JL_NOTSAFEPOINT
@@ -443,6 +448,10 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
         // Generate an adapter to a dynamic dispatch
         if (cfuncdata->unspecialized == nullptr)
             cfuncdata->unspecialized = jl_jit_abi_converter(ct, from_abi, nullptr);
+        if (cfuncdata->unspecialized == nullptr) {
+            JL_UNLOCK(&cfun_lock);
+            jl_errorf("cfunction not available in this build of Julia");
+        }
 
         return assign_fptr(cfuncdata->unspecialized);
     }
@@ -455,7 +464,17 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
         // even though we're likely to encounter memory errors in that case
         jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name_from_method_instance((jl_method_instance_t*)mi));
     }
-    return assign_fptr(jl_jit_abi_converter(ct, from_abi, codeinst));
+    f = jl_jit_abi_converter(ct, from_abi, codeinst);
+    if (f == nullptr) {
+        // JIT is unavailable - fall back to dynamic dispatch so that we
+        // can re-enter the interpreter etc. as needed
+        f = cfuncdata->unspecialized;
+        if (f == nullptr) {
+            JL_UNLOCK(&cfun_lock);
+            jl_errorf("cfunction not available in this build of Julia");
+        }
+    }
+    return assign_fptr(f);
 }
 
 void jl_init_runtime_ccall(void)

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -2029,3 +2029,11 @@ const sym = :ZSTD_versionString
 get_zstd_version() = prefix * unsafe_string(ccall((sym, libzstd), Cstring, ()))
 @test startswith(get_zstd_version(), "Zstd")
 end
+
+# A single partially-covering method keeps dispatching at call time, so uncovered
+# arguments raise MethodError instead of being reinterpreted (#62246).
+abi_partial_target(x::Float32, y::Cint) = x + Float32(y)   # partially covers (Any, Cint)
+let cf = @cfunction(abi_partial_target, Any, (Any, Cint))
+    @test ccall(cf, Any, (Any, Cint), Float32(1.5), Cint(2)) === Float32(3.5)
+    @test_throws MethodError ccall(cf, Any, (Any, Cint), 1.5, Cint(2))
+end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1218,6 +1218,248 @@ precompile_test_harness("precompiletools") do dir
     end
 end
 
+# `@cfunction` must be able to re-enter the interpreter as needed, even if codegen is not available
+precompile_test_harness("cfunction without codegen") do dir
+    write(joinpath(dir, "CFunc61949A.jl"),
+          """
+          module CFunc61949A
+              llvm_version() = ccall(:jl_get_LLVM_VERSION, UInt32, ())       # 0 = no-codegen stub
+              match_target(x::Integer) = Cint(x + 1)                         # specsig Cint -> Cint, no adapter
+              wide_target(x::Integer) = Cint(x + 1)                          # site declares rt Any (needs a boxing adapter)
+              nospec_target(x::Integer) = Cint(x + 1)                        # B adds a @nospecialize method (specTypes != sigt)
+              boxed_target(@nospecialize(a), @nospecialize(b), @nospecialize(c), @nospecialize(d)) = a  # jl_fptr_args, no adapter (image only:
+                  # no `@cfunction` retarget can reach a compiled jl_fptr_args target, a more specific method makes the site ambiguous)
+              box_target(x::Cint) = x                                        # well-inferred Cint
+              any_target(x::Cint) = Core.compilerbarrier(:type, x + Cint(1)) # inferred ::Any
+              const_target(x::Cint) = Cint(42)                               # const-return
+              unresolved_target(x::Float64) = x                              # no method for (Cint,)
+              function run_match(x::Cint)
+                  cf = @cfunction(match_target, Cint, (Cint,))
+                  ccall(cf, Cint, (Cint,), x)
+              end
+              function run_wide(x::Cint)
+                  cf = @cfunction(wide_target, Any, (Cint,))
+                  ccall(cf, Any, (Cint,), x)
+              end
+              function run_nospec(x::Cint)
+                  cf = @cfunction(nospec_target, Cint, (Cint,))
+                  ccall(cf, Cint, (Cint,), x)
+              end
+              function run_boxed(@nospecialize(a), @nospecialize(b), @nospecialize(c), @nospecialize(d))
+                  cf = @cfunction(boxed_target, Any, (Any, Any, Any, Any))
+                  ccall(cf, Any, (Any, Any, Any, Any), a, b, c, d)
+              end
+              function run_widen(x::Cint)
+                  cf = @cfunction(box_target, Any, (Cint,))
+                  ccall(cf, Any, (Cint,), x)
+              end
+              function run_narrow(x::Cint)
+                  cf = @cfunction(any_target, Cint, (Cint,))
+                  ccall(cf, Cint, (Cint,), x)
+              end
+              function run_const(x::Cint)
+                  cf = @cfunction(const_target, Cint, (Cint,))
+                  ccall(cf, Cint, (Cint,), x)
+              end
+              function run_unresolved(x::Cint)
+                  cf = @cfunction(unresolved_target, Cint, (Cint,))
+                  ccall(cf, Cint, (Cint,), x)
+              end
+              function run_dispatch(x::Cint)      # abstract `Any` arg; the single (partially covering) method
+                                                  # is compiled, so the image gets an unboxing adapter to it
+                  cf = @cfunction(box_target, Any, (Any,))
+                  ccall(cf, Any, (Any,), x)
+              end
+              call_box(x::Cint) = box_target(x)   # ordinary caller, with a backedge to `box_target`
+              precompile(call_box, (Cint,))
+              precompile(run_match, (Cint,))
+              precompile(match_target, (Cint,))
+              precompile(run_wide, (Cint,))
+              precompile(wide_target, (Cint,))
+              precompile(run_nospec, (Cint,))
+              precompile(nospec_target, (Cint,))
+              precompile(run_boxed, (Any, Any, Any, Any))
+              precompile(boxed_target, (Any, Any, Any, Any))
+              precompile(run_widen, (Cint,))
+              precompile(run_narrow, (Cint,))
+              precompile(run_const, (Cint,))
+              precompile(run_unresolved, (Cint,))
+              precompile(run_dispatch, (Cint,))
+              precompile(llvm_version, ())
+
+              # Newest CodeInstance of method `m` specialized exactly on `argtypes`.
+              function method_ci(m::Method, argtypes)
+                  sig = Tuple{m.sig.parameters[1], argtypes...}
+                  mi = only(mi for mi in Base.specializations(m) if mi.specTypes === sig)
+                  return mi.cache
+              end
+              ci_valid(ci::Core.CodeInstance) = ci.max_world == typemax(UInt)
+              ci_interpreted(ci::Core.CodeInstance) = ci.specptr == C_NULL &&
+                  ci.invoke == unsafe_load(cglobal(:jl_fptr_interpret_call_addr, Ptr{Cvoid}))
+              precompile(method_ci, (Method, Tuple{DataType}))
+              precompile(ci_valid, (Core.CodeInstance,))
+              precompile(ci_interpreted, (Core.CodeInstance,))
+          end
+          """)
+    # A second image with more specific, compiled targets for A's `@cfunction` sites: one whose
+    # specptr matches the site's ABI exactly, and two that must not be called directly (a
+    # wrong ABI-match check would call them with the wrong ABI and misbehave).
+    write(joinpath(dir, "CFunc61949B.jl"),
+          """
+          module CFunc61949B
+              using CFunc61949A
+              CFunc61949A.match_target(x::Cint) = x + Cint(100)                    # specsig (Cint) -> Cint == site ABI
+              CFunc61949A.wide_target(x::Cint) = x + Cint(100)                     # returns Cint, but the site expects a boxed Any
+              CFunc61949A.nospec_target(@nospecialize(x::Signed)) = Cint(x + 100)  # specTypes (Signed) != site sigt (Cint)
+              precompile(CFunc61949A.match_target, (Cint,))
+              precompile(CFunc61949A.wide_target, (Cint,))
+              precompile(CFunc61949A.nospec_target, (Cint,))
+          end
+          """)
+    Base.compilecache(Base.PkgId("CFunc61949A"))
+    Base.compilecache(Base.PkgId("CFunc61949B"))
+    M = Base.require(Main, :CFunc61949A)
+    # invokelatest: the run_* methods are defined in a world newer than this function's.
+    @test Base.invokelatest(M.run_match, Cint(3)) == Cint(4)
+    @test Base.invokelatest(M.run_wide, Cint(3)) === Cint(4)
+    @test Base.invokelatest(M.run_nospec, Cint(3)) == Cint(4)
+    @test Base.invokelatest(M.run_boxed, 1, 2, 3, 4) === 1
+    @test Base.invokelatest(M.run_widen, Cint(5)) === Cint(5)
+    @test Base.invokelatest(M.run_narrow, Cint(7)) == Cint(8)
+    @test Base.invokelatest(M.run_const, Cint(3)) == Cint(42)
+    @test_throws MethodError Base.invokelatest(M.run_unresolved, Cint(3))
+    @test Base.invokelatest(M.run_dispatch, Cint(5)) === Cint(5)
+    if Bool(Base.JLOptions().use_pkgimages)
+        # Now with codegen disabled: reuse the image adapters, retarget to an ABI-compatible
+        # specptr from B's image without a JIT, and fall back to the image's dynamic-dispatch
+        # adapter after redefinition instead of trying (and failing) to JIT a new one.
+        # `--trace-dispatch` records the first dynamic dispatch to each MethodInstance, which is
+        # how we can tell a direct specptr call from a call through the dynamic-dispatch adapter.
+        sep = Sys.iswindows() ? ";" : ":"
+        dispatch_log = joinpath(dir, "dispatch.log")
+        script = """
+            using CFunc61949A
+            const M = CFunc61949A
+            println("llvm=", M.llvm_version())
+            println("match=", M.run_match(Cint(3)))
+            println("wide=", M.run_wide(Cint(3)))
+            println("nospec=", M.run_nospec(Cint(3)))
+            println("boxed=", M.run_boxed(1, 2, 3, 4))
+            println("widen=", M.run_widen(Cint(5)))
+            println("narrow=", M.run_narrow(Cint(7)))
+            println("const=", M.run_const(Cint(3)))
+            # Image adapters and image specptrs call their targets directly, without dynamic dispatch
+            dispatched = read($(repr(dispatch_log)), String)
+            println("image_dispatched=", any(t -> occursin(t * ")", dispatched),
+                ("match_target", "wide_target", "nospec_target", "boxed_target", "box_target", "any_target", "const_target")))
+            println("dispatch=", M.run_dispatch(Cint(5)))
+            println("unresolved=", try; M.run_unresolved(Cint(3)); "no-error"; catch e; e isa MethodError ? "MethodError" : "other-error"; end)
+            using CFunc61949B
+            println("cross_match=", M.run_match(Cint(3)))
+            println("cross_wide=", M.run_wide(Cint(3)))
+            println("cross_nospec=", M.run_nospec(Cint(3)))
+            dispatched = read($(repr(dispatch_log)), String)
+            println("cross_dispatched=", (occursin("match_target), Int32})", dispatched),
+                                          occursin("wide_target), Int32})", dispatched),
+                                          occursin("nospec_target), Signed})", dispatched)))
+            # Image CodeInstances of the targets and of the `@cfunction` sites, before redefinition
+            m_match = which(M.match_target, (Cint,)); ci_match = M.method_ci(m_match, (Cint,))
+            m_box = which(M.box_target, (Cint,)); ci_box = M.method_ci(m_box, (Cint,))
+            ci_caller = M.method_ci(which(M.call_box, (Cint,)), (Cint,))
+            ci_sites = map(f -> M.method_ci(which(f, (Cint,)), (Cint,)), (M.run_match, M.run_widen, M.run_dispatch, M.run_unresolved))
+            println("pre_valid=", (M.ci_valid(ci_match), M.ci_valid(ci_box), M.ci_valid(ci_caller), all(M.ci_valid, ci_sites)))
+            @eval M match_target(x::Cint) = x + Cint(200)
+            @eval M box_target(x::Cint) = x + Cint(100)
+            @eval M unresolved_target(x::Cint) = x + Cint(100)
+            # Dispatch now resolves to the new methods and the ordinary caller was invalidated
+            # through its backedge, but the `@cfunction` sites' CodeInstances must survive: they
+            # have no backedge (retargeting is a runtime world check) and nothing could recompile them.
+            println("target_replaced=", (which(M.match_target, (Cint,)) !== m_match, which(M.box_target, (Cint,)) !== m_box))
+            println("caller_invalidated=", !M.ci_valid(ci_caller))
+            println("sites_valid=", all(M.ci_valid, ci_sites))
+            println("caller=", Base.invokelatest(M.call_box, Cint(5)))
+            println("redef_match=", Base.invokelatest(M.run_match, Cint(3)))
+            println("redef_widen=", Base.invokelatest(M.run_widen, Cint(5)))
+            println("redef_dispatch=", Base.invokelatest(M.run_dispatch, Cint(5)))
+            println("redef_unresolved=", Base.invokelatest(M.run_unresolved, Cint(3)))
+            # ... all of which went through the dynamic-dispatch adapter
+            dispatched = read($(repr(dispatch_log)), String)
+            println("redef_dispatched=", (occursin("match_target), Int32})", dispatched),
+                                          occursin("box_target), Int32})", dispatched),
+                                          occursin("unresolved_target), Int32})", dispatched)))
+            # The new targets are running in the interpreter (no specptr anywhere for the fallback to use)
+            ci_new = map(f -> M.method_ci(which(f, (Cint,)), (Cint,)), (M.match_target, M.box_target, M.unresolved_target))
+            println("new_distinct=", (ci_new[1] !== ci_match, ci_new[2] !== ci_box))
+            println("new_valid=", all(M.ci_valid, ci_new))
+            println("new_interpreted=", all(M.ci_interpreted, ci_new))
+            println("sites_still_valid=", all(M.ci_valid, ci_sites))
+            """
+        function run_child(script; codegen::Bool)
+            outbuf = IOBuffer(); errbuf = IOBuffer()
+            cmd = addenv(`$(Base.julia_cmd()) --startup-file=no --trace-dispatch=$dispatch_log -e $script`,
+                         "JULIA_LOAD_CODEGEN_LIB" => codegen ? "1" : "0",
+                         "JULIA_LOAD_PATH" => dir * sep * "@stdlib",
+                         "JULIA_DEPOT_PATH" => first(DEPOT_PATH) * sep)
+            proc = run(pipeline(ignorestatus(cmd), stdout=outbuf, stderr=errbuf))
+            out = String(take!(outbuf))
+            success(proc) || println(stderr, "child (codegen=$codegen) failed:\n", String(take!(errbuf)))
+            @test success(proc)
+            return out
+        end
+        out = run_child(script; codegen=false)
+        @test occursin("llvm=0", out)              # codegen really was absent
+        @test occursin("image_dispatched=false", out)   # image adapters / specptrs: no dynamic dispatch
+        @test occursin("match=4", out)             # image specptr used directly
+        @test occursin("wide=4", out)              # image boxing adapter
+        @test occursin("nospec=4", out)            # image specptr used directly
+        @test occursin("boxed=1", out)
+        @test occursin("widen=5", out)             # image specsig-widening adapter
+        @test occursin("narrow=8", out)            # image narrowing adapter
+        @test occursin("const=42", out)            # image const-return adapter
+        @test occursin("dispatch=5", out)          # image unboxing adapter
+        @test occursin("unresolved=MethodError", out)
+        @test occursin("cross_match=103", out)     # B's image specptr, matching ABI, no JIT
+        @test occursin("cross_wide=103", out)      # B's specptr returns Cint, site wants Any: dynamic-dispatch adapter
+        @test occursin("cross_nospec=103", out)    # B's specptr takes a boxed Signed, site passes Cint: dynamic-dispatch adapter
+        @test occursin("cross_dispatched=(false, true, true)", out)  # only the mismatches went through dynamic dispatch
+        @test occursin("pre_valid=(true, true, true, true)", out)
+        @test occursin("target_replaced=(true, true)", out)
+        @test occursin("caller_invalidated=true", out)
+        @test occursin("sites_valid=true", out)
+        @test occursin("caller=105", out)          # interpreted after invalidation
+        @test occursin("redef_match=203", out)     # retargeted via the dynamic-dispatch adapter
+        @test occursin("redef_widen=105", out)
+        @test occursin("redef_dispatch=105", out)
+        @test occursin("redef_unresolved=103", out)
+        @test occursin("redef_dispatched=(true, true, true)", out)  # via the dynamic-dispatch adapter
+        @test occursin("new_distinct=(true, true)", out)
+        @test occursin("new_valid=true", out)
+        @test occursin("new_interpreted=true", out)
+        @test occursin("sites_still_valid=true", out)
+
+        # With codegen available, the same cross-image retargets get JIT-built adapters that call
+        # B's specptr directly, so none of the targets are ever dynamically dispatched to.
+        rm(dispatch_log)
+        out = run_child("""
+            using CFunc61949A, CFunc61949B
+            const M = CFunc61949A
+            println("llvm_nonzero=", M.llvm_version() != 0)
+            println("jit_match=", M.run_match(Cint(3)))
+            println("jit_wide=", M.run_wide(Cint(3)))
+            println("jit_nospec=", M.run_nospec(Cint(3)))
+            dispatched = read($(repr(dispatch_log)), String)
+            println("jit_dispatched=", (occursin("match_target), Int32})", dispatched),
+                                        occursin("wide_target), Int32})", dispatched),
+                                        occursin("nospec_target), Signed})", dispatched)))
+            """; codegen=true)
+        @test occursin("llvm_nonzero=true", out)
+        @test occursin("jit_match=103", out)
+        @test occursin("jit_wide=103", out)
+        @test occursin("jit_nospec=103", out)
+        @test occursin("jit_dispatched=(false, false, false)", out)
+    end
+end
+
 precompile_test_harness("invoke") do dir
     InvokeModule = :Invoke0x030e7e97c2365aad
     CallerModule = :Caller0x030e7e97c2365aad

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1233,6 +1233,7 @@ precompile_test_harness("cfunction without codegen") do dir
               any_target(x::Cint) = Core.compilerbarrier(:type, x + Cint(1)) # inferred ::Any
               const_target(x::Cint) = Cint(42)                               # const-return
               unresolved_target(x::Float64) = x                              # no method for (Cint,)
+              partial_target(x::Float32) = x + Float32(1)                    # partially covers (Any,)
               function run_match(x::Cint)
                   cf = @cfunction(match_target, Cint, (Cint,))
                   ccall(cf, Cint, (Cint,), x)
@@ -1265,9 +1266,12 @@ precompile_test_harness("cfunction without codegen") do dir
                   cf = @cfunction(unresolved_target, Cint, (Cint,))
                   ccall(cf, Cint, (Cint,), x)
               end
-              function run_dispatch(x::Cint)      # abstract `Any` arg; the single (partially covering) method
-                                                  # is compiled, so the image gets an unboxing adapter to it
+              function run_dispatch(x::Cint)      # abstract `Any` arg, single partially-covering method -> dynamic-dispatch adapter
                   cf = @cfunction(box_target, Any, (Any,))
+                  ccall(cf, Any, (Any,), x)
+              end
+              function run_partial(x)             # likewise, and uncovered arguments must raise MethodError (#62246)
+                  cf = @cfunction(partial_target, Any, (Any,))
                   ccall(cf, Any, (Any,), x)
               end
               call_box(x::Cint) = box_target(x)   # ordinary caller, with a backedge to `box_target`
@@ -1285,6 +1289,9 @@ precompile_test_harness("cfunction without codegen") do dir
               precompile(run_const, (Cint,))
               precompile(run_unresolved, (Cint,))
               precompile(run_dispatch, (Cint,))
+              precompile(run_partial, (Float32,))
+              precompile(run_partial, (Cint,))
+              precompile(partial_target, (Float32,))
               precompile(llvm_version, ())
 
               # Newest CodeInstance of method `m` specialized exactly on `argtypes`.
@@ -1329,6 +1336,8 @@ precompile_test_harness("cfunction without codegen") do dir
     @test Base.invokelatest(M.run_const, Cint(3)) == Cint(42)
     @test_throws MethodError Base.invokelatest(M.run_unresolved, Cint(3))
     @test Base.invokelatest(M.run_dispatch, Cint(5)) === Cint(5)
+    @test Base.invokelatest(M.run_partial, Float32(1.5)) === Float32(2.5)
+    @test_throws MethodError Base.invokelatest(M.run_partial, Cint(3))
     if Bool(Base.JLOptions().use_pkgimages)
         # Now with codegen disabled: reuse the image adapters, retarget to an ABI-compatible
         # specptr from B's image without a JIT, and fall back to the image's dynamic-dispatch
@@ -1353,7 +1362,12 @@ precompile_test_harness("cfunction without codegen") do dir
             println("image_dispatched=", any(t -> occursin(t * ")", dispatched),
                 ("match_target", "wide_target", "nospec_target", "boxed_target", "box_target", "any_target", "const_target")))
             println("dispatch=", M.run_dispatch(Cint(5)))
+            println("partial=", M.run_partial(Float32(1.5)) === Float32(2.5))
+            println("partial_miss=", try; M.run_partial(Cint(3)); "no-error"; catch e; e isa MethodError ? "MethodError" : "other-error"; end)
             println("unresolved=", try; M.run_unresolved(Cint(3)); "no-error"; catch e; e isa MethodError ? "MethodError" : "other-error"; end)
+            # ... whereas the partially-covering sites are dynamic-dispatch adapters (#62246)
+            dispatched = read($(repr(dispatch_log)), String)
+            println("partial_dispatched=", (occursin("box_target), Int32})", dispatched), occursin("partial_target), Float32})", dispatched)))
             using CFunc61949B
             println("cross_match=", M.run_match(Cint(3)))
             println("cross_wide=", M.run_wide(Cint(3)))
@@ -1416,7 +1430,10 @@ precompile_test_harness("cfunction without codegen") do dir
         @test occursin("widen=5", out)             # image specsig-widening adapter
         @test occursin("narrow=8", out)            # image narrowing adapter
         @test occursin("const=42", out)            # image const-return adapter
-        @test occursin("dispatch=5", out)          # image unboxing adapter
+        @test occursin("dispatch=5", out)          # image dynamic-dispatch adapter
+        @test occursin("partial=true", out)        # image dynamic-dispatch adapter
+        @test occursin("partial_miss=MethodError", out)
+        @test occursin("partial_dispatched=(true, true)", out)
         @test occursin("unresolved=MethodError", out)
         @test occursin("cross_match=103", out)     # B's image specptr, matching ABI, no JIT
         @test occursin("cross_wide=103", out)      # B's specptr returns Cint, site wants Any: dynamic-dispatch adapter


### PR DESCRIPTION
Thanks to @vtjnash for reporting the regression: I should have backported a fix sooner.

Targets `backports-release-1.13` for expedience, but the tests / fix can be forward-ported to `master`. Alternatively this will be fixed by https://github.com/JuliaLang/julia/pull/62245 if that makes progress on review. This should fix the missing interpreter fallback when running without codegen, as reported in #61949.

Resolves #61949. Resolves #62246. Also backports #62555.

Drafted by Claude Fable 5 🤖 based on the (human) fix in https://github.com/JuliaLang/julia/pull/62245: Tests are straight from the bot but I verified they match my intent, including testing that we don't dispatch to `jl_apply_generic` despite having a compatible CI, which would otherwise be a possible invisible (perf-only) future regression.