### PR TITLE
Mmap: Use unique shared memory names in tests

### DIFF
--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -380,6 +380,9 @@ elseif Sys.isfreebsd()
 end
 
 @testset "SharedMemory" begin
+    # Keep machine-global shared memory names unique to this test process.
+    shm_name = "/jlsharedsegment_$(Base.Libc.getpid())_$(string(rand(UInt32), base=16))"
+
     @testset "Properties" begin
         io = open(Mmap.SharedMemory, "", 12; readonly = false, create = true)
         @test io.name == ""
@@ -403,7 +406,7 @@ end
         close(io)
         @test !isopen(io)
 
-        name = "/jlsharedsegment"
+        name = shm_name
         io = open(Mmap.SharedMemory, name, 12; readonly = false, create = true)
         @test io.name == name
         @test io.handle != Base.INVALID_OS_HANDLE
@@ -419,7 +422,7 @@ end
         @test_throws ArgumentError mmap(io, Vector{UInt8}, 12)
         close(io); finalize(m); m = nothing; GC.gc()
 
-        io = open(Mmap.SharedMemory, "/jlsharedsegment", 12; readonly = false, create = true)
+        io = open(Mmap.SharedMemory, shm_name, 12; readonly = false, create = true)
         m = mmap(io, Vector{UInt8}, 12)
         @test_throws ArgumentError mmap(io, Vector{UInt8}, 12)
         close(io); finalize(m); m = nothing; GC.gc()
@@ -441,11 +444,11 @@ end
     @testset "SharedMemory modes" begin
         @test_throws ArgumentError open(Mmap.SharedMemory, "", 12; readonly = false, create = false)
         @test_throws ArgumentError open(Mmap.SharedMemory, "", 12; readonly = true, create = true)
-        @test_throws Base.IOError open(Mmap.SharedMemory, "/jlsharedsegment", 12; readonly = false, create = false)
+        @test_throws Base.IOError open(Mmap.SharedMemory, shm_name, 12; readonly = false, create = false)
 
-        io1 = open(Mmap.SharedMemory, "/jlsharedsegment", 12; readonly = false, create = true)
-        @test_throws Base.IOError open(Mmap.SharedMemory, "/jlsharedsegment", 12; readonly = false, create = true)
-        io2 = open(Mmap.SharedMemory, "/jlsharedsegment", 12; readonly = true, create = false)
+        io1 = open(Mmap.SharedMemory, shm_name, 12; readonly = false, create = true)
+        @test_throws Base.IOError open(Mmap.SharedMemory, shm_name, 12; readonly = false, create = true)
+        io2 = open(Mmap.SharedMemory, shm_name, 12; readonly = true, create = false)
         m = mmap(io2, Vector{UInt8}, 12)
         if !(Sys.isfreebsd() && Sys.ARCH === :aarch64)
             @test_throws ReadOnlyMemoryError m .= 1
@@ -455,7 +458,7 @@ end
 
     @static if Sys.islinux()
         @testset "Opening an existing region with an oversized declared size is rejected at mmap()" begin
-            name = "/jlsharedsegment"
+            name = shm_name
             io1 = open(Mmap.SharedMemory, name, 12; readonly = false, create = true)
 
             io2 = open(Mmap.SharedMemory, name, 13; readonly = false, create = false)
@@ -474,7 +477,7 @@ end
         end
     elseif Sys.isapple() || Sys.iswindows()
         @testset "Opening an existing region with a declared size beyond the real page allocation still fails safely at mmap()" begin
-            name = "/jlsharedsegment"
+            name = shm_name
             io1 = open(Mmap.SharedMemory, name, 12; readonly = false, create = true)
 
             io2 = open(Mmap.SharedMemory, name, 1_000_000; readonly = false, create = false)
@@ -495,8 +498,8 @@ end
     end
 
     @testset "Named SharedMemory mmaps are shared" begin
-        io1 = open(Mmap.SharedMemory, "/jlsharedsegment", 12; readonly = false, create = true)
-        io2 = open(Mmap.SharedMemory, "/jlsharedsegment", 12; readonly = false, create = false)
+        io1 = open(Mmap.SharedMemory, shm_name, 12; readonly = false, create = true)
+        io2 = open(Mmap.SharedMemory, shm_name, 12; readonly = false, create = false)
         m1 = mmap(io1, Vector{UInt8}, 12)
         m2 = mmap(io2, Vector{UInt8}, 12)
         @test all(m1 .== 0)
@@ -508,7 +511,7 @@ end
     end
 
     @testset "Resource cleanup" begin
-        name = "/jlsharedsegment"
+        name = shm_name
 
         @static if !Sys.isapple()
 
@@ -529,7 +532,7 @@ end
     end
 
     @testset "SharedMemory handles/fds are not inherited by child processes" begin
-        name = "/jlsharedsegment"
+        name = shm_name
 
         @static if Sys.islinux()
 
@@ -570,7 +573,7 @@ end
     end
 
     @testset "String mode" begin
-        name = "/jlsharedsegment"
+        name = shm_name
         io1 = open(Mmap.SharedMemory, name, 12, "w+")
         @test isreadable(io1)
         @test iswritable(io1)


### PR DESCRIPTION
Give each Mmap test process its own randomized shared-memory name. This prevents concurrent CI jobs on the same host from racing over the machine-global name.

CI failures:
https://buildkite.com/organizations/julialang/pipelines/julia-ci/builds/148/jobs/019fa121-741a-4663-93c5-4383ca9e5e6a/log https://buildkite.com/organizations/julialang/pipelines/julia-ci/builds/158/jobs/019fa611-584c-4bad-8b34-a88a865b8b83/log

Manifest as:
```
Mmap                                                         (7) |         failed at 2026-07-27T02:04:47.716
Error During Test at /cache/build/tester-amdci5-9/julialang/julia-ci/julia-bcbea400a2/share/julia/stdlib/v1.14/Mmap/test/runtests.jl:451
  Got exception outside of a @test
  IOError: Failed to create shared memory
```

This happens despite our sandboxes because AFAIU POSIX shm names are machine-global, and the Buildkite tester agents on one host share `/dev/shm`.

Assisted-by: Claude Fable and GPT 5.6 Sol