### PR TITLE
llvm-propagate-addrspaces: ensure we don't lift incompatible addrspaces

### DIFF
--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -86,17 +86,11 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
     SmallVector<Value *, 4> Stack;
     SmallVector<Value *, 0> Worklist;
     std::set<Value *> LocalVisited;
-    // The address space we lift into is dictated by the leaves of the chain:
-    // stripping the special address spaces must not change which underlying
-    // address space a pointer lives in, so all non-null leaves have to agree
-    // on it (e.g. on AMDGPU an alloca leaf lives in the alloca address space
-    // while a global constant leaf lives in address space 0, and no cast
-    // between the two is valid in general).
-    unsigned LiftAS = UINT_MAX; // not known yet
+    // We need to ensure all non-null leaves agree on an address space in
+    // order to lift them. This affects GPU backends where allocas might live
+    // in a different AS than global consts for example
+    unsigned LiftAS = UINT_MAX;
     auto mergeLeafAS = [&](Value *Leaf) -> bool {
-        // Strip casts the same way CollapseCastsAndLift below does, so that
-        // we constrain the exact value it will substitute into the lifted
-        // instructions.
         while (!LiftingMap.count(Leaf)) {
             if (auto *BCI = dyn_cast<BitCastInst>(Leaf))
                 Leaf = BCI->getOperand(0);
@@ -106,7 +100,7 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
                 break;
         }
         if (isa<ConstantPointerNull>(Leaf))
-            return true; // null lifts into any address space
+            return true; // null can be lifted into any address space
         auto It = LiftingMap.find(Leaf);
         if (It != LiftingMap.end())
             Leaf = It->second;
@@ -198,8 +192,7 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
     }
 
     if (LiftAS == UINT_MAX) {
-        // Every leaf was null; any address space works, so use the one
-        // allocas live in.
+        // Use alloca AS if there are no non-null leaves
         LiftAS = M->getDataLayout().getAllocaAddrSpace();
     }
 

--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -86,7 +86,37 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
     SmallVector<Value *, 4> Stack;
     SmallVector<Value *, 0> Worklist;
     std::set<Value *> LocalVisited;
-    unsigned allocaAddressSpace = M->getDataLayout().getAllocaAddrSpace();
+    // The address space we lift into is dictated by the leaves of the chain:
+    // stripping the special address spaces must not change which underlying
+    // address space a pointer lives in, so all non-null leaves have to agree
+    // on it (e.g. on AMDGPU an alloca leaf lives in the alloca address space
+    // while a global constant leaf lives in address space 0, and no cast
+    // between the two is valid in general).
+    unsigned LiftAS = UINT_MAX; // not known yet
+    auto mergeLeafAS = [&](Value *Leaf) -> bool {
+        // Strip casts the same way CollapseCastsAndLift below does, so that
+        // we constrain the exact value it will substitute into the lifted
+        // instructions.
+        while (!LiftingMap.count(Leaf)) {
+            if (auto *BCI = dyn_cast<BitCastInst>(Leaf))
+                Leaf = BCI->getOperand(0);
+            else if (auto *ACI = dyn_cast<AddrSpaceCastInst>(Leaf))
+                Leaf = ACI->getOperand(0);
+            else
+                break;
+        }
+        if (isa<ConstantPointerNull>(Leaf))
+            return true; // null lifts into any address space
+        auto It = LiftingMap.find(Leaf);
+        if (It != LiftingMap.end())
+            Leaf = It->second;
+        unsigned AS = getValueAddrSpace(Leaf);
+        if (isSpecialAS(AS))
+            return false;
+        if (LiftAS == UINT_MAX)
+            LiftAS = AS;
+        return LiftAS == AS;
+    };
     Worklist.push_back(V);
     // Follow pointer casts back, see if we're based on a pointer in
     // an untracked address space, in which case we're allowed to drop
@@ -102,11 +132,16 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
                 CurrentV = BCI->getOperand(0);
             else if (auto *ACI = dyn_cast<AddrSpaceCastInst>(CurrentV)) {
                 CurrentV = ACI->getOperand(0);
-                if (!isSpecialAS(getValueAddrSpace(ACI)))
+                if (!isSpecialAS(getValueAddrSpace(ACI))) {
+                    if (!mergeLeafAS(CurrentV))
+                        return nullptr;
                     break;
+                }
             }
             else if (auto *GEP = dyn_cast<GetElementPtrInst>(CurrentV)) {
                 if (LiftingMap.count(GEP)) {
+                    if (!mergeLeafAS(GEP))
+                        return nullptr;
                     break;
                 } else if (Visited.count(GEP)) {
                     return nullptr;
@@ -116,6 +151,8 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
                 CurrentV = GEP->getOperand(0);
             } else if (auto *Phi = dyn_cast<PHINode>(CurrentV)) {
                 if (LiftingMap.count(Phi)) {
+                    if (!mergeLeafAS(Phi))
+                        return nullptr;
                     break;
                 }
                 for (Value *Incoming : Phi->incoming_values()) {
@@ -126,6 +163,8 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
                 break;
             } else if (auto *Select = dyn_cast<SelectInst>(CurrentV)) {
                 if (LiftingMap.count(Select)) {
+                    if (!mergeLeafAS(Select))
+                        return nullptr;
                     break;
                 } else if (Visited.count(Select)) {
                     return nullptr;
@@ -151,9 +190,17 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
                     PoisonValues(Worklist);
                     return nullptr;
                 }
+                if (!mergeLeafAS(CurrentV))
+                    return nullptr;
                 break;
             }
         }
+    }
+
+    if (LiftAS == UINT_MAX) {
+        // Every leaf was null; any address space works, so use the one
+        // allocas live in.
+        LiftAS = M->getDataLayout().getAllocaAddrSpace();
     }
 
     // Go through and insert lifted versions of all instructions on the list.
@@ -165,14 +212,14 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
             Instruction *InstV = cast<Instruction>(V);
             Instruction *NewV = InstV->clone();
             ToInsert.push_back(std::make_pair(NewV, InstV));
-            Type *NewRetTy = PointerType::get(InstV->getContext(), allocaAddressSpace);
+            Type *NewRetTy = PointerType::get(InstV->getContext(), LiftAS);
             NewV->mutateType(NewRetTy);
             LiftingMap[InstV] = NewV;
             ToRevisit.push_back(NewV);
         }
     }
     auto CollapseCastsAndLift = [&](Value *CurrentV, Instruction *InsertPt) -> Value * {
-        PointerType *TargetType = PointerType::get(CurrentV->getContext(), allocaAddressSpace);
+        PointerType *TargetType = PointerType::get(CurrentV->getContext(), LiftAS);
         while (!LiftingMap.count(CurrentV)) {
             if (isa<BitCastInst>(CurrentV))
                 CurrentV = cast<BitCastInst>(CurrentV)->getOperand(0);

--- a/test/llvmpasses/propagate-addrspace-non-zero.ll
+++ b/test/llvmpasses/propagate-addrspace-non-zero.ll
@@ -63,3 +63,42 @@ define i64 @nullptr() {
     %load = load i64, i64 addrspace(11)* %casted
     ret i64 %load
 }
+
+@gbox = private unnamed_addr constant { i64, i64 } { i64 42, i64 42 }, align 16
+
+; A phi between an alloca (addrspace 5) and a global constant (addrspace 0):
+; there is no single address space the phi can be lifted into, so it must be
+; left alone (lifting it used to produce a phi with mismatched operand types).
+define i64 @phi_mixed_addrspace(i1 %cond) {
+; CHECK-LABEL: @phi_mixed_addrspace
+; CHECK: phi ptr addrspace(11)
+; CHECK: load i64, ptr addrspace(11)
+top:
+    %stack = alloca i64, addrspace(5)
+    %stack_casted = addrspacecast ptr addrspace(5) %stack to ptr addrspace(11)
+    br i1 %cond, label %A, label %B
+A:
+    %global_casted = addrspacecast ptr getelementptr inbounds (i8, ptr @gbox, i64 8) to ptr addrspace(11)
+    br label %B
+B:
+    %phi = phi ptr addrspace(11) [ %stack_casted, %top ], [ %global_casted, %A ]
+    %load = load i64, ptr addrspace(11) %phi
+    ret i64 %load
+}
+
+; A phi between a global constant (addrspace 0) and null: lifting is fine, but
+; must lift into the address space of the global, not the alloca address space.
+define i64 @phi_global_null(i1 %cond) {
+; CHECK-LABEL: @phi_global_null
+; CHECK: phi ptr [
+; CHECK-NOT: addrspace(11)
+top:
+    br i1 %cond, label %A, label %B
+A:
+    %global_casted = addrspacecast ptr getelementptr inbounds (i8, ptr @gbox, i64 8) to ptr addrspace(11)
+    br label %B
+B:
+    %phi = phi ptr addrspace(11) [ null, %top ], [ %global_casted, %A ]
+    %load = load i64, ptr addrspace(11) %phi
+    ret i64 %load
+}


### PR DESCRIPTION
Encountered in AMDGPU.jl on nightly. We can't assume every leaf of a lifted pointer chain lives in the alloca addrspace, e.g. leaves can be addrspace-0 pointers into a custom global while allocas live in a different addrspace (AS 5 in AMDGPU)

