### PR TITLE
WIP: cancellation: Route all (graceful) abnormal termination through cancel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,14 @@ New language features
   and a fresh ^C epoch is re-armed at each prompt; a script that catches a ^C
   cancellation continues under the cancelled scope unless it re-arms one itself
   (`ScopedValues.@with Base.CANCEL_TOKEN => Base.sigint_new_episode!() ...`) ([#60281]).
+* On Unix, `SIGTERM` now requests graceful termination through the cancellation system:
+  it cancels a process-wide root cancellation source (with a terminate flag on the
+  resulting `Base.CancellationRequest`s, see `Base.is_terminate_request` and
+  `Base.process_terminating`), the governed work unwinds (running its `finally` blocks),
+  and the process exits through the ordinary exit path - `atexit` hooks run on a sound
+  stack instead of a frame interrupted at an arbitrary point - before dying by the
+  signal, preserving the exit status. A repeat `SIGTERM` (or one during startup)
+  terminates the process abruptly ([#62774]).
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,14 +53,20 @@ New language features
   and a fresh ^C epoch is re-armed at each prompt; a script that catches a ^C
   cancellation continues under the cancelled scope unless it re-arms one itself
   (`ScopedValues.@with Base.CANCEL_TOKEN => Base.sigint_new_episode!() ...`) ([#60281]).
-* On Unix, `SIGTERM` now requests graceful termination through the cancellation system:
-  it cancels a process-wide root cancellation source (with a terminate flag on the
+* Termination signals now request graceful termination through the cancellation system:
+  they cancel a process-wide root cancellation source (with a terminate flag on the
   resulting `Base.CancellationRequest`s, see `Base.is_terminate_request` and
   `Base.process_terminating`), the governed work unwinds (running its `finally` blocks),
   and the process exits through the ordinary exit path - `atexit` hooks run on a sound
   stack instead of a frame interrupted at an arbitrary point - before dying by the
-  signal, preserving the exit status. A repeat `SIGTERM` (or one during startup)
-  terminates the process abruptly ([#62774]).
+  signal, preserving the exit status. This covers `SIGTERM` on Unix, console
+  close/logoff/shutdown and Ctrl+Break events on Windows, and - with
+  `Base.exit_on_sigint` enabled, as it is for non-interactive scripts - `SIGINT` (which
+  previously also printed a backtrace on ^C; the graceful exit is quiet). A repeat
+  termination signal (or one during startup) terminates the process abruptly. `SIGQUIT`
+  remains an abrupt dump-and-die: it prints the all-task backtraces and exits
+  immediately - it no longer runs `atexit` hooks - so it works even on a process that
+  cannot cooperate with a graceful request ([#62774]).
 
 Language changes
 ----------------

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -410,6 +410,58 @@ end
 # targeted this very generation, so a press for a previous episode can
 # never cancel a newly installed one.
 const _sigint_episode = Ref{Tuple{Union{Nothing, CancellationTokenSource}, UInt64}}((nothing, 0))
+
+# The process-wide root cancellation source. Created (fresh, per process) in
+# `__init__` and registered with the runtime; a termination signal (SIGTERM)
+# cancels it - with the terminate flag, see `is_terminate_request` - and the
+# process then exits through the ordinary exit path once the governed work
+# has unwound (the C side re-raises the signal at the end of
+# `jl_atexit_hook`, preserving the exit status). The session and episode
+# sources attach underneath it (see base/client.jl), so a termination
+# request reaches everything an interactive session or script runs; only
+# internal machinery deliberately running unscoped (the signal listeners,
+# cleanup tasks) is outside its reach. This Ref roots the source for the
+# lifetime of the process; the C mirror reads are lock-free.
+const _process_cancel_source = Ref{Union{Nothing, CancellationTokenSource}}(nothing)
+
+const _process_cancel_lock = ReentrantLock()
+
+# The process root source, created on first use. `__init__` eagerly creates
+# and registers it (so a SIGTERM is deliverable from process start), but
+# environments that run `_start` without Base's `__init__` (e.g. the
+# sysimage output stage) still get a working - if unregistered-with-the-
+# runtime-after-restore - source tree through the lazy path.
+function process_cancel_source!()
+    src = _process_cancel_source[]
+    src === nothing || return src
+    lock(_process_cancel_lock; cancel=nothing)
+    try
+        src = _process_cancel_source[]
+        if src === nothing
+            src = CancellationTokenSource()
+            _process_cancel_source[] = src
+            ccall(:jl_set_term_source, Cvoid, (Any,), src)
+        end
+        return src
+    finally
+        unlock(_process_cancel_lock)
+    end
+end
+
+# The token of the process root source, for linking session-level sources
+# underneath it.
+process_cancel_token() = CancellationToken(process_cancel_source!())
+
+"""
+    Base.process_terminating() -> Bool
+
+Whether graceful process termination has been requested (a termination
+signal - SIGTERM - was received): the process-wide root cancellation source
+has been cancelled and the process exits once the work governed by it has
+unwound. Cleanup code that runs during the unwind can use this to
+distinguish a terminating process from an ordinary cancellation.
+"""
+process_terminating() = ccall(:jl_process_term_signo, Cint, ()) != 0
 # The task driving the current foreground evaluation (the caller of
 # sigint_new_episode!). Nothing in Base reads it yet: the ^C escalation
 # machinery (follow-up PR) targets it directly when the running computation
@@ -471,6 +523,16 @@ const sigint_pass_lock = ReentrantLock()
 # `sigint_pass_lock` held; level-based (it re-reads the episode state), so
 # serializing passes through the lock is enough.
 function _sigint_dispatch_pass()
+    if process_terminating()
+        # A termination signal cancelled the process root source (the C
+        # side marked the whole tree - see jl_request_process_termination -
+        # but cannot wake parked waiters); finish the delivery. Idempotent
+        # and level-based, like the ^C path below. Any coincident ^C press
+        # is moot - the process is exiting.
+        root = _process_cancel_source[]
+        root === nothing || redeliver!(root)
+        return nothing
+    end
     src, gen = _sigint_episode[]
     # A press is consumed only if it targeted this episode's generation; a
     # press for a previous episode self-invalidates (its source was already
@@ -603,6 +665,15 @@ function __init__()
     @static if !Sys.iswindows()
         # triggering a profile via signals is not implemented on windows
         start_profile_listener()
+    end
+    # The process root cancellation source: termination signals (SIGTERM)
+    # cancel it so the process can exit through the ordinary exit path. Must
+    # be a fresh source per process (severities are monotonic; one restored
+    # from an image could have been cancelled in the build session - and the
+    # runtime-side mirror is not serialized either way).
+    let root = CancellationTokenSource()
+        _process_cancel_source[] = root
+        ccall(:jl_set_term_source, Cvoid, (Any,), root)
     end
     start_sigint_listener()
     _require_world_age[] = get_world_counter()

--- a/base/c.jl
+++ b/base/c.jl
@@ -183,9 +183,12 @@ which is capturable in a `try` block.
 This is the default behavior in REPL, any code run via `-e` and `-E`
 and in Julia script run with `-i` option.
 
-If `true`, Ctrl-C terminates the process directly.  Running code
-upon such event requires [`atexit`](@ref).  This is the default
-behavior in Julia script run without `-i` option.
+If `true`, Ctrl-C terminates the process: it requests graceful process
+termination, like a `SIGTERM` (the process-wide root cancellation source is
+cancelled, the governed work unwinds, and the process exits through the
+ordinary exit path, running [`atexit`](@ref) hooks, before dying by the
+signal).  This is the default behavior in Julia script run without `-i`
+option.
 
 !!! compat "Julia 1.5"
     Function `exit_on_sigint` requires at least Julia 1.5.

--- a/base/cancellation.jl
+++ b/base/cancellation.jl
@@ -40,7 +40,9 @@ The exception thrown by cancellation points whose governing cancellation
 token has been cancelled. The `request` field records the severity
 ([`CANCEL_REQUEST_SAFE`](@ref), [`CANCEL_REQUEST_ABANDON_EXTERNAL`](@ref) or
 [`CANCEL_REQUEST_ABANDON_ALL`](@ref)) as observed at delivery time; the
-source may escalate afterwards.
+source may escalate afterwards. Use `Base.severity` to read the severity:
+the field may additionally carry the process-termination flag (see
+`Base.is_terminate_request`).
 """
 struct CancellationRequest <: Exception
     request::UInt8
@@ -91,15 +93,31 @@ frozen in place and never scheduled again.
 const CANCEL_REQUEST_ABANDON_ALL = CancellationRequest(0x4)
 
 # The status byte reported by a cancellation point (`Core.cancellation_point!`)
-# is the governing source's state byte (0 while uncancelled, the severity once
-# cancelled) with the 0x40 bit merged in when the task has a pending
-# cooperative-yield request. The mask recovers the severity half of such a
-# status byte; source state reads themselves need no masking.
+# is the governing source's state byte (0 while uncancelled; once cancelled
+# the severity, with the `TERMINATE_BIT` set when the cancellation is a
+# process-termination request) with the 0x40 bit merged in when the task has
+# a pending cooperative-yield request. `SEVERITY_MASK` recovers the severity
+# half; every severity *ordering* comparison must apply it (the flag bits are
+# orthogonal to the escalation order). Mirrors the C-side
+# JL_CANCEL_SEVERITY_MASK / JL_CANCEL_TERMINATE_BIT (src/julia_threads.h).
 const STATUS_PREEMPT_BIT = 0x40
-const SEVERITY_MASK = 0x3f
+const TERMINATE_BIT = 0x20
+const SEVERITY_MASK = 0x1f
 
 # The severity of a request, for the delivery layer's comparisons.
-severity(cr::CancellationRequest) = cr.request
+severity(cr::CancellationRequest) = cr.request & SEVERITY_MASK
+
+"""
+    Base.is_terminate_request(cr::CancellationRequest) -> Bool
+
+Whether the cancellation is a process-termination request: a termination
+signal (SIGTERM) cancels the process-wide root cancellation source (see
+`Base.process_terminating`), and the resulting requests carry this
+flag in addition to their severity. Unlike an ordinary cancellation, a
+termination request is not resumable: drivers (the REPL, script runners)
+exit instead of continuing.
+"""
+is_terminate_request(cr::CancellationRequest) = cr.request & TERMINATE_BIT != 0x00
 
 """
     cancel_severity(src::CancellationTokenSource) -> Union{Nothing, CancellationRequest}
@@ -174,18 +192,26 @@ _cancel_parent(src::CancellationTokenSource, i::Int) =
 _cancel_next_child(parent::CancellationTokenSource, child::CancellationTokenSource) =
     ccall(:jl_cancel_source_next_child, Any, (Any, Any), parent, child)::Union{Nothing, CancellationTokenSource}
 
-# CAS-max the source's state to `sev` (a valid, nonzero severity). Returns
-# true if the state was raised, false if it was already at (or above) the
-# severity.
+# The join of two state bytes: the higher severity, plus every flag bit set
+# in either (the two halves are ordered pointwise - a terminate flag never
+# outranks, nor is outranked by, a severity escalation). Mirrors the C-side
+# jl_cancel_state_join.
+_join_states(a::UInt8, b::UInt8) =
+    max(a & SEVERITY_MASK, b & SEVERITY_MASK) | ((a | b) & TERMINATE_BIT)
+
+# Advance the source's state to its join with `sev` (a nonzero state byte:
+# severity plus optional flags). Returns true if the state changed, false if
+# it already subsumed the request.
 # seq_cst: pairs with the (child-list publication; state read) sequence in
 # `jl_new_cancel_source` - see the walk in `_cancel_walk_node!`.
 function _raise_state!(src::CancellationTokenSource, sev::UInt8)
     old = @atomic :monotonic src.state
     while true
-        if old >= sev
+        new = _join_states(old, sev)
+        if new == old
             return false
         end
-        old, success = @atomicreplace :sequentially_consistent :monotonic src.state old => sev
+        old, success = @atomicreplace :sequentially_consistent :monotonic src.state old => new
         success && return true
     end
 end
@@ -801,7 +827,7 @@ function _walk_waiters!(node::CancellationTokenSource, sev::UInt8)
             # (conservatively, e.g. by detaching the awaited request).
             aux = slot.aux
             if sev != 0x00 && (@atomic :sequentially_consistent t.waiting_on) === w &&
-                    aux % UInt8 <= sev
+                    aux % UInt8 <= sev & SEVERITY_MASK
                 if (@atomicreplace t.waiting_on w => nothing).success
                     towake = Pair{Tuple{Task, WaitEntry, UInt64}, Any}((t, w, aux), towake)
                 end
@@ -837,7 +863,7 @@ function _cancel_walk_node!(node::CancellationTokenSource, sev::UInt8,
     # the source registration (state write before walk on this side, push
     # or arm before state recheck on the registrant's).
     st = @atomic :sequentially_consistent node.state
-    sev < st && (sev = st)
+    sev = _join_states(sev, st)
     creq = CancellationRequest(sev)
     towake = _walk_waiters!(node, sev)
     # The actual wakes happen after the walk lock is released: holding it

--- a/base/client.jl
+++ b/base/client.jl
@@ -639,7 +639,9 @@ function session_cancel_source!()
     try
         ses = _session_cancel_source[]
         if ses === nothing
-            ses = CancellationTokenSource()
+            # A child of the process root source, so a termination request
+            # (SIGTERM) sweeps the session's work along with everything else.
+            ses = CancellationTokenSource(process_cancel_token())
             _session_cancel_source[] = ses
         end
         return ses
@@ -687,10 +689,12 @@ function _start()
     # The whole foreground execution runs as a ^C episode: a SIGINT (with
     # exit-on-sigint disabled) cancels the episode token's scope. An
     # interactive session installs its own per-evaluation episodes later
-    # (see REPL.repl_backend_loop), superseding this one. Deliberately a
-    # standalone root, not a session child - see the `sigint_new_episode!`
-    # docstring.
-    sigint_tok = sigint_new_episode!()
+    # (see REPL.repl_backend_loop), superseding this one. Deliberately not a
+    # session child (see the `sigint_new_episode!` docstring), but a child
+    # of the process root source, so a termination request (SIGTERM) unwinds
+    # the foreground work and the process exits through the ordinary exit
+    # path.
+    sigint_tok = sigint_new_episode!(CancellationTokenSource(process_cancel_token()))
     @Base.ScopedValues.with MainInclude.main_parser=>parser_for_active_project() CANCEL_TOKEN=>sigint_tok try
         repl_was_requested = exec_options(JLOptions())
         if invokelatest(should_use_main_entrypoint) && !is_interactive
@@ -714,21 +718,29 @@ function _start()
         end
     catch
         ret = Cint(1)
-        # report the error in a fresh ^C epoch (the script's epoch may be
-        # the very cancellation being reported; level-triggered checks in
-        # the printing path would re-throw it mid-report)
-        local errs = scrub_repl_backtrace(current_exceptions())
-        try
-            ScopedValues.@with(CANCEL_TOKEN => sigint_new_episode!(),
-                               invokelatest(display_error, errs))
-        catch
-            # The report itself failed - e.g. a further ^C cancelled the
-            # display epoch, or a user-defined `show` method errored. The
-            # exit code already reflects the original failure; leave a bare
-            # note rather than dying with an unhandled exception.
-            Core.print(Core.stderr, "\nSYSTEM: displaying the error report failed\n")
-        finally
+        if process_terminating()
+            # A termination signal unwound the foreground work: exit quietly
+            # through the ordinary exit path - the atexit hooks run next
+            # (shielded, see `_atexit`) and `jl_atexit_hook` then re-raises
+            # the signal, so the exit status reports the signal death.
             sigint_close_episode!()
+        else
+            # report the error in a fresh ^C epoch (the script's epoch may be
+            # the very cancellation being reported; level-triggered checks in
+            # the printing path would re-throw it mid-report)
+            local errs = scrub_repl_backtrace(current_exceptions())
+            try
+                ScopedValues.@with(CANCEL_TOKEN => sigint_new_episode!(),
+                                   invokelatest(display_error, errs))
+            catch
+                # The report itself failed - e.g. a further ^C cancelled the
+                # display epoch, or a user-defined `show` method errored. The
+                # exit code already reflects the original failure; leave a bare
+                # note rather than dying with an unhandled exception.
+                Core.print(Core.stderr, "\nSYSTEM: displaying the error report failed\n")
+            finally
+                sigint_close_episode!()
+            end
         end
     end
     if is_interactive && get(stdout, :color, false)

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -334,7 +334,7 @@ function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
     # public kwarg method restores the lock-held contract.
     if src !== nothing && cancel_value
         st = @atomic :acquire src.state
-        if st >= max(min_severity, 0x01)
+        if st & SEVERITY_MASK >= max(min_severity, 0x01)
             return CancellationRequest(st)
         end
     elseif src !== nothing && min_severity == 0x00 && iscancelled(src)
@@ -378,7 +378,8 @@ function wait(c::GenericCondition, tok::MaybeToken; first::Bool=false,
         withdraw!(ws, w, WAKE_FIRED)
         if cancel_value
             st = @atomic :acquire src.state
-            st >= max(min_severity, 0x01) || error("park fired without a cancelled source")
+            st & SEVERITY_MASK >= max(min_severity, 0x01) ||
+                error("park fired without a cancelled source")
             return CancellationRequest(st)
         end
         unlock(c.lock)

--- a/base/park.jl
+++ b/base/park.jl
@@ -343,7 +343,7 @@ function wait_recheck(x::SourceWait, w::WaitEntry)
     # Post-publication recheck: either the concurrent cancellation walk
     # observes our push/arm, or we observe its state write here.
     st = @atomic :sequentially_consistent x.src.state
-    return st != 0x00 && st >= x.floor
+    return st != 0x00 && st & SEVERITY_MASK >= x.floor
 end
 
 wait_dequeue!(x::SourceWait, w::WaitEntry, why::UInt8) = nothing
@@ -377,7 +377,8 @@ wait_enqueue!(x::WatcherWait, w::WaitEntry, first::Bool) =
         WAIT_AUX_WATCHER_BIT | UInt64(max(x.floor, CANCEL_REQUEST_SAFE.request)))
 
 wait_recheck(x::WatcherWait, w::WaitEntry) =
-    (@atomic :sequentially_consistent x.src.state) >= max(x.floor, CANCEL_REQUEST_SAFE.request)
+    (@atomic :sequentially_consistent x.src.state) & SEVERITY_MASK >=
+        max(x.floor, CANCEL_REQUEST_SAFE.request)
 
 wait_dequeue!(x::WatcherWait, w::WaitEntry, why::UInt8) = nothing
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -301,11 +301,12 @@ function show(io::IO, src::Core.CancellationTokenSource)
     if sev === nothing
         print(io, "active")
     else
-        r = sev.request
+        r = severity(sev)
         print(io, r == 0x1 ? "cancelled" :
                   r == 0x3 ? "cancelled, abandon external" :
                   r == 0x4 ? "cancelled, abandon all" :
                   "cancelled, severity $(repr(r))")
+        is_terminate_request(sev) && print(io, ", terminating")
     end
     np = Int(src.nparents)
     np > 0 && print(io, ", ", np, np == 1 ? " parent" : " parents")

--- a/base/task.jl
+++ b/base/task.jl
@@ -743,11 +743,13 @@ end
 
 function showerror(io::IO, cr::CancellationRequest)
     print(io, "CancellationRequest: ")
-    if cr === CANCEL_REQUEST_SAFE
+    is_terminate_request(cr) && print(io, "Process Termination, ")
+    sev = severity(cr)
+    if sev == CANCEL_REQUEST_SAFE.request
         print(io, "Safe Cancellation (CANCEL_REQUEST_SAFE)")
-    elseif cr === CANCEL_REQUEST_ABANDON_EXTERNAL
+    elseif sev == CANCEL_REQUEST_ABANDON_EXTERNAL.request
         print(io, "Abandonment of External Resources (CANCEL_REQUEST_ABANDON_EXTERNAL)")
-    elseif cr === CANCEL_REQUEST_ABANDON_ALL
+    elseif sev == CANCEL_REQUEST_ABANDON_ALL.request
         print(io, "Task Abandonment (CANCEL_REQUEST_ABANDON_ALL)")
     else
         print(io, "Unknown ($(cr.request))")

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -78,6 +78,8 @@ Base.@cancel_check
 Base.CANCEL_REQUEST_SAFE
 Base.CANCEL_REQUEST_ABANDON_EXTERNAL
 Base.CANCEL_REQUEST_ABANDON_ALL
+Base.is_terminate_request
+Base.process_terminating
 ```
 
 ## Channels

--- a/src/init.c
+++ b/src/init.c
@@ -349,6 +349,12 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode) JL_NO_SAFEPOINT_ANALYSIS
 #ifdef _OS_WINDOWS_
     jl_fin_stackwalk();
 #endif
+    // A graceful, signal-requested termination ran the ordinary teardown
+    // above; the process must nevertheless die by that signal, preserving
+    // the exit status and disposition a supervisor expects of it.
+    int termsig = jl_process_term_signo();
+    if (termsig != 0)
+        jl_raise(termsig);
 }
 
 JL_DLLEXPORT void jl_postoutput_hook(void)

--- a/src/init.c
+++ b/src/init.c
@@ -353,8 +353,15 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode) JL_NO_SAFEPOINT_ANALYSIS
     // above; the process must nevertheless die by that signal, preserving
     // the exit status and disposition a supervisor expects of it.
     int termsig = jl_process_term_signo();
-    if (termsig != 0)
+    if (termsig != 0) {
+#ifdef _OS_WINDOWS_
+        // There is no death-by-signal on Windows; report the conventional
+        // 128 + signo exit status instead.
+        exit(128 + termsig);
+#else
         jl_raise(termsig);
+#endif
+    }
 }
 
 JL_DLLEXPORT void jl_postoutput_hook(void)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -959,6 +959,9 @@ void jl_install_thread_signal_handler(jl_ptls_t ptls) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_wakeup_thread_from_foreign(int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_membarrier(void) JL_NOTSAFEPOINT;
 extern _Atomic(int) jl_sigint_dispatch_pending;
+// The signal that requested graceful process termination (0 = none); see
+// jl_request_process_termination in signal-handling.c.
+JL_DLLEXPORT int jl_process_term_signo(void) JL_NOTSAFEPOINT;
 
 extern uv_loop_t *jl_io_loop;
 JL_DLLEXPORT void jl_uv_flush(uv_stream_t *stream) JL_CANSAFEPOINT;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -387,8 +387,10 @@ struct _jl_cancel_source_t {
     // installed lazily by the first walker.
     _Atomic(jl_value_t*) walk_lock;
     // 0x00 = uncancelled; otherwise the (nonzero) severity at which the
-    // source is cancelled (0x1 SAFE, 0x3 ABANDON_EXTERNAL, 0x4 ABANDON_ALL).
-    // Monotonic (CAS-max).
+    // source is cancelled (0x1 SAFE, 0x3 ABANDON_EXTERNAL, 0x4 ABANDON_ALL)
+    // in the low bits, with the 0x20 bit set when the cancellation is a
+    // process-termination request (see jl_request_process_termination).
+    // Monotonic (CAS to the lattice join, see jl_cancel_state_join).
     _Atomic(uint8_t) state;
     // Number of parent links following the fixed fields. Const.
     uint16_t nparents;
@@ -404,6 +406,23 @@ struct _jl_cancel_source_t {
     _Atomic(uint32_t) reg_count;
     // jl_cancel_parent_link_t links[nparents];  (see jl_cancel_source_links)
 };
+
+// The source state byte: the low bits hold the severity, the 0x20 bit flags
+// a process-termination request. The two halves form a lattice ordered
+// pointwise (severities escalate, the terminate flag is sticky); state
+// advances are CAS loops to the join. Mirrors `Base.SEVERITY_MASK` /
+// `Base.TERMINATE_BIT` / `Base._join_states`. (The 0x40 bit is used in
+// cancellation-point *status* bytes for a pending cooperative yield and
+// never appears in a source's state.)
+#define JL_CANCEL_SEVERITY_MASK 0x1f
+#define JL_CANCEL_TERMINATE_BIT 0x20
+
+static inline uint8_t jl_cancel_state_join(uint8_t a, uint8_t b) JL_NOTSAFEPOINT
+{
+    uint8_t sa = a & JL_CANCEL_SEVERITY_MASK;
+    uint8_t sb = b & JL_CANCEL_SEVERITY_MASK;
+    return (sa > sb ? sa : sb) | ((a | b) & JL_CANCEL_TERMINATE_BIT);
+}
 
 // The fixed-field layout above must be kept in sync with the registration
 // in jltypes.c; the trailing links are invisible to the field system.

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -568,8 +568,11 @@ static void jl_cancel_subtree_mark(jl_cancel_source_t *root, uint8_t sev) JL_NOT
         // parent's state): an attacher this walk misses observes the state.
         uint8_t st = jl_atomic_load(&node->state);
         int advanced = 0;
-        while (st < sev) {
-            if (jl_atomic_cmpswap(&node->state, &st, sev)) {
+        while (1) {
+            uint8_t nw = jl_cancel_state_join(st, sev);
+            if (nw == st)
+                break;
+            if (jl_atomic_cmpswap(&node->state, &st, nw)) {
                 advanced = 1;
                 break;
             }
@@ -670,6 +673,78 @@ static void jl_sigint_request_cancellation(void) JL_NOTSAFEPOINT
     }
     jl_atomic_store_release(&sigint_pending_gen, gen);
     deliver_sigint_notification();
+}
+
+// The process-wide root cancellation source: Base.__init__ creates it,
+// keeps a rooted reference for the lifetime of the process, and registers
+// this mirror. Every session/episode source attaches underneath it, so
+// cancelling it reaches everything a termination request should stop. The
+// signal thread reads the mirror lock-free and uses the object only under
+// a GC exclusion (the subtree walk follows weak child links).
+static _Atomic(jl_value_t *) jl_term_source = NULL;
+// The signal that requested process termination (0 = none). Set (once)
+// before the root source is marked, so any observer of a terminate-flagged
+// cancellation also observes the signal number. Read by Base (the dispatch
+// pass and the exit drivers) and by jl_atexit_hook, which re-raises it at
+// the end of the ordinary teardown to preserve the exit status and
+// disposition of a signal death.
+static _Atomic(int) jl_term_signo = 0;
+
+JL_DLLEXPORT void jl_set_term_source(jl_value_t *src) JL_NOTSAFEPOINT
+{
+    jl_atomic_store_release(&jl_term_source,
+                            (src == NULL || src == jl_nothing) ? NULL : src);
+}
+
+JL_DLLEXPORT int jl_process_term_signo(void) JL_NOTSAFEPOINT
+{
+    return jl_atomic_load_acquire(&jl_term_signo);
+}
+
+// A termination signal (SIGTERM) requests graceful process termination:
+// mark the root source's subtree cancelled with the terminate bit and let
+// the cancellation unwind the governed work, so the process exits through
+// the ordinary exit path - atexit hooks run on a sound stack instead of a
+// frame hijacked at an arbitrary point (issue #62774). Returns 1 when the
+// request was delivered; 0 when it cannot be (no root source registered -
+// still initializing, or an embedder that never runs Base.__init__ - or
+// termination was already requested once), in which case the caller must
+// exit abruptly instead. Runs on an ordinary (non-Julia) thread; must not
+// allocate GC memory or take Julia-side locks.
+static int jl_request_process_termination(int sig) JL_NOTSAFEPOINT
+{
+    // One graceful attempt per process: a repeat request reports failure so
+    // the caller escalates to an abrupt exit (the cooperative delivery
+    // evidently did not lead to an exit).
+    int expected = 0;
+    if (!jl_atomic_cmpswap(&jl_term_signo, &expected, sig))
+        return 0;
+    int have_listener = jl_atomic_load_relaxed(&sigint_cond_loc) != NULL;
+    jl_safepoint_exclude_gc_begin();
+    jl_cancel_source_t *src =
+        (jl_cancel_source_t*)jl_atomic_load_acquire(&jl_term_source);
+    if (src != NULL) {
+        // SAFE severity plus the terminate bit: a termination request wants
+        // the same orderly unwinding as a ^C - resources are released, not
+        // abandoned - it is just not resumable (drivers exit instead of
+        // continuing; see e.g. `Base._start`).
+        jl_cancel_subtree_mark(src, JL_CANCEL_TERMINATE_BIT | 0x1);
+        jl_membarrier();
+    }
+    jl_safepoint_exclude_gc_end();
+    if (src == NULL)
+        return 0;
+    // Delivery, exactly like jl_sigint_request_cancellation's: flag the
+    // dispatch (idle threads keep the event loop moving until a listener
+    // claims it and wakes the parked waiters), interrupt asynchronously-
+    // interruptible regions on every thread, and notify the listener.
+    if (have_listener)
+        jl_atomic_store_release(&jl_sigint_dispatch_pending, 1);
+    int nthreads = jl_atomic_load_acquire(&jl_n_threads);
+    for (int16_t tid = 0; tid < (int16_t)nthreads; tid++)
+        jl_send_cancellation_signal(tid);
+    deliver_sigint_notification();
+    return 1;
 }
 
 static void stack_overflow_warning(void)

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -819,39 +819,6 @@ void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT
     pthread_mutex_unlock(&ctx_rewrite_lock);
 }
 
-static void jl_exit_thread0_cb(int signo)
-{
-    jl_fprint_critical_error(ios_safe_stderr, signo, 0, NULL, jl_current_task);
-    jl_atexit_hook(128);
-    jl_raise(signo);
-}
-
-static void jl_exit_thread0(int signo, jl_bt_element_t *bt_data, size_t bt_size)
-{
-    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[0];
-    mach_port_t thread = pthread_mach_thread_np(ptls2->system_id);
-
-    host_thread_state_t state;
-    if (!jl_thread_suspend_and_get_state2(0, &state)) {
-        // thread 0 is gone? just do the signal ourself
-        jl_raise(signo);
-    }
-
-    // This aborts `sleep` and other syscalls.
-    kern_return_t ret = thread_abort(thread);
-    HANDLE_MACH_ERROR("thread_abort", ret);
-
-    ptls2->bt_size = bt_size; // <= JL_MAX_BT_SIZE
-    memcpy(ptls2->bt_data, bt_data, ptls2->bt_size * sizeof(bt_data[0]));
-
-    jl_noreturn_call_in_state(&state, (void (*)(void))&jl_exit_thread0_cb, signo, 0);
-    unsigned int count = MACH_THREAD_STATE_COUNT;
-    ret = thread_set_state(thread, MACH_THREAD_STATE, (thread_state_t)&state, count);
-    HANDLE_MACH_ERROR("thread_set_state", ret);
-
-    ret = thread_resume(thread);
-    HANDLE_MACH_ERROR("thread_resume", ret);
-}
 
 static int profile_started = 0;
 mach_timespec_t timerprof;

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -62,8 +62,6 @@ static bt_context_t *jl_to_bt_context(void *sigctx) JL_NOTSAFEPOINT
 #endif
 }
 
-static int thread0_exit_count = 0;
-static void jl_exit_thread0(int signo, jl_bt_element_t *bt_data, size_t bt_size);
 static void jl_longjmp_in_ctx(int sig, void *_ctx, jl_jmp_buf jmpbuf, int val);
 
 #if !defined(_OS_DARWIN_)
@@ -726,42 +724,15 @@ void jl_send_abandon_signal(int16_t tid) JL_NOTSAFEPOINT
     pthread_mutex_unlock(&in_signal_lock);
 }
 
-// Write only by signal handling thread, read only by main thread
-// no sync necessary.
-static int thread0_exit_signo = 0;
-static void jl_exit_thread0_cb(void) JL_CANSAFEPOINT
-{
-    jl_gc_enable_from_nonmutator(1);
-    jl_fprint_critical_error(ios_safe_stderr, thread0_exit_signo, 0, NULL, jl_current_task);
-    jl_atexit_hook(128);
-    jl_raise(thread0_exit_signo);
-}
-
-static void jl_exit_thread0(int signo, jl_bt_element_t *bt_data, size_t bt_size)
-{
-    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[0];
-    bt_context_t signal_context;
-    // This also makes sure `sleep` is aborted.
-    if (jl_thread_suspend_and_get_state(0, 30, &signal_context)) {
-        thread0_exit_signo = signo;
-        ptls2->bt_size = bt_size; // <= JL_MAX_BT_SIZE
-        memcpy(ptls2->bt_data, bt_data, ptls2->bt_size * sizeof(bt_data[0]));
-        jl_atomic_store_release(&ptls2->signal_request, 3);
-        jl_thread_resume(0); // resume with message 3 (call jl_exit_thread0_cb)
-    }
-    else {
-        // thread 0 is gone? just do the exit ourself
-        jl_raise(signo);
-    }
-}
-
 // request:
 // -1: processing
 //  0: nothing [not from here]
 //  1: get state & wait for request
 //  2: unused (was the sigint force-throw request, removed with the old ^C
 //     mechanism)
-//  3: raise `thread0_exit_signo` and try to exit
+//  3: unused (was the exit-signal thread-0 hijack into jl_atexit_hook,
+//     removed when termination signals became graceful root-source
+//     cancellations - see jl_request_process_termination)
 //  4: no-op
 //  5: deliver a pending cancellation to the current task's published
 //     interruptible-region context(s), if any and the task's bound token
@@ -917,7 +888,7 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
         assert(got == 1);
         request = jl_atomic_exchange(&ptls->signal_request, -1);
         usr2_signal_context = NULL;
-        assert(request == 3 || request == 4);
+        assert(request == 4);
     }
     {
         // Acknowledge the request to its synchronously waiting sender (the
@@ -930,9 +901,6 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx) JL_CANSAFEPOINT
     }
     sig_atomic_t processing = -1;
     jl_atomic_cmpswap(&ptls->signal_request, &processing, 0);
-    if (request == 3) {
-        jl_call_in_ctx(ct->ptls, jl_exit_thread0_cb, sig, ctx);
-    }
     errno = errno_save;
 }
 
@@ -1290,12 +1258,28 @@ static void *signal_listener(void *arg) JL_NOTSAFEPOINT
 #endif
 #endif
 
+        // Signals that terminate the process gracefully - SIGTERM and
+        // (with exit-on-sigint) SIGINT - request termination through the
+        // cancellation system: the root source's cancellation unwinds the
+        // governed work and the process exits through the ordinary exit
+        // path, which runs the atexit hooks on a sound stack and then
+        // re-raises the signal (see jl_request_process_termination).
+        // Hijacking a thread into jl_atexit_hook at an arbitrary point is
+        // unsound - the interrupted frame may hold runtime locks the
+        // teardown needs, or the image may still be initializing (issue
+        // #62774). SIGQUIT is deliberately NOT graceful: its contract is
+        // "dump state and die now" - watchdogs aim it at wedged processes
+        // that a cooperative request cannot unwind - so it prints the
+        // all-task backtraces (via `critical` below) and exits abruptly,
+        // preserving the core-dump disposition; it no longer runs the
+        // atexit hooks.
+        int termsig = 0;
         if (sig == SIGINT) {
             if (jl_ignore_sigint()) {
                 continue;
             }
             else if (exit_on_sigint) {
-                critical = 1;
+                termsig = sig;
             }
             else {
                 // Deliver the press through the cancellation system (see
@@ -1304,85 +1288,20 @@ static void *signal_listener(void *arg) JL_NOTSAFEPOINT
                 continue;
             }
         }
-        else if (sig == SIGTERM) {
-            // Request graceful termination through the cancellation system:
-            // the root source's cancellation unwinds the governed work and
-            // the process exits through the ordinary exit path, which runs
-            // the atexit hooks on a sound stack and then re-raises the
-            // signal (see jl_request_process_termination). Hijacking a
-            // thread into jl_atexit_hook at an arbitrary point is unsound -
-            // the interrupted frame may hold runtime locks the teardown
-            // needs, or the image may still be initializing (issue #62774).
-            if (jl_request_process_termination(sig))
-                continue;
-            // No root source is registered (still initializing, or an
-            // embedder that never runs Base.__init__ - no Julia atexit
-            // hooks can exist either way), or this is a repeat request and
-            // the graceful attempt did not lead to an exit: die abruptly
-            // with the signal's default disposition, preserving the exit
-            // status.
-            sigset_t tset;
-            sigemptyset(&tset);
-            sigaddset(&tset, sig);
-            pthread_sigmask(SIG_UNBLOCK, &tset, NULL);
-#ifdef HAVE_KEVENT
-            signal(sig, SIG_DFL);
-#endif
-            uv_tty_reset_mode();
-            fflush(NULL);
-            raise(sig); // very unlikely to return
-            _exit(128 + sig);
-        }
-        else {
-            critical = 0;
-        }
-
+        critical = 0;
+        if (sig == SIGTERM)
+            termsig = sig;
+        critical |= (sig == SIGQUIT); // dump state, then exit abruptly below
         critical |= (sig == SIGABRT);
-        critical |= (sig == SIGQUIT);
 #ifdef SIGINFO
         critical |= (sig == SIGINFO);
+        if (sig == SIGINFO && profile_running != 1)
+            trigger_profile_peek();
 #else
         critical |= (sig == SIGUSR1 && !profile);
+        if (sig == SIGUSR1 && profile_running != 1 && timer_graceperiod_elapsed())
+            trigger_profile_peek();
 #endif
-
-        int doexit = critical;
-#ifdef SIGINFO
-        if (sig == SIGINFO) {
-            if (profile_running != 1)
-                trigger_profile_peek();
-            doexit = 0;
-        }
-#else
-        if (sig == SIGUSR1) {
-            if (profile_running != 1 && timer_graceperiod_elapsed())
-                trigger_profile_peek();
-            doexit = 0;
-        }
-#endif
-        if (doexit) {
-            // The exit can get stuck if it happens at an unfortunate spot in thread 0
-            // (unavoidable due to its async nature).
-            // Try much harder to exit next time, if we get multiple exit requests.
-            // 1. unblock the signal, so this thread can be killed by it
-            // 2. reset the tty next, because we might die before we get another chance to do that
-            // 3. attempt a graceful cleanup of julia, followed by an abrupt end to the C runtime (except for fflush)
-            // 4. kill this thread with `raise`, to preserve the signo / exit code / and coredump configuration
-            // Similar to jl_raise, but a slightly different order of operations
-            sigset_t sset;
-            sigemptyset(&sset);
-            sigaddset(&sset, sig);
-            pthread_sigmask(SIG_UNBLOCK, &sset, NULL);
-#ifdef HAVE_KEVENT
-            signal(sig, SIG_DFL);
-#endif
-            uv_tty_reset_mode();
-            thread0_exit_count++;
-            fflush(NULL);
-            if (thread0_exit_count > 1) {
-                raise(sig); // very unlikely to return
-                _exit(128 + sig);
-            }
-        }
 
         signal_bt_size = 0;
 #if !defined(JL_DISABLE_LIBUNWIND)
@@ -1410,19 +1329,10 @@ static void *signal_listener(void *arg) JL_NOTSAFEPOINT
 
         // this part is async with the running of the rest of the program
         // and must be thread-safe, but not necessarily signal-handler safe
-        if (doexit) {
-//            // this is probably always SI_USER (0x10001 / 65537), so we suppress it
-//            int si_code = 0;
-//#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 199309L && !HAVE_KEVENT
-//            si_code = info.si_code;
-//#endif
-            // Let's forbid threads from running GC while we're trying to exit,
-            // also let's make sure we're not in the middle of GC.
-            jl_gc_enable_from_nonmutator(0);
-            jl_exit_thread0(sig, signal_bt_data, signal_bt_size);
-        }
-        else if (critical) {
-            // critical in this case actually means SIGINFO request
+        if (critical) {
+            // a state-dump request: SIGQUIT (before terminating), a
+            // SIGINFO/SIGUSR1 information request, or the can't-happen
+            // SIGABRT fallback above
 #ifndef SIGINFO // SIGINFO already prints something similar automatically
             int nthreads = jl_atomic_load_acquire(&jl_n_threads);
             int n_threads_running = 0;
@@ -1439,8 +1349,38 @@ static void *signal_listener(void *arg) JL_NOTSAFEPOINT
                 jl_fprint_bt_entry_codeloc(ios_safe_stderr, signal_bt_data + i);
             }
             jl_safe_printf("\n");
-            // Enable trace compilation to stderr with timing during profile collection
-            jl_force_trace_compile_timing_enable();
+            if (termsig == 0) {
+                // Enable trace compilation to stderr with timing during profile collection
+                jl_force_trace_compile_timing_enable();
+            }
+        }
+        if (termsig != 0) {
+            if (!jl_request_process_termination(termsig)) {
+                // No root source is registered (still initializing, or an
+                // embedder that never runs Base.__init__ - no Julia atexit
+                // hooks can exist either way), or termination was already
+                // requested once and the graceful attempt did not lead to
+                // an exit: die abruptly with the signal's default
+                // disposition, preserving the exit status.
+                sigset_t tset;
+                sigemptyset(&tset);
+                sigaddset(&tset, sig);
+                pthread_sigmask(SIG_UNBLOCK, &tset, NULL);
+#ifdef HAVE_KEVENT
+                signal(sig, SIG_DFL);
+#endif
+                uv_tty_reset_mode();
+                fflush(NULL);
+                raise(sig); // very unlikely to return
+                _exit(128 + sig);
+            }
+        }
+        else if (sig == SIGQUIT || sig == SIGABRT) {
+            // dump-and-die (SIGQUIT; SIGABRT can't occur - only set by the
+            // sigwait-corruption fallback above): exit abruptly after the
+            // dump, with the signal's default disposition (a core dump,
+            // where enabled)
+            jl_raise(sig);
         }
     }
     return NULL;

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -818,7 +818,10 @@ static void usr2_deliver_reset(jl_task_t *ct, jl_ptls_t ptls, uint8_t reqflags,
             // for an actual cancellation of the bound token, level-
             // triggered - whichever request delivered the signal.
             if (bound_cancelled) {
-                uint8_t sev = jl_atomic_load_relaxed(&((jl_cancel_source_t*)bound)->state);
+                // The handler contract is in terms of the severity levels
+                // alone - mask off the terminate flag.
+                uint8_t sev = jl_atomic_load_relaxed(&((jl_cancel_source_t*)bound)->state)
+                              & JL_CANCEL_SEVERITY_MASK;
                 hctx->fn(hctx->state, sev);
             }
         }
@@ -1301,11 +1304,39 @@ static void *signal_listener(void *arg) JL_NOTSAFEPOINT
                 continue;
             }
         }
+        else if (sig == SIGTERM) {
+            // Request graceful termination through the cancellation system:
+            // the root source's cancellation unwinds the governed work and
+            // the process exits through the ordinary exit path, which runs
+            // the atexit hooks on a sound stack and then re-raises the
+            // signal (see jl_request_process_termination). Hijacking a
+            // thread into jl_atexit_hook at an arbitrary point is unsound -
+            // the interrupted frame may hold runtime locks the teardown
+            // needs, or the image may still be initializing (issue #62774).
+            if (jl_request_process_termination(sig))
+                continue;
+            // No root source is registered (still initializing, or an
+            // embedder that never runs Base.__init__ - no Julia atexit
+            // hooks can exist either way), or this is a repeat request and
+            // the graceful attempt did not lead to an exit: die abruptly
+            // with the signal's default disposition, preserving the exit
+            // status.
+            sigset_t tset;
+            sigemptyset(&tset);
+            sigaddset(&tset, sig);
+            pthread_sigmask(SIG_UNBLOCK, &tset, NULL);
+#ifdef HAVE_KEVENT
+            signal(sig, SIG_DFL);
+#endif
+            uv_tty_reset_mode();
+            fflush(NULL);
+            raise(sig); // very unlikely to return
+            _exit(128 + sig);
+        }
         else {
             critical = 0;
         }
 
-        critical |= (sig == SIGTERM);
         critical |= (sig == SIGABRT);
         critical |= (sig == SIGQUIT);
 #ifdef SIGINFO

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -49,26 +49,56 @@ void __cdecl crt_sig_handler(int sig, int num)
     case SIGINT:
         signal(SIGINT, (void (__cdecl *)(int))crt_sig_handler);
         if (!jl_ignore_sigint()) {
-            if (exit_on_sigint)
-                jl_exit(130); // 128 + SIGINT
-            // This handler runs synchronously on the raising thread. If that
-            // is a GC-unsafe Julia mutator, the request path's GC exclusion
-            // could deadlock against a collection waiting for this very
-            // thread - transition to GC-safe for the duration (the exclusion
-            // then holds off any new collection while the sources are
-            // touched).
+            // These handlers run synchronously on the raising thread. If
+            // that is a GC-unsafe Julia mutator, the request paths' GC
+            // exclusion could deadlock against a collection waiting for
+            // this very thread - transition to GC-safe for the duration
+            // (the exclusion then holds off any new collection while the
+            // sources are touched).
             jl_task_t *ct = jl_get_current_task();
-            if (ct != NULL && ct->ptls != NULL) {
-                int8_t gc_state = jl_gc_safe_enter(ct->ptls);
-                jl_sigint_request_cancellation();
-                jl_gc_safe_leave(ct->ptls, gc_state);
+            jl_ptls_t ptls = (ct != NULL) ? ct->ptls : NULL;
+            int8_t gc_state = (ptls != NULL) ? jl_gc_safe_enter(ptls) : 0;
+            int handled;
+            if (exit_on_sigint) {
+                // exit-on-sigint: ^C terminates the process. Request
+                // graceful termination (see jl_request_process_termination
+                // and the unix signal listener); the raising thread resumes
+                // and the governed work unwinds through its cancellation
+                // points into the ordinary exit path.
+                handled = jl_request_process_termination(sig);
             }
             else {
+                // Deliver the press through the cancellation system (see
+                // jl_sigint_request_cancellation).
                 jl_sigint_request_cancellation();
+                handled = 1;
             }
+            if (ptls != NULL)
+                jl_gc_safe_leave(ptls, gc_state);
+            if (!handled)
+                jl_exit(128 + sig);
         }
         break;
-    default: // SIGSEGV, SIGTERM, SIGILL, SIGABRT
+    case SIGTERM: {
+        // A C-runtime raise(SIGTERM): request graceful termination, like a
+        // unix SIGTERM; the raising thread resumes and the governed work
+        // unwinds through its cancellation points into the ordinary exit
+        // path. Without a registered root source, or on a repeat request,
+        // exit abruptly with the C runtime's default disposition.
+        signal(SIGTERM, (void (__cdecl *)(int))crt_sig_handler);
+        jl_task_t *ct = jl_get_current_task();
+        jl_ptls_t ptls = (ct != NULL) ? ct->ptls : NULL;
+        int8_t gc_state = (ptls != NULL) ? jl_gc_safe_enter(ptls) : 0;
+        int handled = jl_request_process_termination(sig);
+        if (ptls != NULL)
+            jl_gc_safe_leave(ptls, gc_state);
+        if (!handled) {
+            signal(SIGTERM, SIG_DFL);
+            raise(sig);
+        }
+        break;
+    }
+    default: // SIGSEGV, SIGILL, SIGABRT
         if (sig == SIGSEGV) { // restarting jl_ or profile
             jl_jmp_buf *saferestore = jl_get_safe_restore();
             if (saferestore) {
@@ -519,19 +549,24 @@ static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guara
         default: sig = SIGTERM; break;
     }
     if (!jl_ignore_sigint()) {
-        if (exit_on_sigint)
-            jl_exit(128 + sig); // 128 + SIGINT
-        if (sig == SIGINT) {
+        if (sig == SIGINT && !exit_on_sigint) {
             // Deliver the press through the cancellation system (see
             // jl_sigint_request_cancellation).
             jl_sigint_request_cancellation();
         }
         else {
-            // Close/logoff/shutdown (and Ctrl+Break): a termination
-            // request. Windows kills the process the moment this handler
-            // returns for CTRL_CLOSE_EVENT, so run the orderly teardown
-            // synchronously here rather than delivering anything to a
-            // Julia thread. (Matches unix SIGTERM's exit status.)
+            // A termination request: close/logoff/shutdown (and
+            // Ctrl+Break), or ^C with exit-on-sigint. Request graceful
+            // termination (see jl_request_process_termination) and block
+            // this handler thread: Windows kills the process the moment
+            // the handler returns for CTRL_CLOSE_EVENT, while the ordinary
+            // exit path terminates it first when the teardown succeeds -
+            // and the OS's own handler deadline bounds one that does not.
+            // Without a registered root source, or on a repeat request,
+            // run the orderly teardown synchronously here, as before.
+            // (Matches unix SIGTERM's exit status.)
+            if (jl_request_process_termination(sig))
+                Sleep(INFINITE);
             jl_exit(128 + sig);
         }
     }

--- a/src/task.c
+++ b/src/task.c
@@ -1948,15 +1948,17 @@ JL_DLLEXPORT int jl_abandon_task_withdraw(int16_t tid)
 
 // cancellation token sources -----------------------------------------------
 
-// CAS-max the source's state to `sev` (a nonzero severity); returns whether
-// the state was raised. Mirrors `Base._raise_state!`.
+// Advance the source's state to its join with `sev` (a nonzero state byte:
+// severity plus optionally the terminate bit); returns whether the state
+// changed. Mirrors `Base._raise_state!`.
 static int cancel_source_raise_state(jl_cancel_source_t *src, uint8_t sev) JL_NOTSAFEPOINT
 {
     uint8_t old = jl_atomic_load_relaxed(&src->state);
     while (1) {
-        if (old >= sev)
+        uint8_t nw = jl_cancel_state_join(old, sev);
+        if (nw == old)
             return 0;
-        if (jl_atomic_cmpswap(&src->state, &old, sev))
+        if (jl_atomic_cmpswap(&src->state, &old, nw))
             return 1;
     }
 }
@@ -1994,8 +1996,7 @@ static void cancel_source_attach(jl_cancel_source_t *src) JL_NOTSAFEPOINT
         // child_head read) so that either the canceller's walk observes
         // this node, or this load observes the cancelled state.
         uint8_t pst = jl_atomic_load(&p->state);
-        if (pst > sev)
-            sev = pst;
+        sev = jl_cancel_state_join(sev, pst);
     }
     if (sev != 0)
         cancel_source_raise_state(src, sev);

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -616,6 +616,9 @@ show_repl(io::IO, ::MIME"text/plain", ex::Expr) =
         sprint(show, ex, context=IOContext(io, :color => false))))
 
 function print_response(repl::AbstractREPL, response, show_value::Bool, have_color::Bool)
+    # An evaluation unwound by a process-termination request (SIGTERM) needs
+    # no report - the session is exiting, not returning to a prompt.
+    Base.process_terminating() && return nothing
     repl.waserror = response[2]
     with_repl_linfo(repl) do io
         io = IOContext(io, :module => Base.active_module(repl)::Module)
@@ -804,11 +807,17 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
             write(repl.terminal, '\n')
             ((!interrupted && isempty(line)) || hit_eof) && break
         catch e
+            # A process-termination request unwinds the blocked reads; shut
+            # down like an EOF (see the LineEditREPL frontend).
+            Base.process_terminating() && break
             isa(e, InterruptException) || rethrow()
         end
     end
-    # terminate backend
-    put!(backend.repl_channel, (nothing, -1))
+    # terminate backend (shielded: this is REPL teardown and must work while
+    # the frontend's own scope is being cancelled)
+    Base.ScopedValues.@with Base.CANCEL_TOKEN => nothing begin
+        put!(backend.repl_channel, (nothing, -1))
+    end
     dopushdisplay && popdisplay(d)
     nothing
 end
@@ -1770,9 +1779,22 @@ function run_frontend(repl::LineEditREPL, backend::REPLBackendRef)
     if isdefined(repl, :prompt_ready_event) && repl.prompt_ready_event !== nothing
         repl.mistate.prompt_ready_event = repl.prompt_ready_event
     end
-    run_interface(terminal(repl), interface, repl.mistate)
-    # Terminate Backend
-    put!(backend.repl_channel, (nothing, -1))
+    try
+        run_interface(terminal(repl), interface, repl.mistate)
+    catch
+        # A process-termination request (SIGTERM) cancels the root source,
+        # which unwinds the frontend's blocked terminal reads (this task
+        # runs under a root-descendant scope; see the session tree in
+        # base/client.jl): shut the REPL down like an EOF would, so the
+        # process exits through the ordinary exit path. Anything else is a
+        # real frontend failure.
+        Base.process_terminating() || rethrow()
+    end
+    # Terminate Backend. The put! is REPL teardown and must work while the
+    # frontend's own scope is being cancelled - shield it.
+    Base.ScopedValues.@with Base.CANCEL_TOKEN => nothing begin
+        put!(backend.repl_channel, (nothing, -1))
+    end
     dopushdisplay && popdisplay(d)
     nothing
 end

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -2684,9 +2684,9 @@ Sys.isunix() && @testset "SIGTERM graceful termination" begin
     # Bare executable, as in the "^C" testset: these scenarios assert the
     # termination semantics, not the suite's flag matrix.
     exe = joinpath(Sys.BINDIR, Base.julia_exename())
-    function run_with_sigterm(code::String, delays)
+    function run_with_sigterm(code::String, delays; signum::Int=Base.SIGTERM)
         # The readiness marker proves the runtime is up before the first
-        # SIGTERM is sent (see the "^C" testset's run_with_sigint).
+        # signal is sent (see the "^C" testset's run_with_sigint).
         code = "println(\"CHILD-READY\")\n" * code
         out = Pipe()
         p = run(pipeline(`$exe --startup-file=no -e $code`,
@@ -2697,7 +2697,7 @@ Sys.isunix() && @testset "SIGTERM graceful termination" begin
         killer = @async begin
             for d in delays
                 sleep(d)
-                process_running(p) && kill(p) # SIGTERM
+                process_running(p) && kill(p, signum)
             end
         end
         exited = timedwait(() -> process_exited(p), 60.0)
@@ -2765,6 +2765,34 @@ Sys.isunix() && @testset "SIGTERM graceful termination" begin
     """, [0.5, 3.0])
     @test exited === :ok
     @test p.termsignal == Base.SIGTERM
+
+    # with exit-on-sigint, a SIGINT terminates the process through the same
+    # graceful path: the atexit hooks run, the exit is quiet, and the
+    # process dies by SIGINT
+    output, p, exited = run_with_sigterm("""
+        Base.exit_on_sigint(true)
+        atexit(() -> println("ATEXIT-RAN"))
+        sleep(100)
+        println("FAIL: not terminated")
+    """, [0.5]; signum=Int(Base.SIGINT))
+    @test exited === :ok
+    @test occursin("ATEXIT-RAN", output)
+    @test !occursin("FAIL", output)
+    @test !occursin("CancellationRequest", output)
+    @test p.termsignal == Base.SIGINT
+
+    # SIGQUIT is the wedge-proof dump-and-die escape hatch: it prints the
+    # all-task backtraces and exits abruptly - no graceful unwinding, no
+    # atexit hooks - so watchdogs can rely on it even when the process
+    # cannot cooperate
+    output, p, exited = run_with_sigterm("""
+        atexit(() -> println("ATEXIT-RAN"))
+        sleep(100)
+    """, [0.5]; signum=Int(Base.SIGQUIT))
+    @test exited === :ok
+    @test occursin("signal (3)", output)
+    @test !occursin("ATEXIT-RAN", output)
+    @test p.termsignal == Base.SIGQUIT
 
     # a SIGTERM at any point during startup must terminate the process:
     # before Base registers the root source it exits abruptly, afterwards

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -2679,3 +2679,174 @@ Sys.isunix() && @testset "^C in the REPL (pty)" begin
     close(ptm)
     wait(reader)
 end
+
+Sys.isunix() && @testset "SIGTERM graceful termination" begin
+    # Bare executable, as in the "^C" testset: these scenarios assert the
+    # termination semantics, not the suite's flag matrix.
+    exe = joinpath(Sys.BINDIR, Base.julia_exename())
+    function run_with_sigterm(code::String, delays)
+        # The readiness marker proves the runtime is up before the first
+        # SIGTERM is sent (see the "^C" testset's run_with_sigint).
+        code = "println(\"CHILD-READY\")\n" * code
+        out = Pipe()
+        p = run(pipeline(`$exe --startup-file=no -e $code`,
+                         stdin=devnull, stdout=out, stderr=out), wait=false)
+        close(out.in)
+        readuntil(out, "CHILD-READY\n") # returns early (at EOF) if the child dies
+        reader = @async read(out, String)
+        killer = @async begin
+            for d in delays
+                sleep(d)
+                process_running(p) && kill(p) # SIGTERM
+            end
+        end
+        exited = timedwait(() -> process_exited(p), 60.0)
+        exited === :ok || kill(p, Base.SIGKILL) # never wedge the suite
+        wait(p)
+        wait(killer)
+        return fetch(reader), p, exited
+    end
+
+    # SIGTERM cancels the process root source: the parked sleep unwinds
+    # quietly (no error report), the atexit hooks run in the ordinary exit
+    # path, and the process still dies by SIGTERM (the runtime re-raises it
+    # at the end of the teardown) - issue #62774
+    output, p, exited = run_with_sigterm("""
+        atexit(() -> println("ATEXIT-RAN"))
+        sleep(100)
+        println("FAIL: not terminated")
+    """, [0.5])
+    @test exited === :ok
+    @test occursin("ATEXIT-RAN", output)
+    @test !occursin("FAIL", output)
+    @test !occursin("CancellationRequest", output)
+    @test p.termsignal == Base.SIGTERM
+
+    # `finally` blocks of the governed work run before the exit (shielded,
+    # like any cleanup that must still block - here: write to a pipe - under
+    # its own cancelled scope)
+    output, p, exited = run_with_sigterm("""
+        try
+            sleep(100)
+        finally
+            Base.ScopedValues.with(Base.CANCEL_TOKEN => nothing) do
+                println("FINALLY-RAN")
+            end
+        end
+    """, [0.5])
+    @test exited === :ok
+    @test occursin("FINALLY-RAN", output)
+    @test p.termsignal == Base.SIGTERM
+
+    # cleanup code can distinguish a terminating process from an ordinary
+    # cancellation - and catching the request does not avert the exit
+    output, p, exited = run_with_sigterm("""
+        try
+            sleep(100)
+        catch e
+            Base.ScopedValues.with(Base.CANCEL_TOKEN => nothing) do
+                println("terminating=", Base.process_terminating())
+                println("terminate-request=",
+                        e isa Base.CancellationRequest && Base.is_terminate_request(e))
+            end
+        end
+    """, [0.5])
+    @test exited === :ok
+    @test occursin("terminating=true", output)
+    @test occursin("terminate-request=true", output)
+    @test p.termsignal == Base.SIGTERM
+
+    # work shielded from cancellation cannot be unwound by the graceful
+    # request; a repeat SIGTERM exits abruptly instead
+    output, p, exited = run_with_sigterm("""
+        Base.ScopedValues.with(Base.CANCEL_TOKEN => nothing) do
+            sleep(100)
+        end
+    """, [0.5, 3.0])
+    @test exited === :ok
+    @test p.termsignal == Base.SIGTERM
+
+    # a SIGTERM at any point during startup must terminate the process:
+    # before Base registers the root source it exits abruptly, afterwards
+    # through the graceful path - it must never wedge (the failure mode of
+    # issue #62774: a teardown hijacked onto a half-initialized thread 0
+    # deadlocking on runtime locks)
+    for delay in (0.0, 0.05, 0.2)
+        p = run(pipeline(`$exe --startup-file=no -e 'sleep(60)'`,
+                         stdin=devnull, stdout=devnull, stderr=devnull), wait=false)
+        delay > 0 && sleep(delay)
+        process_running(p) && kill(p)
+        exited = timedwait(() -> process_exited(p), 60.0)
+        exited === :ok || kill(p, Base.SIGKILL)
+        wait(p)
+        @test exited === :ok
+        @test p.termsignal == Base.SIGTERM || p.exitcode == 128 + Base.SIGTERM
+    end
+end
+
+Sys.isunix() && @testset "SIGTERM in the REPL (pty)" begin
+    isdefined(Main, :FakePTYs) || @eval Main include("testhelpers/FakePTYs.jl")
+
+    # Interactive julia on a pty (like the "^C in the REPL" testset); the
+    # session must shut down cleanly on SIGTERM, dying by the signal.
+    function repl_sigterm_session(drive!::Function)
+        pts, ptm = Main.FakePTYs.open_fake_pty()
+        env = copy(ENV)
+        env["TERM"] = "dumb"
+        env["JULIA_HISTORY"] = tempname()
+        exe = joinpath(Sys.BINDIR, Base.julia_exename())
+        p = run(detach(setenv(`$exe -i -q --startup-file=no --color=no`, env)),
+                pts, pts, pts; wait=false)
+        ccall(:close, Cint, (Cint,), pts) # only the child owns the pts now
+        transcript_lock = ReentrantLock()
+        transcript = UInt8[]
+        reader = @async try
+            while true
+                chunk = readavailable(ptm)
+                isempty(chunk) && break
+                @lock transcript_lock append!(transcript, chunk)
+            end
+        catch # pty closes when the child exits
+        end
+        snapshot() = @lock transcript_lock String(copy(transcript))
+        cursor = Ref(1)
+        function expect(needle::String; timeout::Real=120.0)
+            status = timedwait(timeout; pollint=0.05) do
+                idx = findnext(needle, snapshot(), cursor[])
+                idx === nothing && return false
+                cursor[] = last(idx) + 1
+                return true
+            end
+            if status !== :ok && process_running(p)
+                kill(p, 3) # SIGQUIT: dump task backtraces into the CI log
+                timedwait(() -> istaskdone(reader), 20.0)
+                @error "expect timed out" needle tail=snapshot()[max(1, cursor[]):end]
+            end
+            @test status == :ok
+        end
+        sendline(s) = write(ptm, s * "\n")
+        expect("julia> ")
+        drive!(p, expect, sendline)
+        kill(p) # SIGTERM
+        exited = timedwait(() -> process_exited(p), 60.0)
+        exited === :ok || kill(p, Base.SIGKILL)
+        wait(p)
+        @test exited === :ok
+        @test p.termsignal == Base.SIGTERM
+        close(ptm)
+        wait(reader)
+    end
+
+    # SIGTERM at an idle prompt: the frontend's terminal read unwinds and
+    # the session exits
+    repl_sigterm_session() do p, expect, sendline
+    end
+
+    # SIGTERM during an evaluation: the evaluation unwinds (with no error
+    # report) and the session exits
+    repl_sigterm_session() do p, expect, sendline
+        sendline("println(\"EVAL-1\"); sleep(1000)")
+        expect("EVAL-1")
+        sleep(0.5)
+    end
+end


### PR DESCRIPTION
This routes SIGTERM plus the various windows termination conditions through cancellation.
Currently these just hijack whatever task happens to be running on task 0 and runs atexit hooks.
This has the same problem that SIGINT used to have, which is that the point at which this happens
is ill defined. In particular, it may be unsafe to run code there (e.g. because the interrupted task
was holding a runtime lock). Since we have the cancellation mechanism to describe exactly this
kind of situation, let's just use it by having a big global cancellation source and propagating cancellation
to everyone. Of course it's still possible for things to get wedged, but things could also get wedged
before as mentioned. At least this way, we only need to improve things for one mechanism and
both ^C and SIGTERM will benefit 