### PR TITLE
[backports-release-1.13] Separate inference cache for `--trim` (#61983)

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1673,7 +1673,10 @@ const TRIM_SAFE = 0x1
 const TRIM_UNSAFE = 0x2
 const TRIM_UNSAFE_WARN = 0x3
 function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim_mode::UInt8)
-    inf_params = InferenceParams(; force_enable_inference = trim_mode != TRIM_NO)
+    # During `--trim`, infer against an isolated cache namespace. The owner is re-stamped
+    # back to `nothing` at serialization time (see `src/staticdata.c`).
+    cache_owner = trim_mode == TRIM_NO ? nothing : :trim
+    inf_params = InferenceParams(; force_enable_inference = trim_mode != TRIM_NO, cache_owner)
 
     # Create an "invokelatest" queue to enable eager compilation of speculative
     # invokelatest calls such as from `Core.finalizer` and `ccallable`

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1321,7 +1321,11 @@ function ci_has_source(interp::AbstractInterpreter, code::CodeInstance)
     if isa(inf, String)
         inf = _uncompressed_ir(code, inf)
     end
-    if code.owner === nothing
+    if code.owner === nothing || code.owner === :trim
+        # `:trim`-owned instances (see `typeinf_ext_toplevel`) are plain
+        # NativeInterpreter results in an isolated cache namespace; codegen
+        # must see them like unowned ones, or `compile!` cannot find source
+        # for edges discovered through them.
         if isa(inf, CodeInfo)
             codegen[code] = inf
             return true

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -207,6 +207,7 @@ struct InferenceParams
     assume_bindings_static::Bool
     ignore_recursion_hardlimit::Bool
     force_enable_inference::Bool
+    cache_owner::Any
 
     function InferenceParams(
         max_methods::Int,
@@ -219,6 +220,7 @@ struct InferenceParams
         assume_bindings_static::Bool,
         ignore_recursion_hardlimit::Bool,
         force_enable_inference::Bool,
+        @nospecialize(cache_owner),
     )
         return new(
             max_methods,
@@ -231,6 +233,7 @@ struct InferenceParams
             assume_bindings_static,
             ignore_recursion_hardlimit,
             force_enable_inference,
+            cache_owner,
         )
     end
 end
@@ -245,7 +248,8 @@ function InferenceParams(
         #=aggressive_constant_propagation::Bool=# false,
         #=assume_bindings_static::Bool=# false,
         #=ignore_recursion_hardlimit::Bool=# false,
-        #=force_enable_inference::Bool=# false
+        #=force_enable_inference::Bool=# false,
+        #=cache_owner=# nothing
     );
     max_methods::Int = params.max_methods,
     max_union_splitting::Int = params.max_union_splitting,
@@ -257,6 +261,7 @@ function InferenceParams(
     assume_bindings_static::Bool = params.assume_bindings_static,
     ignore_recursion_hardlimit::Bool = params.ignore_recursion_hardlimit,
     force_enable_inference::Bool = params.force_enable_inference,
+    cache_owner = params.cache_owner,
 )
     return InferenceParams(
         max_methods,
@@ -269,6 +274,7 @@ function InferenceParams(
         assume_bindings_static,
         ignore_recursion_hardlimit,
         force_enable_inference,
+        cache_owner,
     )
 end
 
@@ -416,7 +422,7 @@ InferenceParams(interp::NativeInterpreter) = interp.inf_params
 OptimizationParams(interp::NativeInterpreter) = interp.opt_params
 get_inference_world(interp::NativeInterpreter) = interp.world
 get_inference_cache(interp::NativeInterpreter) = interp.inf_cache
-cache_owner(::NativeInterpreter) = nothing
+cache_owner(interp::NativeInterpreter) = interp.inf_params.cache_owner
 
 engine_reserve(interp::AbstractInterpreter, mi::MethodInstance) = engine_reserve(mi, cache_owner(interp))
 engine_reserve(mi::MethodInstance, @nospecialize owner) = ccall(:jl_engine_reserve, Any, (Any, Any), mi, owner)::CodeInstance

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -316,7 +316,10 @@ function get_verify_typeinf_trim(codeinfos::Vector{Any})
         item = codeinfos[i]
         if item isa CodeInstance
             push!(inspected, item)
-            if item.owner === nothing && item.min_world <= this_world <= item.max_world
+            # Trim inference caches its results under the `:trim` symbol as the owner (see
+            # `typeinf_ext_toplevel`), so the `CodeInstance`s handed to us here carry that
+            # owner rather than `nothing`.
+            if item.owner === :trim && item.min_world <= this_world <= item.max_world
                 mi = get_ci_mi(item)
                 if mi === item.def
                     caches[mi] = item

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -580,7 +580,8 @@ static void generate_cfunc_thunks(jl_codegen_params_t &params, jl_compiled_funct
     for (auto &def : compiled_functions) {
         jl_code_instance_t *this_code = def.first;
         jl_method_instance_t *mi = jl_get_ci_mi(this_code);
-        if (this_code->owner == jl_nothing && jl_atomic_load_relaxed(&this_code->max_world) == ~(size_t)0 && this_code->def == (jl_value_t*)mi)
+        if ((this_code->owner == jl_nothing || this_code->owner == (jl_value_t*)jl_trim_sym) &&
+            jl_atomic_load_relaxed(&this_code->max_world) == ~(size_t)0 && this_code->def == (jl_value_t*)mi)
             compiled_mi[mi] = this_code;
     }
     size_t latestworld = jl_atomic_load_acquire(&jl_world_counter);

--- a/src/ast.c
+++ b/src/ast.c
@@ -326,6 +326,7 @@ void jl_init_common_symbols(void)
     jl_sequentially_consistent_sym = jl_symbol("sequentially_consistent");
     jl_uninferred_sym = jl_symbol("uninferred");
     jl_latestworld_sym = jl_symbol("latestworld");
+    jl_trim_sym = jl_symbol("trim");
 }
 
 JL_DLLEXPORT void jl_lisp_prompt(void)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2021,6 +2021,7 @@ JL_DLLEXPORT int jl_isabspath(const char *in) JL_NOTSAFEPOINT;
     XX(thunk_sym) \
     XX(top_sym) \
     XX(toplevel_sym) \
+    XX(trim_sym) \
     XX(uninferred_sym) \
     XX(unordered_sym) \
     XX(unused_sym) \

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -678,6 +678,27 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
             // prevent this from happening, so we do not need to detect that user
             // error now.
         }
+        else if (jl_options.trim) {
+            // Rebuild the `mi->cache` list with any non-:trim-owned CodeInstances removed.
+            jl_code_instance_t *first = NULL;
+            jl_code_instance_t *prev = NULL;
+            jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
+            while (codeinst) {
+                jl_code_instance_t *next = jl_atomic_load_relaxed(&codeinst->next);
+                if (codeinst->owner == (jl_value_t *)jl_trim_sym) {
+                    record_field_change((jl_value_t**)&codeinst->owner, jl_nothing);
+                    if (prev == NULL)
+                        first = codeinst;
+                    else
+                        record_field_change((jl_value_t**)&prev->next, (jl_value_t*)codeinst);
+                    prev = codeinst;
+                }
+                codeinst = next;
+            }
+            if (prev != NULL)
+                record_field_change((jl_value_t**)&prev->next, NULL);
+            record_field_change((jl_value_t**)&mi->cache, (jl_value_t*)first);
+        }
         // don't recurse into all backedges memory (yet)
         jl_value_t *backedges = get_replaceable_field((jl_value_t**)&mi->backedges, 1);
         if (backedges) {
@@ -795,7 +816,7 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
                 }
                 else if (may_discard_trees &&
                          native_functions && // don't delete any code if making a ji file
-                         (ci->owner == jl_nothing) && // don't delete code for external interpreters
+                         (ci->owner == jl_nothing || ci->owner == (jl_value_t*)jl_trim_sym) && // don't delete code for external interpreters
                          !effects_foldable(jl_atomic_load_relaxed(&ci->ipo_purity_bits)) && // don't delete code we may want for irinterp
                          jl_ir_inlining_cost(inferred) == UINT16_MAX) { // don't delete inlineable code
                     // delete the code now: if we thought it was worth keeping, it would have been converted to object code


### PR DESCRIPTION
Currently JuliaC / `--trim` suffers from some serious spurious failures due to cache poisoning from non-`--trim` inference. The "normal" Julia JIT runs inference with different `InferenceParams`, less aggressive `max_args` heuristics, and other differences that can lead to `--trim` failures.

If inference was forced to widen, or generated results for too-wide signatures, then the `--trim` job will fail to notice that it would actually succeed if it re-inferred under its own settings. The solution to this is to separate the inference cache for `--trim` from the usual inference cache used by JIT / default AOT compilation (resolves #58834)

(cherry picked from commit 5ef5b2dd16fbf90e5366b41f23433f6255363204)

Straightforward backport - I noticed that MTK is starting to run into this problem on some FMUs so I think we need to take the fix on Julia 1.13