### PR TITLE
Switch `BigInt` to Julia managed memory, 

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -217,6 +217,8 @@ end
 const scratch_t = Ref{Scratch}
 
 # Copy a GMP-owned mpz, given as its signed size and limb pointer, into `x`.
+# No normalization: every mpz function leaves its output with a nonzero top
+# limb, so `BigInt`'s invariant carries over as is.
 function _take!(x::BigInt, sz::Cint, p::Ptr{Limb})
     n = abs(Int(sz))
     d = _ensure!(x, n)
@@ -454,7 +456,9 @@ function tdiv_qr!(x::BigInt, y::BigInt, a::BigInt, b::BigInt)
     neg = (as < 0) != (bs < 0)
     if bn == 1
         v = @inbounds bd[1]
-        qd = _dest(x, an, ad, bd)
+        # `mpn_divrem_1` allows `qp == np`, and `v` is already read, so `x`
+        # may alias either input here, as in `tdiv_q!`.
+        qd = _ensure!(x, an)
         rl = _mpn_divrem_1(qd, ad, an % mp_size_t, v)
         rdy = _ensure!(y, 1)
         @inbounds rdy[1] = rl
@@ -601,7 +605,9 @@ function mul_2exp!(x::BigInt, a::BigInt, c)
     ad = a.d
     off, sh = divrem(s, BITS_PER_LIMB)
     n = an + off + (sh > 0)
-    d = Memory{Limb}(undef, n)
+    # In place is fine: `mpn_lshift` permits overlap when `rp >= up`, which
+    # holds with `rp = d + off`, and `copyto!` on one buffer is a memmove.
+    d = _ensure!(x, n)
     if sh == 0
         copyto!(d, off+1, ad, 1, an)
     else
@@ -635,7 +641,9 @@ function fdiv_q_2exp!(x::BigInt, a::BigInt, c)
     lost = neg && (any(!iszero, @view ad[1:off]) ||
                    (sh > 0 && (@inbounds ad[off+1]) & ((one(Limb) << sh) - one(Limb)) != 0))
     n = an - off
-    d = Memory{Limb}(undef, n)
+    # In place is fine: `mpn_rshift` permits overlap when `rp <= up`, which
+    # holds with `up = ad + off`, and `lost` has already read the low limbs.
+    d = _ensure!(x, n)
     if sh == 0
         copyto!(d, 1, ad, off+1, n)
     else
@@ -661,7 +669,7 @@ function sqrt!(x::BigInt, a::BigInt)
     an = as # `as > 0` here, so the size and the limb count agree
     ad = a.d
     sn = cld(an, 2)
-    d = Memory{Limb}(undef, sn)
+    d = _dest(x, sn, ad) # mpn_sqrtrem forbids overlap between `sp` and `up`
     _mpn_sqrt(d, ad, an % mp_size_t)
     return _finish!(x, d, sn, false)
 end
@@ -845,6 +853,16 @@ end # module MPZ
 
 const ZERO = BigInt()
 const ONE  = MPZ.set_ui(one(Limb))
+
+# Packages used to hand a `BigInt` to GMP as `Ref{BigInt}`, relying on it being
+# laid out as an `__mpz_struct`. It no longer is: the limbs live in a `Memory`,
+# so the C side would read `size` as alloc/size and take the `Memory` object
+# itself for the limb pointer. Fail loudly instead of corrupting memory. Both
+# `ccall(..., (Ref{BigInt},), x)` and `Ref(x)` reach this method.
+function Base.unsafe_convert(::Type{Ref{BigInt}}, ::Base.RefValue{BigInt})
+    throw(ArgumentError("`BigInt` cannot be passed to C as `Ref{BigInt}`: its limbs are GC-managed, so it is not an `__mpz_struct`. " *
+                        "For arguments GMP only reads, use `Base.GMP.MPZ.mpz_t`; for ones it writes, use `Base.GMP.MPZ.with_output`."))
+end
 
 widen(::Type{Int128})  = BigInt
 widen(::Type{UInt128}) = BigInt

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -182,26 +182,16 @@ Base.cconvert(::Type{mpz_t}, a::BigInt) = (Ref(_view(a)), a.d)
 Base.unsafe_convert(::Type{mpz_t}, t::Tuple{Base.RefValue{MPZView},MP}) =
     Base.unsafe_convert(mpz_t, t[1])
 
-# Capacity for `n` limbs. Contents are not preserved and `x.d` may be replaced,
-# so a caller that also reads `x`'s old limbs must bind them first.
-@inline function _ensure!(x::BigInt, n::Int)
-    d = x.d
-    if length(d) < n
-        d = MP(undef, n)
-        x.d = d
-    end
-    return d
-end
-
-# An `n`-limb buffer for an output that must not overlap any of `avoid`: `x`'s
-# own limbs if they are big enough and not among `avoid`, otherwise a new one.
+# An `n`-limb buffer for `x`'s new value: its own limbs if they are big enough
+# and not among `avoid`, otherwise a new one. `_finish!` installs it, so until
+# then `x`'s old limbs stay readable.
 @inline function _dest(x::BigInt, n::Int, avoid::Vararg{MP,N}) where {N}
     d = x.d
     return (length(d) >= n && !any(m -> m === d, avoid)) ? d : MP(undef, n)
 end
 
-# Publish `n` limbs of `d` as `x`'s value, with sign `neg`. Every kernel-backed
-# write ends here, which is what restores `BigInt`'s invariants.
+# Publish `n` limbs of `d` as `x`'s value, with sign `neg`. Every write of new
+# limbs ends here, which is what restores `BigInt`'s invariants.
 @inline function _finish!(x::BigInt, d::MP, n::Int, neg::Bool)
     x.d = d
     sz = n
@@ -223,17 +213,14 @@ _zero!(x::BigInt) = (x.size = 0; x)
     return d
 end
 
-realloc2!(x::BigInt, a) = (_ensure!(x, cld(Int(a), BITS_PER_LIMB)); x)
+realloc2!(x::BigInt, a) = (x.d = _dest(x, cld(Int(a), BITS_PER_LIMB)); x)
 
 # Copy a GMP-owned mpz, given as its signed size and limb pointer, into `x`.
-# No normalization: every mpz function leaves its output with a nonzero top
-# limb, so `BigInt`'s invariant carries over as is.
 function _take!(x::BigInt, sz::Cint, p::Ptr{Limb})
     n = abs(Int(sz))
-    d = _ensure!(x, n)
+    d = _dest(x, n)
     n > 0 && GC.@preserve d unsafe_copyto!(pointer(d), p, n)
-    x.size = Int(sz)
-    return x
+    return _finish!(x, d, n, sz < 0)
 end
 _take!(x::BigInt, s::MPZOwned) = _take!(x, s.size, s.d)
 
@@ -308,11 +295,7 @@ end
 function set!(x::BigInt, a::BigInt)
     x === a && return x
     n = abs(a.size)
-    ad = a.d
-    d = _ensure!(x, n)
-    copyto!(d, 1, ad, 1, n)
-    x.size = a.size
-    return x
+    return _finish!(x, copyto!(_dest(x, n), 1, a.d, 1, n), n, a.size < 0)
 end
 
 function _addsub!(x::BigInt, a::BigInt, b::BigInt, negb::Bool)
@@ -322,11 +305,10 @@ function _addsub!(x::BigInt, a::BigInt, b::BigInt, negb::Bool)
     bs == 0 && return set!(x, a)
     as == 0 && return negb ? neg!(x, b) : set!(x, b)
     an, bn = abs(as), abs(bs)
-    # Bind the operands before `_ensure!` can replace `x.d` out from under them.
     ad, bd = a.d, b.d
     if (as > 0) == (bs > 0)
         an < bn && ((ad, an, bd, bn) = (bd, bn, ad, an)) # longer operand first
-        d = _ensure!(x, an + 1)
+        d = _dest(x, an + 1)
         c = _mpn_add(d, ad, an % mp_size_t, bd, bn % mp_size_t)
         @inbounds d[an+1] = c
         return _finish!(x, d, an + 1, as < 0)
@@ -335,7 +317,7 @@ function _addsub!(x::BigInt, a::BigInt, b::BigInt, negb::Bool)
     rel == 0 && return _zero!(x)
     neg = (rel < 0) != (as < 0)   # the larger magnitude's sign
     rel < 0 && ((ad, an, bd, bn) = (bd, bn, ad, an))
-    d = _ensure!(x, an)
+    d = _dest(x, an)
     _mpn_sub(d, ad, an % mp_size_t, bd, bn % mp_size_t)
     return _finish!(x, d, an, neg)
 end
@@ -350,17 +332,17 @@ function _addsub_mag!(x::BigInt, a::BigInt, v::Limb, neg::Bool)
     an = abs(as)
     ad = a.d
     if as != 0 && (as > 0) != neg      # magnitudes add
-        d = _ensure!(x, an + 1)
+        d = _dest(x, an + 1)
         @inbounds d[an+1] = _mpn_add_1(d, ad, an % mp_size_t, v)
         return _finish!(x, d, an + 1, as < 0)
     elseif an > 1 || (an == 1 && (@inbounds ad[1]) >= v)   # |a| >= v
-        d = _ensure!(x, an)
+        d = _dest(x, an)
         _mpn_sub_1(d, ad, an % mp_size_t, v)
         return _finish!(x, d, an, as < 0)
     end
     # |a| < v, which `v` being one limb confines to `an <= 1`, so the result
     # is the single limb `v - |a|`, with `v`'s sign.
-    d = _ensure!(x, 1)
+    d = _dest(x, 1)
     @inbounds d[1] = v - (an == 0 ? zero(Limb) : (@inbounds ad[1]))
     return _finish!(x, d, 1, neg)
 end
@@ -397,7 +379,7 @@ function _mul_mag!(x::BigInt, a::BigInt, v::Limb, neg::Bool)
     (as == 0 || v == 0) && return _zero!(x)
     an = abs(as)
     ad = a.d
-    d = _ensure!(x, an + 1)
+    d = _dest(x, an + 1)
     @inbounds d[an+1] = _mpn_mul_1(d, ad, an % mp_size_t, v)
     return _finish!(x, d, an + 1, (as < 0) != neg)
 end
@@ -430,12 +412,12 @@ function _tdiv!(q::Union{BigInt,Nothing}, r::Union{BigInt,Nothing}, a::BigInt, b
         else
             # `mpn_divrem_1` allows `qp == np`, and `v` is already read, so `q`
             # may alias either input.
-            qd = _ensure!(q, an)
+            qd = _dest(q, an)
             rl = _mpn_divrem_1(qd, ad, an % mp_size_t, v)
             _finish!(q, qd, an, qneg)
         end
         if r !== nothing
-            rd = _ensure!(r, 1)
+            rd = _dest(r, 1)
             @inbounds rd[1] = rl
             _finish!(r, rd, 1, as < 0)
         end
@@ -513,8 +495,7 @@ function _bitop!(op::F, x::BigInt, a::BigInt, b::BigInt) where {F}
     as, bs = a.size, b.size
     an, bn = abs(as), abs(bs)
     aneg, bneg = as < 0, bs < 0
-    # Bind before `_ensure!`; `d` may then be `ad` or `bd`, which the upward
-    # scans tolerate.
+    # `d` may be `ad` or `bd`, which the upward scans tolerate.
     ad, bd = a.d, b.d
     if !aneg && !bneg
         # A non-negative magnitude is its own two's-complement expansion,
@@ -524,7 +505,7 @@ function _bitop!(op::F, x::BigInt, a::BigInt, b::BigInt) where {F}
         lo, hi = minmax(an, bn)
         hd = an >= bn ? ad : bd
         n = iszero(op(~zero(Limb), zero(Limb))) ? lo : hi
-        d = _ensure!(x, n)
+        d = _dest(x, n)
         @inbounds for i in 1:lo
             d[i] = op(ad[i], bd[i])
         end
@@ -538,7 +519,7 @@ function _bitop!(op::F, x::BigInt, a::BigInt, b::BigInt) where {F}
     # One limb beyond both operands, holding each one's sign extension: 0 or
     # ~0, so it records the result's sign and absorbs the negation's carry.
     n = max(an, bn) + 1
-    d = _ensure!(x, n)
+    d = _dest(x, n)
     @inbounds for i in 1:n
         d[i] = op(_tc(ad, an, aneg, alow, i), _tc(bd, bn, bneg, blow, i))
     end
@@ -568,7 +549,7 @@ function mul_2exp!(x::BigInt, a::BigInt, c)
     n = an + off + (sh > 0)
     # In place is fine: `mpn_lshift` permits overlap when `rp >= up`, which
     # holds with `rp = d + off`, and `copyto!` on one buffer is a memmove.
-    d = _ensure!(x, n)
+    d = _dest(x, n)
     if sh == 0
         copyto!(d, off+1, ad, 1, an)
     else
@@ -595,7 +576,7 @@ function fdiv_q_2exp!(x::BigInt, a::BigInt, c)
     # In place is fine: `mpn_rshift` permits overlap when `rp <= up`, which
     # holds with `up = ad + off`, and `lost` has already read the low limbs.
     # The extra limb leaves `_dec!` room for a carry without reallocating.
-    d = _ensure!(x, n + lost)
+    d = _dest(x, n + lost)
     if sh == 0
         copyto!(d, 1, ad, off+1, n)
     else
@@ -670,7 +651,7 @@ end
 
 function _set_mag!(x::BigInt, u::UInt64, neg::Bool)
     n = cld(64, BITS_PER_LIMB)
-    d = _ensure!(x, n)
+    d = _dest(x, n)
     return _finish!(x, _store!(d, 0, u), n, neg)
 end
 
@@ -690,7 +671,7 @@ function set_d!(x::BigInt, a)
     off, sh = divrem(e, BITS_PER_LIMB)
     w = UInt128(sig) << sh         # at most 53 + 63 bits
     n = off + cld(128, BITS_PER_LIMB)
-    d = _ensure!(x, n)
+    d = _dest(x, n)
     fill!(@view(d[1:off]), zero(Limb))
     return _finish!(x, _store!(d, off, w), n, v < 0)
 end
@@ -880,7 +861,7 @@ function BigInt(x::Integer)
     ux = unsigned(x < 0 ? -%(x) : x)
     n = cld(top_set_bit(ux), BITS_PER_LIMB)
     z = BigInt()
-    d = MPZ._ensure!(z, n)
+    d = MPZ._dest(z, n)
     @inbounds for i in 1:n
         d[i] = ux % Limb
         ux >>= BITS_PER_LIMB

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -497,7 +497,7 @@ function _rdiv_q!(x::BigInt, a::BigInt, b::BigInt, down::Bool)
         rd = Memory{Limb}(undef, bn)
         _mpn_tdiv_qr(qd, rd, ad, an % mp_size_t, bd, bn % mp_size_t)
         _finish!(x, qd, qn, neg)
-        rnz = _norm(rd, bn) != 0
+        rnz = any(!iszero, @view rd[1:bn])
     end
     wrong && rnz && (down ? _dec!(x) : _inc!(x))
     return x

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -401,108 +401,62 @@ mul_ui!(x::BigInt, a::BigInt, b) = _mul_mag!(x, a, Limb(b), false)
 mul_si!(x::BigInt, a::BigInt, b) = ((v, neg) = _magsign(b); _mul_mag!(x, a, Limb(v), neg))
 
 # Truncated division: q = trunc(a/b) and r = a - q*b, so `r` carries `a`'s
-# sign. `mpn_tdiv_qr` writes both outputs and forbids overlap among them and
-# its inputs, so each variant below gives the output it does not want scratch
-# limbs, and only the wanted one a `_dest` buffer.
-function tdiv_q!(x::BigInt, a::BigInt, b::BigInt)
+# sign. Either output may be `nothing` when it is not wanted; every call site
+# passes a literal, so each combination compiles to its own body. `mpn_tdiv_qr`
+# writes both outputs and forbids overlap among them and its inputs, so an
+# unwanted output gets scratch limbs and a wanted one a `_dest` buffer.
+# Returns whether the remainder is nonzero, which the rounding variants need.
+function _tdiv!(q::Union{BigInt,Nothing}, r::Union{BigInt,Nothing}, a::BigInt, b::BigInt)
     Base.@cancel_check
     as, bs = a.size, b.size
     bs == 0 && throw(DivideError())
     an, bn = abs(as), abs(bs)
-    an < bn && (x.size = 0; return x)
+    if an < bn # |a| < |b|: the quotient is 0 and the remainder is `a`
+        q === nothing || (q.size = 0)
+        r === nothing || set!(r, a)
+        return as != 0
+    end
     ad, bd = a.d, b.d
-    neg = (as < 0) != (bs < 0)
+    qneg = (as < 0) != (bs < 0)
     if bn == 1
         v = @inbounds bd[1]
-        qd = _ensure!(x, an)
-        _mpn_divrem_1(qd, ad, an % mp_size_t, v)
-        return _finish!(x, qd, an, neg)
+        if q === nothing
+            rl = _mpn_mod_1(ad, an % mp_size_t, v)
+        else
+            # `mpn_divrem_1` allows `qp == np`, and `v` is already read, so `q`
+            # may alias either input.
+            qd = _ensure!(q, an)
+            rl = _mpn_divrem_1(qd, ad, an % mp_size_t, v)
+            _finish!(q, qd, an, qneg)
+        end
+        if r !== nothing
+            rd = _ensure!(r, 1)
+            @inbounds rd[1] = rl
+            _finish!(r, rd, 1, as < 0)
+        end
+        return rl != 0
     end
     qn = an - bn + 1
-    qd = _dest(x, qn, ad, bd)
-    _mpn_tdiv_qr(qd, Memory{Limb}(undef, bn), ad, an % mp_size_t, bd, bn % mp_size_t)
-    return _finish!(x, qd, qn, neg)
-end
-
-function tdiv_r!(x::BigInt, a::BigInt, b::BigInt)
-    Base.@cancel_check
-    as, bs = a.size, b.size
-    bs == 0 && throw(DivideError())
-    an, bn = abs(as), abs(bs)
-    an < bn && return set!(x, a)
-    ad, bd = a.d, b.d
-    if bn == 1
-        rl = _mpn_mod_1(ad, an % mp_size_t, @inbounds bd[1])
-        d = _ensure!(x, 1)
-        @inbounds d[1] = rl
-        return _finish!(x, d, 1, as < 0)
-    end
-    rd = _dest(x, bn, ad, bd)
-    _mpn_tdiv_qr(Memory{Limb}(undef, an - bn + 1), rd, ad, an % mp_size_t, bd, bn % mp_size_t)
-    return _finish!(x, rd, bn, as < 0)
-end
-
-function tdiv_qr!(x::BigInt, y::BigInt, a::BigInt, b::BigInt)
-    Base.@cancel_check
-    as, bs = a.size, b.size
-    bs == 0 && throw(DivideError())
-    an, bn = abs(as), abs(bs)
-    if an < bn
-        x.size = 0
-        set!(y, a)
-        return x, y
-    end
-    ad, bd = a.d, b.d
-    neg = (as < 0) != (bs < 0)
-    if bn == 1
-        v = @inbounds bd[1]
-        # `mpn_divrem_1` allows `qp == np`, and `v` is already read, so `x`
-        # may alias either input here, as in `tdiv_q!`.
-        qd = _ensure!(x, an)
-        rl = _mpn_divrem_1(qd, ad, an % mp_size_t, v)
-        rdy = _ensure!(y, 1)
-        @inbounds rdy[1] = rl
-        _finish!(x, qd, an, neg)
-        _finish!(y, rdy, 1, as < 0)
-        return x, y
-    end
-    qn = an - bn + 1
-    qd = _dest(x, qn, ad, bd)
-    rd = _dest(y, bn, ad, bd, qd)
+    qd = q === nothing ? Memory{Limb}(undef, qn) : _dest(q, qn, ad, bd)
+    rd = r === nothing ? Memory{Limb}(undef, bn) : _dest(r, bn, ad, bd, qd)
     _mpn_tdiv_qr(qd, rd, ad, an % mp_size_t, bd, bn % mp_size_t)
-    _finish!(x, qd, qn, neg)
-    _finish!(y, rd, bn, as < 0)
-    return x, y
+    q === nothing || _finish!(q, qd, qn, qneg)
+    r === nothing && return any(!iszero, @view rd[1:bn])
+    _finish!(r, rd, bn, as < 0)
+    return r.size != 0
 end
+
+tdiv_q!(x::BigInt, a::BigInt, b::BigInt) = (_tdiv!(x, nothing, a, b); x)
+tdiv_r!(x::BigInt, a::BigInt, b::BigInt) = (_tdiv!(nothing, x, a, b); x)
+tdiv_qr!(x::BigInt, y::BigInt, a::BigInt, b::BigInt) = (_tdiv!(x, y, a, b); (x, y))
 tdiv_qr(a::BigInt, b::BigInt) = tdiv_qr!(BigInt(), BigInt(), a, b)
 
-# Floor (`down`) and ceiling division. The truncated result is off by one
+# Floor (`down`) and ceiling division. The truncated quotient is off by one
 # exactly when the remainder is nonzero and carries the "wrong" sign, which is
 # `a`'s, so `wrong` is known before the division runs.
 function _rdiv_q!(x::BigInt, a::BigInt, b::BigInt, down::Bool)
-    Base.@cancel_check
-    as, bs = a.size, b.size
-    bs == 0 && throw(DivideError())
-    an, bn = abs(as), abs(bs)
-    wrong = ((as < 0) != (bs < 0)) == down
-    # |a| < |b|: the truncated quotient is 0 and the remainder is `a`.
-    an < bn && return set_si!(x, (as != 0 && wrong) ? (down ? -1 : 1) : 0)
-    ad, bd = a.d, b.d
-    neg = (as < 0) != (bs < 0)
-    # Only whether the discarded remainder is nonzero matters.
-    if bn == 1
-        v = @inbounds bd[1]
-        qd = _ensure!(x, an)
-        rnz = _mpn_divrem_1(qd, ad, an % mp_size_t, v) != 0
-        _finish!(x, qd, an, neg)
-    else
-        qn = an - bn + 1
-        qd = _dest(x, qn, ad, bd)
-        rd = Memory{Limb}(undef, bn)
-        _mpn_tdiv_qr(qd, rd, ad, an % mp_size_t, bd, bn % mp_size_t)
-        _finish!(x, qd, qn, neg)
-        rnz = any(!iszero, @view rd[1:bn])
-    end
+    wrong = ((a.size < 0) != (b.size < 0)) == down
+    rnz = _tdiv!(x, nothing, a, b)
     wrong && rnz && (down ? _dec!(x) : _inc!(x))
     return x
 end

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -174,8 +174,8 @@ Base.unsafe_convert(::Type{mpz_t}, t::Tuple{Base.RefValue{MPZView},Memory{Limb}}
     return d
 end
 
-# An `n`-limb buffer for an output that must not overlap any of `avoid`:
-# `x`'s own limbs when they are big enough and none of those, else a new one.
+# An `n`-limb buffer for an output that must not overlap any of `avoid`: `x`'s
+# own limbs if they are big enough and not among `avoid`, otherwise a new one.
 @inline function _dest(x::BigInt, n::Int, avoid::Vararg{Memory{Limb},N}) where {N}
     d = x.d
     return (length(d) >= n && !any(m -> m === d, avoid)) ? d : Memory{Limb}(undef, n)
@@ -226,17 +226,24 @@ function _take!(x::BigInt, sz::Cint, p::Ptr{Limb})
     x.size = Int(sz)
     return x
 end
+_take!(x::BigInt, s::Scratch) = _take!(x, s.size, s.d)
 
-# Run `f` on a GMP-owned output mpz, move it into `x`, free it, return `f`'s value.
-function with_output(f::F, x::BigInt) where {F}
-    s = Scratch()
-    ccall((:__gmpz_init, libgmp), Cvoid, (scratch_t,), s)
+# The GMP-owned scratch object for an output `x`, and its init/clear entry
+# points. `MPQ` extends these for `Rational{BigInt}`.
+_scratch(::BigInt) = Scratch()
+_init!(s::Scratch) = (ccall((:__gmpz_init, libgmp), Cvoid, (scratch_t,), s); s)
+_clear!(s::Scratch) = ccall((:__gmpz_clear, libgmp), Cvoid, (scratch_t,), s)
+
+# Run `f` on a GMP-owned scratch output, move it into `x`, free it, and return
+# `f`'s value. Only the output needs GMP-owned limbs; inputs stay views.
+function with_output(f::F, x) where {F}
+    s = _init!(_scratch(x))
     try
         ret = f(s)
-        _take!(x, s.size, s.d)
+        _take!(x, s)
         return ret
     finally
-        ccall((:__gmpz_clear, libgmp), Cvoid, (scratch_t,), s)
+        _clear!(s)
     end
 end
 
@@ -290,9 +297,6 @@ function _ucmp(ad::Memory{Limb}, an::Int, bd::Memory{Limb}, bn::Int)
     return Int(_mpn_cmp(ad, bd, an % mp_size_t))
 end
 
-# Move `y`'s limbs into `x`. `y` must be a temporary that no longer escapes.
-@inline _move!(x::BigInt, y::BigInt) = (x.d = y.d; x.size = y.size; x)
-
 function set!(x::BigInt, a::BigInt)
     x === a && return x
     n = abs(a.size)
@@ -302,7 +306,6 @@ function set!(x::BigInt, a::BigInt)
     x.size = a.size
     return x
 end
-set(a::BigInt) = set!(BigInt(), a)
 
 function _addsub!(x::BigInt, a::BigInt, b::BigInt, negb::Bool)
     as = a.size
@@ -467,7 +470,9 @@ function _rdiv_r!(x::BigInt, a::BigInt, b::BigInt, down::Bool)
     tdiv_r!(r, a, b)
     rs = r.size
     rs != 0 && ((rs < 0) != bneg) == down && _addsub!(r, r, b, !down)
-    return r === x ? x : _move!(x, r)
+    r === x && return x
+    x.d, x.size = r.d, r.size   # `r` was a temporary, so its buffer just moves
+    return x
 end
 
 fdiv_q!(x::BigInt, a::BigInt, b::BigInt) = _rdiv_q!(x, a, b, true)
@@ -727,12 +732,11 @@ for op in (:add_ui, :sub_ui, :mul_ui, :mul_si, :mul_2exp, :fdiv_q_2exp, :pow_ui,
     end
 end
 
-for op in (:neg, :com, :sqrt)
+for op in (:neg, :com, :sqrt, :set)
     op! = Symbol(op, :!)
-    @eval begin
-        $op(a::BigInt) = $op!(BigInt(), a)
-        $op!(x::BigInt) = $op!(x, x)
-    end
+    @eval $op(a::BigInt) = $op!(BigInt(), a)
+    op === :set && continue # MPZ.set!(x) would make no sense
+    @eval $op!(x::BigInt) = $op!(x, x)
 end
 
 # None of these writes its operand, so a borrowed view is sound throughout.
@@ -749,9 +753,28 @@ popcount(a::BigInt) = Int(signed(ccall((:__gmpz_popcount, libgmp), Culong, (mpz_
 mpn_popcount(d::MP, s::Integer) = Int(ccall((:__gmpn_popcount, libgmp), Culong, (Ptr{Limb}, Csize_t), d, s))
 mpn_popcount(a::BigInt) = mpn_popcount(a.d, abs(a.size))
 
-cmp(a::BigInt, b::BigInt) = Int(ccall((:__gmpz_cmp, libgmp), Cint, (mpz_t, mpz_t), a, b))
-cmp_si(a::BigInt, b) = Int(ccall((:__gmpz_cmp_si, libgmp), Cint, (mpz_t, Clong), a, b))
-cmp_ui(a::BigInt, b) = Int(ccall((:__gmpz_cmp_ui, libgmp), Cint, (mpz_t, Culong), a, b))
+# The signed `size` orders first: its sign is the number's, and with equal signs
+# more limbs means a larger magnitude. Only equal sizes need the limbs compared.
+function cmp(a::BigInt, b::BigInt)
+    as, bs = a.size, b.size
+    as != bs && return as < bs ? -1 : 1
+    as == 0 && return 0
+    c = _ucmp(a.d, abs(as), b.d, abs(as))
+    return as < 0 ? -c : c
+end
+
+# Compare `a` with the one-limb magnitude `v` carrying sign `neg`.
+function _cmp_mag(a::BigInt, v::Limb, neg::Bool)
+    as = a.size
+    bs = v == 0 ? 0 : (neg ? -1 : 1)
+    as != bs && return as < bs ? -1 : 1
+    as == 0 && return 0
+    a1 = @inbounds a.d[1]
+    c = a1 == v ? 0 : (a1 < v ? -1 : 1)
+    return as < 0 ? -c : c
+end
+cmp_si(a::BigInt, b) = ((v, neg) = _magsign(b); _cmp_mag(a, Limb(v), neg))
+cmp_ui(a::BigInt, b) = _cmp_mag(a, Limb(b), false)
 cmp_d(a::BigInt, b) = Int(ccall((:__gmpz_cmp_d, libgmp), Cint, (mpz_t, Cdouble), a, b))
 
 mpn_cmp(a::BigInt, b::BigInt, c) = _mpn_cmp(a.d, b.d, c)
@@ -871,20 +894,15 @@ function BigInt(x::Integer)
     # On 64-bit Windows, `Clong` is `Int32`, not `Int64`, so construction of
     # `Int64` constants, e.g. `BigInt(3)`, uses this method.
     isbits(x) && typemin(Clong) <= x <= typemax(Clong) && return BigInt((x % Clong)::Clong)
-    nd = ndigits(x, base=2)
-    z = MPZ.realloc2(nd)
-    d = z.d
+    n = cld(ndigits(x, base=2), BITS_PER_LIMB)
+    z = BigInt()
+    d = MPZ._ensure!(z, n)
     ux = unsigned(x < 0 ? -%(x) : x)
-    size = 0
-    limbnbits = sizeof(Limb) << 3
-    while nd > 0
-        size += 1
-        @inbounds d[size] = ux % Limb
-        ux >>= limbnbits
-        nd -= limbnbits
+    @inbounds for i in 1:n
+        d[i] = ux % Limb
+        ux >>= BITS_PER_LIMB
     end
-    z.size = x < 0 ? -size : size
-    z
+    return MPZ._finish!(z, d, n, x < 0)
 end
 
 
@@ -1442,17 +1460,18 @@ if Limb === UInt64 === UInt
 
     using .Base: HASH_SECRET, hash_bytes
 
-    struct LimbView <: AbstractVector{UInt8}
+    # UnsafeLimbView provides a safe iterator interface to BigInt limb data
+    struct UnsafeLimbView <: AbstractVector{UInt8}
         bigint::BigInt
         start_byte::Int
         num_bytes::Int
     end
 
-    function Base.size(view::LimbView)
+    function Base.size(view::UnsafeLimbView)
         return (view.num_bytes,)
     end
 
-    function Base.getindex(view::LimbView, i::Int)
+    function Base.getindex(view::UnsafeLimbView, i::Int)
         @boundscheck checkbounds(view, i)
         limb_index = div(view.start_byte + i - 2, 8) + 1
         byte_in_limb = (view.start_byte + i - 2) % 8
@@ -1460,12 +1479,12 @@ if Limb === UInt64 === UInt
         return UInt8((limb >> (8 * byte_in_limb)) & 0xff)
     end
 
-    function Base.iterate(view::LimbView, state::Int = 1)
+    function Base.iterate(view::UnsafeLimbView, state::Int = 1)
         state > view.num_bytes && return nothing
         return @inbounds(view[state]), state + 1
     end
 
-    function Base.length(view::LimbView)
+    function Base.length(view::UnsafeLimbView)
         return view.num_bytes
     end
 
@@ -1478,7 +1497,8 @@ if Limb === UInt64 === UInt
         leading_zero_bytes = div(leading_zeros(@inbounds n.d[us]), 8)
         num_bytes = 8 * us - leading_zero_bytes
 
-        limb_view = LimbView(n, 1, num_bytes)
+        # Use UnsafeLimbView for safe iterator-based access
+        limb_view = UnsafeLimbView(n, 1, num_bytes)
         return hash_bytes(limb_view, h, HASH_SECRET)
     end
 
@@ -1515,7 +1535,8 @@ if Limb === UInt64 === UInt
         trailing_zero_bytes = div(pow, 8)
         num_bytes = 8 * asz - (leading_zero_bytes + trailing_zero_bytes)
 
-        limb_view = LimbView(x, trailing_zero_bytes + 1, num_bytes)
+        # Use UnsafeLimbView for safe iterator-based access
+        limb_view = UnsafeLimbView(x, trailing_zero_bytes + 1, num_bytes)
         return hash_bytes(limb_view, h, HASH_SECRET)
     end
 end
@@ -1559,25 +1580,17 @@ mutable struct _MPQ
 end
 const mpq_t = Ref{_MPQ}
 
-_init!(q::_MPQ) = (ccall((:__gmpq_init, libgmp), Cvoid, (mpq_t,), q); q)
-_clear!(q::_MPQ) = ccall((:__gmpq_clear, libgmp), Cvoid, (mpq_t,), q)
-
-function _take!(z::Rational{BigInt}, q::_MPQ)
+# Hook `Rational{BigInt}` into `MPZ.with_output`.
+MPZ._scratch(::Rational{BigInt}) = _MPQ()
+MPZ._init!(q::_MPQ) = (ccall((:__gmpq_init, libgmp), Cvoid, (mpq_t,), q); q)
+MPZ._clear!(q::_MPQ) = ccall((:__gmpq_clear, libgmp), Cvoid, (mpq_t,), q)
+function MPZ._take!(z::Rational{BigInt}, q::_MPQ)
     MPZ._take!(z.num, q.num_size, q.num_d)
     MPZ._take!(z.den, q.den_size, q.den_d)
     return z
 end
-
-# Only the output needs GMP-owned limbs; `mpq_add` and friends take const operands.
-function _with_output(f::F, z::Rational{BigInt}) where {F}
-    q = _init!(_MPQ())
-    try
-        f(q)
-        return _take!(z, q)
-    finally
-        _clear!(q)
-    end
-end
+# `mpq` results always come back as the rational itself.
+_with_output(f::F, z::Rational{BigInt}) where {F} = (MPZ.with_output(f, z); z)
 
 function Rational{BigInt}(num::BigInt, den::BigInt)
     if iszero(den)

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -62,15 +62,13 @@ end
 Arbitrary precision integer type.
 """
 mutable struct BigInt <: Signed
-    alloc::Cint
-    size::Cint
-    d::Ptr{Limb}
+    # sign(size) is the sign of the number, `abs(size)` is the number of significant limbs.
+    # Invariants, matching GMP: `abs(size) <= length(d)`, `d[abs(size)] != 0` when `size != 0`.
+    size::Int
+    d::Memory{Limb}
 
-    function BigInt(; nbits::Integer=0)
-        b = MPZ.init2!(new(), nbits)
-        finalizer(cglobal((:__gmpz_clear, libgmp)), b)
-        return b
-    end
+    global _bigint(size::Int, d::Memory{Limb}) = new(size, d)
+    BigInt(; nbits::Integer=0) = new(0, Memory{Limb}(undef, cld(Int(nbits), BITS_PER_LIMB)))
 end
 
 """
@@ -122,8 +120,6 @@ function __init__()
               cglobal(:jl_gmp_counted_malloc),
               cglobal(:jl_gmp_counted_realloc_with_old_size),
               cglobal(:jl_gmp_counted_free_with_size))
-        ZERO.alloc, ZERO.size, ZERO.d = 0, 0, C_NULL
-        ONE.alloc, ONE.size, ONE.d = 1, 1, pointer(_ONE)
     catch ex
         Base.showerror_nostdio(ex, "WARNING: Error during initialization of module GMP")
     end
@@ -143,129 +139,665 @@ end
 
 
 module MPZ
-# wrapping of libgmp functions
-# - "output parameters" are labeled x, y, z, and are returned when appropriate
-# - constant input parameters are labeled a, b, c
-# - a method modifying its input has a "!" appended to its name, according to Julia's conventions
-# - some convenient methods are added (in addition to the pure MPZ ones), e.g. `add(a, b) = add!(BigInt(), a, b)`
-#   and `add!(x, a) = add!(x, x, a)`.
+# We reimplement the mpz layer of gmp using either mpn or Julia implementations
+# so that we can handle the memory management ourselves. For some complicated functions
+# we wrap mpz using MPZView rather than BigInt.
 using ..GMP: BigInt, Limb, BITS_PER_LIMB, libgmp
 
-const mpz_t = Ref{BigInt}
+# `mpz_t` is `__mpz_struct*`, so `Ref{MPZView}` is ABI-identical.
+# Valid only  for calls that never reallocate: those would hand a GC pointer to `free`.
+struct MPZView
+    alloc::Cint
+    size::Cint
+    d::Ptr{Limb}
+end
+const mpz_t = Ref{MPZView}
 const bitcnt_t = Culong
+const mp_size_t = Clong
 
-gmpz(op::Symbol) = Expr(:tuple, QuoteNode(Symbol(:__gmpz_, op)), GlobalRef(MPZ, :libgmp))
+@inline _view(a::BigInt) = MPZView(length(a.d) % Cint, a.size % Cint, pointer(a.d))
 
-init!(x::BigInt) = (ccall((:__gmpz_init, libgmp), Cvoid, (mpz_t,), x); x)
-init2!(x::BigInt, a) = (ccall((:__gmpz_init2, libgmp), Cvoid, (mpz_t, bitcnt_t), x, a); x)
+# `cconvert` hands back the limbs alongside the header, so `ccall` roots them
+# for the duration of the call.
+Base.cconvert(::Type{mpz_t}, a::BigInt) = (Ref(_view(a)), a.d)
+Base.unsafe_convert(::Type{mpz_t}, t::Tuple{Base.RefValue{MPZView},Memory{Limb}}) =
+    Base.unsafe_convert(mpz_t, t[1])
 
-realloc2!(x, a) = (ccall((:__gmpz_realloc2, libgmp), Cvoid, (mpz_t, bitcnt_t), x, a); x)
+# Capacity for `n` limbs. Contents are not preserved and `x.d` may be replaced,
+# so a caller that also reads `x`'s old limbs must bind them first.
+@inline function _ensure!(x::BigInt, n::Int)
+    d = x.d
+    if length(d) < n
+        d = Memory{Limb}(undef, n)
+        x.d = d
+    end
+    return d
+end
+
+# An `n`-limb buffer for an output that must not overlap any of `avoid`:
+# `x`'s own limbs when they are big enough and none of those, else a new one.
+@inline function _dest(x::BigInt, n::Int, avoid::Vararg{Memory{Limb},N}) where {N}
+    d = x.d
+    return (length(d) >= n && !any(m -> m === d, avoid)) ? d : Memory{Limb}(undef, n)
+end
+
+# Publish `n` limbs of `d` as `x`'s value, with sign `neg`. Every write ends
+# here, which is what restores `BigInt`'s invariants.
+@inline function _finish!(x::BigInt, d::Memory{Limb}, n::Int, neg::Bool)
+    x.d === d || (x.d = d)
+    sz = something(findlast(!iszero, @view d[1:n]), 0)
+    x.size = neg ? -sz : sz
+    return x
+end
+
+@inline function _magsign(a)
+    s = Int64(a)
+    u = s % UInt64
+    return (s < 0 ? -u : u, s < 0)
+end
+
+# Split `u` into limbs, writing them at `d[off+1:]`.
+@inline function _store!(d::Memory{Limb}, off::Int, u::Union{UInt64,UInt128})
+    @inbounds for i in 1:cld(8*sizeof(u), BITS_PER_LIMB)
+        d[off+i] = (u >> ((i - 1) * BITS_PER_LIMB)) % Limb
+    end
+    return d
+end
+
+realloc2!(x::BigInt, a) = (_ensure!(x, cld(Int(a), BITS_PER_LIMB)); x)
 realloc2(a) = realloc2!(BigInt(), a)
+
+# A GMP-owned mpz, for the operations with no suitable `mpn` form.
+mutable struct Scratch
+    alloc::Cint
+    size::Cint
+    d::Ptr{Limb}
+    Scratch() = new(0, 0, C_NULL)
+end
+const scratch_t = Ref{Scratch}
+
+# Copy a GMP-owned mpz, given as its signed size and limb pointer, into `x`.
+function _take!(x::BigInt, sz::Cint, p::Ptr{Limb})
+    n = abs(Int(sz))
+    d = _ensure!(x, n)
+    n > 0 && GC.@preserve d unsafe_copyto!(pointer(d), p, n)
+    x.size = Int(sz)
+    return x
+end
+
+# Run `f` on a GMP-owned output mpz, move it into `x`, free it, return `f`'s value.
+function with_output(f::F, x::BigInt) where {F}
+    s = Scratch()
+    ccall((:__gmpz_init, libgmp), Cvoid, (scratch_t,), s)
+    try
+        ret = f(s)
+        _take!(x, s.size, s.d)
+        return ret
+    finally
+        ccall((:__gmpz_clear, libgmp), Cvoid, (scratch_t,), s)
+    end
+end
+
+# Limb-array kernels; callers must respect each one's overlap rules. `ccall`
+# roots a `Memory`, so no caller needs `GC.@preserve`. `ro`/`uo` are the limb
+# offsets of the shifts, the only kernels not applied at a buffer's start.
+const MP = Memory{Limb}
+
+_mpn_add(r::MP, u::MP, un, v::MP, vn) = ccall((:__gmpn_add, libgmp), Limb,
+    (Ptr{Limb}, Ptr{Limb}, mp_size_t, Ptr{Limb}, mp_size_t), r, u, un, v, vn)
+_mpn_add_1(r::MP, u::MP, un, v) = ccall((:__gmpn_add_1, libgmp), Limb,
+    (Ptr{Limb}, Ptr{Limb}, mp_size_t, Limb), r, u, un, v)
+_mpn_sub(r::MP, u::MP, un, v::MP, vn) = ccall((:__gmpn_sub, libgmp), Limb,
+    (Ptr{Limb}, Ptr{Limb}, mp_size_t, Ptr{Limb}, mp_size_t), r, u, un, v, vn)
+_mpn_sub_1(r::MP, u::MP, un, v) = ccall((:__gmpn_sub_1, libgmp), Limb,
+    (Ptr{Limb}, Ptr{Limb}, mp_size_t, Limb), r, u, un, v)
+_mpn_mul_1(r::MP, u::MP, un, v) = ccall((:__gmpn_mul_1, libgmp), Limb,
+    (Ptr{Limb}, Ptr{Limb}, mp_size_t, Limb), r, u, un, v)
+_mpn_cmp(u::MP, v::MP, n) = ccall((:__gmpn_cmp, libgmp), Cint,
+    (Ptr{Limb}, Ptr{Limb}, mp_size_t), u, v, n)
+# Single-limb division, which needs no buffer for the remainder: both return
+# it. `mpn_divrem_1` allows its quotient to be the numerator buffer itself.
+_mpn_divrem_1(q::MP, u::MP, un, v) = ccall((:__gmpn_divrem_1, libgmp), Limb,
+    (Ptr{Limb}, mp_size_t, Ptr{Limb}, mp_size_t, Limb), q, 0, u, un, v)
+_mpn_mod_1(u::MP, un, v) = ccall((:__gmpn_mod_1, libgmp), Limb,
+    (Ptr{Limb}, mp_size_t, Limb), u, un, v)
+_mpn_lshift(r::MP, ro::Int, u::MP, n, cnt) = GC.@preserve r ccall((:__gmpn_lshift, libgmp),
+    Limb, (Ptr{Limb}, Ptr{Limb}, mp_size_t, Cuint), pointer(r, ro+1), u, n, cnt)
+_mpn_rshift(r::MP, u::MP, uo::Int, n, cnt) = GC.@preserve u ccall((:__gmpn_rshift, libgmp),
+    Limb, (Ptr{Limb}, Ptr{Limb}, mp_size_t, Cuint), r, pointer(u, uo+1), n, cnt)
+
+# The superlinear kernels are the ones worth abandoning mid-flight, so they
+# are `:reset_safe`. An unwind discards their output buffer, and the
+# allocation hooks free any GMP temporary, so nothing that matters leaks.
+_mpn_mul(r::MP, u::MP, un, v::MP, vn) = Base.@assume_effects :reset_safe @ccall libgmp.__gmpn_mul(
+    r::Ptr{Limb}, u::Ptr{Limb}, un::mp_size_t, v::Ptr{Limb}, vn::mp_size_t)::Limb
+_mpn_sqr(r::MP, u::MP, un) = Base.@assume_effects :reset_safe @ccall libgmp.__gmpn_sqr(
+    r::Ptr{Limb}, u::Ptr{Limb}, un::mp_size_t)::Cvoid
+_mpn_tdiv_qr(q::MP, r::MP, n::MP, nn, d::MP, dn) = Base.@assume_effects :reset_safe @ccall libgmp.__gmpn_tdiv_qr(
+    q::Ptr{Limb}, r::Ptr{Limb}, 0::mp_size_t, n::Ptr{Limb}, nn::mp_size_t,
+    d::Ptr{Limb}, dn::mp_size_t)::Cvoid
+# the remainder is never wanted here, so `rp` is always NULL
+_mpn_sqrt(s::MP, u::MP, n) = Base.@assume_effects :reset_safe @ccall libgmp.__gmpn_sqrtrem(
+    s::Ptr{Limb}, C_NULL::Ptr{Limb}, u::Ptr{Limb}, n::mp_size_t)::mp_size_t
 
 sizeinbase(a::BigInt, b) = Int(ccall((:__gmpz_sizeinbase, libgmp), Csize_t, (mpz_t, Cint), a, b))
 
-for (op, nbits) in (:add => :(BITS_PER_LIMB*(1 + max(abs(a.size), abs(b.size)))),
-                    :sub => :(BITS_PER_LIMB*(1 + max(abs(a.size), abs(b.size)))),
-                    :mul => 0, :fdiv_q => 0, :tdiv_q => 0, :cdiv_q => 0,
-                    :fdiv_r => 0, :tdiv_r => 0, :cdiv_r => 0,
-                    :gcd => 0, :lcm => 0, :and => 0, :ior => 0, :xor => 0)
-    op! = Symbol(op, :!)
+function _ucmp(ad::Memory{Limb}, an::Int, bd::Memory{Limb}, bn::Int)
+    an != bn && return an < bn ? -1 : 1
+    an == 0 && return 0
+    return Int(_mpn_cmp(ad, bd, an % mp_size_t))
+end
+
+# Move `y`'s limbs into `x`. `y` must be a temporary that no longer escapes.
+@inline _move!(x::BigInt, y::BigInt) = (x.d = y.d; x.size = y.size; x)
+
+function set!(x::BigInt, a::BigInt)
+    x === a && return x
+    n = abs(a.size)
+    ad = a.d
+    d = _ensure!(x, n)
+    copyto!(d, 1, ad, 1, n)
+    x.size = a.size
+    return x
+end
+set(a::BigInt) = set!(BigInt(), a)
+
+function _addsub!(x::BigInt, a::BigInt, b::BigInt, negb::Bool)
+    as = a.size
+    bs = negb ? -b.size : b.size
+    # `mpn_add`/`mpn_sub` require a positive limb count, so zero stops here.
+    bs == 0 && return set!(x, a)
+    as == 0 && return negb ? neg!(x, b) : set!(x, b)
+    an, bn = abs(as), abs(bs)
+    # Bind the operands before `_ensure!` can replace `x.d` out from under them.
+    ad, bd = a.d, b.d
+    if (as > 0) == (bs > 0)
+        an < bn && ((ad, an, bd, bn) = (bd, bn, ad, an)) # longer operand first
+        d = _ensure!(x, an + 1)
+        c = _mpn_add(d, ad, an % mp_size_t, bd, bn % mp_size_t)
+        @inbounds d[an+1] = c
+        return _finish!(x, d, an + 1, as < 0)
+    end
+    rel = _ucmp(ad, an, bd, bn)
+    rel == 0 && (x.size = 0; return x)
+    rel < 0 && ((ad, an, as, bd, bn) = (bd, bn, bs, ad, an))
+    d = _ensure!(x, an)
+    _mpn_sub(d, ad, an % mp_size_t, bd, bn % mp_size_t)
+    return _finish!(x, d, an, as < 0)
+end
+
+add!(x::BigInt, a::BigInt, b::BigInt) = _addsub!(x, a, b, false)
+sub!(x::BigInt, a::BigInt, b::BigInt) = _addsub!(x, a, b, true)
+
+# x = a ± v. Here and below, `v` is an unsigned magnitude and `neg` its sign.
+function _addsub_mag!(x::BigInt, a::BigInt, v::Limb, neg::Bool)
+    v == 0 && return set!(x, a)
+    as = a.size
+    an = abs(as)
+    ad = a.d
+    if as != 0 && (as > 0) != neg      # magnitudes add
+        d = _ensure!(x, an + 1)
+        @inbounds d[an+1] = _mpn_add_1(d, ad, an % mp_size_t, v)
+        return _finish!(x, d, an + 1, as < 0)
+    elseif an > 1 || (an == 1 && (@inbounds ad[1]) >= v)   # |a| >= v
+        d = _ensure!(x, an)
+        _mpn_sub_1(d, ad, an % mp_size_t, v)
+        return _finish!(x, d, an, as < 0)
+    end
+    # |a| < v, which `v` being one limb confines to `an <= 1`, so the result
+    # is the single limb `v - |a|`, with `v`'s sign.
+    d = _ensure!(x, 1)
+    @inbounds d[1] = v - (an == 0 ? zero(Limb) : (@inbounds ad[1]))
+    return _finish!(x, d, 1, neg)
+end
+
+add_ui!(x::BigInt, a::BigInt, b) = _addsub_mag!(x, a, Limb(b), false)
+sub_ui!(x::BigInt, a::BigInt, b) = _addsub_mag!(x, a, Limb(b), true)
+# x = a - b, with `a` an unsigned magnitude
+ui_sub!(x::BigInt, a, b::BigInt) = (_addsub_mag!(x, b, Limb(a), true); x.size = -x.size; x)
+ui_sub(a, b::BigInt) = ui_sub!(BigInt(), a, b)
+
+_inc!(x::BigInt) = _addsub_mag!(x, x, one(Limb), false)
+_dec!(x::BigInt) = _addsub_mag!(x, x, one(Limb), true)
+
+function mul!(x::BigInt, a::BigInt, b::BigInt)
+    Base.@cancel_check
+    as, bs = a.size, b.size
+    if as == 0 || bs == 0
+        x.size = 0
+        return x
+    end
+    an, bn = abs(as), abs(bs)
+    ad, bd = a.d, b.d
+    n = an + bn
+    # mpn_mul forbids overlap, so unalias x if needed.
+    d = _dest(x, n, ad, bd)
+    if ad === bd && an == bn
+        _mpn_sqr(d, ad, an % mp_size_t)
+    elseif an >= bn
+        _mpn_mul(d, ad, an % mp_size_t, bd, bn % mp_size_t)
+    else
+        _mpn_mul(d, bd, bn % mp_size_t, ad, an % mp_size_t)
+    end
+    return _finish!(x, d, n, (as < 0) != (bs < 0))
+end
+
+function _mul_mag!(x::BigInt, a::BigInt, v::Limb, neg::Bool)
+    as = a.size
+    if as == 0 || v == 0
+        x.size = 0
+        return x
+    end
+    an = abs(as)
+    ad = a.d
+    d = _ensure!(x, an + 1)
+    @inbounds d[an+1] = _mpn_mul_1(d, ad, an % mp_size_t, v)
+    return _finish!(x, d, an + 1, (as < 0) != neg)
+end
+
+mul_ui!(x::BigInt, a::BigInt, b) = _mul_mag!(x, a, Limb(b), false)
+mul_si!(x::BigInt, a::BigInt, b) = ((v, neg) = _magsign(b); _mul_mag!(x, a, Limb(v), neg))
+
+# Truncated division: q = trunc(a/b) and r = a - q*b, so `r` carries `a`'s
+# sign. `mpn_tdiv_qr` writes both outputs and forbids overlap among them and
+# its inputs, so each variant below gives the output it does not want scratch
+# limbs, and only the wanted one a `_dest` buffer.
+function tdiv_q!(x::BigInt, a::BigInt, b::BigInt)
+    Base.@cancel_check
+    as, bs = a.size, b.size
+    bs == 0 && throw(DivideError())
+    an, bn = abs(as), abs(bs)
+    an < bn && (x.size = 0; return x)
+    ad, bd = a.d, b.d
+    neg = (as < 0) != (bs < 0)
+    if bn == 1
+        v = @inbounds bd[1]
+        qd = _ensure!(x, an)
+        _mpn_divrem_1(qd, ad, an % mp_size_t, v)
+        return _finish!(x, qd, an, neg)
+    end
+    qn = an - bn + 1
+    qd = _dest(x, qn, ad, bd)
+    _mpn_tdiv_qr(qd, Memory{Limb}(undef, bn), ad, an % mp_size_t, bd, bn % mp_size_t)
+    return _finish!(x, qd, qn, neg)
+end
+
+function tdiv_r!(x::BigInt, a::BigInt, b::BigInt)
+    Base.@cancel_check
+    as, bs = a.size, b.size
+    bs == 0 && throw(DivideError())
+    an, bn = abs(as), abs(bs)
+    an < bn && return set!(x, a)
+    ad, bd = a.d, b.d
+    if bn == 1
+        rl = _mpn_mod_1(ad, an % mp_size_t, @inbounds bd[1])
+        d = _ensure!(x, 1)
+        @inbounds d[1] = rl
+        return _finish!(x, d, 1, as < 0)
+    end
+    rd = _dest(x, bn, ad, bd)
+    _mpn_tdiv_qr(Memory{Limb}(undef, an - bn + 1), rd, ad, an % mp_size_t, bd, bn % mp_size_t)
+    return _finish!(x, rd, bn, as < 0)
+end
+
+function tdiv_qr!(x::BigInt, y::BigInt, a::BigInt, b::BigInt)
+    Base.@cancel_check
+    as, bs = a.size, b.size
+    bs == 0 && throw(DivideError())
+    an, bn = abs(as), abs(bs)
+    if an < bn
+        x.size = 0
+        set!(y, a)
+        return x, y
+    end
+    ad, bd = a.d, b.d
+    neg = (as < 0) != (bs < 0)
+    if bn == 1
+        v = @inbounds bd[1]
+        qd = _dest(x, an, ad, bd)
+        rl = _mpn_divrem_1(qd, ad, an % mp_size_t, v)
+        rdy = _ensure!(y, 1)
+        @inbounds rdy[1] = rl
+        _finish!(x, qd, an, neg)
+        _finish!(y, rdy, 1, as < 0)
+        return x, y
+    end
+    qn = an - bn + 1
+    qd = _dest(x, qn, ad, bd)
+    rd = _dest(y, bn, ad, bd, qd)
+    _mpn_tdiv_qr(qd, rd, ad, an % mp_size_t, bd, bn % mp_size_t)
+    _finish!(x, qd, qn, neg)
+    _finish!(y, rd, bn, as < 0)
+    return x, y
+end
+tdiv_qr(a::BigInt, b::BigInt) = tdiv_qr!(BigInt(), BigInt(), a, b)
+
+# Floor (`down`) and ceiling division. The truncated result is off by one
+# exactly when the remainder is nonzero and carries the "wrong" sign, which is
+# `a`'s, so `wrong` is known before the division runs.
+function _rdiv_q!(x::BigInt, a::BigInt, b::BigInt, down::Bool)
+    Base.@cancel_check
+    as, bs = a.size, b.size
+    bs == 0 && throw(DivideError())
+    an, bn = abs(as), abs(bs)
+    wrong = ((as < 0) != (bs < 0)) == down
+    # |a| < |b|: the truncated quotient is 0 and the remainder is `a`.
+    an < bn && return set_si!(x, (as != 0 && wrong) ? (down ? -1 : 1) : 0)
+    ad, bd = a.d, b.d
+    neg = (as < 0) != (bs < 0)
+    # Only whether the discarded remainder is nonzero matters.
+    if bn == 1
+        v = @inbounds bd[1]
+        qd = _ensure!(x, an)
+        rnz = _mpn_divrem_1(qd, ad, an % mp_size_t, v) != 0
+        _finish!(x, qd, an, neg)
+    else
+        qn = an - bn + 1
+        qd = _dest(x, qn, ad, bd)
+        rd = Memory{Limb}(undef, bn)
+        _mpn_tdiv_qr(qd, rd, ad, an % mp_size_t, bd, bn % mp_size_t)
+        _finish!(x, qd, qn, neg)
+        rnz = _norm(rd, bn) != 0
+    end
+    wrong && rnz && (down ? _dec!(x) : _inc!(x))
+    return x
+end
+
+function _rdiv_r!(x::BigInt, a::BigInt, b::BigInt, down::Bool)
+    bneg = b.size < 0
+    r = x === b ? BigInt() : x   # `b` is still needed after the division
+    tdiv_r!(r, a, b)
+    rs = r.size
+    rs != 0 && ((rs < 0) != bneg) == down && _addsub!(r, r, b, !down)
+    return r === x ? x : _move!(x, r)
+end
+
+fdiv_q!(x::BigInt, a::BigInt, b::BigInt) = _rdiv_q!(x, a, b, true)
+cdiv_q!(x::BigInt, a::BigInt, b::BigInt) = _rdiv_q!(x, a, b, false)
+fdiv_r!(x::BigInt, a::BigInt, b::BigInt) = _rdiv_r!(x, a, b, true)
+cdiv_r!(x::BigInt, a::BigInt, b::BigInt) = _rdiv_r!(x, a, b, false)
+
+# mpn_gcd destroys its operands and constrains their normalization and parity,
+# so driving it from here would cost the same copying that mpz does anyway.
+for op in (:gcd, :lcm)
     fname = Symbol(:__gmpz_, op)
+    @eval function $(Symbol(op, :!))(x::BigInt, a::BigInt, b::BigInt)
+        Base.@cancel_check
+        with_output(x) do s
+            Base.@assume_effects :reset_safe @ccall libgmp.$fname(s::scratch_t, a::mpz_t, b::mpz_t)::Cvoid
+        end
+        return x
+    end
+end
+
+# GMP never exported mpn_and_n and friends, and mpz's semantics are those of
+# an infinite two's-complement expansion, so these are done over limbs here.
+
+# Limb `i` of the infinite two's-complement expansion of the value with
+# magnitude `d[1:n]`. Negated, that is the magnitude complemented above its
+# lowest nonzero limb `low`, where the +1 of the negation lands.
+@inline function _tc(d::Memory{Limb}, n::Int, neg::Bool, low::Int, i::Int)
+    v = i <= n ? (@inbounds d[i]) : zero(Limb)
+    if neg
+        v = i < low ? zero(Limb) : (i == low ? (-v) : ~v)
+    end
+    return v
+end
+
+function _bitop!(op::F, x::BigInt, a::BigInt, b::BigInt) where {F}
+    as, bs = a.size, b.size
+    an, bn = abs(as), abs(bs)
+    aneg, bneg = as < 0, bs < 0
+    # Bind before `_ensure!`; `d` may then be `ad` or `bd`, which the upward
+    # scans tolerate.
+    ad, bd = a.d, b.d
+    if !aneg && !bneg
+        # A non-negative magnitude is its own two's-complement expansion,
+        # sign-extended with zeros, so `&` stops at the shorter operand while
+        # `|`/`xor` pass the longer one's tail through. Keeps `bignum & small`
+        # linear in the *small* operand.
+        lo, hi = minmax(an, bn)
+        hd = an >= bn ? ad : bd
+        n = iszero(op(~zero(Limb), zero(Limb))) ? lo : hi
+        d = _ensure!(x, n)
+        @inbounds for i in 1:lo
+            d[i] = op(ad[i], bd[i])
+        end
+        @inbounds for i in lo+1:n
+            d[i] = op(hd[i], zero(Limb))
+        end
+        return _finish!(x, d, n, false)
+    end
+    alow = aneg ? findfirst(!iszero, @view ad[1:an])::Int : 0
+    blow = bneg ? findfirst(!iszero, @view bd[1:bn])::Int : 0
+    # One limb beyond both operands, holding each one's sign extension: 0 or
+    # ~0, so it records the result's sign and absorbs the negation's carry.
+    n = max(an, bn) + 1
+    d = _ensure!(x, n)
+    @inbounds for i in 1:n
+        d[i] = op(_tc(ad, an, aneg, alow, i), _tc(bd, bn, bneg, blow, i))
+    end
+    neg = (@inbounds d[n]) != 0
+    if neg
+        # Back to sign-magnitude. The sign-extension limb is `~0`, so it
+        # complements to 0 and always absorbs the carry.
+        @inbounds for i in 1:n
+            d[i] = ~d[i]
+        end
+        _mpn_add_1(d, d, n % mp_size_t, one(Limb))
+    end
+    return _finish!(x, d, n, neg)
+end
+
+and!(x::BigInt, a::BigInt, b::BigInt) = _bitop!(&, x, a, b)
+ior!(x::BigInt, a::BigInt, b::BigInt) = _bitop!(|, x, a, b)
+xor!(x::BigInt, a::BigInt, b::BigInt) = _bitop!(Base.xor, x, a, b)
+
+function mul_2exp!(x::BigInt, a::BigInt, c)
+    s = Int(c)
+    as = a.size
+    (as == 0 || s == 0) && return set!(x, a)
+    an = abs(as)
+    ad = a.d
+    off, sh = divrem(s, BITS_PER_LIMB)
+    n = an + off + (sh > 0)
+    d = Memory{Limb}(undef, n)
+    if sh == 0
+        copyto!(d, off+1, ad, 1, an)
+    else
+        @inbounds d[an+off+1] = _mpn_lshift(d, off, ad, an % mp_size_t, sh % Cuint)
+    end
+    fill!(@view(d[1:off]), zero(Limb))
+    return _finish!(x, d, n, as < 0)
+end
+
+# Arithmetic shift right, rounding towards -Inf as mpz_fdiv_q_2exp does.
+function fdiv_q_2exp!(x::BigInt, a::BigInt, c)
+    s = Int(c)
+    as = a.size
+    (as == 0 || s == 0) && return set!(x, a)
+    an = abs(as)
+    ad = a.d
+    neg = as < 0
+    off, sh = divrem(s, BITS_PER_LIMB)
+    if off >= an
+        # Everything is shifted out; flooring leaves -1 for a negative value.
+        if neg
+            d = _ensure!(x, 1)
+            @inbounds d[1] = one(Limb)
+            x.size = -1
+        else
+            x.size = 0
+        end
+        return x
+    end
+    # Flooring rounds away from zero when a negative value loses a set bit.
+    lost = neg && (any(!iszero, @view ad[1:off]) ||
+                   (sh > 0 && (@inbounds ad[off+1]) & ((one(Limb) << sh) - one(Limb)) != 0))
+    n = an - off
+    d = Memory{Limb}(undef, n)
+    if sh == 0
+        copyto!(d, 1, ad, off+1, n)
+    else
+        _mpn_rshift(d, ad, off, n % mp_size_t, sh % Cuint)
+    end
+    _finish!(x, d, n, neg)
+    lost && _dec!(x)
+    return x
+end
+
+neg!(x::BigInt, a::BigInt) = (set!(x, a); x.size = -x.size; x)
+# ~a == -a - 1
+com!(x::BigInt, a::BigInt) = (neg!(x, a); _dec!(x))
+
+function sqrt!(x::BigInt, a::BigInt)
+    Base.@cancel_check
+    as = a.size
+    as < 0 && throw(DomainError(a, "`x` must be non-negative"))
+    if as == 0
+        x.size = 0
+        return x
+    end
+    an = as # `as > 0` here, so the size and the limb count agree
+    ad = a.d
+    sn = cld(an, 2)
+    d = Memory{Limb}(undef, sn)
+    _mpn_sqrt(d, ad, an % mp_size_t)
+    return _finish!(x, d, sn, false)
+end
+
+# Operations with no suitable `mpn` form: computed into a GMP-owned mpz, with
+# read-only inputs left as views. `z` marks a `BigInt` argument, `u` a `Culong`.
+for (op, ret, kinds) in ((:invert, :Cint,  (:z, :z)),
+                         (:powm,   :Cvoid, (:z, :z, :z)),
+                         (:pow_ui, :Cvoid, (:z, :u)),
+                         (:bin_ui, :Cvoid, (:z, :u)),
+                         (:fac_ui, :Cvoid, (:u,)))
+    fname = Symbol(:__gmpz_, op)
+    ps = [Symbol(:a, i) for i in eachindex(kinds)]
+    decls = [k === :z ? :($p::BigInt) : p for (p, k) in zip(ps, kinds)]
+    cargs = [k === :z ? :($p::mpz_t) : :($p::Culong) for (p, k) in zip(ps, kinds)]
+    out = ret === :Cvoid ? :x : :(Int(r))
+    @eval function $(Symbol(op, :!))(x::BigInt, $(decls...))
+        Base.@cancel_check
+        r = with_output(x) do s
+            Base.@assume_effects :reset_safe @ccall libgmp.$fname(s::scratch_t, $(cargs...))::$ret
+        end
+        return $out
+    end
+end
+
+invert!(x::BigInt, b::BigInt) = invert!(x, x, b)
+invert(a::BigInt, b::BigInt) = (ret = BigInt(); invert!(ret, a, b); ret)
+powm(a::BigInt, b::BigInt, c::BigInt) = powm!(BigInt(), a, b, c)
+powm!(x::BigInt, b::BigInt, c::BigInt) = powm!(x, x, b, c)
+fac_ui(a) = fac_ui!(BigInt(), a)
+
+function gcdext!(x::BigInt, y::BigInt, z::BigInt, a::BigInt, b::BigInt)
+    Base.@cancel_check
+    with_output(x) do sg
+        with_output(y) do ss
+            with_output(z) do st
+                Base.@assume_effects :reset_safe @ccall libgmp.__gmpz_gcdext(
+                    sg::scratch_t, ss::scratch_t, st::scratch_t, a::mpz_t, b::mpz_t)::Cvoid
+            end
+        end
+    end
+    return x, y, z
+end
+gcdext(a::BigInt, b::BigInt) = gcdext!(BigInt(), BigInt(), BigInt(), a, b)
+
+set_str!(x::BigInt, a, b) = with_output(x) do s
+    Base.@cancel_check
+    Int(Base.@assume_effects :reset_safe @ccall libgmp.__gmpz_set_str(s::scratch_t, a::Ptr{UInt8}, b::Cint)::Cint)
+end
+
+function _set_mag!(x::BigInt, u::UInt64, neg::Bool)
+    n = cld(64, BITS_PER_LIMB)
+    d = _ensure!(x, n)
+    return _finish!(x, _store!(d, 0, u), n, neg)
+end
+
+set_ui!(x::BigInt, a) = _set_mag!(x, UInt64(a), false)
+set_si!(x::BigInt, a) = ((u, neg) = _magsign(a); _set_mag!(x, u, neg))
+
+# Truncates towards zero, as mpz_set_d does.
+function set_d!(x::BigInt, a)
+    v = Float64(a)
+    if -1.0 < v < 1.0
+        x.size = 0
+        return x
+    end
+    m, ex = frexp(abs(v))          # abs(v) == m * 2^ex, with 0.5 <= m < 1
+    sig = unsafe_trunc(UInt64, ldexp(m, 53))  # exact: the 53-bit significand
+    e = ex - 53                    # abs(v) truncated == sig * 2^e
+    if e < 0
+        sig >>= -e                 # truncate towards zero
+        e = 0
+    end
+    off, sh = divrem(e, BITS_PER_LIMB)
+    w = UInt128(sig) << sh         # at most 53 + 63 bits
+    n = off + cld(128, BITS_PER_LIMB)
+    d = _ensure!(x, n)
+    fill!(@view(d[1:off]), zero(Limb))
+    return _finish!(x, _store!(d, off, w), n, v < 0)
+end
+
+for op in (:set_ui, :set_si, :set_d)
+    op! = Symbol(op, :!)
+    @eval $op(a) = $op!(BigInt(), a)
+end
+
+for op in (:add, :sub, :mul, :fdiv_q, :tdiv_q, :cdiv_q, :fdiv_r, :tdiv_r, :cdiv_r,
+           :gcd, :lcm, :and, :ior, :xor)
+    op! = Symbol(op, :!)
     @eval begin
-        $op!(x::BigInt, a::BigInt, b::BigInt) =
-            (Base.@cancel_check; Base.@assume_effects :reset_safe @ccall(libgmp.$fname(x::mpz_t, a::mpz_t, b::mpz_t)::Cvoid); x)
-        $op(a::BigInt, b::BigInt) = $op!(BigInt(nbits=$nbits), a, b)
+        $op(a::BigInt, b::BigInt) = $op!(BigInt(), a, b)
         $op!(x::BigInt, b::BigInt) = $op!(x, x, b)
     end
 end
 
-invert!(x::BigInt, a::BigInt, b::BigInt) =
-    (Base.@cancel_check; Base.@assume_effects :reset_safe @ccall libgmp.__gmpz_invert(x::mpz_t, a::mpz_t, b::mpz_t)::Cint)
-invert!(x::BigInt, b::BigInt) = invert!(x, x, b)
-invert(a::BigInt, b::BigInt) = (ret=BigInt(); invert!(ret, a, b); ret)
-
-for op in (:add_ui, :sub_ui, :mul_ui, :mul_2exp, :fdiv_q_2exp, :pow_ui, :bin_ui)
+for op in (:add_ui, :sub_ui, :mul_ui, :mul_si, :mul_2exp, :fdiv_q_2exp, :pow_ui, :bin_ui)
     op! = Symbol(op, :!)
-    fname = Symbol(:__gmpz_, op)
     @eval begin
-        $op!(x::BigInt, a::BigInt, b) =
-            (Base.@cancel_check; Base.@assume_effects :reset_safe @ccall(libgmp.$fname(x::mpz_t, a::mpz_t, b::Culong)::Cvoid); x)
         $op(a::BigInt, b) = $op!(BigInt(), a, b)
         $op!(x::BigInt, b) = $op!(x, x, b)
     end
 end
 
-ui_sub!(x::BigInt, a, b::BigInt) = (Base.@cancel_check; Base.@assume_effects :reset_safe @ccall(libgmp.__gmpz_ui_sub(x::mpz_t, a::Culong, b::mpz_t)::Cvoid); x)
-ui_sub(a, b::BigInt) = ui_sub!(BigInt(), a, b)
+for op in (:neg, :com, :sqrt)
+    op! = Symbol(op, :!)
+    @eval begin
+        $op(a::BigInt) = $op!(BigInt(), a)
+        $op!(x::BigInt) = $op!(x, x)
+    end
+end
+
+# None of these writes its operand, so a borrowed view is sound throughout.
 
 for op in (:scan1, :scan0)
     # when there is no meaningful answer, ccall returns typemax(Culong), where Culong can
     # be UInt32 (Windows) or UInt64; we return -1 in this case for all architectures
-    @eval $op(a::BigInt, b) = Int(signed(ccall($(gmpz(op)), Culong, (mpz_t, Culong), a, b)))
-end
-
-mul_si!(x::BigInt, a::BigInt, b) = (Base.@cancel_check; Base.@assume_effects :reset_safe @ccall(libgmp.__gmpz_mul_si(x::mpz_t, a::mpz_t, b::Clong)::Cvoid); x)
-mul_si(a::BigInt, b) = mul_si!(BigInt(), a, b)
-mul_si!(x::BigInt, b) = mul_si!(x, x, b)
-
-for op in (:neg, :com, :sqrt, :set)
-    op! = Symbol(op, :!)
     fname = Symbol(:__gmpz_, op)
-    @eval begin
-        $op!(x::BigInt, a::BigInt) =
-            (Base.@cancel_check; Base.@assume_effects :reset_safe @ccall(libgmp.$fname(x::mpz_t, a::mpz_t)::Cvoid); x)
-        $op(a::BigInt) = $op!(BigInt(), a)
-    end
-    op === :set && continue # MPZ.set!(x) would make no sense
-    @eval $op!(x::BigInt) = $op!(x, x)
-end
-
-fac_ui!(x::BigInt, a) = (Base.@cancel_check; Base.@assume_effects :reset_safe @ccall(libgmp.__gmpz_fac_ui(x::mpz_t, a::Culong)::Cvoid); x)
-fac_ui(a) = fac_ui!(BigInt(), a)
-
-for (op, T) in ((:set_ui, Culong), (:set_si, Clong), (:set_d, Cdouble))
-    op! = Symbol(op, :!)
-    @eval begin
-        $op!(x::BigInt, a) = (ccall($(gmpz(op)), Cvoid, (mpz_t, $T), x, a); x)
-        $op(a) = $op!(BigInt(), a)
-    end
+    @eval $op(a::BigInt, b) = Int(signed(ccall(($(QuoteNode(fname)), libgmp), Culong, (mpz_t, Culong), a, b)))
 end
 
 popcount(a::BigInt) = Int(signed(ccall((:__gmpz_popcount, libgmp), Culong, (mpz_t,), a)))
 
-mpn_popcount(d::Ptr{Limb}, s::Integer) = Int(ccall((:__gmpn_popcount, libgmp), Culong, (Ptr{Limb}, Csize_t), d, s))
+mpn_popcount(d::MP, s::Integer) = Int(ccall((:__gmpn_popcount, libgmp), Culong, (Ptr{Limb}, Csize_t), d, s))
 mpn_popcount(a::BigInt) = mpn_popcount(a.d, abs(a.size))
-
-function tdiv_qr!(x::BigInt, y::BigInt, a::BigInt, b::BigInt)
-    Base.@cancel_check
-    Base.@assume_effects :reset_safe @ccall libgmp.__gmpz_tdiv_qr(x::mpz_t, y::mpz_t, a::mpz_t, b::mpz_t)::Cvoid
-    x, y
-end
-tdiv_qr(a::BigInt, b::BigInt) = tdiv_qr!(BigInt(), BigInt(), a, b)
-
-powm!(x::BigInt, a::BigInt, b::BigInt, c::BigInt) =
-    (Base.@cancel_check; Base.@assume_effects :reset_safe @ccall(libgmp.__gmpz_powm(x::mpz_t, a::mpz_t, b::mpz_t, c::mpz_t)::Cvoid); x)
-powm(a::BigInt, b::BigInt, c::BigInt) = powm!(BigInt(), a, b, c)
-powm!(x::BigInt, b::BigInt, c::BigInt) = powm!(x, x, b, c)
-
-function gcdext!(x::BigInt, y::BigInt, z::BigInt, a::BigInt, b::BigInt)
-    Base.@cancel_check
-    Base.@assume_effects :reset_safe @ccall libgmp.__gmpz_gcdext(x::mpz_t, y::mpz_t, z::mpz_t, a::mpz_t, b::mpz_t)::Cvoid
-    x, y, z
-end
-gcdext(a::BigInt, b::BigInt) = gcdext!(BigInt(), BigInt(), BigInt(), a, b)
 
 cmp(a::BigInt, b::BigInt) = Int(ccall((:__gmpz_cmp, libgmp), Cint, (mpz_t, mpz_t), a, b))
 cmp_si(a::BigInt, b) = Int(ccall((:__gmpz_cmp_si, libgmp), Cint, (mpz_t, Clong), a, b))
 cmp_ui(a::BigInt, b) = Int(ccall((:__gmpz_cmp_ui, libgmp), Cint, (mpz_t, Culong), a, b))
 cmp_d(a::BigInt, b) = Int(ccall((:__gmpz_cmp_d, libgmp), Cint, (mpz_t, Cdouble), a, b))
 
-mpn_cmp(a::Ptr{Limb}, b::Ptr{Limb}, c) = ccall((:__gmpn_cmp, libgmp), Cint, (Ptr{Limb}, Ptr{Limb}, Clong), a, b, c)
-mpn_cmp(a::BigInt, b::BigInt, c) = mpn_cmp(a.d, b.d, c)
+mpn_cmp(a::BigInt, b::BigInt, c) = _mpn_cmp(a.d, b.d, c)
 
 get_str!(x, a, b::BigInt) = (Base.@cancel_check; Base.@assume_effects :reset_safe @ccall(libgmp.__gmpz_get_str(x::Ptr{Cchar}, a::Cint, b::mpz_t)::Ptr{Cchar}); x)
-set_str!(x::BigInt, a, b) = Int(begin Base.@cancel_check; Base.@assume_effects :reset_safe @ccall(libgmp.__gmpz_set_str(x::mpz_t, a::Ptr{UInt8}, b::Cint)::Cint) end)
 get_d(a::BigInt) = ccall((:__gmpz_get_d, libgmp), Cdouble, (mpz_t,), a)
+
+tstbit(a::BigInt, b) = ccall((:__gmpz_tstbit, libgmp), Cint, (mpz_t, bitcnt_t), a, b) % Bool
 
 function export!(a::AbstractVector{T}, n::BigInt; order::Integer=-1, nails::Integer=0, endian::Integer=0) where {T<:Base.BitInteger}
     stride(a, 1) == 1 || throw(ArgumentError("a must have stride 1"))
@@ -279,17 +811,40 @@ function export!(a::AbstractVector{T}, n::BigInt; order::Integer=-1, nails::Inte
     return a, Int(count[])
 end
 
-limbs_write!(x::BigInt, a) = ccall((:__gmpz_limbs_write, libgmp), Ptr{Limb}, (mpz_t, Clong), x, a)
-limbs_finish!(x::BigInt, a) = ccall((:__gmpz_limbs_finish, libgmp), Cvoid, (mpz_t, Clong), x, a)
-
-setbit!(x, a) = (ccall((:__gmpz_setbit, libgmp), Cvoid, (mpz_t, bitcnt_t), x, a); x)
-tstbit(a::BigInt, b) = ccall((:__gmpz_tstbit, libgmp), Cint, (mpz_t, bitcnt_t), a, b) % Bool
+# mpz_setbit's semantics are those of an infinite two's-complement expansion.
+function setbit!(x::BigInt, a)
+    b = Int(a)
+    n = x.size
+    if n >= 0
+        # One limb's OR. Worth doing in place: the only caller sets bits in a
+        # loop, and the scratch path below copies all of `x` twice per bit.
+        i = (b ÷ BITS_PER_LIMB) + 1
+        d = x.d
+        if i > n
+            if length(d) < i        # grow, preserving the limbs already set
+                nd = Memory{Limb}(undef, i)
+                copyto!(nd, 1, d, 1, n)
+                x.d = d = nd
+            end
+            fill!(@view(d[n+1:i]), zero(Limb))
+            x.size = i
+        end
+        @inbounds d[i] |= one(Limb) << (b % BITS_PER_LIMB)
+        return x
+    end
+    # Stored sign-magnitude, so the bit to set is not a bit of any stored
+    # limb; let mpz do it, on a scratch seeded from `x`.
+    with_output(x) do s
+        ccall((:__gmpz_set, libgmp), Cvoid, (scratch_t, mpz_t), s, x)
+        ccall((:__gmpz_setbit, libgmp), Cvoid, (scratch_t, bitcnt_t), s, a)
+    end
+    return x
+end
 
 end # module MPZ
 
 const ZERO = BigInt()
-const ONE  = BigInt()
-const _ONE = Limb[1]
+const ONE  = MPZ.set_ui(one(Limb))
 
 widen(::Type{Int128})  = BigInt
 widen(::Type{UInt128}) = BigInt
@@ -346,12 +901,13 @@ function BigInt(x::Integer)
     isbits(x) && typemin(Clong) <= x <= typemax(Clong) && return BigInt((x % Clong)::Clong)
     nd = ndigits(x, base=2)
     z = MPZ.realloc2(nd)
+    d = z.d
     ux = unsigned(x < 0 ? -%(x) : x)
     size = 0
     limbnbits = sizeof(Limb) << 3
     while nd > 0
         size += 1
-        unsafe_store!(z.d, ux % Limb, size)
+        @inbounds d[size] = ux % Limb
         ux >>= limbnbits
         nd -= limbnbits
     end
@@ -360,15 +916,16 @@ function BigInt(x::Integer)
 end
 
 
-rem(x::BigInt, ::Type{Bool}) = !iszero(x) & unsafe_load(x.d) % Bool # never unsafe here
+rem(x::BigInt, ::Type{Bool}) = iszero(x) ? false : ((@inbounds x.d[1]) % Bool)
 
 rem(x::BigInt, ::Type{T}) where T<:Union{SLimbMax,ULimbMax} =
-    iszero(x) ? zero(T) : flipsign(unsafe_load(x.d) % T, x.size)
+    iszero(x) ? zero(T) : flipsign((@inbounds x.d[1]) % T, x.size)
 
 function rem(x::BigInt, ::Type{T}) where T<:Union{Base.BitUnsigned,Base.BitSigned}
     u = zero(T)
+    d = x.d
     for l = 1:min(abs(x.size), cld(sizeof(T), sizeof(Limb)))
-        u += (unsafe_load(x.d, l) % T) << ((sizeof(Limb)<<3)*(l-1))
+        u += ((@inbounds d[l]) % T) << ((sizeof(Limb)<<3)*(l-1))
     end
     flipsign(u, x.size)
 end
@@ -424,19 +981,20 @@ function Float64(x::BigInt, ::RoundingMode{:Nearest})
     if xsize*BITS_PER_LIMB > 1024
         z = Inf64
     elseif xsize == 1
-        z = Float64(unsafe_load(x.d))
+        z = Float64(@inbounds x.d[1])
     elseif Limb == UInt32 && xsize == 2
-        z = Float64((unsafe_load(x.d, 2) % UInt64) << BITS_PER_LIMB + unsafe_load(x.d))
+        z = Float64(((@inbounds x.d[2]) % UInt64) << BITS_PER_LIMB + (@inbounds x.d[1]))
     else
-        y1 = unsafe_load(x.d, xsize) % UInt64
+        d = x.d
+        y1 = (@inbounds d[xsize]) % UInt64
         n = top_set_bit(y1)
         # load first 54(1 + 52 bits of fraction + 1 for rounding)
         y = y1 >> (n - (precision(Float64)+1))
         if Limb == UInt64
-            y += n > precision(Float64) ? 0 : (unsafe_load(x.d, xsize-1) >> (10+n))
+            y += n > precision(Float64) ? 0 : ((@inbounds d[xsize-1]) >> (10+n))
         else
-            y += (unsafe_load(x.d, xsize-1) % UInt64) >> (n-22)
-            y += n > (precision(Float64) - 32) ? 0 : (unsafe_load(x.d, xsize-2) >> (10+n))
+            y += ((@inbounds d[xsize-1]) % UInt64) >> (n-22)
+            y += n > (precision(Float64) - 32) ? 0 : ((@inbounds d[xsize-2]) >> (10+n))
         end
         y = (y + 1) >> 1 # round, ties up
         y &= ~UInt64(trailing_zeros(x) == (n-54 + (xsize-1)*BITS_PER_LIMB)) # fix last bit to round to even
@@ -453,13 +1011,14 @@ function Float32(x::BigInt, ::RoundingMode{:Nearest})
     if xsize*BITS_PER_LIMB > 128
         z = Inf32
     elseif xsize == 1
-        z = Float32(unsafe_load(x.d))
+        z = Float32(@inbounds x.d[1])
     else
-        y1 = unsafe_load(x.d, xsize)
+        d = x.d
+        y1 = @inbounds d[xsize]
         n = BITS_PER_LIMB - leading_zeros(y1)
         # load first 25(1 + 23 bits of fraction + 1 for rounding)
         y = (y1 >> (n - (precision(Float32)+1))) % UInt32
-        y += (n > precision(Float32) ? 0 : unsafe_load(x.d, xsize-1) >> (BITS_PER_LIMB - (25-n))) % UInt32
+        y += (n > precision(Float32) ? 0 : (@inbounds d[xsize-1]) >> (BITS_PER_LIMB - (25-n))) % UInt32
         y = (y + one(UInt32)) >> 1 # round, ties up
         y &= ~UInt32(trailing_zeros(x) == (n-25 + (xsize-1)*BITS_PER_LIMB)) # fix last bit to round to even
         d = ((n+125) % UInt32) << 23
@@ -471,7 +1030,7 @@ end
 
 function Float16(x::BigInt, ::RoundingMode{:Nearest})
     x == 0 && return Float16(0.0)
-    y1 = unsafe_load(x.d)
+    y1 = @inbounds x.d[1]
     n = BITS_PER_LIMB - leading_zeros(y1)
     if n > 16 || abs(x.size) > 1
         z = Inf16
@@ -627,7 +1186,7 @@ Number of ones in the binary representation of abs(x).
 count_ones_abs(x::BigInt) = iszero(x) ? 0 : MPZ.mpn_popcount(x)
 
 # all uses of _bit_magnitude MUST ensure at callsite that `x` is strictly positive, otherwise it is UB
-_bit_magnitude(x::BigInt) = x.size * sizeof(Limb) << 3 - leading_zeros(GC.@preserve x unsafe_load(x.d, x.size))
+_bit_magnitude(x::BigInt) = x.size * sizeof(Limb) << 3 - leading_zeros(@inbounds x.d[x.size])
 
 function exponent(x::BigInt)
     iszero(x) && throw(DomainError(x, "cannot be zero"))
@@ -711,26 +1270,48 @@ sum(arr::Union{AbstractArray{BigInt}, Tuple{BigInt, Vararg{BigInt}}}) =
 
 function prod(arr::AbstractArray{BigInt})
     any(iszero, arr) && return zero(BigInt)
-    _prod(arr, firstindex(arr), lastindex(arr))
-end
-function _prod(arr::AbstractArray{BigInt}, lo, hi)
-    if hi - lo + 1 <= 16
-        # compute first the needed number of bits for the result,
-        # to avoid re-allocations
-        nlimbs = 0
-        for i in lo:hi
-            nlimbs += abs(arr[i].size)
-        end
-        init = BigInt(; nbits=nlimbs*BITS_PER_LIMB)
-        MPZ.set_si!(init, 1)
-        for i in lo:hi
-            MPZ.mul!(init, arr[i])
-        end
-        init
-    else
-        mid = (lo + hi) ÷ 2
-        MPZ.mul!(_prod(arr, lo, mid), _prod(arr, mid+1, hi))
+    n = Int(length(arr))
+    n == 0 && return one(BigInt)
+    lo = Int(firstindex(arr))
+    n == 1 && return MPZ.set(arr[lo])
+    hi = lo + n - 1
+    nlimbs = 0
+    for i in lo:hi
+        nlimbs += abs(arr[i].size)
     end
+    if nlimbs <= 64 # with few total limbs linear prod is faster
+        nbits = nlimbs*BITS_PER_LIMB
+        acc = MPZ.set_si!(BigInt(; nbits=nbits), 1)
+        tmp = BigInt(; nbits=nbits)
+        for i in lo:hi
+            MPZ.mul!(tmp, acc, arr[i])
+            acc, tmp = tmp, acc
+        end
+        return acc
+    end
+    # Otherwise multiply pairwise, keeping both operands of comparable size 
+    # DFS leaves 1 partial product live per level, so one scratch per level is enough
+    # plus a spare to multiply into
+    depth = top_set_bit(n)
+    return _prod!([BigInt() for _ in 1:depth+2], arr, lo, hi, 1)
+end
+
+# The product of `arr[lo:hi]`: `scratch[d]` for a range of two or more, and
+# for a single element that element, which the caller may then only read.
+function _prod!(scratch::Vector{BigInt}, arr::AbstractArray{BigInt}, lo::Int, hi::Int, d::Int)
+    lo == hi && return arr[lo]
+    hi - lo == 1 && return MPZ.mul!(scratch[d], arr[lo], arr[hi])
+    # Split so the left range holds two or more and so lands in `scratch[d+1]`;
+    # only the right one can come back as an array element.
+    mid = lo + ((hi - lo) >> 1)
+    l = _prod!(scratch, arr, lo, mid, d + 1)
+    # Park it: the right half reuses every slot below this level.
+    scratch[d], scratch[d+1] = l, scratch[d]
+    r = _prod!(scratch, arr, mid + 1, hi, d + 1)
+    spare = scratch[end]   # neither operand, so mul! reuses its buffer
+    MPZ.mul!(spare, scratch[d], r)
+    scratch[d], scratch[end] = spare, scratch[d]
+    return scratch[d]
 end
 
 factorial(n::BigInt) = !isnegative(n) ? MPZ.fac_ui(n) : throw(DomainError(n, "`n` must not be negative."))
@@ -889,33 +1470,30 @@ if Limb === UInt64 === UInt
 
     using .Base: HASH_SECRET, hash_bytes
 
-    # UnsafeLimbView provides a safe iterator interface to BigInt limb data
-    struct UnsafeLimbView <: AbstractVector{UInt8}
+    struct LimbView <: AbstractVector{UInt8}
         bigint::BigInt
         start_byte::Int
         num_bytes::Int
     end
 
-    function Base.size(view::UnsafeLimbView)
+    function Base.size(view::LimbView)
         return (view.num_bytes,)
     end
 
-    function Base.getindex(view::UnsafeLimbView, i::Int)
+    function Base.getindex(view::LimbView, i::Int)
         @boundscheck checkbounds(view, i)
-        GC.@preserve view begin
-            limb_index = div(view.start_byte + i - 2, 8) + 1
-            byte_in_limb = (view.start_byte + i - 2) % 8
-            limb = unsafe_load(view.bigint.d, limb_index)
-            return UInt8((limb >> (8 * byte_in_limb)) & 0xff)
-        end
+        limb_index = div(view.start_byte + i - 2, 8) + 1
+        byte_in_limb = (view.start_byte + i - 2) % 8
+        limb = @inbounds view.bigint.d[limb_index]
+        return UInt8((limb >> (8 * byte_in_limb)) & 0xff)
     end
 
-    function Base.iterate(view::UnsafeLimbView, state::Int = 1)
+    function Base.iterate(view::LimbView, state::Int = 1)
         state > view.num_bytes && return nothing
         return @inbounds(view[state]), state + 1
     end
 
-    function Base.length(view::UnsafeLimbView)
+    function Base.length(view::LimbView)
         return view.num_bytes
     end
 
@@ -925,52 +1503,48 @@ if Limb === UInt64 === UInt
         h ⊻= (s < 0)
 
         us = abs(s)
-        leading_zero_bytes = div(leading_zeros(unsafe_load(n.d, us)), 8)
+        leading_zero_bytes = div(leading_zeros(@inbounds n.d[us]), 8)
         num_bytes = 8 * us - leading_zero_bytes
 
-        # Use UnsafeLimbView for safe iterator-based access
-        limb_view = UnsafeLimbView(n, 1, num_bytes)
+        limb_view = LimbView(n, 1, num_bytes)
         return hash_bytes(limb_view, h, HASH_SECRET)
     end
 
     function hash(x::BigInt, h::UInt)
-        GC.@preserve x begin
-            sz = x.size
-            sz == 0 && return hash(0, h)
-            ptr = Ptr{UInt64}(x.d)
-            if sz == 1
-                return hash(unsafe_load(ptr), h)
-            elseif sz == -1
-                limb = unsafe_load(ptr)
-                limb <= typemin(Int) % UInt && return hash(-%(limb % Int), h)
-            end
-            pow = trailing_zeros(x)
-            nd = Base.ndigits0z(x, 2)
-            idx = (pow >>> 6) + 1
-            shift = (pow & 63) % UInt
-            upshift = BITS_PER_LIMB - shift
-            asz = abs(sz)
-            if shift == 0
-                limb = unsafe_load(ptr, idx)
-            else
-                limb1 = unsafe_load(ptr, idx)
-                limb2 = idx < asz ? unsafe_load(ptr, idx+1) : UInt(0)
-                limb = limb2 << upshift | limb1 >> shift
-            end
-            if nd <= 1024 && nd - pow <= 53
-                return hash(ldexp(flipsign(Float64(limb), sz), pow), h)
-            end
-            h = hash_integer(pow, h)
-
-            h ⊻= (sz < 0)
-            leading_zero_bytes = div(leading_zeros(unsafe_load(x.d, asz)), 8)
-            trailing_zero_bytes = div(pow, 8)
-            num_bytes = 8 * asz - (leading_zero_bytes + trailing_zero_bytes)
-
-            # Use UnsafeLimbView for safe iterator-based access
-            limb_view = UnsafeLimbView(x, trailing_zero_bytes + 1, num_bytes)
-            return hash_bytes(limb_view, h, HASH_SECRET)
+        sz = x.size
+        sz == 0 && return hash(0, h)
+        d = x.d
+        if sz == 1
+            return hash(@inbounds(d[1]), h)
+        elseif sz == -1
+            limb = @inbounds d[1]
+            limb <= typemin(Int) % UInt && return hash(-%(limb % Int), h)
         end
+        pow = trailing_zeros(x)
+        nd = Base.ndigits0z(x, 2)
+        idx = (pow >>> 6) + 1
+        shift = (pow & 63) % UInt
+        upshift = BITS_PER_LIMB - shift
+        asz = abs(sz)
+        if shift == 0
+            limb = @inbounds d[idx]
+        else
+            limb1 = @inbounds d[idx]
+            limb2 = idx < asz ? (@inbounds d[idx+1]) : UInt(0)
+            limb = limb2 << upshift | limb1 >> shift
+        end
+        if nd <= 1024 && nd - pow <= 53
+            return hash(ldexp(flipsign(Float64(limb), sz), pow), h)
+        end
+        h = hash_integer(pow, h)
+
+        h ⊻= (sz < 0)
+        leading_zero_bytes = div(leading_zeros(@inbounds d[asz]), 8)
+        trailing_zero_bytes = div(pow, 8)
+        num_bytes = 8 * asz - (leading_zero_bytes + trailing_zero_bytes)
+
+        limb_view = LimbView(x, trailing_zero_bytes + 1, num_bytes)
+        return hash_bytes(limb_view, h, HASH_SECRET)
     end
 end
 
@@ -982,6 +1556,26 @@ import ..GMP: BigInt, MPZ, Limb, libgmp
 
 gmpq(op::Symbol) = Expr(:tuple, QuoteNode(Symbol(:__gmpq_, op)), GlobalRef(MPZ, :libgmp))
 
+# As for `mpz` above: reads take `_MPQView`, a borrowed `__mpq_struct`, and
+# writes run on a GMP-owned scratch `mpq`, released before the call returns.
+struct _MPQView
+    num_alloc::Cint
+    num_size::Cint
+    num_d::Ptr{Limb}
+    den_alloc::Cint
+    den_size::Cint
+    den_d::Ptr{Limb}
+end
+const mpq_view_t = Ref{_MPQView}
+
+@inline _view(x::Rational{BigInt}) = _MPQView(
+    length(x.num.d) % Cint, x.num.size % Cint, pointer(x.num.d),
+    length(x.den.d) % Cint, x.den.size % Cint, pointer(x.den.d))
+
+Base.cconvert(::Type{mpq_view_t}, x::Rational{BigInt}) = (Ref(_view(x)), x.num.d, x.den.d)
+Base.unsafe_convert(::Type{mpq_view_t}, t::Tuple{Base.RefValue{_MPQView},Memory{Limb},Memory{Limb}}) =
+    Base.unsafe_convert(mpq_view_t, t[1])
+
 mutable struct _MPQ
     num_alloc::Cint
     num_size::Cint
@@ -989,26 +1583,28 @@ mutable struct _MPQ
     den_alloc::Cint
     den_size::Cint
     den_d::Ptr{Limb}
-    # to prevent GC
-    rat::Rational{BigInt}
+    _MPQ() = new(0, 0, C_NULL, 0, 0, C_NULL)
 end
-
 const mpq_t = Ref{_MPQ}
 
-_MPQ(x::BigInt,y::BigInt) = _MPQ(x.alloc, x.size, x.d,
-                                 y.alloc, y.size, y.d,
-                                 unsafe_rational(BigInt, x, y))
-_MPQ() = _MPQ(BigInt(), BigInt())
-_MPQ(x::Rational{BigInt}) = _MPQ(x.num, x.den)
+_init!(q::_MPQ) = (ccall((:__gmpq_init, libgmp), Cvoid, (mpq_t,), q); q)
+_clear!(q::_MPQ) = ccall((:__gmpq_clear, libgmp), Cvoid, (mpq_t,), q)
 
-function sync_rational!(xq::_MPQ)
-    xq.rat.num.alloc = xq.num_alloc
-    xq.rat.num.size  = xq.num_size
-    xq.rat.num.d     = xq.num_d
-    xq.rat.den.alloc = xq.den_alloc
-    xq.rat.den.size  = xq.den_size
-    xq.rat.den.d     = xq.den_d
-    return xq.rat
+function _take!(z::Rational{BigInt}, q::_MPQ)
+    MPZ._take!(z.num, q.num_size, q.num_d)
+    MPZ._take!(z.den, q.den_size, q.den_d)
+    return z
+end
+
+# Only the output needs GMP-owned limbs; `mpq_add` and friends take const operands.
+function _with_output(f::F, z::Rational{BigInt}) where {F}
+    q = _init!(_MPQ())
+    try
+        f(q)
+        return _take!(z, q)
+    finally
+        _clear!(q)
+    end
 end
 
 function Rational{BigInt}(num::BigInt, den::BigInt)
@@ -1016,23 +1612,20 @@ function Rational{BigInt}(num::BigInt, den::BigInt)
         iszero(num) && __throw_rational_argerror_zero(BigInt)
         return set_si(flipsign(1, num), 0)
     end
-    xq = _MPQ(MPZ.set(num), MPZ.set(den))
-    ccall((:__gmpq_canonicalize, libgmp), Cvoid, (mpq_t,), xq)
-    return sync_rational!(xq)
+    return _with_output(unsafe_rational(BigInt(), BigInt())) do q
+        ccall((:__gmpq_set_num, libgmp), Cvoid, (mpq_t, MPZ.mpz_t), q, num)
+        ccall((:__gmpq_set_den, libgmp), Cvoid, (mpq_t, MPZ.mpz_t), q, den)
+        ccall((:__gmpq_canonicalize, libgmp), Cvoid, (mpq_t,), q)
+    end
 end
 
 # define set, set_ui, set_si, set_z, and their inplace versions
-function set!(z::Rational{BigInt}, x::Rational{BigInt})
-    zq = _MPQ(z)
-    ccall((:__gmpq_set, libgmp), Cvoid, (mpq_t, mpq_t), zq, _MPQ(x))
-    return sync_rational!(zq)
-end
+# `x` is already canonical, so its components are copied across directly.
+set!(z::Rational{BigInt}, x::Rational{BigInt}) =
+    (MPZ.set!(z.num, x.num); MPZ.set!(z.den, x.den); z)
 
-function set_z!(z::Rational{BigInt}, x::BigInt)
-    zq = _MPQ(z)
-    ccall((:__gmpq_set_z, libgmp), Cvoid, (mpq_t, MPZ.mpz_t), zq, x)
-    return sync_rational!(zq)
-end
+set_z!(z::Rational{BigInt}, x::BigInt) =
+    (MPZ.set!(z.num, x); MPZ.set_ui!(z.den, one(Limb)); z)
 
 for (op, T) in ((:set, Rational{BigInt}), (:set_z, BigInt))
     op! = Symbol(op, :!)
@@ -1044,10 +1637,8 @@ end
 for (op, T1, T2) in ((:set_ui, Culong, Culong), (:set_si, Clong, Culong))
     op! = Symbol(op, :!)
     @eval begin
-        function $op!(z::Rational{BigInt}, a, b)
-            zq = _MPQ(z)
-            ccall($(gmpq(op)), Cvoid, (mpq_t, $T1, $T2), zq, a, b)
-            return sync_rational!(zq)
+        $op!(z::Rational{BigInt}, a, b) = _with_output(z) do q
+            ccall($(gmpq(op)), Cvoid, (mpq_t, $T1, $T2), q, a, b)
         end
         $op(a, b) = $op!(unsafe_rational(BigInt(), BigInt()), a, b)
     end
@@ -1061,10 +1652,9 @@ function add!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         end
         return set!(z, iszero(x.den) ? x : y)
     end
-    zq = _MPQ(z)
-    ccall((:__gmpq_add, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
-    return sync_rational!(zq)
+    return _with_output(z) do q
+        ccall((:__gmpq_add, libgmp), Cvoid, (mpq_t, mpq_view_t, mpq_view_t), q, x, y)
+    end
 end
 
 function sub!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
@@ -1075,10 +1665,9 @@ function sub!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         iszero(x.den) && return set!(z, x)
         return set_si!(z, flipsign(-1, y.num), 0)
     end
-    zq = _MPQ(z)
-    ccall((:__gmpq_sub, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
-    return sync_rational!(zq)
+    return _with_output(z) do q
+        ccall((:__gmpq_sub, libgmp), Cvoid, (mpq_t, mpq_view_t, mpq_view_t), q, x, y)
+    end
 end
 
 function mul!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
@@ -1088,10 +1677,9 @@ function mul!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         end
         return set_si!(z, ifelse(xor(isnegative(x.num), isnegative(y.num)), -1, 1), 0)
     end
-    zq = _MPQ(z)
-    ccall((:__gmpq_mul, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
-    return sync_rational!(zq)
+    return _with_output(z) do q
+        ccall((:__gmpq_mul, libgmp), Cvoid, (mpq_t, mpq_view_t, mpq_view_t), q, x, y)
+    end
 end
 
 function div!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
@@ -1109,10 +1697,9 @@ function div!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         end
         return set_si!(z, flipsign(1, x.num), 0)
     end
-    zq = _MPQ(z)
-    ccall((:__gmpq_div, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
-    return sync_rational!(zq)
+    return _with_output(z) do q
+        ccall((:__gmpq_div, libgmp), Cvoid, (mpq_t, mpq_view_t, mpq_view_t), q, x, y)
+    end
 end
 
 for (fJ, fC) in ((:+, :add), (:-, :sub), (:*, :mul), (://, :div))
@@ -1124,7 +1711,7 @@ for (fJ, fC) in ((:+, :add), (:-, :sub), (:*, :mul), (://, :div))
 end
 
 function Base.cmp(x::Rational{BigInt}, y::Rational{BigInt})
-    Int(ccall((:__gmpq_cmp, libgmp), Cint, (mpq_t, mpq_t), _MPQ(x), _MPQ(y)))
+    Int(ccall((:__gmpq_cmp, libgmp), Cint, (mpq_view_t, mpq_view_t), x, y))
 end
 
 end # MPQ module

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -67,7 +67,6 @@ mutable struct BigInt <: Signed
     size::Int
     d::Memory{Limb}
 
-    global _bigint(size::Int, d::Memory{Limb}) = new(size, d)
     BigInt(; nbits::Integer=0) = new(0, Memory{Limb}(undef, cld(Int(nbits), BITS_PER_LIMB)))
 end
 
@@ -139,19 +138,39 @@ end
 
 
 module MPZ
-# We reimplement the mpz layer of gmp using either mpn or Julia implementations
-# so that we can handle the memory management ourselves. For some complicated functions
-# we wrap mpz using MPZView rather than BigInt.
+# The mpz layer of GMP, reimplemented over `mpn` or in Julia so that `BigInt`
+# limbs can live in GC-managed memory. Operations with no suitable `mpn` form
+# still call mpz, through the two `__mpz_struct` wrappers below.
 using ..GMP: BigInt, Limb, BITS_PER_LIMB, libgmp
 
-# `mpz_t` is `__mpz_struct*`, so `Ref{MPZView}` is ABI-identical.
-# Valid only  for calls that never reallocate: those would hand a GC pointer to `free`.
+const MP = Memory{Limb}   # a limb buffer
+
+# Two Julia types share the layout of `__mpz_struct`, so a `Ref` to either is
+# ABI-identical to `mpz_t`. Which one to use depends on who owns the limbs:
+#
+# - `MPZView` points into a `BigInt`'s GC-managed `Memory`. Use it, via
+#   `mpz_t`, for arguments GMP only reads. GMP must never reallocate one, as
+#   that would hand a GC pointer to `free`.
+# - `MPZOwned` has limbs allocated by GMP itself. Use it, via `mpz_owned_t`
+#   and `with_output`, for arguments GMP writes. Its result is copied into a
+#   `BigInt` and the object is then cleared.
+#
+# Keeping them distinct types means a `BigInt` cannot convert into a slot GMP
+# might reallocate.
 struct MPZView
     alloc::Cint
     size::Cint
     d::Ptr{Limb}
 end
 const mpz_t = Ref{MPZView}
+
+mutable struct MPZOwned
+    alloc::Cint
+    size::Cint
+    d::Ptr{Limb}
+    MPZOwned() = new(0, 0, C_NULL)
+end
+const mpz_owned_t = Ref{MPZOwned}
 const bitcnt_t = Culong
 const mp_size_t = Clong
 
@@ -160,7 +179,7 @@ const mp_size_t = Clong
 # `cconvert` hands back the limbs alongside the header, so `ccall` roots them
 # for the duration of the call.
 Base.cconvert(::Type{mpz_t}, a::BigInt) = (Ref(_view(a)), a.d)
-Base.unsafe_convert(::Type{mpz_t}, t::Tuple{Base.RefValue{MPZView},Memory{Limb}}) =
+Base.unsafe_convert(::Type{mpz_t}, t::Tuple{Base.RefValue{MPZView},MP}) =
     Base.unsafe_convert(mpz_t, t[1])
 
 # Capacity for `n` limbs. Contents are not preserved and `x.d` may be replaced,
@@ -168,7 +187,7 @@ Base.unsafe_convert(::Type{mpz_t}, t::Tuple{Base.RefValue{MPZView},Memory{Limb}}
 @inline function _ensure!(x::BigInt, n::Int)
     d = x.d
     if length(d) < n
-        d = Memory{Limb}(undef, n)
+        d = MP(undef, n)
         x.d = d
     end
     return d
@@ -176,28 +195,28 @@ end
 
 # An `n`-limb buffer for an output that must not overlap any of `avoid`: `x`'s
 # own limbs if they are big enough and not among `avoid`, otherwise a new one.
-@inline function _dest(x::BigInt, n::Int, avoid::Vararg{Memory{Limb},N}) where {N}
+@inline function _dest(x::BigInt, n::Int, avoid::Vararg{MP,N}) where {N}
     d = x.d
-    return (length(d) >= n && !any(m -> m === d, avoid)) ? d : Memory{Limb}(undef, n)
+    return (length(d) >= n && !any(m -> m === d, avoid)) ? d : MP(undef, n)
 end
 
-# Publish `n` limbs of `d` as `x`'s value, with sign `neg`. Every write ends
-# here, which is what restores `BigInt`'s invariants.
-@inline function _finish!(x::BigInt, d::Memory{Limb}, n::Int, neg::Bool)
-    x.d === d || (x.d = d)
-    sz = something(findlast(!iszero, @view d[1:n]), 0)
+# Publish `n` limbs of `d` as `x`'s value, with sign `neg`. Every kernel-backed
+# write ends here, which is what restores `BigInt`'s invariants.
+@inline function _finish!(x::BigInt, d::MP, n::Int, neg::Bool)
+    x.d = d
+    sz = n
+    @inbounds while sz > 0 && iszero(d[sz])
+        sz -= 1
+    end
     x.size = neg ? -sz : sz
     return x
 end
+_zero!(x::BigInt) = (x.size = 0; x)
 
-@inline function _magsign(a)
-    s = Int64(a)
-    u = s % UInt64
-    return (s < 0 ? -u : u, s < 0)
-end
+@inline _magsign(a) = (s = Int64(a); (Base.uabs(s), s < 0))
 
 # Split `u` into limbs, writing them at `d[off+1:]`.
-@inline function _store!(d::Memory{Limb}, off::Int, u::Union{UInt64,UInt128})
+@inline function _store!(d::MP, off::Int, u::Union{UInt64,UInt128})
     @inbounds for i in 1:cld(8*sizeof(u), BITS_PER_LIMB)
         d[off+i] = (u >> ((i - 1) * BITS_PER_LIMB)) % Limb
     end
@@ -205,16 +224,6 @@ end
 end
 
 realloc2!(x::BigInt, a) = (_ensure!(x, cld(Int(a), BITS_PER_LIMB)); x)
-realloc2(a) = realloc2!(BigInt(), a)
-
-# A GMP-owned mpz, for the operations with no suitable `mpn` form.
-mutable struct Scratch
-    alloc::Cint
-    size::Cint
-    d::Ptr{Limb}
-    Scratch() = new(0, 0, C_NULL)
-end
-const scratch_t = Ref{Scratch}
 
 # Copy a GMP-owned mpz, given as its signed size and limb pointer, into `x`.
 # No normalization: every mpz function leaves its output with a nonzero top
@@ -226,18 +235,18 @@ function _take!(x::BigInt, sz::Cint, p::Ptr{Limb})
     x.size = Int(sz)
     return x
 end
-_take!(x::BigInt, s::Scratch) = _take!(x, s.size, s.d)
+_take!(x::BigInt, s::MPZOwned) = _take!(x, s.size, s.d)
 
-# The GMP-owned scratch object for an output `x`, and its init/clear entry
-# points. `MPQ` extends these for `Rational{BigInt}`.
-_scratch(::BigInt) = Scratch()
-_init!(s::Scratch) = (ccall((:__gmpz_init, libgmp), Cvoid, (scratch_t,), s); s)
-_clear!(s::Scratch) = ccall((:__gmpz_clear, libgmp), Cvoid, (scratch_t,), s)
+# The GMP-owned object for an output `x`, and its init/clear entry points.
+# `MPQ` extends these for `Rational{BigInt}`.
+_owned(::BigInt) = MPZOwned()
+_init!(s::MPZOwned) = (ccall((:__gmpz_init, libgmp), Cvoid, (mpz_owned_t,), s); s)
+_clear!(s::MPZOwned) = ccall((:__gmpz_clear, libgmp), Cvoid, (mpz_owned_t,), s)
 
-# Run `f` on a GMP-owned scratch output, move it into `x`, free it, and return
-# `f`'s value. Only the output needs GMP-owned limbs; inputs stay views.
+# Run `f` on a GMP-owned output, move it into `x`, free it, and return `f`'s
+# value. Only the output needs GMP-owned limbs; inputs stay views.
 function with_output(f::F, x) where {F}
-    s = _init!(_scratch(x))
+    s = _init!(_owned(x))
     try
         ret = f(s)
         _take!(x, s)
@@ -247,37 +256,36 @@ function with_output(f::F, x) where {F}
     end
 end
 
-# Limb-array kernels; callers must respect each one's overlap rules. `ccall`
-# roots a `Memory`, so no caller needs `GC.@preserve`. `ro`/`uo` are the limb
-# offsets of the shifts, the only kernels not applied at a buffer's start.
-const MP = Memory{Limb}
-
-_mpn_add(r::MP, u::MP, un, v::MP, vn) = ccall((:__gmpn_add, libgmp), Limb,
-    (Ptr{Limb}, Ptr{Limb}, mp_size_t, Ptr{Limb}, mp_size_t), r, u, un, v, vn)
-_mpn_add_1(r::MP, u::MP, un, v) = ccall((:__gmpn_add_1, libgmp), Limb,
-    (Ptr{Limb}, Ptr{Limb}, mp_size_t, Limb), r, u, un, v)
-_mpn_sub(r::MP, u::MP, un, v::MP, vn) = ccall((:__gmpn_sub, libgmp), Limb,
-    (Ptr{Limb}, Ptr{Limb}, mp_size_t, Ptr{Limb}, mp_size_t), r, u, un, v, vn)
-_mpn_sub_1(r::MP, u::MP, un, v) = ccall((:__gmpn_sub_1, libgmp), Limb,
-    (Ptr{Limb}, Ptr{Limb}, mp_size_t, Limb), r, u, un, v)
-_mpn_mul_1(r::MP, u::MP, un, v) = ccall((:__gmpn_mul_1, libgmp), Limb,
-    (Ptr{Limb}, Ptr{Limb}, mp_size_t, Limb), r, u, un, v)
-_mpn_cmp(u::MP, v::MP, n) = ccall((:__gmpn_cmp, libgmp), Cint,
-    (Ptr{Limb}, Ptr{Limb}, mp_size_t), u, v, n)
-# Single-limb division, which needs no buffer for the remainder: both return
-# it. `mpn_divrem_1` allows its quotient to be the numerator buffer itself.
-_mpn_divrem_1(q::MP, u::MP, un, v) = ccall((:__gmpn_divrem_1, libgmp), Limb,
-    (Ptr{Limb}, mp_size_t, Ptr{Limb}, mp_size_t, Limb), q, 0, u, un, v)
-_mpn_mod_1(u::MP, un, v) = ccall((:__gmpn_mod_1, libgmp), Limb,
-    (Ptr{Limb}, mp_size_t, Limb), u, un, v)
-_mpn_lshift(r::MP, ro::Int, u::MP, n, cnt) = GC.@preserve r ccall((:__gmpn_lshift, libgmp),
-    Limb, (Ptr{Limb}, Ptr{Limb}, mp_size_t, Cuint), pointer(r, ro+1), u, n, cnt)
-_mpn_rshift(r::MP, u::MP, uo::Int, n, cnt) = GC.@preserve u ccall((:__gmpn_rshift, libgmp),
-    Limb, (Ptr{Limb}, Ptr{Limb}, mp_size_t, Cuint), r, pointer(u, uo+1), n, cnt)
+# Limb-array kernels. Each has its own overlap rules, which callers must
+# respect. `ccall` roots a `Memory`, so `GC.@preserve` is only needed where a
+# `pointer` is taken: the shifts, the only kernels applied at an offset
+# (`ro`/`uo`) into a buffer rather than at its start.
+_mpn_add(r::MP, u::MP, un, v::MP, vn) =
+    @ccall libgmp.__gmpn_add(r::Ptr{Limb}, u::Ptr{Limb}, un::mp_size_t, v::Ptr{Limb}, vn::mp_size_t)::Limb
+_mpn_add_1(r::MP, u::MP, un, v) =
+    @ccall libgmp.__gmpn_add_1(r::Ptr{Limb}, u::Ptr{Limb}, un::mp_size_t, v::Limb)::Limb
+_mpn_sub(r::MP, u::MP, un, v::MP, vn) =
+    @ccall libgmp.__gmpn_sub(r::Ptr{Limb}, u::Ptr{Limb}, un::mp_size_t, v::Ptr{Limb}, vn::mp_size_t)::Limb
+_mpn_sub_1(r::MP, u::MP, un, v) =
+    @ccall libgmp.__gmpn_sub_1(r::Ptr{Limb}, u::Ptr{Limb}, un::mp_size_t, v::Limb)::Limb
+_mpn_mul_1(r::MP, u::MP, un, v) =
+    @ccall libgmp.__gmpn_mul_1(r::Ptr{Limb}, u::Ptr{Limb}, un::mp_size_t, v::Limb)::Limb
+_mpn_cmp(u::MP, v::MP, n) =
+    @ccall libgmp.__gmpn_cmp(u::Ptr{Limb}, v::Ptr{Limb}, n::mp_size_t)::Cint
+# Single-limb division returns the remainder, so it needs no buffer for it.
+# `mpn_divrem_1` may write the quotient over the numerator; `qxn` is always 0.
+_mpn_divrem_1(q::MP, u::MP, un, v) =
+    @ccall libgmp.__gmpn_divrem_1(q::Ptr{Limb}, 0::mp_size_t, u::Ptr{Limb}, un::mp_size_t, v::Limb)::Limb
+_mpn_mod_1(u::MP, un, v) =
+    @ccall libgmp.__gmpn_mod_1(u::Ptr{Limb}, un::mp_size_t, v::Limb)::Limb
+_mpn_lshift(r::MP, ro::Int, u::MP, n, cnt) = GC.@preserve r @ccall libgmp.__gmpn_lshift(
+    pointer(r, ro+1)::Ptr{Limb}, u::Ptr{Limb}, n::mp_size_t, cnt::Cuint)::Limb
+_mpn_rshift(r::MP, u::MP, uo::Int, n, cnt) = GC.@preserve u @ccall libgmp.__gmpn_rshift(
+    r::Ptr{Limb}, pointer(u, uo+1)::Ptr{Limb}, n::mp_size_t, cnt::Cuint)::Limb
 
 # The superlinear kernels are the ones worth abandoning mid-flight, so they
-# are `:reset_safe`. An unwind discards their output buffer, and the
-# allocation hooks free any GMP temporary, so nothing that matters leaks.
+# are `:reset_safe`: an unwind discards their output buffer, and the
+# allocation hooks free any GMP temporary, so nothing leaks.
 _mpn_mul(r::MP, u::MP, un, v::MP, vn) = Base.@assume_effects :reset_safe @ccall libgmp.__gmpn_mul(
     r::Ptr{Limb}, u::Ptr{Limb}, un::mp_size_t, v::Ptr{Limb}, vn::mp_size_t)::Limb
 _mpn_sqr(r::MP, u::MP, un) = Base.@assume_effects :reset_safe @ccall libgmp.__gmpn_sqr(
@@ -285,14 +293,14 @@ _mpn_sqr(r::MP, u::MP, un) = Base.@assume_effects :reset_safe @ccall libgmp.__gm
 _mpn_tdiv_qr(q::MP, r::MP, n::MP, nn, d::MP, dn) = Base.@assume_effects :reset_safe @ccall libgmp.__gmpn_tdiv_qr(
     q::Ptr{Limb}, r::Ptr{Limb}, 0::mp_size_t, n::Ptr{Limb}, nn::mp_size_t,
     d::Ptr{Limb}, dn::mp_size_t)::Cvoid
-# the remainder is never wanted here, so `rp` is always NULL
+# The remainder is never wanted here, so `rp` is always NULL.
 _mpn_sqrt(s::MP, u::MP, n) = Base.@assume_effects :reset_safe @ccall libgmp.__gmpn_sqrtrem(
     s::Ptr{Limb}, C_NULL::Ptr{Limb}, u::Ptr{Limb}, n::mp_size_t)::mp_size_t
 
 sizeinbase(a::BigInt, b) = Int(ccall((:__gmpz_sizeinbase, libgmp), Csize_t, (mpz_t, Cint), a, b))
 
-function _ucmp(ad::Memory{Limb}, an::Int, bd::Memory{Limb}, bn::Int)
-    an != bn && return an < bn ? -1 : 1
+function _ucmp(ad::MP, an::Int, bd::MP, bn::Int)
+    an != bn && return Base.cmp(an, bn)
     an == 0 && return 0
     return Int(_mpn_cmp(ad, bd, an % mp_size_t))
 end
@@ -324,11 +332,12 @@ function _addsub!(x::BigInt, a::BigInt, b::BigInt, negb::Bool)
         return _finish!(x, d, an + 1, as < 0)
     end
     rel = _ucmp(ad, an, bd, bn)
-    rel == 0 && (x.size = 0; return x)
-    rel < 0 && ((ad, an, as, bd, bn) = (bd, bn, bs, ad, an))
+    rel == 0 && return _zero!(x)
+    neg = (rel < 0) != (as < 0)   # the larger magnitude's sign
+    rel < 0 && ((ad, an, bd, bn) = (bd, bn, ad, an))
     d = _ensure!(x, an)
     _mpn_sub(d, ad, an % mp_size_t, bd, bn % mp_size_t)
-    return _finish!(x, d, an, as < 0)
+    return _finish!(x, d, an, neg)
 end
 
 add!(x::BigInt, a::BigInt, b::BigInt) = _addsub!(x, a, b, false)
@@ -359,7 +368,7 @@ end
 add_ui!(x::BigInt, a::BigInt, b) = _addsub_mag!(x, a, Limb(b), false)
 sub_ui!(x::BigInt, a::BigInt, b) = _addsub_mag!(x, a, Limb(b), true)
 # x = a - b, with `a` an unsigned magnitude
-ui_sub!(x::BigInt, a, b::BigInt) = (_addsub_mag!(x, b, Limb(a), true); x.size = -x.size; x)
+ui_sub!(x::BigInt, a, b::BigInt) = neg!(sub_ui!(x, b, a))
 ui_sub(a, b::BigInt) = ui_sub!(BigInt(), a, b)
 
 _inc!(x::BigInt) = _addsub_mag!(x, x, one(Limb), false)
@@ -368,31 +377,24 @@ _dec!(x::BigInt) = _addsub_mag!(x, x, one(Limb), true)
 function mul!(x::BigInt, a::BigInt, b::BigInt)
     Base.@cancel_check
     as, bs = a.size, b.size
-    if as == 0 || bs == 0
-        x.size = 0
-        return x
-    end
+    (as == 0 || bs == 0) && return _zero!(x)
     an, bn = abs(as), abs(bs)
     ad, bd = a.d, b.d
+    an < bn && ((ad, an, bd, bn) = (bd, bn, ad, an)) # longer operand first
     n = an + bn
     # mpn_mul forbids overlap, so unalias x if needed.
     d = _dest(x, n, ad, bd)
     if ad === bd && an == bn
         _mpn_sqr(d, ad, an % mp_size_t)
-    elseif an >= bn
-        _mpn_mul(d, ad, an % mp_size_t, bd, bn % mp_size_t)
     else
-        _mpn_mul(d, bd, bn % mp_size_t, ad, an % mp_size_t)
+        _mpn_mul(d, ad, an % mp_size_t, bd, bn % mp_size_t)
     end
     return _finish!(x, d, n, (as < 0) != (bs < 0))
 end
 
 function _mul_mag!(x::BigInt, a::BigInt, v::Limb, neg::Bool)
     as = a.size
-    if as == 0 || v == 0
-        x.size = 0
-        return x
-    end
+    (as == 0 || v == 0) && return _zero!(x)
     an = abs(as)
     ad = a.d
     d = _ensure!(x, an + 1)
@@ -407,7 +409,7 @@ mul_si!(x::BigInt, a::BigInt, b) = ((v, neg) = _magsign(b); _mul_mag!(x, a, Limb
 # sign. Either output may be `nothing` when it is not wanted; every call site
 # passes a literal, so each combination compiles to its own body. `mpn_tdiv_qr`
 # writes both outputs and forbids overlap among them and its inputs, so an
-# unwanted output gets scratch limbs and a wanted one a `_dest` buffer.
+# unwanted output gets throwaway limbs and a wanted one a `_dest` buffer.
 # Returns whether the remainder is nonzero, which the rounding variants need.
 function _tdiv!(q::Union{BigInt,Nothing}, r::Union{BigInt,Nothing}, a::BigInt, b::BigInt)
     Base.@cancel_check
@@ -415,7 +417,7 @@ function _tdiv!(q::Union{BigInt,Nothing}, r::Union{BigInt,Nothing}, a::BigInt, b
     bs == 0 && throw(DivideError())
     an, bn = abs(as), abs(bs)
     if an < bn # |a| < |b|: the quotient is 0 and the remainder is `a`
-        q === nothing || (q.size = 0)
+        q === nothing || _zero!(q)
         r === nothing || set!(r, a)
         return as != 0
     end
@@ -440,8 +442,8 @@ function _tdiv!(q::Union{BigInt,Nothing}, r::Union{BigInt,Nothing}, a::BigInt, b
         return rl != 0
     end
     qn = an - bn + 1
-    qd = q === nothing ? Memory{Limb}(undef, qn) : _dest(q, qn, ad, bd)
-    rd = r === nothing ? Memory{Limb}(undef, bn) : _dest(r, bn, ad, bd, qd)
+    qd = q === nothing ? MP(undef, qn) : _dest(q, qn, ad, bd)
+    rd = r === nothing ? MP(undef, bn) : _dest(r, bn, ad, bd, qd)
     _mpn_tdiv_qr(qd, rd, ad, an % mp_size_t, bd, bn % mp_size_t)
     q === nothing || _finish!(q, qd, qn, qneg)
     r === nothing && return any(!iszero, @view rd[1:bn])
@@ -487,7 +489,7 @@ for op in (:gcd, :lcm)
     @eval function $(Symbol(op, :!))(x::BigInt, a::BigInt, b::BigInt)
         Base.@cancel_check
         with_output(x) do s
-            Base.@assume_effects :reset_safe @ccall libgmp.$fname(s::scratch_t, a::mpz_t, b::mpz_t)::Cvoid
+            Base.@assume_effects :reset_safe @ccall libgmp.$fname(s::mpz_owned_t, a::mpz_t, b::mpz_t)::Cvoid
         end
         return x
     end
@@ -499,7 +501,7 @@ end
 # Limb `i` of the infinite two's-complement expansion of the value with
 # magnitude `d[1:n]`. Negated, that is the magnitude complemented above its
 # lowest nonzero limb `low`, where the +1 of the negation lands.
-@inline function _tc(d::Memory{Limb}, n::Int, neg::Bool, low::Int, i::Int)
+@inline function _tc(d::MP, n::Int, neg::Bool, low::Int, i::Int)
     v = i <= n ? (@inbounds d[i]) : zero(Limb)
     if neg
         v = i < low ? zero(Limb) : (i == low ? (-v) : ~v)
@@ -585,24 +587,15 @@ function fdiv_q_2exp!(x::BigInt, a::BigInt, c)
     ad = a.d
     neg = as < 0
     off, sh = divrem(s, BITS_PER_LIMB)
-    if off >= an
-        # Everything is shifted out; flooring leaves -1 for a negative value.
-        if neg
-            d = _ensure!(x, 1)
-            @inbounds d[1] = one(Limb)
-            x.size = -1
-        else
-            x.size = 0
-        end
-        return x
-    end
+    # Everything shifted out floors to -1 for a negative value.
+    off >= an && return neg ? set_si!(x, -1) : _zero!(x)
     # Flooring rounds away from zero when a negative value loses a set bit.
-    lost = neg && (any(!iszero, @view ad[1:off]) ||
-                   (sh > 0 && (@inbounds ad[off+1]) & ((one(Limb) << sh) - one(Limb)) != 0))
+    lost = neg && (any(!iszero, @view ad[1:off]) || trailing_zeros(@inbounds ad[off+1]) < sh)
     n = an - off
     # In place is fine: `mpn_rshift` permits overlap when `rp <= up`, which
     # holds with `up = ad + off`, and `lost` has already read the low limbs.
-    d = _ensure!(x, n)
+    # The extra limb leaves `_dec!` room for a carry without reallocating.
+    d = _ensure!(x, n + lost)
     if sh == 0
         copyto!(d, 1, ad, off+1, n)
     else
@@ -621,15 +614,11 @@ function sqrt!(x::BigInt, a::BigInt)
     Base.@cancel_check
     as = a.size
     as < 0 && throw(DomainError(a, "`x` must be non-negative"))
-    if as == 0
-        x.size = 0
-        return x
-    end
-    an = as # `as > 0` here, so the size and the limb count agree
+    as == 0 && return _zero!(x)
     ad = a.d
-    sn = cld(an, 2)
+    sn = cld(as, 2)
     d = _dest(x, sn, ad) # mpn_sqrtrem forbids overlap between `sp` and `up`
-    _mpn_sqrt(d, ad, an % mp_size_t)
+    _mpn_sqrt(d, ad, as % mp_size_t)
     return _finish!(x, d, sn, false)
 end
 
@@ -648,7 +637,7 @@ for (op, ret, kinds) in ((:invert, :Cint,  (:z, :z)),
     @eval function $(Symbol(op, :!))(x::BigInt, $(decls...))
         Base.@cancel_check
         r = with_output(x) do s
-            Base.@assume_effects :reset_safe @ccall libgmp.$fname(s::scratch_t, $(cargs...))::$ret
+            Base.@assume_effects :reset_safe @ccall libgmp.$fname(s::mpz_owned_t, $(cargs...))::$ret
         end
         return $out
     end
@@ -666,7 +655,7 @@ function gcdext!(x::BigInt, y::BigInt, z::BigInt, a::BigInt, b::BigInt)
         with_output(y) do ss
             with_output(z) do st
                 Base.@assume_effects :reset_safe @ccall libgmp.__gmpz_gcdext(
-                    sg::scratch_t, ss::scratch_t, st::scratch_t, a::mpz_t, b::mpz_t)::Cvoid
+                    sg::mpz_owned_t, ss::mpz_owned_t, st::mpz_owned_t, a::mpz_t, b::mpz_t)::Cvoid
             end
         end
     end
@@ -676,7 +665,7 @@ gcdext(a::BigInt, b::BigInt) = gcdext!(BigInt(), BigInt(), BigInt(), a, b)
 
 set_str!(x::BigInt, a, b) = with_output(x) do s
     Base.@cancel_check
-    Int(Base.@assume_effects :reset_safe @ccall libgmp.__gmpz_set_str(s::scratch_t, a::Ptr{UInt8}, b::Cint)::Cint)
+    Int(Base.@assume_effects :reset_safe @ccall libgmp.__gmpz_set_str(s::mpz_owned_t, a::Ptr{UInt8}, b::Cint)::Cint)
 end
 
 function _set_mag!(x::BigInt, u::UInt64, neg::Bool)
@@ -691,13 +680,9 @@ set_si!(x::BigInt, a) = ((u, neg) = _magsign(a); _set_mag!(x, u, neg))
 # Truncates towards zero, as mpz_set_d does.
 function set_d!(x::BigInt, a)
     v = Float64(a)
-    if -1.0 < v < 1.0
-        x.size = 0
-        return x
-    end
-    m, ex = frexp(abs(v))          # abs(v) == m * 2^ex, with 0.5 <= m < 1
-    sig = unsafe_trunc(UInt64, ldexp(m, 53))  # exact: the 53-bit significand
-    e = ex - 53                    # abs(v) truncated == sig * 2^e
+    -1.0 < v < 1.0 && return _zero!(x)
+    sig, e, _ = Base.decompose(v)  # abs(v) == sig * 2^e, `sig` the 53-bit significand
+    sig %= UInt64
     if e < 0
         sig >>= -e                 # truncate towards zero
         e = 0
@@ -757,21 +742,18 @@ mpn_popcount(a::BigInt) = mpn_popcount(a.d, abs(a.size))
 # more limbs means a larger magnitude. Only equal sizes need the limbs compared.
 function cmp(a::BigInt, b::BigInt)
     as, bs = a.size, b.size
-    as != bs && return as < bs ? -1 : 1
+    as != bs && return Base.cmp(as, bs)
     as == 0 && return 0
-    c = _ucmp(a.d, abs(as), b.d, abs(as))
-    return as < 0 ? -c : c
+    return flipsign(_ucmp(a.d, abs(as), b.d, abs(as)), as)
 end
 
 # Compare `a` with the one-limb magnitude `v` carrying sign `neg`.
 function _cmp_mag(a::BigInt, v::Limb, neg::Bool)
     as = a.size
     bs = v == 0 ? 0 : (neg ? -1 : 1)
-    as != bs && return as < bs ? -1 : 1
+    as != bs && return Base.cmp(as, bs)
     as == 0 && return 0
-    a1 = @inbounds a.d[1]
-    c = a1 == v ? 0 : (a1 < v ? -1 : 1)
-    return as < 0 ? -c : c
+    return flipsign(Base.cmp(@inbounds(a.d[1]), v), as)
 end
 cmp_si(a::BigInt, b) = ((v, neg) = _magsign(b); _cmp_mag(a, Limb(v), neg))
 cmp_ui(a::BigInt, b) = _cmp_mag(a, Limb(b), false)
@@ -802,26 +784,27 @@ function setbit!(x::BigInt, a)
     n = x.size
     if n >= 0
         # One limb's OR. Worth doing in place: the only caller sets bits in a
-        # loop, and the scratch path below copies all of `x` twice per bit.
-        i = (b ÷ BITS_PER_LIMB) + 1
+        # loop, and the mpz path below copies all of `x` twice per bit.
+        off, sh = divrem(b, BITS_PER_LIMB)
+        i = off + 1
         d = x.d
         if i > n
             if length(d) < i        # grow, preserving the limbs already set
-                nd = Memory{Limb}(undef, i)
+                nd = MP(undef, i)
                 copyto!(nd, 1, d, 1, n)
                 x.d = d = nd
             end
             fill!(@view(d[n+1:i]), zero(Limb))
             x.size = i
         end
-        @inbounds d[i] |= one(Limb) << (b % BITS_PER_LIMB)
+        @inbounds d[i] |= one(Limb) << sh
         return x
     end
     # Stored sign-magnitude, so the bit to set is not a bit of any stored
-    # limb; let mpz do it, on a scratch seeded from `x`.
+    # limb; let mpz do it, on a GMP-owned copy of `x`.
     with_output(x) do s
-        ccall((:__gmpz_set, libgmp), Cvoid, (scratch_t, mpz_t), s, x)
-        ccall((:__gmpz_setbit, libgmp), Cvoid, (scratch_t, bitcnt_t), s, a)
+        ccall((:__gmpz_set, libgmp), Cvoid, (mpz_owned_t, mpz_t), s, x)
+        ccall((:__gmpz_setbit, libgmp), Cvoid, (mpz_owned_t, bitcnt_t), s, a)
     end
     return x
 end
@@ -894,10 +877,10 @@ function BigInt(x::Integer)
     # On 64-bit Windows, `Clong` is `Int32`, not `Int64`, so construction of
     # `Int64` constants, e.g. `BigInt(3)`, uses this method.
     isbits(x) && typemin(Clong) <= x <= typemax(Clong) && return BigInt((x % Clong)::Clong)
-    n = cld(ndigits(x, base=2), BITS_PER_LIMB)
+    ux = unsigned(x < 0 ? -%(x) : x)
+    n = cld(top_set_bit(ux), BITS_PER_LIMB)
     z = BigInt()
     d = MPZ._ensure!(z, n)
-    ux = unsigned(x < 0 ? -%(x) : x)
     @inbounds for i in 1:n
         d[i] = ux % Limb
         ux >>= BITS_PER_LIMB
@@ -1265,10 +1248,7 @@ function prod(arr::AbstractArray{BigInt})
     lo = Int(firstindex(arr))
     n == 1 && return MPZ.set(arr[lo])
     hi = lo + n - 1
-    nlimbs = 0
-    for i in lo:hi
-        nlimbs += abs(arr[i].size)
-    end
+    nlimbs = sum(a -> abs(a.size), arr)
     if nlimbs <= 64 # with few total limbs linear prod is faster
         nbits = nlimbs*BITS_PER_LIMB
         acc = MPZ.set_si!(BigInt(; nbits=nbits), 1)
@@ -1279,7 +1259,7 @@ function prod(arr::AbstractArray{BigInt})
         end
         return acc
     end
-    # Otherwise multiply pairwise, keeping both operands of comparable size 
+    # Otherwise multiply pairwise, keeping both operands of comparable size
     # DFS leaves 1 partial product live per level, so one scratch per level is enough
     # plus a spare to multiply into
     depth = top_set_bit(n)
@@ -1549,9 +1529,10 @@ import ..GMP: BigInt, MPZ, Limb, libgmp
 
 gmpq(op::Symbol) = Expr(:tuple, QuoteNode(Symbol(:__gmpq_, op)), GlobalRef(MPZ, :libgmp))
 
-# As for `mpz` above: reads take `_MPQView`, a borrowed `__mpq_struct`, and
-# writes run on a GMP-owned scratch `mpq`, released before the call returns.
-struct _MPQView
+# As for `mpz` above: reads take `MPQView`, a borrowed `__mpq_struct`, via
+# `mpq_t`; writes run on a GMP-owned `MPQOwned`, via `mpq_owned_t`, that is
+# released before the call returns.
+struct MPQView
     num_alloc::Cint
     num_size::Cint
     num_d::Ptr{Limb}
@@ -1559,32 +1540,32 @@ struct _MPQView
     den_size::Cint
     den_d::Ptr{Limb}
 end
-const mpq_view_t = Ref{_MPQView}
+const mpq_t = Ref{MPQView}
 
-@inline _view(x::Rational{BigInt}) = _MPQView(
+@inline _view(x::Rational{BigInt}) = MPQView(
     length(x.num.d) % Cint, x.num.size % Cint, pointer(x.num.d),
     length(x.den.d) % Cint, x.den.size % Cint, pointer(x.den.d))
 
-Base.cconvert(::Type{mpq_view_t}, x::Rational{BigInt}) = (Ref(_view(x)), x.num.d, x.den.d)
-Base.unsafe_convert(::Type{mpq_view_t}, t::Tuple{Base.RefValue{_MPQView},Memory{Limb},Memory{Limb}}) =
-    Base.unsafe_convert(mpq_view_t, t[1])
+Base.cconvert(::Type{mpq_t}, x::Rational{BigInt}) = (Ref(_view(x)), x.num.d, x.den.d)
+Base.unsafe_convert(::Type{mpq_t}, t::Tuple{Base.RefValue{MPQView},Memory{Limb},Memory{Limb}}) =
+    Base.unsafe_convert(mpq_t, t[1])
 
-mutable struct _MPQ
+mutable struct MPQOwned
     num_alloc::Cint
     num_size::Cint
     num_d::Ptr{Limb}
     den_alloc::Cint
     den_size::Cint
     den_d::Ptr{Limb}
-    _MPQ() = new(0, 0, C_NULL, 0, 0, C_NULL)
+    MPQOwned() = new(0, 0, C_NULL, 0, 0, C_NULL)
 end
-const mpq_t = Ref{_MPQ}
+const mpq_owned_t = Ref{MPQOwned}
 
 # Hook `Rational{BigInt}` into `MPZ.with_output`.
-MPZ._scratch(::Rational{BigInt}) = _MPQ()
-MPZ._init!(q::_MPQ) = (ccall((:__gmpq_init, libgmp), Cvoid, (mpq_t,), q); q)
-MPZ._clear!(q::_MPQ) = ccall((:__gmpq_clear, libgmp), Cvoid, (mpq_t,), q)
-function MPZ._take!(z::Rational{BigInt}, q::_MPQ)
+MPZ._owned(::Rational{BigInt}) = MPQOwned()
+MPZ._init!(q::MPQOwned) = (ccall((:__gmpq_init, libgmp), Cvoid, (mpq_owned_t,), q); q)
+MPZ._clear!(q::MPQOwned) = ccall((:__gmpq_clear, libgmp), Cvoid, (mpq_owned_t,), q)
+function MPZ._take!(z::Rational{BigInt}, q::MPQOwned)
     MPZ._take!(z.num, q.num_size, q.num_d)
     MPZ._take!(z.den, q.den_size, q.den_d)
     return z
@@ -1598,9 +1579,9 @@ function Rational{BigInt}(num::BigInt, den::BigInt)
         return set_si(flipsign(1, num), 0)
     end
     return _with_output(unsafe_rational(BigInt(), BigInt())) do q
-        ccall((:__gmpq_set_num, libgmp), Cvoid, (mpq_t, MPZ.mpz_t), q, num)
-        ccall((:__gmpq_set_den, libgmp), Cvoid, (mpq_t, MPZ.mpz_t), q, den)
-        ccall((:__gmpq_canonicalize, libgmp), Cvoid, (mpq_t,), q)
+        ccall((:__gmpq_set_num, libgmp), Cvoid, (mpq_owned_t, MPZ.mpz_t), q, num)
+        ccall((:__gmpq_set_den, libgmp), Cvoid, (mpq_owned_t, MPZ.mpz_t), q, den)
+        ccall((:__gmpq_canonicalize, libgmp), Cvoid, (mpq_owned_t,), q)
     end
 end
 
@@ -1623,7 +1604,7 @@ for (op, T1, T2) in ((:set_ui, Culong, Culong), (:set_si, Clong, Culong))
     op! = Symbol(op, :!)
     @eval begin
         $op!(z::Rational{BigInt}, a, b) = _with_output(z) do q
-            ccall($(gmpq(op)), Cvoid, (mpq_t, $T1, $T2), q, a, b)
+            ccall($(gmpq(op)), Cvoid, (mpq_owned_t, $T1, $T2), q, a, b)
         end
         $op(a, b) = $op!(unsafe_rational(BigInt(), BigInt()), a, b)
     end
@@ -1638,7 +1619,7 @@ function add!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         return set!(z, iszero(x.den) ? x : y)
     end
     return _with_output(z) do q
-        ccall((:__gmpq_add, libgmp), Cvoid, (mpq_t, mpq_view_t, mpq_view_t), q, x, y)
+        ccall((:__gmpq_add, libgmp), Cvoid, (mpq_owned_t, mpq_t, mpq_t), q, x, y)
     end
 end
 
@@ -1651,7 +1632,7 @@ function sub!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         return set_si!(z, flipsign(-1, y.num), 0)
     end
     return _with_output(z) do q
-        ccall((:__gmpq_sub, libgmp), Cvoid, (mpq_t, mpq_view_t, mpq_view_t), q, x, y)
+        ccall((:__gmpq_sub, libgmp), Cvoid, (mpq_owned_t, mpq_t, mpq_t), q, x, y)
     end
 end
 
@@ -1663,7 +1644,7 @@ function mul!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         return set_si!(z, ifelse(xor(isnegative(x.num), isnegative(y.num)), -1, 1), 0)
     end
     return _with_output(z) do q
-        ccall((:__gmpq_mul, libgmp), Cvoid, (mpq_t, mpq_view_t, mpq_view_t), q, x, y)
+        ccall((:__gmpq_mul, libgmp), Cvoid, (mpq_owned_t, mpq_t, mpq_t), q, x, y)
     end
 end
 
@@ -1683,7 +1664,7 @@ function div!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         return set_si!(z, flipsign(1, x.num), 0)
     end
     return _with_output(z) do q
-        ccall((:__gmpq_div, libgmp), Cvoid, (mpq_t, mpq_view_t, mpq_view_t), q, x, y)
+        ccall((:__gmpq_div, libgmp), Cvoid, (mpq_owned_t, mpq_t, mpq_t), q, x, y)
     end
 end
 
@@ -1696,7 +1677,7 @@ for (fJ, fC) in ((:+, :add), (:-, :sub), (:*, :mul), (://, :div))
 end
 
 function Base.cmp(x::Rational{BigInt}, y::Rational{BigInt})
-    Int(ccall((:__gmpq_cmp, libgmp), Cint, (mpq_view_t, mpq_view_t), x, y))
+    Int(ccall((:__gmpq_cmp, libgmp), Cint, (mpq_t, mpq_t), x, y))
 end
 
 end # MPQ module

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -1319,6 +1319,8 @@ function decompose(x::BigFloat)::Tuple{BigInt, Int, Int}
     n = cld(x.prec, 8*sizeof(Limb))      # limbs
     b = n * sizeof(Limb)                 # bytes
     sd = MPZ._ensure!(s, n)
+    # A finite nonzero BigFloat's significand has its top bit set, so the top
+    # limb copied below is nonzero and `BigInt`'s invariant holds.
     s.size = n
     xd = x.d
     GC.@preserve sd xd memcpy(pointer(sd), Base.unsafe_convert(Ptr{Limb}, xd), b)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -33,7 +33,7 @@ import ..GMP: ClongMax, CulongMax, CdoubleMax, Limb, libgmp, BigInt, MPZ
 
 # A `BigInt`'s limbs are GC-managed, so libmpfr sees one through a borrowed
 # `__mpz_struct`. Sound only for entry points that do not write the mpz;
-# `mpfr_get_z`, which does, goes through a GMP-owned scratch mpz instead.
+# `mpfr_get_z`, which does, goes through a GMP-owned mpz instead.
 const mpz_t = MPZ.mpz_t
 
 import ..FastMath.sincos_fast
@@ -444,7 +444,7 @@ function _unchecked_cast(::Type{BigInt}, x::BigFloat, r::MPFRRoundingMode)
     z = BigInt()
     # mpfr_get_z writes its mpz, so it needs one that GMP owns.
     MPZ.with_output(z) do s
-        ccall((:mpfr_get_z, libmpfr), Int32, (MPZ.scratch_t, Ref{BigFloat}, MPFRRoundingMode), s, x, r)
+        ccall((:mpfr_get_z, libmpfr), Int32, (MPZ.mpz_owned_t, Ref{BigFloat}, MPFRRoundingMode), s, x, r)
     end
     return z
 end
@@ -1315,16 +1315,12 @@ function decompose(x::BigFloat)::Tuple{BigInt, Int, Int}
     isnan(x) && return 0, 0, 0
     isinf(x) && return x.sign, 0, 0
     x == 0 && return 0, 0, x.sign
-    s = BigInt()
     n = cld(x.prec, 8*sizeof(Limb))      # limbs
-    b = n * sizeof(Limb)                 # bytes
-    sd = MPZ._ensure!(s, n)
     # A finite nonzero BigFloat's significand has its top bit set, so the top
-    # limb copied below is nonzero and `BigInt`'s invariant holds.
-    s.size = n
+    # limb copied here is nonzero and `BigInt`'s invariant holds.
     xd = x.d
-    GC.@preserve sd xd memcpy(pointer(sd), Base.unsafe_convert(Ptr{Limb}, xd), b)
-    s, x.exp - 8b, x.sign
+    s = GC.@preserve xd MPZ._take!(BigInt(), n % Cint, Base.unsafe_convert(Ptr{Limb}, xd))
+    s, x.exp - 8*n*sizeof(Limb), x.sign
 end
 
 function lerpi(j::Integer, d::Integer, a::BigFloat, b::BigFloat)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -29,7 +29,12 @@ import ..Rounding: Rounding,
     rounding_raw, setrounding_raw, rounds_to_nearest, rounds_away_from_zero,
     tie_breaker_is_to_even, correct_rounding_requires_increment
 
-import ..GMP: ClongMax, CulongMax, CdoubleMax, Limb, libgmp, BigInt
+import ..GMP: ClongMax, CulongMax, CdoubleMax, Limb, libgmp, BigInt, MPZ
+
+# A `BigInt`'s limbs are GC-managed, so libmpfr sees one through a borrowed
+# `__mpz_struct`. Sound only for entry points that do not write the mpz;
+# `mpfr_get_z`, which does, goes through a GMP-owned scratch mpz instead.
+const mpz_t = MPZ.mpz_t
 
 import ..FastMath.sincos_fast
 
@@ -373,7 +378,7 @@ end
 
 function BigFloat(x::BigInt, r::MPFRRoundingMode=rounding_raw(BigFloat); precision::Integer=_precision_with_base_2(BigFloat))
     z = BigFloat(;precision=precision)
-    ccall((:mpfr_set_z, libmpfr), Int32, (Ref{BigFloat}, Ref{BigInt}, MPFRRoundingMode), z, x, r)
+    ccall((:mpfr_set_z, libmpfr), Int32, (Ref{BigFloat}, mpz_t, MPFRRoundingMode), z, x, r)
     return z
 end
 
@@ -437,7 +442,10 @@ end
 
 function _unchecked_cast(::Type{BigInt}, x::BigFloat, r::MPFRRoundingMode)
     z = BigInt()
-    ccall((:mpfr_get_z, libmpfr), Int32, (Ref{BigInt}, Ref{BigFloat}, MPFRRoundingMode), z, x, r)
+    # mpfr_get_z writes its mpz, so it needs one that GMP owns.
+    MPZ.with_output(z) do s
+        ccall((:mpfr_get_z, libmpfr), Int32, (MPZ.scratch_t, Ref{BigFloat}, MPFRRoundingMode), s, x, r)
+    end
     return z
 end
 
@@ -607,7 +615,7 @@ for (fJ, fC) in ((:+,:add), (:*,:mul))
         # BigInt
         function ($fJ)(x::BigFloat, c::BigInt)
             z = BigFloat()
-            ccall(($(string(:mpfr_,fC,:_z)), libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Ref{BigInt}, MPFRRoundingMode), z, x, c, rounding_raw(BigFloat))
+            ccall(($(string(:mpfr_,fC,:_z)), libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, mpz_t, MPFRRoundingMode), z, x, c, rounding_raw(BigFloat))
             return z
         end
         ($fJ)(c::BigInt, x::BigFloat) = ($fJ)(x,c)
@@ -662,7 +670,7 @@ for (fJ, fC) in ((:-,:sub), (:/,:div))
         # BigInt
         function ($fJ)(x::BigFloat, c::BigInt)
             z = BigFloat()
-            ccall(($(string(:mpfr_,fC,:_z)), libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Ref{BigInt}, MPFRRoundingMode), z, x, c, rounding_raw(BigFloat))
+            ccall(($(string(:mpfr_,fC,:_z)), libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, mpz_t, MPFRRoundingMode), z, x, c, rounding_raw(BigFloat))
             return z
         end
         # no :mpfr_z_div function
@@ -671,7 +679,7 @@ end
 
 function -(c::BigInt, x::BigFloat)
     z = BigFloat()
-    ccall((:mpfr_z_sub, libmpfr), Int32, (Ref{BigFloat}, Ref{BigInt}, Ref{BigFloat}, MPFRRoundingMode), z, c, x, rounding_raw(BigFloat))
+    ccall((:mpfr_z_sub, libmpfr), Int32, (Ref{BigFloat}, mpz_t, Ref{BigFloat}, MPFRRoundingMode), z, c, x, rounding_raw(BigFloat))
     return z
 end
 
@@ -739,7 +747,7 @@ end
 # BigInt
 function div(x::BigFloat, c::BigInt)
     z = BigFloat()
-    ccall((:mpfr_div_z, libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Ref{BigInt}, MPFRRoundingMode), z, x, c, RoundToZero)
+    ccall((:mpfr_div_z, libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, mpz_t, MPFRRoundingMode), z, x, c, RoundToZero)
     ccall((:mpfr_trunc, libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}), z, z)
     return z
 end
@@ -808,7 +816,7 @@ end
 
 function ^(x::BigFloat, y::BigInt)
     z = BigFloat()
-    ccall((:mpfr_pow_z, libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Ref{BigInt}, MPFRRoundingMode), z, x, y, rounding_raw(BigFloat))
+    ccall((:mpfr_pow_z, libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, mpz_t, MPFRRoundingMode), z, x, y, rounding_raw(BigFloat))
     return z
 end
 
@@ -993,7 +1001,7 @@ end
 
 function cmp(x::BigFloat, y::BigInt)
     isnan(x) && return 1
-    ccall((:mpfr_cmp_z, libmpfr), Int32, (Ref{BigFloat}, Ref{BigInt}), x, y)
+    ccall((:mpfr_cmp_z, libmpfr), Int32, (Ref{BigFloat}, mpz_t), x, y)
 end
 function cmp(x::BigFloat, y::ClongMax)
     isnan(x) && return 1
@@ -1308,11 +1316,12 @@ function decompose(x::BigFloat)::Tuple{BigInt, Int, Int}
     isinf(x) && return x.sign, 0, 0
     x == 0 && return 0, 0, x.sign
     s = BigInt()
-    s.size = cld(x.prec, 8*sizeof(Limb)) # limbs
-    b = s.size * sizeof(Limb)            # bytes
-    ccall((:__gmpz_realloc2, libgmp), Cvoid, (Ref{BigInt}, Culong), s, 8b) # bits
+    n = cld(x.prec, 8*sizeof(Limb))      # limbs
+    b = n * sizeof(Limb)                 # bytes
+    sd = MPZ._ensure!(s, n)
+    s.size = n
     xd = x.d
-    GC.@preserve xd memcpy(s.d, Base.unsafe_convert(Ptr{Limb}, xd), b)
+    GC.@preserve sd xd memcpy(pointer(sd), Base.unsafe_convert(Ptr{Limb}, xd), b)
     s, x.exp - 8b, x.sign
 end
 

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -259,5 +259,3 @@ function (ss::SummarySize)(obj::Task)
     # TODO: add stack size, and possibly traverse stack roots
     return size
 end
-
-(ss::SummarySize)(obj::BigInt) = _summarysize(ss, obj, ss.count) + (ss.count ? 1 : obj.alloc * sizeof(GMP.Limb))

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -317,9 +317,7 @@ typedef struct {
     int8_t incremental;
 } jl_serializer_state;
 
-static jl_value_t *jl_bigint_type = NULL;
 static jl_debuginfo_t *jl_nulldebuginfo;
-static int gmp_limb_size = 0;
 
 #ifdef _P64
 #define RELOC_TAG_OFFSET 61
@@ -1702,25 +1700,6 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
             // The object has no fields, so we just snapshot its byte representation
             assert(t->layout->npointers == 0);
             ios_write(f, (char*)v, jl_datatype_size(t));
-        }
-        else if (jl_bigint_type && jl_typetagis(v, jl_bigint_type)) {
-            // foreign types require special handling
-            assert(f == s->s);
-            jl_value_t *sizefield = jl_get_nth_field(v, 1);
-            int32_t sz = jl_unbox_int32(sizefield);
-            int32_t nw = (sz == 0 ? 1 : (sz < 0 ? -sz : sz));
-            size_t nb = nw * gmp_limb_size;
-            ios_write(f, (char*)&nw, sizeof(int32_t));
-            ios_write(f, (char*)&sz, sizeof(int32_t));
-            uintptr_t data = LLT_ALIGN(ios_pos(s->const_data), 8);
-            write_padding(s->const_data, data - ios_pos(s->const_data));
-            data /= sizeof(void*);
-            assert(data < ((uintptr_t)1 << RELOC_TAG_OFFSET) && "offset to constant data too large");
-            arraylist_push(&s->relocs_list, (void*)(reloc_offset + 8)); // relocation location
-            arraylist_push(&s->relocs_list, (void*)(((uintptr_t)ConstDataRef << RELOC_TAG_OFFSET) + data)); // relocation target
-            void *pdata = jl_unbox_voidpointer(jl_get_nth_field(v, 2));
-            ios_write(s->const_data, (char*)pdata, nb);
-            write_pointer(f);
         }
         else {
             // Generic object::DataType serialization by field
@@ -3150,11 +3129,6 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
                 jl_array_del_end(args, jl_array_len(args));
             }
         }
-    }
-    jl_bigint_type = jl_base_module ? jl_get_global(jl_base_module, jl_symbol("BigInt")) : NULL;
-    if (jl_bigint_type) {
-        gmp_limb_size = jl_unbox_long(jl_get_global((jl_module_t*)jl_get_global(jl_base_module, jl_symbol("GMP")),
-                                                    jl_symbol("BITS_PER_LIMB"))) / 8;
     }
     jl_genericmemory_t *global_roots_list = NULL;
     jl_genericmemory_t *global_roots_keyset = NULL;

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -456,13 +456,8 @@ function rand!(rng::AbstractRNG, x::BigInt, sp::SamplerBigInt)
             hx < hm && break # avoid calling mpn_cmp most of the time
             MPZ.mpn_cmp(x, sp.m, nlimbs) <= 0 && break
         end
-        # normalize: drop high zero limbs so that `x.size` counts significant limbs
-        while nlimbs > 0
-            limbs[nlimbs] != 0 && break
-            nlimbs -= 1
-        end
-        x.size = nlimbs
     end
+    MPZ._finish!(x, xd, nlimbs, false)   # drops high zero limbs
     MPZ.add!(x, sp.a)
 end
 

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -456,7 +456,7 @@ function rand!(rng::AbstractRNG, x::BigInt, sp::SamplerBigInt)
             hx < hm && break # avoid calling mpn_cmp most of the time
             MPZ.mpn_cmp(x, sp.m, nlimbs) <= 0 && break
         end
-        # adjust x.size (normally done by mpz_limbs_finish, in GMP version >= 6)
+        # normalize: drop high zero limbs so that `x.size` counts significant limbs
         while nlimbs > 0
             limbs[nlimbs] != 0 && break
             nlimbs -= 1

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -422,7 +422,7 @@ function SamplerBigInt(::Type{RNG}, r::AbstractUnitRange{BigInt}, N::Repetition=
     m = last(r) - first(r)
     m.size < 0 && empty_collection_error()
     nlimbs = Int(m.size)
-    hm = nlimbs == 0 ? Limb(0) : GC.@preserve m unsafe_load(m.d, nlimbs)
+    hm = nlimbs == 0 ? Limb(0) : (@inbounds m.d[nlimbs])
     highsp = Sampler(RNG, Limb(0):hm, N)
     nlimbsmax = max(nlimbs, abs(last(r).size), abs(first(r).size))
     return SamplerBigInt(first(r), m, nlimbs, nlimbsmax, highsp)
@@ -438,15 +438,18 @@ function rand!(rng::AbstractRNG, x::BigInt, sp::SamplerBigInt)
     nlimbs = sp.nlimbs
     nlimbs == 0 && return MPZ.set!(x, sp.a)
     MPZ.realloc2!(x, sp.nlimbsmax*8*sizeof(Limb))
-    @assert x.alloc >= nlimbs
+    @assert length(x.d) >= nlimbs
     # we randomize x ∈ [0, m] with rejection sampling:
     # 1. the first nlimbs-1 limbs of x are uniformly randomized
     # 2. the high limb hx of x is sampled from 0:hm where hm is the
     #    high limb of m
     # We repeat 1. and 2. until x <= m
-    hm = GC.@preserve sp unsafe_load(sp.m.d, nlimbs)
-    GC.@preserve x begin
-        limbs = UnsafeView(x.d, nlimbs-1)
+    hm = @inbounds sp.m.d[nlimbs]
+    xd = x.d
+    GC.@preserve xd begin
+        # deliberately a view of only nlimbs-1 limbs: the high limb is drawn
+        # separately below, and the buffer is sized for nlimbsmax
+        limbs = UnsafeView(pointer(xd), nlimbs-1)
         while true
             rand!(rng, limbs)
             hx = limbs[nlimbs] = rand(rng, sp.highsp)

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -454,12 +454,12 @@ end
 
     function Base_GMP_MPZ_import!(x::BigInt, n::AbstractVector{T}; order::Integer=-1, nails::Integer=0, endian::Integer=0) where {T<:Base.BitInteger}
         # mpz_import writes its mpz operand, so it cannot be handed a borrowed
-        # view of a BigInt's GC-managed limbs; it gets a GMP-owned scratch mpz
+        # view of a BigInt's GC-managed limbs; it gets a GMP-owned mpz
         # whose value `with_output` moves into `x`.
         Base.GMP.MPZ.with_output(x) do s
             ccall((:__gmpz_import, Base.GMP.MPZ.libgmp),
                    Cvoid,
-                   (Base.GMP.MPZ.scratch_t, Csize_t, Cint, Csize_t, Cint, Csize_t, Ptr{Cvoid}),
+                   (Base.GMP.MPZ.mpz_owned_t, Csize_t, Cint, Csize_t, Cint, Csize_t, Ptr{Cvoid}),
                    s, length(n), order, sizeof(T), endian, nails, n)
         end
         return x

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -453,10 +453,15 @@ end
 @testset "Base.GMP.MPZ.export!" begin
 
     function Base_GMP_MPZ_import!(x::BigInt, n::AbstractVector{T}; order::Integer=-1, nails::Integer=0, endian::Integer=0) where {T<:Base.BitInteger}
-        ccall((:__gmpz_import, Base.GMP.MPZ.libgmp),
-               Cvoid,
-               (Base.GMP.MPZ.mpz_t, Csize_t, Cint, Csize_t, Cint, Csize_t, Ptr{Cvoid}),
-               x, length(n), order, sizeof(T), endian, nails, n)
+        # mpz_import writes its mpz operand, so it cannot be handed a borrowed
+        # view of a BigInt's GC-managed limbs; it gets a GMP-owned scratch mpz
+        # whose value `with_output` moves into `x`.
+        Base.GMP.MPZ.with_output(x) do s
+            ccall((:__gmpz_import, Base.GMP.MPZ.libgmp),
+                   Cvoid,
+                   (Base.GMP.MPZ.scratch_t, Csize_t, Cint, Csize_t, Cint, Csize_t, Ptr{Cvoid}),
+                   s, length(n), order, sizeof(T), endian, nails, n)
+        end
         return x
     end
     # test import


### PR DESCRIPTION
This allows us to remove the finalizer, and serializer hacks, and improves performance

Operations that create a `BigInt`/ `Rational{BigInt}` are moved to Julia (wraping gmp mpn layer) which work on caller-owned memory or computed into a scratch mpz that GMP owns and frees before returning.

`prod` of `AbstractArray{BigInt}` is improved to do the linear fallback only when the number of total limbs is small.

This is a breaking change for users that relied on the `BigInt` layout. Code that passes `Ref{BigInt}` into C as an `mpz_t`, or that reads the `alloc` and `d` fields, needs to change. `isqrt` of a negative `BigInt` now throws `DomainError` rather than `DivideError`, matching every other integer type.

| op | nightly (ns) | PR (ns) | ratio |
  |---|---|---|---|
  | `BigInt(Int)` | 18.5 | 7.3 | **2.54× faster** |
  | `x + y  (1 limb)` | 37.7 | 26.3 | **1.43× faster** |
  | `x + y  (10 limb)` | 39.0 | 28.0 | **1.39× faster** |
  | `x + y  (1000 limb)` | 254.7 | 295.0 | 1.16× slower |
  | `x + 1  (10 limb)` | 50.3 | 22.6 | **2.23× faster** |
  | `x - y  (10 limb)` | 41.4 | 28.4 | **1.46× faster** |
  | `x * y  (1 limb)` | 54.3 | 31.7 | **1.71× faster** |
  | `x * y  (10 limb)` | 94.3 | 78.4 | **1.20× faster** |
  | `x * y  (100 limb)` | 1264.4 | 1239.4 | ≈ |
  | `x * y  (1000 limb)` | 40829.0 | 41169.0 | ≈ |
  | `x * 3  (10 limb)` | 50.6 | 23.3 | **2.17× faster** |
  | `div (10/1 limb)` | 74.2 | 49.7 | **1.49× faster** |
  | `div (100/10 limb)` | 797.2 | 810.9 | ≈ |
  | `div (1000/100 limb)` | 42942.0 | 33403.0 | **1.29× faster** |
  | `rem (10/1 limb)` | 59.5 | 58.5 | ≈ |
  | `mod (100/10 limb)` | 814.0 | 814.6 | ≈ |
  | `fld (100/10 limb)` | 827.6 | 811.4 | ≈ |
  | `cld (100/10 limb)` | 828.6 | 820.4 | ≈ |
  | `divrem (100/10)` | 863.7 | 821.4 | ≈ |
  | `x & small` | 37.4 | 24.3 | **1.54× faster** |
  | `x & y  (100 limb)` | 76.9 | 36.6 | **2.10× faster** |
  | `x \| small` | 62.4 | 35.7 | **1.75× faster** |
  | `x xor y (100 limb)` | 82.7 | 56.3 | **1.47× faster** |
  | `~x     (100 limb)` | 69.5 | 88.7 | 1.28× slower |
  | `-x     (100 limb)` | 56.0 | 26.9 | **2.08× faster** |
  | `x << 1 (100 limb)` | 81.4 | 64.8 | **1.26× faster** |
  | `x >> 1 (100 limb)` | 70.5 | 45.6 | **1.55× faster** |
  | `x << 300 (100 limb)` | 113.7 | 65.8 | **1.73× faster** |
  | `x < y  (100 limb)` | 35.2 | 37.2 | 1.06× slower |
  | `isodd  (100 limb)` | 11.6 | 12.0 | ≈ |
  | `hash   (10 limb)` | 67.0 | 58.1 | **1.15× faster** |
  | `gcd    (10 limb)` | 154.2 | 172.9 | 1.12× slower |
  | `isqrt  (100 limb)` | 1019.0 | 967.1 | **1.05× faster** |
  | `x^7    (10 limb)` | 662.2 | 683.6 | ≈ |
  | `powermod` | 89081.0 | 89150.0 | ≈ |
  | `string (10 limb)` | 415.6 | 378.1 | **1.10× faster** |
  | `parse  (10 limb)` | 302.6 | 273.7 | **1.11× faster** |
  | `Float64(x) (10 limb)` | 53.8 | 66.4 | 1.23× slower |
  | `factorial(200)` | 203.4 | 189.0 | **1.08× faster** |
  | `prod 16 x 2limb` | 249.0 | 287.4 | 1.15× slower |
  | `prod 16 x 20limb` | 5078.0 | 3291.2 | **1.54× faster** |
  | `prod 256 x 2limb` | 14197.0 | 14789.0 | ≈ |
  | `prod 256 x 20limb` | 298401.0 | 268995.0 | **1.11× faster** |
  | `sum 256 x 2limb` | 2026.0 | 1508.9 | **1.34× faster** |
  | `Rational +` | 309.4 | 230.2 | **1.34× faster** |
  | `Rational *` | 319.0 | 232.0 | **1.38× faster** |
  
Assisted-by: Claude Code (Opus 5)