### PR TITLE
signals-mach: step past the safepoint poll instead of re-executing it

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1418,6 +1418,7 @@ extern pthread_mutex_t in_signal_lock;
 #endif
 
 void jl_set_gc_and_wait(jl_task_t *ct) JL_CANSAFEPOINT;
+void jl_safepoint_wait_gc_and_resume(jl_task_t *ct) JL_NOTSAFEPOINT;
 
 // Query if this object is perm-allocated in an image.
 JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t* v) JL_NOTSAFEPOINT;

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -244,6 +244,23 @@ void jl_set_gc_and_wait(jl_task_t *ct)
     jl_safepoint_wait_thread_resume(ct); // block in thread-suspend now if requested, after clearing the gc_state
 }
 
+void jl_safepoint_wait_gc_and_resume(jl_task_t *ct) JL_NOTSAFEPOINT
+{
+    int8_t state = jl_atomic_load_relaxed(&ct->ptls->gc_state);
+    jl_atomic_store_release(&ct->ptls->gc_state, JL_GC_STATE_WAITING);
+    uv_mutex_lock(&safepoint_lock);
+    uv_cond_broadcast(&safepoint_cond_begin);
+    {
+        JL_TIMING_SUSPEND_TASK(GC_SAFEPOINT, ct);
+        while (jl_atomic_load_acquire(&jl_gc_running))
+            uv_cond_wait(&safepoint_cond_end, &safepoint_lock);
+    }
+    // No collection can be claimed until the running state is visible.
+    jl_atomic_store_release(&ct->ptls->gc_state, state);
+    uv_mutex_unlock(&safepoint_lock);
+    jl_gc_notify_task_resume(ct);
+}
+
 // Exclude garbage collection for a brief critical section on a thread that
 // does not participate in stop-the-world (the SIGINT listener thread, a
 // Windows console-ctrl handler thread). Holding `safepoint_lock` blocks

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -326,18 +326,13 @@ static void mach_safepoint_trampoline(jl_ptls_t ptls)
     // and nothing arms the sigint page anymore.)
 }
 
-// A safepoint poll is a load of the safepoint page whose result is discarded
-// (`jl_gc_safepoint_`, `FinalLowerGC::lowerSafepoint`), so its destination
-// register is dead and the interrupted thread may resume *after* the poll
-// instead of re-executing it. Re-executing (what the Unix signal handler
-// does, where sigreturn makes it cheap) is not viable here: resuming requires
-// a second round-trip through the handler thread (jl_mach_restore_trigger),
-// and if another collection arms the page during that window the thread
-// faults again without having made progress. Under back-to-back collections
-// from another thread it can lose that race every time and starve.
-//
-// Returns the length of the poll instruction at `pc`, or 0 if it is not a
-// recognized poll load (leaving the PC alone re-executes it as before).
+// Return the length of the safepoint poll instruction at `pc`, or 0 if it is
+// not a recognized poll load (which then re-executes as before). A poll's
+// load result is dead (jl_gc_safepoint_, FinalLowerGC::lowerSafepoint), so
+// the poll may be skipped: re-executing it would fault again whenever
+// another collection arms the page before the Mach restore round-trip
+// completes, which under back-to-back collections can repeat forever and
+// starve the thread.
 static size_t safepoint_poll_insn_len(uintptr_t pc)
 {
 #if defined(_CPU_AARCH64_)
@@ -360,8 +355,11 @@ static size_t safepoint_poll_insn_len(uintptr_t pc)
     uint8_t rm = modrm & 0x7;
     if (mod == 3) // register source: not a load
         return 0;
-    if (rm == 4) // SIB byte
-        i++;
+    if (rm == 4) { // SIB byte
+        uint8_t sib = p[i++];
+        if (mod == 0 && (sib & 0x7) == 5)
+            i += 4; // no base: disp32 follows
+    }
     if (mod == 1)
         i += 1; // disp8
     else if (mod == 2 || (mod == 0 && rm == 5))
@@ -529,10 +527,8 @@ kern_return_t catch_mach_exception_raise_state_identity(
                                              (thread_state_t)float_state, &float_count);
         HANDLE_MACH_ERROR("thread_get_state", ret);
         assert(float_count == jl_mach_float_state_info.count);
-        // Step the saved PC past the poll so the eventual restore resumes
-        // after it, guaranteeing forward progress even if another collection
-        // arms the page before the restore completes (see
-        // safepoint_poll_insn_len).
+        // Skip recognized polls so another collection cannot fault the
+        // thread again before the Mach restore round-trip completes.
 #if defined(_CPU_X86_64_)
         state->__rip += safepoint_poll_insn_len(state->__rip);
 #elif defined(_CPU_AARCH64_)

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -326,6 +326,52 @@ static void mach_safepoint_trampoline(jl_ptls_t ptls)
     // and nothing arms the sigint page anymore.)
 }
 
+// A safepoint poll is a load of the safepoint page whose result is discarded
+// (`jl_gc_safepoint_`, `FinalLowerGC::lowerSafepoint`), so its destination
+// register is dead and the interrupted thread may resume *after* the poll
+// instead of re-executing it. Re-executing (what the Unix signal handler
+// does, where sigreturn makes it cheap) is not viable here: resuming requires
+// a second round-trip through the handler thread (jl_mach_restore_trigger),
+// and if another collection arms the page during that window the thread
+// faults again without having made progress. Under back-to-back collections
+// from another thread it can lose that race every time and starve.
+//
+// Returns the length of the poll instruction at `pc`, or 0 if it is not a
+// recognized poll load (leaving the PC alone re-executes it as before).
+static size_t safepoint_poll_insn_len(uintptr_t pc)
+{
+#if defined(_CPU_AARCH64_)
+    uint32_t insn = *(const uint32_t*)pc;
+    if ((insn & 0xFFC00000u) == 0xF9400000u || // LDR Xt, [Xn, #pimm]
+        (insn & 0xFFE00C00u) == 0xF8400000u || // LDUR Xt, [Xn, #simm]
+        (insn & 0xFFE00C00u) == 0xF8600800u)   // LDR Xt, [Xn, Xm{, extend}]
+        return 4;
+    return 0;
+#elif defined(_CPU_X86_64_)
+    // MOV r64, r/m64 (REX.W + 8B /r), the only form our polls compile to
+    const uint8_t *p = (const uint8_t*)pc;
+    size_t i = 0;
+    if ((p[i] & 0xF8) == 0x48) // REX.W prefix
+        i++;
+    if (p[i++] != 0x8B)
+        return 0;
+    uint8_t modrm = p[i++];
+    uint8_t mod = modrm >> 6;
+    uint8_t rm = modrm & 0x7;
+    if (mod == 3) // register source: not a load
+        return 0;
+    if (rm == 4) // SIB byte
+        i++;
+    if (mod == 1)
+        i += 1; // disp8
+    else if (mod == 2 || (mod == 0 && rm == 5))
+        i += 4; // disp32 / RIP-relative
+    return i;
+#else
+    return 0;
+#endif
+}
+
 #if defined(_CPU_AARCH64_)
 __attribute__((naked, used)) static void jl_mach_restore_trigger(void)
 {
@@ -483,6 +529,15 @@ kern_return_t catch_mach_exception_raise_state_identity(
                                              (thread_state_t)float_state, &float_count);
         HANDLE_MACH_ERROR("thread_get_state", ret);
         assert(float_count == jl_mach_float_state_info.count);
+        // Step the saved PC past the poll so the eventual restore resumes
+        // after it, guaranteeing forward progress even if another collection
+        // arms the page before the restore completes (see
+        // safepoint_poll_insn_len).
+#if defined(_CPU_X86_64_)
+        state->__rip += safepoint_poll_insn_len(state->__rip);
+#elif defined(_CPU_AARCH64_)
+        state->__pc += safepoint_poll_insn_len(state->__pc);
+#endif
         // Hijack the faulting thread to handle the safepoint on its own
         // stack, using the same jl_set_gc_and_wait() codepath as Unix signals.
         jl_call_in_state(state, (void (*)(void))&mach_safepoint_trampoline,

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -321,18 +321,14 @@ static void mach_safepoint_trampoline(jl_ptls_t ptls)
     if (ct == NULL)
         return; // thread is dead, just resume
     jl_set_gc_and_wait(ct);
+    jl_safepoint_wait_gc_and_resume(ct);
     // (The sigint force-throw that lived here is gone: SIGINT is delivered
     // through the cancellation system - see jl_sigint_request_cancellation -
     // and nothing arms the sigint page anymore.)
 }
 
-// Return the length of the safepoint poll instruction at `pc`, or 0 if it is
-// not a recognized poll load (which then re-executes as before). A poll's
-// load result is dead (jl_gc_safepoint_, FinalLowerGC::lowerSafepoint), so
-// the poll may be skipped: re-executing it would fault again whenever
-// another collection arms the page before the Mach restore round-trip
-// completes, which under back-to-back collections can repeat forever and
-// starve the thread.
+// Return the poll instruction length, or 0 to re-execute an unrecognized load.
+// Safepoint poll results are unused, so recognized polls can be skipped.
 static size_t safepoint_poll_insn_len(uintptr_t pc)
 {
 #if defined(_CPU_AARCH64_)
@@ -527,8 +523,7 @@ kern_return_t catch_mach_exception_raise_state_identity(
                                              (thread_state_t)float_state, &float_count);
         HANDLE_MACH_ERROR("thread_get_state", ret);
         assert(float_count == jl_mach_float_state_info.count);
-        // Skip recognized polls so another collection cannot fault the
-        // thread again before the Mach restore round-trip completes.
+        // Avoid repeatedly faulting at the same poll under back-to-back GCs.
 #if defined(_CPU_X86_64_)
         state->__rip += safepoint_poll_insn_len(state->__rip);
 #elif defined(_CPU_AARCH64_)

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -925,3 +925,65 @@ let code = """
     # JULIA_COPY_STACKS is broken on Windows (#35147)
     @test read(cmd, String) == "75025" skip=Sys.iswindows()
 end
+
+# Regression test for the macOS mach-exception safepoint path: a thread resumed
+# from a safepoint used to re-execute the faulting poll load, and under
+# back-to-back collections could fault again every time without making
+# progress, starving the main thread in the hijack/restore dance
+# (`jl_mach_restore_trigger`). The child keeps collections back-to-back while
+# the main task must keep crossing safepoint polls to spawn and reap workers;
+# on affected builds it hangs and the timer fires.
+@testset "no starvation at safepoint polls under back-to-back collections" begin
+    code = """
+    function work(n)
+        s = 0.0
+        for i in 1:n
+            s += sqrt(i)
+        end
+        return s
+    end
+    function main(iters)
+        done = Threads.Atomic{Bool}(false)
+        gcspam = Threads.@spawn while !done[]
+            GC.gc(false)
+            yield()
+        end
+        nworkers = max(2, Threads.nthreads() - 1)
+        for i in 1:iters
+            tasks = [Threads.@spawn work(10_000) for _ in 1:nworkers]
+            foreach(wait, tasks)
+        end
+        done[] = true
+        wait(gcspam)
+    end
+    main(300)
+    """
+    cmd = `$(Base.julia_cmd()) --depwarn=error --rr-detach --startup-file=no -t8 -e $code`
+    cmd = ignorestatus(setenv(cmd; dir = @__DIR__))
+    cmd = pipeline(cmd; stdout = stderr, stderr)
+    proc = run(cmd; wait = false)
+    # a passing run takes a few seconds; the timeout only fires on starvation
+    timeout = false
+    timer = Timer(120) do t
+        timeout = true
+        # a starved process ignores SIGTERM-level requests; go straight to the
+        # backtrace-dumping and then killing signals
+        for sig in (Base.SIGQUIT, Base.SIGKILL)
+            for _ in 1:3
+                process_running(proc) || return
+                kill(proc, sig)
+                sleep(1)
+            end
+        end
+    end
+    try
+        wait(proc)
+    finally
+        close(timer)
+    end
+    if !success(proc) || timeout
+        @error "The safepoint poll starvation test failed" proc.exitcode proc.termsignal timeout
+    end
+    @test success(proc)
+    @test !timeout
+end

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -926,15 +926,14 @@ let code = """
     @test read(cmd, String) == "75025" skip=Sys.iswindows()
 end
 
-# The macOS exception handler must resume a safepoint-faulting thread past the
-# poll: re-executing the poll under back-to-back collections can fault again
-# every time and starve the thread (here the child's main task) indefinitely.
+# A macOS thread faulting at a safepoint must progress under back-to-back GCs.
 @testset "no starvation at safepoint polls under back-to-back collections" begin
     code = """
-    function work(n)
-        s = 0.0
-        for i in 1:n
-            s += sqrt(i)
+    function work(prec)
+        x = BigFloat(1.5, precision=prec)
+        s = BigFloat(0, precision=prec)
+        for i in 1:50
+            s += x * x + i
         end
         return s
     end
@@ -947,10 +946,9 @@ end
         nworkers = max(2, Threads.nthreads() - 1)
         t0 = time()
         for i in 1:iters
-            tasks = [Threads.@spawn work(10_000) for _ in 1:nworkers]
+            prec = 256 + 32 * i
+            tasks = [Threads.@spawn work(prec) for _ in 1:nworkers]
             foreach(wait, tasks)
-            # bound the healthy runtime on slow machines; a starved main
-            # task never gets back here, so this cannot mask the hang
             time() - t0 < budget || break
         end
         done[] = true
@@ -962,13 +960,10 @@ end
     cmd = ignorestatus(setenv(cmd; dir = @__DIR__))
     cmd = pipeline(cmd; stdout = stderr, stderr)
     proc = run(cmd; wait = false)
-    # a passing run takes a few seconds; the timeout only fires on starvation
     timeout = false
     timer = Timer(120) do t
         timeout = true
-        # a starved process ignores SIGTERM-level requests; go straight to the
-        # backtrace-dumping and then killing signals (SIGQUIT is unsupported
-        # on Windows, where kill would throw and skip the SIGKILL fallback)
+        # The deadlock does not respond to SIGTERM. Dump a backtrace, then kill.
         sigs = Sys.iswindows() ? (Base.SIGKILL,) : (Base.SIGQUIT, Base.SIGKILL)
         for sig in sigs
             for _ in 1:3

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -926,13 +926,9 @@ let code = """
     @test read(cmd, String) == "75025" skip=Sys.iswindows()
 end
 
-# Regression test for the macOS mach-exception safepoint path: a thread resumed
-# from a safepoint used to re-execute the faulting poll load, and under
-# back-to-back collections could fault again every time without making
-# progress, starving the main thread in the hijack/restore dance
-# (`jl_mach_restore_trigger`). The child keeps collections back-to-back while
-# the main task must keep crossing safepoint polls to spawn and reap workers;
-# on affected builds it hangs and the timer fires.
+# The macOS exception handler must resume a safepoint-faulting thread past the
+# poll: re-executing the poll under back-to-back collections can fault again
+# every time and starve the thread (here the child's main task) indefinitely.
 @testset "no starvation at safepoint polls under back-to-back collections" begin
     code = """
     function work(n)

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -942,21 +942,25 @@ end
         end
         return s
     end
-    function main(iters)
+    function main(iters, budget)
         done = Threads.Atomic{Bool}(false)
         gcspam = Threads.@spawn while !done[]
             GC.gc(false)
             yield()
         end
         nworkers = max(2, Threads.nthreads() - 1)
+        t0 = time()
         for i in 1:iters
             tasks = [Threads.@spawn work(10_000) for _ in 1:nworkers]
             foreach(wait, tasks)
+            # bound the healthy runtime on slow machines; a starved main
+            # task never gets back here, so this cannot mask the hang
+            time() - t0 < budget || break
         end
         done[] = true
         wait(gcspam)
     end
-    main(300)
+    main(300, 10)
     """
     cmd = `$(Base.julia_cmd()) --depwarn=error --rr-detach --startup-file=no -t8 -e $code`
     cmd = ignorestatus(setenv(cmd; dir = @__DIR__))
@@ -967,11 +971,16 @@ end
     timer = Timer(120) do t
         timeout = true
         # a starved process ignores SIGTERM-level requests; go straight to the
-        # backtrace-dumping and then killing signals
-        for sig in (Base.SIGQUIT, Base.SIGKILL)
+        # backtrace-dumping and then killing signals (SIGQUIT is unsupported
+        # on Windows, where kill would throw and skip the SIGKILL fallback)
+        sigs = Sys.iswindows() ? (Base.SIGKILL,) : (Base.SIGQUIT, Base.SIGKILL)
+        for sig in sigs
             for _ in 1:3
                 process_running(proc) || return
-                kill(proc, sig)
+                try
+                    kill(proc, sig)
+                catch
+                end
                 sleep(1)
             end
         end


### PR DESCRIPTION
Claude and Codex:

---

Since #61341, a macOS safepoint hit hijacks the faulting thread to wait out the collection on its own stack. Resuming requires another round-trip through the Mach exception handler, after which the thread used to re-execute the poll. Under back-to-back collections it can repeatedly return to an armed page without making progress and starve. Both macOS jobs on the #62756 CI build hung in this state: the [aarch64 task dump and core](https://buildkite.com/julialang/julia-pr/builds/1640#01a01685-b0c4-4eee-99c6-bde9fe0971c7) show the root task at `jl_mach_restore_trigger`, with no MPFR cache-lock involvement.

Safepoint poll results are unused (`jl_gc_safepoint_`, `FinalLowerGC::lowerSafepoint`), so this advances the saved PC past recognized poll loads. Before the Mach restore, a final barrier republishes the thread as waiting, handles any collection already in flight, and restores its running state while holding `safepoint_lock`, which prevents another collection from being claimed during the handoff. Unrecognized loads retain the old re-execute behavior, and Unix and Windows handlers are unchanged.

The regression test uses the BigFloat workload needed to reproduce the starvation while another task keeps collections back-to-back. The pure-Julia workload from the original version did not reproduce it. The final barrier passed six consecutive stress runs locally on aarch64; the x86_64 instruction decoder is covered by its poll encodings but is exercised for real only on CI.
