### PR TITLE
tests: Shut down the wait(::Process) cancellation test child gracefully

### DIFF
--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -561,16 +561,17 @@ end
             # would keep the kernel object alive after we close our own handle, and
             # recreating the segment here would fail with ERROR_ALREADY_EXISTS.
             io = open(Mmap.SharedMemory, name, 12; readonly = false, create = true)
-            child = run(`$(Base.julia_cmd()) -e "sleep(5)"`; wait = false)
+            child = open(`$(Base.julia_cmd()) -e "read(stdin)"`, "w")
             try
                 sleep(0.5)
                 close(io)
                 io2 = open(Mmap.SharedMemory, name, 12; readonly = false, create = true)
                 close(io2)
             finally
-                kill(child)
+                close(child)
                 wait(child)
             end
+            @test success(child)
 
         else # macOS, tests TODO
 

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -1209,13 +1209,14 @@ end
     @lock cond notify(cond) # still functional (no waiters)
 
     # Task blocked in wait(::Base.Process); the process itself keeps running
-    p = run(sleep_cmd(1000); wait=false)
+    p = open(`$(Base.julia_cmd()) --startup-file=no -e "read(stdin)"`, "w")
     t, src = cancellable(() -> wait(p))
     spin()
     cancel!(src)
     expect_cancelled(t)
     @test process_running(p)
-    kill(p); wait(p)
+    close(p); wait(p)
+    @test success(p)
 
     # Task blocked in waitany; the awaited tasks live in different scopes and
     # remain unaffected by the waiter's cancellation


### PR DESCRIPTION
Implements suggestion in https://github.com/JuliaLang/julia/pull/62673#issuecomment-5329946099 to decouple this test from the correctness of our SIGTERM handling. Should fix #62774 by decoupling what is actually tested here. For the underlying issue, I'd like to move in the direction of #62814.

Assisted-by: Claude Code (Fable 5)