### PR TITLE
Compiler: fix hang in phi-edge cleanup during compaction

### DIFF
--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -1526,7 +1526,10 @@ function kill_edge_terminator!(compact::IncrementalCompact, active_bb::Int, from
             idx = first(stmts)
             while idx <= last(stmts)
                 stmt = compact.result[idx][:stmt]
-                stmt === nothing && continue
+                if stmt === nothing
+                    idx += 1
+                    continue
+                end
                 isa(stmt, PhiNode) || break
                 i = findfirst(x::Int32->x==bb_rename_pred[from], stmt.edges)
                 if i !== nothing

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -919,3 +919,21 @@ end
     (Float32, Float32, Float64),
     (Float32, Float32, Float32),
 ]
+
+# Tests that phi-edge cleanup during compaction terminates when the phi block
+# begins with a `nothing` statement rather than a PhiNode (#62818).
+function f62818(c)
+    r = Ref(false)
+    while true
+        if c !== nothing
+            r[] = true
+        end
+        if r[]
+            continue
+        else
+            break
+        end
+    end
+end
+@test only(Base.return_types(f62818, Tuple{Nothing})) === Nothing
+@test f62818(nothing) === nothing


### PR DESCRIPTION
`kill_edge_terminator!` scans the start of the `to` block to remove the killed edge from its `PhiNode`s. That scan skips `nothing` statements, but the skip re-entered the loop without advancing the index so the first `nothing` statement in the block made it spin forever.

The loop is reached from `adce_pass!` while inferring ordinary Julia code, so it presents as a compilation that never returns, with no diagnostic and no way to interrupt it. Present since 1.11.

Fixes #62818 

Assisted-by: Claude Code (Opus 5)