### PR TITLE
loading: say why the strict-mode precompile load failed

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2957,7 +2957,7 @@ function __require_prelocked(pkg::PkgId, env)
     end
 
     if JLOptions().use_compiled_modules == 3
-        error("Precompiled image $pkg not available with flags $(CacheFlags())")
+        error("Precompiled image $pkg not available with flags $(CacheFlags())$(list_reasons(reasons; full=true))")
     end
 
     # if the module being required was supposed to have a particular version
@@ -4400,7 +4400,7 @@ const CACHE_REJECT_REASONS = Dict{Symbol,Pair{Symbol,String}}(
     :dep_buildid_mismatch    => :internal    => "different dependency build identifier",
 )
 
-function list_reasons(reasons::Dict{Symbol,Int})
+function list_reasons(reasons::Dict{Symbol,Int}; full::Bool=false)
     isempty(reasons) && return ""
     actionable = String[]
     wrong_julia = false
@@ -4415,6 +4415,7 @@ function list_reasons(reasons::Dict{Symbol,Int})
         end
     end
     @debug "Caches not reused: $(join(verbose, ", "))"
+    full && return " (cache not reused: $(join(sort!(verbose), ", ")))"
     if !isempty(actionable)
         return " (cache not reused: $(join(sort!(actionable), ", ")))"
     elseif wrong_julia
@@ -4423,7 +4424,7 @@ function list_reasons(reasons::Dict{Symbol,Int})
         return ""
     end
 end
-list_reasons(::Nothing) = ""
+list_reasons(::Nothing; full::Bool=false) = ""
 
 function in_package_store(path::String)
     for depot in DEPOT_PATH


### PR DESCRIPTION
🤖 `--compiled-modules=strict` failures printed only the requested flags:

    Precompiled image Pkg [...] not available with flags CacheFlags(...)

while the per-candidate rejection reasons — already collected into `reasons` by `_require_search_from_serialized` right above — were discarded. That made real failures undiagnosable from logs alone: a recent PkgEval run needed a rerun under JULIA_DEBUG=loading to learn a cache was rejected for a dependency build_id mismatch.

Render the reasons into the error via `list_reasons(reasons; full=true)`. The new `full` mode reports every reason including the :internal category (buildid mismatches). The idea is that `--compiled-modules=strict` is expected to work, so users are most likely interested in a more comprehensive debug view (e.g. in PkgEval).