### PR TITLE
type system: delete unreachable jl_type_typename special cases

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -308,7 +308,7 @@ function show_method_list_header(io::IO, ms::MethodList, namefmt::Function)
         printstyled(io, tn.module, color=col)
     elseif '#' in sname
         print(io, " for anonymous function ", namedisplay)
-    elseif tn === _TYPE_NAME || iskindtype(tn.wrapper)
+    elseif iskindtype(tn.wrapper)
         print(io, " for type constructor")
     else
         print(io, " for callable object")

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -233,7 +233,6 @@ function binding_module(m::Module, s::Symbol)
 end
 
 const _NAMEDTUPLE_NAME = NamedTuple.body.body.name
-const _TYPE_NAME = TypeEq.name
 
 function _fieldnames(@nospecialize t)
     if t.name === _NAMEDTUPLE_NAME

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1223,12 +1223,6 @@ static ssize_t lookup_type_idx_linearvalue(jl_svec_t *cache, jl_value_t *key1, j
 static jl_value_t *lookup_type(jl_typename_t *tn JL_PROPAGATES_ROOT, jl_value_t **key, size_t n) JL_CANSAFEPOINT
 {
     JL_TIMING(TYPE_CACHE_LOOKUP, TYPE_CACHE_LOOKUP);
-    if (tn == jl_type_typename) {
-        assert(n == 1);
-        jl_value_t *uw = jl_unwrap_unionall(key[0]);
-        if (jl_is_datatype(uw) && key[0] == ((jl_datatype_t*)uw)->name->wrapper)
-            return jl_atomic_load_acquire(&((jl_datatype_t*)uw)->name->Typeofwrapper);
-    }
     unsigned hv = typekey_hash(tn, key, n, 0);
     if (hv) {
         jl_svec_t *cache = jl_atomic_load_relaxed(&tn->cache);
@@ -1366,15 +1360,6 @@ void jl_cache_type_(jl_datatype_t *type)
     assert(is_cacheable(type));
     jl_value_t **key = jl_svec_data(type->parameters);
     int n = jl_svec_len(type->parameters);
-    if (type->name == jl_type_typename) {
-        assert(n == 1);
-        jl_value_t *uw = jl_unwrap_unionall(key[0]);
-        if (jl_is_datatype(uw) && key[0] == ((jl_datatype_t*)uw)->name->wrapper) {
-            jl_typename_t *tn2 = ((jl_datatype_t*)uw)->name;
-            jl_gc_write_atomic(tn2, tn2->Typeofwrapper, jl_value_t, (jl_value_t*)type, release);
-            return;
-        }
-    }
     unsigned hv = typekey_hash(type->name, key, n, 0);
     if (hv) {
         assert(hv == type->hash);
@@ -1444,7 +1429,7 @@ static int has_concrete_supertype(jl_value_t *kj) JL_NOTSAFEPOINT
     jl_value_t *uw = jl_is_unionall(kj) ? jl_unwrap_unionall(kj) : kj;
     if (jl_is_datatype(uw)) {
         jl_datatype_t *dt = (jl_datatype_t*)uw;
-        if (dt->name->abstract && dt->name != jl_type_typename)
+        if (dt->name->abstract)
             return 0;
         if (!dt->maybe_subtype_of_cache)
             return 0;
@@ -2171,16 +2156,6 @@ void jl_precompute_memoized_dt(jl_datatype_t *dt, int cacheable)
         }
     }
     assert(dt->isconcretetype || dt->isdispatchtuple ? dt->maybe_subtype_of_cache : 1);
-    if (dt->name == jl_type_typename) {
-        jl_value_t *p = jl_tparam(dt, 0);
-        if (!jl_is_type(p) && !jl_is_typevar(p)) // Type{v} has no subtypes, if v is not a Type
-            dt->has_concrete_subtype = 0;
-        dt->maybe_subtype_of_cache = 1;
-        jl_value_t *uw = jl_unwrap_unionall(p);
-        // n.b. the cache for Type ignores parameter normalization except for Typeofwrapper, so it can't be used to make a stable hash value
-        if (!jl_is_datatype(uw) || ((jl_datatype_t*)uw)->name->wrapper != p)
-            cacheable = 0;
-    }
     dt->hash = typekey_hash(dt->name, jl_svec_data(dt->parameters), l, cacheable);
 }
 
@@ -2535,20 +2510,15 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                 continue;
             if (!cacheable && jl_has_free_typevars(pi))
                 continue;
-            // normalize types equal to wrappers (prepare for Typeofwrapper)
+            // normalize types equal to wrappers
             jl_value_t *tw = extract_wrapper(pi);
-            if (tw && tw != pi && (tn != jl_type_typename || jl_typeof(pi) == jl_typeof(tw)) &&
+            if (tw && tw != pi &&
                     !jl_has_free_typevars(pi) && jl_types_equal(pi, tw)) {
                 if (p)
                     jl_gc_write(p, iparams[i], jl_value_t, tw);
                 else
                     iparams[i] = tw;
             }
-        }
-        if (tn == jl_type_typename && jl_is_typeeq(iparams[0]) &&
-            jl_typeeq_T(iparams[0]) == jl_bottom_type) {
-            // normalize Type{Type{Union{}}} to Type{TypeofBottom}
-            iparams[0] = (jl_value_t*)jl_typeofbottom_type;
         }
     }
     // then check the cache again, if applicable
@@ -2623,7 +2593,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
     assert(jl_is_svec(p) && iparams == jl_svec_data(p));
 
     // try to simplify some type parameters
-    if (check && tn != jl_type_typename) {
+    if (check) {
         int changed = 0;
         if (istuple) // normalization might change Tuple's, but not other types's, cacheable status
             cacheable = 1;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -4048,9 +4048,6 @@ int jl_has_intersect_type_not_kind(jl_value_t *t)
     }
     if (jl_is_typevar(t))
         return jl_has_intersect_type_not_kind(((jl_tvar_t*)t)->ub);
-    if (jl_is_datatype(t))
-        if (((jl_datatype_t*)t)->name == jl_type_typename)
-            return 1;
     return 0;
 }
 

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -83,7 +83,7 @@ static int jl_type_extract_name_precise(jl_value_t *t1, int invariant)
     }
     else if (jl_is_datatype(t1)) {
         jl_datatype_t *dt = (jl_datatype_t*)t1;
-        if (invariant || !dt->name->abstract || dt->name == jl_type_typename)
+        if (invariant || !dt->name->abstract)
             return 1;
         return 0;
     }


### PR DESCRIPTION
🤖 Since the TypeEq refactor, Type{X} values are TypeEq/TypeEgal instances intercepted in apply_type and inst_type_w_ before datatype instantiation, so no datatype other than the (non-abstract, parameterless) TypeEq kind object itself can carry name == jl_type_typename. Delete the now unreachable Type{...}-datatype special cases: the Typeofwrapper cache fast paths in lookup_type/jl_cache_type_ (only the typeof(Union{}) slot remains live, managed directly by jl_wrap_Type), the Type-branch in jl_precompute_memoized_dt (which would have read a parameter out of bounds if ever reached), the wrapper-normalization guard in inst_datatype_inner, and the dead disjuncts in
jl_has_intersect_type_not_kind and jl_type_extract_name_precise.