### PR TITLE
types: return AnyType's typename from the deprecated Type name shims

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -635,7 +635,7 @@ end
         return Core.svec(type_parameter(x))
     elseif s === :name
         depwarn_if_not_pure("accessing `Type.name` is deprecated without replacement. If for detection, use `Base.isType(x)`.", :getproperty)
-        return TypeEq.name
+        return Core.AnyType.name
     elseif s === :hash
         depwarn_if_not_pure("accessing `Type.hash` is deprecated; use `Base._jl_type_cache_hash(x)` instead", :getproperty)
         return reinterpret(Int32, UInt32(_jl_type_cache_hash(x)))
@@ -645,7 +645,7 @@ end
 
 @noinline function typename(x::TypeEq)
     depwarn_if_not_pure("calling `typename` on `Type` is deprecated. If for detection, use `Base.isType(x)`.", :typename)
-    return TypeEq.name
+    return Core.AnyType.name
 end
 
 @noinline function nameof(x::TypeEq)
@@ -669,7 +669,7 @@ end
         return Core.svec(type_parameter(x))
     elseif s === :name
         depwarn_if_not_pure("accessing `Type.name` is deprecated without replacement. If for detection, use `Base.isType(x)`.", :getproperty)
-        return TypeEq.name
+        return Core.AnyType.name
     elseif s === :hash
         depwarn_if_not_pure("accessing `Type.hash` is deprecated; use `Base._jl_type_cache_hash(x)` instead", :getproperty)
         return reinterpret(Int32, UInt32(_jl_type_cache_hash(x)))
@@ -679,7 +679,7 @@ end
 
 @noinline function typename(x::Core.TypeEgal)
     depwarn_if_not_pure("calling `typename` on `Type` is deprecated. If for detection, use `Base.isType(x)`.", :typename)
-    return TypeEq.name
+    return Core.AnyType.name
 end
 
 @noinline function nameof(x::Core.TypeEgal)

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -137,7 +137,7 @@ begin # @deprecate
     @noinline deprecated_parentmodule(T) = parentmodule(T)
     @noinline deprecated_isabstracttype(T) = isabstracttype(T)
     deprecated_type_ref = Ref{Any}(Type{Int})
-    @test @test_warn "calling `typename` on `Type` is deprecated" deprecated_typename(deprecated_type_ref[]) === TypeEq.name
+    @test @test_warn "calling `typename` on `Type` is deprecated" deprecated_typename(deprecated_type_ref[]) === Core.AnyType.name
     @test @test_warn "calling `nameof` on `Type` is deprecated" deprecated_nameof(deprecated_type_ref[]) === :Type
     @test @test_warn "calling `parentmodule` on `Type` is deprecated" deprecated_parentmodule(deprecated_type_ref[]) === Core
     @test @test_warn "calling `isabstracttype` on a `Type{...}` is deprecated" deprecated_isabstracttype(deprecated_type_ref[]) === true


### PR DESCRIPTION
These used to return `Type.name`, which doesn't really exist any more. For the deprecation, it's not really important which value they return as long as it's consistent. However, I think `AnyType` makes more sense than `TypeEq`, since the typename was mostly about the position in the subtype hierachy, where `AnyType` is the correct replacement.