### PR TITLE
RFC/WIP: Turn world age into a DAG

### DIFF
--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -27,7 +27,13 @@ world_at_most(w::UInt, maxw::UInt) =
     maxw == typemax(UInt) || !world_reaches(maxw + UInt(1), w)
 world_in_range(w::UInt, minw::UInt, maxw::UInt) =
     world_reaches(minw, w) && world_at_most(w, maxw)
-world_on_spine(w::UInt) = world_reaches(w, get_world_counter())
+# Whether `w` is on the spine's trunk: only trunk worlds may publish interval
+# validity, since their positions in the spine's total order are themselves.
+# Worlds of merged side branches (e.g. grafted image histories) reach the
+# spine but are not on its trunk; results computed at them publish point
+# validity instead.
+world_on_spine(w::UInt) =
+    ccall(:jl_world_on_trunk, Cint, (Csize_t, Csize_t), w, get_world_counter()) != 0
 # The earliest spine world whose history includes both `a` and `b` (the join
 # in the world DAG, projected onto the spine, where positions compare exactly
 # as integers). For comparable worlds this is simply the later of the two.

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -9,14 +9,44 @@ WorldRange(w::UInt) = WorldRange(w, w)
 WorldRange(r::UnitRange) = WorldRange(first(r), last(r))
 first(wr::WorldRange) = wr.min_world
 last(wr::WorldRange) = wr.max_world
-in(world::UInt, wr::WorldRange) = wr.min_world <= world <= wr.max_world
 min_world(wr::WorldRange) = first(wr)
 max_world(wr::WorldRange) = last(wr)
 
+# World DAG predicates, mirroring the jl_world_* inlines in
+# src/julia_internal.h: a world is a packed (segment, index) pair and
+# (sa, ia) preceq (sb, ib) iff sa == sb ? ia <= ib : sa is an ancestor
+# segment of sb. Worlds on the spine (the chain of segments the world
+# counter traverses) always compare exactly with plain integer compares.
+const WORLD_IDX_BITS = UInt === UInt64 ? 48 : 24
+world_seg(w::UInt) = w >> WORLD_IDX_BITS
+world_seg_reaches(sa::UInt, sb::UInt) =
+    ccall(:jl_world_seg_reaches, Cint, (Csize_t, Csize_t), sa, sb) != 0
+world_reaches(a::UInt, b::UInt) =
+    world_seg(a) == world_seg(b) ? a <= b : world_seg_reaches(world_seg(a), world_seg(b))
+world_at_most(w::UInt, maxw::UInt) =
+    maxw == typemax(UInt) || !world_reaches(maxw + UInt(1), w)
+world_in_range(w::UInt, minw::UInt, maxw::UInt) =
+    world_reaches(minw, w) && world_at_most(w, maxw)
+world_on_spine(w::UInt) = world_reaches(w, get_world_counter())
+
+in(world::UInt, wr::WorldRange) = world_in_range(world, wr.min_world, wr.max_world)
+
 @inline function intersect(a::WorldRange, b::WorldRange)
-    ret = WorldRange(max(a.min_world, b.min_world), min(a.max_world, b.max_world))
-    @assert ret.min_world <= ret.max_world
-    return ret
+    minw = max(a.min_world, b.min_world)
+    maxw = min(a.max_world, b.max_world)
+    if minw > maxw
+        # Interval arithmetic cannot describe the validity region of a world
+        # off the spine; a point range there absorbs any bounds whose region
+        # contains its world (e.g. bounds capped by an invalidation on the
+        # spine, whose future cone does not contain the point's world).
+        if a.min_world == a.max_world && a.min_world in b
+            return a
+        elseif b.min_world == b.max_world && b.min_world in a
+            return b
+        end
+        @assert false "attempting to intersect disjoint world ranges"
+    end
+    return WorldRange(minw, maxw)
 end
 
 @inline function union(a::WorldRange, b::WorldRange)

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -28,11 +28,20 @@ world_at_most(w::UInt, maxw::UInt) =
 world_in_range(w::UInt, minw::UInt, maxw::UInt) =
     world_reaches(minw, w) && world_at_most(w, maxw)
 world_on_spine(w::UInt) = world_reaches(w, get_world_counter())
+# The earliest spine world whose history includes both `a` and `b` (the join
+# in the world DAG, projected onto the spine, where positions compare exactly
+# as integers). For comparable worlds this is simply the later of the two.
+function world_join(a::UInt, b::UInt)
+    world_seg(a) == world_seg(b) && return max(a, b)
+    return ccall(:jl_world_spine_join, Csize_t, (Csize_t, Csize_t), a, b) % UInt
+end
 
 in(world::UInt, wr::WorldRange) = world_in_range(world, wr.min_world, wr.max_world)
 
 @inline function intersect(a::WorldRange, b::WorldRange)
-    minw = max(a.min_world, b.min_world)
+    # the min side joins in the world DAG: bounds from different merged
+    # branches are incomparable and their join lies on the spine
+    minw = world_join(a.min_world, b.min_world)
     maxw = min(a.max_world, b.max_world)
     if minw > maxw
         # Interval arithmetic cannot describe the validity region of a world

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -17,7 +17,7 @@ max_world(wr::WorldRange) = last(wr)
 # (sa, ia) preceq (sb, ib) iff sa == sb ? ia <= ib : sa is an ancestor
 # segment of sb. Worlds on the spine (the chain of segments the world
 # counter traverses) always compare exactly with plain integer compares.
-const WORLD_IDX_BITS = UInt === UInt64 ? 48 : 24
+const WORLD_IDX_BITS = UInt === UInt64 ? 48 : 16
 world_seg(w::UInt) = w >> WORLD_IDX_BITS
 world_seg_reaches(sa::UInt, sb::UInt) =
     ccall(:jl_world_seg_reaches, Cint, (Csize_t, Csize_t), sa, sb) != 0

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -34,35 +34,42 @@ world_in_range(w::UInt, minw::UInt, maxw::UInt) =
 # validity instead.
 world_on_spine(w::UInt) =
     ccall(:jl_world_on_trunk, Cint, (Csize_t, Csize_t), w, get_world_counter()) != 0
-# The earliest spine world whose history includes both `a` and `b` (the join
-# in the world DAG, projected onto the spine, where positions compare exactly
-# as integers). For comparable worlds this is simply the later of the two.
-function world_join(a::UInt, b::UInt)
+# The earliest world in the observer's total order whose history includes
+# both `a` and `b`. For comparable worlds this is simply the later of the
+# two; for worlds on different branches it is the later of their merge
+# points on the observer's trunk.
+function world_join(a::UInt, b::UInt, observer::UInt)
     world_seg(a) == world_seg(b) && return max(a, b)
-    return ccall(:jl_world_spine_join, Csize_t, (Csize_t, Csize_t), a, b) % UInt
+    return ccall(:jl_world_join, Csize_t, (Csize_t, Csize_t, Csize_t), a, b, observer) % UInt
 end
+# Combine two validity caps; 0 if their invalidation cones are incomparable
+# (see jl_world_cap_meet), in which case the caller must degrade to point
+# validity.
+world_cap_meet(a::UInt, b::UInt) =
+    ccall(:jl_world_cap_meet, Csize_t, (Csize_t, Csize_t), a, b) % UInt
 
 in(world::UInt, wr::WorldRange) = world_in_range(world, wr.min_world, wr.max_world)
 
-@inline function intersect(a::WorldRange, b::WorldRange)
-    # the min side joins in the world DAG: bounds from different merged
-    # branches are incomparable and their join lies on the spine
-    minw = world_join(a.min_world, b.min_world)
-    maxw = min(a.max_world, b.max_world)
-    if minw > maxw
-        # Interval arithmetic cannot describe the validity region of a world
-        # off the spine; a point range there absorbs any bounds whose region
-        # contains its world (e.g. bounds capped by an invalidation on the
-        # spine, whose future cone does not contain the point's world).
-        if a.min_world == a.max_world && a.min_world in b
-            return a
-        elseif b.min_world == b.max_world && b.min_world in a
-            return b
-        end
-        @assert false "attempting to intersect disjoint world ranges"
+# Intersect two validity regions, as observed from `observer` (the world the
+# result will be used at). Both endpoints may lie off the observer's trunk
+# (e.g. a min_world within a grafted image history together with a cap from a
+# later spine invalidation); such intervals are nonempty whenever the cap's
+# invalidation cone does not contain the min. Only when the two caps'
+# invalidation cones are incomparable (shadowing events on two different side
+# branches) can a single interval not represent the region, and the result
+# degrades to point validity at the observer.
+@inline function intersect(a::WorldRange, b::WorldRange, observer::UInt)
+    minw = world_join(a.min_world, b.min_world, observer)
+    maxw = world_cap_meet(a.max_world, b.max_world)
+    if iszero(maxw)
+        @assert world_in_range(observer, a.min_world, a.max_world) &&
+            world_in_range(observer, b.min_world, b.max_world) "attempting to intersect disjoint world ranges"
+        return WorldRange(observer, observer)
     end
+    @assert world_at_most(minw, maxw) "attempting to intersect disjoint world ranges"
     return WorldRange(minw, maxw)
 end
+intersect(a::WorldRange, b::WorldRange) = intersect(a, b, get_world_counter())
 
 @inline function union(a::WorldRange, b::WorldRange)
     if b.min_world < a.min_world

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -268,7 +268,7 @@ struct WorldWithRange
 end
 
 intersect(world::WorldWithRange, valid_worlds::WorldRange) =
-    WorldWithRange(world.this, intersect(world.valid_worlds, valid_worlds))
+    WorldWithRange(world.this, intersect(world.valid_worlds, valid_worlds, world.this))
 
 # `InferenceState` and `IRInterpretationState` are defined together in a `typegroup`
 # block so each can reference the other in its `callstack` field type. They are not
@@ -406,9 +406,7 @@ mutable struct InferenceState{I<:AbstractInterpreter}
         callstack = Union{InferenceState{I},IRInterpretationState{I}}[]
         tasks = WorkThunk[]
 
-        frame_world = get_inference_world(interp)
-        valid_worlds = world_on_spine(frame_world) ? WorldRange(1, get_world_counter()) :
-            WorldRange(frame_world, frame_world)
+        valid_worlds = WorldRange(1, get_world_counter())
         bestguess = Bottom
         exc_bestguess = Bottom
         ipo_effects = EFFECTS_TOTAL
@@ -1305,15 +1303,9 @@ function update_valid_age!(sv::AbsIntState, world, valid_worlds::WorldRange)
     if !(world in valid_worlds)
         error("invalid age range update")
     end
-    if world_on_spine(world)
-        valid_worlds = intersect(sv.valid_worlds, valid_worlds)
-        if !(world in valid_worlds)
-            error("invalid age range update")
-        end
-    else
-        # Off the spine, interval bounds cannot describe the validity region;
-        # results are published with point validity for exactly this world.
-        valid_worlds = WorldRange(world, world)
+    valid_worlds = intersect(sv.valid_worlds, valid_worlds, UInt(world))
+    if !(world in valid_worlds)
+        error("invalid age range update")
     end
     sv.valid_worlds = valid_worlds
     return valid_worlds

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -406,7 +406,9 @@ mutable struct InferenceState{I<:AbstractInterpreter}
         callstack = Union{InferenceState{I},IRInterpretationState{I}}[]
         tasks = WorkThunk[]
 
-        valid_worlds = WorldRange(1, get_world_counter())
+        frame_world = get_inference_world(interp)
+        valid_worlds = world_on_spine(frame_world) ? WorldRange(1, get_world_counter()) :
+            WorldRange(frame_world, frame_world)
         bestguess = Bottom
         exc_bestguess = Bottom
         ipo_effects = EFFECTS_TOTAL
@@ -1300,9 +1302,18 @@ has_mustalias(::AbstractLattice, ::IRInterpretationState) = false
 
 # work towards converging the valid age range for sv
 function update_valid_age!(sv::AbsIntState, world, valid_worlds::WorldRange)
-    valid_worlds = intersect(sv.valid_worlds, valid_worlds)
     if !(world in valid_worlds)
         error("invalid age range update")
+    end
+    if world_on_spine(world)
+        valid_worlds = intersect(sv.valid_worlds, valid_worlds)
+        if !(world in valid_worlds)
+            error("invalid age range update")
+        end
+    else
+        # Off the spine, interval bounds cannot describe the validity region;
+        # results are published with point validity for exactly this world.
+        valid_worlds = WorldRange(world, world)
     end
     sv.valid_worlds = valid_worlds
     return valid_worlds

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -3,7 +3,7 @@
 using ..Compiler.Base
 using ..Compiler: _findsup, store_backedges, JLOptions, get_world_counter,
     _methods_by_ftype, get_methodtable, get_ci_mi, should_instrument,
-    morespecific, RefValue, get_require_world, Vector, IdDict
+    morespecific, RefValue, get_require_world, Vector, IdDict, world_on_spine
 using .Core: CodeInstance, MethodInstance
 
 const CI_FLAGS_NATIVE_CACHE_VALID = 0b1000
@@ -200,6 +200,15 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
 
             # unable to backdate before require_world, since Bindings are not able to track that information
             minworld, maxworld = get_require_world(), validation_world
+            ci_minworld = @atomic :monotonic initial.codeinst.min_world
+            if !world_on_spine(ci_minworld)
+                # This CodeInstance came from a grafted image history: its
+                # (translated) creation world stays authoritative, so that it is
+                # not considered valid at earlier worlds of that same history --
+                # e.g. at a world token captured before a method whose dispatch
+                # result it embeds was defined.
+                minworld = max(minworld, ci_minworld)
+            end
 
             # Check for invalidation of GlobalRef edges
             if (initial.def.did_scan_source & 0x1) == 0x0

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -179,7 +179,7 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
         end
         # if we aren't cached, we don't need this edge
         # but our caller might, so let's just make it anyways
-        if max_world >= validation_world
+        if world_reaches(validation_world, max_world)
             # if we can record all of the backedges in the global reverse-cache,
             # we can now widen our applicability in the global cache too
             store_backedges(ci, edges)
@@ -279,7 +279,7 @@ function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstan
     ipo_effects = zero(UInt32)
     min_world = src.min_world
     max_world = src.max_world
-    if max_world >= get_world_counter()
+    if world_reaches(get_world_counter(), max_world)
         max_world = typemax(UInt)
     end
     if max_world == typemax(UInt)
@@ -1612,7 +1612,8 @@ end
 function ci_worlds_cover(code::CodeInstance, valid_worlds::WorldRange)
     min_world = @atomic :acquire code.min_world
     max_world = @atomic :acquire code.max_world
-    return min_world <= first(valid_worlds) && last(valid_worlds) <= max_world
+    return world_reaches(min_world, first(valid_worlds)) &&
+        world_at_most(last(valid_worlds), max_world)
 end
 
 function ci_cache_head(mi::MethodInstance)
@@ -2054,7 +2055,7 @@ function compile!(codeinfos::Vector{Any}, workqueue::CompilationQueue;
             # if this method is generally visible to the current compilation world,
             # and this is either the primary world, or not applicable in the primary world
             # then we want to compile and emit this
-            if item.def.primary_world <= world
+            if world_reaches(item.def.primary_world, world)
                 ci = typeinf_ext(interp, item, SOURCE_MODE_GET_SOURCE)
                 ci isa CodeInstance && push!(workqueue, ci)
             end

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -158,18 +158,17 @@ mutable struct LocalInferenceProof
     const edges::SimpleVector
     function LocalInferenceProof(valid_worlds::WorldRange, edges::SimpleVector)
         # Local proofs are not registered with the global invalidation machinery.
-        # Inference states cap their range at the current world counter (or pin it to
-        # the inference world when that world is off the spine), and exact-world
-        # local-cache reuse relies on that cap to keep an unregistered proof from
-        # claiming validity in a future world.
-        @assert first(valid_worlds) <= last(valid_worlds)
+        # Inference states cap their range at the current world counter, and
+        # exact-world local-cache reuse relies on that cap to keep an
+        # unregistered proof from claiming validity in a future world.
+        @assert world_at_most(first(valid_worlds), last(valid_worlds)) # nonempty (both endpoints may lie off the spine's trunk)
         @assert world_at_most(last(valid_worlds), get_world_counter())
         for edge in edges
             edge_worlds = if edge isa LocalInferenceProof
                 edge.valid_worlds
-            elseif edge isa CodeInstance && edge.min_world <= edge.max_world
-                # Skip a provisional CI (`min_world > max_world`); an SCC fills it
-                # before any proof containing it can escape.
+            elseif edge isa CodeInstance && world_at_most(edge.min_world, edge.max_world)
+                # Skip a provisional CI (its empty world region, `(1, 0)`);
+                # an SCC fills it before any proof containing it can escape.
                 WorldRange(edge.min_world, edge.max_world)
             else
                 continue
@@ -205,7 +204,7 @@ struct LocalInferenceResult <: InferredCallResult
         if proof isa CodeInstance
             @assert proof.def === result.linfo "CodeInstance proof does not match InferenceResult"
         else
-            @assert first(proof.valid_worlds) <= last(proof.valid_worlds)
+            @assert world_at_most(first(proof.valid_worlds), last(proof.valid_worlds))
         end
         return new(result, proof)
     end

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -158,10 +158,12 @@ mutable struct LocalInferenceProof
     const edges::SimpleVector
     function LocalInferenceProof(valid_worlds::WorldRange, edges::SimpleVector)
         # Local proofs are not registered with the global invalidation machinery.
-        # Inference states cap their range at the current world counter, and exact-world
+        # Inference states cap their range at the current world counter (or pin it to
+        # the inference world when that world is off the spine), and exact-world
         # local-cache reuse relies on that cap to keep an unregistered proof from
         # claiming validity in a future world.
-        @assert first(valid_worlds) <= last(valid_worlds) <= get_world_counter()
+        @assert first(valid_worlds) <= last(valid_worlds)
+        @assert world_at_most(last(valid_worlds), get_world_counter())
         for edge in edges
             edge_worlds = if edge isa LocalInferenceProof
                 edge.valid_worlds
@@ -172,8 +174,8 @@ mutable struct LocalInferenceProof
             else
                 continue
             end
-            @assert (first(edge_worlds) <= first(valid_worlds) &&
-                last(valid_worlds) <= last(edge_worlds))
+            @assert (world_reaches(first(edge_worlds), first(valid_worlds)) &&
+                world_at_most(last(valid_worlds), last(edge_worlds)))
         end
         return new(valid_worlds, edges)
     end
@@ -543,8 +545,10 @@ function NativeInterpreter(world::UInt = get_world_counter();
         world = curr_max_world
     end
     # If they didn't pass typemax(UInt) but passed something more subtly
-    # incorrect, fail out loudly.
-    @assert world <= curr_max_world
+    # incorrect, fail out loudly. (Worlds on closed sibling branches of the
+    # world DAG are legal inference worlds; only unrealized future worlds
+    # are not.)
+    @assert world_at_most(world, curr_max_world)
     method_table = CachedMethodTable(InternalMethodTable(world))
     inf_cache = InferenceCache() # Initially empty cache
     codegen = IdDict{CodeInstance,CodeInfo}()

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -293,13 +293,16 @@ as they existed at the given `world` age. In a sense, this is like the opposite
 of [`invokelatest`](@ref).
 
 !!! note
-    It is not valid to store world ages obtained in precompilation for later use.
-    This is because precompilation generates a "parallel universe" where the
-    world age refers to system state unrelated to the main Julia session.
+    It is not valid to store raw world ages obtained in precompilation for later
+    use. This is because precompilation generates a "parallel universe" where
+    the world age refers to system state unrelated to the main Julia session.
+    Use an opaque token from [`Base.world_token`](@ref) instead, which remains
+    meaningful after the precompiled image is loaded and can be passed to
+    `invoke_in_world` in place of a raw world age.
 """
 const invoke_in_world = Core.invoke_in_world
 
-function Core.kwcall(kwargs::NamedTuple, ::typeof(invoke_in_world), world::UInt, f, args...)
+function Core.kwcall(kwargs::NamedTuple, ::typeof(invoke_in_world), world::Union{UInt,Core.WorldToken}, f, args...)
     @inline
     return Core.invoke_in_world(world, Core.kwcall, kwargs, f, args...)
 end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -1254,6 +1254,16 @@ const _apply_pure = _apply
 const _call_latest = invokelatest
 const _call_in_world = invoke_in_world
 
+# An opaque, serializable capture of a world age, applied with
+# `invoke_in_world`. Mutable so that every token is a distinct heap object:
+# precompilation rebases the world of tokens serialized in a package image
+# onto a grafted world segment at load time, which requires each token to be
+# independently addressable (and never inlined into a parent object).
+mutable struct WorldToken
+    const world::UInt
+    WorldToken(world::UInt) = new(world)
+end
+
 struct Pair{A, B}
     first::A
     second::B

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1634,6 +1634,23 @@ Return the world the [`current_task`](@ref) is executing within.
 """
 tls_world_age() = ccall(:jl_get_tls_world_age, UInt, ())
 
+"""
+    Base.world_token()
+
+Capture the current world age as an opaque `Core.WorldToken`, which can be
+passed to [`invoke_in_world`](@ref Base.invoke_in_world) in place of a raw
+world age.
+
+Unlike a raw world age, a token remains meaningful across precompilation: when
+a token is serialized into a package image, the loading process grafts the
+image's world history into the world-age DAG as its own segment and rebases
+the token onto it, so invoking at the token continues to see the captured
+state and is isolated from later redefinitions. (The granularity within the
+capturing package itself is currently the whole image: a token does not
+distinguish definitions made before and after its capture in its own package.)
+"""
+world_token() = Core.WorldToken(tls_world_age())
+
 get_require_world() = unsafe_load(cglobal(:jl_require_world, UInt))
 
 """

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1643,11 +1643,13 @@ world age.
 
 Unlike a raw world age, a token remains meaningful across precompilation: when
 a token is serialized into a package image, the loading process grafts the
-image's world history into the world-age DAG as its own segment and rebases
-the token onto it, so invoking at the token continues to see the captured
-state and is isolated from later redefinitions. (The granularity within the
-capturing package itself is currently the whole image: a token does not
-distinguish definitions made before and after its capture in its own package.)
+image's world history into the world-age DAG and rebases the token onto it, so
+invoking at the token continues to see exactly the captured state. In
+particular, the token distinguishes definitions made before and after its
+capture (including within its own package), is isolated from redefinitions
+made after the image is loaded, and does not see definitions that are not part
+of its own history (such as packages loaded by the loading process that the
+capturing package did not depend on).
 """
 world_token() = Core.WorldToken(tls_world_age())
 

--- a/doc/src/manual/worldage.md
+++ b/doc/src/manual/worldage.md
@@ -286,10 +286,20 @@ julia> fetch(t)
 
 In addition to tasks, opaque closures also capture their world age at creation. See [`Base.Experimental.@opaque`](@ref).
 
+## World tokens
+
+A raw world age is only meaningful within the session that produced it. To capture a world
+age that remains meaningful after precompilation, use [`Base.world_token`](@ref), which
+returns an opaque token that can be passed to [`Base.invoke_in_world`](@ref) in place of a
+raw world age. When a token is serialized into a package image, the loading process grafts
+the image's world history into the world-age graph and rebases the token onto it, so that
+invoking at the token continues to see exactly the state that was captured.
+
 ```@docs
 Base.@world
 Base.get_world_counter
 Base.tls_world_age
 Base.invoke_in_world
+Base.world_token
 Base.Experimental.@opaque
 ```

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ SRCS := \
 	dlload sys init task array genericmemory staticdata toplevel jl_uv datatype \
 	simplevector runtime_intrinsics precompile jloptions mtarraylist \
 	threading scheduler stackwalk null_sysimage \
-	method jlapi signal-handling safepoint timing subtype rtutils \
+	method jlapi signal-handling safepoint timing subtype rtutils world \
 	crc32c APInt processor ircode opaque_closure codegen-stubs coverage runtime_ccall engine \
 	$(GC_SRCS)
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1067,7 +1067,7 @@ JL_CALLABLE(jl_f_invoke_in_world)
     size_t world = jl_unbox_ulong(args[0]);
     if (!ct->ptls->in_pure_callback) {
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-        if (ct->world_age > world)
+        if (jl_world_at_most(world, ct->world_age))
             ct->world_age = world;
     }
     jl_value_t *ret = jl_apply(&args[1], nargs - 1);
@@ -1087,7 +1087,7 @@ JL_CALLABLE(jl_f__call_in_world_total)
         ct->ptls->in_pure_callback = 1;
         size_t world = jl_unbox_ulong(args[0]);
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-        if (ct->world_age > world)
+        if (jl_world_at_most(world, ct->world_age))
             ct->world_age = world;
         ret = jl_apply(&args[1], nargs - 1);
         ct->world_age = last_age;
@@ -1933,8 +1933,8 @@ JL_CALLABLE(jl_f_invoke)
                 jl_type_error("invoke: argument type error", mi->specTypes, arg_tuple(args[0], &args[2], nargs - 1));
             }
         }
-        if (jl_atomic_load_relaxed(&codeinst->min_world) > jl_current_task->world_age ||
-            jl_current_task->world_age > jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (!jl_world_in_range(jl_current_task->world_age, jl_atomic_load_relaxed(&codeinst->min_world),
+                               jl_atomic_load_relaxed(&codeinst->max_world))) {
             jl_error("invoke: CodeInstance not valid for this world");
         }
         if (!invoke) {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1063,8 +1063,14 @@ JL_CALLABLE(jl_f_invoke_in_world)
     JL_NARGSV(invoke_in_world, 2);
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
-    JL_TYPECHK(invoke_in_world, ulong, args[0]);
-    size_t world = jl_unbox_ulong(args[0]);
+    size_t world;
+    if (jl_typetagis(args[0], jl_worldtoken_type)) {
+        world = ((jl_worldtoken_t*)args[0])->world;
+    }
+    else {
+        JL_TYPECHK(invoke_in_world, ulong, args[0]);
+        world = jl_unbox_ulong(args[0]);
+    }
     if (!ct->ptls->in_pure_callback) {
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
         if (jl_world_at_most(world, ct->world_age))
@@ -1078,14 +1084,17 @@ JL_CALLABLE(jl_f_invoke_in_world)
 JL_CALLABLE(jl_f__call_in_world_total)
 {
     JL_NARGSV(_call_in_world_total, 2);
-    JL_TYPECHK(_call_in_world_total, ulong, args[0]);
+    if (!jl_typetagis(args[0], jl_worldtoken_type)) {
+        JL_TYPECHK(_call_in_world_total, ulong, args[0]);
+    }
     jl_task_t *ct = jl_current_task;
     int last_in = ct->ptls->in_pure_callback;
     jl_value_t *ret = NULL;
     size_t last_age = ct->world_age;
     JL_TRY {
         ct->ptls->in_pure_callback = 1;
-        size_t world = jl_unbox_ulong(args[0]);
+        size_t world = jl_typetagis(args[0], jl_worldtoken_type) ?
+            ((jl_worldtoken_t*)args[0])->world : jl_unbox_ulong(args[0]);
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
         if (jl_world_at_most(world, ct->world_age))
             ct->world_age = world;

--- a/src/gf.c
+++ b/src/gf.c
@@ -5072,7 +5072,7 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     }
     else if (!jl_world_at_most(closure->world, max_world)) {
         // exclude method table entries that have been replaced in the current world
-        closure->match.min_valid = jl_world_spine_join(closure->match.min_valid, max_world + 1);
+        closure->match.min_valid = jl_world_join(closure->match.min_valid, max_world + 1, closure->world);
         return 1;
     }
     if (closure->match.max_valid > max_world)
@@ -5470,7 +5470,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                 jl_array_ptr_set(env.t, 0, env.matc);
                 size_t min_world = jl_atomic_load_relaxed(&entry->min_world);
                 size_t max_world = jl_atomic_load_relaxed(&entry->max_world);
-                *min_valid = jl_world_spine_join(*min_valid, min_world);
+                *min_valid = jl_world_join(*min_valid, min_world, world);
                 if (*max_valid > max_world)
                     *max_valid = max_world;
                 JL_GC_POP();
@@ -5502,7 +5502,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                         env.match.env, meth, FULLY_COVERS);
                     env.t = (jl_value_t*)jl_alloc_vec_any(1);
                     jl_array_ptr_set(env.t, 0, env.matc);
-                    *min_valid = jl_world_spine_join(*min_valid, min_world);
+                    *min_valid = jl_world_join(*min_valid, min_world, world);
                     if (*max_valid > max_world)
                         *max_valid = max_world;
                     JL_GC_POP();
@@ -5692,7 +5692,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
         // method applicability is the same as typemapentry applicability
         size_t min_world = jl_atomic_load_relaxed(&m->primary_world);
         // intersect the env valid range with method lookup's inclusive valid range
-        env.match.min_valid = jl_world_spine_join(env.match.min_valid, min_world);
+        env.match.min_valid = jl_world_join(env.match.min_valid, min_world, world);
     }
     if (mc && cache_result_recursion && ((jl_datatype_t*)unw)->isdispatchtuple) { // cache_result_recursion prevents lock confusion and unnecessary work
         if (len == 1 && !has_ambiguity) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -411,7 +411,7 @@ static jl_code_instance_t *jl_method_inferred_with_abi(jl_method_instance_t *mi 
     for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
         if (codeinst->owner != jl_nothing)
             continue;
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (jl_world_in_range(world, jl_atomic_load_relaxed(&codeinst->min_world), jl_atomic_load_relaxed(&codeinst->max_world))) {
             if (emit_codeinst_and_edges(codeinst) && jl_atomic_load_relaxed(&codeinst->invoke) != NULL)
                 return codeinst;
         }
@@ -589,8 +589,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_uninferred(
     jl_value_t *owner = jl_nothing; // TODO: owner should be arg
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= min_world &&
-            jl_atomic_load_relaxed(&codeinst->max_world) >= max_world &&
+        if (jl_world_range_in_range(min_world, max_world, jl_atomic_load_relaxed(&codeinst->min_world), jl_atomic_load_relaxed(&codeinst->max_world)) &&
             jl_egal(codeinst->owner, owner) &&
             jl_egal(codeinst->rettype, rettype)) {
             if (di == NULL)
@@ -1762,7 +1761,7 @@ static inline jl_typemap_entry_t *lookup_leafcache(jl_genericmemory_t *leafcache
         //
         // n.b. this entire chain is type-equal to tt (by construction), so it is unnecessary to call `tt<:entry->sig`
         do {
-            if (jl_atomic_load_relaxed(&entry->min_world) <= world && world <= jl_atomic_load_relaxed(&entry->max_world)) {
+            if (jl_world_in_range(world, jl_atomic_load_relaxed(&entry->min_world), jl_atomic_load_relaxed(&entry->max_world))) {
                 if (entry->simplesig == (void*)jl_nothing || concretesig_equal(tt, (jl_value_t*)entry->simplesig))
                     return entry;
             }
@@ -3590,8 +3589,7 @@ STATIC_INLINE jl_value_t *_jl_rettype_inferred(jl_value_t *owner, jl_method_inst
 {
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     while (codeinst) {
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= min_world &&
-            max_world <= jl_atomic_load_relaxed(&codeinst->max_world) &&
+        if (jl_world_range_in_range(min_world, max_world, jl_atomic_load_relaxed(&codeinst->min_world), jl_atomic_load_relaxed(&codeinst->max_world)) &&
             jl_egal(codeinst->owner, owner)) {
 
             jl_value_t *code = jl_atomic_load_relaxed(&codeinst->inferred);
@@ -3621,7 +3619,7 @@ STATIC_INLINE jl_callptr_t jl_method_compiled_callptr(jl_method_instance_t *mi, 
     for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
         if (codeinst->owner != jl_nothing)
             continue;
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (jl_world_in_range(world, jl_atomic_load_relaxed(&codeinst->min_world), jl_atomic_load_relaxed(&codeinst->max_world))) {
             jl_callptr_t invoke = jl_atomic_load_acquire(&codeinst->invoke);
             if (!invoke)
                 continue;
@@ -4724,7 +4722,7 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
             entry = jl_atomic_load_relaxed(&call_cache[cache_idx[i]]); \
             if (entry && nargs == jl_svec_len(entry->sig->parameters) && \
                 sig_match_fast(FT, args, jl_svec_data(entry->sig->parameters), nargs) && \
-                world >= jl_atomic_load_relaxed(&entry->min_world) && world <= jl_atomic_load_relaxed(&entry->max_world)) { \
+                jl_world_in_range(world, jl_atomic_load_relaxed(&entry->min_world), jl_atomic_load_relaxed(&entry->max_world))) { \
                 goto have_entry; \
             } \
         } while (0);
@@ -5047,13 +5045,13 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     // excluding it from the results is valid for the full span.
     size_t min_world = jl_atomic_load_relaxed(&ml->min_world);
     size_t max_world = jl_atomic_load_relaxed(&ml->max_world);
-    if (closure->world < min_world) {
-        // exclude method table entries that are part of a later world
+    if (!jl_world_at_least(closure->world, min_world)) {
+        // exclude method table entries that are part of a later (or unrelated) world
         if (closure->match.max_valid >= min_world)
             closure->match.max_valid = min_world - 1;
         return 1;
     }
-    else if (closure->world > max_world) {
+    else if (!jl_world_at_most(closure->world, max_world)) {
         // exclude method table entries that have been replaced in the current world
         if (closure->match.min_valid <= max_world)
             closure->match.min_valid = max_world + 1;
@@ -5378,8 +5376,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                               size_t *min_valid, size_t *max_valid, int *ambig)
 {
     size_t current_world = jl_atomic_load_acquire(&jl_world_counter);
-    if (world > current_world)
-        return jl_nothing; // the future is not enumerable
+    if (!jl_world_at_most(world, current_world))
+        return jl_nothing; // the future is not enumerable (but closed sibling branches of the world DAG are)
     JL_TIMING(METHOD_MATCH, METHOD_MATCH);
     int has_ambiguity = 0;
     jl_value_t *unw = jl_unwrap_unionall((jl_value_t*)type);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3006,13 +3006,14 @@ JL_DLLEXPORT void jl_method_table_disable(jl_method_t *method) JL_CANSAFEPOINT
     int enabled = jl_atomic_load_relaxed(&methodentry->max_world) == ~(size_t)0;
     if (enabled) {
         // Narrow the world age on the method to make it uncallable
-        size_t world = jl_atomic_load_relaxed(&jl_world_counter);
+        size_t new_world = jl_world_next_locked();
+        size_t world = new_world - 1;
         assert(method == methodentry->func.method);
         jl_atomic_store_relaxed(&method->dispatch_status, 0);
         assert(jl_atomic_load_relaxed(&methodentry->max_world) == ~(size_t)0);
         jl_atomic_store_relaxed(&methodentry->max_world, world);
         jl_method_table_invalidate(method, world);
-        jl_atomic_store_release(&jl_world_counter, world + 1);
+        jl_atomic_store_release(&jl_world_counter, new_world);
     }
     JL_UNLOCK(&world_counter_lock);
     if (!enabled)
@@ -3471,7 +3472,7 @@ JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method
     JL_LOCK(&world_counter_lock);
     if (!jl_atomic_load_relaxed(&allow_new_worlds))
         jl_error("Method changes have been disabled via a call to disable_new_worlds.");
-    size_t world = jl_atomic_load_relaxed(&jl_world_counter) + 1;
+    size_t world = jl_world_next_locked();
     jl_atomic_store_relaxed(&method->primary_world, world);
     jl_method_table_activate(newentry);
     jl_atomic_store_release(&jl_world_counter, world);
@@ -5842,12 +5843,12 @@ JL_DLLEXPORT void jl_drop_all_caches(void)
     JL_LOCK(&world_counter_lock);
 
     // Get current world age - we'll invalidate everything at this world
-    size_t current_world = jl_atomic_load_relaxed(&jl_world_counter);
+    size_t new_world = jl_world_next_locked();
+    size_t current_world = new_world - 1;
 
     invalidate_all_caches(jl_method_table, current_world);
 
     // Increment world age - this forces all subsequent compilation to happen in the new world
-    size_t new_world = current_world + 1;
     jl_atomic_store_release(&jl_world_counter, new_world);
 
     JL_UNLOCK(&world_counter_lock);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1933,12 +1933,11 @@ static jl_method_instance_t *cache_result(
 {
     // caller must hold the parent->writelock, which this releases
     int8_t offs = mc ? jl_cachearg_offset() : 1;
-    // A cache entry created for a query world off the spine gets point
-    // validity: interval bounds cannot describe its DAG validity region, and
-    // lookups at exactly that world are its only consumers. (A world in the
-    // current spine segment beyond the counter -- a pending insertion world
-    // -- is on the spine, not off it.)
-    if (jl_world_seg(world) != jl_world_seg(current_world) && !jl_world_reaches(world, current_world)) {
+    // A cache entry created for a query world off the spine's trunk (a
+    // fabricated branch, or a world within a grafted image history) gets
+    // point validity: interval bounds cannot describe its DAG validity
+    // region, and lookups at exactly that world are its only consumers.
+    if (!jl_world_on_trunk(world, current_world)) {
         min_valid = world;
         max_valid = world;
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -5072,8 +5072,7 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     }
     else if (!jl_world_at_most(closure->world, max_world)) {
         // exclude method table entries that have been replaced in the current world
-        if (closure->match.min_valid <= max_world)
-            closure->match.min_valid = max_world + 1;
+        closure->match.min_valid = jl_world_spine_join(closure->match.min_valid, max_world + 1);
         return 1;
     }
     if (closure->match.max_valid > max_world)
@@ -5471,8 +5470,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                 jl_array_ptr_set(env.t, 0, env.matc);
                 size_t min_world = jl_atomic_load_relaxed(&entry->min_world);
                 size_t max_world = jl_atomic_load_relaxed(&entry->max_world);
-                if (*min_valid < min_world)
-                    *min_valid = min_world;
+                *min_valid = jl_world_spine_join(*min_valid, min_world);
                 if (*max_valid > max_world)
                     *max_valid = max_world;
                 JL_GC_POP();
@@ -5504,8 +5502,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                         env.match.env, meth, FULLY_COVERS);
                     env.t = (jl_value_t*)jl_alloc_vec_any(1);
                     jl_array_ptr_set(env.t, 0, env.matc);
-                    if (*min_valid < min_world)
-                        *min_valid = min_world;
+                    *min_valid = jl_world_spine_join(*min_valid, min_world);
                     if (*max_valid > max_world)
                         *max_valid = max_world;
                     JL_GC_POP();
@@ -5695,8 +5692,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
         // method applicability is the same as typemapentry applicability
         size_t min_world = jl_atomic_load_relaxed(&m->primary_world);
         // intersect the env valid range with method lookup's inclusive valid range
-        if (env.match.min_valid < min_world)
-            env.match.min_valid = min_world;
+        env.match.min_valid = jl_world_spine_join(env.match.min_valid, min_world);
     }
     if (mc && cache_result_recursion && ((jl_datatype_t*)unw)->isdispatchtuple) { // cache_result_recursion prevents lock confusion and unnecessary work
         if (len == 1 && !has_ambiguity) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -3207,7 +3207,11 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     jl_value_t *oldvalue = NULL;
     jl_array_t *oldmi = NULL;
     size_t world = jl_atomic_load_relaxed(&method->primary_world);
-    assert(world == jl_atomic_load_relaxed(&jl_world_counter) + 1); // min-world
+    // min-world is the next spine world, or the base of a grafted image
+    // segment that the current spine segment has already merged
+    assert(world == jl_atomic_load_relaxed(&jl_world_counter) + 1 ||
+           (jl_world_idx(world) == 0 &&
+            jl_world_seg_reaches(jl_world_seg(world), jl_world_seg(jl_atomic_load_relaxed(&jl_world_counter)))));
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_WHICH) == 0);
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     assert(jl_atomic_load_relaxed(&newentry->min_world) == ~(size_t)0);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3028,7 +3028,11 @@ jl_typemap_entry_t *jl_method_table_add(jl_methtable_t *mt, jl_method_t *method,
     jl_typemap_entry_t *newentry = NULL;
     JL_GC_PUSH1(&newentry);
     // add our new entry
-    assert(jl_atomic_load_relaxed(&method->primary_world) == ~(size_t)0); // min-world
+    // min-world: either not yet activated, or already carrying its original
+    // world from a grafted image history (activation preserves it)
+    assert(jl_atomic_load_relaxed(&method->primary_world) == ~(size_t)0 ||
+           jl_world_seg(jl_atomic_load_relaxed(&method->primary_world)) !=
+               jl_world_seg(jl_atomic_load_relaxed(&jl_world_counter)));
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_WHICH) == 0);
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     JL_LOCK(&mt->cache->writelock);
@@ -3207,11 +3211,10 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     jl_value_t *oldvalue = NULL;
     jl_array_t *oldmi = NULL;
     size_t world = jl_atomic_load_relaxed(&method->primary_world);
-    // min-world is the next spine world, or the base of a grafted image
-    // segment that the current spine segment has already merged
+    // min-world is the next spine world, or a world within a grafted image
+    // history (which the spine merges once the graft completes)
     assert(world == jl_atomic_load_relaxed(&jl_world_counter) + 1 ||
-           (jl_world_idx(world) == 0 &&
-            jl_world_seg_reaches(jl_world_seg(world), jl_world_seg(jl_atomic_load_relaxed(&jl_world_counter)))));
+           jl_world_seg(world) != jl_world_seg(jl_atomic_load_relaxed(&jl_world_counter)));
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_WHICH) == 0);
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     assert(jl_atomic_load_relaxed(&newentry->min_world) == ~(size_t)0);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1838,7 +1838,10 @@ static void cache_insert(
     // exact-dispatch lookups (`jl_typemap_entry_assoc_exact`) require datatype sigs
     assert(jl_is_datatype(cachett));
     int unconstrained_max = max_valid == ~(size_t)0;
-    if (max_valid > current_world)
+    // clamp bounds that extend past the current spine world (they are
+    // restored below if the world has not advanced); a point bound on a
+    // closed branch does not extend into the spine's future and stays as is
+    if (max_valid > current_world && (unconstrained_max || jl_world_reaches(current_world, max_valid)))
         max_valid = current_world;
     jl_datatype_t *simplett = NULL;
     jl_typemap_entry_t *newentry = NULL;
@@ -1930,6 +1933,15 @@ static jl_method_instance_t *cache_result(
 {
     // caller must hold the parent->writelock, which this releases
     int8_t offs = mc ? jl_cachearg_offset() : 1;
+    // A cache entry created for a query world off the spine gets point
+    // validity: interval bounds cannot describe its DAG validity region, and
+    // lookups at exactly that world are its only consumers. (A world in the
+    // current spine segment beyond the counter -- a pending insertion world
+    // -- is on the spine, not off it.)
+    if (jl_world_seg(world) != jl_world_seg(current_world) && !jl_world_reaches(world, current_world)) {
+        min_valid = world;
+        max_valid = world;
+    }
     // short-circuit (now that we hold the lock) if this entry is already present
     if (!tt_known_absent) {
         jl_typemap_entry_t *entry = mt_find_cache_entry(cache, mc ? &mc->leafcache : NULL, tt, world, offs);

--- a/src/gf.c
+++ b/src/gf.c
@@ -684,7 +684,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
         uint32_t effects, jl_value_t *analysis_results,
         jl_debuginfo_t *di, jl_svec_t *edges /*, int absolute_max*/)
 {
-    assert(min_world <= max_world && "attempting to set invalid world constraints");
+    assert(jl_world_at_most(min_world, max_world) && "attempting to set invalid world constraints");
     //assert((!jl_is_method(mi->def.value) || max_world != ~(size_t)0 || min_world <= 1 || edges == NULL || jl_svec_len(edges) != 0) && "missing edges");
     jl_task_t *ct = jl_current_task;
     jl_code_instance_t *codeinst = (jl_code_instance_t*)jl_gc_alloc(ct->ptls, sizeof(jl_code_instance_t),
@@ -730,7 +730,7 @@ JL_DLLEXPORT void jl_fill_codeinst(
         double time_infer_total, double time_infer_cache_saved, double time_infer_self,
         jl_debuginfo_t *di, jl_svec_t *edges /* , int absolute_max*/)
 {
-    assert(min_world <= max_world && "attempting to set invalid world constraints");
+    assert(jl_world_at_most(min_world, max_world) && "attempting to set invalid world constraints");
     //assert((!jl_is_method(codeinst->def->def.value) || max_world != ~(size_t)0 || min_world <= 1 || jl_svec_len(edges) != 0) && "missing edges");
     jl_gc_write(codeinst, codeinst->rettype, jl_value_t, rettype);
     jl_gc_write(codeinst, codeinst->exctype, jl_value_t, exctype);
@@ -1933,14 +1933,6 @@ static jl_method_instance_t *cache_result(
 {
     // caller must hold the parent->writelock, which this releases
     int8_t offs = mc ? jl_cachearg_offset() : 1;
-    // A cache entry created for a query world off the spine's trunk (a
-    // fabricated branch, or a world within a grafted image history) gets
-    // point validity: interval bounds cannot describe its DAG validity
-    // region, and lookups at exactly that world are its only consumers.
-    if (!jl_world_on_trunk(world, current_world)) {
-        min_valid = world;
-        max_valid = world;
-    }
     // short-circuit (now that we hold the lock) if this entry is already present
     if (!tt_known_absent) {
         jl_typemap_entry_t *entry = mt_find_cache_entry(cache, mc ? &mc->leafcache : NULL, tt, world, offs);
@@ -2450,7 +2442,9 @@ static void invalidate_code_instance(jl_code_instance_t *replaced, size_t max_wo
     JL_LOCK(&replaced_mi->def.method->writelock);
     size_t replacedmaxworld = jl_atomic_load_relaxed(&replaced->max_world);
     if (replacedmaxworld == ~(size_t)0) {
-        assert(jl_atomic_load_relaxed(&replaced->min_world) - 1 <= max_world && "attempting to set illogical world constraints (probable race condition)");
+        assert((jl_world_at_most(jl_atomic_load_relaxed(&replaced->min_world), max_world) ||
+                max_world + 1 == jl_atomic_load_relaxed(&replaced->min_world)) &&
+               "attempting to set illogical world constraints (probable race condition)");
         jl_atomic_store_release(&replaced->max_world, max_world);
         // recurse to all backedges to update their valid range also
         _invalidate_backedges(replaced_mi, replaced, max_world, depth + 1);
@@ -5066,8 +5060,14 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
     size_t max_world = jl_atomic_load_relaxed(&ml->max_world);
     if (!jl_world_at_least(closure->world, min_world)) {
         // exclude method table entries that are part of a later (or unrelated) world
-        if (closure->match.max_valid >= min_world)
-            closure->match.max_valid = min_world - 1;
+        size_t cap = jl_world_cap_meet(closure->match.max_valid, min_world - 1);
+        if (cap == 0) {
+            // incomparable exclusion cones: degrade to point validity
+            closure->match.min_valid = closure->match.max_valid = closure->world;
+        }
+        else {
+            closure->match.max_valid = cap;
+        }
         return 1;
     }
     else if (!jl_world_at_most(closure->world, max_world)) {
@@ -5075,8 +5075,13 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
         closure->match.min_valid = jl_world_join(closure->match.min_valid, max_world + 1, closure->world);
         return 1;
     }
-    if (closure->match.max_valid > max_world)
-        closure->match.max_valid = max_world;
+    {
+        size_t cap = jl_world_cap_meet(closure->match.max_valid, max_world);
+        if (cap == 0)
+            closure->match.min_valid = closure->match.max_valid = closure->world;
+        else
+            closure->match.max_valid = cap;
+    }
     jl_method_t *meth = ml->func.method;
     int only = jl_atomic_load_relaxed(&meth->dispatch_status) & METHOD_SIG_LATEST_ONLY;
     if (closure->lim >= 0 && only) {
@@ -5471,8 +5476,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                 size_t min_world = jl_atomic_load_relaxed(&entry->min_world);
                 size_t max_world = jl_atomic_load_relaxed(&entry->max_world);
                 *min_valid = jl_world_join(*min_valid, min_world, world);
-                if (*max_valid > max_world)
-                    *max_valid = max_world;
+                *max_valid = jl_world_cap_meet(*max_valid, max_world);
+                assert(*max_valid != 0);
                 JL_GC_POP();
                 return env.t;
             }
@@ -5503,8 +5508,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                     env.t = (jl_value_t*)jl_alloc_vec_any(1);
                     jl_array_ptr_set(env.t, 0, env.matc);
                     *min_valid = jl_world_join(*min_valid, min_world, world);
-                    if (*max_valid > max_world)
-                        *max_valid = max_world;
+                    *max_valid = jl_world_cap_meet(*max_valid, max_world);
+                    assert(*max_valid != 0);
                     JL_GC_POP();
                     return env.t;
                 }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -138,8 +138,8 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
     jl_value_t *result = NULL;
     if (jl_is_code_instance(c)) {
         jl_code_instance_t *codeinst = (jl_code_instance_t*)c;
-        assert(jl_atomic_load_relaxed(&codeinst->min_world) <= jl_current_task->world_age &&
-               jl_current_task->world_age <= jl_atomic_load_relaxed(&codeinst->max_world));
+        assert(jl_world_in_range(jl_current_task->world_age, jl_atomic_load_relaxed(&codeinst->min_world),
+                                 jl_atomic_load_relaxed(&codeinst->max_world)));
         jl_callptr_t invoke = jl_atomic_load_acquire(&codeinst->invoke);
         if (!invoke) {
             jl_compile_codeinst(codeinst);

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -154,6 +154,7 @@
     XX(voidpointer_type, jl_datatype_t*) \
     XX(wait_entry_type, jl_datatype_t*) \
     XX(weakref_type, jl_datatype_t*) \
+    XX(worldtoken_type, jl_datatype_t*) \
     XX(typeapp_type, jl_datatype_t*)
 
 // Global constant values (jl_true, jl_false, jl_nothing)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4605,6 +4605,7 @@ void post_boot_hooks(void)
     jl_typeapp_type = (jl_datatype_t*)core("TypeApp");
 
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");
+    jl_worldtoken_type = (jl_datatype_t*)core("WorldToken");
     jl_vecelement_typename = ((jl_datatype_t*)jl_unwrap_unionall(core("VecElement")))->name;
     jl_abioverride_type = (jl_datatype_t*)core("ABIOverride");
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -572,16 +572,18 @@ extern JL_DLLEXPORT _Atomic(size_t) jl_world_counter;
 // that test a stored world bound against an arbitrary query world must use
 // the predicates below.
 
-#ifdef _P64
-#define JL_WORLD_IDX_BITS 48
-#else
-#define JL_WORLD_IDX_BITS 24
-#endif
-#define JL_WORLD_IDX_MASK ((~(size_t)0) >> (8 * sizeof(size_t) - JL_WORLD_IDX_BITS))
+// 16 bits of segment id on every platform (real environments can graft
+// several segments per loaded image, so fewer is not enough), with the rest
+// of the word as the index. On 32-bit platforms a run's index space is only
+// 16 bits; when it is exhausted, jl_world_next_locked simply continues the
+// trunk in a fresh run segment.
+#define JL_WORLD_IDX_BITS (8 * sizeof(size_t) - 16)
+#define JL_WORLD_IDX_MASK ((~(size_t)0) >> 16)
 // number of allocatable segments; the top segment id is never allocated so
 // that sentinel worlds (~(size_t)0 and values near it) fall in an
 // unmaterialized segment
-#define JL_WORLD_MAX_SEGMENTS ((~(size_t)0) >> JL_WORLD_IDX_BITS)
+#define JL_WORLD_MAX_SEGMENTS ((size_t)0xffff)
+#define JL_WORLD_PACK(seg, idx) ((((size_t)(seg)) << JL_WORLD_IDX_BITS) | (size_t)(idx))
 
 STATIC_INLINE size_t jl_world_seg(size_t world) JL_NOTSAFEPOINT
 {
@@ -637,10 +639,11 @@ typedef struct {
 } jl_world_segment_t;
 
 JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT;
-JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents);
-JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra);
-JL_DLLEXPORT void jl_world_init_runs(void);
-JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents);
+JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents) JL_CANSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra) JL_CANSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_next_locked(void) JL_CANSAFEPOINT;
+JL_DLLEXPORT void jl_world_init_runs(void) JL_CANSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents) JL_CANSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_world_segment_t *jl_world_get_segment(size_t seg) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT;
@@ -657,9 +660,9 @@ typedef struct {
 // i.e. is the state of the world as of `a` part of the history of `b`?
 STATIC_INLINE int jl_world_reaches(size_t a, size_t b) JL_NOTSAFEPOINT
 {
-    if ((a >> JL_WORLD_IDX_BITS) == (b >> JL_WORLD_IDX_BITS))
+    if (jl_world_seg(a) == jl_world_seg(b))
         return a <= b;
-    return jl_world_seg_reaches(a >> JL_WORLD_IDX_BITS, b >> JL_WORLD_IDX_BITS);
+    return jl_world_seg_reaches(jl_world_seg(a), jl_world_seg(b));
 }
 
 // Had an entry with the given `min_world` bound already been created as of

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -524,16 +524,19 @@ extern JL_DLLEXPORT _Atomic(size_t) jl_world_counter;
 
 // === world age segments ===
 //
-// World ages form an append-only DAG rather than a single linear sequence: a
-// world is a packed (segment, index) pair with the segment id in the high
-// bits. Segments are maximal linear runs of worlds. Segment 0 is the boot
-// segment; while it is the only segment, packed worlds coincide with the
-// historical linear numbering and every query below degenerates to the
-// integer compares it replaced.
+// World ages form an append-only DAG (matching the shape of the precompile
+// graph) rather than a single linear sequence: a world is a packed
+// (segment, index) pair with the segment id in the high bits. Segments are
+// maximal linear runs of worlds. Segment 0 is the boot segment; while it is
+// the only segment, packed worlds coincide with the historical linear
+// numbering and every query below degenerates to the integer compares it
+// replaced.
 //
 // A segment's parent set is fixed at its creation and only ever references
 // segments that are closed (will allocate no further worlds), at their full
-// extent. This yields the central decomposition used by jl_world_reaches:
+// extent. This yields the central decomposition used by jl_world_reaches,
+// the two-point visibility predicate ("running at world (sb, ib), can I see
+// something that happened at world (sa, ia)?"):
 //
 //    (sa, ia) preceq (sb, ib)  iff  sa == sb ? ia <= ib
 //                                           : sa is an ancestor of sb
@@ -546,14 +549,28 @@ extern JL_DLLEXPORT _Atomic(size_t) jl_world_counter;
 // in), ancestry falls back to the chain order sa < sb, which agrees with the
 // DAG on any prefix of history that is still a pure chain.
 //
-// Integer comparison of two worlds remains exact whenever both lie on the
-// spine -- the chain of segments the world counter has traversed -- because
-// segment ids and indices are both monotone along it. Sites that compare or
-// intersect worlds that are all known to be on the spine (e.g. the world
-// counter, method insertion worlds, and validity bounds computed from them
-// in-process) may therefore still use integer compares; sites that test a
-// stored world bound against an arbitrary query world must use the
-// predicates below.
+// Joins in the DAG are not symmetric: a segment's first parent continues its
+// trunk (the main branch), and the remaining parents are side branches whose
+// events semantically happen after the main-branch events preceding the join
+// point and before those following it. Each segment therefore imposes a
+// total order on its entire visible cone -- the three-point predicate
+// (sa, ia) preceq_[observer] (sb, ib), see jl_world_ordered_before -- in
+// which trunk worlds order as themselves and a side branch's worlds order at
+// its merge point (recursively, by the side branch's own total order within
+// one merge point). jl_world_join computes the earliest world in the
+// observer's order whose history includes two given worlds; interval bounds
+// from different branches are incomparable under the two-point predicate, so
+// intersecting validity intervals must use this join rather than an integer
+// max.
+//
+// Integer comparison of two worlds remains exact whenever both lie on one
+// trunk -- e.g. the spine, the chain of segments the world counter has
+// traversed -- because segment ids and indices are both monotone along it.
+// Sites that compare worlds all known to be on the spine (e.g. the world
+// counter, method insertion worlds, and invalidation caps, which only ever
+// happen at the spine head) may therefore still use integer compares; sites
+// that test a stored world bound against an arbitrary query world must use
+// the predicates below.
 
 #ifdef _P64
 #define JL_WORLD_IDX_BITS 48
@@ -589,16 +606,29 @@ enum jl_world_seg_kind {
     JL_WORLD_SEG_OTHER = 3,
 };
 
+// Join-position sentinel: the segment lies on the observer's trunk, so a
+// world's position in the observer's total order is the world itself.
+#define JL_WORLD_POS_TRUNK (~(size_t)0)
+
 typedef struct {
     uint32_t id;
     uint32_t anc_nbits;         // number of valid bits in anc_row (== id)
     _Atomic(size_t) end_idx;    // terminal index once closed; JL_WORLD_IDX_MASK while open
-    _Atomic(size_t) joined_spine; // first spine world whose history includes this segment; 0 while unmerged
     uint8_t kind;               // enum jl_world_seg_kind
     uint32_t run;               // RUN: spine run ordinal; IMAGE: run ordinal within the origin image
     uint64_t image_id;          // IMAGE: origin image id; 0 otherwise
     uint32_t nparents;
-    size_t *parents;            // parent worlds, in declaration order
+    size_t *parents;            // parent worlds; parents[0] is the trunk (main-branch) parent
+    // This segment's total order over its visible cone (the three-point
+    // predicate): for each ancestor segment, either JL_WORLD_POS_TRUNK (the
+    // ancestor is on this segment's trunk -- its chain of first parents --
+    // and its worlds are positioned at themselves), or the trunk world at
+    // which the ancestor's branch was merged. Joins are asymmetric: a side
+    // branch's events are positioned at its merge point, i.e. after every
+    // main-branch event before the join and before every one after it.
+    // Positions are trunk worlds and compare exactly as integers. 0 = unset.
+    size_t *join_pos;
+
 #ifdef __cplusplus
     uint64_t anc_row[1];        // ancestor segment bitset, immutable after publication
 #else
@@ -614,7 +644,9 @@ JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size
 JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_world_segment_t *jl_world_get_segment(size_t seg) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_join(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_world_ordered_before(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT;
 
 // mirror of Core.WorldToken
 typedef struct {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -651,6 +651,7 @@ JL_DLLEXPORT size_t jl_world_join(size_t a, size_t b, size_t observer) JL_NOTSAF
 JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_world_ordered_before(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_world_on_trunk(size_t w, size_t observer) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_cap_meet(size_t a, size_t b) JL_NOTSAFEPOINT;
 
 // mirror of Core.WorldToken
 typedef struct {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -578,6 +578,12 @@ STATIC_INLINE size_t jl_world_idx(size_t world) JL_NOTSAFEPOINT
 JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents);
 JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra);
+JL_DLLEXPORT size_t jl_world_graft_segment(void);
+
+// mirror of Core.WorldToken
+typedef struct {
+    size_t world;
+} jl_worldtoken_t;
 
 // a preceq b: does world `a` precede (or equal) world `b` in the world DAG,
 // i.e. is the state of the world as of `a` part of the history of `b`?

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -593,12 +593,17 @@ typedef struct {
     uint32_t id;
     uint32_t anc_nbits;         // number of valid bits in anc_row (== id)
     _Atomic(size_t) end_idx;    // terminal index once closed; JL_WORLD_IDX_MASK while open
+    _Atomic(size_t) joined_spine; // first spine world whose history includes this segment; 0 while unmerged
     uint8_t kind;               // enum jl_world_seg_kind
     uint32_t run;               // RUN: spine run ordinal; IMAGE: run ordinal within the origin image
     uint64_t image_id;          // IMAGE: origin image id; 0 otherwise
     uint32_t nparents;
     size_t *parents;            // parent worlds, in declaration order
+#ifdef __cplusplus
+    uint64_t anc_row[1];        // ancestor segment bitset, immutable after publication
+#else
     uint64_t anc_row[];         // ancestor segment bitset, immutable after publication
+#endif
 } jl_world_segment_t;
 
 JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT;
@@ -609,6 +614,7 @@ JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size
 JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_world_segment_t *jl_world_get_segment(size_t seg) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT;
 
 // mirror of Core.WorldToken
 typedef struct {
@@ -1291,6 +1297,7 @@ JL_DLLEXPORT jl_binding_partition_t *jl_replace_binding_locked(jl_binding_t *b J
 JL_DLLEXPORT jl_binding_partition_t *jl_replace_binding_locked2(jl_binding_t *b JL_PROPAGATES_ROOT,
     jl_binding_partition_t *old_bpart, jl_value_t *restriction_val, size_t kind, size_t new_world) JL_CANSAFEPOINT JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT void jl_update_loaded_bpart(jl_binding_t *b, jl_binding_partition_t *bpart) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_binding_partition_t *jl_bpart_reresolve_loaded(jl_binding_t *b, jl_binding_partition_t *bpart) JL_CANSAFEPOINT;
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;
 extern jl_module_t *jl_precompile_toplevel_module JL_GLOBALLY_ROOTED;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -522,6 +522,103 @@ static inline jl_callptr_t jl_invoke_api_callptr(jl_invoke_api_t type) JL_NOTSAF
 // useful constants
 extern JL_DLLEXPORT _Atomic(size_t) jl_world_counter;
 
+// === world age segments ===
+//
+// World ages form an append-only DAG rather than a single linear sequence: a
+// world is a packed (segment, index) pair with the segment id in the high
+// bits. Segments are maximal linear runs of worlds. Segment 0 is the boot
+// segment; while it is the only segment, packed worlds coincide with the
+// historical linear numbering and every query below degenerates to the
+// integer compares it replaced.
+//
+// A segment's parent set is fixed at its creation and only ever references
+// segments that are closed (will allocate no further worlds), at their full
+// extent. This yields the central decomposition used by jl_world_reaches:
+//
+//    (sa, ia) preceq (sb, ib)  iff  sa == sb ? ia <= ib
+//                                           : sa is an ancestor of sb
+//
+// Segment-level ancestry is answered by an immutable per-segment bitset
+// built when the segment is created, so readers need no locks. Segment ids
+// are assigned in creation order and are therefore topologically sorted; for
+// segments that have never been materialized (plain linear operation, and
+// the reserved all-ones segment that sentinel values like ~(size_t)0 fall
+// in), ancestry falls back to the chain order sa < sb, which agrees with the
+// DAG on any prefix of history that is still a pure chain.
+//
+// Integer comparison of two worlds remains exact whenever both lie on the
+// spine -- the chain of segments the world counter has traversed -- because
+// segment ids and indices are both monotone along it. Sites that compare or
+// intersect worlds that are all known to be on the spine (e.g. the world
+// counter, method insertion worlds, and validity bounds computed from them
+// in-process) may therefore still use integer compares; sites that test a
+// stored world bound against an arbitrary query world must use the
+// predicates below.
+
+#ifdef _P64
+#define JL_WORLD_IDX_BITS 48
+#else
+#define JL_WORLD_IDX_BITS 24
+#endif
+#define JL_WORLD_IDX_MASK ((~(size_t)0) >> (8 * sizeof(size_t) - JL_WORLD_IDX_BITS))
+// number of allocatable segments; the top segment id is never allocated so
+// that sentinel worlds (~(size_t)0 and values near it) fall in an
+// unmaterialized segment
+#define JL_WORLD_MAX_SEGMENTS ((~(size_t)0) >> JL_WORLD_IDX_BITS)
+
+STATIC_INLINE size_t jl_world_seg(size_t world) JL_NOTSAFEPOINT
+{
+    return world >> JL_WORLD_IDX_BITS;
+}
+STATIC_INLINE size_t jl_world_idx(size_t world) JL_NOTSAFEPOINT
+{
+    return world & JL_WORLD_IDX_MASK;
+}
+
+JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents);
+JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra);
+
+// a preceq b: does world `a` precede (or equal) world `b` in the world DAG,
+// i.e. is the state of the world as of `a` part of the history of `b`?
+STATIC_INLINE int jl_world_reaches(size_t a, size_t b) JL_NOTSAFEPOINT
+{
+    if ((a >> JL_WORLD_IDX_BITS) == (b >> JL_WORLD_IDX_BITS))
+        return a <= b;
+    return jl_world_seg_reaches(a >> JL_WORLD_IDX_BITS, b >> JL_WORLD_IDX_BITS);
+}
+
+// Had an entry with the given `min_world` bound already been created as of
+// `world`?
+STATIC_INLINE int jl_world_at_least(size_t world, size_t min_world) JL_NOTSAFEPOINT
+{
+    return jl_world_reaches(min_world, world);
+}
+
+// Is `world` still covered by validity bounds capped (inclusively) at
+// `max_world`? `max_world == ~(size_t)0` means the entry has not been
+// invalidated; otherwise `max_world + 1` is the world of the invalidating
+// event and the entry is invalid exactly in that world's future cone.
+STATIC_INLINE int jl_world_at_most(size_t world, size_t max_world) JL_NOTSAFEPOINT
+{
+    if (max_world == ~(size_t)0)
+        return 1;
+    return !jl_world_reaches(max_world + 1, world);
+}
+
+// Is `world` within the validity bounds [min_world, max_world]?
+STATIC_INLINE int jl_world_in_range(size_t world, size_t min_world, size_t max_world) JL_NOTSAFEPOINT
+{
+    return jl_world_at_least(world, min_world) && jl_world_at_most(world, max_world);
+}
+
+// Is the entire (spine) world range [query_min, query_max] within the
+// validity bounds [min_world, max_world]?
+STATIC_INLINE int jl_world_range_in_range(size_t query_min, size_t query_max, size_t min_world, size_t max_world) JL_NOTSAFEPOINT
+{
+    return jl_world_at_least(query_min, min_world) && jl_world_at_most(query_max, max_world);
+}
+
 typedef void (*tracer_cb)(jl_value_t *tracee);
 extern tracer_cb jl_newmeth_tracer;
 void jl_call_tracer(tracer_cb callback, jl_value_t *tracee) JL_CANSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -650,6 +650,7 @@ JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_join(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_world_ordered_before(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_world_on_trunk(size_t w, size_t observer) JL_NOTSAFEPOINT;
 
 // mirror of Core.WorldToken
 typedef struct {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -575,10 +575,40 @@ STATIC_INLINE size_t jl_world_idx(size_t world) JL_NOTSAFEPOINT
     return world & JL_WORLD_IDX_MASK;
 }
 
+// Segment kinds, for serializing world histories. The boot prefix (the
+// worlds the system image was built at, shared verbatim by every process
+// that loads it) is never materialized and reports JL_WORLD_SEG_BOOT. Spine
+// runs are the maximal linear stretches of this process's own history
+// between graft events. Image runs are runs grafted from a loaded package
+// image, identified stably by (image id, run ordinal). Other segments
+// (e.g. fabricated by tests) are not serializable.
+enum jl_world_seg_kind {
+    JL_WORLD_SEG_BOOT = 0,
+    JL_WORLD_SEG_RUN = 1,
+    JL_WORLD_SEG_IMAGE = 2,
+    JL_WORLD_SEG_OTHER = 3,
+};
+
+typedef struct {
+    uint32_t id;
+    uint32_t anc_nbits;         // number of valid bits in anc_row (== id)
+    _Atomic(size_t) end_idx;    // terminal index once closed; JL_WORLD_IDX_MASK while open
+    uint8_t kind;               // enum jl_world_seg_kind
+    uint32_t run;               // RUN: spine run ordinal; IMAGE: run ordinal within the origin image
+    uint64_t image_id;          // IMAGE: origin image id; 0 otherwise
+    uint32_t nparents;
+    size_t *parents;            // parent worlds, in declaration order
+    uint64_t anc_row[];         // ancestor segment bitset, immutable after publication
+} jl_world_segment_t;
+
 JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents);
 JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra);
-JL_DLLEXPORT size_t jl_world_graft_segment(void);
+JL_DLLEXPORT void jl_world_init_runs(void);
+JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents);
+JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_world_segment_t *jl_world_get_segment(size_t seg) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT;
 
 // mirror of Core.WorldToken
 typedef struct {

--- a/src/method.c
+++ b/src/method.c
@@ -1221,7 +1221,7 @@ JL_DLLEXPORT void jl_check_gf(jl_value_t *gf, jl_sym_t *name)
 JL_DLLEXPORT jl_value_t *jl_declare_const_gf(jl_module_t *mod, jl_sym_t *name)
 {
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_relaxed(&jl_world_counter) + 1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_t *b = jl_get_module_binding(mod, name, 1);
     jl_value_t *gf = jl_get_existing_strong_gf(b, new_world);
     if (gf) {

--- a/src/method.c
+++ b/src/method.c
@@ -747,7 +747,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_cached_uninferred(jl_code_instance_t *codein
     for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
         if (codeinst->owner != (void*)jl_uninferred_sym)
             continue;
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (jl_world_in_range(world, jl_atomic_load_relaxed(&codeinst->min_world), jl_atomic_load_relaxed(&codeinst->max_world))) {
             return codeinst;
         }
     }
@@ -805,7 +805,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi JL_PROP
     JL_TRY {
         ct->ptls->in_pure_callback = 1;
         ct->world_age = jl_atomic_load_relaxed(&def->primary_world);
-        if (ct->world_age > jl_atomic_load_acquire(&jl_world_counter))
+        if (!jl_world_at_least(jl_atomic_load_acquire(&jl_world_counter), ct->world_age))
             jl_error("The generator method cannot run until it is added to a method table.");
 
         // invoke code generator

--- a/src/module.c
+++ b/src/module.c
@@ -52,7 +52,7 @@ STATIC_INLINE jl_binding_partition_t *jl_get_binding_partition__(jl_binding_t *b
     // resolution if necessary.
     while (is_some_partition(gap->replace)) {
         size_t replace_min_world = jl_atomic_load_relaxed(&gap->replace->min_world);
-        if (world >= replace_min_world)
+        if (jl_world_at_least(world, replace_min_world))
             break;
         gap->insert = &gap->replace->next;
         gap->max_world = replace_min_world - 1;
@@ -61,7 +61,7 @@ STATIC_INLINE jl_binding_partition_t *jl_get_binding_partition__(jl_binding_t *b
         // `gap->replace` becomes that binding (not a partition) at end-of-chain.
         gap->replace = jl_atomic_load_relaxed(gap->insert);
     }
-    if (is_some_partition(gap->replace) && world <= jl_atomic_load_relaxed(&gap->replace->max_world)) {
+    if (is_some_partition(gap->replace) && jl_world_at_most(world, jl_atomic_load_relaxed(&gap->replace->max_world))) {
         return gap->replace;
     }
     gap->min_world = is_some_partition(gap->replace) ? jl_atomic_load_relaxed(&gap->replace->max_world) + 1 : 0;
@@ -569,7 +569,7 @@ jl_binding_partition_t *jl_get_binding_partition_all(jl_binding_t *b, size_t min
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, min_world);
     if (!bpart)
         return NULL;
-    if (jl_atomic_load_relaxed(&bpart->max_world) < max_world)
+    if (!jl_world_at_most(max_world, jl_atomic_load_relaxed(&bpart->max_world)))
         return NULL;
     return bpart;
 }
@@ -1326,7 +1326,7 @@ static int jl_print_using_dep_messages(jl_module_t *m, jl_sym_t *name, jl_sym_t 
         JL_LOCK(&m->lock);
         struct _jl_module_using data = *module_usings_getidx(m, i);
         JL_UNLOCK(&m->lock);
-        if (data.min_world > world || data.max_world < world)
+        if (!jl_world_in_range(world, data.min_world, data.max_world))
             continue;
         jl_module_t *imp = data.mod;
         JL_GC_PROMISE_ROOTED(imp); // rooted via `m->usings`
@@ -2267,7 +2267,7 @@ static void _materialize_reexported_bindings(jl_module_t *m, size_t world, jl_ar
         struct _jl_module_using data = *module_usings_getidx(m, i);
         JL_UNLOCK(&m->lock);
 
-        if (data.min_world > world || data.max_world < world)
+        if (!jl_world_in_range(world, data.min_world, data.max_world))
             continue;
 
         if (data.flags & JL_MODULE_USING_REEXPORT) {

--- a/src/module.c
+++ b/src/module.c
@@ -462,6 +462,42 @@ JL_DLLEXPORT void jl_update_loaded_bpart(jl_binding_t *b, jl_binding_partition_t
     bpart->kind = resolution.ultimate_kind | resolution.deprecation_flags;
 }
 
+// During image loading: the head partition `bpart` of `b` came from a grafted
+// world history and carries the resolution the saving process computed.
+// Recompute the implicit resolution at the current world; if it matches, the
+// grafted partition stays valid everywhere it reaches (returns NULL).
+// Otherwise cap the grafted partition just before the current world -- it
+// remains valid in its own branch's cone of the world DAG -- and prepend a
+// fresh partition carrying this process's resolution for spine worlds
+// (returned). The new partition's min_world deliberately lies on the spine,
+// which is not an ancestor of the grafted history, so queries at grafted
+// worlds fall through to the capped partition.
+JL_DLLEXPORT jl_binding_partition_t *jl_bpart_reresolve_loaded(jl_binding_t *b, jl_binding_partition_t *bpart)
+{
+    size_t cur = jl_atomic_load_acquire(&jl_world_counter);
+    struct implicit_search_resolution resolution = jl_resolve_implicit_import(b, NULL, cur, 0);
+    size_t flags = bpart->kind & PARTITION_MASK_FLAG;
+    if ((enum jl_partition_kind)(resolution.ultimate_kind) == (enum jl_partition_kind)(bpart->kind & PARTITION_MASK_KIND) &&
+        resolution.binding_or_const == bpart->restriction)
+        return NULL;
+    jl_value_t *restriction = resolution.binding_or_const;
+    JL_GC_PUSH1(&restriction);
+    jl_binding_partition_t *newp = new_binding_partition(b);
+    jl_gc_write(newp, newp->restriction, jl_value_t, restriction);
+    newp->kind = resolution.ultimate_kind | resolution.deprecation_flags | flags;
+    jl_atomic_store_relaxed(&newp->min_world, cur);
+    // (max_world is already ~(size_t)0)
+    jl_atomic_store_relaxed(&newp->next, bpart);
+    jl_gc_wb(newp, bpart);
+    jl_atomic_store_release(&b->partitions, newp);
+    jl_gc_wb(b, newp);
+    // the grafted resolution ends just before this process's resolution takes
+    // over on the spine
+    jl_atomic_store_release(&bpart->max_world, cur - 1);
+    JL_GC_POP();
+    return newp;
+}
+
 static void jl_walk_binding_inplace(jl_binding_t **bnd, jl_binding_partition_t **pbpart, size_t world) JL_CANSAFEPOINT
 {
     jl_binding_partition_t *bpart = *pbpart;

--- a/src/module.c
+++ b/src/module.c
@@ -1504,7 +1504,7 @@ JL_DLLEXPORT void jl_module_import(jl_task_t *ct, jl_module_t *to, jl_module_t *
         return;
     }
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_partition_t *btopart = jl_get_binding_partition(bto, new_world);
     enum jl_partition_kind btokind = jl_binding_kind(btopart);
     if (jl_bkind_is_some_implicit(btokind)) {
@@ -1603,7 +1603,7 @@ JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from, size_t fla
         }
     }
 
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
 
     if (existing_idx == (size_t)-1) {
         // Add new using entry
@@ -1728,7 +1728,7 @@ JL_DLLEXPORT void jl_module_public(jl_module_t *from, jl_value_t **symbols, size
 {
     volatile int any_new = 0;
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
     JL_TRY {
         for (size_t i = 0; i < nsymbols; i++) {
             jl_sym_t *name = (jl_sym_t*)symbols[i];
@@ -2051,7 +2051,7 @@ JL_DLLEXPORT jl_binding_partition_t *jl_replace_binding(jl_binding_t *b,
         return NULL;
     }
 
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_partition_t *bpart = jl_replace_binding_locked(b, old_bpart, restriction_val, kind, new_world);
     if (bpart && jl_atomic_load_relaxed(&bpart->min_world) == new_world)
         jl_atomic_store_release(&jl_world_counter, new_world);
@@ -2108,7 +2108,7 @@ JL_DLLEXPORT void jl_deprecate_binding(jl_module_t *m, jl_sym_t *var, int flag) 
                        flag == 2 ? PARTITION_FLAG_DEPRECATED :
                                    0;
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_partition_t *old_bpart = jl_get_binding_partition(b, jl_current_task->world_age);
     if ((old_bpart->kind & DEPWARN_FLAGS) == new_flags) {
         JL_UNLOCK(&world_counter_lock);
@@ -2134,7 +2134,7 @@ JL_DLLEXPORT void jl_module_set_visibility(jl_module_t *m, jl_sym_t *var, int st
     int want_public = state >= 1;
     jl_binding_t *b = jl_get_module_binding(m, var, 1);
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_partition_t *old_bpart = jl_get_binding_partition(b, jl_current_task->world_age);
     int was_exported = (old_bpart->kind & PARTITION_FLAG_EXPORTED) != 0;
     if (was_exported != want_exported) {

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -404,7 +404,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
                 }
             }
             else {
-                if ((jl_value_t*)jl_get_ci_mi(last_ci) == mi && jl_atomic_load_relaxed(&last_ci->max_world) >= world) { // same dispatch and source
+                if ((jl_value_t*)jl_get_ci_mi(last_ci) == mi && jl_world_at_most(world, jl_atomic_load_relaxed(&last_ci->max_world))) { // same dispatch and source
                     jl_atomic_store_release(&cfuncdata->last_world, world);
                     JL_UNLOCK(&cfun_lock);
                     return f;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -4075,7 +4075,7 @@ static size_t world_remap(size_t w, size_t *segmap, uint32_t maplen)
     size_t seg = jl_world_seg(w);
     if (seg >= maplen || segmap[seg] == ~(size_t)0)
         jl_error("cannot translate a serialized world with no stable segment identity");
-    return (segmap[seg] << JL_WORLD_IDX_BITS) | jl_world_idx(w);
+    return JL_WORLD_PACK(segmap[seg], jl_world_idx(w));
 }
 
 static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
@@ -4288,7 +4288,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                     size_t pseg = jl_world_seg(pw);
                     if (pseg >= i || world_segmap[pseg] == ~(size_t)0)
                         jl_error("world-segment table has an untranslatable parent");
-                    parents[p] = (world_segmap[pseg] << JL_WORLD_IDX_BITS) | jl_world_idx(pw);
+                    parents[p] = JL_WORLD_PACK(world_segmap[pseg], jl_world_idx(pw));
                 }
                 size_t base = jl_world_new_image_run(self_id, nruns++, parents, np);
                 free(parents);
@@ -4873,7 +4873,7 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
             }
             else {
                 if (new_methods)
-                    world += 1;
+                    world = jl_world_next_locked();
                 jl_activate_methods(extext_methods, internal_methods, world, pkgname);
                 // TODO: inject internal_methods into caches here, so the system can see them immediately as potential candidates (before validation)
                 // allow users to start running in this updated world

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -622,7 +622,7 @@ static int codeinst_may_be_runnable(jl_code_instance_t *ci, int incremental) {
         return 1;
     if (incremental)
         return 0;
-    return jl_atomic_load_relaxed(&ci->min_world) <= jl_typeinf_world && jl_typeinf_world <= max_world;
+    return jl_world_in_range(jl_typeinf_world, jl_atomic_load_relaxed(&ci->min_world), max_world);
 }
 
 // Anything that requires uniquing or fixing during deserialization needs to be "toplevel"

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1328,7 +1328,9 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
             newm_data->min_world = data->min_world;
             newm_data->max_world = data->max_world;
             newm_data->flags = data->flags;
-            if (s->incremental) {
+            if (s->incremental && !s->world_table_mode) {
+                // (in world-table mode the bounds are kept verbatim and
+                // translated by segment at load)
                 if (data->max_world != ~(size_t)0)
                     newm_data->max_world = 0;
                 newm_data->min_world = jl_require_world;
@@ -1347,7 +1349,7 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
         for (i = 0; i < module_usings_length(m); i++) {
             struct _jl_module_using *data = module_usings_getidx(m, i);
             write_pointerfield(s, (jl_value_t*)data->mod);
-            if (s->incremental) {
+            if (s->incremental && !s->world_table_mode) {
                 // TODO: Drop dead ones entirely?
                 write_uint(s->s, jl_require_world);
                 write_uint(s->s, data->max_world == ~(size_t)0 ? ~(size_t)0 : 1);
@@ -1804,7 +1806,9 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                     jl_atomic_store_relaxed(&newentry->max_world, 0);
                 }
             }
-            else if (s->incremental && jl_is_binding_partition(v)) {
+            else if (s->incremental && !s->world_table_mode && jl_is_binding_partition(v)) {
+                // (in world-table mode, the whole partition chain keeps its
+                // verbatim world bounds and is translated by segment at load)
                 jl_binding_partition_t *newbpart = (jl_binding_partition_t*)&s->s->buf[reloc_offset];
                 size_t max_world = jl_atomic_load_relaxed(&newbpart->max_world);
                 if (max_world == ~(size_t)0) {
@@ -3957,19 +3961,28 @@ JL_DLLEXPORT jl_image_buf_t jl_set_sysimg_so(void *handle)
 int IMAGE_NATIVE_CODE_TAINTED = 0;
 
 // TODO: This should possibly be in Julia
-static int jl_validate_binding_partition(jl_binding_t *b, jl_binding_partition_t *bpart, size_t mod_idx, int unchanged_implicit, int no_replacement) JL_CANSAFEPOINT
+static int jl_validate_binding_partition(jl_binding_t *b, jl_binding_partition_t *bpart, size_t mod_idx, int unchanged_implicit, int no_replacement, int grafted) JL_CANSAFEPOINT
 {
     if (jl_atomic_load_relaxed(&bpart->max_world) != ~(size_t)0)
         return 1;
     size_t raw_kind = bpart->kind;
     enum jl_partition_kind kind = (enum jl_partition_kind)(raw_kind & PARTITION_MASK_KIND);
     if (!unchanged_implicit && jl_bkind_is_some_implicit(kind)) {
-        // TODO: Should we actually update this in place or delete it from the partitions list
-        // and allocate a fresh bpart?
-        jl_update_loaded_bpart(b, bpart);
-        bpart->kind |= (raw_kind & PARTITION_MASK_FLAG);
-        if (jl_atomic_load_relaxed(&bpart->min_world) > jl_require_world)
-            goto invalidated;
+        if (grafted) {
+            // the grafted resolution stays valid in its own branch's cone; if
+            // this process's resolution differs, the partition is capped and
+            // a fresh spine resolution is prepended
+            if (jl_bpart_reresolve_loaded(b, bpart) != NULL)
+                goto invalidated;
+        }
+        else {
+            // TODO: Should we actually update this in place or delete it from the partitions list
+            // and allocate a fresh bpart?
+            jl_update_loaded_bpart(b, bpart);
+            bpart->kind |= (raw_kind & PARTITION_MASK_FLAG);
+            if (jl_atomic_load_relaxed(&bpart->min_world) > jl_require_world)
+                goto invalidated;
+        }
     }
     {
         if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL)
@@ -3992,9 +4005,14 @@ static int jl_validate_binding_partition(jl_binding_t *b, jl_binding_partition_t
         }
         else {
             // Binding partition was invalidated
-            assert(jl_atomic_load_relaxed(&bpart->min_world) == jl_require_world);
-            jl_atomic_store_relaxed(&bpart->min_world,
-                jl_atomic_load_relaxed(&latest_imported_bpart->min_world));
+            if (!grafted) {
+                assert(jl_atomic_load_relaxed(&bpart->min_world) == jl_require_world);
+                jl_atomic_store_relaxed(&bpart->min_world,
+                    jl_atomic_load_relaxed(&latest_imported_bpart->min_world));
+            }
+            // (a grafted partition keeps its branch worlds; the
+            // changed-since-prefix signal is already carried by its
+            // min_world lying above the prefix)
         }
     }
 invalidated:
@@ -4010,7 +4028,7 @@ invalidated:
             if (!jl_atomic_load_relaxed(&bedge->partitions))
                 continue;
             JL_UNLOCK(&b->globalref->mod->lock);
-            jl_validate_binding_partition(bedge, jl_atomic_load_relaxed(&bedge->partitions), mod_idx, 0, 0);
+            jl_validate_binding_partition(bedge, jl_atomic_load_relaxed(&bedge->partitions), mod_idx, 0, 0, grafted);
             JL_LOCK(&b->globalref->mod->lock);
         }
         JL_UNLOCK(&b->globalref->mod->lock);
@@ -4029,7 +4047,7 @@ invalidated:
                 if (!jl_atomic_load_relaxed(&importee->partitions))
                     continue;
                 JL_UNLOCK(&mod->lock);
-                jl_validate_binding_partition(importee, jl_atomic_load_relaxed(&importee->partitions), mod_idx, 0, 0);
+                jl_validate_binding_partition(importee, jl_atomic_load_relaxed(&importee->partitions), mod_idx, 0, 0, grafted);
                 JL_LOCK(&mod->lock);
             }
         }
@@ -4577,6 +4595,13 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                 // Rebuild cross-image usings backedges
                 for (size_t i = 0; i < module_usings_length(mod); ++i) {
                     struct _jl_module_using *data = module_usings_getidx(mod, i);
+                    if (world_segmap) {
+                        // translate the entries' verbatim world bounds onto
+                        // the grafted copy of the image's world history
+                        data->min_world = world_remap(data->min_world, world_segmap, world_segmap_len);
+                        if (data->max_world != ~(size_t)0)
+                            data->max_world = world_remap(data->max_world, world_segmap, world_segmap_len);
+                    }
                     if (external_blob_index((jl_value_t*)data->mod) != mod_idx) {
                         jl_add_usings_backedge(data->mod, mod);
                     }
@@ -4597,7 +4622,6 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
             abort();
         }
     }
-    free(world_segmap);
     if (worldtoken_graft)
         *worldtoken_graft = graft_head;
     if (s.incremental) {
@@ -4615,13 +4639,26 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                     if ((jl_value_t*)b == jl_nothing)
                         continue;
                     jl_binding_partition_t *bpart = jl_atomic_load_relaxed(&b->partitions);
-                    if (!jl_validate_binding_partition(b, bpart, mod_idx, unchanged_implicit, no_replacement)) {
+                    if (world_segmap) {
+                        // translate the verbatim world bounds of the whole
+                        // partition chain: the image's binding history
+                        for (jl_binding_partition_t *p = bpart; p != NULL && jl_is_binding_partition((jl_value_t*)p);
+                                p = jl_atomic_load_relaxed(&p->next)) {
+                            jl_atomic_store_relaxed(&p->min_world,
+                                world_remap(jl_atomic_load_relaxed(&p->min_world), world_segmap, world_segmap_len));
+                            size_t pmax = jl_atomic_load_relaxed(&p->max_world);
+                            if (pmax != ~(size_t)0)
+                                jl_atomic_store_relaxed(&p->max_world, world_remap(pmax, world_segmap, world_segmap_len));
+                        }
+                    }
+                    if (!jl_validate_binding_partition(b, bpart, mod_idx, unchanged_implicit, no_replacement, world_segmap != NULL)) {
                         unchanged_implicit = all_usings_unchanged_implicit(mod);
                     }
                 }
             }
         }
     }
+    free(world_segmap);
     arraylist_free(&s.fixup_types);
     arraylist_free(&s.fixup_objs);
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -315,6 +315,10 @@ typedef struct {
     jl_ptls_t ptls;
     jl_image_t *image;
     int8_t incremental;
+    // incremental only: the serialized data captures worlds above the shared
+    // prefix (world tokens), so the image carries its world-segment table and
+    // serializes world bounds verbatim for translation at load time
+    int8_t world_table_mode;
 } jl_serializer_state;
 
 static jl_value_t *jl_bigint_type = NULL;
@@ -1041,6 +1045,13 @@ static void jl_queue_for_serialization_(jl_serializer_state *s, jl_value_t *v, i
     // check early from errors, so we have a little bit of contextual state for debugging them
     if (t == jl_task_type) {
         jl_error("Task cannot be serialized");
+    }
+    if (s->incremental && (jl_value_t*)t == (jl_value_t*)jl_worldtoken_type &&
+        !jl_world_reaches(((jl_worldtoken_t*)v)->world, jl_require_world)) {
+        // a world capture above the shared prefix escapes into the image:
+        // serialize this process's world-segment table so the loader can
+        // graft this image's world history
+        s->world_table_mode = 1;
     }
     if (s->incremental && needs_uniquing(v, s->query_cache) && t == jl_binding_type) {
         jl_binding_t *b = (jl_binding_t*)v;
@@ -1779,7 +1790,10 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 jl_typemap_entry_t *newentry = (jl_typemap_entry_t*)&s->s->buf[reloc_offset];
                 if (jl_atomic_load_relaxed(&newentry->max_world) == ~(size_t)0) {
                     if (jl_atomic_load_relaxed(&newentry->min_world) > 1) {
-                        jl_atomic_store_relaxed(&newentry->min_world, ~(size_t)0);
+                        // in world-table mode min_world is kept verbatim and
+                        // translated by segment at load time
+                        if (!s->world_table_mode)
+                            jl_atomic_store_relaxed(&newentry->min_world, ~(size_t)0);
                         jl_atomic_store_relaxed(&newentry->max_world, WORLD_AGE_REVALIDATION_SENTINEL);
                         arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                     }
@@ -1811,19 +1825,16 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
             else if (s->incremental && jl_typetagis(v, jl_worldtoken_type)) {
                 assert(f == s->s);
                 jl_worldtoken_t *newtok = (jl_worldtoken_t*)&f->buf[reloc_offset];
-                if (newtok->world > jl_require_world) {
-                    // The captured world is above the shared sysimage prefix
-                    // and its numbering has no meaning in a loading process.
-                    // Rewrite it to an offset from the prefix; the loader
-                    // grafts this image's world history as a fresh segment of
-                    // the world DAG and rebases the token into it.
-                    if (jl_world_seg(newtok->world) != jl_world_seg(jl_require_world))
-                        jl_error("cannot serialize a world token captured above another grafted image history (not implemented yet)");
-                    newtok->world -= jl_require_world;
+                if (!jl_world_reaches(newtok->world, jl_require_world)) {
+                    // Captured above the shared prefix: the world is kept
+                    // verbatim, and the loader translates its segment through
+                    // the image's world-segment table onto the grafted copy of
+                    // this process's world history.
+                    assert(s->world_table_mode);
                     arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                 }
-                // else: part of the shared sysimage prefix; remains valid as
-                // an absolute world in any loading process
+                // else: part of the shared prefix; remains valid as an
+                // absolute world in any loading process
             }
             else if (jl_is_method(v)) {
                 assert(f == s->s);
@@ -1832,7 +1843,10 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 jl_method_t *newm = (jl_method_t*)&f->buf[reloc_offset];
                 if (s->incremental) {
                     if (jl_atomic_load_relaxed(&newm->primary_world) > 1) {
-                        jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
+                        // in world-table mode primary_world is kept verbatim
+                        // and translated by segment at load time
+                        if (!s->world_table_mode)
+                            jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
                         int dispatch_status = jl_atomic_load_relaxed(&newm->dispatch_status);
                         int new_dispatch_status = 0;
                         if (!(dispatch_status & METHOD_SIG_LATEST_ONLY))
@@ -1863,7 +1877,10 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 if (s->incremental) {
                     if (jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0) {
                         //assert(jl_atomic_load_relaxed(&ci->edges) != jl_emptysvec); // some code (such as !==) might add a method lookup restriction but not keep the edges
-                        jl_atomic_store_release(&newci->min_world, ~(size_t)0);
+                        // in world-table mode min_world is kept verbatim and
+                        // translated by segment at load time
+                        if (!s->world_table_mode)
+                            jl_atomic_store_release(&newci->min_world, ~(size_t)0);
                         jl_atomic_store_release(&newci->max_world, WORLD_AGE_REVALIDATION_SENTINEL);
                         arraylist_push(&s->fixup_objs, (void*)reloc_offset);
                     }
@@ -3320,6 +3337,40 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
         jl_write_arraylist(s.relocs, &s.fixup_types);
     }
     jl_write_arraylist(s.relocs, &s.fixup_objs);
+    // World-segment table: present when the serialized data captures worlds
+    // above the shared prefix (world tokens). Rows describe every segment of
+    // this process's world history, so that a loading process can graft this
+    // image's own spine runs (with their true parent structure) and translate
+    // the verbatim-serialized worlds by segment. Boot-prefix segments map
+    // verbatim; runs grafted from dependency images resolve through their
+    // stable (image id, run ordinal) identity.
+    write_uint8(s.relocs, s.world_table_mode);
+    if (s.world_table_mode) {
+        write_uint64(s.relocs, s.worklist_key);
+        uint32_t nsegs = jl_world_nsegments();
+        write_uint32(s.relocs, nsegs);
+        for (uint32_t i = 0; i < nsegs; i++) {
+            jl_world_segment_t *seg = jl_world_get_segment(i);
+            uint8_t kind = seg ? seg->kind : JL_WORLD_SEG_BOOT;
+            write_uint8(s.relocs, kind);
+            if (kind == JL_WORLD_SEG_RUN) {
+                size_t end = jl_atomic_load_relaxed(&seg->end_idx);
+                if (end == JL_WORLD_IDX_MASK) {
+                    // the still-open run: this image's history ends at the save counter
+                    assert(jl_world_seg(jl_atomic_load_relaxed(&jl_world_counter)) == i);
+                    end = jl_world_idx(jl_atomic_load_relaxed(&jl_world_counter));
+                }
+                write_uint(s.relocs, end);
+                write_uint32(s.relocs, seg->nparents);
+                for (uint32_t p = 0; p < seg->nparents; p++)
+                    write_uint(s.relocs, seg->parents[p]);
+            }
+            else if (kind == JL_WORLD_SEG_IMAGE) {
+                write_uint64(s.relocs, seg->image_id);
+                write_uint32(s.relocs, seg->run);
+            }
+        }
+    }
     write_uint(f, relocs.size);
     write_padding(f, LLT_ALIGN(ios_pos(f), 8) - ios_pos(f));
     ios_seek(&relocs, 0);
@@ -3998,6 +4049,17 @@ static int all_usings_unchanged_implicit(jl_module_t *mod)
     return unchanged_implicit;
 }
 
+// Translate a world serialized verbatim by another process through the
+// image's world-segment map (identity for the shared boot prefix, grafted
+// segments for the image's own runs and its dependencies' runs).
+static size_t world_remap(size_t w, size_t *segmap, uint32_t maplen)
+{
+    size_t seg = jl_world_seg(w);
+    if (seg >= maplen || segmap[seg] == ~(size_t)0)
+        jl_error("cannot translate a serialized world with no stable segment identity");
+    return (segmap[seg] << JL_WORLD_IDX_BITS) | jl_world_idx(w);
+}
+
 static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                                                  jl_array_t *depmods, uint32_t checksum,
                                 /* outputs */    jl_array_t **restored JL_REQUIRE_ROOTED_SLOT,
@@ -4107,6 +4169,9 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         jl_atomic_store_release(&jl_world_counter, jl_require_world);
         jl_typeinf_world = read_uint(f);
         jl_set_gs_ctr(gs_ctr);
+        // the image's worlds become the closed, shared boot prefix; this
+        // process's own history starts in a fresh spine run
+        jl_world_init_runs();
     }
     else {
         offset_restored = jl_read_offset(&s);
@@ -4177,6 +4242,59 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         arraylist_new(&s.fixup_types, 0);
     }
     jl_read_arraylist(s.relocs, &s.fixup_objs);
+    // World-segment table (see the write side): graft this image's spine runs
+    // into the world DAG and prepare the segment translation map used to
+    // rebase the image's verbatim-serialized worlds.
+    size_t *world_segmap = NULL;
+    uint32_t world_segmap_len = 0;
+    size_t graft_head = 0; // the final world of the image's last run
+    if (read_uint8(s.relocs)) {
+        assert(s.incremental);
+        uint64_t self_id = read_uint64(s.relocs);
+        uint32_t nsegs = read_uint32(s.relocs);
+        world_segmap = (size_t*)malloc_s(nsegs * sizeof(size_t));
+        world_segmap_len = nsegs;
+        uint32_t nruns = 0;
+        for (uint32_t i = 0; i < nsegs; i++) {
+            uint8_t kind = read_uint8(s.relocs);
+            if (kind == JL_WORLD_SEG_BOOT) {
+                // the shared prefix maps verbatim
+                world_segmap[i] = i;
+            }
+            else if (kind == JL_WORLD_SEG_RUN) {
+                size_t end = read_uint(s.relocs);
+                uint32_t np = read_uint32(s.relocs);
+                size_t *parents = np ? (size_t*)malloc_s(np * sizeof(size_t)) : NULL;
+                for (uint32_t p = 0; p < np; p++) {
+                    size_t pw = read_uint(s.relocs);
+                    size_t pseg = jl_world_seg(pw);
+                    if (pseg >= i || world_segmap[pseg] == ~(size_t)0)
+                        jl_error("world-segment table has an untranslatable parent");
+                    parents[p] = (world_segmap[pseg] << JL_WORLD_IDX_BITS) | jl_world_idx(pw);
+                }
+                size_t base = jl_world_new_image_run(self_id, nruns++, parents, np);
+                free(parents);
+                world_segmap[i] = jl_world_seg(base);
+                jl_world_segment_t *newseg = jl_world_get_segment(world_segmap[i]);
+                jl_atomic_store_relaxed(&newseg->end_idx, end);
+                graft_head = base + end;
+            }
+            else if (kind == JL_WORLD_SEG_IMAGE) {
+                uint64_t image_id = read_uint64(s.relocs);
+                uint32_t run = read_uint32(s.relocs);
+                size_t w = jl_world_image_run(image_id, run);
+                if (w == ~(size_t)0)
+                    jl_error("the world history of a dependency image was not grafted (dependency image mismatch?)");
+                world_segmap[i] = jl_world_seg(w);
+            }
+            else {
+                // not serializable (e.g. a fabricated test segment); error
+                // only if something actually references it
+                world_segmap[i] = ~(size_t)0;
+            }
+        }
+        assert(graft_head != 0 && "world-table image must contain at least one spine run");
+    }
     // Perform the uniquing of objects that we don't "own" and consequently can't promise
     // weren't created by some other package before this one got loaded:
     // - iterate through all objects that need to be uniqued. The first encounter has to be the
@@ -4403,13 +4521,32 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         o->bits.in_image = 1;
     }
     arraylist_free(&cleanup_list);
-    size_t graft_world = 0;
     for (size_t i = 0; i < s.fixup_objs.len; i++) {
         uintptr_t item = (uintptr_t)s.fixup_objs.items[i];
         jl_value_t *obj = (jl_value_t*)(image_base + item);
         if (jl_typetagis(obj, jl_typemap_entry_type) || jl_is_method(obj) || jl_is_code_instance(obj)) {
-            jl_array_ptr_1d_push(*internal_methods, obj);
             assert(s.incremental);
+            if (world_segmap) {
+                // rebase the entry's verbatim-serialized creation world onto
+                // the grafted copy of the saving process's world history;
+                // activation later preserves these per-entry worlds
+                if (jl_typetagis(obj, jl_typemap_entry_type)) {
+                    jl_typemap_entry_t *entry = (jl_typemap_entry_t*)obj;
+                    jl_atomic_store_relaxed(&entry->min_world,
+                        world_remap(jl_atomic_load_relaxed(&entry->min_world), world_segmap, world_segmap_len));
+                }
+                else if (jl_is_method(obj)) {
+                    jl_method_t *m = (jl_method_t*)obj;
+                    jl_atomic_store_relaxed(&m->primary_world,
+                        world_remap(jl_atomic_load_relaxed(&m->primary_world), world_segmap, world_segmap_len));
+                }
+                else {
+                    jl_code_instance_t *ci = (jl_code_instance_t*)obj;
+                    jl_atomic_store_relaxed(&ci->min_world,
+                        world_remap(jl_atomic_load_relaxed(&ci->min_world), world_segmap, world_segmap_len));
+                }
+            }
+            jl_array_ptr_1d_push(*internal_methods, obj);
         }
         else if (jl_is_method_instance(obj)) {
             jl_method_instance_t *newobj = jl_specializations_get_or_insert((jl_method_instance_t*)obj);
@@ -4452,21 +4589,17 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
             jl_cancel_source_relink((jl_cancel_source_t*)obj);
         }
         else if (jl_typetagis(obj, jl_worldtoken_type)) {
-            // this image's world history must survive: graft it as its own
-            // segment of the world DAG (once per image) and rebase the
-            // token's serialized offset onto it
-            assert(s.incremental);
-            if (graft_world == 0)
-                graft_world = jl_world_graft_segment();
+            assert(s.incremental && world_segmap);
             jl_worldtoken_t *tok = (jl_worldtoken_t*)obj;
-            tok->world += graft_world;
+            tok->world = world_remap(tok->world, world_segmap, world_segmap_len);
         }
         else {
             abort();
         }
     }
+    free(world_segmap);
     if (worldtoken_graft)
-        *worldtoken_graft = graft_world;
+        *worldtoken_graft = graft_head;
     if (s.incremental) {
         int no_replacement = jl_atomic_load_relaxed(&jl_first_image_replacement_world) == ~(size_t)0;
         for (size_t i = 0; i < s.fixup_objs.len; i++) {
@@ -4694,11 +4827,12 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
             // allocate a world for the new methods, and insert them there, invalidating content as needed
             size_t world = jl_atomic_load_relaxed(&jl_world_counter);
             if (worldtoken_graft) {
-                // this image's world history was grafted as its own segment
-                // (it contains captured world tokens); its content activates
-                // at the segment's base world, which the current spine
-                // segment has already merged
-                jl_activate_methods(extext_methods, internal_methods, worldtoken_graft, pkgname);
+                // this image's world history was grafted as its own spine
+                // runs (it contains captured world tokens); its content
+                // activates at its original, per-entry worlds, and the spine
+                // then merges the image's final run
+                jl_activate_methods(extext_methods, internal_methods, 0, pkgname);
+                jl_world_advance_into_segment(&worldtoken_graft, 1);
             }
             else {
                 if (new_methods)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1808,6 +1808,23 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                     jl_atomic_store_relaxed(&newbpart->max_world, 0);
                 }
             }
+            else if (s->incremental && jl_typetagis(v, jl_worldtoken_type)) {
+                assert(f == s->s);
+                jl_worldtoken_t *newtok = (jl_worldtoken_t*)&f->buf[reloc_offset];
+                if (newtok->world > jl_require_world) {
+                    // The captured world is above the shared sysimage prefix
+                    // and its numbering has no meaning in a loading process.
+                    // Rewrite it to an offset from the prefix; the loader
+                    // grafts this image's world history as a fresh segment of
+                    // the world DAG and rebases the token into it.
+                    if (jl_world_seg(newtok->world) != jl_world_seg(jl_require_world))
+                        jl_error("cannot serialize a world token captured above another grafted image history (not implemented yet)");
+                    newtok->world -= jl_require_world;
+                    arraylist_push(&s->fixup_objs, (void*)reloc_offset);
+                }
+                // else: part of the shared sysimage prefix; remains valid as
+                // an absolute world in any loading process
+            }
             else if (jl_is_method(v)) {
                 assert(f == s->s);
                 write_padding(f, sizeof(jl_method_t) - tot); // hidden fields
@@ -3988,7 +4005,8 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                                                  jl_array_t **extext_methods JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **internal_methods JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **method_roots_list JL_REQUIRE_ROOTED_SLOT,
-                                                 pkgcachesizes *cachesizes) JL_CANSAFEPOINT JL_GC_DISABLED
+                                                 pkgcachesizes *cachesizes,
+                                                 size_t *worldtoken_graft) JL_CANSAFEPOINT JL_GC_DISABLED
 {
     jl_task_t *ct = jl_current_task;
     int en = jl_gc_enable(0);
@@ -4385,6 +4403,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         o->bits.in_image = 1;
     }
     arraylist_free(&cleanup_list);
+    size_t graft_world = 0;
     for (size_t i = 0; i < s.fixup_objs.len; i++) {
         uintptr_t item = (uintptr_t)s.fixup_objs.items[i];
         jl_value_t *obj = (jl_value_t*)(image_base + item);
@@ -4432,10 +4451,22 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
             // child links were dropped at serialization)
             jl_cancel_source_relink((jl_cancel_source_t*)obj);
         }
+        else if (jl_typetagis(obj, jl_worldtoken_type)) {
+            // this image's world history must survive: graft it as its own
+            // segment of the world DAG (once per image) and rebase the
+            // token's serialized offset onto it
+            assert(s.incremental);
+            if (graft_world == 0)
+                graft_world = jl_world_graft_segment();
+            jl_worldtoken_t *tok = (jl_worldtoken_t*)obj;
+            tok->world += graft_world;
+        }
         else {
             abort();
         }
     }
+    if (worldtoken_graft)
+        *worldtoken_graft = graft_world;
     if (s.incremental) {
         int no_replacement = jl_atomic_load_relaxed(&jl_first_image_replacement_world) == ~(size_t)0;
         for (size_t i = 0; i < s.fixup_objs.len; i++) {
@@ -4637,7 +4668,8 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
                 ios_close(f);
             ios_static_buffer(f, sysimg, len);
             pkgcachesizes cachesizes;
-            jl_restore_system_image_from_stream_(f, image, depmods, checksum, (jl_array_t**)&restored, &init_order, &extext_methods, &internal_methods, &method_roots_list, &cachesizes);
+            size_t worldtoken_graft = 0;
+            jl_restore_system_image_from_stream_(f, image, depmods, checksum, (jl_array_t**)&restored, &init_order, &extext_methods, &internal_methods, &method_roots_list, &cachesizes, &worldtoken_graft);
             JL_SIGATOMIC_END();
 
             // Add roots to methods
@@ -4661,13 +4693,22 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
             JL_LOCK(&world_counter_lock);
             // allocate a world for the new methods, and insert them there, invalidating content as needed
             size_t world = jl_atomic_load_relaxed(&jl_world_counter);
-            if (new_methods)
-                world += 1;
-            jl_activate_methods(extext_methods, internal_methods, world, pkgname);
-            // TODO: inject internal_methods into caches here, so the system can see them immediately as potential candidates (before validation)
-            // allow users to start running in this updated world
-            if (new_methods)
-                jl_atomic_store_release(&jl_world_counter, world);
+            if (worldtoken_graft) {
+                // this image's world history was grafted as its own segment
+                // (it contains captured world tokens); its content activates
+                // at the segment's base world, which the current spine
+                // segment has already merged
+                jl_activate_methods(extext_methods, internal_methods, worldtoken_graft, pkgname);
+            }
+            else {
+                if (new_methods)
+                    world += 1;
+                jl_activate_methods(extext_methods, internal_methods, world, pkgname);
+                // TODO: inject internal_methods into caches here, so the system can see them immediately as potential candidates (before validation)
+                // allow users to start running in this updated world
+                if (new_methods)
+                    jl_atomic_store_release(&jl_world_counter, world);
+            }
             // now permit more methods to be added again
             JL_UNLOCK(&world_counter_lock);
 
@@ -4710,7 +4751,7 @@ static void jl_restore_system_image_from_stream(ios_t *f, jl_image_t *image) JL_
     ios_t f_payload;
     ios_static_buffer(&f_payload, f->buf + datastartpos, f->size - datastartpos);
     jl_restore_system_image_from_stream_(&f_payload, image, NULL,
-                                         checksum, NULL, NULL, NULL, NULL, NULL, NULL);
+                                         checksum, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(jl_image_buf_t buf, jl_image_t *image, jl_array_t *depmods, int completeinfo, const char *pkgname, int needs_permalloc) JL_CANSAFEPOINT

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -913,6 +913,9 @@ static void jl_add_methods(jl_array_t *external) JL_CANSAFEPOINT
 }
 
 extern _Atomic(int) allow_new_worlds;
+// `world == 0` means the image's world history was grafted and every object
+// already carries its original (translated) creation world, which activation
+// preserves.
 static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size_t world, const char *pkgname) JL_CANSAFEPOINT
 {
     size_t i, l = jl_array_nrows(internal);
@@ -921,21 +924,24 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
         jl_value_t *obj = jl_array_ptr_ref(internal, i);
         if (jl_typetagis(obj, jl_typemap_entry_type)) {
             jl_typemap_entry_t *entry = (jl_typemap_entry_t*)obj;
-            assert(jl_atomic_load_relaxed(&entry->min_world) == ~(size_t)0);
+            assert((jl_atomic_load_relaxed(&entry->min_world) == ~(size_t)0) == (world != 0));
             assert(jl_atomic_load_relaxed(&entry->max_world) == WORLD_AGE_REVALIDATION_SENTINEL);
-            jl_atomic_store_release(&entry->min_world, world);
+            if (world)
+                jl_atomic_store_release(&entry->min_world, world);
             jl_atomic_store_release(&entry->max_world, ~(size_t)0);
         }
         else if (jl_is_method(obj)) {
             jl_method_t *m = (jl_method_t*)obj;
-            assert(jl_atomic_load_relaxed(&m->primary_world) == ~(size_t)0);
-            jl_atomic_store_release(&m->primary_world, world);
+            assert((jl_atomic_load_relaxed(&m->primary_world) == ~(size_t)0) == (world != 0));
+            if (world)
+                jl_atomic_store_release(&m->primary_world, world);
         }
         else if (jl_is_code_instance(obj)) {
             jl_code_instance_t *ci = (jl_code_instance_t*)obj;
-            assert(jl_atomic_load_relaxed(&ci->min_world) == ~(size_t)0);
+            assert((jl_atomic_load_relaxed(&ci->min_world) == ~(size_t)0) == (world != 0));
             assert(jl_atomic_load_relaxed(&ci->max_world) == WORLD_AGE_REVALIDATION_SENTINEL);
-            jl_atomic_store_relaxed(&ci->min_world, world);
+            if (world)
+                jl_atomic_store_relaxed(&ci->min_world, world);
             // n.b. ci->max_world is not updated until edges are verified
         }
         else {

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -305,7 +305,7 @@ void jl_declare_global(jl_module_t *m, jl_value_t *arg, jl_value_t *set_type, in
         gs = (jl_sym_t*)arg;
     }
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_relaxed(&jl_world_counter) + 1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_t *b = jl_get_module_binding(gm, gs, 1);
     jl_binding_partition_t *bpart = NULL;
     if (!strong && set_type)
@@ -569,7 +569,7 @@ JL_DLLEXPORT jl_binding_partition_t *jl_declare_constant_val2(
 {
     JL_GC_PUSH1(&val);
     JL_LOCK(&world_counter_lock);
-    size_t new_world = jl_atomic_load_relaxed(&jl_world_counter) + 1;
+    size_t new_world = jl_world_next_locked();
     jl_binding_partition_t *bpart = jl_declare_constant_val3(b, mod, var, val, constant_kind, new_world);
     if (jl_atomic_load_relaxed(&bpart->min_world) == new_world)
         jl_atomic_store_release(&jl_world_counter, new_world);

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -610,9 +610,9 @@ static int jl_typemap_intersection_node_visitor(jl_typemap_entry_t *ml, struct t
     // that can be absolutely critical for speed
     register jl_typemap_intersection_visitor_fptr fptr = closure->fptr;
     for (;  ml != (void*)jl_nothing; ml = jl_atomic_load_relaxed(&ml->next)) {
-        if (closure->max_valid < jl_atomic_load_relaxed(&ml->min_world))
+        if (!jl_world_at_least(closure->max_valid, jl_atomic_load_relaxed(&ml->min_world)))
             continue;
-        if (closure->min_valid > jl_atomic_load_relaxed(&ml->max_world))
+        if (!jl_world_at_most(closure->min_valid, jl_atomic_load_relaxed(&ml->max_world)))
             continue;
         int nonempty;
         if (closure->emptiness_only) {
@@ -922,7 +922,7 @@ static jl_typemap_entry_t *jl_typemap_entry_assoc_by_type(
     size_t n = jl_nparams(unw);
     int typesisva = n == 0 ? 0 : jl_is_vararg(jl_tparam(unw, n-1));
     for (; ml != (void*)jl_nothing; ml = jl_atomic_load_relaxed(&ml->next)) {
-        if (search->world < jl_atomic_load_relaxed(&ml->min_world) || search->world > jl_atomic_load_relaxed(&ml->max_world))
+        if (!jl_world_in_range(search->world, jl_atomic_load_relaxed(&ml->min_world), jl_atomic_load_relaxed(&ml->max_world)))
             continue;
         size_t lensig = jl_nparams(jl_unwrap_unionall((jl_value_t*)ml->sig));
         if (lensig == n || (ml->va && lensig <= n+1)) {
@@ -974,7 +974,7 @@ static jl_typemap_entry_t *jl_typemap_entry_lookup_by_type(
         jl_typemap_entry_t *ml, struct jl_typemap_assoc *search) JL_CANSAFEPOINT
 {
     for (; ml != (void*)jl_nothing; ml = jl_atomic_load_relaxed(&ml->next)) {
-        if (search->world < jl_atomic_load_relaxed(&ml->min_world) || search->world > jl_atomic_load_relaxed(&ml->max_world))
+        if (!jl_world_in_range(search->world, jl_atomic_load_relaxed(&ml->min_world), jl_atomic_load_relaxed(&ml->max_world)))
             continue;
         // unroll the first few cases here, to the extent that is possible to do fast and easily
         jl_value_t *types = search->types;
@@ -1184,7 +1184,7 @@ jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_valu
     // some manually-unrolled common special cases
     while (ml->simplesig == (void*)jl_nothing && ml->guardsigs == jl_emptysvec && ml->isleafsig) {
         // use a tight loop for as long as possible
-        if (world >= jl_atomic_load_relaxed(&ml->min_world) && world <= jl_atomic_load_relaxed(&ml->max_world)) {
+        if (jl_world_in_range(world, jl_atomic_load_relaxed(&ml->min_world), jl_atomic_load_relaxed(&ml->max_world))) {
             if (n == jl_nparams(ml->sig) && jl_typeof(arg1) == jl_tparam(ml->sig, 0)) {
                 if (n == 1)
                     return ml;
@@ -1209,7 +1209,7 @@ jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_valu
     }
 
     for (; ml != (void*)jl_nothing; ml = jl_atomic_load_relaxed(&ml->next)) {
-        if (world < jl_atomic_load_relaxed(&ml->min_world) || world > jl_atomic_load_relaxed(&ml->max_world))
+        if (!jl_world_in_range(world, jl_atomic_load_relaxed(&ml->min_world), jl_atomic_load_relaxed(&ml->max_world)))
             continue; // ignore replaced methods
         size_t lensig = jl_nparams(ml->sig);
         if (lensig == n || (ml->va && lensig <= n+1)) {

--- a/src/world.c
+++ b/src/world.c
@@ -1,0 +1,113 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// World age segment bookkeeping. See the overview comment next to
+// jl_world_reaches in julia_internal.h: a world is a packed
+// (segment, index) pair, segments form an append-only DAG whose edges are
+// fixed at segment creation, and segment-level ancestry is answered by an
+// immutable per-segment bitset so that readers require no synchronization
+// beyond an acquire load of the segment pointer.
+
+#include "julia.h"
+#include "julia_internal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint32_t id;
+    uint32_t anc_nbits;         // number of valid bits in anc_row (== id)
+    _Atomic(size_t) end_idx;    // terminal index once closed; JL_WORLD_IDX_MASK while open
+    uint64_t anc_row[];         // ancestor segment bitset, immutable after publication
+} jl_world_segment_t;
+
+// Append-only table of materialized segments. Segment 0 (boot) is implicit
+// and never materialized; its entry stays NULL and the chain fallback in
+// jl_world_seg_reaches gives the correct answers for it.
+static _Atomic(jl_world_segment_t*) world_segments[JL_WORLD_MAX_SEGMENTS];
+static uint32_t world_nsegments = 1; // protected by world_counter_lock
+
+JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT
+{
+    if (sa == sb)
+        return 1;
+    jl_world_segment_t *seg = sb < JL_WORLD_MAX_SEGMENTS ?
+        jl_atomic_load_acquire(&world_segments[sb]) : NULL;
+    if (seg == NULL)
+        return sa < sb; // unmaterialized segment: pure chain order
+    return sa < seg->anc_nbits && ((seg->anc_row[sa >> 6] >> (sa & 63)) & 1);
+}
+
+// Requires world_counter_lock. `chain_parent == ~(size_t)0` means no
+// implicit parent.
+static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t *parent_worlds, size_t nparents)
+{
+    uint32_t id = world_nsegments;
+    assert(id < JL_WORLD_MAX_SEGMENTS);
+    size_t nwords = (id + 63) / 64;
+    jl_world_segment_t *seg = (jl_world_segment_t*)calloc_s(sizeof(jl_world_segment_t) + nwords * sizeof(uint64_t));
+    seg->id = id;
+    seg->anc_nbits = id; // ancestors always have smaller ids
+    jl_atomic_store_relaxed(&seg->end_idx, JL_WORLD_IDX_MASK);
+    for (size_t i = 0; i <= nparents; i++) {
+        size_t pw = i == 0 ? chain_parent : parent_worlds[i - 1];
+        if (pw == ~(size_t)0)
+            continue;
+        size_t psid = jl_world_seg(pw);
+        assert(psid < id && "parent segment must precede the new segment");
+        seg->anc_row[psid >> 6] |= (uint64_t)1 << (psid & 63);
+        jl_world_segment_t *pseg = jl_atomic_load_relaxed(&world_segments[psid]);
+        assert((pseg || psid == 0) && "non-boot parent segment must be materialized");
+        if (pseg) {
+            size_t pwords = (pseg->anc_nbits + 63) / 64;
+            for (size_t w = 0; w < pwords; w++)
+                seg->anc_row[w] |= pseg->anc_row[w];
+        }
+    }
+    world_nsegments = id + 1;
+    jl_atomic_store_release(&world_segments[id], seg);
+    return seg;
+}
+
+// Create a new segment, without moving the world counter into it, whose
+// parents are the segments of `parent_worlds` (referenced at full extent).
+// Returns the segment's first world. Exposed for grafting serialized world
+// histories and for testing.
+JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents)
+{
+    JL_LOCK(&world_counter_lock);
+    if (world_nsegments >= JL_WORLD_MAX_SEGMENTS) {
+        JL_UNLOCK(&world_counter_lock);
+        jl_error("world age segment limit exceeded");
+    }
+    jl_world_segment_t *seg = world_new_segment_locked(~(size_t)0, parent_worlds, nparents);
+    JL_UNLOCK(&world_counter_lock);
+    return (size_t)seg->id << JL_WORLD_IDX_BITS;
+}
+
+// Close the currently open segment at the current world counter and continue
+// counting worlds in a fresh child segment. `extra_parent_worlds` (possibly
+// none) name additional history -- e.g. a grafted image's final world --
+// merged into the new segment. Returns the new segment's first world, which
+// becomes the current world counter value.
+JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra)
+{
+    JL_LOCK(&world_counter_lock);
+    if (world_nsegments >= JL_WORLD_MAX_SEGMENTS) {
+        JL_UNLOCK(&world_counter_lock);
+        jl_error("world age segment limit exceeded");
+    }
+    size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
+    jl_world_segment_t *seg = world_new_segment_locked(cur, extra_parent_worlds, nextra);
+    jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
+    if (oldseg)
+        jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
+    size_t w = (size_t)seg->id << JL_WORLD_IDX_BITS;
+    jl_atomic_store_release(&jl_world_counter, w);
+    JL_UNLOCK(&world_counter_lock);
+    return w;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/world.c
+++ b/src/world.c
@@ -108,6 +108,32 @@ JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, s
     return w;
 }
 
+// Close the currently open segment and continue the counter in a fresh
+// segment, additionally materializing a side segment G (a child of the
+// closed spine head) that the new spine segment also merges. A serialized
+// image's world history is grafted into G: entries and world tokens from the
+// image reference (G, offset) worlds, which are part of the new spine's
+// history but isolated from invalidation events that happen after the graft.
+// Returns G's first world.
+JL_DLLEXPORT size_t jl_world_graft_segment(void)
+{
+    JL_LOCK(&world_counter_lock);
+    if (world_nsegments + 1 >= JL_WORLD_MAX_SEGMENTS) {
+        JL_UNLOCK(&world_counter_lock);
+        jl_error("world age segment limit exceeded");
+    }
+    size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
+    jl_world_segment_t *gseg = world_new_segment_locked(cur, NULL, 0);
+    size_t gbase = (size_t)gseg->id << JL_WORLD_IDX_BITS;
+    jl_world_segment_t *sseg = world_new_segment_locked(cur, &gbase, 1);
+    jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
+    if (oldseg)
+        jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
+    jl_atomic_store_release(&jl_world_counter, (size_t)sseg->id << JL_WORLD_IDX_BITS);
+    JL_UNLOCK(&world_counter_lock);
+    return gbase;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/world.c
+++ b/src/world.c
@@ -181,6 +181,26 @@ static size_t world_pos(size_t w, jl_world_segment_t *obs) JL_NOTSAFEPOINT
     return p;
 }
 
+// Combine two validity caps: the result's invalidation cone must contain
+// both inputs' cones, so intervals capped by it are invalid wherever either
+// input was. Returns 0 if the cones are incomparable (neither contains the
+// other, e.g. shadowing events on two different side branches), in which
+// case a single cap cannot represent the exclusion and the caller must
+// degrade (typically to point validity at its query world). Caps that are
+// events on one trunk are always comparable.
+JL_DLLEXPORT size_t jl_world_cap_meet(size_t a, size_t b) JL_NOTSAFEPOINT
+{
+    if (a == ~(size_t)0)
+        return b;
+    if (b == ~(size_t)0)
+        return a;
+    if (jl_world_reaches(a + 1, b + 1))
+        return a; // cone(b+1) is contained in cone(a+1)
+    if (jl_world_reaches(b + 1, a + 1))
+        return b;
+    return 0;
+}
+
 // Is `w` on the observer's trunk? Trunk worlds are exactly the worlds whose
 // position in the observer's total order is themselves, so interval bounds
 // between them compare exactly as integers; a merged side branch's worlds

--- a/src/world.c
+++ b/src/world.c
@@ -52,7 +52,11 @@ JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT
 }
 
 // Requires world_counter_lock. `chain_parent == ~(size_t)0` means no
-// implicit parent.
+// implicit parent; otherwise it is the trunk (main-branch) parent, and the
+// remaining parents are side branches merged at this segment's base world.
+// Joins are asymmetric: a side branch's events order after every main-branch
+// event before the join point and before every one after it, which is
+// recorded in join_pos (the segment's total order over its visible cone).
 static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t *parent_worlds, size_t nparents)
 {
     uint32_t id = world_nsegments_;
@@ -65,11 +69,14 @@ static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t 
     jl_atomic_store_relaxed(&seg->end_idx, JL_WORLD_IDX_MASK);
     seg->nparents = (uint32_t)nparents + (chain_parent != ~(size_t)0);
     seg->parents = seg->nparents ? (size_t*)malloc_s(seg->nparents * sizeof(size_t)) : NULL;
+    seg->join_pos = id ? (size_t*)calloc_s(id * sizeof(size_t)) : NULL;
+    size_t base = (size_t)id << JL_WORLD_IDX_BITS;
     uint32_t pi = 0;
     for (size_t i = 0; i <= nparents; i++) {
         size_t pw = i == 0 ? chain_parent : parent_worlds[i - 1];
         if (pw == ~(size_t)0)
             continue;
+        int is_trunk = pi == 0; // the first parent continues the trunk
         seg->parents[pi++] = pw;
         size_t psid = jl_world_seg(pw);
         assert(psid < id && "parent segment must precede the new segment");
@@ -79,12 +86,30 @@ static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t 
             size_t pwords = (pseg->anc_nbits + 63) / 64;
             for (size_t w = 0; w < pwords; w++)
                 seg->anc_row[w] |= pseg->anc_row[w];
+            if (is_trunk) {
+                // inherit the trunk parent's total order and extend the trunk
+                memcpy(seg->join_pos, pseg->join_pos, pseg->anc_nbits * sizeof(size_t));
+                seg->join_pos[psid] = JL_WORLD_POS_TRUNK;
+            }
+            else {
+                // a side branch: everything newly visible through it joins
+                // the trunk at this segment's base world
+                for (uint32_t b = 0; b <= psid; b++) {
+                    if (b == psid || ((pseg->anc_row[b >> 6] >> (b & 63)) & 1)) {
+                        if (seg->join_pos[b] == 0)
+                            seg->join_pos[b] = base;
+                    }
+                }
+            }
         }
         else {
             // an unmaterialized (boot prefix) parent: its history is the
             // whole linear chain of segments up to and including it
-            for (size_t b = 0; b <= psid; b++)
+            for (size_t b = 0; b <= psid; b++) {
                 seg->anc_row[b >> 6] |= (uint64_t)1 << (b & 63);
+                if (seg->join_pos[b] == 0)
+                    seg->join_pos[b] = is_trunk ? JL_WORLD_POS_TRUNK : base;
+            }
         }
     }
     world_nsegments_ = id + 1;
@@ -120,45 +145,84 @@ static jl_world_segment_t *world_advance_locked(size_t *extra_parent_worlds, siz
     jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
     if (oldseg)
         jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
-    size_t base = (size_t)seg->id << JL_WORLD_IDX_BITS;
-    // every newly merged segment joins the spine at this run's base world
-    for (uint32_t i = 0; i < seg->anc_nbits; i++) {
-        if ((seg->anc_row[i >> 6] >> (i & 63)) & 1) {
-            jl_world_segment_t *anc = jl_atomic_load_relaxed(&world_segments[i]);
-            if (anc && anc->kind != JL_WORLD_SEG_RUN && jl_atomic_load_relaxed(&anc->joined_spine) == 0)
-                jl_atomic_store_relaxed(&anc->joined_spine, base);
-        }
-    }
-    jl_atomic_store_release(&jl_world_counter, base);
+    jl_atomic_store_release(&jl_world_counter, (size_t)seg->id << JL_WORLD_IDX_BITS);
     return seg;
 }
 
-// The position on the spine at (or from) which the history of `w` is
-// included: `w` itself for spine worlds (boot prefix and spine runs), the
-// merge point for grafted segments. Spine positions compare exactly as
-// integers.
-static size_t world_spine_pos(size_t w) JL_NOTSAFEPOINT
+// Position of `w` in the total order that the observer segment imposes on
+// its visible cone: `w` itself for worlds on the observer's trunk, the merge
+// point for worlds of merged side branches. Positions are trunk worlds and
+// compare exactly as integers.
+static size_t world_pos(size_t w, jl_world_segment_t *obs) JL_NOTSAFEPOINT
 {
-    jl_world_segment_t *seg = jl_world_get_segment(jl_world_seg(w));
-    if (seg == NULL || seg->kind == JL_WORLD_SEG_RUN)
-        return w;
-    size_t j = jl_atomic_load_relaxed(&seg->joined_spine);
-    assert(j != 0 && "join of a world whose segment has not been merged into the spine");
-    return j ? j : jl_atomic_load_relaxed(&jl_world_counter);
+    size_t ws = jl_world_seg(w);
+    if (obs == NULL || ws == obs->id)
+        return w; // the observer's own segment, or a fully linear history
+    size_t p = ws < obs->anc_nbits ? obs->join_pos[ws] : 0;
+    if (p == JL_WORLD_POS_TRUNK || p == 0)
+        return w; // on the trunk (0: not visible; fall back to chain order)
+    return p;
 }
 
-// The earliest spine world whose history includes both `a` and `b`. For
-// comparable worlds this is simply the later of the two; for worlds on
-// different branches it is the later of their spine merge points.
-JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT
+// The earliest world in the observer's total order whose history includes
+// both `a` and `b`. For comparable worlds this is simply the later of the
+// two; for worlds on different branches it is the later of their merge
+// points on the observer's trunk.
+JL_DLLEXPORT size_t jl_world_join(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT
 {
     if (jl_world_reaches(a, b))
         return b;
     if (jl_world_reaches(b, a))
         return a;
-    size_t pa = world_spine_pos(a);
-    size_t pb = world_spine_pos(b);
+    jl_world_segment_t *obs = jl_world_get_segment(jl_world_seg(observer));
+    size_t pa = world_pos(a, obs);
+    size_t pb = world_pos(b, obs);
     return pa > pb ? pa : pb;
+}
+
+// The join with the current spine head as the observer.
+JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT
+{
+    return jl_world_join(a, b, jl_atomic_load_acquire(&jl_world_counter));
+}
+
+// The three-point predicate `a preceq_observer b`: does `a` come at or
+// before `b` in the total order that the observer's segment imposes on its
+// visible history? Trunk worlds order as themselves; a merged side branch's
+// worlds order at its merge point (after the main-branch events preceding
+// the join, before those following it), and within one merge point, by the
+// side branch's own total order, recursively.
+JL_DLLEXPORT int jl_world_ordered_before(size_t a, size_t b, size_t observer) JL_NOTSAFEPOINT
+{
+    if (a == b)
+        return 1;
+    if (jl_world_reaches(a, b))
+        return 1;
+    if (jl_world_reaches(b, a))
+        return 0;
+    jl_world_segment_t *obs = jl_world_get_segment(jl_world_seg(observer));
+    size_t pa = world_pos(a, obs);
+    size_t pb = world_pos(b, obs);
+    if (pa != pb)
+        return pa < pb;
+    // both worlds joined the observer's trunk at the same merge point:
+    // order them by the total order of the side branch that merged there
+    jl_world_segment_t *pseg = jl_world_get_segment(jl_world_seg(pa));
+    if (pseg != NULL) {
+        for (uint32_t i = 1; i < pseg->nparents; i++) {
+            size_t pw = pseg->parents[i];
+            int ra = jl_world_reaches(a, pw);
+            int rb = jl_world_reaches(b, pw);
+            if (ra && rb) {
+                assert(jl_world_seg(pw) != jl_world_seg(observer) && "side branch cannot be the observer's segment");
+                return jl_world_ordered_before(a, b, pw);
+            }
+            if (ra || rb)
+                return ra; // side branches merged together order by parent position
+        }
+    }
+    // not visible through materialized structure: fall back to chain order
+    return a < b;
 }
 
 // Close the currently open segment at the current world counter and continue

--- a/src/world.c
+++ b/src/world.c
@@ -70,7 +70,7 @@ static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t 
     seg->nparents = (uint32_t)nparents + (chain_parent != ~(size_t)0);
     seg->parents = seg->nparents ? (size_t*)malloc_s(seg->nparents * sizeof(size_t)) : NULL;
     seg->join_pos = id ? (size_t*)calloc_s(id * sizeof(size_t)) : NULL;
-    size_t base = (size_t)id << JL_WORLD_IDX_BITS;
+    size_t base = JL_WORLD_PACK(id, 0);
     uint32_t pi = 0;
     for (size_t i = 0; i <= nparents; i++) {
         size_t pw = i == 0 ? chain_parent : parent_worlds[i - 1];
@@ -121,7 +121,7 @@ static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t 
 // parents are the segments of `parent_worlds` (referenced at full extent).
 // Returns the segment's first world. Exposed for testing; segments created
 // this way carry no serializable identity.
-JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents)
+JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents) JL_CANSAFEPOINT
 {
     JL_LOCK(&world_counter_lock);
     if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
@@ -130,7 +130,7 @@ JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents)
     }
     jl_world_segment_t *seg = world_new_segment_locked(~(size_t)0, parent_worlds, nparents);
     JL_UNLOCK(&world_counter_lock);
-    return (size_t)seg->id << JL_WORLD_IDX_BITS;
+    return JL_WORLD_PACK(seg->id, 0);
 }
 
 // Requires world_counter_lock: close the currently open segment at the
@@ -145,8 +145,25 @@ static jl_world_segment_t *world_advance_locked(size_t *extra_parent_worlds, siz
     jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
     if (oldseg)
         jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
-    jl_atomic_store_release(&jl_world_counter, (size_t)seg->id << JL_WORLD_IDX_BITS);
+    jl_atomic_store_release(&jl_world_counter, JL_WORLD_PACK(seg->id, 0));
     return seg;
+}
+
+// Requires world_counter_lock: the world that the next modification event
+// should be assigned -- normally jl_world_counter + 1. When the current
+// run's index space is exhausted (realistic only with 16-bit indices on
+// 32-bit platforms), the trunk first continues into a fresh run, so that
+// indices never carry into the segment field.
+JL_DLLEXPORT size_t jl_world_next_locked(void) JL_CANSAFEPOINT
+{
+    size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
+    if (jl_world_idx(cur) >= JL_WORLD_IDX_MASK - 1) {
+        if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS)
+            jl_error("world age segment limit exceeded");
+        world_advance_locked(NULL, 0);
+        cur = jl_atomic_load_relaxed(&jl_world_counter);
+    }
+    return cur + 1;
 }
 
 // Position of `w` in the total order that the observer segment imposes on
@@ -230,7 +247,7 @@ JL_DLLEXPORT int jl_world_ordered_before(size_t a, size_t b, size_t observer) JL
 // none) name additional history -- e.g. a grafted image's final world --
 // merged into the new run. Returns the new run's first world, which becomes
 // the current world counter value.
-JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra)
+JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra) JL_CANSAFEPOINT
 {
     JL_LOCK(&world_counter_lock);
     if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
@@ -238,7 +255,7 @@ JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, s
         jl_error("world age segment limit exceeded");
     }
     jl_world_segment_t *seg = world_advance_locked(extra_parent_worlds, nextra);
-    size_t w = (size_t)seg->id << JL_WORLD_IDX_BITS;
+    size_t w = JL_WORLD_PACK(seg->id, 0);
     JL_UNLOCK(&world_counter_lock);
     return w;
 }
@@ -249,7 +266,7 @@ JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, s
 // and this process's first spine run starts in a fresh segment. This keeps
 // every parent reference to the prefix exact: prefix segments are referenced
 // only at full extent, never mid-segment.
-JL_DLLEXPORT void jl_world_init_runs(void)
+JL_DLLEXPORT void jl_world_init_runs(void) JL_CANSAFEPOINT
 {
     JL_LOCK(&world_counter_lock);
     size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
@@ -269,7 +286,7 @@ JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSA
     for (uint32_t i = 0; i < n; i++) {
         jl_world_segment_t *seg = jl_atomic_load_acquire(&world_segments[i]);
         if (seg && seg->kind == JL_WORLD_SEG_IMAGE && seg->image_id == image_id && seg->run == run)
-            return (size_t)i << JL_WORLD_IDX_BITS;
+            return JL_WORLD_PACK(i, 0);
     }
     return ~(size_t)0;
 }
@@ -279,7 +296,7 @@ JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSA
 // world. The counter does not move; the caller is expected to eventually
 // merge the image's final run into the spine with
 // jl_world_advance_into_segment.
-JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents)
+JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents) JL_CANSAFEPOINT
 {
     JL_LOCK(&world_counter_lock);
     if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
@@ -291,7 +308,7 @@ JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size
     seg->kind = JL_WORLD_SEG_IMAGE;
     seg->image_id = image_id;
     seg->run = run;
-    size_t w = (size_t)seg->id << JL_WORLD_IDX_BITS;
+    size_t w = JL_WORLD_PACK(seg->id, 0);
     JL_UNLOCK(&world_counter_lock);
     return w;
 }

--- a/src/world.c
+++ b/src/world.c
@@ -181,6 +181,23 @@ static size_t world_pos(size_t w, jl_world_segment_t *obs) JL_NOTSAFEPOINT
     return p;
 }
 
+// Is `w` on the observer's trunk? Trunk worlds are exactly the worlds whose
+// position in the observer's total order is themselves, so interval bounds
+// between them compare exactly as integers; a merged side branch's worlds
+// (e.g. a grafted image history) are not on the trunk even though they reach
+// the observer.
+JL_DLLEXPORT int jl_world_on_trunk(size_t w, size_t observer) JL_NOTSAFEPOINT
+{
+    jl_world_segment_t *obs = jl_world_get_segment(jl_world_seg(observer));
+    size_t ws = jl_world_seg(w);
+    if (obs == NULL || ws == obs->id)
+        return 1; // the observer's own segment, or a fully linear history
+    if (ws < obs->anc_nbits && obs->join_pos[ws] == JL_WORLD_POS_TRUNK)
+        return 1;
+    // unmaterialized ancestors (the boot prefix) are part of every trunk
+    return ws < obs->id && jl_world_get_segment(ws) == NULL;
+}
+
 // The earliest world in the observer's total order whose history includes
 // both `a` and `b`. For comparable worlds this is simply the later of the
 // two; for worlds on different branches it is the later of their merge

--- a/src/world.c
+++ b/src/world.c
@@ -6,6 +6,13 @@
 // fixed at segment creation, and segment-level ancestry is answered by an
 // immutable per-segment bitset so that readers require no synchronization
 // beyond an acquire load of the segment pointer.
+//
+// Segments additionally carry a serializable identity (see
+// enum jl_world_seg_kind): the unmaterialized boot prefix is shared verbatim
+// between every process built on the same system image; this process's own
+// spine runs are numbered consecutively; and runs grafted from a loaded
+// package image are keyed by (image id, run ordinal), which is stable across
+// processes because a given image file grafts identically everywhere.
 
 #include "julia.h"
 #include "julia_internal.h"
@@ -14,18 +21,24 @@
 extern "C" {
 #endif
 
-typedef struct {
-    uint32_t id;
-    uint32_t anc_nbits;         // number of valid bits in anc_row (== id)
-    _Atomic(size_t) end_idx;    // terminal index once closed; JL_WORLD_IDX_MASK while open
-    uint64_t anc_row[];         // ancestor segment bitset, immutable after publication
-} jl_world_segment_t;
-
-// Append-only table of materialized segments. Segment 0 (boot) is implicit
-// and never materialized; its entry stays NULL and the chain fallback in
-// jl_world_seg_reaches gives the correct answers for it.
+// Append-only table of materialized segments. Boot-prefix segments are
+// implicit and never materialized; their entries stay NULL and the chain
+// fallback in jl_world_seg_reaches gives the correct answers for them.
 static _Atomic(jl_world_segment_t*) world_segments[JL_WORLD_MAX_SEGMENTS];
-static uint32_t world_nsegments = 1; // protected by world_counter_lock
+static uint32_t world_nsegments_ = 1; // protected by world_counter_lock
+static uint32_t world_nruns = 0;      // spine run ordinals handed out; protected by world_counter_lock
+
+JL_DLLEXPORT jl_world_segment_t *jl_world_get_segment(size_t seg) JL_NOTSAFEPOINT
+{
+    if (seg >= JL_WORLD_MAX_SEGMENTS)
+        return NULL;
+    return jl_atomic_load_acquire(&world_segments[seg]);
+}
+
+JL_DLLEXPORT uint32_t jl_world_nsegments(void) JL_NOTSAFEPOINT
+{
+    return world_nsegments_;
+}
 
 JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT
 {
@@ -42,41 +55,51 @@ JL_DLLEXPORT int jl_world_seg_reaches(size_t sa, size_t sb) JL_NOTSAFEPOINT
 // implicit parent.
 static jl_world_segment_t *world_new_segment_locked(size_t chain_parent, size_t *parent_worlds, size_t nparents)
 {
-    uint32_t id = world_nsegments;
+    uint32_t id = world_nsegments_;
     assert(id < JL_WORLD_MAX_SEGMENTS);
     size_t nwords = (id + 63) / 64;
     jl_world_segment_t *seg = (jl_world_segment_t*)calloc_s(sizeof(jl_world_segment_t) + nwords * sizeof(uint64_t));
     seg->id = id;
     seg->anc_nbits = id; // ancestors always have smaller ids
+    seg->kind = JL_WORLD_SEG_OTHER;
     jl_atomic_store_relaxed(&seg->end_idx, JL_WORLD_IDX_MASK);
+    seg->nparents = (uint32_t)nparents + (chain_parent != ~(size_t)0);
+    seg->parents = seg->nparents ? (size_t*)malloc_s(seg->nparents * sizeof(size_t)) : NULL;
+    uint32_t pi = 0;
     for (size_t i = 0; i <= nparents; i++) {
         size_t pw = i == 0 ? chain_parent : parent_worlds[i - 1];
         if (pw == ~(size_t)0)
             continue;
+        seg->parents[pi++] = pw;
         size_t psid = jl_world_seg(pw);
         assert(psid < id && "parent segment must precede the new segment");
-        seg->anc_row[psid >> 6] |= (uint64_t)1 << (psid & 63);
         jl_world_segment_t *pseg = jl_atomic_load_relaxed(&world_segments[psid]);
-        assert((pseg || psid == 0) && "non-boot parent segment must be materialized");
         if (pseg) {
+            seg->anc_row[psid >> 6] |= (uint64_t)1 << (psid & 63);
             size_t pwords = (pseg->anc_nbits + 63) / 64;
             for (size_t w = 0; w < pwords; w++)
                 seg->anc_row[w] |= pseg->anc_row[w];
         }
+        else {
+            // an unmaterialized (boot prefix) parent: its history is the
+            // whole linear chain of segments up to and including it
+            for (size_t b = 0; b <= psid; b++)
+                seg->anc_row[b >> 6] |= (uint64_t)1 << (b & 63);
+        }
     }
-    world_nsegments = id + 1;
+    world_nsegments_ = id + 1;
     jl_atomic_store_release(&world_segments[id], seg);
     return seg;
 }
 
 // Create a new segment, without moving the world counter into it, whose
 // parents are the segments of `parent_worlds` (referenced at full extent).
-// Returns the segment's first world. Exposed for grafting serialized world
-// histories and for testing.
+// Returns the segment's first world. Exposed for testing; segments created
+// this way carry no serializable identity.
 JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents)
 {
     JL_LOCK(&world_counter_lock);
-    if (world_nsegments >= JL_WORLD_MAX_SEGMENTS) {
+    if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
         JL_UNLOCK(&world_counter_lock);
         jl_error("world age segment limit exceeded");
     }
@@ -85,53 +108,91 @@ JL_DLLEXPORT size_t jl_world_new_segment(size_t *parent_worlds, size_t nparents)
     return (size_t)seg->id << JL_WORLD_IDX_BITS;
 }
 
-// Close the currently open segment at the current world counter and continue
-// counting worlds in a fresh child segment. `extra_parent_worlds` (possibly
-// none) name additional history -- e.g. a grafted image's final world --
-// merged into the new segment. Returns the new segment's first world, which
-// becomes the current world counter value.
-JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra)
+// Requires world_counter_lock: close the currently open segment at the
+// current counter and continue counting worlds in a fresh spine run whose
+// extra parents (beyond the closed segment) are `extra_parent_worlds`.
+static jl_world_segment_t *world_advance_locked(size_t *extra_parent_worlds, size_t nextra)
 {
-    JL_LOCK(&world_counter_lock);
-    if (world_nsegments >= JL_WORLD_MAX_SEGMENTS) {
-        JL_UNLOCK(&world_counter_lock);
-        jl_error("world age segment limit exceeded");
-    }
     size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
     jl_world_segment_t *seg = world_new_segment_locked(cur, extra_parent_worlds, nextra);
+    seg->kind = JL_WORLD_SEG_RUN;
+    seg->run = world_nruns++;
     jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
     if (oldseg)
         jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
+    jl_atomic_store_release(&jl_world_counter, (size_t)seg->id << JL_WORLD_IDX_BITS);
+    return seg;
+}
+
+// Close the currently open segment at the current world counter and continue
+// counting worlds in a fresh spine run. `extra_parent_worlds` (possibly
+// none) name additional history -- e.g. a grafted image's final world --
+// merged into the new run. Returns the new run's first world, which becomes
+// the current world counter value.
+JL_DLLEXPORT size_t jl_world_advance_into_segment(size_t *extra_parent_worlds, size_t nextra)
+{
+    JL_LOCK(&world_counter_lock);
+    if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
+        JL_UNLOCK(&world_counter_lock);
+        jl_error("world age segment limit exceeded");
+    }
+    jl_world_segment_t *seg = world_advance_locked(extra_parent_worlds, nextra);
     size_t w = (size_t)seg->id << JL_WORLD_IDX_BITS;
-    jl_atomic_store_release(&jl_world_counter, w);
     JL_UNLOCK(&world_counter_lock);
     return w;
 }
 
-// Close the currently open segment and continue the counter in a fresh
-// segment, additionally materializing a side segment G (a child of the
-// closed spine head) that the new spine segment also merges. A serialized
-// image's world history is grafted into G: entries and world tokens from the
-// image reference (G, offset) worlds, which are part of the new spine's
-// history but isolated from invalidation events that happen after the graft.
-// Returns G's first world.
-JL_DLLEXPORT size_t jl_world_graft_segment(void)
+// Called once after a system image restore has set jl_world_counter: the
+// worlds the image was built at become the closed, shared boot prefix
+// (reserving segment ids for them if the image's counter was itself packed),
+// and this process's first spine run starts in a fresh segment. This keeps
+// every parent reference to the prefix exact: prefix segments are referenced
+// only at full extent, never mid-segment.
+JL_DLLEXPORT void jl_world_init_runs(void)
 {
     JL_LOCK(&world_counter_lock);
-    if (world_nsegments + 1 >= JL_WORLD_MAX_SEGMENTS) {
+    size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
+    uint32_t reserve = (uint32_t)jl_world_seg(cur) + 1;
+    if (world_nsegments_ < reserve)
+        world_nsegments_ = reserve;
+    assert(world_nruns == 0 && "spine runs already initialized");
+    world_advance_locked(NULL, 0);
+    JL_UNLOCK(&world_counter_lock);
+}
+
+// The materialized segment for run `run` of the image identified by
+// `image_id`, or ~(size_t)0 if that run has not been grafted.
+JL_DLLEXPORT size_t jl_world_image_run(uint64_t image_id, uint32_t run) JL_NOTSAFEPOINT
+{
+    uint32_t n = world_nsegments_;
+    for (uint32_t i = 0; i < n; i++) {
+        jl_world_segment_t *seg = jl_atomic_load_acquire(&world_segments[i]);
+        if (seg && seg->kind == JL_WORLD_SEG_IMAGE && seg->image_id == image_id && seg->run == run)
+            return (size_t)i << JL_WORLD_IDX_BITS;
+    }
+    return ~(size_t)0;
+}
+
+// Graft run `run` of the image identified by `image_id`, whose parents are
+// the segments of `parent_worlds` at full extent. Returns the run's first
+// world. The counter does not move; the caller is expected to eventually
+// merge the image's final run into the spine with
+// jl_world_advance_into_segment.
+JL_DLLEXPORT size_t jl_world_new_image_run(uint64_t image_id, uint32_t run, size_t *parent_worlds, size_t nparents)
+{
+    JL_LOCK(&world_counter_lock);
+    if (world_nsegments_ >= JL_WORLD_MAX_SEGMENTS) {
         JL_UNLOCK(&world_counter_lock);
         jl_error("world age segment limit exceeded");
     }
-    size_t cur = jl_atomic_load_relaxed(&jl_world_counter);
-    jl_world_segment_t *gseg = world_new_segment_locked(cur, NULL, 0);
-    size_t gbase = (size_t)gseg->id << JL_WORLD_IDX_BITS;
-    jl_world_segment_t *sseg = world_new_segment_locked(cur, &gbase, 1);
-    jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
-    if (oldseg)
-        jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
-    jl_atomic_store_release(&jl_world_counter, (size_t)sseg->id << JL_WORLD_IDX_BITS);
+    assert(jl_world_image_run(image_id, run) == ~(size_t)0 && "image run already grafted");
+    jl_world_segment_t *seg = world_new_segment_locked(~(size_t)0, parent_worlds, nparents);
+    seg->kind = JL_WORLD_SEG_IMAGE;
+    seg->image_id = image_id;
+    seg->run = run;
+    size_t w = (size_t)seg->id << JL_WORLD_IDX_BITS;
     JL_UNLOCK(&world_counter_lock);
-    return gbase;
+    return w;
 }
 
 #ifdef __cplusplus

--- a/src/world.c
+++ b/src/world.c
@@ -120,8 +120,45 @@ static jl_world_segment_t *world_advance_locked(size_t *extra_parent_worlds, siz
     jl_world_segment_t *oldseg = jl_atomic_load_relaxed(&world_segments[jl_world_seg(cur)]);
     if (oldseg)
         jl_atomic_store_relaxed(&oldseg->end_idx, jl_world_idx(cur));
-    jl_atomic_store_release(&jl_world_counter, (size_t)seg->id << JL_WORLD_IDX_BITS);
+    size_t base = (size_t)seg->id << JL_WORLD_IDX_BITS;
+    // every newly merged segment joins the spine at this run's base world
+    for (uint32_t i = 0; i < seg->anc_nbits; i++) {
+        if ((seg->anc_row[i >> 6] >> (i & 63)) & 1) {
+            jl_world_segment_t *anc = jl_atomic_load_relaxed(&world_segments[i]);
+            if (anc && anc->kind != JL_WORLD_SEG_RUN && jl_atomic_load_relaxed(&anc->joined_spine) == 0)
+                jl_atomic_store_relaxed(&anc->joined_spine, base);
+        }
+    }
+    jl_atomic_store_release(&jl_world_counter, base);
     return seg;
+}
+
+// The position on the spine at (or from) which the history of `w` is
+// included: `w` itself for spine worlds (boot prefix and spine runs), the
+// merge point for grafted segments. Spine positions compare exactly as
+// integers.
+static size_t world_spine_pos(size_t w) JL_NOTSAFEPOINT
+{
+    jl_world_segment_t *seg = jl_world_get_segment(jl_world_seg(w));
+    if (seg == NULL || seg->kind == JL_WORLD_SEG_RUN)
+        return w;
+    size_t j = jl_atomic_load_relaxed(&seg->joined_spine);
+    assert(j != 0 && "join of a world whose segment has not been merged into the spine");
+    return j ? j : jl_atomic_load_relaxed(&jl_world_counter);
+}
+
+// The earliest spine world whose history includes both `a` and `b`. For
+// comparable worlds this is simply the later of the two; for worlds on
+// different branches it is the later of their spine merge points.
+JL_DLLEXPORT size_t jl_world_spine_join(size_t a, size_t b) JL_NOTSAFEPOINT
+{
+    if (jl_world_reaches(a, b))
+        return b;
+    if (jl_world_reaches(b, a))
+        return a;
+    size_t pa = world_spine_pos(a);
+    size_t pb = world_spine_pos(b);
+    return pa > pb ? pa : pb;
 }
 
 // Close the currently open segment at the current world counter and continue

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -797,6 +797,37 @@ end
     @test Base.invoke_in_world(sib, f_before_advance) == 1
     @test Base.invoke_in_world(sib, +, 1, 2) == 3
 end
+@testset "three-point total order (asymmetric joins)" begin
+    ordered(x, y, obs) = ccall(:jl_world_ordered_before, Cint, (Csize_t, Csize_t, Csize_t), x, y, obs) != 0
+    w_pre = Base.get_world_counter()
+    t1 = advance_into_segment(UInt[]) # close w_pre's run; the trunk continues
+    a = new_segment([w_pre]) + UInt(1)          # side branch A forked at w_pre
+    b = new_segment([w_pre]) + UInt(1)          # side branch B forked at w_pre
+    t2 = advance_into_segment([a - UInt(1)])    # spine merges A
+    t3 = advance_into_segment([b - UInt(1)])    # spine merges B
+    obs = Base.get_world_counter()
+    @test !reaches(a, b) && !reaches(b, a)
+    # comparable pairs order by visibility
+    @test ordered(w_pre, a, obs) && !ordered(a, w_pre, obs)
+    @test ordered(a, t2, obs) && ordered(b, t3, obs)
+    # incomparable pairs order by their merge points on the observer's trunk:
+    # trunk events before a join precede the side branch's events, which
+    # precede trunk events after it
+    @test ordered(t1, a, obs) && !ordered(a, t1, obs)
+    @test ordered(a, b, obs) && !ordered(b, a, obs) # A merged before B
+    @test ordered(a, t3, obs) && !ordered(t3, a, obs)
+    # a side branch with internal structure merged wholesale: worlds that
+    # join at the same merge point order by the branch's own total order
+    x1 = new_segment([w_pre]) + UInt(1)
+    x2 = new_segment([w_pre]) + UInt(1)
+    z = new_segment([x1, x2]) # z's trunk is x1's branch; x2 is its side branch
+    advance_into_segment([z])
+    obs2 = Base.get_world_counter()
+    @test !reaches(x1, x2) && !reaches(x2, x1)
+    @test ordered(x1, x2, obs2) && !ordered(x2, x1, obs2)
+    @test ordered(x2, z, obs2) && !ordered(z, x1, obs2)
+end
+
 @testset "inference and compilation at branch worlds" begin
     sib2 = new_segment([w_preadvance]) + UInt(1)
     # a function that has never been called or inferred, invoked at a branch

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -840,9 +840,13 @@ precompile_test_harness("WorldToken precompilation") do load_path
           """
           module WTokenPkg
           wfn() = 1
+          sfn(::Any) = 1
+          cfn(x) = sfn(x)
           const tok = Base.world_token()
           gfn() = 1
+          sfn(::Int) = 2
           const tok2 = Base.world_token()
+          precompile(cfn, (Int,))
           end
           """)
     @test !isa(Base.compilecache(Base.PkgId("WTokenPkg")), Base.PrecompilableError)
@@ -859,6 +863,13 @@ precompile_test_harness("WorldToken precompilation") do load_path
         @test_throws MethodError Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.gfn)
         @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.wfn) == 1
         @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.gfn) == 1
+        # a CodeInstance compiled against a method added after the capture
+        # keeps its true creation world through edge validation: it is not
+        # valid at tok, and off-spine inference resolves the older method
+        # state there instead
+        @test invokelatest(WTokenPkg.cfn, 1) == 2
+        @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.cfn, 1) == 2
+        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.cfn, 1) == 1
         # redefinitions after loading are invisible at the tokens: they are
         # not in the invalidating event's future cone
         @eval WTokenPkg wfn() = 42
@@ -891,6 +902,38 @@ precompile_test_harness("WorldToken precompilation") do load_path
         # the dependency's own token still works and does not see WTokenNested
         @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
         @test_throws MethodError Base.invoke_in_world(WTokenPkg.tok2, WTokenNested.nfn)
+    end
+    # binding history: partition chains and usings entries keep their
+    # (translated) verbatim worlds, so tokens see the binding state as of
+    # their capture
+    write(joinpath(load_path, "WTokenBind.jl"),
+          """
+          module WTokenBind
+          module Sub
+          export subname
+          const subname = 7
+          end
+          const cv = 1
+          const cw = 10
+          const tokb = Base.world_token()
+          const cv = 2
+          using .Sub
+          end
+          """)
+    @test !isa(Base.compilecache(Base.PkgId("WTokenBind")), Base.PrecompilableError)
+    @eval using WTokenBind
+    invokelatest() do
+        # a const replaced after the capture: the token sees the original value
+        @test invokelatest(getglobal, WTokenBind, :cv) == 2
+        @test Base.invoke_in_world(WTokenBind.tokb, getglobal, WTokenBind, :cv) == 1
+        # a `using` after the capture: the implicitly-resolved name is not
+        # visible at the token
+        @test invokelatest(getglobal, WTokenBind, :subname) == 7
+        @test_throws UndefVarError Base.invoke_in_world(WTokenBind.tokb, getglobal, WTokenBind, :subname)
+        # a const replaced after loading is likewise invisible at the token
+        @eval WTokenBind const cw = 20
+        @test invokelatest(getglobal, WTokenBind, :cw) == 20
+        @test Base.invoke_in_world(WTokenBind.tokb, getglobal, WTokenBind, :cw) == 10
     end
 end
 

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -858,17 +858,18 @@ end
     # a function that has never been called or inferred, invoked at a branch
     # world: dispatch, inference, compilation and caching must work off-spine
     @test Base.invoke_in_world(sib2, fresh_branch_fn, 21) == 42
-    # the published CodeInstance has point validity at exactly sib2
+    # the published CodeInstance covers sib2 (its interval endpoints need not
+    # both lie on the spine's trunk)
     mi = only(Base.specializations(only(methods(fresh_branch_fn))))
-    found_point_ci = false
+    found_ci = false
     ci = isdefined(mi, :cache) ? mi.cache : nothing
     while ci !== nothing
-        if ci.min_world == sib2 && ci.max_world == sib2
-            found_point_ci = true
+        if in_range(sib2, ci.min_world, ci.max_world)
+            found_ci = true
         end
         ci = isdefined(ci, :next) ? ci.next : nothing
     end
-    @test found_point_ci
+    @test found_ci
     # the spine is unaffected and can still run and infer the same function
     @test fresh_branch_fn(21) == 42
     @test Base.infer_return_type(fresh_branch_fn, (Int,); world=sib2) == Int
@@ -955,6 +956,20 @@ precompile_test_harness("WorldToken precompilation") do load_path
         # not part of the token's history: nfn resolves the dependency's
         # original definition (via off-spine inference at the token's world)
         @test Base.invoke_in_world(WTokenNested.ntok, WTokenNested.nfn) == 101
+        # that inference publishes a mixed-endpoint interval: created within
+        # the grafted history and capped by the session's spine redefinition,
+        # so it covers the token but not the latest world
+        nmi = only(Base.specializations(only(methods(WTokenNested.nfn))))
+        found_mixed = false
+        nci = isdefined(nmi, :cache) ? nmi.cache : nothing
+        while nci !== nothing
+            if in_range(WTokenNested.ntok.world, nci.min_world, nci.max_world) &&
+               !in_range(Base.get_world_counter(), nci.min_world, nci.max_world)
+                found_mixed = true
+            end
+            nci = isdefined(nci, :next) ? nci.next : nothing
+        end
+        @test found_mixed
         # the dependency's own token still works and does not see WTokenNested
         @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
         @test_throws MethodError Base.invoke_in_world(WTokenPkg.tok2, WTokenNested.nfn)

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -842,25 +842,55 @@ precompile_test_harness("WorldToken precompilation") do load_path
           wfn() = 1
           const tok = Base.world_token()
           gfn() = 1
+          const tok2 = Base.world_token()
           end
           """)
     @test !isa(Base.compilecache(Base.PkgId("WTokenPkg")), Base.PrecompilableError)
     @eval using WTokenPkg
     invokelatest() do
         @test WTokenPkg.tok isa Core.WorldToken
-        # the token was rebased onto a grafted segment of the world DAG, not
-        # left at the saving process's meaningless numbering
+        # the tokens were rebased onto grafted copies of the saving process's
+        # spine runs, not left at its meaningless numbering
         @test wseg(WTokenPkg.tok.world) != wseg(unsafe_load(cglobal(:jl_require_world, UInt)))
         @test wseg(WTokenPkg.tok.world) != wseg(Base.get_world_counter())
-        # image content is visible at the token (granularity within the
-        # capturing image itself is currently the whole image)
+        # full fidelity within the image: tok predates gfn's definition,
+        # tok2 postdates it
         @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
-        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.gfn) == 1
-        # redefinitions after loading are invisible at the token: it is not in
-        # the invalidating event's future cone
+        @test_throws MethodError Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.gfn)
+        @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.wfn) == 1
+        @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.gfn) == 1
+        # redefinitions after loading are invisible at the tokens: they are
+        # not in the invalidating event's future cone
         @eval WTokenPkg wfn() = 42
         @test invokelatest(WTokenPkg.wfn) == 42
         @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
+        @test Base.invoke_in_world(WTokenPkg.tok2, WTokenPkg.wfn) == 1
+    end
+    # nested capture: a package that depends on the token-capturing package
+    # and captures its own token re-serializes both world histories; its
+    # token resolves the dependency's runs by their stable image identity
+    write(joinpath(load_path, "WTokenNested.jl"),
+          """
+          module WTokenNested
+          using WTokenPkg
+          nfn() = WTokenPkg.wfn() + 100
+          const ntok = Base.world_token()
+          end
+          """)
+    @test !isa(Base.compilecache(Base.PkgId("WTokenNested")), Base.PrecompilableError)
+    @eval using WTokenNested
+    invokelatest() do
+        @test WTokenNested.ntok isa Core.WorldToken
+        # at the latest world, nfn sees this session's wfn redefinition (the
+        # image CodeInstance fails edge validation and is re-inferred)
+        @test invokelatest(WTokenNested.nfn) == 142
+        # at the nested token, the loading session's redefinition of wfn is
+        # not part of the token's history: nfn resolves the dependency's
+        # original definition (via off-spine inference at the token's world)
+        @test Base.invoke_in_world(WTokenNested.ntok, WTokenNested.nfn) == 101
+        # the dependency's own token still works and does not see WTokenNested
+        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
+        @test_throws MethodError Base.invoke_in_world(WTokenPkg.tok2, WTokenNested.nfn)
     end
 end
 

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -686,7 +686,7 @@ end
 module WorldAgeSegments
 using Test
 
-const WORLD_IDX_BITS = Sys.WORD_SIZE == 64 ? 48 : 24
+const WORLD_IDX_BITS = Sys.WORD_SIZE == 64 ? 48 : 16
 wseg(w::UInt) = w >> WORLD_IDX_BITS
 widx(w::UInt) = w & ((UInt(1) << WORLD_IDX_BITS) - UInt(1))
 seg_reaches(sa::UInt, sb::UInt) = ccall(:jl_world_seg_reaches, Cint, (Csize_t, Csize_t), sa, sb) != 0
@@ -797,6 +797,31 @@ end
     @test Base.invoke_in_world(sib, f_before_advance) == 1
     @test Base.invoke_in_world(sib, +, 1, 2) == 3
 end
+@testset "run rollover on index exhaustion" begin
+    # Force the counter near the end of its run's index space in a throwaway
+    # subprocess and check that definitions roll the trunk over into a fresh
+    # run segment (the natural path on 32-bit platforms, where indices are
+    # only 16 bits).
+    code = """
+        const IDXBITS = $(WORLD_IDX_BITS)
+        IDXMASK = (UInt(1) << IDXBITS) - UInt(1)
+        w0 = Base.get_world_counter()
+        unsafe_store!(cglobal(:jl_world_counter, UInt), (w0 & ~IDXMASK) | (IDXMASK - UInt(8)))
+        seg0 = Base.get_world_counter() >> IDXBITS
+        for i in 1:8
+            Core.eval(Main, :(\$(Symbol(:rollfn, i))() = \$i))
+        end
+        seg1 = Base.get_world_counter() >> IDXBITS
+        @assert seg1 > seg0
+        for i in 1:8
+            @assert Base.invokelatest(getglobal(Main, Symbol(:rollfn, i))) == i
+        end
+        println("ROLLOVER OK")
+        """
+    out = read(`$(Base.julia_cmd()) --startup-file=no -e $code`, String)
+    @test occursin("ROLLOVER OK", out)
+end
+
 @testset "three-point total order (asymmetric joins)" begin
     ordered(x, y, obs) = ccall(:jl_world_ordered_before, Cint, (Csize_t, Csize_t, Csize_t), x, y, obs) != 0
     w_pre = Base.get_world_counter()

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -822,4 +822,46 @@ end
     @test Base.invoke_in_world(sib2, g_frozen) == 1
 end
 
+# WorldToken: opaque world capture, usable in place of a raw world age
+wt_f() = 1
+const wt_tok1 = Base.world_token()
+wt_f() = 2
+@testset "WorldToken (in-process)" begin
+    @test wt_tok1 isa Core.WorldToken
+    @test wt_f() == 2
+    @test Base.invoke_in_world(wt_tok1, wt_f) == 1
+    @test Base.invoke_in_world(wt_tok1.world, wt_f) == 1
+    @test Base.invoke_in_world(wt_tok1, sort, [3, 1, 2]; rev=true) == [3, 2, 1] # kwargs path accepts tokens
+end
+
+include("precompile_utils.jl")
+precompile_test_harness("WorldToken precompilation") do load_path
+    write(joinpath(load_path, "WTokenPkg.jl"),
+          """
+          module WTokenPkg
+          wfn() = 1
+          const tok = Base.world_token()
+          gfn() = 1
+          end
+          """)
+    @test !isa(Base.compilecache(Base.PkgId("WTokenPkg")), Base.PrecompilableError)
+    @eval using WTokenPkg
+    invokelatest() do
+        @test WTokenPkg.tok isa Core.WorldToken
+        # the token was rebased onto a grafted segment of the world DAG, not
+        # left at the saving process's meaningless numbering
+        @test wseg(WTokenPkg.tok.world) != wseg(unsafe_load(cglobal(:jl_require_world, UInt)))
+        @test wseg(WTokenPkg.tok.world) != wseg(Base.get_world_counter())
+        # image content is visible at the token (granularity within the
+        # capturing image itself is currently the whole image)
+        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
+        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.gfn) == 1
+        # redefinitions after loading are invisible at the token: it is not in
+        # the invalidating event's future cone
+        @eval WTokenPkg wfn() = 42
+        @test invokelatest(WTokenPkg.wfn) == 42
+        @test Base.invoke_in_world(WTokenPkg.tok, WTokenPkg.wfn) == 1
+    end
+end
+
 end # module WorldAgeSegments

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -680,3 +680,119 @@ let ci = method_instance(iter61667, ()).cache
     Base.iterate(A::IterInval61667, y...) = iterate(A.v, y...)
     @test ci.max_world == typemax(UInt)
 end
+
+## world age segments: worlds form an append-only DAG of (segment, index)
+## pairs; see the comment next to jl_world_reaches in julia_internal.h
+module WorldAgeSegments
+using Test
+
+const WORLD_IDX_BITS = Sys.WORD_SIZE == 64 ? 48 : 24
+wseg(w::UInt) = w >> WORLD_IDX_BITS
+widx(w::UInt) = w & ((UInt(1) << WORLD_IDX_BITS) - UInt(1))
+seg_reaches(sa::UInt, sb::UInt) = ccall(:jl_world_seg_reaches, Cint, (Csize_t, Csize_t), sa, sb) != 0
+# mirror of the C-side jl_world_reaches/jl_world_in_range inlines
+reaches(a::UInt, b::UInt) = wseg(a) == wseg(b) ? a <= b : seg_reaches(wseg(a), wseg(b))
+in_range(w::UInt, minw::UInt, maxw::UInt) =
+    reaches(minw, w) && (maxw == typemax(UInt) || !reaches(maxw + UInt(1), w))
+new_segment(parents::Vector{UInt}) =
+    ccall(:jl_world_new_segment, Csize_t, (Ptr{Csize_t}, Csize_t), parents, length(parents)) % UInt
+advance_into_segment(extra::Vector{UInt}) =
+    ccall(:jl_world_advance_into_segment, Csize_t, (Ptr{Csize_t}, Csize_t), extra, length(extra)) % UInt
+mt_entry(@nospecialize(ft), w::UInt) = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, Csize_t), ft, nothing, w)
+
+@testset "world segment reachability algebra" begin
+    w0 = Base.get_world_counter()
+    @test widx(w0) > UInt(16) # plenty of room below the current index
+    a = new_segment([w0]) # branch A off the current spine segment
+    b = new_segment([w0]) # branch B, sibling of A
+    m = new_segment([a + UInt(9), b + UInt(9)]) # merge of A and B
+    @test reaches(w0, a) && reaches(w0, b) && reaches(w0, m)
+    @test !reaches(a, b) && !reaches(b, a) # siblings are unordered
+    @test reaches(a, m) && reaches(b, m) # a merge sees both parents
+    @test !reaches(m, a) && !reaches(m, b) && !reaches(m, w0)
+    @test !reaches(a, w0) && !reaches(b, w0) # nothing reaches back in time
+    # within-segment order is the index order
+    @test reaches(a + UInt(5), a + UInt(9)) && !reaches(a + UInt(9), a + UInt(5))
+    @test reaches(a + UInt(5), a + UInt(5)) && reaches(w0, w0) # reflexivity
+    @test reaches(a + UInt(5), m) # parent segments are ancestors at full extent
+    # transitivity through a deeper chain
+    c = new_segment([m])
+    @test reaches(w0, c) && reaches(a, c) && reaches(b, c) && reaches(m, c)
+    @test !reaches(c, m)
+    # ~0 acts as the end of time: everything reaches it, it reaches nothing
+    @test reaches(w0, typemax(UInt)) && reaches(m, typemax(UInt))
+    @test !reaches(typemax(UInt), m)
+end
+
+@testset "validity bounds across branches" begin
+    w0 = Base.get_world_counter()
+    x = new_segment([w0])
+    y = new_segment([w0])
+    # an entry created on X and never invalidated is visible on X and its
+    # descendants, but not on the sibling branch Y
+    @test in_range(x + UInt(2), x + UInt(1), typemax(UInt))
+    @test !in_range(y + UInt(2), x + UInt(1), typemax(UInt))
+    xy = new_segment([x + UInt(3), y + UInt(3)])
+    @test in_range(xy, x + UInt(1), typemax(UInt))
+    # an entry created before the fork and invalidated on X (max_world capped
+    # inclusively at x+4, i.e. the invalidating event is at x+5) is dead in
+    # that event's future cone, but still live on the sibling branch
+    minw = w0 - UInt(5)
+    capw = x + UInt(4)
+    @test in_range(x + UInt(2), minw, capw)
+    @test !in_range(x + UInt(6), minw, capw)
+    @test in_range(y + UInt(6), minw, capw) # sibling never sees the invalidation
+    @test !in_range(xy, minw, capw) # but the merge of both branches does
+    # hard-killed bounds (max_world = 0) match nowhere
+    @test !in_range(x + UInt(2), minw, UInt(0))
+    # inverted "unactivated" bounds (min=~0, max=1) match nowhere
+    @test !in_range(x + UInt(2), typemax(UInt), UInt(1))
+end
+
+# Advancing the spine into a fresh segment must be transparent to execution:
+# everything below exercises the cross-segment paths of the world predicates
+# through real dispatch.
+f_before_advance() = 1
+@test f_before_advance() == 1
+const w_preadvance = Base.get_world_counter()
+const w_postadvance = advance_into_segment(UInt[])
+@testset "spine advance is transparent" begin
+    # the `const` declaration of w_postadvance itself bumped the counter, so
+    # compare segments rather than exact worlds
+    @test wseg(Base.get_world_counter()) == wseg(w_postadvance)
+    @test reaches(w_postadvance, Base.get_world_counter())
+    @test wseg(w_postadvance) != wseg(w_preadvance)
+    @test widx(w_postadvance) == UInt(0)
+    @test reaches(w_preadvance, w_postadvance)
+    @test f_before_advance() == 1 # pre-advance code still dispatches
+    @test Base.invoke_in_world(w_preadvance, f_before_advance) == 1
+    @test invokelatest(f_before_advance) == 1
+end
+f_after_advance() = 2
+g_redefined() = 1
+@test f_after_advance() == 2
+@test g_redefined() == 1
+const w_mid = Base.get_world_counter()
+g_redefined() = 2
+@testset "definitions and invalidations after the advance" begin
+    @test g_redefined() == 2
+    @test Base.invoke_in_world(w_mid, g_redefined) == 1
+    @test mt_entry(Tuple{typeof(f_after_advance)}, Base.get_world_counter()) !== nothing
+end
+@testset "sibling branches of the spine" begin
+    # fork a branch at the (now closed) pre-advance spine world: spine
+    # definitions made after the advance must be invisible there, while
+    # everything from before the fork remains visible
+    sib = new_segment([w_preadvance]) + UInt(1)
+    @test reaches(w_preadvance, sib) && !reaches(w_postadvance, sib) && !reaches(sib, w_postadvance)
+    @test mt_entry(Tuple{typeof(f_before_advance)}, sib) !== nothing
+    @test mt_entry(Tuple{typeof(f_after_advance)}, sib) === nothing
+    # (n.b. lookup at typemax(UInt) is refused by ml_matches as an
+    # unenumerable future world, as it was with linear world ages)
+    @test mt_entry(Tuple{typeof(f_after_advance)}, Base.get_world_counter()) !== nothing
+    # dispatch of already-compiled code at a branch world
+    @test Base.invoke_in_world(sib, f_before_advance) == 1
+    @test Base.invoke_in_world(sib, +, 1, 2) == 3
+end
+
+end # module WorldAgeSegments

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -753,6 +753,8 @@ end
 # everything below exercises the cross-segment paths of the world predicates
 # through real dispatch.
 f_before_advance() = 1
+fresh_branch_fn(x) = 2x # deliberately not called (or inferred) until the branch tests
+g_frozen() = 1
 @test f_before_advance() == 1
 const w_preadvance = Base.get_world_counter()
 const w_postadvance = advance_into_segment(UInt[])
@@ -770,6 +772,7 @@ const w_postadvance = advance_into_segment(UInt[])
 end
 f_after_advance() = 2
 g_redefined() = 1
+g_frozen() = 2 # redefinition on the spine, invisible to branches forked before it
 @test f_after_advance() == 2
 @test g_redefined() == 1
 const w_mid = Base.get_world_counter()
@@ -793,6 +796,30 @@ end
     # dispatch of already-compiled code at a branch world
     @test Base.invoke_in_world(sib, f_before_advance) == 1
     @test Base.invoke_in_world(sib, +, 1, 2) == 3
+end
+@testset "inference and compilation at branch worlds" begin
+    sib2 = new_segment([w_preadvance]) + UInt(1)
+    # a function that has never been called or inferred, invoked at a branch
+    # world: dispatch, inference, compilation and caching must work off-spine
+    @test Base.invoke_in_world(sib2, fresh_branch_fn, 21) == 42
+    # the published CodeInstance has point validity at exactly sib2
+    mi = only(Base.specializations(only(methods(fresh_branch_fn))))
+    found_point_ci = false
+    ci = isdefined(mi, :cache) ? mi.cache : nothing
+    while ci !== nothing
+        if ci.min_world == sib2 && ci.max_world == sib2
+            found_point_ci = true
+        end
+        ci = isdefined(ci, :next) ? ci.next : nothing
+    end
+    @test found_point_ci
+    # the spine is unaffected and can still run and infer the same function
+    @test fresh_branch_fn(21) == 42
+    @test Base.infer_return_type(fresh_branch_fn, (Int,); world=sib2) == Int
+    # a method redefined on the spine after the fork keeps its old meaning on
+    # the branch: the invalidation's future cone does not contain sib2
+    @test g_frozen() == 2
+    @test Base.invoke_in_world(sib2, g_frozen) == 1
 end
 
 end # module WorldAgeSegments


### PR DESCRIPTION
As contemplated in https://github.com/JuliaLang/julia/pull/62715, turn worldage into a DAG (basically matching the precompile graph) that we can use to reference world ages that existed at precompile time. Future use cases may include various form of separate compilation. The key change is to turn the top 16 bits of the world age into a segment ID which may have arbitrary DAG structure. The runtime caches a bitmap for parentage of any active segment allowing fast ancestor queries for runtime lookups.