### PR TITLE
Add direct constraint syntax to `UnionAll` type examples in documentation

### DIFF
--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -79,11 +79,12 @@ Consider the following methods:
 f1(A::Array) = 1
 f2(A::Array{Int}) = 2
 f3(A::Array{T}) where {T<:Any} = 3
-f4(A::Array{Any}) = 4
+f4(A::Array{<:Any}) = 4
+f5(A::Array{Any}) = 5
 ```
 
 The signature - as described in [Function calls](@ref Function-calls) - of `f3` is a `UnionAll` type wrapping a tuple type: `Tuple{typeof(f3), Array{T}} where T`.
-All but `f4` can be called with `a = [1,2]`; all but `f2` can be called with `b = Any[1,2]`.
+All but `f5` can be called with `a = [1,2]`; all but `f2` can be called with `b = Any[1,2]`.
 
 Let's look at these types a little more closely:
 


### PR DESCRIPTION
It's valuable to have all cases in one place and this one was missing. Although this is strictly speaking a duplicate, that is exactly what the reader should have a chance to learn about.