### PR TITLE
strings: fix `lpad`/`rpad` remainder with a `Char` pad

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -509,6 +509,19 @@ julia> lpad("March", 10)
 """
 lpad(s, n::Integer, p::Union{AbstractChar,AbstractString}=' ') = lpad(string(s)::AbstractString, n, string(p))
 
+# Pad for the last `0 < r < textwidth(p)` columns: the shortest prefix of a string pad
+# covering `r` columns, or the whole char for a char pad. When `r` falls inside a wide
+# character, the pad overshoots the requested width.
+function _pad_remainder(p::AbstractString, r::Int)
+    width = 0
+    for (i, c) in pairs(p)
+        width += Int(textwidth(c))::Int
+        width >= r && return @view p[begin:i]
+    end
+    return SubString(p) # unreachable: caller guarantees r < textwidth(p)
+end
+_pad_remainder(p::AbstractChar, r::Int) = p
+
 function lpad(
     s::Union{AbstractChar,AbstractString},
     n::Integer,
@@ -526,7 +539,7 @@ function lpad(
             (s isa AbstractString && codeunit(s) != UInt8 ? "?" : " (bytes)?"))))
     end
     q, r = divrem(m, l)
-    r == 0 ? stringfn(p^q, s) : stringfn(p^q, first(p, r), s)
+    r == 0 ? stringfn(p^q, s) : stringfn(p^q, _pad_remainder(p, r), s)
 end
 
 """
@@ -566,7 +579,7 @@ function rpad(
             (s isa AbstractString && codeunit(s) != UInt8 ? "?" : " (bytes)?"))))
     end
     q, r = divrem(m, l)
-    r == 0 ? stringfn(s, p^q) : stringfn(s, p^q, first(p, r))
+    r == 0 ? stringfn(s, p^q) : stringfn(s, p^q, _pad_remainder(p, r))
 end
 
 """

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -67,6 +67,18 @@ end
     @test rpad("⟨k|H₁|k̃⟩", 12) |> textwidth == 12
     @test lpad("⟨k|H₁|k⟩", 12) |> textwidth == 12
     @test rpad("⟨k|H₁|k⟩", 12) |> textwidth == 12
+    # wide pad with a remainder: fill whole columns when possible, otherwise
+    # overshoot the requested width
+    @test lpad("x", 6, '🍕') == "🍕🍕🍕x" == lpad("x", 6, "🍕")
+    @test rpad("x", 6, '🍕') == "x🍕🍕🍕" == rpad("x", 6, "🍕")
+    @test lpad('x', 6, '🍕') == "🍕🍕🍕x"
+    @test rpad('x', 6, '🍕') == "x🍕🍕🍕"
+    @test lpad("x", 6, "🍕a") == "🍕a🍕x"
+    @test rpad("x", 6, "🍕a") == "x🍕a🍕"
+    @test lpad("x", 5, "🍕a") == "🍕a🍕x"
+    @test rpad("x", 5, "🍕a") == "x🍕a🍕"
+    @test lpad("x", 7, "a🍕b") == "a🍕ba🍕x"
+    @test rpad("x", 7, "a🍕b") == "xa🍕ba🍕"
     for pad in (rpad, lpad), p in ('\0', "\0", "\0\0", "\u302")
         if ncodeunits(p) == 1
             @test_throws r".*has zero textwidth.*maybe you want.*bytes.*" pad("foo", 10, p)


### PR DESCRIPTION
When the pad width does not evenly divide the remaining columns, `lpad`/`rpad` filled the last `r` columns with `first(p, r)`. For a `Char` pad `p` this iterates the char into a `Vector{Char}`, which is then stringified into the result:

```julia-repl
julia> rpad("x", 6, '🍕')
"x🍕🍕['🍕']"
```

Use the whole char instead, matching the string-pad behavior of overshooting the requested width. This also fixes `lpad`/`rpad` failing `--trim=safe` verification through this code path.
