### PR TITLE
Diagnose second system image before aborting

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -7,6 +7,7 @@
 #include "julia.h"
 #include "julia_internal.h"
 #include "julia_assert.h"
+#include "processor.h"
 
 #ifdef _COMPILER_TSAN_ENABLED_
 #include <sanitizer/tsan_interface.h>
@@ -351,8 +352,10 @@ jl_ptls_t jl_init_threadtls(int16_t tid)
     if (pthread_getspecific(jl_task_exit_key))
         abort();
 #endif
-    if (jl_get_pgcstack() != NULL)
+    if (jl_get_pgcstack() != NULL) {
+        fprintf(stderr, "fatal: jl_init_threadtls called on a thread that already belongs to the runtime\n");
         abort();
+    }
     jl_ptls_t ptls;
 #if defined(_OS_WINDOWS_)
     ptls = (jl_ptls_t)_aligned_malloc(sizeof(jl_tls_states_t), alignof(jl_tls_states_t));
@@ -477,10 +480,27 @@ JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void)
     return &ct->gcstack;
 }
 
+static int in_unloaded_image(void *addr) JL_NOTSAFEPOINT
+{
+    void *handle = jl_find_dynamic_library_by_addr(addr, 0, 1);
+    if (handle == NULL)
+        return 0;
+    jl_image_pointers_t *pointers;
+    if (!jl_dlsym(handle, "jl_image_pointers", (void **)&pointers, 0, 0))
+        return 0;
+    // Loading an image stores the runtime's pgcstack getter into the
+    // image's `jl_pgcstack_func_slot`; until then the slot holds the image's
+    // built-in default getter.
+    jl_get_pgcstack_func_t getter;
+    jl_pgcstack_key_t key;
+    jl_pgcstack_getkey(&getter, &key);
+    return *(jl_get_pgcstack_func_t*)pointers->ptls->pgcstack_func_slot != getter;
+}
+
 JL_DLLEXPORT jl_gcframe_t **jl_autoinit_and_adopt_thread(void) JL_CANSAFEPOINT_ENTER
 {
+    void *retaddr = __builtin_extract_return_addr(__builtin_return_address(0));
     if (!jl_is_initialized()) {
-        void *retaddr = __builtin_extract_return_addr(__builtin_return_address(0));
         void *handle = jl_find_dynamic_library_by_addr(retaddr, 0, 0);
         if (handle == NULL) {
             fprintf(stderr, "error: runtime auto-initialization failed due to bad sysimage lookup\n"
@@ -489,6 +509,19 @@ JL_DLLEXPORT jl_gcframe_t **jl_autoinit_and_adopt_thread(void) JL_CANSAFEPOINT_E
         }
         jl_init_with_image_handle(handle);
         return &jl_get_current_task()->gcstack;
+    }
+
+    if (jl_get_pgcstack() != NULL || in_unloaded_image(retaddr)) {
+        const char *caller = jl_pathname_for_symbol(retaddr);
+        const char *loaded = jl_options.image_file;
+        fprintf(stderr, "error: a Julia runtime is already initialized in this process with image\n"
+                        "           %s\n"
+                        "       so the image\n"
+                        "           %s\n"
+                        "       cannot also be initialized. Loading two Julia images into one process\n"
+                        "       requires each to use its own private copy of libjulia.\n",
+                        loaded ? loaded : "<unknown>", caller ? caller : "<unknown>");
+        abort();
     }
 
     return jl_adopt_thread();

--- a/src/threading.c
+++ b/src/threading.c
@@ -480,21 +480,21 @@ JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void)
     return &ct->gcstack;
 }
 
-static int in_unloaded_image(void *addr) JL_NOTSAFEPOINT
+static int image_is_initialized(void *image) JL_NOTSAFEPOINT
 {
-    void *handle = jl_find_dynamic_library_by_addr(addr, 0, 1);
-    if (handle == NULL)
-        return 0;
     jl_image_pointers_t *pointers;
-    if (!jl_dlsym(handle, "jl_image_pointers", (void **)&pointers, 0, 0))
+    if (!jl_dlsym(image, "jl_image_pointers", (void **)&pointers, 0, 0)) {
+        // cannot have been initialized.
+        assert(0 && "no jl_image_pointers in library");
         return 0;
+    }
     // Loading an image stores the runtime's pgcstack getter into the
     // image's `jl_pgcstack_func_slot`; until then the slot holds the image's
     // built-in default getter.
     jl_get_pgcstack_func_t getter;
     jl_pgcstack_key_t key;
     jl_pgcstack_getkey(&getter, &key);
-    return *(jl_get_pgcstack_func_t*)pointers->ptls->pgcstack_func_slot != getter;
+    return *(jl_get_pgcstack_func_t*)pointers->ptls->pgcstack_func_slot == getter;
 }
 
 JL_DLLEXPORT jl_gcframe_t **jl_autoinit_and_adopt_thread(void) JL_CANSAFEPOINT_ENTER
@@ -511,7 +511,14 @@ JL_DLLEXPORT jl_gcframe_t **jl_autoinit_and_adopt_thread(void) JL_CANSAFEPOINT_E
         return &jl_get_current_task()->gcstack;
     }
 
-    if (jl_get_pgcstack() != NULL || in_unloaded_image(retaddr)) {
+    void *handle = jl_find_dynamic_library_by_addr(retaddr, 0, 1);
+    if (handle == NULL) {
+        assert(0 && "caller of jl_autoinit_and_adopt_thread not in any library");
+        fprintf(stderr, "error: thread adoption failed due to bad sysimage lookup\n"
+                        "       (this should not happen, please file a bug report)\n");
+        exit(1);
+    }
+    if (jl_get_pgcstack() != NULL || !image_is_initialized(handle)) {
         const char *caller = jl_pathname_for_symbol(retaddr);
         const char *loaded = jl_options.image_file;
         fprintf(stderr, "error: a Julia runtime is already initialized in this process with image\n"

--- a/test/trim/TwoImages/Project.toml
+++ b/test/trim/TwoImages/Project.toml
@@ -1,0 +1,2 @@
+# Test harness environment; the two packages built by `build.jl` are the
+# sibling projects `TwoImagesA` and `TwoImagesB`.

--- a/test/trim/TwoImages/TwoImagesA/Project.toml
+++ b/test/trim/TwoImages/TwoImagesA/Project.toml
@@ -1,0 +1,3 @@
+name = "TwoImagesA"
+uuid = "fb5082d6-44df-4afa-b9bd-e1ae7abe675e"
+version = "0.1.0"

--- a/test/trim/TwoImages/TwoImagesA/src/TwoImagesA.jl
+++ b/test/trim/TwoImages/TwoImagesA/src/TwoImagesA.jl
@@ -1,0 +1,9 @@
+module TwoImagesA
+# One of two trimmed libraries loaded into a single process; `TwoImagesB` is the
+# other. Each is built as its own system image against the same libjulia.
+
+Base.@ccallable function twoimages_a_answer()::Int32
+    return Int32(1)
+end
+
+end

--- a/test/trim/TwoImages/TwoImagesB/Project.toml
+++ b/test/trim/TwoImages/TwoImagesB/Project.toml
@@ -1,0 +1,3 @@
+name = "TwoImagesB"
+uuid = "9d9ec9e4-af33-4425-9473-c5817777df1c"
+version = "0.1.0"

--- a/test/trim/TwoImages/TwoImagesB/src/TwoImagesB.jl
+++ b/test/trim/TwoImages/TwoImagesB/src/TwoImagesB.jl
@@ -1,0 +1,9 @@
+module TwoImagesB
+# One of two trimmed libraries loaded into a single process; `TwoImagesA` is the
+# other. Each is built as its own system image against the same libjulia.
+
+Base.@ccallable function twoimages_b_answer()::Int32
+    return Int32(2)
+end
+
+end

--- a/test/trim/TwoImages/build.jl
+++ b/test/trim/TwoImages/build.jl
@@ -1,0 +1,39 @@
+# Custom build: produce two trimmed C-callable shared libraries from the sibling
+# projects `TwoImagesA` and `TwoImagesB`, plus the C driver that loads them into
+# one process. The libraries are not bundled, so both resolve the same libjulia
+# from the build tree.
+#
+# Included in-process by `test/trim.jl`, so `run_juliac` and `run_cc` (defined
+# there) are in scope. `ARGS[1]` is the output directory.
+outdir = ARGS[1]
+harnessdir = @__DIR__
+
+for (name, pkg) in (("twoimages_a", "TwoImagesA"), ("twoimages_b", "TwoImagesB"))
+    pkgdir = joinpath(harnessdir, pkg)
+    run_juliac(String[
+        "--output-lib", joinpath(outdir, name),
+        "--project", pkgdir,
+        "--compile-ccallable",
+        "--trim=safe",
+        "--experimental",
+        joinpath(pkgdir, "src", pkg * ".jl"),
+    ])
+end
+
+dlext = Base.BinaryPlatforms.platform_dlext()
+for name in ("twoimages_a", "twoimages_b")
+    isfile(joinpath(outdir, name * "." * dlext)) ||
+        error("expected library at ", joinpath(outdir, name * "." * dlext))
+end
+
+bindir = joinpath(outdir, "bin")
+mkpath(bindir)
+exe = joinpath(bindir, "twoimages" * (Sys.iswindows() ? ".exe" : ""))
+csrc = joinpath(harnessdir, "twoimages.c")
+if Sys.islinux()
+    run_cc(["-o", exe, csrc, "-ldl", "-lpthread"])
+elseif Sys.isunix()
+    run_cc(["-o", exe, csrc, "-lpthread"])
+else
+    run_cc(["-o", exe, csrc])
+end

--- a/test/trim/TwoImages/runtests.jl
+++ b/test/trim/TwoImages/runtests.jl
@@ -1,0 +1,53 @@
+# Test that a second *non-privatized* library loaded into the same process
+# throws an informative error.
+using Test
+
+outdir = ARGS[1]
+
+exe_suffix = splitext(Base.julia_exename())[2]
+dlext = Base.BinaryPlatforms.platform_dlext()
+driver = joinpath(outdir, "bin", "twoimages" * exe_suffix)
+liba = joinpath(outdir, "twoimages_a." * dlext)
+libb = joinpath(outdir, "twoimages_b." * dlext)
+
+const SIGABRT = 6
+const MESSAGE = "a Julia runtime is already initialized in this process with image"
+
+function run_driver(mode)
+    cmd = `$driver $mode $liba $libb`
+    if Sys.iswindows()
+        # Windows resolves libjulia through PATH rather than a run path.
+        cmd = addenv(cmd, "PATH" => string(Sys.BINDIR, ';', get(ENV, "PATH", "")))
+    end
+    errfile = tempname()
+    proc = run(pipeline(ignorestatus(cmd), stdout=devnull, stderr=errfile))
+    err = read(errfile, String)
+    rm(errfile, force=true)
+    return proc, err
+end
+
+@testset "TwoImages" begin
+    # One library on its own initializes the runtime and returns normally.
+    proc, err = run_driver("solo")
+    @test success(proc)
+    @test isempty(err)
+
+    # Entering the second image aborts, whether or not the calling thread has
+    # already been adopted by the runtime.
+    @testset "$mode" for mode in ("samethread", "newthread")
+        proc, err = run_driver(mode)
+        @test !success(proc)
+        if !Sys.iswindows()
+            @test Base.process_signaled(proc) && proc.termsignal == SIGABRT
+        end
+        # The message names the image that owns the runtime first, then the one
+        # that cannot be initialized.
+        i = findfirst(MESSAGE, err)
+        @test i !== nothing
+        if i !== nothing
+            j = findnext("twoimages_a." * dlext, err, last(i))
+            @test j !== nothing
+            @test j !== nothing && findnext("twoimages_b." * dlext, err, last(j)) !== nothing
+        end
+    end
+end

--- a/test/trim/TwoImages/twoimages.c
+++ b/test/trim/TwoImages/twoimages.c
@@ -1,0 +1,138 @@
+// Loads one or both of the trimmed libraries and calls their entry points.
+//
+// Usage: twoimages <solo|samethread|newthread> <libA> <libB>
+//   solo        load A, call it (expect 1) and exit
+//   samethread  load both, call A then B on the main thread
+//   newthread   load both, call A on the main thread and B on a fresh thread
+//
+// In the two-library modes the call into B is expected to terminate the process:
+// libjulia is already initialized with A's image, so B's image can never be
+// relocated. Reaching the end of `main` therefore means the check is missing.
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+typedef HMODULE lib_handle_t;
+#else
+#include <dlfcn.h>
+#include <pthread.h>
+typedef void* lib_handle_t;
+#endif
+
+typedef int32_t (*answer_t)(void);
+
+static lib_handle_t load_library(const char* path) {
+#ifdef _WIN32
+    return LoadLibraryA(path);
+#else
+    return dlopen(path, RTLD_NOW | RTLD_LOCAL);
+#endif
+}
+
+static void* get_symbol(lib_handle_t handle, const char* name) {
+#ifdef _WIN32
+    return (void*)GetProcAddress(handle, name);
+#else
+    return dlsym(handle, name);
+#endif
+}
+
+static void print_load_error(const char* context) {
+#ifdef _WIN32
+    fprintf(stderr, "%s failed: error code %lu\n", context, GetLastError());
+#else
+    fprintf(stderr, "%s failed: %s\n", context, dlerror());
+#endif
+}
+
+static answer_t thread_entry;
+
+#ifdef _WIN32
+static DWORD WINAPI thread_main(LPVOID unused) {
+    (void)unused;
+    thread_entry();
+    return 0;
+}
+static int call_on_new_thread(answer_t f) {
+    thread_entry = f;
+    HANDLE t = CreateThread(NULL, 0, thread_main, NULL, 0, NULL);
+    if (t == NULL)
+        return 0;
+    WaitForSingleObject(t, INFINITE);
+    CloseHandle(t);
+    return 1;
+}
+#else
+static void* thread_main(void* unused) {
+    (void)unused;
+    thread_entry();
+    return NULL;
+}
+static int call_on_new_thread(answer_t f) {
+    pthread_t t;
+    thread_entry = f;
+    if (pthread_create(&t, NULL, thread_main, NULL) != 0)
+        return 0;
+    pthread_join(t, NULL);
+    return 1;
+}
+#endif
+
+int main(int argc, char** argv) {
+    if (argc < 4) {
+        fprintf(stderr, "usage: %s <solo|samethread|newthread> <libA> <libB>\n", argv[0]);
+        return 2;
+    }
+    const char* mode = argv[1];
+
+    lib_handle_t ha = load_library(argv[2]);
+    if (!ha) {
+        print_load_error("LoadLibrary/dlopen A");
+        return 3;
+    }
+    answer_t a = (answer_t)get_symbol(ha, "twoimages_a_answer");
+    if (!a) {
+        print_load_error("GetProcAddress/dlsym twoimages_a_answer");
+        return 4;
+    }
+
+    if (strcmp(mode, "solo") == 0) {
+        int32_t r = a();
+        printf("a=%d\n", r);
+        fflush(stdout);
+        return r == 1 ? 0 : 5;
+    }
+
+    lib_handle_t hb = load_library(argv[3]);
+    if (!hb) {
+        print_load_error("LoadLibrary/dlopen B");
+        return 6;
+    }
+    answer_t b = (answer_t)get_symbol(hb, "twoimages_b_answer");
+    if (!b) {
+        print_load_error("GetProcAddress/dlsym twoimages_b_answer");
+        return 7;
+    }
+
+    int32_t r = a();
+    printf("a=%d\n", r);
+    fflush(stdout);
+    if (r != 1)
+        return 5;
+
+    if (strcmp(mode, "newthread") == 0) {
+        if (!call_on_new_thread(b)) {
+            fprintf(stderr, "could not create a thread\n");
+            return 8;
+        }
+    }
+    else {
+        b();
+    }
+
+    fprintf(stderr, "the second image was entered without being reported\n");
+    return 9;
+}


### PR DESCRIPTION
This is outside my normal wheelhouse, so please do check it carefully. I've taken time to understand the change, redesigned Fable's initial API to make it more transparent about what's actually being checked, and slimmed and reworded the narrative text. I reduced the text to what was useful to me, but it still might be excessive to someone who lives in the `dlload` world all the time.

Commit message below (also extensively edited by me).

-------------

JuliaLibWrapping creates wrappers for trimmed libraries. In a future "Julia is the language for scientific libraries" world, we expect that many Python, R, etc. users will have more than one such library in their session. This is safe *if* `privatize`d. The problem this PR fixes is that privatization is not required, and if done wrong we currently get a bare `abort()`.

`jl_autoinit_and_adopt_thread` now detects an entry from an image that was never loaded into this runtime, by checking whether the image's `jl_pgcstack_func_slot` still holds the image's built-in getter rather than the runtime's, and aborts with a message naming both images and the remedy (a private copy of libjulia per library).

Assisted-by: Claude Code (Fable 5)