### PR TITLE
WIP/RFC: runtime: Add RCJulia, a restricted-capability evaluation mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,13 @@ New language features
   `continue name` to continue a labeled loop ([#60481]).
 * `typegroup` blocks allow defining mutually recursive struct types that reference each other in their
   field types. All types in the group are resolved atomically at the end of the block ([#60569]).
+* A new internal *RCJulia* (restricted-capability Julia) evaluation mode
+  (`Core._rcjulia_call(world, f, args...)`) executes a call with the world age frozen and every
+  primitive operation requiring a withheld capability trapped (throwing the new `CapabilityError`):
+  no mutable-memory reads or writes, no I/O, no world mutation, and only structurally terminating
+  control flow — loops are rejected and recursion must decrease in a built-in well-founded order.
+  Any call that completes under the mode is `:foldable` by construction, making its result safe to
+  constant-fold and cache across sessions without relying on effects proofs.
 * Primitive types with non-byte-multiple logical widths can now be defined ([#61359]).
 * Introduced explicitly wrapping arithmetic operators `+%`, `-%`, `*%` to annotate arithmetic operations
   that are semantically safe to wrap/overflow. Their behavior is currently identical to the default `+`, `-`, `*`

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -239,7 +239,7 @@ export
     InterruptException, InexactError, OutOfMemoryError, ReadOnlyMemoryError,
     OverflowError, StackOverflowError, SegmentationFault, UndefRefError, UndefVarError,
     TypeError, ArgumentError, MethodError, AssertionError, LoadError, InitError,
-    UndefKeywordError, ConcurrencyViolationError, FieldError,
+    UndefKeywordError, ConcurrencyViolationError, FieldError, CapabilityError,
     # AST representation
     Expr, QuoteNode, LineNumberNode, GlobalRef,
     # object model functions
@@ -507,6 +507,10 @@ end
 struct ConcurrencyViolationError <: Exception
     msg::AbstractString
     ConcurrencyViolationError(msg::AbstractString) = new(msg)
+end
+struct CapabilityError <: Exception
+    op::Symbol
+    CapabilityError(op::Symbol) = new(op)
 end
 struct MissingCodeError <: Exception
     mi::MethodInstance

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4295,6 +4295,56 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    CapabilityError(op::Symbol) <: Exception
+
+An error thrown when code executing in RCJulia — restricted-capability
+evaluation, see [`Core._rcjulia_call`](@ref) — attempts an operation whose
+capability the mode withholds, such as reading or writing mutable memory,
+performing I/O, or using unrestricted recursion. `op` names the offending
+operation.
+
+The trap itself is deterministic — it depends only on the operation attempted
+and its operands — so even a computation that throws this error has a
+consistent, foldable outcome.
+"""
+CapabilityError
+
+"""
+    Core._rcjulia_call(world::UInt, f, args...)
+
+Call `f(args...)` in *RCJulia* (restricted-capability Julia) mode: the task's
+world age is frozen to `world` and every operation whose result could depend
+on mutable state, or whose effects could be observed from outside, throws a
+[`CapabilityError`](@ref) instead of executing. Any call that completes
+(or throws) under the mode is therefore `:foldable` by construction — the
+outcome is a pure function of the arguments and `world` — with no requirement
+of `:nothrow`: "consistently throws" is a foldable outcome.
+
+The withheld capabilities include: reading fields of mutable objects (except
+fields declared `const`, which never change after construction — this is what
+admits set-once runtime metadata such as `DataType.parameters`), reading
+non-`const` globals, all mutation and all allocation of mutable memory,
+`ccall`/`cfunction`, task and scheduler operations, and method definition and
+other world-mutating reflection. Generic calls execute through the
+interpreter so that every primitive operation stays checked.
+
+Termination is structural: loop backedges are rejected, and re-entering a
+method that is already executing is permitted only when its arguments
+strictly decrease in a built-in well-founded order — structurally smaller
+types are smaller, and at equal types, smaller values interpreted as
+bitstypes are smaller. Since the order admits no infinite descending chains
+and the method table is frozen, every call chain is finite; a fixed
+platform-independent frame cap additionally bounds physical stack use.
+
+!!! warning
+    This is an internal interface primarily intended as runtime
+    infrastructure (e.g. for computed struct field types). Its exact
+    restrictions may be extended or relaxed (for example with per-method
+    custom recursion orders).
+"""
+Core._rcjulia_call
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -170,6 +170,8 @@ showerror(io::IO, ex::ArgumentError) = print(io, "ArgumentError: ", ex.msg)
 showerror(io::IO, ex::DimensionMismatch) = print(io, "DimensionMismatch: ", ex.msg)
 showerror(io::IO, ex::AssertionError) = print(io, "AssertionError: ", ex.msg)
 showerror(io::IO, ex::OverflowError) = print(io, "OverflowError: ", ex.msg)
+showerror(io::IO, ex::CapabilityError) =
+    print(io, "CapabilityError: `", ex.op, "` is not available in RCJulia (restricted-capability evaluation)")
 
 showerror(io::IO, ex::UndefKeywordError) =
     print(io, "UndefKeywordError: keyword argument `$(ex.var)` not assigned")

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -21,7 +21,7 @@ export Core,
     InterruptException, InexactError, OutOfMemoryError, ReadOnlyMemoryError,
     OverflowError, StackOverflowError, SegmentationFault, UndefRefError, UndefVarError,
     TypeError, ArgumentError, MethodError, AssertionError, LoadError, InitError,
-    UndefKeywordError, ConcurrencyViolationError, FieldError,
+    UndefKeywordError, ConcurrencyViolationError, FieldError, CapabilityError,
     # AST representation
     Expr, QuoteNode, LineNumberNode, GlobalRef,
     # object model functions

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -453,6 +453,8 @@ Core.ReadOnlyMemoryError
 Core.OverflowError
 Base.ProcessFailedException
 Base.TaskFailedException
+Core.CapabilityError
+Core._rcjulia_call
 Core.StackOverflowError
 Base.SystemError
 Core.TypeError

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -18,6 +18,7 @@ extern "C" {
     XX(_import, "_import") \
     XX(_new_cancel_source,"_new_cancel_source") \
     XX(_primitivetype,"_primitivetype") \
+    XX(_rcjulia_call,"_rcjulia_call") \
     XX(_setsuper,"_setsuper!") \
     XX(_structtype,"_structtype") \
     XX(_svec_len,"_svec_len") \

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -735,12 +735,14 @@ JL_CALLABLE(jl_f_ifelse)
 
 JL_CALLABLE(jl_f_current_scope)
 {
+    jl_check_rc("current_scope");
     JL_NARGS(current_scope, 0, 0);
     return jl_current_task->scope;
 }
 
 JL_CALLABLE(jl_f__new_cancel_source)
 {
+    jl_check_rc("_new_cancel_source");
     // each argument is a parent CancellationTokenSource (checked, along
     // with distinctness, by jl_new_cancel_source); no arguments makes a
     // root source
@@ -758,6 +760,7 @@ JL_CALLABLE(jl_f__new_cancel_source)
 // (reset_ctx), which has no interpreter equivalent.
 JL_CALLABLE(jl_f_cancellation_point)
 {
+    jl_check_rc("cancellation_point!");
     JL_NARGS(cancellation_point!, 1, 1);
     jl_task_t *ct = jl_current_task;
     jl_value_t *src = args[0];
@@ -826,7 +829,12 @@ JL_CALLABLE(jl_f__apply_iterate)
     assert(iterate);
     args += 1;
     nargs -= 1;
-    if (nargs == 2) {
+    // In RCJulia mode only tuple/svec/NamedTuple splatting is
+    // permitted (checked in the sizing loop below): splatting Memory/Array
+    // reads mutable memory, and the generic path calls `iterate` natively.
+    // The fast paths are skipped so the final apply stays checked.
+    int pure = jl_current_task->rcjulia != 0;
+    if (nargs == 2 && !pure) {
         // some common simple cases
         if (f == BUILTIN(svec)) {
             if (jl_is_svec(args[1]))
@@ -873,6 +881,9 @@ JL_CALLABLE(jl_f__apply_iterate)
         }
         else if (jl_is_tuple(args[i]) || jl_is_namedtuple(args[i])) {
             precount += jl_nfields(args[i]);
+        }
+        else if (pure) {
+            jl_capability_error("_apply_iterate");
         }
         else if (jl_is_genericmemory(args[i])) {
             precount += ((jl_genericmemory_t*)args[i])->length;
@@ -1038,7 +1049,7 @@ JL_CALLABLE(jl_f__apply_iterate)
         ((void**)roots)[-2] = (void*)JL_GC_ENCODE_PUSHARGS(1);
 #endif
     }
-    jl_value_t *result = jl_apply(newargs, n);
+    jl_value_t *result = pure ? jl_rc_apply(newargs, n) : jl_apply(newargs, n);
     JL_GC_POP();
     return result;
 }
@@ -1046,6 +1057,7 @@ JL_CALLABLE(jl_f__apply_iterate)
 // this is like a regular call, but always runs in the newest world
 JL_CALLABLE(jl_f_invokelatest)
 {
+    jl_check_rc("invokelatest");
     JL_NARGSV(invokelatest, 1);
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
@@ -1060,6 +1072,7 @@ JL_CALLABLE(jl_f_invokelatest)
 // If world > jl_atomic_load_acquire(&jl_world_counter), run in the latest world.
 JL_CALLABLE(jl_f_invoke_in_world)
 {
+    jl_check_rc("invoke_in_world");
     JL_NARGSV(invoke_in_world, 2);
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
@@ -1075,10 +1088,49 @@ JL_CALLABLE(jl_f_invoke_in_world)
     return ret;
 }
 
+// Enter RCJulia mode: freeze the task's world age to `args[0]` and
+// apply `args[1:end]` with every impure primitive operation trapped (throwing
+// CapabilityError). Any call that completes under the mode is
+// `:foldable` by construction; `:nothrow` is deliberately not implied — a
+// consistent throw (including the traps themselves) is a foldable outcome.
+JL_CALLABLE(jl_f__rcjulia_call)
+{
+    JL_NARGSV(_rcjulia_call, 2);
+    JL_TYPECHK(_rcjulia_call, ulong, args[0]);
+    jl_task_t *ct = jl_current_task;
+    size_t last_age = ct->world_age;
+    uint16_t last_rc = ct->rcjulia;
+    jl_value_t *ret = NULL;
+    size_t world = jl_unbox_ulong(args[0]);
+    size_t max_world = jl_atomic_load_acquire(&jl_world_counter);
+    if (world > max_world)
+        world = max_world;
+    // nested entries must not raise the frozen world: the outer mode's
+    // execution would otherwise observe state its own world cannot see
+    if (last_rc && world > last_age)
+        jl_capability_error("_rcjulia_call");
+    if (last_rc == UINT16_MAX)
+        jl_capability_error("depth_limit");
+    JL_TRY {
+        ct->world_age = world;
+        ct->rcjulia = last_rc + 1;
+        ret = jl_rc_apply(&args[1], nargs - 1);
+        ct->world_age = last_age;
+        ct->rcjulia = last_rc;
+    }
+    JL_CATCH {
+        ct->world_age = last_age;
+        ct->rcjulia = last_rc;
+        jl_rethrow();
+    }
+    return ret;
+}
+
 JL_CALLABLE(jl_f__call_in_world_total)
 {
     JL_NARGSV(_call_in_world_total, 2);
     JL_TYPECHK(_call_in_world_total, ulong, args[0]);
+    jl_check_rc("_call_in_world_total");
     jl_task_t *ct = jl_current_task;
     int last_in = ct->ptls->in_pure_callback;
     jl_value_t *ret = NULL;
@@ -1214,6 +1266,12 @@ JL_CALLABLE(jl_f_getfield)
         return jl_f_getglobal(NULL, args, 2); // we just ignore the atomic order and boundschecks
     jl_datatype_t *st = (jl_datatype_t*)vt;
     size_t idx = get_checked_fieldindex("getfield", st, v, args[1], 0);
+    // RCJulia mode may read `const` fields of mutable objects — the language
+    // already guarantees they never change after construction (this is what
+    // admits set-once runtime metadata such as `DataType.parameters`)
+    if (__unlikely(jl_current_task->rcjulia) && st->name->mutabl &&
+            !jl_field_isconst(st, idx))
+        jl_capability_error("getfield");
     int isatomic = jl_field_isatomic(st, idx);
     if (!isatomic && order != jl_memory_order_notatomic && order != jl_memory_order_unspecified)
         jl_atomic_error("getfield: non-atomic field cannot be accessed atomically");
@@ -1229,6 +1287,7 @@ JL_CALLABLE(jl_f_getfield)
 
 JL_CALLABLE(jl_f_setfield)
 {
+    jl_check_rc("setfield!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(setfield!, 3, 4);
     if (nargs == 4) {
@@ -1253,6 +1312,7 @@ JL_CALLABLE(jl_f_setfield)
 
 JL_CALLABLE(jl_f_swapfield)
 {
+    jl_check_rc("swapfield!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(swapfield!, 3, 4);
     if (nargs == 4) {
@@ -1272,6 +1332,7 @@ JL_CALLABLE(jl_f_swapfield)
 
 JL_CALLABLE(jl_f_modifyfield)
 {
+    jl_check_rc("modifyfield!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(modifyfield!, 4, 5);
     if (nargs == 5) {
@@ -1291,6 +1352,7 @@ JL_CALLABLE(jl_f_modifyfield)
 
 JL_CALLABLE(jl_f_replacefield)
 {
+    jl_check_rc("replacefield!");
     enum jl_memory_order success_order = jl_memory_order_notatomic;
     JL_NARGS(replacefield!, 4, 6);
     if (nargs >= 5) {
@@ -1321,6 +1383,7 @@ JL_CALLABLE(jl_f_replacefield)
 
 JL_CALLABLE(jl_f_setfieldonce)
 {
+    jl_check_rc("setfieldonce!");
     enum jl_memory_order success_order = jl_memory_order_notatomic;
     JL_NARGS(setfieldonce!, 3, 5);
     if (nargs >= 4) {
@@ -1465,6 +1528,13 @@ JL_CALLABLE(jl_f_isdefined)
             order = jl_memory_order_unordered;
         if (order < jl_memory_order_unordered)
             jl_atomic_error("isdefined: module binding cannot be accessed non-atomically");
+        if (__unlikely(jl_current_task->rcjulia)) {
+            jl_value_t *v = NULL;
+            int kind = jl_rc_binding_constant(m, s, jl_current_task->world_age, &v);
+            if (kind < 0)
+                jl_capability_error("isdefined");
+            return kind == 1 ? jl_true : jl_false;
+        }
         int bound = jl_boundp(m, s, 1); // seq_cst always
         return bound ? jl_true : jl_false;
     }
@@ -1488,6 +1558,9 @@ JL_CALLABLE(jl_f_isdefined)
             return jl_false;
         }
     }
+    if (__unlikely(jl_current_task->rcjulia) && vt->name->mutabl &&
+            !jl_field_isconst(vt, idx))
+        jl_capability_error("isdefined");
     int isatomic = jl_field_isatomic(vt, idx);
     if (!isatomic && order != jl_memory_order_notatomic && order != jl_memory_order_unspecified)
         jl_atomic_error("isdefined: non-atomic field cannot be accessed atomically");
@@ -1520,6 +1593,8 @@ JL_CALLABLE(jl_f_getglobal)
         jl_atomic_error("getglobal: module binding cannot be read non-atomically");
     else if (order >= jl_memory_order_seq_cst)
         jl_fence();
+    if (__unlikely(jl_current_task->rcjulia))
+        return jl_rc_globalref_value(mod, sym, jl_current_task->world_age);
     jl_value_t *v = jl_eval_global_var(mod, sym, jl_current_task->world_age); // relaxed load
     if (order >= jl_memory_order_acquire)
         jl_fence();
@@ -1549,12 +1624,22 @@ JL_CALLABLE(jl_f_isdefinedglobal)
         order = jl_memory_order_unordered;
     if (order < jl_memory_order_unordered)
         jl_atomic_error("isdefined: module binding cannot be accessed non-atomically");
+    if (__unlikely(jl_current_task->rcjulia)) {
+        // in RCJulia mode, definedness may only be observed for
+        // bindings whose state is fixed within the frozen world
+        jl_value_t *v = NULL;
+        int kind = jl_rc_binding_constant(m, s, jl_current_task->world_age, &v);
+        if (kind < 0)
+            jl_capability_error("isdefinedglobal");
+        return kind == 1 ? jl_true : jl_false;
+    }
     int bound = jl_boundp(m, s, allow_import); // seq_cst always
     return bound ? jl_true : jl_false;
 }
 
 JL_CALLABLE(jl_f_setglobal)
 {
+    jl_check_rc("setglobal!");
     enum jl_memory_order order = jl_memory_order_release;
     JL_NARGS(setglobal!, 3, 4);
     if (nargs == 4) {
@@ -1591,6 +1676,7 @@ JL_CALLABLE(jl_f_get_binding_type)
 
 JL_CALLABLE(jl_f_swapglobal)
 {
+    jl_check_rc("swapglobal!");
     enum jl_memory_order order = jl_memory_order_release;
     JL_NARGS(swapglobal!, 3, 4);
     if (nargs == 4) {
@@ -1610,6 +1696,7 @@ JL_CALLABLE(jl_f_swapglobal)
 
 JL_CALLABLE(jl_f_modifyglobal)
 {
+    jl_check_rc("modifyglobal!");
     enum jl_memory_order order = jl_memory_order_release;
     JL_NARGS(modifyglobal!, 4, 5);
     if (nargs == 5) {
@@ -1629,6 +1716,7 @@ JL_CALLABLE(jl_f_modifyglobal)
 
 JL_CALLABLE(jl_f_replaceglobal)
 {
+    jl_check_rc("replaceglobal!");
     enum jl_memory_order success_order = jl_memory_order_release;
     JL_NARGS(replaceglobal!, 4, 6);
     if (nargs >= 5) {
@@ -1658,6 +1746,7 @@ JL_CALLABLE(jl_f_replaceglobal)
 
 JL_CALLABLE(jl_f_setglobalonce)
 {
+    jl_check_rc("setglobalonce!");
     enum jl_memory_order success_order = jl_memory_order_release;
     JL_NARGS(setglobalonce!, 3, 5);
     if (nargs >= 4) {
@@ -1689,6 +1778,7 @@ JL_CALLABLE(jl_f_setglobalonce)
 // declare_global(module::Module, name::Symbol, [strong::Bool=false, [ty::Type]])
 JL_CALLABLE(jl_f_declare_global)
 {
+    jl_check_rc("declare_global");
     JL_NARGS(declare_global, 3, 4);
     JL_TYPECHK(declare_global, module, args[0]);
     JL_TYPECHK(declare_global, symbol, args[1]);
@@ -1705,6 +1795,7 @@ JL_CALLABLE(jl_f_declare_global)
 
 JL_CALLABLE(jl_f_declare_const)
 {
+    jl_check_rc("declare_const");
     JL_NARGS(declare_const, 2, 3);
     JL_TYPECHK(declare_const, module, args[0]);
     if (nargs == 3)
@@ -1719,6 +1810,7 @@ JL_CALLABLE(jl_f_declare_const)
 // define_method(module::Module, fname_or_mt, argdata, code) - define method
 JL_CALLABLE(jl_f_define_method)
 {
+    jl_check_rc("define_method");
     if (nargs != 2 && nargs != 4)
         jl_error("define_method requires 2 or 4 arguments");
     JL_TYPECHK(define_method, module, args[0]);
@@ -1765,6 +1857,7 @@ JL_CALLABLE(jl_f_define_method)
 //     _import(to::Module, mod::Module, asname::Symbol)
 JL_CALLABLE(jl_f__import)
 {
+    jl_check_rc("_import");
     JL_NARGS(_import, 3, 5);
     JL_TYPECHK(_import, module, args[0]);
     JL_TYPECHK(_import, module, args[1]);
@@ -1788,6 +1881,7 @@ JL_CALLABLE(jl_f__import)
 // _using(to::Module, from::Module)
 JL_CALLABLE(jl_f__using)
 {
+    jl_check_rc("_using");
     JL_NARGS(_using, 2, 3);
     JL_TYPECHK(_using, module, args[0]);
     JL_TYPECHK(_using, module, args[1]);
@@ -1910,6 +2004,7 @@ JL_CALLABLE(jl_f_applicable)
 
 JL_CALLABLE(jl_f_invoke)
 {
+    jl_check_rc("invoke");
     JL_NARGSV(invoke, 2);
     jl_value_t *argtypes = args[1];
     if (jl_is_method(argtypes)) {
@@ -1974,6 +2069,7 @@ jl_expr_t *jl_exprn(jl_sym_t *head, size_t n)
 
 JL_CALLABLE(jl_f__expr)
 {
+    jl_check_rc("_expr");
     jl_task_t *ct = jl_current_task;
     JL_NARGSV(Expr, 1);
     JL_TYPECHK(Expr, symbol, args[0]);
@@ -2015,6 +2111,7 @@ JL_CALLABLE(jl_f__typevar)
 // genericmemory ---------------------------------------------------------------------
 JL_CALLABLE(jl_f_memorynew)
 {
+    jl_check_rc("memorynew");
     JL_NARGS(memorynew, 2, 2);
     jl_datatype_t *jl_genericmemory_type_type = jl_datatype_type;
     JL_TYPECHK(memorynew, genericmemory_type, args[0]);
@@ -2100,6 +2197,7 @@ JL_CALLABLE(jl_f_memoryrefoffset)
 
 JL_CALLABLE(jl_f_memoryrefget)
 {
+    jl_check_rc("memoryrefget");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefget, 3, 3);
     JL_TYPECHK(memoryrefget, genericmemoryref, args[0]);
@@ -2125,6 +2223,7 @@ JL_CALLABLE(jl_f_memoryrefget)
 
 JL_CALLABLE(jl_f_memoryrefset)
 {
+    jl_check_rc("memoryrefset!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefset!, 4, 4);
     JL_TYPECHK(memoryrefset!, genericmemoryref, args[0]);
@@ -2151,6 +2250,7 @@ JL_CALLABLE(jl_f_memoryrefset)
 
 JL_CALLABLE(jl_f_memoryrefunset)
 {
+    jl_check_rc("memoryrefunset!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefunset!, 3, 3);
     JL_TYPECHK(memoryrefunset!, genericmemoryref, args[0]);
@@ -2177,6 +2277,7 @@ JL_CALLABLE(jl_f_memoryrefunset)
 
 JL_CALLABLE(jl_f_memoryref_isassigned)
 {
+    jl_check_rc("memoryref_isassigned");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryref_isassigned, 3, 3);
     JL_TYPECHK(memoryref_isassigned, genericmemoryref, args[0]);
@@ -2203,6 +2304,7 @@ JL_CALLABLE(jl_f_memoryref_isassigned)
 
 JL_CALLABLE(jl_f_memoryrefswap)
 {
+    jl_check_rc("memoryrefswap!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefswap!, 4, 4);
     JL_TYPECHK(memoryrefswap!, genericmemoryref, args[0]);
@@ -2228,6 +2330,7 @@ JL_CALLABLE(jl_f_memoryrefswap)
 
 JL_CALLABLE(jl_f_memoryrefmodify)
 {
+    jl_check_rc("memoryrefmodify!");
     enum jl_memory_order order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefmodify!, 5, 5);
     JL_TYPECHK(memoryrefmodify!, genericmemoryref, args[0]);
@@ -2253,6 +2356,7 @@ JL_CALLABLE(jl_f_memoryrefmodify)
 
 JL_CALLABLE(jl_f_memoryrefreplace)
 {
+    jl_check_rc("memoryrefreplace!");
     enum jl_memory_order success_order = jl_memory_order_notatomic;
     enum jl_memory_order failure_order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefreplace!, 6, 6);
@@ -2287,6 +2391,7 @@ JL_CALLABLE(jl_f_memoryrefreplace)
 
 JL_CALLABLE(jl_f_memoryrefsetonce)
 {
+    jl_check_rc("memoryrefsetonce!");
     enum jl_memory_order success_order = jl_memory_order_notatomic;
     enum jl_memory_order failure_order = jl_memory_order_notatomic;
     JL_NARGS(memoryrefsetonce!, 5, 5);
@@ -2323,6 +2428,7 @@ JL_CALLABLE(jl_f_memoryrefsetonce)
 
 JL_CALLABLE(jl_f__structtype)
 {
+    jl_check_rc("_structtype");
     JL_NARGS(_structtype, 7, 7);
     JL_TYPECHK(_structtype, module, args[0]);
     JL_TYPECHK(_structtype, symbol, args[1]);
@@ -2342,6 +2448,7 @@ JL_CALLABLE(jl_f__structtype)
 
 JL_CALLABLE(jl_f__abstracttype)
 {
+    jl_check_rc("_abstracttype");
     JL_NARGS(_abstracttype, 3, 3);
     JL_TYPECHK(_abstracttype, module, args[0]);
     JL_TYPECHK(_abstracttype, symbol, args[1]);
@@ -2352,6 +2459,7 @@ JL_CALLABLE(jl_f__abstracttype)
 
 JL_CALLABLE(jl_f__primitivetype)
 {
+    jl_check_rc("_primitivetype");
     JL_NARGS(_primitivetype, 4, 4);
     JL_TYPECHK(_primitivetype, module, args[0]);
     JL_TYPECHK(_primitivetype, symbol, args[1]);
@@ -2385,6 +2493,7 @@ static void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super) JL_CANSA
 
 JL_CALLABLE(jl_f__setsuper)
 {
+    jl_check_rc("_setsuper!");
     JL_NARGS(_setsuper!, 2, 2);
     jl_datatype_t *dt = (jl_datatype_t*)jl_unwrap_unionall(args[0]);
     JL_TYPECHK(_setsuper!, datatype, (jl_value_t*)dt);
@@ -2413,6 +2522,7 @@ JL_CALLABLE(jl_f_compilerbarrier)
 
 JL_CALLABLE(jl_f_finalizer)
 {
+    jl_check_rc("finalizer");
     // NOTE the compiler may temporarily insert additional argument for the later inlining pass
     JL_NARGS(finalizer, 2, 4);
     jl_task_t *ct = jl_current_task;
@@ -2469,6 +2579,7 @@ JL_CALLABLE(jl_f__svec_ref)
 
 JL_CALLABLE(jl_f__task)
 {
+    jl_check_rc("_task");
     JL_NARGS(_task, 2, 3);
     jl_value_t *start = args[0];
     JL_TYPECHK(_task, long, args[1]);
@@ -2487,6 +2598,7 @@ JL_CALLABLE(jl_f__task)
 
 JL_CALLABLE(jl_f_task_result_type)
 {
+    jl_check_rc("task_result_type");
     JL_NARGS(task_result_type, 1, 1);
     JL_TYPECHK(task_result_type, task, args[0]);
     // Without inference, this returns Any, but inference can inject other Types here
@@ -2555,6 +2667,7 @@ int references_name(jl_value_t *p, jl_typename_t *name, int affects_layout, int 
 
 JL_CALLABLE(jl_f__typebody)
 {
+    jl_check_rc("_typebody!");
     JL_NARGS(_typebody!, 1, 2);
     jl_datatype_t *dt = (jl_datatype_t*)jl_unwrap_unionall(args[0]);
     JL_TYPECHK(_typebody!, datatype, (jl_value_t*)dt);
@@ -2663,6 +2776,7 @@ int equiv_type(jl_value_t *ta, jl_value_t *tb) JL_CANSAFEPOINT
 
 JL_CALLABLE(jl_f__equiv_typedef)
 {
+    jl_check_rc("_equiv_typedef");
     JL_NARGS(_equiv_typedef, 2, 2);
     return equiv_type(args[0], args[1]) ? jl_true : jl_false;
 }
@@ -2678,8 +2792,12 @@ JL_CALLABLE(jl_f_intrinsic_call)
     if (f == cglobal && nargs == 1)
         f = cglobal_auto;
     unsigned fargs = intrinsic_nargs[f];
-    if (!fargs)
+    if (!fargs) {
+        // compiler-required intrinsics (llvmcall) run native code the mode's
+        // traps cannot see
+        jl_check_rc(jl_intrinsic_name(f));
         jl_errorf("`%s` requires the compiler", jl_intrinsic_name(f));
+    }
     JL_NARGS(intrinsic_call, fargs, fargs);
 
     union {

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -320,6 +320,14 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     memcpy(&save_rngState[0], &ct->rngState[0], sizeof(save_rngState));
     jl_rng_split(ct->rngState, finalizer_rngState);
     int last_errno = errno;
+    // Finalizers may fire at allocation safepoints inside RCJulia mode; they
+    // are semantically outside the restricted computation (which cannot
+    // observe their effects, since it cannot read mutable memory), so
+    // suspend the mode while they run rather than trapping unrelated code.
+    uint16_t last_rc = ct->rcjulia;
+    jl_rc_frame_t *last_rc_frames = ct->rc_frames;
+    ct->rcjulia = 0;
+    ct->rc_frames = NULL;
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
 #endif
@@ -331,6 +339,8 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
     ct->ptls->in_finalizer = was_in_finalizer;
     arraylist_free(&copied_list);
 
+    ct->rcjulia = last_rc;
+    ct->rc_frames = last_rc_frames;
     memcpy(&ct->rngState[0], &save_rngState[0], sizeof(save_rngState));
 #ifdef _OS_WINDOWS_
     SetLastError(last_error);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -112,6 +112,8 @@ static jl_value_t *eval_methoddef(jl_expr_t *ex, interpreter_state *s) JL_CANSAF
 
 // expression evaluator
 
+static jl_value_t *interpret_call(jl_method_instance_t *mi, jl_value_t *f, jl_value_t **args, uint32_t nargs) JL_CANSAFEPOINT;
+
 static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s) JL_CANSAFEPOINT
 {
     jl_value_t **argv;
@@ -120,7 +122,11 @@ static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s
     size_t i;
     for (i = 0; i < nargs; i++)
         argv[i] = eval_value(args[i], s);
-    jl_value_t *result = jl_apply(argv, nargs);
+    jl_value_t *result;
+    if (__unlikely(jl_current_task->rcjulia))
+        result = jl_rc_apply(argv, nargs);
+    else
+        result = jl_apply(argv, nargs);
     JL_GC_POP();
     return result;
 }
@@ -136,6 +142,17 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
     jl_value_t *c = args[0];
     assert(jl_is_code_instance(c) || jl_is_method_instance(c));
     jl_value_t *result = NULL;
+    if (__unlikely(jl_current_task->rcjulia)) {
+        // RCJulia mode never runs native code (v1): re-route the
+        // invoke target through the interpreter so its operations stay
+        // checked. (Only reachable from generated-function-produced IR;
+        // uninferred lowered source contains no :invoke.)
+        jl_method_instance_t *mi = jl_is_code_instance(c) ?
+            jl_get_ci_mi((jl_code_instance_t*)c) : (jl_method_instance_t*)c;
+        result = interpret_call(mi, argv[0], &argv[1], nargs - 2);
+        JL_GC_POP();
+        return result;
+    }
     if (jl_is_code_instance(c)) {
         jl_code_instance_t *codeinst = (jl_code_instance_t*)c;
         assert(jl_atomic_load_relaxed(&codeinst->min_world) <= jl_current_task->world_age &&
@@ -234,10 +251,16 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         return jl_quotenode_value(e);
     }
     if (jl_is_globalref(e)) {
-        return jl_eval_globalref((jl_globalref_t*)e, jl_current_task->world_age);
+        jl_task_t *ct = jl_current_task;
+        if (__unlikely(ct->rcjulia))
+            return jl_rc_globalref_value(jl_globalref_mod(e), jl_globalref_name(e), ct->world_age);
+        return jl_eval_globalref((jl_globalref_t*)e, ct->world_age);
     }
     if (jl_is_symbol(e)) {  // bare symbols appear in toplevel exprs not wrapped in `thunk`
-        return jl_eval_global_var(s->module, (jl_sym_t*)e, jl_current_task->world_age);
+        jl_task_t *ct = jl_current_task;
+        if (__unlikely(ct->rcjulia))
+            return jl_rc_globalref_value(s->module, (jl_sym_t*)e, ct->world_age);
+        return jl_eval_global_var(s->module, (jl_sym_t*)e, ct->world_age);
     }
     if (jl_is_pinode(e)) {
         jl_value_t *val = eval_value(jl_fieldref_noalloc(e, 0), s);
@@ -311,6 +334,9 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         JL_GC_PUSHARGS(argv, nargs);
         for (size_t i = 0; i < nargs; i++)
             argv[i] = eval_value(args[i], s);
+        if (__unlikely(jl_current_task->rcjulia) && jl_is_datatype(argv[0]) &&
+                jl_is_mutable_datatype(argv[0]))
+            jl_capability_error("new");
         jl_value_t *v = jl_new_structv((jl_datatype_t*)argv[0], &argv[1], nargs - 1);
         JL_GC_POP();
         return v;
@@ -320,11 +346,15 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         JL_GC_PUSHARGS(argv, 2);
         argv[0] = eval_value(args[0], s);
         argv[1] = eval_value(args[1], s);
+        if (__unlikely(jl_current_task->rcjulia) && jl_is_datatype(argv[0]) &&
+                jl_is_mutable_datatype(argv[0]))
+            jl_capability_error("new");
         jl_value_t *v = jl_new_structt((jl_datatype_t*)argv[0], argv[1]);
         JL_GC_POP();
         return v;
     }
     else if (head == jl_new_opaque_closure_sym) {
+        jl_check_rc("new_opaque_closure");
         jl_value_t **argv;
         JL_GC_PUSHARGS(argv, nargs);
         for (size_t i = 0; i < nargs; i++)
@@ -364,6 +394,9 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         jl_error("could not determine static parameter value");
     }
     else if (head == jl_copyast_sym) {
+        // quoted `Expr` literals materialize a fresh mutable AST copy per
+        // evaluation: both a mutable allocation and an egal-unstable result
+        jl_check_rc("copyast");
         return jl_copy_ast(eval_value(args[0], s));
     }
     else if (head == jl_exc_sym) {
@@ -383,12 +416,15 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         return jl_nothing;
     }
     else if (head == jl_method_sym && nargs == 1) {
+        jl_check_rc("method");
         return eval_methoddef(ex, s);
     }
     else if (head == jl_foreigncall_sym) {
+        jl_check_rc("foreigncall");
         jl_error("`ccall` requires the compiler");
     }
     else if (head == jl_foreignglobal_sym) {
+        jl_check_rc("foreignglobal");
         assert(nargs == 1);
         jl_value_t *fptr = jl_exprarg(ex, 0);
         if (jl_is_quotenode(fptr)) {
@@ -423,6 +459,7 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         return r;
     }
     else if (head == jl_cfunction_sym) {
+        jl_check_rc("cfunction");
         jl_error("`cfunction` requires the compiler");
     }
     jl_errorf("unsupported or misplaced expression %s", jl_symbol_name(head));
@@ -858,7 +895,14 @@ jl_value_t *jl_code_or_ci_for_interpreter(jl_method_instance_t *mi JL_PROPAGATES
     jl_value_t *ret = NULL;
     jl_code_info_t *src = NULL;
     if (jl_is_method(mi->def.value)) {
-        if (mi->def.method->source) {
+        // For dual-body (`if @generated`) methods the interpreter normally
+        // runs the fallback source, but under RCJulia mode we prefer
+        // the generated expansion: it is what compiled execution uses, and
+        // fallback bodies are commonly impure in ways the expansion is not
+        // (e.g. `ntuple`'s fallback consults `Base._return_type`). The choice
+        // is a fixed function of the mode, so it stays consistent.
+        int prefer_expansion = jl_current_task->rcjulia && mi->def.method->generator != NULL;
+        if (mi->def.method->source && !prefer_expansion) {
             jl_method_t *m = mi->def.method;
             // Acquire pairs with the release publish below: a reader that sees
             // the uncompressed CodeInfo pointer must also see its contents.
@@ -915,12 +959,209 @@ jl_code_info_t *jl_code_for_interpreter(jl_method_instance_t *mi, size_t world)
     return (jl_code_info_t*)code_or_ci;
 }
 
+// RCJulia mode (`Core._rcjulia_call`)
+
+// Reject any control flow that could re-execute a statement: termination of
+// RCJulia code is structural, not proven. Statement `i` (0-based) is branch
+// label `i + 1` (1-based), so a legal (forward) branch target must be
+// strictly greater than `i + 1`. `EnterNode` catch destinations are forward
+// in front-end-lowered IR, but are checked too since generated functions may
+// return arbitrary IR.
+static void rc_check_no_backedges(jl_code_info_t *src) JL_CANSAFEPOINT
+{
+    jl_array_t *stmts = src->code;
+    size_t ns = jl_array_nrows(stmts);
+    for (size_t i = 0; i < ns; i++) {
+        jl_value_t *stmt = jl_array_ptr_ref(stmts, i);
+        size_t target = 0;
+        if (jl_is_gotonode(stmt))
+            target = jl_gotonode_label(stmt);
+        else if (jl_is_gotoifnot(stmt))
+            target = jl_gotoifnot_label(stmt);
+        else if (jl_is_enternode(stmt))
+            target = jl_enternode_catch_dest(stmt); // 0 if no catch
+        if (target && target <= i + 1)
+            jl_capability_error("backedge");
+    }
+}
+
+// --- well-founded recursion order ---
+//
+// Re-entering a method that already has an active RCJulia frame is permitted
+// only if the arguments strictly decrease in the order defined here:
+// structurally smaller types are smaller, and at equal types, smaller values
+// interpreted as bitstypes are smaller. The order is well-founded (no
+// infinite strictly-decreasing chains), and the method table is frozen
+// inside the mode, so an infinite call chain would require infinitely many
+// occurrences of some single method — impossible when each successive
+// occurrence must decrease. Every call chain is therefore finite by
+// construction; the depth cap below is only a physical stack backstop.
+//
+// TODO: allow methods to supply a custom well-founded relation (cf.
+// `Method.recursion_relation` used by inference), checked/trusted per the
+// mode's rules.
+
+static size_t rc_type_size(jl_value_t *t) JL_NOTSAFEPOINT;
+
+static size_t rc_term_size(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    if (jl_is_type(t) || jl_is_vararg(t))
+        return rc_type_size(t);
+    return 1; // bits values, symbols and other leaves
+}
+
+// number of nodes in the type term, counting non-type parameters as leaves
+static size_t rc_type_size(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    if (jl_is_datatype(t)) {
+        size_t sz = 1;
+        jl_svec_t *p = ((jl_datatype_t*)t)->parameters;
+        for (size_t i = 0; i < jl_svec_len(p); i++)
+            sz += rc_term_size(jl_svecref(p, i));
+        return sz;
+    }
+    if (jl_is_uniontype(t))
+        return 1 + rc_type_size(((jl_uniontype_t*)t)->a) + rc_type_size(((jl_uniontype_t*)t)->b);
+    if (jl_is_unionall(t)) {
+        jl_unionall_t *ua = (jl_unionall_t*)t;
+        return 1 + rc_type_size(ua->var->lb) + rc_type_size(ua->var->ub) + rc_type_size(ua->body);
+    }
+    if (jl_is_vararg(t)) {
+        jl_vararg_t *v = (jl_vararg_t*)t;
+        return 1 + (v->T ? rc_term_size(v->T) : 0) + (v->N ? rc_term_size(v->N) : 0);
+    }
+    return 1; // TypeVar occurrences and other leaves
+}
+
+// three-way comparison of two isbits values of the same concrete type:
+// primitive types compare their bit pattern as an unsigned (little-endian)
+// integer; composite types compare field-lexicographically, which never
+// looks at padding bytes. Returns -1/0/1, or 2 for incomparable (inline
+// union fields, kept out of scope for now).
+static int rc_bits_cmp(jl_datatype_t *dt, const char *pa, const char *pb) JL_NOTSAFEPOINT
+{
+    if (jl_is_primitivetype(dt)) {
+        size_t nb = jl_datatype_size(dt);
+        for (size_t i = nb; i-- > 0; ) {
+            uint8_t av = ((const uint8_t*)pa)[i], bv = ((const uint8_t*)pb)[i];
+            if (av != bv)
+                return av < bv ? -1 : 1;
+        }
+        return 0;
+    }
+    assert(jl_is_datatype(dt));
+    size_t nf = jl_datatype_nfields(dt);
+    for (size_t i = 0; i < nf; i++) {
+        jl_value_t *ft = jl_field_type_concrete(dt, i);
+        if (!jl_is_datatype(ft))
+            return 2;
+        int c = rc_bits_cmp((jl_datatype_t*)ft, pa + jl_field_offset(dt, i), pb + jl_field_offset(dt, i));
+        if (c != 0)
+            return c;
+    }
+    return 0;
+}
+
+static int rc_type_smaller(jl_value_t *t, jl_value_t *s) JL_CANSAFEPOINT;
+
+// order on type parameters: types compare as type terms; other parameter
+// values (Val payloads, tuple lengths, ...) compare as bits at equal type
+static int rc_param_smaller(jl_value_t *p, jl_value_t *q) JL_CANSAFEPOINT
+{
+    if (jl_is_type(p) && jl_is_type(q))
+        return rc_type_smaller(p, q);
+    jl_value_t *tp = jl_typeof(p);
+    if (tp == jl_typeof(q) && jl_is_datatype(tp) && jl_isbits(tp))
+        return rc_bits_cmp((jl_datatype_t*)tp, (const char*)p, (const char*)q) == -1;
+    return 0;
+}
+
+// structural order on type terms: smaller size is smaller; at equal size,
+// the same type constructor may descend lexicographically through its
+// parameters (this is what orders `Val{2}` below `Val{3}`)
+static int rc_type_smaller(jl_value_t *t, jl_value_t *s)
+{
+    size_t szt = rc_type_size(t), szs = rc_type_size(s);
+    if (szt != szs)
+        return szt < szs;
+    if (!jl_is_datatype(t) || !jl_is_datatype(s))
+        return 0;
+    jl_datatype_t *dt = (jl_datatype_t*)t, *ds = (jl_datatype_t*)s;
+    if (dt->name != ds->name)
+        return 0;
+    jl_svec_t *pt = dt->parameters, *ps = ds->parameters;
+    size_t np = jl_svec_len(pt);
+    if (np != jl_svec_len(ps))
+        return 0;
+    for (size_t i = 0; i < np; i++) {
+        jl_value_t *p = jl_svecref(pt, i), *q = jl_svecref(ps, i);
+        if (jl_egal(p, q))
+            continue;
+        return rc_param_smaller(p, q);
+    }
+    return 0; // egal
+}
+
+static int rc_value_smaller(jl_value_t *a, jl_value_t *b) JL_CANSAFEPOINT
+{
+    if (jl_is_type(a) && jl_is_type(b))
+        return rc_type_smaller(a, b);
+    jl_value_t *ta = jl_typeof(a);
+    if (ta != jl_typeof(b))
+        return rc_type_smaller(ta, jl_typeof(b));
+    if (jl_is_datatype(ta) && jl_isbits(ta))
+        return rc_bits_cmp((jl_datatype_t*)ta, (const char*)a, (const char*)b) == -1;
+    return 0; // same non-bits type, not egal: no order (v1)
+}
+
+// shortlex over the argument list: fewer arguments is smaller (tuple
+// peeling through Vararg methods); at equal length, the first non-egal
+// position must decrease. An egal re-entry is never smaller — and under
+// the mode's consistency it is guaranteed to diverge, so rejecting it
+// loses no terminating program.
+static int rc_args_smaller(jl_value_t *newf, jl_value_t **newargs, uint32_t nnew,
+                           jl_value_t *oldf, jl_value_t **oldargs, uint32_t nold) JL_CANSAFEPOINT
+{
+    if (nnew != nold)
+        return nnew < nold;
+    if (!jl_egal(newf, oldf))
+        return rc_value_smaller(newf, oldf);
+    for (uint32_t i = 0; i < nnew; i++) {
+        jl_value_t *a = newargs[i], *b = oldargs[i];
+        if (jl_egal(a, b))
+            continue;
+        return rc_value_smaller(a, b);
+    }
+    return 0;
+}
+
+// Apply `args` (with args[0] the callable) under RCJulia mode.
+// Builtins and intrinsics carry their traps in their C implementations, so
+// they may run their (native) fptrs; generic methods are forced through the
+// interpreter so that every primitive operation they perform stays checked.
+JL_DLLEXPORT jl_value_t *jl_rc_apply(jl_value_t **args, size_t nargs)
+{
+    jl_task_t *ct = jl_current_task;
+    assert(ct->rcjulia);
+    assert(nargs >= 1);
+    jl_value_t *f = args[0];
+    if (jl_isa(f, (jl_value_t*)jl_builtin_type) || jl_typeof(f) == (jl_value_t*)jl_intrinsic_type)
+        return jl_apply(args, nargs);
+    if (jl_is_opaque_closure(f))
+        jl_capability_error("opaque_closure");
+    size_t world = ct->world_age;
+    jl_method_instance_t *mi = jl_method_lookup(args, nargs, world);
+    if (mi == NULL)
+        jl_method_error(f, &args[1], nargs, world);
+    JL_GC_PROMISE_ROOTED(mi); // rooted through the method's specialization cache
+    return interpret_call(mi, f, &args[1], nargs - 1);
+}
+
 // interpreter entry points
 
-jl_value_t *NOINLINE jl_fptr_interpret_call(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *codeinst)
+static jl_value_t *NOINLINE interpret_call(jl_method_instance_t *mi, jl_value_t *f, jl_value_t **args, uint32_t nargs)
 {
     interpreter_state *s;
-    jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
     jl_task_t *ct = jl_current_task;
     size_t world = ct->world_age;
     jl_code_info_t *src = NULL;
@@ -964,12 +1205,53 @@ jl_value_t *NOINLINE jl_fptr_interpret_call(jl_value_t *f, jl_value_t **args, ui
     s->sparam_vals = mi->sparam_vals;
     s->preevaluation = 0;
     s->continue_at = 0;
+    // The RCJulia checks below may throw before eval_body ever assigns
+    // s->ip; leaving it uninitialized would put stack garbage into any
+    // captured backtrace frame.
+    s->ip = 0;
     s->mi = mi;
     s->ci = ci;
     JL_GC_ENABLEFRAME(s);
+    jl_rc_frame_t rcframe;
+    int rc = ct->rcjulia != 0;
+    if (__unlikely(rc)) {
+        rc_check_no_backedges(src);
+        uint32_t depth = ct->rc_frames ? ct->rc_frames->depth + 1 : 1;
+        if (depth > JL_RC_MAX_DEPTH)
+            jl_capability_error("depth_limit");
+        jl_method_t *method = jl_is_method(mi->def.value) ? mi->def.method : NULL;
+        if (method != NULL) {
+            // well-founded recursion: compare against the innermost active
+            // frame of the same method (adjacent decreases suffice for
+            // well-foundedness; no transitivity needed)
+            for (jl_rc_frame_t *pf = ct->rc_frames; pf != NULL; pf = pf->prev) {
+                if (pf->method == method) {
+                    if (!rc_args_smaller(f, args, nargs, pf->f, pf->args, pf->nargs))
+                        jl_capability_error("recursion");
+                    break;
+                }
+            }
+        }
+        rcframe.method = method;
+        rcframe.f = f;
+        rcframe.args = args; // rooted by the calling frame for this frame's extent
+        rcframe.nargs = nargs;
+        rcframe.depth = depth;
+        rcframe.prev = ct->rc_frames;
+        ct->rc_frames = &rcframe;
+        // exceptional exits restore ct->rc_frames via the handler chain
+        // (see jl_eh_restore_state)
+    }
     jl_value_t *r = eval_body(stmts, s, 0, 0);
+    if (__unlikely(rc))
+        ct->rc_frames = rcframe.prev;
     JL_GC_POP();
     return r;
+}
+
+jl_value_t *NOINLINE jl_fptr_interpret_call(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *codeinst)
+{
+    return interpret_call(jl_get_ci_mi(codeinst), f, args, nargs);
 }
 
 JL_DLLEXPORT const jl_callptr_t jl_fptr_interpret_call_addr = &jl_fptr_interpret_call;

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -29,6 +29,7 @@
     XX(bool_type, jl_datatype_t*) \
     XX(bottom_type, jl_value_t*) \
     XX(boundserror_type, jl_datatype_t*) \
+    XX(capabilityerror_type, jl_datatype_t*) \
     XX(builtin_type, jl_datatype_t*) \
     XX(cancel_source_type, jl_datatype_t*) \
     XX(char_type, jl_datatype_t*) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4558,6 +4558,7 @@ void post_boot_hooks(void)
     jl_undefvarerror_type    = (jl_datatype_t*)core("UndefVarError");
     jl_fielderror_type       = (jl_datatype_t*)core("FieldError");
     jl_atomicerror_type      = (jl_datatype_t*)core("ConcurrencyViolationError");
+    jl_capabilityerror_type      = (jl_datatype_t*)core("CapabilityError");
     jl_boundserror_type      = (jl_datatype_t*)core("BoundsError");
     jl_typeerror_type        = (jl_datatype_t*)core("TypeError");
     jl_argumenterror_type    = (jl_datatype_t*)core("ArgumentError");

--- a/src/julia.h
+++ b/src/julia.h
@@ -2573,6 +2573,11 @@ struct _jl_handler_t {
     // Published ccall handler (if any). Used if we must unwind across a C function
     // that calls back into julia.
     struct _jl_cancel_handler_ctx_t *cancel_handler_ctx;
+    // The innermost RCJulia-mode interpreter frame at handler entry
+    // (see `jl_task_t->rc_frames`). Restored on unwind so an exception
+    // thrown out of interpreted pure frames does not leave the chain pointing
+    // into C stack frames the unwind destroyed.
+    struct _jl_rc_frame_t *rc_frames;
     sig_atomic_t defer_signal;
     int8_t gc_state;
     // Saved `bound_cancel_default` flag, restored with `bound_cancel_token`

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -947,6 +947,49 @@ JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t
 void JL_NORETURN jl_method_error(jl_value_t *F, jl_value_t **args, size_t na, size_t world) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_get_exceptionf(jl_datatype_t *exception_type, const char *fmt, ...) JL_CANSAFEPOINT;
 
+// RCJulia — restricted-capability evaluation mode (`Core._rcjulia_call`) ----
+
+// An interpreter frame executing under RCJulia mode. Nodes live on the
+// interpreter's C stack, chained through `jl_task_t->rc_frames`; the chain
+// implements the well-founded recursion check and the physical depth
+// backstop. `f`/`args` point into the calling frame's rooted argument
+// buffer, which outlives this frame; `method` is NULL for non-method frames.
+typedef struct _jl_rc_frame_t {
+    jl_method_t *method;
+    jl_value_t *f;
+    jl_value_t **args;
+    uint32_t nargs;
+    uint32_t depth;
+    struct _jl_rc_frame_t *prev;
+} jl_rc_frame_t;
+
+// Physical stack backstop for RCJulia frames. Termination is guaranteed by
+// the well-founded recursion order (see interpreter.c), but well-founded
+// chains can still be astronomically long, and a machine StackOverflowError
+// is not `:consistent` — so a fixed, platform-independent frame cap must
+// fire deterministically first.
+#define JL_RC_MAX_DEPTH 1000
+
+JL_DLLEXPORT void JL_NORETURN jl_capability_error(const char *op) JL_CANSAFEPOINT;
+// Trap executed by builtins and runtime intrinsics whose semantics require a
+// capability RCJulia mode withholds. The trap is deterministic (a function
+// of the operation alone), which is what keeps even violating programs
+// `:consistent`.
+STATIC_INLINE void jl_check_rc(const char *op) JL_CANSAFEPOINT
+{
+    if (__unlikely(jl_current_task->rcjulia))
+        jl_capability_error(op);
+}
+JL_DLLEXPORT jl_value_t *jl_rc_apply(jl_value_t **args, size_t nargs) JL_CANSAFEPOINT;
+// classify binding (m.s) at `world` for RCJulia mode:
+// returns 1 if it is a defined constant (sets *val), 0 if it is undefined
+// (guard or valueless `const`/`global` declaration), -1 if it is a mutable
+// global (or otherwise not legal to read under the mode)
+JL_DLLEXPORT int jl_rc_binding_constant(jl_module_t *m, jl_sym_t *s, size_t world, jl_value_t **val) JL_CANSAFEPOINT;
+// read global (m.s) at `world` under RCJulia mode, throwing
+// CapabilityError for mutable globals and UndefVarError for undefined ones
+JL_DLLEXPORT jl_value_t *jl_rc_globalref_value(jl_module_t *m, jl_sym_t *s, size_t world) JL_CANSAFEPOINT;
+
 JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t) JL_CANSAFEPOINT;
 
 #define JL_CALLABLE(name)                                               \
@@ -1789,10 +1832,10 @@ STATIC_INLINE int is_valid_intrinsic_elptr(jl_value_t *ety)
 }
 JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align) JL_CANSAFEPOINT;
-JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i);
-JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order, jl_value_t *syncscope);
+JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order, jl_value_t *syncscope) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerref(jl_value_t *p, jl_value_t *order) JL_CANSAFEPOINT;
-JL_DLLEXPORT jl_value_t *jl_atomic_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *order);
+JL_DLLEXPORT jl_value_t *jl_atomic_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *order) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerswap(jl_value_t *p, jl_value_t *x, jl_value_t *order) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_atomic_pointermodify(jl_value_t *p, jl_value_t *f, jl_value_t *x, jl_value_t *order) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerreplace(jl_value_t *p, jl_value_t *x, jl_value_t *expected, jl_value_t *success_order, jl_value_t *failure_order) JL_CANSAFEPOINT;
@@ -1878,7 +1921,7 @@ JL_DLLEXPORT jl_value_t *jl_abs_float(jl_value_t *a) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_copysign_float(jl_value_t *a, jl_value_t *b) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_flipsign_int(jl_value_t *a, jl_value_t *b) JL_CANSAFEPOINT;
 
-JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *a) JL_CANSAFEPOINT;
 JL_DLLEXPORT int jl_stored_inline(jl_value_t *el_type) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 JL_DLLEXPORT jl_array_t *jl_array_copy(jl_array_t *ary) JL_CANSAFEPOINT;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -554,12 +554,17 @@ typedef struct _jl_task_t {
     // Bit 1-2: 0-3 counter of how many times we've reentered inference
     // Bit 3: 1 if we are writing the image and inference is illegal
     uint8_t reentrant_timing;
-    // 2 bytes of padding on 32-bit, 6 bytes on 64-bit
-    // uint16_t padding2_32;
-    // uint48_t padding2_64;
+    // nonzero while this task executes inside RCJulia mode
+    // (`Core._rcjulia_call`); counts the nesting depth of mode entries
+    uint16_t rcjulia;
+    // 2 bytes of padding
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
     size_t world_age;
+    // innermost interpreter frame executing under RCJulia mode, or
+    // NULL; the chain (through the C stack) implements the recursion-cycle
+    // and depth traps of the mode
+    struct _jl_rc_frame_t *rc_frames;
     // quick lookup for current ptls
     jl_ptls_t ptls; // == jl_all_tls_states[tid]
 #ifdef USE_TRACY

--- a/src/method.c
+++ b/src/method.c
@@ -801,8 +801,17 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi JL_PROP
     int last_lineno = jl_atomic_load_relaxed(&jl_lineno);
     int last_in = ct->ptls->in_pure_callback;
     size_t last_age = ct->world_age;
+    // Generator expansion is always permitted, even when reached from pure
+    // evaluation mode: generators are already language-contractually required
+    // to be pure functions of their argument types, and trapping only when
+    // the expansion is uncached would make behavior depend on cache warmth
+    // (i.e. not be consistent). Suspend the mode while the generator runs.
+    uint16_t last_rc = ct->rcjulia;
+    jl_rc_frame_t *last_rc_frames = ct->rc_frames;
 
     JL_TRY {
+        ct->rcjulia = 0;
+        ct->rc_frames = NULL;
         ct->ptls->in_pure_callback = 1;
         ct->world_age = jl_atomic_load_relaxed(&def->primary_world);
         if (ct->world_age > jl_atomic_load_acquire(&jl_world_counter))
@@ -900,10 +909,14 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi JL_PROP
         ct->ptls->in_pure_callback = last_in;
         jl_atomic_store_relaxed(&jl_lineno, last_lineno);
         ct->world_age = last_age;
+        ct->rcjulia = last_rc;
+        ct->rc_frames = last_rc_frames;
     }
     JL_CATCH {
         ct->ptls->in_pure_callback = last_in;
         jl_atomic_store_relaxed(&jl_lineno, last_lineno);
+        ct->rcjulia = last_rc;
+        ct->rc_frames = last_rc_frames;
         jl_rethrow();
     }
     JL_GC_POP();

--- a/src/module.c
+++ b/src/module.c
@@ -1064,6 +1064,40 @@ JL_DLLEXPORT jl_value_t *jl_get_binding_value_in_world(jl_binding_t *b, size_t w
     return jl_atomic_load_relaxed(&b->value);
 }
 
+// RCJulia mode: classify binding (m.s) at `world`.
+// Returns 1 if the binding is a defined constant there (sets *val), 0 if it is
+// undefined (guard, failed import, or a valueless `const`/`global` declaration
+// with no value slot to read), and -1 if reading it would observe mutable
+// state (an assignable global). Constants are read without the backdated-const
+// admonition: printing would be a side effect, and the value itself is fixed
+// within the (frozen) world.
+JL_DLLEXPORT int jl_rc_binding_constant(jl_module_t *m, jl_sym_t *s, size_t world, jl_value_t **val)
+{
+    jl_binding_t *b = jl_get_module_binding(m, s, 1);
+    jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
+    jl_walk_binding_inplace(&b, &bpart, world);
+    enum jl_partition_kind kind = jl_binding_kind(bpart);
+    if (jl_bkind_is_defined_constant(kind)) {
+        *val = bpart->restriction;
+        return 1;
+    }
+    *val = NULL;
+    if (jl_bkind_is_some_guard(kind) || kind == PARTITION_KIND_UNDEF_CONST)
+        return 0;
+    return -1;
+}
+
+JL_DLLEXPORT jl_value_t *jl_rc_globalref_value(jl_module_t *m, jl_sym_t *s, size_t world)
+{
+    jl_value_t *v = NULL;
+    int kind = jl_rc_binding_constant(m, s, world, &v);
+    if (kind < 0)
+        jl_capability_error("getglobal");
+    if (kind == 0)
+        jl_undefined_var_error(s, (jl_value_t*)m);
+    return v;
+}
+
 // Read a binding's value at `world`, warning if it is deprecated (unless reached through an
 // explicit import, which `jl_walk_binding_inplace_depwarn` suppresses).
 static jl_value_t *jl_get_binding_value_depwarn_(jl_binding_t *b, size_t world, int seqcst) JL_CANSAFEPOINT

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -216,6 +216,9 @@ int jl_tupletype_length_compat(jl_value_t *v, size_t nargs)
 
 JL_CALLABLE(jl_f_opaque_closure_call) JL_CANSAFEPOINT
 {
+    // opaque closures capture their own world and may carry native code the
+    // mode's traps cannot see (v1 restriction)
+    jl_check_rc("opaque_closure");
     jl_opaque_closure_t *oc = (jl_opaque_closure_t*)F;
     jl_value_t *argt = jl_tparam0(jl_typeof(oc));
     if (!jl_tupletype_length_compat(argt, nargs))

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -186,6 +186,14 @@ JL_DLLEXPORT void JL_NORETURN JL_NO_SAFEPOINT_ANALYSIS jl_atomic_error(char *str
     jl_throw(jl_new_struct(jl_atomicerror_type, msg));
 }
 
+JL_DLLEXPORT void JL_NORETURN jl_capability_error(const char *op)
+{
+    // The exception is constructed from the operation name alone so that the
+    // trap is a deterministic function of the operation attempted, keeping
+    // even violating programs `:consistent`.
+    jl_throw(jl_new_struct(jl_capabilityerror_type, (jl_value_t*)jl_symbol(op)));
+}
+
 
 JL_DLLEXPORT void JL_NORETURN JL_NO_SAFEPOINT_ANALYSIS jl_bounds_error(jl_value_t *v, jl_value_t *t)
 {
@@ -271,6 +279,7 @@ JL_DLLEXPORT void jl_enter_handler(jl_task_t *ct, jl_handler_t *eh)
     eh->bound_cancel_token = jl_atomic_load_relaxed(&ct->bound_cancel_token);
     eh->bound_cancel_default = ct->bound_cancel_default;
     eh->cancel_handler_ctx = jl_atomic_load_relaxed(&ct->cancel_handler_ctx);
+    eh->rc_frames = ct->rc_frames;
     eh->gc_state = jl_atomic_load_relaxed(&ct->ptls->gc_state);
     eh->locks_len = ct->ptls->locks.len;
     eh->defer_signal = ct->ptls->defer_signal;
@@ -306,6 +315,7 @@ JL_DLLEXPORT void jl_eh_restore_state(jl_task_t *ct, jl_handler_t *eh) JL_NO_SAF
     jl_gc_wb_current_task(ct, eh->bound_cancel_token);
     jl_atomic_store_release(&ct->reset_ctx, eh->reset_ctx);
     jl_atomic_store_release(&ct->cancel_handler_ctx, eh->cancel_handler_ctx);
+    ct->rc_frames = eh->rc_frames;
     jl_gc_wb_current_task(ct, eh->scope);
     ct->scope = eh->scope;
     small_arraylist_t *locks = &ptls->locks;
@@ -354,6 +364,7 @@ JL_DLLEXPORT void jl_eh_restore_state_noexcept(jl_task_t *ct, jl_handler_t *eh)
     jl_gc_wb_current_task(ct, eh->bound_cancel_token);
     jl_atomic_store_release(&ct->reset_ctx, eh->reset_ctx);
     jl_atomic_store_release(&ct->cancel_handler_ctx, eh->cancel_handler_ctx);
+    ct->rc_frames = eh->rc_frames;
     ct->ptls->defer_signal = eh->defer_signal; // optional, but certain try-finally (in stream.jl) may be slightly harder to write without this
 }
 

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -422,6 +422,7 @@ JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v)
 // run time version of pointerref intrinsic (warning: i is not rooted)
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align)
 {
+    jl_check_rc("pointerref");
     JL_TYPECHK(pointerref, pointer, p);
     JL_TYPECHK(pointerref, long, i)
     JL_TYPECHK(pointerref, long, align);
@@ -442,6 +443,7 @@ JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t 
 // run time version of pointerset intrinsic (warning: x is not gc-rooted)
 JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i, jl_value_t *align)
 {
+    jl_check_rc("pointerset");
     JL_TYPECHK(pointerset, pointer, p);
     JL_TYPECHK(pointerset, long, i);
     JL_TYPECHK(pointerset, long, align);
@@ -465,6 +467,7 @@ JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t 
 
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerref(jl_value_t *p, jl_value_t *order)
 {
+    jl_check_rc("atomic_pointerref");
     JL_TYPECHK(atomic_pointerref, pointer, p);
     JL_TYPECHK(atomic_pointerref, symbol, order)
     (void)jl_get_atomic_order_checked((jl_sym_t*)order, 1, 0);
@@ -485,6 +488,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerref(jl_value_t *p, jl_value_t *order)
 
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *order)
 {
+    jl_check_rc("atomic_pointerset");
     JL_TYPECHK(atomic_pointerset, pointer, p);
     JL_TYPECHK(atomic_pointerset, symbol, order);
     (void)jl_get_atomic_order_checked((jl_sym_t*)order, 0, 1);
@@ -508,6 +512,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerset(jl_value_t *p, jl_value_t *x, jl_v
 
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerswap(jl_value_t *p, jl_value_t *x, jl_value_t *order)
 {
+    jl_check_rc("atomic_pointerswap");
     JL_TYPECHK(atomic_pointerswap, pointer, p);
     JL_TYPECHK(atomic_pointerswap, symbol, order);
     (void)jl_get_atomic_order_checked((jl_sym_t*)order, 1, 1);
@@ -532,6 +537,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerswap(jl_value_t *p, jl_value_t *x, jl_
 
 JL_DLLEXPORT jl_value_t *jl_atomic_pointermodify(jl_value_t *p, jl_value_t *f, jl_value_t *x, jl_value_t *order)
 {
+    jl_check_rc("atomic_pointermodify");
     JL_TYPECHK(atomic_pointermodify, pointer, p);
     JL_TYPECHK(atomic_pointermodify, symbol, order)
     (void)jl_get_atomic_order_checked((jl_sym_t*)order, 1, 1);
@@ -585,6 +591,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointermodify(jl_value_t *p, jl_value_t *f, j
 
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerreplace(jl_value_t *p, jl_value_t *expected, jl_value_t *x, jl_value_t *success_order_sym, jl_value_t *failure_order_sym)
 {
+    jl_check_rc("atomic_pointerreplace");
     JL_TYPECHK(atomic_pointerreplace, pointer, p);
     JL_TYPECHK(atomic_pointerreplace, symbol, success_order_sym);
     JL_TYPECHK(atomic_pointerreplace, symbol, failure_order_sym);
@@ -635,6 +642,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerreplace(jl_value_t *p, jl_value_t *exp
 
 JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order_sym, jl_value_t *syncscope_sym)
 {
+    jl_check_rc("atomic_fence");
     JL_TYPECHK(fence, symbol, order_sym);
     JL_TYPECHK(fence, symbol, syncscope_sym);
     enum jl_memory_order order = jl_get_atomic_order_checked((jl_sym_t*)order_sym, 1, 1);
@@ -675,6 +683,7 @@ jl_value_t *jl_lookup_foreignsymbol(jl_value_t *v)
 
 // The auto-switching behavior here is deprecated, but preserved for Core.Intrinsics.cglobal
 JL_DLLEXPORT jl_value_t *jl_cglobal(jl_value_t *v, jl_value_t *ty) {
+    jl_check_rc("cglobal"); // symbol lookup in shared libraries is machine state
     JL_TYPECHK(cglobal, type, ty);
     jl_value_t *rt =
         ty == (jl_value_t*)jl_nothing_type ? (jl_value_t*)jl_voidpointer_type : // a common case
@@ -1772,6 +1781,7 @@ un_fintrinsic(sqrt_float,sqrt_llvm_fast)
 
 JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *typ)
 {
+    jl_check_rc("have_fma");
     JL_TYPECHK(have_fma, datatype, typ); // TODO what about float16/bfloat16?
     if (typ == (jl_value_t*)jl_float32_type)
         return jl_cpu_has_fma(32);

--- a/src/task.c
+++ b/src/task.c
@@ -1131,6 +1131,8 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_fu
     t->threadpoolid = ct->threadpoolid;
     t->ptls = NULL;
     t->world_age = ct->world_age;
+    t->rcjulia = 0;
+    t->rc_frames = NULL;
     t->reentrant_timing = 0;
     t->metrics_enabled = jl_atomic_load_relaxed(&jl_task_metrics_enabled) != 0;
     jl_atomic_store_relaxed(&t->first_enqueued_at, 0);
@@ -1601,6 +1603,8 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     ct->sticky = 1;
     ct->ptls = ptls;
     ct->world_age = 1; // OK to run Julia code on this task
+    ct->rcjulia = 0;
+    ct->rc_frames = NULL;
     ct->reentrant_timing = 0;
     jl_atomic_store_relaxed(&ct->running_time_ns, 0);
     jl_atomic_store_relaxed(&ct->finished_at, 0);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -789,6 +789,7 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval(jl_module_t *m, jl_value_t *v)
 // Check module `m` is open for `eval/include`, or throw an error.
 JL_DLLEXPORT void jl_check_top_level_effect(jl_module_t *m, const char *fname) JL_CANSAFEPOINT
 {
+    jl_check_rc(fname);
     if (jl_current_task->ptls->in_pure_callback)
         jl_errorf("%s cannot be used in a generated function", fname);
     if (jl_options.incremental && jl_generating_output()) {

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -23,7 +23,7 @@ const TESTNAMES = [
         "errorshow", "sets", "goto", "llvmcall", "llvmcall2", "ryu",
         "some", "meta", "stacktraces", "docs", "gc",
         "misc", "threads", "stress", "binaryplatforms","stdlib_dependencies", "atexit",
-        "enums", "cmdlineargs", "int", "interpreter",
+        "enums", "cmdlineargs", "int", "interpreter", "rcjulia",
         "checked", "bitset", "floatfuncs", "precompile", "relocatedepot",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "cancellation", "iostream", "secretbuffer", "specificity",

--- a/test/rcjulia.jl
+++ b/test/rcjulia.jl
@@ -1,0 +1,333 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Tests for RCJulia — restricted-capability evaluation mode
+# (`Core._rcjulia_call`): an execution mode that is `:foldable` by
+# construction. Operations requiring a withheld capability throw
+# CapabilityError instead of executing.
+
+using Test
+
+pcall(f, args...) = Core._rcjulia_call(Base.get_world_counter(), f, args...)
+
+# Helpers defined at toplevel so they have stable method identities.
+rc_add(x, y) = x + y
+rc_tuplen(t) = nfields(t)
+struct RCJuliaParams{R,C} end
+rc_paramprod(::Type{P}) where {P} = (P.parameters[1]::Int) * (P.parameters[2]::Int)
+rc_throws(x) = x < 0 ? throw(DomainError(x, "negative")) : x
+rc_loop(n) = (s = 0; for i = 1:n; s += i; end; s)
+rc_splat(t) = tuple(t...)
+rc_gen(::Val{N}) where {N} = ntuple(identity, Val(N))
+rc_reads_global() = RCJULIA_NONCONST_GLOBAL
+rc_reads_const() = RCJULIA_CONST_GLOBAL
+rc_closure_call(f, x) = f(x)
+rc_nested_call(w, f) = Core._rcjulia_call(w, f)
+
+# recursion shapes, exercising the well-founded order
+rc_countdown(n) = n <= 0 ? 0 : rc_countdown(n - 1)            # bits value decreases
+rc_countup(n) = n >= 10 ? n : rc_countup(n + 1)               # bits value increases
+rc_same(x) = rc_same(x)                                       # egal re-entry
+rc_below_zero(n) = n == -3 ? 0 : rc_below_zero(n - 1)         # crosses into negative bits
+rc_fact(n) = n <= 1 ? 1 : n * rc_fact(n - 1)
+rc_peel(t) = t === () ? 0 : rc_peel(Base.tail(t))             # typeof(t) shrinks structurally
+rc_val_descent(::Val{0}) = 0
+rc_val_descent(::Val{N}) where {N} = rc_val_descent(Val(N - 1)) # type parameter decreases
+rc_ttail(::Type{T}) where {T<:Tuple} = Tuple{Base.argtail(T.parameters...)...}
+rc_tdesc(::Type{T}) where {T<:Tuple} =                        # type argument shrinks structurally
+    T === Tuple{} ? 0 : 1 + rc_tdesc(rc_ttail(T))
+rc_mutual_a(n) = n <= 0 ? 0 : rc_mutual_b(n)
+rc_mutual_b(n) = rc_mutual_a(n - 1)
+
+global RCJULIA_NONCONST_GLOBAL::Int = 1
+const RCJULIA_CONST_GLOBAL = 42
+
+mutable struct RCJuliaMutable
+    x::Int
+end
+struct RCJuliaImmutable
+    x::Int
+end
+mutable struct RCJuliaMutableConst
+    const c::Int
+    x::Int
+end
+
+# Two generations of a method, with the world in between captured (at
+# toplevel, so later statements see the redefinition).
+rc_redefined() = 1
+const RCJULIA_WORLD1 = Base.get_world_counter()
+rc_redefined() = 2
+const RCJULIA_WORLD2 = Base.get_world_counter()
+
+@testset "basic evaluation" begin
+    @test pcall(rc_add, 1, 2) === 3
+    @test pcall(rc_add, 1.5, 2.5) === 4.0
+    @test pcall(tuple, 1, 2) === (1, 2)
+    @test pcall(rc_tuplen, (1, 2, 3)) === 3
+    @test pcall(typeof, 1) === Int
+    @test pcall(===, 1, 1) === true
+    # construction of immutables is legal
+    @test pcall(RCJuliaImmutable, 7) === RCJuliaImmutable(7)
+    @test pcall(getfield, RCJuliaImmutable(7), :x) === 7
+    # type computation
+    @test pcall(Core.apply_type, NTuple, 3, Float64) === NTuple{3,Float64}
+    @test pcall(fieldtype, RCJuliaImmutable, 1) === Int
+end
+
+@testset "const fields of mutable objects are readable" begin
+    # `const` fields never change after construction, so reading them is
+    # consistent; this is also what admits set-once runtime metadata such as
+    # DataType.parameters (the computed-field-types use case)
+    @test pcall(rc_paramprod, RCJuliaParams{2,3}) === 6
+    let m = RCJuliaMutableConst(1, 2)
+        @test pcall(getfield, m, :c) === 1
+        @test pcall(isdefined, m, :c) === true
+        @test_throws CapabilityError pcall(getfield, m, :x)
+        @test_throws CapabilityError pcall(isdefined, m, :x)
+    end
+end
+
+@testset "tuple splatting and generated functions" begin
+    @test pcall(rc_splat, (1, 2, 3)) === (1, 2, 3)
+    # generated function expansion is always permitted; the expanded code
+    # then executes under the mode
+    @test pcall(rc_gen, Val(3)) === (1, 2, 3)
+    # splatting an array reads mutable memory
+    let a = [1, 2, 3]
+        @test_throws CapabilityError pcall(rc_splat, a)
+    end
+end
+
+@testset "consistent throwing is permitted" begin
+    @test pcall(rc_throws, 1) === 1
+    @test_throws DomainError pcall(rc_throws, -1)
+    @test_throws DivideError pcall(div, 1, 0)
+    # after an exception propagates out, the mode is fully exited
+    @test RCJULIA_NONCONST_GLOBAL === 1
+end
+
+@testset "mutable memory reads are trapped" begin
+    let m = RCJuliaMutable(1)
+        @test_throws CapabilityError pcall(getfield, m, :x)
+        @test_throws CapabilityError pcall(isdefined, m, :x)
+    end
+    let a = [1, 2, 3]
+        @test_throws CapabilityError pcall(getindex, a, 1)
+        @test_throws CapabilityError pcall(length, a)
+    end
+end
+
+@testset "mutation and mutable allocation are trapped" begin
+    let m = RCJuliaMutable(1)
+        @test_throws CapabilityError pcall(setfield!, m, :x, 2)
+        @test m.x === 1
+    end
+    @test_throws CapabilityError pcall(RCJuliaMutable, 1)
+    @test_throws CapabilityError pcall(Vector{Int}, undef, 3)
+    @test_throws CapabilityError pcall(push!, Int[], 1)
+    # string building goes through IOBuffer/Memory
+    @test_throws CapabilityError pcall(string, 1, "x")
+end
+
+@testset "globals" begin
+    @test pcall(rc_reads_const) === 42
+    @test pcall(getglobal, @__MODULE__, :RCJULIA_CONST_GLOBAL) === 42
+    @test_throws CapabilityError pcall(rc_reads_global)
+    @test_throws CapabilityError pcall(getglobal, @__MODULE__, :RCJULIA_NONCONST_GLOBAL)
+    @test_throws CapabilityError pcall(setglobal!, @__MODULE__, :RCJULIA_NONCONST_GLOBAL, 2)
+    @test pcall(isdefinedglobal, @__MODULE__, :RCJULIA_CONST_GLOBAL) === true
+    @test pcall(isdefinedglobal, @__MODULE__, :this_name_is_not_defined_anywhere) === false
+    @test_throws CapabilityError pcall(isdefinedglobal, @__MODULE__, :RCJULIA_NONCONST_GLOBAL)
+    @test_throws UndefVarError pcall(getglobal, @__MODULE__, :this_name_is_not_defined_anywhere)
+end
+
+@testset "well-founded recursion" begin
+    # loops have backedges: iteration must be expressed as recursion
+    @test_throws CapabilityError pcall(rc_loop, 3)
+    # value recursion with decreasing bits is permitted
+    @test pcall(rc_countdown, 5) === 0
+    @test pcall(rc_fact, 5) === 120
+    # increasing bits is not a decrease in the order
+    @test_throws CapabilityError pcall(rc_countup, 0)
+    # egal re-entry is guaranteed divergent under consistency
+    @test_throws CapabilityError pcall(rc_same, 1)
+    # the bits order is unsigned: -1 is larger than 0
+    @test_throws CapabilityError pcall(rc_below_zero, 0)
+    # structurally smaller types: tuple peeling and type-argument descent
+    @test pcall(rc_peel, (1, 2, 3)) === 0
+    @test pcall(rc_tdesc, Tuple{Int,Int,Int}) === 3
+    # descent through distinct specializations (decreasing type parameter)
+    @test pcall(rc_val_descent, Val(10)) === 0
+    # mutual recursion, each method decreasing per occurrence
+    @test pcall(rc_mutual_a, 5) === 0
+    # the physical frame cap fires deterministically before stack overflow
+    @test_throws CapabilityError pcall(rc_val_descent, Val(2000))
+    let err = try pcall(rc_val_descent, Val(2000)); nothing catch e; e end
+        @test err isa CapabilityError && err.op === :depth_limit
+    end
+    let err = try pcall(rc_countup, 0); nothing catch e; e end
+        @test err isa CapabilityError && err.op === :recursion
+    end
+end
+
+@testset "world-mutating and impure operations are trapped" begin
+    @test_throws CapabilityError pcall(Core.eval, @__MODULE__, :(1 + 1))
+    @test_throws CapabilityError pcall(Core.invokelatest, rc_add, 1, 2)
+    @test_throws CapabilityError pcall(Core.finalizer, identity, RCJuliaMutable(1))
+    @test_throws CapabilityError pcall(Core.current_scope)
+    @test_throws CapabilityError pcall(Core._expr, :call, :f)
+    @test_throws CapabilityError pcall(print, "hello")
+    @test_throws CapabilityError pcall(time_ns)
+end
+
+@testset "world freezing" begin
+    # a frozen world sees the definitions of that world
+    @test Core._rcjulia_call(RCJULIA_WORLD1, rc_redefined) === 1
+    @test Core._rcjulia_call(RCJULIA_WORLD2, rc_redefined) === 2
+    @test pcall(rc_redefined) === 2
+    # nesting may lower the frozen world...
+    @test Core._rcjulia_call(RCJULIA_WORLD2, rc_nested_call, RCJULIA_WORLD1, rc_redefined) === 1
+    # ...but not raise it
+    @test_throws CapabilityError Core._rcjulia_call(RCJULIA_WORLD1, rc_nested_call, RCJULIA_WORLD2, rc_redefined)
+end
+
+@testset "closures and higher-order calls" begin
+    @test pcall(rc_closure_call, x -> x + 1, 1) === 2
+    @test pcall(map, x -> 2x, (1, 2, 3)) === (2, 4, 6)
+end
+
+@testset "CapabilityError" begin
+    @test CapabilityError <: Exception
+    err = try
+        pcall(rc_loop, 1)
+        nothing
+    catch e
+        e
+    end
+    @test err isa CapabilityError
+    @test err.op === :backedge
+    @test occursin("RCJulia", sprint(showerror, err))
+    # the trap is deterministic; the exception is egal across replays
+    err2 = try pcall(rc_loop, 1); nothing catch e; e end
+    @test err === err2
+end
+
+@testset "every builtin and intrinsic has decided RCJulia semantics" begin
+    # This test is the audited classification of ALL builtins and intrinsics
+    # for RCJulia mode. When adding a builtin or intrinsic, you must decide
+    # its RCJulia semantics and add it to exactly one set below (and, for
+    # trapped operations, add the corresponding `jl_check_rc` in the runtime).
+
+    # Builtins that execute under the mode (their semantics are consistent in
+    # a frozen world, or their C implementation performs no restricted
+    # operation).
+    BUILTIN_ALLOWED = Set([
+        "_compute_sparams", "_rcjulia_call", "_svec_len", "_svec_ref",
+        "_typevar", "applicable", "apply_type", "bitsizeof", "compilerbarrier",
+        "donotdelete", "fieldtype", "get_binding_type", "===", "isa", "<:",
+        "ifelse", "intrinsic_call", "memoryrefnew", "memoryrefoffset",
+        "nfields", "sizeof", "svec", "throw", "throw_methoderror", "tuple",
+        "typeassert", "typeof", "has_free_typevars",
+    ])
+    # Builtins that execute conditionally: legal on immutable/`const`/
+    # tuple-splat operands, CapabilityError otherwise.
+    BUILTIN_CONDITIONAL = Set([
+        "getfield", "getglobal", "isdefined", "isdefinedglobal",
+        "_apply_iterate",
+    ])
+    # Builtins that always throw CapabilityError under the mode.
+    BUILTIN_TRAPPED = Set([
+        "_abstracttype", "_call_in_world_total", "_equiv_typedef", "_expr",
+        "_import", "_new_cancel_source", "_primitivetype", "_setsuper!",
+        "_structtype", "_task", "_typebody!", "_using", "cancellation_point!",
+        "current_scope", "declare_const", "declare_global", "define_method",
+        "finalizer", "invoke", "invoke_in_world", "invokelatest", "memorynew",
+        "memoryref_isassigned", "memoryrefget", "memoryrefmodify!",
+        "memoryrefreplace!", "memoryrefset!", "memoryrefsetonce!",
+        "memoryrefunset!", "memoryrefswap!", "modifyfield!", "modifyglobal!",
+        "opaque_closure_call", "replacefield!", "replaceglobal!", "setfield!",
+        "setfieldonce!", "setglobal!", "setglobalonce!", "swapfield!",
+        "swapglobal!", "task_result_type",
+    ])
+    classified = union(BUILTIN_ALLOWED, BUILTIN_CONDITIONAL, BUILTIN_TRAPPED)
+    @test isempty(intersect(BUILTIN_ALLOWED, BUILTIN_TRAPPED))
+    @test isempty(intersect(BUILTIN_CONDITIONAL, BUILTIN_TRAPPED))
+    # every builtin reachable as a Core binding is classified; classification
+    # is by function identity (via the canonical creation name), so alias
+    # bindings such as `Core.getproperty === Core.getfield` and
+    # `Core._call_latest === Core.invokelatest` inherit their target's semantics
+    for n in names(Core; all=true)
+        isdefined(Core, n) || continue
+        f = getglobal(Core, n)
+        f isa Core.Builtin || continue
+        @test string(nameof(f)) in classified
+    end
+    # and the classification exactly matches the full builtin table when the
+    # runtime sources are available (covers builtins not bound in Core, such
+    # as opaque_closure_call)
+    proto = joinpath(@__DIR__, "..", "src", "builtin_proto.h")
+    if isfile(proto)
+        tbl = Set(m.captures[1] for m in eachmatch(r"XX\(\w+,\s*\"([^\"]+)\"\)", read(proto, String)))
+        @test tbl == classified
+    end
+
+    # Intrinsics that always throw CapabilityError under the mode: pointer
+    # and atomic memory access, machine queries, library symbol lookup, and
+    # native-code execution.
+    INTRINSIC_TRAPPED = Set([
+        :pointerref, :pointerset, :atomic_fence, :atomic_pointerref,
+        :atomic_pointerset, :atomic_pointerswap, :atomic_pointermodify,
+        :atomic_pointerreplace, :cglobal, :have_fma, :llvmcall,
+    ])
+    # All other intrinsics are value-deterministic and allowed. (The
+    # fast-math aliases and `muladd_float` share the strict runtime
+    # implementations, so they are deterministic under interpretation; if the
+    # mode ever compiles natively they must be pinned to those semantics.
+    # The hidden `cglobal_auto` shares `cglobal`'s trap.)
+    INTRINSIC_ALLOWED = Set([
+        :abs_float, :add_float, :add_float_fast, :add_int, :add_ptr, :and_int,
+        :ashr_int, :bitcast, :bswap_int, :ceil_llvm, :checked_sadd_int,
+        :checked_sdiv_int, :checked_smul_int, :checked_srem_int,
+        :checked_ssub_int, :checked_uadd_int, :checked_udiv_int,
+        :checked_umul_int, :checked_urem_int, :checked_usub_int,
+        :copysign_float, :ctlz_int, :ctpop_int, :cttz_int, :div_float,
+        :div_float_fast, :eq_float, :eq_float_fast, :eq_int, :flipsign_int,
+        :floor_llvm, :fma_float, :fpext, :fpiseq, :fptosi, :fptoui, :fptrunc,
+        :le_float, :le_float_fast, :lshr_int, :lt_float, :lt_float_fast,
+        :max_float, :max_float_fast, :min_float, :min_float_fast, :mul_float,
+        :mul_float_fast, :mul_int, :muladd_float, :ne_float, :ne_float_fast,
+        :ne_int, :neg_float, :neg_float_fast, :neg_int, :not_int, :or_int,
+        :rint_llvm, :sdiv_int, :sext_int, :shl_int, :sitofp, :sle_int,
+        :slt_int, :sqrt_llvm, :sqrt_llvm_fast, :srem_int, :sub_float,
+        :sub_float_fast, :sub_int, :sub_ptr, :trunc_int, :trunc_llvm,
+        :udiv_int, :uitofp, :ule_int, :ult_int, :urem_int, :xor_int,
+        :zext_int,
+    ])
+    @test isempty(intersect(INTRINSIC_ALLOWED, INTRINSIC_TRAPPED))
+    intr_classified = union(INTRINSIC_ALLOWED, INTRINSIC_TRAPPED)
+    for n in names(Core.Intrinsics; all=true)
+        isdefined(Core.Intrinsics, n) || continue
+        getglobal(Core.Intrinsics, n) isa Core.IntrinsicFunction || continue
+        @test n in intr_classified
+    end
+
+    # spot-check that the trapped intrinsics actually trap (before touching
+    # their operands)
+    p = Ptr{Int}(0)
+    @test_throws CapabilityError pcall(Core.Intrinsics.pointerref, p, 1, 1)
+    @test_throws CapabilityError pcall(Core.Intrinsics.pointerset, p, 1, 1, 1)
+    @test_throws CapabilityError pcall(Core.Intrinsics.atomic_pointerref, p, :monotonic)
+    @test_throws CapabilityError pcall(Core.Intrinsics.atomic_fence, :seq_cst, :system)
+    @test_throws CapabilityError pcall(Core.Intrinsics.have_fma, Float64)
+    @test_throws CapabilityError pcall(Core.Intrinsics.cglobal, :jl_n_threads, Int)
+    @test_throws CapabilityError pcall(Core.Intrinsics.llvmcall)
+end
+
+# quoted `Expr` literals materialize fresh mutable ASTs (copyast) and trap;
+# quoted immutables (QuoteNode of a Symbol) are plain values and are fine
+rc_quoted_expr() = :(1 + 2)
+rc_quoted_sym() = :a_symbol
+@testset "quoted AST literals" begin
+    @test_throws CapabilityError pcall(rc_quoted_expr)
+    @test pcall(rc_quoted_sym) === :a_symbol
+end


### PR DESCRIPTION
This is part 2 of the redesign contemplated in #62715. Rather than hoisting an inference artifact into the semantics, we define a restricted subset of the julia execution semantics that is :foldable by construction (note that we still need #62834 for world freezing). Note that this execution mode is *quite* restricted. In particular all reads from mutable memory are disallowed, as are loops. Recursion is limited to recursion that is well formed under a new runtime-defined predicate (future extensions might reuse the recursion_relation field of `Method` to relax this). The current scope of this work is intended to be useful enough for #62715, but not much more. That said, future extensions could import a lot of the tricks from pure functional language to make RCJulia almost as expressive as ordinary julia. PR opened for discussion with interpreter support, compiler support and optimizations are still missing.