### PR TITLE
Improve trimmability of string interpolation

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -42,8 +42,10 @@ end
 function print(io::IO, xs...)
     lock(io)
     try
-        for x in xs
-            print(io, x)
+        # xs[i] might be a known Union, and under --trim that gets split regardless of length.
+        # In contrast, `for x in xs` will fall back to Any for unions longer than 3.
+        for i in 1:nfields(xs)
+            print(io, xs[i])
         end
     finally
         unlock(io)
@@ -139,8 +141,8 @@ function print_to_string(xs...)
     end
     # specialized for performance reasons
     s = IOBuffer(sizehint=siz)
-    for x in xs
-        print(s, x)
+    for i in 1:nfields(xs)
+        print(s, xs[i])
     end
     takestring!(s)
 end
@@ -156,8 +158,8 @@ function string_with_env(env, xs...)
     # specialized for performance reasons
     s = IOBuffer(sizehint=siz)
     env_io = IOContext(s, env)
-    for x in xs
-        print(env_io, x)
+    for i in 1:nfields(xs)
+        print(env_io, xs[i])
     end
     takestring!(s)
 end

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -336,6 +336,31 @@ end
     @test string() == ""
 end
 
+@testset "`string`/`print` of many argument types resolve statically" begin
+    # For an exact signature (what `--trim` compiles), each argument's `print` must
+    # be resolved at compile time even when the arguments span more distinct types
+    # than inference keeps in a merged union.
+    function isdynamic_call(stmt)
+        Meta.isexpr(stmt, :call) || return false
+        f = stmt.args[1]
+        f isa GlobalRef && (f = getglobal(f.mod, f.name))
+        return !(f isa Core.Builtin || f isa Core.IntrinsicFunction)
+    end
+    args = ("got ", 1:3, " vs ", 1, " with ", 2.5, " and ", :s, " and ", 'c')
+    expected = "got 1:3 vs 1 with 2.5 and s and c"
+    @test string(args...) == expected
+    @test sprint(print, args...) == expected
+    T = typeof(args)
+    for (f, sig) in ((Base.print_to_string, T), (print, Tuple{IOBuffer, T.parameters...}))
+        src, _ = only(code_typed(f, sig))
+        @test !any(isdynamic_call, src.code)
+    end
+    # arguments of unknown type still take the dynamic path
+    v = Any[args...]
+    @test string(v...) == expected
+    @test sprint(print, v...) == expected
+end
+
 module StringsIOStringReturnTypesTestModule
     struct S end
     Base.joinpath(::S) = S()

--- a/test/trim/Trimmability/runtests.jl
+++ b/test/trim/Trimmability/runtests.jl
@@ -18,4 +18,5 @@ outdir = ARGS[1]
     @test lines[8] == "# preferences: 0"
     @test lines[9] == "finalizers: 27 32"
     @test lines[10] == "collected: 0 kept, 10 dropped"
+    @test lines[11] == "got 1:3 vs 1 with 2.5 and sym and c"
 end

--- a/test/trim/Trimmability/src/Trimmability.jl
+++ b/test/trim/Trimmability/src/Trimmability.jl
@@ -166,6 +166,10 @@ function _test_cat()
 end
 
 
+# String interpolation whose arguments span more distinct types than inference
+# keeps in a merged union: each `print` must still resolve statically.
+@noinline interpolate_many(r, x, s, c) = "got $(r) vs $(first(r)) with $(x) and $(s) and $(c)"
+
 function @main(args::Vector{String})::Cint
     println(Core.stdout, str())
     println(Core.stdout, PROGRAM_FILE)
@@ -203,6 +207,8 @@ function @main(args::Vector{String})::Cint
     end
 
     println(Core.stdout, "collected: ", kept[], " kept, ", dropped[], " dropped")
+
+    println(Core.stdout, interpolate_many(1:3, 2.5, :sym, 'c'))
 
     try
         sock = connect("localhost", 4900)


### PR DESCRIPTION
The vararg methods `print(io, xs...)`, `print_to_string` and `string_with_env` printed their arguments with `for x in xs`. That loop variable is a phi node merging the type of the first element with the union of the rest, and inference widens such a union to `Any` once it has more than three members, so every `print(io, x)` in the loop became a dynamic dispatch. Under `juliac --trim=safe`, which compiles these methods for their exact argument types, any interpolated string whose arguments spanned more than three distinct types was rejected as an unresolved call, e.g. `"got $(r) vs $(i) with $(x) and $(s)"`.

Indexing the tuple instead (`xs[i]`) keeps the exact union of element types, which union-splits into statically resolved calls regardless of how many members it has.

This helps only for exact unions; `Vararg{Any}` is still not trimmable.

Assisted-by: Claude Code (Fable 5)