### PR TITLE
deps: backport patchelf fix for overlapping segments (fixes FreeBSD lld)

### DIFF
--- a/deps/patchelf.mk
+++ b/deps/patchelf.mk
@@ -14,10 +14,21 @@ $(SRCCACHE)/patchelf-$(PATCHELF_VER)/source-extracted: $(SRCCACHE)/patchelf-$(PA
 checksum-patchelf: $(SRCCACHE)/patchelf-$(PATCHELF_VER).tar.bz2
 	$(JLCHECKSUM) $<
 
+# Backport of https://github.com/NixOS/patchelf/pull/469 (in patchelf 0.18.0): without it,
+# growing an rpath can produce a binary whose first two PT_LOAD segments share a page,
+# which FreeBSD's execve() rejects (the process dies with a silent SIGABRT).
+$(SRCCACHE)/patchelf-$(PATCHELF_VER)/patchelf-overlapping-segments.patch-applied: $(SRCCACHE)/patchelf-$(PATCHELF_VER)/source-extracted
+	cd $(dir $@) && \
+		patch -p1 -f < $(SRCDIR)/patches/patchelf-overlapping-segments.patch
+	echo 1 > $@
+
+$(SRCCACHE)/patchelf-$(PATCHELF_VER)/source-patched: $(SRCCACHE)/patchelf-$(PATCHELF_VER)/patchelf-overlapping-segments.patch-applied
+	echo 1 > $@
+
 $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured: CC:=$(HOSTCC)
 $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured: CXX:=$(HOSTCXX)
 $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured: XC_HOST:=$(BUILD_MACHINE)
-$(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured: $(SRCCACHE)/patchelf-$(PATCHELF_VER)/source-extracted
+$(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured: $(SRCCACHE)/patchelf-$(PATCHELF_VER)/source-patched
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(dir $<)/configure $(CONFIGURE_COMMON) LDFLAGS="$(CXXLDFLAGS)" CPPFLAGS="$(CPPFLAGS)" MAKE=$(MAKE)
@@ -51,6 +62,7 @@ distclean-patchelf:
 
 get-patchelf: $(SRCCACHE)/patchelf-$(PATCHELF_VER).tar.bz2
 extract-patchelf: $(SRCCACHE)/patchelf-$(PATCHELF_VER)/source-extracted
+patch-patchelf: $(SRCCACHE)/patchelf-$(PATCHELF_VER)/source-patched
 configure-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured
 compile-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled
 check-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-checked

--- a/deps/patchelf.version
+++ b/deps/patchelf.version
@@ -1,4 +1,5 @@
 ## source build
 # Patchelf (we don't ship this or even use a JLL, we just always build it)
 # NOTE: Do not upgrade this to 0.18+ until https://github.com/NixOS/patchelf/issues/492 is fixed
+# (we carry a backport of https://github.com/NixOS/patchelf/pull/469 in deps/patches instead)
 PATCHELF_VER := 0.17.2

--- a/deps/patches/patchelf-overlapping-segments.patch
+++ b/deps/patches/patchelf-overlapping-segments.patch
@@ -1,0 +1,34 @@
+From de3e1f5e11f533d8678474eb9234ba35efa960d6 Mon Sep 17 00:00:00 2001
+From: Breno Rodrigues Guimaraes <brenorg@gmail.com>
+Date: Mon, 20 Feb 2023 18:22:17 -0300
+Subject: [PATCH] Add one extra page to avoid overlapping with next page if its
+ rounded down
+
+Backport of https://github.com/NixOS/patchelf/pull/469 (released in
+patchelf 0.18.0) to 0.17.2, which we are pinned to because of
+https://github.com/NixOS/patchelf/issues/492.
+
+When `--set-rpath` has to grow `.dynstr`, patchelf moves the affected
+sections into a new segment placed just before the first PT_LOAD. If the
+size of that new segment is not a multiple of the page size, its last
+page can overlap with the (rounded-down) first page of the following
+segment. Linux tolerates that, but the FreeBSD ELF image activator maps
+segments with MAP_CHECK_EXCL and execve() then fails after the point of
+no return, killing the process with an (uncatchable, coreless) SIGABRT.
+This is what happened to the `lld` we ship with LLVM 22 on FreeBSD.
+
+diff --git a/src/patchelf.cc b/src/patchelf.cc
+index ca247c12..b78210c4 100644
+--- a/src/patchelf.cc
++++ b/src/patchelf.cc
+@@ -914,7 +914,9 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsExecutable()
+ 
+         /* Calculate how many bytes are needed out of the additional pages. */
+         size_t extraSpace = neededSpace - startOffset; 
+-        unsigned int neededPages = roundUp(extraSpace, getPageSize()) / getPageSize();
++        // Always give one extra page to avoid colliding with segments that start at
++        // unaligned addresses and will be rounded down when loaded
++        unsigned int neededPages = 1 + roundUp(extraSpace, getPageSize()) / getPageSize();
+         debug("needed pages is %d\n", neededPages);
+         if (neededPages * getPageSize() > firstPage)
+             error("virtual address space underrun!");


### PR DESCRIPTION
Since the LLVM 22.1.8 bump (#62563) every FreeBSD CI test job fails: any package precompilation dies with

    failed process: Process(`.../libexec/julia/lld -flavor gnu ...`, ProcessSignaled(6))

with no output from lld at all. The shipped lld (from LLD_jll) dies at execve() time: `lld --version` aborts, no core is written and neither lldb nor truss can attach.

Cause: during `make install` we run `patchelf --set-rpath` on lld to point its RUNPATH at `$ORIGIN/../../lib/julia`. That is longer than the original `$ORIGIN/../lib`, so patchelf has to grow `.dynstr` and moves the affected sections into a new PT_LOAD placed just before the first one. With patchelf 0.17.2 that new segment is sized exactly to its contents, so its last page can overlap the (rounded down) first page of the next segment. For the LLVM 22 lld the contents are 0x73018 bytes, 24 bytes past a page boundary, so the two segments share a page (the LLVM 21 lld was 0x6dd18 bytes and happened to fit). Linux tolerates that; FreeBSD's ELF image activator maps segments with MAP_CHECK_EXCL, execve() fails after the old address space is gone, and the kernel kills the process with SIGABRT.

patchelf fixed this in 0.18.0 (NixOS/patchelf#469) but we are pinned to 0.17.2 because of NixOS/patchelf#492 (caused by a different change, NixOS/patchelf#482). Backport just NixOS/patchelf#469, which adds one extra page of slack.

Verified on a FreeBSD VM with the CI tarball from julia-pr build 1705: the shipped lld aborts; the pristine LLD_jll lld works; lld re-patched with the fixed patchelf works and package precompilation succeeds.

Assisted by: Fable