### PR TITLE
types: compute self-referential supertypes lazily

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1157,7 +1157,9 @@ end
 function _getfield_tfunc_const(@nospecialize(sv), name::Const)
     nv = _getfield_fieldindex(typeof(sv), name)
     nv === nothing && return Bottom
-    if isa(sv, DataType) && nv == DATATYPE_TYPES_FIELDINDEX && isdefined(sv, nv)
+    # `types` and `super` are write-once: non-const (filled lazily), but once
+    # a defined value is observed it can never change, so folding it is sound
+    if isa(sv, DataType) && (nv == DATATYPE_TYPES_FIELDINDEX || nv == DATATYPE_SUPER_FIELDINDEX) && isdefined(sv, nv)
         return Const(getfield(sv, nv))
     end
     if !isa(sv, Module) && isconst(typeof(sv), nv)
@@ -1256,10 +1258,14 @@ end
             sv = type_parameter(s)
             if isa(sv, DataType) && isa(name, Const) &&
                _getfield_fieldindex(DataType, name) == DATATYPE_SUPER_FIELDINDEX &&
-               !has_free_typevars(sv.super)
+               # read without forcing: on a deferred instantiation whose slot
+               # is still unset the modeled `getfield` throws, so no precision
+               # is lost by falling through (see issue #61347)
+               isdefined(sv, :super) &&
+               (svsuper = getfield(sv, :super); !has_free_typevars(svsuper))
                 # only `DataType` reps reach `.super` without throwing, and the
                 # `.super`s of `==`-equal `DataType`s are `==`-equal (if not egal)
-                return Type{sv.super}
+                return Type{svsuper}
             end
             if isTypeDataType(sv) && isa(name, Const)
                 nv = _getfield_fieldindex(DataType, name)::Int

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -784,18 +784,18 @@ end
     heighta = 0
     while a !== Any
         heighta += 1
-        a = a.super
+        a = datatype_super(a)
     end
     b = unwrap_unionall(bname.wrapper)
     heightb = 0
     while b !== Any
         b.name === aname && return aname
         heightb += 1
-        b = b.super
+        b = datatype_super(b)
     end
     a = unwrap_unionall(aname.wrapper)
     while heighta > heightb
-        a = a.super
+        a = datatype_super(a)
         heighta -= 1
     end
     return a.name === bname ? bname : nothing
@@ -865,11 +865,11 @@ end
                         uw = unwrap_unionall(wr)::DataType
                         ui = unwrap_unionall(ti)::DataType
                         while ui.name !== ijname
-                            ui = ui.super
+                            ui = datatype_super(ui)
                         end
                         uj = unwrap_unionall(tj)::DataType
                         while uj.name !== ijname
-                            uj = uj.super
+                            uj = datatype_super(uj)
                         end
                         p = Vector{Any}(undef, length(uw.parameters))
                         usep = true

--- a/Compiler/src/utilities.jl
+++ b/Compiler/src/utilities.jl
@@ -1,5 +1,10 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+# supertype access that forces a deferred supertype (an instantiation of a
+# self-referential definition fills `super` lazily, see issue #61347); a
+# plain field read on such an instantiation would see an undefined field
+datatype_super(x::DataType) = ccall(:jl_datatype_super, Any, (Any,), x)::DataType
+
 ###########
 # generic #
 ###########

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -83,7 +83,22 @@ julia> supertype(Vector)
 DenseVector (alias for DenseArray{T, 1} where T)
 ```
 """
-supertype(T::DataType) = (@_total_meta; T.super)
+function supertype(T::DataType)
+    @_foldable_meta
+    # force the computation of a deferred supertype (an instantiation of a
+    # self-referential definition materializes its supertype graph lazily,
+    # one level per demand, see issue #61347); idempotent, so still foldable.
+    # The subsequent plain field read keeps `getfield`'s inference precision.
+    ccall(:jl_datatype_compute_super, Ptr{Cvoid}, (Any,), T)
+    return getfield(T, :super)
+end
+function getproperty(T::DataType, s::Symbol)
+    @inline
+    # fill the deferred supertype cache on access, so raw `.super` reads keep
+    # working for instantiations of self-referential definitions (#61347)
+    s === :super && return supertype(T)
+    return getfield(T, s)
+end
 supertype(T::UnionAll) = (@_foldable_meta; UnionAll(T.var, supertype(T.body)))
 
 ## generic comparison ##

--- a/src/ast.c
+++ b/src/ast.c
@@ -135,9 +135,13 @@ static value_t fl_module_unique_name(fl_context_t *fl_ctx, value_t *args, uint32
 static int jl_is_number(jl_value_t *v)
 {
     jl_datatype_t *t = (jl_datatype_t*)jl_typeof(v);
-    for (; t->super != t; t = t->super)
-        if (t == jl_number_type)
+    // only the typename lineage matters here, so walk the wrapper supertypes,
+    // which are set at definition and never deferred
+    while (t != NULL && t != jl_any_type) {
+        if (t->name == jl_number_type->name)
             return 1;
+        t = ((jl_datatype_t*)jl_unwrap_unionall(t->name->wrapper))->super;
+    }
     return 0;
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -896,12 +896,12 @@ static void foreach_top_nth_typename(void (*f)(jl_typename_t*, int, void*) JL_CA
                 }
                 else {
                     while (1) {
-                        jl_datatype_t *super = dt->super;
+                        jl_datatype_t *super = jl_datatype_compute_super(dt);
                         if (super == jl_function_type) {
                             *facts |= HAVE_FUNCTION;
                             break;
                         }
-                        if (super == jl_any_type || super->super == dt)
+                        if (super == NULL || super == jl_any_type || super->super == dt)
                             break;
                         dt = super;
                     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2436,6 +2436,60 @@ static jl_value_t *lookup_deferred_type(jl_deferred_typecache_t *dcache, jl_type
     return NULL;
 }
 
+
+static int typename_on_stack(jl_typestack_t *stack, jl_typename_t *tn) JL_NOTSAFEPOINT
+{
+    while (stack != NULL) {
+        if (stack->tt && stack->tt->name == tn)
+            return 1;
+        stack = stack->prev;
+    }
+    return 0;
+}
+
+// does `t` (a type or parameter value) mention an application of `tn`? Used to
+// recognize self-referential definitions, whose supertype/field-type graph may
+// have no finite materialization when the recursive applications are
+// structurally increasing (issue #61347), and is completed lazily instead.
+static int typename_occurs_in(jl_value_t *t, jl_typename_t *tn) JL_NOTSAFEPOINT
+{
+    if (t == NULL)
+        return 0;
+    if (jl_is_svec(t)) {
+        size_t i, l = jl_svec_len(t);
+        for (i = 0; i < l; i++) {
+            if (typename_occurs_in(jl_svecref(t, i), tn))
+                return 1;
+        }
+        return 0;
+    }
+    if (jl_is_datatype(t)) {
+        if (((jl_datatype_t*)t)->name == tn)
+            return 1;
+        return typename_occurs_in((jl_value_t*)((jl_datatype_t*)t)->parameters, tn);
+    }
+    if (jl_is_unionall(t)) {
+        jl_unionall_t *u = (jl_unionall_t*)t;
+        return typename_occurs_in(u->var->lb, tn) || typename_occurs_in(u->var->ub, tn) ||
+               typename_occurs_in(u->body, tn);
+    }
+    if (jl_is_uniontype(t)) {
+        return typename_occurs_in(((jl_uniontype_t*)t)->a, tn) ||
+               typename_occurs_in(((jl_uniontype_t*)t)->b, tn);
+    }
+    if (jl_is_vararg(t)) {
+        jl_vararg_t *vm = (jl_vararg_t*)t;
+        return typename_occurs_in(vm->T, tn) || typename_occurs_in(vm->N, tn);
+    }
+    if (jl_is_typeeq(t))
+        return typename_occurs_in(jl_typeeq_T(t), tn);
+    if (jl_is_typeegal(t))
+        return typename_occurs_in(jl_typeegal_T(t), tn);
+    // n.b. free TypeVar bounds are not walked: materialized typevar bound
+    // graphs may be cyclic
+    return 0;
+}
+
 static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **iparams, size_t ntp,
                                        jl_typestack_t *stack, jl_typeenv_t *env, int check, int nothrow,
                                        jl_deferred_typecache_t *dcache)
@@ -2766,8 +2820,26 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
     if (primarydt->layout && !defer)
         jl_compute_field_offsets(ndt);
 
+    // A definition whose supertype declaration recursively applies the type
+    // being defined at structurally increasing parameters (issue #61347, e.g.
+    // `struct S{T} <: A{S{Tuple{T}}} end`) has an infinite supertype graph:
+    // eagerly instantiating each level's supertype creates the next level.
+    // When another instantiation of this typename is already in flight above
+    // this one (`stack` has `ndt` itself on top) and the supertype template
+    // mentions the typename, defer the supertype and complete it lazily, one
+    // level per demand (`jl_datatype_compute_super`). Same-parameter
+    // self-references never get here (`lookup_type_stack` ties that knot),
+    // so ordinary recursive types are unaffected. Field types stay eager: a
+    // concrete type must publish with its layout, and only the supertype
+    // declaration can force an infinite graph through abstract levels.
+    int defer_super = check && !istuple && !isnamedtuple && dt->super != NULL &&
+        typename_on_stack(top.prev, tn) &&
+        typename_occurs_in((jl_value_t*)primarydt->super, tn);
     if (istuple || isnamedtuple) {
         ndt->super = jl_any_type;
+    }
+    else if (defer_super) {
+        // deferred (see above)
     }
     else if (dt->super) {
         jl_value_t *super = inst_type_w_((jl_value_t*)dt->super, env, stack, check, nothrow, dcache);
@@ -3342,6 +3414,58 @@ JL_DLLEXPORT jl_svec_t *jl_compute_fieldtypes(jl_datatype_t *st JL_PROPAGATES_RO
 }
 
 
+// Complete the deferred supertype of an instantiation of a self-referential
+// definition (issue #61347): eager instantiation of a structurally increasing
+// supertype graph would not terminate, so it is materialized lazily, one
+// level per demand. Returns NULL if the type's definition is still in
+// progress. Consumers that do not funnel through here (raw `getfield`,
+// direct C reads) see either the published value or an undefined field: the
+// Julia-side metadata declares `super` maybe-undefined, non-const and atomic,
+// so an unfilled slot reads as `UndefRefError`, never as garbage.
+JL_DLLEXPORT jl_datatype_t *jl_datatype_compute_super(jl_datatype_t *ndt JL_PROPAGATES_ROOT)
+{
+    // one-time lazy initialization; the acquire pairs with the releasing
+    // compare-and-swap below and makes the computed object graph visible
+    _Atomic(jl_datatype_t*) *superp = (_Atomic(jl_datatype_t*)*)&ndt->super;
+    jl_datatype_t *super = jl_atomic_load_acquire(superp);
+    if (super != NULL)
+        return super;
+    if (ndt->name->wrapper == NULL)
+        return NULL; // too early in bootstrap
+    jl_datatype_t *primarydt = (jl_datatype_t*)jl_unwrap_unionall(ndt->name->wrapper);
+    if (primarydt == ndt || primarydt->super == NULL)
+        return NULL; // definition in progress
+    size_t nparams = jl_svec_len(ndt->parameters), pi;
+    jl_typeenv_t *penv = (jl_typeenv_t*)alloca(nparams * sizeof(jl_typeenv_t));
+    for (pi = 0; pi < nparams; pi++) {
+        penv[pi].var = (jl_tvar_t*)jl_svecref(primarydt->parameters, pi);
+        penv[pi].val = jl_svecref(ndt->parameters, pi);
+        penv[pi].prev = pi == 0 ? NULL : &penv[pi - 1];
+    }
+    jl_typestack_t stop = { ndt, NULL };
+    jl_value_t *s = inst_type_w_((jl_value_t*)primarydt->super,
+                                 nparams == 0 ? NULL : &penv[nparams - 1],
+                                 &stop, 1, 0, NULL);
+    // concurrent first queries compute equal values; the compare-and-swap
+    // keeps a single winner
+    super = NULL;
+    if (jl_atomic_cmpswap(superp, &super, (jl_datatype_t*)s)) {
+        jl_gc_wb(ndt, s);
+        super = (jl_datatype_t*)s;
+    }
+    return super;
+}
+
+// forcing accessor for Julia-visible supertype reads
+JL_DLLEXPORT jl_value_t *jl_datatype_super(jl_datatype_t *dt)
+{
+    jl_datatype_t *super = jl_datatype_compute_super(dt);
+    if (super == NULL)
+        jl_errorf("supertype of %s is not defined yet (type definition in progress)",
+                  jl_symbol_name(dt->name->name));
+    return (jl_value_t*)super;
+}
+
 void jl_reinstantiate_inner_types(jl_datatype_t *t, jl_deferred_typecache_t *dcache) // can throw!
 {
     assert(jl_is_datatype(t));
@@ -3480,7 +3604,11 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_datatype_type->name->wrapper = (jl_value_t*)jl_datatype_type;
     jl_datatype_type->super = jl_anytype_type;
     jl_datatype_type->parameters = jl_emptysvec;
-    jl_datatype_type->name->n_uninitialized = 8 - 3;
+    // only `name` is guaranteed initialized: `super` of a deferred
+    // self-referential instantiation stays NULL until
+    // `jl_datatype_compute_super` fills it (reads then see an undefined
+    // field, matching the interpreter), and `types`/`layout` are lazy too
+    jl_datatype_type->name->n_uninitialized = 8 - 1;
     jl_datatype_type->name->names = jl_perm_symsvec(8,
             "name",
             "super",
@@ -3499,8 +3627,8 @@ void jl_init_types(void) JL_GC_DISABLED
             jl_any_type /*jl_voidpointer_type*/,
             jl_any_type /*jl_int32_type*/,
             jl_any_type /*jl_uint16_type*/);
-    const static uint32_t datatype_constfields[1] = { 0x00000057 }; // (1<<0)|(1<<1)|(1<<2)|(1<<4)|(1<<6)
-    const static uint32_t datatype_atomicfields[1] = { 0x00000028 }; // (1<<3)|(1<<5)
+    const static uint32_t datatype_constfields[1] = { 0x00000055 }; // (1<<0)|(1<<2)|(1<<4)|(1<<6)
+    const static uint32_t datatype_atomicfields[1] = { 0x0000002a }; // (1<<1)|(1<<3)|(1<<5)
     jl_datatype_type->name->constfields = datatype_constfields;
     jl_datatype_type->name->atomicfields = datatype_atomicfields;
     jl_precompute_memoized_dt(jl_datatype_type, 1);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1034,6 +1034,8 @@ typedef struct {
     htable_t group;   // the in-flight group's datatypes
 } jl_deferred_typecache_t;
 void jl_reinstantiate_inner_types(jl_datatype_t *t, jl_deferred_typecache_t *dcache) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_datatype_t *jl_datatype_compute_super(jl_datatype_t *ndt JL_PROPAGATES_ROOT) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_datatype_super(jl_datatype_t *dt) JL_CANSAFEPOINT;
 jl_value_t *jl_apply_type_deferred(jl_value_t *tc, jl_value_t **params, size_t n, jl_deferred_typecache_t *dcache) JL_CANSAFEPOINT;
 int equiv_type(jl_value_t *ta, jl_value_t *tb) JL_CANSAFEPOINT;
 int references_name(jl_value_t *p, jl_typename_t *name, int affects_layout, int freevars) JL_NOTSAFEPOINT;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1015,7 +1015,7 @@ done_fields: ;
         // which would order the supertype before its own parameters in the queue. Defer it
         // until the recursion unwinds; any forward reference this creates in the image is
         // handled at load time by the uniquing_super/delay_list machinery.
-        if (jl_needs_serialization(s, (jl_value_t*)dt->super))
+        if (dt->super && jl_needs_serialization(s, (jl_value_t*)dt->super))
             arraylist_push(&deferred_supers, (void*)dt->super);
         immediate = 0;
         char *data = (char*)jl_data_ptr(v);
@@ -1947,7 +1947,7 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                         ios_write(s->const_data, (char*)&dyn, sizeof(jl_fielddescdyn_t));
                     }
                 }
-                void *superidx = ptrhash_get(&serialization_order, dt->super);
+                void *superidx = dt->super ? ptrhash_get(&serialization_order, dt->super) : HT_NOTFOUND;
                 if (s->incremental && superidx != HT_NOTFOUND && from_seroder_entry(superidx) > item && needs_uniquing((jl_value_t*)dt->super, s->query_cache))
                     arraylist_push(&s->uniquing_super, dt->super);
             }

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -743,12 +743,20 @@ int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity) JL_NOTSAFE
         jl_datatype_t *ad = (jl_datatype_t*)a, *bd = (jl_datatype_t*)b;
         if (ad->name != bd->name) {
             jl_datatype_t *temp = ad;
-            while (temp != jl_any_type && temp->name != bd->name)
+            while (temp != jl_any_type && temp->name != bd->name) {
+                // raw read: this heuristic must not reach a safepoint, so a
+                // deferred (unset) supertype conservatively proves nothing
                 temp = temp->super;
+                if (temp == NULL)
+                    return 0;
+            }
             if (temp == jl_any_type) {
                 temp = bd;
-                while (temp != jl_any_type && temp->name != ad->name)
+                while (temp != jl_any_type && temp->name != ad->name) {
                     temp = temp->super;
+                    if (temp == NULL)
+                        return 0;
+                }
                 if (temp == jl_any_type)
                     return 1;
                 bd = temp;
@@ -2941,7 +2949,7 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
             return 1;
         jl_datatype_t *xd = (jl_datatype_t*)ux, *yd = (jl_datatype_t*)uy;
         while (xd != NULL && xd != jl_any_type && xd->name != yd->name) {
-            xd = xd->super;
+            xd = jl_datatype_compute_super(xd);
         }
         if (xd == jl_any_type)
             return 0;
@@ -3067,11 +3075,12 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
         if (y == (jl_value_t*)jl_any_type) return 1;
         jl_datatype_t *xd = (jl_datatype_t*)x, *yd = (jl_datatype_t*)y;
         while (xd != jl_any_type && xd->name != yd->name) {
-            if (xd->super == NULL) {
+            jl_datatype_t *xsuper = jl_datatype_compute_super(xd);
+            if (xsuper == NULL) {
                 assert(xd->parameters && jl_is_typename(xd->name));
                 jl_errorf("circular type parameter constraint in definition of %s", jl_symbol_name(xd->name->name));
             }
-            xd = xd->super;
+            xd = xsuper;
         }
         if (xd == jl_any_type) return 0;
         if (xd->name == jl_tuple_typename)
@@ -3639,8 +3648,11 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
             if (((jl_datatype_t*)x)->name != ((jl_datatype_t*)y)->name) {
                 jl_datatype_t *temp = (jl_datatype_t*)x;
                 while (temp->name != ((jl_datatype_t*)y)->name) {
+                    // raw read: this heuristic must not reach a safepoint, so
+                    // a deferred (unset) supertype stays undecided and the
+                    // full algorithm resolves it
                     temp = temp->super;
-                    if (temp == NULL) // invalid state during type declaration
+                    if (temp == NULL)
                         return 0;
                     if (temp == jl_any_type) {
                         *subtype = 0;
@@ -5483,8 +5495,11 @@ static jl_value_t *intersect_sub_datatype(jl_datatype_t *xd, jl_datatype_t *yd, 
     // if that attempt fails, then return bottom
     // otherwise return xd (finish_unionall will later handle propagating those constraints)
     assert(e->Loffset == 0);
-    jl_value_t *isuper = R ? intersect((jl_value_t*)yd, (jl_value_t*)xd->super, e, param) :
-                             intersect((jl_value_t*)xd->super, (jl_value_t*)yd, e, param);
+    jl_datatype_t *xdsuper = jl_datatype_compute_super(xd);
+    if (xdsuper == NULL)
+        return jl_bottom_type; // definition in progress
+    jl_value_t *isuper = R ? intersect((jl_value_t*)yd, (jl_value_t*)xdsuper, e, param) :
+                             intersect((jl_value_t*)xdsuper, (jl_value_t*)yd, e, param);
     if (isuper == jl_bottom_type)
         return jl_bottom_type;
     return (jl_value_t*)xd;
@@ -5999,13 +6014,13 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_par
             return res;
         }
         if (param == PARAM_INVARIANT) return jl_bottom_type;
-        while (xd != jl_any_type && xd->name != yd->name)
-            xd = xd->super;
-        if (xd == jl_any_type) {
+        while (xd != NULL && xd != jl_any_type && xd->name != yd->name)
+            xd = jl_datatype_compute_super(xd);
+        if (xd == NULL || xd == jl_any_type) {
             xd = (jl_datatype_t*)x;
-            while (yd != jl_any_type && yd->name != xd->name)
-                yd = yd->super;
-            if (yd == jl_any_type)
+            while (yd != NULL && yd != jl_any_type && yd->name != xd->name)
+                yd = jl_datatype_compute_super(yd);
+            if (yd == NULL || yd == jl_any_type)
                 return jl_bottom_type;
             return intersect_sub_datatype((jl_datatype_t*)y, xd, e, 1, param);
         }
@@ -7286,7 +7301,9 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, jl_value_t *a0, jl_v
                     return 0;
                 return ascore > bscore || adiag > bdiag;
             }
-            tta = tta->super; super = 1;
+            tta = jl_datatype_compute_super(tta); super = 1;
+            if (tta == NULL)
+                return 0; // definition in progress
         }
         return 0;
     }

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -455,37 +455,39 @@ exit:
     }
 }
 
-static unsigned jl_supertype_height(jl_datatype_t *dt) JL_NOTSAFEPOINT
+static unsigned jl_supertype_height(jl_datatype_t *dt) JL_CANSAFEPOINT
 {
     unsigned height = 1;
-    while (dt != jl_any_type) {
+    while (dt != NULL && dt != jl_any_type) {
         height++;
-        dt = dt->super;
+        dt = jl_datatype_compute_super(dt);
     }
     return height;
 }
 
 // return true if a and b might intersect in the type domain (over just their type-names)
-static int tname_intersection_dt(jl_datatype_t *a, jl_typename_t *bname, unsigned ha) JL_NOTSAFEPOINT
+static int tname_intersection_dt(jl_datatype_t *a, jl_typename_t *bname, unsigned ha) JL_CANSAFEPOINT
 {
     if (a == jl_any_type)
         return 1;
     jl_datatype_t *b = (jl_datatype_t*)jl_unwrap_unionall(bname->wrapper);
     unsigned hb = 1;
-    while (b != jl_any_type) {
+    while (b != NULL && b != jl_any_type) {
         if (a->name == b->name)
             return 1;
         hb++;
-        b = b->super;
+        b = jl_datatype_compute_super(b);
     }
     while (ha > hb) {
-        a = a->super;
+        a = jl_datatype_compute_super(a);
         ha--;
+        if (a == NULL)
+            return 1; // definition in progress: conservatively may intersect
     }
     return a->name == bname;
 }
 
-static int tname_intersection(jl_value_t *a, jl_typename_t *bname, int8_t tparam) JL_NOTSAFEPOINT
+static int tname_intersection(jl_value_t *a, jl_typename_t *bname, int8_t tparam) JL_CANSAFEPOINT
 {
     if (a == (jl_value_t*)jl_any_type)
         return 1;
@@ -857,7 +859,9 @@ int jl_typemap_intersection_visitor(jl_typemap_t *map, int offs,
                         }
                         if (super == jl_any_type)
                             break;
-                        super = super->super;
+                        super = jl_datatype_compute_super(super);
+                        if (super == NULL)
+                            break; // definition in progress
                     }
                 }
                 else {
@@ -880,7 +884,9 @@ int jl_typemap_intersection_visitor(jl_typemap_t *map, int offs,
                         }
                         if (super == jl_any_type)
                             break;
-                        super = super->super;
+                        super = jl_datatype_compute_super(super);
+                        if (super == NULL)
+                            break; // definition in progress
                     }
                 }
                 else {
@@ -1098,7 +1104,9 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
                         }
                         if (super == jl_any_type || !subtype)
                             break;
-                        super = super->super;
+                        super = jl_datatype_compute_super(super);
+                        if (super == NULL)
+                            break; // definition in progress
                     }
                 }
                 else {
@@ -1138,7 +1146,9 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
                             }
                             if (super == jl_any_type || !subtype)
                                 break;
-                            super = super->super;
+                            super = jl_datatype_compute_super(super);
+                            if (super == NULL)
+                                break; // definition in progress
                         }
                     }
                 }
@@ -1295,7 +1305,9 @@ jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_v
                     if (ml) return ml;
                     if (a1 == (jl_value_t*)jl_any_type)
                         break;
-                    a1 = (jl_value_t*)((jl_datatype_t*)a1)->super;
+                    a1 = (jl_value_t*)jl_datatype_compute_super((jl_datatype_t*)a1);
+                    if (a1 == NULL)
+                        break; // definition in progress
                 }
             }
             else {
@@ -1326,7 +1338,9 @@ jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_v
                 if (ml) return ml;
                 if (ty == (jl_value_t*)jl_any_type)
                     break;
-                ty = (jl_value_t*)((jl_datatype_t*)ty)->super;
+                ty = (jl_value_t*)jl_datatype_compute_super((jl_datatype_t*)ty);
+                if (ty == NULL)
+                    break; // definition in progress
             }
         }
     }

--- a/test/core.jl
+++ b/test/core.jl
@@ -24,7 +24,9 @@ for (T, c) in (
         (Core.TypeMapEntry, [:sig, :simplesig, :guardsigs, :func, :isleafsig, :issimplesig, :va]),
         (Core.TypeMapLevel, []),
         (Core.TypeName, [:name, :module, :names, :wrapper, :hash, :n_uninitialized, :flags]),
-        (DataType, [:name, :super, :parameters, :instance, :hash]),
+        # `super` is filled lazily for instantiations of self-referential
+        # definitions (issue #61347), so it is deliberately non-const (and atomic)
+        (DataType, [:name, :parameters, :instance, :hash]),
         (TypeVar, [:name, :ub, :lb]),
         (Core.Memory, [:length, :ptr]),
         (Core.GenericMemoryRef, [:mem, :ptr_or_offset]),
@@ -45,7 +47,7 @@ for (T, c) in (
         (Core.TypeMapEntry, [:next, :min_world, :max_world]),
         (Core.TypeMapLevel, [:arg1, :targ, :name1, :tname, :list, :any]),
         (Core.TypeName, [:cache, :linearcache, :Typeofwrapper, :max_args, :cache_entry_count]),
-        (DataType, [:types, :layout]),
+        (DataType, [:super, :types, :layout]),
         (Core.Memory, []),
         (Core.GenericMemoryRef, []),
         (Task, [:_state, :preempt_request, :running_time_ns, :finished_at, :first_enqueued_at, :last_started_running_at, :waiting_on, :bound_cancel_token]),
@@ -9351,4 +9353,41 @@ let f = (x...) -> length(x)
     m3 = reshape(w, 3, 3)
     @test f(m3...) == 9
     @test ccall(:jl_array_copy, Ref{Matrix{Int}}, (Any,), m3) == m3
+end
+
+# issue #61347 (supertype half): every level of a structurally increasing
+# recursive supertype graph must be correct independently of instantiation
+# order, and deferred (lazily computed) supertypes must present the same
+# field-access semantics to compiled and interpreted code. (The field-type
+# analogue `struct S1{T}; x::S1{A{T}}; end` still hangs on instantiation;
+# a concrete type must publish with its layout, so its fix needs more.)
+module Issue61347
+abstract type A{T} end
+struct S2{T} <: A{S2{A{T}}} end
+end
+let A = Issue61347.A, S2 = Issue61347.S2
+    @test supertype(S2{Int}) === A{S2{A{Int}}}
+    # deep levels materialize lazily, one per demand, and stay correct
+    deep = S2{A{A{Int}}}
+    @test supertype(deep) === A{S2{A{A{A{Int}}}}}
+    # reaching the same interned type by walking or by direct construction
+    # yields the same supertype
+    walked = getfield(supertype(S2{Int}), :parameters)[1]
+    walked = getfield(supertype(walked), :parameters)[1]
+    @test walked === S2{A{A{Int}}}
+    @test supertype(walked) === supertype(deep)
+    @test S2{A{A{A{Int}}}} <: A
+    # compiled and interpreted field access agree on the deferred slot. The
+    # slot can be filled at any moment by unrelated activity, so bracket the
+    # interpreted read with compiled reads and require monotone agreement
+    # (an unfilled slot can only become filled, never the reverse)
+    lazy = getfield(supertype(S2{A{A{A{A{Int}}}}}), :parameters)[1]
+    @noinline compiled_isdef(x::DataType) = isdefined(x, :super)
+    c1 = compiled_isdef(Base.inferencebarrier(lazy))
+    itp = Core.eval(@__MODULE__, :(isdefined($lazy, :super)))
+    c2 = compiled_isdef(Base.inferencebarrier(lazy))
+    @test c1 <= itp <= c2
+    @test supertype(lazy) isa Type # forcing accessor
+    @test isdefined(lazy, :super)
+    @test getfield(lazy, :super) === supertype(lazy)
 end


### PR DESCRIPTION
🤖 A struct definition whose supertype declaration recursively applies the type being defined at structurally increasing parameters, such as

    struct S{T} <: A{S{Tuple{T}}} end

has an infinite supertype graph: eagerly instantiating each level's supertype creates the next level. Today the definition-time partial fixup truncates that recursion by silently caching wrong supertypes — the same interned type can permanently report `Any` or its true supertype depending on which expression happened to construct it first, and `supertype` disagrees with `<:`.

With this PR, an instantiation created while another instantiation of the same (supertype-self-referential) typename is in flight now defers its supertype and completes it lazily, one level per demand (`jl_datatype_compute_super`). Every level of the graph is correct and independent of instantiation order. Same-parameter self-references still tie their knot through the instantiation stack, so ordinary recursive types are unaffected, and field types stay eager — a concrete type must publish with its layout, so the field-type analogue of this recursion (the `S1` case of #61347) is left for a follow-up.

Addresses the supertype half of #61347.

Assisted-by: Claude Code (Fable 5)