### PR TITLE
Compiler: have the executable cache root CodeInstances handed to the JIT

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1966,6 +1966,35 @@ function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vec
     end
 end
 
+"""
+    jit_cache_root!(cache, ci::CodeInstance)
+
+Establish a GC root for `ci` that is adequate for handing it to the JIT.
+
+The JIT retains raw, non-GC-visible pointers to every CodeInstance it emits code
+for (in its symbol table and in the debuginfo address map used for backtraces
+and profiling), for the lifetime of the process. Every CodeInstance passed to
+`jl_add_codeinsts_to_jit` must therefore remain GC-reachable permanently.
+[`add_codeinsts_to_jit!`](@ref) calls this function for each CodeInstance it is
+about to emit that is not already rooted through the native `mi.cache` chain
+(which guarantees the required lifetime on its own); the executable cache that
+holds the CodeInstance is responsible for guaranteeing an equivalent lifetime.
+
+The generic fallback conservatively promotes the CodeInstance to a global root,
+which matches the lifetime of the code emitted for it (JIT code is never
+freed). A custom cache whose entries are process-rooted by other means may
+override this with a no-op.
+"""
+function jit_cache_root!(cache, ci::CodeInstance)
+    ccall(:jl_as_global_root, Any, (Any, Cint), ci, 1)
+    return nothing
+end
+# Entries in the native `mi.cache` chain are already rooted for the lifetime of
+# the process through their MethodInstance.
+jit_cache_root!(::InternalCodeCache, ::CodeInstance) = nothing
+jit_cache_root!(cache::OverlayCodeCache, ci::CodeInstance) =
+    jit_cache_root!(cache.globalcache, ci)
+
 function add_codeinsts_to_jit!(interp::AbstractInterpreter, ci, source_mode::UInt8)
     source_mode == SOURCE_MODE_ABI || return ci
     ci isa CodeInstance && !ci_has_invoke(ci) || return ci
@@ -2010,13 +2039,17 @@ function add_codeinsts_to_jit!(interp::AbstractInterpreter, ci, source_mode::UIn
             cached = find_equivalent_cached_ci(
                 workqueue.interp, callee, valid_worlds)
             if cached === nothing
-                # make sure callee is gc-rooted and cached, as required by jl_add_codeinsts_to_jit
+                # make sure callee is cached, as required by jl_add_codeinsts_to_jit
                 code_cache(workqueue.interp)[mi] = callee
             else
                 # use an existing CI from the cache, if there is available one that is compatible
                 callee === ci && (ci = cached)
                 callee = cached
             end
+            # `callee` is about to be emitted while absent from the native
+            # `mi.cache` chain; the executable cache it lives in must root it
+            # for the lifetime of the process (see `jit_cache_root!`).
+            jit_cache_root!(code_cache(workqueue.interp), callee)
         end
         push!(codeinsts, callee)
         push!(srcs, src)

--- a/Compiler/test/AbstractInterpreter.jl
+++ b/Compiler/test/AbstractInterpreter.jl
@@ -613,6 +613,10 @@ let interp = SourceModeWinnerInterp()
         interp, mi, Compiler.SOURCE_MODE_ABI) === inadequate
     @test Compiler.ci_has_invoke(inadequate)
     @test iszero(@ccall jl_mi_cache_has_ci(mi::Any, ci::Any)::Cint)
+    # `inadequate` lives in the native `mi.cache` chain (an `InternalCodeCache`
+    # with a custom owner), which already roots it for the process lifetime, so
+    # the JIT handoff must not have leaked a redundant global root for it.
+    @test (@ccall jl_as_global_root(inadequate::Any, 0::Cint)::Ptr{Cvoid}) == C_NULL
 end
 
 # A source-inadequate winner with a different return ABI cannot suppress normal
@@ -655,6 +659,10 @@ let interp = SourceModeEphemeralInterp()
         interp, mi, Compiler.SOURCE_MODE_ABI) === winner
     @test Compiler.code_cache(interp)[mi] === winner
     @test Compiler.ci_has_invoke(winner)
+    # The JIT retains raw pointers to the emitted `winner` for the lifetime of
+    # the process, and this ephemeral cache dies with `interp`, so the JIT
+    # handoff must have promoted `winner` to a global root (`jit_cache_root!`).
+    @test (@ccall jl_as_global_root(winner::Any, 0::Cint)::Ptr{Cvoid}) != C_NULL
     empty!(source_mode_ephemeral_codegen)
 end
 


### PR DESCRIPTION
Attempt 3. Ref #62799. cc @vtjnash @maleadt 

🤖 The JIT retains raw, non-GC-visible pointers to every CodeInstance whose body it emits: as keys in the CISymbols ORC symbol map, in pending MaterializationUnit linker info, and in the debuginfo address map used for backtraces and profiling. A CodeInstance passed to jl_add_codeinsts_to_jit must therefore remain GC-reachable for the lifetime of the process. That is normally guaranteed by its presence in the native `mi.cache` chain (whose entries are never unlinked), with the known exceptions handled explicitly: opaque-closure CodeInstances are promoted to global roots in jl_register_jit_object, and top-level thunks are unregistered by jl_invoke_oneshot before they become collectible.

An AbstractInterpreter whose executable cache is not the integrated InternalCodeCache breaks that guarantee: add_codeinsts_to_jit! re-establishes caching through the interpreter's cache abstraction, which for a custom cache roots the CodeInstance only in GC-managed interpreter state. Since #62359, the SOURCE_MODE_ABI path can also select an existing equivalent winner from such a cache and compile it from local source; a sourceless winner has empty edges, so it is not even incidentally kept alive through callee backedge lists. Once the interpreter is dropped, the CodeInstance is collected while its CISymbols entry remains, and a later CodeInstance allocated at the same address trips the `!CISymbols.contains(CI)` assertion in JuliaOJIT::registerCI (in release builds it could instead be linked to the dead CodeInstance's symbols). This is what intermittently killed Compiler/test/AbstractInterpreter.jl on the assert CI jobs: https://buildkite.com/organizations/julialang/pipelines/julia-ci/builds/224/jobs/019fd02f-6157-415d-89ce-b63474f47073/log

Make the lifetime requirement part of the executable-cache interface rather than hiding a root inside the JIT: add_codeinsts_to_jit! now calls the overloadable jit_cache_root! on the interpreter's executable cache for each CodeInstance it is about to emit that is absent from the native `mi.cache` chain. The generic fallback conservatively promotes the CodeInstance to a global root, matching the lifetime of the emitted code itself (JIT code is never freed), while InternalCodeCache overrides it with a no-op because the native chain already provides the root; a custom cache whose entries are process-rooted by other means can do the same.

Replaces the jitlayers-side pin from the previous version of this branch, which established the root inside the JIT at the emission chokepoint, per review discussion.

Assisted-by: Claude Code (Fable 5)