### PR TITLE
gf: resolve unordered pairs that an empty-set cover for computed ambiguities

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3319,6 +3319,68 @@ static int check_interferences_covers(jl_method_t *m, jl_value_t *ti, jl_array_t
     return status == COVER_CERTIFIED;
 }
 
+// `m` and `m2` are unordered with each other, but that only makes the query
+// ambiguous if some point where both apply has no other winner. Look for a
+// match that beats them both over the whole region they contest, `ti` ∩ `ti2`:
+// dispatch selects that method there, so the pair is resolved rather than
+// ambiguous.
+//
+// Only a cover with an empty interference set is admitted as that witness,
+// since such a method is strictly morespecific than every method it intersects,
+// and therefore
+//  - wins at every point of the contested region, whatever else applies there,
+//    so no further check of the rest of the match list is needed;
+//  - can never be dropped from the report (no method covers it, as a cover must
+//    beat it), so the resolution stays visible to the caller;
+//  - cannot sit on a specificity cycle, unlike a merely-morespecific cover,
+//    whose own selectability could depend on the ordering this sort is still
+//    computing (compare the admissibility rules in `check_interferences_covers`).
+// A cover that beats `m` is recorded in `m`'s interference set, so scanning that
+// set (the one the caller is already walking) finds every candidate. `ambig10`
+// in test/ambiguous.jl is this shape: `Vararg` methods with pairwise-disjoint
+// element types are unordered with each other, yet they overlap only at the
+// empty tuple, which the nullary method covers and beats.
+static int pair_resolved_by_empty_cover(jl_method_t *m, jl_method_t *m2, jl_value_t *ti, jl_value_t *ti2, jl_array_t *t) JL_CANSAFEPOINT
+{
+    int result = 0;
+    jl_value_t *region = NULL;
+    jl_genericmemory_t *interferences = jl_atomic_load_relaxed(&m->interferences);
+    JL_GC_PUSH2(&region, &interferences);
+    for (size_t i = 0; i < interferences->length; i++) {
+        jl_method_t *r = (jl_method_t*)jl_genericmemory_ptr_ref(interferences, i);
+        if (r == NULL)
+            continue;
+        // the emptiness test is the O(1) bail; it also implies `r` beats `m`,
+        // which recorded it here
+        if (jl_atomic_load_relaxed(&r->interferences)->length != 0)
+            continue;
+        if (find_method_in_matches(t, r) < 0)
+            continue; // not applicable to this query in this world
+        if (!method_morespecific_recorded(r, m2))
+            continue; // `r` must beat the partner too
+        if (region == NULL) {
+            // Computed only once a candidate exists, since the whole point of
+            // the interference graph is to answer these questions without a
+            // `typeintersect` per pair.
+            region = jl_type_intersection(ti, ti2);
+            if (region == jl_bottom_type) {
+                // the pair is recorded as overlapping, but not anywhere inside
+                // this query, so nothing here can dispatch to either of them
+                result = 1;
+                break;
+            }
+        }
+        // An over-approximated `region` only makes this containment harder to
+        // satisfy, so the imprecision costs acceptances, never soundness.
+        if (jl_subtype(region, (jl_value_t*)r->sig)) {
+            result = 1;
+            break;
+        }
+    }
+    JL_GC_POP();
+    return result;
+}
+
 static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, int include_ambiguous, int *has_ambiguity) JL_CANSAFEPOINT
 {
     if (include_ambiguous && *has_ambiguity)
@@ -3335,9 +3397,23 @@ static int check_fully_ambiguous(jl_method_t *m, jl_value_t *ti, jl_array_t *t, 
             continue;
         if (!method_in_interferences(m, m2))
             continue;
-        *has_ambiguity = 1;
-        if (include_ambiguous)
-            break; // the rest of the scan could only set *has_ambiguity again
+        // Once the flag is set, the search for a resolving cover cannot change
+        // anything, so only pay for it while the answer is still open.
+        if (!*has_ambiguity) {
+            jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(t, idx);
+            if (!pair_resolved_by_empty_cover(m, m2, ti, (jl_value_t*)matc2->spec_types, t))
+                *has_ambiguity = 1;
+        }
+        if (include_ambiguous) {
+            if (*has_ambiguity)
+                break; // the rest of the scan could only set *has_ambiguity again
+            continue; // a resolved pair reports nothing, but a later one may
+        }
+        // Whether or not the pair was resolved, `m` is unselectable wherever the
+        // partner it cannot beat applies, so a partner covering all of `ti`
+        // removes it: for a resolved pair the empty-set cover contains `ti` too
+        // (and its blocker-transfer obligations are automatic), and otherwise the
+        // ambiguity is now recorded.
         if (jl_subtype(ti, m2->sig)) {
             result = 1;
             break;

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -586,7 +586,9 @@ let has_ambig = Ref(Int32(0))
     ms = Base._methods_by_ftype(Tuple{typeof(fnoambig), Any, Any}, nothing, 4, Base.get_world_counter(), false, Ref(typemin(UInt)), Ref(typemax(UInt)), has_ambig)
     @test ms isa Vector
     @test length(ms) == 4
-    @test has_ambig[] == 1 # 0 is better, but expensive and probably unnecessary to compute
+    # the (Int,Any)/(Any,Int) pair is unordered, but everywhere both apply the
+    # (Int,Int) method wins, so the call is not ambiguous anywhere
+    @test has_ambig[] == 0
 end
 
 # issue #11407
@@ -653,17 +655,60 @@ let ambig = Ref{Int32}(0)
     ms = Base._methods_by_ftype(Tuple{typeof(ambig10), Vararg}, nothing, -1, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ms isa Vector
     @test length(ms) == 6
-    @test_broken ambig[] == 0
+    @test ambig[] == 0
 end
 let ambig = Ref{Int32}(0)
     ms = Base._methods_by_ftype(Tuple{typeof(ambig10), Vararg{Number}}, nothing, -1, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ms isa Vector
     @test length(ms) == 4
-    @test_broken ambig[] == 0
+    @test ambig[] == 0
     @test ms[1].method === which(ambig10, ())
     @test ms[2].method === which(ambig10, (Vararg{Union{Int32, Int64}},))
     @test ms[3].method === which(ambig10, Tuple{Vararg{N}} where N<:Number,)
     @test ms[4].method === which(ambig10, (Vararg{Number},))
+end
+
+# An unordered pair is only ambiguous where no other method wins: `ambig10`
+# above resolves at the empty tuple, and this is the same shape without the
+# `Vararg`. Only a cover with an empty interference set is accepted as the
+# witness, since it is morespecific than everything it intersects and so can
+# neither lose to a method applying there nor sit on a specificity cycle.
+module AmbigEmptyCover
+k(::Int, ::Any, ::Any) = 1
+k(::Any, ::Int, ::Any) = 2
+k(::Int, ::Int, ::Any) = 3 # empty interference set: beats both, covers their overlap
+p(::Int, ::Any, ::Any) = 1
+p(::Any, ::Int, ::Any) = 2
+p(::Int, ::Int, ::Int) = 3 # covers only part of the overlap
+q(::Int, ::Any, ::Any) = 1
+q(::Any, ::Int, ::Any) = 2
+q(::Int, ::Int, ::Any) = 3
+q(::Integer, ::Int, ::Int) = 4 # leaves `q`'s cover unordered with this one
+end
+let ambig = Ref{Int32}(0)
+    ms = Base._methods_by_ftype(Tuple{typeof(AmbigEmptyCover.k), Vararg{Any}}, nothing, -1, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    @test length(ms) == 3
+    @test ambig[] == 0
+    @test AmbigEmptyCover.k(1, 1, "x") == 3
+end
+let ambig = Ref{Int32}(0)
+    # the cover contains only part of the contested region, so the rest of it is
+    # a real ambiguity
+    ms = Base._methods_by_ftype(Tuple{typeof(AmbigEmptyCover.p), Vararg{Any}}, nothing, -1, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    @test length(ms) == 3
+    @test ambig[] == 1
+    @test AmbigEmptyCover.p(1, 1, 1) == 3
+    @test_throws MethodError AmbigEmptyCover.p(1, 1, "x")
+end
+let ambig = Ref{Int32}(0)
+    # `q(::Integer, ::Int, ::Int)` cannot apply within this query, so nothing here
+    # is ambiguous, but the cover's interference set is no longer empty and the
+    # pair is reported conservatively
+    ms = Base._methods_by_ftype(Tuple{typeof(AmbigEmptyCover.q), Int, Union{Int,String}, String, Vararg{Any}}, nothing, -1, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    @test length(ms) == 2
+    @test_broken ambig[] == 0
+    @test AmbigEmptyCover.q(1, 1, "x") == 3
+    @test AmbigEmptyCover.q(1, "y", "x") == 1
 end
 
 # issue #62262: an ambiguity can be resolved by the union of several more


### PR DESCRIPTION
`check_fully_ambiguous` reported an ambiguity for every unordered pair whose partner was still in the raw match list, even when no point of the region the pair contests could actually fail to dispatch. A pair is only ambiguous where neither member is beaten by something else that applies, so look for a match that covers the whole contested region and beats both members before flagging it.

Only a cover with an empty interference set is admitted as that witness. Such a method is strictly morespecific than every method it intersects, so it wins at every point of the region no matter what else applies there, no method can cover it in turn and drop it from the report, and it cannot sit on a specificity cycle whose resolution would depend on the ordering the sort is still computing. A merely-morespecific cover has none of these properties, and accepting one would reopen the cycle counterexamples that `check_interferences_covers` guards against, so those pairs continue to report conservatively.

The decision to drop the dominated match is deliberately left unchanged: a resolved pair whose partner covers the match is dropped exactly as before, which stays silent because the empty-set cover contains that region too and its blocker-transfer obligations are automatic.

Queries whose imprecise answer was previously recorded as such now compute the exact one, including `Vararg` methods with pairwise-disjoint element types that overlap only at the empty tuple, and the four-method `(Int,Any)`/`(Any,Int)` lattice that its most specific method resolves everywhere.

Assisted-by: Claude Code (Fable, Opus 5)

 - [ ] rebased, but still probably needs AI comments to be corrected