### PR TITLE
clangsa: Detect uninitialized GC roots

### DIFF
--- a/src/clangsa/GCCheckerPropagation.cpp
+++ b/src/clangsa/GCCheckerPropagation.cpp
@@ -1586,6 +1586,10 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
       State = addFrameRoot(State, CurrentDepth, Region, C);
       // Now for the value
       SVal Value = State->getSVal(Region);
+      if (Value.isUndef()) {
+        report_error(C, "Pushing an uninitialized value to the GC root stack");
+        return true;
+      }
       SymbolRef Sym = Value.getAsSymbol();
       if (!Sym)
         continue;

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -422,7 +422,7 @@ int jl_typemap_visitor(jl_typemap_t *cache, jl_typemap_visitor_fptr fptr, void *
 {
     if (jl_typeof(cache) == (jl_value_t*)jl_typemap_level_type) {
         jl_typemap_level_t *node = (jl_typemap_level_t*)cache;
-        jl_genericmemory_t *a;
+        jl_genericmemory_t *a = NULL;
         JL_GC_PUSH1(&a);
         a = jl_atomic_load_relaxed(&node->targ);
         if (a != (jl_genericmemory_t*)jl_an_empty_memory_any)

--- a/test/clangsa/GCPushPop.cpp
+++ b/test/clangsa/GCPushPop.cpp
@@ -22,6 +22,13 @@ void superfluousPop() {
   JL_GC_POP(); // expected-warning{{JL_GC_POP without corresponding push}}
 }              // expected-note@-1{{JL_GC_POP without corresponding push}}
 
+void uninitializedValuePush() {
+  jl_value_t *x;
+  JL_GC_PUSH1(&x); // expected-warning{{Pushing an uninitialized value to the GC root stack}}
+                   // expected-note@-1{{Pushing an uninitialized value to the GC root stack}}
+  JL_GC_POP();
+}
+
 extern void JL_NORETURN no_return_error(void);
 void noreturnAfterPush() {
   jl_value_t *x = NULL;


### PR DESCRIPTION
make gcanalyzer identify uninitialized values being pushed to root stack and fix one surfaced example

fixes https://github.com/JuliaLang/julia/issues/38083

Assisted-by: Codex (GPT-5)