### PR TITLE
Add `constructors` showing all `UnionAll` constructors (opposed to `methods`)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,10 @@ New library functions
   `mod`, keyed by `(including_module, absolute_path)`. The table is stored inside the package
   image, so it survives precompilation; revision tools (e.g. Revise) use it to re-apply the
   original transform when an `include(mapexpr, …)`-ed file is edited.
+* `constructors(T)` lists the constructor methods of `T` and of all its parameterizations.
+  `methods(T)` only covers the type object `T` itself, so for a parametric type it reports
+  neither the inner constructors nor those written for a specific parameterization such as
+  `T{Int}`. `constructors` is exported from `Base` to parallel `methods`.
 
 New library features
 --------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -850,6 +850,7 @@ export
 # help and reflection
     code_typed,
     code_lowered,
+    constructors,
     fullname,
     functionloc,
     isconst,

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1717,10 +1717,13 @@ The methods are ordered from most to least specific. The relative order of
 methods without a specificity relationship (i.e. ambiguous or incomparable)
 is unspecified.
 
+For a type `T`, this only returns the methods dispatching on `T` itself. Use
+[`constructors`](@ref) to also get those of its parameterizations.
+
 !!! compat "Julia 1.4"
     At least Julia 1.4 is required for specifying a module.
 
-See also [`which`](@ref), [`@which`](@ref Main.InteractiveUtils.@which), [`methodswith`](@ref Main.InteractiveUtils.methodswith).
+See also [`which`](@ref), [`@which`](@ref Main.InteractiveUtils.@which), [`methodswith`](@ref Main.InteractiveUtils.methodswith), [`constructors`](@ref).
 """
 function methods(@nospecialize(f), @nospecialize(t),
                  mod::Union{Tuple{Module},AbstractArray{Module},AbstractSet{Module},Nothing}=nothing)
@@ -1746,6 +1749,48 @@ function methods(@nospecialize(f),
     # return all matches
     return methods(f, Tuple{Vararg{Any}}, mod)
 end
+
+"""
+    constructors(T::Type, [module])
+
+Return the constructor methods applicable to `T` or to any of its parameterizations if it is a `UnionAll`.
+
+`T` and `T{Int}` are separate constructor functions, so [`methods`](@ref) on one of them misses those
+written for the other. `constructors(T)`, however, matches on `Type{<:T}` covering all of them,
+including generic ones such as `(::Type{S})(x) where S<:T`.
+
+If `module` is specified, only return methods defined in that module. A list of modules can
+also be specified as an array or set.
+
+!!! compat "Julia 1.14"
+    This function requires at least Julia 1.14.
+
+# Examples
+```jldoctest
+julia> struct Point{T}
+           x::T
+           y::T
+       end
+
+julia> length(methods(Point))
+1
+
+julia> length(constructors(Point))
+2
+```
+
+See also [`methods`](@ref), [`which`](@ref), [`methodswith`](@ref Main.InteractiveUtils.methodswith).
+"""
+function constructors(@nospecialize(T::Type),
+                      mod::Union{Tuple{Module},AbstractArray{Module},AbstractSet{Module},Nothing}=nothing)
+    world = get_world_counter()
+    world == typemax(UInt) && error("code reflection cannot be used from generated functions")
+    ms = _methods_by_ftype(Tuple{Type{<:T}, Vararg{Any}}, -1, world)::Vector{Any}
+    # Union{} <: T always holds, so the query also matches boot.jl's Union{}(a...)
+    filter!(m -> (m::Core.MethodMatch).method.sig !== Tuple{Type{Union{}}, Vararg{Any}}, ms)
+    return matches_to_methods(ms, typeof(T).name, mod)
+end
+constructors(@nospecialize(T::Type), mod::Module) = constructors(T, (mod,))
 
 # low-level method lookup functions used by the compiler
 

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -39,6 +39,7 @@ Base.OncePerTask
 Base.OncePerThread
 Base.which(::Any, ::Any)
 Base.methods
+Base.constructors
 Base.@show
 ans
 err

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -322,6 +322,9 @@ arguments with matching type may be given to the generic `Point` constructor.
 
 What's really going on here is that `Point`, `Point{Float64}` and `Point{Int64}` are all different
 constructor functions. In fact, `Point{T}` is a distinct constructor function for each type `T`.
+Because they are distinct functions, [`methods`](@ref) applied to `Point` lists only the methods
+dispatching on `Point` itself, and applied to `Point{Int64}` only those dispatching on
+`Point{Int64}`. [`constructors(Point)`](@ref constructors) lists the methods of all of them at once.
 Without any explicitly provided inner constructors, the declaration of the composite type `Point{T<:Real}`
 automatically provides an inner constructor, `Point{T}`, for each possible type `T<:Real`, that
 behaves just like non-parametric default inner constructors do. It also provides a single general

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1277,6 +1277,70 @@ end
     @test length(methods(g, ())) == 1
 end
 
+module TestCtors
+struct P{T}
+    x::T
+    P{T}(x::T) where T = new{T}(x)
+    P{T}(x::String) where T = new{T}(parse(T, x))
+end
+P(x::T) where T = P{T}(x)
+P{Int}(x::Bool) = P{Int}(Int(x))
+(::Type{S})(x::Char) where S<:P = S(string(x))
+struct Q
+    x::Int
+end
+struct D{T,S}
+    t::T
+    s::S
+end
+(::Type{D{Int,S}})(t::Bool, s::S) where S = D{Int,S}(Int(t), s)
+(::Type{D{T,Float64}})(t::T, s::Char) where T = D{T,Float64}(t, Float64(s))
+module Sub
+import ..TestCtors: P
+P{Float64}(::Nothing) = P{Float64}(0.0)
+end
+end
+
+@testset "constructors" begin
+    using .TestCtors: P, Q, D
+    # methods() sees only what dispatches on the queried type object itself
+    @test length(methods(P)) == 1
+    @test length(constructors(P)) == 6
+    @test Set(constructors(P)) ==
+        (P, P{Int}, P{Float64}) .|> methods |> Iterators.flatten |> Set
+
+    # a type without proper subtypes has no further parameterizations to collect
+    @test Set(constructors(P{Int})) == Set(methods(P{Int}))
+    @test Set(constructors(Q)) == Set(methods(Q))
+
+    # for a two-parameter type nothing dispatches on a partial parameterization at all,
+    # since `D{Int}` is the type object `D{Int,S} where S`
+    @test isempty(methods(D{Int}))
+    @test length(constructors(D)) == 4
+    # querying `D` adds exactly what is written for `D` itself
+    @test D |> constructors |> Set ==
+        (D{Int}, D) .|> (constructors, methods) |> Iterators.flatten |> Set
+    # the two incomparable partial parameterizations collect the same constructors,
+    # since a signature matches by intersection and they meet at `D{Int,Float64}`
+    @test allequal((D{Int}, D{T,Float64} where T) .|> constructors .|> Set)
+
+    @test length(constructors(P, TestCtors)) == 5
+    @test length(constructors(P, [TestCtors])) == 5
+    @test length(constructors(P, TestCtors.Sub)) == 1
+    @test length(constructors(P, Set([TestCtors, TestCtors.Sub]))) == 6
+
+    # boot.jl's Union{}(a...) matches every query, since Union{} <: T
+    @test isempty(constructors(Union{}))
+    @test !any(m -> m.sig === Tuple{Type{Union{}}, Vararg{Any}}, constructors(Any))
+
+    # non-DataType arguments are accepted
+    @test Set(constructors(Union{Int8,UInt8})) ==
+        (Int8, UInt8) .|> constructors |> Iterators.flatten |> Set
+
+    @test constructors(P) isa Base.MethodList
+    @test occursin("6 methods", sprint(show, constructors(P)))
+end
+
 module BodyFunctionLookup
 f1(x, y; a=1) = error("oops")
 f2(f::Function, args...; kwargs...) = f1(args...; kwargs...)


### PR DESCRIPTION
`Base.methods` is a great tool to get an overview about the different methods of a function. Especially when these methods work together by calling into each other, this overview is very valuable to avoid missing the big picture.

When you have a `UnionAll` it's typical that the constructors also work together. For example a constructor without type parameters might call into a constructor using default type parameters. However, `methods` does not cover this case, as `MyType` and `MyType{T}` are seen as different functions and therefore you'd need to have multiple queries with `methods`. But calling `methods` manually gets complex quickly, both by structure (two type parameters already lead to 4 cases of having no, either of one or two free parameters) and by implementation (there can be lot of types like MyType{Int}, MyType{Float16}, MyType{MyOtherType{Int}} …).

 So we lack a tool for this use case which covers the problem similarly to what `methods` does for non-`UnionAll` types. Extending `methods` would have been possible, but only getting the methods of the single type can be useful, so it would have been an option (argument with default value). However, this option does not make sense for regular functions, but only for constructors, indicating that this is best implemented separately.

 This is done by adding `constructors`, which is implemented similarly to `methods`, but with the extension of checking for the different parameterized types. For certain types the difference is striking: `methods(Array)` currently shows 22 methods with current master (no packages explicitly loaded), whereas `constructors(Array)` shows 103 methods. Although it might still be difficult to analyze 103 methods, it's definitely easier when having a complete overview. However, `Array` is a complicated type. Most other calls just show a single digit of implemented methods.

Strictly speaking, this handles callable types and not only constructors, as a callable type does not need to construct an object. However, `constructor` is the official name used in the documentation, so this implementation sticks to it.

Normally, we would make a new `Base` function `public`. However, I think no-one could understand in the future why `methods` is exported and `constructors` is public. So for all our long-term sanity, let's bite the bullet and export another function in the name of practicality and consistency.

Claude Opus 5 supported in creating this PR.