### PR TITLE
fix write barrier ordering and document `jl_gc_write[_atomic]`

### DIFF
--- a/doc/src/devdocs/gc.md
+++ b/doc/src/devdocs/gc.md
@@ -53,7 +53,7 @@ Julia stores age information for its generational GC in the object header: the l
 
 Generational collection is implemented through sticky bits: objects are only pushed to the mark-stack, and therefore traced, if their mark-bits have not been set. When objects reach the oldest generation, their mark-bits aren't reset during a quick sweep, so these objects aren't traced during a subsequent mark phase. A full sweep, however, resets the mark-bits of all objects, so all of them are traced in a subsequent collection.
 
-When the mutator is running, a write barrier intercepts field writes and pushes an object’s address into a per-thread remembered set if the reference crosses generations. Objects in this remembered set are then traced during the next mark phase.
+When the mutator is running, a write barrier intercepts field writes and pushes an object’s address into a per-thread remembered set if the reference crosses generations. Objects in this remembered set are then traced during the next mark phase. The barrier is issued *before* the store, so that a collector needing the displaced reference can still read it; see [Updating fields of GC-managed objects](@ref).
 
 ## Sweeping
 

--- a/doc/src/devdocs/object.md
+++ b/doc/src/devdocs/object.md
@@ -76,7 +76,16 @@ The mutability property of a value can be queried for with:
 int jl_is_mutable(jl_value_t *v);
 ```
 
-If the object being stored is a `jl_value_t`, the Julia garbage collector must be notified also:
+If the object being stored is a `jl_value_t`, the Julia garbage collector must be notified also.
+The preferred form performs the store and the write barrier together, in the correct order:
+
+```c
+jl_gc_write(parent, field, type, val);
+jl_gc_write_atomic(parent, field, type, val, order); // for an _Atomic field
+```
+
+For updates that are not a single assignment, the barrier can be issued on its own, but must
+run *before* the store it guards:
 
 ```c
 void jl_gc_wb(jl_value_t *parent, jl_value_t *ptr);

--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -420,29 +420,45 @@ jl_checked_assignment(bp, mod, var, val);
 
 The garbage collector also operates under the assumption that it is aware of every
 older-generation object pointing to a younger-generation one. Any time a pointer is updated
-breaking that assumption, it must be signaled to the collector with the `jl_gc_wb` (write
-barrier) function like so:
+breaking that assumption, it must be signaled to the collector with a write barrier.
+
+Prefer the `jl_gc_write` macro, which performs the barrier and the store together, in the
+correct order:
 
 ```c
 jl_value_t *parent = some_old_value, *child = some_young_value;
-((some_specific_type*)parent)->field = child;
-jl_gc_wb(parent, child);
+jl_gc_write(parent, ((some_specific_type*)parent)->field, jl_value_t, child);
+jl_gc_write_atomic(parent, ((some_specific_type*)parent)->atomic_field, jl_value_t, child, release);
 ```
 
-It is in general impossible to predict which values will be old at runtime, so the write
-barrier must be inserted after all explicit stores. One notable exception is if the `parent`
+`type` is the pointed-to type of the field; the atomic variant takes the memory ordering
+(`relaxed` or `release`) last.
+
+Use the underlying `jl_gc_wb` (write barrier) function directly only when the update is not a
+single assignment — a compare-and-swap, a bulk copy over several fields, or a destination
+that is not a plain lvalue. It must be issued **before** the store, because a collector may
+need to read the reference the store is about to displace:
+
+```c
+jl_value_t *parent = some_old_value, *child = some_young_value;
+jl_gc_wb(parent, child);
+((some_specific_type*)parent)->field = child;
+```
+
+It is in general impossible to predict which values will be old at runtime, so a write
+barrier is needed for all explicit stores. One notable exception is if the `parent`
 object has just been allocated and no garbage collection has run since then. Note that most
 `jl_...` functions can sometimes invoke garbage collection.
 
-The write barrier is also necessary for arrays of pointers when updating their data directly.
+A write barrier is also necessary for arrays of pointers when updating their data directly.
 Calling `jl_array_ptr_set` is usually much preferred. But direct updates can be done. For example:
 
 ```c
 jl_array_t *some_array = ...; // e.g. a Vector{Any}
 void **data = jl_array_data(some_array, void*);
 jl_value_t *some_value = ...;
-data[0] = some_value;
 jl_gc_wb(jl_array_owner(some_array), some_value);
+data[0] = some_value;
 ```
 
 ### Controlling the Garbage Collector


### PR DESCRIPTION
since #62224 `jl_gc_wb*` goes before the write and we have `jl_gc_write[_atomic]` to make the process easy to do correctly automatically. None of this was updated in the devdocs, so agents were continually writing the old (incorrect version).

Assisted-by: Claude Code (Opus 5)