### PR TITLE
compiler: Preserve undefined slot entry state

### DIFF
--- a/Compiler/src/ssair/slot2ssa.jl
+++ b/Compiler/src/ssair/slot2ssa.jl
@@ -662,10 +662,8 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, sv::OptimizationState,
     initial_incoming_vals = Pair{Any, Any}[
         if 0 in defuses[x].defs
             Pair{Any, Any}(Argument(x), true)
-        elseif !defuses[x].any_newvar
-            Pair{Any, Any}(UNDEF_TOKEN, false)
         else
-            Pair{Any, Any}(SSAValue(-2), false)
+            Pair{Any, Any}(UNDEF_TOKEN, false)
         end for x in 1:length(ci.slotflags)
     ]
     worklist = Tuple{Int, Int, Vector{Pair{Any, Any}}}[(1, 0, initial_incoming_vals)]
@@ -727,7 +725,6 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, sv::OptimizationState,
         for slot in live_slots[item]
             (ival, idef) = incoming_vals[slot]
             (ival === SSAValue(-1)) && continue
-            (ival === SSAValue(-2)) && continue
             (ival === UNDEF_TOKEN) && continue
 
             bbstate = sv.bb_states[item]

--- a/Compiler/src/ssair/slot2ssa.jl
+++ b/Compiler/src/ssair/slot2ssa.jl
@@ -3,15 +3,13 @@
 mutable struct SlotInfo
     defs::Vector{Int}
     uses::Vector{Int}
-    any_newvar::Bool
 end
-SlotInfo() = SlotInfo(Int[], Int[], false)
+SlotInfo() = SlotInfo(Int[], Int[])
 
 function scan_entry!(result::Vector{SlotInfo}, idx::Int, @nospecialize(stmt))
     # NewvarNodes count as defs for the purpose
     # of liveness analysis (i.e. they kill use chains)
     if isa(stmt, NewvarNode)
-        result[slot_id(stmt.slot)].any_newvar = true
         push!(result[slot_id(stmt.slot)].defs, idx)
         return
     elseif isexpr(stmt, :(=))
@@ -578,7 +576,7 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, sv::OptimizationState,
         # No uses => no need for phi nodes
         isempty(slot.uses) && continue
         # TODO: Restore this optimization
-        if false # length(slot.defs) == 1 && slot.any_newvar
+        if false # length(slot.defs) == 1
             if slot.defs[] == 0
                 typ = sv.slottypes[idx]
                 ssaval = Argument(idx)
@@ -694,11 +692,6 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, sv::OptimizationState,
         for (idx, slot) in Iterators.enumerate(phi_slots[item])
             (; ssaval, node, undef_ssaval, undef_node) = new_phi_nodes[item][idx]
             (incoming_val, incoming_def) = incoming_vals[slot]
-            if incoming_val === SSAValue(-1)
-                # Optimistically omit this path.
-                # Liveness analysis would probably have prevented us from inserting this phi node
-                continue
-            end
             push!(node.edges, pred)
             if incoming_val === UNDEF_TOKEN
                 resize!(node.values, length(node.values)+1)
@@ -724,7 +717,6 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, sv::OptimizationState,
         has_pinode = fill(false, length(sv.slottypes))
         for slot in live_slots[item]
             (ival, idef) = incoming_vals[slot]
-            (ival === SSAValue(-1)) && continue
             (ival === UNDEF_TOKEN) && continue
 
             bbstate = sv.bb_states[item]
@@ -779,14 +771,15 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, sv::OptimizationState,
                     if isa(arg1, SlotNumber)
                         id = slot_id(arg1)
                         val = stmt.args[2]
-                        typ = typ_for_val(val, ci, ir, idx, sv.slottypes)
                         # Having UNDEF_TOKEN appear on the RHS is possible if we're on a dead branch.
                         # Do something reasonable here, by marking the LHS as undef as well.
                         if val !== UNDEF_TOKEN
                             thisdef = true
+                            typ = typ_for_val(val, ci, ir, idx, sv.slottypes)
                             thisval = make_ssa!(ci, code, idx, typ)
                         else
                             code[idx] = nothing
+                            typ = Union{}
                             thisval = UNDEF_TOKEN
                             thisdef = false
                         end
@@ -801,10 +794,6 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, sv::OptimizationState,
                                 new_phic_nodes[leave_block])
                             if cidx !== nothing
                                 node = thisdef ? UpsilonNode(thisval) : UpsilonNode()
-                                if incoming_vals[id] === UNDEF_TOKEN
-                                    node = UpsilonNode()
-                                    typ = Union{}
-                                end
                                 insert = new_phic_nodes[leave_block][cidx].insert
                                 push!(insert.node.values,
                                       NewSSAValue(insert_node!(ir, idx, NewInstruction(node, typ), true).id - length(ir.stmts)))

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -800,6 +800,26 @@ end
 end
 @test f_unreachable_phinode_edge2(1, 2) == 2
 
+# Preserve an undefined incoming value when slot2ssa creates a PhiNode (#55388).
+function undef_phinode55388(nextstate, loopcond, valuecond, returncond)
+    nextstate && @goto state3
+    while loopcond
+        ct = valuecond ? [] : nothing
+        if returncond
+            return
+            @label state3
+        end
+        Base.donotdelete(ct)
+    end
+    nothing
+end
+let src = code_typed1(undef_phinode55388, (Bool, Bool, Bool, Bool))
+    @test any(src.code) do stmt
+        isa(stmt, PhiNode) || return false
+        return any(i -> !isassigned(stmt.values, i), eachindex(stmt.edges))
+    end
+end
+
 global global_error_switch::Bool = true
 function gen_must_throw_phinode_edge(world::UInt, source, _)
     ci = make_codeinfo(Any[

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -819,6 +819,34 @@ let src = code_typed1(undef_phinode55388, (Bool, Bool, Bool, Bool))
         return any(i -> !isassigned(stmt.values, i), eachindex(stmt.edges))
     end
 end
+@test_throws UndefVarError undef_phinode55388(true, true, true, false)
+@test undef_phinode55388(false, false, false, false) === nothing
+
+# ... and the same for a slot whose definitions live inside an exception region,
+# which reaches the `PhiCNode`/`UpsilonNode` path instead (#55388).
+@noinline maythrow55388(x) = x === nothing ? throw(ArgumentError("nothing")) : x
+function undef_phicnode55388(nextstate, loopcond, valuecond)
+    nextstate && @goto state3
+    while loopcond
+        local ct
+        try
+            ct = maythrow55388(valuecond ? [] : nothing)
+        catch
+            ct = nothing
+        end
+        @label state3
+        Base.donotdelete(ct)
+    end
+    nothing
+end
+let src = code_typed1(undef_phicnode55388, (Bool, Bool, Bool))
+    @test any(src.code) do stmt
+        isa(stmt, PhiNode) || return false
+        return any(i -> !isassigned(stmt.values, i), eachindex(stmt.edges))
+    end
+end
+@test_throws UndefVarError undef_phicnode55388(true, true, true)
+@test undef_phicnode55388(false, false, false) === nothing
 
 global global_error_switch::Bool = true
 function gen_must_throw_phinode_edge(world::UInt, source, _)


### PR DESCRIPTION
fixes #55388 

the first commit does the main thing described below, and the second commit removes some code that becomes dead after the first one.

------------
🤖: Treat every non-argument slot as undefined on entry so control flow that bypasses a NewvarNode creates an undefined phi edge.


------------

👦🏼: why was this added? it looks intentional. please dig into the history

------------

🤖
• Yes, %−2 was intentional—but as an internal assertion poison, not as part of Julia’s undefined-variable semantics. After tracing the history, I’m comfortable that removing this specific sentinel is the root fix.

  The design evolved like this:

  1. In the original 2018 `slot2ssa`, `NewvarNode` counted as a definition because it kills the previous value. The implementation assumed that if a slot contained any `NewvarNode`, every reachable use would execute one first. It placed an invalid `SSAValue(-1)` at function entry so violations would crash rather than silently miscompile.

  2. In 2019, PR #31786  changed that sentinel to `%−2`. The PR explicitly says negative SSA values were used “to trigger errors later,” and Keno described it as an “internal assertion.” The only purpose of the new number was to distinguish this failure from another `%−1` assertion during debugging.

  3. In 2023, PR #50257 redesigned undefined-slot handling. Instead of encoding maybe-undefined in the type lattice, `slot2ssa` began tracking every incoming slot as `(value, definedness)` and generating `throw_undef_if_not` directly. The old poison was carried forward as `(SSAValue(-2), false)`. That is the crucial mismatch: definedness was now represented correctly by false, but the value half still contained an invalid SSA reference.

  4. Issue #55388 demonstrates that the original assertion is false for legal control flow: `@goto` can enter the loop after its `NewvarNode`. `%−2` then becomes an actual phi operand and eventually indexes an SSA array at `-2`.

  This is not merely theoretical. Current JuliaLowering explicitly recognizes initialization being skipped “by `@goto` jumping into a loop body.” PR #61148 fixed another instance of exactly that control-flow shape using `isdefined`. The language documentation does not prohibit these jumps.

  The runtime semantics also agree with the patch:

  - Function locals start undefined.
  - Executing `NewvarNode` resets a local to undefined.
  - Skipping a `NewvarNode` from function entry therefore still leaves the local undefined.

Assisted-by: Codex (GPT-5)