### PR TITLE
juliac: emit Cvoid as a primitive type in --export-abi

### DIFF
--- a/contrib/juliac/abi_export.jl
+++ b/contrib/juliac/abi_export.jl
@@ -111,13 +111,14 @@ function emit_struct_info!(ctx::TypeEmitter, @nospecialize(dt::DataType); indent
     end
 end
 
-function emit_primitive_type!(ctx::TypeEmitter, @nospecialize(dt::DataType); indent::Int = 0)
+function emit_primitive_type!(ctx::TypeEmitter, @nospecialize(dt::DataType); indent::Int = 0,
+                              name_json::String = type_name_json(dt))
     type_id = ctx.type_ids[dt]
     let indented_println(args...) = println(ctx.io, " " ^ indent, args...)
         indented_println("{")
         indented_println("  \"id\": ", type_id, ",")
         indented_println("  \"kind\": \"primitive\",")
-        indented_println("  \"name\": ", type_name_json(dt), ",")
+        indented_println("  \"name\": ", name_json, ",")
         indented_println("  \"signed\": ", (dt <: Signed), ",")
         indented_println("  \"bits\": ", 8 * Base.packedsize(dt), ",") # size for reinterpret / in-register
         indented_println("  \"size\": ", Base.aligned_sizeof(dt), ",") # size with padding / in-memory
@@ -129,6 +130,10 @@ end
 function emit_type_info!(ctx::TypeEmitter, @nospecialize(dt::DataType); indent::Int = 0)
     if dt.name === Ptr.body.name
         emit_pointer_info!(ctx, dt; indent)
+    elseif dt === Cvoid
+        # `Nothing` is a fieldless struct rather than a `primitive type`, but we treat
+        # it the same way we handle primitives (but call it `Cvoid`)
+        emit_primitive_type!(ctx, dt; indent, name_json = escape_string_json("Cvoid"))
     elseif Base.isprimitivetype(dt)
         emit_primitive_type!(ctx, dt; indent)
     else


### PR DESCRIPTION
`Nothing` is a fieldless singleton struct, so kind dispatch sent `Cvoid` down the struct path and produced an empty struct node that C consumers cannot represent. It is now emitted as a primitive node named `Cvoid`, which consumers map to `void`, and `Ptr{Cvoid}` pointee ids resolve to that node.

This is a backport of https://github.com/JuliaLang/JuliaC.jl/pull/178; it's being made against `backports-release-1.13` rather than `master`. It would probably be best to review the JuliaC PR first, get it merged, and then merge this.

Assisted-by: Claude Code (Fable 5)