### PR TITLE
EscapeAnalysis: track address observation by the GC, and capture by finalizers

### DIFF
--- a/Compiler/src/ssair/EscapeAnalysis.jl
+++ b/Compiler/src/ssair/EscapeAnalysis.jl
@@ -8,6 +8,8 @@ export
     has_arg_escape,
     has_return_escape,
     has_thrown_escape,
+    has_heap_capture,
+    has_finalizer_escape,
     has_all_escape
 
 using Base: Base
@@ -53,6 +55,21 @@ A lattice for escape information, which holds the following properties:
   * `pc ∈ x.ThrownEscape`: `x` may be thrown at the SSA statement at `pc`
   * `-1 ∈ x.ThrownEscape`: `x` may be thrown at arbitrary points of this call frame (the top)
   This information will be used by `escape_exception!` to propagate potential escapes via exception.
+- `x.HeapCapture::Bool`: indicates `x` may become reachable from a location the GC scans,
+  e.g. a field of another (possibly heap-allocated) object, a global binding, GC frame roots
+  set up for `GC.@preserve` or `:foreigncall`, the finalizer list, or the exception state.
+  Note that this property does not track ABI-level rooting performed by codegen
+  (e.g. a callee keeping a GC-tracked argument alive across a safepoint in its GC frame),
+  which is an artifact of the calling convention rather than of the analyzed program:
+  consumers that require `x` to never be observed by the GC need to control the calling
+  convention of the calls `x` is passed to in addition to querying this property.
+- `x.FinalizerEscape::Bool`: indicates `x` may be registered with a finalizer via
+  `Core.finalizer` (either as the finalized object or as the callback).
+  This is a refinement of `HeapCapture` (`FinalizerEscape` implies `HeapCapture`, since
+  the finalizer list is scanned by the GC), separated out because it has strictly stronger
+  lifetime semantics than the other `HeapCapture` sources: the finalizer list outlives the
+  current frame, and the callback is eventually invoked on the object at an arbitrary
+  later point.
 - `x.AliasInfo::Union{Bool,IndexableFields,Unindexable}`: maintains all possible values
   that can be aliased to fields or array elements of `x`:
   * `x.AliasInfo === false` indicates the fields/elements of `x` aren't analyzed yet
@@ -86,6 +103,8 @@ struct EscapeInfo
     Analyzed::Bool
     ReturnEscape::Bool
     ThrownEscape::BitSet
+    HeapCapture::Bool
+    FinalizerEscape::Bool
     AliasInfo #::Union{IndexableFields,Unindexable,Bool}
     Liveness::BitSet
 
@@ -93,6 +112,8 @@ struct EscapeInfo
         Analyzed::Bool,
         ReturnEscape::Bool,
         ThrownEscape::BitSet,
+        HeapCapture::Bool,
+        FinalizerEscape::Bool,
         AliasInfo#=::Union{IndexableFields,Unindexable,Bool}=#,
         Liveness::BitSet)
         @nospecialize AliasInfo
@@ -100,6 +121,8 @@ struct EscapeInfo
             Analyzed,
             ReturnEscape,
             ThrownEscape,
+            HeapCapture,
+            FinalizerEscape,
             AliasInfo,
             Liveness)
     end
@@ -111,12 +134,16 @@ struct EscapeInfo
         Analyzed::Bool = x.Analyzed,
         ReturnEscape::Bool = x.ReturnEscape,
         ThrownEscape::BitSet = x.ThrownEscape,
+        HeapCapture::Bool = x.HeapCapture,
+        FinalizerEscape::Bool = x.FinalizerEscape,
         Liveness::BitSet = x.Liveness)
         @nospecialize AliasInfo
         return new(
             Analyzed,
             ReturnEscape,
             ThrownEscape,
+            HeapCapture,
+            FinalizerEscape,
             AliasInfo,
             Liveness)
     end
@@ -136,13 +163,16 @@ const TOP_LIVENESS = BitSet(-1:0)
 const ARG_LIVENESS = BitSet(0)
 
 # the constructors
-NotAnalyzed() = EscapeInfo(false, false, BOT_THROWN_ESCAPE, false, BOT_LIVENESS) # not formally part of the lattice
-NoEscape() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, false, BOT_LIVENESS)
-ArgEscape() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, true, ARG_LIVENESS)
-ReturnEscape(pc::Int) = EscapeInfo(true, true, BOT_THROWN_ESCAPE, false, BitSet(pc))
-AllReturnEscape() = EscapeInfo(true, true, BOT_THROWN_ESCAPE, false, TOP_LIVENESS)
-ThrownEscape(pc::Int) = EscapeInfo(true, false, BitSet(pc), false, BOT_LIVENESS)
-AllEscape() = EscapeInfo(true, true, TOP_THROWN_ESCAPE, true, TOP_LIVENESS)
+NotAnalyzed() = EscapeInfo(false, false, BOT_THROWN_ESCAPE, false, false, false, BOT_LIVENESS) # not formally part of the lattice
+NoEscape() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, false, false, false, BOT_LIVENESS)
+ArgEscape() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, false, false, true, ARG_LIVENESS)
+ReturnEscape(pc::Int) = EscapeInfo(true, true, BOT_THROWN_ESCAPE, false, false, false, BitSet(pc))
+AllReturnEscape() = EscapeInfo(true, true, BOT_THROWN_ESCAPE, false, false, false, TOP_LIVENESS)
+ThrownEscape(pc::Int) = EscapeInfo(true, false, BitSet(pc), false, false, false, BOT_LIVENESS)
+HeapCapture() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, true, false, false, BOT_LIVENESS)
+# N.B. `FinalizerEscape` implies `HeapCapture` since the finalizer list is scanned by the GC
+FinalizerEscape() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, true, true, false, BOT_LIVENESS)
+AllEscape() = EscapeInfo(true, true, TOP_THROWN_ESCAPE, true, true, true, TOP_LIVENESS)
 
 const ⊥, ⊤ = NotAnalyzed(), AllEscape()
 
@@ -153,6 +183,8 @@ has_return_escape(x::EscapeInfo) = x.ReturnEscape
 has_return_escape(x::EscapeInfo, pc::Int) = x.ReturnEscape && (-1 ∈ x.Liveness || pc ∈ x.Liveness)
 has_thrown_escape(x::EscapeInfo) = !isempty(x.ThrownEscape)
 has_thrown_escape(x::EscapeInfo, pc::Int) = -1 ∈ x.ThrownEscape || pc ∈ x.ThrownEscape
+has_heap_capture(x::EscapeInfo) = x.HeapCapture
+has_finalizer_escape(x::EscapeInfo) = x.FinalizerEscape
 has_all_escape(x::EscapeInfo) = ⊤ ⊑ₑ x
 
 # utility lattice constructors
@@ -160,6 +192,7 @@ ignore_argescape(x::EscapeInfo) = EscapeInfo(x; Liveness=delete!(copy(x.Liveness
 ignore_thrownescapes(x::EscapeInfo) = EscapeInfo(x; ThrownEscape=BOT_THROWN_ESCAPE)
 ignore_aliasinfo(x::EscapeInfo) = EscapeInfo(x, false)
 ignore_liveness(x::EscapeInfo) = EscapeInfo(x; Liveness=BOT_LIVENESS)
+with_heap_capture(x::EscapeInfo) = x.HeapCapture ? x : EscapeInfo(x; HeapCapture=true)
 
 # AliasInfo
 struct IndexableFields
@@ -190,6 +223,8 @@ x::EscapeInfo == y::EscapeInfo = begin
     x === y && return true
     x.Analyzed === y.Analyzed || return false
     x.ReturnEscape === y.ReturnEscape || return false
+    x.HeapCapture === y.HeapCapture || return false
+    x.FinalizerEscape === y.FinalizerEscape || return false
     xt, yt = x.ThrownEscape, y.ThrownEscape
     if xt === TOP_THROWN_ESCAPE
         yt === TOP_THROWN_ESCAPE || return false
@@ -238,6 +273,8 @@ x::EscapeInfo ⊑ₑ y::EscapeInfo = begin
     end
     x.Analyzed ≤ y.Analyzed || return false
     x.ReturnEscape ≤ y.ReturnEscape || return false
+    x.HeapCapture ≤ y.HeapCapture || return false
+    x.FinalizerEscape ≤ y.FinalizerEscape || return false
     xt, yt = x.ThrownEscape, y.ThrownEscape
     if xt === TOP_THROWN_ESCAPE
         yt !== TOP_THROWN_ESCAPE && return false
@@ -336,6 +373,8 @@ x::EscapeInfo ⊔ₑ y::EscapeInfo = begin
         x.Analyzed | y.Analyzed,
         x.ReturnEscape | y.ReturnEscape,
         ThrownEscape,
+        x.HeapCapture | y.HeapCapture,
+        x.FinalizerEscape | y.FinalizerEscape,
         AliasInfo,
         Liveness,
         )
@@ -484,17 +523,23 @@ function ArgEscapeInfo(x::EscapeInfo)
     escape_bits = 0x00
     has_return_escape(x) && (escape_bits |= ARG_RETURN_ESCAPE)
     has_thrown_escape(x) && (escape_bits |= ARG_THROWN_ESCAPE)
+    has_heap_capture(x)  && (escape_bits |= ARG_HEAP_CAPTURE)
+    has_finalizer_escape(x) && (escape_bits |= ARG_FINALIZER_ESCAPE)
     return ArgEscapeInfo(escape_bits)
 end
 
-const ARG_ALL_ESCAPE    = 0x01 << 0
-const ARG_RETURN_ESCAPE = 0x01 << 1
-const ARG_THROWN_ESCAPE = 0x01 << 2
+const ARG_ALL_ESCAPE       = 0x01 << 0
+const ARG_RETURN_ESCAPE    = 0x01 << 1
+const ARG_THROWN_ESCAPE    = 0x01 << 2
+const ARG_HEAP_CAPTURE     = 0x01 << 3
+const ARG_FINALIZER_ESCAPE = 0x01 << 4
 
 has_no_escape(x::ArgEscapeInfo)     = !has_all_escape(x) && !has_return_escape(x) && !has_thrown_escape(x)
 has_all_escape(x::ArgEscapeInfo)    = x.escape_bits & ARG_ALL_ESCAPE    ≠ 0
 has_return_escape(x::ArgEscapeInfo) = x.escape_bits & ARG_RETURN_ESCAPE ≠ 0
 has_thrown_escape(x::ArgEscapeInfo) = x.escape_bits & ARG_THROWN_ESCAPE ≠ 0
+has_heap_capture(x::ArgEscapeInfo)  = x.escape_bits & ARG_HEAP_CAPTURE  ≠ 0
+has_finalizer_escape(x::ArgEscapeInfo) = x.escape_bits & ARG_FINALIZER_ESCAPE ≠ 0
 
 struct ArgAliasing
     aidx::Int
@@ -968,6 +1013,13 @@ function escape_invoke!(astate::AnalysisState, pc::Int, args::Vector{Any})
                 if arg isa GlobalRef
                     continue # :effect_free guarantees that nothing escapes to the global scope
                 end
+                # N.B. `cache === true` is inferred from the callee's `:effect_free` and
+                # `:inaccessiblememonly` effects, but those still permit the callee to store
+                # this argument into a freshly allocated (caller-invisible) object, which the
+                # GC would trace, so we must still taint the argument with `HeapCapture`
+                # (no `FinalizerEscape` taint is needed however, since `Core.finalizer` is
+                # incompatible with the `:effect_free`+`:inaccessiblememonly` effects)
+                add_escape_change!(astate, arg, HeapCapture())
                 if !is_identity_free_argtype(argextype(arg, astate.ir))
                     add_alias_change!(astate, ret, arg)
                 end
@@ -1014,6 +1066,8 @@ in the context of the caller frame, where `pc` is the SSA statement number of th
 function from_interprocedural(argescape::ArgEscapeInfo, pc::Int)
     has_all_escape(argescape) && return ⊤
     ThrownEscape = has_thrown_escape(argescape) ? BitSet(pc) : BOT_THROWN_ESCAPE
+    HeapCapture = has_heap_capture(argescape)
+    FinalizerEscape = has_finalizer_escape(argescape)
     # TODO implement interprocedural memory effect-analysis:
     # currently, this essentially disables the entire field analysis–it might be okay from
     # the SROA point of view, since we can't remove the allocation as far as it's passed to
@@ -1021,7 +1075,7 @@ function from_interprocedural(argescape::ArgEscapeInfo, pc::Int)
     # or some other IPO optimizations
     AliasInfo = true
     Liveness = BitSet(pc)
-    return EscapeInfo(#=Analyzed=#true, #=ReturnEscape=#false, ThrownEscape, AliasInfo, Liveness)
+    return EscapeInfo(#=Analyzed=#true, #=ReturnEscape=#false, ThrownEscape, HeapCapture, FinalizerEscape, AliasInfo, Liveness)
 end
 
 # the only possible 'escape' here is really just that it can return a
@@ -1073,7 +1127,9 @@ function escape_foreigncall!(astate::AnalysisState, pc::Int, args::Vector{Any})
     end
     for i = (5+nargs):length(args)
         arg = args[i]
-        add_escape_change!(astate, arg, ⊥)
+        # these trailing arguments are GC-rooted for the duration of the call,
+        # i.e. placed in a location the GC scans
+        add_escape_change!(astate, arg, HeapCapture())
         add_liveness_change!(astate, arg, pc)
     end
 end
@@ -1085,6 +1141,11 @@ function escape_gc_preserve!(astate::AnalysisState, pc::Int, args::Vector{Any})
     beginstmt = astate.ir[val][:stmt]
     @assert isexpr(beginstmt, :gc_preserve_begin) "invalid :gc_preserve_end"
     beginargs = beginstmt.args
+    # the preserved values are rooted in a GC frame for the duration of the region,
+    # i.e. placed in a location the GC scans
+    for i = 1:length(beginargs)
+        add_escape_change!(astate, beginargs[i], HeapCapture())
+    end
     # COMBAK we might need to add liveness for all statements from `:gc_preserve_begin` to `:gc_preserve_end`
     add_liveness_changes!(astate, pc, beginargs)
 end
@@ -1127,8 +1188,23 @@ escape_builtin!(::typeof(===), _...) = false
 escape_builtin!(::typeof(Core.donotdelete), _...) = false
 # not really safe, but `ThrownEscape` will be imposed later
 escape_builtin!(::typeof(isdefined), _...) = false
-escape_builtin!(::typeof(throw), _...) = false
-escape_builtin!(::typeof(Core.throw_methoderror), _...) = false
+
+function escape_builtin!(::typeof(throw), astate::AnalysisState, pc::Int, args::Vector{Any})
+    if length(args) ≥ 2
+        # the thrown object enters the task's exception state, which the GC scans
+        add_escape_change!(astate, args[2], HeapCapture())
+    end
+    return false
+end
+
+function escape_builtin!(::typeof(Core.throw_methoderror), astate::AnalysisState, pc::Int, args::Vector{Any})
+    # the arguments are wrapped into a `MethodError` that enters the task's
+    # exception state, which the GC scans
+    for i = 2:length(args)
+        add_escape_change!(astate, args[i], HeapCapture())
+    end
+    return false
+end
 
 function escape_builtin!(::typeof(ifelse), astate::AnalysisState, pc::Int, args::Vector{Any})
     length(args) == 4 || return false
@@ -1179,13 +1255,15 @@ function escape_new!(astate::AnalysisState, pc::Int, args::Vector{Any})
         # fields are known precisely: propagate escape information imposed on recorded possibilities to the exact field values
         infos = AliasInfo.infos
         nf = length(infos)
-        objinfo′ = ignore_aliasinfo(objinfo)
+        # propagate the escape information of this object ignoring field information,
+        # and taint the field values with `HeapCapture` since this object may be
+        # heap-allocated, making them reachable from GC-traced memory
+        objinfo′ = with_heap_capture(ignore_aliasinfo(objinfo))
         for i in 2:nargs
             i-1 > nf && break # may happen when e.g. ϕ-node merges values with different types
             arg = args[i]
             add_alias_escapes!(astate, arg, infos[i-1])
             push!(infos[i-1], LocalDef(pc))
-            # propagate the escape information of this object ignoring field information
             add_escape_change!(astate, arg, objinfo′)
             add_liveness_change!(astate, arg, pc)
         end
@@ -1195,12 +1273,14 @@ function escape_new!(astate::AnalysisState, pc::Int, args::Vector{Any})
         @label escape_unindexable_def
         # fields are known partially: propagate escape information imposed on recorded possibilities to all field values
         info = AliasInfo.info
-        objinfo′ = ignore_aliasinfo(objinfo)
+        # propagate the escape information of this object ignoring field information,
+        # and taint the field values with `HeapCapture` since this object may be
+        # heap-allocated, making them reachable from GC-traced memory
+        objinfo′ = with_heap_capture(ignore_aliasinfo(objinfo))
         for i in 2:nargs
             arg = args[i]
             add_alias_escapes!(astate, arg, info)
             push!(info, LocalDef(pc))
-            # propagate the escape information of this object ignoring field information
             add_escape_change!(astate, arg, objinfo′)
             add_liveness_change!(astate, arg, pc)
         end
@@ -1212,9 +1292,11 @@ function escape_new!(astate::AnalysisState, pc::Int, args::Vector{Any})
         @label conservative_propagation
         # the fields couldn't be analyzed precisely: propagate the entire escape information
         # of this object to all its fields as the most conservative propagation
+        # (also taint them with `HeapCapture` since this object may be heap-allocated)
+        objinfo′ = with_heap_capture(objinfo)
         for i in 2:nargs
             arg = args[i]
-            add_escape_change!(astate, arg, objinfo)
+            add_escape_change!(astate, arg, objinfo′)
             add_liveness_change!(astate, arg, pc)
         end
     end
@@ -1353,8 +1435,10 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
         push!(AliasInfo.infos[fidx], LocalDef(pc))
         objinfo = EscapeInfo(objinfo, AliasInfo)
         add_escape_change!(astate, obj, objinfo) # update with new AliasInfo
-        # propagate the escape information of this object ignoring field information
-        add_escape_change!(astate, val, ignore_aliasinfo(objinfo))
+        # propagate the escape information of this object ignoring field information,
+        # and taint the stored value with `HeapCapture` since this object may be
+        # heap-allocated, making the value reachable from GC-traced memory
+        add_escape_change!(astate, val, with_heap_capture(ignore_aliasinfo(objinfo)))
     elseif isa(AliasInfo, Unindexable)
         AliasInfo = copy(AliasInfo)
         @label escape_unindexable_def
@@ -1362,8 +1446,10 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
         push!(AliasInfo.info, LocalDef(pc))
         objinfo = EscapeInfo(objinfo, AliasInfo)
         add_escape_change!(astate, obj, objinfo) # update with new AliasInfo
-        # propagate the escape information of this object ignoring field information
-        add_escape_change!(astate, val, ignore_aliasinfo(objinfo))
+        # propagate the escape information of this object ignoring field information,
+        # and taint the stored value with `HeapCapture` since this object may be
+        # heap-allocated, making the value reachable from GC-traced memory
+        add_escape_change!(astate, val, with_heap_capture(ignore_aliasinfo(objinfo)))
     else
         # this object has been used as array, but it is used as struct here (i.e. should throw)
         # update obj's field information and just handle this case conservatively
@@ -1372,6 +1458,11 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
         # the field couldn't be analyzed: alias this object to the value being assigned
         # as the most conservative propagation (as required for ArgAliasing)
         add_alias_change!(astate, val, obj)
+        # taint the stored value with `HeapCapture` since this object may be heap-allocated
+        # (N.B. the alias change above equalizes escape information between `val` and `obj`,
+        # so `obj` is tainted as well; this is conservative but unavoidable without
+        # interprocedural field analysis for unanalyzable objects such as arguments)
+        add_escape_change!(astate, val, HeapCapture())
     end
     # also propagate escape information imposed on the return value of this `setfield!`
     ssainfo = estate[SSAValue(pc)]
@@ -1392,8 +1483,14 @@ end
 
 function escape_builtin!(::typeof(Core.finalizer), astate::AnalysisState, pc::Int, args::Vector{Any})
     if length(args) ≥ 3
-        obj = args[3]
-        add_liveness_change!(astate, obj, pc) # TODO setup a proper FinalizerEscape?
+        f, obj = args[2], args[3]
+        # the finalizer callback and the finalized object are registered in the
+        # task-local finalizer list, which the GC scans and which outlives this frame
+        # (`FinalizerEscape()` also includes the `HeapCapture` taint)
+        # TODO also model the effects of the eventual `f(obj)` invocation?
+        add_escape_change!(astate, f, FinalizerEscape())
+        add_escape_change!(astate, obj, FinalizerEscape())
+        add_liveness_change!(astate, obj, pc)
     end
     return false
 end

--- a/Compiler/src/ssair/EscapeAnalysis.jl
+++ b/Compiler/src/ssair/EscapeAnalysis.jl
@@ -8,7 +8,7 @@ export
     has_arg_escape,
     has_return_escape,
     has_thrown_escape,
-    has_heap_capture,
+    has_heap_observed,
     has_finalizer_escape,
     has_all_escape
 
@@ -55,19 +55,22 @@ A lattice for escape information, which holds the following properties:
   * `pc ∈ x.ThrownEscape`: `x` may be thrown at the SSA statement at `pc`
   * `-1 ∈ x.ThrownEscape`: `x` may be thrown at arbitrary points of this call frame (the top)
   This information will be used by `escape_exception!` to propagate potential escapes via exception.
-- `x.HeapCapture::Bool`: indicates `x` may become reachable from a location the GC scans,
-  e.g. a field of another (possibly heap-allocated) object, a global binding, GC frame roots
-  set up for `GC.@preserve` or `:foreigncall`, the finalizer list, or the exception state.
-  Note that this property does not track ABI-level rooting performed by codegen
-  (e.g. a callee keeping a GC-tracked argument alive across a safepoint in its GC frame),
-  which is an artifact of the calling convention rather than of the analyzed program:
-  consumers that require `x` to never be observed by the GC need to control the calling
-  convention of the calls `x` is passed to in addition to querying this property.
+- `x.HeapObserved::Bool`: indicates `x` may become reachable from GC-managed memory,
+  i.e. it may be stored into a field of another (possibly heap-allocated) object,
+  or registered in the finalizer list.
+  Note that this is distinct from escape in the traditional sense: storing `x` into an
+  object that itself never escapes the frame still sets this property, since the GC would
+  trace `x` through that object if it remains heap-allocated.
+  This property does not track GC rooting performed by codegen (GC frame slots at
+  safepoints, `GC.@preserve`, `:foreigncall` roots), which is an artifact of the calling
+  convention rather than of the analyzed program: consumers that require `x` to never be
+  observed by the GC need to control the calling convention of the calls `x` is passed to
+  in addition to querying this property.
 - `x.FinalizerEscape::Bool`: indicates `x` may be registered with a finalizer via
   `Core.finalizer` (either as the finalized object or as the callback).
-  This is a refinement of `HeapCapture` (`FinalizerEscape` implies `HeapCapture`, since
+  This is a refinement of `HeapObserved` (`FinalizerEscape` implies `HeapObserved`, since
   the finalizer list is scanned by the GC), separated out because it has strictly stronger
-  lifetime semantics than the other `HeapCapture` sources: the finalizer list outlives the
+  lifetime semantics than the other `HeapObserved` sources: the finalizer list outlives the
   current frame, and the callback is eventually invoked on the object at an arbitrary
   later point.
 - `x.AliasInfo::Union{Bool,IndexableFields,Unindexable}`: maintains all possible values
@@ -103,7 +106,7 @@ struct EscapeInfo
     Analyzed::Bool
     ReturnEscape::Bool
     ThrownEscape::BitSet
-    HeapCapture::Bool
+    HeapObserved::Bool
     FinalizerEscape::Bool
     AliasInfo #::Union{IndexableFields,Unindexable,Bool}
     Liveness::BitSet
@@ -112,7 +115,7 @@ struct EscapeInfo
         Analyzed::Bool,
         ReturnEscape::Bool,
         ThrownEscape::BitSet,
-        HeapCapture::Bool,
+        HeapObserved::Bool,
         FinalizerEscape::Bool,
         AliasInfo#=::Union{IndexableFields,Unindexable,Bool}=#,
         Liveness::BitSet)
@@ -121,7 +124,7 @@ struct EscapeInfo
             Analyzed,
             ReturnEscape,
             ThrownEscape,
-            HeapCapture,
+            HeapObserved,
             FinalizerEscape,
             AliasInfo,
             Liveness)
@@ -134,7 +137,7 @@ struct EscapeInfo
         Analyzed::Bool = x.Analyzed,
         ReturnEscape::Bool = x.ReturnEscape,
         ThrownEscape::BitSet = x.ThrownEscape,
-        HeapCapture::Bool = x.HeapCapture,
+        HeapObserved::Bool = x.HeapObserved,
         FinalizerEscape::Bool = x.FinalizerEscape,
         Liveness::BitSet = x.Liveness)
         @nospecialize AliasInfo
@@ -142,7 +145,7 @@ struct EscapeInfo
             Analyzed,
             ReturnEscape,
             ThrownEscape,
-            HeapCapture,
+            HeapObserved,
             FinalizerEscape,
             AliasInfo,
             Liveness)
@@ -169,8 +172,8 @@ ArgEscape() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, false, false, true, ARG
 ReturnEscape(pc::Int) = EscapeInfo(true, true, BOT_THROWN_ESCAPE, false, false, false, BitSet(pc))
 AllReturnEscape() = EscapeInfo(true, true, BOT_THROWN_ESCAPE, false, false, false, TOP_LIVENESS)
 ThrownEscape(pc::Int) = EscapeInfo(true, false, BitSet(pc), false, false, false, BOT_LIVENESS)
-HeapCapture() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, true, false, false, BOT_LIVENESS)
-# N.B. `FinalizerEscape` implies `HeapCapture` since the finalizer list is scanned by the GC
+HeapObserved() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, true, false, false, BOT_LIVENESS)
+# N.B. `FinalizerEscape` implies `HeapObserved` since the finalizer list is scanned by the GC
 FinalizerEscape() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, true, true, false, BOT_LIVENESS)
 AllEscape() = EscapeInfo(true, true, TOP_THROWN_ESCAPE, true, true, true, TOP_LIVENESS)
 
@@ -183,7 +186,7 @@ has_return_escape(x::EscapeInfo) = x.ReturnEscape
 has_return_escape(x::EscapeInfo, pc::Int) = x.ReturnEscape && (-1 ∈ x.Liveness || pc ∈ x.Liveness)
 has_thrown_escape(x::EscapeInfo) = !isempty(x.ThrownEscape)
 has_thrown_escape(x::EscapeInfo, pc::Int) = -1 ∈ x.ThrownEscape || pc ∈ x.ThrownEscape
-has_heap_capture(x::EscapeInfo) = x.HeapCapture
+has_heap_observed(x::EscapeInfo) = x.HeapObserved
 has_finalizer_escape(x::EscapeInfo) = x.FinalizerEscape
 has_all_escape(x::EscapeInfo) = ⊤ ⊑ₑ x
 
@@ -192,7 +195,7 @@ ignore_argescape(x::EscapeInfo) = EscapeInfo(x; Liveness=delete!(copy(x.Liveness
 ignore_thrownescapes(x::EscapeInfo) = EscapeInfo(x; ThrownEscape=BOT_THROWN_ESCAPE)
 ignore_aliasinfo(x::EscapeInfo) = EscapeInfo(x, false)
 ignore_liveness(x::EscapeInfo) = EscapeInfo(x; Liveness=BOT_LIVENESS)
-with_heap_capture(x::EscapeInfo) = x.HeapCapture ? x : EscapeInfo(x; HeapCapture=true)
+with_heap_observed(x::EscapeInfo) = x.HeapObserved ? x : EscapeInfo(x; HeapObserved=true)
 
 # AliasInfo
 struct IndexableFields
@@ -223,7 +226,7 @@ x::EscapeInfo == y::EscapeInfo = begin
     x === y && return true
     x.Analyzed === y.Analyzed || return false
     x.ReturnEscape === y.ReturnEscape || return false
-    x.HeapCapture === y.HeapCapture || return false
+    x.HeapObserved === y.HeapObserved || return false
     x.FinalizerEscape === y.FinalizerEscape || return false
     xt, yt = x.ThrownEscape, y.ThrownEscape
     if xt === TOP_THROWN_ESCAPE
@@ -273,7 +276,7 @@ x::EscapeInfo ⊑ₑ y::EscapeInfo = begin
     end
     x.Analyzed ≤ y.Analyzed || return false
     x.ReturnEscape ≤ y.ReturnEscape || return false
-    x.HeapCapture ≤ y.HeapCapture || return false
+    x.HeapObserved ≤ y.HeapObserved || return false
     x.FinalizerEscape ≤ y.FinalizerEscape || return false
     xt, yt = x.ThrownEscape, y.ThrownEscape
     if xt === TOP_THROWN_ESCAPE
@@ -373,7 +376,7 @@ x::EscapeInfo ⊔ₑ y::EscapeInfo = begin
         x.Analyzed | y.Analyzed,
         x.ReturnEscape | y.ReturnEscape,
         ThrownEscape,
-        x.HeapCapture | y.HeapCapture,
+        x.HeapObserved | y.HeapObserved,
         x.FinalizerEscape | y.FinalizerEscape,
         AliasInfo,
         Liveness,
@@ -523,7 +526,7 @@ function ArgEscapeInfo(x::EscapeInfo)
     escape_bits = 0x00
     has_return_escape(x) && (escape_bits |= ARG_RETURN_ESCAPE)
     has_thrown_escape(x) && (escape_bits |= ARG_THROWN_ESCAPE)
-    has_heap_capture(x)  && (escape_bits |= ARG_HEAP_CAPTURE)
+    has_heap_observed(x) && (escape_bits |= ARG_HEAP_OBSERVED)
     has_finalizer_escape(x) && (escape_bits |= ARG_FINALIZER_ESCAPE)
     return ArgEscapeInfo(escape_bits)
 end
@@ -531,14 +534,14 @@ end
 const ARG_ALL_ESCAPE       = 0x01 << 0
 const ARG_RETURN_ESCAPE    = 0x01 << 1
 const ARG_THROWN_ESCAPE    = 0x01 << 2
-const ARG_HEAP_CAPTURE     = 0x01 << 3
+const ARG_HEAP_OBSERVED    = 0x01 << 3
 const ARG_FINALIZER_ESCAPE = 0x01 << 4
 
 has_no_escape(x::ArgEscapeInfo)     = !has_all_escape(x) && !has_return_escape(x) && !has_thrown_escape(x)
 has_all_escape(x::ArgEscapeInfo)    = x.escape_bits & ARG_ALL_ESCAPE    ≠ 0
 has_return_escape(x::ArgEscapeInfo) = x.escape_bits & ARG_RETURN_ESCAPE ≠ 0
 has_thrown_escape(x::ArgEscapeInfo) = x.escape_bits & ARG_THROWN_ESCAPE ≠ 0
-has_heap_capture(x::ArgEscapeInfo)  = x.escape_bits & ARG_HEAP_CAPTURE  ≠ 0
+has_heap_observed(x::ArgEscapeInfo) = x.escape_bits & ARG_HEAP_OBSERVED  ≠ 0
 has_finalizer_escape(x::ArgEscapeInfo) = x.escape_bits & ARG_FINALIZER_ESCAPE ≠ 0
 
 struct ArgAliasing
@@ -1016,10 +1019,10 @@ function escape_invoke!(astate::AnalysisState, pc::Int, args::Vector{Any})
                 # N.B. `cache === true` is inferred from the callee's `:effect_free` and
                 # `:inaccessiblememonly` effects, but those still permit the callee to store
                 # this argument into a freshly allocated (caller-invisible) object, which the
-                # GC would trace, so we must still taint the argument with `HeapCapture`
+                # GC would trace, so we must still taint the argument with `HeapObserved`
                 # (no `FinalizerEscape` taint is needed however, since `Core.finalizer` is
                 # incompatible with the `:effect_free`+`:inaccessiblememonly` effects)
-                add_escape_change!(astate, arg, HeapCapture())
+                add_escape_change!(astate, arg, HeapObserved())
                 if !is_identity_free_argtype(argextype(arg, astate.ir))
                     add_alias_change!(astate, ret, arg)
                 end
@@ -1066,7 +1069,7 @@ in the context of the caller frame, where `pc` is the SSA statement number of th
 function from_interprocedural(argescape::ArgEscapeInfo, pc::Int)
     has_all_escape(argescape) && return ⊤
     ThrownEscape = has_thrown_escape(argescape) ? BitSet(pc) : BOT_THROWN_ESCAPE
-    HeapCapture = has_heap_capture(argescape)
+    HeapObserved = has_heap_observed(argescape)
     FinalizerEscape = has_finalizer_escape(argescape)
     # TODO implement interprocedural memory effect-analysis:
     # currently, this essentially disables the entire field analysis–it might be okay from
@@ -1075,7 +1078,7 @@ function from_interprocedural(argescape::ArgEscapeInfo, pc::Int)
     # or some other IPO optimizations
     AliasInfo = true
     Liveness = BitSet(pc)
-    return EscapeInfo(#=Analyzed=#true, #=ReturnEscape=#false, ThrownEscape, HeapCapture, FinalizerEscape, AliasInfo, Liveness)
+    return EscapeInfo(#=Analyzed=#true, #=ReturnEscape=#false, ThrownEscape, HeapObserved, FinalizerEscape, AliasInfo, Liveness)
 end
 
 # the only possible 'escape' here is really just that it can return a
@@ -1127,9 +1130,7 @@ function escape_foreigncall!(astate::AnalysisState, pc::Int, args::Vector{Any})
     end
     for i = (5+nargs):length(args)
         arg = args[i]
-        # these trailing arguments are GC-rooted for the duration of the call,
-        # i.e. placed in a location the GC scans
-        add_escape_change!(astate, arg, HeapCapture())
+        add_escape_change!(astate, arg, ⊥)
         add_liveness_change!(astate, arg, pc)
     end
 end
@@ -1141,11 +1142,6 @@ function escape_gc_preserve!(astate::AnalysisState, pc::Int, args::Vector{Any})
     beginstmt = astate.ir[val][:stmt]
     @assert isexpr(beginstmt, :gc_preserve_begin) "invalid :gc_preserve_end"
     beginargs = beginstmt.args
-    # the preserved values are rooted in a GC frame for the duration of the region,
-    # i.e. placed in a location the GC scans
-    for i = 1:length(beginargs)
-        add_escape_change!(astate, beginargs[i], HeapCapture())
-    end
     # COMBAK we might need to add liveness for all statements from `:gc_preserve_begin` to `:gc_preserve_end`
     add_liveness_changes!(astate, pc, beginargs)
 end
@@ -1188,23 +1184,8 @@ escape_builtin!(::typeof(===), _...) = false
 escape_builtin!(::typeof(Core.donotdelete), _...) = false
 # not really safe, but `ThrownEscape` will be imposed later
 escape_builtin!(::typeof(isdefined), _...) = false
-
-function escape_builtin!(::typeof(throw), astate::AnalysisState, pc::Int, args::Vector{Any})
-    if length(args) ≥ 2
-        # the thrown object enters the task's exception state, which the GC scans
-        add_escape_change!(astate, args[2], HeapCapture())
-    end
-    return false
-end
-
-function escape_builtin!(::typeof(Core.throw_methoderror), astate::AnalysisState, pc::Int, args::Vector{Any})
-    # the arguments are wrapped into a `MethodError` that enters the task's
-    # exception state, which the GC scans
-    for i = 2:length(args)
-        add_escape_change!(astate, args[i], HeapCapture())
-    end
-    return false
-end
+escape_builtin!(::typeof(throw), _...) = false
+escape_builtin!(::typeof(Core.throw_methoderror), _...) = false
 
 function escape_builtin!(::typeof(ifelse), astate::AnalysisState, pc::Int, args::Vector{Any})
     length(args) == 4 || return false
@@ -1256,9 +1237,9 @@ function escape_new!(astate::AnalysisState, pc::Int, args::Vector{Any})
         infos = AliasInfo.infos
         nf = length(infos)
         # propagate the escape information of this object ignoring field information,
-        # and taint the field values with `HeapCapture` since this object may be
+        # and taint the field values with `HeapObserved` since this object may be
         # heap-allocated, making them reachable from GC-traced memory
-        objinfo′ = with_heap_capture(ignore_aliasinfo(objinfo))
+        objinfo′ = with_heap_observed(ignore_aliasinfo(objinfo))
         for i in 2:nargs
             i-1 > nf && break # may happen when e.g. ϕ-node merges values with different types
             arg = args[i]
@@ -1274,9 +1255,9 @@ function escape_new!(astate::AnalysisState, pc::Int, args::Vector{Any})
         # fields are known partially: propagate escape information imposed on recorded possibilities to all field values
         info = AliasInfo.info
         # propagate the escape information of this object ignoring field information,
-        # and taint the field values with `HeapCapture` since this object may be
+        # and taint the field values with `HeapObserved` since this object may be
         # heap-allocated, making them reachable from GC-traced memory
-        objinfo′ = with_heap_capture(ignore_aliasinfo(objinfo))
+        objinfo′ = with_heap_observed(ignore_aliasinfo(objinfo))
         for i in 2:nargs
             arg = args[i]
             add_alias_escapes!(astate, arg, info)
@@ -1292,8 +1273,8 @@ function escape_new!(astate::AnalysisState, pc::Int, args::Vector{Any})
         @label conservative_propagation
         # the fields couldn't be analyzed precisely: propagate the entire escape information
         # of this object to all its fields as the most conservative propagation
-        # (also taint them with `HeapCapture` since this object may be heap-allocated)
-        objinfo′ = with_heap_capture(objinfo)
+        # (also taint them with `HeapObserved` since this object may be heap-allocated)
+        objinfo′ = with_heap_observed(objinfo)
         for i in 2:nargs
             arg = args[i]
             add_escape_change!(astate, arg, objinfo′)
@@ -1436,9 +1417,9 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
         objinfo = EscapeInfo(objinfo, AliasInfo)
         add_escape_change!(astate, obj, objinfo) # update with new AliasInfo
         # propagate the escape information of this object ignoring field information,
-        # and taint the stored value with `HeapCapture` since this object may be
+        # and taint the stored value with `HeapObserved` since this object may be
         # heap-allocated, making the value reachable from GC-traced memory
-        add_escape_change!(astate, val, with_heap_capture(ignore_aliasinfo(objinfo)))
+        add_escape_change!(astate, val, with_heap_observed(ignore_aliasinfo(objinfo)))
     elseif isa(AliasInfo, Unindexable)
         AliasInfo = copy(AliasInfo)
         @label escape_unindexable_def
@@ -1447,9 +1428,9 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
         objinfo = EscapeInfo(objinfo, AliasInfo)
         add_escape_change!(astate, obj, objinfo) # update with new AliasInfo
         # propagate the escape information of this object ignoring field information,
-        # and taint the stored value with `HeapCapture` since this object may be
+        # and taint the stored value with `HeapObserved` since this object may be
         # heap-allocated, making the value reachable from GC-traced memory
-        add_escape_change!(astate, val, with_heap_capture(ignore_aliasinfo(objinfo)))
+        add_escape_change!(astate, val, with_heap_observed(ignore_aliasinfo(objinfo)))
     else
         # this object has been used as array, but it is used as struct here (i.e. should throw)
         # update obj's field information and just handle this case conservatively
@@ -1458,11 +1439,11 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
         # the field couldn't be analyzed: alias this object to the value being assigned
         # as the most conservative propagation (as required for ArgAliasing)
         add_alias_change!(astate, val, obj)
-        # taint the stored value with `HeapCapture` since this object may be heap-allocated
+        # taint the stored value with `HeapObserved` since this object may be heap-allocated
         # (N.B. the alias change above equalizes escape information between `val` and `obj`,
         # so `obj` is tainted as well; this is conservative but unavoidable without
         # interprocedural field analysis for unanalyzable objects such as arguments)
-        add_escape_change!(astate, val, HeapCapture())
+        add_escape_change!(astate, val, HeapObserved())
     end
     # also propagate escape information imposed on the return value of this `setfield!`
     ssainfo = estate[SSAValue(pc)]
@@ -1486,7 +1467,7 @@ function escape_builtin!(::typeof(Core.finalizer), astate::AnalysisState, pc::In
         f, obj = args[2], args[3]
         # the finalizer callback and the finalized object are registered in the
         # task-local finalizer list, which the GC scans and which outlives this frame
-        # (`FinalizerEscape()` also includes the `HeapCapture` taint)
+        # (`FinalizerEscape()` also includes the `HeapObserved` taint)
         # TODO also model the effects of the eventual `f(obj)` invocation?
         add_escape_change!(astate, f, FinalizerEscape())
         add_escape_change!(astate, obj, FinalizerEscape())

--- a/Compiler/src/ssair/EscapeAnalysis.jl
+++ b/Compiler/src/ssair/EscapeAnalysis.jl
@@ -8,7 +8,7 @@ export
     has_arg_escape,
     has_return_escape,
     has_thrown_escape,
-    has_heap_observed,
+    has_address_observed,
     has_finalizer_escape,
     has_all_escape
 
@@ -55,7 +55,7 @@ A lattice for escape information, which holds the following properties:
   * `pc ∈ x.ThrownEscape`: `x` may be thrown at the SSA statement at `pc`
   * `-1 ∈ x.ThrownEscape`: `x` may be thrown at arbitrary points of this call frame (the top)
   This information will be used by `escape_exception!` to propagate potential escapes via exception.
-- `x.HeapObserved::Bool`: indicates `x` may become reachable from GC-managed memory,
+- `x.AddressObserved::Bool`: indicates `x` may become reachable from GC-managed memory,
   i.e. it may be stored into a field of another (possibly heap-allocated) object,
   or registered in the finalizer list.
   Note that this is distinct from escape in the traditional sense: storing `x` into an
@@ -68,9 +68,9 @@ A lattice for escape information, which holds the following properties:
   in addition to querying this property.
 - `x.FinalizerEscape::Bool`: indicates `x` may be registered with a finalizer via
   `Core.finalizer` (either as the finalized object or as the callback).
-  This is a refinement of `HeapObserved` (`FinalizerEscape` implies `HeapObserved`, since
+  This is a refinement of `AddressObserved` (`FinalizerEscape` implies `AddressObserved`, since
   the finalizer list is scanned by the GC), separated out because it has strictly stronger
-  lifetime semantics than the other `HeapObserved` sources: the finalizer list outlives the
+  lifetime semantics than the other `AddressObserved` sources: the finalizer list outlives the
   current frame, and the callback is eventually invoked on the object at an arbitrary
   later point.
 - `x.AliasInfo::Union{Bool,IndexableFields,Unindexable}`: maintains all possible values
@@ -106,7 +106,7 @@ struct EscapeInfo
     Analyzed::Bool
     ReturnEscape::Bool
     ThrownEscape::BitSet
-    HeapObserved::Bool
+    AddressObserved::Bool
     FinalizerEscape::Bool
     AliasInfo #::Union{IndexableFields,Unindexable,Bool}
     Liveness::BitSet
@@ -115,7 +115,7 @@ struct EscapeInfo
         Analyzed::Bool,
         ReturnEscape::Bool,
         ThrownEscape::BitSet,
-        HeapObserved::Bool,
+        AddressObserved::Bool,
         FinalizerEscape::Bool,
         AliasInfo#=::Union{IndexableFields,Unindexable,Bool}=#,
         Liveness::BitSet)
@@ -124,7 +124,7 @@ struct EscapeInfo
             Analyzed,
             ReturnEscape,
             ThrownEscape,
-            HeapObserved,
+            AddressObserved,
             FinalizerEscape,
             AliasInfo,
             Liveness)
@@ -137,7 +137,7 @@ struct EscapeInfo
         Analyzed::Bool = x.Analyzed,
         ReturnEscape::Bool = x.ReturnEscape,
         ThrownEscape::BitSet = x.ThrownEscape,
-        HeapObserved::Bool = x.HeapObserved,
+        AddressObserved::Bool = x.AddressObserved,
         FinalizerEscape::Bool = x.FinalizerEscape,
         Liveness::BitSet = x.Liveness)
         @nospecialize AliasInfo
@@ -145,7 +145,7 @@ struct EscapeInfo
             Analyzed,
             ReturnEscape,
             ThrownEscape,
-            HeapObserved,
+            AddressObserved,
             FinalizerEscape,
             AliasInfo,
             Liveness)
@@ -172,8 +172,8 @@ ArgEscape() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, false, false, true, ARG
 ReturnEscape(pc::Int) = EscapeInfo(true, true, BOT_THROWN_ESCAPE, false, false, false, BitSet(pc))
 AllReturnEscape() = EscapeInfo(true, true, BOT_THROWN_ESCAPE, false, false, false, TOP_LIVENESS)
 ThrownEscape(pc::Int) = EscapeInfo(true, false, BitSet(pc), false, false, false, BOT_LIVENESS)
-HeapObserved() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, true, false, false, BOT_LIVENESS)
-# N.B. `FinalizerEscape` implies `HeapObserved` since the finalizer list is scanned by the GC
+AddressObserved() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, true, false, false, BOT_LIVENESS)
+# N.B. `FinalizerEscape` implies `AddressObserved` since the finalizer list is scanned by the GC
 FinalizerEscape() = EscapeInfo(true, false, BOT_THROWN_ESCAPE, true, true, false, BOT_LIVENESS)
 AllEscape() = EscapeInfo(true, true, TOP_THROWN_ESCAPE, true, true, true, TOP_LIVENESS)
 
@@ -186,7 +186,7 @@ has_return_escape(x::EscapeInfo) = x.ReturnEscape
 has_return_escape(x::EscapeInfo, pc::Int) = x.ReturnEscape && (-1 ∈ x.Liveness || pc ∈ x.Liveness)
 has_thrown_escape(x::EscapeInfo) = !isempty(x.ThrownEscape)
 has_thrown_escape(x::EscapeInfo, pc::Int) = -1 ∈ x.ThrownEscape || pc ∈ x.ThrownEscape
-has_heap_observed(x::EscapeInfo) = x.HeapObserved
+has_address_observed(x::EscapeInfo) = x.AddressObserved
 has_finalizer_escape(x::EscapeInfo) = x.FinalizerEscape
 has_all_escape(x::EscapeInfo) = ⊤ ⊑ₑ x
 
@@ -195,7 +195,7 @@ ignore_argescape(x::EscapeInfo) = EscapeInfo(x; Liveness=delete!(copy(x.Liveness
 ignore_thrownescapes(x::EscapeInfo) = EscapeInfo(x; ThrownEscape=BOT_THROWN_ESCAPE)
 ignore_aliasinfo(x::EscapeInfo) = EscapeInfo(x, false)
 ignore_liveness(x::EscapeInfo) = EscapeInfo(x; Liveness=BOT_LIVENESS)
-with_heap_observed(x::EscapeInfo) = x.HeapObserved ? x : EscapeInfo(x; HeapObserved=true)
+with_address_observed(x::EscapeInfo) = x.AddressObserved ? x : EscapeInfo(x; AddressObserved=true)
 
 # AliasInfo
 struct IndexableFields
@@ -226,7 +226,7 @@ x::EscapeInfo == y::EscapeInfo = begin
     x === y && return true
     x.Analyzed === y.Analyzed || return false
     x.ReturnEscape === y.ReturnEscape || return false
-    x.HeapObserved === y.HeapObserved || return false
+    x.AddressObserved === y.AddressObserved || return false
     x.FinalizerEscape === y.FinalizerEscape || return false
     xt, yt = x.ThrownEscape, y.ThrownEscape
     if xt === TOP_THROWN_ESCAPE
@@ -276,7 +276,7 @@ x::EscapeInfo ⊑ₑ y::EscapeInfo = begin
     end
     x.Analyzed ≤ y.Analyzed || return false
     x.ReturnEscape ≤ y.ReturnEscape || return false
-    x.HeapObserved ≤ y.HeapObserved || return false
+    x.AddressObserved ≤ y.AddressObserved || return false
     x.FinalizerEscape ≤ y.FinalizerEscape || return false
     xt, yt = x.ThrownEscape, y.ThrownEscape
     if xt === TOP_THROWN_ESCAPE
@@ -376,7 +376,7 @@ x::EscapeInfo ⊔ₑ y::EscapeInfo = begin
         x.Analyzed | y.Analyzed,
         x.ReturnEscape | y.ReturnEscape,
         ThrownEscape,
-        x.HeapObserved | y.HeapObserved,
+        x.AddressObserved | y.AddressObserved,
         x.FinalizerEscape | y.FinalizerEscape,
         AliasInfo,
         Liveness,
@@ -526,22 +526,22 @@ function ArgEscapeInfo(x::EscapeInfo)
     escape_bits = 0x00
     has_return_escape(x) && (escape_bits |= ARG_RETURN_ESCAPE)
     has_thrown_escape(x) && (escape_bits |= ARG_THROWN_ESCAPE)
-    has_heap_observed(x) && (escape_bits |= ARG_HEAP_OBSERVED)
+    has_address_observed(x) && (escape_bits |= ARG_ADDRESS_OBSERVED)
     has_finalizer_escape(x) && (escape_bits |= ARG_FINALIZER_ESCAPE)
     return ArgEscapeInfo(escape_bits)
 end
 
-const ARG_ALL_ESCAPE       = 0x01 << 0
-const ARG_RETURN_ESCAPE    = 0x01 << 1
-const ARG_THROWN_ESCAPE    = 0x01 << 2
-const ARG_HEAP_OBSERVED    = 0x01 << 3
-const ARG_FINALIZER_ESCAPE = 0x01 << 4
+const ARG_ALL_ESCAPE        = 0x01 << 0
+const ARG_RETURN_ESCAPE     = 0x01 << 1
+const ARG_THROWN_ESCAPE     = 0x01 << 2
+const ARG_ADDRESS_OBSERVED  = 0x01 << 3
+const ARG_FINALIZER_ESCAPE  = 0x01 << 4
 
 has_no_escape(x::ArgEscapeInfo)     = !has_all_escape(x) && !has_return_escape(x) && !has_thrown_escape(x)
 has_all_escape(x::ArgEscapeInfo)    = x.escape_bits & ARG_ALL_ESCAPE    ≠ 0
 has_return_escape(x::ArgEscapeInfo) = x.escape_bits & ARG_RETURN_ESCAPE ≠ 0
 has_thrown_escape(x::ArgEscapeInfo) = x.escape_bits & ARG_THROWN_ESCAPE ≠ 0
-has_heap_observed(x::ArgEscapeInfo) = x.escape_bits & ARG_HEAP_OBSERVED  ≠ 0
+has_address_observed(x::ArgEscapeInfo) = x.escape_bits & ARG_ADDRESS_OBSERVED ≠ 0
 has_finalizer_escape(x::ArgEscapeInfo) = x.escape_bits & ARG_FINALIZER_ESCAPE ≠ 0
 
 struct ArgAliasing
@@ -1019,10 +1019,10 @@ function escape_invoke!(astate::AnalysisState, pc::Int, args::Vector{Any})
                 # N.B. `cache === true` is inferred from the callee's `:effect_free` and
                 # `:inaccessiblememonly` effects, but those still permit the callee to store
                 # this argument into a freshly allocated (caller-invisible) object, which the
-                # GC would trace, so we must still taint the argument with `HeapObserved`
+                # GC would trace, so we must still taint the argument with `AddressObserved`
                 # (no `FinalizerEscape` taint is needed however, since `Core.finalizer` is
                 # incompatible with the `:effect_free`+`:inaccessiblememonly` effects)
-                add_escape_change!(astate, arg, HeapObserved())
+                add_escape_change!(astate, arg, AddressObserved())
                 if !is_identity_free_argtype(argextype(arg, astate.ir))
                     add_alias_change!(astate, ret, arg)
                 end
@@ -1069,7 +1069,7 @@ in the context of the caller frame, where `pc` is the SSA statement number of th
 function from_interprocedural(argescape::ArgEscapeInfo, pc::Int)
     has_all_escape(argescape) && return ⊤
     ThrownEscape = has_thrown_escape(argescape) ? BitSet(pc) : BOT_THROWN_ESCAPE
-    HeapObserved = has_heap_observed(argescape)
+    AddressObserved = has_address_observed(argescape)
     FinalizerEscape = has_finalizer_escape(argescape)
     # TODO implement interprocedural memory effect-analysis:
     # currently, this essentially disables the entire field analysis–it might be okay from
@@ -1078,7 +1078,7 @@ function from_interprocedural(argescape::ArgEscapeInfo, pc::Int)
     # or some other IPO optimizations
     AliasInfo = true
     Liveness = BitSet(pc)
-    return EscapeInfo(#=Analyzed=#true, #=ReturnEscape=#false, ThrownEscape, HeapObserved, FinalizerEscape, AliasInfo, Liveness)
+    return EscapeInfo(#=Analyzed=#true, #=ReturnEscape=#false, ThrownEscape, AddressObserved, FinalizerEscape, AliasInfo, Liveness)
 end
 
 # the only possible 'escape' here is really just that it can return a
@@ -1237,9 +1237,9 @@ function escape_new!(astate::AnalysisState, pc::Int, args::Vector{Any})
         infos = AliasInfo.infos
         nf = length(infos)
         # propagate the escape information of this object ignoring field information,
-        # and taint the field values with `HeapObserved` since this object may be
+        # and taint the field values with `AddressObserved` since this object may be
         # heap-allocated, making them reachable from GC-traced memory
-        objinfo′ = with_heap_observed(ignore_aliasinfo(objinfo))
+        objinfo′ = with_address_observed(ignore_aliasinfo(objinfo))
         for i in 2:nargs
             i-1 > nf && break # may happen when e.g. ϕ-node merges values with different types
             arg = args[i]
@@ -1255,9 +1255,9 @@ function escape_new!(astate::AnalysisState, pc::Int, args::Vector{Any})
         # fields are known partially: propagate escape information imposed on recorded possibilities to all field values
         info = AliasInfo.info
         # propagate the escape information of this object ignoring field information,
-        # and taint the field values with `HeapObserved` since this object may be
+        # and taint the field values with `AddressObserved` since this object may be
         # heap-allocated, making them reachable from GC-traced memory
-        objinfo′ = with_heap_observed(ignore_aliasinfo(objinfo))
+        objinfo′ = with_address_observed(ignore_aliasinfo(objinfo))
         for i in 2:nargs
             arg = args[i]
             add_alias_escapes!(astate, arg, info)
@@ -1273,8 +1273,8 @@ function escape_new!(astate::AnalysisState, pc::Int, args::Vector{Any})
         @label conservative_propagation
         # the fields couldn't be analyzed precisely: propagate the entire escape information
         # of this object to all its fields as the most conservative propagation
-        # (also taint them with `HeapObserved` since this object may be heap-allocated)
-        objinfo′ = with_heap_observed(objinfo)
+        # (also taint them with `AddressObserved` since this object may be heap-allocated)
+        objinfo′ = with_address_observed(objinfo)
         for i in 2:nargs
             arg = args[i]
             add_escape_change!(astate, arg, objinfo′)
@@ -1417,9 +1417,9 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
         objinfo = EscapeInfo(objinfo, AliasInfo)
         add_escape_change!(astate, obj, objinfo) # update with new AliasInfo
         # propagate the escape information of this object ignoring field information,
-        # and taint the stored value with `HeapObserved` since this object may be
+        # and taint the stored value with `AddressObserved` since this object may be
         # heap-allocated, making the value reachable from GC-traced memory
-        add_escape_change!(astate, val, with_heap_observed(ignore_aliasinfo(objinfo)))
+        add_escape_change!(astate, val, with_address_observed(ignore_aliasinfo(objinfo)))
     elseif isa(AliasInfo, Unindexable)
         AliasInfo = copy(AliasInfo)
         @label escape_unindexable_def
@@ -1428,9 +1428,9 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
         objinfo = EscapeInfo(objinfo, AliasInfo)
         add_escape_change!(astate, obj, objinfo) # update with new AliasInfo
         # propagate the escape information of this object ignoring field information,
-        # and taint the stored value with `HeapObserved` since this object may be
+        # and taint the stored value with `AddressObserved` since this object may be
         # heap-allocated, making the value reachable from GC-traced memory
-        add_escape_change!(astate, val, with_heap_observed(ignore_aliasinfo(objinfo)))
+        add_escape_change!(astate, val, with_address_observed(ignore_aliasinfo(objinfo)))
     else
         # this object has been used as array, but it is used as struct here (i.e. should throw)
         # update obj's field information and just handle this case conservatively
@@ -1439,11 +1439,11 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
         # the field couldn't be analyzed: alias this object to the value being assigned
         # as the most conservative propagation (as required for ArgAliasing)
         add_alias_change!(astate, val, obj)
-        # taint the stored value with `HeapObserved` since this object may be heap-allocated
+        # taint the stored value with `AddressObserved` since this object may be heap-allocated
         # (N.B. the alias change above equalizes escape information between `val` and `obj`,
         # so `obj` is tainted as well; this is conservative but unavoidable without
         # interprocedural field analysis for unanalyzable objects such as arguments)
-        add_escape_change!(astate, val, HeapObserved())
+        add_escape_change!(astate, val, AddressObserved())
     end
     # also propagate escape information imposed on the return value of this `setfield!`
     ssainfo = estate[SSAValue(pc)]
@@ -1467,7 +1467,7 @@ function escape_builtin!(::typeof(Core.finalizer), astate::AnalysisState, pc::In
         f, obj = args[2], args[3]
         # the finalizer callback and the finalized object are registered in the
         # task-local finalizer list, which the GC scans and which outlives this frame
-        # (`FinalizerEscape()` also includes the `HeapObserved` taint)
+        # (`FinalizerEscape()` also includes the `AddressObserved` taint)
         # TODO also model the effects of the eventual `f(obj)` invocation?
         add_escape_change!(astate, f, FinalizerEscape())
         add_escape_change!(astate, obj, FinalizerEscape())

--- a/Compiler/test/EAUtils.jl
+++ b/Compiler/test/EAUtils.jl
@@ -131,6 +131,10 @@ function get_name_color(x::EscapeInfo, symbol::Bool = false)
     if name !== nothing && !isa(x.AliasInfo, Bool)
         name = string(name, "′")
     end
+    if name !== nothing && EA.has_heap_capture(x) && !EA.has_all_escape(x)
+        # `†` implies `↓` (`FinalizerEscape` implies `HeapCapture`), so show only one
+        name = string(name, EA.has_finalizer_escape(x) ? "†" : "↓")
+    end
     return name, color
 end
 
@@ -158,25 +162,16 @@ function get_sym_color(x::ArgEscapeInfo)
         if !iszero(escape_bits & EA.ARG_THROWN_ESCAPE)
             color = :yellow
         end
+        if !iszero(escape_bits & EA.ARG_HEAP_CAPTURE)
+            # `†` implies `↓` (`ARG_FINALIZER_ESCAPE` implies `ARG_HEAP_CAPTURE`), so show only one
+            sym = string(sym, !iszero(escape_bits & EA.ARG_FINALIZER_ESCAPE) ? "†" : "↓")
+        end
     end
     return sym, color
 end
 
 function Base.show(io::IO, x::ArgEscapeInfo)
-    escape_bits = x.escape_bits
-    if escape_bits == EA.ARG_ALL_ESCAPE
-        color, sym = :red, "X"
-    elseif escape_bits == 0x00
-        color, sym = :green, "✓"
-    else
-        color, sym = :bold, "*"
-        if !iszero(escape_bits & EA.ARG_RETURN_ESCAPE)
-            color, sym = :blue, "↑"
-        end
-        if !iszero(escape_bits & EA.ARG_THROWN_ESCAPE)
-            color = :yellow
-        end
-    end
+    sym, color = get_sym_color(x)
     printstyled(io, "ArgEscapeInfo(", sym, ")"; color)
 end
 

--- a/Compiler/test/EAUtils.jl
+++ b/Compiler/test/EAUtils.jl
@@ -131,8 +131,8 @@ function get_name_color(x::EscapeInfo, symbol::Bool = false)
     if name !== nothing && !isa(x.AliasInfo, Bool)
         name = string(name, "′")
     end
-    if name !== nothing && EA.has_heap_observed(x) && !EA.has_all_escape(x)
-        # `†` implies `↓` (`FinalizerEscape` implies `HeapObserved`), so show only one
+    if name !== nothing && EA.has_address_observed(x) && !EA.has_all_escape(x)
+        # `†` implies `↓` (`FinalizerEscape` implies `AddressObserved`), so show only one
         name = string(name, EA.has_finalizer_escape(x) ? "†" : "↓")
     end
     return name, color
@@ -162,8 +162,8 @@ function get_sym_color(x::ArgEscapeInfo)
         if !iszero(escape_bits & EA.ARG_THROWN_ESCAPE)
             color = :yellow
         end
-        if !iszero(escape_bits & EA.ARG_HEAP_OBSERVED)
-            # `†` implies `↓` (`ARG_FINALIZER_ESCAPE` implies `ARG_HEAP_OBSERVED`), so show only one
+        if !iszero(escape_bits & EA.ARG_ADDRESS_OBSERVED)
+            # `†` implies `↓` (`ARG_FINALIZER_ESCAPE` implies `ARG_ADDRESS_OBSERVED`), so show only one
             sym = string(sym, !iszero(escape_bits & EA.ARG_FINALIZER_ESCAPE) ? "†" : "↓")
         end
     end

--- a/Compiler/test/EAUtils.jl
+++ b/Compiler/test/EAUtils.jl
@@ -131,8 +131,8 @@ function get_name_color(x::EscapeInfo, symbol::Bool = false)
     if name !== nothing && !isa(x.AliasInfo, Bool)
         name = string(name, "′")
     end
-    if name !== nothing && EA.has_heap_capture(x) && !EA.has_all_escape(x)
-        # `†` implies `↓` (`FinalizerEscape` implies `HeapCapture`), so show only one
+    if name !== nothing && EA.has_heap_observed(x) && !EA.has_all_escape(x)
+        # `†` implies `↓` (`FinalizerEscape` implies `HeapObserved`), so show only one
         name = string(name, EA.has_finalizer_escape(x) ? "†" : "↓")
     end
     return name, color
@@ -162,8 +162,8 @@ function get_sym_color(x::ArgEscapeInfo)
         if !iszero(escape_bits & EA.ARG_THROWN_ESCAPE)
             color = :yellow
         end
-        if !iszero(escape_bits & EA.ARG_HEAP_CAPTURE)
-            # `†` implies `↓` (`ARG_FINALIZER_ESCAPE` implies `ARG_HEAP_CAPTURE`), so show only one
+        if !iszero(escape_bits & EA.ARG_HEAP_OBSERVED)
+            # `†` implies `↓` (`ARG_FINALIZER_ESCAPE` implies `ARG_HEAP_OBSERVED`), so show only one
             sym = string(sym, !iszero(escape_bits & EA.ARG_FINALIZER_ESCAPE) ? "†" : "↓")
         end
     end

--- a/Compiler/test/EscapeAnalysis.jl
+++ b/Compiler/test/EscapeAnalysis.jl
@@ -1716,4 +1716,162 @@ end
 @test (@code_escapes scope_folding()) isa EAUtils.EscapeResult
 @test (@code_escapes scope_folding_opt()) isa EAUtils.EscapeResult
 
+# HeapCapture
+# ===========
+# `HeapCapture` tracks whether a value may become reachable from a location the GC scans:
+# fields of a (possibly heap-allocated) object, a global binding, GC frame roots set up
+# for `GC.@preserve`/`:foreigncall`, the finalizer list, or the exception state.
+
+@noinline hc_fin_callback(x) = (println("finalizing"); nothing)
+
+@testset "HeapCapture" begin
+    # storing into a local heap-allocated object taints the stored value,
+    # even when that object itself doesn't escape the frame
+    let result = code_escapes((SafeRef{String},)) do a
+            r = Ref{Any}()
+            r[] = a
+            return r
+        end
+        @test has_heap_capture(result.state[Argument(2)])
+        @test !has_all_escape(result.state[Argument(2)])
+    end
+
+    # plain field reads don't taint
+    let result = code_escapes((SafeRef{String},)) do s
+            s[]
+        end
+        @test !has_heap_capture(result.state[Argument(2)])
+    end
+
+    # mutating a bitstype field of an argument doesn't taint the argument
+    let result = code_escapes((SafeRef{Int},)) do c
+            c[] = c[] + 1
+            return c[]
+        end
+        @test !has_heap_capture(result.state[Argument(2)])
+    end
+
+    # values captured into a fresh allocation are tainted (the allocation may be on the heap),
+    # but bitstype values are not (they are stored by value)
+    let result = code_escapes((SafeRef{String},Int)) do a, b
+            t = tuple(a, b)
+            return t
+        end
+        @test has_heap_capture(result.state[Argument(2)])
+        @test !has_heap_capture(result.state[Argument(3)])
+    end
+
+    # global store means all escape, which includes `HeapCapture`
+    let result = code_escapes((SafeRef{String},)) do a
+            global GV = a
+            nothing
+        end
+        @test has_heap_capture(result.state[Argument(2)])
+    end
+
+    # `Core.finalizer` registers its arguments in the GC-scanned finalizer list:
+    # this sets the dedicated `FinalizerEscape` bit, which implies `HeapCapture`
+    # (the finalizer list outlives the frame, unlike the other `HeapCapture` sources)
+    let result = code_escapes((SafeRef{String},)) do s
+            Core.finalizer(hc_fin_callback, s)
+            return s.x
+        end
+        @test has_finalizer_escape(result.state[Argument(2)])
+        @test has_heap_capture(result.state[Argument(2)])
+    end
+
+    # ... but ordinary `HeapCapture` sources don't set `FinalizerEscape`
+    let result = code_escapes((SafeRef{String},)) do a
+            r = Ref{Any}()
+            r[] = a
+            return r
+        end
+        @test has_heap_capture(result.state[Argument(2)])
+        @test !has_finalizer_escape(result.state[Argument(2)])
+    end
+
+    # `GC.@preserve`d values are rooted in a GC frame
+    let result = code_escapes((SafeRef{String},)) do s
+            GC.@preserve s begin end
+            return s.x
+        end
+        @test has_heap_capture(result.state[Argument(2)])
+    end
+
+    # thrown objects enter the GC-scanned exception state (even without a try/catch)
+    let result = code_escapes((Bool,SafeRef{String},)) do c, s
+            c && throw(s)
+            return 0
+        end
+        @test has_heap_capture(result.state[Argument(3)])
+    end
+
+    # the taint propagates through ϕ merges
+    let result = code_escapes((Bool,SafeRef{String},SafeRef{String},)) do c, a, b
+            x = c ? a : b
+            r = Ref{Any}()
+            r[] = x
+            return r
+        end
+        @test has_heap_capture(result.state[Argument(3)])
+        @test has_heap_capture(result.state[Argument(4)])
+    end
+end
+
+# interprocedural HeapCapture
+@noinline hc_store!(r, a) = (r[] = a; nothing)
+@noinline hc_read(s) = s.x
+@noinline hc_identity(x) = x
+@noinline hc_finalize!(s) = (Core.finalizer(hc_fin_callback, s); nothing)
+
+# a cache callback that unconditionally claims the best-case `true` for every callee,
+# mimicking the `:effect_free`+`:inaccessiblememonly` fallback of `GetNativeEscapeCache`
+struct ReturnTrueEscapeCache end
+(::ReturnTrueEscapeCache)(codeinst) = true
+
+@testset "HeapCapture interprocedural" begin
+    # callee stores the argument => the caller sees the taint via the cached summary
+    let result = code_escapes((SafeRef{String},)) do a
+            s = SafeRef{Any}(nothing)
+            hc_store!(s, a)
+            return s.x === nothing
+        end
+        @test has_heap_capture(result.state[Argument(2)])
+        @test !has_finalizer_escape(result.state[Argument(2)])
+    end
+
+    # callee registers a finalizer => the caller sees both taints via the cached summary
+    let result = code_escapes((SafeRef{String},)) do s
+            hc_finalize!(s)
+            return s.x
+        end
+        @test has_finalizer_escape(result.state[Argument(2)])
+        @test has_heap_capture(result.state[Argument(2)])
+    end
+
+    # callee returns the argument and the caller stores the result:
+    # the taint is applied by the caller through the replayed ret-arg aliasing
+    let result = code_escapes((SafeRef{String},)) do a
+            r = Ref{Any}()
+            r[] = hc_identity(a)
+            return r
+        end
+        @test has_heap_capture(result.state[Argument(2)])
+    end
+
+    # callee only reads the argument => no taint
+    let result = code_escapes((SafeRef{String},)) do s
+            return hc_read(s)
+        end
+        @test !has_heap_capture(result.state[Argument(2)])
+
+        # however the `cache === true` fallback must still taint the argument, since
+        # `:effect_free`+`:inaccessiblememonly` still permit the callee to store the
+        # argument into a freshly allocated (caller-invisible) object that the GC traces
+        estate = EscapeAnalysis.analyze_escapes(result.ir, 2,
+            Compiler.SimpleInferenceLattice.instance, ReturnTrueEscapeCache())
+        @test has_heap_capture(estate[Argument(2)])
+    end
+end
+
 end # module test_EA

--- a/Compiler/test/EscapeAnalysis.jl
+++ b/Compiler/test/EscapeAnalysis.jl
@@ -1716,15 +1716,14 @@ end
 @test (@code_escapes scope_folding()) isa EAUtils.EscapeResult
 @test (@code_escapes scope_folding_opt()) isa EAUtils.EscapeResult
 
-# HeapCapture
+# HeapObserved
 # ===========
-# `HeapCapture` tracks whether a value may become reachable from a location the GC scans:
-# fields of a (possibly heap-allocated) object, a global binding, GC frame roots set up
-# for `GC.@preserve`/`:foreigncall`, the finalizer list, or the exception state.
+# `HeapObserved` tracks whether a value may become reachable from GC-managed memory:
+# fields of a (possibly heap-allocated) object, or the finalizer list.
 
 @noinline hc_fin_callback(x) = (println("finalizing"); nothing)
 
-@testset "HeapCapture" begin
+@testset "HeapObserved" begin
     # storing into a local heap-allocated object taints the stored value,
     # even when that object itself doesn't escape the frame
     let result = code_escapes((SafeRef{String},)) do a
@@ -1732,7 +1731,7 @@ end
             r[] = a
             return r
         end
-        @test has_heap_capture(result.state[Argument(2)])
+        @test has_heap_observed(result.state[Argument(2)])
         @test !has_all_escape(result.state[Argument(2)])
     end
 
@@ -1740,7 +1739,7 @@ end
     let result = code_escapes((SafeRef{String},)) do s
             s[]
         end
-        @test !has_heap_capture(result.state[Argument(2)])
+        @test !has_heap_observed(result.state[Argument(2)])
     end
 
     # mutating a bitstype field of an argument doesn't taint the argument
@@ -1748,7 +1747,7 @@ end
             c[] = c[] + 1
             return c[]
         end
-        @test !has_heap_capture(result.state[Argument(2)])
+        @test !has_heap_observed(result.state[Argument(2)])
     end
 
     # values captured into a fresh allocation are tainted (the allocation may be on the heap),
@@ -1757,53 +1756,37 @@ end
             t = tuple(a, b)
             return t
         end
-        @test has_heap_capture(result.state[Argument(2)])
-        @test !has_heap_capture(result.state[Argument(3)])
+        @test has_heap_observed(result.state[Argument(2)])
+        @test !has_heap_observed(result.state[Argument(3)])
     end
 
-    # global store means all escape, which includes `HeapCapture`
+    # global store means all escape, which includes `HeapObserved`
     let result = code_escapes((SafeRef{String},)) do a
             global GV = a
             nothing
         end
-        @test has_heap_capture(result.state[Argument(2)])
+        @test has_heap_observed(result.state[Argument(2)])
     end
 
     # `Core.finalizer` registers its arguments in the GC-scanned finalizer list:
-    # this sets the dedicated `FinalizerEscape` bit, which implies `HeapCapture`
-    # (the finalizer list outlives the frame, unlike the other `HeapCapture` sources)
+    # this sets the dedicated `FinalizerEscape` bit, which implies `HeapObserved`
+    # (the finalizer list outlives the frame, unlike the other `HeapObserved` sources)
     let result = code_escapes((SafeRef{String},)) do s
             Core.finalizer(hc_fin_callback, s)
             return s.x
         end
         @test has_finalizer_escape(result.state[Argument(2)])
-        @test has_heap_capture(result.state[Argument(2)])
+        @test has_heap_observed(result.state[Argument(2)])
     end
 
-    # ... but ordinary `HeapCapture` sources don't set `FinalizerEscape`
+    # ... but ordinary `HeapObserved` sources don't set `FinalizerEscape`
     let result = code_escapes((SafeRef{String},)) do a
             r = Ref{Any}()
             r[] = a
             return r
         end
-        @test has_heap_capture(result.state[Argument(2)])
+        @test has_heap_observed(result.state[Argument(2)])
         @test !has_finalizer_escape(result.state[Argument(2)])
-    end
-
-    # `GC.@preserve`d values are rooted in a GC frame
-    let result = code_escapes((SafeRef{String},)) do s
-            GC.@preserve s begin end
-            return s.x
-        end
-        @test has_heap_capture(result.state[Argument(2)])
-    end
-
-    # thrown objects enter the GC-scanned exception state (even without a try/catch)
-    let result = code_escapes((Bool,SafeRef{String},)) do c, s
-            c && throw(s)
-            return 0
-        end
-        @test has_heap_capture(result.state[Argument(3)])
     end
 
     # the taint propagates through ϕ merges
@@ -1813,12 +1796,12 @@ end
             r[] = x
             return r
         end
-        @test has_heap_capture(result.state[Argument(3)])
-        @test has_heap_capture(result.state[Argument(4)])
+        @test has_heap_observed(result.state[Argument(3)])
+        @test has_heap_observed(result.state[Argument(4)])
     end
 end
 
-# interprocedural HeapCapture
+# interprocedural HeapObserved
 @noinline hc_store!(r, a) = (r[] = a; nothing)
 @noinline hc_read(s) = s.x
 @noinline hc_identity(x) = x
@@ -1829,14 +1812,14 @@ end
 struct ReturnTrueEscapeCache end
 (::ReturnTrueEscapeCache)(codeinst) = true
 
-@testset "HeapCapture interprocedural" begin
+@testset "HeapObserved interprocedural" begin
     # callee stores the argument => the caller sees the taint via the cached summary
     let result = code_escapes((SafeRef{String},)) do a
             s = SafeRef{Any}(nothing)
             hc_store!(s, a)
             return s.x === nothing
         end
-        @test has_heap_capture(result.state[Argument(2)])
+        @test has_heap_observed(result.state[Argument(2)])
         @test !has_finalizer_escape(result.state[Argument(2)])
     end
 
@@ -1846,7 +1829,7 @@ struct ReturnTrueEscapeCache end
             return s.x
         end
         @test has_finalizer_escape(result.state[Argument(2)])
-        @test has_heap_capture(result.state[Argument(2)])
+        @test has_heap_observed(result.state[Argument(2)])
     end
 
     # callee returns the argument and the caller stores the result:
@@ -1856,21 +1839,21 @@ struct ReturnTrueEscapeCache end
             r[] = hc_identity(a)
             return r
         end
-        @test has_heap_capture(result.state[Argument(2)])
+        @test has_heap_observed(result.state[Argument(2)])
     end
 
     # callee only reads the argument => no taint
     let result = code_escapes((SafeRef{String},)) do s
             return hc_read(s)
         end
-        @test !has_heap_capture(result.state[Argument(2)])
+        @test !has_heap_observed(result.state[Argument(2)])
 
         # however the `cache === true` fallback must still taint the argument, since
         # `:effect_free`+`:inaccessiblememonly` still permit the callee to store the
         # argument into a freshly allocated (caller-invisible) object that the GC traces
         estate = EscapeAnalysis.analyze_escapes(result.ir, 2,
             Compiler.SimpleInferenceLattice.instance, ReturnTrueEscapeCache())
-        @test has_heap_capture(estate[Argument(2)])
+        @test has_heap_observed(estate[Argument(2)])
     end
 end
 

--- a/Compiler/test/EscapeAnalysis.jl
+++ b/Compiler/test/EscapeAnalysis.jl
@@ -1716,14 +1716,14 @@ end
 @test (@code_escapes scope_folding()) isa EAUtils.EscapeResult
 @test (@code_escapes scope_folding_opt()) isa EAUtils.EscapeResult
 
-# HeapObserved
+# AddressObserved
 # ===========
-# `HeapObserved` tracks whether a value may become reachable from GC-managed memory:
+# `AddressObserved` tracks whether a value may become reachable from GC-managed memory:
 # fields of a (possibly heap-allocated) object, or the finalizer list.
 
 @noinline hc_fin_callback(x) = (println("finalizing"); nothing)
 
-@testset "HeapObserved" begin
+@testset "AddressObserved" begin
     # storing into a local heap-allocated object taints the stored value,
     # even when that object itself doesn't escape the frame
     let result = code_escapes((SafeRef{String},)) do a
@@ -1731,7 +1731,7 @@ end
             r[] = a
             return r
         end
-        @test has_heap_observed(result.state[Argument(2)])
+        @test has_address_observed(result.state[Argument(2)])
         @test !has_all_escape(result.state[Argument(2)])
     end
 
@@ -1739,7 +1739,7 @@ end
     let result = code_escapes((SafeRef{String},)) do s
             s[]
         end
-        @test !has_heap_observed(result.state[Argument(2)])
+        @test !has_address_observed(result.state[Argument(2)])
     end
 
     # mutating a bitstype field of an argument doesn't taint the argument
@@ -1747,7 +1747,7 @@ end
             c[] = c[] + 1
             return c[]
         end
-        @test !has_heap_observed(result.state[Argument(2)])
+        @test !has_address_observed(result.state[Argument(2)])
     end
 
     # values captured into a fresh allocation are tainted (the allocation may be on the heap),
@@ -1756,36 +1756,36 @@ end
             t = tuple(a, b)
             return t
         end
-        @test has_heap_observed(result.state[Argument(2)])
-        @test !has_heap_observed(result.state[Argument(3)])
+        @test has_address_observed(result.state[Argument(2)])
+        @test !has_address_observed(result.state[Argument(3)])
     end
 
-    # global store means all escape, which includes `HeapObserved`
+    # global store means all escape, which includes `AddressObserved`
     let result = code_escapes((SafeRef{String},)) do a
             global GV = a
             nothing
         end
-        @test has_heap_observed(result.state[Argument(2)])
+        @test has_address_observed(result.state[Argument(2)])
     end
 
     # `Core.finalizer` registers its arguments in the GC-scanned finalizer list:
-    # this sets the dedicated `FinalizerEscape` bit, which implies `HeapObserved`
-    # (the finalizer list outlives the frame, unlike the other `HeapObserved` sources)
+    # this sets the dedicated `FinalizerEscape` bit, which implies `AddressObserved`
+    # (the finalizer list outlives the frame, unlike the other `AddressObserved` sources)
     let result = code_escapes((SafeRef{String},)) do s
             Core.finalizer(hc_fin_callback, s)
             return s.x
         end
         @test has_finalizer_escape(result.state[Argument(2)])
-        @test has_heap_observed(result.state[Argument(2)])
+        @test has_address_observed(result.state[Argument(2)])
     end
 
-    # ... but ordinary `HeapObserved` sources don't set `FinalizerEscape`
+    # ... but ordinary `AddressObserved` sources don't set `FinalizerEscape`
     let result = code_escapes((SafeRef{String},)) do a
             r = Ref{Any}()
             r[] = a
             return r
         end
-        @test has_heap_observed(result.state[Argument(2)])
+        @test has_address_observed(result.state[Argument(2)])
         @test !has_finalizer_escape(result.state[Argument(2)])
     end
 
@@ -1796,12 +1796,12 @@ end
             r[] = x
             return r
         end
-        @test has_heap_observed(result.state[Argument(3)])
-        @test has_heap_observed(result.state[Argument(4)])
+        @test has_address_observed(result.state[Argument(3)])
+        @test has_address_observed(result.state[Argument(4)])
     end
 end
 
-# interprocedural HeapObserved
+# interprocedural AddressObserved
 @noinline hc_store!(r, a) = (r[] = a; nothing)
 @noinline hc_read(s) = s.x
 @noinline hc_identity(x) = x
@@ -1812,14 +1812,14 @@ end
 struct ReturnTrueEscapeCache end
 (::ReturnTrueEscapeCache)(codeinst) = true
 
-@testset "HeapObserved interprocedural" begin
+@testset "AddressObserved interprocedural" begin
     # callee stores the argument => the caller sees the taint via the cached summary
     let result = code_escapes((SafeRef{String},)) do a
             s = SafeRef{Any}(nothing)
             hc_store!(s, a)
             return s.x === nothing
         end
-        @test has_heap_observed(result.state[Argument(2)])
+        @test has_address_observed(result.state[Argument(2)])
         @test !has_finalizer_escape(result.state[Argument(2)])
     end
 
@@ -1829,7 +1829,7 @@ struct ReturnTrueEscapeCache end
             return s.x
         end
         @test has_finalizer_escape(result.state[Argument(2)])
-        @test has_heap_observed(result.state[Argument(2)])
+        @test has_address_observed(result.state[Argument(2)])
     end
 
     # callee returns the argument and the caller stores the result:
@@ -1839,21 +1839,21 @@ struct ReturnTrueEscapeCache end
             r[] = hc_identity(a)
             return r
         end
-        @test has_heap_observed(result.state[Argument(2)])
+        @test has_address_observed(result.state[Argument(2)])
     end
 
     # callee only reads the argument => no taint
     let result = code_escapes((SafeRef{String},)) do s
             return hc_read(s)
         end
-        @test !has_heap_observed(result.state[Argument(2)])
+        @test !has_address_observed(result.state[Argument(2)])
 
         # however the `cache === true` fallback must still taint the argument, since
         # `:effect_free`+`:inaccessiblememonly` still permit the callee to store the
         # argument into a freshly allocated (caller-invisible) object that the GC traces
         estate = EscapeAnalysis.analyze_escapes(result.ir, 2,
             Compiler.SimpleInferenceLattice.instance, ReturnTrueEscapeCache())
-        @test has_heap_observed(estate[Argument(2)])
+        @test has_address_observed(estate[Argument(2)])
     end
 end
 

--- a/doc/src/devdocs/EscapeAnalysis.md
+++ b/doc/src/devdocs/EscapeAnalysis.md
@@ -57,6 +57,9 @@ The symbols on the side of each call argument and SSA statements represent the f
 - `X` (red): this value can escape to somewhere the escape analysis can't reason about like escapes to a global memory (`has_all_escape(result.state[x])` holds)
 - `*` (bold): this value's escape state is between the `ReturnEscape` and `AllEscape` in the partial order of [`EscapeInfo`](@ref Base.Compiler.EscapeAnalysis.EscapeInfo), colored yellow if it has unhandled thrown escape also (`has_thrown_escape(result.state[x])` holds)
 - `′`: this value has additional object field / array element information in its `AliasInfo` property
+- `↓`: this value may become reachable from a location the GC scans (`has_heap_capture(result.state[x])` holds)
+- `†`: this value may be registered with a finalizer (`has_finalizer_escape(result.state[x])` holds);
+  shown in place of `↓`, since `FinalizerEscape` implies `HeapCapture`
 
 Escape information of each call argument and SSA value can be inspected programmatically as like:
 ```@repl EAUtils
@@ -76,6 +79,21 @@ which is composed of the following properties:
 - `x.ReturnEscape::BitSet`: records SSA statements where `x` can escape to the caller via return
 - `x.ThrownEscape::BitSet`: records SSA statements where `x` can be thrown as exception
   (used for the [exception handling](@ref EA-Exception-Handling) described below)
+- `x.HeapCapture::Bool`: indicates `x` may become reachable from a location the GC scans,
+  e.g. a field of a (possibly heap-allocated) object, a global binding, GC frame roots
+  set up for `GC.@preserve` or `:foreigncall`, the finalizer list, or the exception state.
+  Note that this property tracks reachability from GC-traced memory rather than escape in
+  the traditional sense: a value can be stored into an object that never escapes the frame
+  and still have `HeapCapture` set, since the GC would trace it through that object.
+  It also does not track ABI-level rooting performed by codegen (e.g. a callee keeping a
+  GC-tracked argument alive across a safepoint in its GC frame), which is an artifact of
+  the calling convention rather than of the analyzed program.
+- `x.FinalizerEscape::Bool`: indicates `x` may be registered with a finalizer via
+  `Core.finalizer`, either as the finalized object or as the callback.
+  This is a refinement of `HeapCapture` (`FinalizerEscape` implies `HeapCapture`) that is
+  separated out because it has strictly stronger lifetime semantics than the other
+  `HeapCapture` sources: the finalizer list outlives the current frame, and the callback
+  is eventually invoked on the object at an arbitrary later point.
 - `x.AliasInfo`: maintains all possible values that can be aliased to fields or array elements of `x`
   (used for the [alias analysis](@ref EA-Alias-Analysis) described below)
 - `x.ArgEscape::Int` (not implemented yet): indicates it will escape to the caller through

--- a/doc/src/devdocs/EscapeAnalysis.md
+++ b/doc/src/devdocs/EscapeAnalysis.md
@@ -57,9 +57,9 @@ The symbols on the side of each call argument and SSA statements represent the f
 - `X` (red): this value can escape to somewhere the escape analysis can't reason about like escapes to a global memory (`has_all_escape(result.state[x])` holds)
 - `*` (bold): this value's escape state is between the `ReturnEscape` and `AllEscape` in the partial order of [`EscapeInfo`](@ref Base.Compiler.EscapeAnalysis.EscapeInfo), colored yellow if it has unhandled thrown escape also (`has_thrown_escape(result.state[x])` holds)
 - `′`: this value has additional object field / array element information in its `AliasInfo` property
-- `↓`: this value may become reachable from a location the GC scans (`has_heap_capture(result.state[x])` holds)
+- `↓`: this value may become reachable from GC-managed memory (`has_heap_observed(result.state[x])` holds)
 - `†`: this value may be registered with a finalizer (`has_finalizer_escape(result.state[x])` holds);
-  shown in place of `↓`, since `FinalizerEscape` implies `HeapCapture`
+  shown in place of `↓`, since `FinalizerEscape` implies `HeapObserved`
 
 Escape information of each call argument and SSA value can be inspected programmatically as like:
 ```@repl EAUtils
@@ -79,20 +79,21 @@ which is composed of the following properties:
 - `x.ReturnEscape::BitSet`: records SSA statements where `x` can escape to the caller via return
 - `x.ThrownEscape::BitSet`: records SSA statements where `x` can be thrown as exception
   (used for the [exception handling](@ref EA-Exception-Handling) described below)
-- `x.HeapCapture::Bool`: indicates `x` may become reachable from a location the GC scans,
-  e.g. a field of a (possibly heap-allocated) object, a global binding, GC frame roots
-  set up for `GC.@preserve` or `:foreigncall`, the finalizer list, or the exception state.
+- `x.HeapObserved::Bool`: indicates `x` may become reachable from GC-managed memory,
+  i.e. it may be stored into a field of another (possibly heap-allocated) object,
+  or registered in the finalizer list.
   Note that this property tracks reachability from GC-traced memory rather than escape in
   the traditional sense: a value can be stored into an object that never escapes the frame
-  and still have `HeapCapture` set, since the GC would trace it through that object.
-  It also does not track ABI-level rooting performed by codegen (e.g. a callee keeping a
-  GC-tracked argument alive across a safepoint in its GC frame), which is an artifact of
-  the calling convention rather than of the analyzed program.
+  and still have `HeapObserved` set, since the GC would trace it through that object if it
+  remains heap-allocated.
+  It does not track GC rooting performed by codegen (GC frame slots at safepoints,
+  `GC.@preserve`, `:foreigncall` roots), which is an artifact of the calling convention
+  rather than of the analyzed program.
 - `x.FinalizerEscape::Bool`: indicates `x` may be registered with a finalizer via
   `Core.finalizer`, either as the finalized object or as the callback.
-  This is a refinement of `HeapCapture` (`FinalizerEscape` implies `HeapCapture`) that is
+  This is a refinement of `HeapObserved` (`FinalizerEscape` implies `HeapObserved`) that is
   separated out because it has strictly stronger lifetime semantics than the other
-  `HeapCapture` sources: the finalizer list outlives the current frame, and the callback
+  `HeapObserved` sources: the finalizer list outlives the current frame, and the callback
   is eventually invoked on the object at an arbitrary later point.
 - `x.AliasInfo`: maintains all possible values that can be aliased to fields or array elements of `x`
   (used for the [alias analysis](@ref EA-Alias-Analysis) described below)

--- a/doc/src/devdocs/EscapeAnalysis.md
+++ b/doc/src/devdocs/EscapeAnalysis.md
@@ -57,9 +57,9 @@ The symbols on the side of each call argument and SSA statements represent the f
 - `X` (red): this value can escape to somewhere the escape analysis can't reason about like escapes to a global memory (`has_all_escape(result.state[x])` holds)
 - `*` (bold): this value's escape state is between the `ReturnEscape` and `AllEscape` in the partial order of [`EscapeInfo`](@ref Base.Compiler.EscapeAnalysis.EscapeInfo), colored yellow if it has unhandled thrown escape also (`has_thrown_escape(result.state[x])` holds)
 - `′`: this value has additional object field / array element information in its `AliasInfo` property
-- `↓`: this value may become reachable from GC-managed memory (`has_heap_observed(result.state[x])` holds)
+- `↓`: this value may become reachable from GC-managed memory (`has_address_observed(result.state[x])` holds)
 - `†`: this value may be registered with a finalizer (`has_finalizer_escape(result.state[x])` holds);
-  shown in place of `↓`, since `FinalizerEscape` implies `HeapObserved`
+  shown in place of `↓`, since `FinalizerEscape` implies `AddressObserved`
 
 Escape information of each call argument and SSA value can be inspected programmatically as like:
 ```@repl EAUtils
@@ -79,21 +79,21 @@ which is composed of the following properties:
 - `x.ReturnEscape::BitSet`: records SSA statements where `x` can escape to the caller via return
 - `x.ThrownEscape::BitSet`: records SSA statements where `x` can be thrown as exception
   (used for the [exception handling](@ref EA-Exception-Handling) described below)
-- `x.HeapObserved::Bool`: indicates `x` may become reachable from GC-managed memory,
+- `x.AddressObserved::Bool`: indicates `x` may become reachable from GC-managed memory,
   i.e. it may be stored into a field of another (possibly heap-allocated) object,
   or registered in the finalizer list.
   Note that this property tracks reachability from GC-traced memory rather than escape in
   the traditional sense: a value can be stored into an object that never escapes the frame
-  and still have `HeapObserved` set, since the GC would trace it through that object if it
+  and still have `AddressObserved` set, since the GC would trace it through that object if it
   remains heap-allocated.
   It does not track GC rooting performed by codegen (GC frame slots at safepoints,
   `GC.@preserve`, `:foreigncall` roots), which is an artifact of the calling convention
   rather than of the analyzed program.
 - `x.FinalizerEscape::Bool`: indicates `x` may be registered with a finalizer via
   `Core.finalizer`, either as the finalized object or as the callback.
-  This is a refinement of `HeapObserved` (`FinalizerEscape` implies `HeapObserved`) that is
+  This is a refinement of `AddressObserved` (`FinalizerEscape` implies `AddressObserved`) that is
   separated out because it has strictly stronger lifetime semantics than the other
-  `HeapObserved` sources: the finalizer list outlives the current frame, and the callback
+  `AddressObserved` sources: the finalizer list outlives the current frame, and the callback
   is eventually invoked on the object at an arbitrary later point.
 - `x.AliasInfo`: maintains all possible values that can be aliased to fields or array elements of `x`
   (used for the [alias analysis](@ref EA-Alias-Analysis) described below)


### PR DESCRIPTION
This PR extends escape analysis with two new escape states:

1. `AddressObserved`: this bit is set anytime a pointer to the object may be stored into memory the GC traces, i.e. into a field of another object or into the finalizer list. This means that for example, if you have a *non*-escaping object that gets put into a heap allocated container, even if that container doesn't escape, the GC will eventually look inside the container and can observe the object.
2. `FinalizerEscape`: This bit is set when an object is captured by a finalizer. This is actually a subset of `AddressObserved`, but it's the scary one, and it's the subset that most consumers probably care about. This is scary because finalizers can run on different threads, and significantly later after a function body finishes, even if the value is technically non-escaping.

My motivation for this is that I want to work towards eventually being able to stack-allocate mutable structs which cross non-inlined function barriers. What I have learned is that we never really stack-allocate mutable structs fully intact, but instead avoid creating them in the first place, and put their **contents** on the stack. This poses a problem for non-inlined function barriers, since in those cases we really do need to have the value cross the function barrier, and just not constructing the mutable wrapper is insufficient.

One of the big problems when trying to approach this is making sure the GC can't ever observe, and definitely not mark the mutable struct, which made this PR a natural first step.

Here's a few small demos of this analysis:
```julia
include(joinpath(@__DIR__, "Compiler", "test", "EAUtils.jl"))
using .EAUtils

mutable struct Counter
    n::Int
end
```
```julia
julia> code_escapes((Int,)) do n
           c = Counter(n)
           box = Ref{Any}(c)      # heap box; never leaves this frame
           Core.donotdelete(box)  # (only defeats SROA so the store survives for the demo)
           return c.n
       end
#1(✓ n::Int64) in Main at REPL[5]:2
✓′↓ 1 ─ %1 = %new(Main.Counter, _2)::Counter  # <---- the ↓ glyph denotes AddressObserved
✓′ │   %2 = %new(Base.RefValue{Any}, %1)::Base.RefValue{Any}
◌  │          builtin (Core.donotdelete)(%2)::Core.Const(nothing)
✓  │   %4 =   builtin Base.getfield(%1, :n)::Int64
◌  └──      return %4
```

And here's a finalizer example:
```julia
julia> code_escapes((Int,)) do n
           c = Counter(n)
           finalizer(c) do c
               println(c.n)
           end
           return c.n
       end
#15(✓ n::Int64) in Main at REPL[10]:2
✓′† 1 ─ %1 = %new(Main.Counter, _2)::Counter    # <---- the † glyph denotes that it's captured by a finalizer
◌  │          builtin (Core.finalizer)(var"#17#18"(), %1)::Nothing
✓  │   %3 =   builtin Base.getfield(%1, :n)::Int64
◌  └──      return %3
```

The main usage for this is interprocedural stuff, you can see some examples of that in action in the tests.

____________________


<details>

<summary>:robot: summary </summary>

Add two new lattice properties to `EscapeInfo`:

`AddressObserved` tracks whether a pointer to a value may be stored into memory the GC traces: a field of another (possibly heap-allocated) object, or the finalizer list. This is distinct from escape in the traditional sense: storing a value into an object that itself never escapes the frame still sets the property, since the GC would trace the value through that object if it remains heap-allocated. For the same reason, the best-case `cache === true` fallback used for `:effect_free`+`:inaccessiblememonly` callees without a cached summary must still taint arguments, as those effects permit storing an argument into a freshly allocated, caller-invisible object.

The property deliberately does not track GC rooting performed by codegen (GC frame slots at safepoints, `GC.@preserve`, `:foreigncall` roots), which is an artifact of the calling convention rather than of the analyzed program; consumers that require the GC to never observe a value need to control the calling convention of the calls it is passed to in addition to querying this property.

`FinalizerEscape` refines `AddressObserved` (which it implies) for values registered with `Core.finalizer`, resolving an old TODO. It is kept separate because the finalizer list has strictly stronger lifetime semantics than the other `AddressObserved` sources: it outlives the current frame and the callback is eventually invoked on the object, so consumers that can tolerate observation from frame-local locations (but not past frame death) can distinguish the two.

Both properties are projected into `ArgEscapeInfo` as new `ARG_ADDRESS_OBSERVED`/`ARG_FINALIZER_ESCAPE` bits and propagated interprocedurally through the cached argument-escape summaries.

These properties are groundwork for optimizations that place objects outside of GC-managed memory (e.g. stack allocation of mutable structs across non-inlined function calls), which need to prove that the GC can never observe a pointer to the object.

Assisted-by: Claude Code (Fable 5.1)

</details>