### PR TITLE
Compiler: don't crash `return_type_tfunc` on signatures without a function type

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3435,6 +3435,8 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
         argtypes_vec = Any[af_argtype.parameters...]
         isempty(argtypes_vec) && push!(argtypes_vec, Union{})
         aft = argtypes_vec[1]
+        # e.g. `return_type(Tuple{Vararg{Any}})`: there is no function type to model
+        isvarargtype(aft) && return Future(UNKNOWN)
     end
     # effects are not an issue if we know this statement will get removed, but if it does not get removed,
     # then this could be recursively re-entering inference (via concrete-eval), which will not terminate

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7825,6 +7825,15 @@ end == Type{<:Real}
     Compiler.return_type(oc, Tuple{String})
 end == Type{Union{}}
 
+# `return_type_tfunc` should bail out (rather than crash inference) when the queried
+# signature has no function type to model
+@test Base.infer_return_type() do
+    Compiler.return_type(Tuple{Vararg{Any}})
+end == Type
+@test Base.infer_return_type() do
+    Compiler.return_type(Tuple)
+end == Type
+
 @test Base.infer_return_type(Core.task_result_type, (Task,)) === Type
 task_returner() = Task(() -> "hello")
 @test Base.infer_return_type((typeof(task_returner),)) do f


### PR DESCRIPTION
The single-argument `return_type(t::DataType)` model takes `t.parameters[1]` as the type of the function to be called, but for signatures such as `Tuple{Vararg{Any}}` (i.e. `Tuple`) that parameter is a `Vararg`, which `widenconst` rejects and thereby aborts inference of the caller:

    julia> f() = Core.Compiler.return_type(Tuple)
    julia> Base.return_types(f)
    ERROR: unhandled Vararg

Have the tfunc conservatively return an unknown result for such calls, like it already does for the other argument shapes it cannot model.

@vtjnash Is this what you meant in https://github.com/JuliaLang/julia/pull/62690#issuecomment-5333247751?

Assisted-by: Claude Code (Fable 5)