### PR TITLE
Compiler: skip abstractly-bounded typevars in compile_all_tvar_union

### DIFF
--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -56,8 +56,9 @@ function compile_all_tvar_union(methsig)
             tv = tv.ub
         end
 
-        if isa(tv, DataType) && isabstracttype(tv) && !isa(tv, Type)
-            return false  # Any as TypeVar is common and not useful here
+        # Any as TypeVar is common and not useful here to try to analyze further
+        if isabstracttype(tv) && !isType(tv)
+            return false
         end
 
         env[2*i] = tv

--- a/Compiler/test/precompile.jl
+++ b/Compiler/test/precompile.jl
@@ -1,0 +1,34 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Tests for Compiler/src/precompile.jl: the logic that selects and compiles code for
+# system and package images (`--output-o`, `--output-ji`), formerly precompile_utils.c.
+
+include("setup_Compiler.jl")
+
+using Test
+
+@testset "compile_all_tvar_union" begin
+    # When generating a system image, every method definition is compiled for the
+    # signatures obtainable by expanding `where T<:Union{...}` typevars. Typevars with
+    # an abstract upper bound are not worth instantiating: doing so would compile a
+    # fully generic specialization for every such method, which is wasteful and can
+    # even fail codegen (e.g. `LLVMPtr{T, Any}` has no valid address space).
+    # A typevar used as a type parameter makes the instantiated signature a dispatch
+    # tuple (`Type{TVParam{Any}}` is concrete), which is how e.g. `LLVMPtr{T, Any}`
+    # methods ended up being compiled.
+    struct TVParam{T} end
+    f_tvar_any(::Type{TVParam{T}}) where {T} = T
+    @test !Compiler.compile_all_tvar_union(Tuple{typeof(f_tvar_any), Type{TVParam{T}}} where {T})
+    @test isempty(Base.specializations(only(methods(f_tvar_any))))
+
+    f_tvar_abstract(::Type{TVParam{T}}) where {T<:Real} = T
+    @test !Compiler.compile_all_tvar_union(Tuple{typeof(f_tvar_abstract), Type{TVParam{T}}} where {T<:Real})
+    @test isempty(Base.specializations(only(methods(f_tvar_abstract))))
+
+    # ... but typevars bounded by a union of concrete types are expanded and compiled
+    f_tvar_union(x::T) where {T<:Union{Int,Float64}} = x
+    @test Compiler.compile_all_tvar_union(Tuple{typeof(f_tvar_union), T} where {T<:Union{Int,Float64}})
+    specs = collect(Base.specializations(only(methods(f_tvar_union))))
+    @test Set(mi.specTypes for mi in specs) ==
+          Set([Tuple{typeof(f_tvar_union), Int}, Tuple{typeof(f_tvar_union), Float64}])
+end

--- a/Compiler/test/testgroups
+++ b/Compiler/test/testgroups
@@ -9,6 +9,7 @@ inference
 inline
 interpreter_exec
 invalidation
+precompile
 irpasses
 newinterp
 ssair


### PR DESCRIPTION
The Julia port of _compile_all_tvar_union (#59361) translated `jl_is_abstracttype(tv) && !jl_is_type_type(tv)` as `isa(tv, DataType) && isabstracttype(tv) && !isa(tv, Type)`, which is always false. Signatures with Any-bounded typevars were therefore instantiated with Any during --output-o compile-all. When the typevar is a type parameter the result is a dispatch tuple and gets compiled: e.g. every package defining methods on `LLVMPtr{T,A}` produced `LLVMPtr{T, Any}` specializations and "invalid pointer address space" internal errors during sysimage builds, and in general far more was compiled than the C implementation ever did.

Discovered during debugging of https://github.com/JuliaGPU/GPUCompiler.jl/issues/611

Assisted by: Fable 5