### PR TITLE
Fixes for GPU-only methods

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -304,6 +304,10 @@ elseif head === :call && length(x.args) >= 1 && isexpr(x.args[1], :(::))
         # for documenting (x::y)(args...), extract the name from y
         # otherwise, for documenting `x::y`, it will be extracted from x
         astname((x.args[1]::Expr).args[end], ismacro)
+    elseif head === :overlay
+        # for documenting `Base.Experimental.@overlay mt f(args...)`, the callee is
+        # `Expr(:overlay, mt, f)`: extract the name from f
+        astname(x.args[end], ismacro)
     else
         n = if isexpr(x, :module)
             isa(x.args[1], Bool) ? 2 : 3

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -363,11 +363,13 @@ include("opaque_closure.jl")
 
 """
     Base.Experimental.@overlay mt def
+    Base.Experimental.@overlay mt begin defs... end
 
 Define a method and add it to the method table `mt` instead of to the global method table.
 This can be used to implement a method override mechanism. Regular compilation will not
 consider these methods, and you should customize the compilation flow to look in these
-method tables (e.g., using [`Core.Compiler.OverlayMethodTable`](@ref)).
+method tables (e.g., using [`Core.Compiler.OverlayMethodTable`](@ref)). The block form
+overlays every definition in the block; definitions may carry docstrings and other macros.
 
 !!! note
     Please be aware that when defining overlay methods using `@overlay`, it is not necessary
@@ -392,8 +394,18 @@ method tables (e.g., using [`Core.Compiler.OverlayMethodTable`](@ref)).
 """
 macro overlay(mt, def)
     inner = Base.unwrap_macrocalls(def)
-    is_function_def(inner) || error("@overlay requires a function definition")
-    overlay_def!(mt, inner)
+    if isexpr(inner, :block)
+        # `@overlay mt begin ... end`: overlay every definition in the block
+        for arg in inner.args
+            isa(arg, LineNumberNode) && continue
+            innerarg = Base.unwrap_macrocalls(arg)
+            is_function_def(innerarg) || error("@overlay requires a function definition")
+            overlay_def!(mt, innerarg)
+        end
+    else
+        is_function_def(inner) || error("@overlay requires a function definition")
+        overlay_def!(mt, inner)
+    end
     return esc(def)
 end
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -740,6 +740,35 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
 
 // --- code generator for llvmcall ---
 
+// Intrinsics that belong to a different target cannot be selected by the back-end for
+// the current one, which LLVM reports as a fatal error (`Cannot select: intrinsic ...`),
+// aborting the process. Reject them during codegen instead, so that the failure is an
+// ordinary Julia error. This also keeps ahead-of-time compilation from aborting on
+// methods that are only valid on another target (e.g. GPU kernels), which `--output-o`
+// compiles whether or not they are ever called.
+//
+// The check is against the triple of the module being emitted, so external users of
+// codegen that target another architecture (such as GPUCompiler.jl, which sets the
+// module's triple before emitting into it) can still use that target's intrinsics.
+static bool is_foreign_target_intrinsic(jl_codectx_t &ctx, Intrinsic::ID ID, StringRef name, std::string &msg)
+{
+    if (ID == Intrinsic::not_intrinsic || !Intrinsic::isTargetIntrinsic(ID))
+        return false;
+    const Triple &TT = ctx.emission_context.TargetTriple;
+    StringRef host = Triple::getArchTypePrefix(TT.getArch());
+    if (host.empty())
+        return false;
+    // intrinsic names are `llvm.<target prefix>.<name>`
+    StringRef target = name;
+    target.consume_front("llvm.");
+    target = target.split('.').first;
+    if (target == host)
+        return false;
+    msg = "llvmcall: intrinsic " + name.str() + " is not available on the " + host.str() +
+          " target (it belongs to the " + target.str() + " target)";
+    return true;
+}
+
 static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs) JL_CANSAFEPOINT
 {
     ++EmittedLLVMCalls;
@@ -987,6 +1016,15 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
                 return jl_cgval_t();
             }
             Mod = std::move(ModuleOrErr.get());
+        }
+
+        for (Function &F : *Mod) {
+            std::string msg;
+            if (F.isIntrinsic() && is_foreign_target_intrinsic(ctx, F.getIntrinsicID(), F.getName(), msg)) {
+                emit_error(ctx, msg);
+                JL_GC_POP();
+                return jl_cgval_t();
+            }
         }
 
         f = Mod->getFunction(jl_string_data(entry));
@@ -2153,6 +2191,11 @@ jl_cgval_t function_sig_t::emit_a_ccall(
 #else
                 auto ID = Function::lookupIntrinsicID(f_name);
 #endif
+                std::string foreign_msg;
+                if (is_foreign_target_intrinsic(ctx, ID, f_name, foreign_msg)) {
+                    emit_error(ctx, foreign_msg);
+                    return jl_cgval_t();
+                }
                 if (ID != Intrinsic::not_intrinsic) {
                     // Accumulate an array of overloaded types for the given intrinsic
                     // and compute the new name mangling schema

--- a/test/core.jl
+++ b/test/core.jl
@@ -8851,6 +8851,18 @@ end
 @overlay mt cos(x::Float64) = 2
 # parametric function def
 @overlay mt tan(x::T) where {T} = 3
+# block form, including docstrings and other macros
+@overlay mt begin
+    """
+    an overlaid exp
+    """
+    exp(x::Float64) = 4
+
+    @inline log(x::Float64) = 5
+end
+@test_throws ErrorException @macroexpand @overlay mt begin
+    x = 1
+end
 
 end # module OverlayModule
 
@@ -8858,6 +8870,10 @@ let ms = Base._methods_by_ftype(Tuple{typeof(sin), Float64}, nothing, 1, Base.ge
     @test only(ms).method.module === Base.Math
 end
 let ms = Base._methods_by_ftype(Tuple{typeof(sin), Float64}, OverlayModule.mt, 1, Base.get_world_counter())
+    @test only(ms).method.module === OverlayModule
+end
+for f in (exp, log)
+    ms = Base._methods_by_ftype(Tuple{typeof(f), Float64}, OverlayModule.mt, 1, Base.get_world_counter())
     @test only(ms).method.module === OverlayModule
 end
 let ms = Base._methods_by_ftype(Tuple{typeof(sin), Int}, OverlayModule.mt, 1, Base.get_world_counter())

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -120,6 +120,17 @@ end
 @doc "I am a macro"  :@ModuleMacroDoc.m
 
 @test docstrings_equal(@doc(ModuleMacroDoc), doc"I am a module")
+
+# docstrings on overlay methods (`Base.Experimental.@overlay`) apply to the function binding
+module OverlayDocs
+using Base.Experimental: @MethodTable, @overlay
+@MethodTable mt
+function devfun end
+"I am an overlay method"
+@overlay mt devfun(x::Int) = 1
+end
+@test docstrings_equal(@doc(OverlayDocs.devfun), doc"I am an overlay method")
+@test isempty(methods(OverlayDocs.devfun))
 @test docstrings_equal(@doc(ModuleMacroDoc.@m), doc"I am a macro")
 
 # issue #38819

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -239,3 +239,31 @@ end
 
 llvmcall_nothing_arg() = Core.Intrinsics.llvmcall("ret i8 0", Int8, Tuple{Nothing}, nothing)
 @test_throws ErrorException llvmcall_nothing_arg()
+
+# Intrinsics that belong to a different target cannot be selected by the host back-end.
+# LLVM reports that as a fatal error (`LLVM ERROR: Cannot select: intrinsic ...`) and
+# aborts the process, so such code must be rejected during codegen instead. This matters
+# for ahead-of-time compilation (`--output-o`, PackageCompiler.jl, juliac), which compiles
+# every concretely-typed method whether or not it is ever called: GPU packages define
+# methods whose bodies are only valid on the device (JuliaGPU/GPUCompiler.jl#611).
+@testset "intrinsics of another target" begin
+    script = """
+        f_nvvm() = ccall("llvm.nvvm.membar.cta", llvmcall, Cvoid, ())
+        g_nvvm() = Base.llvmcall(("declare i32 @llvm.nvvm.read.ptx.sreg.tid.x()",
+                                  "%r = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()\\nret i32 %r"),
+                                 Int32, Tuple{})
+        h_amdgcn() = ccall("llvm.amdgcn.s.barrier", llvmcall, Cvoid, ())
+        for f in (f_nvvm, g_nvvm, h_amdgcn)
+            try
+                f()
+                exit(1)  # ran to completion
+            catch err
+                err isa ErrorException || exit(2)
+                occursin("not available", err.msg) || exit(3)
+            end
+        end
+        exit(0)
+        """
+    cmd = `$(Base.julia_cmd()) --startup-file=no -e $script`
+    @test success(pipeline(cmd; stderr=devnull))
+end

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -249,9 +249,12 @@ llvmcall_nothing_arg() = Core.Intrinsics.llvmcall("ret i8 0", Int8, Tuple{Nothin
 @testset "intrinsics of another target" begin
     script = """
         f_nvvm() = ccall("llvm.nvvm.membar.cta", llvmcall, Cvoid, ())
-        g_nvvm() = Base.llvmcall(("declare i32 @llvm.nvvm.read.ptx.sreg.tid.x()",
-                                  "%r = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()\\nret i32 %r"),
-                                 Int32, Tuple{})
+        g_nvvm() = Base.llvmcall((\"""
+            declare i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+            define i32 @entry() {
+                %r = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+                ret i32 %r
+            }\""", "entry"), Int32, Tuple{})
         h_amdgcn() = ccall("llvm.amdgcn.s.barrier", llvmcall, Cvoid, ())
         for f in (f_nvvm, g_nvvm, h_amdgcn)
             try
@@ -266,4 +269,50 @@ llvmcall_nothing_arg() = Core.Intrinsics.llvmcall("ret i8 0", Int8, Tuple{Nothin
         """
     cmd = `$(Base.julia_cmd()) --startup-file=no -e $script`
     @test success(pipeline(cmd; stderr=devnull))
+end
+
+# The opposite direction: intrinsics of the host target must still be accepted, both as
+# `ccall(..., llvmcall, ...)` and declared in a `Base.llvmcall` module. Only intrinsics
+# that do not require an ISA extension are used, so that this holds on any CPU of the target.
+@testset "intrinsics of the host target" begin
+    @static if Sys.ARCH === :x86_64 || Sys.ARCH === :i686
+        host_ccall() = ccall("llvm.x86.sse2.pause", llvmcall, Cvoid, ())
+        host_ir() = Base.llvmcall(("""
+            declare void @llvm.x86.sse2.pause()
+            define void @entry() {
+                call void @llvm.x86.sse2.pause()
+                ret void
+            }""", "entry"), Cvoid, Tuple{})
+    elseif Sys.ARCH === :aarch64
+        host_ccall() = ccall("llvm.aarch64.isb", llvmcall, Cvoid, (Int32,), Int32(15))
+        host_ir() = Base.llvmcall(("""
+            declare void @llvm.aarch64.isb(i32)
+            define void @entry() {
+                call void @llvm.aarch64.isb(i32 15)
+                ret void
+            }""", "entry"), Cvoid, Tuple{})
+    elseif Sys.ARCH === :armv7l || Sys.ARCH === :armv6l
+        host_ccall() = ccall("llvm.arm.hint", llvmcall, Cvoid, (Int32,), Int32(0))
+        host_ir() = Base.llvmcall(("""
+            declare void @llvm.arm.hint(i32)
+            define void @entry() {
+                call void @llvm.arm.hint(i32 0)
+                ret void
+            }""", "entry"), Cvoid, Tuple{})
+    elseif Sys.ARCH === :powerpc64le
+        host_ccall() = ccall("llvm.ppc.lwsync", llvmcall, Cvoid, ())
+        host_ir() = Base.llvmcall(("""
+            declare void @llvm.ppc.lwsync()
+            define void @entry() {
+                call void @llvm.ppc.lwsync()
+                ret void
+            }""", "entry"), Cvoid, Tuple{})
+    else
+        # riscv64: every `llvm.riscv.*` intrinsic requires an ISA extension (e.g.
+        # `llvm.riscv.pause` needs Zihintpause, which `generic-rv64` lacks).
+        host_ccall() = nothing
+        host_ir() = nothing
+    end
+    @test host_ccall() === nothing
+    @test host_ir() === nothing
 end


### PR DESCRIPTION
GPU packages define many functions whose bodies are only valid on the device: `llvmcall`s of NVPTX/AMDGPU intrinsics (`llvm.nvvm.barrier0`, `llvm.amdgcn.s.barrier`, ...) or inline PTX. Today such a definition must not exist in the global method table, because two Julia behaviours combine against it:

1. Compile-all (`--output-o`: PackageCompiler.jl, juliac, `create_app`) compiles every method with a concrete signature in every loaded module, whether or not anything calls it. A zero-argument or concretely-typed device function is therefore compiled for the host.
2. Host codegen accepts intrinsics of any target, so the module reaches instruction selection and LLVM aborts the process: `LLVM ERROR: Cannot select: intrinsic %llvm.nvvm.membar.cta`. The same happens at the REPL when someone calls such a function by accident.

The workaround, used by CUDA.jl since JuliaGPU/CUDA.jl#2998, is `@device_function`: for every device function, generate an erroring CPU stub for the global method table and put the real definition in an overlay method table via `Base.Experimental.@overlay`, by rewriting the definition in a macro. That is fragile in exactly the way JuliaGPU/GPUCompiler.jl#611 keeps demonstrating: the rewrite has to understand whatever `@doc` (and other macros) expand to, and after #62236 changed the expansion of `@doc` in 1.13, every documented device function silently escaped back into the global table and broke AOT compilation of anything loading CUDA.jl.

The stub only exists because an overlay-only definition (`function f end` plus `@overlay mt f() = ...`) currently cannot be documented, and because a single leaked definition is fatal rather than an error. This PR removes both obstacles, so that device functions can simply be overlay methods with no global method at all, leaving nothing for compile-all to compile.

## Changes

- **codegen: reject intrinsics of another target in llvmcall.** `ccall("llvm.nvvm.*", llvmcall, ...)` and intrinsics declared in `Base.llvmcall` IR are checked against the triple of the module being emitted; a mismatch emits an ordinary runtime error instead of reaching isel:
  ```
  julia> f() = ccall("llvm.nvvm.membar.cta", llvmcall, Cvoid, ()); f()
  ERROR: llvmcall: intrinsic llvm.nvvm.membar.cta is not available on the x86 target (it belongs to the nvvm target)
  ```
  Under `--output-o` the same method now just compiles to that error, so a device-only method in a package no longer aborts sysimage builds:
  ```
  $ echo 'f() = ccall("llvm.nvvm.membar.cta", llvmcall, Cvoid, ())' > demo.jl
  $ julia --sysimage usr/lib/julia/sys.so --output-o demo.o demo.jl
  LLVM ERROR: Cannot select: intrinsic %llvm.nvvm.membar.cta   # before; succeeds after
  ```
  Keying on the emission triple (rather than on cgparams) is what keeps external users of codegen working: GPUCompiler.jl sets the NVPTX/AMDGPU triple on the module before emitting into it, so its intrinsics are not foreign there. Verified by compiling a PTX kernel using `llvm.nvvm.read.ptx.sreg.tid.x` and `llvm.nvvm.membar.cta` through GPUCompiler in the same process that rejects the host call. Inline asm is not covered (it is only seen by the MC layer), so this is a safety net rather than a replacement for the changes below.
- **Docs: support docstrings on overlay method definitions.** `"""...""" @overlay mt f(x) = ...` failed with "Could not find something to document" because `astname` did not understand the `Expr(:overlay, mt, f)` callee. The docstring now attaches to the function binding like for any other method.
- **`@overlay` block form.** `@overlay mt begin ... end` overlays every definition in the block, including documented ones and ones using `@inline` etc.

With these, CUDA.jl's `@device_functions` can become `@overlay mt begin ... end` with no rewriting and no stubs; a friendly "not available on the CPU" message can be provided through a `MethodError` hint.

Assisted by: Fable 5