### PR TITLE
Rename the image's `jl_tls_offset` global to `jl_image_tls_offset`

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1096,7 +1096,7 @@ static GlobalVariable *emit_ptls_table(Module &M, Type *T_size, Type *T_ptr) {
     std::array<Constant *, 3> ptls_table{
         new GlobalVariable(M, T_ptr, false, GlobalValue::ExternalLinkage, emit_pgcstack_default_func(M, T_ptr), "jl_pgcstack_func_slot"),
         new GlobalVariable(M, T_size, false, GlobalValue::ExternalLinkage, Constant::getNullValue(T_size), "jl_pgcstack_key_slot"),
-        new GlobalVariable(M, T_size, false, GlobalValue::ExternalLinkage, Constant::getNullValue(T_size), "jl_tls_offset"),
+        new GlobalVariable(M, T_size, false, GlobalValue::ExternalLinkage, Constant::getNullValue(T_size), "jl_image_tls_offset"),
     };
     for (auto &gv : ptls_table) {
         cast<GlobalVariable>(gv)->setVisibility(GlobalValue::HiddenVisibility);

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -316,7 +316,9 @@ bool LowerPTLS::run(bool *CFGModified)
             if (imaging_mode) {
                 pgcstack_func_slot = create_hidden_global(T_pgcstack_getter, "jl_pgcstack_func_slot");
                 pgcstack_key_slot = create_hidden_global(T_size, "jl_pgcstack_key_slot"); // >= sizeof(jl_pgcstack_key_t)
-                pgcstack_offset = create_hidden_global(T_size, "jl_tls_offset");
+                // n.b. not named `jl_tls_offset`, to avoid clashing with the libjulia-internal
+                // variable of that name when the image is linked statically with the runtime
+                pgcstack_offset = create_hidden_global(T_size, "jl_image_tls_offset");
             }
             need_init = false;
         }


### PR DESCRIPTION
Images emit a hidden global named `jl_tls_offset` (the third slot of `jl_ptls_table`, see `emit_ptls_table` in `aotcompile.cpp` and `LowerPTLS` in `llvm-ptls.cpp`). libjulia-internal exports a variable of the same name (`threading.c`). When an image is linked statically into the same binary as libjulia-internal (follow-up to #62868), the two definitions collide, so give the image's copy its own name, `jl_image_tls_offset`.

No functional change for shared images; the symbol is hidden and only reached through `jl_ptls_table`.

Part of the static libjulia-internal work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
