### PR TITLE
Use JL_IMAGE_IN_MEMORY in jl_init_with_image_handle

### DIFF
--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -97,7 +97,8 @@ JL_DLLEXPORT void jl_init_with_image_handle(void *handle) {
     const char *image_path = jl_pathname_for_handle(handle);
     jl_options.image_file = image_path;
 
-    jl_resolve_sysimg_location(JL_IMAGE_JULIA_HOME, NULL);
+    // the image is already loaded, so its path must not be re-interpreted relative to julia_bindir
+    jl_resolve_sysimg_location(JL_IMAGE_IN_MEMORY, NULL);
     jl_image_buf_t sysimage = jl_set_sysimg_so(handle);
 
     jl_init_(sysimage);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2370,10 +2370,12 @@ JL_DLLEXPORT void JL_NORETURN jl_bounds_error_ints(jl_value_t *v JL_MAYBE_UNROOT
     }
 
 // initialization functions
+
+// How jl_resolve_sysimg_location interprets a non-absolute jl_options.image_file
 typedef enum {
-    JL_IMAGE_CWD = 0,
-    JL_IMAGE_JULIA_HOME = 1,
-    JL_IMAGE_IN_MEMORY = 2
+    JL_IMAGE_CWD = 0,        // leave the path as-is (resolved against the current directory)
+    JL_IMAGE_JULIA_HOME = 1, // resolve the path relative to julia_bindir
+    JL_IMAGE_IN_MEMORY = 2   // the image is already loaded; the path is informational only
 } JL_IMAGE_SEARCH;
 
 typedef enum {


### PR DESCRIPTION
`jl_init_with_image_handle` receives an already-loaded image and sets `jl_options.image_file` from `jl_pathname_for_handle`. It then called `jl_resolve_sysimg_location(JL_IMAGE_JULIA_HOME, ...)`, which would prefix a non-absolute `image_file` with `julia_bindir`. That is not the right interpretation for an in-memory image; `JL_IMAGE_IN_MEMORY` exists for this case and skips the re-rooting.

In practice the path returned by `jl_pathname_for_handle` is absolute, so this is mostly a correctness/intent fix, but it matters for the static-linking case where the "image" is the executable itself.

Part of the static libjulia-internal work (#62868 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
