### PR TITLE
Call jl_init_options from jl_autoinit_and_adopt_thread

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -380,6 +380,11 @@ static const char opts_hidden[] =
 
 JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
 {
+    // ensure the defaults are in place before parsing over them; a no-op when
+    // the loader (or a previous call) already initialized the options, but a
+    // static build may parse options (e.g. from a constructor) before any
+    // other runtime entry point has run
+    jl_init_options();
     enum { opt_machinefile = 300,
            opt_color,
            opt_history_file,

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -86,7 +86,7 @@ uint64_t parse_heap_size_option(const char *optarg, const char *option_name, int
 
 static int jl_options_initialized = 0;
 
-JL_DLLEXPORT void jl_init_options(void)
+JL_DLLEXPORT void jl_init_options(void) JL_NOTSAFEPOINT
 {
     if (jl_options_initialized)
         return;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1357,7 +1357,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi) JL_
 void jl_init_serializer(void) JL_CANSAFEPOINT;
 void jl_init_uv(void) JL_NOTSAFEPOINT;
 void jl_init_box_caches(void) JL_NOTSAFEPOINT;
-JL_DLLEXPORT void jl_init_options(void);
+JL_DLLEXPORT void jl_init_options(void) JL_NOTSAFEPOINT;
 
 void jl_set_base_ctx(char *__stk);
 

--- a/src/threading.c
+++ b/src/threading.c
@@ -487,6 +487,9 @@ JL_DLLEXPORT jl_gcframe_t **jl_autoinit_and_adopt_thread(void) JL_CANSAFEPOINT_E
                             "       (this should not happen, please file a bug report)\n");
             exit(1);
         }
+        // normally done by the libjulia loader, but there is none when the
+        // runtime is linked statically into the image
+        jl_init_options();
         jl_init_with_image_handle(handle);
         return &jl_get_current_task()->gcstack;
     }


### PR DESCRIPTION
`jl_init_options` is normally called by the libjulia loader (`cli/loader_lib.c`) before any other runtime code. In a static build of libjulia-internal (#62868) there is no loader, and `jl_autoinit_and_adopt_thread` — the trampoline that images call on first entry — becomes the first runtime entry point, so `jl_options` would never be initialized. Call `jl_init_options` there before `jl_init_with_image_handle`.

`jl_init_options` guards itself with `jl_options_initialized`, so this is a no-op for the regular shared build.

Part of the static libjulia-internal work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
