### PR TITLE
Fix misprinting of multi-frame stacktrace cycles

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -895,9 +895,14 @@ function _backtrace_find_and_remove_cycles(t)
     # Second: length of the cycle as a count in the trace
     # Third:  number of cycle repetitions
 
+    #= For each entry of the trace, where it ended up in `displayed_stackframes`, or 0 if it
+    was collapsed away, so that a cycle can be bracketed from where its turn began. =#
+    displayed_at = zeros(Int, length(t))
+
     t_curr = 1
 
     while t_curr ≤ length(t)
+        t_this = t_curr
         (last_frame, n) = t[t_curr]
         current_hash = hash(t[t_curr])
         positions = get(recorded_positions, current_hash,  Int[])
@@ -923,7 +928,7 @@ function _backtrace_find_and_remove_cycles(t)
             if t_prev_end ≥ t_curr - 1
                 #= At least one cycle repeated =#
                 ncycles = div(t_curr_end - t_prev + 1, t_cycle_length)
-                push!(repeated_cycles, (length(displayed_stackframes) - 1, t_cycle_length, ncycles))
+                push!(repeated_cycles, (displayed_at[t_prev - 1], t_cycle_length, ncycles))
                 t_curr += t_cycle_length * (ncycles - 1) - 1
                 nnested_cycles += 1
             end
@@ -935,6 +940,7 @@ function _backtrace_find_and_remove_cycles(t)
 
         if ncycles == 0
             push!(displayed_stackframes, (last_frame, n))
+            displayed_at[t_this] = length(displayed_stackframes)
         end
     end
     return displayed_stackframes, repeated_cycles, max_nested_cycles

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -951,41 +951,85 @@ end
     Base.show_backtrace(io, bt)
     output = split(String(take!(io)), '\n')
     length(output) >= 21 || println(output) # for better errors when this fails
-    @test startswith(lstrip(output[3]), "┌ ")
-    @test lstrip(lstrip(output[3])[4:end])[1:3] == "[1]"
+    @test startswith(lstrip(output[3]), "┌┌ ")
+    @test lstrip(lstrip(output[3])[7:end])[1:3] == "[1]"
     @test occursin("f28442b", output[3])
-    @test startswith(lstrip(output[5]), "├ ")
-    @test lstrip(lstrip(output[5])[4:end])[1:3] == "[2]"
+    @test startswith(lstrip(output[5]), "├├ ")
+    @test lstrip(lstrip(output[5])[7:end])[1:3] == "[2]"
     @test occursin("g28442b", output[5])
 
     is_windows_32_bit = Sys.iswindows() && (Sys.WORD_SIZE == 32)
     if is_windows_32_bit
         # Assuming tests are broken on 32-bit Windows as above, no need to repeat loose tests here.
     else
-        @test startswith(lstrip(output[8]), "┌┌ ")
+        @test occursin("repeated 10 times", output[7])
+
+        @test startswith(lstrip(output[8]), "├┌ ")
         @test occursin("h28442b", output[8])
+        @test lstrip(lstrip(output[8])[7:end])[1:4] == "[21]"
         @test startswith(lstrip(output[10]), "├├ ")
         @test occursin("g28442b", output[10])
-
-        @test startswith(lstrip(output[13]), "├┌ ")
-        @test occursin("f28442b", output[13])
-        @test startswith(lstrip(output[15]), "├├ ")
-        @test occursin("g28442b", output[15])
-
-        @test occursin("f28442b", output[19])
-
-        @test occursin("repeated 10 times", output[7])
-        @test lstrip(lstrip(output[8])[7:end])[1:4] == "[21]"
         @test lstrip(lstrip(output[10])[7:end])[1:4] == "[22]"
         @test occursin("repeated 10 times", output[12])
-        @test lstrip(lstrip(output[13])[7:end])[1:4] == "[41]"
-        @test lstrip(lstrip(output[15])[7:end])[1:4] == "[42]"
-        @test occursin("repeated 10 times", output[17])
-        @test occursin("repeated 2 times", output[18])
+
+        # The outer cycle closes here, having stood for two turns of the two above
+        @test occursin("repeated 2 times", output[13])
+
+        @test startswith(lstrip(output[14]), "┌ ")
+        @test occursin("f28442b", output[14])
+        @test lstrip(lstrip(output[14])[4:end])[1:4] == "[81]"
+        @test startswith(lstrip(output[16]), "├ ")
+        @test occursin("g28442b", output[16])
+        @test lstrip(lstrip(output[16])[4:end])[1:4] == "[82]"
+        @test occursin("repeated 10 times", output[18])
+
+        @test occursin("f28442b", output[19])
         @test lstrip(output[19])[1:5] == "[101]"
         @test lstrip(output[21])[1:5] == "[102]"
     end
 end
+
+@testset "Long stacktrace printing - cycle longer than two frames" begin
+    f59999(c) = g59999(c + 1)
+    g59999(c) = h59999(c + 1)
+    h59999(c) = c > 10000 ? (return backtrace()) : f59999(c + 1)
+    bt = f59999(1)
+    io = IOBuffer()
+    Base.show_backtrace(io, bt)
+    output = split(String(take!(io)), '\n')
+    length(output) >= 9 || println(output) # for better errors when this fails
+
+    # The bracket opens on the first frame of the repeating unit, not part way round it
+    @test lstrip(output[3])[1] == '┌'
+    @test lstrip(lstrip(output[3])[4:end])[1:3] == "[1]"
+    @test occursin("h59999", output[3])
+    @test lstrip(output[5])[1] == '├'
+    @test occursin("g59999", output[5])
+    @test lstrip(output[7])[1] == '├'
+    @test occursin("f59999", output[7])
+    @test occursin(r"repeated \d+ times", output[9])
+end
+
+@testset "Long stacktrace printing - cycle ending near the end of the trace" begin
+    #= Built by hand so the number of frames after the cycle is exact: thirteen turns of a
+    four-frame unit, then one frame. The bracket has to be closed within the trace. =#
+    frame59999(name) = Base.StackTraces.StackFrame(Symbol(name), Symbol("demo.jl"), 1)
+    trace = Any[[(frame59999("u$u"), 1) for _ ∈ 1:13 for u ∈ 1:4]...,
+                (frame59999("tail"), 1)]
+    @test length(trace) > Base.BIG_STACKTRACE_SIZE
+
+    io = IOBuffer()
+    Base.show_backtrace(io, trace)
+    output = split(String(take!(io)), '\n')
+
+    @test lstrip(output[3])[1] == '┌'
+    @test lstrip(lstrip(output[3])[4:end])[1:3] == "[1]"
+    @test occursin("u1", output[3])
+    # The cycle is closed, and what follows it is numbered past all of its repetitions
+    @test any(l -> occursin("repeated 13 times", l), output)
+    @test any(l -> occursin("[53] tail", l), output)
+end
+
 
 @testset "Line number correction" begin
     getbt() = backtrace()


### PR DESCRIPTION
Discovered (with help of Claude) that in 1.13, the first version where my prior changes to stacktrace cycle printing are landing, has a flaw - more than two frames in the cycle, and the brackets are printed on the wrong frames, even being left unclosed:

```
Stacktrace:
     [1] error()
       @ Base .\error.jl:45
     [2] r(n::Int64)
       @ Main .\REPL[9]:1
     [3] (::var"#r##0#r##1"{Int64})(::Int64)
       @ Main .\REPL[9]:1
     [4] iterate
       @ .\generator.jl:48 [inlined]
     [5] _collect(c::UnitRange{Int64}, itr::Base.Generator{UnitRange{Int64}, var"#r##0#r##1"{Int64}}, ::Base.EltypeUnknown, isz::Base.HasShape{1})
       @ Base .\array.jl:848
 ┌   [6] collect_similar(cont::UnitRange{Int64}, itr::Base.Generator{UnitRange{Int64}, var"#r##0#r##1"{Int64}})
 │     @ Base .\array.jl:763
 ├   [7] map(f::Function, A::UnitRange{Int64})
 │     @ Base .\abstractarray.jl:3396
 ├   [8] r(n::Int64)
 │     @ Main .\REPL[9]:1
 ├   [9] top-level scope
 │     @ REPL[10]:1
```

This PR fixes this:

```
Stacktrace:
    [1] error()
 ┌  [2] r(n::Int64)
 ├  [3] (::var"#r_map##0#r_map##1"{Int64})(::Int64)
 ├  [4] iterate(::Base.Generator{...})
 ├  [5] _collect(c::UnitRange{Int64}, ...)
 ├  [6] collect_similar(cont::UnitRange{Int64}, ...)
 ├  [7] map(f::Function, A::UnitRange{Int64})
 ╰───── repeated 10 times
   [62] r(n::Int64)
```

Side-effect is that the presentation order of the nested example flips (b/c all else equal, inner cycle now comes first instead of last), which is why that test changed.

Please mark for 1.13 backport.