### PR TITLE
[Apple Silicon] Count all cores when determining cpu threads

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,6 +30,12 @@ Multi-threading changes
 
 * A new `AbstractSpinLock` is defined with `SpinLock <: AbstractSpinLock` ([#55944]).
 * A new `PaddedSpinLock <: AbstractSpinLock` is defined. It has extra padding to avoid false sharing ([#55944]).
+* On Apple Silicon, `Sys.CPU_THREADS` and `Sys.EFFECTIVE_CPU_THREADS` now count all CPU cores rather
+  than only the highest-performance tier. This affects the the following defaults: `--threads=auto`
+  (`JULIA_NUM_THREADS=auto`), the `--gcthreads` default, `--procs=auto`, `Distributed.addprocs()`,
+  and `JULIA_NUM_PRECOMPILE_TASKS`. Set `JULIA_CPU_THREADS` to override the detected count. The
+  performance-core heuristic has been improved and now lives in LinearAlgebra, where it continues
+  to size the default BLAS thread pool ([#62891], [JuliaLang/LinearAlgebra.jl#1686](https://github.com/JuliaLang/LinearAlgebra.jl/pull/1686)).
 
 New library functions
 ---------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -65,11 +65,6 @@ Language changes
   unaffected, and a method on `Type{Int}` remains more specific than one on `DataType`
   ([#33136], [#62141]).
 
-Multi-threading changes
------------------------
-
-* CPU count detection (`Sys.CPU_THREADS` & `Sys.EFFECTIVE_CPU_THREADS`) on Apple Silicon now considers all cores. The BLAS threads heuristic has been moved to LinearAlgebra ([#62891], [LinearAlgebra#1691]).
-
 Compiler/Runtime improvements
 -----------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,11 @@ Language changes
   unaffected, and a method on `Type{Int}` remains more specific than one on `DataType`
   ([#33136], [#62141]).
 
+Multi-threading changes
+-----------------------
+
+* CPU count detection (`Sys.CPU_THREADS` & `Sys.EFFECTIVE_CPU_THREADS`) on Apple Silicon now considers all cores. The BLAS threads heuristic has been moved to LinearAlgebra ([#62891], [LinearAlgebra#1691]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -410,15 +410,6 @@ typedef DWORD (WINAPI *GAPC)(WORD);
 #endif
 #endif
 
-// Apple's M1 processor is a big.LITTLE style processor, with 4x "performance"
-// cores, and 4x "efficiency" cores.  Because Julia expects to be able to run
-// things like heavy linear algebra workloads on all cores, it's best for us
-// to only spawn as many threads as there are performance cores.  Once macOS
-// 12 is released, we'll be able to query the multiple "perf levels" of the
-// cores of a CPU (see this PR [0] to pytorch/cpuinfo for an example) but
-// until it's released, we will just recognize the M1 by its CPU family
-// identifier, then subtract how many efficiency cores we know it has.
-
 JL_DLLEXPORT int jl_cpu_threads(void) JL_NOTSAFEPOINT
 {
 #if defined(HW_AVAILCPU) && defined(HW_NCPU)

--- a/src/sys.c
+++ b/src/sys.c
@@ -431,28 +431,6 @@ JL_DLLEXPORT int jl_cpu_threads(void) JL_NOTSAFEPOINT
         sysctl(nm, 2, &count, &len, NULL, 0);
         if (count < 1) { count = 1; }
     }
-
-#if defined(__APPLE__) && defined(_CPU_AARCH64_)
-//MacOS 12 added a way to query performance cores
-    char buf[7];
-    len = 7;
-    sysctlbyname("kern.osrelease", buf, &len, NULL, 0);
-    if (buf[0] > 1 && buf[1] > 0){
-        len = 4;
-        sysctlbyname("hw.perflevel0.physicalcpu", &count, &len, NULL, 0);
-    }
-    else {
-        int32_t family = 0;
-        len = 4;
-        sysctlbyname("hw.cpufamily", &family, &len, NULL, 0);
-        if (family >= 1 && count > 1) {
-            if (family == CPUFAMILY_ARM_FIRESTORM_ICESTORM) {
-                // We know the Apple M1 has 4 efficiency cores, so subtract them out.
-                count -= 4;
-            }
-        }
-    }
-#endif
     return count;
 #elif defined(_SC_NPROCESSORS_ONLN)
     long count = sysconf(_SC_NPROCESSORS_ONLN);


### PR DESCRIPTION
Edit: I opened https://github.com/JuliaLang/LinearAlgebra.jl/pull/1691 which just moves the logic over.

Current behaviour is to only count the highest performance cores in an attempt to ignore the Efficiency cores. This distinction was meaningless until Apple released the M5 Pro and M5 Max which have no Efficiency cores, and they recently announced the M6 which has 3 performance tiers, and only 2 core in the highest performance tier. Detection was done this way mostly for BLAS, so I opened https://github.com/JuliaLang/LinearAlgebra.jl/pull/1686 to move the logic there and for all other purposes, Julia sees all cores on Apple Silicon unless the user decides otherwise.

Not sure what the next LTS is, but if it's 1.13 I think this should be backported so future M6 users aren't cunfused as to why Julia thinks their 12-core device has 2 cores

@gbaraldi