### PR TITLE
stdlib: Restore JLL path compatibility accessors

### DIFF
--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -148,6 +148,11 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessors
+get_libgfortran_path() = libgfortran_path
+get_libstdcxx_path() = libstdcxx_path
+get_libgomp_path() = libgomp_path
+
 function __init__()
     global libatomic_path = string(libatomic.path)
     global libgcc_s_path = string(libgcc_s.path)

--- a/stdlib/CompilerSupportLibraries_jll/test/runtests.jl
+++ b/stdlib/CompilerSupportLibraries_jll/test/runtests.jl
@@ -7,4 +7,11 @@ using Test, CompilerSupportLibraries_jll
     @test isfile(CompilerSupportLibraries_jll.libgfortran_path)
     @test isfile(CompilerSupportLibraries_jll.libstdcxx_path)
     @test isfile(CompilerSupportLibraries_jll.libgomp_path)
+
+    # Preserve the JLLWrappers path compatibility accessors used by packages.
+    for product in (:libgfortran, :libstdcxx, :libgomp)
+        path = getfield(CompilerSupportLibraries_jll, Symbol(product, "_path"))
+        get_path = getfield(CompilerSupportLibraries_jll, Symbol("get_", product, "_path"))
+        @test get_path() == path
+    end
 end

--- a/stdlib/GMP_jll/src/GMP_jll.jl
+++ b/stdlib/GMP_jll/src/GMP_jll.jl
@@ -54,6 +54,10 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessors
+get_libgmp_path() = libgmp_path
+get_libgmpxx_path() = libgmpxx_path
+
 function __init__()
     global libgmp_path = string(libgmp.path)
     global libgmpxx_path = string(libgmpxx.path)

--- a/stdlib/GMP_jll/test/runtests.jl
+++ b/stdlib/GMP_jll/test/runtests.jl
@@ -5,4 +5,8 @@ using Test, Libdl, GMP_jll
 @testset "GMP_jll" begin
     vn = VersionNumber(unsafe_string(unsafe_load(cglobal(dlsym(libgmp, :__gmp_version), Ptr{Cchar}))))
     @test vn == v"6.3.0"
+
+    # Preserve the JLLWrappers path compatibility accessors used by packages.
+    @test GMP_jll.get_libgmp_path() == GMP_jll.libgmp_path
+    @test GMP_jll.get_libgmpxx_path() == GMP_jll.libgmpxx_path
 end

--- a/stdlib/LLVMLibUnwind_jll/src/LLVMLibUnwind_jll.jl
+++ b/stdlib/LLVMLibUnwind_jll/src/LLVMLibUnwind_jll.jl
@@ -22,6 +22,9 @@ function eager_mode()
 end
 is_available() = @static Sys.isapple() ? true : false
 
+# JLLWrappers path compatibility accessor
+get_llvmlibunwind_path() = llvmlibunwind_path
+
 function __init__()
     global llvmlibunwind_path = string(llvmlibunwind.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/LLVMLibUnwind_jll/test/runtests.jl
+++ b/stdlib/LLVMLibUnwind_jll/test/runtests.jl
@@ -11,4 +11,7 @@ using Test, Libdl, LLVMLibUnwind_jll
         @test dlsym(llvmlibunwind, :unw_set_reg; throw_error=false) !== nothing
         @test dlsym(llvmlibunwind, :unw_resume; throw_error=false) !== nothing
     end
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test LLVMLibUnwind_jll.get_llvmlibunwind_path() == LLVMLibUnwind_jll.llvmlibunwind_path
 end

--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -57,6 +57,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libcurl_path() = libcurl_path
+
 function __init__()
     global libcurl_path = string(libcurl.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/LibCURL_jll/test/runtests.jl
+++ b/stdlib/LibCURL_jll/test/runtests.jl
@@ -6,4 +6,7 @@ using LibCURL_jll
 @testset "LibCURL_jll" begin
     v = unsafe_string(ccall((:curl_version, libcurl), Cstring, ()))
     @test startswith(v, "libcurl/")
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test LibCURL_jll.get_libcurl_path() == LibCURL_jll.libcurl_path
 end

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -56,6 +56,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libgit2_path() = libgit2_path
+
 function __init__()
     global libgit2_path = string(libgit2.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/LibGit2_jll/test/runtests.jl
+++ b/stdlib/LibGit2_jll/test/runtests.jl
@@ -8,4 +8,7 @@ using Test, Libdl, LibGit2_jll
     patch = Ref{Cint}(0)
     @test ccall((:git_libgit2_version, libgit2), Cint, (Ref{Cint}, Ref{Cint}, Ref{Cint}), major, minor, patch) == 0
     @test VersionNumber(major[], minor[], patch[]) == v"1.9.7"
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test LibGit2_jll.get_libgit2_path() == LibGit2_jll.libgit2_path
 end

--- a/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
+++ b/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
@@ -61,6 +61,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libssh2_path() = libssh2_path
+
 function __init__()
     global libssh2_path = string(libssh2.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/LibSSH2_jll/test/runtests.jl
+++ b/stdlib/LibSSH2_jll/test/runtests.jl
@@ -8,4 +8,7 @@ using Test, Libdl, LibSSH2_jll
     # BinaryBuilder or built from source here), the version number is
     # either "1.11.1" or "1.11.1_DEV", respectively.
     @test startswith(vn, "1.11.1")
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test LibSSH2_jll.get_libssh2_path() == LibSSH2_jll.libssh2_path
 end

--- a/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
+++ b/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
@@ -33,6 +33,9 @@ function eager_mode()
 end
 is_available() = @static(Sys.islinux() || Sys.isfreebsd()) ? true : false
 
+# JLLWrappers path compatibility accessor
+get_libunwind_path() = libunwind_path
+
 function __init__()
     global libunwind_path = string(libunwind.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/LibUnwind_jll/test/runtests.jl
+++ b/stdlib/LibUnwind_jll/test/runtests.jl
@@ -6,4 +6,7 @@ using Test, Libdl, LibUnwind_jll
     if !Sys.isapple() && !Sys.iswindows()
         @test dlsym(LibUnwind_jll.libunwind, :unw_backtrace; throw_error=false) !== nothing
     end
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test LibUnwind_jll.get_libunwind_path() == LibUnwind_jll.libunwind_path
 end

--- a/stdlib/MPFR_jll/src/MPFR_jll.jl
+++ b/stdlib/MPFR_jll/src/MPFR_jll.jl
@@ -43,6 +43,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libmpfr_path() = libmpfr_path
+
 function __init__()
     global libmpfr_path = string(libmpfr.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/MPFR_jll/test/runtests.jl
+++ b/stdlib/MPFR_jll/test/runtests.jl
@@ -5,4 +5,7 @@ using Test, Libdl, MPFR_jll
 @testset "MPFR_jll" begin
     vn = VersionNumber(unsafe_string(ccall((:mpfr_get_version,libmpfr), Cstring, ())))
     @test vn == v"4.2.2"
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test MPFR_jll.get_libmpfr_path() == MPFR_jll.libmpfr_path
 end

--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -53,6 +53,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libopenblas_path() = libopenblas_path
+
 function __init__()
     global libopenblas_path = string(libopenblas.path)
     # make sure OpenBLAS does not set CPU affinity (#1070, #9639)

--- a/stdlib/OpenBLAS_jll/test/runtests.jl
+++ b/stdlib/OpenBLAS_jll/test/runtests.jl
@@ -14,4 +14,7 @@ end
 
 @testset "OpenBLAS_jll" begin
     @test dlsym(OpenBLAS_jll.libopenblas, @blasfunc(openblas_set_num_threads); throw_error=false) !== nothing
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test OpenBLAS_jll.get_libopenblas_path() == OpenBLAS_jll.libopenblas_path
 end

--- a/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
+++ b/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
@@ -40,6 +40,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libopenlibm_path() = libopenlibm_path
+
 function __init__()
     global libopenlibm_path = string(libopenlibm.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/OpenLibm_jll/test/runtests.jl
+++ b/stdlib/OpenLibm_jll/test/runtests.jl
@@ -4,4 +4,7 @@ using Test, Libdl, OpenLibm_jll
 
 @testset "OpenLibm_jll" begin
     @test ccall((:isopenlibm, libopenlibm), Cint, ()) == 1
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test OpenLibm_jll.get_libopenlibm_path() == OpenLibm_jll.libopenlibm_path
 end

--- a/stdlib/OpenSSL_jll/src/OpenSSL_jll.jl
+++ b/stdlib/OpenSSL_jll/src/OpenSSL_jll.jl
@@ -55,6 +55,10 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessors
+get_libcrypto_path() = libcrypto_path
+get_libssl_path() = libssl_path
+
 function __init__()
     global libcrypto_path = string(libcrypto.path)
     global libssl_path = string(libssl.path)

--- a/stdlib/OpenSSL_jll/test/runtests.jl
+++ b/stdlib/OpenSSL_jll/test/runtests.jl
@@ -7,4 +7,8 @@ using Test, Libdl, OpenSSL_jll
     minor = ccall((:OPENSSL_version_minor, libcrypto), Cuint, ())
     patch = ccall((:OPENSSL_version_patch, libcrypto), Cuint, ())
     @test VersionNumber(major, minor, patch) == v"3.5.8"
+
+    # Preserve the JLLWrappers path compatibility accessors used by packages.
+    @test OpenSSL_jll.get_libcrypto_path() == OpenSSL_jll.libcrypto_path
+    @test OpenSSL_jll.get_libssl_path() == OpenSSL_jll.libssl_path
 end

--- a/stdlib/PCRE2_jll/src/PCRE2_jll.jl
+++ b/stdlib/PCRE2_jll/src/PCRE2_jll.jl
@@ -31,6 +31,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libpcre2_8_path() = libpcre2_8_path
+
 function __init__()
     global libpcre2_8_path = string(libpcre2_8.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/PCRE2_jll/test/runtests.jl
+++ b/stdlib/PCRE2_jll/test/runtests.jl
@@ -7,4 +7,7 @@ using Test, Libdl, PCRE2_jll
     @test ccall((:pcre2_config_8, libpcre2_8), Cint, (UInt32, Ref{UInt8}), 11, vstr) > 0
     vn = VersionNumber(split(unsafe_string(pointer(vstr)), " ")[1])
     @test vn == v"10.47.0"
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test PCRE2_jll.get_libpcre2_8_path() == PCRE2_jll.libpcre2_8_path
 end

--- a/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
+++ b/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
@@ -246,6 +246,20 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessors
+get_libamd_path() = libamd_path
+get_libbtf_path() = libbtf_path
+get_libcamd_path() = libcamd_path
+get_libccolamd_path() = libccolamd_path
+get_libcholmod_path() = libcholmod_path
+get_libcolamd_path() = libcolamd_path
+get_libklu_path() = libklu_path
+get_libldl_path() = libldl_path
+get_librbio_path() = librbio_path
+get_libspqr_path() = libspqr_path
+get_libsuitesparseconfig_path() = libsuitesparseconfig_path
+get_libumfpack_path() = libumfpack_path
+
 function __init__()
     # BSD-3-Clause
     global libamd_path = string(libamd.path)

--- a/stdlib/SuiteSparse_jll/test/runtests.jl
+++ b/stdlib/SuiteSparse_jll/test/runtests.jl
@@ -8,4 +8,24 @@ using Test, SuiteSparse_jll
 # This should be safe and unnecessary since we specify exact version of the BB JLL.
 @testset "SuiteSparse_jll" begin
     @test ccall((:SuiteSparse_version, libsuitesparseconfig), Cint, (Ptr{Cint},), C_NULL) > 7000
+
+    # Preserve the JLLWrappers path compatibility accessors used by packages.
+    for product in (
+        :libamd,
+        :libbtf,
+        :libcamd,
+        :libccolamd,
+        :libcholmod,
+        :libcolamd,
+        :libklu,
+        :libldl,
+        :librbio,
+        :libspqr,
+        :libsuitesparseconfig,
+        :libumfpack,
+    )
+        path = getfield(SuiteSparse_jll, Symbol(product, "_path"))
+        get_path = getfield(SuiteSparse_jll, Symbol("get_", product, "_path"))
+        @test get_path() == path
+    end
 end

--- a/stdlib/Zlib_jll/src/Zlib_jll.jl
+++ b/stdlib/Zlib_jll/src/Zlib_jll.jl
@@ -31,6 +31,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libz_path() = libz_path
+
 function __init__()
     global libz_path = string(libz.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/Zlib_jll/test/runtests.jl
+++ b/stdlib/Zlib_jll/test/runtests.jl
@@ -4,4 +4,7 @@ using Test, Zlib_jll
 
 @testset "Zlib_jll" begin
     @test VersionNumber(unsafe_string(ccall((:zlibVersion, libz), Cstring, ()))) == v"1.3.2"
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test Zlib_jll.get_libz_path() == Zlib_jll.libz_path
 end

--- a/stdlib/dSFMT_jll/src/dSFMT_jll.jl
+++ b/stdlib/dSFMT_jll/src/dSFMT_jll.jl
@@ -30,6 +30,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libdSFMT_path() = libdSFMT_path
+
 function __init__()
     global libdSFMT_path = string(libdSFMT.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/dSFMT_jll/test/runtests.jl
+++ b/stdlib/dSFMT_jll/test/runtests.jl
@@ -5,4 +5,7 @@ using Test, dSFMT_jll
 @testset "dSFMT_jll" begin
     idstring = ccall((:dsfmt_get_idstring, libdSFMT), Ptr{UInt8}, ())
     @test startswith(unsafe_string(idstring), "dSFMT2-")
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test dSFMT_jll.get_libdSFMT_path() == dSFMT_jll.libdSFMT_path
 end

--- a/stdlib/libLLVM_jll/src/libLLVM_jll.jl
+++ b/stdlib/libLLVM_jll/src/libLLVM_jll.jl
@@ -46,6 +46,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libLLVM_path() = libLLVM_path
+
 function __init__()
     global libLLVM_path = string(libLLVM.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/libLLVM_jll/test/runtests.jl
+++ b/stdlib/libLLVM_jll/test/runtests.jl
@@ -5,4 +5,7 @@ using Test, Libdl, libLLVM_jll
 @testset "libLLVM_jll" begin
     # Try to find a symbol from the C API of libLLVM as a simple sanity check.
     @test dlsym(libLLVM_jll.libLLVM, :LLVMContextCreate; throw_error=false) !== nothing
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test libLLVM_jll.get_libLLVM_path() == libLLVM_jll.libLLVM_path
 end

--- a/stdlib/libblastrampoline_jll/src/libblastrampoline_jll.jl
+++ b/stdlib/libblastrampoline_jll/src/libblastrampoline_jll.jl
@@ -53,6 +53,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libblastrampoline_path() = libblastrampoline_path
+
 function __init__()
     global libblastrampoline_path = string(libblastrampoline.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/libblastrampoline_jll/test/runtests.jl
+++ b/stdlib/libblastrampoline_jll/test/runtests.jl
@@ -4,4 +4,7 @@ using Test, Libdl, libblastrampoline_jll
 
 @testset "libblastrampoline_jll" begin
     @test isa(Libdl.dlsym(libblastrampoline_jll.libblastrampoline, :dgemm_64_), Ptr{Nothing})
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test libblastrampoline_jll.get_libblastrampoline_path() == libblastrampoline_jll.libblastrampoline_path
 end

--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
@@ -40,6 +40,9 @@ function eager_mode()
 end
 is_available() = true
 
+# JLLWrappers path compatibility accessor
+get_libnghttp2_path() = libnghttp2_path
+
 function __init__()
     global libnghttp2_path = string(libnghttp2.path)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/nghttp2_jll/test/runtests.jl
+++ b/stdlib/nghttp2_jll/test/runtests.jl
@@ -12,4 +12,7 @@ end
 @testset "nghttp2_jll" begin
     info = unsafe_load(ccall((:nghttp2_version,libnghttp2), Ptr{nghttp2_info}, (Cint,), 0))
     @test VersionNumber(unsafe_string(info.version_str)) == v"1.70.0"
+
+    # Preserve the JLLWrappers path compatibility accessor used by packages.
+    @test nghttp2_jll.get_libnghttp2_path() == nghttp2_jll.libnghttp2_path
 end


### PR DESCRIPTION
The LazyLibrary conversions in #57719 and #58444 dropped the `get_*_path()` compatibility functions from bundled stdlib JLLs. External packages generated by JLLWrappers still provide these accessors, and BlockTriangularForm now fails on 1.14 because `SuiteSparse_jll.get_libbtf_path` is undefined:

https://pkgeval.s3.us-east-2.amazonaws.com/runs/gh-5428371050/logs/primary/BlockTriangularForm.log

Restore the exact 33 accessors that existed before those conversions across the 18 affected bundled JLLs. Each returns the already initialized `*_path` binding, preserving the previous behavior without forcing eager loading.

Assisted-by: OpenAI Codex (GPT-5)
