### PR TITLE
codegen: Preserve alias metadata on small copies

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1201,6 +1201,30 @@ static unsigned get_box_tindex(jl_datatype_t *jt, jl_value_t *ut)
 
 // --- generating various field accessors ---
 
+static bool try_emit_typed_copy(jl_codectx_t &ctx, Value *dst, const jl_aliasinfo_t &dst_ai,
+                                Value *src, const jl_aliasinfo_t &src_ai, jl_value_t *typ,
+                                uint64_t sz, Align align_dst, Align align_src, bool is_volatile) JL_CANSAFEPOINT
+{
+    // A memcpy cannot carry separate source and destination alias metadata.
+    // Limit aggregate scalarization to small values commonly carried in registers.
+    constexpr uint64_t max_typed_copy_size = 16;
+    if (sz == 0 || is_volatile || sz > max_typed_copy_size || !jl_is_pointerfree(typ))
+        return false;
+    jl_datatype_t *dt = (jl_datatype_t*)typ;
+    if (dt->layout->flags.haspadding || sz != jl_datatype_size(dt))
+        return false;
+    Type *T = julia_type_to_llvm(ctx, typ);
+    const DataLayout &DL = ctx.builder.GetInsertBlock()->getModule()->getDataLayout();
+    if (DL.getTypeStoreSize(T) != sz)
+        return false;
+    LoadInst *load = ctx.builder.CreateAlignedLoad(T, src, align_src);
+    setName(ctx.emission_context, load, src->getName() + ".copyload");
+    src_ai.decorateInst(load);
+    StoreInst *store = ctx.builder.CreateAlignedStore(load, dst, align_dst);
+    dst_ai.decorateInst(store);
+    return true;
+}
+
 static void emit_memcpy_llvm(jl_codectx_t &ctx, Value *dst, jl_aliasinfo_t const &dst_ai, Value *src,
                              jl_aliasinfo_t const &src_ai, uint64_t sz, Align align_dst, Align align_src, bool is_volatile)
 {
@@ -1236,6 +1260,9 @@ static void emit_memcpy(jl_codectx_t &ctx, Value *dst, jl_aliasinfo_t const &dst
                         T1 &&sz, Align align_dst, Align align_src, bool is_volatile=false) JL_CANSAFEPOINT
 {
     auto [src_ptr, src_ai] = data_pointer_ai(ctx, src);
+    if (try_emit_typed_copy(ctx, dst, dst_ai, src_ptr, src_ai, src.typ, sz,
+                            align_dst, align_src, is_volatile))
+        return;
     emit_memcpy_llvm(ctx, dst, dst_ai, src_ptr, src_ai, sz, align_dst, align_src, is_volatile);
 }
 

--- a/test/llvmpasses/pipeline-o2.jl
+++ b/test/llvmpasses/pipeline-o2.jl
@@ -3,6 +3,8 @@
 # RUNx: julia --startup-file=no -O2 --check-bounds=yes %s %t -O && llvm-link -S %t/* | FileCheck %s --check-prefixes=ALL
 # RUNx: julia --startup-file=no -O3 --check-bounds=yes %s %t -O && llvm-link -S %t/* | FileCheck %s --check-prefixes=ALL
 
+# RUN: julia --startup-file=no %s %t && llvm-link -S %t/* | FileCheck %s --check-prefix=UNOPT
+
 # RUN: julia --startup-file=no -O2 --check-bounds=no %s %t -O && llvm-link -S %t/* | FileCheck %s --check-prefixes=ALL,BC_OFF
 # RUN: julia --startup-file=no -O3 --check-bounds=no %s %t -O && llvm-link -S %t/* | FileCheck %s --check-prefixes=ALL,BC_OFF
 
@@ -73,6 +75,40 @@ function multiiterate_write!(arr1, arr2)
     for i in eachindex(arr1, arr2)
         arr1[i] += arr2[i]
     end
+end
+
+# COM: Preserve alias information for complete small typed copies while keeping padded and large copies as memcpy
+
+# ALL-LABEL: @"julia_copy_complex!
+# ALL: vector.body
+# UNOPT-LABEL: @"julia_copy_complex!
+# UNOPT: [[COPY:%.*]] = load [2 x double]
+# UNOPT: store [2 x double] [[COPY]], ptr addrspace(13)
+function copy_complex!(dest, src)
+    @inbounds @simd for i in eachindex(dest, src)
+        dest[i] = src[i]
+    end
+end
+
+struct PaddedCopy
+    x::UInt8
+    y::UInt16
+end
+
+# UNOPT-LABEL: @"julia_copy_padded!
+# UNOPT: call void @llvm.memcpy{{.*}}(ptr addrspace(13) {{.*}}, ptr{{.*}}%"split::PaddedCopy", i64 4
+function copy_padded!(dest, src)
+    @inbounds dest[1] = src[1]
+end
+
+struct LargeCopy
+    data::NTuple{17, UInt8}
+end
+
+# UNOPT-LABEL: @"julia_copy_large!
+# UNOPT: call void @llvm.memcpy{{.*}}(ptr addrspace(13) {{.*}}, ptr{{.*}}%"split::LargeCopy", i64 17
+function copy_large!(dest, src)
+    @inbounds dest[1] = src[1]
 end
 
 # COM: memset checks
@@ -151,6 +187,9 @@ emit(iterate_write!, Vector{Int64})
 emit(multiiterate_read, Vector{Int64}, Vector{Int64})
 emit(multiiterate_write, Vector{Int64}, Vector{Int64}, Vector{Int64})
 emit(multiiterate_write!, Vector{Int64}, Vector{Int64})
+emit(copy_complex!, Vector{ComplexF64}, Vector{ComplexF64})
+emit(copy_padded!, Vector{PaddedCopy}, Vector{PaddedCopy})
+emit(copy_large!, Vector{LargeCopy}, Vector{LargeCopy})
 
 emit(zeros, Core.TypeEgal{Int64}, Int64)
 emit(zeros, Core.TypeEgal{Int32}, Int64)


### PR DESCRIPTION
Emit load/store pairs for small padding-free pointer-free values, keeping source and destination alias metadata separate.

Helps quite a bit with vectorization over a variety of common types

```julia
Base.@noinline function _copyto_bench!(dst, src)
    for i in eachindex(dst, src)
        dst[i] = src[i]
    end
    dst
end

n = 1024

T = Tuple{Bool, UInt8}
src = (rand(T, n));
dst = copy(src);

@btime _copyto_bench!($dst, $src);
```
<img width="866" height="323" alt="image" src="https://github.com/user-attachments/assets/ff96c25a-d443-4163-8874-bb23688c9ca3" />

Fixes #60409

Coauthored-by: Codex (GPT-5.6 Sol xhigh)