### PR TITLE
precompile: keep `__init__` of `compile=min` modules as trim entrypoints

### DIFF
--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -359,9 +359,7 @@ function compile_and_emit_native(worlds::Vector{UInt},
             # Get module compile setting
             setting = ccall(:jl_get_module_compile, Cint, (Any,), mod)
             # When trimming, the entrypoint list is the only thing that keeps `__init__`
-            # alive, and `jl_module_run_initializer` will call it regardless of the
-            # module's `compile=` setting. So `compile=min` (e.g. every JLLWrappers
-            # generated JLL) must not exclude it from the entrypoints here.
+            # alive so keep them regardless of compile option
             if setting != JL_OPTIONS_COMPILE_OFF && (trim_mode != 0x00 || setting != JL_OPTIONS_COMPILE_MIN)
                 tt = Tuple{Core.Typeof(f)}
                 compile_hint(tt)

--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -358,7 +358,11 @@ function compile_and_emit_native(worlds::Vector{UInt},
             f = Core.invoke_in_world(latestworld, getglobal, mod, :__init__)
             # Get module compile setting
             setting = ccall(:jl_get_module_compile, Cint, (Any,), mod)
-            if setting != JL_OPTIONS_COMPILE_OFF && setting != JL_OPTIONS_COMPILE_MIN
+            # When trimming, the entrypoint list is the only thing that keeps `__init__`
+            # alive, and `jl_module_run_initializer` will call it regardless of the
+            # module's `compile=` setting. So `compile=min` (e.g. every JLLWrappers
+            # generated JLL) must not exclude it from the entrypoints here.
+            if setting != JL_OPTIONS_COMPILE_OFF && (trim_mode != 0x00 || setting != JL_OPTIONS_COMPILE_MIN)
                 tt = Tuple{Core.Typeof(f)}
                 compile_hint(tt)
                 trim_mode == 0x00 || add_entrypoint(tt)

--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -360,7 +360,7 @@ function compile_and_emit_native(worlds::Vector{UInt},
             setting = ccall(:jl_get_module_compile, Cint, (Any,), mod)
             # When trimming, the entrypoint list is the only thing that keeps `__init__`
             # alive so keep them regardless of compile option
-            if setting != JL_OPTIONS_COMPILE_OFF && (trim_mode != 0x00 || setting != JL_OPTIONS_COMPILE_MIN)
+            if setting != JL_OPTIONS_COMPILE_OFF && (trim_mode != TRIM_NO || setting != JL_OPTIONS_COMPILE_MIN)
                 tt = Tuple{Core.Typeof(f)}
                 compile_hint(tt)
                 trim_mode == 0x00 || add_entrypoint(tt)

--- a/test/trim/BasicJLL/Zstd_jll/src/Zstd_jll.jl
+++ b/test/trim/BasicJLL/Zstd_jll/src/Zstd_jll.jl
@@ -5,6 +5,11 @@
 baremodule Zstd_jll
 using Base, Libdl
 
+# Mirror what JLLWrappers emits into every generated JLL. This matters for trimming:
+# `__init__` of a `compile=min` module must still be treated as an entrypoint,
+# otherwise it is trimmed away and the binary aborts in `jl_module_run_initializer`.
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
+
 export libzstd, zstd, zstdmt
 
 # These get calculated in __init__()

--- a/test/trim/CompileMinInit/MinInitDep/Project.toml
+++ b/test/trim/CompileMinInit/MinInitDep/Project.toml
@@ -1,0 +1,3 @@
+name = "MinInitDep"
+uuid = "3f9b1e2c-7a4d-4b8e-a1c5-6d0e2f8b9a37"
+version = "0.1.0"

--- a/test/trim/CompileMinInit/MinInitDep/src/MinInitDep.jl
+++ b/test/trim/CompileMinInit/MinInitDep/src/MinInitDep.jl
@@ -1,0 +1,14 @@
+# A `compile=min` module with an `__init__`. Under `--trim`, the entrypoint list is the
+# only thing keeping `__init__` alive, but `jl_module_run_initializer` calls it at
+# startup regardless of the module's compile setting.
+module MinInitDep
+
+Base.Experimental.@compiler_options compile=min
+
+const initialized = Ref(false)
+
+function __init__()
+    initialized[] = true
+end
+
+end

--- a/test/trim/CompileMinInit/Project.toml
+++ b/test/trim/CompileMinInit/Project.toml
@@ -1,0 +1,9 @@
+name = "CompileMinInit"
+uuid = "5a2d7c31-0d3a-4c1b-9d36-8b2f9a6c4e10"
+version = "0.1.0"
+
+[deps]
+MinInitDep = "3f9b1e2c-7a4d-4b8e-a1c5-6d0e2f8b9a37"
+
+[sources]
+MinInitDep = {path = "MinInitDep"}

--- a/test/trim/CompileMinInit/runtests.jl
+++ b/test/trim/CompileMinInit/runtests.jl
@@ -1,0 +1,10 @@
+# Verify the trimmed `CompileMinInit` executable ran its `compile=min` dependency's `__init__`
+using Test
+
+outdir = ARGS[1]
+
+@testset "CompileMinInit" begin
+    exe_suffix = splitext(Base.julia_exename())[2]
+    exe = joinpath(outdir, "bin", "compilemininit" * exe_suffix)
+    @test readchomp(`$exe`) == "initialized: true"
+end

--- a/test/trim/CompileMinInit/src/CompileMinInit.jl
+++ b/test/trim/CompileMinInit/src/CompileMinInit.jl
@@ -1,0 +1,11 @@
+# Test that `__init__` of a `compile=min` module survives trimming and runs at startup
+module CompileMinInit
+
+using MinInitDep
+
+function @main(args::Vector{String})::Cint
+    println(Core.stdout, "initialized: ", MinInitDep.initialized[])
+    return 0
+end
+
+end


### PR DESCRIPTION
When moving precompile to Julia this got accidentally dropped so re-add the logic that used to be in C where we keep the __init__ always

<details>
<summary>Details</summary>

Fixes a 1.12 → 1.13 regression where `juliac --trim` silently drops the `__init__` of any module with `@compiler_options compile=min` — i.e. every JLLWrappers-generated JLL — and the resulting binary aborts at startup:

```
fatal: error thrown and no exception handler available.
Core.InitError(mod=:Lz4_jll, error=Core.MethodError(f=Lz4_jll.__init__, args=(), world=0x000000000000995f))
jl_method_error_bare at src/gf.c:3196
...
jl_module_run_initializer at src/toplevel.c:70
```

The build itself reports 0 verifier errors (also with `--trim=unsafe-warn`), so there is no build-time signal.

### Cause

Under `--trim`, the entrypoint list built in `compile_and_emit_native` is the only thing keeping `__init__` alive, while `jl_module_run_initializer` calls it at startup regardless of the module's `compile=` setting. The 1.12 C code (`src/precompile.c`) accounted for this:

```c
if ((setting != JL_OPTIONS_COMPILE_OFF && (jl_options.trim ||
    (setting != JL_OPTIONS_COMPILE_MIN)))) {
```

The port to Julia in #59361 dropped the `jl_options.trim ||` bypass. That was masked because it also used the wrong constant (`setting != 1`, which is `COMPILE_ON`, so nothing was actually excluded); #62462 corrected the constant to `JL_OPTIONS_COMPILE_MIN` and exposed the regression. So 1.13.0-rc2 works and rc3 fails.

Stdlib JLLs (hand-written, no `@compiler_options`) and plain packages are unaffected; only `compile=min` modules are.

### Fix

Restore the bypass:

```Julia
if setting != JL_OPTIONS_COMPILE_OFF && (trim_mode != 0x00 || setting != JL_OPTIONS_COMPILE_MIN)
```

Non-trim behaviour is unchanged. This is the `compile=min` analogue of #57653 (`force_enable_inference`), which already makes trim override a module-level `infer=false`.

### Test

The vendored `Zstd_jll` stub in `test/trim/BasicJLL` now declares `Base.Experimental.@compiler_options compile=min optimize=0 infer=false`, exactly what JLLWrappers emits. Without the fix, `BasicJLL` reproduces the abort above; with it, `julia test/runtests.jl trim` passes all four projects.

Note for real JLLs: with `__init__` back as an entrypoint, `--trim=safe` now correctly surfaces the `unique!` → `issorted` keyword-dispatch verifier error from `@generate_init_footer`. JuliaC.jl already ships the `issorted` specialization in its `juliac-trim-base.jl`, so end-to-end builds through JuliaC work; that part is out of scope here.


</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
