### PR TITLE
Make `foreigncall` / `foreignsymbol` `dlopen`-aware in `collectinvokes!` / `TrimVerifier`

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1893,7 +1893,25 @@ function has_valid_abi_sparams(mi::MethodInstance)
     return true
 end
 
-# collect a list of all code that is needed along with CodeInstance to codegen it fully
+function _libdl_dlopen()
+    dlopen_ptr = unsafe_load(cglobal(:jl_libdl_dlopen_func, Ptr{Cvoid}))
+    dlopen_ptr == C_NULL && return nothing # Libdl was never loaded
+    dlopen_fn = unsafe_load(cglobal(:jl_libdl_dlopen_func, Any))
+    return dlopen_fn
+end
+
+# Returns the type of library for a foreigncall / foreignglobal spec (aka foreignsymbol)
+function foreign_library_type(@nospecialize(spec), ci::CodeInfo, sptypes::Vector{VarState})
+    if isexpr(spec, :tuple) && length(spec.args) >= 2
+        lib = spec.args[2]
+    elseif spec isa Tuple && length(spec) >= 2
+        lib = spec[2]
+    else # either using a function pointer or an invalid foreigncall - no dlopen applies
+        return nothing
+    end
+    return argextype_widened(lib, ci, sptypes)
+end
+
 function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vector{VarState};
                          invokelatest_queue::Union{CompilationQueue,Nothing} = nothing,
                          enqueue_unprepared_invokes::Bool = false,
@@ -1963,6 +1981,15 @@ function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vec
             t, _, _, _ = instanceof_tfunc(argextype(stmt.args[1], ci, sptypes))
             t <: Function || continue
             atype = Tuple{t, Vararg}
+        elseif isexpr(stmt, :foreigncall) || isexpr(stmt, :foreignglobal)
+            # the runtime `dlopen(lib)` a site with a runtime library value performs on
+            # first use runs in the latest world (see `jl_lazy_load_and_lookup`)
+            library_type = foreign_library_type(stmt.args[1], ci, sptypes)
+            library_type === nothing && continue
+            library_type <: Union{Symbol,String} && continue # resolved natively by the runtime
+            dlopen_fn = _libdl_dlopen()
+            dlopen_fn === nothing && continue
+            atype = Tuple{typeof(dlopen_fn), library_type}
         else
             # TODO: handle other StmtInfo like OpaqueClosure?
             continue

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import ..Compiler: verify_typeinf_trim, NativeInterpreter, argtypes_to_type, compileable_specialization_for_call
+import ..Compiler: verify_typeinf_trim, NativeInterpreter, argtypes_to_type,
+    compileable_specialization_for_call, foreign_library_type, _libdl_dlopen
 
 using ..Compiler:
      # operators
@@ -401,10 +402,10 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
             end
 
             error = "unresolved cfunction"
-        elseif isexpr(stmt, :foreigncall)
-            foreigncall = stmt.args[1]
-            if isexpr(foreigncall, :tuple, 1)
-                foreigncall = foreigncall.args[1]
+        elseif isexpr(stmt, :foreigncall) || isexpr(stmt, :foreignglobal)
+            spec = stmt.args[1]
+            if isexpr(stmt, :foreigncall) && isexpr(spec, :tuple, 1)
+                foreigncall = spec.args[1]
                 if foreigncall isa String
                     foreigncall = QuoteNode(Symbol(foreigncall))
                 end
@@ -415,6 +416,21 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
                 else
                     error = "disallowed ccall with non-constant name and no library"
                 end
+            end
+            if isempty(error)
+                library_type = foreign_library_type(spec, codeinfo, sptypes)
+                dlopen_fn = _libdl_dlopen()
+                if library_type === nothing || library_type <: Union{Symbol,String}
+                    continue # no runtime `dlopen()` invocation
+                elseif dlopen_fn !== nothing
+                    atype = Tuple{typeof(dlopen_fn), library_type}
+                    mi = compileable_specialization_for_call(interp, atype)
+                    if mi !== nothing
+                        ci = get(caches, mi, nothing)
+                        ci isa CodeInstance && continue
+                    end
+                end
+                error = "unresolved dlopen for ccall / cglobal"
             end
         elseif isexpr(stmt, :new_opaque_closure)
             error = "unresolved opaque closure"

--- a/Compiler/test/verifytrim.jl
+++ b/Compiler/test/verifytrim.jl
@@ -150,3 +150,41 @@ let infos = typeinf_ext_toplevel(Any[mi], [Base.get_world_counter()], TRIM_UNSAF
     errors, parents = get_verify_typeinf_trim(infos)
     @test !isempty(errors)
 end
+
+# TrimVerifier (and also `collectinvokes!`) should check the implicit `Libdl.dlopen`
+# call for foreign library types on first use of a `ccall` / `cglobal`
+struct StaticTrimLib end
+const static_trim_lib = StaticTrimLib()
+const static_trim_libname = "libjulia-internal"
+Base.Libc.Libdl.dlopen(::StaticTrimLib) =
+    ccall(:jl_load_dynamic_library, Ptr{Cvoid}, (Ptr{UInt8}, UInt32, Cint),
+          static_trim_libname, Base.Libc.Libdl.RTLD_LAZY, Cint(0))
+trim_ccall_static_lib() = ccall((:jl_getpid, static_trim_lib), Int32, ())
+
+let infos = typeinf_ext_toplevel(Any[Core.svec(Int32, Tuple{typeof(trim_ccall_static_lib)})],
+                                 [Base.get_world_counter()], TRIM_UNSAFE, false)[1]
+    errors, parents = get_verify_typeinf_trim(infos)
+    @test isempty(errors)
+    # the `dlopen(::StaticTrimLib)` call the runtime makes was enqueued and compiled
+    @test any(infos) do item
+        item isa Core.CodeInstance || return false
+        mi = item.def
+        mi isa Core.MethodInstance &&
+            mi.specTypes === Tuple{typeof(Base.Libc.Libdl.dlopen), StaticTrimLib}
+    end
+end
+
+# verification should fail if an imprecise library type blocks dispatch resolution
+global loose_trim_lib = static_trim_lib
+trim_ccall_loose_lib() = ccall((:jl_getpid, loose_trim_lib), Int32, ())
+
+let infos = typeinf_ext_toplevel(Any[Core.svec(Int32, Tuple{typeof(trim_ccall_loose_lib)})],
+                                 [Base.get_world_counter()], TRIM_UNSAFE, false)[1]
+    errors, parents = get_verify_typeinf_trim(infos)
+    (warn, desc) = only(errors)
+    @test !warn
+    @test desc isa CallMissing
+    @test desc.desc == "unresolved dlopen for ccall / cglobal"
+    repr = sprint(verify_print_error, desc, parents, warn)
+    @test occursin("unresolved dlopen for ccall / cglobal", repr)
+end

--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,10 @@ Language changes
   (e.g. `Type{Int} <: Union{DataType,UnionAll}` holds). `isa` and dispatch of type *values* are
   unaffected, and a method on `Type{Int}` remains more specific than one on `DataType`
   ([#33136], [#62141]).
+* The `Libdl.dlopen(lib)` call that the runtime makes on first use of a `ccall` or `cglobal`
+  whose library is a runtime value (e.g. a `LazyLibrary` or a custom type) now runs in the
+  latest world age, as if through `invokelatest`, rather than in the world of the calling
+  code. A `dlopen` method defined after the caller was compiled is now used at that site.
 
 Compiler/Runtime improvements
 -----------------------------

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -975,7 +975,8 @@ However, it is assumed that the library location and handle does not change
 once it is determined, so the result of the call may be cached and reused.
 Therefore, the number of times the `dlopen` expression executes is unspecified,
 and returning different values for multiple calls will result in unspecified
-(but valid) behavior.
+(but valid) behavior. The call runs in the latest world age, as if through
+[`invokelatest`](@ref Base.invokelatest).
 
 ### Computed Function Names
 

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -80,7 +80,13 @@ void *jl_lazy_load_and_lookup(jl_value_t *lib_val, jl_value_t *f_name)
         else if (jl_is_string(lib_val))
             lib_ptr = jl_get_library(jl_string_data(lib_val));
         else if (jl_libdl_dlopen_func != NULL) {
-            lib_ptr = jl_unbox_voidpointer(jl_apply_generic(jl_libdl_dlopen_func, &lib_val, 1));
+            jl_task_t *ct = jl_current_task;
+            size_t last_age = ct->world_age;
+            if (!ct->ptls->in_pure_callback)
+                ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
+            jl_value_t *ret = jl_apply_generic(jl_libdl_dlopen_func, &lib_val, 1);
+            ct->world_age = last_age;
+            lib_ptr = jl_unbox_voidpointer(ret);
         } else
             jl_type_error("cglobal/ccall", (jl_value_t*)jl_symbol_type, lib_val);
     }

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -2165,3 +2165,16 @@ const sym = :ZSTD_versionString
 get_zstd_version() = prefix * unsafe_string(ccall((sym, libzstd), Cstring, ()))
 @test startswith(get_zstd_version(), "Zstd")
 end
+
+# The `dlopen(lib)` that a `ccall` with a runtime library value performs on first use runs
+# in the latest world, like `invokelatest`, so a `dlopen` method defined after the calling
+# code was compiled is still used when the site first executes.
+struct LatestWorldLib end
+const latest_world_lib = LatestWorldLib()
+latest_world_lib_ccall(x) = ccall((:testUcharX, latest_world_lib), Int32, (UInt8,), x)
+function define_dlopen_then_ccall(x)
+    # this method lands in a newer world than the one the enclosing function runs in
+    Core.eval(@__MODULE__, :(Base.Libc.Libdl.dlopen(::LatestWorldLib) = Base.Libc.Libdl.dlopen(libccalltest)))
+    return latest_world_lib_ccall(x)
+end
+@test define_dlopen_then_ccall(3) == ccall((:testUcharX, libccalltest), Int32, (UInt8,), 3)

--- a/test/trim/Trimmability/runtests.jl
+++ b/test/trim/Trimmability/runtests.jl
@@ -19,4 +19,5 @@ outdir = ARGS[1]
     @test lines[9] == "finalizers: 27 32"
     @test lines[10] == "collected: 0 kept, 10 dropped"
     @test lines[11] == "got 1:3 vs 1 with 2.5 and sym and c"
+    @test lines[12] == "custom_library_ccall: $(VERSION.major)"
 end

--- a/test/trim/Trimmability/src/Trimmability.jl
+++ b/test/trim/Trimmability/src/Trimmability.jl
@@ -102,6 +102,18 @@ end
     return (fin_total[], total)
 end
 
+# Test that `dlopen(...)` for user-provided library types in `ccall` / `cglobal` works
+struct CustomLib end
+const custom_lib = CustomLib()
+function Base.Libc.Libdl.dlopen(::CustomLib)
+    print(Core.stdout, "custom_library_ccall: ")
+    return ccall(:jl_load_dynamic_library, Ptr{Cvoid}, (Ptr{UInt8}, UInt32, Cint),
+                 "libjulia", Base.Libc.Libdl.RTLD_LAZY, Cint(0))
+end
+function user_library_ccall()
+    println(Core.stdout, ccall((:jl_ver_major, custom_lib), Cint, ()))
+end
+
 function _test_cat()
     # hcat
     _cat1a = hcat(randn(3), rand(3), randn(3))
@@ -219,6 +231,8 @@ function @main(args::Vector{String})::Cint
         end
     catch
     end
+
+    user_library_ccall() # prints as a side effect
 
     Base.donotdelete(reshape([1,2,3],:,1,1))
 


### PR DESCRIPTION
Dependent on https://github.com/JuliaLang/julia/pull/63021

Teach inference and the trim verifier about the dynamic dlopen calls that we do in the runtime for `foreignsymbol` / `foreigncall` (AKA `ccall`). This is a pre-requisite for LazyLibrary to be functional under `--trim`

This was waiting on #61709 and #59165 for a long time to be sound, but now that those are both merged we have usable `ccall` semantics for trimming. Basic `dlopen(...)` now works, although LazyLibrary (and callbacks) bring another set of challenges - those are not functional yet.

Resolves https://github.com/JuliaLang/julia/issues/57706. Resolves https://github.com/JuliaLang/julia/issues/57707.

Written with assistance from Claude Opus 5 🤖 - most source changes are done by me