### PR TITLE
Math: restore `*_domain_error` helpers removed in #62842

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -734,4 +734,13 @@ function setindex!(x::Threads.Atomic, v)
     return @atomic x[] = v
 end
 
+# The `*_domain_error` helpers were replaced by `Math.throw_finite_domainerror` in #62842,
+# but some packages call them directly. Not deprecated, just kept for compatibility.
+@eval Math begin
+    @noinline sin_domain_error(x) = throw_finite_domainerror(:sin, x)
+    @noinline cos_domain_error(x) = throw_finite_domainerror(:cos, x)
+    @noinline sincos_domain_error(x) = throw_finite_domainerror(:sincos, x)
+    @noinline tan_domain_error(x) = throw_finite_domainerror(:tan, x)
+end
+
 # END 1.14 deprecations


### PR DESCRIPTION
`sin_domain_error`, `cos_domain_error`, `sincos_domain_error` and `tan_domain_error` were internal, but some packages call them directly and now fail to load with `UndefVarError` (https://pkgeval.s3.us-east-2.amazonaws.com/runs/gh-5428371050/logs/primary/BlochSimulators.log). Add them back in `deprecated.jl` as thin wrappers around `throw_finite_domainerror`, without deprecating them.