### PR TITLE
Test: add `ambiguous_bottom` to `detect_unbound_args`

### DIFF
--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -756,22 +756,35 @@ reachable with `invoke` and is consistent with the covariant occurrence rule.
 matched at least one argument (it is not propagated into nested positions,
 where an empty tuple can always occur); it is an assumption the caller must
 justify (see `Test.detect_unbound_args`).
+
+`inhabited_params` assumes that no invariant type parameter position of the
+matching arguments is filled with `Union{}`, so that an occurrence of an inner
+variable there always pins it to an inhabited type (see `pin_grade`), and the
+descent through an inner variable's upper bound is also taken for
+`MATCH_INHABITED` positions: a `Type{<:T}` slot then pins `T` even though the
+call `f(Union{})` would not.
 """
-function constrains_var(var::TypeVar, @nospecialize(t), match::Int, nonempty_vararg::Bool=false)
+function constrains_var(var::TypeVar, @nospecialize(t), match::Int, nonempty_vararg::Bool=false,
+                        inhabited_params::Bool=false)
     if t === var
         # equality pins unconditionally; a lower-bound contribution pins only
         # when nothing else can union into the least solution
         return match === MATCH_EGAL || var.lb === Union{}
     end
     while t isa UnionAll
-        # only a concrete `typeof` argument can carry the pin through an inner
-        # variable's range; the cheap occurs-check gates the `pin_grade` body
-        # traversal just for performance since constrains_var would be false
-        if match === MATCH_TYPEOF && t.var.lb === Union{} && has_typevar(t.var.ub, var)
-            pin = pin_grade(t.var, t.body, nonempty_vararg)
-            if pin == PIN_TYPEOF && constrains_var(var, t.var.ub, MATCH_TYPEOF)
+        # only a concrete `typeof` argument (or any inhabited type, under
+        # `inhabited_params`) can carry the pin through an inner variable's
+        # range; the cheap occurs-check gates the `pin_grade` body traversal
+        # just for performance since constrains_var would be false
+        if (match === MATCH_TYPEOF || (match === MATCH_INHABITED && inhabited_params)) &&
+                t.var.lb === Union{} && has_typevar(t.var.ub, var)
+            pin = pin_grade(t.var, t.body, nonempty_vararg, inhabited_params)
+            # an inhabited (possibly abstract) type filling this position can
+            # pin the inner variable at most as inhabited
+            match === MATCH_INHABITED && (pin = min(pin, PIN_INHABITED))
+            if pin == PIN_TYPEOF && constrains_var(var, t.var.ub, MATCH_TYPEOF, false, inhabited_params)
                 return true
-            elseif pin == PIN_INHABITED && constrains_var(var, t.var.ub, MATCH_INHABITED)
+            elseif pin == PIN_INHABITED && constrains_var(var, t.var.ub, MATCH_INHABITED, false, inhabited_params)
                 return true
             end
         end
@@ -789,28 +802,28 @@ function constrains_var(var::TypeVar, @nospecialize(t), match::Int, nonempty_var
         # only as `var = Union{}` (issue #58427), which we deliberately still
         # report — so in both cases require every arm to pin `var`, accepting
         # the false positive for arms every match must expose (issue #59023)
-        return constrains_var(var, t.a, match) &&
-               constrains_var(var, t.b, match)
+        return constrains_var(var, t.a, match, false, inhabited_params) &&
+               constrains_var(var, t.b, match, false, inhabited_params)
     end
     if isTypeEq(t) # TypeEgal cannot constrain (or contain) a parameter
-        return constrains_var(var, type_parameter(t), MATCH_EGAL)
+        return constrains_var(var, type_parameter(t), MATCH_EGAL, false, inhabited_params)
     end
     t isa DataType || return false
     if t.name === Tuple.name
         for p in t.parameters
             if p isa Core.TypeofVararg
                 # the argument count pins `N` exactly (including zero)
-                isdefined(p, :N) && constrains_var(var, p.N, match) && return true
+                isdefined(p, :N) && constrains_var(var, p.N, match, false, inhabited_params) && return true
                 if match === MATCH_TYPEOF && nonempty_vararg && isdefined(p, :T)
-                    constrains_var(var, p.T, MATCH_TYPEOF) && return true
+                    constrains_var(var, p.T, MATCH_TYPEOF, false, inhabited_params) && return true
                 end
             else
-                constrains_var(var, p, match) && return true
+                constrains_var(var, p, match, false, inhabited_params) && return true
             end
         end
     else
         for p in t.parameters
-            constrains_var(var, p, MATCH_EGAL) && return true
+            constrains_var(var, p, MATCH_EGAL, false, inhabited_params) && return true
         end
     end
     return false
@@ -830,11 +843,14 @@ end
 #  * `PIN_NONE`: neither is guaranteed; `v` may be `Union{}` (e.g. `Type{v}`
 #    positions matched by the argument `Union{}`, or invariant parameters
 #    without such a field), leaving its bounds unconstraining.
+# With `inhabited_params`, any invariant parameter occurrence of `v` (at any
+# depth, in any constructor) is assumed to be filled with an inhabited type,
+# so it grades `PIN_INHABITED` without the field requirement.
 const PIN_NONE = 0
 const PIN_INHABITED = 1
 const PIN_TYPEOF = 2
 
-function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
+function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false, inhabited_params::Bool=false)
     # Implementation note: a covariant occurrence of `v` reports `PIN_TYPEOF`
     # (concrete typeof value) computed in isolation. Strictly this over-reports
     # when `v` also occurs elsewhere. We don't take the minimum (that would
@@ -855,7 +871,7 @@ function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
             # concrete `t.var` (`PIN_TYPEOF`) makes `v` concrete, an
             # inhabited-but-abstract one (`PIN_INHABITED`) makes `v` inhabited
             # (mirroring the two-grade handling in `constrains_var`)
-            g = pin_grade(t.var, t.body, nonempty_vararg)
+            g = pin_grade(t.var, t.body, nonempty_vararg, inhabited_params)
             g == PIN_TYPEOF && return PIN_TYPEOF
             grade = max(grade, g)
         end
@@ -867,18 +883,24 @@ function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
     if t isa Union
         # a where-clause position (`grade`) pins on its own; the union itself
         # pins only if every arm does
-        return max(grade, min(pin_grade(v, t.a), pin_grade(v, t.b)))
+        return max(grade, min(pin_grade(v, t.a, false, inhabited_params),
+                              pin_grade(v, t.b, false, inhabited_params)))
+    end
+    if isTypeEq(t)
+        # a `Type{X}` position is filled by a type, `Union{}` included
+        inhabited_params || return grade
+        return max(grade, min(PIN_INHABITED, pin_grade(v, type_parameter(t), false, inhabited_params)))
     end
     t isa DataType || return grade
-    isabstracttype(t) && return grade
+    isabstracttype(t) && !inhabited_params && return grade
     if t.name === Tuple.name
         for p in t.parameters
             if p isa Core.TypeofVararg
                 if nonempty_vararg && isdefined(p, :T)
-                    grade = max(grade, pin_grade(v, p.T))
+                    grade = max(grade, pin_grade(v, p.T, false, inhabited_params))
                 end
             else
-                grade = max(grade, pin_grade(v, p))
+                grade = max(grade, pin_grade(v, p, false, inhabited_params))
             end
             grade == PIN_TYPEOF && break
         end
@@ -886,8 +908,15 @@ function pin_grade(v::TypeVar, @nospecialize(t), nonempty_vararg::Bool=false)
     end
     for i in 1:length(t.parameters)
         p = t.parameters[i]
-        if p === v && some_field_requires_inhabited_param(t, i)
-            return max(grade, PIN_INHABITED)
+        if p === v
+            if inhabited_params || some_field_requires_inhabited_param(t, i)
+                return max(grade, PIN_INHABITED)
+            end
+        elseif inhabited_params
+            # a nested invariant position is filled by a type, so it pins at
+            # most as inhabited even where `v` occurs covariantly inside
+            g = min(PIN_INHABITED, pin_grade(v, p, false, inhabited_params))
+            g == PIN_INHABITED && return max(grade, g)
         end
     end
     return grade

--- a/NEWS.md
+++ b/NEWS.md
@@ -235,7 +235,9 @@ Standard library changes
   unbound when called with `Union{}`, or `f(::Vector{<:T}) where {T}` with a
   `Vector{Union{}}` argument), and no longer reports methods whose problematic calls are
   all shadowed by more specific methods (such as a `f(::Type{Union{}})` fallback), or
-  whose lowered bodies never read the possibly-unbound parameters.
+  whose lowered bodies never read the possibly-unbound parameters. Parameters left
+  unbound only by calls with `Union{}` type parameters are reported only with the new
+  `ambiguous_bottom=true` keyword argument, as for `detect_ambiguities` ([#62405]).
 
 #### Dates
 

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2747,13 +2747,21 @@ See also [`detect_closure_boxes`](@ref) to check specific modules.
 detect_closure_boxes_all_modules() = detect_closure_boxes(Base.loaded_modules_array()...)
 
 """
-    detect_unbound_args(mod1, mod2...; recursive=false, allowed_undefineds=nothing)
+    detect_unbound_args(mod1, mod2...; recursive=false,
+                                       ambiguous_bottom=false,
+                                       allowed_undefineds=nothing)
 
 Return a vector of `Method`s which may have unbound type parameters: some
 call matching the method's signature does not pin every static parameter to
 a definite value, so reading such a parameter in the method body may throw an
 `UndefVarError`.
 Use `recursive=true` to test in all submodules.
+
+`ambiguous_bottom` controls whether parameters left unbound only by calls
+with `Union{}` type parameters are included, such as `T` in
+`f(::Type{<:T}) where {T}` for the call `f(Union{})`, or in
+`f(::Vector{<:T}) where {T}` for a `Vector{Union{}}` argument; in most cases
+you probably want to leave this `false`. See [`Test.detect_ambiguities`](@ref).
 
 The check is a conservative static approximation of how subtyping assigns
 static parameters, so a reported method may in practice never see the calls
@@ -2783,18 +2791,23 @@ would suppress warnings about `Base.active_repl` and
 
 !!! compat "Julia 1.8"
     `allowed_undefineds` requires at least Julia 1.8.
+
+!!! compat "Julia 1.14"
+    `ambiguous_bottom` requires at least Julia 1.14.
 """
 function detect_unbound_args(mods...;
                              recursive::Bool = false,
+                             ambiguous_bottom::Bool = false,
                              allowed_undefineds=nothing)
     @nospecialize mods
+    inhabited_params = !ambiguous_bottom
     ambs = Set{Method}()
     mods = Module[mods...]
     world = Base.get_world_counter()
     function examine(mt::Core.MethodTable)
         for m in Base.MethodList(mt)
             is_in_mods(parentmodule(m), recursive, mods) || continue
-            idxs = unbound_sparams(m.sig)
+            idxs = unbound_sparams(m.sig, inhabited_params)
             isempty(idxs) && continue
             tuple_sig = Base.unwrap_unionall(m.sig)::DataType
             params = tuple_sig.parameters
@@ -2833,7 +2846,7 @@ function detect_unbound_args(mods...;
                 # way needs no method-table probe (`idxs` is a superset of
                 # the parameters still unbound under `nonempty_vararg`)
                 any(idx -> (var = sig_vars[idx];
-                            v !== var && Base.Compiler.constrains_var(var, v.ub, Core.Compiler.MATCH_INHABITED)),
+                            v !== var && Base.Compiler.constrains_var(var, v.ub, Core.Compiler.MATCH_INHABITED, false, inhabited_params)),
                     idxs) || continue
                 bot_params = Any[params...]
                 bot_params[i] = Type{Union{}}
@@ -2845,7 +2858,7 @@ function detect_unbound_args(mods...;
             end
             # re-check unboundness under the verified assumptions
             if nonempty_vararg || !isempty(shadowed_slots)
-                idxs = unbound_sparams(m.sig, nonempty_vararg, shadowed_slots)
+                idxs = unbound_sparams(m.sig, inhabited_params, nonempty_vararg, shadowed_slots)
                 isempty(idxs) && continue
             end
             # unboundness only matters if the body actually reads one of the
@@ -2874,9 +2887,10 @@ end
 
 # The 1-based positions in the signature's `where` chain of parameters that
 # some matching call may leave unbound.
+# - `inhabited_params` assumes no invariant type parameter of the arguments is `Union{}`;
 # - `nonempty_vararg` assumes the signature's trailing `Vararg` matches at least one argument;
 # - `shadowed_slots` lists `Type{S}` argument positions whose `Union{}` member never reaches this method.
-function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
+function unbound_sparams(@nospecialize(sig), inhabited_params::Bool, nonempty_vararg::Bool=false,
                          shadowed_slots::Vector{Int}=Int[])
     idxs = Int[]
     params = isempty(shadowed_slots) ? Core.svec() :
@@ -2887,13 +2901,13 @@ function unbound_sparams(@nospecialize(sig), nonempty_vararg::Bool=false,
         i += 1
         var = body.var
         body = body.body
-        Base.Compiler.constrains_var(var, body, Core.Compiler.MATCH_TYPEOF, nonempty_vararg) && continue
+        Base.Compiler.constrains_var(var, body, Core.Compiler.MATCH_TYPEOF, nonempty_vararg, inhabited_params) && continue
         pinned = false
         for j in shadowed_slots
             # any non-`Union{}` value of this slot's `Type` parameter pins
             # `var` if it occurs invariantly below a constructor of its bound
             v = type_slot_var(params[j])::TypeVar
-            if v !== var && Base.Compiler.constrains_var(var, v.ub, Core.Compiler.MATCH_INHABITED)
+            if v !== var && Base.Compiler.constrains_var(var, v.ub, Core.Compiler.MATCH_INHABITED, false, inhabited_params)
                 pinned = true
                 break
             end

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -343,6 +343,8 @@ module UnboundDetect
     unbound9(x::Ref{Vector{<:T}}) where {T} = T                # f(Ref{Vector}(...))
     unbound10(x::Type{<:T}, y::Type{<:S}) where {T, S} = T     # f(Union{}, Int): S is never read, but T is
     unbound13(x::Type{<:T}) where {T} = @isdefined(T) ? T : 0
+    unbound16(x::Type{<:Ref{<:Vector{T}}}) where {T} = T       # f(Ref{Union{}})
+    unbound17(x::Vector{Ref{S}}) where {T, S<:T} = T           # f(Vector{Ref{Union{}}}())
     unused1(x::Type{<:T}) where {T} = 0
     unused2(x::Type{<:T}) where {T} = @isdefined(T)
     # every matching call pins the parameter
@@ -422,7 +424,11 @@ module UnboundDetect
         x::T
     end
 end
-let unbound = Set{Method}(detect_unbound_args(UnboundDetect))
+let unbound = Set{Method}(detect_unbound_args(UnboundDetect; ambiguous_bottom=true)),
+    unbound_nobottom = Set{Method}(detect_unbound_args(UnboundDetect))
+    # parameters left unbound only by calls with `Union{}` type parameters
+    bottom_only = (:unbound1, :unbound2, :unbound7, :unbound10, :unbound11, :unbound13,
+                   :unbound16, :unbound17, :notshadowed2, :notshadowed4, :nofieldpins)
     tested = 0
     for name in names(UnboundDetect; all=true)
         startswith(String(name), '#') && continue
@@ -435,22 +441,41 @@ let unbound = Set{Method}(detect_unbound_args(UnboundDetect))
                       startswith(String(name), "notshadowed") ||
                       name === :nofieldpins
         @test (m in unbound) == should_flag context=name
+        @test (m in unbound_nobottom) == (should_flag && name ∉ bottom_only) context=name
         tested += 1
     end
-    @test tested == 37
+    @test tested == 39
     let ms = filter(m -> m.sig isa UnionAll, collect(methods(UnboundDetect.Foo54893)))
         @test only(ms) in unbound
+        @test only(ms) in unbound_nobottom
     end
 end
 
 # Test that Core and Base are free of UndefVarErrors
 @testset "detect_unbound_args in Base and Core" begin
     let need_to_handle_undef_sparam =
-            Set{Method}(detect_unbound_args(Core; recursive=true))
+            Set{Method}(detect_unbound_args(Core; recursive=true, ambiguous_bottom=true))
         @test isempty(need_to_handle_undef_sparam)
     end
     let need_to_handle_undef_sparam =
             Set{Method}(detect_unbound_args(Base; recursive=true, allowed_undefineds))
+        # the parameters left unbound by non-`Union{}` calls (see the reviewed list below)
+        expected_undef_sparam = Any[
+            Tuple{typeof(Base._totuple), Type{Tuple{Vararg{E}}}, Any, Vararg{Any}} where E,
+            Tuple{typeof(Base._eltype_ntuple), Type{<:Tuple{Vararg{E}}}} where E,
+            Tuple{typeof(Base.reduce_empty_iter), Any, Tuple{Vararg{T}}, Base.HasEltype} where T,
+            Tuple{typeof(float), AbstractArray{Union{Missing, T}}} where T,
+            Tuple{typeof(Base._cat), Any, Vararg{AbstractArray{T}}} where T,
+        ]
+        for sig in expected_undef_sparam
+            m = which(sig)
+            @test m in need_to_handle_undef_sparam context=sig
+            delete!(need_to_handle_undef_sparam, m)
+        end
+        @test isempty(need_to_handle_undef_sparam)
+    end
+    let need_to_handle_undef_sparam =
+            Set{Method}(detect_unbound_args(Base; recursive=true, ambiguous_bottom=true, allowed_undefineds))
         # reviewed and expected
         expected_undef_sparam = Any[
             Tuple{typeof(Base._totuple), Type{Tuple{Vararg{E}}}, Any, Vararg{Any}} where E,


### PR DESCRIPTION
Since #62405, `detect_unbound_args` reports parameters that are left unbound only by calls with `Union{}` type parameters, such as `T` in `f(::Type{<:T}) where {T}` for `f(Union{})`, which many packages trip over in their unbound-parameter tests. Mirror `detect_ambiguities` with an `ambiguous_bottom` keyword that defaults to `false`, excluding those parameters as in previous releases, while `ambiguous_bottom=true` keeps the stricter check.

Assisted-by: Claude Code (Fable 5)