### PR TITLE
[1.13] Compiler: don't crash return_type_tfunc on signatures without a function type

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3122,6 +3122,8 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
         argtypes_vec = Any[af_argtype.parameters...]
         isempty(argtypes_vec) && push!(argtypes_vec, Union{})
         aft = argtypes_vec[1]
+        # e.g. `return_type(Tuple{Vararg{Any}})`: there is no function type to model
+        isvarargtype(aft) && return Future(UNKNOWN)
     end
     if !(isa(aft, Const) || (isType(aft) && !has_free_typevars(aft)) ||
             (isconcretetype(aft) && !(aft <: Builtin) && !iskindtype(aft)))

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6590,4 +6590,13 @@ end
     jetls618(1,2,3), jetls618(1,2,3,4)
 end == Tuple{Int,Int}
 
+# `return_type_tfunc` should bail out (rather than crash inference) when the queried
+# signature has no function type to model
+@test Base.infer_return_type() do
+    Compiler.return_type(Tuple{Vararg{Any}})
+end == Type
+@test Base.infer_return_type() do
+    Compiler.return_type(Tuple)
+end == Type
+
 end # module inference


### PR DESCRIPTION
Back-port of https://github.com/JuliaLang/julia/pull/62872