### PR TITLE
Set a concrete type for WaitEntryN.task

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4598,6 +4598,8 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_binding_type->types, 3, jl_array_any_type);
     jl_value_t *partition_next_types[2] = { (jl_value_t*)jl_binding_partition_type, (jl_value_t*)jl_binding_type };
     jl_svecset(jl_binding_partition_type->types, 3, jl_type_union(partition_next_types, 2));
+    jl_value_t *wait_entry_task_types[2] = { (jl_value_t*)jl_nothing_type, (jl_value_t*)jl_task_type };
+    jl_svecset(jl_wait_entry_type->types, 0, jl_type_union(wait_entry_task_types, 2));
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);

--- a/src/task.c
+++ b/src/task.c
@@ -2062,6 +2062,9 @@ JL_DLLEXPORT jl_value_t *jl_new_cancel_source(jl_value_t **parents, size_t np)
 JL_DLLEXPORT jl_value_t *jl_new_wait_entry(jl_value_t *task, size_t nslots)
 {
     jl_task_t *ct = jl_current_task;
+    // the `task` field is declared `Union{Nothing, Task}` (see `jl_init_types`), which
+    // this store bypasses.
+    assert(task == jl_nothing || jl_is_task(task));
     // `nslots` must fit the uint32_t field *and* keep the allocation-size
     // arithmetic below from wrapping (on 32-bit, SIZE_MAX overflows long
     // before UINT32_MAX slots do).


### PR DESCRIPTION
This makes users of the type less vulnerable to invalidations.

In particular, fixes this *absolute unit* of a tree seen when loading CairoMakie:
```julia
 inserting istaskdone(t::Makie.TrackedTask) @ Makie ~/.julia/dev/Makie/Makie/src/utilities/timing.jl:6 invalidated:                                                                                                                            
   mt_backedges: 1: signature Tuple{typeof(istaskdone), Any} triggered MethodInstance for Base._cancel_walk_node!(::Core.CancellationTokenSource, ::UInt8, ::Vector{Core.CancellationTokenSource}, ::IdSet{Core.CancellationTokenSource}) (0 children)
                 2: signature Tuple{typeof(istaskdone), Any} triggered MethodInstance for Base._walk_waiters!(::Core.CancellationTokenSource, ::UInt8) (10496 children, 155 revived)
```

Fix suggested by Claude :robot: 