### PR TITLE
timing: report runtime dispatches from `@time`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -182,10 +182,11 @@ New library features
   fit on a single line, truncated to the display width, instead of showing no data at all ([#62543]).
 * The element type of broadcast expressions now uses regular inference machinery rather than an idiosyncratic
   heuristic. This can help fused or empty broadcasts infer to more precise element types ([#62564]).
-* `@time` now reports the number of runtime dispatches when there are enough of them to plausibly account
-  for a percent or so of the elapsed time, which is usually a symptom of type instability. `@timev` always
-  reports the count, `@timed` returns it in a new `dispatches` field, and the new `@dispatches` macro
-  measures it on its own ([#62929]).
+* `@time` now reports the share of the elapsed time spent on runtime dispatch, when that share reaches one
+  percent, which is usually a symptom of type instability. The share is estimated from the dispatch count and
+  a per-dispatch cost measured on the running machine. `@timev` also reports the raw count, `@timed` returns
+  it in new `dispatches` and `dispatch_time` fields, and the new `@dispatches` macro measures the count on
+  its own ([#62929]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -185,7 +185,7 @@ New library features
 * `@time` now reports the number of runtime dispatches when there are enough of them to plausibly account
   for a percent or so of the elapsed time, which is usually a symptom of type instability. `@timev` always
   reports the count, `@timed` returns it in a new `dispatches` field, and the new `@dispatches` macro
-  measures it on its own.
+  measures it on its own ([#62929]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -182,6 +182,10 @@ New library features
   fit on a single line, truncated to the display width, instead of showing no data at all ([#62543]).
 * The element type of broadcast expressions now uses regular inference machinery rather than an idiosyncratic
   heuristic. This can help fused or empty broadcasts infer to more precise element types ([#62564]).
+* `@time` now reports the number of runtime dispatches when there are enough of them to plausibly account
+  for a percent or so of the elapsed time, which is usually a symptom of type instability. `@timev` always
+  reports the count, `@timed` returns it in a new `dispatches` field, and the new `@dispatches` macro
+  measures it on its own.
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -182,9 +182,9 @@ New library features
   fit on a single line, truncated to the display width, instead of showing no data at all ([#62543]).
 * The element type of broadcast expressions now uses regular inference machinery rather than an idiosyncratic
   heuristic. This can help fused or empty broadcasts infer to more precise element types ([#62564]).
-* `@time` now reports the share of the elapsed time spent on runtime dispatch, when that share reaches one
-  percent, which is usually a symptom of type instability. The share is estimated from the dispatch count and
-  a per-dispatch cost measured on the running machine. `@timev` also reports the raw count, `@timed` returns
+* `@time` now reports the number of dynamic dispatches and the share of the elapsed time they took, when that
+  share reaches one percent, which is usually a symptom of type instability. The share is estimated from the
+  count and a per-dispatch cost measured on the running machine. `@timev` also reports the raw count, `@timed` returns
   it in new `dispatches` and `dispatch_time` fields, and the new `@dispatches` macro measures the count on
   its own ([#62929]).
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1103,6 +1103,7 @@ export
     @elapsed,
     @allocated,
     @allocations,
+    @dispatches,
     @lock_conflicts,
 
     # tasks

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -213,7 +213,7 @@ end
 const _mem_units = ["byte", "KiB", "MiB", "GiB", "TiB", "PiB"]
 const _cnt_units = ["", " k", " M", " G", " T", " P"]
 
-# Cost of one runtime dispatch in nanoseconds, as (call-site cache hit, cache miss). These
+# Cost of one dynamic dispatch in nanoseconds, as (call-site cache hit, cache miss). These
 # are measured on first use rather than hardcoded: a hit and a miss differ by an order of
 # magnitude, and both scale with the machine, so any single literal is several times wrong
 # on most hardware. The fallback is only used if measurement gives an implausible answer.
@@ -298,7 +298,7 @@ function _calibrate_loop_ns(v::Vector{Any}, n::Int, reps::Int)
     return Float64(dispatched) - Float64(invoked)
 end
 
-# Estimated nanoseconds spent looking up methods for runtime dispatches. This is a lower
+# Estimated nanoseconds spent looking up methods for dynamic dispatches. This is a lower
 # bound on what the type instability behind them costs: the boxing, the lost inlining and
 # the lost specialization it also causes do not show up in the lookup being measured here.
 function dispatch_time_ns(counts::DispatchCounts)
@@ -363,9 +363,9 @@ end
 function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, dispatch_time=0, dispatches=0, lock_conflicts=0, compile_time=0, recompile_time=0, newline=false;
                     msg::Union{String,Nothing}=nothing)
     timestr = Ryu.writefixed(Float64(elapsedtime/1e9), 6)
-    # Shown as a share of the elapsed time rather than as a count, because a count is not
+    # The share is what says whether the count matters, since a count alone is not
     # interpretable without knowing how much work accompanied it. Unlike the other figures
-    # here this one is estimated rather than measured, hence the `~` and no decimals.
+    # here the share is estimated rather than measured, hence the `~` and no decimals.
     dispatch_pct = elapsedtime > 0 ? 100 * dispatch_time / elapsedtime : 0.0
     # Gate on the rounded value so nothing is ever reported as `~0%`, and on a floor of a
     # few dispatches: over a short enough measurement a single call-cache miss is a whole
@@ -400,7 +400,13 @@ function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, dispatch_t
             if had_allocs || gctime > 0
                 print(io, ", ")
             end
-            print(io, "~", Ryu.writefixed(dispatch_pct, 0), "% dynamic dispatch")
+            dispatches_scaled, md = prettyprint_getunits(dispatches, length(_cnt_units), Int64(1000))
+            if md == 1
+                print(io, Int(dispatches_scaled))
+            else
+                print(io, Ryu.writefixed(Float64(dispatches_scaled), 2), _cnt_units[md])
+            end
+            print(io, " dynamic dispatches: ~", Ryu.writefixed(dispatch_pct, 0), "% time")
         end
         if lock_conflicts > 0
             if had_allocs || gctime > 0 || show_dispatches
@@ -468,13 +474,13 @@ returning the value of the expression. Any time spent garbage collecting (gc), c
 new code, or recompiling invalidated code is shown as a percentage. Any lock conflicts
 where a [`ReentrantLock`](@ref) had to wait are shown as a count.
 
-Time spent on runtime dispatch is shown as an approximate share of the elapsed time, when
-that share reaches one percent. Unlike the other percentages reported here it is estimated,
-from the number of dispatches and a per-dispatch cost measured on this machine, rather than
-measured directly: timing each dispatch would cost several times more than the dispatch. It
-is also a lower bound, since the boxing and lost inlining that come with the type
-instability behind it are not included. See [`@code_warntype`](@ref) and the
-[Performance Tips](@ref man-performance-tips), and [`@dispatches`](@ref) for the raw count.
+The number of dynamic dispatches is shown along with the approximate share of the elapsed
+time they took, when that share reaches one percent. Unlike the other percentages reported
+here the share is estimated, from the count and a per-dispatch cost measured on this machine,
+rather than measured directly: timing each dispatch would cost several times more than the
+dispatch. It is also a lower bound, since the boxing and lost inlining that come with the
+type instability behind it are not included. See [`@code_warntype`](@ref) and the
+[Performance Tips](@ref man-performance-tips).
 
 Optionally provide a description string to print before the time report.
 
@@ -499,7 +505,7 @@ See also [`@showtime`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@
     The reporting of any lock conflicts was added in Julia 1.11.
 
 !!! compat "Julia 1.14"
-    The reporting of runtime dispatches was added in Julia 1.14.
+    The reporting of dynamic dispatches was added in Julia 1.14.
 
 ```julia-repl
 julia> x = rand(10,10);
@@ -569,7 +575,7 @@ end
     @timev "description" expr
 
 This is a verbose version of the `@time` macro. It first prints the same information as
-`@time`, then any non-zero memory allocation counters and the number of runtime dispatches,
+`@time`, then any non-zero memory allocation counters and the number of dynamic dispatches,
 then returns the value of the expression.
 
 Optionally provide a description string to print before the time report.
@@ -829,10 +835,10 @@ end
     @dispatches
 
 A macro to evaluate an expression, discard the resulting value, and instead return the
-number of runtime dispatches performed during evaluation, that is, calls whose method had
+number of dynamic dispatches performed during evaluation, that is, calls whose method had
 to be looked up at run time because the compiler could not resolve them statically.
 
-Runtime dispatch is usually a symptom of type instability, so this is a way to check that
+Dynamic dispatch is usually a symptom of type instability, so this is a way to check that
 code stays statically resolved. Dispatches made by the compiler while inferring or
 generating code are not counted; dispatches made on other threads during the expression are.
 
@@ -882,7 +888,7 @@ A macro to execute an expression, and return the value of the expression, elapse
 total bytes allocated, garbage collection time, an object with various memory allocation
 counters, compilation time in seconds, and recompilation time in seconds. Any lock conflicts
 where a [`ReentrantLock`](@ref) had to wait are shown as a count, as is the number of
-runtime dispatches (see [`@dispatches`](@ref)) and the estimated time they took.
+dynamic dispatches (see [`@dispatches`](@ref)) and the estimated time they took.
 
 In some cases the system will look inside the `@timed` expression and compile some of the
 called code before execution of the top-level expression begins. When that happens, some

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -132,8 +132,18 @@ end
 # total time spent in garbage collection, in nanoseconds
 gc_time_ns() = ccall(:jl_gc_total_hrtime, UInt64, ())
 
-# cumulative number of runtime dispatches, excluding those made by the compiler itself
-dispatch_count() = ccall(:jl_dispatch_count, UInt64, ())
+# This type must be kept in sync with the C struct in src/julia_internal.h
+struct DispatchCounts
+    # Calls whose method had to be looked up at run time. Lookups made by the compiler
+    # itself are not counted.
+    total::UInt64
+    # Of those, the ones that missed the call-site cache and had to search the method
+    # tables, which costs an order of magnitude more than a hit.
+    slow::UInt64
+end
+
+dispatch_counts() = ccall(:jl_dispatch_counts, DispatchCounts, ())
+dispatch_counts_thread() = ccall(:jl_dispatch_counts_thread, DispatchCounts, ())
 
 """
     Base.gc_live_bytes()
@@ -203,11 +213,101 @@ end
 const _mem_units = ["byte", "KiB", "MiB", "GiB", "TiB", "PiB"]
 const _cnt_units = ["", " k", " M", " G", " T", " P"]
 
-# A dispatch count is reported only if it clears both the absolute floor and, at this
-# nominal per-dispatch cost, this share of the elapsed time.
-const DISPATCH_COST_NS = 20
-const DISPATCH_REPORT_MIN = 100
-const DISPATCH_REPORT_FRACTION = 0.01
+# Cost of one runtime dispatch in nanoseconds, as (call-site cache hit, cache miss). These
+# are measured on first use rather than hardcoded: a hit and a miss differ by an order of
+# magnitude, and both scale with the machine, so any single literal is several times wrong
+# on most hardware. The fallback is only used if measurement gives an implausible answer.
+const DISPATCH_COST_FALLBACK = (6.0, 70.0)
+
+# Below this many dispatches the share is not reported however large it computes to be.
+const DISPATCH_REPORT_MIN = 10
+
+# Every probe reads this. Without a mutable load the bodies are constant and effect-free,
+# and inference deletes the statically resolved `invoke` baseline entirely while leaving the
+# dispatched loop intact, so their difference would be the whole call rather than the lookup.
+# The load costs the same in both loops, so it cancels.
+const _dispatch_sink = Ref(0)
+@noinline _dispatch_probe(@nospecialize x) = _dispatch_sink[]
+@noinline _dispatch_probe(x::Int) = _dispatch_sink[] + 1
+@noinline _dispatch_probe(x::Float64) = _dispatch_sink[] + 2
+@noinline _dispatch_probe(x::Char) = _dispatch_sink[] + 3
+@noinline _dispatch_probe(x::Symbol) = _dispatch_sink[] + 4
+@noinline _dispatch_probe(x::String) = _dispatch_sink[] + 5
+@noinline _dispatch_probe(x::Float32) = _dispatch_sink[] + 6
+@noinline _dispatch_probe(x::Nothing) = _dispatch_sink[] + 7
+@noinline _dispatch_probe(x::UInt8) = _dispatch_sink[] + 8
+
+@noinline function _dispatch_probe_loop(v::Vector{Any}, n::Int)
+    s = 0
+    for _ in 1:n, i in eachindex(v)
+        s += _dispatch_probe(v[i])::Int
+    end
+    return s
+end
+
+# The same loop with the method lookup removed, so the difference between the two is the
+# lookup and nothing else: same element loads, same non-inlined call.
+@noinline function _dispatch_invoke_loop(v::Vector{Any}, n::Int)
+    s = 0
+    for _ in 1:n, i in eachindex(v)
+        s += invoke(_dispatch_probe, Tuple{Any}, v[i])::Int
+    end
+    return s
+end
+
+const dispatch_cost = OncePerProcess{Tuple{Float64,Float64}}() do
+    hot = Any[1, 1, 1, 1]                                  # one type, so the cache always hits
+    cold = Any[1, 1.0, 'c', :a, "s", 1.0f0, nothing, 0x1]  # more types than cache slots
+    reps = 15
+    n = 2000
+    for v in (hot, cold)
+        _dispatch_probe_loop(v, 1); _dispatch_invoke_loop(v, 1)
+    end
+    hit = _calibrate_loop_ns(hot, n, reps) / (n * length(hot))
+    # For the miss cost let the counters say exactly how many of the cold loop's dispatches
+    # actually missed, and charge the rest at the hit cost just measured.
+    before = dispatch_counts_thread()
+    cold_ns = _calibrate_loop_ns(cold, n, reps)
+    after = dispatch_counts_thread()
+    per_pass = n * length(cold)
+    misses = (after.slow -% before.slow) / reps
+    # A task that migrated threads mid-calibration, or any other surprise, shows up as a
+    # miss count that cannot have come from this loop.
+    if !(0 < misses <= per_pass)
+        return DISPATCH_COST_FALLBACK
+    end
+    miss = (cold_ns - (per_pass - misses) * hit) / misses
+    if !(isfinite(hit) && isfinite(miss) && hit > 0)
+        return DISPATCH_COST_FALLBACK
+    end
+    return (clamp(hit, 0.5, 200.0), clamp(miss, hit, 5000.0))
+end
+
+# Best-of-`reps` nanoseconds spent on method lookup by one pass of the dispatching loop.
+function _calibrate_loop_ns(v::Vector{Any}, n::Int, reps::Int)
+    dispatched = typemax(UInt64)
+    invoked = typemax(UInt64)
+    for _ in 1:reps
+        local t = time_ns()
+        _dispatch_probe_loop(v, n)
+        dispatched = min(dispatched, time_ns() -% t)
+        t = time_ns()
+        _dispatch_invoke_loop(v, n)
+        invoked = min(invoked, time_ns() -% t)
+    end
+    return Float64(dispatched) - Float64(invoked)
+end
+
+# Estimated nanoseconds spent looking up methods for runtime dispatches. This is a lower
+# bound on what the type instability behind them costs: the boxing, the lost inlining and
+# the lost specialization it also causes do not show up in the lookup being measured here.
+function dispatch_time_ns(counts::DispatchCounts)
+    hit, miss = dispatch_cost()
+    # The two counters are sampled per thread without a lock, so a thread caught between
+    # its total and slow increments can leave slow ahead of total over a short window.
+    slow = min(counts.slow, counts.total)
+    return (counts.total - slow) * hit + slow * miss
+end
 function prettyprint_getunits(value, numunits, factor)
     if value == 0 || value == 1
         return (value, 1)
@@ -260,13 +360,17 @@ function format_bytes(bytes; binary=true) # also used by InteractiveUtils
     end
 end
 
-function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, dispatches=0, lock_conflicts=0, compile_time=0, recompile_time=0, newline=false;
+function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, dispatch_time=0, dispatches=0, lock_conflicts=0, compile_time=0, recompile_time=0, newline=false;
                     msg::Union{String,Nothing}=nothing)
     timestr = Ryu.writefixed(Float64(elapsedtime/1e9), 6)
-    # Almost every timed expression makes a handful of dispatches, so reporting any nonzero
-    # count would be noise rather than signal.
-    show_dispatches = dispatches >= DISPATCH_REPORT_MIN &&
-        DISPATCH_COST_NS * dispatches >= elapsedtime * DISPATCH_REPORT_FRACTION
+    # Shown as a share of the elapsed time rather than as a count, because a count is not
+    # interpretable without knowing how much work accompanied it. Unlike the other figures
+    # here this one is estimated rather than measured, hence the `~` and no decimals.
+    dispatch_pct = elapsedtime > 0 ? 100 * dispatch_time / elapsedtime : 0.0
+    # Gate on the rounded value so nothing is ever reported as `~0%`, and on a floor of a
+    # few dispatches: over a short enough measurement a single call-cache miss is a whole
+    # percent, and every expression makes a dispatch or two.
+    show_dispatches = dispatches >= DISPATCH_REPORT_MIN && round(dispatch_pct) >= 1
     str = sprint() do io
         if msg isa String
             print(io, msg, ": ")
@@ -296,13 +400,7 @@ function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, dispatches
             if had_allocs || gctime > 0
                 print(io, ", ")
             end
-            dispatches_scaled, md = prettyprint_getunits(dispatches, length(_cnt_units), Int64(1000))
-            if md == 1
-                print(io, Int(dispatches_scaled))
-            else
-                print(io, Ryu.writefixed(Float64(dispatches_scaled), 2), _cnt_units[md])
-            end
-            print(io, " dynamic dispatches")
+            print(io, "~", Ryu.writefixed(dispatch_pct, 0), "% dynamic dispatch")
         end
         if lock_conflicts > 0
             if had_allocs || gctime > 0 || show_dispatches
@@ -329,11 +427,11 @@ function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, dispatches
     nothing
 end
 
-function timev_print(elapsedtime, diff::GC_Diff, dispatches, lock_conflicts, compile_times; msg::Union{String,Nothing}=nothing)
+function timev_print(elapsedtime, diff::GC_Diff, dispatches, dispatch_time, lock_conflicts, compile_times; msg::Union{String,Nothing}=nothing)
     allocs = gc_alloc_count(diff)
     compile_time = first(compile_times)
     recompile_time = last(compile_times)
-    time_print(stdout, elapsedtime, diff.allocd, diff.total_time, allocs, dispatches, lock_conflicts, compile_time, recompile_time, true; msg)
+    time_print(stdout, elapsedtime, diff.allocd, diff.total_time, allocs, dispatch_time, dispatches, lock_conflicts, compile_time, recompile_time, true; msg)
     padded_nonzero_print(elapsedtime,       "elapsed time (ns)")
     padded_nonzero_print(diff.total_time,   "gc time (ns)")
     padded_nonzero_print(diff.allocd,       "bytes allocated")
@@ -347,6 +445,7 @@ function timev_print(elapsedtime, diff::GC_Diff, dispatches, lock_conflicts, com
     padded_nonzero_print(minor_collects,    "minor collections")
     padded_nonzero_print(diff.full_sweep,   "full collections")
     padded_nonzero_print(dispatches,        "dynamic dispatches")
+    padded_nonzero_print(round(Int, dispatch_time), "est. dispatch (ns)")
 end
 
 # Like a try-finally block, except without introducing the try scope
@@ -369,12 +468,13 @@ returning the value of the expression. Any time spent garbage collecting (gc), c
 new code, or recompiling invalidated code is shown as a percentage. Any lock conflicts
 where a [`ReentrantLock`](@ref) had to wait are shown as a count.
 
-The number of runtime dispatches is shown when there are enough of them to plausibly
-account for a percent or so of the elapsed time; small counts are not reported, since almost
-every expression makes a few. Runtime dispatch, where the method to call must be looked up
-at run time because the compiler could not resolve it statically, is usually a symptom of
-type instability; see [`@code_warntype`](@ref) and the
-[Performance Tips](@ref man-performance-tips).
+Time spent on runtime dispatch is shown as an approximate share of the elapsed time, when
+that share reaches one percent. Unlike the other percentages reported here it is estimated,
+from the number of dispatches and a per-dispatch cost measured on this machine, rather than
+measured directly: timing each dispatch would cost several times more than the dispatch. It
+is also a lower bound, since the boxing and lost inlining that come with the type
+instability behind it are not included. See [`@code_warntype`](@ref) and the
+[Performance Tips](@ref man-performance-tips), and [`@dispatches`](@ref) for the raw count.
 
 Optionally provide a description string to print before the time report.
 
@@ -438,7 +538,7 @@ macro time(msg, ex)
         local ret = @timed $(esc(ex))
         local _msg = $(esc(msg))
         local _msg_str = _msg === nothing ? _msg : string(_msg)
-        time_print(stdout, ret.time*1e9, ret.gcstats.allocd, ret.gcstats.total_time, gc_alloc_count(ret.gcstats), ret.dispatches, ret.lock_conflicts, ret.compile_time*1e9, ret.recompile_time*1e9, true; msg=_msg_str)
+        time_print(stdout, ret.time*1e9, ret.gcstats.allocd, ret.gcstats.total_time, gc_alloc_count(ret.gcstats), ret.dispatch_time*1e9, ret.dispatches, ret.lock_conflicts, ret.compile_time*1e9, ret.recompile_time*1e9, true; msg=_msg_str)
         ret.value
     end
 end
@@ -511,7 +611,7 @@ macro timev(msg, ex)
         local ret = @timed $(esc(ex))
         local _msg = $(esc(msg))
         local _msg_str = _msg === nothing ? _msg : string(_msg)
-        timev_print(ret.time*1e9, ret.gcstats, ret.dispatches, ret.lock_conflicts, (ret.compile_time*1e9, ret.recompile_time*1e9); msg=_msg_str)
+        timev_print(ret.time*1e9, ret.gcstats, ret.dispatches, ret.dispatch_time*1e9, ret.lock_conflicts, (ret.compile_time*1e9, ret.recompile_time*1e9); msg=_msg_str)
         ret.value
     end
 end
@@ -571,9 +671,9 @@ end
 only(methods(allocations)).called = 0xff
 
 @constprop :none function dispatches(f, args::Vararg{Any,N}) where {N}
-    start = dispatch_count()
+    start = dispatch_counts().total
     @noinline f(args...)
-    return Int(dispatch_count() -% start)
+    return Int(dispatch_counts().total -% start)
 end
 only(methods(dispatches)).called = 0xff
 
@@ -769,9 +869,9 @@ macro dispatches(ex)
     end
     return quote
         Experimental.@force_compile
-        local start = dispatch_count()
+        local start = dispatch_counts().total
         $(esc(ex))
-        Int(dispatch_count() -% start)
+        Int(dispatch_counts().total -% start)
     end
 end
 
@@ -782,7 +882,7 @@ A macro to execute an expression, and return the value of the expression, elapse
 total bytes allocated, garbage collection time, an object with various memory allocation
 counters, compilation time in seconds, and recompilation time in seconds. Any lock conflicts
 where a [`ReentrantLock`](@ref) had to wait are shown as a count, as is the number of
-runtime dispatches (see [`@dispatches`](@ref)).
+runtime dispatches (see [`@dispatches`](@ref)) and the estimated time they took.
 
 In some cases the system will look inside the `@timed` expression and compile some of the
 called code before execution of the top-level expression begins. When that happens, some
@@ -825,20 +925,22 @@ julia> stats.recompile_time
     The `lock_conflicts`, `compile_time`, and `recompile_time` fields were added in Julia 1.11.
 
 !!! compat "Julia 1.14"
-    The `dispatches` field was added in Julia 1.14.
+    The `dispatches` and `dispatch_time` fields were added in Julia 1.14.
 """
 macro timed(ex)
     quote
         Experimental.@force_compile
+        dispatch_cost() # calibrate before the measured region, not inside it
         Threads.lock_profiling(true)
         local lock_conflicts = Threads.LOCK_CONFLICT_COUNT[]
         local stats = gc_num()
         local elapsedtime = time_ns()
         cumulative_compile_timing(true)
         local compile_elapsedtimes = cumulative_compile_time_ns()
-        local dispatches = dispatch_count()
+        local dispatch0 = dispatch_counts()
+        local dispatch1 = dispatch0
         local val = @__tryfinally($(esc(ex)),
-            (dispatches = dispatch_count() -% dispatches;
+            (dispatch1 = dispatch_counts();
             elapsedtime = time_ns() -% elapsedtime;
             cumulative_compile_timing(false);
             compile_elapsedtimes = map(-%, cumulative_compile_time_ns(), compile_elapsedtimes);
@@ -846,13 +948,16 @@ macro timed(ex)
             Threads.lock_profiling(false))
         )
         local diff = GC_Diff(gc_num(), stats)
+        local dispatches = DispatchCounts(dispatch1.total -% dispatch0.total,
+                                          dispatch1.slow -% dispatch0.slow)
         (
             value=val,
             time=elapsedtime/1e9,
             bytes=diff.allocd,
             gctime=diff.total_time/1e9,
             gcstats=diff,
-            dispatches=Int(dispatches),
+            dispatches=Int(dispatches.total),
+            dispatch_time=dispatch_time_ns(dispatches)/1e9,
             lock_conflicts=lock_conflicts,
             compile_time=compile_elapsedtimes[1]/1e9,
             recompile_time=compile_elapsedtimes[2]/1e9

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -132,6 +132,9 @@ end
 # total time spent in garbage collection, in nanoseconds
 gc_time_ns() = ccall(:jl_gc_total_hrtime, UInt64, ())
 
+# cumulative number of runtime dispatches, excluding those made by the compiler itself
+dispatch_count() = ccall(:jl_dispatch_count, UInt64, ())
+
 """
     Base.gc_live_bytes()
 
@@ -199,6 +202,12 @@ end
 # print elapsed time, return expression value
 const _mem_units = ["byte", "KiB", "MiB", "GiB", "TiB", "PiB"]
 const _cnt_units = ["", " k", " M", " G", " T", " P"]
+
+# A dispatch count is reported only if it clears both the absolute floor and, at this
+# nominal per-dispatch cost, this share of the elapsed time.
+const DISPATCH_COST_NS = 20
+const DISPATCH_REPORT_MIN = 100
+const DISPATCH_REPORT_FRACTION = 0.01
 function prettyprint_getunits(value, numunits, factor)
     if value == 0 || value == 1
         return (value, 1)
@@ -251,9 +260,13 @@ function format_bytes(bytes; binary=true) # also used by InteractiveUtils
     end
 end
 
-function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, lock_conflicts=0, compile_time=0, recompile_time=0, newline=false;
+function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, dispatches=0, lock_conflicts=0, compile_time=0, recompile_time=0, newline=false;
                     msg::Union{String,Nothing}=nothing)
     timestr = Ryu.writefixed(Float64(elapsedtime/1e9), 6)
+    # Almost every timed expression makes a handful of dispatches, so reporting any nonzero
+    # count would be noise rather than signal.
+    show_dispatches = dispatches >= DISPATCH_REPORT_MIN &&
+        DISPATCH_COST_NS * dispatches >= elapsedtime * DISPATCH_REPORT_FRACTION
     str = sprint() do io
         if msg isa String
             print(io, msg, ": ")
@@ -261,7 +274,7 @@ function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, lock_confl
             print(io, length(timestr) < 10 ? (" "^(10 - length(timestr))) : "")
         end
         print(io, timestr, " seconds")
-        parens = bytes != 0 || allocs != 0 || gctime > 0 || lock_conflicts > 0 || compile_time > 0
+        parens = bytes != 0 || allocs != 0 || gctime > 0 || show_dispatches || lock_conflicts > 0 || compile_time > 0
         parens && print(io, " (")
         had_allocs = bytes != 0 || allocs != 0
         if had_allocs
@@ -279,15 +292,27 @@ function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, lock_confl
             end
             print(io, Ryu.writefixed(Float64(100*gctime/elapsedtime), 2), "% gc time")
         end
-        if lock_conflicts > 0
+        if show_dispatches
             if had_allocs || gctime > 0
+                print(io, ", ")
+            end
+            dispatches_scaled, md = prettyprint_getunits(dispatches, length(_cnt_units), Int64(1000))
+            if md == 1
+                print(io, Int(dispatches_scaled))
+            else
+                print(io, Ryu.writefixed(Float64(dispatches_scaled), 2), _cnt_units[md])
+            end
+            print(io, " dynamic dispatches")
+        end
+        if lock_conflicts > 0
+            if had_allocs || gctime > 0 || show_dispatches
                 print(io, ", ")
             end
             plural = lock_conflicts == 1 ? "" : "s"
             print(io, lock_conflicts, " lock conflict$plural")
         end
         if compile_time > 0
-            if had_allocs || gctime > 0 || lock_conflicts > 0
+            if had_allocs || gctime > 0 || show_dispatches || lock_conflicts > 0
                 print(io, ", ")
             end
             print(io, Ryu.writefixed(Float64(100*compile_time/elapsedtime), 2), "% compilation time")
@@ -304,11 +329,11 @@ function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, lock_confl
     nothing
 end
 
-function timev_print(elapsedtime, diff::GC_Diff, lock_conflicts, compile_times; msg::Union{String,Nothing}=nothing)
+function timev_print(elapsedtime, diff::GC_Diff, dispatches, lock_conflicts, compile_times; msg::Union{String,Nothing}=nothing)
     allocs = gc_alloc_count(diff)
     compile_time = first(compile_times)
     recompile_time = last(compile_times)
-    time_print(stdout, elapsedtime, diff.allocd, diff.total_time, allocs, lock_conflicts, compile_time, recompile_time, true; msg)
+    time_print(stdout, elapsedtime, diff.allocd, diff.total_time, allocs, dispatches, lock_conflicts, compile_time, recompile_time, true; msg)
     padded_nonzero_print(elapsedtime,       "elapsed time (ns)")
     padded_nonzero_print(diff.total_time,   "gc time (ns)")
     padded_nonzero_print(diff.allocd,       "bytes allocated")
@@ -321,6 +346,7 @@ function timev_print(elapsedtime, diff::GC_Diff, lock_conflicts, compile_times; 
     minor_collects = diff.pause - diff.full_sweep
     padded_nonzero_print(minor_collects,    "minor collections")
     padded_nonzero_print(diff.full_sweep,   "full collections")
+    padded_nonzero_print(dispatches,        "dynamic dispatches")
 end
 
 # Like a try-finally block, except without introducing the try scope
@@ -343,6 +369,13 @@ returning the value of the expression. Any time spent garbage collecting (gc), c
 new code, or recompiling invalidated code is shown as a percentage. Any lock conflicts
 where a [`ReentrantLock`](@ref) had to wait are shown as a count.
 
+The number of runtime dispatches is shown when there are enough of them to plausibly
+account for a percent or so of the elapsed time; small counts are not reported, since almost
+every expression makes a few. Runtime dispatch, where the method to call must be looked up
+at run time because the compiler could not resolve it statically, is usually a symptom of
+type instability; see [`@code_warntype`](@ref) and the
+[Performance Tips](@ref man-performance-tips).
+
 Optionally provide a description string to print before the time report.
 
 In some cases the system will look inside the `@time` expression and compile some of the
@@ -350,7 +383,7 @@ called code before execution of the top-level expression begins. When that happe
 compilation time will not be counted. To include this time you can run `@time @eval ...`.
 
 See also [`@showtime`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@ref),
-[`@allocated`](@ref), and [`@allocations`](@ref).
+[`@allocated`](@ref), [`@allocations`](@ref), and [`@dispatches`](@ref).
 
 !!! note
     For more serious benchmarking, consider the `@btime` macro from the BenchmarkTools.jl
@@ -364,6 +397,9 @@ See also [`@showtime`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@
 
 !!! compat "Julia 1.11"
     The reporting of any lock conflicts was added in Julia 1.11.
+
+!!! compat "Julia 1.14"
+    The reporting of runtime dispatches was added in Julia 1.14.
 
 ```julia-repl
 julia> x = rand(10,10);
@@ -402,7 +438,7 @@ macro time(msg, ex)
         local ret = @timed $(esc(ex))
         local _msg = $(esc(msg))
         local _msg_str = _msg === nothing ? _msg : string(_msg)
-        time_print(stdout, ret.time*1e9, ret.gcstats.allocd, ret.gcstats.total_time, gc_alloc_count(ret.gcstats), ret.lock_conflicts, ret.compile_time*1e9, ret.recompile_time*1e9, true; msg=_msg_str)
+        time_print(stdout, ret.time*1e9, ret.gcstats.allocd, ret.gcstats.total_time, gc_alloc_count(ret.gcstats), ret.dispatches, ret.lock_conflicts, ret.compile_time*1e9, ret.recompile_time*1e9, true; msg=_msg_str)
         ret.value
     end
 end
@@ -433,8 +469,8 @@ end
     @timev "description" expr
 
 This is a verbose version of the `@time` macro. It first prints the same information as
-`@time`, then any non-zero memory allocation counters, and then returns the value of the
-expression.
+`@time`, then any non-zero memory allocation counters and the number of runtime dispatches,
+then returns the value of the expression.
 
 Optionally provide a description string to print before the time report.
 
@@ -442,7 +478,7 @@ Optionally provide a description string to print before the time report.
     The option to add a description was introduced in Julia 1.8.
 
 See also [`@time`](@ref), [`@timed`](@ref), [`@elapsed`](@ref),
-[`@allocated`](@ref), and [`@allocations`](@ref).
+[`@allocated`](@ref), [`@allocations`](@ref), and [`@dispatches`](@ref).
 
 ```julia-repl
 julia> x = rand(10,10);
@@ -475,7 +511,7 @@ macro timev(msg, ex)
         local ret = @timed $(esc(ex))
         local _msg = $(esc(msg))
         local _msg_str = _msg === nothing ? _msg : string(_msg)
-        timev_print(ret.time*1e9, ret.gcstats, ret.lock_conflicts, (ret.compile_time*1e9, ret.recompile_time*1e9); msg=_msg_str)
+        timev_print(ret.time*1e9, ret.gcstats, ret.dispatches, ret.lock_conflicts, (ret.compile_time*1e9, ret.recompile_time*1e9); msg=_msg_str)
         ret.value
     end
 end
@@ -533,6 +569,13 @@ only(methods(allocated)).called = 0xff
     return Base.gc_alloc_count(diff)
 end
 only(methods(allocations)).called = 0xff
+
+@constprop :none function dispatches(f, args::Vararg{Any,N}) where {N}
+    start = dispatch_count()
+    @noinline f(args...)
+    return Int(dispatch_count() -% start)
+end
+only(methods(dispatches)).called = 0xff
 
 function is_simply_call(@nospecialize ex)
     is_simple_atom(a) = a isa QuoteNode || a isa Symbol || !isa_ast_node(a)
@@ -683,19 +726,71 @@ macro lock_conflicts(ex)
 end
 
 """
+    @dispatches
+
+A macro to evaluate an expression, discard the resulting value, and instead return the
+number of runtime dispatches performed during evaluation, that is, calls whose method had
+to be looked up at run time because the compiler could not resolve them statically.
+
+Runtime dispatch is usually a symptom of type instability, so this is a way to check that
+code stays statically resolved. Dispatches made by the compiler while inferring or
+generating code are not counted; dispatches made on other threads during the expression are.
+
+As for [`@allocations`](@ref), if the expression is a function call then the dispatch of the
+call itself is excluded. To include it, use `@dispatches (()->f(1))()`.
+
+See also [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@allocations`](@ref),
+and [`@code_warntype`](@ref).
+
+```julia-repl
+julia> f(x) = sum(x);
+
+julia> @dispatches f([1,2,3])
+0
+
+julia> @dispatches f(Any[1,2,3])
+2
+```
+
+!!! compat "Julia 1.14"
+    This macro was added in Julia 1.14.
+"""
+macro dispatches(ex)
+    # Exclude the dispatch of the call itself, as in `@allocations`.
+    if isexpr(ex, :call)
+        if !is_simply_call(ex)
+            ex = :((() -> $ex)())
+        end
+        pushfirst!(ex.args, GlobalRef(Base, :dispatches))
+        return quote
+            Experimental.@force_compile
+            $(esc(ex))
+        end
+    end
+    return quote
+        Experimental.@force_compile
+        local start = dispatch_count()
+        $(esc(ex))
+        Int(dispatch_count() -% start)
+    end
+end
+
+"""
     @timed
 
 A macro to execute an expression, and return the value of the expression, elapsed time in seconds,
 total bytes allocated, garbage collection time, an object with various memory allocation
 counters, compilation time in seconds, and recompilation time in seconds. Any lock conflicts
-where a [`ReentrantLock`](@ref) had to wait are shown as a count.
+where a [`ReentrantLock`](@ref) had to wait are shown as a count, as is the number of
+runtime dispatches (see [`@dispatches`](@ref)).
 
 In some cases the system will look inside the `@timed` expression and compile some of the
 called code before execution of the top-level expression begins. When that happens, some
 compilation time will not be counted. To include this time you can run `@timed @eval ...`.
 
 See also [`@time`](@ref), [`@timev`](@ref), [`@elapsed`](@ref),
-[`@allocated`](@ref), [`@allocations`](@ref), and [`@lock_conflicts`](@ref).
+[`@allocated`](@ref), [`@allocations`](@ref), [`@lock_conflicts`](@ref), and
+[`@dispatches`](@ref).
 
 ```julia-repl
 julia> stats = @timed rand(10^6);
@@ -728,6 +823,9 @@ julia> stats.recompile_time
 
 !!! compat "Julia 1.11"
     The `lock_conflicts`, `compile_time`, and `recompile_time` fields were added in Julia 1.11.
+
+!!! compat "Julia 1.14"
+    The `dispatches` field was added in Julia 1.14.
 """
 macro timed(ex)
     quote
@@ -738,8 +836,10 @@ macro timed(ex)
         local elapsedtime = time_ns()
         cumulative_compile_timing(true)
         local compile_elapsedtimes = cumulative_compile_time_ns()
+        local dispatches = dispatch_count()
         local val = @__tryfinally($(esc(ex)),
-            (elapsedtime = time_ns() -% elapsedtime;
+            (dispatches = dispatch_count() -% dispatches;
+            elapsedtime = time_ns() -% elapsedtime;
             cumulative_compile_timing(false);
             compile_elapsedtimes = map(-%, cumulative_compile_time_ns(), compile_elapsedtimes);
             lock_conflicts = Threads.LOCK_CONFLICT_COUNT[] - lock_conflicts;
@@ -752,6 +852,7 @@ macro timed(ex)
             bytes=diff.allocd,
             gctime=diff.total_time/1e9,
             gcstats=diff,
+            dispatches=Int(dispatches),
             lock_conflicts=lock_conflicts,
             compile_time=compile_elapsedtimes[1]/1e9,
             recompile_time=compile_elapsedtimes[2]/1e9

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -479,7 +479,7 @@ time they took, when that share reaches one percent. Unlike the other percentage
 here the share is estimated, from the count and a per-dispatch cost measured on this machine,
 rather than measured directly: timing each dispatch would cost several times more than the
 dispatch. It is also a lower bound, since the boxing and lost inlining that come with the
-type instability behind it are not included. See [`@code_warntype`](@ref) and the
+type instability behind it are not included. See [`InteractiveUtils.@code_warntype`](@ref) and the
 [Performance Tips](@ref man-performance-tips).
 
 Optionally provide a description string to print before the time report.
@@ -846,7 +846,7 @@ As for [`@allocations`](@ref), if the expression is a function call then the dis
 call itself is excluded. To include it, use `@dispatches (()->f(1))()`.
 
 See also [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@allocations`](@ref),
-and [`@code_warntype`](@ref).
+and [`InteractiveUtils.@code_warntype`](@ref).
 
 ```julia-repl
 julia> f(x) = sum(x);

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -383,6 +383,7 @@ Base.@timed
 Base.@elapsed
 Base.@allocated
 Base.@allocations
+Base.@dispatches
 Base.@lock_conflicts
 Base.TRACE_EVAL
 Base.EnvDict

--- a/src/gf.c
+++ b/src/gf.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include "julia.h"
 #include "julia_internal.h"
+#include "threading.h"
 #ifndef _OS_WINDOWS_
 #include <unistd.h>
 #endif
@@ -4824,12 +4825,36 @@ jl_method_instance_t *jl_apply_lookup(jl_value_t **args, size_t nargs, size_t wo
 
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint32_t nargs)
 {
-    size_t world = jl_current_task->world_age;
+    jl_task_t *ct = jl_current_task;
+    size_t world = ct->world_age;
+    // Inference is Julia code and dispatches heavily, so counting while this task is
+    // inside the compiler would swamp whatever the caller is actually measuring.
+    if (ct->reentrant_timing == 0) {
+        jl_ptls_t ptls = ct->ptls;
+        jl_atomic_store_relaxed(&ptls->dispatch_count,
+                jl_atomic_load_relaxed(&ptls->dispatch_count) + 1);
+    }
     jl_method_instance_t *mfunc = jl_lookup_generic_(F, args, nargs,
                                                      jl_int32hash_fast(jl_return_address()),
                                                      world, 1);
     JL_GC_PROMISE_ROOTED(mfunc);
     return _jl_invoke(F, args, nargs, mfunc, world, TRIGGER_DISPATCH);
+}
+
+// Total number of runtime dispatches since the process started. Threads that
+// have exited keep their `jl_all_tls_states` slot, so this only ever grows.
+JL_DLLEXPORT uint64_t jl_dispatch_count(void)
+{
+    uint64_t count = 0;
+    int nthreads = jl_atomic_load_acquire(&jl_n_threads);
+    jl_ptls_t *allstates = jl_atomic_load_relaxed(&jl_all_tls_states);
+    for (int i = 0; i < nthreads; i++) {
+        jl_ptls_t ptls = allstates[i];
+        if (ptls == NULL)
+            continue;
+        count += jl_atomic_load_relaxed(&ptls->dispatch_count);
+    }
+    return count;
 }
 
 // buggy way to lookup a method given a list of arguments

--- a/src/gf.c
+++ b/src/gf.c
@@ -4678,9 +4678,16 @@ void call_cache_stats()
 }
 #endif
 
+// `count_ptls` is the caller's ptls when this lookup should be counted for `@time`, and
+// NULL otherwise. It is a parameter rather than a lookup here so that the caller's decision
+// (is this a real call, is this task inside the compiler) is made once, at the call site.
 STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t **args, uint32_t nargs,
-                                                       uint32_t callsite, size_t world, int for_call) JL_CANSAFEPOINT
+                                                       uint32_t callsite, size_t world, int for_call,
+                                                       jl_ptls_t count_ptls) JL_CANSAFEPOINT
 {
+    if (count_ptls)
+        jl_atomic_store_relaxed(&count_ptls->dispatch_count,
+                jl_atomic_load_relaxed(&count_ptls->dispatch_count) + 1);
 #ifdef JL_GF_PROFILE
     ncalls++;
 #endif
@@ -4737,6 +4744,9 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
     i = 4;
     if (i == 4) {
         // if no method was found in the associative cache, check the full cache
+        if (count_ptls)
+            jl_atomic_store_relaxed(&count_ptls->dispatch_slow_count,
+                    jl_atomic_load_relaxed(&count_ptls->dispatch_slow_count) + 1);
         JL_TIMING(METHOD_LOOKUP_FAST, METHOD_LOOKUP_FAST);
         jl_methcache_t *mc = jl_method_table->cache;
         jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
@@ -4820,7 +4830,7 @@ jl_method_instance_t *jl_apply_lookup(jl_value_t **args, size_t nargs, size_t wo
 {
     assert(nargs);
     return jl_lookup_generic_(args[0], &args[1], nargs - 1,
-            jl_int32hash_fast(jl_return_address()), world, 0);
+            jl_int32hash_fast(jl_return_address()), world, 0, NULL);
 }
 
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint32_t nargs)
@@ -4829,32 +4839,40 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint
     size_t world = ct->world_age;
     // Inference is Julia code and dispatches heavily, so counting while this task is
     // inside the compiler would swamp whatever the caller is actually measuring.
-    if (ct->reentrant_timing == 0) {
-        jl_ptls_t ptls = ct->ptls;
-        jl_atomic_store_relaxed(&ptls->dispatch_count,
-                jl_atomic_load_relaxed(&ptls->dispatch_count) + 1);
-    }
+    jl_ptls_t count_ptls = ct->reentrant_timing == 0 ? ct->ptls : NULL;
     jl_method_instance_t *mfunc = jl_lookup_generic_(F, args, nargs,
                                                      jl_int32hash_fast(jl_return_address()),
-                                                     world, 1);
+                                                     world, 1, count_ptls);
     JL_GC_PROMISE_ROOTED(mfunc);
     return _jl_invoke(F, args, nargs, mfunc, world, TRIGGER_DISPATCH);
 }
 
-// Total number of runtime dispatches since the process started. Threads that
-// have exited keep their `jl_all_tls_states` slot, so this only ever grows.
-JL_DLLEXPORT uint64_t jl_dispatch_count(void)
+// Runtime dispatches since the process started, and how many of them missed the call-site
+// cache. Threads that have exited keep their `jl_all_tls_states` slot, so these only grow.
+JL_DLLEXPORT jl_dispatch_counts_t jl_dispatch_counts(void)
 {
-    uint64_t count = 0;
+    jl_dispatch_counts_t counts = {0, 0};
     int nthreads = jl_atomic_load_acquire(&jl_n_threads);
     jl_ptls_t *allstates = jl_atomic_load_relaxed(&jl_all_tls_states);
     for (int i = 0; i < nthreads; i++) {
         jl_ptls_t ptls = allstates[i];
         if (ptls == NULL)
             continue;
-        count += jl_atomic_load_relaxed(&ptls->dispatch_count);
+        counts.total += jl_atomic_load_relaxed(&ptls->dispatch_count);
+        counts.slow += jl_atomic_load_relaxed(&ptls->dispatch_slow_count);
     }
-    return count;
+    return counts;
+}
+
+// Just this thread's counters. Calibration uses these rather than the process-wide totals
+// so that dispatches on other threads cannot be charged to the loop it is timing.
+JL_DLLEXPORT jl_dispatch_counts_t jl_dispatch_counts_thread(void)
+{
+    jl_ptls_t ptls = jl_current_task->ptls;
+    jl_dispatch_counts_t counts;
+    counts.total = jl_atomic_load_relaxed(&ptls->dispatch_count);
+    counts.slow = jl_atomic_load_relaxed(&ptls->dispatch_slow_count);
+    return counts;
 }
 
 // buggy way to lookup a method given a list of arguments

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1465,6 +1465,15 @@ JL_DLLEXPORT extern jl_value_t *(*const jl_rettype_inferred_addr)(jl_method_inst
 JL_DLLEXPORT void jl_force_trace_compile_timing_enable(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_force_trace_compile_timing_disable(void) JL_NOTSAFEPOINT;
 
+// Runtime dispatch counters for `@time`. Must be kept in sync with `DispatchCounts` in
+// base/timing.jl.
+typedef struct {
+    uint64_t total;
+    uint64_t slow;
+} jl_dispatch_counts_t;
+JL_DLLEXPORT jl_dispatch_counts_t jl_dispatch_counts(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_dispatch_counts_t jl_dispatch_counts_thread(void) JL_NOTSAFEPOINT;
+
 JL_DLLEXPORT void jl_force_trace_dispatch_enable(void);
 JL_DLLEXPORT void jl_force_trace_dispatch_disable(void);
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -296,6 +296,9 @@ typedef struct _jl_tls_states_t {
     // currently-held locks, to be released when an exception is thrown
     small_arraylist_t locks;
     size_t engine_nqueued;
+    // Number of runtime dispatches made by this thread, excluding the compiler's own
+    // (never reset by the runtime; `jl_dispatch_count` sums this across threads)
+    _Atomic(uint64_t) dispatch_count;
 
     JULIA_DEBUG_SLEEPWAKE(
         uint64_t uv_run_enter;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -296,9 +296,12 @@ typedef struct _jl_tls_states_t {
     // currently-held locks, to be released when an exception is thrown
     small_arraylist_t locks;
     size_t engine_nqueued;
-    // Number of runtime dispatches made by this thread, excluding the compiler's own
-    // (never reset by the runtime; `jl_dispatch_count` sums this across threads)
+    // Runtime dispatches made by this thread, excluding the compiler's own. `slow` counts
+    // the subset that missed the call-site cache and had to search the method tables, which
+    // costs an order of magnitude more than a hit.
+    // (never reset by the runtime; `jl_dispatch_counts` sums these across threads)
     _Atomic(uint64_t) dispatch_count;
+    _Atomic(uint64_t) dispatch_slow_count;
 
     JULIA_DEBUG_SLEEPWAKE(
         uint64_t uv_run_enter;

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -385,16 +385,18 @@ end
 @test sprint(Base.time_print, 1e9) == "  1.000000 seconds"
 @test sprint(Base.time_print, 1e9, 111, 0, 222) == "  1.000000 seconds (222 allocations: 111 bytes)"
 @test sprint(Base.time_print, 1e9, 111, 0.5e9, 222) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time)"
-@test sprint(Base.time_print, 1e9, 111, 0, 222, 0, 333) == "  1.000000 seconds (222 allocations: 111 bytes, 333 lock conflicts)"
-@test sprint(Base.time_print, 1e9, 0, 0, 0, 0, 333) == "  1.000000 seconds (333 lock conflicts)"
-@test sprint(Base.time_print, 1e9, 111, 0, 222, 0, 333, 0.25e9) == "  1.000000 seconds (222 allocations: 111 bytes, 333 lock conflicts, 25.00% compilation time)"
-@test sprint(Base.time_print, 1e9, 111, 0.5e9, 222, 0, 333, 0.25e9, 0.175e9) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time, 333 lock conflicts, 25.00% compilation time: 70% of which was recompilation)"
-# dispatch counts are only reported once they could account for ~1% of the elapsed time
-@test sprint(Base.time_print, 1e9, 0, 0, 0, 99) == "  1.000000 seconds"
-@test sprint(Base.time_print, 1e9, 0, 0, 0, 500) == "  1.000000 seconds"
-@test sprint(Base.time_print, 1e6, 0, 0, 0, 500) == "  0.001000 seconds (500 dynamic dispatches)"
-@test sprint(Base.time_print, 1e9, 0, 0, 0, 3_400_000) == "  1.000000 seconds (3.40 M dynamic dispatches)"
-@test sprint(Base.time_print, 1e9, 111, 0.5e9, 222, 3_400_000, 333, 0.25e9, 0.175e9) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time, 3.40 M dynamic dispatches, 333 lock conflicts, 25.00% compilation time: 70% of which was recompilation)"
+@test sprint(Base.time_print, 1e9, 111, 0, 222, 0, 0, 333) == "  1.000000 seconds (222 allocations: 111 bytes, 333 lock conflicts)"
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 0, 0, 333) == "  1.000000 seconds (333 lock conflicts)"
+@test sprint(Base.time_print, 1e9, 111, 0, 222, 0, 0, 333, 0.25e9) == "  1.000000 seconds (222 allocations: 111 bytes, 333 lock conflicts, 25.00% compilation time)"
+@test sprint(Base.time_print, 1e9, 111, 0.5e9, 222, 0, 0, 333, 0.25e9, 0.175e9) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time, 333 lock conflicts, 25.00% compilation time: 70% of which was recompilation)"
+# estimated dispatch time is reported as a share of elapsed, once it rounds to >=1% and
+# enough dispatches happened for that share to mean anything
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 1e6, 1000) == "  1.000000 seconds"
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 5e6, 1000) == "  1.000000 seconds"   # 0.5% rounds to 0
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 6e6, 1000) == "  1.000000 seconds (~1% dynamic dispatch)"
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 6e6, 9) == "  1.000000 seconds"      # too few to report
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 2.4e8, 1000) == "  1.000000 seconds (~24% dynamic dispatch)"
+@test sprint(Base.time_print, 1e9, 111, 0.5e9, 222, 2.4e8, 1000, 333, 0.25e9, 0.175e9) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time, ~24% dynamic dispatch, 333 lock conflicts, 25.00% compilation time: 70% of which was recompilation)"
 
 # @showtime
 @test @showtime true
@@ -1607,6 +1609,13 @@ end
     @test (@dispatches stable_dispatch_test()) == 0
     @test (@dispatches unstable_dispatch_test()) > 0
     @test (@timed unstable_dispatch_test()).dispatches > 0
+    @test (@timed unstable_dispatch_test()).dispatch_time > 0
+    # the call-cache miss cost must come out above the hit cost for the estimate to mean
+    # anything, and both must be plausible for a method lookup
+    let (hit, miss) = Base.dispatch_cost()
+        @test 0.5 <= hit <= 200.0
+        @test hit <= miss <= 5000.0
+    end
     # the dispatches inference itself makes are not attributed to the code being measured,
     # so compiling a fresh method does not swamp the count
     let f = @eval $(gensym())(x) = x + 1

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -393,10 +393,11 @@ end
 # enough dispatches happened for that share to mean anything
 @test sprint(Base.time_print, 1e9, 0, 0, 0, 1e6, 1000) == "  1.000000 seconds"
 @test sprint(Base.time_print, 1e9, 0, 0, 0, 5e6, 1000) == "  1.000000 seconds"   # 0.5% rounds to 0
-@test sprint(Base.time_print, 1e9, 0, 0, 0, 6e6, 1000) == "  1.000000 seconds (~1% dynamic dispatch)"
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 6e6, 1000) == "  1.000000 seconds (1000 dynamic dispatches: ~1% time)"
 @test sprint(Base.time_print, 1e9, 0, 0, 0, 6e6, 9) == "  1.000000 seconds"      # too few to report
-@test sprint(Base.time_print, 1e9, 0, 0, 0, 2.4e8, 1000) == "  1.000000 seconds (~24% dynamic dispatch)"
-@test sprint(Base.time_print, 1e9, 111, 0.5e9, 222, 2.4e8, 1000, 333, 0.25e9, 0.175e9) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time, ~24% dynamic dispatch, 333 lock conflicts, 25.00% compilation time: 70% of which was recompilation)"
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 2.4e8, 1000) == "  1.000000 seconds (1000 dynamic dispatches: ~24% time)"
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 2.4e8, 1460) == "  1.000000 seconds (1.46 k dynamic dispatches: ~24% time)"
+@test sprint(Base.time_print, 1e9, 111, 0.5e9, 222, 2.4e8, 1000, 333, 0.25e9, 0.175e9) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time, 1000 dynamic dispatches: ~24% time, 333 lock conflicts, 25.00% compilation time: 70% of which was recompilation)"
 
 # @showtime
 @test @showtime true
@@ -1602,7 +1603,7 @@ end
     '`, String)))
     @test _lock_conflicts > 0 skip=(_nthreads < 2) # can only test if the worker can multithread
 
-    # runtime dispatch counting
+    # dynamic dispatch counting
     stable_dispatch_test() = sum(Int[1, 2, 3])
     unstable_dispatch_test() = sum(Any[1, 2, 3])
     stable_dispatch_test(); unstable_dispatch_test() # compile before measuring

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -385,10 +385,16 @@ end
 @test sprint(Base.time_print, 1e9) == "  1.000000 seconds"
 @test sprint(Base.time_print, 1e9, 111, 0, 222) == "  1.000000 seconds (222 allocations: 111 bytes)"
 @test sprint(Base.time_print, 1e9, 111, 0.5e9, 222) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time)"
-@test sprint(Base.time_print, 1e9, 111, 0, 222, 333) == "  1.000000 seconds (222 allocations: 111 bytes, 333 lock conflicts)"
-@test sprint(Base.time_print, 1e9, 0, 0, 0, 333) == "  1.000000 seconds (333 lock conflicts)"
-@test sprint(Base.time_print, 1e9, 111, 0, 222, 333, 0.25e9) == "  1.000000 seconds (222 allocations: 111 bytes, 333 lock conflicts, 25.00% compilation time)"
-@test sprint(Base.time_print, 1e9, 111, 0.5e9, 222, 333, 0.25e9, 0.175e9) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time, 333 lock conflicts, 25.00% compilation time: 70% of which was recompilation)"
+@test sprint(Base.time_print, 1e9, 111, 0, 222, 0, 333) == "  1.000000 seconds (222 allocations: 111 bytes, 333 lock conflicts)"
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 0, 333) == "  1.000000 seconds (333 lock conflicts)"
+@test sprint(Base.time_print, 1e9, 111, 0, 222, 0, 333, 0.25e9) == "  1.000000 seconds (222 allocations: 111 bytes, 333 lock conflicts, 25.00% compilation time)"
+@test sprint(Base.time_print, 1e9, 111, 0.5e9, 222, 0, 333, 0.25e9, 0.175e9) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time, 333 lock conflicts, 25.00% compilation time: 70% of which was recompilation)"
+# dispatch counts are only reported once they could account for ~1% of the elapsed time
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 99) == "  1.000000 seconds"
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 500) == "  1.000000 seconds"
+@test sprint(Base.time_print, 1e6, 0, 0, 0, 500) == "  0.001000 seconds (500 dynamic dispatches)"
+@test sprint(Base.time_print, 1e9, 0, 0, 0, 3_400_000) == "  1.000000 seconds (3.40 M dynamic dispatches)"
+@test sprint(Base.time_print, 1e9, 111, 0.5e9, 222, 3_400_000, 333, 0.25e9, 0.175e9) == "  1.000000 seconds (222 allocations: 111 bytes, 50.00% gc time, 3.40 M dynamic dispatches, 333 lock conflicts, 25.00% compilation time: 70% of which was recompilation)"
 
 # @showtime
 @test @showtime true
@@ -1593,6 +1599,19 @@ end
         _lock_conflicts,Threads.nthreads()
     '`, String)))
     @test _lock_conflicts > 0 skip=(_nthreads < 2) # can only test if the worker can multithread
+
+    # runtime dispatch counting
+    stable_dispatch_test() = sum(Int[1, 2, 3])
+    unstable_dispatch_test() = sum(Any[1, 2, 3])
+    stable_dispatch_test(); unstable_dispatch_test() # compile before measuring
+    @test (@dispatches stable_dispatch_test()) == 0
+    @test (@dispatches unstable_dispatch_test()) > 0
+    @test (@timed unstable_dispatch_test()).dispatches > 0
+    # the dispatches inference itself makes are not attributed to the code being measured,
+    # so compiling a fresh method does not swamp the count
+    let f = @eval $(gensym())(x) = x + 1
+        @test (@dispatches f(1)) < 100
+    end
 
     # Test the output of `format_bytes()`
     inputs = [(factor * (Int64(1000)^e),binary) for binary in (false,true), factor in (1,2), e in 0:6][:]


### PR DESCRIPTION
An idea for exposing type instability etc.

Claude:

---

`@time` reports allocations, gc and compilation time, but nothing about dynamic dispatch,
which is usually what a type instability actually costs. This counts `jl_apply_generic` calls
per thread and reports them with the share of elapsed time they took.

```julia-repl
julia> x = rand(1000); y = Any[i for i in 1:1000];

julia> @time sum(x)
  0.000003 seconds (1 allocation: 16 bytes)

julia> @time sum(y)
  0.000025 seconds (969 allocations: 15.141 KiB, 1000 dynamic dispatches: ~22% time)
```

The share is what says whether the count matters, since a count alone means nothing without
knowing how much work accompanied it. It is estimated, hence the `~`: timing each dispatch would cost several times
the dispatch itself, so the per-dispatch cost is instead measured once per process, separately
for call-site cache hits and misses (6ns and 28ns here, 8ms to measure).

Dispatches made while a task is inside the compiler are excluded, so a first call reports its
own rather than inference's.

`@timev` also reports the estimated time in nanoseconds, `@timed` returns `dispatches` and `dispatch_time`, and
the new `@dispatches` macro returns just the count, which makes `@test (@dispatches f(x)) == 0`
a type stability regression test.

The counter is per thread rather than one global atomic, since `jl_apply_generic` is too hot
for a shared cache line; A/B with the increment compiled out puts it below the noise floor
(5.53 against 5.52ns, best of 5, macOS aarch64).

