### PR TITLE
Markdown: accept any integer header level

### DIFF
--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -43,7 +43,7 @@ mutable struct Header{level} <: MarkdownElement
     text
 end
 
-Header(s, level::Int) = Header{level}(s)
+Header(s, level::Integer) = Header{Int(level)}(s)
 Header(s) = Header(s, 1)
 
 @breaking true ->

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1789,7 +1789,5 @@ include("test_spec_html_github.jl")
 include("test_spec_html_julia.jl")
 
 @testset "Header accepts any integer level" begin
-    # `Header{Int32(2)}` and `Header{2}` are distinct types that print identically, so the
-    # level has to be canonicalized rather than merely accepted.
     @test Markdown.Header("x", Int32(2)) isa Markdown.Header{2}
 end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1787,3 +1787,9 @@ include("test_spec_roundtrip_julia.jl")
 include("test_spec_html_common.jl")
 include("test_spec_html_github.jl")
 include("test_spec_html_julia.jl")
+
+@testset "Header accepts any integer level" begin
+    # `Header{Int32(2)}` and `Header{2}` are distinct types that print identically, so the
+    # level has to be canonicalized rather than merely accepted.
+    @test Markdown.Header("x", Int32(2)) isa Markdown.Header{2}
+end


### PR DESCRIPTION
Fixes #62931 by automatically converting `Integer`s to `Int`.