### PR TITLE
precompile: don't re-infer image-compiled callees when generating a pkgimage

### DIFF
--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -435,7 +435,7 @@ function compile_and_emit_native(worlds::Vector{UInt},
     # list for codegen, plus the ordered CodeInstances to place in the method
     # caches of the output image.
     result = try
-        typeinf_ext_toplevel(tocompile, worlds, trim_mode)
+        typeinf_ext_toplevel(tocompile, worlds, trim_mode; external_linkage)
     catch exc
         # Handle trimming failures
         isa(exc, Core.TrimFailure) || rethrow()

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1602,6 +1602,19 @@ function ci_has_invoke(code::CodeInstance)
     return (@atomic :monotonic code.invoke) !== C_NULL
 end
 
+# mirrors JL_CI_FLAGS_FROM_IMAGE in julia.h
+const CI_FLAGS_FROM_IMAGE = 0x04
+
+"""
+    ci_has_image_code(code::CodeInstance)
+
+Whether `code` already has native code in a loaded system or package image.
+"""
+function ci_has_image_code(code::CodeInstance)
+    ((@atomic :acquire code.flags) & CI_FLAGS_FROM_IMAGE) === 0x00 && return false
+    return ci_has_invoke(code)
+end
+
 function ci_meets_requirement(interp::AbstractInterpreter, code::CodeInstance, source_mode::UInt8)
     source_mode == SOURCE_MODE_NOT_REQUIRED && return true
     source_mode == SOURCE_MODE_ABI && return ci_has_abi(interp, code)
@@ -2075,6 +2088,7 @@ end
 function compile!(codeinfos::Vector{Any}, workqueue::CompilationQueue;
     invokelatest_queue::Union{CompilationQueue,Nothing} = nothing,
     enqueue_unprepared_invokes::Bool = false,
+    skip_image_code::Bool = false,
 )
     interp = workqueue.interp
     world = get_inference_world(interp)
@@ -2088,6 +2102,13 @@ function compile!(codeinfos::Vector{Any}, workqueue::CompilationQueue;
             # and this is either the primary world, or not applicable in the primary world
             # then we want to compile and emit this
             if item.def.primary_world <= world
+                if skip_image_code
+                    cached = get(code_cache(interp), item, nothing)
+                    if cached isa CodeInstance && ci_has_image_code(cached)
+                        markinspected!(workqueue, item)
+                        continue
+                    end
+                end
                 ci = typeinf_ext(interp, item, SOURCE_MODE_GET_SOURCE)
                 ci isa CodeInstance && push!(workqueue, ci)
             end
@@ -2110,6 +2131,13 @@ function compile!(codeinfos::Vector{Any}, workqueue::CompilationQueue;
             isinspected(workqueue, callee) && continue
             mi = get_ci_mi(callee)
             if !has_valid_abi_sparams(mi)
+                markinspected!(workqueue, callee)
+                continue
+            end
+            if skip_image_code && ci_has_image_code(callee)
+                # Already compiled into a loaded image, so codegen calls that code directly
+                # (see `jl_emit_native`). Obtaining source here would only re-run inference,
+                # since images do not retain it.
                 markinspected!(workqueue, callee)
                 continue
             end
@@ -2160,11 +2188,16 @@ const TRIM_NO = 0x0
 const TRIM_SAFE = 0x1
 const TRIM_UNSAFE = 0x2
 const TRIM_UNSAFE_WARN = 0x3
-function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim_mode::UInt8)
+function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim_mode::UInt8;
+                              external_linkage::Bool = false)
     # During `--trim`, infer against an isolated cache namespace. The owner is re-stamped
     # back to `nothing` at serialization time (see `src/staticdata.c`).
     cache_owner = trim_mode == TRIM_NO ? nothing : :trim
     inf_params = InferenceParams(; force_enable_inference = trim_mode != TRIM_NO, cache_owner)
+    # A package image can call code that is already compiled into other images, so
+    # there is no need to fetch (and for sysimage code, re-infer) source for it.
+    # Trimmed and system images must contain everything they call.
+    skip_image_code = external_linkage && trim_mode == TRIM_NO
 
     # Create an "invokelatest" queue to enable eager compilation of speculative
     # invokelatest calls such as from `Core.finalizer` and `ccallable`
@@ -2180,14 +2213,14 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim_m
         )
 
         append!(workqueue, methods)
-        compile!(codeinfos, workqueue; invokelatest_queue,
+        compile!(codeinfos, workqueue; invokelatest_queue, skip_image_code,
                  enqueue_unprepared_invokes = trim_mode != TRIM_NO)
     end
 
     if invokelatest_queue !== nothing
         # This queue is intentionally aliased, to handle e.g. a `finalizer` calling `Core.finalizer`
         # (it will enqueue into itself and immediately drain)
-        compile!(codeinfos, invokelatest_queue; invokelatest_queue,
+        compile!(codeinfos, invokelatest_queue; invokelatest_queue, skip_image_code,
                  enqueue_unprepared_invokes = trim_mode != TRIM_NO)
     end
 

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7662,6 +7662,21 @@ let code = Compiler.typeinf_ext_toplevel(Any[Core.svec(Any,Tuple{typeof(tt57873)
     #   @ Main REPL[1]:4
 end
 
+# generating a package image must not re-infer or emit callees that are already
+# compiled into a loaded image (JuliaLang/julia#62934)
+let
+    f62934(p::String) = (isfile(p), Base.homedir())
+    mi = Compiler.specialize_method(only(methods(f62934)), Tuple{typeof(f62934), String}, Core.svec())
+    world = Base.get_world_counter()
+    cis(out) = Core.CodeInstance[x for x in (out isa Core.SimpleVector ? out[1] : out) if x isa Core.CodeInstance]
+    all_cis = cis(Compiler.typeinf_ext_toplevel(Any[mi], UInt[world], Compiler.TRIM_NO))
+    @test any(Compiler.ci_has_image_code, all_cis)
+    pkg_cis = cis(Compiler.typeinf_ext_toplevel(Any[mi], UInt[world], Compiler.TRIM_NO; external_linkage=true))
+    @test length(pkg_cis) == 1
+    @test Compiler.get_ci_mi(only(pkg_cis)) === mi
+    @test !any(Compiler.ci_has_image_code, pkg_cis)
+end
+
 function ss57873(a::Vector{String}, pref)
     ret = String[]
     for j in a


### PR DESCRIPTION
Seems when generating pkgimages we're re-interring stuff that's already in loaded images. Developed with Fable, passed review by Sol. 

Claude:

---

Since #59361, pkgimage worklists pass through `typeinf_ext_toplevel`, where `compile!` recursively enqueues each `:invoke` target and requests its source. Sysimage source IR is no longer retained (#58172, #58662), so this needlessly re-infers image callees; master then discards the result under external linkage (JL_CI_FLAGS_FROM_IMAGE, #60031), while 1.13's older emit path additionally emits some of it as redundant copies in the image. This change skips those callees when building untrimmed package images.

Codegen continues to call skipped callees through their image fptr. Trimmed and system images are unaffected because they must contain everything they call.

Measured on `backports-release-1.13` (1.13.0-rc3.32), macOS aarch64, with a cold `compiled/` directory for each run:

| | before | after | 1.12.7 |
|---|---:|---:|---:|
| `Base.compilecache(Preferences)` | 0.658s | 0.253s | 0.31s |
| `Pkg.precompile()`, Static | 10.01s | 5.11s | 7.0s |
| `Pkg.precompile()`, ComponentArrays tree | 13.32s | 7.61s | 9.5-10.2s |
| Preferences image size | 317,824 B | 256,768 B | 256,800 B |

The Preferences image returns to the 1.12 shape: non-specsig image callees use `tojlinvoke` instead of receiving a local `japi1_` copy. Package load and first-call times for the ComponentArrays and ShareAdd tasks are unchanged.

This should be backported to 1.13, where the regression first appears.

