### PR TITLE
build: add JULIA_RELEASE_BUILD for tag-independent release builds

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -266,8 +266,23 @@ else
 JULIA_COMMIT := $(JULIA_VERSION)
 endif
 
-# Override `JULIA_COMMIT` to `JULIA_VERSION` if we're on a tagged commit
-ifeq ($(shell git -C $(JULIAHOME) describe --tags --exact-match > /dev/null 2>&1 && echo true),true)
+# JULIA_RELEASE_BUILD=1 declares this build to be the release build of
+# $(JULIA_VERSION), independent of whether the v$(JULIA_VERSION) git tag exists:
+# the release pipeline builds and validates the artifacts first and creates the
+# tag last. It forces the same naming (here) and `tagged_commit` state
+# (base/version_git.sh) that building from the tag would produce.
+JULIA_RELEASE_BUILD ?= 0
+ifeq ($(JULIA_RELEASE_BUILD),1)
+ifneq (,$(findstring DEV,$(JULIA_VERSION))$(findstring pre,$(JULIA_VERSION)))
+$(error JULIA_RELEASE_BUILD=1 requires a releasable VERSION, got "$(JULIA_VERSION)")
+endif
+endif
+
+# Override `JULIA_COMMIT` to `JULIA_VERSION` for a declared release build or a
+# checkout of the release tag itself
+ifeq ($(JULIA_RELEASE_BUILD),1)
+JULIA_COMMIT := $(JULIA_VERSION)
+else ifeq ($(shell git -C $(JULIAHOME) describe --tags --exact-match > /dev/null 2>&1 && echo true),true)
 JULIA_COMMIT := $(JULIA_VERSION)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -212,16 +212,17 @@ release-candidate: release testall
 	@echo 3. Bump VERSION
 	@echo 4. Increase SOMAJOR and SOMINOR if needed.
 	@echo 5. Update SPDX document by running the script contrib/updateSPDX.jl
-	@echo 6. Create tag, push to github "\(git tag v\`cat VERSION\` && git push --tags\)"		#"` # These comments deal with incompetent syntax highlighting rules
-	@echo 7. Clean out old .tar.gz files living in deps/, "\`git clean -fdx\`" seems to work	#"`
-	@echo 8. Replace github release tarball with tarballs created from make light-source-dist and make full-source-dist with USE_BINARYBUILDER=0
-	@echo 9. Check that 'make && make install && make test' succeed with unpacked tarballs even without Internet access.
-	@echo 10. Follow packaging instructions in doc/src/devdocs/build/distributing.md to create binary packages for all platforms
-	@echo 11. Upload to AWS, update https://julialang.org/downloads and https://status.julialang.org/stable links
-	@echo 12. Update checksums on AWS for tarball and packaged binaries
-	@echo 13. Update versions.json. Wait at least 60 minutes before proceeding to step 14.
-	@echo 14. Push to Juliaup (https://github.com/JuliaLang/juliaup/wiki/Adding-a-Julia-version)
-	@echo 15. Announce on mailing lists
+	@echo 6. Clean out old .tar.gz files living in deps/, "\`git clean -fdx\`" seems to work	#"`
+	@echo 7. Create tarballs with make light-source-dist and make full-source-dist, with USE_BINARYBUILDER=0 and JULIA_RELEASE_BUILD=1
+	@echo 8. Check that 'make && make install && make test' succeed with unpacked tarballs even without Internet access.
+	@echo 9. Follow packaging instructions in doc/src/devdocs/build/distributing.md to create binary packages for all platforms, with JULIA_RELEASE_BUILD=1
+	@echo 10. Upload to AWS, update https://julialang.org/downloads and https://status.julialang.org/stable links
+	@echo 11. Update checksums on AWS for tarball and packaged binaries
+	@echo 12. Create tag last, push to github "\(git tag v\`cat VERSION\` && git push --tags\)"		#"` # These comments deal with incompetent syntax highlighting rules
+	@echo 13. Replace github release tarball with the tarballs from step 7
+	@echo 14. Update versions.json. Wait at least 60 minutes before proceeding to step 15.
+	@echo 15. Push to Juliaup (https://github.com/JuliaLang/juliaup/wiki/Adding-a-Julia-version)
+	@echo 16. Announce on mailing lists
 	@echo 16. Change master to release-0.X in base/version.jl and base/version_git.sh as in 4cb1e20
 	@echo 17. Move NEWS.md contents to HISTORY.md
 	@echo

--- a/base/Makefile
+++ b/base/Makefile
@@ -100,7 +100,7 @@ endif
 
 $(BUILDDIR)/version_git.jl.phony: $(SRCDIR)/version_git.sh
 ifneq ($(NO_GIT), 1)
-	sh $< $(SRCDIR) > $@
+	JULIA_RELEASE_BUILD=$(JULIA_RELEASE_BUILD) sh $< $(SRCDIR) > $@
 	@# This to avoid touching version_git.jl when it is not modified,
 	@# so that the system image does not need to be rebuilt.
 	@if ! cmp -s $@ version_git.jl; then \

--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -99,7 +99,11 @@ case $(uname) in
     date_string="$(date --date="@$git_time" -u '+%Y-%m-%d %H:%M %Z')"
     ;;
 esac
-if [ $(git describe --tags --exact-match 2> /dev/null) ]; then
+if [ "${JULIA_RELEASE_BUILD:-0}" = "1" ]; then
+    # Declared release build (see JULIA_RELEASE_BUILD in Make.inc): report the
+    # state that building from the (possibly not yet created) release tag would.
+    tagged_commit="true"
+elif [ $(git describe --tags --exact-match 2> /dev/null) ]; then
     tagged_commit="true"
 else
     tagged_commit="false"

--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -5,8 +5,12 @@
 JULIAHOME := $(abspath ../../..)
 include ../../../Make.inc
 
-# X.Y.Z or X.Y.Z-hash
-JULIA_VERSION_OPT_COMMIT:=$(shell [ $$(git describe --tags --exact-match 2>/dev/null) ] && echo $(JULIA_VERSION) || echo $(JULIA_VERSION)-$(JULIA_COMMIT))
+# X.Y.Z or X.Y.Z-hash (JULIA_COMMIT is JULIA_VERSION for release builds, see Make.inc)
+ifeq ($(JULIA_COMMIT),$(JULIA_VERSION))
+JULIA_VERSION_OPT_COMMIT:=$(JULIA_VERSION)
+else
+JULIA_VERSION_OPT_COMMIT:=$(JULIA_VERSION)-$(JULIA_COMMIT)
+endif
 
 # X.Y
 JULIA_VERSION_MAJOR_MINOR:=$(shell echo $(JULIA_VERSION) | grep -o '^[0-9]\+.[0-9]\+')

--- a/doc/src/devdocs/build/distributing.md
+++ b/doc/src/devdocs/build/distributing.md
@@ -42,6 +42,14 @@ to create a Make.user file containing:
 
     override TAGGED_RELEASE_BANNER = "my-package-repository build"
 
+The official release builds are not built from the `vx.y.z` tag: the tag is
+created only after the artifacts have been built, validated, and published
+(see [Tagging the release](#tagging-the-release)). Instead, passing
+`JULIA_RELEASE_BUILD=1` to `make` declares the build to be the release build
+of the version in the `VERSION` file, producing the same artifacts that
+building from the tag would (release naming, `tagged_commit` set). It refuses
+to run when `VERSION` carries a `-DEV` (or legacy `-pre`) suffix.
+
 Target Architectures
 --------------------
 
@@ -282,31 +290,16 @@ Do not remove the label from PRs that have not been backported.
 
 The release-x.y branch should now contain all of the new commits.
 The last thing we want to do to the branch is to adjust the version number.
-To do this, submit a PR against release-x.y that edits the VERSION file to remove `-pre`
+To do this, submit a PR against release-x.y that edits the VERSION file to remove `-DEV`
 from the version number.
-Once that's merged, we're ready to tag.
+Once that's merged, the branch is ready to release.
 
-## Tagging the release
-
-It's time!
-Check out the release-x.y branch and make sure that your local copy of the branch is
-up to date with the remote branch.
-At the command line, run
-
-```
-git tag v$(cat VERSION)
-git push --tags
-```
-
-This creates the tag locally and pushes it to GitHub.
-
-After tagging the release, submit another PR to release-x.y to bump the patch number
-and add `-pre` back to the end.
-This denotes that the branch state reflects a prerelease version of the next point
-release in the x.y series.
-
-Pushing the tag is what sets the release machinery in motion; see
-[Publishing the release](#publishing-the-release) below.
+The release is built and published from that commit on release-x.y; the
+`vx.y.z` tag is created only afterwards, as the last step (see
+[Tagging the release](#tagging-the-release)). If a problem is found after the
+version bump has been merged, simply merge the fix and release from the new
+tip of the branch — nothing has been tagged or published yet, so nothing
+needs to be moved or deleted.
 
 ## Publishing the release
 
@@ -316,32 +309,56 @@ exists outside of a cloud KMS. The authoritative runbook, including recovery
 procedures, lives in `ops/README.md` of
 [JuliaCI/julia-buildkite](https://github.com/JuliaCI/julia-buildkite); in outline:
 
-1. Pushing the `vx.y.z` tag triggers a `julia-ci` Buildkite build, which builds
-   binaries for every platform, runs the tests, and additionally builds the
-   light and full source tarballs (with the bundled HTML documentation).
+1. The release manager starts a release `julia-ci` build (New Build with
+   branch = `release-x.y` at the release commit, with `RELEASE_VERSION=x.y.z`
+   in the environment). The pipeline checks `RELEASE_VERSION` against the
+   `VERSION` file and builds with `JULIA_RELEASE_BUILD=1`, producing the same
+   artifacts a build of the (future) `vx.y.z` tag would: binaries for every
+   platform, plus the light and full source tarballs (with the bundled HTML
+   documentation). The tests run as usual.
 2. When the tests pass, `julia-ci` automatically triggers the trusted
    `julia-publish` pipeline, which signs everything (GPG for the Linux/FreeBSD
    and source tarballs, notarization for macOS, Authenticode for Windows),
    publishes version-named artifacts to the `julialangnightlies` bucket, and
-   deploys the documentation.
-3. The release manager then starts a `julia-promote` build (New Build with
-   branch = `vx.y.z`), which copies everything into the release bucket layout
+   deploys the documentation. Nothing user-facing points at this bucket, so
+   this is the moment to download and sanity-check the artifacts.
+3. The release manager then starts a `julia-promote` build for the same
+   commit and version, which copies everything into the release bucket layout
    served at `julialang-s3.julialang.org` — including the source tarballs under
    `bin/src/x.y/` — repoints the `julia-x.y-latest-*` files, generates and
    uploads the `bin/checksums/julia-x.y.z.{sha256,md5}` files, and purges the
    CDN cache.
-4. Dispatch the CI workflow of
+
+## Tagging the release
+
+The tag is created last, once the artifacts are published, so that it
+immutably records exactly what was released and never needs to be moved or
+deleted. Check out release-x.y at the exact commit that was built and
+promoted, then run
+
+```
+git tag v$(cat VERSION)
+git push --tags
+```
+
+The tag does not trigger any builds. What remains:
+
+1. Dispatch the CI workflow of
    [VersionsJSONUtil.jl](https://github.com/JuliaLang/VersionsJSONUtil.jl) to
    regenerate `versions.json`, then the "Update Version DB" workflow of
    [juliaup](https://github.com/JuliaLang/juliaup) (its upload jobs need manual
    approval) so `juliaup` picks up the release.
-5. Create the GitHub release with the CI-signed source tarballs attached by
+2. Create the GitHub release with the CI-signed source tarballs attached by
    running `contrib/github_source_release.sh x.y.z` — it downloads them from the
    release bucket, verifies the signatures and layout, and shows what it would
    do; rerun with `--execute` to create the (pre)release and upload.
-6. Update [the website](https://github.com/JuliaLang/www.julialang.org): bump
+3. Update [the website](https://github.com/JuliaLang/www.julialang.org): bump
    the version in `config.md` and regenerate the old releases page with
    `downloads/oldreleases.jl`. Finally, announce the release on Discourse.
+
+After the release, submit another PR to release-x.y to bump the patch number
+and add `-DEV` back to the end, denoting that the branch state reflects a
+development version of the next point release in the x.y series.
 
 
 ## Verifying signatures


### PR DESCRIPTION
Release artifacts are currently built from the vX.Y.Z tag: its presence at
build time is baked into build content (`tagged_commit`, and thereby
`Base.VERSION` for prereleases, the REPL banner, and versioninfo) and into
artifact naming (`JULIA_COMMIT`). This forces the tag to be created before the
release is built and validated, so a problem found late means moving or
deleting the tag.

Add a `JULIA_RELEASE_BUILD=1` make flag that declares the build to be the
release build of $(VERSION), producing the same content and naming that
building from the tag would, without requiring the tag to exist. This lets
the release pipeline build, validate, and publish first, and create the
immutable tag as the last step. The flag refuses -DEV/-pre versions.

Update the release process docs for the tag-last flow, and fix them to match
the actual -DEV (not -pre) convention on release branches.

After this we also need to update buildkite:

<details><summary>Buildkite updates</summary>

:robot: 

**Release-flow detection (core change)**
- `utilities/build_envs.sh` — extend `RELEASE_TAG_FLOW` so it also turns true for a build carrying `RELEASE_VERSION=x.y.z` in the env (a manual "New Build" on `release-x.y` at the release commit), not just `BUILDKITE_TAG`/`branch=v*`. Repurpose the existing tag-vs-VERSION guard to check `RELEASE_VERSION == $(cat VERSION)`.
- Same file — fix `TAR_VERSION` for build pipelines: it currently uses `git describe --tags --exact-match` on the checkout; it must use the release-flow condition instead so artifact names agree with what `make` now produces.
- `utilities/build_julia.sh` — pass `JULIA_RELEASE_BUILD=1` in `MFLAGS` when the release flow is active.

**Steps gated on `v*` today**
- `pipelines/main/misc/source_dist.yml` — its `if: build.tag =~ /^v[0-9]/ || build.branch =~ /^v[0-9]/` gate must also fire for the env-var-triggered release build (Buildkite `if:` can test `build.env("RELEASE_VERSION")`). Its `make ... JULIA_COMMIT=$V` override becomes redundant but harmless.
- `pipelines/main/misc/doctest.yml:78` — same condition, same fix.

**Publish and promote**
- `utilities/render_launch_pipeline.py` — the `julia-publish` trigger must pass `RELEASE_VERSION` through in the triggered build's env (it already passes commit/branch).
- `utilities/publish_srcdist.sh` / `STAGING_FLAVOR` — keep the `tag/` staging flavor keyed on the new flow condition (or rename to `release/`). Note the dual-build race it defends against disappears entirely once tag builds stop happening.
- `utilities/promote_release.sh` — drop the hard requirement that `BUILDKITE_BRANCH` is `v<version>` (the tag won't exist yet); accept a manual build on `release-x.y` with `RELEASE_VERSION` and take the version identity from that. `verify_trusted_commit.sh` needs **no change** — it already accepts commits reachable from `release-*`.
- Optionally add a write-once guard in promote: refuse if `bin/checksums/julia-<version>.sha256` already exists in the release bucket, so a version can only ever be promoted once.

**Turning off the old trigger**
- Buildkite webUI settings for `julia-ci` (recorded in `pipelines/main/0_webui.yml` comments): switch "Build tags: ON (v*)" to OFF so the final `git push --tags` triggers nothing. Keep it ON until the new flow has shipped a release, since old release branches (1.10/1.12) still need the tag-triggered path unless the knob is backported to them.

**Docs**
- `ops/README.md` — update the runbook: release flow starts with the manual `RELEASE_VERSION` build, tag comes last; describe the transition period where both flows work.

Sequencing: all of this can land while remaining backward-compatible — the `v*` conditions stay as an alternative trigger — so you can trial the new flow on an rc, and only flip the webUI tag setting off once it's proven.

</details>



Assisted-by: Claude Code (Fable 5)
