### PR TITLE
staticdata: deduplicate types with deferred supertypes

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1363,6 +1363,8 @@ void jl_cache_type_(jl_datatype_t *type)
     unsigned hv = typekey_hash(type->name, key, n, 0);
     if (hv) {
         assert(hv == type->hash);
+        // Type cache keys must be unique.
+        assert(jl_lookup_cache_type_(type) == NULL);
         cache_insert_type_set(type, hv);
     }
     else {

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -58,8 +58,13 @@ int must_be_new_dt(jl_value_t *t, htable_t *news, char *image_base, size_t sizeo
         // waiting for `t` to be resolved, then will be determined later as
         // soon as possible afterwards).
         while (super != NULL && super != jl_any_type) {
-            if (ptrhash_has(news, (void*)super))
-                return 1;
+            void *entry = ptrhash_get(news, (void*)super);
+            if (entry != HT_NOTFOUND) {
+                if (entry != (void*)super)
+                    return 1;
+                // A self-mapping marks an unresolved forward reference.
+                break;
+            }
             if (!(image_base < (char*)super && (char*)super <= image_base + sizeof_sysimg))
                break; // the rest must all be non-new
             // otherwise super might be something that was not cached even though a later supertype might be

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3799,4 +3799,67 @@ precompile_test_harness("Ambiguity-pruned dispatch edge revalidation") do load_p
     @eval @test_throws MethodError AmbigPruneB.caller(Int8(1), "hi")
 end
 
+precompile_test_harness("pkgimage type cache dedup") do dir
+    # Check deduplication when a type precedes its supertype in the image.
+    # The unused IFD binding preserves that order.
+    write(joinpath(dir, "DedupColors.jl"),
+          """
+          module DedupColors
+              export CAbstractGray, CGray
+              abstract type CAbstractGray{T} end
+              struct CGray{T} <: CAbstractGray{T}
+                  val::T
+              end
+              Base.adjoint(c::CAbstractGray) = c
+          end
+          """)
+    write(joinpath(dir, "DedupTrigger.jl"),
+          """
+          module DedupTrigger
+              using DedupColors
+
+              const IFD = Dict{UInt16, Any}
+
+              function readdata!(target::AbstractArray)
+                  fill!(reinterpret(UInt8, view(target, 1:length(target))), 0x00)
+              end
+
+              function load()
+                  ifd = IFD()
+                  ifd[0x0106] = UInt16(1)
+                  type = Int(ifd[0x0106]) == 2 ? Ref : CGray
+                  pixeltype = type{UInt8}
+                  cache = Array{pixeltype}(undef, 2, 2)
+                  readdata!(cache)
+                  Matrix(cache')
+              end
+
+              load()
+          end
+          """)
+    Base.compilecache(Base.PkgId("DedupColors"))
+    Base.compilecache(Base.PkgId("DedupTrigger"))
+    @eval using DedupColors
+    M = invokelatest() do
+        Memory{DedupColors.CGray{UInt8}}
+    end
+    @eval using DedupTrigger
+    invokelatest() do
+        CGrayU8 = DedupColors.CGray{UInt8}
+        for T in (Memory{CGrayU8}, DenseVector{CGrayU8})
+            tn = T.name
+            n = 0
+            for t in tn.cache
+                if t isa DataType && t.name === tn &&
+                        length(t.parameters) == length(T.parameters) &&
+                        all(i -> t.parameters[i] === T.parameters[i], eachindex(T.parameters))
+                    n += 1
+                end
+            end
+            @test n == 1
+        end
+        @test M === Memory{DedupColors.CGray{UInt8}}
+    end
+end
+
 finish_precompile_test!()


### PR DESCRIPTION
This is aimed at solving an `unreachable reached` as manifested in e.g. https://pkgeval.s3.us-east-2.amazonaws.com/runs/gh-5428371050/logs/primary/AstroIC.log (but also happens in more package) from checking 1.14 regressions vs 1.13 in #62879. The added test was minified from the what happened in this stacktrace:

```
[165] signal 4 (2): Illegal instruction
in expression starting at /home/pkgeval/.julia/packages/ImageBinarization/7p4P1/test/algorithms/single_histogram_threshold.jl:1
getproperty at ./Base_compiler.jl:58:0 [inlined]
dataids at ./abstractarray.jl:1628:0 [inlined]
mightalias at ./abstractarray.jl:1603:0 [inlined]
unalias at ./abstractarray.jl:1566:0 [inlined]
copyto! at ./abstractarray.jl:1078:0 [inlined]
copyto_axcheck! at ./abstractarray.jl:1188:0 (pc: 43)
Array at ./array.jl:663:0 [inlined]
Array at ./boot.jl:843:0 (pc: 25)
unknown function (ip: 0x7d7b43995cd2) at (unknown file)
_jl_invoke at /cache/build/builder-amdci4-4/julialang/julia-pr/src/gf.c:4584:23 [inlined]
ijl_apply_generic at /cache/build/builder-amdci4-4/julialang/julia-pr/src/gf.c:4832:12
#load#57 at /home/pkgeval/.julia/packages/TiffImages/VlJh4/src/load.jl:100:0 (pc: 22)
load at /home/pkgeval/.julia/packages/TiffImages/VlJh4/src/load.jl:95:0 [inlined]
#load#56 at /home/pkgeval/.julia/packages/TiffImages/VlJh4/src/load.jl:47:0 (pc: 126)
load at /home/pkgeval/.julia/packages/TiffImages/VlJh4/src/load.jl:26:0 [inlined]
#load#55 at /home/pkgeval/.julia/packages/TiffImages/VlJh4/src/load.jl:25:0 (pc: 65)
load at /home/pkgeval/.julia/packages/TiffImages/VlJh4/src/load.jl:25:0 [inlined]
#53 at /home/pkgeval/.julia/packages/TiffImages/VlJh4/src/load.jl:21:0 [inlined]
#open#339 at ./io.jl:451:0 [inlined]
open at ./io.jl:448:0 [inlined]
#load#51 at /home/pkgeval/.julia/packages/TiffImages/VlJh4/src/load.jl:20:0 (pc: 4)
load at /home/pkgeval/.julia/packages/TiffImages/VlJh4/src/load.jl:19:0 (pc: 1)
```

---

🤖 

Package image loading treated unresolved, forward-referenced supertypes as new. This skipped the type cache lookup and could insert a duplicate DataType.

Keep pending forward references separate from supertypes known to be new so the normal cache lookup still runs.
