### PR TITLE
timing: fix task-init hazards in the Tracy fiber-name lookup

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -1137,7 +1137,6 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_fu
     jl_atomic_store_relaxed(&t->last_started_running_at, 0);
     jl_atomic_store_relaxed(&t->running_time_ns, 0);
     jl_atomic_store_relaxed(&t->finished_at, 0);
-    jl_timing_task_init(t);
     jl_atomic_store_relaxed(&t->preempt_request, 0);
     jl_atomic_store_relaxed(&t->bound_cancel_token, jl_nothing);
     t->bound_cancel_default = 0;
@@ -1154,6 +1153,9 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_fu
 #ifdef _COMPILER_ASAN_ENABLED_
     t->ctx.asan_fake_stack = NULL;
 #endif
+    // Last, since it can allocate (and thus run GC): `t` must be fully
+    // initialized before this call.
+    jl_timing_task_init(t);
     return t;
 }
 

--- a/src/timing.c
+++ b/src/timing.c
@@ -671,9 +671,6 @@ void jl_timing_task_init(jl_task_t *t)
     char *fiber_name;
     jl_method_instance_t *mi = NULL;
     if (start_name[0] == '#') {
-        // This lookup can allocate and hence run GC, so it must only be done
-        // once `t` is fully initialized, and with `t` rooted. It can also fail
-        // (e.g. if `t->start` is not callable with zero arguments).
         JL_GC_PUSH1(&t);
         mi = jl_apply_lookup(&t->start, 1, jl_get_world_counter());
         JL_GC_POP();

--- a/src/timing.c
+++ b/src/timing.c
@@ -669,8 +669,16 @@ void jl_timing_task_init(jl_task_t *t)
     // XXX: Tracy uses this as a handle internally and requires that this
     // string live forever, so this allocation is intentionally leaked.
     char *fiber_name;
+    jl_method_instance_t *mi = NULL;
     if (start_name[0] == '#') {
-        jl_method_instance_t *mi = jl_apply_lookup(&t->start, 1, jl_get_world_counter());
+        // This lookup can allocate and hence run GC, so it must only be done
+        // once `t` is fully initialized, and with `t` rooted. It can also fail
+        // (e.g. if `t->start` is not callable with zero arguments).
+        JL_GC_PUSH1(&t);
+        mi = jl_apply_lookup(&t->start, 1, jl_get_world_counter());
+        JL_GC_POP();
+    }
+    if (mi != NULL && jl_is_method(mi->def.value)) {
         const char *filename = gnu_basename(jl_symbol_name(mi->def.method->file));
         const char *module_name = jl_symbol_name(mi->def.method->module->name);
 


### PR DESCRIPTION
With `WITH_TRACY`, `jl_timing_task_init` names the task's Tracy fiber by looking up the start function's method via `jl_apply_lookup`. That call had two problems: the result was dereferenced without a NULL check, so creating a Task whose `#`-named start function has no zero-argument method segfaulted immediately; and the lookup can allocate (and hence run GC) while the freshly allocated task was unrooted and only partially initialized in `jl_new_task`, corrupting the task under allocation pressure.

Move the call to the end of `jl_new_task`, root the task around the lookup, and fall back to the type-name label when the lookup fails.

Assisted-by: Claude Code (Fable 5)