### PR TITLE
Fall back to Sys.BINDIR-relative path in private_shlibdir

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -323,7 +323,14 @@ Base.print(io::IO, llp::LazyLibraryPath) = print(io, string(llp))
 struct PrivateShlibdirGetter; end
 const private_shlibdir = Base.OncePerProcess{String}() do
     libname = ifelse(isdebugbuild(), "libjulia-internal-debug", "libjulia-internal")
-    dirname(dlpath(libname))
+    handle = dlopen(libname; throw_error=false)
+    if handle === nothing
+        # No libjulia-internal shared library (e.g. the runtime is statically
+        # linked into this executable): fall back to the standard layout
+        # relative to the executable's directory.
+        return abspath(Sys.BINDIR, Base.PRIVATE_LIBDIR)
+    end
+    return dirname(dlpath(handle))
 end
 Base.string(::PrivateShlibdirGetter) = private_shlibdir()
 


### PR DESCRIPTION
`private_shlibdir` answers "where is this installation's `lib/julia`" by `dlpath("libjulia-internal")`. In an executable with the runtime statically linked (follow-up to #62868, #62884, #62885) that library doesn't exist, so the first `BundledLazyLibraryPath` use — `CompilerSupportLibraries_jll.__init__` loading `libgcc_s` — threw `could not load library \"libjulia-internal\"`. Fall back to `abspath(Sys.BINDIR, Base.PRIVATE_LIBDIR)`, the standard bundle layout.

Tested: full build; a JuliaC-style static executable (runtime + sysimage in one binary) now runs through CSL_jll init and bundled-library loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)