### PR TITLE
arrays: restore tuple dims support in `Array{T}`(nothing/missing) constructors

### DIFF
--- a/base/baseext.jl
+++ b/base/baseext.jl
@@ -36,8 +36,8 @@ Vector() = Vector{Any}(undef, 0)
 
 # Array constructors for nothing and missing
 # type and dimensionality specified
-Array{T,N}(::Nothing, d...) where {T,N} = fill!(Array{T,N}(undef, convert(Tuple{Vararg{Int}}, d)), nothing)
-Array{T,N}(::Missing, d...) where {T,N} = fill!(Array{T,N}(undef, convert(Tuple{Vararg{Int}}, d)), missing)
+Array{T,N}(::Nothing, d...) where {T,N} = fill!(Array{T,N}(undef, d...), nothing)
+Array{T,N}(::Missing, d...) where {T,N} = fill!(Array{T,N}(undef, d...), missing)
 # type but not dimensionality specified
-Array{T}(::Nothing, d...) where {T} = fill!(Array{T}(undef, convert(Tuple{Vararg{Int}}, d)), nothing)
-Array{T}(::Missing, d...) where {T} = fill!(Array{T}(undef, convert(Tuple{Vararg{Int}}, d)), missing)
+Array{T}(::Nothing, d...) where {T} = fill!(Array{T}(undef, d...), nothing)
+Array{T}(::Missing, d...) where {T} = fill!(Array{T}(undef, d...), missing)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2910,6 +2910,17 @@ end
     @test size(a) ==  size(b) == (9,8,7,6,5,4,3,2,1)
     @test all(x -> x isa U, a)
     @test all(x -> x isa U, b)
+    # dims as a single tuple (issue introduced by #57692)
+    a = Array{Union{T, U}}(U(), (10,))
+    b = Vector{Union{T, U}}(U(), (10,))
+    @test size(a) == size(b) == (10,)
+    @test all(x -> x isa U, a)
+    @test all(x -> x isa U, b)
+    a = Array{Union{T, U}}(U(), (2, 3))
+    b = Matrix{Union{T, U}}(U(), (2, 3))
+    @test size(a) == size(b) == (2, 3)
+    @test all(x -> x isa U, a)
+    @test all(x -> x isa U, b)
 end
 
 @testset "diff" begin


### PR DESCRIPTION
#57692 changed the `nothing`/`missing` Array constructors to convert the slurped vararg tuple directly via `convert(Tuple{Vararg{Int}}, d)`, which broke passing the dims as a single tuple (e.g.
`Vector{Nothing}(nothing, (5,))`) since the dims tuple ends up nested. Splat the arguments back into the `undef` constructors, which accept both tuple and vararg dims and already convert them to `Int`.

Found via PkgEval (OffsetArrays, Perth, Tesseract, QRCode, ZBar).

Assisted-by: Claude Code (Fable 5)