### PR TITLE
reflection: define `fieldcount` for `Core.TypeEgal` kinds

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1446,6 +1446,9 @@ function fieldcount(@nospecialize t)
     if t === Union{}
         throw(ArgumentError("The empty type does not have a well-defined number of fields since it does not have instances."))
     end
+    if t isa Core.TypeEgal
+        return nfields(type_parameter(t))
+    end
     t = unwrap_unionall(t)
     if t isa Union
         fcount = _fieldcount_noerror(t)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -954,6 +954,9 @@ end
 @test_throws ArgumentError fieldcount(Real)
 @test_throws ArgumentError fieldcount(AbstractArray)
 @test_throws ArgumentError fieldcount(Tuple{Any,Vararg{Any}})
+# TypeEgal{T} has the single instance `T` (issue #62890)
+@test fieldcount(Core.TypeEgal{Int}) == nfields(Int)
+@test fieldcount(Core.TypeEgal{Type{Int}}) == nfields(Type{Int}) == 1
 
 # Common-field unions are definite only when all alternatives share the field count.
 @test fieldcount(Union{Tuple{Int,Float64},Tuple{Int,Int}}) == 2


### PR DESCRIPTION
The only instance of `TypeEgal{T}` is `T` itself, so the number of fields an instance would have is exactly `nfields(T)`. Previously `fieldcount` threw `TypeError: in fieldcount, expected DataType` for these kinds, which broke packages (e.g. JLD2) that call `fieldcount(typeof(x))` when `x` is a type, since `typeof` of a closed type is now `TypeEgal{x}`.

Addresses the `fieldcount` failure reported in #62890 (https://github.com/JuliaLang/julia/issues/62890#issuecomment-5459838396).

Authored by Claude Code (Fable 5