### PR TITLE
type system: declare the `T` field of `TypeEq` as `Any`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -624,7 +624,11 @@ end
 io_has_tvar_name(io::IO, name::Symbol, @nospecialize(x)) = false
 
 modulesof!(s::Set{Module}, x::TypeVar) = modulesof!(s, x.ub)
-modulesof!(s::Set{Module}, x::TypeEq) = modulesof!(s, type_parameter(x))
+function modulesof!(s::Set{Module}, x::TypeEq)
+    p = type_parameter(x)
+    # the parameter may be a non-type value, e.g. `Type{1}` (#62897)
+    p isa Union{Core.AnyType,TypeVar} ? modulesof!(s, p) : s
+end
 modulesof!(s::Set{Module}, x::Core.TypeEgal) = modulesof!(s, type_parameter(x))
 function modulesof!(s::Set{Module}, x::Type)
     x = unwrap_unionall(x)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3757,9 +3757,11 @@ void jl_init_types(void) JL_GC_DISABLED
                                         jl_emptysvec, 0, 0, 2);
     jl_intersect_type->name->mayinlinealloc = 0;
 
+    // `T` must be declared `Any`: jl_valid_type_param admits non-type values
+    // (`Type{1}`), so a narrower field type would be unsound (#62897)
     jl_typeeq_type = jl_new_datatype(jl_symbol("TypeEq"), core, jl_anytype_type, jl_emptysvec,
                                      jl_perm_symsvec(1, "T"),
-                                     jl_svec(1, kind_or_typevar_type),
+                                     jl_svec(1, jl_any_type),
                                      jl_emptysvec, 0, 0, 1);
     XX(typeeq);
     // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist

--- a/test/core.jl
+++ b/test/core.jl
@@ -434,6 +434,14 @@ end  |> only == Core.TypeEgal{typejoin(Int, UInt, Float64)}
 @test ccall(:jl_types_struct_equiv, Cint, (Any, Any), Int, Int) == 1
 @test ccall(:jl_types_struct_equiv, Cint, (Any, Any), Int, String) == 0
 
+# issue #62897: `Type{v}` with a non-type parameter is constructible (like 1.13), so the
+# `T` field of `TypeEq` must be declared `Any` — a narrower field type would let inference
+# unsoundly assume the parameter is a type or TypeVar.
+@test fieldtype(Core.TypeEq, :T) === Any
+@test Base.type_parameter(Type{setindex!}) === setindex!
+@test Base.type_parameter(Type{1}) === 1
+@test Base.type_parameter(Type{:sym}) === :sym
+
 # `isType` covers both type-object kinds; use split predicates when exactness matters.
 @test Base.isType(Type{Int})
 @test Base.isType(Core.TypeEgal{Int})

--- a/test/show.jl
+++ b/test/show.jl
@@ -3040,3 +3040,14 @@ end
         @test !contains(str, "\e[93m")
     end
 end
+
+# issue #62897: `show` of `Type{v}` with a non-type parameter must not be memory-unsafe
+@testset "show Type{v} with value parameter" begin
+    @test repr(Type{setindex!}) == "Type{setindex!}"
+    @test repr(Type{1}) == "Type{1}"
+    @test repr(Type{:sym}) == "Type{:sym}"
+    @test repr(Type{(1, 2)}) == "Type{(1, 2)}"
+    @test sprint(show, Type{1}; context=:compact => false) == "TypeEq{1}"
+    @test repr("text/plain", Type{setindex!}) == "Type{setindex!}"
+    @test repr("text/plain", Type{1}) == "Type{1}"
+end


### PR DESCRIPTION
Not sure if this is the best way to solve this but opening anyway and @Keno can say what he thinks.

`jl_valid_type_param` admits non-type values as type parameters, so `Type{1}` and `Type{setindex!}` are constructible (as on 1.13), and subtyping can also produce such types by binding a typevar to a value. Declaring the field as `Union{AnyType,TypeVar}` let inference unsoundly devirtualize on the declared field type, so `show` dispatched a function value parameter to the `TypeVar` method and dereferenced it as one, segfaulting. Widen the declared field type to `Any` to match what construction actually admits (this also restores the inference behavior of the untyped `.parameters` access on 1.13), and make `modulesof!` tolerate a non-type parameter.

Fixes #62897

---

This change was written by Claude Code (Fable 5)
