### PR TITLE
types: fix declared field type of TypeName.linearcache

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3654,7 +3654,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                       jl_simplevector_type,
                                       jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/,
                                       jl_type_type, jl_simplevector_type, jl_simplevector_type,
-                                      jl_methcache_type, jl_any_type,
+                                      jl_simplevector_type, jl_any_type,
                                       jl_any_type /*jl_long_type*/,
                                       jl_any_type /*jl_int32_type*/,
                                       jl_any_type /*jl_int32_type*/,


### PR DESCRIPTION
Commit 1c26f43717 (#58636) removed the method-cache field from `jl_typename_t` but deleted a `jl_type_type` entry instead of the `jl_methcache_type` entry from the static `jl_typename_type->types` list. The post-boot fixups reassign the wrapper and Typeofwrapper slots, so the net effect was that the linearcache field, which holds a `SimpleVector`, was declared as `Core.MethodCache`. Inference trusts the declared field type, so valid code reading `tn.linearcache` was proven unreachable, e.g. `iterate(tn.linearcache)` compiled to a guaranteed `MethodError` while working fine in the interpreter.

Assisted-by: Claude Code (Fable 5)