### PR TITLE
Add gdb pretty-printers and lldb summaries for Julia runtime values

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -35,6 +35,7 @@ Debugging
 | Name                           |  Description                                                |
 | ------------------------------ | ----------------------------------------------------------- |
 |[ debug_bootstrap.gdb ](https://github.com/JuliaLang/julia/blob/master/contrib/debug_bootstrap.gdb) | Bootstrap process using the debug build |
+|[ julia_debug_core.py ](https://github.com/JuliaLang/julia/blob/master/contrib/julia_debug_core.py) | Shared renderer for the gdb/lldb debugger extensions below |
 |[ julia_gdb.py ](https://github.com/JuliaLang/julia/blob/master/contrib/julia_gdb.py) | GDB pretty-printers for Julia runtime values and GC safepoint signal filtering |
 |[ julia_lldb.py ](https://github.com/JuliaLang/julia/blob/master/contrib/julia_lldb.py) | LLDB type summaries for Julia runtime values and GC safepoint signal filtering |
 |[ valgrind-julia.supp ](https://github.com/JuliaLang/julia/blob/master/contrib/valgrind-julia.supp) | Suppressions for Valgrind debugging tool |

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -35,4 +35,6 @@ Debugging
 | Name                           |  Description                                                |
 | ------------------------------ | ----------------------------------------------------------- |
 |[ debug_bootstrap.gdb ](https://github.com/JuliaLang/julia/blob/master/contrib/debug_bootstrap.gdb) | Bootstrap process using the debug build |
+|[ julia_gdb.py ](https://github.com/JuliaLang/julia/blob/master/contrib/julia_gdb.py) | GDB pretty-printers for Julia runtime values and GC safepoint signal filtering |
+|[ julia_lldb.py ](https://github.com/JuliaLang/julia/blob/master/contrib/julia_lldb.py) | LLDB type summaries for Julia runtime values and GC safepoint signal filtering |
 |[ valgrind-julia.supp ](https://github.com/JuliaLang/julia/blob/master/contrib/valgrind-julia.supp) | Suppressions for Valgrind debugging tool |

--- a/contrib/julia_debug_core.py
+++ b/contrib/julia_debug_core.py
@@ -477,6 +477,44 @@ class JuliaRuntime:
         except JLDebugError:
             return None
 
+    def is_union_type(self, taddr):
+        try:
+            return self.datatype_qualname(self.typeof_addr(taddr)) == \
+                "Core.Union"
+        except JLDebugError:
+            return False
+
+    def nth_union_component(self, uaddr, sel):
+        """The sel-th (0-based, depth-first) non-Union component of the
+        Union type at uaddr, mirroring jl_nth_union_component; 0 when sel
+        is out of range."""
+        count = [sel]
+
+        def walk(t):
+            while self.is_union_type(t):
+                a = walk(self.field_u(t, "jl_uniontype_t", "a"))
+                if a:
+                    return a
+                t = self.field_u(t, "jl_uniontype_t", "b")
+            if count[0] == 0:
+                return t
+            count[0] -= 1
+            return 0
+
+        return walk(uaddr)
+
+    def render_inline_field(self, ftype, faddr, fsz, depth):
+        """Render an inline-stored field: for an isbits-Union field the
+        selector byte sits after the payload (see jl_get_nth_field in
+        datatype.c) and picks the stored component."""
+        if ftype and fsz > 0 and self.is_union_type(ftype):
+            comp = self.nth_union_component(
+                ftype, self.read_uint(faddr + fsz - 1, 1))
+            if comp:
+                return self.render_unboxed(comp, faddr, depth)
+            return "<union field>"
+        return self.render_unboxed(ftype, faddr, depth)
+
     def render_unboxed(self, taddr, addr, depth):
         """Render the unboxed (inline-stored) value of type taddr at addr."""
         if depth < 0 or self.exhausted():
@@ -523,7 +561,8 @@ class JuliaRuntime:
                 p = self.read_ptr(addr + off)
                 r = self.render_value(p, depth - 1) if p else "#undef"
             else:
-                r = self.render_unboxed(ftypes[i], addr + off, depth - 1)
+                r = self.render_inline_field(ftypes[i], addr + off, size,
+                                             depth - 1)
             fname = names[i] if names and i < len(names) else str(i + 1)
             parts.append(r if istuple else "%s = %s" % (fname, r))
             self.spend(len(parts[-1]))
@@ -539,12 +578,16 @@ class JuliaRuntime:
     # ---- arrays -------------------------------------------------------------
 
     def array_info(self, addr):
-        """(dims, eltype, dataptr, elsize, isboxed, isunion) of the
-        jl_array_t (or Memory) at addr."""
+        """(dims, eltype, dataptr, elsize, isboxed, seladdr) of the
+        jl_array_t (or Memory) at addr. For union-layout element storage,
+        seladdr is the address of this view's first selector byte (the
+        selector bytes for the whole Memory sit after its last element, see
+        jl_genericmemory_typetagdata); it is 0 for non-union layouts."""
         dtaddr = self.typeof_addr(addr)
         tname = self.typename_of(dtaddr)
         params = self.field_u(dtaddr, "jl_datatype_t", "parameters")
         if tname == "GenericMemory":
+            mem_addr = addr
             mem_dt_addr = dtaddr
             dims = [self.field_u(addr, "jl_genericmemory_t", "length")]
             dataptr = self.field_u(addr, "jl_genericmemory_t", "ptr")
@@ -570,7 +613,16 @@ class JuliaRuntime:
                                "arrayelem_isboxed")
         isunion = self.field_u(mlayout, "jl_datatype_layout_t", "flags",
                                "arrayelem_isunion")
-        return dims, eltype, dataptr, elsize, isboxed, isunion
+        seladdr = 0
+        if isunion:
+            # for union layouts a memoryref's ptr_or_offset is the element
+            # *index* into the Memory, not a pointer
+            idx = 0 if mem_addr == addr else dataptr
+            memlen = self.field_u(mem_addr, "jl_genericmemory_t", "length")
+            memptr = self.field_u(mem_addr, "jl_genericmemory_t", "ptr")
+            dataptr = memptr + idx * elsize
+            seladdr = memptr + memlen * elsize + idx
+        return dims, eltype, dataptr, elsize, isboxed, seladdr
 
     def is_array_value(self, addr):
         try:
@@ -590,7 +642,8 @@ class JuliaRuntime:
     def array_children(self, addr):
         """Yield ("index", ("val", addr) | ("str", s)) pairs for the first
         MAX_ELEMS elements of the array/Memory at addr."""
-        dims, eltype, dataptr, elsize, isboxed, isunion = self.array_info(addr)
+        dims, eltype, dataptr, elsize, isboxed, seladdr = \
+            self.array_info(addr)
         n = 1
         for d in dims:
             n *= d
@@ -599,8 +652,12 @@ class JuliaRuntime:
             if isboxed:
                 p = self.read_ptr(dataptr + i * self.a.ptrsize)
                 yield str(i + 1), (("val", p) if p else ("str", "#undef"))
-            elif isunion:
-                yield str(i + 1), ("str", "<union element>")
+            elif seladdr:
+                comp = self.nth_union_component(
+                    eltype, self.read_uint(seladdr + i, 1))
+                yield str(i + 1), ("str", self.render_unboxed(
+                    comp, dataptr + i * elsize, MAX_DEPTH - 1) if comp
+                    else "<union element>")
             else:
                 yield str(i + 1), ("str", self.render_unboxed(
                     eltype, dataptr + i * elsize, MAX_DEPTH - 1))
@@ -737,6 +794,8 @@ class JuliaRuntime:
             return prim
         if qual == "Core.Nothing":
             return "nothing"
+        if qual == "Base.Missing":
+            return "missing"
         if qual == "Core.Symbol":
             name = self.symbol_name(addr)
             if name.isidentifier():
@@ -879,28 +938,38 @@ class JuliaRuntime:
                 raise JLDebugError("field %s is #undef" % key)
             return ("val", p)
         ftype = self.field_types(taddr, len(fields))[idx]
+        if ftype and size > 0 and self.is_union_type(ftype):
+            comp = self.nth_union_component(
+                ftype, self.read_uint(addr + off + size - 1, 1))
+            if comp == 0:
+                raise JLDebugError("field %s has an invalid union selector"
+                                   % key)
+            return ("inline", comp, addr + off)
         if ftype == 0 or self.datatype_qualname(self.typeof_addr(ftype)) != \
                 "Core.DataType":
-            raise JLDebugError("field %s has union layout; cannot access"
-                               % key)
+            raise JLDebugError("cannot determine layout of field %s" % key)
         return ("inline", ftype, addr + off)
 
     def array_getindex(self, addr, key):
-        dims, eltype, dataptr, elsize, isboxed, isunion = \
+        dims, eltype, dataptr, elsize, isboxed, seladdr = \
             self.array_info(addr)
         n = 1
         for d in dims:
             n *= d
         if not (1 <= key <= n):
             raise JLDebugError("index %d out of bounds (1:%d)" % (key, n))
-        if isunion:
-            raise JLDebugError("union-layout array elements are not"
-                               " supported")
         if isboxed:
             p = self.read_ptr(dataptr + (key - 1) * self.a.ptrsize)
             if p == 0:
                 raise JLDebugError("element %d is #undef" % key)
             return ("val", p)
+        if seladdr:
+            comp = self.nth_union_component(
+                eltype, self.read_uint(seladdr + (key - 1), 1))
+            if comp == 0:
+                raise JLDebugError("element %d has an invalid union"
+                                   " selector" % key)
+            return ("inline", comp, dataptr + (key - 1) * elsize)
         return ("inline", eltype, dataptr + (key - 1) * elsize)
 
     # ---- module bindings ------------------------------------------------------

--- a/contrib/julia_debug_core.py
+++ b/contrib/julia_debug_core.py
@@ -37,6 +37,9 @@ MAX_ELEMS = 10
 MAX_STRING = 200
 # Hard cap on the total size of a rendered summary.
 MAX_OUTPUT = 4096
+# Smaller cap for values rendered as part of an enclosing expansion (e.g.
+# each element the debugger prints while expanding an array's children).
+BRIEF_OUTPUT = 512
 
 # The GC safepoint region is this many pages at jl_safepoint_pages
 # (see the layout description in src/safepoint.c).
@@ -154,6 +157,35 @@ class JuliaRuntime:
     def __init__(self, adapter):
         self.a = adapter
         self.dt_names = {}  # jl_datatype_t* address -> qualified name
+        self._budget = None  # remaining output chars for this render pass
+
+    # ---- output budget ----------------------------------------------------
+    #
+    # The element/string/depth caps bound each *level* of a summary, but a
+    # recursively big structure could still make the renderer compute far
+    # more text than MAX_OUTPUT keeps. A per-render-pass character budget
+    # makes deeply/widely nested rendering stop early instead: once it is
+    # exhausted, nested renderers return "…" immediately.
+
+    def spend(self, n):
+        if self._budget is not None:
+            self._budget[0] -= n
+
+    def exhausted(self):
+        return self._budget is not None and self._budget[0] <= 0
+
+    def _render_budgeted(self, fn, *args, limit=MAX_OUTPUT):
+        fresh = self._budget is None
+        if fresh:
+            self._budget = [limit]
+        try:
+            out = fn(*args)
+        finally:
+            if fresh:
+                self._budget = None
+        if len(out) > limit:
+            out = out[:limit] + "…"
+        return out
 
     # ---- basic reads ----------------------------------------------------
 
@@ -258,6 +290,11 @@ class JuliaRuntime:
         return "%s<:%s<:%s" % (lb, name, ub)
 
     def flatten_union(self, addr, parts, depth):
+        if parts and parts[-1] == "…":
+            return
+        if self.exhausted():
+            parts.append("…")
+            return
         if self.datatype_qualname(self.typeof_addr(addr)) == "Core.Union":
             self.flatten_union(self.field_u(addr, "jl_uniontype_t", "a"),
                                parts, depth)
@@ -265,12 +302,13 @@ class JuliaRuntime:
                                parts, depth)
         else:
             parts.append(self.render_type(addr, depth))
+            self.spend(len(parts[-1]))
 
     def render_type(self, addr, depth=MAX_DEPTH):
         """Render a Julia type object (or type parameter) as a string."""
         if addr == 0:
             return "#<null>"
-        if depth < 0:
+        if depth < 0 or self.exhausted():
             return "…"
         dtaddr = self.typeof_addr(addr)
         if dtaddr == 0:
@@ -334,10 +372,17 @@ class JuliaRuntime:
                     return "Memory{%s}" % eltstr
                 if oname == "atomic":
                     return "AtomicMemory{%s}" % eltstr
-        rendered = [self.render_type(self.svec_ref(params, i), depth - 1)
-                    for i in range(min(nparams, MAX_ELEMS))]
-        if nparams > MAX_ELEMS:
-            rendered.append("…")
+        rendered = []
+        for i in range(min(nparams, MAX_ELEMS)):
+            if self.exhausted():
+                rendered.append("…")
+                break
+            rendered.append(self.render_type(self.svec_ref(params, i),
+                                             depth - 1))
+            self.spend(len(rendered[-1]))
+        else:
+            if nparams > MAX_ELEMS:
+                rendered.append("…")
         return "%s{%s}" % (name, ", ".join(rendered))
 
     # ---- data rendering ----------------------------------------------------
@@ -434,7 +479,7 @@ class JuliaRuntime:
 
     def render_unboxed(self, taddr, addr, depth):
         """Render the unboxed (inline-stored) value of type taddr at addr."""
-        if depth < 0:
+        if depth < 0 or self.exhausted():
             return "…"
         if taddr == 0:
             return "<?>"
@@ -471,6 +516,9 @@ class JuliaRuntime:
         ftypes = self.field_types(taddr, len(fields))
         parts = []
         for i, (off, size, isptr) in enumerate(fields[:MAX_ELEMS]):
+            if self.exhausted():
+                parts.append("…")
+                break
             if isptr:
                 p = self.read_ptr(addr + off)
                 r = self.render_value(p, depth - 1) if p else "#undef"
@@ -478,8 +526,10 @@ class JuliaRuntime:
                 r = self.render_unboxed(ftypes[i], addr + off, depth - 1)
             fname = names[i] if names and i < len(names) else str(i + 1)
             parts.append(r if istuple else "%s = %s" % (fname, r))
-        if len(fields) > MAX_ELEMS:
-            parts.append("…")
+            self.spend(len(parts[-1]))
+        else:
+            if len(fields) > MAX_ELEMS:
+                parts.append("…")
         if istuple and len(fields) == 1:
             return "(%s,)" % parts[0]
         if istuple or tname == "NamedTuple":
@@ -563,8 +613,12 @@ class JuliaRuntime:
             return summary
         parts = []
         for _, (kind, v) in self.array_children(addr):
+            if self.exhausted():
+                parts.append("…")
+                break
             parts.append(self.render_value(v, depth - 1) if kind == "val"
                          else v)
+            self.spend(len(parts[-1]))
         return "%s = {%s}" % (summary, ", ".join(parts))
 
     # ---- runtime objects ------------------------------------------------------
@@ -648,10 +702,15 @@ class JuliaRuntime:
         n = self.svec_len(addr)
         parts = []
         for i in range(min(n, MAX_ELEMS)):
+            if self.exhausted():
+                parts.append("…")
+                break
             p = self.svec_ref(addr, i)
             parts.append(self.render_value(p, depth - 1) if p else "#undef")
-        if n > MAX_ELEMS:
-            parts.append("…")
+            self.spend(len(parts[-1]))
+        else:
+            if n > MAX_ELEMS:
+                parts.append("…")
         return "svec(%s)" % ", ".join(parts)
 
     # ---- main value renderer -----------------------------------------------
@@ -660,7 +719,7 @@ class JuliaRuntime:
         """Render the Julia value at addr as a compact single-line string."""
         if addr == 0:
             return "#<null>"
-        if depth < 0:
+        if depth < 0 or self.exhausted():
             return "…"
         dtaddr = self.typeof_addr(addr)
         if dtaddr == 0:
@@ -687,6 +746,7 @@ class JuliaRuntime:
             s, strlen = self.string_data(addr)
             suffix = "…" if strlen > len(s.encode("utf-8", "replace")) \
                 else ""
+            self.spend(len(s))
             return '"%s%s"' % (escape_string(s), suffix)
         if qual == "Core.SimpleVector":
             return self.render_svec(addr, depth)
@@ -738,10 +798,14 @@ class JuliaRuntime:
 
     def render_value_capped(self, addr):
         """render_value with a hard cap on the output size, for printers."""
-        out = self.render_value(addr)
-        if len(out) > MAX_OUTPUT:
-            out = out[:MAX_OUTPUT] + "…"
-        return out
+        return self._render_budgeted(self.render_value, addr)
+
+    def render_value_brief(self, addr):
+        """A terser render_value (smaller budget, shallower depth) for
+        values that appear inside an enclosing expansion, so the total
+        output stays bounded when the debugger expands nested children."""
+        return self._render_budgeted(self.render_value, addr,
+                                     MAX_DEPTH - 1, limit=BRIEF_OUTPUT)
 
     # ---- Julia-semantics field/index access (the `jl` command) ---------------
     #
@@ -753,12 +817,9 @@ class JuliaRuntime:
 
     def render_loc(self, loc):
         if loc[0] == "val":
-            out = self.render_value(loc[1])
-        else:
-            out = self.render_unboxed(loc[1], loc[2], MAX_DEPTH)
-        if len(out) > MAX_OUTPUT:
-            out = out[:MAX_OUTPUT] + "…"
-        return out
+            return self._render_budgeted(self.render_value, loc[1])
+        return self._render_budgeted(self.render_unboxed, loc[1], loc[2],
+                                     MAX_DEPTH)
 
     def loc_type_and_addr(self, loc):
         if loc[0] == "val":

--- a/contrib/julia_debug_core.py
+++ b/contrib/julia_debug_core.py
@@ -1,0 +1,929 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+"""Debugger-agnostic rendering and inspection of Julia runtime values.
+
+This module contains the logic shared by the gdb (`julia_gdb.py`) and lldb
+(`julia_lldb.py`) extensions: rendering of runtime values from their type
+tags, Julia-semantics field/index access for the `jl` command, and module
+binding lookup. It must be kept next to those files — they import it by path.
+
+Nothing here depends on a specific debugger. All access goes through an
+adapter object providing:
+
+    ptrsize                              pointer size in bytes
+    read_mem(addr, n) -> bytes           raise JLDebugError on failure
+    read_cstr(addr, maxlen) -> str
+    type_size(typename) -> int           sizeof from debug info
+    field_offset(typename, field) -> int offsetof from debug info
+    field(addr, typename, path, signed=False) -> int
+        the integer value of (possibly nested, possibly bitfield) member
+        `path` (a tuple of names) of the struct `typename` at `addr`
+    has_field(typename, field) -> bool
+    global_addr(symbol) -> int           load address of a global, 0 if absent
+
+Struct layouts are resolved through the debug info rather than hard-coded, so
+this tracks Julia struct changes automatically. The only baked-in knowledge
+is the type-tag scheme and the layouts of symbols/strings/svecs (stable ABI),
+and the binding-partition kinds for module lookups.
+"""
+
+import re
+
+# Render at most this many nested levels in a single summary string.
+MAX_DEPTH = 3
+# Render at most this many elements of arrays/svecs/tuples in a summary.
+MAX_ELEMS = 10
+# Truncate strings longer than this many bytes.
+MAX_STRING = 200
+# Hard cap on the total size of a rendered summary.
+MAX_OUTPUT = 4096
+
+# The GC safepoint region is this many pages at jl_safepoint_pages
+# (see the layout description in src/safepoint.c).
+SAFEPOINT_PAGES = 4
+
+
+class JLDebugError(Exception):
+    """A memory read / debug info lookup failed, or a `jl` path is invalid."""
+
+
+# Objects whose type tag is a small constant rather than a pointer to the
+# jl_datatype_t (see `enum jl_small_typeof_tags` in julia.h). Only used as a
+# fallback when the `jl_small_typeof` symbol cannot be found; the list is
+# append-only in the runtime so existing indices are stable.
+SMALL_TAG_NAMES = [
+    "#null",
+    "TypeofBottom", "DataType", "UnionAll", "Union",
+    "TypeofVararg", "TypeVar", "Symbol", "Module",
+    "SimpleVector", "String", "Task",
+    "Bool", "Nothing", "Char",
+    "Int16", "Int32", "Int64", "Int8",
+    "UInt16", "UInt32", "UInt64", "UInt8",
+]
+
+PRIMITIVE_FMT = {
+    "Core.Int8": ("i", 1), "Core.Int16": ("i", 2),
+    "Core.Int32": ("i", 4), "Core.Int64": ("i", 8),
+    "Core.UInt8": ("u", 1), "Core.UInt16": ("u", 2),
+    "Core.UInt32": ("u", 4), "Core.UInt64": ("u", 8),
+    "Core.Float16": ("f", 2), "Core.Float32": ("f", 4),
+    "Core.Float64": ("f", 8),
+}
+
+# C type equivalents of unboxed primitive fields, for debuggers that want to
+# hand back a typed native value.
+PRIMITIVE_CTYPES = {
+    "Core.Int8": "int8_t", "Core.Int16": "int16_t",
+    "Core.Int32": "int32_t", "Core.Int64": "int64_t",
+    "Core.UInt8": "uint8_t", "Core.UInt16": "uint16_t",
+    "Core.UInt32": "uint32_t", "Core.UInt64": "uint64_t",
+    "Core.Float32": "float", "Core.Float64": "double",
+    "Core.Bool": "unsigned char", "Core.Char": "uint32_t",
+}
+
+TASK_STATES = {0: "runnable", 1: "done", 2: "failed", 3: "abandoned"}
+
+# see enum jl_partition_kind in julia.h
+PARTITION_KINDS_CONST = (0x0, 0x1, 0x4, 0xb)   # restriction is the value
+PARTITION_KINDS_IMPORT = (0x3, 0x5, 0x6)       # restriction is a binding
+PARTITION_KINDS_GLOBAL = (0x2, 0x8)            # value lives in binding->value
+
+
+def escape_string(s):
+    out = []
+    for c in s:
+        if c == '"':
+            out.append('\\"')
+        elif c == "\\":
+            out.append("\\\\")
+        elif c == "\n":
+            out.append("\\n")
+        elif c == "\t":
+            out.append("\\t")
+        elif ord(c) < 32:
+            out.append("\\x%02x" % ord(c))
+        else:
+            out.append(c)
+    return "".join(out)
+
+
+def render_char(u):
+    # Char stores the UTF-8 bytes left-aligned in a UInt32
+    raw = u.to_bytes(4, "big").rstrip(b"\0") or b"\0"
+    try:
+        return "'%s'" % raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return "Char(0x%08x)" % u
+
+
+def is_type_kind(qual):
+    return qual in ("Core.DataType", "Core.Union", "Core.UnionAll",
+                    "Core.TypeVar", "Core.TypeofVararg", "Core.TypeofBottom")
+
+
+_ACCESSOR_RE = re.compile(r"(\.[^\W\d][\w!]*|\.\d+|\[\d+\])$", re.UNICODE)
+
+
+def split_path(expr):
+    """Split `expr` into candidate (base, accessors) pairs for the `jl`
+    command, longest base first. Accessors are field names (str) or 1-based
+    indices (int), peeled from trailing `.name`, `.i` and `[i]` syntax."""
+    expr = expr.strip()
+    bases = [(expr, [])]
+    s, accessors = expr, []
+    while True:
+        m = _ACCESSOR_RE.search(s)
+        if m is None or m.start() == 0:
+            break
+        tok = m.group(0)
+        if tok.startswith("["):
+            key = int(tok[1:-1])
+        elif tok[1:].isdigit():
+            key = int(tok[1:])
+        else:
+            key = tok[1:]
+        accessors.insert(0, key)
+        s = s[:m.start()]
+        bases.append((s, list(accessors)))
+    return bases
+
+
+class JuliaRuntime:
+    """Renders and inspects the Julia runtime of one debugged process."""
+
+    def __init__(self, adapter):
+        self.a = adapter
+        self.dt_names = {}  # jl_datatype_t* address -> qualified name
+
+    # ---- basic reads ----------------------------------------------------
+
+    def read_uint(self, addr, size, signed=False):
+        return int.from_bytes(self.a.read_mem(addr, size), "little",
+                              signed=signed)
+
+    def read_ptr(self, addr):
+        return self.read_uint(addr, self.a.ptrsize)
+
+    def field_u(self, addr, typename, *path):
+        return self.a.field(addr, typename, path)
+
+    def field_i(self, addr, typename, *path):
+        return self.a.field(addr, typename, path, signed=True)
+
+    # ---- type tags -------------------------------------------------------
+
+    def typetag(self, addr):
+        """Type tag of the object at addr: header word, GC bits masked."""
+        return self.read_ptr(addr - self.a.ptrsize) & ~15
+
+    def typeof_addr(self, addr):
+        """Address of the jl_datatype_t of the object at addr (0: unknown)."""
+        tag = self.typetag(addr)
+        if tag < (64 << 4):
+            for sym in ("jl_small_typeof", "ijl_small_typeof"):
+                table = self.a.global_addr(sym)
+                if table:
+                    # entry at byte offset `tag`, see jl_to_typeof in julia.h
+                    return self.read_ptr(table + tag)
+            return 0
+        return tag
+
+    def symbol_name(self, addr):
+        return self.a.read_cstr(addr + self.a.type_size("jl_sym_t"))
+
+    def svec_len(self, addr):
+        return self.field_u(addr, "jl_svec_t", "length")
+
+    def svec_ref(self, addr, i):
+        return self.read_ptr(addr + self.a.type_size("jl_svec_t")
+                             + i * self.a.ptrsize)
+
+    def module_path(self, addr, depth=0):
+        """Dotted name of the jl_module_t at addr, e.g. "Base.Iterators"."""
+        if addr == 0 or depth > 10:
+            return "?"
+        name = self.symbol_name(self.field_u(addr, "jl_module_t", "name"))
+        parent = self.field_u(addr, "jl_module_t", "parent")
+        if parent == 0 or parent == addr:
+            return name
+        pname = self.module_path(parent, depth + 1)
+        if pname == "Main":
+            return name
+        return pname + "." + name
+
+    def datatype_qualname(self, dtaddr):
+        """Qualified name of a jl_datatype_t, e.g. "Core.Int64". Cached,
+        since datatypes are interned and long-lived."""
+        name = self.dt_names.get(dtaddr)
+        if name is None:
+            tn = self.field_u(dtaddr, "jl_datatype_t", "name")
+            name = (self.module_path(self.field_u(tn, "jl_typename_t",
+                                                  "module"))
+                    + "." + self.symbol_name(
+                        self.field_u(tn, "jl_typename_t", "name")))
+            self.dt_names[dtaddr] = name
+        return name
+
+    def typename_of(self, dtaddr):
+        tn = self.field_u(dtaddr, "jl_datatype_t", "name")
+        return self.symbol_name(self.field_u(tn, "jl_typename_t", "name"))
+
+    def is_cpu_addrspace(self, addr):
+        """True when addr is an instance of Core.AddrSpace{Core}, value 0."""
+        if addr == 0:
+            return False
+        try:
+            dtaddr = self.typeof_addr(addr)
+            if dtaddr == 0:
+                return False
+            return self.typename_of(dtaddr) == "AddrSpace" and \
+                self.read_uint(addr, 1) == 0
+        except JLDebugError:
+            return False
+
+    # ---- type rendering ---------------------------------------------------
+
+    def render_typevar(self, addr, with_bounds):
+        name = self.symbol_name(self.field_u(addr, "jl_tvar_t", "name"))
+        if not with_bounds:
+            return name
+        lb = self.render_type(self.field_u(addr, "jl_tvar_t", "lb"),
+                              MAX_DEPTH - 1)
+        ub = self.render_type(self.field_u(addr, "jl_tvar_t", "ub"),
+                              MAX_DEPTH - 1)
+        if lb == "Union{}" and ub == "Any":
+            return name
+        if lb == "Union{}":
+            return "%s<:%s" % (name, ub)
+        return "%s<:%s<:%s" % (lb, name, ub)
+
+    def flatten_union(self, addr, parts, depth):
+        if self.datatype_qualname(self.typeof_addr(addr)) == "Core.Union":
+            self.flatten_union(self.field_u(addr, "jl_uniontype_t", "a"),
+                               parts, depth)
+            self.flatten_union(self.field_u(addr, "jl_uniontype_t", "b"),
+                               parts, depth)
+        else:
+            parts.append(self.render_type(addr, depth))
+
+    def render_type(self, addr, depth=MAX_DEPTH):
+        """Render a Julia type object (or type parameter) as a string."""
+        if addr == 0:
+            return "#<null>"
+        if depth < 0:
+            return "…"
+        dtaddr = self.typeof_addr(addr)
+        if dtaddr == 0:
+            return "<?type 0x%x>" % addr
+        qual = self.datatype_qualname(dtaddr)
+        if qual == "Core.TypeofBottom":
+            return "Union{}"
+        if qual == "Core.Union":
+            parts = []
+            self.flatten_union(addr, parts, depth - 1)
+            return "Union{%s}" % ", ".join(parts)
+        if qual == "Core.UnionAll":
+            body = self.render_type(
+                self.field_u(addr, "jl_unionall_t", "body"), depth - 1)
+            var = self.render_typevar(
+                self.field_u(addr, "jl_unionall_t", "var"), True)
+            return "%s where %s" % (body, var)
+        if qual == "Core.TypeVar":
+            return self.render_typevar(addr, False)
+        if qual == "Core.TypeofVararg":
+            t = self.field_u(addr, "jl_vararg_t", "T")
+            n = self.field_u(addr, "jl_vararg_t", "N")
+            if t == 0:
+                return "Vararg"
+            if n == 0:
+                return "Vararg{%s}" % self.render_type(t, depth - 1)
+            return "Vararg{%s, %s}" % (self.render_type(t, depth - 1),
+                                       self.render_value(n, depth - 1))
+        if qual == "Core.Module":
+            return self.module_path(addr)
+        if qual != "Core.DataType":
+            # a value used as a type parameter (1, :x, true, ...)
+            return self.render_value(addr, depth)
+
+        tn = self.field_u(addr, "jl_datatype_t", "name")
+        modpath = self.module_path(self.field_u(tn, "jl_typename_t",
+                                                "module"))
+        name = self.symbol_name(self.field_u(tn, "jl_typename_t", "name"))
+        if modpath not in ("Core", "Main") and not name.startswith("typeof("):
+            name = modpath + "." + name
+        params = self.field_u(addr, "jl_datatype_t", "parameters")
+        nparams = self.svec_len(params) if params else 0
+        if nparams == 0:
+            return name + "{}" if name == "Tuple" else name
+        # sugar: Array{T, 1} => Vector{T}, Array{T, 2} => Matrix{T}
+        if name == "Array" and nparams == 2:
+            ndim = self.render_type(self.svec_ref(params, 1), depth - 1)
+            if ndim == "1":
+                return "Vector{%s}" % self.render_type(
+                    self.svec_ref(params, 0), depth - 1)
+            if ndim == "2":
+                return "Matrix{%s}" % self.render_type(
+                    self.svec_ref(params, 0), depth - 1)
+        # sugar: GenericMemory{:not_atomic, T, Core.CPU} => Memory{T}
+        if name == "GenericMemory" and nparams == 3:
+            order = self.svec_ref(params, 0)
+            if self.is_cpu_addrspace(self.svec_ref(params, 2)):
+                eltstr = self.render_type(self.svec_ref(params, 1), depth - 1)
+                oname = self.symbol_name(order) if order else ""
+                if oname == "not_atomic":
+                    return "Memory{%s}" % eltstr
+                if oname == "atomic":
+                    return "AtomicMemory{%s}" % eltstr
+        rendered = [self.render_type(self.svec_ref(params, i), depth - 1)
+                    for i in range(min(nparams, MAX_ELEMS))]
+        if nparams > MAX_ELEMS:
+            rendered.append("…")
+        return "%s{%s}" % (name, ", ".join(rendered))
+
+    # ---- data rendering ----------------------------------------------------
+
+    def string_data(self, addr):
+        strlen = self.read_uint(addr, self.a.ptrsize)
+        n = min(strlen, MAX_STRING)
+        s = self.a.read_mem(addr + self.a.ptrsize, n).decode(
+            "utf-8", errors="replace") if n else ""
+        return s, strlen
+
+    def render_primitive(self, qual, addr):
+        """The unboxed primitive of type `qual` stored at addr, or None."""
+        fmt = PRIMITIVE_FMT.get(qual)
+        if fmt is not None:
+            kind, size = fmt
+            if kind == "i":
+                return str(self.read_uint(addr, size, signed=True))
+            if kind == "u":
+                return "0x%0*x" % (2 * size, self.read_uint(addr, size))
+            import struct as _struct
+            return repr(_struct.unpack(
+                "<" + {2: "e", 4: "f", 8: "d"}[size],
+                self.a.read_mem(addr, size))[0])
+        if qual == "Core.Bool":
+            return "true" if self.read_uint(addr, 1) else "false"
+        if qual == "Core.Char":
+            return render_char(self.read_uint(addr, 4))
+        return None
+
+    def layout_fields(self, dtaddr):
+        """[(offset, size, isptr), ...] for a concrete jl_datatype_t, or
+        None when there is no field table (opaque/foreign layouts)."""
+        laddr = self.field_u(dtaddr, "jl_datatype_t", "layout")
+        if laddr == 0:
+            return None
+        nfields = self.field_u(laddr, "jl_datatype_layout_t", "nfields")
+        fdkind = self.field_u(laddr, "jl_datatype_layout_t", "flags",
+                              "fielddesc_type")
+        if fdkind == 3:  # foreign type: no descriptors
+            return None
+        fdname = ("jl_fielddesc8_t", "jl_fielddesc16_t",
+                  "jl_fielddesc32_t")[fdkind]
+        fdsize = self.a.type_size(fdname)
+        base = laddr + self.a.type_size("jl_datatype_layout_t")
+        fields = []
+        for i in range(nfields):
+            fd = base + i * fdsize
+            fields.append((self.field_u(fd, fdname, "offset"),
+                           self.field_u(fd, fdname, "size"),
+                           self.field_u(fd, fdname, "isptr")))
+        return fields
+
+    def field_names(self, dtaddr, nfields):
+        """Field names of a concrete datatype (NamedTuple aware)."""
+        tn = self.field_u(dtaddr, "jl_datatype_t", "name")
+        if self.symbol_name(self.field_u(tn, "jl_typename_t", "name")) == \
+                "NamedTuple":
+            names = self.namedtuple_names(dtaddr)
+            if names is not None:
+                return names
+        names = []
+        namesv = self.field_u(tn, "jl_typename_t", "names") if tn else 0
+        n = self.svec_len(namesv) if namesv else 0
+        for i in range(nfields):
+            if i < n:
+                sym = self.svec_ref(namesv, i)
+                names.append(self.symbol_name(sym) if sym else str(i + 1))
+            else:
+                names.append(str(i + 1))
+        return names
+
+    def field_types(self, dtaddr, nfields):
+        typesv = self.field_u(dtaddr, "jl_datatype_t", "types")
+        n = self.svec_len(typesv) if typesv else 0
+        return [self.svec_ref(typesv, i) if i < n else 0
+                for i in range(nfields)]
+
+    def namedtuple_names(self, dtaddr):
+        """Field names of a concrete NamedTuple type, from its first type
+        parameter (a tuple of symbols), or None."""
+        try:
+            params = self.field_u(dtaddr, "jl_datatype_t", "parameters")
+            if self.svec_len(params) != 2:
+                return None
+            namestup = self.svec_ref(params, 0)
+            fields = self.layout_fields(self.typeof_addr(namestup))
+            if fields is None:
+                return None
+            return [self.symbol_name(self.read_ptr(namestup + off))
+                    for (off, _, _) in fields]
+        except JLDebugError:
+            return None
+
+    def render_unboxed(self, taddr, addr, depth):
+        """Render the unboxed (inline-stored) value of type taddr at addr."""
+        if depth < 0:
+            return "…"
+        if taddr == 0:
+            return "<?>"
+        if self.datatype_qualname(self.typeof_addr(taddr)) != "Core.DataType":
+            return "<union field>"
+        qual = self.datatype_qualname(taddr)
+        prim = self.render_primitive(qual, addr)
+        if prim is not None:
+            return prim
+        if self.field_u(taddr, "jl_datatype_t", "isprimitivetype"):
+            laddr = self.field_u(taddr, "jl_datatype_t", "layout")
+            size = self.field_u(laddr, "jl_datatype_layout_t", "size") \
+                if laddr else 0
+            if 0 < size <= 8:
+                return "%s(0x%0*x)" % (self.render_type(taddr, 1), 2 * size,
+                                       self.read_uint(addr, size))
+            return "%s(...)" % self.render_type(taddr, 1)
+        fields = self.layout_fields(taddr)
+        if fields is None:
+            return "<%s>" % self.render_type(taddr, depth - 1)
+        if len(fields) == 0:
+            inst = self.field_u(taddr, "jl_datatype_t", "instance")
+            return self.render_value(inst, depth) if inst \
+                else self.render_type(taddr, depth - 1) + "()"
+        return self.render_struct_inline(taddr, addr, fields, depth)
+
+    def render_struct_inline(self, taddr, addr, fields, depth):
+        tn = self.field_u(taddr, "jl_datatype_t", "name")
+        tname = self.symbol_name(self.field_u(tn, "jl_typename_t", "name"))
+        istuple = tname == "Tuple" and \
+            self.module_path(self.field_u(tn, "jl_typename_t",
+                                          "module")) == "Core"
+        names = None if istuple else self.field_names(taddr, len(fields))
+        ftypes = self.field_types(taddr, len(fields))
+        parts = []
+        for i, (off, size, isptr) in enumerate(fields[:MAX_ELEMS]):
+            if isptr:
+                p = self.read_ptr(addr + off)
+                r = self.render_value(p, depth - 1) if p else "#undef"
+            else:
+                r = self.render_unboxed(ftypes[i], addr + off, depth - 1)
+            fname = names[i] if names and i < len(names) else str(i + 1)
+            parts.append(r if istuple else "%s = %s" % (fname, r))
+        if len(fields) > MAX_ELEMS:
+            parts.append("…")
+        if istuple and len(fields) == 1:
+            return "(%s,)" % parts[0]
+        if istuple or tname == "NamedTuple":
+            return "(%s)" % ", ".join(parts)
+        return "%s(%s)" % (self.render_type(taddr, 2), ", ".join(parts))
+
+    # ---- arrays -------------------------------------------------------------
+
+    def array_info(self, addr):
+        """(dims, eltype, dataptr, elsize, isboxed, isunion) of the
+        jl_array_t (or Memory) at addr."""
+        dtaddr = self.typeof_addr(addr)
+        tname = self.typename_of(dtaddr)
+        params = self.field_u(dtaddr, "jl_datatype_t", "parameters")
+        if tname == "GenericMemory":
+            mem_dt_addr = dtaddr
+            dims = [self.field_u(addr, "jl_genericmemory_t", "length")]
+            dataptr = self.field_u(addr, "jl_genericmemory_t", "ptr")
+            eltype = self.svec_ref(params, 1)
+        else:
+            mem_addr = self.field_u(addr, "jl_array_t", "ref", "mem")
+            mem_dt_addr = self.typeof_addr(mem_addr)
+            dataptr = self.field_u(addr, "jl_array_t", "ref",
+                                   "ptr_or_offset")
+            dimoff = self.a.field_offset("jl_array_t", "dimsize")
+            try:
+                ndims = self.read_uint(self.svec_ref(params, 1), 8)
+            except JLDebugError:
+                ndims = 1
+            if not (0 < ndims < 33):
+                ndims = 1
+            dims = [self.read_uint(addr + dimoff + i * self.a.ptrsize,
+                                   self.a.ptrsize) for i in range(ndims)]
+            eltype = self.svec_ref(params, 0)
+        mlayout = self.field_u(mem_dt_addr, "jl_datatype_t", "layout")
+        elsize = self.field_u(mlayout, "jl_datatype_layout_t", "size")
+        isboxed = self.field_u(mlayout, "jl_datatype_layout_t", "flags",
+                               "arrayelem_isboxed")
+        isunion = self.field_u(mlayout, "jl_datatype_layout_t", "flags",
+                               "arrayelem_isunion")
+        return dims, eltype, dataptr, elsize, isboxed, isunion
+
+    def is_array_value(self, addr):
+        try:
+            dtaddr = self.typeof_addr(addr)
+            return dtaddr != 0 and \
+                self.typename_of(dtaddr) in ("Array", "GenericMemory")
+        except JLDebugError:
+            return False
+
+    def render_array_summary(self, addr, depth):
+        dims = self.array_info(addr)[0]
+        tstr = self.render_type(self.typeof_addr(addr), depth)
+        if len(dims) == 1:
+            return "%d-element %s" % (dims[0], tstr)
+        return "%s %s" % ("×".join(str(d) for d in dims), tstr)
+
+    def array_children(self, addr):
+        """Yield ("index", ("val", addr) | ("str", s)) pairs for the first
+        MAX_ELEMS elements of the array/Memory at addr."""
+        dims, eltype, dataptr, elsize, isboxed, isunion = self.array_info(addr)
+        n = 1
+        for d in dims:
+            n *= d
+        shown = min(n, MAX_ELEMS)
+        for i in range(shown):
+            if isboxed:
+                p = self.read_ptr(dataptr + i * self.a.ptrsize)
+                yield str(i + 1), (("val", p) if p else ("str", "#undef"))
+            elif isunion:
+                yield str(i + 1), ("str", "<union element>")
+            else:
+                yield str(i + 1), ("str", self.render_unboxed(
+                    eltype, dataptr + i * elsize, MAX_DEPTH - 1))
+        if n > shown:
+            yield "...", ("str", "(%d more)" % (n - shown))
+
+    def render_array(self, addr, depth):
+        summary = self.render_array_summary(addr, depth)
+        if depth < MAX_DEPTH:
+            return summary
+        parts = []
+        for _, (kind, v) in self.array_children(addr):
+            parts.append(self.render_value(v, depth - 1) if kind == "val"
+                         else v)
+        return "%s = {%s}" % (summary, ", ".join(parts))
+
+    # ---- runtime objects ------------------------------------------------------
+
+    def render_sig_call(self, fname, sigaddr, depth):
+        """Render "f(::T, ::S)" from a Tuple{typeof(f), T, S} signature."""
+        seen = 0
+        while self.datatype_qualname(self.typeof_addr(sigaddr)) == \
+                "Core.UnionAll" and seen < 32:
+            sigaddr = self.field_u(sigaddr, "jl_unionall_t", "body")
+            seen += 1
+        if self.datatype_qualname(self.typeof_addr(sigaddr)) != \
+                "Core.DataType":
+            return "%s(...)" % fname
+        params = self.field_u(sigaddr, "jl_datatype_t", "parameters")
+        n = self.svec_len(params) if params else 0
+        args = ["::" + self.render_type(self.svec_ref(params, i), depth - 1)
+                for i in range(1, min(n, MAX_ELEMS + 1))]
+        if n > MAX_ELEMS + 1:
+            args.append("…")
+        return "%s(%s)" % (fname, ", ".join(args))
+
+    def render_method(self, addr, depth):
+        name = self.symbol_name(self.field_u(addr, "jl_method_t", "name"))
+        where = ""
+        mod = self.field_u(addr, "jl_method_t", "module")
+        if mod:
+            where = " @ " + self.module_path(mod)
+        faddr = self.field_u(addr, "jl_method_t", "file")
+        if faddr:
+            where += " %s:%d" % (self.symbol_name(faddr),
+                                 self.field_i(addr, "jl_method_t", "line"))
+        return self.render_sig_call(
+            name, self.field_u(addr, "jl_method_t", "sig"), depth) + where
+
+    def render_method_instance(self, addr, depth):
+        defaddr = self.field_u(addr, "jl_method_instance_t", "def", "value")
+        name = "?"
+        if defaddr:
+            if self.datatype_qualname(self.typeof_addr(defaddr)) == \
+                    "Core.Method":
+                name = self.symbol_name(
+                    self.field_u(defaddr, "jl_method_t", "name"))
+            else:  # toplevel thunk: def is a module
+                return "MethodInstance for top-level scope in " + \
+                    self.module_path(defaddr)
+        return "MethodInstance for " + self.render_sig_call(
+            name, self.field_u(addr, "jl_method_instance_t", "specTypes"),
+            depth)
+
+    def render_code_instance(self, addr, depth):
+        defaddr = self.field_u(addr, "jl_code_instance_t", "def")
+        inner = "?"
+        if defaddr:
+            qual = self.datatype_qualname(self.typeof_addr(defaddr))
+            if qual == "Core.ABIOverride":
+                defaddr = self.field_u(defaddr, "jl_abi_override_t", "def")
+                qual = self.datatype_qualname(self.typeof_addr(defaddr))
+            if qual == "Core.MethodInstance":
+                inner = self.render_method_instance(defaddr, depth - 1)
+        return "CodeInstance for %s" % inner
+
+    def render_task(self, addr):
+        state = TASK_STATES.get(self.field_u(addr, "jl_task_t", "_state"),
+                                "?")
+        return "Task (%s) @0x%016x" % (state, addr)
+
+    def render_expr(self, addr, depth):
+        head = self.field_u(addr, "jl_expr_t", "head")
+        headname = self.symbol_name(head) if head else "?"
+        args = self.field_u(addr, "jl_expr_t", "args")
+        nargs = 0
+        if args:
+            try:
+                nargs = self.array_info(args)[0][0]
+            except JLDebugError:
+                pass
+        return "Expr(:%s, <%d args>)" % (headname, nargs)
+
+    def render_svec(self, addr, depth):
+        n = self.svec_len(addr)
+        parts = []
+        for i in range(min(n, MAX_ELEMS)):
+            p = self.svec_ref(addr, i)
+            parts.append(self.render_value(p, depth - 1) if p else "#undef")
+        if n > MAX_ELEMS:
+            parts.append("…")
+        return "svec(%s)" % ", ".join(parts)
+
+    # ---- main value renderer -----------------------------------------------
+
+    def render_value(self, addr, depth=MAX_DEPTH):
+        """Render the Julia value at addr as a compact single-line string."""
+        if addr == 0:
+            return "#<null>"
+        if depth < 0:
+            return "…"
+        dtaddr = self.typeof_addr(addr)
+        if dtaddr == 0:
+            tag = self.typetag(addr)
+            idx = tag >> 4
+            if tag < (64 << 4) and idx < len(SMALL_TAG_NAMES):
+                return "<%s 0x%x>" % (SMALL_TAG_NAMES[idx], addr)
+            return "<julia value 0x%x>" % addr
+        qual = self.datatype_qualname(dtaddr)
+
+        if is_type_kind(qual):
+            return self.render_type(addr, depth)
+        prim = self.render_primitive(qual, addr)
+        if prim is not None:
+            return prim
+        if qual == "Core.Nothing":
+            return "nothing"
+        if qual == "Core.Symbol":
+            name = self.symbol_name(addr)
+            if name.isidentifier():
+                return ":" + name
+            return 'Symbol("%s")' % escape_string(name)
+        if qual == "Core.String":
+            s, strlen = self.string_data(addr)
+            suffix = "…" if strlen > len(s.encode("utf-8", "replace")) \
+                else ""
+            return '"%s%s"' % (escape_string(s), suffix)
+        if qual == "Core.SimpleVector":
+            return self.render_svec(addr, depth)
+        if qual == "Core.Module":
+            return "Module %s" % self.module_path(addr)
+        if qual == "Core.Task":
+            return self.render_task(addr)
+        if qual == "Core.Method":
+            return self.render_method(addr, depth)
+        if qual == "Core.MethodInstance":
+            return self.render_method_instance(addr, depth)
+        if qual == "Core.CodeInstance":
+            return self.render_code_instance(addr, depth)
+        if qual == "Core.Expr":
+            return self.render_expr(addr, depth)
+        if qual == "Core.GlobalRef":
+            return "%s.%s" % (
+                self.module_path(self.field_u(addr, "jl_globalref_t",
+                                              "mod")),
+                self.symbol_name(self.field_u(addr, "jl_globalref_t",
+                                              "name")))
+        if qual == "Core.TypeName":
+            return "typename(%s)" % self.symbol_name(
+                self.field_u(addr, "jl_typename_t", "name"))
+
+        tname = self.typename_of(dtaddr)
+        if tname in ("Array", "GenericMemory"):
+            try:
+                return self.render_array(addr, depth)
+            except JLDebugError:
+                return self.render_type(dtaddr, depth - 1) + " <unreadable>"
+
+        # generic instances
+        if self.field_u(dtaddr, "jl_datatype_t", "instance") == addr:
+            tn = self.field_u(dtaddr, "jl_datatype_t", "name")
+            sname = self.field_u(tn, "jl_typename_t", "singletonname") \
+                if self.a.has_field("jl_typename_t", "singletonname") else 0
+            # functions and similar get a distinct singleton name ("sin");
+            # for other singletons render the type, e.g. Irrational{:π}()
+            if sname and sname != self.field_u(tn, "jl_typename_t", "name"):
+                return self.symbol_name(sname)
+            return self.render_type(dtaddr, depth) + "()"
+        if self.field_u(dtaddr, "jl_datatype_t", "isprimitivetype"):
+            return self.render_unboxed(dtaddr, addr, depth)
+        fields = self.layout_fields(dtaddr)
+        if fields is not None:
+            return self.render_struct_inline(dtaddr, addr, fields, depth)
+        return "%s @0x%016x" % (self.render_type(dtaddr, depth - 1), addr)
+
+    def render_value_capped(self, addr):
+        """render_value with a hard cap on the output size, for printers."""
+        out = self.render_value(addr)
+        if len(out) > MAX_OUTPUT:
+            out = out[:MAX_OUTPUT] + "…"
+        return out
+
+    # ---- Julia-semantics field/index access (the `jl` command) ---------------
+    #
+    # A "location" is ("val", addr) for a boxed value, or
+    # ("inline", typeaddr, addr) for an unboxed value stored inline.
+
+    def loc_of_value(self, addr):
+        return ("val", addr)
+
+    def render_loc(self, loc):
+        if loc[0] == "val":
+            out = self.render_value(loc[1])
+        else:
+            out = self.render_unboxed(loc[1], loc[2], MAX_DEPTH)
+        if len(out) > MAX_OUTPUT:
+            out = out[:MAX_OUTPUT] + "…"
+        return out
+
+    def loc_type_and_addr(self, loc):
+        if loc[0] == "val":
+            return self.typeof_addr(loc[1]), loc[1]
+        return loc[1], loc[2]
+
+    def getfield(self, loc, key):
+        """Julia-semantics getfield/getindex: `key` is a field name (str) or
+        a 1-based index (int). Returns a new location."""
+        taddr, addr = self.loc_type_and_addr(loc)
+        if addr == 0:
+            raise JLDebugError("cannot access field of NULL")
+        if taddr == 0:
+            raise JLDebugError("cannot determine type of 0x%x" % addr)
+        qual = self.datatype_qualname(taddr)
+        if qual == "Core.Module" and loc[0] == "val":
+            if not isinstance(key, str):
+                raise JLDebugError("module access needs a name, got %r"
+                                   % key)
+            return self.module_getfield(addr, key)
+        if qual == "Core.SimpleVector" and loc[0] == "val":
+            if not isinstance(key, int):
+                raise JLDebugError("svec access needs an index")
+            n = self.svec_len(addr)
+            if not (1 <= key <= n):
+                raise JLDebugError("index %d out of bounds (1:%d)"
+                                   % (key, n))
+            p = self.svec_ref(addr, key - 1)
+            if p == 0:
+                raise JLDebugError("svec element %d is #undef" % key)
+            return ("val", p)
+        tname = self.typename_of(taddr)
+        if tname in ("Array", "GenericMemory") and loc[0] == "val" and \
+                isinstance(key, int):
+            return self.array_getindex(addr, key)
+
+        fields = self.layout_fields(taddr)
+        if fields is None or len(fields) == 0:
+            raise JLDebugError("%s has no fields" % self.render_type(taddr, 1))
+        names = self.field_names(taddr, len(fields))
+        if isinstance(key, int):
+            idx = key - 1
+            if not (0 <= idx < len(fields)):
+                raise JLDebugError("field index %d out of bounds (1:%d)"
+                                   % (key, len(fields)))
+        else:
+            try:
+                idx = names.index(key)
+            except ValueError:
+                raise JLDebugError("%s has no field %s; fields are (%s)"
+                                   % (self.render_type(taddr, 1), key,
+                                      ", ".join(names[:25])))
+        off, size, isptr = fields[idx]
+        if isptr:
+            p = self.read_ptr(addr + off)
+            if p == 0:
+                raise JLDebugError("field %s is #undef" % key)
+            return ("val", p)
+        ftype = self.field_types(taddr, len(fields))[idx]
+        if ftype == 0 or self.datatype_qualname(self.typeof_addr(ftype)) != \
+                "Core.DataType":
+            raise JLDebugError("field %s has union layout; cannot access"
+                               % key)
+        return ("inline", ftype, addr + off)
+
+    def array_getindex(self, addr, key):
+        dims, eltype, dataptr, elsize, isboxed, isunion = \
+            self.array_info(addr)
+        n = 1
+        for d in dims:
+            n *= d
+        if not (1 <= key <= n):
+            raise JLDebugError("index %d out of bounds (1:%d)" % (key, n))
+        if isunion:
+            raise JLDebugError("union-layout array elements are not"
+                               " supported")
+        if isboxed:
+            p = self.read_ptr(dataptr + (key - 1) * self.a.ptrsize)
+            if p == 0:
+                raise JLDebugError("element %d is #undef" % key)
+            return ("val", p)
+        return ("inline", eltype, dataptr + (key - 1) * elsize)
+
+    # ---- module bindings ------------------------------------------------------
+
+    def module_getfield(self, modaddr, name, depth=0):
+        """Look up the global `name` in the module at modaddr, walking the
+        binding table and its partitions (newest partition only)."""
+        if depth > 10:
+            raise JLDebugError("binding chain too deep")
+        bindings = self.field_u(modaddr, "jl_module_t", "bindings")
+        if bindings == 0:
+            raise JLDebugError("module has no binding table")
+        n = self.svec_len(bindings)
+        if n > 100000:
+            raise JLDebugError("implausible binding table size %d" % n)
+        for i in range(n):
+            b = self.svec_ref(bindings, i)
+            if b == 0:
+                continue
+            try:
+                if self.datatype_qualname(self.typeof_addr(b)) != \
+                        "Core.Binding":
+                    continue
+                gr = self.field_u(b, "jl_binding_t", "globalref")
+                if gr == 0:
+                    continue
+                sym = self.field_u(gr, "jl_globalref_t", "name")
+                if self.symbol_name(sym) != name:
+                    continue
+            except JLDebugError:
+                continue
+            return self.binding_value(b, name, depth)
+        raise JLDebugError("%s has no binding named %s"
+                           % (self.module_path(modaddr), name))
+
+    def binding_value(self, baddr, name, depth):
+        part = self.field_u(baddr, "jl_binding_t", "partitions")
+        if part == 0:
+            value = self.field_u(baddr, "jl_binding_t", "value")
+            if value:
+                return ("val", value)
+            raise JLDebugError("binding %s has no value" % name)
+        kind = self.field_u(part, "jl_binding_partition_t", "kind") & 0xf
+        restriction = self.field_u(part, "jl_binding_partition_t",
+                                   "restriction")
+        if kind in PARTITION_KINDS_CONST:
+            if restriction == 0:
+                raise JLDebugError("constant %s is undefined" % name)
+            return ("val", restriction)
+        if kind in PARTITION_KINDS_IMPORT:
+            if restriction == 0:
+                raise JLDebugError("import %s is unresolved" % name)
+            return self.binding_value(restriction, name, depth + 1)
+        if kind in PARTITION_KINDS_GLOBAL:
+            value = self.field_u(baddr, "jl_binding_t", "value")
+            if value:
+                return ("val", value)
+            raise JLDebugError("global %s is undefined" % name)
+        raise JLDebugError("binding %s is not resolvable (kind %d)"
+                           % (name, kind))
+
+    def root_module(self, name):
+        """Address of Main/Core/Base, or a top-level module/global visible
+        from Main or Core, for use as the base of a `jl` path. 0 if absent."""
+        roots = {"Main": "jl_main_module", "Core": "jl_core_module",
+                 "Base": "jl_base_module"}
+        if name in roots:
+            slot = self.a.global_addr(roots[name])
+            return self.read_ptr(slot) if slot else 0
+        for root in ("jl_main_module", "jl_core_module"):
+            slot = self.a.global_addr(root)
+            if not slot:
+                continue
+            mod = self.read_ptr(slot)
+            if not mod:
+                continue
+            try:
+                loc = self.module_getfield(mod, name)
+                return loc[1] if loc[0] == "val" else 0
+            except JLDebugError:
+                continue
+        return 0
+
+    def eval_accessors(self, loc, accessors):
+        for key in accessors:
+            loc = self.getfield(loc, key)
+        return loc

--- a/contrib/julia_debug_core.py
+++ b/contrib/julia_debug_core.py
@@ -110,13 +110,23 @@ def escape_string(s):
     return "".join(out)
 
 
+CHAR_ESCAPES = {"\n": "\\n", "\t": "\\t", "\r": "\\r",
+                "'": "\\'", "\\": "\\\\"}
+
+
 def render_char(u):
     # Char stores the UTF-8 bytes left-aligned in a UInt32
     raw = u.to_bytes(4, "big").rstrip(b"\0") or b"\0"
     try:
-        return "'%s'" % raw.decode("utf-8")
+        c = raw.decode("utf-8")
     except UnicodeDecodeError:
         return "Char(0x%08x)" % u
+    if len(c) != 1:
+        return "Char(0x%08x)" % u
+    esc = CHAR_ESCAPES.get(c)
+    if esc is None and (ord(c) < 32 or ord(c) == 0x7f):
+        esc = "\\x%02x" % ord(c)
+    return "'%s'" % (esc if esc is not None else c)
 
 
 def is_type_kind(qual):
@@ -599,10 +609,12 @@ class JuliaRuntime:
                                    "ptr_or_offset")
             dimoff = self.a.field_offset("jl_array_t", "dimsize")
             try:
-                ndims = self.read_uint(self.svec_ref(params, 1), 8)
+                # the N parameter of Array{T, N} is a boxed Int
+                ndims = self.read_uint(self.svec_ref(params, 1),
+                                       self.a.ptrsize)
             except JLDebugError:
                 ndims = 1
-            if not (0 < ndims < 33):
+            if not (0 <= ndims < 33):
                 ndims = 1
             dims = [self.read_uint(addr + dimoff + i * self.a.ptrsize,
                                    self.a.ptrsize) for i in range(ndims)]
@@ -635,6 +647,8 @@ class JuliaRuntime:
     def render_array_summary(self, addr, depth):
         dims = self.array_info(addr)[0]
         tstr = self.render_type(self.typeof_addr(addr), depth)
+        if len(dims) == 0:
+            return "0-dimensional %s" % tstr
         if len(dims) == 1:
             return "%d-element %s" % (dims[0], tstr)
         return "%s %s" % ("×".join(str(d) for d in dims), tstr)

--- a/contrib/julia_debug_core.py
+++ b/contrib/julia_debug_core.py
@@ -1057,3 +1057,38 @@ class JuliaRuntime:
         for key in accessors:
             loc = self.getfield(loc, key)
         return loc
+
+    def resolve_type_name(self, name, size=None):
+        """Address of the concrete jl_datatype_t named by a dotted path like
+        "Main.MaybeInt" (as debug info names unboxed struct values), or 0.
+        Parametric names cannot be resolved this way. When `size` is given,
+        the type's layout size must match it (a guard against unrelated
+        same-named native types)."""
+        if not name or "{" in name:
+            return 0
+        parts = name.split(".")
+        if not all(p.isidentifier() for p in parts):
+            return 0
+        try:
+            mod = self.root_module(parts[0])
+            if mod == 0:
+                return 0
+            loc = ("val", mod)
+            for p in parts[1:]:
+                loc = self.getfield(loc, p)
+                if loc[0] != "val":
+                    return 0
+            dt = loc[1]
+            if self.datatype_qualname(self.typeof_addr(dt)) != \
+                    "Core.DataType":
+                return 0
+            laddr = self.field_u(dt, "jl_datatype_t", "layout")
+            if laddr == 0:
+                return 0
+            if size is not None and \
+                    self.field_u(laddr, "jl_datatype_layout_t",
+                                 "size") != size:
+                return 0
+            return dt
+        except JLDebugError:
+            return 0

--- a/contrib/julia_gdb.py
+++ b/contrib/julia_gdb.py
@@ -1,0 +1,1006 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+"""GDB pretty-printers for Julia runtime values.
+
+Load this script into gdb to make `print` render `jl_value_t*` (and other
+Julia runtime pointers such as `jl_datatype_t*`, `jl_sym_t*`, `jl_svec_t*`,
+`jl_array_t*`, `jl_method_t*`, ...) the way Julia would show them, instead of
+as raw addresses:
+
+    (gdb) print v
+    $1 = Symbol("foo")
+    (gdb) print (jl_value_t*)some_array
+    $2 = 3-element Vector{Int64} = {1, 2, 3}
+
+Usage (pick one):
+  * `source /path/to/julia/contrib/julia_gdb.py` inside gdb, or
+  * add that line to your `~/.gdbinit`, or
+  * `gdb -x /path/to/julia/contrib/julia_gdb.py --args ./julia ...`
+
+The printers dispatch on the *runtime* type tag of the object, so a plain
+`jl_value_t*` prints as whatever it actually is. Everything is resolved
+through the debug info (DWARF) of libjulia-internal, so this script does not
+hard-code struct offsets and should work across Julia versions; it requires a
+build of Julia with debug info (the default) and gracefully degrades to raw
+pointers when the debug info or the memory is unavailable.
+
+A convenience function `$jl_typeof(v)` is also provided:
+
+    (gdb) print $jl_typeof(v)
+    $3 = Vector{Int64}
+
+To temporarily see raw pointers again use `print/r`:
+
+    (gdb) print/r v
+    $4 = (jl_value_t *) 0x7f0f2c81f4d0
+"""
+
+import re
+import struct
+
+import gdb
+import gdb.printing
+
+# Render at most this many nested levels in a single summary string.
+MAX_DEPTH = 3
+# Render at most this many elements of arrays/svecs/tuples in a summary.
+MAX_ELEMS = 10
+# Truncate strings longer than this many bytes.
+MAX_STRING = 200
+
+# Objects whose type tag is a small constant rather than a pointer to the
+# jl_datatype_t (see `enum jl_small_typeof_tags` in julia.h). Only used as a
+# fallback when the `jl_small_typeof` symbol cannot be found; the list is
+# append-only in the runtime so existing indices are stable.
+SMALL_TAG_NAMES = [
+    "#null",
+    "TypeofBottom", "DataType", "UnionAll", "Union",
+    "TypeofVararg", "TypeVar", "Symbol", "Module",
+    "SimpleVector", "String", "Task",
+    "Bool", "Nothing", "Char",
+    "Int16", "Int32", "Int64", "Int8",
+    "UInt16", "UInt32", "UInt64", "UInt8",
+]
+
+
+class _Cache:
+    """Per-process caches for type lookups; flushed when objfiles change."""
+
+    def __init__(self):
+        self.clear()
+
+    def clear(self):
+        self.types = {}
+        self.sizes = {}
+        self.small_typeof = -1  # -1: not looked up yet; 0: unavailable
+        self.ptrsize = None
+        self.dt_names = {}  # jl_datatype_t* address -> qualified name
+
+
+CACHE = _Cache()
+
+
+def _clear_cache(event=None):
+    CACHE.clear()
+
+
+gdb.events.new_objfile.connect(_clear_cache)
+if hasattr(gdb.events, "free_objfile"):
+    gdb.events.free_objfile.connect(_clear_cache)
+gdb.events.exited.connect(_clear_cache)
+
+
+def lookup_type(name):
+    t = CACHE.types.get(name)
+    if t is None:
+        t = gdb.lookup_type(name)
+        CACHE.types[name] = t
+    return t
+
+
+def type_size(name):
+    s = CACHE.sizes.get(name)
+    if s is None:
+        s = lookup_type(name).sizeof
+        CACHE.sizes[name] = s
+    return s
+
+
+def ptr_size():
+    if CACHE.ptrsize is None:
+        CACHE.ptrsize = lookup_type("void").pointer().sizeof
+    return CACHE.ptrsize
+
+
+def read_mem(addr, size):
+    return bytes(gdb.selected_inferior().read_memory(addr, size))
+
+
+def read_uint(addr, size, signed=False):
+    return int.from_bytes(read_mem(addr, size), "little", signed=signed)
+
+
+def read_ptr(addr):
+    return read_uint(addr, ptr_size())
+
+
+def read_cstring(addr, maxlen=512):
+    buf = read_mem(addr, maxlen)
+    nul = buf.find(b"\0")
+    if nul >= 0:
+        buf = buf[:nul]
+    return buf.decode("utf-8", errors="replace")
+
+
+def value_at(addr, typename):
+    """A gdb.Value of type `typename` located at `addr`."""
+    return gdb.Value(addr).cast(lookup_type(typename).pointer()).dereference()
+
+
+def small_typeof_addr():
+    """Address of the runtime's jl_small_typeof table, or 0."""
+    if CACHE.small_typeof == -1:
+        CACHE.small_typeof = 0
+        for sym in ("jl_small_typeof", "ijl_small_typeof"):
+            try:
+                CACHE.small_typeof = int(
+                    gdb.parse_and_eval("(unsigned long)&" + sym))
+                break
+            except gdb.error:
+                continue
+    return CACHE.small_typeof
+
+
+def typetag(addr):
+    """The type tag of the object at addr: header word with GC bits masked."""
+    return read_ptr(addr - ptr_size()) & ~15
+
+
+def typeof_addr(addr):
+    """Address of the jl_datatype_t for the object at addr (0 if unknown)."""
+    tag = typetag(addr)
+    if tag < (64 << 4):
+        table = small_typeof_addr()
+        if table == 0:
+            return 0
+        # entry lives at byte offset `tag` (see jl_to_typeof in julia.h)
+        return read_ptr(table + tag)
+    return tag
+
+
+def symbol_name(addr):
+    """The name of the jl_sym_t at addr."""
+    return read_cstring(addr + type_size("jl_sym_t"))
+
+
+def svec_len(addr):
+    return int(value_at(addr, "jl_svec_t")["length"])
+
+
+def svec_ref(addr, i):
+    return read_ptr(addr + type_size("jl_svec_t") + i * ptr_size())
+
+
+def is_cpu_addrspace(addr):
+    """True when addr is an instance of Core.AddrSpace{Core} with value 0."""
+    if addr == 0:
+        return False
+    try:
+        dtaddr = typeof_addr(addr)
+        if dtaddr == 0:
+            return False
+        dt = value_at(dtaddr, "jl_datatype_t")
+        tname = symbol_name(int(value_at(int(dt["name"]),
+                                         "jl_typename_t")["name"]))
+        return tname == "AddrSpace" and read_uint(addr, 1) == 0
+    except (gdb.error, gdb.MemoryError):
+        return False
+
+
+def module_path(addr, depth=0):
+    """Dotted name of the jl_module_t at addr, e.g. "Base.Iterators"."""
+    if addr == 0 or depth > 10:
+        return "?"
+    mod = value_at(addr, "jl_module_t")
+    name = symbol_name(int(mod["name"]))
+    parent = int(mod["parent"])
+    if parent == 0 or parent == addr:
+        return name
+    pname = module_path(parent, depth + 1)
+    if pname == "Main":
+        return name
+    return pname + "." + name
+
+
+def datatype_qualname(dtaddr):
+    """Qualified name of a jl_datatype_t, e.g. "Core.Int64". Cached, since
+    datatypes are interned and long-lived."""
+    name = CACHE.dt_names.get(dtaddr)
+    if name is None:
+        dt = value_at(dtaddr, "jl_datatype_t")
+        tn = value_at(int(dt["name"]), "jl_typename_t")
+        name = module_path(int(tn["module"])) + "." + symbol_name(int(tn["name"]))
+        CACHE.dt_names[dtaddr] = name
+    return name
+
+
+def string_data(addr):
+    """(contents, length) of the Core.String at addr."""
+    strlen = read_uint(addr, ptr_size())
+    n = min(strlen, MAX_STRING)
+    s = read_mem(addr + ptr_size(), n).decode("utf-8", errors="replace")
+    return s, strlen
+
+
+def escape_string(s):
+    out = []
+    for c in s:
+        if c == '"':
+            out.append('\\"')
+        elif c == "\\":
+            out.append("\\\\")
+        elif c == "\n":
+            out.append("\\n")
+        elif c == "\t":
+            out.append("\\t")
+        elif ord(c) < 32:
+            out.append("\\x%02x" % ord(c))
+        else:
+            out.append(c)
+    return "".join(out)
+
+
+# --------------------------------------------------------------------------
+# rendering of type objects (DataType/Union/UnionAll/TypeVar/Vararg)
+# --------------------------------------------------------------------------
+
+def is_type_kind(qual):
+    return qual in ("Core.DataType", "Core.Union", "Core.UnionAll",
+                    "Core.TypeVar", "Core.TypeofVararg", "Core.TypeofBottom")
+
+
+def render_typevar(addr, with_bounds):
+    tv = value_at(addr, "jl_tvar_t")
+    name = symbol_name(int(tv["name"]))
+    if not with_bounds:
+        return name
+    lb = render_type(int(tv["lb"]), MAX_DEPTH - 1)
+    ub = render_type(int(tv["ub"]), MAX_DEPTH - 1)
+    if lb == "Union{}" and ub == "Any":
+        return name
+    if lb == "Union{}":
+        return "%s<:%s" % (name, ub)
+    return "%s<:%s<:%s" % (lb, name, ub)
+
+
+def flatten_union(addr, parts, depth):
+    qual = datatype_qualname(typeof_addr(addr))
+    if qual == "Core.Union":
+        u = value_at(addr, "jl_uniontype_t")
+        flatten_union(int(u["a"]), parts, depth)
+        flatten_union(int(u["b"]), parts, depth)
+    else:
+        parts.append(render_type(addr, depth))
+
+
+def render_type(addr, depth=MAX_DEPTH):
+    """Render a Julia type object (or type parameter) as a string."""
+    if addr == 0:
+        return "#<null>"
+    if depth < 0:
+        return "…"
+    dtaddr = typeof_addr(addr)
+    if dtaddr == 0:
+        return "<?type 0x%x>" % addr
+    qual = datatype_qualname(dtaddr)
+    if qual == "Core.TypeofBottom":
+        return "Union{}"
+    if qual == "Core.Union":
+        parts = []
+        flatten_union(addr, parts, depth - 1)
+        return "Union{%s}" % ", ".join(parts)
+    if qual == "Core.UnionAll":
+        ua = value_at(addr, "jl_unionall_t")
+        body = render_type(int(ua["body"]), depth - 1)
+        var = render_typevar(int(ua["var"]), True)
+        return "%s where %s" % (body, var)
+    if qual == "Core.TypeVar":
+        return render_typevar(addr, False)
+    if qual == "Core.TypeofVararg":
+        va = value_at(addr, "jl_vararg_t")
+        t, n = int(va["T"]), int(va["N"])
+        if t == 0:
+            return "Vararg"
+        if n == 0:
+            return "Vararg{%s}" % render_type(t, depth - 1)
+        return "Vararg{%s, %s}" % (render_type(t, depth - 1),
+                                   render_value(n, depth - 1))
+    if qual == "Core.Module":
+        return module_path(addr)
+    if qual != "Core.DataType":
+        # a value used as a type parameter (1, :x, true, ...)
+        return render_value(addr, depth)
+
+    dt = value_at(addr, "jl_datatype_t")
+    tn = value_at(int(dt["name"]), "jl_typename_t")
+    modpath = module_path(int(tn["module"]))
+    name = symbol_name(int(tn["name"]))
+    if modpath not in ("Core", "Main") and not name.startswith("typeof("):
+        name = modpath + "." + name
+    params = int(dt["parameters"])
+    nparams = svec_len(params) if params else 0
+    if nparams == 0:
+        return name + "{}" if name == "Tuple" else name
+    # sugar: Array{T, 1} => Vector{T}, Array{T, 2} => Matrix{T}
+    if name == "Array" and nparams == 2:
+        ndim = render_type(svec_ref(params, 1), depth - 1)
+        if ndim == "1":
+            return "Vector{%s}" % render_type(svec_ref(params, 0), depth - 1)
+        if ndim == "2":
+            return "Matrix{%s}" % render_type(svec_ref(params, 0), depth - 1)
+    # sugar: GenericMemory{:not_atomic, T, Core.CPU} => Memory{T}
+    if name == "GenericMemory" and nparams == 3:
+        order = svec_ref(params, 0)
+        aspace = svec_ref(params, 2)
+        if is_cpu_addrspace(aspace):
+            eltstr = render_type(svec_ref(params, 1), depth - 1)
+            oname = symbol_name(order) if order else ""
+            if oname == "not_atomic":
+                return "Memory{%s}" % eltstr
+            if oname == "atomic":
+                return "AtomicMemory{%s}" % eltstr
+    rendered = [render_type(svec_ref(params, i), depth - 1)
+                for i in range(min(nparams, MAX_ELEMS))]
+    if nparams > MAX_ELEMS:
+        rendered.append("…")
+    return "%s{%s}" % (name, ", ".join(rendered))
+
+
+# --------------------------------------------------------------------------
+# rendering of plain data (bits values, structs, arrays)
+# --------------------------------------------------------------------------
+
+PRIMITIVE_FMT = {
+    "Core.Int8": ("i", 1), "Core.Int16": ("i", 2),
+    "Core.Int32": ("i", 4), "Core.Int64": ("i", 8),
+    "Core.UInt8": ("u", 1), "Core.UInt16": ("u", 2),
+    "Core.UInt32": ("u", 4), "Core.UInt64": ("u", 8),
+    "Core.Float16": ("f", 2), "Core.Float32": ("f", 4),
+    "Core.Float64": ("f", 8),
+}
+
+
+def render_char(u):
+    # Char stores the UTF-8 bytes left-aligned in a UInt32
+    raw = u.to_bytes(4, "big").rstrip(b"\0") or b"\0"
+    try:
+        return "'%s'" % raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return "Char(0x%08x)" % u
+
+
+def render_primitive(qual, addr):
+    """Render the unboxed primitive of type `qual` stored at addr, or None."""
+    fmt = PRIMITIVE_FMT.get(qual)
+    if fmt is not None:
+        kind, size = fmt
+        if kind == "i":
+            return str(read_uint(addr, size, signed=True))
+        if kind == "u":
+            return "0x%0*x" % (2 * size, read_uint(addr, size))
+        return repr(struct.unpack("<" + {2: "e", 4: "f", 8: "d"}[size],
+                                  read_mem(addr, size))[0])
+    if qual == "Core.Bool":
+        return "true" if read_uint(addr, 1) else "false"
+    if qual == "Core.Char":
+        return render_char(read_uint(addr, 4))
+    return None
+
+
+def layout_fields(dt):
+    """[(offset, size, isptr), ...] for the concrete jl_datatype_t value dt,
+    or None when there is no field table (opaque/foreign layouts)."""
+    laddr = int(dt["layout"])
+    if laddr == 0:
+        return None
+    layout = value_at(laddr, "jl_datatype_layout_t")
+    nfields = int(layout["nfields"])
+    fdkind = int(layout["flags"]["fielddesc_type"])
+    if fdkind == 3:  # foreign type: no descriptors
+        return None
+    fdname = ("jl_fielddesc8_t", "jl_fielddesc16_t", "jl_fielddesc32_t")[fdkind]
+    fdsize = type_size(fdname)
+    base = laddr + type_size("jl_datatype_layout_t")
+    fields = []
+    for i in range(nfields):
+        fd = value_at(base + i * fdsize, fdname)
+        fields.append((int(fd["offset"]), int(fd["size"]), int(fd["isptr"])))
+    return fields
+
+
+def field_names(dt, nfields):
+    names = []
+    tnaddr = int(dt["name"])
+    namesv = int(value_at(tnaddr, "jl_typename_t")["names"]) if tnaddr else 0
+    n = svec_len(namesv) if namesv else 0
+    for i in range(nfields):
+        if i < n:
+            sym = svec_ref(namesv, i)
+            names.append(symbol_name(sym) if sym else str(i + 1))
+        else:
+            names.append(str(i + 1))
+    return names
+
+
+def field_types(dt, nfields):
+    typesv = int(dt["types"])
+    n = svec_len(typesv) if typesv else 0
+    return [svec_ref(typesv, i) if i < n else 0 for i in range(nfields)]
+
+
+def render_unboxed(taddr, addr, depth):
+    """Render the unboxed (inline-stored) value of type taddr at addr."""
+    if depth < 0:
+        return "…"
+    if taddr == 0:
+        return "<?>"
+    if datatype_qualname(typeof_addr(taddr)) != "Core.DataType":
+        return "<union field>"
+    qual = datatype_qualname(taddr)
+    prim = render_primitive(qual, addr)
+    if prim is not None:
+        return prim
+    dt = value_at(taddr, "jl_datatype_t")
+    if int(dt["isprimitivetype"]):
+        laddr = int(dt["layout"])
+        size = int(value_at(laddr, "jl_datatype_layout_t")["size"]) if laddr else 0
+        if 0 < size <= 8:
+            return "%s(0x%0*x)" % (render_type(taddr, 1), 2 * size,
+                                   read_uint(addr, size))
+        return "%s(...)" % render_type(taddr, 1)
+    fields = layout_fields(dt)
+    if fields is None:
+        return "<%s>" % render_type(taddr, depth - 1)
+    if len(fields) == 0:
+        return render_value(int(dt["instance"]), depth) if int(dt["instance"]) \
+            else render_type(taddr, depth - 1) + "()"
+    return render_struct_inline(taddr, dt, addr, fields, depth)
+
+
+def render_struct_inline(taddr, dt, addr, fields, depth):
+    tn = value_at(int(dt["name"]), "jl_typename_t")
+    tname = symbol_name(int(tn["name"]))
+    istuple = tname == "Tuple" and module_path(int(tn["module"])) == "Core"
+    names = None
+    if tname == "NamedTuple":
+        names = namedtuple_names(dt)
+    if names is None and not istuple:
+        names = field_names(dt, len(fields))
+    ftypes = field_types(dt, len(fields))
+    parts = []
+    for i, (off, size, isptr) in enumerate(fields[:MAX_ELEMS]):
+        if isptr:
+            p = read_ptr(addr + off)
+            r = render_value(p, depth - 1) if p else "#undef"
+        else:
+            r = render_unboxed(ftypes[i], addr + off, depth - 1)
+        fname = names[i] if names and i < len(names) else str(i + 1)
+        parts.append(r if istuple else "%s = %s" % (fname, r))
+    if len(fields) > MAX_ELEMS:
+        parts.append("…")
+    if istuple and len(fields) == 1:
+        return "(%s,)" % parts[0]
+    if istuple or tname == "NamedTuple":
+        return "(%s)" % ", ".join(parts)
+    return "%s(%s)" % (render_type(taddr, 2), ", ".join(parts))
+
+
+def namedtuple_names(dt):
+    """Field names of a concrete NamedTuple type, from its first type
+    parameter (a tuple of symbols), or None."""
+    try:
+        params = int(dt["parameters"])
+        if svec_len(params) != 2:
+            return None
+        namestup = svec_ref(params, 0)
+        ndt = value_at(typeof_addr(namestup), "jl_datatype_t")
+        fields = layout_fields(ndt)
+        if fields is None:
+            return None
+        return [symbol_name(read_ptr(namestup + off))
+                for (off, _, _) in fields]
+    except (gdb.error, gdb.MemoryError):
+        return None
+
+
+def array_info(addr):
+    """(dims, eltype, dataptr, elsize, isboxed, isunion) of the jl_array_t (or
+    Memory) at addr; eltype and layout come from the underlying Memory."""
+    dtaddr = typeof_addr(addr)
+    dt = value_at(dtaddr, "jl_datatype_t")
+    tname = symbol_name(int(value_at(int(dt["name"]), "jl_typename_t")["name"]))
+    if tname == "GenericMemory":
+        mem_addr = addr
+        mem_dt_addr = dtaddr
+        mem = value_at(addr, "jl_genericmemory_t")
+        dims = [int(mem["length"])]
+        dataptr = int(mem["ptr"])
+        eltype = svec_ref(int(dt["parameters"]), 1)
+    else:
+        arr = value_at(addr, "jl_array_t")
+        mem_addr = int(arr["ref"]["mem"])
+        mem_dt_addr = typeof_addr(mem_addr)
+        dataptr = int(arr["ref"]["ptr_or_offset"])
+        dimoff = lookup_type("jl_array_t")["dimsize"].bitpos // 8
+        params = int(dt["parameters"])
+        try:
+            ndims = read_uint(svec_ref(params, 1), 8)
+        except (gdb.error, gdb.MemoryError):
+            ndims = 1
+        if not (0 < ndims < 33):
+            ndims = 1
+        dims = [read_uint(addr + dimoff + i * ptr_size(), ptr_size())
+                for i in range(ndims)]
+        eltype = svec_ref(params, 0)
+    mlayout = value_at(int(value_at(mem_dt_addr, "jl_datatype_t")["layout"]),
+                       "jl_datatype_layout_t")
+    elsize = int(mlayout["size"])
+    isboxed = int(mlayout["flags"]["arrayelem_isboxed"])
+    isunion = int(mlayout["flags"]["arrayelem_isunion"])
+    return dims, eltype, dataptr, elsize, isboxed, isunion
+
+
+def render_array_summary(addr, depth):
+    dims, _, _, _, _, _ = array_info(addr)
+    tstr = render_type(typeof_addr(addr), depth)
+    if len(dims) == 1:
+        return "%d-element %s" % (dims[0], tstr)
+    return "%s %s" % ("×".join(str(d) for d in dims), tstr)
+
+
+def array_children(addr):
+    dims, eltype, dataptr, elsize, isboxed, isunion = array_info(addr)
+    n = 1
+    for d in dims:
+        n *= d
+    shown = min(n, MAX_ELEMS)
+    for i in range(shown):
+        if isboxed:
+            p = read_ptr(dataptr + i * ptr_size())
+            yield str(i + 1), jl_value(p) if p else "#undef"
+        elif isunion:
+            yield str(i + 1), "<union element>"
+        else:
+            yield str(i + 1), render_unboxed(eltype, dataptr + i * elsize,
+                                             MAX_DEPTH - 1)
+    if n > shown:
+        yield "...", "(%d more)" % (n - shown)
+
+
+def jl_value(addr):
+    """A gdb.Value holding addr as a jl_value_t*."""
+    return gdb.Value(addr).cast(lookup_type("jl_value_t").pointer())
+
+
+# --------------------------------------------------------------------------
+# rendering of runtime objects (Method, MethodInstance, Task, ...)
+# --------------------------------------------------------------------------
+
+def render_sig_call(fname, sigaddr, depth):
+    """Render "f(::T, ::S)" from a Tuple{typeof(f), T, S} signature."""
+    # peel UnionAll wrappers
+    seen = 0
+    while datatype_qualname(typeof_addr(sigaddr)) == "Core.UnionAll" and seen < 32:
+        sigaddr = int(value_at(sigaddr, "jl_unionall_t")["body"])
+        seen += 1
+    if datatype_qualname(typeof_addr(sigaddr)) != "Core.DataType":
+        return "%s(...)" % fname
+    params = int(value_at(sigaddr, "jl_datatype_t")["parameters"])
+    n = svec_len(params) if params else 0
+    args = ["::" + render_type(svec_ref(params, i), depth - 1)
+            for i in range(1, min(n, MAX_ELEMS + 1))]
+    if n > MAX_ELEMS + 1:
+        args.append("…")
+    return "%s(%s)" % (fname, ", ".join(args))
+
+
+def render_method(addr, depth):
+    m = value_at(addr, "jl_method_t")
+    name = symbol_name(int(m["name"]))
+    where = ""
+    if int(m["module"]):
+        where = " @ " + module_path(int(m["module"]))
+    faddr = int(m["file"])
+    if faddr:
+        where += " %s:%d" % (symbol_name(faddr), int(m["line"]))
+    return render_sig_call(name, int(m["sig"]), depth) + where
+
+
+def render_method_instance(addr, depth):
+    mi = value_at(addr, "jl_method_instance_t")
+    defaddr = int(mi["def"]["value"])
+    name = "?"
+    if defaddr:
+        if datatype_qualname(typeof_addr(defaddr)) == "Core.Method":
+            name = symbol_name(int(value_at(defaddr, "jl_method_t")["name"]))
+        else:  # toplevel thunk: def is a module
+            name = "top-level scope in " + module_path(defaddr)
+            return "MethodInstance for " + name
+    return "MethodInstance for " + render_sig_call(name, int(mi["specTypes"]),
+                                                   depth)
+
+
+def render_code_instance(addr, depth):
+    ci = value_at(addr, "jl_code_instance_t")
+    defaddr = int(ci["def"])
+    inner = "?"
+    if defaddr:
+        qual = datatype_qualname(typeof_addr(defaddr))
+        if qual == "Core.ABIOverride":
+            defaddr = int(value_at(defaddr, "jl_abi_override_t")["def"])
+            qual = datatype_qualname(typeof_addr(defaddr))
+        if qual == "Core.MethodInstance":
+            inner = render_method_instance(defaddr, depth - 1)
+    return "CodeInstance for %s" % inner
+
+
+TASK_STATES = {0: "runnable", 1: "done", 2: "failed", 3: "abandoned"}
+
+
+def render_task(addr):
+    t = value_at(addr, "jl_task_t")
+    state = TASK_STATES.get(int(t["_state"]), "?")
+    return "Task (%s) @0x%016x" % (state, addr)
+
+
+def render_expr(addr, depth):
+    e = value_at(addr, "jl_expr_t")
+    head = symbol_name(int(e["head"])) if int(e["head"]) else "?"
+    nargs = 0
+    if int(e["args"]):
+        try:
+            nargs = array_info(int(e["args"]))[0][0]
+        except (gdb.error, gdb.MemoryError):
+            pass
+    return "Expr(:%s, <%d args>)" % (head, nargs)
+
+
+def render_svec(addr, depth):
+    n = svec_len(addr)
+    parts = []
+    for i in range(min(n, MAX_ELEMS)):
+        p = svec_ref(addr, i)
+        parts.append(render_value(p, depth - 1) if p else "#undef")
+    if n > MAX_ELEMS:
+        parts.append("…")
+    return "svec(%s)" % ", ".join(parts)
+
+
+# --------------------------------------------------------------------------
+# main value renderer
+# --------------------------------------------------------------------------
+
+def render_value(addr, depth=MAX_DEPTH):
+    """Render the Julia value at addr as a compact single-line string."""
+    if addr == 0:
+        return "#<null>"
+    if depth < 0:
+        return "…"
+    dtaddr = typeof_addr(addr)
+    if dtaddr == 0:
+        tag = typetag(addr)
+        idx = tag >> 4
+        if tag < (64 << 4) and idx < len(SMALL_TAG_NAMES):
+            return "<%s 0x%x>" % (SMALL_TAG_NAMES[idx], addr)
+        return "<julia value 0x%x>" % addr
+    qual = datatype_qualname(dtaddr)
+
+    if is_type_kind(qual):
+        return render_type(addr, depth)
+    prim = render_primitive(qual, addr)
+    if prim is not None:
+        return prim
+    if qual == "Core.Nothing":
+        return "nothing"
+    if qual == "Core.Symbol":
+        name = symbol_name(addr)
+        if name.isidentifier():
+            return ":" + name
+        return 'Symbol("%s")' % escape_string(name)
+    if qual == "Core.String":
+        s, strlen = string_data(addr)
+        suffix = "…" if strlen > len(s.encode("utf-8", "replace")) else ""
+        return '"%s%s"' % (escape_string(s), suffix)
+    if qual == "Core.SimpleVector":
+        return render_svec(addr, depth)
+    if qual == "Core.Module":
+        return "Module %s" % module_path(addr)
+    if qual == "Core.Task":
+        return render_task(addr)
+    if qual == "Core.Method":
+        return render_method(addr, depth)
+    if qual == "Core.MethodInstance":
+        return render_method_instance(addr, depth)
+    if qual == "Core.CodeInstance":
+        return render_code_instance(addr, depth)
+    if qual == "Core.Expr":
+        return render_expr(addr, depth)
+    if qual == "Core.GlobalRef":
+        gr = value_at(addr, "jl_globalref_t")
+        return "%s.%s" % (module_path(int(gr["mod"])),
+                          symbol_name(int(gr["name"])))
+    if qual == "Core.TypeName":
+        tn = value_at(addr, "jl_typename_t")
+        return "typename(%s)" % symbol_name(int(tn["name"]))
+
+    dt = value_at(dtaddr, "jl_datatype_t")
+    tname = symbol_name(int(value_at(int(dt["name"]), "jl_typename_t")["name"]))
+    if tname in ("Array", "GenericMemory"):
+        try:
+            summary = render_array_summary(addr, depth - 1)
+            parts = ["%s" % v if isinstance(v, str) else render_value(int(v), depth - 1)
+                     for _, v in array_children(addr)]
+            return "%s = {%s}" % (summary, ", ".join(parts)) if depth == MAX_DEPTH \
+                else "%s" % summary
+        except (gdb.error, gdb.MemoryError):
+            return render_type(dtaddr, depth - 1) + " <unreadable>"
+
+    # generic instances
+    if int(dt["instance"]) == addr:
+        tn = value_at(int(dt["name"]), "jl_typename_t")
+        sname = int(tn["singletonname"]) if "singletonname" in \
+            (f.name for f in lookup_type("jl_typename_t").fields()) else 0
+        return symbol_name(sname) if sname else render_type(dtaddr, depth) + "()"
+    if int(dt["isprimitivetype"]):
+        return render_unboxed(dtaddr, addr, depth)
+    fields = layout_fields(dt)
+    if fields is not None:
+        return render_struct_inline(dtaddr, dt, addr, fields, depth)
+    return "%s @0x%016x" % (render_type(dtaddr, depth - 1), addr)
+
+
+# --------------------------------------------------------------------------
+# gdb integration
+# --------------------------------------------------------------------------
+
+# struct tags / typedef names whose pointers we pretty-print
+JULIA_POINTER_TYPES = {
+    "jl_value_t", "_jl_value_t",
+    "jl_function_t",
+    "jl_sym_t", "_jl_sym_t",
+    "jl_datatype_t", "_jl_datatype_t", "jl_tupletype_t",
+    "jl_typename_t",
+    "jl_svec_t",
+    "jl_module_t", "_jl_module_t",
+    "jl_array_t", "_jl_array_t",
+    "jl_genericmemory_t", "_jl_genericmemory_t",
+    "jl_string_t",
+    "jl_task_t", "_jl_task_t",
+    "jl_method_t", "_jl_method_t",
+    "jl_method_instance_t", "_jl_method_instance_t",
+    "jl_code_instance_t", "_jl_code_instance_t",
+    "jl_code_info_t", "_jl_code_info_t",
+    "jl_expr_t",
+    "jl_globalref_t", "_jl_globalref_t",
+    "jl_tvar_t",
+    "jl_unionall_t",
+    "jl_uniontype_t",
+    "jl_vararg_t", "_jl_vararg_t",
+    "jl_typemap_t",
+}
+
+# runtime types whose printer exposes expandable children
+CHILDREN_KINDS = ("Core.SimpleVector",)
+
+
+class JuliaValuePrinter:
+    """to_string-based printer: dispatches on the runtime type tag."""
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            addr = int(self.val)
+        except gdb.error:
+            return None
+        if addr == 0:
+            return "(jl_value_t *) NULL"
+        try:
+            return render_value(addr)
+        except (gdb.error, gdb.MemoryError) as e:
+            return "<not a julia value: 0x%x (%s)>" % (addr, e)
+        except Exception as e:  # never break `print` on a printer bug
+            return "<error rendering julia value 0x%x: %s>" % (addr, e)
+
+
+class JuliaArrayPrinter(JuliaValuePrinter):
+    """Adds expandable children for arrays so IDE variable views can drill
+    down into elements."""
+
+    def to_string(self):
+        try:
+            return render_array_summary(int(self.val), MAX_DEPTH)
+        except (gdb.error, gdb.MemoryError):
+            return JuliaValuePrinter.to_string(self)
+
+    def children(self):
+        try:
+            for name, v in array_children(int(self.val)):
+                yield name, str(v) if not isinstance(v, gdb.Value) else v
+        except (gdb.error, gdb.MemoryError):
+            return
+
+    def display_hint(self):
+        return "array"
+
+
+def is_array_value(addr):
+    try:
+        dtaddr = typeof_addr(addr)
+        if dtaddr == 0:
+            return False
+        dt = value_at(dtaddr, "jl_datatype_t")
+        tname = symbol_name(int(value_at(int(dt["name"]),
+                                         "jl_typename_t")["name"]))
+        return tname in ("Array", "GenericMemory")
+    except (gdb.error, gdb.MemoryError):
+        return False
+
+
+class JuliaPrettyPrinter(gdb.printing.PrettyPrinter):
+    def __init__(self):
+        super().__init__("julia")
+
+    def __call__(self, val):
+        t = val.type
+        if t.code != gdb.TYPE_CODE_PTR:
+            return None
+        target = t.target()
+        name = target.name
+        stripped = target.strip_typedefs()
+        tag = stripped.tag or stripped.name
+        if name not in JULIA_POINTER_TYPES and tag not in JULIA_POINTER_TYPES:
+            return None
+        try:
+            if int(val) == 0:
+                return None
+        except gdb.error:
+            return None
+        try:
+            if is_array_value(int(val)):
+                return JuliaArrayPrinter(val)
+        except (gdb.error, gdb.MemoryError):
+            pass
+        return JuliaValuePrinter(val)
+
+
+class JlTypeofFunction(gdb.Function):
+    """$jl_typeof(v): the jl_datatype_t* of a Julia value.
+
+    Usage: print $jl_typeof(v)"""
+
+    def __init__(self):
+        super().__init__("jl_typeof")
+
+    def invoke(self, v):
+        addr = typeof_addr(int(v))
+        return gdb.Value(addr).cast(lookup_type("jl_datatype_t").pointer())
+
+
+# --------------------------------------------------------------------------
+# GC safepoint handling
+#
+# Julia's GC stops the world by mprotecting a page that every thread reads at
+# safepoints, so during normal operation every thread takes a benign SIGSEGV
+# whenever a GC runs. By default gdb stops on each of those, making stepping
+# through Julia code nearly unusable. Instead of gdb's all-or-nothing `handle
+# SIGSEGV`, we tell gdb not to stop on SIGSEGV in general and install a
+# conditional signal catchpoint that only fires when the faulting address is
+# *outside* the safepoint page region: safepoint hits are resumed silently,
+# real segfaults (including stack overflows) still stop the debugger.
+# --------------------------------------------------------------------------
+
+# 4 pages, see the layout description in src/safepoint.c
+SAFEPOINT_COND = (
+    "!((unsigned long)$_siginfo._sifields._sigfault.si_addr"
+    " >= (unsigned long)jl_safepoint_pages"
+    " && (unsigned long)$_siginfo._sifields._sigfault.si_addr"
+    " < (unsigned long)jl_safepoint_pages"
+    " + 4*(unsigned long)jl_page_size)")
+
+_segv_catchpoint = [None]
+_segv_cond_armed = [False]
+
+
+def _try_arm_segv_condition(event=None):
+    """Attach the safepoint condition to the SIGSEGV catchpoint. This can
+    only succeed once libjulia-internal's symbols are available, so it is
+    retried every time an objfile is loaded."""
+    if _segv_catchpoint[0] is None or _segv_cond_armed[0]:
+        return
+    try:
+        gdb.execute("condition %d %s" % (_segv_catchpoint[0], SAFEPOINT_COND),
+                    to_string=True)
+        _segv_cond_armed[0] = True
+    except gdb.error:
+        pass
+
+
+gdb.events.new_objfile.connect(_try_arm_segv_condition)
+
+
+def enable_safepoint_filter():
+    if _segv_catchpoint[0] is not None:
+        return
+    gdb.execute("handle SIGSEGV nostop noprint pass", to_string=True)
+    out = gdb.execute("catch signal SIGSEGV", to_string=True)
+    m = re.search(r"Catchpoint (\d+)", out)
+    if m is None:
+        return
+    _segv_catchpoint[0] = int(m.group(1))
+    _try_arm_segv_condition()
+
+
+def disable_safepoint_filter():
+    if _segv_catchpoint[0] is None:
+        return
+    gdb.execute("delete %d" % _segv_catchpoint[0], to_string=True)
+    gdb.execute("handle SIGSEGV stop print pass", to_string=True)
+    _segv_catchpoint[0] = None
+    _segv_cond_armed[0] = False
+
+
+class JlSafepointCommand(gdb.Command):
+    """jl-safepoint-filter [on|off]: filter out GC safepoint SIGSEGVs.
+
+    When on (the default), gdb silently resumes the benign SIGSEGVs Julia's
+    GC uses to stop the world at safepoints, while still stopping on real
+    segfaults. When off, gdb's default SIGSEGV behavior is restored."""
+
+    def __init__(self):
+        super().__init__("jl-safepoint-filter", gdb.COMMAND_RUNNING)
+
+    def invoke(self, arg, from_tty):
+        arg = arg.strip()
+        if arg == "on":
+            enable_safepoint_filter()
+        elif arg == "off":
+            disable_safepoint_filter()
+        elif arg:
+            raise gdb.GdbError("usage: jl-safepoint-filter [on|off]")
+        print("julia safepoint SIGSEGV filter is %s"
+              % ("on" if _segv_catchpoint[0] is not None else "off"))
+
+
+class JlHandleSignalsCommand(gdb.Command):
+    """jl-handle-signals: tell gdb to ignore signals Julia uses internally.
+
+    Runs `handle nostop noprint pass` for SIGSEGV and SIGUSR2 (used by the GC
+    safepoint and the profiler/thread wakeups). This is a bigger hammer than
+    the default `jl-safepoint-filter`: gdb will no longer stop on *any*
+    segfault (Julia's own crash handler still reports them), which can be
+    useful when the inferior takes many signals, e.g. while profiling."""
+
+    def __init__(self):
+        super().__init__("jl-handle-signals", gdb.COMMAND_RUNNING)
+
+    def invoke(self, arg, from_tty):
+        disable_safepoint_filter()
+        gdb.execute("handle SIGSEGV nostop noprint pass")
+        gdb.execute("handle SIGUSR2 nostop noprint pass")
+
+
+def register(obj=None):
+    gdb.printing.register_pretty_printer(obj, JuliaPrettyPrinter(),
+                                         replace=True)
+    JlTypeofFunction()
+    JlSafepointCommand()
+    JlHandleSignalsCommand()
+    try:
+        enable_safepoint_filter()
+    except gdb.error:
+        pass
+
+
+register(gdb.current_objfile())

--- a/contrib/julia_gdb.py
+++ b/contrib/julia_gdb.py
@@ -166,6 +166,22 @@ def jl_value(addr):
     return gdb.Value(addr).cast(gdb.lookup_type("jl_value_t").pointer())
 
 
+def unboxed_struct_loc(rt, v):
+    """A core location for an unboxed Julia struct value in a JIT frame
+    (e.g. a by-reference argument): its debug-info type name resolves to
+    the Julia datatype, its address to the payload. None if not that."""
+    st = v.type.strip_typedefs()
+    if st.code != gdb.TYPE_CODE_STRUCT or v.address is None:
+        return None
+    tname = st.name or st.tag or v.type.name
+    if not tname:
+        return None
+    dt = rt.resolve_type_name(tname, size=st.sizeof)
+    if dt == 0:
+        return None
+    return ("inline", dt, int(v.address))
+
+
 def loc_to_gdb_value(rt, loc):
     """Convert a core location to a gdb.Value: jl_value_t* for boxed values,
     a native typed value for unboxed primitives, void* otherwise."""
@@ -410,9 +426,14 @@ class JlCommand(gdb.Command):
             else:
                 try:
                     v = gdb.parse_and_eval(base)
-                    loc0 = ("val", int(v))
                 except gdb.error:
                     continue
+                try:
+                    loc0 = ("val", int(v))
+                except gdb.error:
+                    loc0 = unboxed_struct_loc(rt, v)
+                    if loc0 is None:
+                        continue
             parsed_any = True
             try:
                 self.finish(rt, rt.eval_accessors(loc0, accessors))

--- a/contrib/julia_gdb.py
+++ b/contrib/julia_gdb.py
@@ -298,14 +298,20 @@ class JuliaPrettyPrinter(gdb.printing.PrettyPrinter):
         super().__init__("julia")
 
     def __call__(self, val):
-        t = val.type
+        # look through typedefs on the pointer itself too: JIT debug info
+        # types boxed values as typedefs of jl_value_t* named after the
+        # Julia type (e.g. "Array{Int64, 1}")
+        t = val.type.strip_typedefs()
         if t.code != gdb.TYPE_CODE_PTR:
             return None
+        names = set()
+        if val.type.code == gdb.TYPE_CODE_PTR:
+            names.add(val.type.target().name)
         target = t.target()
-        name = target.name
+        names.add(target.name)
         stripped = target.strip_typedefs()
-        tag = stripped.tag or stripped.name
-        if name not in JULIA_POINTER_TYPES and tag not in JULIA_POINTER_TYPES:
+        names.add(stripped.tag or stripped.name)
+        if names.isdisjoint(JULIA_POINTER_TYPES):
             return None
         try:
             if int(val) == 0:

--- a/contrib/julia_gdb.py
+++ b/contrib/julia_gdb.py
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-"""GDB pretty-printers for Julia runtime values.
+"""GDB pretty-printers and commands for Julia runtime values.
 
 Load this script into gdb to make `print` render `jl_value_t*` (and other
 Julia runtime pointers such as `jl_datatype_t*`, `jl_sym_t*`, `jl_svec_t*`,
@@ -17,71 +17,141 @@ Usage (pick one):
   * add that line to your `~/.gdbinit`, or
   * `gdb -x /path/to/julia/contrib/julia_gdb.py --args ./julia ...`
 
-The printers dispatch on the *runtime* type tag of the object, so a plain
-`jl_value_t*` prints as whatever it actually is. Everything is resolved
-through the debug info (DWARF) of libjulia-internal, so this script does not
-hard-code struct offsets and should work across Julia versions; it requires a
-build of Julia with debug info (the default) and gracefully degrades to raw
-pointers when the debug info or the memory is unavailable.
+The rendering logic lives in `julia_debug_core.py`, which must stay next to
+this file. The printers dispatch on the *runtime* type tag of the object, so
+a plain `jl_value_t*` prints as whatever it actually is. Everything is
+resolved through the debug info (DWARF) of libjulia-internal, so this script
+does not hard-code struct offsets and should work across Julia versions; it
+requires a build of Julia with debug info (the default) and gracefully
+degrades to raw pointers when the debug info or the memory is unavailable.
 
-A convenience function `$jl_typeof(v)` is also provided:
+Julia-semantics field and index access is available through the `jl` command
+(1-based indexing, fields by name; also module globals):
+
+    (gdb) jl v.inner.name
+    $jl = "hello"
+    (gdb) jl v.vec[2]
+    $jl = 42
+    (gdb) jl Base.pi
+    $jl = π
+
+The result is also stored in the convenience variable `$jl` for further use.
+Convenience functions `$jl_typeof(v)` and `$jl_field(v, "name")` compose
+inside larger gdb expressions:
 
     (gdb) print $jl_typeof(v)
     $3 = Vector{Int64}
+    (gdb) print $jl_field($jl_field(v, "inner"), "count") + 1
 
-To temporarily see raw pointers again use `print/r`:
-
-    (gdb) print/r v
-    $4 = (jl_value_t *) 0x7f0f2c81f4d0
+To temporarily see raw pointers again use `print/r v`.
 """
 
+import os
 import re
-import struct
+import sys
 
 import gdb
 import gdb.printing
 
-# Render at most this many nested levels in a single summary string.
-MAX_DEPTH = 3
-# Render at most this many elements of arrays/svecs/tuples in a summary.
-MAX_ELEMS = 10
-# Truncate strings longer than this many bytes.
-MAX_STRING = 200
-
-# Objects whose type tag is a small constant rather than a pointer to the
-# jl_datatype_t (see `enum jl_small_typeof_tags` in julia.h). Only used as a
-# fallback when the `jl_small_typeof` symbol cannot be found; the list is
-# append-only in the runtime so existing indices are stable.
-SMALL_TAG_NAMES = [
-    "#null",
-    "TypeofBottom", "DataType", "UnionAll", "Union",
-    "TypeofVararg", "TypeVar", "Symbol", "Module",
-    "SimpleVector", "String", "Task",
-    "Bool", "Nothing", "Char",
-    "Int16", "Int32", "Int64", "Int8",
-    "UInt16", "UInt32", "UInt64", "UInt8",
-]
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import julia_debug_core as core
+from julia_debug_core import JLDebugError
 
 
-class _Cache:
-    """Per-process caches for type lookups; flushed when objfiles change."""
+class GdbAdapter:
+    """Debug-info and memory access for julia_debug_core, via gdb."""
 
     def __init__(self):
-        self.clear()
-
-    def clear(self):
+        self.ptrsize = gdb.lookup_type("void").pointer().sizeof
         self.types = {}
         self.sizes = {}
-        self.small_typeof = -1  # -1: not looked up yet; 0: unavailable
-        self.ptrsize = None
-        self.dt_names = {}  # jl_datatype_t* address -> qualified name
+        self.offsets = {}
+        self.globals = {}
+
+    def lookup_type(self, name):
+        t = self.types.get(name)
+        if t is None:
+            try:
+                t = gdb.lookup_type(name)
+            except gdb.error as e:
+                raise JLDebugError(str(e))
+            self.types[name] = t
+        return t
+
+    def value_at(self, addr, typename):
+        return gdb.Value(addr).cast(
+            self.lookup_type(typename).pointer()).dereference()
+
+    def type_size(self, name):
+        s = self.sizes.get(name)
+        if s is None:
+            s = self.lookup_type(name).sizeof
+            self.sizes[name] = s
+        return s
+
+    def field_offset(self, typename, fieldname):
+        key = (typename, fieldname)
+        off = self.offsets.get(key)
+        if off is None:
+            try:
+                off = self.lookup_type(typename)[fieldname].bitpos // 8
+            except (gdb.error, KeyError) as e:
+                raise JLDebugError(str(e))
+            self.offsets[key] = off
+        return off
+
+    def field(self, addr, typename, path, signed=False):
+        try:
+            v = self.value_at(addr, typename)
+            for name in path:
+                v = v[name]
+            return int(v)
+        except (gdb.error, gdb.MemoryError, KeyError) as e:
+            raise JLDebugError(str(e))
+
+    def has_field(self, typename, fieldname):
+        try:
+            return any(f.name == fieldname
+                       for f in self.lookup_type(typename).fields())
+        except JLDebugError:
+            return False
+
+    def read_mem(self, addr, size):
+        try:
+            return bytes(gdb.selected_inferior().read_memory(addr, size))
+        except (gdb.error, gdb.MemoryError) as e:
+            raise JLDebugError(str(e))
+
+    def read_cstr(self, addr, maxlen=512):
+        buf = self.read_mem(addr, maxlen)
+        nul = buf.find(b"\0")
+        if nul >= 0:
+            buf = buf[:nul]
+        return buf.decode("utf-8", errors="replace")
+
+    def global_addr(self, name):
+        addr = self.globals.get(name)
+        if addr is None:
+            try:
+                addr = int(gdb.parse_and_eval("(unsigned long)&" + name))
+            except gdb.error:
+                addr = 0
+            self.globals[name] = addr
+        return addr
 
 
-CACHE = _Cache()
+_RT = [None]
+
+
+def get_rt():
+    if _RT[0] is None:
+        _RT[0] = core.JuliaRuntime(GdbAdapter())
+    return _RT[0]
 
 
 def _clear_cache(event=None):
-    CACHE.clear()
+    _RT[0] = None
+    JlCommand.last_loc = None
 
 
 gdb.events.new_objfile.connect(_clear_cache)
@@ -90,677 +160,26 @@ if hasattr(gdb.events, "free_objfile"):
 gdb.events.exited.connect(_clear_cache)
 
 
-def lookup_type(name):
-    t = CACHE.types.get(name)
-    if t is None:
-        t = gdb.lookup_type(name)
-        CACHE.types[name] = t
-    return t
-
-
-def type_size(name):
-    s = CACHE.sizes.get(name)
-    if s is None:
-        s = lookup_type(name).sizeof
-        CACHE.sizes[name] = s
-    return s
-
-
-def ptr_size():
-    if CACHE.ptrsize is None:
-        CACHE.ptrsize = lookup_type("void").pointer().sizeof
-    return CACHE.ptrsize
-
-
-def read_mem(addr, size):
-    return bytes(gdb.selected_inferior().read_memory(addr, size))
-
-
-def read_uint(addr, size, signed=False):
-    return int.from_bytes(read_mem(addr, size), "little", signed=signed)
-
-
-def read_ptr(addr):
-    return read_uint(addr, ptr_size())
-
-
-def read_cstring(addr, maxlen=512):
-    buf = read_mem(addr, maxlen)
-    nul = buf.find(b"\0")
-    if nul >= 0:
-        buf = buf[:nul]
-    return buf.decode("utf-8", errors="replace")
-
-
-def value_at(addr, typename):
-    """A gdb.Value of type `typename` located at `addr`."""
-    return gdb.Value(addr).cast(lookup_type(typename).pointer()).dereference()
-
-
-def small_typeof_addr():
-    """Address of the runtime's jl_small_typeof table, or 0."""
-    if CACHE.small_typeof == -1:
-        CACHE.small_typeof = 0
-        for sym in ("jl_small_typeof", "ijl_small_typeof"):
-            try:
-                CACHE.small_typeof = int(
-                    gdb.parse_and_eval("(unsigned long)&" + sym))
-                break
-            except gdb.error:
-                continue
-    return CACHE.small_typeof
-
-
-def typetag(addr):
-    """The type tag of the object at addr: header word with GC bits masked."""
-    return read_ptr(addr - ptr_size()) & ~15
-
-
-def typeof_addr(addr):
-    """Address of the jl_datatype_t for the object at addr (0 if unknown)."""
-    tag = typetag(addr)
-    if tag < (64 << 4):
-        table = small_typeof_addr()
-        if table == 0:
-            return 0
-        # entry lives at byte offset `tag` (see jl_to_typeof in julia.h)
-        return read_ptr(table + tag)
-    return tag
-
-
-def symbol_name(addr):
-    """The name of the jl_sym_t at addr."""
-    return read_cstring(addr + type_size("jl_sym_t"))
-
-
-def svec_len(addr):
-    return int(value_at(addr, "jl_svec_t")["length"])
-
-
-def svec_ref(addr, i):
-    return read_ptr(addr + type_size("jl_svec_t") + i * ptr_size())
-
-
-def is_cpu_addrspace(addr):
-    """True when addr is an instance of Core.AddrSpace{Core} with value 0."""
-    if addr == 0:
-        return False
-    try:
-        dtaddr = typeof_addr(addr)
-        if dtaddr == 0:
-            return False
-        dt = value_at(dtaddr, "jl_datatype_t")
-        tname = symbol_name(int(value_at(int(dt["name"]),
-                                         "jl_typename_t")["name"]))
-        return tname == "AddrSpace" and read_uint(addr, 1) == 0
-    except (gdb.error, gdb.MemoryError):
-        return False
-
-
-def module_path(addr, depth=0):
-    """Dotted name of the jl_module_t at addr, e.g. "Base.Iterators"."""
-    if addr == 0 or depth > 10:
-        return "?"
-    mod = value_at(addr, "jl_module_t")
-    name = symbol_name(int(mod["name"]))
-    parent = int(mod["parent"])
-    if parent == 0 or parent == addr:
-        return name
-    pname = module_path(parent, depth + 1)
-    if pname == "Main":
-        return name
-    return pname + "." + name
-
-
-def datatype_qualname(dtaddr):
-    """Qualified name of a jl_datatype_t, e.g. "Core.Int64". Cached, since
-    datatypes are interned and long-lived."""
-    name = CACHE.dt_names.get(dtaddr)
-    if name is None:
-        dt = value_at(dtaddr, "jl_datatype_t")
-        tn = value_at(int(dt["name"]), "jl_typename_t")
-        name = module_path(int(tn["module"])) + "." + symbol_name(int(tn["name"]))
-        CACHE.dt_names[dtaddr] = name
-    return name
-
-
-def string_data(addr):
-    """(contents, length) of the Core.String at addr."""
-    strlen = read_uint(addr, ptr_size())
-    n = min(strlen, MAX_STRING)
-    s = read_mem(addr + ptr_size(), n).decode("utf-8", errors="replace")
-    return s, strlen
-
-
-def escape_string(s):
-    out = []
-    for c in s:
-        if c == '"':
-            out.append('\\"')
-        elif c == "\\":
-            out.append("\\\\")
-        elif c == "\n":
-            out.append("\\n")
-        elif c == "\t":
-            out.append("\\t")
-        elif ord(c) < 32:
-            out.append("\\x%02x" % ord(c))
-        else:
-            out.append(c)
-    return "".join(out)
-
-
-# --------------------------------------------------------------------------
-# rendering of type objects (DataType/Union/UnionAll/TypeVar/Vararg)
-# --------------------------------------------------------------------------
-
-def is_type_kind(qual):
-    return qual in ("Core.DataType", "Core.Union", "Core.UnionAll",
-                    "Core.TypeVar", "Core.TypeofVararg", "Core.TypeofBottom")
-
-
-def render_typevar(addr, with_bounds):
-    tv = value_at(addr, "jl_tvar_t")
-    name = symbol_name(int(tv["name"]))
-    if not with_bounds:
-        return name
-    lb = render_type(int(tv["lb"]), MAX_DEPTH - 1)
-    ub = render_type(int(tv["ub"]), MAX_DEPTH - 1)
-    if lb == "Union{}" and ub == "Any":
-        return name
-    if lb == "Union{}":
-        return "%s<:%s" % (name, ub)
-    return "%s<:%s<:%s" % (lb, name, ub)
-
-
-def flatten_union(addr, parts, depth):
-    qual = datatype_qualname(typeof_addr(addr))
-    if qual == "Core.Union":
-        u = value_at(addr, "jl_uniontype_t")
-        flatten_union(int(u["a"]), parts, depth)
-        flatten_union(int(u["b"]), parts, depth)
-    else:
-        parts.append(render_type(addr, depth))
-
-
-def render_type(addr, depth=MAX_DEPTH):
-    """Render a Julia type object (or type parameter) as a string."""
-    if addr == 0:
-        return "#<null>"
-    if depth < 0:
-        return "…"
-    dtaddr = typeof_addr(addr)
-    if dtaddr == 0:
-        return "<?type 0x%x>" % addr
-    qual = datatype_qualname(dtaddr)
-    if qual == "Core.TypeofBottom":
-        return "Union{}"
-    if qual == "Core.Union":
-        parts = []
-        flatten_union(addr, parts, depth - 1)
-        return "Union{%s}" % ", ".join(parts)
-    if qual == "Core.UnionAll":
-        ua = value_at(addr, "jl_unionall_t")
-        body = render_type(int(ua["body"]), depth - 1)
-        var = render_typevar(int(ua["var"]), True)
-        return "%s where %s" % (body, var)
-    if qual == "Core.TypeVar":
-        return render_typevar(addr, False)
-    if qual == "Core.TypeofVararg":
-        va = value_at(addr, "jl_vararg_t")
-        t, n = int(va["T"]), int(va["N"])
-        if t == 0:
-            return "Vararg"
-        if n == 0:
-            return "Vararg{%s}" % render_type(t, depth - 1)
-        return "Vararg{%s, %s}" % (render_type(t, depth - 1),
-                                   render_value(n, depth - 1))
-    if qual == "Core.Module":
-        return module_path(addr)
-    if qual != "Core.DataType":
-        # a value used as a type parameter (1, :x, true, ...)
-        return render_value(addr, depth)
-
-    dt = value_at(addr, "jl_datatype_t")
-    tn = value_at(int(dt["name"]), "jl_typename_t")
-    modpath = module_path(int(tn["module"]))
-    name = symbol_name(int(tn["name"]))
-    if modpath not in ("Core", "Main") and not name.startswith("typeof("):
-        name = modpath + "." + name
-    params = int(dt["parameters"])
-    nparams = svec_len(params) if params else 0
-    if nparams == 0:
-        return name + "{}" if name == "Tuple" else name
-    # sugar: Array{T, 1} => Vector{T}, Array{T, 2} => Matrix{T}
-    if name == "Array" and nparams == 2:
-        ndim = render_type(svec_ref(params, 1), depth - 1)
-        if ndim == "1":
-            return "Vector{%s}" % render_type(svec_ref(params, 0), depth - 1)
-        if ndim == "2":
-            return "Matrix{%s}" % render_type(svec_ref(params, 0), depth - 1)
-    # sugar: GenericMemory{:not_atomic, T, Core.CPU} => Memory{T}
-    if name == "GenericMemory" and nparams == 3:
-        order = svec_ref(params, 0)
-        aspace = svec_ref(params, 2)
-        if is_cpu_addrspace(aspace):
-            eltstr = render_type(svec_ref(params, 1), depth - 1)
-            oname = symbol_name(order) if order else ""
-            if oname == "not_atomic":
-                return "Memory{%s}" % eltstr
-            if oname == "atomic":
-                return "AtomicMemory{%s}" % eltstr
-    rendered = [render_type(svec_ref(params, i), depth - 1)
-                for i in range(min(nparams, MAX_ELEMS))]
-    if nparams > MAX_ELEMS:
-        rendered.append("…")
-    return "%s{%s}" % (name, ", ".join(rendered))
-
-
-# --------------------------------------------------------------------------
-# rendering of plain data (bits values, structs, arrays)
-# --------------------------------------------------------------------------
-
-PRIMITIVE_FMT = {
-    "Core.Int8": ("i", 1), "Core.Int16": ("i", 2),
-    "Core.Int32": ("i", 4), "Core.Int64": ("i", 8),
-    "Core.UInt8": ("u", 1), "Core.UInt16": ("u", 2),
-    "Core.UInt32": ("u", 4), "Core.UInt64": ("u", 8),
-    "Core.Float16": ("f", 2), "Core.Float32": ("f", 4),
-    "Core.Float64": ("f", 8),
-}
-
-
-def render_char(u):
-    # Char stores the UTF-8 bytes left-aligned in a UInt32
-    raw = u.to_bytes(4, "big").rstrip(b"\0") or b"\0"
-    try:
-        return "'%s'" % raw.decode("utf-8")
-    except UnicodeDecodeError:
-        return "Char(0x%08x)" % u
-
-
-def render_primitive(qual, addr):
-    """Render the unboxed primitive of type `qual` stored at addr, or None."""
-    fmt = PRIMITIVE_FMT.get(qual)
-    if fmt is not None:
-        kind, size = fmt
-        if kind == "i":
-            return str(read_uint(addr, size, signed=True))
-        if kind == "u":
-            return "0x%0*x" % (2 * size, read_uint(addr, size))
-        return repr(struct.unpack("<" + {2: "e", 4: "f", 8: "d"}[size],
-                                  read_mem(addr, size))[0])
-    if qual == "Core.Bool":
-        return "true" if read_uint(addr, 1) else "false"
-    if qual == "Core.Char":
-        return render_char(read_uint(addr, 4))
-    return None
-
-
-def layout_fields(dt):
-    """[(offset, size, isptr), ...] for the concrete jl_datatype_t value dt,
-    or None when there is no field table (opaque/foreign layouts)."""
-    laddr = int(dt["layout"])
-    if laddr == 0:
-        return None
-    layout = value_at(laddr, "jl_datatype_layout_t")
-    nfields = int(layout["nfields"])
-    fdkind = int(layout["flags"]["fielddesc_type"])
-    if fdkind == 3:  # foreign type: no descriptors
-        return None
-    fdname = ("jl_fielddesc8_t", "jl_fielddesc16_t", "jl_fielddesc32_t")[fdkind]
-    fdsize = type_size(fdname)
-    base = laddr + type_size("jl_datatype_layout_t")
-    fields = []
-    for i in range(nfields):
-        fd = value_at(base + i * fdsize, fdname)
-        fields.append((int(fd["offset"]), int(fd["size"]), int(fd["isptr"])))
-    return fields
-
-
-def field_names(dt, nfields):
-    names = []
-    tnaddr = int(dt["name"])
-    namesv = int(value_at(tnaddr, "jl_typename_t")["names"]) if tnaddr else 0
-    n = svec_len(namesv) if namesv else 0
-    for i in range(nfields):
-        if i < n:
-            sym = svec_ref(namesv, i)
-            names.append(symbol_name(sym) if sym else str(i + 1))
-        else:
-            names.append(str(i + 1))
-    return names
-
-
-def field_types(dt, nfields):
-    typesv = int(dt["types"])
-    n = svec_len(typesv) if typesv else 0
-    return [svec_ref(typesv, i) if i < n else 0 for i in range(nfields)]
-
-
-def render_unboxed(taddr, addr, depth):
-    """Render the unboxed (inline-stored) value of type taddr at addr."""
-    if depth < 0:
-        return "…"
-    if taddr == 0:
-        return "<?>"
-    if datatype_qualname(typeof_addr(taddr)) != "Core.DataType":
-        return "<union field>"
-    qual = datatype_qualname(taddr)
-    prim = render_primitive(qual, addr)
-    if prim is not None:
-        return prim
-    dt = value_at(taddr, "jl_datatype_t")
-    if int(dt["isprimitivetype"]):
-        laddr = int(dt["layout"])
-        size = int(value_at(laddr, "jl_datatype_layout_t")["size"]) if laddr else 0
-        if 0 < size <= 8:
-            return "%s(0x%0*x)" % (render_type(taddr, 1), 2 * size,
-                                   read_uint(addr, size))
-        return "%s(...)" % render_type(taddr, 1)
-    fields = layout_fields(dt)
-    if fields is None:
-        return "<%s>" % render_type(taddr, depth - 1)
-    if len(fields) == 0:
-        return render_value(int(dt["instance"]), depth) if int(dt["instance"]) \
-            else render_type(taddr, depth - 1) + "()"
-    return render_struct_inline(taddr, dt, addr, fields, depth)
-
-
-def render_struct_inline(taddr, dt, addr, fields, depth):
-    tn = value_at(int(dt["name"]), "jl_typename_t")
-    tname = symbol_name(int(tn["name"]))
-    istuple = tname == "Tuple" and module_path(int(tn["module"])) == "Core"
-    names = None
-    if tname == "NamedTuple":
-        names = namedtuple_names(dt)
-    if names is None and not istuple:
-        names = field_names(dt, len(fields))
-    ftypes = field_types(dt, len(fields))
-    parts = []
-    for i, (off, size, isptr) in enumerate(fields[:MAX_ELEMS]):
-        if isptr:
-            p = read_ptr(addr + off)
-            r = render_value(p, depth - 1) if p else "#undef"
-        else:
-            r = render_unboxed(ftypes[i], addr + off, depth - 1)
-        fname = names[i] if names and i < len(names) else str(i + 1)
-        parts.append(r if istuple else "%s = %s" % (fname, r))
-    if len(fields) > MAX_ELEMS:
-        parts.append("…")
-    if istuple and len(fields) == 1:
-        return "(%s,)" % parts[0]
-    if istuple or tname == "NamedTuple":
-        return "(%s)" % ", ".join(parts)
-    return "%s(%s)" % (render_type(taddr, 2), ", ".join(parts))
-
-
-def namedtuple_names(dt):
-    """Field names of a concrete NamedTuple type, from its first type
-    parameter (a tuple of symbols), or None."""
-    try:
-        params = int(dt["parameters"])
-        if svec_len(params) != 2:
-            return None
-        namestup = svec_ref(params, 0)
-        ndt = value_at(typeof_addr(namestup), "jl_datatype_t")
-        fields = layout_fields(ndt)
-        if fields is None:
-            return None
-        return [symbol_name(read_ptr(namestup + off))
-                for (off, _, _) in fields]
-    except (gdb.error, gdb.MemoryError):
-        return None
-
-
-def array_info(addr):
-    """(dims, eltype, dataptr, elsize, isboxed, isunion) of the jl_array_t (or
-    Memory) at addr; eltype and layout come from the underlying Memory."""
-    dtaddr = typeof_addr(addr)
-    dt = value_at(dtaddr, "jl_datatype_t")
-    tname = symbol_name(int(value_at(int(dt["name"]), "jl_typename_t")["name"]))
-    if tname == "GenericMemory":
-        mem_addr = addr
-        mem_dt_addr = dtaddr
-        mem = value_at(addr, "jl_genericmemory_t")
-        dims = [int(mem["length"])]
-        dataptr = int(mem["ptr"])
-        eltype = svec_ref(int(dt["parameters"]), 1)
-    else:
-        arr = value_at(addr, "jl_array_t")
-        mem_addr = int(arr["ref"]["mem"])
-        mem_dt_addr = typeof_addr(mem_addr)
-        dataptr = int(arr["ref"]["ptr_or_offset"])
-        dimoff = lookup_type("jl_array_t")["dimsize"].bitpos // 8
-        params = int(dt["parameters"])
-        try:
-            ndims = read_uint(svec_ref(params, 1), 8)
-        except (gdb.error, gdb.MemoryError):
-            ndims = 1
-        if not (0 < ndims < 33):
-            ndims = 1
-        dims = [read_uint(addr + dimoff + i * ptr_size(), ptr_size())
-                for i in range(ndims)]
-        eltype = svec_ref(params, 0)
-    mlayout = value_at(int(value_at(mem_dt_addr, "jl_datatype_t")["layout"]),
-                       "jl_datatype_layout_t")
-    elsize = int(mlayout["size"])
-    isboxed = int(mlayout["flags"]["arrayelem_isboxed"])
-    isunion = int(mlayout["flags"]["arrayelem_isunion"])
-    return dims, eltype, dataptr, elsize, isboxed, isunion
-
-
-def render_array_summary(addr, depth):
-    dims, _, _, _, _, _ = array_info(addr)
-    tstr = render_type(typeof_addr(addr), depth)
-    if len(dims) == 1:
-        return "%d-element %s" % (dims[0], tstr)
-    return "%s %s" % ("×".join(str(d) for d in dims), tstr)
-
-
-def array_children(addr):
-    dims, eltype, dataptr, elsize, isboxed, isunion = array_info(addr)
-    n = 1
-    for d in dims:
-        n *= d
-    shown = min(n, MAX_ELEMS)
-    for i in range(shown):
-        if isboxed:
-            p = read_ptr(dataptr + i * ptr_size())
-            yield str(i + 1), jl_value(p) if p else "#undef"
-        elif isunion:
-            yield str(i + 1), "<union element>"
-        else:
-            yield str(i + 1), render_unboxed(eltype, dataptr + i * elsize,
-                                             MAX_DEPTH - 1)
-    if n > shown:
-        yield "...", "(%d more)" % (n - shown)
-
-
 def jl_value(addr):
     """A gdb.Value holding addr as a jl_value_t*."""
-    return gdb.Value(addr).cast(lookup_type("jl_value_t").pointer())
+    return gdb.Value(addr).cast(gdb.lookup_type("jl_value_t").pointer())
+
+
+def loc_to_gdb_value(rt, loc):
+    """Convert a core location to a gdb.Value: jl_value_t* for boxed values,
+    a native typed value for unboxed primitives, void* otherwise."""
+    if loc[0] == "val":
+        return jl_value(loc[1])
+    _, taddr, addr = loc
+    ctype = core.PRIMITIVE_CTYPES.get(rt.datatype_qualname(taddr))
+    if ctype is not None:
+        return gdb.Value(addr).cast(
+            gdb.lookup_type(ctype).pointer()).dereference()
+    return gdb.Value(addr).cast(gdb.lookup_type("void").pointer())
 
 
 # --------------------------------------------------------------------------
-# rendering of runtime objects (Method, MethodInstance, Task, ...)
-# --------------------------------------------------------------------------
-
-def render_sig_call(fname, sigaddr, depth):
-    """Render "f(::T, ::S)" from a Tuple{typeof(f), T, S} signature."""
-    # peel UnionAll wrappers
-    seen = 0
-    while datatype_qualname(typeof_addr(sigaddr)) == "Core.UnionAll" and seen < 32:
-        sigaddr = int(value_at(sigaddr, "jl_unionall_t")["body"])
-        seen += 1
-    if datatype_qualname(typeof_addr(sigaddr)) != "Core.DataType":
-        return "%s(...)" % fname
-    params = int(value_at(sigaddr, "jl_datatype_t")["parameters"])
-    n = svec_len(params) if params else 0
-    args = ["::" + render_type(svec_ref(params, i), depth - 1)
-            for i in range(1, min(n, MAX_ELEMS + 1))]
-    if n > MAX_ELEMS + 1:
-        args.append("…")
-    return "%s(%s)" % (fname, ", ".join(args))
-
-
-def render_method(addr, depth):
-    m = value_at(addr, "jl_method_t")
-    name = symbol_name(int(m["name"]))
-    where = ""
-    if int(m["module"]):
-        where = " @ " + module_path(int(m["module"]))
-    faddr = int(m["file"])
-    if faddr:
-        where += " %s:%d" % (symbol_name(faddr), int(m["line"]))
-    return render_sig_call(name, int(m["sig"]), depth) + where
-
-
-def render_method_instance(addr, depth):
-    mi = value_at(addr, "jl_method_instance_t")
-    defaddr = int(mi["def"]["value"])
-    name = "?"
-    if defaddr:
-        if datatype_qualname(typeof_addr(defaddr)) == "Core.Method":
-            name = symbol_name(int(value_at(defaddr, "jl_method_t")["name"]))
-        else:  # toplevel thunk: def is a module
-            name = "top-level scope in " + module_path(defaddr)
-            return "MethodInstance for " + name
-    return "MethodInstance for " + render_sig_call(name, int(mi["specTypes"]),
-                                                   depth)
-
-
-def render_code_instance(addr, depth):
-    ci = value_at(addr, "jl_code_instance_t")
-    defaddr = int(ci["def"])
-    inner = "?"
-    if defaddr:
-        qual = datatype_qualname(typeof_addr(defaddr))
-        if qual == "Core.ABIOverride":
-            defaddr = int(value_at(defaddr, "jl_abi_override_t")["def"])
-            qual = datatype_qualname(typeof_addr(defaddr))
-        if qual == "Core.MethodInstance":
-            inner = render_method_instance(defaddr, depth - 1)
-    return "CodeInstance for %s" % inner
-
-
-TASK_STATES = {0: "runnable", 1: "done", 2: "failed", 3: "abandoned"}
-
-
-def render_task(addr):
-    t = value_at(addr, "jl_task_t")
-    state = TASK_STATES.get(int(t["_state"]), "?")
-    return "Task (%s) @0x%016x" % (state, addr)
-
-
-def render_expr(addr, depth):
-    e = value_at(addr, "jl_expr_t")
-    head = symbol_name(int(e["head"])) if int(e["head"]) else "?"
-    nargs = 0
-    if int(e["args"]):
-        try:
-            nargs = array_info(int(e["args"]))[0][0]
-        except (gdb.error, gdb.MemoryError):
-            pass
-    return "Expr(:%s, <%d args>)" % (head, nargs)
-
-
-def render_svec(addr, depth):
-    n = svec_len(addr)
-    parts = []
-    for i in range(min(n, MAX_ELEMS)):
-        p = svec_ref(addr, i)
-        parts.append(render_value(p, depth - 1) if p else "#undef")
-    if n > MAX_ELEMS:
-        parts.append("…")
-    return "svec(%s)" % ", ".join(parts)
-
-
-# --------------------------------------------------------------------------
-# main value renderer
-# --------------------------------------------------------------------------
-
-def render_value(addr, depth=MAX_DEPTH):
-    """Render the Julia value at addr as a compact single-line string."""
-    if addr == 0:
-        return "#<null>"
-    if depth < 0:
-        return "…"
-    dtaddr = typeof_addr(addr)
-    if dtaddr == 0:
-        tag = typetag(addr)
-        idx = tag >> 4
-        if tag < (64 << 4) and idx < len(SMALL_TAG_NAMES):
-            return "<%s 0x%x>" % (SMALL_TAG_NAMES[idx], addr)
-        return "<julia value 0x%x>" % addr
-    qual = datatype_qualname(dtaddr)
-
-    if is_type_kind(qual):
-        return render_type(addr, depth)
-    prim = render_primitive(qual, addr)
-    if prim is not None:
-        return prim
-    if qual == "Core.Nothing":
-        return "nothing"
-    if qual == "Core.Symbol":
-        name = symbol_name(addr)
-        if name.isidentifier():
-            return ":" + name
-        return 'Symbol("%s")' % escape_string(name)
-    if qual == "Core.String":
-        s, strlen = string_data(addr)
-        suffix = "…" if strlen > len(s.encode("utf-8", "replace")) else ""
-        return '"%s%s"' % (escape_string(s), suffix)
-    if qual == "Core.SimpleVector":
-        return render_svec(addr, depth)
-    if qual == "Core.Module":
-        return "Module %s" % module_path(addr)
-    if qual == "Core.Task":
-        return render_task(addr)
-    if qual == "Core.Method":
-        return render_method(addr, depth)
-    if qual == "Core.MethodInstance":
-        return render_method_instance(addr, depth)
-    if qual == "Core.CodeInstance":
-        return render_code_instance(addr, depth)
-    if qual == "Core.Expr":
-        return render_expr(addr, depth)
-    if qual == "Core.GlobalRef":
-        gr = value_at(addr, "jl_globalref_t")
-        return "%s.%s" % (module_path(int(gr["mod"])),
-                          symbol_name(int(gr["name"])))
-    if qual == "Core.TypeName":
-        tn = value_at(addr, "jl_typename_t")
-        return "typename(%s)" % symbol_name(int(tn["name"]))
-
-    dt = value_at(dtaddr, "jl_datatype_t")
-    tname = symbol_name(int(value_at(int(dt["name"]), "jl_typename_t")["name"]))
-    if tname in ("Array", "GenericMemory"):
-        try:
-            summary = render_array_summary(addr, depth - 1)
-            parts = ["%s" % v if isinstance(v, str) else render_value(int(v), depth - 1)
-                     for _, v in array_children(addr)]
-            return "%s = {%s}" % (summary, ", ".join(parts)) if depth == MAX_DEPTH \
-                else "%s" % summary
-        except (gdb.error, gdb.MemoryError):
-            return render_type(dtaddr, depth - 1) + " <unreadable>"
-
-    # generic instances
-    if int(dt["instance"]) == addr:
-        tn = value_at(int(dt["name"]), "jl_typename_t")
-        sname = int(tn["singletonname"]) if "singletonname" in \
-            (f.name for f in lookup_type("jl_typename_t").fields()) else 0
-        return symbol_name(sname) if sname else render_type(dtaddr, depth) + "()"
-    if int(dt["isprimitivetype"]):
-        return render_unboxed(dtaddr, addr, depth)
-    fields = layout_fields(dt)
-    if fields is not None:
-        return render_struct_inline(dtaddr, dt, addr, fields, depth)
-    return "%s @0x%016x" % (render_type(dtaddr, depth - 1), addr)
-
-
-# --------------------------------------------------------------------------
-# gdb integration
+# pretty printers
 # --------------------------------------------------------------------------
 
 # struct tags / typedef names whose pointers we pretty-print
@@ -789,9 +208,6 @@ JULIA_POINTER_TYPES = {
     "jl_typemap_t",
 }
 
-# runtime types whose printer exposes expandable children
-CHILDREN_KINDS = ("Core.SimpleVector",)
-
 
 class JuliaValuePrinter:
     """to_string-based printer: dispatches on the runtime type tag."""
@@ -807,8 +223,8 @@ class JuliaValuePrinter:
         if addr == 0:
             return "(jl_value_t *) NULL"
         try:
-            return render_value(addr)
-        except (gdb.error, gdb.MemoryError) as e:
+            return get_rt().render_value_capped(addr)
+        except JLDebugError as e:
             return "<not a julia value: 0x%x (%s)>" % (addr, e)
         except Exception as e:  # never break `print` on a printer bug
             return "<error rendering julia value 0x%x: %s>" % (addr, e)
@@ -820,32 +236,20 @@ class JuliaArrayPrinter(JuliaValuePrinter):
 
     def to_string(self):
         try:
-            return render_array_summary(int(self.val), MAX_DEPTH)
-        except (gdb.error, gdb.MemoryError):
+            return get_rt().render_array_summary(int(self.val),
+                                                 core.MAX_DEPTH)
+        except (JLDebugError, Exception):
             return JuliaValuePrinter.to_string(self)
 
     def children(self):
         try:
-            for name, v in array_children(int(self.val)):
-                yield name, str(v) if not isinstance(v, gdb.Value) else v
-        except (gdb.error, gdb.MemoryError):
+            for name, (kind, v) in get_rt().array_children(int(self.val)):
+                yield name, jl_value(v) if kind == "val" else v
+        except (JLDebugError, Exception):
             return
 
     def display_hint(self):
         return "array"
-
-
-def is_array_value(addr):
-    try:
-        dtaddr = typeof_addr(addr)
-        if dtaddr == 0:
-            return False
-        dt = value_at(dtaddr, "jl_datatype_t")
-        tname = symbol_name(int(value_at(int(dt["name"]),
-                                         "jl_typename_t")["name"]))
-        return tname in ("Array", "GenericMemory")
-    except (gdb.error, gdb.MemoryError):
-        return False
 
 
 class JuliaPrettyPrinter(gdb.printing.PrettyPrinter):
@@ -865,15 +269,16 @@ class JuliaPrettyPrinter(gdb.printing.PrettyPrinter):
         try:
             if int(val) == 0:
                 return None
-        except gdb.error:
-            return None
-        try:
-            if is_array_value(int(val)):
+            if get_rt().is_array_value(int(val)):
                 return JuliaArrayPrinter(val)
-        except (gdb.error, gdb.MemoryError):
+        except (gdb.error, JLDebugError):
             pass
         return JuliaValuePrinter(val)
 
+
+# --------------------------------------------------------------------------
+# convenience functions and the `jl` command
+# --------------------------------------------------------------------------
 
 class JlTypeofFunction(gdb.Function):
     """$jl_typeof(v): the jl_datatype_t* of a Julia value.
@@ -884,8 +289,114 @@ class JlTypeofFunction(gdb.Function):
         super().__init__("jl_typeof")
 
     def invoke(self, v):
-        addr = typeof_addr(int(v))
-        return gdb.Value(addr).cast(lookup_type("jl_datatype_t").pointer())
+        addr = get_rt().typeof_addr(int(v))
+        return gdb.Value(addr).cast(gdb.lookup_type("jl_datatype_t").pointer())
+
+
+class JlFieldFunction(gdb.Function):
+    """$jl_field(v, key): Julia-semantics getfield/getindex on a value.
+
+    `key` is a field name string or a 1-based index. Boxed fields come back
+    as jl_value_t*, unboxed primitive fields as native typed values, so the
+    result composes inside larger expressions:
+
+        print $jl_field(v, "inner")
+        print $jl_field($jl_field(v, "counts"), 2) + 1
+    """
+
+    def __init__(self):
+        super().__init__("jl_field")
+
+    def invoke(self, v, key):
+        rt = get_rt()
+        if key.type.code in (gdb.TYPE_CODE_ARRAY, gdb.TYPE_CODE_PTR):
+            k = key.string()
+        else:
+            k = int(key)
+        try:
+            loc = rt.getfield(("val", int(v)), k)
+            if loc[0] == "inline" and \
+                    core.PRIMITIVE_CTYPES.get(
+                        rt.datatype_qualname(loc[1])) is None:
+                raise JLDebugError(
+                    "field %s is a struct stored inline in its parent;"
+                    " use the `jl` command to access it further" % k)
+            return loc_to_gdb_value(rt, loc)
+        except JLDebugError as e:
+            raise gdb.GdbError(str(e))
+
+
+class JlCommand(gdb.Command):
+    """jl <path>: inspect a Julia value with Julia field/index semantics.
+
+    The path starts from a C expression (a variable, convenience variable,
+    or cast) or from a module name, followed by `.field` and `[i]` accessors
+    with Julia (1-based) indexing:
+
+        jl v.inner.name
+        jl v.vec[2]
+        jl v.tup.1
+        jl Base.have_fma
+        jl $1.x
+        jl $jl.name
+
+    The result is rendered like `print` would and stored in the convenience
+    variable `$jl` (as jl_value_t*, or a native value for unboxed fields).
+    A path starting with `$jl` continues from the previous result, which
+    also works when that result was a struct stored inline in its parent."""
+
+    last_loc = None
+
+    def __init__(self):
+        super().__init__("jl", gdb.COMMAND_DATA)
+
+    def invoke(self, arg, from_tty):
+        arg = arg.strip()
+        if not arg:
+            raise gdb.GdbError("usage: jl <expr>[.field|[index]]...")
+        rt = get_rt()
+        first_err = None
+        parsed_any = False
+        for base, accessors in core.split_path(arg):
+            if base == "$jl" and JlCommand.last_loc is not None:
+                loc0 = JlCommand.last_loc
+            else:
+                try:
+                    v = gdb.parse_and_eval(base)
+                    loc0 = ("val", int(v))
+                except gdb.error:
+                    continue
+            parsed_any = True
+            try:
+                self.finish(rt, rt.eval_accessors(loc0, accessors))
+                return
+            except JLDebugError as e:
+                first_err = first_err or e
+        # base is not a C expression: try Julia module/global resolution
+        base, accessors = core.split_path(arg)[-1]
+        if not parsed_any and base.isidentifier():
+            try:
+                modaddr = rt.root_module(base)
+            except JLDebugError:
+                modaddr = 0
+            if modaddr:
+                try:
+                    self.finish(rt, rt.eval_accessors(("val", modaddr),
+                                                      accessors))
+                    return
+                except JLDebugError as e:
+                    first_err = first_err or e
+        if first_err is not None:
+            raise gdb.GdbError(str(first_err))
+        raise gdb.GdbError("cannot evaluate %r" % arg)
+
+    def finish(self, rt, loc):
+        JlCommand.last_loc = loc
+        try:
+            gdb.set_convenience_variable("jl", loc_to_gdb_value(rt, loc))
+        except (gdb.error, JLDebugError, AttributeError):
+            pass
+        print("$jl = %s" % rt.render_loc(loc))
 
 
 # --------------------------------------------------------------------------
@@ -901,13 +412,12 @@ class JlTypeofFunction(gdb.Function):
 # real segfaults (including stack overflows) still stop the debugger.
 # --------------------------------------------------------------------------
 
-# 4 pages, see the layout description in src/safepoint.c
 SAFEPOINT_COND = (
     "!((unsigned long)$_siginfo._sifields._sigfault.si_addr"
     " >= (unsigned long)jl_safepoint_pages"
     " && (unsigned long)$_siginfo._sifields._sigfault.si_addr"
     " < (unsigned long)jl_safepoint_pages"
-    " + 4*(unsigned long)jl_page_size)")
+    " + %d*(unsigned long)jl_page_size)" % core.SAFEPOINT_PAGES)
 
 _segv_catchpoint = [None]
 _segv_cond_armed = [False]
@@ -995,6 +505,8 @@ def register(obj=None):
     gdb.printing.register_pretty_printer(obj, JuliaPrettyPrinter(),
                                          replace=True)
     JlTypeofFunction()
+    JlFieldFunction()
+    JlCommand()
     JlSafepointCommand()
     JlHandleSignalsCommand()
     try:

--- a/contrib/julia_gdb.py
+++ b/contrib/julia_gdb.py
@@ -511,12 +511,19 @@ gdb.events.new_objfile.connect(_try_arm_segv_condition)
 def enable_safepoint_filter():
     if _segv_catchpoint[0] is not None:
         return
+    # transactional: never leave SIGSEGV set to nostop without the
+    # catchpoint in place, or real segfaults would no longer stop gdb
     gdb.execute("handle SIGSEGV nostop noprint pass", to_string=True)
-    out = gdb.execute("catch signal SIGSEGV", to_string=True)
-    m = re.search(r"Catchpoint (\d+)", out)
-    if m is None:
-        return
-    _segv_catchpoint[0] = int(m.group(1))
+    try:
+        out = gdb.execute("catch signal SIGSEGV", to_string=True)
+        m = re.search(r"Catchpoint (\d+)", out)
+        if m is None:
+            raise gdb.error("cannot parse catchpoint id from: %s"
+                            % out.strip())
+        _segv_catchpoint[0] = int(m.group(1))
+    except Exception:
+        gdb.execute("handle SIGSEGV stop print pass", to_string=True)
+        raise
     _try_arm_segv_condition()
 
 
@@ -579,8 +586,9 @@ def register(obj=None):
     JlHandleSignalsCommand()
     try:
         enable_safepoint_filter()
-    except gdb.error:
-        pass
+    except gdb.error as e:
+        print("julia_gdb: GC safepoint SIGSEGV filter not installed (%s)"
+              % e)
 
 
 register(gdb.current_objfile())

--- a/contrib/julia_gdb.py
+++ b/contrib/julia_gdb.py
@@ -152,6 +152,7 @@ def get_rt():
 def _clear_cache(event=None):
     _RT[0] = None
     JlCommand.last_loc = None
+    _expand_depth[0] = 0
 
 
 gdb.events.new_objfile.connect(_clear_cache)
@@ -223,11 +224,28 @@ class JuliaValuePrinter:
         if addr == 0:
             return "(jl_value_t *) NULL"
         try:
-            return get_rt().render_value_capped(addr)
+            rt = get_rt()
+            # inside an array expansion each element is rendered by its own
+            # printer; keep those terse and drawing from the expansion-wide
+            # budget so the total output stays bounded
+            if _expand_depth[0] > 0:
+                s = rt.render_value_brief(addr)
+                rt.spend(len(s))
+                return s
+            rt._budget = None  # recover from any abandoned expansion
+            return rt.render_value_capped(addr)
         except JLDebugError as e:
             return "<not a julia value: 0x%x (%s)>" % (addr, e)
         except Exception as e:  # never break `print` on a printer bug
             return "<error rendering julia value 0x%x: %s>" % (addr, e)
+
+
+# Number of array children() generators currently being expanded. gdb drives
+# nested expansion itself (our depth caps don't apply to it), so without a
+# guard a self-referential array would be re-expanded until gdb's own limits
+# kick in. Elements yielded at nesting >= MAX_DEPTH become pre-rendered
+# (depth-capped) strings instead of jl_value_t* values.
+_expand_depth = [0]
 
 
 class JuliaArrayPrinter(JuliaValuePrinter):
@@ -242,11 +260,34 @@ class JuliaArrayPrinter(JuliaValuePrinter):
             return JuliaValuePrinter.to_string(self)
 
     def children(self):
+        rt = get_rt()
+        # the outermost expansion owns a budget that everything nested
+        # (element to_strings, leaf renders) draws from, so gdb's
+        # multiplicative child expansion cannot produce unbounded output
+        owns_budget = _expand_depth[0] == 0 and rt._budget is None
+        if owns_budget:
+            rt._budget = [core.MAX_OUTPUT]
+        _expand_depth[0] += 1
         try:
-            for name, (kind, v) in get_rt().array_children(int(self.val)):
-                yield name, jl_value(v) if kind == "val" else v
+            for name, (kind, v) in rt.array_children(int(self.val)):
+                if rt.exhausted():
+                    yield name, "…"
+                    break
+                if kind != "val":
+                    rt.spend(len(v))
+                    yield name, v
+                elif _expand_depth[0] < core.MAX_DEPTH:
+                    yield name, jl_value(v)
+                else:
+                    s = rt.render_value_brief(v)
+                    rt.spend(len(s))
+                    yield name, s
         except (JLDebugError, Exception):
             return
+        finally:
+            _expand_depth[0] -= 1
+            if owns_budget:
+                rt._budget = None
 
     def display_hint(self):
         return "array"

--- a/contrib/julia_lldb.py
+++ b/contrib/julia_lldb.py
@@ -156,6 +156,11 @@ def get_rt(target, process):
     rt = core.JuliaRuntime(LldbAdapter(target, process))
     _RT[0] = rt
     _last_loc[0] = None
+    if process.IsValid():
+        # opportunistically install the safepoint stop-hook the first time
+        # we see this process (importing from ~/.lldbinit happens before a
+        # target exists, so it cannot be done at import time)
+        _install_stop_hook(target.GetDebugger())
     return rt
 
 
@@ -175,7 +180,6 @@ def rt_of(valobj):
 # --------------------------------------------------------------------------
 
 _FAULT_ADDR_RE = re.compile(r"fault address:?\s*(0x[0-9a-fA-F]+)")
-_stop_hook_installed = [False]
 
 
 def _global_uint(target, name):
@@ -218,16 +222,27 @@ class JLSafepointStopHook:
         return True
 
 
-def _install_stop_hook(debugger):
-    if _stop_hook_installed[0]:
-        return
-    if debugger.GetNumTargets() == 0:
-        return
+def _run_command(debugger, cmd):
     res = lldb.SBCommandReturnObject()
-    debugger.GetCommandInterpreter().HandleCommand(
-        "target stop-hook add -P %s.JLSafepointStopHook" % __name__, res)
-    if res.Succeeded():
-        _stop_hook_installed[0] = True
+    debugger.GetCommandInterpreter().HandleCommand(cmd, res)
+    return res.Succeeded(), (res.GetOutput() or "")
+
+
+def _stop_hook_present(debugger):
+    """Whether the *selected* target has our stop-hook. Stop hooks belong to
+    individual targets, so this must be queried rather than cached."""
+    ok, out = _run_command(debugger, "target stop-hook list")
+    return ok and "JLSafepointStopHook" in out
+
+
+def _install_stop_hook(debugger):
+    if debugger.GetNumTargets() == 0:
+        return False
+    if _stop_hook_present(debugger):
+        return True
+    ok, _ = _run_command(
+        debugger, "target stop-hook add -P %s.JLSafepointStopHook" % __name__)
+    return ok
 
 
 def jl_safepoint_filter_cmd(debugger, command, exe_ctx, result, internal_dict):
@@ -246,8 +261,8 @@ def jl_safepoint_filter_cmd(debugger, command, exe_ctx, result, internal_dict):
         result.SetError("usage: jl-safepoint-filter [on|off]")
         return
     result.AppendMessage(
-        "julia safepoint SIGSEGV filter is %s"
-        % ("on" if JLSafepointStopHook.enabled and _stop_hook_installed[0]
+        "julia safepoint SIGSEGV filter is %s for the selected target"
+        % ("on" if JLSafepointStopHook.enabled and _stop_hook_present(debugger)
            else "off"))
 
 
@@ -271,10 +286,6 @@ def jl_value_summary(valobj, internal_dict):
     if addr == 0:
         return "NULL"
     rt = rt_of(valobj)
-    if rt.a.process.IsValid():
-        # opportunistically install the safepoint stop-hook once a real
-        # process exists (importing from ~/.lldbinit happens before that)
-        _install_stop_hook(valobj.GetTarget().GetDebugger())
     try:
         return rt.render_value_capped(addr)
     except JLDebugError as e:

--- a/contrib/julia_lldb.py
+++ b/contrib/julia_lldb.py
@@ -1,0 +1,905 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+"""LLDB type summaries for Julia runtime values.
+
+Load this script into lldb to make `p`/`frame variable` render `jl_value_t*`
+(and other Julia runtime pointers such as `jl_datatype_t*`, `jl_sym_t*`,
+`jl_svec_t*`, `jl_array_t*`, `jl_method_t*`, ...) the way Julia would show
+them, instead of as raw addresses:
+
+    (lldb) p v
+    (jl_value_t *) 0x00007f... :foo
+    (lldb) p (jl_value_t *)some_array
+    (jl_value_t *) 0x00007f... 3-element Vector{Int64} = {1, 2, 3}
+
+Usage (pick one):
+  * `command script import /path/to/julia/contrib/julia_lldb.py` inside lldb,
+  * add that line to your `~/.lldbinit`, or
+  * `lldb -o "command script import /path/to/julia/contrib/julia_lldb.py" -- ./julia ...`
+
+The summaries dispatch on the *runtime* type tag of the object, so a plain
+`jl_value_t*` prints as whatever it actually is. Everything is resolved
+through the debug info of libjulia-internal, so this script does not
+hard-code struct offsets and should work across Julia versions; it requires a
+build of Julia with debug info (the default) and gracefully degrades to raw
+pointers when the debug info or the memory is unavailable.
+
+The script also installs a stop-hook that transparently resumes the benign
+SIGSEGVs Julia's GC uses to stop the world at safepoints (real segfaults
+still stop the debugger); control it with `jl-safepoint-filter [on|off]`.
+"""
+
+import re
+import struct
+
+import lldb
+
+# Render at most this many nested levels in a single summary string.
+MAX_DEPTH = 3
+# Render at most this many elements of arrays/svecs/tuples in a summary.
+MAX_ELEMS = 10
+# Truncate strings longer than this many bytes.
+MAX_STRING = 200
+
+
+class Ctx:
+    """Debug-info lookups and memory reads for one (target, process) pair."""
+
+    def __init__(self, target, process):
+        self.target = target
+        self.process = process
+        self.ptrsize = target.GetAddressByteSize()
+        self.types = {}
+        self.sizes = {}
+        self.offsets = {}
+        self.dt_names = {}
+
+    def lookup_type(self, name):
+        t = self.types.get(name)
+        if t is None:
+            t = self.target.FindFirstType(name)
+            if not t.IsValid():
+                raise MemoryReadError("no type named %s in debug info" % name)
+            self.types[name] = t
+        return t
+
+    def type_size(self, name):
+        s = self.sizes.get(name)
+        if s is None:
+            s = self.lookup_type(name).GetByteSize()
+            self.sizes[name] = s
+        return s
+
+    def field_offset(self, typename, fieldname):
+        key = (typename, fieldname)
+        off = self.offsets.get(key)
+        if off is None:
+            t = self.lookup_type(typename)
+            for f in t.get_fields_array():
+                if f.GetName() == fieldname:
+                    off = f.GetOffsetInBytes()
+                    break
+            if off is None:
+                raise MemoryReadError("no field %s in %s"
+                                      % (fieldname, typename))
+            self.offsets[key] = off
+        return off
+
+    def read_mem(self, addr, size):
+        err = lldb.SBError()
+        buf = self.process.ReadMemory(addr, size, err)
+        if err.Fail() or buf is None:
+            raise MemoryReadError("cannot read 0x%x" % addr)
+        return buf
+
+    def read_uint(self, addr, size, signed=False):
+        return int.from_bytes(self.read_mem(addr, size), "little",
+                              signed=signed)
+
+    def read_ptr(self, addr):
+        return self.read_uint(addr, self.ptrsize)
+
+    def read_cstring(self, addr, maxlen=512):
+        err = lldb.SBError()
+        s = self.process.ReadCStringFromMemory(addr, maxlen, err)
+        if err.Fail() or s is None:
+            raise MemoryReadError("cannot read string at 0x%x" % addr)
+        return s
+
+    def value_at(self, addr, typename):
+        """An SBValue of type `typename` located at `addr`."""
+        t = self.lookup_type(typename)
+        return self.target.CreateValueFromAddress(
+            "jlval", lldb.SBAddress(addr, self.target), t)
+
+
+class MemoryReadError(Exception):
+    pass
+
+
+_CTX = [None]
+
+
+def get_ctx(valobj):
+    target = valobj.GetTarget()
+    process = valobj.GetProcess()
+    ctx = _CTX[0]
+    if (ctx is None or ctx.target != target or ctx.process != process
+            or ctx.process.GetUniqueID() != process.GetUniqueID()):
+        ctx = Ctx(target, process)
+        _CTX[0] = ctx
+    return ctx
+
+
+def member_u(sbval, *names):
+    v = sbval
+    for name in names:
+        v = v.GetChildMemberWithName(name)
+        if not v.IsValid():
+            raise MemoryReadError("no member %s" % name)
+    return v.GetValueAsUnsigned()
+
+
+def member_i(sbval, name):
+    v = sbval.GetChildMemberWithName(name)
+    if not v.IsValid():
+        raise MemoryReadError("no member %s" % name)
+    return v.GetValueAsSigned()
+
+
+def typetag(ctx, addr):
+    return ctx.read_ptr(addr - ctx.ptrsize) & ~15
+
+
+def small_typeof_addr(ctx):
+    for sym in ("jl_small_typeof", "ijl_small_typeof"):
+        var = ctx.target.FindFirstGlobalVariable(sym)
+        if var.IsValid():
+            addr = var.GetLoadAddress()
+            if addr != lldb.LLDB_INVALID_ADDRESS:
+                return addr
+    return 0
+
+
+def typeof_addr(ctx, addr):
+    tag = typetag(ctx, addr)
+    if tag < (64 << 4):
+        table = small_typeof_addr(ctx)
+        if table == 0:
+            return 0
+        # entry lives at byte offset `tag` (see jl_to_typeof in julia.h)
+        return ctx.read_ptr(table + tag)
+    return tag
+
+
+def symbol_name(ctx, addr):
+    return ctx.read_cstring(addr + ctx.type_size("jl_sym_t"))
+
+
+def svec_len(ctx, addr):
+    return member_u(ctx.value_at(addr, "jl_svec_t"), "length")
+
+
+def svec_ref(ctx, addr, i):
+    return ctx.read_ptr(addr + ctx.type_size("jl_svec_t") + i * ctx.ptrsize)
+
+
+def is_cpu_addrspace(ctx, addr):
+    if addr == 0:
+        return False
+    try:
+        dtaddr = typeof_addr(ctx, addr)
+        if dtaddr == 0:
+            return False
+        dt = ctx.value_at(dtaddr, "jl_datatype_t")
+        tname = symbol_name(ctx, member_u(
+            ctx.value_at(member_u(dt, "name"), "jl_typename_t"), "name"))
+        return tname == "AddrSpace" and ctx.read_uint(addr, 1) == 0
+    except MemoryReadError:
+        return False
+
+
+def module_path(ctx, addr, depth=0):
+    if addr == 0 or depth > 10:
+        return "?"
+    mod = ctx.value_at(addr, "jl_module_t")
+    name = symbol_name(ctx, member_u(mod, "name"))
+    parent = member_u(mod, "parent")
+    if parent == 0 or parent == addr:
+        return name
+    pname = module_path(ctx, parent, depth + 1)
+    if pname == "Main":
+        return name
+    return pname + "." + name
+
+
+def datatype_qualname(ctx, dtaddr):
+    name = ctx.dt_names.get(dtaddr)
+    if name is None:
+        dt = ctx.value_at(dtaddr, "jl_datatype_t")
+        tn = ctx.value_at(member_u(dt, "name"), "jl_typename_t")
+        name = (module_path(ctx, member_u(tn, "module")) + "."
+                + symbol_name(ctx, member_u(tn, "name")))
+        ctx.dt_names[dtaddr] = name
+    return name
+
+
+def typename_of(ctx, dtaddr):
+    dt = ctx.value_at(dtaddr, "jl_datatype_t")
+    tn = ctx.value_at(member_u(dt, "name"), "jl_typename_t")
+    return symbol_name(ctx, member_u(tn, "name"))
+
+
+def string_data(ctx, addr):
+    strlen = ctx.read_uint(addr, ctx.ptrsize)
+    n = min(strlen, MAX_STRING)
+    s = ctx.read_mem(addr + ctx.ptrsize, n).decode("utf-8", errors="replace") \
+        if n else ""
+    return s, strlen
+
+
+def escape_string(s):
+    out = []
+    for c in s:
+        if c == '"':
+            out.append('\\"')
+        elif c == "\\":
+            out.append("\\\\")
+        elif c == "\n":
+            out.append("\\n")
+        elif c == "\t":
+            out.append("\\t")
+        elif ord(c) < 32:
+            out.append("\\x%02x" % ord(c))
+        else:
+            out.append(c)
+    return "".join(out)
+
+
+# --------------------------------------------------------------------------
+# rendering of type objects (DataType/Union/UnionAll/TypeVar/Vararg)
+# --------------------------------------------------------------------------
+
+def is_type_kind(qual):
+    return qual in ("Core.DataType", "Core.Union", "Core.UnionAll",
+                    "Core.TypeVar", "Core.TypeofVararg", "Core.TypeofBottom")
+
+
+def render_typevar(ctx, addr, with_bounds):
+    tv = ctx.value_at(addr, "jl_tvar_t")
+    name = symbol_name(ctx, member_u(tv, "name"))
+    if not with_bounds:
+        return name
+    lb = render_type(ctx, member_u(tv, "lb"), MAX_DEPTH - 1)
+    ub = render_type(ctx, member_u(tv, "ub"), MAX_DEPTH - 1)
+    if lb == "Union{}" and ub == "Any":
+        return name
+    if lb == "Union{}":
+        return "%s<:%s" % (name, ub)
+    return "%s<:%s<:%s" % (lb, name, ub)
+
+
+def flatten_union(ctx, addr, parts, depth):
+    qual = datatype_qualname(ctx, typeof_addr(ctx, addr))
+    if qual == "Core.Union":
+        u = ctx.value_at(addr, "jl_uniontype_t")
+        flatten_union(ctx, member_u(u, "a"), parts, depth)
+        flatten_union(ctx, member_u(u, "b"), parts, depth)
+    else:
+        parts.append(render_type(ctx, addr, depth))
+
+
+def render_type(ctx, addr, depth=MAX_DEPTH):
+    if addr == 0:
+        return "#<null>"
+    if depth < 0:
+        return "…"
+    dtaddr = typeof_addr(ctx, addr)
+    if dtaddr == 0:
+        return "<?type 0x%x>" % addr
+    qual = datatype_qualname(ctx, dtaddr)
+    if qual == "Core.TypeofBottom":
+        return "Union{}"
+    if qual == "Core.Union":
+        parts = []
+        flatten_union(ctx, addr, parts, depth - 1)
+        return "Union{%s}" % ", ".join(parts)
+    if qual == "Core.UnionAll":
+        ua = ctx.value_at(addr, "jl_unionall_t")
+        body = render_type(ctx, member_u(ua, "body"), depth - 1)
+        var = render_typevar(ctx, member_u(ua, "var"), True)
+        return "%s where %s" % (body, var)
+    if qual == "Core.TypeVar":
+        return render_typevar(ctx, addr, False)
+    if qual == "Core.TypeofVararg":
+        va = ctx.value_at(addr, "jl_vararg_t")
+        t, n = member_u(va, "T"), member_u(va, "N")
+        if t == 0:
+            return "Vararg"
+        if n == 0:
+            return "Vararg{%s}" % render_type(ctx, t, depth - 1)
+        return "Vararg{%s, %s}" % (render_type(ctx, t, depth - 1),
+                                   render_value(ctx, n, depth - 1))
+    if qual == "Core.Module":
+        return module_path(ctx, addr)
+    if qual != "Core.DataType":
+        # a value used as a type parameter (1, :x, true, ...)
+        return render_value(ctx, addr, depth)
+
+    dt = ctx.value_at(addr, "jl_datatype_t")
+    tn = ctx.value_at(member_u(dt, "name"), "jl_typename_t")
+    modpath = module_path(ctx, member_u(tn, "module"))
+    name = symbol_name(ctx, member_u(tn, "name"))
+    if modpath not in ("Core", "Main") and not name.startswith("typeof("):
+        name = modpath + "." + name
+    params = member_u(dt, "parameters")
+    nparams = svec_len(ctx, params) if params else 0
+    if nparams == 0:
+        return name + "{}" if name == "Tuple" else name
+    # sugar: Array{T, 1} => Vector{T}, Array{T, 2} => Matrix{T}
+    if name == "Array" and nparams == 2:
+        ndim = render_type(ctx, svec_ref(ctx, params, 1), depth - 1)
+        if ndim == "1":
+            return "Vector{%s}" % render_type(ctx, svec_ref(ctx, params, 0),
+                                              depth - 1)
+        if ndim == "2":
+            return "Matrix{%s}" % render_type(ctx, svec_ref(ctx, params, 0),
+                                              depth - 1)
+    # sugar: GenericMemory{:not_atomic, T, Core.CPU} => Memory{T}
+    if name == "GenericMemory" and nparams == 3:
+        order = svec_ref(ctx, params, 0)
+        if is_cpu_addrspace(ctx, svec_ref(ctx, params, 2)):
+            eltstr = render_type(ctx, svec_ref(ctx, params, 1), depth - 1)
+            oname = symbol_name(ctx, order) if order else ""
+            if oname == "not_atomic":
+                return "Memory{%s}" % eltstr
+            if oname == "atomic":
+                return "AtomicMemory{%s}" % eltstr
+    rendered = [render_type(ctx, svec_ref(ctx, params, i), depth - 1)
+                for i in range(min(nparams, MAX_ELEMS))]
+    if nparams > MAX_ELEMS:
+        rendered.append("…")
+    return "%s{%s}" % (name, ", ".join(rendered))
+
+
+# --------------------------------------------------------------------------
+# rendering of plain data (bits values, structs, arrays)
+# --------------------------------------------------------------------------
+
+PRIMITIVE_FMT = {
+    "Core.Int8": ("i", 1), "Core.Int16": ("i", 2),
+    "Core.Int32": ("i", 4), "Core.Int64": ("i", 8),
+    "Core.UInt8": ("u", 1), "Core.UInt16": ("u", 2),
+    "Core.UInt32": ("u", 4), "Core.UInt64": ("u", 8),
+    "Core.Float16": ("f", 2), "Core.Float32": ("f", 4),
+    "Core.Float64": ("f", 8),
+}
+
+
+def render_char(u):
+    raw = u.to_bytes(4, "big").rstrip(b"\0") or b"\0"
+    try:
+        return "'%s'" % raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return "Char(0x%08x)" % u
+
+
+def render_primitive(ctx, qual, addr):
+    fmt = PRIMITIVE_FMT.get(qual)
+    if fmt is not None:
+        kind, size = fmt
+        if kind == "i":
+            return str(ctx.read_uint(addr, size, signed=True))
+        if kind == "u":
+            return "0x%0*x" % (2 * size, ctx.read_uint(addr, size))
+        return repr(struct.unpack("<" + {2: "e", 4: "f", 8: "d"}[size],
+                                  ctx.read_mem(addr, size))[0])
+    if qual == "Core.Bool":
+        return "true" if ctx.read_uint(addr, 1) else "false"
+    if qual == "Core.Char":
+        return render_char(ctx.read_uint(addr, 4))
+    return None
+
+
+def layout_fields(ctx, dt):
+    laddr = member_u(dt, "layout")
+    if laddr == 0:
+        return None
+    layout = ctx.value_at(laddr, "jl_datatype_layout_t")
+    nfields = member_u(layout, "nfields")
+    fdkind = member_u(layout, "flags", "fielddesc_type")
+    if fdkind == 3:  # foreign type: no descriptors
+        return None
+    fdname = ("jl_fielddesc8_t", "jl_fielddesc16_t", "jl_fielddesc32_t")[fdkind]
+    fdsize = ctx.type_size(fdname)
+    base = laddr + ctx.type_size("jl_datatype_layout_t")
+    fields = []
+    for i in range(nfields):
+        fd = ctx.value_at(base + i * fdsize, fdname)
+        fields.append((member_u(fd, "offset"), member_u(fd, "size"),
+                       member_u(fd, "isptr")))
+    return fields
+
+
+def field_names(ctx, dt, nfields):
+    names = []
+    tnaddr = member_u(dt, "name")
+    namesv = member_u(ctx.value_at(tnaddr, "jl_typename_t"), "names") \
+        if tnaddr else 0
+    n = svec_len(ctx, namesv) if namesv else 0
+    for i in range(nfields):
+        if i < n:
+            sym = svec_ref(ctx, namesv, i)
+            names.append(symbol_name(ctx, sym) if sym else str(i + 1))
+        else:
+            names.append(str(i + 1))
+    return names
+
+
+def field_types(ctx, dt, nfields):
+    typesv = member_u(dt, "types")
+    n = svec_len(ctx, typesv) if typesv else 0
+    return [svec_ref(ctx, typesv, i) if i < n else 0 for i in range(nfields)]
+
+
+def render_unboxed(ctx, taddr, addr, depth):
+    if depth < 0:
+        return "…"
+    if taddr == 0:
+        return "<?>"
+    if datatype_qualname(ctx, typeof_addr(ctx, taddr)) != "Core.DataType":
+        return "<union field>"
+    qual = datatype_qualname(ctx, taddr)
+    prim = render_primitive(ctx, qual, addr)
+    if prim is not None:
+        return prim
+    dt = ctx.value_at(taddr, "jl_datatype_t")
+    if member_u(dt, "isprimitivetype"):
+        laddr = member_u(dt, "layout")
+        size = member_u(ctx.value_at(laddr, "jl_datatype_layout_t"), "size") \
+            if laddr else 0
+        if 0 < size <= 8:
+            return "%s(0x%0*x)" % (render_type(ctx, taddr, 1), 2 * size,
+                                   ctx.read_uint(addr, size))
+        return "%s(...)" % render_type(ctx, taddr, 1)
+    fields = layout_fields(ctx, dt)
+    if fields is None:
+        return "<%s>" % render_type(ctx, taddr, depth - 1)
+    if len(fields) == 0:
+        inst = member_u(dt, "instance")
+        return render_value(ctx, inst, depth) if inst \
+            else render_type(ctx, taddr, depth - 1) + "()"
+    return render_struct_inline(ctx, taddr, dt, addr, fields, depth)
+
+
+def namedtuple_names(ctx, dt):
+    try:
+        params = member_u(dt, "parameters")
+        if svec_len(ctx, params) != 2:
+            return None
+        namestup = svec_ref(ctx, params, 0)
+        ndt = ctx.value_at(typeof_addr(ctx, namestup), "jl_datatype_t")
+        fields = layout_fields(ctx, ndt)
+        if fields is None:
+            return None
+        return [symbol_name(ctx, ctx.read_ptr(namestup + off))
+                for (off, _, _) in fields]
+    except MemoryReadError:
+        return None
+
+
+def render_struct_inline(ctx, taddr, dt, addr, fields, depth):
+    tn = ctx.value_at(member_u(dt, "name"), "jl_typename_t")
+    tname = symbol_name(ctx, member_u(tn, "name"))
+    istuple = tname == "Tuple" and \
+        module_path(ctx, member_u(tn, "module")) == "Core"
+    names = None
+    if tname == "NamedTuple":
+        names = namedtuple_names(ctx, dt)
+    if names is None and not istuple:
+        names = field_names(ctx, dt, len(fields))
+    ftypes = field_types(ctx, dt, len(fields))
+    parts = []
+    for i, (off, size, isptr) in enumerate(fields[:MAX_ELEMS]):
+        if isptr:
+            p = ctx.read_ptr(addr + off)
+            r = render_value(ctx, p, depth - 1) if p else "#undef"
+        else:
+            r = render_unboxed(ctx, ftypes[i], addr + off, depth - 1)
+        fname = names[i] if names and i < len(names) else str(i + 1)
+        parts.append(r if istuple else "%s = %s" % (fname, r))
+    if len(fields) > MAX_ELEMS:
+        parts.append("…")
+    if istuple and len(fields) == 1:
+        return "(%s,)" % parts[0]
+    if istuple or tname == "NamedTuple":
+        return "(%s)" % ", ".join(parts)
+    return "%s(%s)" % (render_type(ctx, taddr, 2), ", ".join(parts))
+
+
+def array_info(ctx, addr):
+    dtaddr = typeof_addr(ctx, addr)
+    dt = ctx.value_at(dtaddr, "jl_datatype_t")
+    tname = typename_of(ctx, dtaddr)
+    if tname == "GenericMemory":
+        mem_dt_addr = dtaddr
+        mem = ctx.value_at(addr, "jl_genericmemory_t")
+        dims = [member_u(mem, "length")]
+        dataptr = member_u(mem, "ptr")
+        eltype = svec_ref(ctx, member_u(dt, "parameters"), 1)
+    else:
+        arr = ctx.value_at(addr, "jl_array_t")
+        mem_addr = member_u(arr, "ref", "mem")
+        mem_dt_addr = typeof_addr(ctx, mem_addr)
+        dataptr = member_u(arr, "ref", "ptr_or_offset")
+        dimoff = ctx.field_offset("jl_array_t", "dimsize")
+        params = member_u(dt, "parameters")
+        try:
+            ndims = ctx.read_uint(svec_ref(ctx, params, 1), 8)
+        except MemoryReadError:
+            ndims = 1
+        if not (0 < ndims < 33):
+            ndims = 1
+        dims = [ctx.read_uint(addr + dimoff + i * ctx.ptrsize, ctx.ptrsize)
+                for i in range(ndims)]
+        eltype = svec_ref(ctx, params, 0)
+    mlayout = ctx.value_at(
+        member_u(ctx.value_at(mem_dt_addr, "jl_datatype_t"), "layout"),
+        "jl_datatype_layout_t")
+    elsize = member_u(mlayout, "size")
+    isboxed = member_u(mlayout, "flags", "arrayelem_isboxed")
+    isunion = member_u(mlayout, "flags", "arrayelem_isunion")
+    return dims, eltype, dataptr, elsize, isboxed, isunion
+
+
+def render_array(ctx, addr, depth):
+    dims, eltype, dataptr, elsize, isboxed, isunion = array_info(ctx, addr)
+    tstr = render_type(ctx, typeof_addr(ctx, addr), depth)
+    if len(dims) == 1:
+        summary = "%d-element %s" % (dims[0], tstr)
+    else:
+        summary = "%s %s" % ("×".join(str(d) for d in dims), tstr)
+    if depth < MAX_DEPTH:
+        return summary
+    n = 1
+    for d in dims:
+        n *= d
+    shown = min(n, MAX_ELEMS)
+    parts = []
+    for i in range(shown):
+        if isboxed:
+            p = ctx.read_ptr(dataptr + i * ctx.ptrsize)
+            parts.append(render_value(ctx, p, depth - 1) if p else "#undef")
+        elif isunion:
+            parts.append("<union element>")
+        else:
+            parts.append(render_unboxed(ctx, eltype, dataptr + i * elsize,
+                                        depth - 1))
+    if n > shown:
+        parts.append("… (%d more)" % (n - shown))
+    return "%s = {%s}" % (summary, ", ".join(parts))
+
+
+# --------------------------------------------------------------------------
+# rendering of runtime objects (Method, MethodInstance, Task, ...)
+# --------------------------------------------------------------------------
+
+def render_sig_call(ctx, fname, sigaddr, depth):
+    seen = 0
+    while datatype_qualname(ctx, typeof_addr(ctx, sigaddr)) == \
+            "Core.UnionAll" and seen < 32:
+        sigaddr = member_u(ctx.value_at(sigaddr, "jl_unionall_t"), "body")
+        seen += 1
+    if datatype_qualname(ctx, typeof_addr(ctx, sigaddr)) != "Core.DataType":
+        return "%s(...)" % fname
+    params = member_u(ctx.value_at(sigaddr, "jl_datatype_t"), "parameters")
+    n = svec_len(ctx, params) if params else 0
+    args = ["::" + render_type(ctx, svec_ref(ctx, params, i), depth - 1)
+            for i in range(1, min(n, MAX_ELEMS + 1))]
+    if n > MAX_ELEMS + 1:
+        args.append("…")
+    return "%s(%s)" % (fname, ", ".join(args))
+
+
+def render_method(ctx, addr, depth):
+    m = ctx.value_at(addr, "jl_method_t")
+    name = symbol_name(ctx, member_u(m, "name"))
+    where = ""
+    if member_u(m, "module"):
+        where = " @ " + module_path(ctx, member_u(m, "module"))
+    faddr = member_u(m, "file")
+    if faddr:
+        where += " %s:%d" % (symbol_name(ctx, faddr), member_i(m, "line"))
+    return render_sig_call(ctx, name, member_u(m, "sig"), depth) + where
+
+
+def render_method_instance(ctx, addr, depth):
+    mi = ctx.value_at(addr, "jl_method_instance_t")
+    defaddr = member_u(mi, "def", "value")
+    name = "?"
+    if defaddr:
+        if datatype_qualname(ctx, typeof_addr(ctx, defaddr)) == "Core.Method":
+            name = symbol_name(ctx, member_u(
+                ctx.value_at(defaddr, "jl_method_t"), "name"))
+        else:  # toplevel thunk: def is a module
+            return "MethodInstance for top-level scope in " + \
+                module_path(ctx, defaddr)
+    return "MethodInstance for " + \
+        render_sig_call(ctx, name, member_u(mi, "specTypes"), depth)
+
+
+def render_code_instance(ctx, addr, depth):
+    ci = ctx.value_at(addr, "jl_code_instance_t")
+    defaddr = member_u(ci, "def")
+    inner = "?"
+    if defaddr:
+        qual = datatype_qualname(ctx, typeof_addr(ctx, defaddr))
+        if qual == "Core.ABIOverride":
+            defaddr = member_u(ctx.value_at(defaddr, "jl_abi_override_t"),
+                               "def")
+            qual = datatype_qualname(ctx, typeof_addr(ctx, defaddr))
+        if qual == "Core.MethodInstance":
+            inner = render_method_instance(ctx, defaddr, depth - 1)
+    return "CodeInstance for %s" % inner
+
+
+TASK_STATES = {0: "runnable", 1: "done", 2: "failed", 3: "abandoned"}
+
+
+def render_task(ctx, addr):
+    t = ctx.value_at(addr, "jl_task_t")
+    state = TASK_STATES.get(member_u(t, "_state"), "?")
+    return "Task (%s) @0x%016x" % (state, addr)
+
+
+def render_expr(ctx, addr, depth):
+    e = ctx.value_at(addr, "jl_expr_t")
+    head = symbol_name(ctx, member_u(e, "head")) if member_u(e, "head") \
+        else "?"
+    nargs = 0
+    if member_u(e, "args"):
+        try:
+            nargs = array_info(ctx, member_u(e, "args"))[0][0]
+        except MemoryReadError:
+            pass
+    return "Expr(:%s, <%d args>)" % (head, nargs)
+
+
+def render_svec(ctx, addr, depth):
+    n = svec_len(ctx, addr)
+    parts = []
+    for i in range(min(n, MAX_ELEMS)):
+        p = svec_ref(ctx, addr, i)
+        parts.append(render_value(ctx, p, depth - 1) if p else "#undef")
+    if n > MAX_ELEMS:
+        parts.append("…")
+    return "svec(%s)" % ", ".join(parts)
+
+
+# --------------------------------------------------------------------------
+# main value renderer
+# --------------------------------------------------------------------------
+
+def render_value(ctx, addr, depth=MAX_DEPTH):
+    if addr == 0:
+        return "#<null>"
+    if depth < 0:
+        return "…"
+    dtaddr = typeof_addr(ctx, addr)
+    if dtaddr == 0:
+        return "<julia value 0x%x>" % addr
+    qual = datatype_qualname(ctx, dtaddr)
+
+    if is_type_kind(qual):
+        return render_type(ctx, addr, depth)
+    prim = render_primitive(ctx, qual, addr)
+    if prim is not None:
+        return prim
+    if qual == "Core.Nothing":
+        return "nothing"
+    if qual == "Core.Symbol":
+        name = symbol_name(ctx, addr)
+        if name.isidentifier():
+            return ":" + name
+        return 'Symbol("%s")' % escape_string(name)
+    if qual == "Core.String":
+        s, strlen = string_data(ctx, addr)
+        suffix = "…" if strlen > len(s.encode("utf-8", "replace")) else ""
+        return '"%s%s"' % (escape_string(s), suffix)
+    if qual == "Core.SimpleVector":
+        return render_svec(ctx, addr, depth)
+    if qual == "Core.Module":
+        return "Module %s" % module_path(ctx, addr)
+    if qual == "Core.Task":
+        return render_task(ctx, addr)
+    if qual == "Core.Method":
+        return render_method(ctx, addr, depth)
+    if qual == "Core.MethodInstance":
+        return render_method_instance(ctx, addr, depth)
+    if qual == "Core.CodeInstance":
+        return render_code_instance(ctx, addr, depth)
+    if qual == "Core.Expr":
+        return render_expr(ctx, addr, depth)
+    if qual == "Core.GlobalRef":
+        gr = ctx.value_at(addr, "jl_globalref_t")
+        return "%s.%s" % (module_path(ctx, member_u(gr, "mod")),
+                          symbol_name(ctx, member_u(gr, "name")))
+    if qual == "Core.TypeName":
+        tn = ctx.value_at(addr, "jl_typename_t")
+        return "typename(%s)" % symbol_name(ctx, member_u(tn, "name"))
+
+    dt = ctx.value_at(dtaddr, "jl_datatype_t")
+    tname = typename_of(ctx, dtaddr)
+    if tname in ("Array", "GenericMemory"):
+        try:
+            return render_array(ctx, addr, depth)
+        except MemoryReadError:
+            return render_type(ctx, dtaddr, depth - 1) + " <unreadable>"
+
+    # generic instances
+    if member_u(dt, "instance") == addr:
+        tn = ctx.value_at(member_u(dt, "name"), "jl_typename_t")
+        sname = member_u(tn, "singletonname") \
+            if tn.GetChildMemberWithName("singletonname").IsValid() else 0
+        return symbol_name(ctx, sname) if sname \
+            else render_type(ctx, dtaddr, depth) + "()"
+    if member_u(dt, "isprimitivetype"):
+        return render_unboxed(ctx, dtaddr, addr, depth)
+    fields = layout_fields(ctx, dt)
+    if fields is not None:
+        return render_struct_inline(ctx, dtaddr, dt, addr, fields, depth)
+    return "%s @0x%016x" % (render_type(ctx, dtaddr, depth - 1), addr)
+
+
+# --------------------------------------------------------------------------
+# GC safepoint handling
+#
+# Julia's GC stops the world by mprotecting a page that every thread reads at
+# safepoints, so during normal operation every thread takes a benign SIGSEGV
+# whenever a GC runs. By default lldb stops on each of those, making stepping
+# through Julia code nearly unusable. The scripted stop-hook below resumes
+# any SIGSEGV whose faulting address lies inside the safepoint page region;
+# real segfaults (including stack overflows) still stop the debugger.
+# --------------------------------------------------------------------------
+
+_FAULT_ADDR_RE = re.compile(r"fault address:?\s*(0x[0-9a-fA-F]+)")
+_stop_hook_installed = [False]
+
+
+def _global_uint(target, name):
+    var = target.FindFirstGlobalVariable(name)
+    if not var.IsValid():
+        return 0
+    return var.GetValueAsUnsigned()
+
+
+class JLSafepointStopHook:
+    enabled = True
+
+    def __init__(self, target, extra_args, internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, stream):
+        """Return False to silently resume from GC safepoint SIGSEGVs."""
+        if not JLSafepointStopHook.enabled:
+            return True
+        thread = exe_ctx.GetThread()
+        if not thread.IsValid() or \
+                thread.GetStopReason() != lldb.eStopReasonSignal:
+            return True
+        process = exe_ctx.GetProcess()
+        signals = process.GetUnixSignals()
+        segv = signals.GetSignalNumberFromName("SIGSEGV")
+        if thread.GetStopReasonDataAtIndex(0) != segv:
+            return True
+        m = _FAULT_ADDR_RE.search(thread.GetStopDescription(1024) or "")
+        if m is None:
+            return True
+        fault = int(m.group(1), 16)
+        target = exe_ctx.GetTarget()
+        base = _global_uint(target, "jl_safepoint_pages")
+        pgsz = _global_uint(target, "jl_page_size")
+        if base == 0 or pgsz == 0:
+            return True
+        # 4 pages, see the layout description in src/safepoint.c
+        if base <= fault < base + 4 * pgsz:
+            return False
+        return True
+
+
+def _install_stop_hook(debugger):
+    if _stop_hook_installed[0]:
+        return
+    if debugger.GetNumTargets() == 0:
+        return
+    res = lldb.SBCommandReturnObject()
+    debugger.GetCommandInterpreter().HandleCommand(
+        "target stop-hook add -P %s.JLSafepointStopHook" % __name__, res)
+    if res.Succeeded():
+        _stop_hook_installed[0] = True
+
+
+def jl_safepoint_filter_cmd(debugger, command, exe_ctx, result, internal_dict):
+    """jl-safepoint-filter [on|off]: filter out GC safepoint SIGSEGVs.
+
+    When on (the default), lldb silently resumes the benign SIGSEGVs Julia's
+    GC uses to stop the world at safepoints, while still stopping on real
+    segfaults. When off, lldb's default SIGSEGV behavior is restored."""
+    arg = command.strip()
+    if arg == "on":
+        JLSafepointStopHook.enabled = True
+        _install_stop_hook(debugger)
+    elif arg == "off":
+        JLSafepointStopHook.enabled = False
+    elif arg:
+        result.SetError("usage: jl-safepoint-filter [on|off]")
+        return
+    result.AppendMessage(
+        "julia safepoint SIGSEGV filter is %s"
+        % ("on" if JLSafepointStopHook.enabled and _stop_hook_installed[0]
+           else "off"))
+
+
+# --------------------------------------------------------------------------
+# lldb integration
+# --------------------------------------------------------------------------
+
+JULIA_POINTER_TYPES = [
+    "jl_value_t", "jl_function_t", "jl_sym_t", "jl_datatype_t",
+    "jl_tupletype_t", "jl_typename_t", "jl_svec_t", "jl_module_t",
+    "jl_array_t", "jl_genericmemory_t", "jl_string_t", "jl_task_t",
+    "jl_method_t", "jl_method_instance_t", "jl_code_instance_t",
+    "jl_code_info_t", "jl_expr_t", "jl_globalref_t", "jl_tvar_t",
+    "jl_unionall_t", "jl_uniontype_t", "jl_vararg_t", "jl_typemap_t",
+]
+
+
+def jl_value_summary(valobj, internal_dict):
+    """Type summary provider dispatching on the runtime type tag."""
+    addr = valobj.GetValueAsUnsigned()
+    if addr == 0:
+        return "NULL"
+    ctx = get_ctx(valobj)
+    if ctx.process.IsValid():
+        # opportunistically install the safepoint stop-hook once a real
+        # process exists (importing from ~/.lldbinit happens before that)
+        _install_stop_hook(valobj.GetTarget().GetDebugger())
+    try:
+        return render_value(ctx, addr)
+    except MemoryReadError as e:
+        return "<not a julia value: 0x%x (%s)>" % (addr, e)
+    except Exception as e:  # never break `p` on a summary bug
+        return "<error rendering julia value 0x%x: %s>" % (addr, e)
+
+
+def jl_typeof_cmd(debugger, command, exe_ctx, result, internal_dict):
+    """jl-typeof <expr>: print the Julia type of a jl_value_t* expression."""
+    frame = exe_ctx.GetFrame()
+    if not frame.IsValid():
+        result.SetError("no frame selected")
+        return
+    val = frame.EvaluateExpression(command)
+    if not val.IsValid() or val.GetError().Fail():
+        result.SetError(str(val.GetError()))
+        return
+    ctx = get_ctx(val)
+    try:
+        result.AppendMessage(
+            render_type(ctx, typeof_addr(ctx, val.GetValueAsUnsigned())))
+    except MemoryReadError as e:
+        result.SetError(str(e))
+
+
+def __lldb_init_module(debugger, internal_dict):
+    for tname in JULIA_POINTER_TYPES:
+        debugger.HandleCommand(
+            'type summary add --python-function %s.jl_value_summary "%s *"'
+            % (__name__, tname))
+    debugger.HandleCommand(
+        "command script add -f %s.jl_typeof_cmd jl-typeof" % __name__)
+    debugger.HandleCommand(
+        "command script add -f %s.jl_safepoint_filter_cmd jl-safepoint-filter"
+        % __name__)
+    _install_stop_hook(debugger)
+    print("julia_lldb: type summaries for Julia values installed "
+          "(commands: jl-typeof, jl-safepoint-filter)")

--- a/contrib/julia_lldb.py
+++ b/contrib/julia_lldb.py
@@ -336,7 +336,20 @@ def jl_cmd(debugger, command, exe_ctx, result, internal_dict):
             val = frame.EvaluateExpression(base)
             if not val.IsValid() or val.GetError().Fail():
                 continue
-            loc0 = ("val", val.GetValueAsUnsigned())
+            canon = val.GetType().GetCanonicalType()
+            if canon.GetTypeClass() == lldb.eTypeClassStruct:
+                # unboxed Julia struct value (e.g. a by-reference argument):
+                # resolve its debug-info type name to the Julia datatype
+                laddr = val.GetLoadAddress()
+                if laddr == lldb.LLDB_INVALID_ADDRESS:
+                    continue
+                dt = rt.resolve_type_name(canon.GetName(),
+                                          size=canon.GetByteSize())
+                if dt == 0:
+                    continue
+                loc0 = ("inline", dt, laddr)
+            else:
+                loc0 = ("val", val.GetValueAsUnsigned())
         parsed_any = True
         try:
             loc = rt.eval_accessors(loc0, accessors)

--- a/contrib/julia_lldb.py
+++ b/contrib/julia_lldb.py
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-"""LLDB type summaries for Julia runtime values.
+"""LLDB type summaries and commands for Julia runtime values.
 
 Load this script into lldb to make `p`/`frame variable` render `jl_value_t*`
 (and other Julia runtime pointers such as `jl_datatype_t*`, `jl_sym_t*`,
@@ -17,33 +17,42 @@ Usage (pick one):
   * add that line to your `~/.lldbinit`, or
   * `lldb -o "command script import /path/to/julia/contrib/julia_lldb.py" -- ./julia ...`
 
-The summaries dispatch on the *runtime* type tag of the object, so a plain
-`jl_value_t*` prints as whatever it actually is. Everything is resolved
-through the debug info of libjulia-internal, so this script does not
+The rendering logic lives in `julia_debug_core.py`, which must stay next to
+this file. The summaries dispatch on the *runtime* type tag of the object, so
+a plain `jl_value_t*` prints as whatever it actually is. Everything is
+resolved through the debug info of libjulia-internal, so this script does not
 hard-code struct offsets and should work across Julia versions; it requires a
 build of Julia with debug info (the default) and gracefully degrades to raw
 pointers when the debug info or the memory is unavailable.
+
+Julia-semantics field and index access is available through the `jl` command
+(1-based indexing, fields by name; also module globals):
+
+    (lldb) jl v.inner.name
+    "hello"
+    (lldb) jl v.vec[2]
+    42
+    (lldb) jl Base.pi
+    π
 
 The script also installs a stop-hook that transparently resumes the benign
 SIGSEGVs Julia's GC uses to stop the world at safepoints (real segfaults
 still stop the debugger); control it with `jl-safepoint-filter [on|off]`.
 """
 
+import os
 import re
-import struct
+import sys
 
 import lldb
 
-# Render at most this many nested levels in a single summary string.
-MAX_DEPTH = 3
-# Render at most this many elements of arrays/svecs/tuples in a summary.
-MAX_ELEMS = 10
-# Truncate strings longer than this many bytes.
-MAX_STRING = 200
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import julia_debug_core as core
+from julia_debug_core import JLDebugError
 
 
-class Ctx:
-    """Debug-info lookups and memory reads for one (target, process) pair."""
+class LldbAdapter:
+    """Debug-info and memory access for julia_debug_core, via lldb."""
 
     def __init__(self, target, process):
         self.target = target
@@ -52,16 +61,21 @@ class Ctx:
         self.types = {}
         self.sizes = {}
         self.offsets = {}
-        self.dt_names = {}
+        self.globals = {}
 
     def lookup_type(self, name):
         t = self.types.get(name)
         if t is None:
             t = self.target.FindFirstType(name)
             if not t.IsValid():
-                raise MemoryReadError("no type named %s in debug info" % name)
+                raise JLDebugError("no type named %s in debug info" % name)
             self.types[name] = t
         return t
+
+    def value_at(self, addr, typename):
+        t = self.lookup_type(typename)
+        return self.target.CreateValueFromAddress(
+            "jlval", lldb.SBAddress(addr, self.target), t)
 
     def type_size(self, name):
         s = self.sizes.get(name)
@@ -74,681 +88,79 @@ class Ctx:
         key = (typename, fieldname)
         off = self.offsets.get(key)
         if off is None:
-            t = self.lookup_type(typename)
-            for f in t.get_fields_array():
+            for f in self.lookup_type(typename).get_fields_array():
                 if f.GetName() == fieldname:
                     off = f.GetOffsetInBytes()
                     break
             if off is None:
-                raise MemoryReadError("no field %s in %s"
-                                      % (fieldname, typename))
+                raise JLDebugError("no field %s in %s"
+                                   % (fieldname, typename))
             self.offsets[key] = off
         return off
+
+    def field(self, addr, typename, path, signed=False):
+        v = self.value_at(addr, typename)
+        for name in path:
+            v = v.GetChildMemberWithName(name)
+            if not v.IsValid():
+                raise JLDebugError("no member %s in %s" % (name, typename))
+        return v.GetValueAsSigned() if signed else v.GetValueAsUnsigned()
+
+    def has_field(self, typename, fieldname):
+        try:
+            return any(f.GetName() == fieldname
+                       for f in self.lookup_type(typename).get_fields_array())
+        except JLDebugError:
+            return False
 
     def read_mem(self, addr, size):
         err = lldb.SBError()
         buf = self.process.ReadMemory(addr, size, err)
         if err.Fail() or buf is None:
-            raise MemoryReadError("cannot read 0x%x" % addr)
+            raise JLDebugError("cannot read 0x%x" % addr)
         return buf
 
-    def read_uint(self, addr, size, signed=False):
-        return int.from_bytes(self.read_mem(addr, size), "little",
-                              signed=signed)
-
-    def read_ptr(self, addr):
-        return self.read_uint(addr, self.ptrsize)
-
-    def read_cstring(self, addr, maxlen=512):
+    def read_cstr(self, addr, maxlen=512):
         err = lldb.SBError()
         s = self.process.ReadCStringFromMemory(addr, maxlen, err)
         if err.Fail() or s is None:
-            raise MemoryReadError("cannot read string at 0x%x" % addr)
+            raise JLDebugError("cannot read string at 0x%x" % addr)
         return s
 
-    def value_at(self, addr, typename):
-        """An SBValue of type `typename` located at `addr`."""
-        t = self.lookup_type(typename)
-        return self.target.CreateValueFromAddress(
-            "jlval", lldb.SBAddress(addr, self.target), t)
-
-
-class MemoryReadError(Exception):
-    pass
-
-
-_CTX = [None]
-
-
-def get_ctx(valobj):
-    target = valobj.GetTarget()
-    process = valobj.GetProcess()
-    ctx = _CTX[0]
-    if (ctx is None or ctx.target != target or ctx.process != process
-            or ctx.process.GetUniqueID() != process.GetUniqueID()):
-        ctx = Ctx(target, process)
-        _CTX[0] = ctx
-    return ctx
-
-
-def member_u(sbval, *names):
-    v = sbval
-    for name in names:
-        v = v.GetChildMemberWithName(name)
-        if not v.IsValid():
-            raise MemoryReadError("no member %s" % name)
-    return v.GetValueAsUnsigned()
-
-
-def member_i(sbval, name):
-    v = sbval.GetChildMemberWithName(name)
-    if not v.IsValid():
-        raise MemoryReadError("no member %s" % name)
-    return v.GetValueAsSigned()
-
-
-def typetag(ctx, addr):
-    return ctx.read_ptr(addr - ctx.ptrsize) & ~15
-
-
-def small_typeof_addr(ctx):
-    for sym in ("jl_small_typeof", "ijl_small_typeof"):
-        var = ctx.target.FindFirstGlobalVariable(sym)
-        if var.IsValid():
-            addr = var.GetLoadAddress()
-            if addr != lldb.LLDB_INVALID_ADDRESS:
-                return addr
-    return 0
-
-
-def typeof_addr(ctx, addr):
-    tag = typetag(ctx, addr)
-    if tag < (64 << 4):
-        table = small_typeof_addr(ctx)
-        if table == 0:
-            return 0
-        # entry lives at byte offset `tag` (see jl_to_typeof in julia.h)
-        return ctx.read_ptr(table + tag)
-    return tag
-
-
-def symbol_name(ctx, addr):
-    return ctx.read_cstring(addr + ctx.type_size("jl_sym_t"))
-
-
-def svec_len(ctx, addr):
-    return member_u(ctx.value_at(addr, "jl_svec_t"), "length")
-
-
-def svec_ref(ctx, addr, i):
-    return ctx.read_ptr(addr + ctx.type_size("jl_svec_t") + i * ctx.ptrsize)
-
-
-def is_cpu_addrspace(ctx, addr):
-    if addr == 0:
-        return False
-    try:
-        dtaddr = typeof_addr(ctx, addr)
-        if dtaddr == 0:
-            return False
-        dt = ctx.value_at(dtaddr, "jl_datatype_t")
-        tname = symbol_name(ctx, member_u(
-            ctx.value_at(member_u(dt, "name"), "jl_typename_t"), "name"))
-        return tname == "AddrSpace" and ctx.read_uint(addr, 1) == 0
-    except MemoryReadError:
-        return False
-
-
-def module_path(ctx, addr, depth=0):
-    if addr == 0 or depth > 10:
-        return "?"
-    mod = ctx.value_at(addr, "jl_module_t")
-    name = symbol_name(ctx, member_u(mod, "name"))
-    parent = member_u(mod, "parent")
-    if parent == 0 or parent == addr:
-        return name
-    pname = module_path(ctx, parent, depth + 1)
-    if pname == "Main":
-        return name
-    return pname + "." + name
-
-
-def datatype_qualname(ctx, dtaddr):
-    name = ctx.dt_names.get(dtaddr)
-    if name is None:
-        dt = ctx.value_at(dtaddr, "jl_datatype_t")
-        tn = ctx.value_at(member_u(dt, "name"), "jl_typename_t")
-        name = (module_path(ctx, member_u(tn, "module")) + "."
-                + symbol_name(ctx, member_u(tn, "name")))
-        ctx.dt_names[dtaddr] = name
-    return name
-
-
-def typename_of(ctx, dtaddr):
-    dt = ctx.value_at(dtaddr, "jl_datatype_t")
-    tn = ctx.value_at(member_u(dt, "name"), "jl_typename_t")
-    return symbol_name(ctx, member_u(tn, "name"))
-
-
-def string_data(ctx, addr):
-    strlen = ctx.read_uint(addr, ctx.ptrsize)
-    n = min(strlen, MAX_STRING)
-    s = ctx.read_mem(addr + ctx.ptrsize, n).decode("utf-8", errors="replace") \
-        if n else ""
-    return s, strlen
-
-
-def escape_string(s):
-    out = []
-    for c in s:
-        if c == '"':
-            out.append('\\"')
-        elif c == "\\":
-            out.append("\\\\")
-        elif c == "\n":
-            out.append("\\n")
-        elif c == "\t":
-            out.append("\\t")
-        elif ord(c) < 32:
-            out.append("\\x%02x" % ord(c))
-        else:
-            out.append(c)
-    return "".join(out)
-
-
-# --------------------------------------------------------------------------
-# rendering of type objects (DataType/Union/UnionAll/TypeVar/Vararg)
-# --------------------------------------------------------------------------
-
-def is_type_kind(qual):
-    return qual in ("Core.DataType", "Core.Union", "Core.UnionAll",
-                    "Core.TypeVar", "Core.TypeofVararg", "Core.TypeofBottom")
-
-
-def render_typevar(ctx, addr, with_bounds):
-    tv = ctx.value_at(addr, "jl_tvar_t")
-    name = symbol_name(ctx, member_u(tv, "name"))
-    if not with_bounds:
-        return name
-    lb = render_type(ctx, member_u(tv, "lb"), MAX_DEPTH - 1)
-    ub = render_type(ctx, member_u(tv, "ub"), MAX_DEPTH - 1)
-    if lb == "Union{}" and ub == "Any":
-        return name
-    if lb == "Union{}":
-        return "%s<:%s" % (name, ub)
-    return "%s<:%s<:%s" % (lb, name, ub)
-
-
-def flatten_union(ctx, addr, parts, depth):
-    qual = datatype_qualname(ctx, typeof_addr(ctx, addr))
-    if qual == "Core.Union":
-        u = ctx.value_at(addr, "jl_uniontype_t")
-        flatten_union(ctx, member_u(u, "a"), parts, depth)
-        flatten_union(ctx, member_u(u, "b"), parts, depth)
-    else:
-        parts.append(render_type(ctx, addr, depth))
-
-
-def render_type(ctx, addr, depth=MAX_DEPTH):
-    if addr == 0:
-        return "#<null>"
-    if depth < 0:
-        return "…"
-    dtaddr = typeof_addr(ctx, addr)
-    if dtaddr == 0:
-        return "<?type 0x%x>" % addr
-    qual = datatype_qualname(ctx, dtaddr)
-    if qual == "Core.TypeofBottom":
-        return "Union{}"
-    if qual == "Core.Union":
-        parts = []
-        flatten_union(ctx, addr, parts, depth - 1)
-        return "Union{%s}" % ", ".join(parts)
-    if qual == "Core.UnionAll":
-        ua = ctx.value_at(addr, "jl_unionall_t")
-        body = render_type(ctx, member_u(ua, "body"), depth - 1)
-        var = render_typevar(ctx, member_u(ua, "var"), True)
-        return "%s where %s" % (body, var)
-    if qual == "Core.TypeVar":
-        return render_typevar(ctx, addr, False)
-    if qual == "Core.TypeofVararg":
-        va = ctx.value_at(addr, "jl_vararg_t")
-        t, n = member_u(va, "T"), member_u(va, "N")
-        if t == 0:
-            return "Vararg"
-        if n == 0:
-            return "Vararg{%s}" % render_type(ctx, t, depth - 1)
-        return "Vararg{%s, %s}" % (render_type(ctx, t, depth - 1),
-                                   render_value(ctx, n, depth - 1))
-    if qual == "Core.Module":
-        return module_path(ctx, addr)
-    if qual != "Core.DataType":
-        # a value used as a type parameter (1, :x, true, ...)
-        return render_value(ctx, addr, depth)
-
-    dt = ctx.value_at(addr, "jl_datatype_t")
-    tn = ctx.value_at(member_u(dt, "name"), "jl_typename_t")
-    modpath = module_path(ctx, member_u(tn, "module"))
-    name = symbol_name(ctx, member_u(tn, "name"))
-    if modpath not in ("Core", "Main") and not name.startswith("typeof("):
-        name = modpath + "." + name
-    params = member_u(dt, "parameters")
-    nparams = svec_len(ctx, params) if params else 0
-    if nparams == 0:
-        return name + "{}" if name == "Tuple" else name
-    # sugar: Array{T, 1} => Vector{T}, Array{T, 2} => Matrix{T}
-    if name == "Array" and nparams == 2:
-        ndim = render_type(ctx, svec_ref(ctx, params, 1), depth - 1)
-        if ndim == "1":
-            return "Vector{%s}" % render_type(ctx, svec_ref(ctx, params, 0),
-                                              depth - 1)
-        if ndim == "2":
-            return "Matrix{%s}" % render_type(ctx, svec_ref(ctx, params, 0),
-                                              depth - 1)
-    # sugar: GenericMemory{:not_atomic, T, Core.CPU} => Memory{T}
-    if name == "GenericMemory" and nparams == 3:
-        order = svec_ref(ctx, params, 0)
-        if is_cpu_addrspace(ctx, svec_ref(ctx, params, 2)):
-            eltstr = render_type(ctx, svec_ref(ctx, params, 1), depth - 1)
-            oname = symbol_name(ctx, order) if order else ""
-            if oname == "not_atomic":
-                return "Memory{%s}" % eltstr
-            if oname == "atomic":
-                return "AtomicMemory{%s}" % eltstr
-    rendered = [render_type(ctx, svec_ref(ctx, params, i), depth - 1)
-                for i in range(min(nparams, MAX_ELEMS))]
-    if nparams > MAX_ELEMS:
-        rendered.append("…")
-    return "%s{%s}" % (name, ", ".join(rendered))
-
-
-# --------------------------------------------------------------------------
-# rendering of plain data (bits values, structs, arrays)
-# --------------------------------------------------------------------------
-
-PRIMITIVE_FMT = {
-    "Core.Int8": ("i", 1), "Core.Int16": ("i", 2),
-    "Core.Int32": ("i", 4), "Core.Int64": ("i", 8),
-    "Core.UInt8": ("u", 1), "Core.UInt16": ("u", 2),
-    "Core.UInt32": ("u", 4), "Core.UInt64": ("u", 8),
-    "Core.Float16": ("f", 2), "Core.Float32": ("f", 4),
-    "Core.Float64": ("f", 8),
-}
-
-
-def render_char(u):
-    raw = u.to_bytes(4, "big").rstrip(b"\0") or b"\0"
-    try:
-        return "'%s'" % raw.decode("utf-8")
-    except UnicodeDecodeError:
-        return "Char(0x%08x)" % u
-
-
-def render_primitive(ctx, qual, addr):
-    fmt = PRIMITIVE_FMT.get(qual)
-    if fmt is not None:
-        kind, size = fmt
-        if kind == "i":
-            return str(ctx.read_uint(addr, size, signed=True))
-        if kind == "u":
-            return "0x%0*x" % (2 * size, ctx.read_uint(addr, size))
-        return repr(struct.unpack("<" + {2: "e", 4: "f", 8: "d"}[size],
-                                  ctx.read_mem(addr, size))[0])
-    if qual == "Core.Bool":
-        return "true" if ctx.read_uint(addr, 1) else "false"
-    if qual == "Core.Char":
-        return render_char(ctx.read_uint(addr, 4))
-    return None
-
-
-def layout_fields(ctx, dt):
-    laddr = member_u(dt, "layout")
-    if laddr == 0:
-        return None
-    layout = ctx.value_at(laddr, "jl_datatype_layout_t")
-    nfields = member_u(layout, "nfields")
-    fdkind = member_u(layout, "flags", "fielddesc_type")
-    if fdkind == 3:  # foreign type: no descriptors
-        return None
-    fdname = ("jl_fielddesc8_t", "jl_fielddesc16_t", "jl_fielddesc32_t")[fdkind]
-    fdsize = ctx.type_size(fdname)
-    base = laddr + ctx.type_size("jl_datatype_layout_t")
-    fields = []
-    for i in range(nfields):
-        fd = ctx.value_at(base + i * fdsize, fdname)
-        fields.append((member_u(fd, "offset"), member_u(fd, "size"),
-                       member_u(fd, "isptr")))
-    return fields
-
-
-def field_names(ctx, dt, nfields):
-    names = []
-    tnaddr = member_u(dt, "name")
-    namesv = member_u(ctx.value_at(tnaddr, "jl_typename_t"), "names") \
-        if tnaddr else 0
-    n = svec_len(ctx, namesv) if namesv else 0
-    for i in range(nfields):
-        if i < n:
-            sym = svec_ref(ctx, namesv, i)
-            names.append(symbol_name(ctx, sym) if sym else str(i + 1))
-        else:
-            names.append(str(i + 1))
-    return names
-
-
-def field_types(ctx, dt, nfields):
-    typesv = member_u(dt, "types")
-    n = svec_len(ctx, typesv) if typesv else 0
-    return [svec_ref(ctx, typesv, i) if i < n else 0 for i in range(nfields)]
-
-
-def render_unboxed(ctx, taddr, addr, depth):
-    if depth < 0:
-        return "…"
-    if taddr == 0:
-        return "<?>"
-    if datatype_qualname(ctx, typeof_addr(ctx, taddr)) != "Core.DataType":
-        return "<union field>"
-    qual = datatype_qualname(ctx, taddr)
-    prim = render_primitive(ctx, qual, addr)
-    if prim is not None:
-        return prim
-    dt = ctx.value_at(taddr, "jl_datatype_t")
-    if member_u(dt, "isprimitivetype"):
-        laddr = member_u(dt, "layout")
-        size = member_u(ctx.value_at(laddr, "jl_datatype_layout_t"), "size") \
-            if laddr else 0
-        if 0 < size <= 8:
-            return "%s(0x%0*x)" % (render_type(ctx, taddr, 1), 2 * size,
-                                   ctx.read_uint(addr, size))
-        return "%s(...)" % render_type(ctx, taddr, 1)
-    fields = layout_fields(ctx, dt)
-    if fields is None:
-        return "<%s>" % render_type(ctx, taddr, depth - 1)
-    if len(fields) == 0:
-        inst = member_u(dt, "instance")
-        return render_value(ctx, inst, depth) if inst \
-            else render_type(ctx, taddr, depth - 1) + "()"
-    return render_struct_inline(ctx, taddr, dt, addr, fields, depth)
-
-
-def namedtuple_names(ctx, dt):
-    try:
-        params = member_u(dt, "parameters")
-        if svec_len(ctx, params) != 2:
-            return None
-        namestup = svec_ref(ctx, params, 0)
-        ndt = ctx.value_at(typeof_addr(ctx, namestup), "jl_datatype_t")
-        fields = layout_fields(ctx, ndt)
-        if fields is None:
-            return None
-        return [symbol_name(ctx, ctx.read_ptr(namestup + off))
-                for (off, _, _) in fields]
-    except MemoryReadError:
-        return None
-
-
-def render_struct_inline(ctx, taddr, dt, addr, fields, depth):
-    tn = ctx.value_at(member_u(dt, "name"), "jl_typename_t")
-    tname = symbol_name(ctx, member_u(tn, "name"))
-    istuple = tname == "Tuple" and \
-        module_path(ctx, member_u(tn, "module")) == "Core"
-    names = None
-    if tname == "NamedTuple":
-        names = namedtuple_names(ctx, dt)
-    if names is None and not istuple:
-        names = field_names(ctx, dt, len(fields))
-    ftypes = field_types(ctx, dt, len(fields))
-    parts = []
-    for i, (off, size, isptr) in enumerate(fields[:MAX_ELEMS]):
-        if isptr:
-            p = ctx.read_ptr(addr + off)
-            r = render_value(ctx, p, depth - 1) if p else "#undef"
-        else:
-            r = render_unboxed(ctx, ftypes[i], addr + off, depth - 1)
-        fname = names[i] if names and i < len(names) else str(i + 1)
-        parts.append(r if istuple else "%s = %s" % (fname, r))
-    if len(fields) > MAX_ELEMS:
-        parts.append("…")
-    if istuple and len(fields) == 1:
-        return "(%s,)" % parts[0]
-    if istuple or tname == "NamedTuple":
-        return "(%s)" % ", ".join(parts)
-    return "%s(%s)" % (render_type(ctx, taddr, 2), ", ".join(parts))
-
-
-def array_info(ctx, addr):
-    dtaddr = typeof_addr(ctx, addr)
-    dt = ctx.value_at(dtaddr, "jl_datatype_t")
-    tname = typename_of(ctx, dtaddr)
-    if tname == "GenericMemory":
-        mem_dt_addr = dtaddr
-        mem = ctx.value_at(addr, "jl_genericmemory_t")
-        dims = [member_u(mem, "length")]
-        dataptr = member_u(mem, "ptr")
-        eltype = svec_ref(ctx, member_u(dt, "parameters"), 1)
-    else:
-        arr = ctx.value_at(addr, "jl_array_t")
-        mem_addr = member_u(arr, "ref", "mem")
-        mem_dt_addr = typeof_addr(ctx, mem_addr)
-        dataptr = member_u(arr, "ref", "ptr_or_offset")
-        dimoff = ctx.field_offset("jl_array_t", "dimsize")
-        params = member_u(dt, "parameters")
-        try:
-            ndims = ctx.read_uint(svec_ref(ctx, params, 1), 8)
-        except MemoryReadError:
-            ndims = 1
-        if not (0 < ndims < 33):
-            ndims = 1
-        dims = [ctx.read_uint(addr + dimoff + i * ctx.ptrsize, ctx.ptrsize)
-                for i in range(ndims)]
-        eltype = svec_ref(ctx, params, 0)
-    mlayout = ctx.value_at(
-        member_u(ctx.value_at(mem_dt_addr, "jl_datatype_t"), "layout"),
-        "jl_datatype_layout_t")
-    elsize = member_u(mlayout, "size")
-    isboxed = member_u(mlayout, "flags", "arrayelem_isboxed")
-    isunion = member_u(mlayout, "flags", "arrayelem_isunion")
-    return dims, eltype, dataptr, elsize, isboxed, isunion
-
-
-def render_array(ctx, addr, depth):
-    dims, eltype, dataptr, elsize, isboxed, isunion = array_info(ctx, addr)
-    tstr = render_type(ctx, typeof_addr(ctx, addr), depth)
-    if len(dims) == 1:
-        summary = "%d-element %s" % (dims[0], tstr)
-    else:
-        summary = "%s %s" % ("×".join(str(d) for d in dims), tstr)
-    if depth < MAX_DEPTH:
-        return summary
-    n = 1
-    for d in dims:
-        n *= d
-    shown = min(n, MAX_ELEMS)
-    parts = []
-    for i in range(shown):
-        if isboxed:
-            p = ctx.read_ptr(dataptr + i * ctx.ptrsize)
-            parts.append(render_value(ctx, p, depth - 1) if p else "#undef")
-        elif isunion:
-            parts.append("<union element>")
-        else:
-            parts.append(render_unboxed(ctx, eltype, dataptr + i * elsize,
-                                        depth - 1))
-    if n > shown:
-        parts.append("… (%d more)" % (n - shown))
-    return "%s = {%s}" % (summary, ", ".join(parts))
-
-
-# --------------------------------------------------------------------------
-# rendering of runtime objects (Method, MethodInstance, Task, ...)
-# --------------------------------------------------------------------------
-
-def render_sig_call(ctx, fname, sigaddr, depth):
-    seen = 0
-    while datatype_qualname(ctx, typeof_addr(ctx, sigaddr)) == \
-            "Core.UnionAll" and seen < 32:
-        sigaddr = member_u(ctx.value_at(sigaddr, "jl_unionall_t"), "body")
-        seen += 1
-    if datatype_qualname(ctx, typeof_addr(ctx, sigaddr)) != "Core.DataType":
-        return "%s(...)" % fname
-    params = member_u(ctx.value_at(sigaddr, "jl_datatype_t"), "parameters")
-    n = svec_len(ctx, params) if params else 0
-    args = ["::" + render_type(ctx, svec_ref(ctx, params, i), depth - 1)
-            for i in range(1, min(n, MAX_ELEMS + 1))]
-    if n > MAX_ELEMS + 1:
-        args.append("…")
-    return "%s(%s)" % (fname, ", ".join(args))
-
-
-def render_method(ctx, addr, depth):
-    m = ctx.value_at(addr, "jl_method_t")
-    name = symbol_name(ctx, member_u(m, "name"))
-    where = ""
-    if member_u(m, "module"):
-        where = " @ " + module_path(ctx, member_u(m, "module"))
-    faddr = member_u(m, "file")
-    if faddr:
-        where += " %s:%d" % (symbol_name(ctx, faddr), member_i(m, "line"))
-    return render_sig_call(ctx, name, member_u(m, "sig"), depth) + where
-
-
-def render_method_instance(ctx, addr, depth):
-    mi = ctx.value_at(addr, "jl_method_instance_t")
-    defaddr = member_u(mi, "def", "value")
-    name = "?"
-    if defaddr:
-        if datatype_qualname(ctx, typeof_addr(ctx, defaddr)) == "Core.Method":
-            name = symbol_name(ctx, member_u(
-                ctx.value_at(defaddr, "jl_method_t"), "name"))
-        else:  # toplevel thunk: def is a module
-            return "MethodInstance for top-level scope in " + \
-                module_path(ctx, defaddr)
-    return "MethodInstance for " + \
-        render_sig_call(ctx, name, member_u(mi, "specTypes"), depth)
-
-
-def render_code_instance(ctx, addr, depth):
-    ci = ctx.value_at(addr, "jl_code_instance_t")
-    defaddr = member_u(ci, "def")
-    inner = "?"
-    if defaddr:
-        qual = datatype_qualname(ctx, typeof_addr(ctx, defaddr))
-        if qual == "Core.ABIOverride":
-            defaddr = member_u(ctx.value_at(defaddr, "jl_abi_override_t"),
-                               "def")
-            qual = datatype_qualname(ctx, typeof_addr(ctx, defaddr))
-        if qual == "Core.MethodInstance":
-            inner = render_method_instance(ctx, defaddr, depth - 1)
-    return "CodeInstance for %s" % inner
-
-
-TASK_STATES = {0: "runnable", 1: "done", 2: "failed", 3: "abandoned"}
-
-
-def render_task(ctx, addr):
-    t = ctx.value_at(addr, "jl_task_t")
-    state = TASK_STATES.get(member_u(t, "_state"), "?")
-    return "Task (%s) @0x%016x" % (state, addr)
-
-
-def render_expr(ctx, addr, depth):
-    e = ctx.value_at(addr, "jl_expr_t")
-    head = symbol_name(ctx, member_u(e, "head")) if member_u(e, "head") \
-        else "?"
-    nargs = 0
-    if member_u(e, "args"):
-        try:
-            nargs = array_info(ctx, member_u(e, "args"))[0][0]
-        except MemoryReadError:
-            pass
-    return "Expr(:%s, <%d args>)" % (head, nargs)
-
-
-def render_svec(ctx, addr, depth):
-    n = svec_len(ctx, addr)
-    parts = []
-    for i in range(min(n, MAX_ELEMS)):
-        p = svec_ref(ctx, addr, i)
-        parts.append(render_value(ctx, p, depth - 1) if p else "#undef")
-    if n > MAX_ELEMS:
-        parts.append("…")
-    return "svec(%s)" % ", ".join(parts)
-
-
-# --------------------------------------------------------------------------
-# main value renderer
-# --------------------------------------------------------------------------
-
-def render_value(ctx, addr, depth=MAX_DEPTH):
-    if addr == 0:
-        return "#<null>"
-    if depth < 0:
-        return "…"
-    dtaddr = typeof_addr(ctx, addr)
-    if dtaddr == 0:
-        return "<julia value 0x%x>" % addr
-    qual = datatype_qualname(ctx, dtaddr)
-
-    if is_type_kind(qual):
-        return render_type(ctx, addr, depth)
-    prim = render_primitive(ctx, qual, addr)
-    if prim is not None:
-        return prim
-    if qual == "Core.Nothing":
-        return "nothing"
-    if qual == "Core.Symbol":
-        name = symbol_name(ctx, addr)
-        if name.isidentifier():
-            return ":" + name
-        return 'Symbol("%s")' % escape_string(name)
-    if qual == "Core.String":
-        s, strlen = string_data(ctx, addr)
-        suffix = "…" if strlen > len(s.encode("utf-8", "replace")) else ""
-        return '"%s%s"' % (escape_string(s), suffix)
-    if qual == "Core.SimpleVector":
-        return render_svec(ctx, addr, depth)
-    if qual == "Core.Module":
-        return "Module %s" % module_path(ctx, addr)
-    if qual == "Core.Task":
-        return render_task(ctx, addr)
-    if qual == "Core.Method":
-        return render_method(ctx, addr, depth)
-    if qual == "Core.MethodInstance":
-        return render_method_instance(ctx, addr, depth)
-    if qual == "Core.CodeInstance":
-        return render_code_instance(ctx, addr, depth)
-    if qual == "Core.Expr":
-        return render_expr(ctx, addr, depth)
-    if qual == "Core.GlobalRef":
-        gr = ctx.value_at(addr, "jl_globalref_t")
-        return "%s.%s" % (module_path(ctx, member_u(gr, "mod")),
-                          symbol_name(ctx, member_u(gr, "name")))
-    if qual == "Core.TypeName":
-        tn = ctx.value_at(addr, "jl_typename_t")
-        return "typename(%s)" % symbol_name(ctx, member_u(tn, "name"))
-
-    dt = ctx.value_at(dtaddr, "jl_datatype_t")
-    tname = typename_of(ctx, dtaddr)
-    if tname in ("Array", "GenericMemory"):
-        try:
-            return render_array(ctx, addr, depth)
-        except MemoryReadError:
-            return render_type(ctx, dtaddr, depth - 1) + " <unreadable>"
-
-    # generic instances
-    if member_u(dt, "instance") == addr:
-        tn = ctx.value_at(member_u(dt, "name"), "jl_typename_t")
-        sname = member_u(tn, "singletonname") \
-            if tn.GetChildMemberWithName("singletonname").IsValid() else 0
-        return symbol_name(ctx, sname) if sname \
-            else render_type(ctx, dtaddr, depth) + "()"
-    if member_u(dt, "isprimitivetype"):
-        return render_unboxed(ctx, dtaddr, addr, depth)
-    fields = layout_fields(ctx, dt)
-    if fields is not None:
-        return render_struct_inline(ctx, dtaddr, dt, addr, fields, depth)
-    return "%s @0x%016x" % (render_type(ctx, dtaddr, depth - 1), addr)
+    def global_addr(self, name):
+        addr = self.globals.get(name)
+        if addr is None:
+            addr = 0
+            var = self.target.FindFirstGlobalVariable(name)
+            if var.IsValid():
+                laddr = var.GetLoadAddress()
+                if laddr != lldb.LLDB_INVALID_ADDRESS:
+                    addr = laddr
+            self.globals[name] = addr
+        return addr
+
+
+_RT = [None]
+_last_loc = [None]  # previous `jl` command result, reachable as `$jl`
+
+
+def get_rt(target, process):
+    rt = _RT[0]
+    if rt is not None and \
+            rt.a.process.GetUniqueID() == process.GetUniqueID():
+        # same process: keep the caches, refresh the (non-comparable)
+        # SB wrapper objects
+        rt.a.target = target
+        rt.a.process = process
+        return rt
+    rt = core.JuliaRuntime(LldbAdapter(target, process))
+    _RT[0] = rt
+    _last_loc[0] = None
+    return rt
+
+
+def rt_of(valobj):
+    return get_rt(valobj.GetTarget(), valobj.GetProcess())
 
 
 # --------------------------------------------------------------------------
@@ -801,8 +213,7 @@ class JLSafepointStopHook:
         pgsz = _global_uint(target, "jl_page_size")
         if base == 0 or pgsz == 0:
             return True
-        # 4 pages, see the layout description in src/safepoint.c
-        if base <= fault < base + 4 * pgsz:
+        if base <= fault < base + core.SAFEPOINT_PAGES * pgsz:
             return False
         return True
 
@@ -859,14 +270,14 @@ def jl_value_summary(valobj, internal_dict):
     addr = valobj.GetValueAsUnsigned()
     if addr == 0:
         return "NULL"
-    ctx = get_ctx(valobj)
-    if ctx.process.IsValid():
+    rt = rt_of(valobj)
+    if rt.a.process.IsValid():
         # opportunistically install the safepoint stop-hook once a real
         # process exists (importing from ~/.lldbinit happens before that)
         _install_stop_hook(valobj.GetTarget().GetDebugger())
     try:
-        return render_value(ctx, addr)
-    except MemoryReadError as e:
+        return rt.render_value_capped(addr)
+    except JLDebugError as e:
         return "<not a julia value: 0x%x (%s)>" % (addr, e)
     except Exception as e:  # never break `p` on a summary bug
         return "<error rendering julia value 0x%x: %s>" % (addr, e)
@@ -882,12 +293,75 @@ def jl_typeof_cmd(debugger, command, exe_ctx, result, internal_dict):
     if not val.IsValid() or val.GetError().Fail():
         result.SetError(str(val.GetError()))
         return
-    ctx = get_ctx(val)
+    rt = rt_of(val)
     try:
         result.AppendMessage(
-            render_type(ctx, typeof_addr(ctx, val.GetValueAsUnsigned())))
-    except MemoryReadError as e:
+            rt.render_type(rt.typeof_addr(val.GetValueAsUnsigned())))
+    except JLDebugError as e:
         result.SetError(str(e))
+
+
+def jl_cmd(debugger, command, exe_ctx, result, internal_dict):
+    """jl <path>: inspect a Julia value with Julia field/index semantics.
+
+    The path starts from a C expression (a variable or cast) or from a
+    module name, followed by `.field` and `[i]` accessors with Julia
+    (1-based) indexing:
+
+        jl v.inner.name
+        jl v.vec[2]
+        jl v.tup.1
+        jl Base.have_fma
+        jl $jl.name    (continue from the previous `jl` result)
+    """
+    arg = command.strip()
+    if not arg:
+        result.SetError("usage: jl <expr>[.field|[index]]...")
+        return
+    frame = exe_ctx.GetFrame()
+    target = exe_ctx.GetTarget()
+    process = exe_ctx.GetProcess()
+    if not process.IsValid():
+        result.SetError("no running process")
+        return
+    rt = get_rt(target, process)
+    first_err = None
+    parsed_any = False
+    for base, accessors in core.split_path(arg):
+        if base == "$jl" and _last_loc[0] is not None:
+            loc0 = _last_loc[0]
+        else:
+            if not frame.IsValid():
+                break
+            val = frame.EvaluateExpression(base)
+            if not val.IsValid() or val.GetError().Fail():
+                continue
+            loc0 = ("val", val.GetValueAsUnsigned())
+        parsed_any = True
+        try:
+            loc = rt.eval_accessors(loc0, accessors)
+            _last_loc[0] = loc
+            result.AppendMessage(rt.render_loc(loc))
+            return
+        except JLDebugError as e:
+            first_err = first_err or e
+    # base is not a C expression: try Julia module/global resolution
+    base, accessors = core.split_path(arg)[-1]
+    if not parsed_any and base.isidentifier():
+        try:
+            modaddr = rt.root_module(base)
+        except JLDebugError:
+            modaddr = 0
+        if modaddr:
+            try:
+                loc = rt.eval_accessors(("val", modaddr), accessors)
+                _last_loc[0] = loc
+                result.AppendMessage(rt.render_loc(loc))
+                return
+            except JLDebugError as e:
+                first_err = first_err or e
+    result.SetError(str(first_err) if first_err is not None
+                    else "cannot evaluate %r" % arg)
 
 
 def __lldb_init_module(debugger, internal_dict):
@@ -896,10 +370,12 @@ def __lldb_init_module(debugger, internal_dict):
             'type summary add --python-function %s.jl_value_summary "%s *"'
             % (__name__, tname))
     debugger.HandleCommand(
+        "command script add -f %s.jl_cmd jl" % __name__)
+    debugger.HandleCommand(
         "command script add -f %s.jl_typeof_cmd jl-typeof" % __name__)
     debugger.HandleCommand(
         "command script add -f %s.jl_safepoint_filter_cmd jl-safepoint-filter"
         % __name__)
     _install_stop_hook(debugger)
     print("julia_lldb: type summaries for Julia values installed "
-          "(commands: jl-typeof, jl-safepoint-filter)")
+          "(commands: jl, jl-typeof, jl-safepoint-filter)")

--- a/doc/src/devdocs/debuggingtips.md
+++ b/doc/src/devdocs/debuggingtips.md
@@ -1,5 +1,55 @@
 # [gdb debugging tips](@id gdb-debugging-tips)
 
+## Pretty-printing Julia values (gdb and lldb)
+
+The repository ships debugger extensions that make `print` render Julia runtime
+values the way Julia would show them, instead of as raw pointers. They also
+teach the debugger to silently skip the benign SIGSEGVs the GC uses to stop the
+world at safepoints (real segfaults still stop the debugger), which otherwise
+interrupt every GC when debugging.
+
+For gdb, source [`contrib/julia_gdb.py`](https://github.com/JuliaLang/julia/blob/master/contrib/julia_gdb.py)
+(interactively, from `~/.gdbinit`, or with `-x`):
+
+```
+$ gdb -x contrib/julia_gdb.py --args ./julia script.jl
+(gdb) print v
+$1 = 3-element Vector{Int64} = {1, 2, 3}
+(gdb) print (jl_datatype_t*)$jl_typeof(v)
+$2 = Vector{Int64}
+```
+
+For lldb, import [`contrib/julia_lldb.py`](https://github.com/JuliaLang/julia/blob/master/contrib/julia_lldb.py)
+(interactively, from `~/.lldbinit`, or with `-o`):
+
+```
+$ lldb -o 'command script import contrib/julia_lldb.py' -- ./julia script.jl
+(lldb) p v
+(jl_value_t *) v = 0x00007fffe2b41ab0 3-element Vector{Int64} = {1, 2, 3}
+(lldb) jl-typeof v
+Vector{Int64}
+```
+
+Any pointer whose static type is a Julia runtime type (`jl_value_t*`,
+`jl_datatype_t*`, `jl_sym_t*`, `jl_svec_t*`, `jl_array_t*`, `jl_method_t*`,
+`jl_task_t*`, ...) is rendered from its *runtime* type tag, so a plain
+`jl_value_t*` prints as whatever it actually holds: numbers, strings, symbols,
+types, arrays with their elements, structs with their fields, methods with
+their signatures, and so on. The scripts read struct layouts from the debug
+info, so they need a build with debug info (the default for source builds) but
+do not need to match the exact Julia version.
+
+Both scripts provide a `jl-safepoint-filter [on|off]` command to control the
+SIGSEGV filtering described above, and the gdb script additionally provides
+`jl-handle-signals` to fully ignore the signals Julia uses internally (useful
+when profiling under the debugger).
+
+!!! note
+    If the debugger appears to hang at startup for minutes, it is usually
+    `debuginfod` trying to download debug info for the system libraries over
+    the network. Run with `DEBUGINFOD_URLS=` in the environment (or answer
+    `n` to gdb's debuginfod prompt) to disable it.
+
 ## Displaying Julia variables
 
 Within `gdb`, any `jl_value_t*` object `obj` can be displayed using

--- a/doc/src/devdocs/debuggingtips.md
+++ b/doc/src/devdocs/debuggingtips.md
@@ -35,9 +35,36 @@ Any pointer whose static type is a Julia runtime type (`jl_value_t*`,
 `jl_task_t*`, ...) is rendered from its *runtime* type tag, so a plain
 `jl_value_t*` prints as whatever it actually holds: numbers, strings, symbols,
 types, arrays with their elements, structs with their fields, methods with
-their signatures, and so on. The scripts read struct layouts from the debug
-info, so they need a build with debug info (the default for source builds) but
-do not need to match the exact Julia version.
+their signatures, and so on. Output is capped (long strings and arrays are
+truncated with a `…`/`(N more)` marker) so printing a huge value is always
+safe. The scripts read struct layouts from the debug info, so they need a
+build with debug info (the default for source builds) but do not need to
+match the exact Julia version. Both files load the shared renderer from
+`contrib/julia_debug_core.py`, so keep the three files together when copying
+them elsewhere.
+
+Both debuggers also gain a `jl` command for Julia-semantics field and index
+access (1-based indexing, fields by name, module globals), since the C
+expression evaluator cannot look through `jl_value_t*`:
+
+```
+(gdb) jl v.inner.name
+$jl = "hello"
+(gdb) jl v.vec[2]
+$jl = 42
+(gdb) jl Base.have_fma
+$jl = false
+(gdb) jl $jl.name              # continue from the previous result
+```
+
+In gdb the result is stored in the convenience variable `$jl`, and the
+convenience functions `$jl_typeof(v)` and `$jl_field(v, "name")` compose
+inside larger expressions (boxed fields come back as `jl_value_t*`, unboxed
+primitive fields as native values):
+
+```
+(gdb) print $jl_field($jl_field(v, "counts"), 2) + 1
+```
 
 Both scripts provide a `jl-safepoint-filter [on|off]` command to control the
 SIGSEGV filtering described above, and the gdb script additionally provides

--- a/typos.toml
+++ b/typos.toml
@@ -3,3 +3,5 @@ extend-ignore-words-re = ["^[a-zA-Z]?[a-zA-Z]?[a-zA-Z]?[a-zA-Z]?$"]
 
 [default.extend-words]
 indexin = "indexin"
+# glibc's siginfo_t union member, spelled with "sig"
+sigfault = "sigfault"


### PR DESCRIPTION
Debugging the Julia runtime with gdb or lldb today means staring at raw `jl_value_t*` pointers (or remembering to `call jl_(obj)`), and getting interrupted by a SIGSEGV at every single GC because the safepoint mechanism uses guard-page faults. This PR adds Python extensions for both debuggers that make debugging Julia feel much closer to a language with native debugger support.

## What you get

`contrib/julia_gdb.py` (source it, add to `~/.gdbinit`, or `gdb -x`):

```
(gdb) print v
$1 = 3-element Vector{Int64} = {1, 2, 3}
(gdb) print some_value
$2 = Base.Dict{Symbol, Int64}(slots = 16-element Memory{UInt8}, keys = 16-element Memory{Symbol}, vals = 16-element Memory{Int64}, ndel = 0, count = 1, age = 0x0000000000000002, idxfloor = 1, maxprobe = 0)
(gdb) print mi
$3 = MethodInstance for +(::Int64, ::Int64)
(gdb) print $jl_typeof(v)
$4 = Vector{Int64}
```

`contrib/julia_lldb.py` (`command script import`, or add to `~/.lldbinit`):

```
(lldb) p v
(jl_value_t *) v = 0x00007fffe2b41ab0 3-element Vector{Int64} = {1, 2, 3}
(lldb) jl-typeof v
Vector{Int64}
```

Both dispatch on the **runtime** type tag, so a plain `jl_value_t*` prints as whatever it actually holds. Rendering covers: primitives (`42`, `3.5`, `true`, `'α'`, `0x1f`), strings, symbols (`:sym`), types with parameters plus `Vector`/`Matrix`/`Memory`/`AtomicMemory` sugar, `Union`/`UnionAll`/`TypeVar`/`Vararg`, arrays and Memory with their elements (expandable as children in gdb for IDE variable views), generic structs with field names, tuples and named tuples, svecs, modules, methods with signature/module/location, MethodInstances, CodeInstances, tasks with their scheduler state, Exprs, and GlobalRefs. Untagged/garbage pointers degrade gracefully to a raw-pointer note instead of erroring, and every summary is size-capped (long strings/arrays truncate with `…` / `(N more)`) so printing a 10-million-element array is safe.

## `x.y`-style access: the `jl` command

The C expression evaluator can't look through an opaque `jl_value_t*`, so both debuggers gain a `jl` command with Julia field/index semantics (1-based indexing, fields by name, module globals via the binding table):

```
(gdb) jl v.inner.name
$jl = "hello"
(gdb) jl v.vec[2]
$jl = 42
(gdb) jl Base.have_fma
$jl = false
(gdb) jl $jl.name          # continue from the previous result
```

In gdb the result lands in the `$jl` convenience variable, and `$jl_typeof(v)` / `$jl_field(v, "name")` compose inside larger expressions — boxed fields come back as `jl_value_t*`, unboxed primitive fields as native typed values, e.g. `print $jl_field($jl_field(v, "vec"), 3) + 1`.

## GC safepoint SIGSEGV filtering

Both scripts also stop the debugger from halting on the benign SIGSEGVs the GC uses to stop the world: gdb gets a conditional signal catchpoint that only fires when the faulting address is outside the safepoint page region, lldb gets a scripted stop-hook that does the same check. Real segfaults (including stack overflows) still stop the debugger with the faulting frame. This means you can step through allocating code with other threads running without hitting a "SIGSEGV in jl_gc_safepoint_" stop at every collection. `jl-safepoint-filter on|off` controls it in both debuggers, and gdb additionally gets `jl-handle-signals` (the bigger hammer that ignores SIGSEGV/SIGUSR2 outright, useful when profiling under the debugger).

## Design notes

- The rendering and inspection logic is shared: `contrib/julia_debug_core.py` is debugger-agnostic and both scripts drive it through a small adapter (memory reads + debug-info lookups), so gdb and lldb cannot drift apart.
- No hard-coded struct offsets: all layouts (`jl_datatype_t`, field descriptors, `jl_array_t`, binding partitions, etc.) are resolved through DWARF at runtime, so the scripts survive struct layout changes and should work across Julia versions. The only baked-in knowledge is the type-tag scheme (`header & ~15`, small-tag table lookup), the value layouts of symbols/strings/svecs, and the binding-partition kinds.
- Everything is wrapped so an unreadable value renders as `<not a julia value: 0x...>` rather than breaking `print`.
- Tested against a current master build: 36 value shapes verified identical between gdb 15 and lldb 18, the `jl` path suite (nested structs, inline structs, arrays, named tuples, module globals, error messages), GC-stress (safepoints silently skipped), and a real-segfault run (debugger stops with fault address) for both debuggers.

## Future work (not in this PR)

- Auto-loading: installing the gdb script as `libjulia-internal.so-gdb.py` next to the library so gdb picks it up automatically.
- Synthetic children providers for lldb (element expansion in IDE variable views).
- JIT frame symbolization quality (bare `?? ()` frames in jitted code when the JIT loader is off) is a separate, deeper issue.

One gotcha worth knowing that surfaced while testing: if lldb (or gdb) appears to hang for minutes at startup, it is `debuginfod` trying to download system-library debug info; `DEBUGINFOD_URLS= lldb ...` fixes it. This is now mentioned in the devdocs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)