### PR TITLE
Codegen: don't drop ABI overrides on invoke fallback paths

### DIFF
--- a/Compiler/test/abioverride.jl
+++ b/Compiler/test/abioverride.jl
@@ -59,3 +59,138 @@ end
 
 @test contains(repr(new_ci), "ABI Overridden")
 @test invoke(myplus, new_ci, 10) == 11
+
+# Test that fallback paths that run when a CodeInstance has no compiled code available
+# do not silently substitute the plain method for a CodeInstance whose semantics
+# (foreign `owner`) or calling convention (`ABIOverride`) differ from it.
+
+# Permanent GC-roots for manually-constructed CodeInstances handed to the JIT
+const ci_roots = Any[]
+
+# Construct a CodeInstance for `mi` (with an ABI override if `abi` is given), rooted
+# permanently; `src` provides the metadata, and is only handed to the JIT if `add_to_jit`
+# is set — otherwise the CodeInstance carries no code and cannot be compiled later.
+function make_codeinst(mi::Core.MethodInstance, src::Core.CodeInfo;
+                       abi=nothing, owner=nothing, add_to_jit::Bool=false)
+    def = abi === nothing ? mi : Core.ABIOverride(abi, mi)
+    ci = Core.CodeInstance(def, owner, src.rettype, Any,
+        #=inferred_const=#nothing, #=code=#nothing, #=const_flags=#Int32(0),
+        src.min_world, typemax(UInt), #=ipo_purity_bits=#UInt32(0),
+        #=analysis_results=#nothing, src.debuginfo, src.edges)
+    push!(ci_roots, ci)
+    if add_to_jit
+        ccall(:jl_add_codeinsts_to_jit, Cvoid, (Any, Any), Any[ci], Any[src])
+    end
+    return ci
+end
+
+mysum(x::Int, y::Int) = x + y
+
+let src = only(code_typed(mysum, (Int, Int)))[1]
+    mi = src.parent
+    # An override CodeInstance with no code attached: compilation is impossible, so
+    # calling it must error rather than silently running plain `mysum`
+    abici = make_codeinst(mi, src; abi=Tuple{typeof(mysum), Int, Int})
+
+    # builtin `invoke` fallback (`jl_f_invoke`)
+    @test_throws ErrorException invoke(mysum, abici, 1, 2)
+
+    # interpreter fallback (`do_invoke`): run an `Expr(:invoke, ci, ...)` statement
+    # through the toplevel interpreter
+    thk = Meta.lower(@__MODULE__, :($mysum(1, 2))).args[1]::Core.CodeInfo
+    callidx = findfirst(x -> isexpr(x, :call), thk.code)
+    @assert callidx !== nothing
+    thk.code[callidx] = Expr(:invoke, abici, mysum, 1, 2)
+    @test_throws ErrorException ccall(:jl_eval_thunk, Any, (Any, Any, Cint), @__MODULE__, thk, 0)
+end
+
+# Same for the `tojlinvoke` trampoline emitted when compiled code targets a
+# CodeInstance that has no code available at link time
+@noinline mycallee(x::Int, y::Int) = x * y
+mycaller(x::Int, y::Int) = mycallee(x, y)
+
+let caller_src = only(code_typed(mycaller, (Int, Int)))[1]
+    caller_mi = caller_src.parent
+    invokeidx = findfirst(x -> isexpr(x, :invoke), caller_src.code)
+    @assert invokeidx !== nothing
+
+    callee_src = only(code_typed(mycallee, (Int, Int)))[1]
+    callee_ci = make_codeinst(callee_src.parent, callee_src;
+                              abi=Tuple{typeof(mycallee), Int, Int})
+
+    # Retarget the caller's `:invoke` at the codeless override CodeInstance and compile it
+    caller_src.code[invokeidx].args[1] = callee_ci
+    caller_ci = make_codeinst(caller_mi, caller_src;
+                              owner=SecondArgConstOverride(2), add_to_jit=true)
+    @test_throws ErrorException invoke(mycaller, caller_ci, 1, 2)
+end
+
+# Test that codegen's self-recursion shortcut is not applied when an `:invoke` targets a
+# *different* CodeInstance of the method currently being compiled
+# (`@noinline` keeps the recursion from being partially inlined, so the typed IR contains
+# exactly one recursive `:invoke` and one `mul_int`)
+@noinline myfact(n::Int) = n <= 1 ? 1 : n * myfact(n - 1)
+
+function retarget_recursion!(src::Core.CodeInfo, @nospecialize(target))
+    invokeidx = findfirst(x -> isexpr(x, :invoke), src.code)
+    @assert invokeidx !== nothing
+    src.code[invokeidx].args[1] = target
+    return src
+end
+
+let mi = only(code_typed(myfact, (Int,)))[1].parent
+    # Variant A: replace the multiply with an add, recursing into plain `myfact`,
+    # i.e. a(n) = n <= 1 ? 1 : n + myfact(n - 1)
+    src_a = only(code_typed(myfact, (Int,)))[1]
+    mulidx = findfirst(x -> is_known_call(x, Core.Intrinsics.mul_int, src_a), src_a.code)
+    @assert mulidx !== nothing
+    src_a.code[mulidx].args[1] = Core.Intrinsics.add_int
+    ci_a = make_codeinst(mi, src_a; owner=SecondArgConstOverride(3), add_to_jit=true)
+    # a(3) = 3 + myfact(2) = 3 + 2
+    @test invoke(myfact, ci_a, 3) == 5
+
+    # Variant B: keep the multiply, but recurse into variant A,
+    # i.e. b(n) = n <= 1 ? 1 : n * a(n - 1)
+    src_b = retarget_recursion!(only(code_typed(myfact, (Int,)))[1], ci_a)
+    ci_b = make_codeinst(mi, src_b; owner=SecondArgConstOverride(4), add_to_jit=true)
+    # b(3) = 3 * a(2) = 3 * (2 + myfact(1)) = 9. If codegen's self-recursion shortcut
+    # incorrectly reused the function being compiled for this `:invoke`, this would
+    # recurse into variant B itself and return factorial(3) == 6
+    @test invoke(myfact, ci_b, 3) == 9
+
+    # A genuinely self-recursive variant is still handled by the shortcut:
+    # c(n) = n <= 1 ? 1 : n + c(n - 1), recursing into its own CodeInstance
+    src_c = only(code_typed(myfact, (Int,)))[1]
+    mulidx = findfirst(x -> is_known_call(x, Core.Intrinsics.mul_int, src_c), src_c.code)
+    @assert mulidx !== nothing
+    src_c.code[mulidx].args[1] = Core.Intrinsics.add_int
+    ci_c = make_codeinst(mi, src_c; owner=SecondArgConstOverride(5))
+    retarget_recursion!(src_c, ci_c)
+    ccall(:jl_add_codeinsts_to_jit, Cvoid, (Any, Any), Any[ci_c], Any[src_c])
+    # c(3) = 3 + c(2) = 3 + 2 + c(1)
+    @test invoke(myfact, ci_c, 3) == 6
+end
+
+# Same for the `needsparams` path in codegen's `emit_invoke`, taken when the target
+# method instance has unresolved static parameters (here `T` in a specialization on
+# the abstract `Vector`), which previously always emitted a plain `jl_invoke`
+@noinline myparam(x::Vector{T}) where T = length(x)
+mycaller2(x::Vector) = myparam(x)
+
+let caller_src = only(code_typed(mycaller2, (Vector,)))[1]
+    caller_mi = caller_src.parent
+    callidx = findfirst(x -> isexpr(x, :call), caller_src.code)
+    @assert callidx !== nothing
+
+    callee_src = only(code_typed(myparam, (Vector,)))[1]
+    @assert any(x -> x isa Core.SimpleVector, callee_src.parent.sparam_vals) # i.e. `needsparams`
+    callee_ci = make_codeinst(callee_src.parent, callee_src;
+                              abi=Tuple{typeof(myparam), Vector})
+
+    # Retarget the caller's call at the codeless override CodeInstance and compile it
+    call = caller_src.code[callidx]
+    caller_src.code[callidx] = Expr(:invoke, callee_ci, call.args...)
+    caller_ci = make_codeinst(caller_mi, caller_src;
+                              owner=SecondArgConstOverride(6), add_to_jit=true)
+    @test_throws ErrorException invoke(mycaller2, caller_ci, [1, 2, 3])
+end

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1944,7 +1944,9 @@ JL_CALLABLE(jl_f_invoke)
         if (invoke) {
             return invoke(args[0], &args[2], nargs - 2, codeinst);
         } else {
-            if (codeinst->owner != jl_nothing) {
+            if (codeinst->owner != jl_nothing || jl_is_abioverride(codeinst->def)) {
+                // the generic fallback below may not implement this codeinst's
+                // semantics or calling convention, so it must not be used here
                 jl_error("Failed to invoke or compile external codeinst");
             }
             return jl_invoke(args[0], &args[2], nargs - 2, mi);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -979,6 +979,11 @@ static const auto jlinvokeoc_func = new JuliaFunction<>{
     get_func2_sig,
     get_func_attrs,
 };
+static const auto jlinvokecodeinst_func = new JuliaFunction<>{
+    XSTR(jl_invoke_codeinst),
+    get_func2_sig,
+    get_func_attrs,
+};
 static const auto jlopaque_closure_call_func = new JuliaFunction<>{
     XSTR(jl_f_opaque_closure_call),
     get_func_sig,
@@ -5977,8 +5982,18 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
             return jl_cgval_t();
         }
         assert(jl_is_method_instance(mi));
-        if (mi == ctx.linfo) {
-            // handle self-recursion specially (TODO: assuming ci is a valid invoke for mi?)
+        bool self_call = mi == ctx.linfo;
+        if (self_call && ci != (jl_value_t*)ctx.codeinst) {
+            // the shortcut below reuses the function currently being emitted, which is
+            // only valid if both the invoke target and this function carry the plain
+            // native semantics and calling convention of `mi` (a foreign `owner` or an
+            // `ABIOverride` implies different code or a different signature)
+            jl_code_instance_t *target = (jl_code_instance_t*)ci;
+            self_call = (ci == nullptr || (target->owner == jl_nothing && !jl_is_abioverride(target->def))) &&
+                        (ctx.codeinst == nullptr || (ctx.codeinst->owner == jl_nothing && !jl_is_abioverride(ctx.codeinst->def)));
+        }
+        if (self_call) {
+            // handle self-recursion specially
             Function *f = ctx.f;
             FunctionType *ft = f->getFunctionType();
             if (ft == ctx.types().T_jlfunc) {
@@ -5993,7 +6008,10 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
                 unsigned return_roots = 0;
                 jl_returninfo_t::CallingConv cc = jl_returninfo_t::CallingConv::Boxed;
                 StringRef protoname = f->getName();
-                result = emit_call_specfun_other(ctx, mi, ctx.rettype, protoname, argv, nargs, &cc, &return_roots, rt);
+                if (ctx.codeinst) // derive the signature from the codeinst `f` was built for (its ABI may be overridden)
+                    result = emit_call_specfun_other(ctx, ctx.codeinst, protoname, argv, nargs, &cc, &return_roots, rt);
+                else
+                    result = emit_call_specfun_other(ctx, mi, ctx.rettype, protoname, argv, nargs, &cc, &return_roots, rt);
             }
             handled = true;
         }
@@ -6009,7 +6027,15 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
                     bool specsig, needsparams;
                     std::tie(specsig, needsparams) = uses_specsig(get_ci_abi(codeinst), mi, codeinst->rettype, ctx.params->prefer_specsig);
                     if (needsparams) {
-                        Value *r = emit_jlcall(ctx, jlinvoke_func, track_pjlvalue(ctx, literal_pointer_val(ctx, (jl_value_t*)mi)), argv, nargs, julia_call2);
+                        Value *r;
+                        if (codeinst->owner != jl_nothing || jl_is_abioverride(codeinst->def)) {
+                            // `jl_invoke` may substitute different code for the method instance,
+                            // so the call must go through the codeinst itself (see `emit_tojlinvoke`)
+                            r = emit_jlcall(ctx, jlinvokecodeinst_func, track_pjlvalue(ctx, literal_pointer_val(ctx, ci)), argv, nargs, julia_call2);
+                        }
+                        else {
+                            r = emit_jlcall(ctx, jlinvoke_func, track_pjlvalue(ctx, literal_pointer_val(ctx, (jl_value_t*)mi)), argv, nargs, julia_call2);
+                        }
                         result = mark_julia_type(ctx, r, true, rt);
                     }
                     else {
@@ -7603,6 +7629,13 @@ static Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Value *theFunc, j
     if (theFunc) {
         theFarg = literal_pointer_val(ctx, (jl_value_t*)codeinst);
     }
+    else if (codeinst->owner != jl_nothing || jl_is_abioverride(codeinst->def)) {
+        // `jl_invoke` may substitute different code for the method instance (a
+        // foreign `owner` implies different semantics; an `ABIOverride` a
+        // different signature), so the call must go through the codeinst itself
+        theFunc = prepare_call(jlinvokecodeinst_func);
+        theFarg = literal_pointer_val(ctx, (jl_value_t*)codeinst);
+    }
     else {
         jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
         bool is_opaque_closure = jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
@@ -7893,7 +7926,7 @@ std::string emit_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_c
         jl_returninfo_t targetspec = get_specsig_function(out, M, target, "", abi, codeinst->rettype, target_is_opaque_closure);
         if (from_abi.specsig)
             emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, from_abi.is_opaque_closure, out,
-                    target, mi->specTypes, codeinst->rettype, &targetspec, nullptr);
+                    target, abi, codeinst->rettype, &targetspec, nullptr);
         else
             gen_invoke_wrapper(mi, abi, codeinst->rettype, from_abi.rt, targetspec, -1, from_abi.is_opaque_closure, gf_thunk_name, M, out);
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -4597,6 +4597,27 @@ JL_DLLEXPORT jl_value_t *jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t na
     return _jl_invoke(F, args, nargs, mfunc, world, TRIGGER_FOREIGN);
 }
 
+// Call a specific CodeInstance, compiling it first if necessary. Unlike `jl_invoke`,
+// this does not permit substituting different code for the same method instance,
+// which matters when the CodeInstance implements semantics (foreign `owner`) or a
+// calling convention (`ABIOverride`) that differ from the plain method.
+JL_DLLEXPORT jl_value_t *jl_invoke_codeinst(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_code_instance_t *codeinst)
+{
+    jl_callptr_t invoke = jl_atomic_load_acquire(&codeinst->invoke);
+    if (!invoke) {
+        jl_compile_codeinst(codeinst);
+        invoke = jl_atomic_load_acquire(&codeinst->invoke);
+    }
+    if (invoke)
+        return invoke(F, args, nargs, codeinst);
+    if (codeinst->owner != jl_nothing || jl_is_abioverride(codeinst->def)) {
+        // the generic fallback below may not implement this codeinst's
+        // semantics or calling convention, so it must not be used here
+        jl_error("Failed to invoke or compile external codeinst");
+    }
+    return jl_invoke(F, args, nargs, jl_get_ci_mi(codeinst));
+}
+
 jl_value_t *jl_invoke_fromdispatch(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *mfunc)
 {
     size_t world = jl_current_task->world_age;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -149,7 +149,9 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
             result = invoke(argv[0], nargs == 2 ? NULL : &argv[1], nargs - 2, codeinst);
 
         } else {
-            if (codeinst->owner != jl_nothing) {
+            if (codeinst->owner != jl_nothing || jl_is_abioverride(codeinst->def)) {
+                // the generic fallback below may not implement this codeinst's
+                // semantics or calling convention, so it must not be used here
                 jl_error("Failed to invoke or compile external codeinst");
             }
             result = jl_invoke(argv[0], nargs == 2 ? NULL : &argv[1], nargs - 2, jl_get_ci_mi(codeinst));

--- a/src/julia.h
+++ b/src/julia.h
@@ -2526,6 +2526,7 @@ STATIC_INLINE int jl_vinfo_usedundef(uint8_t vi)
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint32_t nargs) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *meth) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_invoke_oc(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *meth) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_invoke_codeinst(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_code_instance_t *codeinst) JL_CANSAFEPOINT;
 JL_DLLEXPORT int32_t jl_invoke_api(jl_code_instance_t *linfo);
 
 STATIC_INLINE jl_value_t *jl_apply(jl_value_t **args, uint32_t nargs) JL_CANSAFEPOINT


### PR DESCRIPTION
This is a bugfix for some `ABIOverride` issues I ran into while trying to scope out my plan for stack-allocation of mutable structs across non-inlined function barriers.

The motivation here is to use the `ABIOverride` to communicate information about objects being passed which are stack allocated rather than heap allocated, but there turns out to be a number of cases where fallbacks cause `ABIOverride` information to be silently dropped, which would be really bad if it caused a stack pointer to be treated as a heap pointer. 

See also https://github.com/JuliaLang/julia/pull/62870 for more in this series.

_____________

:robot: summary:

When a CodeInstance carrying a foreign `owner` or an `ABIOverride` had no compiled code available, several fallback paths silently substituted plain `jl_invoke` of the underlying MethodInstance, which executes different code than the CodeInstance requested (and calls with the wrong arity for an arity-changing ABI override):

- The interpreter's `do_invoke` and the `invoke` builtin guarded only against foreign owners, not ABI overrides.
- The `tojlinvoke` trampoline emitted for lazily-linked or codeless invoke targets always degraded to `jl_invoke`. It now routes through a new `jl_invoke_codeinst` entrypoint that compiles and calls the CodeInstance itself, erroring cleanly when that is impossible.
- Codegen's `emit_invoke` likewise emitted a plain `jl_invoke` of the MethodInstance whenever the target needed static parameters passed at runtime (`needsparams`), regardless of which CodeInstance was requested. It now goes through `jl_invoke_codeinst` for such targets too.
- Codegen's self-recursion shortcut reused the function currently being emitted for any `:invoke` of the same MethodInstance, miscompiling invokes that target a different CodeInstance of that method (resolving an in-tree TODO). The shortcut now also derives the callee signature from the CodeInstance being emitted rather than from its `specTypes`, in case its ABI is overridden.
- `emit_abi_converter` passed `mi->specTypes` as the target call signature where the target function was built from the CodeInstance's (possibly overridden) ABI.

Assisted-by: Claude Code (Fable 5.1)