### PR TITLE
gc-mmtk: add a barrier before draining the finalizer queue

### DIFF
--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -313,6 +313,7 @@ void run_finalizers(jl_task_t *ct, int finalizers_thread)
         copied_list.items = copied_list._space;
     }
     jl_atomic_store_relaxed(&jl_gc_have_pending_finalizers, 0);
+    jl_gc_wb_finalizer_queue(&to_finalize);
     arraylist_new(&to_finalize, 0);
 
     // Finalizers shouldn't affect either rng or errno state

--- a/src/gc-common.h
+++ b/src/gc-common.h
@@ -189,7 +189,7 @@ extern jl_mutex_t finalizers_lock;
 // If an object pointer has `GC_FIN_CFUNC_TAG` set, the next pointer is an unboxed c function pointer.
 // If an object pointer has `GC_FIN_COBJ_TAG` set, the current pointer is a c object pointer.
 //   It must be aligned at least 4, and it finalized immediately (at "quiescence").
-// `to_finalize` should not have tagged pointers.
+// `to_finalize` carries the same tags: `sweep_finalizer_list` moves entries over unchanged.
 #define GC_FIN_CFUNC_TAG 1
 #define GC_FIN_COBJ_TAG  2
 #define GC_FIN_TAG_MASK  3

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -346,6 +346,8 @@ STATIC_INLINE void jl_gc_wb_knownold(const void *parent JL_UNUSED, const void *p
 // per field of the object being copied, but may be special-cased for performance reasons.
 STATIC_INLINE void jl_gc_multi_wb(const void *parent,
                                   const struct _jl_value_t *ptr) JL_NOTSAFEPOINT;
+// Write-barrier function that must be used before draining the finalizer queue.
+STATIC_INLINE void jl_gc_wb_finalizer_queue(arraylist_t *queue) JL_NOTSAFEPOINT;
 // Write-barrier function that must be used after copying fields of elements of genericmemory objects
 // into another. It should be semantically equivalent to triggering multiple write barriers – one
 // per field of the object being copied, but may be special-cased for performance reasons.

--- a/src/gc-mmtk/gc-wb-mmtk.h
+++ b/src/gc-mmtk/gc-wb-mmtk.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 extern void mmtk_object_reference_write_pre(void* mutator, const void* parent, const void* ptr);
+extern void mmtk_gc_wb_finalizer_queue(void* mutator, void* queue);
 extern void mmtk_object_reference_write_slow(void* mutator, const void* parent, const void* ptr);
 extern void* MMTK_SIDE_LOG_BIT_BASE_ADDRESS;
 
@@ -38,6 +39,13 @@ STATIC_INLINE void mmtk_gc_wb_full(const void *parent, const void *ptr) JL_NOTSA
     jl_task_t *ct = jl_current_task;
     jl_ptls_t ptls = ct->ptls;
     mmtk_object_reference_write_pre(&ptls->gc_tls.mmtk_mutator, parent, ptr);
+}
+
+STATIC_INLINE void jl_gc_wb_finalizer_queue(arraylist_t *queue) JL_NOTSAFEPOINT
+{
+    jl_task_t *ct = jl_current_task;
+    jl_ptls_t ptls = ct->ptls;
+    mmtk_gc_wb_finalizer_queue(&ptls->gc_tls.mmtk_mutator, (void*)queue);
 }
 
 // Inlined fastpath

--- a/src/gc-mmtk/mmtk_julia/src/api.rs
+++ b/src/gc-mmtk/mmtk_julia/src/api.rs
@@ -593,6 +593,14 @@ pub extern "C" fn mmtk_object_reference_write_post(
 }
 
 #[no_mangle]
+pub extern "C" fn mmtk_gc_wb_finalizer_queue(
+    mutator: &'static mut Mutator<JuliaVM>,
+    queue: *const libc::c_void,
+) {
+    crate::julia_finalizer::wb_finalizer_queue(mutator, queue);
+}
+
+#[no_mangle]
 pub extern "C" fn mmtk_object_reference_write_slow(
     mutator: &'static mut Mutator<JuliaVM>,
     src: ObjectReference,

--- a/src/gc-mmtk/mmtk_julia/src/julia_finalizer.rs
+++ b/src/gc-mmtk/mmtk_julia/src/julia_finalizer.rs
@@ -231,15 +231,16 @@ fn next_finalizer_object(
     None
 }
 
-/// The entries of `to_finalize`, as root nodes for the InitialMark snapshot.
-pub fn to_finalize_root_nodes() -> Vec<ObjectReference> {
-    let list = ArrayListT::to_finalize_list();
-    let mut nodes = Vec::with_capacity(list.len / 2);
+/// Report every reference in `queue` to the concurrent marking closure, for a mutator that is
+/// about to empty it.
+pub fn wb_finalizer_queue(mutator: &mut Mutator<JuliaVM>, queue: *const libc::c_void) {
+    use mmtk::MutatorContext;
+    // `queue` is the `arraylist_t` the mutator is about to reset; see gc-common.c.
+    let queue = unsafe { &*(queue as *const ArrayListT) };
     let mut i = 0;
-    while let Some((_, obj, _)) = next_finalizer_object(list, &mut i) {
-        nodes.push(obj);
+    while let Some((_, obj, _)) = next_finalizer_object(queue, &mut i) {
+        mutator.barrier().load_weak_reference(obj);
     }
-    nodes
 }
 
 // gc_mark_finlist in gc.c

--- a/src/gc-mmtk/mmtk_julia/src/julia_finalizer.rs
+++ b/src/gc-mmtk/mmtk_julia/src/julia_finalizer.rs
@@ -13,8 +13,8 @@ use crate::jl_gc_get_marked_finalizers_list;
 use crate::jl_gc_get_thread_finalizer_list;
 use crate::jl_gc_get_to_finalize_list;
 
-// Entries in the thread-local and marked finalizer lists may have tagged object
-// pointers. These must match the `GC_FIN_*` defines in gc-common.h.
+// Entries in the thread-local, marked and `to_finalize` finalizer lists may have tagged
+// object pointers. These must match the `GC_FIN_*` defines in gc-common.h.
 /// The paired finalizer is an unboxed c function pointer.
 pub const GC_FIN_CFUNC_TAG: usize = 0x1;
 /// The object pointer is a c object pointer, not a `jl_value_t *`.  It must
@@ -195,46 +195,64 @@ fn sweep_finalizer_list(
     list.len = j;
 }
 
+/// Advance `i` to the next entry of `list` that is an object reference, returning
+/// `(slot, object, tag)`.
+fn next_finalizer_object(
+    list: &ArrayListT,
+    i: &mut usize,
+) -> Option<(usize, ObjectReference, usize)> {
+    while *i < list.len {
+        let cur = list.get(*i);
+        let slot = *i;
+        if cur.is_zero() {
+            *i += 1;
+            continue;
+        }
+        let mut tag = 0;
+        let obj = if gc_ptr_tag(cur, GC_FIN_CFUNC_TAG) {
+            *i += 1;
+            debug_assert!(*i < list.len);
+            tag = GC_FIN_CFUNC_TAG;
+            gc_ptr_clear_tag(cur, GC_FIN_CFUNC_TAG)
+        } else {
+            cur
+        };
+        if gc_ptr_tag(cur, GC_FIN_COBJ_TAG) {
+            *i += 1;
+            continue;
+        }
+        *i += 1;
+        return Some((
+            slot,
+            unsafe { ObjectReference::from_raw_address_unchecked(obj) },
+            tag,
+        ));
+    }
+    None
+}
+
+/// The entries of `to_finalize`, as root nodes for the InitialMark snapshot.
+pub fn to_finalize_root_nodes() -> Vec<ObjectReference> {
+    let list = ArrayListT::to_finalize_list();
+    let mut nodes = Vec::with_capacity(list.len / 2);
+    let mut i = 0;
+    while let Some((_, obj, _)) = next_finalizer_object(list, &mut i) {
+        nodes.push(obj);
+    }
+    nodes
+}
+
 // gc_mark_finlist in gc.c
 fn mark_finlist<T: ObjectTracer>(list: &mut ArrayListT, start: usize, tracer: &mut T) {
     if list.len <= start {
         return;
     }
-
     let mut i = start;
-    while i < list.len {
-        let cur = list.get(i);
-        let cur_i = i;
-        let mut cur_tag: usize = 0;
-
-        if cur.is_zero() {
-            i += 1;
-            continue;
-        }
-
-        let new_obj_addr = if gc_ptr_tag(cur, GC_FIN_CFUNC_TAG) {
-            // Skip next
-            i += 1;
-            debug_assert!(i < list.len);
-            cur_tag = GC_FIN_CFUNC_TAG;
-            gc_ptr_clear_tag(cur, GC_FIN_CFUNC_TAG)
-        } else {
-            // unsafe: We checked `cur.is_zero()` before.
-            cur
-        };
-        if gc_ptr_tag(cur, GC_FIN_COBJ_TAG) {
-            i += 1;
-            continue;
-        }
-
-        let new_obj = unsafe { ObjectReference::from_raw_address_unchecked(new_obj_addr) };
-
-        let traced = tracer.trace_object(new_obj);
-        // if object has moved, update the list applying the tag
-        list.set(cur_i, unsafe {
-            Address::from_usize(traced.to_raw_address() | cur_tag)
+    while let Some((slot, obj, tag)) = next_finalizer_object(list, &mut i) {
+        let traced = tracer.trace_object(obj);
+        // if the object has moved, update the list, re-applying the tag
+        list.set(slot, unsafe {
+            Address::from_usize(traced.to_raw_address() | tag)
         });
-
-        i += 1;
     }
 }

--- a/src/gc-mmtk/mmtk_julia/src/scanning.rs
+++ b/src/gc-mmtk/mmtk_julia/src/scanning.rs
@@ -23,6 +23,8 @@ use crate::JuliaVM;
 #[cfg(feature = "concurrentimmix")]
 use dashmap::DashMap;
 #[cfg(feature = "concurrentimmix")]
+use mmtk::plan::Pause;
+#[cfg(feature = "concurrentimmix")]
 use std::sync::{Arc, Mutex};
 
 pub(crate) struct StackRootBuffer {
@@ -191,6 +193,21 @@ impl Scanning<JuliaVM> for VMScanning {
         let mut roots_closure = RootsWorkClosure::from_roots_work_factory(&mut factory);
         unsafe {
             jl_gc_scan_vm_specific_roots(&mut roots_closure as _);
+        }
+
+        // Only InitialMark needs this: every other pause marks `to_finalize` later in
+        // the same pause via `scan_finalizers_in_rust`.
+        #[cfg(feature = "concurrentimmix")]
+        if SINGLETON
+            .get_plan()
+            .concurrent()
+            .and_then(|plan| plan.current_pause())
+            == Some(Pause::InitialMark)
+        {
+            let nodes = crate::julia_finalizer::to_finalize_root_nodes();
+            if !nodes.is_empty() {
+                factory.create_process_pinning_roots_work(nodes);
+            }
         }
     }
 

--- a/src/gc-mmtk/mmtk_julia/src/scanning.rs
+++ b/src/gc-mmtk/mmtk_julia/src/scanning.rs
@@ -23,8 +23,6 @@ use crate::JuliaVM;
 #[cfg(feature = "concurrentimmix")]
 use dashmap::DashMap;
 #[cfg(feature = "concurrentimmix")]
-use mmtk::plan::Pause;
-#[cfg(feature = "concurrentimmix")]
 use std::sync::{Arc, Mutex};
 
 pub(crate) struct StackRootBuffer {
@@ -193,21 +191,6 @@ impl Scanning<JuliaVM> for VMScanning {
         let mut roots_closure = RootsWorkClosure::from_roots_work_factory(&mut factory);
         unsafe {
             jl_gc_scan_vm_specific_roots(&mut roots_closure as _);
-        }
-
-        // Only InitialMark needs this: every other pause marks `to_finalize` later in
-        // the same pause via `scan_finalizers_in_rust`.
-        #[cfg(feature = "concurrentimmix")]
-        if SINGLETON
-            .get_plan()
-            .concurrent()
-            .and_then(|plan| plan.current_pause())
-            == Some(Pause::InitialMark)
-        {
-            let nodes = crate::julia_finalizer::to_finalize_root_nodes();
-            if !nodes.is_empty() {
-                factory.create_process_pinning_roots_work(nodes);
-            }
         }
     }
 

--- a/src/gc-wb-stock.h
+++ b/src/gc-wb-stock.h
@@ -26,6 +26,11 @@ STATIC_INLINE void jl_gc_wb_back(const void *ptr) JL_NOTSAFEPOINT // ptr isa jl_
     }
 }
 
+STATIC_INLINE void jl_gc_wb_finalizer_queue(arraylist_t *queue JL_UNUSED) JL_NOTSAFEPOINT
+{
+    // this is a deletion, so no barrier is required for this GC
+}
+
 STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_NOTSAFEPOINT
 {
     // ptr is an immutable object

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -321,9 +321,17 @@ cd(@__DIR__) do
                 # never ourselves, as we still have to finish exiting. The
                 # workers are all gone by then, so they cannot be in our subtree.
                 ospid = wrkr == 1 ? getpid() : get(worker_ospids, wrkr, nothing)
-                ospid === nothing && continue
+                if ospid === nothing
+                    Core.print(Core.stderr, "Test $test is still running on worker $wrkr at teardown, but no pid was recorded for it; cannot core-dump it.\n")
+                    continue
+                end
                 subtree = reverse!(descendant_pids(ospid))
-                wrkr == 1 && isempty(subtree) && continue
+                if wrkr == 1 && isempty(subtree)
+                    # Nothing to signal: a node 1 test runs in this process, and we must
+                    # not signal ourselves. Report it rather than bailing silently
+                    Core.print(Core.stderr, "Test $test is still running on worker 1 (pid $ospid) at teardown, but it has no live subprocesses; nothing to core-dump.\n")
+                    continue
+                end
                 foreach(quit!, subtree)
                 wrkr == 1 || quit!(ospid)
                 target = (wrkr == 1 ? "" : "it and ") * "its $(length(subtree)) subprocess(es)"


### PR DESCRIPTION
I would love to take credit for this, but this was entirely identified / generated by Claude Fable 🤖 after I tasked it with analyzing https://buildkite.com/julialang/julia-ci/builds/419#01a051f6-c668-4083-a77b-5141f432095e + similar CI failures / coredumps

@qinsoon does this look reasonable?

I do not have a complete mental model of MMTk's rooting obligations here