### PR TITLE
precompilation: drive output through one `IOContext{IO}` specialization

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -309,7 +309,15 @@ Base.showerror(io::IO, err::PkgPrecompileError, bt; kw...) = Base.showerror(io, 
 # This needs a show method to make `julia> err` show nicely
 Base.show(io::IO, err::PkgPrecompileError) = print(io, "PkgPrecompileError: ", err.msg)
 
-can_fancyprint(io::IO) = @something(get(io, :force_fancyprint, nothing), (io isa Base.TTY && (get(ENV, "CI", nothing) != "true")))
+can_fancyprint(io::IO) = @something(get(io, :force_fancyprint, nothing), (Base.unwrapcontext(io)[1] isa Base.TTY && (get(ENV, "CI", nothing) != "true")))
+
+# The driver prints through one concrete io type whatever stream it was given, so it and
+# the closures it spawns are compiled once (into the sysimage) rather than once per
+# stream type. A pipe, for example, is otherwise re-inferred by every process that
+# captures `Pkg.precompile` output.
+unstable_iocontext(io::IOContext{IO}) = io
+unstable_iocontext(io::IOContext) = IOContext{IO}(io.io, io.dict)
+unstable_iocontext(io::IO) = IOContext{IO}(io, Base.ImmutableDict{Symbol, Any}())
 
 function printpkgstyle(io, header, msg; color=:green)
     return @lock io begin
@@ -1189,7 +1197,7 @@ function precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}}=String[];
     # monomorphize this to avoid latency problems
     _precompilepkgs(pkgs, internal_call, strict, warn_loaded, timing, verbose, _from_loading,
                    configs isa Vector{Config} ? configs : [configs],
-                   io isa IOContext ? io : IOContext(io), fancyprint, manifest, ignore_loaded, detachable)
+                   unstable_iocontext(io), fancyprint, manifest, ignore_loaded, detachable)
 end
 
 ## Background lifecycle
@@ -1287,6 +1295,11 @@ end
 
 function monitor_background_precompile(io::IO = stderr, detachable::Bool = true, wait_for_pkg::Union{Nothing, PkgId} = nothing;
                                        key_controls::Union{Bool, Nothing} = nothing)
+    _monitor_background_precompile(unstable_iocontext(io), detachable, wait_for_pkg; key_controls)
+end
+
+function _monitor_background_precompile(io::IOContext{IO}, detachable::Bool, wait_for_pkg::Union{Nothing, PkgId};
+                                        key_controls::Union{Bool, Nothing})
     # By default only enable key controls when this task is the foreground task (see #61563, #61698).
     # Falls back to roottask when no foreground task is registered (e.g. non-REPL interactive scripts).
     key_controls = @something key_controls current_task() === something(Base.foreground_task(), Base.roottask)
@@ -1726,7 +1739,7 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
         else
             nothing
         end
-        monitor_background_precompile(io.io, detachable, wait_for_pkg)
+        monitor_background_precompile(io, detachable, wait_for_pkg)
         if _from_loading
             # _from_loading: package just left pending_pkgids, waiter will put result shortly
             result = take!(req.result)
@@ -1743,7 +1756,7 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
     end
 
     # Launched new task — wait for full completion
-    monitor_background_precompile(io.io, detachable)
+    monitor_background_precompile(io, detachable)
 
     local ret_val, ret_ex
     @lock BG begin


### PR DESCRIPTION
Fixes precompilepkgs not being precompiled for pipes.

Claude:

---

`Pkg.precompile` costs about 0.6s more per process on master when its output is captured through a pipe than when it goes to a terminal, a file or devnull. That is the case for CI logs, for anything driving Julia as a subprocess, and for the TTFX harness, where it shows up as a fixed +0.6s on every task's precompile time relative to 1.13.

The driver in `precompilepkgs`, the background-launch closure and `monitor_background_precompile` are specialized on the stream they print to. Pkg hands over an `IOContext{IO}` by design, but its entry point unwraps that to the raw stream for a TTY, a file or devnull, and those variants are precompiled by the Pkg and sysimage workloads. A pipe is left wrapped so it keeps its colour, and nothing caches that variant, so a piped process re-infers the driver from scratch: `--trace-compile-timing` puts 330ms in the `precompilepkgs` kwcall, 150ms in the launch closure and 70ms in `monitor_background_precompile(::PipeEndpoint, ::Bool)`, 0.63s of compile time in the driver where a file pays 0.05s.

This normalises the io to exactly `IOContext{IO}` at the two public entry points, so one specialization serves every stream kind and the sysimage workload compiles it, and hands the monitor the wrapped io instead of the raw stream. `can_fancyprint` looks through the wrapper so a wrapped TTY keeps its fancy output. Pkg's unwrapping becomes redundant but is harmless.

Measured on a build of this branch against the same base without it (`Pkg.precompile` on a one-package tree, cold caches, macOS aarch64), driver compile time by stderr kind:

| stderr | before | after |
|---|---|---|
| pipe | 1.55s total, 0.63s compile | 0.98s total, 0.05s compile |
| file | 0.94s, 0.05s | 0.94s, 0.04s |
| devnull | 0.94s, 0.05s | 0.94s, 0.04s |
| TTY | 1.22s, 0.07s | 1.20s, 0.06s |

Fancy terminal output and colour on a pipe under `--color=yes` are unchanged. `test/precompile.jl` and `test/loading.jl` pass.
