### PR TITLE
Compiler/test: take the minimum of several `@allocated` runs in the `Dict` hash test

### DIFF
--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -410,7 +410,10 @@ function g_dict_hash_alloc()
 end
 # Warm up
 f_dict_hash_alloc(); g_dict_hash_alloc();
-@test abs((@allocated f_dict_hash_alloc()) / (@allocated g_dict_hash_alloc()) - 1) < 0.3
+# Take the minimum of several runs so that a one-time allocation inside the
+# measured call (e.g. lazy compilation of a call target) does not skew the ratio
+min_dict_hash_alloc(f) = minimum(@allocated(f()) for _ in 1:3)
+@test abs(min_dict_hash_alloc(f_dict_hash_alloc) / min_dict_hash_alloc(g_dict_hash_alloc) - 1) < 0.3
 
 # returning an argument shouldn't alloc a new box
 @noinline f33829(x) = (global called33829 = true; x)


### PR DESCRIPTION
The test comparing allocations of `f_dict_hash_alloc` and `g_dict_hash_alloc` fails rarely on CI (seen on the macOS x86_64 job, for example https://buildkite.com/julialang/julia-ci/builds/420/list?jid=01a051f8-28fc-4ac6-b346-8df3ede1a00d&tab=output) with the ratio evaluating to exactly `0.4294562973158982`, i.e. a deterministic extra `159744` bytes in a single measured call. This is consistent with a one-time allocation inside the measured call, such as lazy compilation of a call target that was linked through a `tojlinvoke` trampoline.

Measure each function a few times and take the minimum, so a one-time effect in the first sample does not skew the ratio while a real per-iteration boxing regression (ratio `0.43`) still fails.

Assisted-by: Claude Code (Fable 5.1)