### PR TITLE
signals: record a marker frame when a profile sample cannot be unwound

### DIFF
--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -463,6 +463,7 @@ Notice how many of the samples contain `sum_of_sqrt`, which is the expensive com
 In the current implementation, the wall-time profiler attempts to sample from tasks that have been alive since the last garbage collection, along with those created afterward. However, if most tasks are extremely short-lived, you may end up sampling tasks that have already completed, resulting in missed backtrace captures.
 
 If you encounter samples containing `failed_to_sample_task_fun` or `failed_to_stop_thread_fun`, this likely indicates a high volume of short-lived tasks, which prevented their backtraces from being collected.
+Samples containing `failed_to_unwind_fun`, which can also appear in CPU profiles, are ones where the profiler stopped a thread but could not walk its stack; this happens occasionally on some platforms.
 
 Let's consider this simple example:
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2175,6 +2175,7 @@ JL_DLLEXPORT uint64_t *jl_coverage_data_pointer(const char *filename, int line) 
 JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(const char *filename, int line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT NOINLINE int failed_to_sample_task_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
 JL_DLLEXPORT NOINLINE int failed_to_stop_thread_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
+JL_DLLEXPORT NOINLINE int failed_to_unwind_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
 int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOINT;
 
 // Values a compiled cancellation reset point's setjmp returns when a

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -993,6 +993,7 @@ void jl_profile_thread_mach(int tid)
             *  and during stack unwinding we only ever read memory, but never write it.
             */
 
+        size_t bt_size_start = profile_bt_size_cur;
         forceDwarf = 0;
         unw_getcontext(&profiler_uc); // will resume from this point if the next lines segfault at any point
 
@@ -1011,6 +1012,11 @@ void jl_profile_thread_mach(int tid)
 #else
         profile_bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)profile_bt_data_prof + profile_bt_size_cur, profile_bt_size_max - profile_bt_size_cur - 1, uc, NULL);
 #endif
+        if (profile_bt_size_cur == bt_size_start) {
+            // unwinding produced no frames: record a marker so the sample is not silently dropped
+            profile_bt_size_cur += failed_to_unwind_fun((jl_bt_element_t*)profile_bt_data_prof + profile_bt_size_cur,
+                    profile_bt_size_max - profile_bt_size_cur - 1, 0);
+        }
         jl_ptls_t ptls = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
 
         // store threadid but add 1 as 0 is preserved to indicate end of block

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -1181,6 +1181,7 @@ static void do_profile(void) JL_NOTSAFEPOINT
         // and restore from the SEGV handler if anything happens.
         jl_jmp_buf *old_buf = jl_get_safe_restore();
         jl_jmp_buf buf;
+        size_t bt_size_start = profile_bt_size_cur;
 
         jl_set_safe_restore(&buf);
         if (jl_setjmp(buf, 0)) {
@@ -1192,6 +1193,11 @@ static void do_profile(void) JL_NOTSAFEPOINT
                     profile_bt_size_max - profile_bt_size_cur - 1, &signal_context, NULL);
         }
         jl_set_safe_restore(old_buf);
+        if (profile_bt_size_cur == bt_size_start) {
+            // unwinding produced no frames: record a marker so the sample is not silently dropped
+            profile_bt_size_cur += failed_to_unwind_fun((jl_bt_element_t*)profile_bt_data_prof + profile_bt_size_cur,
+                    profile_bt_size_max - profile_bt_size_cur - 1, 0);
+        }
 
         jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
 

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -829,8 +829,14 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                 int state = jl_atomic_load_relaxed(&ptls->sleep_check_state) == 0 ? PROFILE_STATE_THREAD_NOT_SLEEPING : PROFILE_STATE_THREAD_SLEEPING;
 
                 // Get backtrace data
+                size_t bt_size_start = profile_bt_size_cur;
                 profile_bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)profile_bt_data_prof + profile_bt_size_cur,
                         profile_bt_size_max - profile_bt_size_cur - 1, &c, NULL);
+                if (profile_bt_size_cur == bt_size_start) {
+                    // unwinding produced no frames: record a marker so the sample is not silently dropped
+                    profile_bt_size_cur += failed_to_unwind_fun((jl_bt_element_t*)profile_bt_data_prof + profile_bt_size_cur,
+                            profile_bt_size_max - profile_bt_size_cur - 1, 0);
+                }
 
 #ifdef _CPU_X86_64_
                 // Clear abort pointer from TLS

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -250,6 +250,15 @@ JL_DLLEXPORT NOINLINE int failed_to_stop_thread_fun(jl_bt_element_t *bt_data, si
     return 1;
 }
 
+JL_DLLEXPORT NOINLINE int failed_to_unwind_fun(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT
+{
+    if (maxsize < 1) {
+        return 0;
+    }
+    bt_data[0].uintptr = (uintptr_t) &failed_to_unwind_fun;
+    return 1;
+}
+
 static jl_value_t *array_ptr_void_type JL_ALWAYS_LEAFTYPE = NULL;
 // Return backtrace information as an svec of (bt1, bt2, [sp])
 //


### PR DESCRIPTION
The thread profiler wrote a sample as just its metadata block when unwinding produced no frames, which happens intermittently on i686 and aarch64. Such samples vanish from reports, and stripping the metadata leaves only the block terminator, which the Profile tests tripped over: https://buildkite.com/julialang/julia-ci/builds/440#01a06020-e7d9-442a-912f-c43e7ffe3baa

Substitute a `failed_to_unwind_fun` marker frame instead, as the task profiler already does with `failed_to_stop_thread_fun`, so the sample is reported rather than silently dropped.

Assisted-by: Claude Code (Fable 5.1)