### PR TITLE
isapprox: restore the `x == y` guard in the `Integer` method

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -235,7 +235,7 @@ function isapprox(x::Integer, y::Integer;
         return x == y
     else
         # We need to take the difference `max` - `min` when comparing unsigned integers.
-        _x, _y = x < y ? (x, y) : (y, x)
+        _x, _y = minmax(x, y)
         # note: check x == y to avoid NaN comparisons for e.g. rtol=Inf and x==y==0
         return x == y || norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
     end

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -236,8 +236,7 @@ function isapprox(x::Integer, y::Integer;
     else
         # We need to take the difference `max` - `min` when comparing unsigned integers.
         _x, _y = x < y ? (x, y) : (y, x)
-        # Equal arguments cannot overflow, so keep the `Number` method's guard: without it a
-        # `NaN` tolerance (e.g. `rtol*0 == Inf*0`) would reject them.
+        # note: check x == y to avoid NaN comparisons for e.g. rtol=Inf and x==y==0
         return x == y || norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
     end
 end

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -236,7 +236,9 @@ function isapprox(x::Integer, y::Integer;
     else
         # We need to take the difference `max` - `min` when comparing unsigned integers.
         _x, _y = x < y ? (x, y) : (y, x)
-        return norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
+        # Equal arguments cannot overflow, so keep the `Number` method's guard: without it a
+        # `NaN` tolerance (e.g. `rtol*0 == Inf*0`) would reject them.
+        return x == y || norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
     end
 end
 

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -235,9 +235,8 @@ function isapprox(x::Integer, y::Integer;
         return x == y
     else
         # We need to take the difference `max` - `min` when comparing unsigned integers.
-        _x, _y = minmax(x, y)
         # note: check x == y to avoid NaN comparisons for e.g. rtol=Inf and x==y==0
-        return x == y || norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
+        return x == y || norm(x < y ? y - x : x - y) <= max(atol, rtol*max(norm(x), norm(y)))
     end
 end
 

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -286,6 +286,22 @@ end
     end
 end
 
+@testset "isapprox(x, x) for integers agrees with the `Number` method" begin
+    tolerances = (0, 1, 0.5, 1e-8, Inf, NaN, -1)
+    for T in (Base.BitInteger_types..., BigInt)
+        for x in (T(0), T(5), T === BigInt ? BigInt(1) << 200 : typemax(T))
+            for atol in tolerances, rtol in tolerances
+                # equal arguments cannot overflow, so the `Integer` method has no reason to
+                # deviate from the `Number` method it specializes
+                @test isapprox(x, x; atol, rtol) ==
+                      invoke(isapprox, Tuple{Number,Number}, x, x; atol, rtol) == true
+            end
+        end
+    end
+    @test isapprox(0, 0; rtol=Inf)
+    @test isapprox(5, 5; atol=NaN)
+end
+
 @testset "Conversion from floating point to unsigned integer near extremes (#51063)" begin
     @test_throws InexactError UInt32(4.2949673f9)
     @test_throws InexactError UInt64(1.8446744f19)


### PR DESCRIPTION
This is a can of worms. I tried to limit the following PR to the (hopefully) non-controversial part.

:robot:
The `Integer` method of `isapprox` exists for one reason: `x - y` overflows for integers,
which is what #50730 fixed. Equal arguments have no difference to compute and therefore
cannot overflow, so on them the method has no reason to deviate from the `Number` method it
specializes. It deviates anyway, because the rewrite dropped that method's `x == y ||` guard:

```julia
julia> isapprox(0, 0; rtol=Inf)
false

julia> isapprox(0, 0.0; rtol=Inf)
true
```

For two zeros with `rtol=Inf` the bound is `Inf*0`, which is `NaN`, so the comparison is
false. The same happens for `rtol=NaN`, for `atol=NaN` with any arguments at all
(`isapprox(5, 5; atol=NaN)` is `false`), and for negative tolerances.

This is a regression:

| version | `isapprox(0,0;rtol=Inf)` | `isapprox(5,5;atol=NaN)` | `isapprox(0.0,0.0;rtol=Inf)` |
| --- | --- | --- | --- |
| 1.6.7, 1.7.3, 1.8.5 | true | true | true |
| 1.10.12, 1.11.9, 1.12.7, 1.13.0-rc3, master | false | false | true |

## Scope

The change is deliberately confined to restoring the dropped clause. Its entire effect is on
equal arguments; no result changes for unequal ones. The test asserts that directly, comparing
against the `Number` method via `invoke` over every combination of 11 integer types, three
magnitudes including `typemax`, and seven values in both `atol` and `rtol`.

This does not settle what `isapprox` should mean for an indeterminate tolerance. The
docstring's prose ("relative distance *or* absolute distance is within tolerance bounds") and
its formula (`norm(x-y) <= max(atol, rtol*max(norm(x), norm(y)))`) disagree precisely there,
since `d <= max(t1, t2)` and `d <= t1 || d <= t2` are equivalent over the reals but not when
`max` propagates a `NaN`. Neither method implements the prose. That question should be
discussed separately.

## Performance

The fast path (`norm === abs && atol < 1 && rtol == 0`, taken by every default call) is
untouched: the LLVM IR of a loop over `isapprox(v[i], w[i])` is byte-identical before and after.

The `else` branch is reached only with explicit non-default keywords. There the added short
circuit trades vectorisation for an early exit — 100k `Int` pairs with `atol=0.0, rtol=1e-8`,
interleaved best-of-500, ns per element:

| data | before | after |
| --- | --- | --- |
| all pairs equal | 5.00 | 0.77 (0.15x) |
| no pairs equal | 3.60 | 5.17 (1.44x) |
| half equal | 3.75 | 2.96 (0.79x) |

A branch-free `(x == y) | (...)` keeps vectorization and is neutral across all three, but
always evaluates the user's `norm` and the subtraction, which costs an allocation for `BigInt`.
The short-circuiting form matches what the `Number` method does, which is the point of the
change.

Assisted-by: Claude Code (Opus 5)