### PR TITLE
add loongarch support

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1126,6 +1126,9 @@ MCPU=native
 else ifneq (,$(findstring riscv64,$(ARCH)))
 # RISC-V doesn't have a native option
 $(error Building for RISC-V requires a specific MARCH to be set))
+else ifneq (,$(findstring loongarch64,$(ARCH)))
+MARCH=loongarch64
+MTUNE=loongarch64
 else
 MARCH=native
 MTUNE=native
@@ -1192,6 +1195,9 @@ endif
 ifneq (,$(findstring arm,$(ARCH)))
 DIST_ARCH:=arm
 endif
+ifneq (,$(findstring loongarch64,$(ARCH)))
+DIST_ARCH:=loongarch64
+endif
 ifneq (,$(findstring riscv64,$(ARCH)))
 DIST_ARCH:=riscv64
 endif
@@ -1219,6 +1225,10 @@ OPENBLAS_DYNAMIC_ARCH:=1
 BINARY:=64
 endif
 
+ifneq (,$(findstring loongarch64,$(ARCH)))
+OPENBLAS_DYNAMIC_ARCH:=1
+endif
+
 # Set MARCH-specific flags
 ifneq ($(MARCH),)
 CC += -march=$(MARCH)
@@ -1227,7 +1237,9 @@ FC += -march=$(MARCH)
 # On RISC-V, don't forward the MARCH ISA string to JULIA_CPU_TARGET,
 # as it's always incompatible with LLVM's CPU target name parser.
 ifeq (,$(findstring riscv64,$(ARCH)))
+ifeq (,$(findstring loongarch64,$(ARCH)))
 JULIA_CPU_TARGET ?= $(MARCH)
+endif
 endif
 endif
 

--- a/base/Makefile
+++ b/base/Makefile
@@ -33,6 +33,7 @@ $(BUILDDIR)/features_h.jl: $(wildcard $(CPUFEATURES_GENDIR)/target_tables_*.h)
 	@$(call parse_cpufeatures,$(CPUFEATURES_GENDIR)/target_tables_x86_64.h,X86)
 	@$(call parse_cpufeatures,$(CPUFEATURES_GENDIR)/target_tables_aarch64.h,AArch64)
 	@$(call parse_cpufeatures,$(CPUFEATURES_GENDIR)/target_tables_riscv64.h,RISCV)
+	@$(call parse_cpufeatures,$(CPUFEATURES_GENDIR)/target_tables_loongarch64.h,LOONGARCH)
 
 $(BUILDDIR)/pcre_h.jl: $(PCRE_INCL_PATH)
 	@$(call PRINT_PERL, $(CPP) -D PCRE2_CODE_UNIT_WIDTH=8 -dM $< | perl -nle '/^\s*#define\s+PCRE2_(\w*)\s*\(?($(PCRE_CONST))\)?u?\s*$$/ and print index($$1, "ERROR_") == 0 ? "const $$1 = Cint($$2)" : "const $$1 = UInt32($$2)"' | LC_ALL=C sort > $@)

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -220,7 +220,7 @@ end
 function validate_tags(tags::Dict)
     throw_invalid_key(k) = throw(ArgumentError("Key \"$(k)\" cannot have value \"$(tags[k])\""))
     # Validate `arch`
-    if tags["arch"] ∉ ("x86_64", "i686", "armv7l", "armv6l", "aarch64", "powerpc64le", "riscv64")
+    if tags["arch"] ∉ ("x86_64", "i686", "armv7l", "armv6l", "aarch64", "powerpc64le", "riscv64", "loongarch64")
         throw_invalid_key("arch")
     end
     # Validate `os`
@@ -659,6 +659,7 @@ const arch_mapping = Dict(
     "armv6l" => "armv6l",
     "powerpc64le" => "p(ower)?pc64le",
     "riscv64" => "(rv64|riscv64)",
+    "loongarch64" => "loongarch64",
 )
 # Keep this in sync with `CPUID.ISAs_by_family`
 # These are the CPUID side of the microarchitectures targeted by GCC flags in BinaryBuilder.jl
@@ -684,6 +685,9 @@ const arch_march_isa_mapping = let
             "armv8_2_crypto" => get_set("aarch64", "armv8.2-a+crypto"),
             "a64fx" => get_set("aarch64", "a64fx"),
             "apple_m1" => get_set("aarch64", "apple_m1"),
+        ],
+        "loongarch64" => [
+            "loongarch64" => get_set("loongarch64", "loongarch64"),
         ],
         "riscv64" => [
             "riscv64" => get_set("riscv64", "riscv64"),

--- a/base/cpuid.jl
+++ b/base/cpuid.jl
@@ -170,6 +170,9 @@ const ISAs_by_family = Dict(
         "a64fx" => "a64fx",
         "apple_m1" => "apple-a14",
     ]),
+    "loongarch64" => _make_isa_list("loongarch64", [
+        "loongarch64" => "",
+    ]),
     "riscv64" => _make_isa_list("riscv64", [
         "riscv64" => "",
     ]),

--- a/cli/dl-cache.h
+++ b/cli/dl-cache.h
@@ -41,6 +41,8 @@
 #define FLAG_MIPS64_LIBN64_NAN2008      0x0e00
 #define FLAG_RISCV_FLOAT_ABI_SOFT       0x0f00
 #define FLAG_RISCV_FLOAT_ABI_DOUBLE     0x1000
+#define FLAG_LOONGARCH_FLOAT_ABI_SOFT   0x1100
+#define FLAG_LOONGARCH_FLOAT_ABI_DOUBLE 0x1200
 
 #if defined(_CPU_X86_64_)
 
@@ -65,6 +67,16 @@
 # define _DL_CACHE_DEFAULT_ID    (FLAG_RISCV_FLOAT_ABI_DOUBLE | FLAG_ELF_LIBC6)
 #else
 # define _DL_CACHE_DEFAULT_ID    (FLAG_RISCV_FLOAT_ABI_SOFT | FLAG_ELF_LIBC6)
+#endif
+
+#define _dl_cache_check_flags(flags)    ((flags) == _DL_CACHE_DEFAULT_ID)
+
+#elif defined(_CPU_LOONG_)
+
+#if defined(__loongarch_soft_float)
+# define _DL_CACHE_DEFAULT_ID    (FLAG_LOONGARCH_FLOAT_ABI_SOFT | FLAG_ELF_LIBC6)
+#else
+# define _DL_CACHE_DEFAULT_ID    (FLAG_LOONGARCH_FLOAT_ABI_DOUBLE | FLAG_ELF_LIBC6)
 #endif
 
 #define _dl_cache_check_flags(flags)    ((flags) == _DL_CACHE_DEFAULT_ID)

--- a/cli/trampolines/trampolines_loongarch64.S
+++ b/cli/trampolines/trampolines_loongarch64.S
@@ -1,0 +1,29 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include "common.h"
+#include "../../src/jl_exported_funcs.inc"
+
+// LoongArch does not require the SEP macro; it natively supports backslash line continuation.
+// Critical Fix: The relocation symbol for ld.d must be identical to the one used for pcaddu12i.
+// Both must use CNAMEADDR(name) (the _addr symbol), NOT the original function name.
+
+#define XX(name) \
+    .global CNAME(name); \
+    .type CNAME(name), @function; \
+    .cfi_startproc; \
+    .p2align 4; \
+CNAME(name): \
+    /* 1. Load the high 20 bits of the _addr symbol (PC-relative) */ \
+    pcalau12i $t0, %pc_hi20(CNAMEADDR(name)); \
+    /* 2. Load the low 12 bits of the _addr symbol and dereference to get the function pointer */ \
+    /* IMPORTANT: Must use CNAMEADDR(name) here to match the high bits calculation above. */ \
+    /* Using CNAME(name) directly would cause incorrect address calculation on LoongArch. */ \
+    ld.d      $t1, $t0, %pc_lo12(CNAMEADDR(name)); \
+    /* 3. Indirect jump to the target function */ \
+    jr        $t1; \
+    .cfi_endproc; \
+    .size CNAME(name), . - CNAME(name);
+
+JL_RUNTIME_EXPORTED_FUNCS(XX)
+JL_CODEGEN_EXPORTED_FUNCS(XX)
+#undef XX

--- a/contrib/normalize_triplet.py
+++ b/contrib/normalize_triplet.py
@@ -14,6 +14,7 @@ arch_mapping = {
     'i686': "i\\d86",
     'aarch64': "(arm|aarch)64",
     'armv7l': "arm(v7l)?",
+    'loongarch64': "(loongarch|loongarch64)",
     'riscv64': "(rv64|riscv64)",
     'powerpc64le': "p(ower)?pc64le",
 }

--- a/doc/src/devdocs/build/build.md
+++ b/doc/src/devdocs/build/build.md
@@ -156,6 +156,7 @@ Notes for various architectures:
 
 * [ARM](https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/build/arm.md)
 * [RISC-V](https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/build/riscv.md)
+* [LOONGARCH](https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/build/loongarch.md)
 
 ## Required Build Tools and External Libraries
 

--- a/doc/src/devdocs/build/loongarch.md
+++ b/doc/src/devdocs/build/loongarch.md
@@ -1,0 +1,26 @@
+# LOONGARCH (Linux)
+
+Julia has experimental support for 64-bit RISC-V (RV64) processors running
+Linux. This file provides general guidelines for compilation, in addition to
+instructions for specific devices.
+
+A list of [known issues](https://github.com/JuliaLang/julia/labels/system:loongarch)
+for LOONGARCH is available. If you encounter difficulties, please create an issue
+including the output from `cat /proc/cpuinfo`.
+
+
+## Compiling Julia
+
+To compile Julia for LOONGARCH, you need to manually indicate what architecture, and
+optionally which CPU to build for. This can be done by setting the `MARCH` and `MCPU`
+variables in `Make.user`
+
+The `MARCH` variable needs to be set to a LOONGARCH ISA string, which can be found by
+looking at the documentation of your device, or by inspecting `/proc/cpuinfo`. Only
+use flags that your compiler supports, e.g., run `gcc -march=help` to see a list of
+supported flags. A common value is `loongarch64`, which is a good starting point.
+
+Build Julia directly with the following command:
+```
+make USE_BINARYBUILDER=0 -j$(nproc)
+```

--- a/src/Makefile
+++ b/src/Makefile
@@ -696,6 +696,7 @@ INCLUDED_CXX_FILES := \
 	codegen.cpp:abi_llvm.cpp \
 	codegen.cpp:abi_arm.cpp \
 	codegen.cpp:abi_aarch64.cpp \
+        codegen.cpp:abi_loongarch64.cpp \
 	codegen.cpp:abi_riscv.cpp \
 	codegen.cpp:abi_ppc64le.cpp \
 	codegen.cpp:abi_win32.cpp \

--- a/src/abi_loongarch64.cpp
+++ b/src/abi_loongarch64.cpp
@@ -1,0 +1,330 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+//===----------------------------------------------------------------------===//
+//
+// The ABI implementation used for LoongArch 64-bit targets.
+//
+//===----------------------------------------------------------------------===//
+//
+// The Procedure Call Standard can be found here:
+// https://loongson.github.io/LoongArch-Documentation/LoongArch-ABI-EN.html
+//
+// This implementation is adapted from Julia's RISC-V ABI code (src/abi_riscv.cpp)
+// because the calling conventions are very similar.
+//
+//===----------------------------------------------------------------------===//
+
+struct ABI_LoongArchLayout : AbiLayout {
+
+    // --- Basic LoongArch64 ABI parameters ---
+    static const size_t XLen = 8;      // General-purpose register width (64-bit)
+    static const size_t FLen = 8;      // Floating-point register width (64-bit)
+    static const int NumArgGPRs = 8;   // Number of argument GPRs: a0-a7
+    static const int NumArgFPRs = 8;   // Number of argument FPRs: fa0-fa7
+
+    // Remaining available registers.
+    // These counters are decremented as arguments are processed,
+    // simulating the actual register allocation during a call.
+    int avail_gprs, avail_fprs;
+
+    // Cache for the preferred LLVM type, computed in use_sret or needPassByRef
+    // and reused by preferred_llvm_type to avoid recomputation.
+    Type *cached_llvmtype = NULL;
+
+    // Constructor: initially all argument registers are available
+    ABI_LoongArchLayout() : avail_gprs(NumArgGPRs), avail_fprs(NumArgFPRs) {}
+
+    // --- Helper classification enums and structs ---
+
+    enum RegPassKind { UNKNOWN = 0, INTEGER = 1, FLOAT = 2 };
+
+    struct ElementType {
+        RegPassKind type;
+        jl_datatype_t *dt;
+        ElementType() : type(RegPassKind::UNKNOWN), dt(NULL) {};
+    };
+
+    // Check if the Julia datatype is a hardware floating-point type
+    bool is_floattype(jl_datatype_t *dt) const
+    {
+        return dt == jl_float16_type || dt == jl_float32_type || dt == jl_float64_type;
+    }
+
+    // Map a Julia floating-point type to the corresponding LLVM FP type
+    Type *get_llvm_fptype(jl_datatype_t *dt, LLVMContext &ctx) const
+    {
+        assert(is_floattype(dt));
+        switch (jl_datatype_size(dt)) {
+        case 2: return Type::getHalfTy(ctx);
+        case 4: return Type::getFloatTy(ctx);
+        case 8: return Type::getDoubleTy(ctx);
+        default: assert(0 && "abi_loongarch: unsupported floating point type"); return NULL;
+        }
+    }
+
+    // Map Julia primitive types (integers, pointers, bitstypes) to LLVM integer types
+    Type *get_llvm_inttype(jl_datatype_t *dt, LLVMContext &ctx) const
+    {
+        assert(jl_is_primitivetype(dt));
+        // LoongArch ABI does not define hardware half-float; pass as integer
+        if (dt == jl_float16_type)
+            return Type::getInt32Ty(ctx);
+        assert(!is_floattype(dt));
+        if (dt == jl_bool_type)
+            return Type::getInt8Ty(ctx);
+        if (dt == jl_int32_type)
+            return Type::getInt32Ty(ctx);
+        if (dt == jl_int64_type)
+            return Type::getInt64Ty(ctx);
+        int nb = jl_datatype_size(dt);
+        return Type::getIntNTy(ctx, nb * 8);
+    }
+
+    // Determine if a struct can be split into fundamental types (Float/Int)
+    // for register passing. This follows the LoongArch ABI rules for small
+    // aggregates containing floating-point values.
+    bool should_use_fp_conv(jl_datatype_t *dt, ElementType &ele1, ElementType &ele2) const
+    {
+        if (jl_is_primitivetype(dt)) {
+            size_t dsz = jl_datatype_size(dt);
+            if (dsz > FLen) {
+                return false;
+            }
+            if (is_floattype(dt)) {
+                if (ele1.type == RegPassKind::UNKNOWN) {
+                    ele1.type = RegPassKind::FLOAT;
+                    ele1.dt = dt;
+                }
+                else if (ele2.type == RegPassKind::UNKNOWN) {
+                    ele2.type = RegPassKind::FLOAT;
+                    ele2.dt = dt;
+                }
+                else {
+                    // More than two elements: cannot split
+                    return false;
+                }
+            }
+            else {
+                // Integer/pointer/bitstype
+                if (ele1.type == RegPassKind::UNKNOWN) {
+                    ele1.type = RegPassKind::INTEGER;
+                    ele1.dt = dt;
+                }
+                else if (ele1.type == RegPassKind::INTEGER) {
+                    // Two integers: not a FP conversion case
+                    return false;
+                }
+                else if (ele1.type == RegPassKind::FLOAT) {
+                    // Mixed pair: first element is float, second is int
+                    if (ele2.type == RegPassKind::UNKNOWN) {
+                        ele2.type = RegPassKind::INTEGER;
+                        ele2.dt = dt;
+                    }
+                    else {
+                        return false;
+                    }
+                }
+            }
+        }
+        else {
+            // Aggregates (structs/tuples)
+            while (size_t nfields = jl_datatype_nfields(dt)) {
+                size_t i;
+                size_t fieldsz;
+                // Skip zero-sized fields
+                for (i = 0; i < nfields; i++) {
+                    if ((fieldsz = jl_field_size(dt, i))) {
+                        break;
+                    }
+                }
+                assert(i < nfields);
+                // If there is only one non-zero sized member, try again on that member
+                if (fieldsz == jl_datatype_size(dt)) {
+                    dt = (jl_datatype_t *)jl_field_type(dt, i);
+                    if (!jl_is_datatype(dt)) // could be inline union
+                        return false;
+                    continue;
+                }
+                // Process all non-zero fields
+                for (; i < nfields; i++) {
+                    size_t fieldsz = jl_field_size(dt, i);
+                    if (fieldsz == 0)
+                        continue;
+                    jl_datatype_t *fieldtype = (jl_datatype_t *)jl_field_type(dt, i);
+                    if (!jl_is_datatype(fieldtype))
+                        return false;
+                    // We already have two elements; cannot add more
+                    if (ele2.type != RegPassKind::UNKNOWN) {
+                        return false;
+                    }
+                    if (!should_use_fp_conv(fieldtype, ele1, ele2)) {
+                        return false;
+                    }
+                }
+                break;
+            }
+        }
+        return true;
+    }
+
+    // Return the LLVM integer type corresponding to the given XLen (always i64 here)
+    Type *get_llvm_inttype_byxlen(size_t xlen, LLVMContext &ctx) const
+    {
+        if (xlen == 8) {
+            return Type::getInt64Ty(ctx);
+        }
+        else {
+            assert(0 && "abi_loongarch: only XLen=8 is supported");
+            return NULL;
+        }
+    }
+
+    // Classify an argument type and return the LLVM type to be used for it.
+    // This function also updates the available register counts and sets `onstack`
+    // if the argument must be passed on the stack.
+    Type *classify_arg(jl_datatype_t *ty, int &avail_gprs, int &avail_fprs, bool &onstack,
+                       LLVMContext &ctx) const
+    {
+        onstack = false;
+        if (ty == jl_nothing_type) {
+            return NULL;
+        }
+
+        ElementType ele1, ele2;
+        // Handle small aggregates that can be split into FP or FP+int registers
+        if (should_use_fp_conv(ty, ele1, ele2)) {
+            if (ele1.type == RegPassKind::FLOAT) {
+                if (ele2.type == RegPassKind::FLOAT) {
+                    // Two floats: pass in two FP registers
+                    if (avail_fprs >= 2) {
+                        avail_fprs -= 2;
+                        SmallVector<Type *, 2> eles;
+                        eles.push_back(get_llvm_fptype(ele1.dt, ctx));
+                        eles.push_back(get_llvm_fptype(ele2.dt, ctx));
+                        return StructType::get(ctx, eles);
+                    }
+                }
+                else if (ele2.type == RegPassKind::INTEGER) {
+                    // Float + integer: pass in one FP and one GPR
+                    if (avail_fprs >= 1 && avail_gprs >= 1) {
+                        avail_fprs -= 1;
+                        avail_gprs -= 1;
+                        SmallVector<Type *, 2> eles;
+                        eles.push_back(get_llvm_fptype(ele1.dt, ctx));
+                        eles.push_back(get_llvm_inttype(ele2.dt, ctx));
+                        return StructType::get(ctx, eles);
+                    }
+                }
+                else {
+                    // Single float: pass as standalone float
+                    if (avail_fprs >= 1) {
+                        avail_fprs -= 1;
+                        return get_llvm_fptype(ele1.dt, ctx);
+                    }
+                }
+            }
+            else if (ele1.type == RegPassKind::INTEGER && ele2.type == RegPassKind::FLOAT) {
+                // Integer + float: pass in one GPR and one FP register
+                if (avail_gprs >= 1 && avail_fprs >= 1) {
+                    avail_gprs -= 1;
+                    avail_fprs -= 1;
+                    return StructType::get(get_llvm_inttype(ele1.dt, ctx),
+                                           get_llvm_fptype(ele2.dt, ctx));
+                }
+            }
+        }
+
+        size_t dsz = jl_datatype_size(ty);
+
+        // Large types (> 16 bytes): pass on stack (unless primitive scalar, e.g. Int128)
+        if (dsz > 2 * XLen) {
+            if (!jl_is_primitivetype(ty)) {
+                onstack = true;
+            }
+            // Consume one GPR for the address if needed
+            if (avail_gprs >= 1) {
+                avail_gprs -= 1;
+            }
+            return NULL;
+        }
+
+        // Medium types (9–16 bytes)
+        if (dsz > XLen) {
+            size_t alignment = jl_datatype_align(ty);
+            bool align_regs = alignment > XLen;
+            // Need two GPRs (or none, if not enough registers -> stack)
+            if (avail_gprs >= 2) {
+                avail_gprs -= 2;
+            }
+            else {
+                avail_gprs = 0;
+            }
+
+            if (!jl_is_primitivetype(ty)) {
+                // Aggregates: if 16-byte aligned, use i128; otherwise an array of two i64s.
+                // This ensures the LLVM backend generates the correct register pair layout.
+                if (align_regs) {
+                    if (alignment == 16) {
+                        return Type::getInt128Ty(ctx);
+                    }
+                    else {
+                        return Type::getInt64Ty(ctx);
+                    }
+                }
+                else {
+                    return ArrayType::get(get_llvm_inttype_byxlen(XLen, ctx), 2);
+                }
+            }
+            // Primitive type (like Int128): let LLVM backend handle it
+            return NULL;
+        }
+
+        // Small types (<= 8 bytes)
+        if (avail_gprs >= 1) {
+            avail_gprs -= 1;
+        }
+        if (!jl_is_primitivetype(ty)) {
+            // Small aggregates: pass as single i64
+            return get_llvm_inttype_byxlen(XLen, ctx);
+        }
+        return get_llvm_inttype(ty, ctx);
+    }
+
+    // Determine if a return value must be passed via hidden pointer (sret).
+    // Uses a separate register set (2 GPRs / 2 FPRs) for return values.
+    bool use_sret(jl_datatype_t *ty, LLVMContext &ctx) override
+    {
+        bool onstack = false;
+        int gprs = 2;                 // Return values can use at most 2 GPRs
+        int fprs = FLen ? 2 : 0;      // and 2 FPRs
+        this->cached_llvmtype = classify_arg(ty, gprs, fprs, onstack, ctx);
+        if (onstack) {
+            this->avail_gprs -= 1;    // sret pointer consumes a GPR
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    // Determine if an argument must be passed by reference (on stack).
+    bool needPassByRef(jl_datatype_t *ty, AttrBuilder &ab, LLVMContext &ctx,
+                       Type *Ty) override
+    {
+        bool onstack = false;
+        // Use the instance's current available register counts
+        this->cached_llvmtype =
+            classify_arg(ty, this->avail_gprs, this->avail_fprs, onstack, ctx);
+        return onstack;
+    }
+
+    // Return the preferred LLVM type for a Julia datatype.
+    // The result was already computed and cached by the previous call to
+    // use_sret or needPassByRef.
+    Type *preferred_llvm_type(jl_datatype_t *ty, bool isret,
+                              LLVMContext &ctx) const override
+    {
+        return this->cached_llvmtype;
+    }
+
+};

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -740,6 +740,11 @@ const char *plt_asm_aarch64 =
 const char *plt_asm_x86_64 =
     "jmpq  *${0:a}\n";
 
+const char *plt_asm_loongarch64 =
+    "pcalau12i $$t0, %pc_hi20(${0})\n"
+    "ld.d      $$t0, $$t0, %pc_lo12(${0})\n"
+    "jr        $$t0";
+
 const char *plt_asm_riscv64 =
     "1b: auipc t3, %pcrel_hi(${0})\n"
     "    ld    t3, %pcrel_lo(1b)(t3)\n"
@@ -774,6 +779,9 @@ static Function *emit_pkg_plt_thunk(jl_codegen_output_t &out, jl_code_instance_t
     }
     else if (out.TargetTriple.getArch() == Triple::x86_64) {
         Code = plt_asm_x86_64;
+    }
+    else if (out.TargetTriple.isLoongArch()) {
+        Code = plt_asm_loongarch64;
     }
     else if (out.TargetTriple.getArch() == Triple::riscv64) {
         Code = plt_asm_riscv64;
@@ -2245,7 +2253,7 @@ static void jl_dump_native_locked(jl_native_code_desc_t *data, const char *bc_fn
     }
 
     CodeModel::Model CMModel = CodeModel::Small;
-    if (TheTriple.isPPC() || TheTriple.isRISCV() ||
+    if (TheTriple.isPPC() || TheTriple.isRISCV() || TheTriple.isLoongArch() ||
         (TheTriple.isX86() && TheTriple.isArch64Bit() && TheTriple.isOSLinux())) {
         // On PPC the small model is limited to 16bit offsets. For very large images the small code model
         CMModel = CodeModel::Medium; //  isn't good enough on x86 so use Medium, it has no cost because only the image goes in .ldata

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -405,6 +405,7 @@ static bool is_native_simd_type(jl_datatype_t *dt) JL_CANSAFEPOINT {
 
 #include "abi_arm.cpp"
 #include "abi_aarch64.cpp"
+#include "abi_loongarch64.cpp"
 #include "abi_riscv.cpp"
 #include "abi_ppc64le.cpp"
 #include "abi_win32.cpp"
@@ -430,6 +431,8 @@ static bool is_native_simd_type(jl_datatype_t *dt) JL_CANSAFEPOINT {
   typedef ABI_ARMLayout DefaultAbiState;
 #elif defined _CPU_AARCH64_
   typedef ABI_AArch64Layout DefaultAbiState;
+#elif defined _CPU_LOONG_
+  typedef ABI_LoongArchLayout DefaultAbiState;
 #elif defined _CPU_RISCV64_
   typedef ABI_RiscvLayout DefaultAbiState;
 #elif defined _CPU_PPC64_

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9275,7 +9275,7 @@ static jl_llvm_functions_t
 
     // Add strong stack protection for debug builds only when using the large code model,
     // otherwise LLVM might try to relocate the stack canary out of range (see e.g. #59303)
-#if defined(JL_DEBUG_BUILD) && !(defined(_CPU_AARCH64_) || defined(_CPU_RISCV_))
+#if defined(JL_DEBUG_BUILD) && !(defined(_CPU_AARCH64_) || defined(_CPU_RISCV_) || defined(_CPU_LOONG_))
     FnAttrs.addAttribute(Attribute::StackProtectStrong);
 #endif
 
@@ -11243,6 +11243,16 @@ extern "C" JL_DLLEXPORT_CODEGEN void jl_teardown_codegen_impl() JL_NOTSAFEPOINT
     }
     PrintStatistics();
 }
+
+#if defined(_CPU_LOONG_)
+extern "C" {
+    __attribute__((visibility("default")))
+    void (*jl_init_codegen_addr)(void) = jl_init_codegen_impl;
+
+    __attribute__((visibility("default")))
+    void (*jl_teardown_codegen_addr)(void) = jl_teardown_codegen_impl;
+}
+#endif
 
 // the rest of this file are convenience functions
 // that are exported for assisting with debugging from gdb

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -1080,7 +1080,7 @@ static void jl_dump_asm_internal(
                 if (insSize == 0) // skip illegible bytes
 #if defined(_CPU_PPC_) || defined(_CPU_PPC64_) || defined(_CPU_ARM_) || defined(_CPU_AARCH64_)
                     insSize = 4; // instructions are always 4 bytes
-#elif defined(_CPU_RISCV64_)
+#elif defined(_CPU_RISCV64_) || defined(_CPU_LOONG_)
                     insSize = 2; // instructions can be 2 bytes when compressed
 #else
                     insSize = 1; // attempt to slide 1 byte forward

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1307,6 +1307,19 @@ namespace {
         options.MCOptions.ABIName = "lp64";
 #endif
 #endif
+
+#if defined(_CPU_LOONG_)
+    // LoongArch: detect float ABI via compiler-defined macros
+#if defined(__loongarch_soft_float)
+    options.MCOptions.ABIName = "lp64s";
+#elif defined(__loongarch_single_float)
+    options.MCOptions.ABIName = "lp64f";
+#elif defined(__loongarch_double_float) || defined(__loongarch_hard_float)
+    options.MCOptions.ABIName = "lp64d";
+#else
+    options.MCOptions.ABIName = "lp64d";
+#endif
+#endif
         auto [TheCPU, FeaturesStr] = jl_get_llvm_target(jl_options.cpu_target, jl_generating_output());
         std::string errorstr;
         const Target *TheTarget = TargetRegistry::lookupTarget("", TheTriple, errorstr);
@@ -1325,6 +1338,11 @@ namespace {
 #endif
         if (TheTriple.isAArch64())
             codemodel = CodeModel::Small;
+        if (TheTriple.isLoongArch()) {
+	    // For the LoongArch architecture, the default LLVM code model is Medium
+            // https://github.com/llvm/llvm-project/pull/132173
+            codemodel = CodeModel::Medium;
+        }
 #if JL_LLVM_VERSION < 200000
         else if (TheTriple.isRISCV()) {
             // RISC-V only supports large code model from LLVM 20

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -439,7 +439,7 @@ public:
     jl_codegen_output_t(Module &M) JL_NOTSAFEPOINT
       : M(M), DL(M.getDataLayout()), TargetTriple(M.getTargetTriple())
     {
-        if (TargetTriple.isRISCV())
+        if (TargetTriple.isRISCV() || TargetTriple.isLoongArch())
             use_swiftcc = false;
     }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -110,7 +110,7 @@ static inline void msan_unpoison_string(const volatile char *a) JL_NOTSAFEPOINT 
 #ifndef _OS_WINDOWS_
     #if defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_WASM_)
         #define MAX_ALIGN 8
-    #elif defined(_CPU_AARCH64_) || defined(_CPU_RISCV64_) || (JL_LLVM_VERSION >= 180000 && (defined(_CPU_X86_64_) || defined(_CPU_X86_)) || (JL_LLVM_VERSION >= 200000 && defined(_CPU_PPC64_)))
+    #elif defined(_CPU_AARCH64_) || defined(_CPU_LOONG_) || defined(_CPU_RISCV64_) || (JL_LLVM_VERSION >= 180000 && (defined(_CPU_X86_64_) || defined(_CPU_X86_)) || (JL_LLVM_VERSION >= 200000 && defined(_CPU_PPC64_)))
     // int128 is 16 bytes aligned on aarch64 and riscv, and on x86 with LLVM >= 18 and on ppc64 with LLVM >= 20
         #define MAX_ALIGN 16
     #elif defined(_P64)
@@ -342,6 +342,14 @@ static inline uint64_t cycleclock(void) JL_NOTSAFEPOINT
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return (int64_t)(tv.tv_sec) * 1000000 + tv.tv_usec;
+#elif defined(_CPU_LOONG_)
+    // TEMPORARY: Fallback to clock_gettime because the assembler 
+    // does not support 'rdtime' instruction yet.
+    // TODO: Upgrade binutils to >= 2.39 or use machine code encoding in a separate .S file.
+    #include <time.h>
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
 #elif defined(_CPU_RISCV64_)
     // taken from https://github.com/google/benchmark/blob/3b3de69400164013199ea448f051d94d7fc7d81f/src/cycleclock.h#L190
     uint64_t ret;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -62,7 +62,8 @@ typedef struct {
 #if !defined(JL_TASK_SWITCH_ASM) && \
     !defined(JL_TASK_SWITCH_LIBUNWIND)
 #if (defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_AARCH64_) ||  \
-     defined(_CPU_ARM_) || defined(_CPU_PPC64_) || defined(_CPU_RISCV64_))
+     defined(_CPU_ARM_) || defined(_CPU_PPC64_) || defined(_CPU_RISCV64_) || \
+     defined(_CPU_LOONG_))
 #define JL_TASK_SWITCH_ASM
 #endif
 #if 0

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -110,6 +110,8 @@ Instruction *LowerPTLS::emit_pgcstack_tp(Value *offset, Instruction *insertBefor
             asm_str = "mrs $0, tpidr_el0";
         } else if (TargetTriple.isARM()) {
             asm_str = "mrc p15, 0, $0, c13, c0, 3";
+        } else if (TargetTriple.isLoongArch()) {
+            asm_str = "move $0, $$tp";
         } else if (TargetTriple.isRISCV()) {
             asm_str = "mv $0, tp";
         } else if (TargetTriple.getArch() == Triple::x86_64) {

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -240,6 +240,8 @@ static inline jl_image_t load_sysimg_target(jl_image_buf_t image, F &&callback, 
 #include <cpufeatures/target_tables_x86_64.h>
 #elif defined(_CPU_AARCH64_)
 #include <cpufeatures/target_tables_aarch64.h>
+#elif defined(__loongarch__)
+#include <cpufeatures/target_tables_loongarch64.h>
 #elif defined(__riscv) && __riscv_xlen == 64
 #include <cpufeatures/target_tables_riscv64.h>
 #else

--- a/src/processor.h
+++ b/src/processor.h
@@ -266,6 +266,8 @@ JL_DLLEXPORT char *jl_expand_sysimage_keyword(const char *cpu_target) JL_NOTSAFE
 #include <cpufeatures/target_tables_x86_64.h>
 #elif defined(__aarch64__) || defined(_M_ARM64)
 #include <cpufeatures/target_tables_aarch64.h>
+#elif defined(__loongarch__)
+#include <cpufeatures/target_tables_loongarch64.h>
 #elif defined(__riscv) && __riscv_xlen == 64
 #include <cpufeatures/target_tables_riscv64.h>
 #else

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -260,7 +260,8 @@ JL_DLLEXPORT float julia_half_to_float(uint16_t param) {
 #if ((defined(__GNUC__) && __GNUC__ > 11) || \
      (defined(__clang__) && __clang_major__ > 14)) && \
     !defined(_CPU_PPC64_) && !defined(_CPU_PPC_) && \
-    !defined(_OS_WINDOWS_) && !defined(_CPU_RISCV64_)
+    !defined(_OS_WINDOWS_) && !defined(_CPU_RISCV64_) && \
+    !defined(_CPU_LOONG_)
     #define FLOAT16_ARG_TYPE _Float16
     #define FLOAT16_RET_TYPE _Float16
     #define FLOAT16_ARG_TO_UINT16(x) (*(uint16_t*)&(x))
@@ -279,7 +280,7 @@ JL_DLLEXPORT float julia_half_to_float(uint16_t param) {
     #define FLOAT16_RET_TYPE __m128
     #define FLOAT16_ARG_TO_UINT16(x) take_from_xmm(x)
     #define FLOAT16_RET_FROM_UINT16(x) return_in_xmm(x)
-#elif defined(_CPU_PPC64_) || defined(_CPU_PPC_)
+#elif defined(_CPU_PPC64_) || defined(_CPU_PPC_) || defined(_CPU_LOONG_)
     // on PPC, pass Float16 as if it were an integer, similar to the old x86 ABI
     // before _Float16
     #define FLOAT16_ARG_TYPE uint16_t
@@ -369,7 +370,8 @@ float julia_bfloat_to_float(uint16_t param) JL_NOTSAFEPOINT {
 #if ((defined(__GNUC__) && __GNUC__ > 12) || \
      (defined(__clang__) && __clang_major__ > 16)) && \
     !defined(_CPU_PPC64_) && !defined(_CPU_PPC_) && \
-    !defined(_OS_WINDOWS_) && !defined(_CPU_RISCV64_)
+    !defined(_OS_WINDOWS_) && !defined(_CPU_RISCV64_) && \
+    !defined(_CPU_LOONG_)
     #define BFLOAT16_TYPE __bf16
     #define BFLOAT16_TO_UINT16(x) (*(uint16_t*)&(x))
     #define BFLOAT16_FROM_UINT16(x) (*(__bf16*)&(x))

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -376,7 +376,8 @@ static void jl_fprint_sigill(ios_t *s, void *_ctx);
 #if defined(_CPU_X86_64_) || defined(_CPU_X86_) \
     || (defined(_OS_LINUX_) && defined(_CPU_AARCH64_)) \
     || (defined(_OS_LINUX_) && defined(_CPU_ARM_)) \
-    || (defined(_OS_LINUX_) && defined(_CPU_RISCV64_))
+    || (defined(_OS_LINUX_) && defined(_CPU_RISCV64_)) \
+    || (defined(_OS_LINUX_) && defined(_CPU_LOONG_))
 static size_t jl_safe_read_mem(const volatile char *ptr, char *out, size_t len)
 {
     jl_jmp_buf *old_buf = jl_get_safe_restore();
@@ -862,6 +863,8 @@ static uintptr_t jl_get_pc_from_ctx(const void *_ctx)
     return ((ucontext_t*)_ctx)->uc_mcontext.mc_gpregs.gp_elr;
 #elif defined(_OS_LINUX_) && defined(_CPU_ARM_)
     return ((ucontext_t*)_ctx)->uc_mcontext.arm_pc;
+#elif defined(_OS_LINUX_) && defined(_CPU_LOONG_)
+    return ((ucontext_t*)_ctx)->uc_mcontext.__gregs[32];
 #elif defined(_OS_LINUX_) && defined(_CPU_RISCV64_)
     return ((ucontext_t*)_ctx)->uc_mcontext.__gregs[REG_PC];
 #else
@@ -940,6 +943,21 @@ static void jl_fprint_sigill(ios_t *s, void *_ctx)
         else {
             jl_safe_fprintf(s, "Invalid ARM instruction at %p: 0x%08" PRIx32 "\n", (void*)pc, inst);
         }
+    }
+#elif defined(_OS_LINUX_) && defined(_CPU_LOONG_)
+    uint32_t inst = 0;
+    size_t len = jl_safe_read_mem(pc, (char*)&inst, 4);
+    if (len < 4)
+        jl_safe_printf("Fault when reading instruction: %d bytes read\n", (int)len);
+    // LoongArch: break 0 -> 0x002a0000
+    // Also treat 0x00000000 as undefined (common convention)
+    // Some toolchains may emit 0x7c0000ff or similar as udf; but 0 is safest fallback.
+    if (inst == 0x002a0000 ||          // break 0
+        inst == 0x00000000) {          // null instruction / udf
+        jl_safe_printf("Unreachable reached at %p\n", pc);
+    }
+    else {
+        jl_safe_printf("Invalid instruction at %p: 0x%08" PRIx32 "\n", pc, inst);
     }
 #elif defined(_OS_LINUX_) && defined(_CPU_RISCV64_)
     uint32_t inst = 0;

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -170,6 +170,9 @@ static inline uintptr_t jl_get_rsp_from_ctx(const void *_ctx)
 #elif defined(_OS_LINUX_) && defined(_CPU_ARM_)
     const ucontext_t *ctx = (const ucontext_t*)_ctx;
     return ctx->uc_mcontext.arm_sp;
+#elif defined(_OS_LINUX_) && (defined(_CPU_LOONG_))
+    const ucontext_t *ctx = (const ucontext_t*)_ctx;
+    return ctx->uc_mcontext.__gregs[LARCH_REG_SP];
 #elif defined(_OS_LINUX_) && (defined(_CPU_RISCV64_))
     const ucontext_t *ctx = (const ucontext_t*)_ctx;
     return ctx->uc_mcontext.__gregs[REG_SP];
@@ -301,6 +304,11 @@ JL_NO_ASAN static void jl_call_in_ctx(jl_ptls_t ptls, void (*fptr)(void) JL_CANS
     ctx->uc_mcontext.arm_sp = rsp;
     ctx->uc_mcontext.arm_lr = 0; // Clear link register
     ctx->uc_mcontext.arm_pc = target;
+#elif defined(_OS_LINUX_) && (defined(_CPU_LOONG_))
+    ucontext_t *ctx = (ucontext_t*)_ctx;
+    ctx->uc_mcontext.__gregs[LARCH_REG_SP] = rsp;
+    ctx->uc_mcontext.__gregs[LARCH_REG_RA] = 0;
+    ctx->uc_mcontext.__pc = (uintptr_t)fptr;
 #elif defined(_OS_LINUX_) && (defined(_CPU_RISCV64_))
     ucontext_t *ctx = (ucontext_t*)_ctx;
     ctx->uc_mcontext.__gregs[REG_SP] = rsp;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -973,7 +973,8 @@ void jl_fprint_bt_entry_codeloc(ios_t *s, jl_bt_element_t *bt_entry) JL_NOTSAFEP
 // The probe follows the approach used by LLVM's aarch64 TSAN runtime:
 // https://github.com/llvm/llvm-project/commit/daa3ebce283a753f280c549cdb103fbb2972f08e
 #if defined(__GLIBC__) && (defined(_CPU_AARCH64_) || defined(_CPU_ARM_) || \
-                           defined(_CPU_X86_64_) || defined(_CPU_X86_))
+                           defined(_CPU_X86_64_) || defined(_CPU_X86_)) || \
+                           defined(_CPU_LOONG_)
 // Index of the mangled SP within glibc's jmp_buf.
 #if defined(_CPU_AARCH64_)
 #define LONG_JMP_SP_ENV_SLOT 13
@@ -981,6 +982,8 @@ void jl_fprint_bt_entry_codeloc(ios_t *s, jl_bt_element_t *bt_entry) JL_NOTSAFEP
 #define LONG_JMP_SP_ENV_SLOT 0
 #elif defined(_CPU_X86_64_)
 #define LONG_JMP_SP_ENV_SLOT 6
+#elif defined(_CPU_LOONG_)
+#define LONG_JMP_SP_ENV_SLOT 1
 #else
 #define LONG_JMP_SP_ENV_SLOT 4
 #endif
@@ -1009,6 +1012,8 @@ static NOINLINE uintptr_t probe_mangled_sp(uintptr_t *sp) JL_NOTSAFEPOINT
     asm volatile ("mov %0, sp" : "=r" (*sp));
 #elif defined(_CPU_X86_64_)
     asm volatile ("movq %%rsp, %0" : "=r" (*sp));
+#elif defined(_CPU_LOONG_)
+    asm volatile ("move  %0, $sp" : "=r" (*sp));
 #else
     asm volatile ("movl %%esp, %0" : "=r" (*sp));
 #endif
@@ -1179,7 +1184,7 @@ _os_ptr_munge(uintptr_t ptr) JL_NOTSAFEPOINT
 
 // Reject values that cannot be user-space longjmp targets. A wrong mangling
 // scheme otherwise turns both values into effectively random addresses.
-#if defined(_CPU_X86_64_) || defined(_CPU_RISCV64_)
+#if defined(_CPU_X86_64_) || defined(_CPU_RISCV64_) || defined(_CPU_LOONG_)
 #define JL_VA_USER_BITS 47
 #elif defined(_CPU_AARCH64_)
 // AArch64 uses its full unsigned VA range, including bit 47 on 48-bit kernels,
@@ -1365,6 +1370,59 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c, int val) JL_NOTSAFEPOI
     mc->pc = mc->regs[30];
     mc->regs[0] = val;
     return valid_longjmp_target(mc->sp, mc->pc);
+    #elif defined(_CPU_LOONG_)
+    // Precise layout based on sysdeps/loongarch/setjmp.S
+    // jmp_buf memory layout (offset * 8 bytes):
+    // 0: ra (mangled via PTR_MANGLE)
+    // 1: sp (mangled via PTR_MANGLE)
+    // 2: x (reserved)
+    // 3: fp (r29)
+    // 4: s0 (r20)
+    // 5: s1 (r21)
+    // 6: s2 (r22)
+    // 7: s3 (r23)
+    // 8: s4 (r24)
+    // 9: s5 (r25)
+    // 10: s6 (r26)
+    // 11: s7 (r27)
+    // 12: s8 (r28)
+    // 13+: f24-f31 (if not soft-float)
+    //
+    // IMPORTANT NOTES:
+    // 1. tp (r2), s10 (r30), and s11 (r31) are NOT saved by setjmp. Do NOT restore them.
+    // 2. PC is not explicitly saved. The longjmp target is RA, so PC = RA.
+    // 3. Field Mapping Discrepancy:
+    //    The assembly writes RA to offset 0 and SP to offset 1.
+    //    However, the C struct defines offset 0 as `__pc` and offset 1 as `__sp`.
+    //    This means `jbp->__pc` actually holds the saved RA, and `jbp->__sp` holds the saved SP.
+    //    The `__regs` array starts at offset 4 (s0).
+    // NOTE: floating‑point registers f24‑f31 are NOT restored for now.
+
+    struct __jmp_buf_internal_tag *jbp = (*_ctx);
+
+    // 1. Restore RA (r1) and SP (r3), apply PTR_DEMANGLE
+    mc->__pc = jl_ptr_demangle(jbp->__pc);
+    mc->__gregs[3] = jl_ptr_demangle(jbp->__sp);      // Restore SP from __sp field
+
+    // 2. Restore FP (r29 / s9)
+    mc->__gregs[29] = jbp->__fp;     // Restore FP from __fp field
+
+    // 3. Restore callee-saved registers s0-s8 (r20-r28)
+    mc->__gregs[20] = jbp->__regs[0]; // s0
+    mc->__gregs[21] = jbp->__regs[1]; // s1
+    mc->__gregs[22] = jbp->__regs[2]; // s2
+    mc->__gregs[23] = jbp->__regs[3]; // s3
+    mc->__gregs[24] = jbp->__regs[4]; // s4
+    mc->__gregs[25] = jbp->__regs[5]; // s5
+    mc->__gregs[26] = jbp->__regs[6]; // s6
+    mc->__gregs[27] = jbp->__regs[7]; // s7
+    mc->__gregs[28] = jbp->__regs[8]; // s8
+
+    // 4. Set Return Value: a0(r4)=1 for longjmp return
+    mc->__gregs[4] = 1;
+
+    // 5. Validate longjmp target (sp/pc validity)
+    return valid_longjmp_target(mc->__gregs[3], mc->__pc);
     #elif defined(_CPU_RISCV64_)
     // https://github.com/bminor/glibc/blob/master/sysdeps/riscv/bits/setjmp.h
     // https://github.com/llvm/llvm-project/blob/7714e0317520207572168388f22012dd9e152e9e/libunwind/src/Registers.hpp -> Registers_riscv

--- a/src/support/platform.h
+++ b/src/support/platform.h
@@ -28,6 +28,7 @@
  *          _CPU_AARCH64_
  *          _CPU_ARM_
  *          _CPU_RISCV64_
+ *          _CPU_LOONG_
  *          _CPU_WASM_
  */
 
@@ -107,6 +108,8 @@
 #define _CPU_AARCH64_
 #elif defined(__arm__) || defined(_M_ARM)
 #define _CPU_ARM_
+#elif defined(__loongarch64) || defined(__loongarch__)
+#define _CPU_LOONG_
 #elif defined(__riscv) && __riscv_xlen == 64
 #define _CPU_RISCV64_
 #elif defined(__PPC64__)

--- a/src/task.c
+++ b/src/task.c
@@ -1381,6 +1381,55 @@ static void jl_set_fiber(jl_ucontext_t *t)
 #define PUSH_RET(ctx, stk) \
     if (unw_set_reg(ctx, UNW_ARM_R14, 0)) /* put NULL into the LR */ \
         abort();
+#elif defined(_CPU_LOONG_)
+// 1. Define semantic register macros.
+// Priority: Use official enum names from header if available; fallback to hardcoded values otherwise.
+// https://github.com/libunwind/libunwind/blob/master/include/libunwind-loongarch64.h
+#ifndef UNW_LOONGARCH64_RA
+    #ifdef UNW_LOONGARCH64_R1
+        #define UNW_LOONGARCH64_RA UNW_LOONGARCH64_R1
+    #else
+        #define UNW_LOONGARCH64_RA 1
+    #endif
+#endif
+
+#ifndef UNW_LOONGARCH64_SP
+    #ifdef UNW_LOONGARCH64_R3
+        #define UNW_LOONGARCH64_SP UNW_LOONGARCH64_R3
+    #else
+        #define UNW_LOONGARCH64_SP 3
+    #endif
+#endif
+
+#ifndef UNW_LOONGARCH64_PC
+    // Explicitly defined as 33 in the provided header file.
+    #define UNW_LOONGARCH64_PC 33
+#endif
+
+#define PUSH_RET(c, stk) do { \
+    unw_word_t ret_addr; \
+    /* Retrieve the return address from the RA register */ \
+    if (unw_get_reg((c), UNW_LOONGARCH64_RA, &ret_addr) != 0) { \
+        ret_addr = 0; \
+    } \
+    (stk) -= 8; \
+    *((uintptr_t*)(stk)) = (uintptr_t)ret_addr; \
+    /* Force 16-byte alignment: ~0xfUL is equivalent to & -16 */ \
+    (stk) = (char*)((uintptr_t)(stk) & ~0xfUL); \
+} while (0)
+
+#define SIMULATE_CALL(c, stk, func) do { \
+    PUSH_RET(c, stk); \
+    unw_word_t func_addr = (unw_word_t)(func); \
+    unw_set_reg((c), UNW_LOONGARCH64_PC, func_addr); \
+    unw_set_reg((c), UNW_LOONGARCH64_SP, (unw_word_t)(stk)); \
+} while (0)
+
+#define INIT_FIBER_CONTEXT(c, sp, func) do { \
+    memset(c, 0, sizeof(*c)); \
+    unw_set_reg((c), UNW_LOONGARCH64_SP, (unw_word_t)(sp)); \
+    unw_set_reg((c), UNW_LOONGARCH64_PC, (unw_word_t)(func)); \
+} while (0)
 #else
 #error please define how to simulate a CALL on this platform
 #endif
@@ -1498,6 +1547,15 @@ CFI_NORETURN
                     // because all our addresses are word-aligned.
         " udf #0" // abort
         : : "r" (stk), "r"(fn) : "memory" );
+#elif defined(_CPU_LOONG_)
+    // LoongArch64 Context Switch Entry
+    asm volatile(
+        " move $r3, %0\n"      // sp = stk
+        " move $r1, $zero\n"   // ra = 0
+        " move $r22, $zero\n"  // fp = 0
+        " jr %1\n"             // jump to fn
+        " break 0\n"           // trap (never reached)
+        : : "r"(stk), "r"(fn) : "memory" );
 #elif defined(_CPU_RISCV64_)
     asm volatile(
         " mv sp, %0;\n"

--- a/src/threading.c
+++ b/src/threading.c
@@ -20,7 +20,7 @@
 // For variant 1 JL_ELF_TLS_INIT_SIZE is the size of the thread control block (TCB)
 // For variant 2 JL_ELF_TLS_INIT_SIZE is 0
 #if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
-#  if defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_RISCV64_)
+#  if defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_LOONG_) || defined(_CPU_RISCV64_)
 #    define JL_ELF_TLS_VARIANT 2
 #    define JL_ELF_TLS_INIT_SIZE 0
 #  elif defined(_CPU_AARCH64_)
@@ -703,6 +703,8 @@ static void jl_check_tls(void) JL_NOTSAFEPOINT
     asm("mrs %0, tpidr_el0" : "=r"(tp));
 #elif defined(__ARM_ARCH) && __ARM_ARCH >= 7
     asm("mrc p15, 0, %0, c13, c0, 3" : "=r"(tp));
+#elif defined(_CPU_LOONG_)
+    asm("move %0, $tp" : "=r"(tp));
 #elif defined(_CPU_RISCV64_)
     asm("mv %0, tp" : "=r"(tp));
 #else


### PR DESCRIPTION
```
[root@localhost julia_Loongarch]# uname -a
Linux localhost.localdomain 6.6.0-72.0.0.76.oe2403sp1.loongarch64 #1 SMP Fri Dec 27 01:20:20 CST 2024 loongarch64 loongarch64 loongarch64 GNU/Linux
```

```
[root@localhost julia_Loongarch]# ./julia 
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.14.0-DEV.3085 (2026-09-02)
 _/ |\__'_|_|_|\__'_|  |  Commit 70f442ef2a* (0 days old master)
|__/                   |

julia> versioninfo(; verbose=true)
Julia Version 1.14.0-DEV.3085
Build Info:
  Commit 70f442ef2a* (2026-09-02 01:00 UTC)
  GC: Built with stock GC
  Sysimage: loongarch64 (loongarch64-openEuler-linux)
Platform Info:
  OS: Linux (loongarch64-openEuler-linux)
  uname: Linux 6.6.0-72.0.0.76.oe2403sp1.loongarch64 #1 SMP Fri Dec 27 01:20:20 CST 2024 loongarch64 loongarch64
  CPU: unknown (generic):
              speed         user         nice          sys         idle          irq
       #1     0 MHz      20587 s         73 s        518 s     676318 s         68 s  
       #2     0 MHz      30825 s         92 s        580 s     666145 s         69 s  
       #3     0 MHz      38592 s         89 s        612 s     658266 s         77 s  
       #4     0 MHz      20456 s         69 s        528 s     676524 s         65 s  
       #5     0 MHz      37907 s         90 s        572 s     658979 s         77 s  
       #6     0 MHz      26500 s         71 s        595 s     670376 s         70 s  
       #7     0 MHz      28822 s         84 s        569 s     668138 s         69 s  
       #8     0 MHz      28835 s         84 s        560 s     668116 s         71 s  
  Memory: 31.656204223632812 GiB (27228.46875 MiB free)
  Uptime: 697995.35 sec
  Load Avg:  0.26  2.81  2.46
  WORD_SIZE: 64
  LLVM: libLLVM-22.1.8 (ORCJIT, generic)
Threads: 1 default, 1 interactive, 1 GC (on 8 virtual cores)
Environment:
  HOME = /root
  TERM = xterm
  PATH = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

julia> ccall(:jl_dump_host_cpu, Nothing, ())
CPU: generic
Features: 32s, 64bit, d, div32, f, lasx, ld-seq-sa, lsx, lvz, ual

julia> @code_native debuginfo=:none 1+2.
	.file	"+"
	.text
	.globl	"julia_+_0"                     # -- Begin function julia_+_0
	.p2align	5
	.type	"julia_+_0",@function
"julia_+_0":                            # @"julia_+_0"
; Function Signature: +(Int64, Float64)
# %bb.0:                                # %top
	#DEBUG_VALUE: +:x <- $r4
	#DEBUG_VALUE: +:x <- $r4
	#DEBUG_VALUE: +:y <- $f0_64
	#DEBUG_VALUE: +:y <- $f0_64
	addi.d	$sp, $sp, -16
	st.d	$ra, $sp, 8                     # 8-byte Folded Spill
	st.d	$fp, $sp, 0                     # 8-byte Folded Spill
	addi.d	$fp, $sp, 16
	movgr2fr.d	$fa1, $a0
	ffint.d.l	$fa1, $fa1
	fadd.d	$fa0, $fa0, $fa1
	ld.d	$fp, $sp, 0                     # 8-byte Folded Reload
	ld.d	$ra, $sp, 8                     # 8-byte Folded Reload
	addi.d	$sp, $sp, 16
	ret
.Lfunc_end0:
	.size	"julia_+_0", .Lfunc_end0-"julia_+_0"
                                        # -- End function
	.section	".note.GNU-stack","",@progbits
```