### PR TITLE
objcache: include the system image identity in the module hash

### DIFF
--- a/src/objcache.cpp
+++ b/src/objcache.cpp
@@ -267,6 +267,11 @@ static ObjCache::Hash hashModule(const llvm::Module &M) JL_NOTSAFEPOINT
     Hasher.update(LLVM_VERSION_STRING);
     Hasher.update(JL_CODEGEN_SRC_HASH);
     Hasher.update(jl_gc_image_abi());
+    // Compiled code depends on the system image's type layouts.
+    if (jl_base_module) {
+        Hasher.update({(uint8_t *)&jl_base_module->build_id,
+                       sizeof jl_base_module->build_id});
+    }
     // Compiled code needs to have the same jl_tls_offset value as the running
     // process (see LowerPTLSPass).
     Hasher.update({(uint8_t *)&jl_tls_offset, sizeof jl_tls_offset});


### PR DESCRIPTION
The object cache lives in `$(DEPOT_PATH[1])/cache/v<major>.<minor>/` and is shared by every build of a Julia minor version. Its module hash mixes in the LLVM version, the codegen source hash, the GC image ABI and `jl_tls_offset`, but nothing that identifies the build the object was compiled against. Compiled code hard-codes the layouts of runtime types, which change between DEV builds: #62673 added a field to `Task`, so a store populated before it made later builds reuse objects that access `Task` fields at stale offsets. The CompilerCaching.jl test suite hit this as a crash in `start_task` with `ct->start == NULL` whenever the JIT served its `Threads.@spawn` closures from such an entry; the same suite passed with `JULIA_OBJCACHE=0`, with an empty cache directory, and on repeated runs against a cache populated by the same build.

Mix `jl_base_module->build_id` into the hash. Its high word is the checksum of the system image, its low word the image's creation stamp, so objects compiled against another image never match, while patch releases that ship the same image keep sharing entries. The field is unset while bootstrapping, when the cache is only used to speed up the build itself.

Assisted by: Fable 5.1