### PR TITLE
MPQ: fix aliasing UB in add!/sub!/mul!/div!/set! on Rational{BigInt}

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -1001,6 +1001,16 @@ _MPQ(x::BigInt,y::BigInt) = _MPQ(x.alloc, x.size, x.d,
 _MPQ() = _MPQ(BigInt(), BigInt())
 _MPQ(x::Rational{BigInt}) = _MPQ(x.num, x.den)
 
+# GMP only supports aliasing between arguments passed as the *same* mpq_t: an
+# input sharing BigInts with the output must not be handed over as a separate
+# struct, or it reads freed limbs once the output is reallocated.
+function _MPQ(zq::_MPQ, x::Rational{BigInt})
+    z = zq.rat
+    x === z && return zq
+    (x.num === z.num || x.den === z.den) && return _MPQ(MPZ.set(x.num), MPZ.set(x.den))
+    return _MPQ(x)
+end
+
 function sync_rational!(xq::_MPQ)
     xq.rat.num.alloc = xq.num_alloc
     xq.rat.num.size  = xq.num_size
@@ -1024,7 +1034,7 @@ end
 # define set, set_ui, set_si, set_z, and their inplace versions
 function set!(z::Rational{BigInt}, x::Rational{BigInt})
     zq = _MPQ(z)
-    ccall((:__gmpq_set, libgmp), Cvoid, (mpq_t, mpq_t), zq, _MPQ(x))
+    ccall((:__gmpq_set, libgmp), Cvoid, (mpq_t, mpq_t), zq, _MPQ(zq, x))
     return sync_rational!(zq)
 end
 
@@ -1063,7 +1073,7 @@ function add!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
     end
     zq = _MPQ(z)
     ccall((:__gmpq_add, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
+          (mpq_t,mpq_t,mpq_t), zq, _MPQ(zq, x), _MPQ(zq, y))
     return sync_rational!(zq)
 end
 
@@ -1077,7 +1087,7 @@ function sub!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
     end
     zq = _MPQ(z)
     ccall((:__gmpq_sub, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
+          (mpq_t,mpq_t,mpq_t), zq, _MPQ(zq, x), _MPQ(zq, y))
     return sync_rational!(zq)
 end
 
@@ -1090,7 +1100,7 @@ function mul!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
     end
     zq = _MPQ(z)
     ccall((:__gmpq_mul, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
+          (mpq_t,mpq_t,mpq_t), zq, _MPQ(zq, x), _MPQ(zq, y))
     return sync_rational!(zq)
 end
 
@@ -1111,7 +1121,7 @@ function div!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
     end
     zq = _MPQ(z)
     ccall((:__gmpq_div, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
+          (mpq_t,mpq_t,mpq_t), zq, _MPQ(zq, x), _MPQ(zq, y))
     return sync_rational!(zq)
 end
 

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -756,6 +756,29 @@ t = Rational{BigInt}(0, 1)
 
     @test aa == a && bb == b && cc == c
 
+    @testset "aliased arguments" begin
+        # inputs sharing BigInts with the output must not be passed to GMP as
+        # separate mpq_t structs (their limb pointers go stale on reallocation)
+        x = big(1)//1
+        @test Base.GMP.MPQ.add!(x, big(1)//2) == 3//2
+        x = big(1)//1
+        @test Base.GMP.MPQ.sub!(x, big(1)//2) == 1//2
+        x = big(1)//1
+        @test Base.GMP.MPQ.mul!(x, big(3)//2) == 3//2
+        x = big(1)//1
+        @test Base.GMP.MPQ.div!(x, big(2)//3) == 3//2
+        z = big(1)//2
+        @test Base.GMP.MPQ.add!(z, big(1)//3, z) == 5//6
+        z = big(1)//1
+        @test Base.GMP.MPQ.add!(z, z, z) == 2
+        z = big(1)//1
+        @test Base.GMP.MPQ.set!(z, z) == 1
+        # partial aliasing: only one BigInt shared with the output
+        n = big(1)
+        z = Base.unsafe_rational(BigInt, n, big(1))
+        @test Base.GMP.MPQ.add!(z, Base.unsafe_rational(BigInt, n, big(2))) == 3//2
+    end
+
     @testset "set" begin
         @test Base.GMP.MPQ.set!(a, b) == b
         @test a == b == bb


### PR DESCRIPTION
## Fix issue #62974

MPQ.add! etc. handed GMP aliased arguments in a way GMP does not support: two different mpq_t structs whose num_d/den_d point at the same limb blocks. GMP may reallocate the output's limbs through one struct and read them through the other, resulting in use-after-free.

Fix by adding `_MPQ(zq::_MPQ, x::Rational{BigInt})` that copies input BigInts when they are shared with the output. This also exposes latent bugs on older versions where glibc's realloc happened to grow in place.

## MWE (from issue)

```julia
julia> using Base.GMP: MPQ

julia> x = big(1)//1; MPQ.add!(x, big(1)//2)
3//160333528  # expected 3//2; now fixed to 3//2
```

## Changes

- `base/gmp.jl`: Add `_MPQ(zq::_MPQ, x::Rational{BigInt})` to handle aliasing, update `set!`, `add!`, `sub!`, `mul!`, `div!` to use it
- `test/gmp.jl`: Add testset for aliased arguments

Fixes #62974
Assisted-by: MiniMax-M2