### PR TITLE
threads: Keep the `ccall` out of the `@threads` macro expansion

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -169,6 +169,9 @@ This includes both mark threads and concurrent sweep threads.
 ngcthreads() = Int(unsafe_load(cglobal(:jl_n_gcthreads, Cint))) + 1
 
 function threading_run(fun, static)
+    if static && ccall(:jl_in_threaded_region, Cint, ()) != 0
+        error("`@threads :static` cannot be used concurrently or nested")
+    end
     ccall(:jl_enter_threaded_region, Cvoid, ())
     n = threadpoolsize()
     tid_offset = threadpoolsize(:interactive)
@@ -233,17 +236,12 @@ function threading_run(fun, static)
     cr === nothing || throw(cr)
 end
 
-# Helper to generate threading run code with schedule checking
+# Helper to generate the threading run call. Keep the expansion free of `ccall`s: a
+# foreigncall in a top-level thunk forces the whole thunk through codegen, even under
+# `--compile=min`, so a top-level `@threads` would otherwise make the interpreter
+# unusable for everything around it.
 function _threading_run_expr(schedule)
-    quote
-        if $(schedule === :greedy || schedule === :dynamic || schedule === :default)
-            threading_run(threadsfor_fun, false)
-        elseif ccall(:jl_in_threaded_region, Cint, ()) != 0 # :static
-            error("`@threads :static` cannot be used concurrently or nested")
-        else # :static
-            threading_run(threadsfor_fun, true)
-        end
-    end
+    :(threading_run(threadsfor_fun, $(schedule === :static)))
 end
 
 function _threadsfor(iter, lbody, schedule)


### PR DESCRIPTION
The `:static` nesting check was emitted inline by the macro, so every `@threads` loop placed a `ccall` in its caller. A top-level thunk containing a foreigncall is always sent through codegen, since the interpreter cannot execute one, so a single `@threads for` at top level forced inference and LLVM compilation of the entire enclosing thunk, even under `--compile=min`. Perform the check inside `threading_run` instead; the macro now only emits a call.

This prompted by excessive compilation as noticed on a dog-slow RISC-V SBC.

Assisted-by: Claude Code (Fable 5.1)