### PR TITLE
precompilation: keep the stream's implied `:color` in `unstable_iocontext`

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -317,7 +317,7 @@ can_fancyprint(io::IO) = @something(get(io, :force_fancyprint, nothing), (Base.u
 # captures `Pkg.precompile` output.
 unstable_iocontext(io::IOContext{IO}) = io
 unstable_iocontext(io::IOContext) = IOContext{IO}(io.io, io.dict)
-unstable_iocontext(io::IO) = IOContext{IO}(io, Base.ImmutableDict{Symbol, Any}())
+unstable_iocontext(io::IO) = IOContext{IO}(io)
 
 function printpkgstyle(io, header, msg; color=:green)
     return @lock io begin

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3862,4 +3862,53 @@ precompile_test_harness("pkgimage type cache dedup") do dir
     end
 end
 
+# Interactive precompile output has to keep its colors: a TTY's implied `:color` must survive
+# the driver's conversion of a raw stream to `IOContext{IO}` (#62970 dropped it). Run a real
+# precompile in a child whose stderr is a pty and look for the color escapes in its output.
+if !Sys.iswindows() # child-on-fake-pty tests are skipped on Windows (see misc.jl)
+    @testset "precompile output to a TTY is colored" begin
+        isdefined(Main, :FakePTYs) || @eval Main include("testhelpers/FakePTYs.jl")
+        mkdepottempdir() do depot
+            pkg_path = joinpath(depot, "dev", "ColorTTY")
+            mkpath(joinpath(pkg_path, "src"))
+            write(joinpath(pkg_path, "src", "ColorTTY.jl"), "module ColorTTY end\n")
+            write(joinpath(pkg_path, "Project.toml"),
+                """
+                name = "ColorTTY"
+                uuid = "c010f000-0000-0000-0000-000000000001"
+                version = "0.1.0"
+                """)
+            write(joinpath(pkg_path, "Manifest.toml"),
+                """
+                julia_version = "$(VERSION.major).$(VERSION.minor).0"
+                manifest_format = "2.0"
+
+                [[deps.ColorTTY]]
+                path = "."
+                uuid = "c010f000-0000-0000-0000-000000000001"
+                version = "0.1.0"
+                """)
+            # `stderr` is passed through untouched so the driver has to wrap the raw TTY itself
+            cmd = addenv(`$(Base.julia_cmd()) --color=yes --startup-file=no --project=$pkg_path -e 'Base.Precompilation.precompilepkgs(["ColorTTY"]; fancyprint=false)'`,
+                         "JULIA_DEPOT_PATH" => depot)
+            pts, ptm = Main.FakePTYs.open_fake_pty()
+            p = run(cmd, devnull, pts, pts; wait=false)
+            Base.close_stdio(pts)
+            output = IOBuffer()
+            try
+                while !eof(ptm)
+                    write(output, readavailable(ptm))
+                end
+            catch # EIO once the child has closed its end of the pty
+            end
+            wait(p)
+            close(ptm)
+            out = String(take!(output))
+            @test success(p)
+            @test occursin("ColorTTY", out)
+            @test occursin("\e[32m", out) # the green ✓ of the precompiled package
+        end
+    end
+end
+
 finish_precompile_test!()


### PR DESCRIPTION
Fixes loss of color reported in https://github.com/JuliaLang/julia/pull/62970#issuecomment-5513891344
Also adds a test.

Claude:

---

#62970 replaced `IOContext(io)` with a hand-built `IOContext{IO}(io, ImmutableDict())` when wrapping a raw stream. That skips `Base.ioproperties`, which is what carries a TTY's implied `:color` into the context dict, so interactive precompile output lost its colors: the `Precompiling` header and the ✓ marks came out plain even on a color terminal. Going through the `IOContext{IO}(io)` constructor restores it while keeping the single `IOContext{IO}` specialization that PR was after.
