### PR TITLE
reduce: avoid spurious widening for array reduction with `init`

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -330,8 +330,17 @@ mapreduce(f, op, A::AbstractArrayOrBroadcasted; dims::D=:, init=_InitialValue())
 mapreduce(f, op, A::AbstractArrayOrBroadcasted, B::AbstractArrayOrBroadcasted...; kw...) =
     reduce(op, map(f, A, B...); kw...)
 
-_mapreduce_dim(f, op, nt, A::AbstractArrayOrBroadcasted, ::Colon) =
-    mapfoldl_impl(f, op, nt, A)
+function _mapreduce_dim(f, op, nt, A::AbstractArrayOrBroadcasted, ::Colon)
+    # equivalent to `mapfoldl_impl(f, op, nt, A)` this logic is expanded here
+    # to work around limitations in inference's recursion heuristic
+    y = iterate(A)
+    y === nothing && return nt
+    v = op(nt, f(y[1]))
+    for x in Iterators.rest(A, y[2])
+        v = op(v, f(x))
+    end
+    return v
+end
 
 _mapreduce_dim(f, op, ::_InitialValue, A::AbstractArrayOrBroadcasted, ::Colon) =
     _mapreduce(f, op, IndexStyle(A), A)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -805,3 +805,16 @@ end
     @test foldl(-, P) == foldl(-, C) && foldr(-, P) == foldr(-, C)
     @test [x for x in P] == C
 end
+
+@testset "type-stability for nested reductions" begin
+    nested_count(v) = maximum(count(!iszero, v .* i) for i in 1:3)
+    @test Base.infer_return_type(nested_count, (Vector{Float64},)) === Int
+    nested_sum(v) = sum(x -> sum(y -> y * x, v; init = 0.0), v; init = 0.0)
+    @test Base.infer_return_type(nested_sum, (Vector{Float64},)) === Float64
+    nested_prod(v) = maximum(prod(v .* i; init = 1.0) for i in 1:3)
+    @test Base.infer_return_type(nested_prod, (Vector{Float64},)) === Float64
+    v = [1.0, 2.0, 0.0]
+    @test nested_count(v) == 2
+    @test nested_sum(v) == sum(v)^2
+    @test nested_prod(v) == 0.0
+end


### PR DESCRIPTION
This is a noticeable improvement to nested reductions in the presence of arrays.

It is a bit silly to have to work around the recursion heuristic in this way, but I am not sure we can do much better unless we teach it to associate an argument's type with the dispatch that is keyed on it (these `mapreduce` methods are non-recursive since they immediately invoke different Methods, but the compiler has a very hard time seeing that from the types alone).

This makes many pithy reduce-heavy examples like `maximum(count(!iszero, v .* i) for i in 1:3)` fully infer and `--trim`-compatible.

Prepared with assistance from Claude Fable 5 🤖 