### PR TITLE
Dates: add `Timestamp{P}` and fractional-second format code `n`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -242,6 +242,18 @@ Standard library changes
 #### Dates
 
 * `unix2datetime` now accepts a keyword argument `localtime=true` to use the host system's local time zone instead of UTC ([#50296]).
+* A new `Timestamp` type represents an instant with nanosecond precision as an `Int64` count of
+  nanoseconds since the unix epoch — the same representation as Apache Arrow's `timestamp[ns]` and
+  numpy's `datetime64[ns]` — covering the years 1677 through 2262. It supports accessors, period
+  arithmetic, rounding, adjusters, ranges, parsing, and formatting. It compares directly with
+  `Date` and `DateTime` and supports mixed arithmetic with in-range `DateTime` values ([#62994]).
+* `hash` is now consistent with `==` across `Date`, `DateTime`, and `Timestamp`, so equal instants of
+  different types can be used interchangeably as dictionary keys ([#62994]).
+* A new `n` format code parses and formats fractional seconds with up to nanosecond precision
+  (`.5` is 500 milliseconds, `.123456789` is 123456789 nanoseconds). The default `Time` format now
+  uses it, so `Time` values with sub-millisecond parts round-trip through their printed form;
+  relatedly, the nanosecond argument of the `Time` constructor may now carry a full fractional
+  second (values up to 999999999) as long as the sub-second parts together stay below one second ([#62994]).
 
 #### InteractiveUtils
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -242,15 +242,18 @@ Standard library changes
 #### Dates
 
 * `unix2datetime` now accepts a keyword argument `localtime=true` to use the host system's local time zone instead of UTC ([#50296]).
-* A new `Timestamp` type represents an instant with nanosecond precision as an `Int64` count of
-  nanoseconds since the unix epoch — the same representation as Apache Arrow's `timestamp[ns]` and
-  numpy's `datetime64[ns]` — covering the years 1677 through 2262. It supports accessors, period
+* A new `Timestamp{P}` type represents an instant as an `Int64` count since the Unix epoch,
+  with `Second`, `Millisecond`, `Microsecond`, or `Nanosecond` resolution. Plain `Timestamp(...)`
+  defaults to nanoseconds, covering the years 1677 through 2262; coarser resolutions have wider
+  ranges. Each concrete type is 8 bytes. Conversions between resolutions require exact
+  representation, and promotion selects the finer resolution. It supports accessors, period
   arithmetic, rounding, adjusters, ranges, parsing, and formatting. It compares directly with
   `Date` and `DateTime` and supports mixed arithmetic with in-range `DateTime` values ([#62994]).
 * `hash` is now consistent with `==` across `Date`, `DateTime`, and `Timestamp`, so equal instants of
   different types can be used interchangeably as dictionary keys ([#62994]).
 * A new `n` format code parses and formats fractional seconds with up to nanosecond precision
-  (`.5` is 500 milliseconds, `.123456789` is 123456789 nanoseconds). The default `Time` format now
+  (`.5` is 500 milliseconds, `.123456789` is 123456789 nanoseconds). This is a breaking
+  change for format strings using a literal `n`, which must now be escaped. The default `Time` format now
   uses it, so `Time` values with sub-millisecond parts round-trip through their printed form;
   relatedly, the nanosecond argument of the `Time` constructor may now carry a full fractional
   second (values up to 999999999) as long as the sub-second parts together stay below one second ([#62994]).

--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -4,34 +4,49 @@
 DocTestSetup = :(using Dates)
 ```
 
-The `Dates` module provides two types for working with dates: [`Date`](@ref) and [`DateTime`](@ref),
-representing day and millisecond precision, respectively; both are subtypes of the abstract [`TimeType`](@ref).
+The `Dates` module provides three types for working with dates: [`Date`](@ref),
+[`DateTime`](@ref), and [`Timestamp`](@ref). They provide day, millisecond, and
+nanosecond precision, respectively. All three are subtypes of the abstract
+[`TimeType`](@ref).
 The motivation for distinct types is simple: some operations are much simpler, both in terms of
 code and mental reasoning, when the complexities of greater precision don't have to be dealt with.
 For example, since the [`Date`](@ref) type only resolves to the precision of a single date (i.e.
 no hours, minutes, or seconds), normal considerations for time zones, daylight savings/summer
 time, and leap seconds are unnecessary and avoided.
 
-Both [`Date`](@ref) and [`DateTime`](@ref) are basically immutable [`Int64`](@ref) wrappers.
-The single `instant` field of either type is actually a `UTInstant{P}` type, which
+[`Date`](@ref), [`DateTime`](@ref), and [`Timestamp`](@ref) are immutable [`Int64`](@ref)
+wrappers. The single `instant` field of each type is a `UTInstant{P}` type, which
 represents a continuously increasing machine timeline based on the UT second [^1]. The
 [`DateTime`](@ref) type is not aware of time zones (*naive*, in Python parlance),
 analogous to a *LocalDateTime* in Java 8. Additional time zone functionality
 can be added through the [TimeZones.jl package](https://github.com/JuliaTime/TimeZones.jl/), which
-compiles the [IANA time zone database](https://www.iana.org/time-zones). Both [`Date`](@ref) and
-[`DateTime`](@ref) are based on the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard, which follows the proleptic Gregorian calendar.
+compiles the [IANA time zone database](https://www.iana.org/time-zones). [`Date`](@ref),
+[`DateTime`](@ref), and [`Timestamp`](@ref) are based on the
+[ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard, which follows the
+proleptic Gregorian calendar.
 One note is that the ISO 8601 standard is particular about BC/BCE dates. In general, the last
 day of the BC/BCE era, 1-12-31 BC/BCE, was followed by 1-1-1 AD/CE, thus no year zero exists.
 The ISO standard, however, states that 1 BC/BCE is year zero, so `0000-12-31` is the day before
 `0001-01-01`, and year `-0001` (yes, negative one for the year) is 2 BC/BCE, year `-0002` is 3
 BC/BCE, etc.
 
+For instants finer than a millisecond, the [`Timestamp`](@ref) type provides nanosecond
+precision. Its value is a count of nanoseconds since
+the unix epoch `1970-01-01T00:00:00`, the same representation used by nanosecond timestamps
+in Apache Arrow, numpy, and pandas — which bounds its representable range to the years 1677
+through 2262. It supports integer and period construction, accessors, arithmetic,
+rounding, adjusters, ranges, parsing, and formatting. It compares directly with
+[`DateTime`](@ref) and supports mixed arithmetic when the `DateTime` value is in
+range. Use [`DateTime`](@ref) for instants outside the [`Timestamp`](@ref) range
+or when sub-millisecond precision is not needed.
+
 [^1]:
     The notion of the UT second is actually quite fundamental. There are basically two different notions
     of time generally accepted, one based on the physical rotation of the earth (one full rotation
     = 1 day), the other based on the SI second (a fixed, constant value). These are radically different!
     Think about it, a "UT second", as defined relative to the rotation of the earth, may have a different
-    absolute length depending on the day! Anyway, the fact that [`Date`](@ref) and [`DateTime`](@ref)
+    absolute length depending on the day! Anyway, the fact that [`Date`](@ref),
+    [`DateTime`](@ref), and [`Timestamp`](@ref)
     are based on UT seconds is a simplifying, yet honest assumption so that things like leap seconds
     and all their complexity can be avoided. This basis of time is formally called [UT](https://en.wikipedia.org/wiki/Universal_Time)
     or UT1. Basing types on the UT second basically means that every minute has 60 seconds and every
@@ -39,8 +54,9 @@ BC/BCE, etc.
 
 ## Constructors
 
-[`Date`](@ref) and [`DateTime`](@ref) types can be constructed by integer or [`Period`](@ref)
-types, by parsing, or through adjusters (more on those later):
+[`Date`](@ref), [`DateTime`](@ref), and [`Timestamp`](@ref) values can be
+constructed by integer or [`Period`](@ref) types, by parsing, or through
+function-based adjuster constructors (more on those later):
 
 ```jldoctest
 julia> DateTime(2013)
@@ -78,12 +94,19 @@ julia> Date(Dates.Year(2013),Dates.Month(7),Dates.Day(1))
 
 julia> Date(Dates.Month(7),Dates.Year(2013))
 2013-07-01
+
+julia> Timestamp(2013,7,1,12,30,59,1,2,3)
+2013-07-01T12:30:59.001002003
+
+julia> Timestamp(Date(2013,7,1), Time(12,30,59) + Dates.Nanosecond(42))
+2013-07-01T12:30:59.000000042
 ```
 
-[`Date`](@ref) or [`DateTime`](@ref) parsing is accomplished by the use of format strings. Format
+[`Date`](@ref), [`DateTime`](@ref), or [`Timestamp`](@ref) parsing uses format strings. Format
 strings work by the notion of defining *delimited* or *fixed-width* "slots" that contain a period
-to parse and passing the text to parse and format string to a [`Date`](@ref) or [`DateTime`](@ref)
-constructor, of the form `Date("2015-01-01",dateformat"y-m-d")` or
+to parse and passing the text to parse and format string to a [`Date`](@ref),
+[`DateTime`](@ref), or [`Timestamp`](@ref) constructor, of the form
+`Date("2015-01-01",dateformat"y-m-d")` or
 `DateTime("20150101",dateformat"yyyymmdd")`.
 
 Delimited slots are marked by specifying the delimiter the parser should expect between two subsequent
@@ -146,9 +169,9 @@ For convenience, you may pass the format string directly (e.g., `Date("2015-01-0
 although this form incurs performance costs if you are parsing the same format repeatedly, as
 it internally creates a new `DateFormat` object each time.
 
-As well as via the constructors, a `Date` or `DateTime` can be constructed from
-strings using the [`parse`](@ref) and [`tryparse`](@ref) functions, but with
-an optional third argument of type `DateFormat` specifying the format; for example,
+As well as via the constructors, a `Date`, `DateTime`, or `Timestamp` can be
+constructed from strings using the [`parse`](@ref) and [`tryparse`](@ref)
+functions, with an optional third argument of type `DateFormat` specifying the format; for example,
 `parse(Date, "06.23.2013", dateformat"m.d.y")`, or
 `tryparse(DateTime, "1999-12-31T23:59:59")` which uses the default format.
 The notable difference between the functions is that with [`tryparse`](@ref),
@@ -166,9 +189,12 @@ A full suite of parsing and formatting tests and examples is available in [`stdl
 
 Finding the length of time between two [`Date`](@ref) or [`DateTime`](@ref) is straightforward
 given their underlying representation as `UTInstant{Day}` and `UTInstant{Millisecond}`, respectively.
-The difference between [`Date`](@ref) is returned in the number of [`Day`](@ref), and [`DateTime`](@ref)
-in the number of [`Millisecond`](@ref). Similarly, comparing [`TimeType`](@ref) is a simple matter
-of comparing the underlying machine instants (which in turn compares the internal [`Int64`](@ref) values).
+The difference between [`Date`](@ref) is returned in the number of [`Day`](@ref), [`DateTime`](@ref)
+in the number of [`Millisecond`](@ref), and [`Timestamp`](@ref) in the number of
+[`Nanosecond`](@ref) — including differences between a [`Timestamp`](@ref) and a
+[`DateTime`](@ref), which promote to [`Timestamp`](@ref). Similarly, comparing [`TimeType`](@ref)
+is a simple matter of comparing the underlying machine instants (which in turn compares the
+internal [`Int64`](@ref) values).
 
 ```jldoctest
 julia> dt = Date(2012,2,29)
@@ -599,8 +625,9 @@ julia> canonicalize(t2-t1) # creates a CompoundPeriod
 
 ## Rounding
 
-[`Date`](@ref) and [`DateTime`](@ref) values can be rounded to a specified resolution (e.g., 1
-month or 15 minutes) with [`floor`](@ref), [`ceil`](@ref), or [`round`](@ref):
+[`Date`](@ref), [`DateTime`](@ref), and [`Timestamp`](@ref) values can be rounded
+to a specified resolution (e.g., 1 month or 15 minutes) with [`floor`](@ref),
+[`ceil`](@ref), or [`round`](@ref):
 
 ```jldoctest
 julia> floor(Date(1985, 8, 16), Dates.Month)
@@ -637,9 +664,10 @@ That may seem confusing, given that the hour (12) is not divisible by 10. The re
 was chosen is that it is 17,676,660 hours after `0000-01-01T00:00:00`, and 17,676,660 is divisible
 by 10.
 
-As Julia [`Date`](@ref) and [`DateTime`](@ref) values are represented according to the ISO 8601
-standard, `0000-01-01T00:00:00` was chosen as base (or "rounding epoch") from which to begin the
-count of days (and milliseconds) used in rounding calculations. (Note that this differs slightly
+As Julia [`Date`](@ref), [`DateTime`](@ref), and [`Timestamp`](@ref) values are
+represented according to the ISO 8601 standard, `0000-01-01T00:00:00` was chosen
+as the base (or "rounding epoch") from which to begin the count of days and
+sub-day units used in rounding calculations. (Note that this differs slightly
 from Julia's internal representation of [`Date`](@ref) s using [Rata Die notation](https://en.wikipedia.org/wiki/Rata_Die);
 but since the ISO 8601 standard is most visible to the end user, `0000-01-01T00:00:00` was chosen as the rounding
 epoch instead of the `0000-12-31T00:00:00` used internally to minimize confusion.)
@@ -697,6 +725,7 @@ Dates.TimeType
 Dates.DateTime
 Dates.Date
 Dates.Time
+Dates.Timestamp
 Dates.TimeZone
 Dates.UTC
 ```
@@ -719,15 +748,24 @@ Dates.Date(::Function, ::Any, ::Any, ::Any)
 Dates.Date(::Dates.TimeType)
 Dates.Date(::AbstractString, ::AbstractString)
 Dates.Date(::AbstractString, ::Dates.DateFormat)
-Dates.Time(::Int64::Int64, ::Int64, ::Int64, ::Int64, ::Int64)
+Dates.Time(::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64)
 Dates.Time(::Dates.TimePeriod)
 Dates.Time(::Function, ::Any...)
-Dates.Time(::Dates.DateTime)
+Dates.Time(::Dates.AbstractDateTime)
 Dates.Time(::AbstractString, ::AbstractString)
 Dates.Time(::AbstractString, ::Dates.DateFormat)
+Dates.Timestamp(::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64)
+Dates.Timestamp(::Dates.Period)
+Dates.Timestamp(::Function, ::Any...)
+Dates.Timestamp(::Dates.Date, ::Dates.Time)
+Dates.Timestamp(::Dates.TimeType)
+Dates.Timestamp(::AbstractString, ::AbstractString)
+Dates.Timestamp(::AbstractString, ::Dates.DateFormat)
 Dates.now()
 Dates.now(::Type{Dates.UTC})
-Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, TimeType})
+Dates.now(::Type{Dates.Timestamp})
+Dates.now(::Type{Dates.Timestamp}, ::Type{Dates.UTC})
+Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, Type{Timestamp}, TimeType})
 ```
 
 #### Accessor Functions
@@ -736,6 +774,9 @@ Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, TimeType})
 Dates.year
 Dates.month
 Dates.week
+Dates.weeksinyear
+Dates.isoyear
+Dates.isoweekdate
 Dates.day
 Dates.hour
 Dates.minute
@@ -753,6 +794,12 @@ Dates.Second(::DateTime)
 Dates.Millisecond(::DateTime)
 Dates.Microsecond(::Dates.Time)
 Dates.Nanosecond(::Dates.Time)
+Dates.Hour(::Dates.Timestamp)
+Dates.Minute(::Dates.Timestamp)
+Dates.Second(::Dates.Timestamp)
+Dates.Millisecond(::Dates.Timestamp)
+Dates.Microsecond(::Dates.Timestamp)
+Dates.Nanosecond(::Dates.Timestamp)
 Dates.yearmonth
 Dates.monthday
 Dates.yearmonthday
@@ -810,8 +857,8 @@ Dates.periods
 
 #### Rounding Functions
 
-`Date` and `DateTime` values can be rounded to a specified resolution (e.g., 1 month or 15 minutes)
-with `floor`, `ceil`, or `round`.
+`Date`, `DateTime`, and `Timestamp` values can be rounded to a specified
+resolution (e.g., 1 month or 15 minutes) with `floor`, `ceil`, or `round`.
 
 ```@docs
 Base.floor(::Dates.TimeType, ::Dates.Period)
@@ -843,6 +890,8 @@ Dates.datetime2epochms
 Dates.today
 Dates.unix2datetime
 Dates.datetime2unix
+Dates.unix2timestamp
+Dates.timestamp2unix
 Dates.julian2datetime
 Dates.datetime2julian
 Dates.rata2datetime
@@ -884,6 +933,7 @@ Months of the Year:
 
 ```@docs
 ISODateTimeFormat
+ISOTimestampFormat
 ISODateFormat
 ISOTimeFormat
 RFC1123Format

--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -5,8 +5,8 @@ DocTestSetup = :(using Dates)
 ```
 
 The `Dates` module provides three types for working with dates: [`Date`](@ref),
-[`DateTime`](@ref), and [`Timestamp`](@ref). They provide day, millisecond, and
-nanosecond precision, respectively. All three are subtypes of the abstract
+[`DateTime`](@ref), and [`Timestamp`](@ref). They provide day precision, millisecond precision, and
+a choice of second, millisecond, microsecond, or nanosecond precision, respectively. All three are subtypes of the abstract
 [`TimeType`](@ref).
 The motivation for distinct types is simple: some operations are much simpler, both in terms of
 code and mental reasoning, when the complexities of greater precision don't have to be dealt with.
@@ -30,15 +30,38 @@ The ISO standard, however, states that 1 BC/BCE is year zero, so `0000-12-31` is
 `0001-01-01`, and year `-0001` (yes, negative one for the year) is 2 BC/BCE, year `-0002` is 3
 BC/BCE, etc.
 
-For instants finer than a millisecond, the [`Timestamp`](@ref) type provides nanosecond
-precision. Its value is a count of nanoseconds since
-the unix epoch `1970-01-01T00:00:00`, the same representation used by nanosecond timestamps
-in Apache Arrow, numpy, and pandas — which bounds its representable range to the years 1677
-through 2262. It supports integer and period construction, accessors, arithmetic,
-rounding, adjusters, ranges, parsing, and formatting. It compares directly with
-[`DateTime`](@ref) and supports mixed arithmetic when the `DateTime` value is in
-range. Use [`DateTime`](@ref) for instants outside the [`Timestamp`](@ref) range
-or when sub-millisecond precision is not needed.
+The [`Timestamp`](@ref) family stores an `Int64` count from the Unix epoch
+`1970-01-01T00:00:00`. Choose `Timestamp{Second}`, `Timestamp{Millisecond}`,
+`Timestamp{Microsecond}`, or `Timestamp{Nanosecond}`. Plain `Timestamp(...)`
+constructs a nanosecond timestamp; `Timestamp(ts::Timestamp)` preserves its resolution.
+Each resolution supports
+construction, accessors, arithmetic, rounding, adjusters, ranges, parsing, and formatting.
+
+| Resolution | Approximate range around 1970 |
+|:-----------|:------------------------------|
+| `Second` | ±292 billion years |
+| `Millisecond` | ±292 million years |
+| `Microsecond` | ±292 thousand years |
+| `Nanosecond` | 1677–2262 |
+
+`Timestamp{Millisecond}` offers the same resolution as `DateTime`, with a Unix
+epoch and a wider supported range. `DateTime` keeps its existing representation
+and API. Use `DateTime` for existing civil-time APIs and `Timestamp{P}` for Unix
+timestamps with an explicit resolution. Use concrete array elements and struct
+fields, such as `Vector{Timestamp{Microsecond}}` and `::Timestamp{Microsecond}`,
+for compact storage; the bare `Timestamp` type is not concrete. Nanosecond value buffers from Arrow or NumPy have the same
+physical layout as `Timestamp{Nanosecond}`; null, sentinel, and timezone handling
+still require care.
+
+Conversions between timestamp resolutions require exact representation. For example,
+`Timestamp{Second}(Timestamp("2020-01-01T00:00:00.5"))` throws an `InexactError`.
+Use `Timestamp{Second}(floor(ts, Second))` to discard fractional seconds explicitly.
+Rounding throws an `InexactError` if the requested result is outside the type's range
+or is not representable at its resolution.
+Period arithmetic preserves the timestamp resolution and rejects a duration that
+cannot be represented at that resolution, whereas `DateTime` rounds finer durations
+to milliseconds. Mixed timestamp arithmetic promotes
+to the finer resolution and requires both inputs to fit its range.
 
 [^1]:
     The notion of the UT second is actually quite fundamental. There are basically two different notions
@@ -191,8 +214,8 @@ Finding the length of time between two [`Date`](@ref) or [`DateTime`](@ref) is s
 given their underlying representation as `UTInstant{Day}` and `UTInstant{Millisecond}`, respectively.
 The difference between [`Date`](@ref) is returned in the number of [`Day`](@ref), [`DateTime`](@ref)
 in the number of [`Millisecond`](@ref), and [`Timestamp`](@ref) in the number of
-[`Nanosecond`](@ref) — including differences between a [`Timestamp`](@ref) and a
-[`DateTime`](@ref), which promote to [`Timestamp`](@ref). Similarly, comparing [`TimeType`](@ref)
+units of its resolution `P`. Mixed timestamp differences use the finer resolution;
+`DateTime` participates with millisecond resolution. Similarly, comparing [`TimeType`](@ref)
 is a simple matter of comparing the underlying machine instants (which in turn compares the
 internal [`Int64`](@ref) values).
 
@@ -754,18 +777,18 @@ Dates.Time(::Function, ::Any...)
 Dates.Time(::Dates.AbstractDateTime)
 Dates.Time(::AbstractString, ::AbstractString)
 Dates.Time(::AbstractString, ::Dates.DateFormat)
-Dates.Timestamp(::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64)
-Dates.Timestamp(::Dates.Period)
+Dates.Timestamp{P}(::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64) where {P}
+Dates.Timestamp{P}(::Dates.Period) where {P}
 Dates.Timestamp(::Function, ::Any...)
-Dates.Timestamp(::Dates.Date, ::Dates.Time)
-Dates.Timestamp(::Dates.TimeType)
-Dates.Timestamp(::AbstractString, ::AbstractString)
-Dates.Timestamp(::AbstractString, ::Dates.DateFormat)
+Dates.Timestamp{P}(::Dates.Date, ::Dates.Time) where {P}
+Dates.Timestamp{P}(::Dates.TimeType) where {P}
+Dates.Timestamp{P}(::AbstractString, ::AbstractString) where {P}
+Dates.Timestamp{P}(::AbstractString, ::Dates.DateFormat) where {P}
 Dates.now()
 Dates.now(::Type{Dates.UTC})
 Dates.now(::Type{Dates.Timestamp})
 Dates.now(::Type{Dates.Timestamp}, ::Type{Dates.UTC})
-Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, Type{Timestamp}, TimeType})
+Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, Type{<:Timestamp}, TimeType})
 ```
 
 #### Accessor Functions

--- a/stdlib/Dates/src/Dates.jl
+++ b/stdlib/Dates/src/Dates.jl
@@ -3,7 +3,7 @@
 """
     Dates
 
-The `Dates` module provides `Date`, `DateTime`, `Time` types, and related functions.
+The `Dates` module provides `Date`, `DateTime`, `Timestamp`, `Time` types, and related functions.
 
 The types are not aware of time zones, are based on UT seconds
 (86400 seconds a day, avoiding leap seconds), and
@@ -27,7 +27,7 @@ julia> d2-d1
 30 days
 ```
 
-Please see the manual section on [`Date`](@ref) and [`DateTime`](@ref)
+Please see the manual section on [`Date`](@ref), [`DateTime`](@ref), and [`Timestamp`](@ref)
 for more information.
 """
 module Dates
@@ -53,7 +53,7 @@ include("deprecated.jl")
 export Period, DatePeriod, TimePeriod,
        Year, Quarter, Month, Week, Day, Hour, Minute, Second, Millisecond,
        Microsecond, Nanosecond,
-       TimeZone, UTC, TimeType, DateTime, Date, Time,
+       TimeZone, UTC, TimeType, DateTime, Date, Time, Timestamp,
        # periods.jl
        canonicalize,
        # accessors.jl
@@ -72,6 +72,7 @@ export Period, DatePeriod, TimePeriod,
        Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec,
        # conversions.jl
        unix2datetime, datetime2unix, now, today,
+       unix2timestamp, timestamp2unix,
        rata2datetime, datetime2rata, julian2datetime, datetime2julian,
        # adjusters.jl
        firstdayofweek, lastdayofweek,
@@ -80,7 +81,8 @@ export Period, DatePeriod, TimePeriod,
        firstdayofquarter, lastdayofquarter,
        tonext, toprev, tofirst, tolast,
        # io.jl
-       ISODateTimeFormat, ISODateFormat, ISOTimeFormat, DateFormat, RFC1123Format, @dateformat_str
+       ISODateTimeFormat, ISODateFormat, ISOTimeFormat, ISOTimestampFormat, DateFormat,
+       RFC1123Format, @dateformat_str
 
 public format
 

--- a/stdlib/Dates/src/accessors.jl
+++ b/stdlib/Dates/src/accessors.jl
@@ -80,8 +80,11 @@ julia> isoyear(Date(2021, 12, 31))
 ```
 !!! compat "Julia 1.13"
     This function requires Julia 1.13 or later.
+
+!!! compat "Julia 1.14"
+    Support for `Timestamp` requires Julia 1.14 or later.
 """
-function isoyear(dt::DateTime)
+function isoyear(dt::Union{DateTime,Timestamp})
     thisyear = Year(dt)
     thismonth = Month(dt)
     weeknumber = week(dt)
@@ -101,7 +104,8 @@ isoyear(dt::Date) = isoyear(DateTime(dt))
 Return the ISO week date that corresponds to `dt` (see
 https://en.wikipedia.org/wiki/ISO_week_date).
 
-The return type is a tuple of `Year`, `Week` and `Int64` (from 1 to 7).
+The return type is a tuple of three `Int64` values: the ISO year, the ISO week
+number, and the ISO weekday (from 1 through 7).
 
 # Examples
 ```jldoctest
@@ -113,8 +117,11 @@ julia> isoweekdate(Date(2023, 01, 01))
 ```
 !!! compat "Julia 1.13"
     This function requires Julia 1.13 or later.
+
+!!! compat "Julia 1.14"
+    Support for `Timestamp` requires Julia 1.14 or later.
 """
-isoweekdate(dt::DateTime) = (isoyear(dt).value, week(dt), dayofweek(dt))
+isoweekdate(dt::Union{DateTime,Timestamp}) = (isoyear(dt).value, week(dt), dayofweek(dt))
 isoweekdate(dt::Date) = isoweekdate(DateTime(dt))
 
 function quarter(days)
@@ -128,6 +135,12 @@ value(dt::TimeType) = dt.instant.periods.value
 value(t::Time) = t.instant.value
 days(dt::Date) = value(dt)
 days(dt::DateTime) = fld(value(dt), 86400000)
+days(dt::Timestamp) = fld(value(dt), NS_PER_DAY) + UNIXEPOCHDAYS
+# time-of-day part of an instant; the unix epoch is midnight-aligned, so
+# fld/mod day arithmetic on Timestamp values works exactly as it does for the
+# Rata Die-anchored DateTime values
+msofday(dt::DateTime) = mod(value(dt), 86400000)
+nsofday(dt::Timestamp) = mod(value(dt), NS_PER_DAY)
 year(dt::TimeType) = year(days(dt))
 quarter(dt::TimeType) = quarter(days(dt))
 month(dt::TimeType) = month(days(dt))
@@ -143,6 +156,12 @@ second(t::Time) = mod(fld(value(t), 1000000000), Int64(60))
 millisecond(t::Time) = mod(fld(value(t), Int64(1000000)), Int64(1000))
 microsecond(t::Time) = mod(fld(value(t), Int64(1000)), Int64(1000))
 nanosecond(t::Time) = mod(value(t), Int64(1000))
+hour(dt::Timestamp)   = mod(fld(value(dt), 3600000000000), Int64(24))
+minute(dt::Timestamp) = mod(fld(value(dt), 60000000000), Int64(60))
+second(dt::Timestamp) = mod(fld(value(dt), 1000000000), Int64(60))
+millisecond(dt::Timestamp) = mod(fld(value(dt), Int64(1000000)), Int64(1000))
+microsecond(dt::Timestamp) = mod(fld(value(dt), Int64(1000)), Int64(1000))
+nanosecond(dt::Timestamp) = mod(value(dt), Int64(1000))
 
 dayofmonth(dt::TimeType) = day(dt)
 
@@ -157,7 +176,7 @@ for func in (:year, :month, :quarter)
         @doc """
             $($name)(dt::TimeType)::Int64
 
-        The $($name) of a `Date` or `DateTime` as an [`Int64`](@ref).
+        The $($name) of a `Date`, `DateTime`, or `Timestamp` as an [`Int64`](@ref).
         """ $func(dt::TimeType)
     end
 end
@@ -165,11 +184,11 @@ end
 """
     week(dt::TimeType)::Int64
 
-Return the [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date) of a `Date` or
-`DateTime` as an [`Int64`](@ref). Note that the first week of a year is the week that
-contains the first Thursday of the year, which can result in dates prior to January 4th
-being in the last week of the previous year. For example, `week(Date(2005, 1, 1))` is the 53rd
-week of 2004.
+Return the [ISO week number](https://en.wikipedia.org/wiki/ISO_week_date) of a
+`Date`, `DateTime`, or `Timestamp` as an [`Int64`](@ref). Note that the first
+week of a year is the week that contains the first Thursday of the year, which
+can result in dates prior to January 4th being in the last week of the previous
+year. For example, `week(Date(2005, 1, 1))` is the 53rd week of 2004.
 
 # Examples
 ```jldoctest
@@ -191,15 +210,15 @@ for func in (:day, :dayofmonth)
         @doc """
             $($name)(dt::TimeType)::Int64
 
-        The day of month of a `Date` or `DateTime` as an [`Int64`](@ref).
+        The day of month of a `Date`, `DateTime`, or `Timestamp` as an [`Int64`](@ref).
         """ $func(dt::TimeType)
     end
 end
 
 """
-    hour(dt::DateTime)::Int64
+    hour(dt::Union{DateTime,Timestamp})::Int64
 
-The hour of day of a `DateTime` as an [`Int64`](@ref).
+The hour of day of a `DateTime` or `Timestamp` as an [`Int64`](@ref).
 """
 hour(dt::DateTime)
 
@@ -207,9 +226,9 @@ for func in (:minute, :second, :millisecond)
     name = string(func)
     @eval begin
         @doc """
-            $($name)(dt::DateTime)::Int64
+            $($name)(dt::Union{DateTime,Timestamp})::Int64
 
-        The $($name) of a `DateTime` as an [`Int64`](@ref).
+        The $($name) of a `DateTime` or `Timestamp` as an [`Int64`](@ref).
         """ $func(dt::DateTime)
     end
 end
@@ -221,8 +240,8 @@ for parts in (["year", "month"], ["month", "day"], ["year", "month", "day"])
         @doc """
             $($name)(dt::TimeType) -> ($(join(repeated(Int64, length($parts)), ", ")))
 
-        Simultaneously return the $(join($parts, ", ", " and ")) parts of a `Date` or
-        `DateTime`.
+        Simultaneously return the $(join($parts, ", ", " and ")) parts of a `Date`,
+        `DateTime`, or `Timestamp`.
         """ $func(dt::TimeType)
     end
 end
@@ -233,7 +252,7 @@ for func in (:hour, :minute, :second, :millisecond, :microsecond, :nanosecond)
         @doc """
             $($name)(t::Time)::Int64
 
-        The $($name) of a `Time` as an [`Int64`](@ref).
+        The $($name) of a `Time` or `Timestamp` as an [`Int64`](@ref).
         """ $func(t::Time)
     end
 end

--- a/stdlib/Dates/src/accessors.jl
+++ b/stdlib/Dates/src/accessors.jl
@@ -135,12 +135,12 @@ value(dt::TimeType) = dt.instant.periods.value
 value(t::Time) = t.instant.value
 days(dt::Date) = value(dt)
 days(dt::DateTime) = fld(value(dt), 86400000)
-days(dt::Timestamp) = fld(value(dt), NS_PER_DAY) + UNIXEPOCHDAYS
+days(dt::Timestamp{P}) where {P} = fld(value(dt), timestamp_ticks_per_day(P)) + UNIXEPOCHDAYS
 # time-of-day part of an instant; the unix epoch is midnight-aligned, so
 # fld/mod day arithmetic on Timestamp values works exactly as it does for the
 # Rata Die-anchored DateTime values
 msofday(dt::DateTime) = mod(value(dt), 86400000)
-nsofday(dt::Timestamp) = mod(value(dt), NS_PER_DAY)
+nsofday(dt::Timestamp{P}) where {P} = mod(value(dt), timestamp_ticks_per_day(P)) * timestamp_scale(P)
 year(dt::TimeType) = year(days(dt))
 quarter(dt::TimeType) = quarter(days(dt))
 month(dt::TimeType) = month(days(dt))
@@ -156,12 +156,15 @@ second(t::Time) = mod(fld(value(t), 1000000000), Int64(60))
 millisecond(t::Time) = mod(fld(value(t), Int64(1000000)), Int64(1000))
 microsecond(t::Time) = mod(fld(value(t), Int64(1000)), Int64(1000))
 nanosecond(t::Time) = mod(value(t), Int64(1000))
-hour(dt::Timestamp)   = mod(fld(value(dt), 3600000000000), Int64(24))
-minute(dt::Timestamp) = mod(fld(value(dt), 60000000000), Int64(60))
-second(dt::Timestamp) = mod(fld(value(dt), 1000000000), Int64(60))
-millisecond(dt::Timestamp) = mod(fld(value(dt), Int64(1000000)), Int64(1000))
-microsecond(dt::Timestamp) = mod(fld(value(dt), Int64(1000)), Int64(1000))
-nanosecond(dt::Timestamp) = mod(value(dt), Int64(1000))
+@inline timestamp_part(dt::Timestamp{P}, unit, modulus) where {P} =
+    unit < timestamp_scale(P) ? Int64(0) :
+    mod(fld(value(dt), unit ÷ timestamp_scale(P)), modulus)
+hour(dt::Timestamp) = timestamp_part(dt, 3600000000000, Int64(24))
+minute(dt::Timestamp) = timestamp_part(dt, 60000000000, Int64(60))
+second(dt::Timestamp) = timestamp_part(dt, Int64(1000000000), Int64(60))
+millisecond(dt::Timestamp) = timestamp_part(dt, Int64(1000000), Int64(1000))
+microsecond(dt::Timestamp) = timestamp_part(dt, Int64(1000), Int64(1000))
+nanosecond(dt::Timestamp) = timestamp_part(dt, Int64(1), Int64(1000))
 
 dayofmonth(dt::TimeType) = day(dt)
 

--- a/stdlib/Dates/src/adjusters.jl
+++ b/stdlib/Dates/src/adjusters.jl
@@ -15,6 +15,8 @@ Base.trunc(dt::DateTime, p::Type{Minute}) = dt - Second(dt) - Millisecond(dt)
 Base.trunc(dt::DateTime, p::Type{Second}) = dt - Millisecond(dt)
 Base.trunc(dt::DateTime, p::Type{Millisecond}) = dt
 
+Base.trunc(dt::Timestamp, ::Type{P}) where {P<:Period} = floor(dt, oneunit(P))
+
 Base.trunc(t::Time, p::Type{Hour}) = Time(Hour(t))
 Base.trunc(t::Time, p::Type{Minute}) = Time(Hour(t), Minute(t))
 Base.trunc(t::Time, p::Type{Second}) = Time(Hour(t), Minute(t), Second(t))
@@ -46,11 +48,14 @@ Adjusts `dt` to the Monday of its week.
 julia> firstdayofweek(DateTime("1996-01-05T12:30:00"))
 1996-01-01T00:00:00
 ```
+
+!!! compat "Julia 1.14"
+    This function was generalized from `DateTime` to `AbstractDateTime` in Julia 1.14.
 """
 function firstdayofweek end
 
 firstdayofweek(dt::Date) = Date(UTD(value(dt) - dayofweek(dt) + 1))
-firstdayofweek(dt::DateTime) = DateTime(firstdayofweek(Date(dt)))
+firstdayofweek(dt::T) where T<:AbstractDateTime = T(firstdayofweek(Date(dt)))
 
 """
     lastdayofweek(dt::TimeType)::TimeType
@@ -62,11 +67,14 @@ Adjusts `dt` to the Sunday of its week.
 julia> lastdayofweek(DateTime("1996-01-05T12:30:00"))
 1996-01-07T00:00:00
 ```
+
+!!! compat "Julia 1.14"
+    This function was generalized from `DateTime` to `AbstractDateTime` in Julia 1.14.
 """
 function lastdayofweek end
 
 lastdayofweek(dt::Date) = Date(UTD(value(dt) + (7 - dayofweek(dt))))
-lastdayofweek(dt::DateTime) = DateTime(lastdayofweek(Date(dt)))
+lastdayofweek(dt::T) where T<:AbstractDateTime = T(lastdayofweek(Date(dt)))
 
 """
     firstdayofmonth(dt::TimeType)::TimeType
@@ -78,11 +86,14 @@ Adjusts `dt` to the first day of its month.
 julia> firstdayofmonth(DateTime("1996-05-20"))
 1996-05-01T00:00:00
 ```
+
+!!! compat "Julia 1.14"
+    This function was generalized from `DateTime` to `AbstractDateTime` in Julia 1.14.
 """
 function firstdayofmonth end
 
 firstdayofmonth(dt::Date) = Date(UTD(value(dt) - day(dt) + 1))
-firstdayofmonth(dt::DateTime) = DateTime(firstdayofmonth(Date(dt)))
+firstdayofmonth(dt::T) where T<:AbstractDateTime = T(firstdayofmonth(Date(dt)))
 
 """
     lastdayofmonth(dt::TimeType)::TimeType
@@ -94,6 +105,9 @@ Adjusts `dt` to the last day of its month.
 julia> lastdayofmonth(DateTime("1996-05-20"))
 1996-05-31T00:00:00
 ```
+
+!!! compat "Julia 1.14"
+    This function was generalized from `DateTime` to `AbstractDateTime` in Julia 1.14.
 """
 function lastdayofmonth end
 
@@ -101,7 +115,7 @@ function lastdayofmonth(dt::Date)
     y, m, d = yearmonthday(dt)
     return Date(UTD(value(dt) + daysinmonth(y, m) - d))
 end
-lastdayofmonth(dt::DateTime) = DateTime(lastdayofmonth(Date(dt)))
+lastdayofmonth(dt::T) where T<:AbstractDateTime = T(lastdayofmonth(Date(dt)))
 
 """
     firstdayofyear(dt::TimeType)::TimeType
@@ -113,11 +127,14 @@ Adjusts `dt` to the first day of its year.
 julia> firstdayofyear(DateTime("1996-05-20"))
 1996-01-01T00:00:00
 ```
+
+!!! compat "Julia 1.14"
+    This function was generalized from `DateTime` to `AbstractDateTime` in Julia 1.14.
 """
 function firstdayofyear end
 
 firstdayofyear(dt::Date) = Date(UTD(value(dt) - dayofyear(dt) + 1))
-firstdayofyear(dt::DateTime) = DateTime(firstdayofyear(Date(dt)))
+firstdayofyear(dt::T) where T<:AbstractDateTime = T(firstdayofyear(Date(dt)))
 
 """
     lastdayofyear(dt::TimeType)::TimeType
@@ -129,6 +146,9 @@ Adjusts `dt` to the last day of its year.
 julia> lastdayofyear(DateTime("1996-05-20"))
 1996-12-31T00:00:00
 ```
+
+!!! compat "Julia 1.14"
+    This function was generalized from `DateTime` to `AbstractDateTime` in Julia 1.14.
 """
 function lastdayofyear end
 
@@ -136,7 +156,7 @@ function lastdayofyear(dt::Date)
     y, m, d = yearmonthday(dt)
     return Date(UTD(value(dt) + daysinyear(y) - dayofyear(y, m, d)))
 end
-lastdayofyear(dt::DateTime) = DateTime(lastdayofyear(Date(dt)))
+lastdayofyear(dt::T) where T<:AbstractDateTime = T(lastdayofyear(Date(dt)))
 
 """
     firstdayofquarter(dt::TimeType)::TimeType
@@ -151,6 +171,9 @@ julia> firstdayofquarter(DateTime("1996-05-20"))
 julia> firstdayofquarter(DateTime("1996-08-20"))
 1996-07-01T00:00:00
 ```
+
+!!! compat "Julia 1.14"
+    This function was generalized from `DateTime` to `AbstractDateTime` in Julia 1.14.
 """
 function firstdayofquarter end
 
@@ -159,7 +182,7 @@ function firstdayofquarter(dt::Date)
     mm = m < 4 ? 1 : m < 7 ? 4 : m < 10 ? 7 : 10
     return Date(y, mm, 1)
 end
-firstdayofquarter(dt::DateTime) = DateTime(firstdayofquarter(Date(dt)))
+firstdayofquarter(dt::T) where T<:AbstractDateTime = T(firstdayofquarter(Date(dt)))
 
 """
     lastdayofquarter(dt::TimeType)::TimeType
@@ -174,6 +197,9 @@ julia> lastdayofquarter(DateTime("1996-05-20"))
 julia> lastdayofquarter(DateTime("1996-08-20"))
 1996-09-30T00:00:00
 ```
+
+!!! compat "Julia 1.14"
+    This function was generalized from `DateTime` to `AbstractDateTime` in Julia 1.14.
 """
 function lastdayofquarter end
 
@@ -182,7 +208,7 @@ function lastdayofquarter(dt::Date)
     mm, d = m < 4 ? (3, 31) : m < 7 ? (6, 30) : m < 10 ? (9, 30) : (12, 31)
     return Date(y, mm, d)
 end
-lastdayofquarter(dt::DateTime) = DateTime(lastdayofquarter(Date(dt)))
+lastdayofquarter(dt::T) where T<:AbstractDateTime = T(lastdayofquarter(Date(dt)))
 
 # Temporal Adjusters
 struct DateFunction
@@ -308,6 +334,60 @@ function DateTime(func::Function, y, m, d, h, mi; step::Period=Second(1), limit:
 end
 function DateTime(func::Function, y, m, d, h, mi, s; step::Period=Millisecond(1), limit::Int=10000)
     return adjust(DateFunction(func, DateTime(y)), DateTime(y, m, d, h, mi, s), step, limit)
+end
+
+"""
+    Timestamp(f::Function, y, m=1; step=Day(1), limit=10000)::Timestamp
+    Timestamp(f::Function, y, m, d; step=Hour(1), limit=10000)::Timestamp
+    Timestamp(f::Function, y, m, d, h; step=Minute(1), limit=10000)::Timestamp
+    Timestamp(f::Function, y, m, d, h, mi; step=Second(1), limit=10000)::Timestamp
+    Timestamp(f::Function, y, m, d, h, mi, s; step=Millisecond(1), limit=10000)::Timestamp
+    Timestamp(f::Function, y, m, d, h, mi, s, ms; step=Microsecond(1), limit=10000)::Timestamp
+    Timestamp(f::Function, y, m, d, h, mi, s, ms, us; step=Nanosecond(1), limit=10000)::Timestamp
+
+Create a `Timestamp` through the adjuster API. The starting point will be constructed from
+the provided `y, m, d...` arguments, and will be adjusted until `f::Function` returns
+`true`. The step size in adjusting can be provided manually through the `step` keyword.
+`limit` provides a limit to the max number of iterations the adjustment API will
+pursue before throwing an error (in the case that `f::Function` is never satisfied).
+The default step is `Day(1)` when only a year or month is supplied. Each
+additional part changes the default to the next finer unit, down to
+`Nanosecond(1)`.
+
+!!! compat "Julia 1.14"
+    `Timestamp` requires Julia 1.14 or later.
+
+# Examples
+```jldoctest
+julia> Timestamp(ts -> second(ts) == 40, 2010, 10, 20, 10; step = Second(1))
+2010-10-20T10:00:40
+
+julia> Timestamp(ts -> nanosecond(ts) == 4, 2010, 10, 20, 10, 0, 0, 0, 0; step = Nanosecond(1))
+2010-10-20T10:00:00.000000004
+```
+"""
+Timestamp(::Function, args...)
+
+function Timestamp(func::Function, y, m=1; step::Period=Day(1), limit::Int=10000)
+    return adjust(func, Timestamp(y, m); step, limit)
+end
+function Timestamp(func::Function, y, m, d; step::Period=Hour(1), limit::Int=10000)
+    return adjust(func, Timestamp(y, m, d); step, limit)
+end
+function Timestamp(func::Function, y, m, d, h; step::Period=Minute(1), limit::Int=10000)
+    return adjust(func, Timestamp(y, m, d, h); step, limit)
+end
+function Timestamp(func::Function, y, m, d, h, mi; step::Period=Second(1), limit::Int=10000)
+    return adjust(func, Timestamp(y, m, d, h, mi); step, limit)
+end
+function Timestamp(func::Function, y, m, d, h, mi, s; step::Period=Millisecond(1), limit::Int=10000)
+    return adjust(func, Timestamp(y, m, d, h, mi, s); step, limit)
+end
+function Timestamp(func::Function, y, m, d, h, mi, s, ms; step::Period=Microsecond(1), limit::Int=10000)
+    return adjust(func, Timestamp(y, m, d, h, mi, s, ms); step, limit)
+end
+function Timestamp(func::Function, y, m, d, h, mi, s, ms, us; step::Period=Nanosecond(1), limit::Int=10000)
+    return adjust(func, Timestamp(y, m, d, h, mi, s, ms, us); step, limit)
 end
 
 """

--- a/stdlib/Dates/src/adjusters.jl
+++ b/stdlib/Dates/src/adjusters.jl
@@ -368,26 +368,26 @@ julia> Timestamp(ts -> nanosecond(ts) == 4, 2010, 10, 20, 10, 0, 0, 0, 0; step =
 """
 Timestamp(::Function, args...)
 
-function Timestamp(func::Function, y, m=1; step::Period=Day(1), limit::Int=10000)
-    return adjust(func, Timestamp(y, m); step, limit)
+function Timestamp{P}(func::Function, y, m=1; step::Period=Day(1), limit::Int=10000) where {P}
+    return adjust(func, Timestamp{P}(y, m); step, limit)
 end
-function Timestamp(func::Function, y, m, d; step::Period=Hour(1), limit::Int=10000)
-    return adjust(func, Timestamp(y, m, d); step, limit)
+function Timestamp{P}(func::Function, y, m, d; step::Period=Hour(1), limit::Int=10000) where {P}
+    return adjust(func, Timestamp{P}(y, m, d); step, limit)
 end
-function Timestamp(func::Function, y, m, d, h; step::Period=Minute(1), limit::Int=10000)
-    return adjust(func, Timestamp(y, m, d, h); step, limit)
+function Timestamp{P}(func::Function, y, m, d, h; step::Period=Minute(1), limit::Int=10000) where {P}
+    return adjust(func, Timestamp{P}(y, m, d, h); step, limit)
 end
-function Timestamp(func::Function, y, m, d, h, mi; step::Period=Second(1), limit::Int=10000)
-    return adjust(func, Timestamp(y, m, d, h, mi); step, limit)
+function Timestamp{P}(func::Function, y, m, d, h, mi; step::Period=Second(1), limit::Int=10000) where {P}
+    return adjust(func, Timestamp{P}(y, m, d, h, mi); step, limit)
 end
-function Timestamp(func::Function, y, m, d, h, mi, s; step::Period=Millisecond(1), limit::Int=10000)
-    return adjust(func, Timestamp(y, m, d, h, mi, s); step, limit)
+function Timestamp{P}(func::Function, y, m, d, h, mi, s; step::Period=max(Millisecond(1), eps(Timestamp{P})), limit::Int=10000) where {P}
+    return adjust(func, Timestamp{P}(y, m, d, h, mi, s); step, limit)
 end
-function Timestamp(func::Function, y, m, d, h, mi, s, ms; step::Period=Microsecond(1), limit::Int=10000)
-    return adjust(func, Timestamp(y, m, d, h, mi, s, ms); step, limit)
+function Timestamp{P}(func::Function, y, m, d, h, mi, s, ms; step::Period=max(Microsecond(1), eps(Timestamp{P})), limit::Int=10000) where {P}
+    return adjust(func, Timestamp{P}(y, m, d, h, mi, s, ms); step, limit)
 end
-function Timestamp(func::Function, y, m, d, h, mi, s, ms, us; step::Period=Nanosecond(1), limit::Int=10000)
-    return adjust(func, Timestamp(y, m, d, h, mi, s, ms, us); step, limit)
+function Timestamp{P}(func::Function, y, m, d, h, mi, s, ms, us; step::Period=max(Nanosecond(1), eps(Timestamp{P})), limit::Int=10000) where {P}
+    return adjust(func, Timestamp{P}(y, m, d, h, mi, s, ms, us); step, limit)
 end
 
 """

--- a/stdlib/Dates/src/arithmetic.jl
+++ b/stdlib/Dates/src/arithmetic.jl
@@ -84,6 +84,14 @@ end
 (-)(x::DateTime, y::Period) = return DateTime(UTM(value(x) - toms(y)))
 (+)(x::Time, y::TimePeriod) = return Time(Nanosecond(value(x) + tons(y)))
 (-)(x::Time, y::TimePeriod) = return Time(Nanosecond(value(x) - tons(y)))
+# Timestamp calendar arithmetic reuses Date's Year/Month/Quarter handling
+# (including end-of-month day clamping) on the day part, carrying the
+# nanosecond-resolution time of day through unchanged. Like DateTime's,
+# Timestamp arithmetic is fixed-point and wraps at the ends of the range.
+(+)(x::Timestamp, y::Union{Year, Quarter, Month}) = Timestamp(UTN(unixns(value(Date(x) + y), nsofday(x))))
+(-)(x::Timestamp, y::Union{Year, Quarter, Month}) = Timestamp(UTN(unixns(value(Date(x) - y), nsofday(x))))
+(+)(x::Timestamp, y::Period) = return Timestamp(UTN(value(x) + tons(y)))
+(-)(x::Timestamp, y::Period) = return Timestamp(UTN(value(x) - tons(y)))
 (+)(y::Period, x::TimeType) = x + y
 
 # Missing support

--- a/stdlib/Dates/src/arithmetic.jl
+++ b/stdlib/Dates/src/arithmetic.jl
@@ -84,14 +84,23 @@ end
 (-)(x::DateTime, y::Period) = return DateTime(UTM(value(x) - toms(y)))
 (+)(x::Time, y::TimePeriod) = return Time(Nanosecond(value(x) + tons(y)))
 (-)(x::Time, y::TimePeriod) = return Time(Nanosecond(value(x) - tons(y)))
-# Timestamp calendar arithmetic reuses Date's Year/Month/Quarter handling
-# (including end-of-month day clamping) on the day part, carrying the
-# nanosecond-resolution time of day through unchanged. Like DateTime's,
-# Timestamp arithmetic is fixed-point and wraps at the ends of the range.
-(+)(x::Timestamp, y::Union{Year, Quarter, Month}) = Timestamp(UTN(unixns(value(Date(x) + y), nsofday(x))))
-(-)(x::Timestamp, y::Union{Year, Quarter, Month}) = Timestamp(UTN(unixns(value(Date(x) - y), nsofday(x))))
-(+)(x::Timestamp, y::Period) = return Timestamp(UTN(value(x) + tons(y)))
-(-)(x::Timestamp, y::Period) = return Timestamp(UTN(value(x) - tons(y)))
+# Fixed-duration arithmetic preserves resolution and wraps in units of P.
+function timestamp_period_ticks(::Type{P}, y::FixedPeriod) where {P}
+    unit, scale = tons(oneunit(y)), timestamp_scale(P)
+    unit >= scale && return value(y) * (unit ÷ scale)
+    ticks, remainder = divrem(value(y), scale ÷ unit)
+    iszero(remainder) || throw(InexactError(:convert, P, y))
+    return ticks
+end
+for op in (:+, :-)
+    @eval begin
+        ($op)(x::Timestamp{P}, y::Union{Year,Quarter,Month}) where {P} =
+            Timestamp{P}(UTInstant(P(((Int128(value(($op)(Date(x), y))) - UNIXEPOCHDAYS) *
+                timestamp_ticks_per_day(P) + nsofday(x) ÷ timestamp_scale(P)) % Int64)))
+        ($op)(x::Timestamp{P}, y::FixedPeriod) where {P} =
+            Timestamp{P}(UTInstant(P(($op)(value(x), timestamp_period_ticks(P, y)))))
+    end
+end
 (+)(y::Period, x::TimeType) = x + y
 
 # Missing support

--- a/stdlib/Dates/src/conversions.jl
+++ b/stdlib/Dates/src/conversions.jl
@@ -3,38 +3,67 @@
 # Conversion/Promotion
 
 """
-    Date(dt::DateTime)
+    Date(dt::TimeType)
 
-Convert a `DateTime` to a `Date`. The hour, minute, second, and millisecond parts of
-the `DateTime` are truncated, so only the year, month and day parts are used in
-construction.
+Convert a `DateTime` or `Timestamp` to a `Date`. The time-of-day parts are
+truncated, so only the year, month, and day parts are used in construction.
 """
 Date(dt::TimeType) = convert(Date, dt)
 
 """
-    DateTime(dt::Date)
+    DateTime(dt::TimeType)
 
-Convert a `Date` to a `DateTime`. The hour, minute, second, and millisecond parts of
-the new `DateTime` are assumed to be zero.
+Convert a `Date` or `Timestamp` to a `DateTime`. For a `Date`, the time-of-day
+parts are zero. For a `Timestamp`, the value is floored to millisecond resolution.
 """
 DateTime(dt::TimeType) = convert(DateTime, dt)
 
 """
-    Time(dt::DateTime)
+    Time(dt::AbstractDateTime)
 
-Convert a `DateTime` to a `Time`. The hour, minute, second, and millisecond parts of
-the `DateTime` are used to create the new `Time`. Microseconds and nanoseconds are zero by default.
+Convert an `AbstractDateTime`, such as a `DateTime` or `Timestamp`, to a `Time`,
+preserving its time-of-day part.
+
+!!! compat "Julia 1.14"
+    This method was generalized from `DateTime` to `AbstractDateTime` in Julia 1.14.
 """
-Time(dt::DateTime) = convert(Time, dt)
+Time(dt::AbstractDateTime) = convert(Time, dt)
+
+"""
+    Timestamp(dt::TimeType)
+
+Convert a `Date` or `DateTime` to a `Timestamp`. Parts finer than the input's
+resolution are assumed to be zero. Throws an `ArgumentError` ([`InexactError`](@ref)
+for a `DateTime`) if the instant lies outside the representable `Timestamp` range.
+
+!!! compat "Julia 1.14"
+    `Timestamp` requires Julia 1.14 or later.
+"""
+Timestamp(dt::TimeType) = convert(Timestamp, dt)
 
 Base.convert(::Type{DateTime}, dt::Date) = DateTime(UTM(value(dt) * 86400000))
 Base.convert(::Type{Date}, dt::DateTime) = Date(UTD(days(dt)))
 Base.convert(::Type{Time}, dt::DateTime) = Time(Nanosecond((value(dt) % 86400000) * 1000000))
+# Timestamp <-> DateTime/Date/Time. DateTime -> Timestamp throws an InexactError
+# for instants outside the Timestamp range; Timestamp -> DateTime floors to the
+# millisecond (fld also rounds pre-1970 instants toward the past, matching
+# Date(::DateTime)).
+function Base.convert(::Type{Timestamp}, dt::DateTime)
+    UNIXEPOCH - typemax(Int64) ÷ 1000000 <= value(dt) <= UNIXEPOCH + typemax(Int64) ÷ 1000000 ||
+        throw(InexactError(:convert, Timestamp, dt))
+    return Timestamp(UTN((value(dt) - UNIXEPOCH) * 1000000))
+end
+Base.convert(::Type{Timestamp}, dt::Date) = Timestamp(dt)
+Base.convert(::Type{DateTime}, dt::Timestamp) = DateTime(UTM(fld(value(dt), 1000000) + UNIXEPOCH))
+Base.convert(::Type{Date}, dt::Timestamp) = Date(UTD(days(dt)))
+Base.convert(::Type{Time}, dt::Timestamp) = Time(Nanosecond(nsofday(dt)))
 
 Base.convert(::Type{DateTime},x::Millisecond)  = DateTime(Dates.UTInstant(x))  # Converts Rata Die milliseconds to a DateTime
 Base.convert(::Type{Millisecond},dt::DateTime) = Millisecond(value(dt))        # Converts DateTime to Rata Die milliseconds
 Base.convert(::Type{Date},x::Day)  = Date(Dates.UTInstant(x))  # Converts Rata Die days to a Date
 Base.convert(::Type{Day},dt::Date) = Day(value(dt))            # Converts Date to Rata Die days
+Base.convert(::Type{Timestamp},x::Nanosecond)  = Timestamp(UTInstant(x))       # Converts unix nanoseconds to a Timestamp
+Base.convert(::Type{Nanosecond},dt::Timestamp) = Nanosecond(value(dt))         # Converts Timestamp to unix nanoseconds
 
 ### External Conversions
 const UNIXEPOCH = value(DateTime(1970)) #Rata Die milliseconds for 1970-01-01T00:00:00
@@ -65,6 +94,39 @@ Take the given `DateTime` and return the number of seconds
 since the unix epoch `1970-01-01T00:00:00` as a [`Float64`](@ref).
 """
 datetime2unix(dt::DateTime) = (value(dt) - UNIXEPOCH) / 1000.0
+
+"""
+    unix2timestamp(x)::Timestamp
+
+Take the number of seconds since unix epoch `1970-01-01T00:00:00` (UTC) and
+convert to the corresponding `Timestamp`. Note that a [`Float64`](@ref) second
+count near the present carries only about microsecond precision; construct a
+`Timestamp` from an integer nanosecond count
+(`convert(Timestamp, Nanosecond(ns))`) when full nanosecond precision is
+required.
+
+!!! compat "Julia 1.14"
+    This function requires Julia 1.14 or later.
+"""
+unix2timestamp(x::Real) = Timestamp(UTN(trunc(Int64, Int64(1000000000) * x)))
+function unix2timestamp(x::Integer)
+    -(typemax(Int64) ÷ 1000000000) <= x <= typemax(Int64) ÷ 1000000000 ||
+        throw(InexactError(:unix2timestamp, Timestamp, x))
+    return Timestamp(UTN(Int64(x) * 1000000000))
+end
+
+"""
+    timestamp2unix(dt::Timestamp)::Float64
+
+Take the given `Timestamp` and return the number of seconds since the unix
+epoch `1970-01-01T00:00:00` as a [`Float64`](@ref). Note that the returned
+value carries only about microsecond precision near the present;
+`Dates.value(dt)` is the exact count of nanoseconds since the unix epoch.
+
+!!! compat "Julia 1.14"
+    This function requires Julia 1.14 or later.
+"""
+timestamp2unix(dt::Timestamp) = value(dt) / 1.0e9
 
 """
     now()::DateTime
@@ -99,6 +161,51 @@ julia> now(UTC)
 """
 now(::Type{UTC}) = unix2datetime(time())
 
+# uv_timespec_t; unlike the platform-dependent C `struct timespec`, its fields
+# have fixed-width types on all supported platforms
+struct UVTimespec
+    sec::Int64
+    nsec::Int32
+end
+
+function unix_now_ns()
+    ts = Ref{UVTimespec}()
+    # 1 is UV_CLOCK_REALTIME; on Windows libuv reads the precise system clock
+    err = ccall(:uv_clock_gettime, Cint, (Cint, Ref{UVTimespec}), 1, ts)
+    err == 0 || Base.uv_error("uv_clock_gettime", err)
+    return ts[]
+end
+
+"""
+    now(::Type{Timestamp})::Timestamp
+
+Return a `Timestamp` corresponding to the user's system time including the
+system timezone locale, at the full resolution of the system clock.
+
+!!! compat "Julia 1.14"
+    This method requires Julia 1.14 or later.
+"""
+function now(::Type{Timestamp})
+    ts = unix_now_ns()
+    tm = Libc.TmStruct(ts.sec)
+    return Timestamp(tm.year + 1900, tm.month + 1, tm.mday, tm.hour, tm.min, tm.sec,
+                     0, 0, Int64(ts.nsec))
+end
+
+"""
+    now(::Type{Timestamp}, ::Type{UTC})::Timestamp
+
+Return a `Timestamp` corresponding to the user's system time as UTC/GMT, at the
+full resolution of the system clock.
+
+!!! compat "Julia 1.14"
+    This method requires Julia 1.14 or later.
+"""
+function now(::Type{Timestamp}, ::Type{UTC})
+    ts = unix_now_ns()
+    return Timestamp(UTN(ts.sec * 1000000000 + ts.nsec))
+end
+
 """
     rata2datetime(days)::DateTime
 
@@ -110,7 +217,8 @@ rata2datetime(days) = DateTime(yearmonthday(days)...)
 """
     datetime2rata(dt::TimeType)::Int64
 
-Return the number of Rata Die days since epoch from the given `Date` or `DateTime`.
+Return the number of Rata Die days since epoch from the given `Date`,
+`DateTime`, or `Timestamp`.
 """
 datetime2rata(dt::TimeType) = days(dt)
 

--- a/stdlib/Dates/src/conversions.jl
+++ b/stdlib/Dates/src/conversions.jl
@@ -30,16 +30,23 @@ preserving its time-of-day part.
 Time(dt::AbstractDateTime) = convert(Time, dt)
 
 """
-    Timestamp(dt::TimeType)
+    Timestamp{P}(dt::TimeType)
 
-Convert a `Date` or `DateTime` to a `Timestamp`. Parts finer than the input's
-resolution are assumed to be zero. Throws an `ArgumentError` ([`InexactError`](@ref)
-for a `DateTime`) if the instant lies outside the representable `Timestamp` range.
+Convert a `Date`, `DateTime`, or `Timestamp` to `Timestamp{P}`. The instant must
+be exactly representable at resolution `P`. A precision loss or out-of-range
+`DateTime` or `Timestamp` throws an [`InexactError`](@ref); an out-of-range
+`Date` throws an `ArgumentError`.
 
 !!! compat "Julia 1.14"
     `Timestamp` requires Julia 1.14 or later.
 """
-Timestamp(dt::TimeType) = convert(Timestamp, dt)
+Timestamp{P}(dt::TimeType) where {P} = convert(Timestamp{P}, dt)
+Base.convert(::Type{Timestamp}, dt::Union{Date,DateTime}) = convert(Timestamp{Nanosecond}, dt)
+Base.convert(::Type{Timestamp}, dt::Timestamp) = dt
+Base.convert(::Type{Timestamp{P}}, dt::Timestamp{P}) where {P} = dt
+function Base.convert(::Type{Timestamp{P}}, dt::Timestamp{Q}) where {P,Q}
+    return Timestamp{P}(UTInstant(P(timestamp_ticks(P, Int128(value(dt)) * timestamp_scale(Q)))))
+end
 
 Base.convert(::Type{DateTime}, dt::Date) = DateTime(UTM(value(dt) * 86400000))
 Base.convert(::Type{Date}, dt::DateTime) = Date(UTD(days(dt)))
@@ -48,13 +55,13 @@ Base.convert(::Type{Time}, dt::DateTime) = Time(Nanosecond((value(dt) % 86400000
 # for instants outside the Timestamp range; Timestamp -> DateTime floors to the
 # millisecond (fld also rounds pre-1970 instants toward the past, matching
 # Date(::DateTime)).
-function Base.convert(::Type{Timestamp}, dt::DateTime)
-    UNIXEPOCH - typemax(Int64) ÷ 1000000 <= value(dt) <= UNIXEPOCH + typemax(Int64) ÷ 1000000 ||
-        throw(InexactError(:convert, Timestamp, dt))
-    return Timestamp(UTN((value(dt) - UNIXEPOCH) * 1000000))
+function Base.convert(::Type{Timestamp{P}}, dt::DateTime) where {P}
+    ticks = timestamp_ticks(P, (Int128(value(dt)) - UNIXEPOCH) * 1000000)
+    return Timestamp{P}(UTInstant(P(ticks)))
 end
-Base.convert(::Type{Timestamp}, dt::Date) = Timestamp(dt)
-Base.convert(::Type{DateTime}, dt::Timestamp) = DateTime(UTM(fld(value(dt), 1000000) + UNIXEPOCH))
+Base.convert(::Type{Timestamp{P}}, dt::Date) where {P} = Timestamp{P}(dt)
+Base.convert(::Type{DateTime}, dt::Timestamp{P}) where {P} =
+    DateTime(UTM(Int64(fld(Int128(value(dt)) * timestamp_scale(P), 1000000) + UNIXEPOCH)))
 Base.convert(::Type{Date}, dt::Timestamp) = Date(UTD(days(dt)))
 Base.convert(::Type{Time}, dt::Timestamp) = Time(Nanosecond(nsofday(dt)))
 
@@ -63,7 +70,12 @@ Base.convert(::Type{Millisecond},dt::DateTime) = Millisecond(value(dt))        #
 Base.convert(::Type{Date},x::Day)  = Date(Dates.UTInstant(x))  # Converts Rata Die days to a Date
 Base.convert(::Type{Day},dt::Date) = Day(value(dt))            # Converts Date to Rata Die days
 Base.convert(::Type{Timestamp},x::Nanosecond)  = Timestamp(UTInstant(x))       # Converts unix nanoseconds to a Timestamp
-Base.convert(::Type{Nanosecond},dt::Timestamp) = Nanosecond(value(dt))         # Converts Timestamp to unix nanoseconds
+# Convert the count since the Unix epoch, rather than a calendar component.
+Base.convert(::Type{P}, dt::Timestamp{Q}) where {P<:Union{Second,Millisecond,Microsecond,Nanosecond},Q} =
+    P(timestamp_ticks(P, Int128(value(dt)) * timestamp_scale(Q)))
+
+Base.convert(::Type{Timestamp{P}}, x::Q) where {P,Q<:Union{Second,Millisecond,Microsecond,Nanosecond}} =
+    Timestamp{P}(UTInstant(P(timestamp_ticks(P, Int128(value(x)) * timestamp_scale(Q)))))
 
 ### External Conversions
 const UNIXEPOCH = value(DateTime(1970)) #Rata Die milliseconds for 1970-01-01T00:00:00
@@ -97,9 +109,12 @@ datetime2unix(dt::DateTime) = (value(dt) - UNIXEPOCH) / 1000.0
 
 """
     unix2timestamp(x)::Timestamp
+    unix2timestamp(Timestamp{P}, x)::Timestamp{P}
 
 Take the number of seconds since unix epoch `1970-01-01T00:00:00` (UTC) and
-convert to the corresponding `Timestamp`. Note that a [`Float64`](@ref) second
+convert to the corresponding `Timestamp`, optionally at resolution `P`.
+Fractional input is truncated toward zero to units of `P`.
+Note that a [`Float64`](@ref) second
 count near the present carries only about microsecond precision; construct a
 `Timestamp` from an integer nanosecond count
 (`convert(Timestamp, Nanosecond(ns))`) when full nanosecond precision is
@@ -108,11 +123,15 @@ required.
 !!! compat "Julia 1.14"
     This function requires Julia 1.14 or later.
 """
-unix2timestamp(x::Real) = Timestamp(UTN(trunc(Int64, Int64(1000000000) * x)))
-function unix2timestamp(x::Integer)
-    -(typemax(Int64) ÷ 1000000000) <= x <= typemax(Int64) ÷ 1000000000 ||
-        throw(InexactError(:unix2timestamp, Timestamp, x))
-    return Timestamp(UTN(Int64(x) * 1000000000))
+unix2timestamp(x::Real) = unix2timestamp(Timestamp{Nanosecond}, x)
+unix2timestamp(::Type{Timestamp}, x::Real) = unix2timestamp(Timestamp{Nanosecond}, x)
+unix2timestamp(::Type{Timestamp{P}}, x::Real) where {P} =
+    Timestamp{P}(UTInstant(P(trunc(Int64, (1000000000 ÷ timestamp_scale(P)) * x))))
+function unix2timestamp(::Type{Timestamp{P}}, x::Integer) where {P}
+    scale = 1000000000 ÷ timestamp_scale(P)
+    cld(typemin(Int64), scale) <= x <= fld(typemax(Int64), scale) ||
+        throw(InexactError(:unix2timestamp, Timestamp{P}, x))
+    return Timestamp{P}(UTInstant(P(Int64(x) * scale)))
 end
 
 """
@@ -121,12 +140,12 @@ end
 Take the given `Timestamp` and return the number of seconds since the unix
 epoch `1970-01-01T00:00:00` as a [`Float64`](@ref). Note that the returned
 value carries only about microsecond precision near the present;
-`Dates.value(dt)` is the exact count of nanoseconds since the unix epoch.
+`Dates.value(dt)` is the exact count in the timestamp's resolution since the unix epoch.
 
 !!! compat "Julia 1.14"
     This function requires Julia 1.14 or later.
 """
-timestamp2unix(dt::Timestamp) = value(dt) / 1.0e9
+timestamp2unix(dt::Timestamp{P}) where {P} = value(dt) / (1000000000 ÷ timestamp_scale(P))
 
 """
     now()::DateTime
@@ -178,32 +197,38 @@ end
 
 """
     now(::Type{Timestamp})::Timestamp
+    now(::Type{Timestamp{P}})::Timestamp{P}
 
 Return a `Timestamp` corresponding to the user's system time including the
-system timezone locale, at the full resolution of the system clock.
+system timezone locale. With a specified resolution `P`, fractional seconds
+are floored to that resolution. The default uses nanoseconds.
 
 !!! compat "Julia 1.14"
     This method requires Julia 1.14 or later.
 """
-function now(::Type{Timestamp})
+now(::Type{Timestamp}) = now(Timestamp{Nanosecond})
+function now(::Type{Timestamp{P}}) where {P}
     ts = unix_now_ns()
     tm = Libc.TmStruct(ts.sec)
-    return Timestamp(tm.year + 1900, tm.month + 1, tm.mday, tm.hour, tm.min, tm.sec,
-                     0, 0, Int64(ts.nsec))
+    return Timestamp{P}(tm.year + 1900, tm.month + 1, tm.mday, tm.hour, tm.min, tm.sec,
+                     0, 0, fld(Int64(ts.nsec), timestamp_scale(P)) * timestamp_scale(P))
 end
 
 """
     now(::Type{Timestamp}, ::Type{UTC})::Timestamp
+    now(::Type{Timestamp{P}}, ::Type{UTC})::Timestamp{P}
 
-Return a `Timestamp` corresponding to the user's system time as UTC/GMT, at the
-full resolution of the system clock.
+Return a `Timestamp` corresponding to the user's system time as UTC/GMT.
+With a specified resolution `P`, fractional seconds are floored to that
+resolution. The default uses nanoseconds.
 
 !!! compat "Julia 1.14"
     This method requires Julia 1.14 or later.
 """
-function now(::Type{Timestamp}, ::Type{UTC})
+now(::Type{Timestamp}, ::Type{UTC}) = now(Timestamp{Nanosecond}, UTC)
+function now(::Type{Timestamp{P}}, ::Type{UTC}) where {P}
     ts = unix_now_ns()
-    return Timestamp(UTN(ts.sec * 1000000000 + ts.nsec))
+    return Timestamp{P}(UTInstant(P(Int64(ts.sec * (1000000000 ÷ timestamp_scale(P)) + fld(ts.nsec, timestamp_scale(P))))))
 end
 
 """

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -158,21 +158,35 @@ for (tok, fn) in zip("uUeE", Any[monthabbr_to_value, monthname_to_value, dayabbr
     end
 end
 
-# 3-digit (base 10) number following a decimal point. For InexactError below.
-struct Decimal3 end
-
-@inline function tryparsenext(d::DatePart{'s'}, str, i, len)
-    val = tryparsenext_base10(str, i, len, min_width(d), max_width(d))
-    val === nothing && return nothing
-    ms0, ii = val
-    len = ii - i
-    if len > 3
-        ms, r = divrem(ms0, Int64(10) ^ (len - 3))
-        r == 0 || return nothing
-    else
-        ms = ms0 * Int64(10) ^ (3 - len)
+@inline function tryparsenext_fraction(d::DatePart, str, i, len, precision)
+    digits = 0
+    value = Int64(0)
+    max_digits = max_width(d)
+    @inbounds while i <= len && (max_digits == 0 || digits < max_digits)
+        c, ii = iterate(str, i)::Tuple{Char, Int}
+        '0' <= c <= '9' || break
+        digit = Int64(c - '0')
+        digits += 1
+        if digits <= precision
+            value = 10value + digit
+        elseif digit != 0
+            return nothing
+        end
+        i = ii
     end
-    return ms, ii
+    digits >= min_width(d) || return nothing
+    digits < precision && (value *= Int64(10) ^ (precision - digits))
+    return value, i
+end
+
+@inline tryparsenext(d::DatePart{'s'}, str, i, len) =
+    tryparsenext_fraction(d, str, i, len, 3)
+
+# Like 's', but reads the digits as a fractional second down to nanosecond
+# resolution: ".5" is 500 milliseconds and ".123456789" is 123456789
+# nanoseconds. Digits past the ninth must be zero.
+@inline function tryparsenext(d::DatePart{'n'}, str, i, len)
+    return tryparsenext_fraction(d, str, i, len, 9)
 end
 
 ### Format tokens
@@ -218,18 +232,26 @@ end
     end
 end
 
-function format(io, d::DatePart{'s'}, dt)
-    ms = millisecond(dt)
-    if ms % 100 == 0
-        str = string(div(ms, 100))
-    elseif ms % 10 == 0
-        str = string(div(ms, 10), pad = 2)
-    else
-        str = string(ms, pad = 3)
+function format_fraction(io, d::DatePart, value, precision)
+    str = rstrip(string(value, pad = precision), '0')
+    if d.fixed && length(str) > d.width
+        str = SubString(str, 1, d.width)
     end
-
     print(io, rpad(str, d.width, '0'))
 end
+
+format(io, d::DatePart{'s'}, dt) = format_fraction(io, d, millisecond(dt), 3)
+
+# The fractional second with trailing zeros stripped, then zero-padded on the
+# right to the code's width: 500 milliseconds formats as "5" under `n` and as
+# "500000000" under `nnnnnnnnn`; both parse back to the same value.
+function format(io, d::DatePart{'n'}, dt)
+    format_fraction(io, d, subsecond_nanoseconds(dt), 9)
+end
+
+subsecond_nanoseconds(dt::DateTime) = 1000000 * millisecond(dt)
+subsecond_nanoseconds(dt::Union{Time,Timestamp}) =
+    1000000 * millisecond(dt) + 1000 * microsecond(dt) + nanosecond(dt)
 
 ### Delimiters
 
@@ -322,6 +344,7 @@ const CONVERSION_SPECIFIERS = Dict{Char, Type}(
     'M' => Minute,
     'S' => Second,
     's' => Millisecond,
+    'n' => Nanosecond,
     'p' => AMPM,
 )
 
@@ -348,6 +371,7 @@ const CONVERSION_TRANSLATIONS = IdDict{Type, Any}(
     Date => (Year, Month, Day),
     DateTime => (Year, Month, Day, Hour, Minute, Second, Millisecond, AMPM),
     Time => (Hour, Minute, Second, Millisecond, Microsecond, Nanosecond, AMPM),
+    Timestamp => (Year, Month, Day, Hour, Minute, Second, Millisecond, Microsecond, Nanosecond, AMPM),
 )
 
 # The `DateFormat(format, locale)` method just below consumes the following Regex.
@@ -386,11 +410,18 @@ string:
 | `I`        | 00        | For outputting hours with 12-hour clock                       |
 | `M`        | 00        | Matches minutes                                               |
 | `S`        | 00        | Matches seconds                                               |
-| `s`        | .500      | Matches milliseconds                                          |
+| `s`        | .5, .500  | Matches fractional seconds to millisecond precision           |
+| `n`        | .5, .123456789 | Matches fractional seconds to nanosecond precision       |
 | `e`        | Mon, Tues | Matches abbreviated days of the week                          |
 | `E`        | Monday    | Matches full name days of the week                            |
 | `p`        | AM        | Matches AM/PM (case-insensitive)                              |
 | `yyyymmdd` | 19960101  | Matches fixed-width year, month, and day                      |
+
+!!! compat "Julia 1.14"
+    The `n` code requires Julia 1.14 or later.
+
+When parsing a `DateTime`, an `n` field must be exactly representable in
+milliseconds.
 
 Characters not listed above are normally treated as delimiters between date and time slots.
 For example a `dt` string of "1996-01-15T00:00:00.0" would have a `format` string like
@@ -499,6 +530,29 @@ const ISODateTimeFormat = DateFormat("yyyy-mm-dd\\THH:MM:SS.s")
 default_format(::Type{DateTime}) = ISODateTimeFormat
 
 """
+    Dates.ISOTimestampFormat
+
+Describes the ISO8601 formatting for a date and time at nanosecond resolution.
+This is the default value for `Dates.format` of a `Timestamp`. The fractional
+second is written with trailing zeros stripped and parsed with up to nanosecond
+precision.
+
+# Examples
+```jldoctest
+julia> Dates.format(Timestamp(2018, 8, 8, 12, 0, 43, 1), ISOTimestampFormat)
+"2018-08-08T12:00:43.001"
+
+julia> Dates.format(Timestamp(2018, 8, 8, 12, 0, 43, 0, 0, 1), ISOTimestampFormat)
+"2018-08-08T12:00:43.000000001"
+```
+
+!!! compat "Julia 1.14"
+    `ISOTimestampFormat` requires Julia 1.14 or later.
+"""
+const ISOTimestampFormat = DateFormat("yyyy-mm-dd\\THH:MM:SS.n")
+default_format(::Type{Timestamp}) = ISOTimestampFormat
+
+"""
     Dates.ISODateFormat
 
 Describes the ISO8601 formatting for a date. This is the default value for `Dates.format` of a `Date`.
@@ -522,8 +576,13 @@ Describes the ISO8601 formatting for a time. This is the default value for `Date
 julia> Dates.format(Time(12, 0, 43, 1), ISOTimeFormat)
 "12:00:43.001"
 ```
+
+!!! compat "Julia 1.14"
+    Before Julia 1.14 the fractional second used the millisecond code `s`, so
+    times with sub-millisecond parts did not round-trip through their printed
+    form.
 """
-const ISOTimeFormat = DateFormat("HH:MM:SS.s")
+const ISOTimeFormat = DateFormat("HH:MM:SS.n")
 default_format(::Type{Time}) = ISOTimeFormat
 
 """
@@ -664,6 +723,46 @@ repeatedly parsing similarly formatted time strings with a pre-created
 """
 Time(t::AbstractString, df::DateFormat=ISOTimeFormat) = parse(Time, t, df)
 
+"""
+    Timestamp(dt::AbstractString, format::AbstractString; locale="english")::Timestamp
+
+Construct a `Timestamp` by parsing the `dt` date time string following the
+pattern given in the `format` string (see [`DateFormat`](@ref) for syntax).
+Use the `n` code to match fractional seconds with up to nanosecond precision.
+
+!!! note
+    This method creates a `DateFormat` object each time it is called. It is recommended
+    that you create a [`DateFormat`](@ref) object instead and use that as the second
+    argument to avoid performance loss when using the same format repeatedly.
+
+!!! compat "Julia 1.14"
+    `Timestamp` requires Julia 1.14 or later.
+
+# Examples
+```jldoctest
+julia> Timestamp("2020-01-01 00:00:00.001002003", "yyyy-mm-dd HH:MM:SS.n")
+2020-01-01T00:00:00.001002003
+```
+"""
+function Timestamp(dt::AbstractString, format::AbstractString; locale::Locale=ENGLISH)
+    return parse(Timestamp, dt, DateFormat(format, locale))
+end
+
+"""
+    Timestamp(dt::AbstractString, df::DateFormat=ISOTimestampFormat)::Timestamp
+
+Construct a `Timestamp` by parsing the `dt` date time string following the
+pattern given in the [`DateFormat`](@ref) object, or $ISOTimestampFormat if omitted.
+
+Similar to `Timestamp(::AbstractString, ::AbstractString)` but more efficient when
+repeatedly parsing similarly formatted date time strings with a pre-created
+`DateFormat` object.
+
+!!! compat "Julia 1.14"
+    `Timestamp` requires Julia 1.14 or later.
+"""
+Timestamp(dt::AbstractString, df::DateFormat=ISOTimestampFormat) = parse(Timestamp, dt, df)
+
 @generated function format(io::IO, dt::TimeType, fmt::DateFormat{<:Any,T}) where T
     N = fieldcount(T)
     quote
@@ -698,9 +797,13 @@ following character codes can be used to construct the `format` string:
 | `H`        | 0, 23     | Hour (24-hour clock) with a minimum width                    |
 | `M`        | 0, 59     | Minute with a minimum width                                  |
 | `S`        | 0, 59     | Second with a minimum width                                  |
-| `s`        | 000, 500  | Millisecond with a minimum width of 3                        |
+| `s`        | 5, 500    | Fractional second to millisecond precision                   |
+| `n`        | 5, 123456789 | Fractional second, trailing zeros stripped                |
 | `e`        | Mon, Tue  | Abbreviated days of the week                                 |
 | `E`        | Monday    | Full day of week name                                        |
+
+!!! compat "Julia 1.14"
+    The `n` code requires Julia 1.14 or later.
 
 The number of sequential code characters indicate the width of the code. A format of
 `yyyy-mm` specifies that the code `y` should have a width of four while `m` a width of two.
@@ -728,6 +831,15 @@ function Base.print(io::IO, dt::DateTime)
     print(io, str)
 end
 
+function Base.print(io::IO, dt::Timestamp)
+    str = if subsecond_nanoseconds(dt) == 0
+        format(dt, dateformat"YYYY-mm-dd\THH:MM:SS", 19)
+    else
+        format(dt, dateformat"YYYY-mm-dd\THH:MM:SS.n", 29)
+    end
+    print(io, str)
+end
+
 function Base.print(io::IO, dt::Date)
     # don't use format - bypassing IOBuffer creation
     # saves a bit of time here.
@@ -738,7 +850,7 @@ function Base.print(io::IO, dt::Date)
     print(io, "$yy-$mm-$dd")
 end
 
-for date_type in (:Date, :DateTime)
+for date_type in (:Date, :DateTime, :Timestamp)
     # Human readable output (i.e. "2012-01-01")
     @eval Base.show(io::IO, ::MIME"text/plain", dt::$date_type) = print(io, dt)
     # Parsable output (i.e. Date("2012-01-01"))

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -250,8 +250,10 @@ function format(io, d::DatePart{'n'}, dt)
 end
 
 subsecond_nanoseconds(dt::DateTime) = 1000000 * millisecond(dt)
-subsecond_nanoseconds(dt::Union{Time,Timestamp}) =
+subsecond_nanoseconds(dt::Time) =
     1000000 * millisecond(dt) + 1000 * microsecond(dt) + nanosecond(dt)
+subsecond_nanoseconds(dt::Timestamp{P}) where {P} =
+    mod(value(dt), 1000000000 ÷ timestamp_scale(P)) * timestamp_scale(P)
 
 ### Delimiters
 
@@ -550,7 +552,7 @@ julia> Dates.format(Timestamp(2018, 8, 8, 12, 0, 43, 0, 0, 1), ISOTimestampForma
     `ISOTimestampFormat` requires Julia 1.14 or later.
 """
 const ISOTimestampFormat = DateFormat("yyyy-mm-dd\\THH:MM:SS.n")
-default_format(::Type{Timestamp}) = ISOTimestampFormat
+default_format(::Type{<:Timestamp}) = ISOTimestampFormat
 
 """
     Dates.ISODateFormat
@@ -744,8 +746,8 @@ julia> Timestamp("2020-01-01 00:00:00.001002003", "yyyy-mm-dd HH:MM:SS.n")
 2020-01-01T00:00:00.001002003
 ```
 """
-function Timestamp(dt::AbstractString, format::AbstractString; locale::Locale=ENGLISH)
-    return parse(Timestamp, dt, DateFormat(format, locale))
+function Timestamp{P}(dt::AbstractString, format::AbstractString; locale::Locale=ENGLISH) where {P}
+    return parse(Timestamp{P}, dt, DateFormat(format, locale))
 end
 
 """
@@ -761,7 +763,7 @@ repeatedly parsing similarly formatted date time strings with a pre-created
 !!! compat "Julia 1.14"
     `Timestamp` requires Julia 1.14 or later.
 """
-Timestamp(dt::AbstractString, df::DateFormat=ISOTimestampFormat) = parse(Timestamp, dt, df)
+Timestamp{P}(dt::AbstractString, df::DateFormat=ISOTimestampFormat) where {P} = parse(Timestamp{P}, dt, df)
 
 @generated function format(io::IO, dt::TimeType, fmt::DateFormat{<:Any,T}) where T
     N = fieldcount(T)
@@ -855,9 +857,12 @@ for date_type in (:Date, :DateTime, :Timestamp)
     @eval Base.show(io::IO, ::MIME"text/plain", dt::$date_type) = print(io, dt)
     # Parsable output (i.e. Date("2012-01-01"))
     @eval Base.show(io::IO, dt::$date_type) = print(io, typeof(dt), "(\"", dt, "\")")
-    # Parsable output will have type info displayed, thus it is implied
-    @eval Base.typeinfo_implicit(::Type{$date_type}) = true
 end
+
+# Parsable output includes the concrete type.
+Base.typeinfo_implicit(::Type{Date}) = true
+Base.typeinfo_implicit(::Type{DateTime}) = true
+Base.typeinfo_implicit(::Type{<:Timestamp}) = true
 
 # minimal Base.TOML support
 Base.TOML.Printer.printvalue(f::Function, io::IO, value::Date, sorted::Bool) =

--- a/stdlib/Dates/src/parse.jl
+++ b/stdlib/Dates/src/parse.jl
@@ -146,12 +146,27 @@ If successful, returns a 2-element tuple `(values, pos)`:
     # Unpacks the value tuple returned by `tryparsenext_core` into separate variables.
     value_tuple = Expr(:tuple, value_names...)
 
+    normalize_fraction = if T === DateTime && Nanosecond in tokens
+        quote
+            millisecond_from_nanoseconds, nanosecond_remainder =
+                divrem(nanosecond, Int64(1000000))
+            if nanosecond_remainder != 0
+                raise && throw(ArgumentError("Fractional second is not exactly representable as a DateTime"))
+                return nothing
+            end
+            millisecond += millisecond_from_nanoseconds
+        end
+    else
+        nothing
+    end
+
     return quote
         val = tryparsenext_core(str, pos, len, df, raise)
         val === nothing && return nothing
         values, pos, num_parsed = val
         $(assign_defaults...)
         $value_tuple = values
+        $normalize_fraction
         return $(Expr(:tuple, output_names...)), pos
     end
 end
@@ -176,7 +191,9 @@ end
     @inbounds while i <= max_pos
         c, ii = iterate(str, i)::Tuple{Char, Int}
         if '0' <= c <= '9'
-            d = d * 10 + (c - '0')
+            digit = Int64(c - '0')
+            d > div(typemax(Int64) - digit, 10) && return nothing
+            d = d * 10 + digit
         else
             break
         end

--- a/stdlib/Dates/src/parse.jl
+++ b/stdlib/Dates/src/parse.jl
@@ -108,6 +108,9 @@ If successful, return a 3-element tuple `(values, pos, num_parsed)`:
     end
 end
 
+conversion_translations(::Type{T}) where {T<:TimeType} = CONVERSION_TRANSLATIONS[T]
+conversion_translations(::Type{<:Timestamp}) = CONVERSION_TRANSLATIONS[Timestamp]
+
 """
     tryparsenext_internal(::Type{<:TimeType}, str, pos, len, df::DateFormat, raise=false)
 
@@ -129,7 +132,7 @@ If successful, returns a 2-element tuple `(values, pos)`:
     tokens = Type[CONVERSION_SPECIFIERS[letter] for letter in letters]
     value_names = Symbol[genvar(t) for t in tokens]
 
-    output_tokens = CONVERSION_TRANSLATIONS[T]
+    output_tokens = conversion_translations(T)
     output_names = Symbol[genvar(t) for t in output_tokens]
     output_defaults = Any[CONVERSION_DEFAULTS[t] for t in output_tokens]
 

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -22,8 +22,9 @@ for period in (:Year, :Quarter, :Month, :Week, :Day, :Hour, :Minute, :Second, :M
     # The period type is printed when output, thus it already implies its own typeinfo
     @eval Base.typeinfo_implicit(::Type{$period}) = true
     # Period accessors
-    typs = period in (:Microsecond, :Nanosecond) ? ["Time"] :
-           period in (:Hour, :Minute, :Second, :Millisecond) ? ["Time", "DateTime"] : ["Date", "DateTime"]
+    typs = period in (:Microsecond, :Nanosecond) ? ["Time", "Timestamp"] :
+           period in (:Hour, :Minute, :Second, :Millisecond) ? ["Time", "DateTime", "Timestamp"] :
+           ["Date", "DateTime", "Timestamp"]
     reference = period === :Week ? " For details see [`$accessor_str(::Union{Date, DateTime})`](@ref)." : ""
     for typ_str in typs
         @eval begin

--- a/stdlib/Dates/src/ranges.jl
+++ b/stdlib/Dates/src/ranges.jl
@@ -8,6 +8,7 @@ Base.:(:)(a::T, b::T) where {T<:Date} = (:)(a, Day(1), b)
 
 # Given a start and end date, how many steps/periods are in between
 guess(a::DateTime, b::DateTime, c) = floor(Int64, (Int128(value(b)) - Int128(value(a))) / toms(c))
+guess(a::Timestamp, b::Timestamp, c) = floor(Int64, div(Int128(value(b)) - Int128(value(a)), tons(c)))
 guess(a::Date, b::Date, c) = Int64(div(value(b - a), days(c)))
 len(a::Time, b::Time, c) = Int64(div(value(b - a), tons(c)))
 function len(a, b, c)

--- a/stdlib/Dates/src/ranges.jl
+++ b/stdlib/Dates/src/ranges.jl
@@ -8,7 +8,7 @@ Base.:(:)(a::T, b::T) where {T<:Date} = (:)(a, Day(1), b)
 
 # Given a start and end date, how many steps/periods are in between
 guess(a::DateTime, b::DateTime, c) = floor(Int64, (Int128(value(b)) - Int128(value(a))) / toms(c))
-guess(a::Timestamp, b::Timestamp, c) = floor(Int64, div(Int128(value(b)) - Int128(value(a)), tons(c)))
+guess(a::Timestamp, b::Timestamp, c) = floor(Int64, div((Int128(value(b)) * timestamp_scale(typeof(b)) - Int128(value(a)) * timestamp_scale(typeof(a))), Int128(value(c)) * tons(oneunit(c))))
 guess(a::Date, b::Date, c) = Int64(div(value(b - a), days(c)))
 len(a::Time, b::Time, c) = Int64(div(value(b - a), tons(c)))
 function len(a, b, c)
@@ -24,6 +24,8 @@ function len(a, b, c)
     return i - 1
 end
 Base.length(r::StepRange{<:TimeType}) = isempty(r) ? Int64(0) : len(r.start, r.stop, r.step) + 1
+Base.length(r::StepRange{<:Timestamp}) = isempty(r) ? Int64(0) :
+    Base.Checked.checked_add(len(r.start, r.stop, r.step), Int64(1))
 # Period ranges hook into Int64 overflow detection
 Base.length(r::StepRange{<:Period}) = length(StepRange(value(r.start), value(r.step), value(r.stop)))
 Base.checked_length(r::StepRange{<:Period}) = Base.checked_length(StepRange(value(r.start), value(r.step), value(r.stop)))

--- a/stdlib/Dates/src/rounding.jl
+++ b/stdlib/Dates/src/rounding.jl
@@ -90,6 +90,19 @@ function Base.floor(t::Time, p::TimePeriod)
     return Time(Nanosecond(nanoseconds - mod(nanoseconds, value(Nanosecond(p)))))
 end
 
+Base.floor(dt::Timestamp, p::DatePeriod) = Timestamp(UTN(unixns(value(Base.floor(Date(dt), p)), 0)))
+
+function Base.floor(dt::Timestamp, p::TimePeriod)
+    value(p) < 1 && throw(DomainError(p))
+    # anchor at the rounding epoch 0000-01-01 so results agree with flooring
+    # the equivalent DateTime; that epoch is more than typemax(Int64)
+    # nanoseconds before 1970, hence the Int128 intermediate, and the result
+    # wraps back to Int64 like the rest of Timestamp arithmetic
+    epochns = Int128(UNIXEPOCHDAYS - DATEEPOCH) * NS_PER_DAY
+    nanoseconds = Int128(value(dt)) + epochns
+    return Timestamp(UTN((nanoseconds - mod(nanoseconds, value(Nanosecond(p))) - epochns) % Int64))
+end
+
 """
     floor(x::Period, precision::T) where T <: Union{TimePeriod, Week, Day} -> T
 
@@ -122,7 +135,8 @@ end
 """
     floor(dt::TimeType, p::Period)::TimeType
 
-Return the nearest `Date` or `DateTime` less than or equal to `dt` at resolution `p`.
+Return the nearest `Date`, `DateTime`, or `Timestamp` less than or equal to `dt`
+at resolution `p`.
 
 For convenience, `p` may be a type instead of a value: `floor(dt, Dates.Hour)` is a shortcut
 for `floor(dt, Dates.Hour(1))`.
@@ -143,7 +157,8 @@ Base.floor(::Dates.TimeType, ::Dates.Period)
 """
     ceil(dt::TimeType, p::Period)::TimeType
 
-Return the nearest `Date` or `DateTime` greater than or equal to `dt` at resolution `p`.
+Return the nearest `Date`, `DateTime`, or `Timestamp` greater than or equal to
+`dt` at resolution `p`.
 
 For convenience, `p` may be a type instead of a value: `ceil(dt, Dates.Hour)` is a shortcut
 for `ceil(dt, Dates.Hour(1))`.
@@ -195,8 +210,9 @@ end
 """
     floorceil(dt::TimeType, p::Period) -> (TimeType, TimeType)
 
-Simultaneously return the `floor` and `ceil` of a `Date` or `DateTime` at resolution `p`.
-More efficient than calling both `floor` and `ceil` individually.
+Simultaneously return the `floor` and `ceil` of a `Date`, `DateTime`, or
+`Timestamp` at resolution `p`. More efficient than calling both `floor` and
+`ceil` individually.
 """
 function floorceil(dt::TimeType, p::Period)
     f = floor(dt, p)
@@ -217,7 +233,7 @@ end
 """
     round(dt::TimeType, p::Period, [r::RoundingMode]) -> TimeType
 
-Return the `Date` or `DateTime` nearest to `dt` at resolution `p`. By default
+Return the `Date`, `DateTime`, or `Timestamp` nearest to `dt` at resolution `p`. By default
 (`RoundNearestTiesUp`), ties (e.g., rounding 9:30 to the nearest hour) will be rounded up.
 
 For convenience, `p` may be a type instead of a value: `round(dt, Dates.Hour)` is a shortcut

--- a/stdlib/Dates/src/rounding.jl
+++ b/stdlib/Dates/src/rounding.jl
@@ -90,17 +90,70 @@ function Base.floor(t::Time, p::TimePeriod)
     return Time(Nanosecond(nanoseconds - mod(nanoseconds, value(Nanosecond(p)))))
 end
 
-Base.floor(dt::Timestamp, p::DatePeriod) = Timestamp(UTN(unixns(value(Base.floor(Date(dt), p)), 0)))
+# Keep rounding candidates wide; only the requested result must fit.
+function timestamp_rounding_value(dt::Timestamp{P}, ns, op::Symbol) where {P}
+    ticks, remainder = divrem(ns, timestamp_scale(P))
+    iszero(remainder) && typemin(Int64) <= ticks <= typemax(Int64) ||
+        throw(InexactError(op, Timestamp{P}, dt))
+    return Timestamp{P}(UTInstant(P(Int64(ticks))))
+end
 
-function Base.floor(dt::Timestamp, p::TimePeriod)
+# Ordinary calendar years use Int64 arithmetic. Large rounding intervals can
+# place a candidate outside even Date's range, so retain a wide fallback.
+@inline function timestamp_rounding_days(y, m)
+    if typemin(Int64) ÷ 366 + 1 <= y <= typemax(Int64) ÷ 366 - 1
+        return Int128(totaldays(Int64(y), Int64(m), 1))
+    end
+    return totaldays(Int128(y), m, 1)
+end
+
+@inline function timestamp_month_bounds(dt::Timestamp, months, step, upper::Bool)
+    lower = months - mod(months, step)
+    fy, fm = fldmod(lower, 12)
+    f = (timestamp_rounding_days(fy, fm + 1) - UNIXEPOCHDAYS) * NS_PER_DAY
+    upper || return f, f
+    x = Int128(value(dt)) * timestamp_scale(typeof(dt))
+    x == f && return f, f
+    cy, cm = fldmod(lower + step, 12)
+    c = (timestamp_rounding_days(cy, cm + 1) - UNIXEPOCHDAYS) * NS_PER_DAY
+    return f, c
+end
+
+@inline function timestamp_rounding_bounds(dt::Timestamp, p::Union{Year,Quarter,Month}, upper::Bool)
     value(p) < 1 && throw(DomainError(p))
-    # anchor at the rounding epoch 0000-01-01 so results agree with flooring
-    # the equivalent DateTime; that epoch is more than typemax(Int64)
-    # nanoseconds before 1970, hence the Int128 intermediate, and the result
-    # wraps back to Int64 like the rest of Timestamp arithmetic
-    epochns = Int128(UNIXEPOCHDAYS - DATEEPOCH) * NS_PER_DAY
-    nanoseconds = Int128(value(dt)) + epochns
-    return Timestamp(UTN((nanoseconds - mod(nanoseconds, value(Nanosecond(p))) - epochns) % Int64))
+    y, m = yearmonth(dt)
+    months = 12y + m - 1
+    step = Int128(value(p)) * (p isa Year ? 12 : p isa Quarter ? 3 : 1)
+    # Timestamp month counts have magnitude below 4e12. If step fits Int64,
+    # the adjacent multiples fit too; Year and Quarter can require a wider step.
+    if step <= typemax(Int64)
+        return timestamp_month_bounds(dt, months, Int64(step), upper)
+    end
+    return timestamp_month_bounds(dt, Int128(months), step, upper)
+end
+
+@inline function timestamp_rounding_bounds(dt::Timestamp, p::FixedPeriod, upper::Bool)
+    value(p) < 1 && throw(DomainError(p))
+    epoch = p isa Week ? WEEKEPOCH : DATEEPOCH
+    epochns = Int128(UNIXEPOCHDAYS - epoch) * NS_PER_DAY
+    x = Int128(value(dt)) * timestamp_scale(typeof(dt))
+    step = Int128(value(p)) * tons(oneunit(p))
+    f = x - mod(x + epochns, step)
+    return f, !upper || x == f ? f : f + step
+end
+
+Base.floor(dt::Timestamp, p::Period) =
+    timestamp_rounding_value(dt, first(timestamp_rounding_bounds(dt, p, false)), :floor)
+Base.ceil(dt::Timestamp, p::Period) =
+    timestamp_rounding_value(dt, last(timestamp_rounding_bounds(dt, p, true)), :ceil)
+function floorceil(dt::Timestamp, p::Period)
+    f, c = timestamp_rounding_bounds(dt, p, true)
+    return timestamp_rounding_value(dt, f, :floor), timestamp_rounding_value(dt, c, :ceil)
+end
+function Base.round(dt::Timestamp, p::Period, ::RoundingMode{:NearestTiesUp})
+    f, c = timestamp_rounding_bounds(dt, p, true)
+    x = Int128(value(dt)) * timestamp_scale(typeof(dt))
+    return timestamp_rounding_value(dt, x - f < c - x ? f : c, :round)
 end
 
 """

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -195,22 +195,17 @@ end
     Timestamp
 
 `Timestamp` represents a point in time according to the proleptic Gregorian
-calendar with nanosecond resolution. It wraps a `UTInstant{Nanosecond}`: an
-`Int64` count of nanoseconds since the unix epoch `1970-01-01T00:00:00`, the
-same physical representation as Apache Arrow's `timestamp[ns]`, numpy's
-`datetime64[ns]`, and pandas timestamps. This makes `Timestamp` 8 bytes and
-`isbits`, and lets value buffers be shared with those systems without
-conversion, though each layers its own conventions on top: numpy reserves
-`typemin(Int64)` as its `NaT` sentinel (so pandas' range starts one
-nanosecond later), and Arrow carries time zone and validity information
-separately.
+calendar with nanosecond resolution. Its value is an `Int64` count of
+nanoseconds since the Unix epoch, `1970-01-01T00:00:00`.
 
 Nanosecond resolution in 64 bits bounds the representable range to
 `1677-09-21T00:12:43.145224192` through `2262-04-11T23:47:16.854775807`
-(`typemin(Timestamp)`/`typemax(Timestamp)`); constructing a `Timestamp` outside
-this range throws an `ArgumentError`. Like `DateTime`, the type uses fixed-point
-arithmetic and is thus prone to underflowing and overflowing: adding a period
-that would leave the representable range wraps around rather than throwing.
+(`typemin(Timestamp)` and `typemax(Timestamp)`); constructing a `Timestamp`
+outside this range throws an `ArgumentError`. Like `DateTime`, the type uses
+fixed-point arithmetic and is thus prone to underflowing and overflowing:
+adding a period that would leave the representable range wraps around rather
+than throwing.
+
 For instants outside this range, or when nanosecond resolution is not needed,
 use [`DateTime`](@ref), which covers ±146 million years at millisecond
 resolution. The two types compare directly. Mixed arithmetic promotes
@@ -229,6 +224,14 @@ julia> DateTime(ts) # floors to millisecond resolution
 
 !!! compat "Julia 1.14"
     `Timestamp` requires Julia 1.14 or later.
+
+# Extended help
+
+The representation is the same as Apache Arrow's `timestamp[ns]`, numpy's
+`datetime64[ns]`, and pandas timestamps, so nanosecond-timestamp value buffers
+from those systems can be reinterpreted as `Timestamp`s directly. Note that
+numpy reserves `typemin(Int64)` as its `NaT` sentinel, so the pandas range
+begins one nanosecond after `typemin(Timestamp)`.
 """
 struct Timestamp <: AbstractDateTime
     instant::UTInstant{Nanosecond}

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -102,6 +102,7 @@ end
 # Convenience default constructors
 UTM(x) = UTInstant(Millisecond(x))
 UTD(x) = UTInstant(Day(x))
+UTN(x) = UTInstant(Nanosecond(x))
 
 # Calendar types provide rules for interpreting instant
 # timelines in human-readable form.
@@ -133,7 +134,7 @@ struct UTC <: TimeZone end
     TimeType
 
 `TimeType` types wrap `Instant` machine instances to provide human representations of the
-machine instant. `Time`, `DateTime` and `Date` are subtypes of `TimeType`.
+machine instant. `Time`, `DateTime`, `Timestamp`, and `Date` are subtypes of `TimeType`.
 """
 abstract type TimeType <: AbstractTime end
 
@@ -190,6 +191,50 @@ struct Time <: TimeType
     Time(instant::Nanosecond) = new(mod(instant, 86400000000000))
 end
 
+"""
+    Timestamp
+
+`Timestamp` represents a point in time according to the proleptic Gregorian
+calendar with nanosecond resolution. It wraps a `UTInstant{Nanosecond}`: an
+`Int64` count of nanoseconds since the unix epoch `1970-01-01T00:00:00`, the
+same physical representation as Apache Arrow's `timestamp[ns]`, numpy's
+`datetime64[ns]`, and pandas timestamps. This makes `Timestamp` 8 bytes and
+`isbits`, and lets value buffers be shared with those systems without
+conversion, though each layers its own conventions on top: numpy reserves
+`typemin(Int64)` as its `NaT` sentinel (so pandas' range starts one
+nanosecond later), and Arrow carries time zone and validity information
+separately.
+
+Nanosecond resolution in 64 bits bounds the representable range to
+`1677-09-21T00:12:43.145224192` through `2262-04-11T23:47:16.854775807`
+(`typemin(Timestamp)`/`typemax(Timestamp)`); constructing a `Timestamp` outside
+this range throws an `ArgumentError`. Like `DateTime`, the type uses fixed-point
+arithmetic and is thus prone to underflowing and overflowing: adding a period
+that would leave the representable range wraps around rather than throwing.
+For instants outside this range, or when nanosecond resolution is not needed,
+use [`DateTime`](@ref), which covers ±146 million years at millisecond
+resolution. The two types compare directly. Mixed arithmetic promotes
+`DateTime` to `Timestamp`, so its value must be in the `Timestamp` range:
+
+```jldoctest
+julia> ts = Timestamp(2020, 1, 1, 0, 0, 0, 1, 0, 500)
+2020-01-01T00:00:00.0010005
+
+julia> ts - DateTime(2020, 1, 1)
+1000500 nanoseconds
+
+julia> DateTime(ts) # floors to millisecond resolution
+2020-01-01T00:00:00.001
+```
+
+!!! compat "Julia 1.14"
+    `Timestamp` requires Julia 1.14 or later.
+"""
+struct Timestamp <: AbstractDateTime
+    instant::UTInstant{Nanosecond}
+    Timestamp(instant::UTInstant{Nanosecond}) = new(instant)
+end
+
 # Convert y,m,d to # of Rata Die days
 # Works by shifting the beginning of the year to March 1,
 # so a leap day is the very last day of the year
@@ -201,6 +246,19 @@ function totaldays(y, m, d)
     # days + month_days + year_days
     return d + mdays + 365z + fld(z, 4) - fld(z, 100) + fld(z, 400) - 306
 end
+
+# Timestamp instants count nanoseconds from the unix epoch rather than the
+# Rata Die epoch: year 0 lies outside the ~±292 year range that nanoseconds
+# afford an Int64, so Rata Die <-> Timestamp conversions work at day granularity.
+const NS_PER_DAY = 86400000000000
+const UNIXEPOCHDAYS = totaldays(1970, 1, 1) # Rata Die days for 1970-01-01
+# The representable range as (days since the unix epoch, nanoseconds of day)
+const TIMESTAMPMIN = fldmod(typemin(Int64), NS_PER_DAY)
+const TIMESTAMPMAX = fldmod(typemax(Int64), NS_PER_DAY)
+# Nanoseconds since the unix epoch for a Rata Die day number and nanosecond of
+# day. This wraps rather than validating, so the arithmetic and rounding built
+# on it wrap at the ends of the range like DateTime's.
+unixns(rata, nsofday) = (rata - UNIXEPOCHDAYS) * NS_PER_DAY + nsofday
 
 # If the year is divisible by 4, except for every 100 years, except for every 400 years
 isleapyear(y::Integer) = (y % 4 == 0) && ((y % 100 != 0) || (y % 400 == 0))
@@ -290,6 +348,12 @@ Date(dt::Base.Libc.TmStruct) = Date(1900 + dt.year, 1 + dt.month, dt.mday)
     Time(h, [mi, s, ms, us, ns])::Time
 
 Construct a `Time` type by parts. Arguments must be convertible to [`Int64`](@ref).
+The `ns` argument can contain a full fractional second from `0` through
+`999999999`. The combined `ms`, `us`, and `ns` arguments must be less than one
+second.
+
+!!! compat "Julia 1.14"
+    Support for a full fractional second in `ns` requires Julia 1.14 or later.
 """
 function Time(h::Int64, mi::Int64=0, s::Int64=0, ms::Int64=0, us::Int64=0, ns::Int64=0, ampm::AMPM=TWENTYFOURHOUR)
     err = validargs(Time, h, mi, s, ms, us, ns, ampm)
@@ -308,11 +372,63 @@ function validargs(::Type{Time}, h::Int64, mi::Int64, s::Int64, ms::Int64, us::I
     -1 < s < 60 || return ArgumentError("Second: $s out of range (0:59)")
     -1 < ms < 1000 || return ArgumentError("Millisecond: $ms out of range (0:999)")
     -1 < us < 1000 || return ArgumentError("Microsecond: $us out of range (0:999)")
-    -1 < ns < 1000 || return ArgumentError("Nanosecond: $ns out of range (0:999)")
+    # ns may carry a full fractional second (e.g. from parsing ".123456789" with
+    # the `n` format code) as long as the parts together stay below one second
+    -1 < ns < 1000000000 || return ArgumentError("Nanosecond: $ns out of range (0:999999999)")
+    1000000ms + 1000us + ns < 1000000000 ||
+        return ArgumentError("Sub-second parts must together be less than one second")
     return nothing
 end
 
 Time(dt::Base.Libc.TmStruct) = Time(dt.hour, dt.min, dt.sec)
+
+"""
+    Timestamp(y, [m, d, h, mi, s, ms, us, ns])::Timestamp
+
+Construct a `Timestamp` type by parts. Arguments must be convertible to
+[`Int64`](@ref) and the result must lie within the representable range
+(`typemin(Timestamp)` to `typemax(Timestamp)`, from 1677-09-21 through
+2262-04-11). The `ns` argument can contain a full fractional second, but the
+combined `ms`, `us`, and `ns` arguments must be less than one second.
+
+!!! compat "Julia 1.14"
+    `Timestamp` requires Julia 1.14 or later.
+"""
+function Timestamp(y::Int64, m::Int64=1, d::Int64=1, h::Int64=0, mi::Int64=0, s::Int64=0,
+                   ms::Int64=0, us::Int64=0, ns::Int64=0, ampm::AMPM=TWENTYFOURHOUR)
+    err = validargs(Timestamp, y, m, d, h, mi, s, ms, us, ns, ampm)
+    err === nothing || throw(err)
+    h = adjusthour(h, ampm)
+    # validargs bounded the result to Int64, so the wrapping arithmetic in unixns
+    # is exact here even on the two partial boundary days, where the day product alone wraps
+    nsofday = ns + 1000us + 1000000ms + 1000000000 * (s + 60mi + 3600h)
+    return Timestamp(UTN(unixns(totaldays(y, m, d), nsofday)))
+end
+
+function validargs(::Type{Timestamp}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64,
+                   s::Int64, ms::Int64, us::Int64, ns::Int64, ampm::AMPM=TWENTYFOURHOUR)
+    1677 <= y <= 2262 || return ArgumentError("Year: $y out of range (1677:2262)")
+    0 < m < 13 || return ArgumentError("Month: $m out of range (1:12)")
+    0 < d < daysinmonth(y, m) + 1 || return ArgumentError("Day: $d out of range (1:$(daysinmonth(y, m)))")
+    if ampm == TWENTYFOURHOUR # 24-hour clock
+        -1 < h < 24 || (h == 24 && mi==s==ms==us==ns==0) ||
+            return ArgumentError("Hour: $h out of range (0:23)")
+    else
+        0 < h < 13 || return ArgumentError("Hour: $h out of range (1:12)")
+    end
+    -1 < mi < 60 || return ArgumentError("Minute: $mi out of range (0:59)")
+    -1 < s < 60 || return ArgumentError("Second: $s out of range (0:59)")
+    -1 < ms < 1000 || return ArgumentError("Millisecond: $ms out of range (0:999)")
+    -1 < us < 1000 || return ArgumentError("Microsecond: $us out of range (0:999)")
+    -1 < ns < 1000000000 || return ArgumentError("Nanosecond: $ns out of range (0:999999999)")
+    1000000ms + 1000us + ns < 1000000000 ||
+        return ArgumentError("Sub-second parts must together be less than one second")
+    epochdays = totaldays(y, m, d) - UNIXEPOCHDAYS
+    nsofday = ns + 1000us + 1000000ms + 1000000000 * (s + 60mi + 3600 * adjusthour(h, ampm))
+    TIMESTAMPMIN <= (epochdays, nsofday) <= TIMESTAMPMAX ||
+        return ArgumentError("Timestamp: $y-$m-$d out of range ($(typemin(Timestamp)) to $(typemax(Timestamp)))")
+    return nothing
+end
 
 # Convenience constructors from Periods
 function DateTime(y::Year, m::Month=Month(1), d::Day=Day(1),
@@ -328,6 +444,14 @@ function Time(h::Hour, mi::Minute=Minute(0), s::Second=Second(0),
               ms::Millisecond=Millisecond(0),
               us::Microsecond=Microsecond(0), ns::Nanosecond=Nanosecond(0))
     return Time(value(h), value(mi), value(s), value(ms), value(us), value(ns))
+end
+
+function Timestamp(y::Year, m::Month=Month(1), d::Day=Day(1),
+                   h::Hour=Hour(0), mi::Minute=Minute(0), s::Second=Second(0),
+                   ms::Millisecond=Millisecond(0),
+                   us::Microsecond=Microsecond(0), ns::Nanosecond=Nanosecond(0))
+    return Timestamp(value(y), value(m), value(d), value(h), value(mi), value(s),
+                     value(ms), value(us), value(ns))
 end
 
 # To allow any order/combination of Periods
@@ -389,6 +513,33 @@ function Time(period::TimePeriod, periods::TimePeriod...)
     return Time(h, mi, s, ms, us, ns)
 end
 
+"""
+    Timestamp(periods::Period...)::Timestamp
+
+Construct a `Timestamp` type by `Period` type parts. Arguments may be in any order.
+`Timestamp` parts not provided will default to the unix epoch, `1970-01-01T00:00:00`.
+
+!!! compat "Julia 1.14"
+    `Timestamp` requires Julia 1.14 or later.
+"""
+function Timestamp(period::Period, periods::Period...)
+    y = Year(1970); m = Month(1); d = Day(1)
+    h = Hour(0); mi = Minute(0); s = Second(0)
+    ms = Millisecond(0); us = Microsecond(0); ns = Nanosecond(0)
+    for p in (period, periods...)
+        isa(p, Year) && (y = p::Year)
+        isa(p, Month) && (m = p::Month)
+        isa(p, Day) && (d = p::Day)
+        isa(p, Hour) && (h = p::Hour)
+        isa(p, Minute) && (mi = p::Minute)
+        isa(p, Second) && (s = p::Second)
+        isa(p, Millisecond) && (ms = p::Millisecond)
+        isa(p, Microsecond) && (us = p::Microsecond)
+        isa(p, Nanosecond) && (ns = p::Nanosecond)
+    end
+    return Timestamp(y, m, d, h, mi, s, ms, us, ns)
+end
+
 # Convenience constructor for DateTime from Date and Time
 """
     DateTime(d::Date, t::Time)
@@ -417,20 +568,46 @@ function DateTime(dt::Date, t::Time)
     return DateTime(y, m, d, hour(t), minute(t), second(t), millisecond(t))
 end
 
+"""
+    Timestamp(d::Date, [t::Time])::Timestamp
+
+Construct a `Timestamp` from a `Date` and, optionally, a `Time` giving the
+nanosecond-resolution time of day. Throws an `ArgumentError` if the result lies
+outside the representable `Timestamp` range.
+
+!!! compat "Julia 1.14"
+    `Timestamp` requires Julia 1.14 or later.
+
+```jldoctest
+julia> Timestamp(Date(2018, 1, 1), Time(8, 15, 42, 0, 0, 5))
+2018-01-01T08:15:42.000000005
+```
+"""
+function Timestamp(d::Date, t::Time=Time(0))
+    epochdays = value(d) - UNIXEPOCHDAYS
+    TIMESTAMPMIN <= (epochdays, value(t)) <= TIMESTAMPMAX ||
+        throw(ArgumentError("Timestamp: $d out of range ($(typemin(Timestamp)) to $(typemax(Timestamp)))"))
+    return Timestamp(UTN(unixns(value(d), value(t))))
+end
+
 # Fallback constructors
 DateTime(y, m=1, d=1, h=0, mi=0, s=0, ms=0, ampm::AMPM=TWENTYFOURHOUR) = DateTime(Int64(y), Int64(m), Int64(d), Int64(h), Int64(mi), Int64(s), Int64(ms), ampm)
 Date(y, m=1, d=1) = Date(Int64(y), Int64(m), Int64(d))
 Time(h, mi=0, s=0, ms=0, us=0, ns=0, ampm::AMPM=TWENTYFOURHOUR) = Time(Int64(h), Int64(mi), Int64(s), Int64(ms), Int64(us), Int64(ns), ampm)
+Timestamp(y, m=1, d=1, h=0, mi=0, s=0, ms=0, us=0, ns=0, ampm::AMPM=TWENTYFOURHOUR) =
+    Timestamp(Int64(y), Int64(m), Int64(d), Int64(h), Int64(mi), Int64(s), Int64(ms), Int64(us), Int64(ns), ampm)
 
 # Traits, Equality
 Base.isfinite(::Union{Type{T}, T}) where {T<:TimeType} = true
 calendar(dt::DateTime) = ISOCalendar
 calendar(dt::Date) = ISOCalendar
+calendar(dt::Timestamp) = ISOCalendar
 
 """
     eps(::Type{DateTime})::Millisecond
     eps(::Type{Date})::Day
     eps(::Type{Time})::Nanosecond
+    eps(::Type{Timestamp})::Nanosecond
     eps(::TimeType)::Period
 
 Return the smallest unit value supported by the `TimeType`.
@@ -445,19 +622,24 @@ julia> eps(Date)
 
 julia> eps(Time)
 1 nanosecond
+
+julia> eps(Timestamp)
+1 nanosecond
 ```
 """
-Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, TimeType})
+Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, Type{Timestamp}, TimeType})
 
 Base.eps(::Type{DateTime}) = Millisecond(1)
 Base.eps(::Type{Date}) = Day(1)
 Base.eps(::Type{Time}) = Nanosecond(1)
+Base.eps(::Type{Timestamp}) = Nanosecond(1)
 Base.eps(::T) where T <: TimeType = eps(T)::Period
 
 # zero returns dt::T - dt::T
 Base.zero(::Type{DateTime}) = Millisecond(0)
 Base.zero(::Type{Date}) = Day(0)
 Base.zero(::Type{Time}) = Nanosecond(0)
+Base.zero(::Type{Timestamp}) = Nanosecond(0)
 Base.zero(::T) where T <: TimeType = zero(T)::Period
 
 
@@ -467,18 +649,38 @@ Base.typemax(::Union{Date, Type{Date}}) = Date(252522163911149, 12, 31)
 Base.typemin(::Union{Date, Type{Date}}) = Date(-252522163911150, 1, 1)
 Base.typemax(::Union{Time, Type{Time}}) = Time(23, 59, 59, 999, 999, 999)
 Base.typemin(::Union{Time, Type{Time}}) = Time(0)
+Base.typemax(::Union{Timestamp, Type{Timestamp}}) = Timestamp(UTN(typemax(Int64)))
+Base.typemin(::Union{Timestamp, Type{Timestamp}}) = Timestamp(UTN(typemin(Int64)))
 # Date-DateTime promotion, isless, ==
 Base.promote_rule(::Type{Date}, x::Type{DateTime}) = DateTime
+Base.promote_rule(::Type{Date}, ::Type{Timestamp}) = Timestamp
+Base.promote_rule(::Type{DateTime}, ::Type{Timestamp}) = Timestamp
 Base.isless(x::T, y::T) where {T<:TimeType} = isless(value(x), value(y))
 Base.isless(x::TimeType, y::TimeType) = isless(promote(x, y)...)
 (==)(x::T, y::T) where {T<:TimeType} = (==)(value(x), value(y))
 (==)(x::TimeType, y::TimeType) = (===)(promote(x, y)...)
+# Comparisons between Timestamp and the wider-ranged Date/DateTime bypass
+# promotion (which would throw for instants outside the Timestamp range) and
+# instead compare (day, time-of-day) pairs, which never overflow.
+Base.isless(x::Timestamp, y::DateTime) = isless((days(x), nsofday(x)), (days(y), 1000000 * msofday(y)))
+Base.isless(x::DateTime, y::Timestamp) = isless((days(x), 1000000 * msofday(x)), (days(y), nsofday(y)))
+Base.isless(x::Timestamp, y::Date) = isless((days(x), nsofday(x)), (value(y), Int64(0)))
+Base.isless(x::Date, y::Timestamp) = isless((value(x), Int64(0)), (days(y), nsofday(y)))
+(==)(x::Timestamp, y::DateTime) = days(x) == days(y) && nsofday(x) == 1000000 * msofday(y)
+(==)(x::DateTime, y::Timestamp) = y == x
+(==)(x::Timestamp, y::Date) = days(x) == value(y) && nsofday(x) == 0
+(==)(x::Date, y::Timestamp) = y == x
 Base.min(x::AbstractTime) = x
 Base.max(x::AbstractTime) = x
 Base.minmax(x::AbstractTime) = (x, x)
 Base.hash(x::Time, h::UInt) =
     hash(hour(x), hash(minute(x), hash(second(x),
         hash(millisecond(x), hash(microsecond(x), hash(nanosecond(x), h))))))
+# Date, DateTime, and Timestamp compare equal across types when they denote the
+# same instant, so they hash alike: on the (day, nanosecond of day) pair.
+Base.hash(x::Date, h::UInt) = hash(Int64(0), hash(days(x), h))
+Base.hash(x::DateTime, h::UInt) = hash(1000000 * msofday(x), hash(days(x), h))
+Base.hash(x::Timestamp, h::UInt) = hash(nsofday(x), hash(days(x), h))
 
 Base.sleep(duration::Period) = sleep(seconds(duration))
 

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -93,7 +93,8 @@ abstract type Instant <: AbstractTime end
 
 The `UTInstant` represents a machine timeline based on UT time (1 day = one revolution of
 the earth). The `T` is a `Period` parameter that indicates the resolution or precision of
-the instant.
+the instant. The enclosing `TimeType` determines the epoch: `Date` and `DateTime`
+use the Rata Die epoch, while `Timestamp` uses the Unix epoch.
 """
 struct UTInstant{P<:Period} <: Instant
     periods::P
@@ -192,11 +193,14 @@ struct Time <: TimeType
 end
 
 """
-    Timestamp
+    Timestamp{P}
 
 `Timestamp` represents a point in time according to the proleptic Gregorian
-calendar with nanosecond resolution. Its value is an `Int64` count of
-nanoseconds since the Unix epoch, `1970-01-01T00:00:00`.
+calendar with resolution `P`, one of `Second`, `Millisecond`, `Microsecond`,
+or `Nanosecond`. Its value is an `Int64` count of units of `P` since the Unix
+epoch, `1970-01-01T00:00:00`. `Timestamp(args...)` defaults to `Timestamp{Nanosecond}`;
+`Timestamp(ts::Timestamp)` preserves the input's resolution. Use a concrete
+`Timestamp{P}` for array elements and struct fields of a known resolution.
 
 Nanosecond resolution in 64 bits bounds the representable range to
 `1677-09-21T00:12:43.145224192` through `2262-04-11T23:47:16.854775807`
@@ -204,12 +208,24 @@ Nanosecond resolution in 64 bits bounds the representable range to
 outside this range throws an `ArgumentError`. Like `DateTime`, the type uses
 fixed-point arithmetic and is thus prone to underflowing and overflowing:
 adding a period that would leave the representable range wraps around rather
-than throwing.
+than throwing. In particular, `typemax(Timestamp{P}) + P(1)` is
+`typemin(Timestamp{P})`.
 
-For instants outside this range, or when nanosecond resolution is not needed,
-use [`DateTime`](@ref), which covers ±146 million years at millisecond
-resolution. The two types compare directly. Mixed arithmetic promotes
-`DateTime` to `Timestamp`, so its value must be in the `Timestamp` range:
+Coarser resolutions cover approximately ±292 billion years (`Second`),
+±292 million years (`Millisecond`), or ±292 thousand years (`Microsecond`).
+`DateTime` keeps its existing representation and API. Unlike `DateTime`,
+`Timestamp{Millisecond}` counts from the Unix epoch.
+
+Constructors, parsing, and conversions between resolutions require exact
+representation. Use `floor`, `ceil`, or `round` before converting to a coarser
+resolution to discard precision explicitly. Period arithmetic preserves `P`
+and requires a duration representable in units of `P`. Unlike `DateTime`, it
+throws an `InexactError` instead of rounding a finer duration. Rounding throws an
+`InexactError` if the requested result is not representable; it does not wrap.
+
+The types compare directly, even outside their shared range. Mixed arithmetic
+promotes to the finer resolution, so both values must fit that resolution.
+For promotion with `DateTime`, its resolution is `Millisecond`:
 
 ```jldoctest
 julia> ts = Timestamp(2020, 1, 1, 0, 0, 0, 1, 0, 500)
@@ -229,14 +245,43 @@ julia> DateTime(ts) # floors to millisecond resolution
 
 The representation is the same as Apache Arrow's `timestamp[ns]`, numpy's
 `datetime64[ns]`, and pandas timestamps, so nanosecond-timestamp value buffers
-from those systems can be reinterpreted as `Timestamp`s directly. Note that
+from those systems can be reinterpreted as `Timestamp{Nanosecond}`s directly. Note that
 numpy reserves `typemin(Int64)` as its `NaT` sentinel, so the pandas range
 begins one nanosecond after `typemin(Timestamp)`.
+
+`Dates.value(ts)` is the raw count since the Unix epoch. `convert(P, ts)`
+returns that count as a period in units of `P`, requiring exact conversion;
+`P(ts)` instead returns the corresponding calendar component. These raw counts
+differ from the Rata Die milliseconds returned by `convert(Millisecond, dt)`
+for a `DateTime`, even when `ts == dt`.
 """
-struct Timestamp <: AbstractDateTime
-    instant::UTInstant{Nanosecond}
-    Timestamp(instant::UTInstant{Nanosecond}) = new(instant)
+struct Timestamp{P<:Union{Second,Millisecond,Microsecond,Nanosecond}} <: AbstractDateTime
+    instant::UTInstant{P}
+    Timestamp{P}(instant::UTInstant{P}) where {P} = new{P}(instant)
 end
+
+Timestamp(args...; kwargs...) = Timestamp{Nanosecond}(args...; kwargs...)
+Timestamp(instant::UTInstant{P}) where {P} = Timestamp{P}(instant)
+Timestamp(ts::Timestamp) = ts
+
+timestamp_scale(::Type{Second}) = Int64(1000000000)
+timestamp_scale(::Type{Millisecond}) = Int64(1000000)
+timestamp_scale(::Type{Microsecond}) = Int64(1000)
+timestamp_scale(::Type{Nanosecond}) = Int64(1)
+timestamp_scale(::Type{Timestamp{P}}) where {P} = timestamp_scale(P)
+timestamp_ticks_per_day(::Type{P}) where {P} = NS_PER_DAY ÷ timestamp_scale(P)
+timestamp_finer(::Type{P}, ::Type{Q}) where {P,Q} =
+    timestamp_scale(P) <= timestamp_scale(Q) ? P : Q
+
+function timestamp_ticks(::Type{P}, ns::Integer) where {P}
+    ticks, remainder = divrem(ns, timestamp_scale(P))
+    iszero(remainder) || throw(InexactError(:convert, Timestamp{P}, ns))
+    return ticks
+end
+
+timestamp_from_day(::Type{Timestamp{P}}, rata, ns) where {P} =
+    Timestamp{P}(UTInstant(P(timestamp_ticks(P, (Int128(rata) - UNIXEPOCHDAYS) * NS_PER_DAY + ns))))
+
 
 # Convert y,m,d to # of Rata Die days
 # Works by shifting the beginning of the year to March 1,
@@ -250,18 +295,9 @@ function totaldays(y, m, d)
     return d + mdays + 365z + fld(z, 4) - fld(z, 100) + fld(z, 400) - 306
 end
 
-# Timestamp instants count nanoseconds from the unix epoch rather than the
-# Rata Die epoch: year 0 lies outside the ~±292 year range that nanoseconds
-# afford an Int64, so Rata Die <-> Timestamp conversions work at day granularity.
+# Timestamp instants count units of P from the Unix epoch.
 const NS_PER_DAY = 86400000000000
-const UNIXEPOCHDAYS = totaldays(1970, 1, 1) # Rata Die days for 1970-01-01
-# The representable range as (days since the unix epoch, nanoseconds of day)
-const TIMESTAMPMIN = fldmod(typemin(Int64), NS_PER_DAY)
-const TIMESTAMPMAX = fldmod(typemax(Int64), NS_PER_DAY)
-# Nanoseconds since the unix epoch for a Rata Die day number and nanosecond of
-# day. This wraps rather than validating, so the arithmetic and rounding built
-# on it wrap at the ends of the range like DateTime's.
-unixns(rata, nsofday) = (rata - UNIXEPOCHDAYS) * NS_PER_DAY + nsofday
+const UNIXEPOCHDAYS = totaldays(1970, 1, 1)
 
 # If the year is divisible by 4, except for every 100 years, except for every 400 years
 isleapyear(y::Integer) = (y % 4 == 0) && ((y % 100 != 0) || (y % 400 == 0))
@@ -386,31 +422,30 @@ end
 Time(dt::Base.Libc.TmStruct) = Time(dt.hour, dt.min, dt.sec)
 
 """
-    Timestamp(y, [m, d, h, mi, s, ms, us, ns])::Timestamp
+    Timestamp{P}(y, [m, d, h, mi, s, ms, us, ns])::Timestamp{P}
 
 Construct a `Timestamp` type by parts. Arguments must be convertible to
 [`Int64`](@ref) and the result must lie within the representable range
-(`typemin(Timestamp)` to `typemax(Timestamp)`, from 1677-09-21 through
-2262-04-11). The `ns` argument can contain a full fractional second, but the
+(`typemin(Timestamp{P})` to `typemax(Timestamp{P})`) at resolution `P`.
+The `ns` argument can contain a full fractional second, but the
 combined `ms`, `us`, and `ns` arguments must be less than one second.
 
 !!! compat "Julia 1.14"
     `Timestamp` requires Julia 1.14 or later.
 """
-function Timestamp(y::Int64, m::Int64=1, d::Int64=1, h::Int64=0, mi::Int64=0, s::Int64=0,
-                   ms::Int64=0, us::Int64=0, ns::Int64=0, ampm::AMPM=TWENTYFOURHOUR)
-    err = validargs(Timestamp, y, m, d, h, mi, s, ms, us, ns, ampm)
+function Timestamp{P}(y::Int64, m::Int64=1, d::Int64=1, h::Int64=0, mi::Int64=0, s::Int64=0,
+                   ms::Int64=0, us::Int64=0, ns::Int64=0, ampm::AMPM=TWENTYFOURHOUR) where {P}
+    err = validargs(Timestamp{P}, y, m, d, h, mi, s, ms, us, ns, ampm)
     err === nothing || throw(err)
     h = adjusthour(h, ampm)
-    # validargs bounded the result to Int64, so the wrapping arithmetic in unixns
-    # is exact here even on the two partial boundary days, where the day product alone wraps
     nsofday = ns + 1000us + 1000000ms + 1000000000 * (s + 60mi + 3600h)
-    return Timestamp(UTN(unixns(totaldays(y, m, d), nsofday)))
+    return timestamp_from_day(Timestamp{P}, totaldays(y, m, d), nsofday)
 end
 
-function validargs(::Type{Timestamp}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64,
-                   s::Int64, ms::Int64, us::Int64, ns::Int64, ampm::AMPM=TWENTYFOURHOUR)
-    1677 <= y <= 2262 || return ArgumentError("Year: $y out of range (1677:2262)")
+function validargs(::Type{Timestamp{P}}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64,
+                   s::Int64, ms::Int64, us::Int64, ns::Int64, ampm::AMPM=TWENTYFOURHOUR) where {P}
+    year(typemin(Timestamp{P})) <= y <= year(typemax(Timestamp{P})) ||
+        return ArgumentError("Year: $y out of range for Timestamp{$P}")
     0 < m < 13 || return ArgumentError("Month: $m out of range (1:12)")
     0 < d < daysinmonth(y, m) + 1 || return ArgumentError("Day: $d out of range (1:$(daysinmonth(y, m)))")
     if ampm == TWENTYFOURHOUR # 24-hour clock
@@ -428,10 +463,15 @@ function validargs(::Type{Timestamp}, y::Int64, m::Int64, d::Int64, h::Int64, mi
         return ArgumentError("Sub-second parts must together be less than one second")
     epochdays = totaldays(y, m, d) - UNIXEPOCHDAYS
     nsofday = ns + 1000us + 1000000ms + 1000000000 * (s + 60mi + 3600 * adjusthour(h, ampm))
-    TIMESTAMPMIN <= (epochdays, nsofday) <= TIMESTAMPMAX ||
-        return ArgumentError("Timestamp: $y-$m-$d out of range ($(typemin(Timestamp)) to $(typemax(Timestamp)))")
+    ticks, remainder = divrem(nsofday, timestamp_scale(P))
+    iszero(remainder) || return ArgumentError("Fractional second is not exactly representable as Timestamp{$P}")
+    fldmod(typemin(Int64), timestamp_ticks_per_day(P)) <= (epochdays, ticks) <=
+        fldmod(typemax(Int64), timestamp_ticks_per_day(P)) ||
+        return ArgumentError("Timestamp: $y-$m-$d out of range ($(typemin(Timestamp{P})) to $(typemax(Timestamp{P})))")
     return nothing
 end
+
+validargs(::Type{Timestamp}, args...) = validargs(Timestamp{Nanosecond}, args...)
 
 # Convenience constructors from Periods
 function DateTime(y::Year, m::Month=Month(1), d::Day=Day(1),
@@ -449,11 +489,11 @@ function Time(h::Hour, mi::Minute=Minute(0), s::Second=Second(0),
     return Time(value(h), value(mi), value(s), value(ms), value(us), value(ns))
 end
 
-function Timestamp(y::Year, m::Month=Month(1), d::Day=Day(1),
+function Timestamp{P}(y::Year, m::Month=Month(1), d::Day=Day(1),
                    h::Hour=Hour(0), mi::Minute=Minute(0), s::Second=Second(0),
                    ms::Millisecond=Millisecond(0),
-                   us::Microsecond=Microsecond(0), ns::Nanosecond=Nanosecond(0))
-    return Timestamp(value(y), value(m), value(d), value(h), value(mi), value(s),
+                   us::Microsecond=Microsecond(0), ns::Nanosecond=Nanosecond(0)) where {P}
+    return Timestamp{P}(value(y), value(m), value(d), value(h), value(mi), value(s),
                      value(ms), value(us), value(ns))
 end
 
@@ -525,7 +565,7 @@ Construct a `Timestamp` type by `Period` type parts. Arguments may be in any ord
 !!! compat "Julia 1.14"
     `Timestamp` requires Julia 1.14 or later.
 """
-function Timestamp(period::Period, periods::Period...)
+function Timestamp{P}(period::Period, periods::Period...) where {P}
     y = Year(1970); m = Month(1); d = Day(1)
     h = Hour(0); mi = Minute(0); s = Second(0)
     ms = Millisecond(0); us = Microsecond(0); ns = Nanosecond(0)
@@ -540,7 +580,7 @@ function Timestamp(period::Period, periods::Period...)
         isa(p, Microsecond) && (us = p::Microsecond)
         isa(p, Nanosecond) && (ns = p::Nanosecond)
     end
-    return Timestamp(y, m, d, h, mi, s, ms, us, ns)
+    return Timestamp{P}(y, m, d, h, mi, s, ms, us, ns)
 end
 
 # Convenience constructor for DateTime from Date and Time
@@ -586,19 +626,21 @@ julia> Timestamp(Date(2018, 1, 1), Time(8, 15, 42, 0, 0, 5))
 2018-01-01T08:15:42.000000005
 ```
 """
-function Timestamp(d::Date, t::Time=Time(0))
-    epochdays = value(d) - UNIXEPOCHDAYS
-    TIMESTAMPMIN <= (epochdays, value(t)) <= TIMESTAMPMAX ||
-        throw(ArgumentError("Timestamp: $d out of range ($(typemin(Timestamp)) to $(typemax(Timestamp)))"))
-    return Timestamp(UTN(unixns(value(d), value(t))))
+function Timestamp{P}(d::Date, t::Time=Time(0)) where {P}
+    ticks, remainder = divrem(value(t), timestamp_scale(P))
+    iszero(remainder) || throw(InexactError(:convert, Timestamp{P}, t))
+    epochdays = Int128(value(d)) - UNIXEPOCHDAYS
+    typemin(Int64) <= epochdays * timestamp_ticks_per_day(P) + ticks <= typemax(Int64) ||
+        throw(ArgumentError("Date out of range for Timestamp{$P}"))
+    return timestamp_from_day(Timestamp{P}, value(d), value(t))
 end
 
 # Fallback constructors
 DateTime(y, m=1, d=1, h=0, mi=0, s=0, ms=0, ampm::AMPM=TWENTYFOURHOUR) = DateTime(Int64(y), Int64(m), Int64(d), Int64(h), Int64(mi), Int64(s), Int64(ms), ampm)
 Date(y, m=1, d=1) = Date(Int64(y), Int64(m), Int64(d))
 Time(h, mi=0, s=0, ms=0, us=0, ns=0, ampm::AMPM=TWENTYFOURHOUR) = Time(Int64(h), Int64(mi), Int64(s), Int64(ms), Int64(us), Int64(ns), ampm)
-Timestamp(y, m=1, d=1, h=0, mi=0, s=0, ms=0, us=0, ns=0, ampm::AMPM=TWENTYFOURHOUR) =
-    Timestamp(Int64(y), Int64(m), Int64(d), Int64(h), Int64(mi), Int64(s), Int64(ms), Int64(us), Int64(ns), ampm)
+Timestamp{P}(y, m=1, d=1, h=0, mi=0, s=0, ms=0, us=0, ns=0, ampm::AMPM=TWENTYFOURHOUR) where {P} =
+    Timestamp{P}(Int64(y), Int64(m), Int64(d), Int64(h), Int64(mi), Int64(s), Int64(ms), Int64(us), Int64(ns), ampm)
 
 # Traits, Equality
 Base.isfinite(::Union{Type{T}, T}) where {T<:TimeType} = true
@@ -611,6 +653,7 @@ calendar(dt::Timestamp) = ISOCalendar
     eps(::Type{Date})::Day
     eps(::Type{Time})::Nanosecond
     eps(::Type{Timestamp})::Nanosecond
+    eps(::Type{Timestamp{P}})::P
     eps(::TimeType)::Period
 
 Return the smallest unit value supported by the `TimeType`.
@@ -630,12 +673,13 @@ julia> eps(Timestamp)
 1 nanosecond
 ```
 """
-Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, Type{Timestamp}, TimeType})
+Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, Type{<:Timestamp}, TimeType})
 
 Base.eps(::Type{DateTime}) = Millisecond(1)
 Base.eps(::Type{Date}) = Day(1)
 Base.eps(::Type{Time}) = Nanosecond(1)
 Base.eps(::Type{Timestamp}) = Nanosecond(1)
+Base.eps(::Type{Timestamp{P}}) where {P} = P(1)
 Base.eps(::T) where T <: TimeType = eps(T)::Period
 
 # zero returns dt::T - dt::T
@@ -643,6 +687,7 @@ Base.zero(::Type{DateTime}) = Millisecond(0)
 Base.zero(::Type{Date}) = Day(0)
 Base.zero(::Type{Time}) = Nanosecond(0)
 Base.zero(::Type{Timestamp}) = Nanosecond(0)
+Base.zero(::Type{Timestamp{P}}) where {P} = P(0)
 Base.zero(::T) where T <: TimeType = zero(T)::Period
 
 
@@ -652,12 +697,21 @@ Base.typemax(::Union{Date, Type{Date}}) = Date(252522163911149, 12, 31)
 Base.typemin(::Union{Date, Type{Date}}) = Date(-252522163911150, 1, 1)
 Base.typemax(::Union{Time, Type{Time}}) = Time(23, 59, 59, 999, 999, 999)
 Base.typemin(::Union{Time, Type{Time}}) = Time(0)
-Base.typemax(::Union{Timestamp, Type{Timestamp}}) = Timestamp(UTN(typemax(Int64)))
-Base.typemin(::Union{Timestamp, Type{Timestamp}}) = Timestamp(UTN(typemin(Int64)))
+Base.typemax(::Type{Timestamp}) = typemax(Timestamp{Nanosecond})
+Base.typemax(::Type{Timestamp{P}}) where {P} = Timestamp{P}(UTInstant(P(typemax(Int64))))
+Base.typemax(x::Timestamp) = typemax(typeof(x))
+Base.typemin(::Type{Timestamp}) = typemin(Timestamp{Nanosecond})
+Base.typemin(::Type{Timestamp{P}}) where {P} = Timestamp{P}(UTInstant(P(typemin(Int64))))
+Base.typemin(x::Timestamp) = typemin(typeof(x))
 # Date-DateTime promotion, isless, ==
 Base.promote_rule(::Type{Date}, x::Type{DateTime}) = DateTime
-Base.promote_rule(::Type{Date}, ::Type{Timestamp}) = Timestamp
-Base.promote_rule(::Type{DateTime}, ::Type{Timestamp}) = Timestamp
+Base.promote_rule(::Type{Date}, ::Type{Timestamp{P}}) where {P} = Timestamp{P}
+Base.promote_rule(::Type{DateTime}, ::Type{Timestamp{P}}) where {P} = Timestamp{timestamp_finer(P, Millisecond)}
+Base.promote_rule(::Type{Timestamp{P}}, ::Type{Timestamp{Q}}) where {P,Q} = Timestamp{timestamp_finer(P, Q)}
+Base.isless(x::Timestamp, y::Timestamp) = isless((days(x), nsofday(x)), (days(y), nsofday(y)))
+(==)(x::Timestamp, y::Timestamp) = days(x) == days(y) && nsofday(x) == nsofday(y)
+Base.isless(x::T, y::T) where {T<:Timestamp} = isless(value(x), value(y))
+(==)(x::T, y::T) where {T<:Timestamp} = value(x) == value(y)
 Base.isless(x::T, y::T) where {T<:TimeType} = isless(value(x), value(y))
 Base.isless(x::TimeType, y::TimeType) = isless(promote(x, y)...)
 (==)(x::T, y::T) where {T<:TimeType} = (==)(value(x), value(y))

--- a/stdlib/Dates/test/io.jl
+++ b/stdlib/Dates/test/io.jl
@@ -514,6 +514,51 @@ end
     @test Dates.parse_components("." * rpad(999, 10, '0'), Dates.DateFormat(".s")) == [Dates.Millisecond(999)]
 end
 
+@testset "fractional second code `n`" begin
+    # digits parse as a fraction of a second, down to nanosecond resolution
+    @test Dates.parse_components(".1", Dates.DateFormat(".n")) == [Dates.Nanosecond(100000000)]
+    @test Dates.parse_components(".123", Dates.DateFormat(".n")) == [Dates.Nanosecond(123000000)]
+    @test Dates.parse_components(".123456789", Dates.DateFormat(".n")) == [Dates.Nanosecond(123456789)]
+    @test Dates.parse_components(".1234567890", Dates.DateFormat(".n")) == [Dates.Nanosecond(123456789)]
+    @test_throws ArgumentError Dates.parse_components(".1234567891", Dates.DateFormat(".n"))
+    @test Dates.parse_components(".1" * "0"^72, Dates.DateFormat(".n")) ==
+        [Dates.Nanosecond(100000000)]
+    @test_throws ArgumentError Dates.parse_components(".123456789" * "0"^64 * "1", Dates.DateFormat(".n"))
+    # formatting strips trailing zeros, padded to at least the code width
+    @test Dates.format(Dates.Time(0, 0, 0, 500), "s") == "5"
+    @test Dates.format(Dates.Time(0, 0, 0, 500), "sss") == "500"
+    @test Dates.format(Dates.Time(0, 0, 0, 500), "n") == "5"
+    @test Dates.format(Dates.Time(0, 0, 0, 500), "nnnnnnnnn") == "500000000"
+    @test Dates.format(Dates.Time(0, 0, 0, 0, 0, 1), "n") == "000000001"
+    @test Dates.format(Dates.Time(0, 0, 0, 0, 0, 1), "nnn") == "000000001"
+    @test Dates.format(Dates.Time(0), "n") == "0"
+    @test Dates.format(Dates.Time(0), "nnn") == "000"
+    # fixed-width fractional fields truncate to their declared precision
+    fixed_ms = Dates.DateFormat("sSS")
+    fixed_ns = Dates.DateFormat("nnnSS")
+    fixed_ns9 = Dates.DateFormat("nnnnnnnnnSS")
+    @test Dates.format(Dates.Time(0, 0, 45, 123), fixed_ms) == "145"
+    @test Dates.format(Dates.Time(0, 0, 45, 0, 0, 1), fixed_ns) == "00045"
+    @test Dates.format(Dates.Time(0, 0, 45, 0, 0, 1), fixed_ns9) == "00000000145"
+    @test Dates.Time(Dates.format(Dates.Time(0, 0, 45, 0, 0, 1), fixed_ns9), fixed_ns9) ==
+        Dates.Time(0, 0, 45, 0, 0, 1)
+    # DateTime can use `n` when the fraction is exactly representable in milliseconds
+    @test Dates.format(Dates.DateTime(2020, 1, 1, 0, 0, 0, 123), "n") == "123"
+    @test Dates.DateTime("2020-01-01T00:00:00.5", dateformat"yyyy-mm-dd\THH:MM:SS.n") ==
+        Dates.DateTime(2020, 1, 1, 0, 0, 0, 500)
+    @test tryparse(Dates.DateTime, "2020-01-01T00:00:00.000000001",
+                   dateformat"yyyy-mm-dd\THH:MM:SS.n") === nothing
+    @test_throws ArgumentError parse(Dates.DateTime, "2020-01-01T00:00:00.000000001",
+                                     dateformat"yyyy-mm-dd\THH:MM:SS.n")
+    # sub-millisecond times now round-trip through the default format
+    t = Dates.Time(12, 0, 0, 123, 456, 789)
+    @test string(t) == "12:00:00.123456789"
+    @test Dates.Time(string(t)) == t
+    @test Dates.Time("12:00:00.5") == Dates.Time(12, 0, 0, 500)
+    @test Dates.Time("12:00:00.123") == Dates.Time(12, 0, 0, 123)
+    @test Dates.format(t, "HH:MM:SS.n") == "12:00:00.123456789"
+end
+
 @testset "Time Parsing" begin
     let t
         time_tuple(t::Dates.Time) = (

--- a/stdlib/Dates/test/testgroups
+++ b/stdlib/Dates/test/testgroups
@@ -8,3 +8,4 @@ types
 io
 arithmetic
 conversions
+timestamps

--- a/stdlib/Dates/test/timestamps.jl
+++ b/stdlib/Dates/test/timestamps.jl
@@ -1,0 +1,403 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module TimestampTests
+
+using Test
+using Dates
+
+# Test the nanosecond Timestamp API.
+
+@testset "Construction and validation" begin
+    ts = Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)
+    @test ts isa Timestamp
+    @test Timestamp(2026) == Timestamp(2026, 1, 1)
+    @test Timestamp(2026, 8) == Timestamp(2026, 8, 1)
+    # the unix epoch is the zero instant
+    @test Dates.value(Timestamp(1970)) == 0
+    @test Timestamp(Dates.UTN(0)) == Timestamp(1970)
+    # 24:00 rolls over like DateTime
+    @test Timestamp(2026, 8, 31, 24) == Timestamp(2026, 9, 1)
+    # AM/PM
+    @test Timestamp(2026, 8, 31, 12, 0, 0, 0, 0, 0, Dates.PM) == Timestamp(2026, 8, 31, 12)
+    @test Timestamp(2026, 8, 31, 12, 0, 0, 0, 0, 0, Dates.AM) == Timestamp(2026, 8, 31, 0)
+    # from Periods, in any order
+    @test Timestamp(Year(2026), Month(8), Day(31)) == Timestamp(2026, 8, 31)
+    @test Timestamp(Hour(1)) == Timestamp(1970, 1, 1, 1)  # parts default to the unix epoch
+    @test Timestamp(Nanosecond(789), Year(2026), Millisecond(123)) ==
+        Timestamp(2026, 1, 1, 0, 0, 0, 123, 0, 789)
+    @test Timestamp(Year(2026), Month(8), Day(31), Hour(13), Minute(45), Second(30),
+                    Millisecond(123), Microsecond(456), Nanosecond(789)) == ts
+    # from Date/Time
+    @test Timestamp(Date(2026, 8, 31)) == Timestamp(2026, 8, 31)
+    @test Timestamp(Date(2026, 8, 31), Time(13, 45, 30, 123, 456, 789)) == ts
+    # argument validation
+    @test_throws ArgumentError Timestamp(2026, 13, 1)
+    @test_throws ArgumentError Timestamp(2026, 2, 30)
+    @test_throws ArgumentError Timestamp(2026, 1, 1, 25)
+    @test_throws ArgumentError Timestamp(2026, 1, 1, 0, 60)
+    @test_throws ArgumentError Timestamp(2026, 1, 1, 0, 0, 60)
+    @test_throws ArgumentError Timestamp(2026, 1, 1, 0, 0, 0, 1000)
+    @test_throws ArgumentError Timestamp(2026, 1, 1, 0, 0, 0, 0, 1000)
+    @test_throws ArgumentError Timestamp(2026, 1, 1, 0, 0, 0, 0, 0, 1000000000)
+    # ns may carry a full fractional second as long as the total stays below 1s
+    @test Timestamp(2026, 1, 1, 0, 0, 0, 0, 0, 999999999) ==
+        Timestamp(2026, 1, 1, 0, 0, 0, 999, 999, 999)
+    @test_throws ArgumentError Timestamp(2026, 1, 1, 0, 0, 0, 1, 0, 999999999)
+    # out-of-range instants throw ArgumentError, not overflow silently
+    @test_throws ArgumentError Timestamp(1677, 9, 20)
+    @test_throws ArgumentError Timestamp(2262, 4, 12)
+    @test_throws ArgumentError Timestamp(1000)
+    @test_throws ArgumentError Timestamp(3000)
+    @test_throws ArgumentError Timestamp(Date(3000))
+    # years are bounds-checked before any calendar arithmetic could wrap into range
+    wrapped_year = Int64(202021879422134420)
+    @test Dates.validargs(Timestamp, wrapped_year, 1, 1, 0, 0, 0, 0, 0, 0) isa ArgumentError
+    @test_throws ArgumentError Timestamp(wrapped_year)
+    @test tryparse(Timestamp, string(wrapped_year)) === nothing
+    # the exact boundary instants are constructible
+    @test Timestamp(2262, 4, 11, 23, 47, 16, 854, 775, 807) == typemax(Timestamp)
+    @test Timestamp(1677, 9, 21, 0, 12, 43, 145, 224, 192) == typemin(Timestamp)
+    @test_throws ArgumentError Timestamp(2262, 4, 11, 23, 47, 16, 854, 775, 808)
+    @test_throws ArgumentError Timestamp(1677, 9, 21, 0, 12, 43, 145, 224, 191)
+end
+
+@testset "Accessors" begin
+    ts = Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)
+    @test year(ts) == 2026
+    @test month(ts) == 8
+    @test day(ts) == 31
+    @test hour(ts) == 13
+    @test minute(ts) == 45
+    @test second(ts) == 30
+    @test millisecond(ts) == 123
+    @test microsecond(ts) == 456
+    @test nanosecond(ts) == 789
+    @test yearmonthday(ts) == (2026, 8, 31)
+    @test week(ts) == 36
+    @test dayofweek(ts) == Dates.Monday
+    @test quarterofyear(ts) == 3
+    @test dayname(ts) == "Monday"
+    @test dayofyear(ts) == 243
+    @test Dates.days(ts) == Dates.days(Date(2026, 8, 31))
+    # pre-1970 instants (negative values) decompose correctly
+    ts2 = Timestamp(1969, 12, 31, 23, 59, 59, 999, 999, 999)
+    @test Dates.value(ts2) == -1
+    @test (year(ts2), month(ts2), day(ts2)) == (1969, 12, 31)
+    @test (hour(ts2), minute(ts2), second(ts2)) == (23, 59, 59)
+    @test (millisecond(ts2), microsecond(ts2), nanosecond(ts2)) == (999, 999, 999)
+    # Period extraction constructors
+    @test Year(ts) == Year(2026)
+    @test Month(ts) == Month(8)
+    @test Day(ts) == Day(31)
+    @test Hour(ts) == Hour(13)
+    @test Minute(ts) == Minute(45)
+    @test Second(ts) == Second(30)
+    @test Millisecond(ts) == Millisecond(123)
+    @test Microsecond(ts) == Microsecond(456)
+    @test Nanosecond(ts) == Nanosecond(789)
+    @test eps(Timestamp) == Nanosecond(1)
+    @test eps(ts) == Nanosecond(1)
+    @test zero(Timestamp) == Nanosecond(0)
+    @test isfinite(Timestamp) && isfinite(ts)
+end
+
+@testset "Conversions and promotion" begin
+    ts = Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)
+    dt = DateTime(2026, 8, 31, 13, 45, 30, 123)
+    # DateTime -> Timestamp is exact
+    @test Timestamp(dt) == Timestamp(2026, 8, 31, 13, 45, 30, 123)
+    @test convert(Timestamp, dt) == Timestamp(dt)
+    # Timestamp -> DateTime floors to the millisecond
+    @test DateTime(ts) == dt
+    @test DateTime(Timestamp(1969, 12, 31, 23, 59, 59, 999, 999, 999)) ==
+        DateTime(1969, 12, 31, 23, 59, 59, 999)
+    @test Date(ts) == Date(2026, 8, 31)
+    @test Time(ts) == Time(13, 45, 30, 123, 456, 789)
+    # out-of-range DateTime -> Timestamp throws
+    @test_throws InexactError Timestamp(DateTime(300000, 1, 1))
+    @test_throws InexactError convert(Timestamp, DateTime(1600, 1, 1))
+    # instants beyond DateTime's own range must not wrap into range either
+    @test_throws InexactError Timestamp(DateTime(Dates.UTM(typemin(Int64) + Dates.UNIXEPOCH)))
+    # raw value conversions (unix nanoseconds)
+    @test convert(Nanosecond, ts) == Nanosecond(Dates.value(ts))
+    @test convert(Timestamp, Nanosecond(Dates.value(ts))) == ts
+    # unix conversions
+    @test unix2timestamp(0) == Timestamp(1970)
+    @test unix2timestamp(86400) == Timestamp(1970, 1, 2)
+    @test timestamp2unix(Timestamp(1970, 1, 2)) == 86400.0
+    @test unix2timestamp(timestamp2unix(Timestamp(2026, 8, 31))) == Timestamp(2026, 8, 31)
+    @test unix2timestamp(9223372036) == Timestamp(2262, 4, 11, 23, 47, 16)
+    @test_throws InexactError unix2timestamp(9223372037)
+    @test_throws InexactError unix2timestamp(typemin(Int64))
+    @test_throws InexactError unix2timestamp(9223372037.0)
+    @test Dates.datetime2rata(ts) == Dates.datetime2rata(Date(2026, 8, 31))
+    # promotion
+    @test promote(dt, ts) isa Tuple{Timestamp, Timestamp}
+    @test promote(Date(2026), Timestamp(2026)) isa Tuple{Timestamp, Timestamp}
+    @test vcat([dt], [ts]) isa Vector{Timestamp}
+end
+
+@testset "Comparisons" begin
+    ts = Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)
+    dt = DateTime(2026, 8, 31, 13, 45, 30, 123)
+    @test ts > dt
+    @test dt < ts
+    @test ts != dt
+    @test Timestamp(dt) == dt
+    @test dt == Timestamp(dt)
+    @test Timestamp(2026, 8, 31) == Date(2026, 8, 31)
+    @test Date(2026, 8, 31) == Timestamp(2026, 8, 31)
+    @test ts != Date(2026, 8, 31)
+    @test Date(2026, 8, 31) < ts
+    @test ts < Date(2026, 9, 1)
+    # comparisons against instants far outside the Timestamp range must not throw
+    @test DateTime(300000, 1, 1) > ts
+    @test DateTime(-300000, 1, 1) < ts
+    @test Date(300000, 1, 1) > ts
+    @test Date(-300000, 1, 1) < ts
+    @test !(DateTime(300000, 1, 1) == ts)
+    @test !(ts == Date(300000, 1, 1))
+    @test isless(ts, DateTime(300000, 1, 1))
+    @test min(ts, DateTime(300000, 1, 1)) === ts
+    @test isoyear(Timestamp(2021, 1, 1)) == Year(2020)
+    @test isoweekdate(Timestamp(2021, 1, 1)) == (2020, 53, 5)
+    # total order within the type
+    a = Timestamp(2026, 1, 1)
+    @test sort([a + Nanosecond(2), a, a + Nanosecond(1)]) ==
+        [a, a + Nanosecond(1), a + Nanosecond(2)]
+end
+
+@testset "Arithmetic" begin
+    ts = Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)
+    # fixed periods are exact to the nanosecond
+    @test ts + Nanosecond(1) - Nanosecond(1) == ts
+    @test ts + Microsecond(3) == Timestamp(2026, 8, 31, 13, 45, 30, 123, 459, 789)
+    @test ts + Millisecond(900) == Timestamp(2026, 8, 31, 13, 45, 31, 23, 456, 789)
+    @test ts + Second(30) == Timestamp(2026, 8, 31, 13, 46, 0, 123, 456, 789)
+    @test ts + Hour(11) == Timestamp(2026, 9, 1, 0, 45, 30, 123, 456, 789)
+    @test ts + Day(1) == Timestamp(2026, 9, 1, 13, 45, 30, 123, 456, 789)
+    @test ts + Week(1) == Timestamp(2026, 9, 7, 13, 45, 30, 123, 456, 789)
+    @test Nanosecond(1) + ts == ts + Nanosecond(1)
+    # calendar periods clamp the day like DateTime and carry sub-second parts
+    @test ts + Month(6) == Timestamp(2027, 2, 28, 13, 45, 30, 123, 456, 789)
+    @test ts - Month(6) == Timestamp(2026, 2, 28, 13, 45, 30, 123, 456, 789)
+    @test ts + Year(1) == Timestamp(2027, 8, 31, 13, 45, 30, 123, 456, 789)
+    @test ts - Year(1) == Timestamp(2025, 8, 31, 13, 45, 30, 123, 456, 789)
+    @test ts + Quarter(1) == Timestamp(2026, 11, 30, 13, 45, 30, 123, 456, 789)
+    @test ts - Quarter(1) == Timestamp(2026, 5, 31, 13, 45, 30, 123, 456, 789)
+    # leap-day clamping
+    @test Timestamp(2024, 2, 29, 0, 0, 0, 0, 0, 1) + Year(1) ==
+        Timestamp(2025, 2, 28, 0, 0, 0, 0, 0, 1)
+    # differences are Nanosecond
+    @test (ts + Nanosecond(5)) - ts == Nanosecond(5)
+    @test ts - Timestamp(2026, 8, 31) == Nanosecond(49530123456789)
+    @test ts - DateTime(2026, 8, 31, 13, 45, 30, 123) == Nanosecond(456789)
+    @test DateTime(2026, 8, 31, 13, 45, 30, 123) - ts == Nanosecond(-456789)
+    # Timestamp - Date is a MethodError, matching DateTime - Date
+    @test_throws MethodError ts - Date(2026, 8, 31)
+    # compound periods
+    @test ts + (Hour(1) + Minute(30)) == Timestamp(2026, 8, 31, 15, 15, 30, 123, 456, 789)
+    @test ts + Day(1) + Hour(1) == Timestamp(2026, 9, 1, 14, 45, 30, 123, 456, 789)
+    # like DateTime, arithmetic is fixed-point and wraps at the ends of the range
+    @test typemax(Timestamp) + Nanosecond(1) == typemin(Timestamp)
+    @test typemin(Timestamp) - Nanosecond(1) == typemax(Timestamp)
+    @test typemax(Timestamp) - typemin(Timestamp) == Nanosecond(-1)
+    @test typemax(Timestamp) - Month(1) == Timestamp(2262, 3, 11, 23, 47, 16, 854, 775, 807)
+    @test typemax(Timestamp) + Month(1) == typemin(Timestamp) + Day(30) - Nanosecond(1)
+    @test typemin(Timestamp) - Year(1) == typemax(Timestamp) - Day(365) + Nanosecond(1)
+    # broadcast
+    @test [ts, ts] .+ Nanosecond(1) == [ts + Nanosecond(1), ts + Nanosecond(1)]
+end
+
+@testset "Rounding and truncation" begin
+    ts = Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)
+    @test floor(ts, Hour) == Timestamp(2026, 8, 31, 13)
+    @test floor(ts, Minute(15)) == Timestamp(2026, 8, 31, 13, 45)
+    @test floor(ts, Second) == Timestamp(2026, 8, 31, 13, 45, 30)
+    @test floor(ts, Millisecond) == Timestamp(2026, 8, 31, 13, 45, 30, 123)
+    @test floor(ts, Microsecond) == Timestamp(2026, 8, 31, 13, 45, 30, 123, 456)
+    @test floor(ts, Nanosecond) == ts
+    @test floor(ts, Day) == Timestamp(2026, 8, 31)
+    @test floor(ts, Week) == Timestamp(2026, 8, 31) # a Monday
+    @test floor(ts, Month) == Timestamp(2026, 8)
+    @test floor(ts, Quarter) == Timestamp(2026, 7)
+    @test floor(ts, Year) == Timestamp(2026)
+    @test ceil(ts, Minute) == Timestamp(2026, 8, 31, 13, 46)
+    @test ceil(ts, Month) == Timestamp(2026, 9)
+    @test round(ts, Second) == Timestamp(2026, 8, 31, 13, 45, 30)
+    @test round(ts, Hour) == Timestamp(2026, 8, 31, 14)
+    @test_throws DomainError floor(ts, Nanosecond(-1))
+    # rounding to time periods wraps like the arithmetic it is built from, so
+    # results near the ends of the range are right whenever they are representable
+    @test ceil(typemin(Timestamp), Nanosecond(10)) == typemin(Timestamp) + Nanosecond(8)
+    @test ceil(typemin(Timestamp), Hour) == Timestamp(1677, 9, 21, 1)
+    @test round(typemin(Timestamp), Minute) == Timestamp(1677, 9, 21, 0, 13)
+    @test floor(typemax(Timestamp), Minute) == Timestamp(2262, 4, 11, 23, 47)
+    @test ceil(typemin(Timestamp), Day) == Timestamp(1677, 9, 22)
+    # rounding agrees with DateTime for any period (shared 0000-01-01 anchor)
+    dt = DateTime(2026, 8, 31, 13, 45, 30, 123)
+    for p in (Hour(7), Minute(11), Second(17), Hour(1), Day(1), Millisecond(21))
+        @test DateTime(floor(Timestamp(dt), p)) == floor(dt, p)
+    end
+    # pre-1970 rounding (floored, not truncated toward zero)
+    @test floor(Timestamp(1969, 12, 31, 23, 59, 59, 999), Second) ==
+        Timestamp(1969, 12, 31, 23, 59, 59)
+    # trunc
+    @test trunc(ts, Year) == Timestamp(2026)
+    @test trunc(ts, Quarter) == Timestamp(2026, 7)
+    @test trunc(ts, Month) == Timestamp(2026, 8)
+    @test trunc(ts, Day) == Timestamp(2026, 8, 31)
+    @test trunc(ts, Hour) == Timestamp(2026, 8, 31, 13)
+    @test trunc(ts, Minute) == Timestamp(2026, 8, 31, 13, 45)
+    @test trunc(ts, Second) == Timestamp(2026, 8, 31, 13, 45, 30)
+    @test trunc(ts, Millisecond) == Timestamp(2026, 8, 31, 13, 45, 30, 123)
+    @test trunc(ts, Microsecond) == Timestamp(2026, 8, 31, 13, 45, 30, 123, 456)
+    @test trunc(ts, Nanosecond) == ts
+end
+
+@testset "Adjusters" begin
+    ts = Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)
+    @test firstdayofweek(ts) == Timestamp(2026, 8, 31)
+    @test lastdayofweek(ts) == Timestamp(2026, 9, 6)
+    @test firstdayofmonth(ts) == Timestamp(2026, 8, 1)
+    @test lastdayofmonth(ts) == Timestamp(2026, 8, 31)
+    @test firstdayofyear(ts) == Timestamp(2026, 1, 1)
+    @test lastdayofyear(ts) == Timestamp(2026, 12, 31)
+    @test firstdayofquarter(ts) == Timestamp(2026, 7, 1)
+    @test lastdayofquarter(ts) == Timestamp(2026, 9, 30)
+    @test tonext(d -> dayofweek(d) == Dates.Thursday, ts) ==
+        Timestamp(2026, 9, 3, 13, 45, 30, 123, 456, 789)
+    @test toprev(d -> dayofweek(d) == Dates.Friday, ts) ==
+        Timestamp(2026, 8, 28, 13, 45, 30, 123, 456, 789)
+    # function-based adjuster constructors, mirroring DateTime's arity ladder
+    starts = (
+        (2026,),
+        (2026, 8),
+        (2026, 8, 31),
+        (2026, 8, 31, 13),
+        (2026, 8, 31, 13, 45),
+        (2026, 8, 31, 13, 45, 30),
+        (2026, 8, 31, 13, 45, 30, 123),
+        (2026, 8, 31, 13, 45, 30, 123, 456),
+    )
+    default_steps = (Day(1), Day(1), Hour(1), Minute(1), Second(1),
+                     Millisecond(1), Microsecond(1), Nanosecond(1))
+    for (args, step) in zip(starts, default_steps)
+        start = Timestamp(args...)
+        @test Timestamp(t -> t == start + step, args...; limit=2) == start + step
+    end
+    @test Timestamp(t -> hour(t) == 12, 2026, 8, 31; step=Hour(1)) == Timestamp(2026, 8, 31, 12)
+    @test Timestamp(t -> second(t) == 40, 2026, 8, 31, 10; step=Second(1)) ==
+        Timestamp(2026, 8, 31, 10, 0, 40)
+    @test Timestamp(t -> microsecond(t) == 3, 2026, 8, 31, 10, 0, 0, 0; step=Microsecond(1)) ==
+        Timestamp(2026, 8, 31, 10, 0, 0, 0, 3)
+    @test Timestamp(t -> nanosecond(t) == 4, 2026, 8, 31, 10, 0, 0, 0, 0; step=Nanosecond(1)) ==
+        Timestamp(2026, 8, 31, 10, 0, 0, 0, 0, 4)
+    @test_throws ArgumentError Timestamp(t -> false, 2026, 8, 31; limit=3)
+    # the predicate is validated at the supplied start, including the partial lower-bound year
+    @test Timestamp(t -> true, 1677, 9, 21, 0, 12, 43, 145, 225) ==
+        Timestamp(1677, 9, 21, 0, 12, 43, 145, 225)
+    @test Timestamp(t -> t == typemax(Timestamp), 2262, 4, 11, 23, 47, 16, 854, 775;
+                    step=Nanosecond(1), limit=808) == typemax(Timestamp)
+end
+
+@testset "Ranges" begin
+    a = Timestamp(2026, 1, 1)
+    r = a:Nanosecond(250):(a + Microsecond(1))
+    @test length(r) == 5
+    @test collect(r) == [a + Nanosecond(250i) for i in 0:4]
+    @test (a + Nanosecond(500)) in r
+    @test !((a + Nanosecond(400)) in r)
+    r2 = a:Month(1):Timestamp(2026, 12, 31)
+    @test length(r2) == 12
+    @test last(collect(r2)) == Timestamp(2026, 12, 1)
+    @test length(a:Day(1):Timestamp(2026, 1, 31)) == 31
+    @test isempty(a:Nanosecond(1):(a - Nanosecond(1)))
+    # calendar-stepped ranges may end within one step of typemax
+    @test length(Timestamp(2262, 1, 1):Month(1):Timestamp(2262, 4, 11)) == 4
+    # step counts are computed exactly, beyond Float64's 2^53 integer precision
+    r53 = a:Nanosecond(1):(a + Nanosecond(2^55 + 5))
+    @test length(r53) == 2^55 + 6
+    @test last(r53) == a + Nanosecond(2^55 + 5)
+    @test reverse(a:Nanosecond(250):(a + Microsecond(1))) == (a + Microsecond(1)):Nanosecond(-250):a
+    @test (a:Nanosecond(250):(a + Microsecond(1)))[2:3] == [a + Nanosecond(250), a + Nanosecond(500)]
+end
+
+@testset "Parsing and formatting" begin
+    ts = Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)
+    # default ISO round trip
+    @test string(ts) == "2026-08-31T13:45:30.123456789"
+    @test Timestamp(string(ts)) == ts
+    @test sprint(show, ts) == "Dates.Timestamp(\"2026-08-31T13:45:30.123456789\")"
+    @test sprint(show, MIME("text/plain"), ts) == "2026-08-31T13:45:30.123456789"
+    # trailing zeros are stripped, and stripped forms parse back
+    @test string(Timestamp(2026, 8, 31)) == "2026-08-31T00:00:00"
+    @test string(Timestamp(2026, 8, 31, 1, 2, 3, 500)) == "2026-08-31T01:02:03.5"
+    @test string(Timestamp(2026, 8, 31, 1, 2, 3, 0, 0, 5)) == "2026-08-31T01:02:03.000000005"
+    @test Timestamp("2026-08-31T01:02:03.5") == Timestamp(2026, 8, 31, 1, 2, 3, 500)
+    @test Timestamp("2026-08-31T13:45:30") == Timestamp(2026, 8, 31, 13, 45, 30)
+    @test Timestamp("2026-08-31") == Timestamp(2026, 8, 31)
+    # digits past the ninth must be zero, as with `s` past the third
+    @test Timestamp("2026-08-31T00:00:00.1234567890") ==
+        Timestamp(2026, 8, 31, 0, 0, 0, 123, 456, 789)
+    @test_throws ArgumentError Timestamp("2026-08-31T00:00:00.1234567891")
+    # custom formats, including the millisecond `s` code
+    @test Timestamp("31/08/2026 13:45", "dd/mm/yyyy HH:MM") == Timestamp(2026, 8, 31, 13, 45)
+    @test Timestamp("2026-08-31T13:45:30.123", dateformat"yyyy-mm-dd\THH:MM:SS.s") ==
+        Timestamp(2026, 8, 31, 13, 45, 30, 123)
+    @test Timestamp("2026-08-31 1:45pm", "yyyy-mm-dd I:MMp") == Timestamp(2026, 8, 31, 13, 45)
+    @test Dates.format(ts, "yyyy-mm-dd HH:MM:SS.n") == "2026-08-31 13:45:30.123456789"
+    @test Dates.format(Timestamp(2026, 8, 31, 1, 2, 3, 500), "HH:MM:SS.n") == "01:02:03.5"
+    @test Dates.format(Timestamp(2026, 8, 31, 1, 2, 3, 500), "HH:MM:SS.nnnnnnnnn") ==
+        "01:02:03.500000000"
+    @test Dates.format(ts, ISOTimestampFormat) == "2026-08-31T13:45:30.123456789"
+    @test Timestamp(Dates.format(ts, ISOTimestampFormat)) == ts
+    # parse/tryparse API
+    @test parse(Timestamp, "2026-08-31T13:45:30.123456789") == ts
+    @test tryparse(Timestamp, "2026-08-31T13:45:30.123456789") == ts
+    @test tryparse(Timestamp, "2026-99-31") === nothing
+    @test tryparse(Timestamp, "3000-01-01") === nothing
+    @test tryparse(Timestamp, "1000-01-01") === nothing
+    @test tryparse(Timestamp, "garbage") === nothing
+    @test tryparse(Timestamp, "18446744073709553636-01-01") === nothing
+    long_zero_fraction = "2020-01-01T00:00:00.1" * "0"^72
+    @test tryparse(Timestamp, long_zero_fraction) == Timestamp(2020, 1, 1, 0, 0, 0, 100)
+    long_nonzero_fraction = "2020-01-01T00:00:00.123456789" * "0"^64 * "1"
+    @test tryparse(Timestamp, long_nonzero_fraction) === nothing
+    @test_throws ArgumentError parse(Timestamp, "3000-01-01")
+    @test_throws ArgumentError Timestamp("")
+    # Timestamp values format with DateTime-compatible codes
+    @test Dates.format(ts, "yyyy-mm-dd HH:MM:SS.s") == "2026-08-31 13:45:30.123"
+    @test Dates.format(ts, "e, dd u yyyy HH:MM:SS") == "Mon, 31 Aug 2026 13:45:30"
+end
+
+@testset "now and today" begin
+    ts = now(Timestamp)
+    @test ts isa Timestamp
+    @test abs(DateTime(ts) - now()) < Millisecond(60000)
+    tsu = now(Timestamp, UTC)
+    @test tsu isa Timestamp
+    @test abs(DateTime(tsu) - now(UTC)) < Millisecond(60000)
+end
+
+@testset "Data layout" begin
+    ts = Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)
+    @test isbitstype(Timestamp)
+    @test sizeof(Timestamp) == 8
+    v = [ts, ts + Nanosecond(1)]
+    @test reinterpret(Int64, v) == [Dates.value(ts), Dates.value(ts) + 1]
+    @test reinterpret(Timestamp, reinterpret(Int64, v)) == v
+    @test hash(ts) == hash(Timestamp(Dates.UTN(Dates.value(ts))))
+    @test hash(ts) != hash(ts + Nanosecond(1))
+    d = Dict(ts => 1)
+    @test d[Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)] == 1
+    # equal instants hash alike across Date, DateTime, and Timestamp
+    @test hash(Timestamp(2026, 8, 31)) == hash(DateTime(2026, 8, 31)) == hash(Date(2026, 8, 31))
+    @test hash(Timestamp(2026, 8, 31, 13, 45, 30, 123)) == hash(DateTime(2026, 8, 31, 13, 45, 30, 123))
+    mixed = Dict{Any, Int}(Date(2026, 8, 31) => 1, DateTime(2026, 8, 31, 12) => 2)
+    @test mixed[Timestamp(2026, 8, 31)] == 1
+    @test mixed[Timestamp(2026, 8, 31, 12)] == 2
+    @test mixed[DateTime(2026, 8, 31)] == 1
+end
+
+end

--- a/stdlib/Dates/test/timestamps.jl
+++ b/stdlib/Dates/test/timestamps.jl
@@ -51,7 +51,7 @@ using Dates
     @test_throws ArgumentError Timestamp(Date(3000))
     # years are bounds-checked before any calendar arithmetic could wrap into range
     wrapped_year = Int64(202021879422134420)
-    @test Dates.validargs(Timestamp, wrapped_year, 1, 1, 0, 0, 0, 0, 0, 0) isa ArgumentError
+    @test Dates.validargs(Timestamp, wrapped_year, Int64(1), Int64(1), zeros(Int64, 6)...) isa ArgumentError
     @test_throws ArgumentError Timestamp(wrapped_year)
     @test tryparse(Timestamp, string(wrapped_year)) === nothing
     # the exact boundary instants are constructible
@@ -316,9 +316,9 @@ end
     # calendar-stepped ranges may end within one step of typemax
     @test length(Timestamp(2262, 1, 1):Month(1):Timestamp(2262, 4, 11)) == 4
     # step counts are computed exactly, beyond Float64's 2^53 integer precision
-    r53 = a:Nanosecond(1):(a + Nanosecond(2^55 + 5))
-    @test length(r53) == 2^55 + 6
-    @test last(r53) == a + Nanosecond(2^55 + 5)
+    r53 = a:Nanosecond(1):(a + Nanosecond(Int64(2)^55 + 5))
+    @test length(r53) == Int64(2)^55 + 6
+    @test last(r53) == a + Nanosecond(Int64(2)^55 + 5)
     @test reverse(a:Nanosecond(250):(a + Microsecond(1))) == (a + Microsecond(1)):Nanosecond(-250):a
     @test (a:Nanosecond(250):(a + Microsecond(1)))[2:3] == [a + Nanosecond(250), a + Nanosecond(500)]
 end

--- a/stdlib/Dates/test/timestamps.jl
+++ b/stdlib/Dates/test/timestamps.jl
@@ -134,7 +134,7 @@ end
     # promotion
     @test promote(dt, ts) isa Tuple{Timestamp, Timestamp}
     @test promote(Date(2026), Timestamp(2026)) isa Tuple{Timestamp, Timestamp}
-    @test vcat([dt], [ts]) isa Vector{Timestamp}
+    @test vcat([dt], [ts]) isa Vector{Timestamp{Nanosecond}}
 end
 
 @testset "Comparisons" begin
@@ -328,7 +328,7 @@ end
     # default ISO round trip
     @test string(ts) == "2026-08-31T13:45:30.123456789"
     @test Timestamp(string(ts)) == ts
-    @test sprint(show, ts) == "Dates.Timestamp(\"2026-08-31T13:45:30.123456789\")"
+    @test sprint(show, ts) == "Dates.Timestamp{Dates.Nanosecond}(\"2026-08-31T13:45:30.123456789\")"
     @test sprint(show, MIME("text/plain"), ts) == "2026-08-31T13:45:30.123456789"
     # trailing zeros are stripped, and stripped forms parse back
     @test string(Timestamp(2026, 8, 31)) == "2026-08-31T00:00:00"
@@ -382,11 +382,11 @@ end
 
 @testset "Data layout" begin
     ts = Timestamp(2026, 8, 31, 13, 45, 30, 123, 456, 789)
-    @test isbitstype(Timestamp)
-    @test sizeof(Timestamp) == 8
+    @test isbitstype(Timestamp{Nanosecond})
+    @test sizeof(Timestamp{Nanosecond}) == 8
     v = [ts, ts + Nanosecond(1)]
     @test reinterpret(Int64, v) == [Dates.value(ts), Dates.value(ts) + 1]
-    @test reinterpret(Timestamp, reinterpret(Int64, v)) == v
+    @test reinterpret(Timestamp{Nanosecond}, reinterpret(Int64, v)) == v
     @test hash(ts) == hash(Timestamp(Dates.UTN(Dates.value(ts))))
     @test hash(ts) != hash(ts + Nanosecond(1))
     d = Dict(ts => 1)
@@ -398,6 +398,175 @@ end
     @test mixed[Timestamp(2026, 8, 31)] == 1
     @test mixed[Timestamp(2026, 8, 31, 12)] == 2
     @test mixed[DateTime(2026, 8, 31)] == 1
+end
+
+# Exercise each resolution, including precision changes and the full Int64 range.
+@testset "Parameterized resolution" begin
+    units = (Second, Millisecond, Microsecond, Nanosecond)
+    scales = (1_000_000_000, 1_000_000, 1_000, 1)
+    for (P, scale) in zip(units, scales)
+        T = Timestamp{P}
+        x = T(2020, 2, 29, 12, 34, 56)
+        @test isbitstype(T)
+        @test sizeof(T) == 8
+        @test eps(T) === eps(x) === P(1)
+        @test zero(T) === zero(x) === P(0)
+        @test T(Hour(1)) === T(1970, 1, 1, 1)
+        @test T(Year(2020), Month(2), Day(29)) === T(2020, 2, 29)
+        @test T(Date(x), Time(x)) === x
+        @test T(DateTime(x)) === x
+        @test DateTime(x) === DateTime(2020, 2, 29, 12, 34, 56)
+        @test yearmonthday(x) == (2020, 2, 29)
+        @test (hour(x), minute(x), second(x)) == (12, 34, 56)
+        @test x + P(1) - x === P(1)
+        @test x + Day(1) === T(2020, 3, 1, 12, 34, 56)
+        @test x + Year(1) === T(2021, 2, 28, 12, 34, 56)
+        @test x + Month(1) === T(2020, 3, 29, 12, 34, 56)
+        @test x + Quarter(1) === T(2020, 5, 29, 12, 34, 56)
+        @test x + Hour(1) + Minute(30) === x + (Hour(1) + Minute(30))
+        @test floor(x, Minute) === T(2020, 2, 29, 12, 34)
+        @test ceil(x, Minute) === T(2020, 2, 29, 12, 35)
+        @test round(x, Minute) === T(2020, 2, 29, 12, 35)
+        @test floor(x, Day) === T(2020, 2, 29)
+        @test trunc(x, Month) === T(2020, 2)
+        @test firstdayofmonth(x) === T(2020, 2)
+        @test lastdayofmonth(x) === T(2020, 2, 29)
+        @test T(t -> second(t) == 2, 2020, 1, 1, 0, 0, 0) === T(2020, 1, 1, 0, 0, 2)
+        @test T(string(x)) === x
+        @test T("29/02/2020 12:34:56", "dd/mm/yyyy HH:MM:SS") === x
+        @test parse(T, string(x)) === x
+        @test tryparse(T, string(x)) === x
+        @test tryparse(T, "2020-02-30") === nothing
+        @test now(T) isa T
+        @test now(T, UTC) isa T
+        @test unix2timestamp(T, 0) === T(1970)
+        @test unix2timestamp(T, -1) === T(1969, 12, 31, 23, 59, 59)
+        @test timestamp2unix(T(1970, 1, 2)) == 86400.0
+        @test convert(T, P(-1)) === T(Dates.UTInstant(P(-1)))
+        @test convert(P, convert(T, P(-1))) === P(-1)
+        @test convert(T, T(1970)) === T(1970)
+        @test convert(Timestamp, typemax(T)) === typemax(T)
+        @test Timestamp(typemin(T)) === typemin(T)
+        @test Timestamp(typemax(T)) === typemax(T)
+        @test (@inferred Timestamp(x)) === x
+        @test Timestamp[typemax(T)][1] === typemax(T)
+        @test reinterpret(Int64, [T(1970), T(1970) + P(1)]) == [0, 1]
+        @test collect(x:P(1):(x + P(3))) == [x, x + P(1), x + P(2), x + P(3)]
+        @test collect((x + P(3)):-P(1):x) == [x + P(3), x + P(2), x + P(1), x]
+        @test length(x:Month(1):(x + Month(3))) == 4
+        @test x + P(2) in x:P(1):(x + P(3))
+        @test length((typemax(T) - P(3)):P(1):typemax(T)) == 4
+        @test_throws OverflowError length(T(1970):P(1):(T(1970) + P(typemax(Int64))))
+        @test length(T(1970):P(1):(T(1970) + P(typemax(Int64) - 1))) == typemax(Int64)
+        @test typemax(T) + P(1) === typemin(T)
+        @test typemin(T) - P(1) === typemax(T)
+        @test typemax(T) - typemin(T) === P(-1)
+        for raw in (typemin(Int64), typemin(Int64) + 1, -1, 0, 1, typemax(Int64) - 1, typemax(Int64))
+            t = T(Dates.UTInstant(P(raw)))
+            @test T(string(t)) === t
+            @test T(Date(t), Time(t)) === t
+            @test T(year(t), month(t), day(t), hour(t), minute(t), second(t),
+                    millisecond(t), microsecond(t), nanosecond(t)) === t
+            @test Int128(Dates.value(Date(t)) - Dates.value(Date(1970))) * 86400000000000 +
+                Dates.value(Time(t)) == Int128(raw) * scale
+        end
+        for Q in units
+            y = Timestamp{Q}(2020, 2, 29, 12, 34, 56)
+            @test x == y
+            @test isequal(x, y)
+            @test !isless(x, y)
+            @test hash(x) == hash(y)
+            @test Dict{Any,Int}(x => 1)[y] == 1
+            @test T(y) === x
+            @test x - y == P(0)
+        end
+        for p in (Hour(7), Minute(11), Second(17), Day(3), Month(2))
+            @test DateTime(floor(x, p)) == floor(DateTime(x), p)
+        end
+    end
+    @test Timestamp(2020) isa Timestamp{Nanosecond}
+    @test Timestamp{Second}(1) == DateTime(1)
+    @test Timestamp{Millisecond}(1) == DateTime(1)
+    @test Timestamp{Microsecond}(1) == DateTime(1)
+    @test_throws ArgumentError Timestamp{Nanosecond}(1)
+    @test_throws TypeError Timestamp{Day}
+    @test_throws TypeError Timestamp{TimePeriod}
+    for (coarse, fine) in ((Second, Millisecond), (Millisecond, Microsecond), (Microsecond, Nanosecond))
+        T, U = Timestamp{coarse}, Timestamp{fine}
+        finevalue = U(1970) + fine(1)
+        @test_throws InexactError T(finevalue)
+        @test_throws InexactError T(1970) + fine(1)
+        @test_throws ArgumentError T(string(finevalue))
+        @test tryparse(T, string(finevalue)) === nothing
+        @test T(floor(finevalue, coarse)) === T(1970)
+        @test T(ceil(finevalue, coarse)) === T(1970) + coarse(1)
+        @test_throws InexactError U(typemax(T))
+        @test_throws InexactError U(typemin(T))
+        @test typemax(T) > typemax(U)
+        @test typemin(T) < typemin(U)
+        @test promote_type(T, U) === U
+        @test promote_type(T, U) === promote_type(U, T)
+        @test promote(T(1970), finevalue) === (U(1970), finevalue)
+        @test length(T(1970):coarse(1):(T(1970) + coarse(Int64(2)^53 + 1))) == Int64(2)^53 + 2
+    end
+    @test promote_type(Timestamp{Second}, DateTime) === Timestamp{Millisecond}
+    @test_throws InexactError Timestamp{Second}(DateTime(1970, 1, 1, 0, 0, 0, 1))
+    @test_throws InexactError DateTime(typemax(Timestamp{Second}))
+    @test_throws InexactError DateTime(typemax(Timestamp{Millisecond}))
+    @test Timestamp{Second}(1970) + Day(200000) === Timestamp{Second}(Date(1970) + Day(200000))
+end
+
+# Large fixed periods wrap in timestamp ticks without overflowing through nanoseconds.
+@testset "Fixed-period arithmetic at each resolution" begin
+    for (P, scale) in zip((Second, Millisecond, Microsecond, Nanosecond), (10^9, 10^6, 10^3, 1))
+        x = Timestamp{P}(1970) + P(17)
+        for Q in (Week, Day, Hour, Minute, Second, Millisecond, Microsecond, Nanosecond)
+            for n in (typemin(Int64), -1000, 0, 1000, typemax(Int64))
+                p = Q(n)
+                ticks, remainder = divrem(big(n) * Dates.tons(oneunit(p)), scale)
+                if iszero(remainder)
+                    @test Dates.value(x + p) == mod(17 + ticks + big(2)^63, big(2)^64) - big(2)^63
+                    @test Dates.value(x - p) == mod(17 - ticks + big(2)^63, big(2)^64) - big(2)^63
+                else
+                    @test_throws InexactError x + p
+                    @test_throws InexactError x - p
+                end
+            end
+        end
+    end
+end
+
+# Rounding checks the selected result without wrapping an intermediate candidate.
+@testset "Rounding at storage limits" begin
+    for P in (Second, Millisecond, Microsecond, Nanosecond)
+        T = Timestamp{P}
+        lo, hi = typemin(T), typemax(T)
+        @test_throws InexactError floor(lo, Second(10))
+        @test_throws InexactError ceil(hi, Second(10))
+        @test lo < ceil(lo, Second(10)) < lo + Second(10)
+        @test hi - Second(10) < floor(hi, Second(10)) < hi
+        @test_throws InexactError Dates.floorceil(lo, Second(10))
+        @test_throws InexactError Dates.floorceil(hi, Second(10))
+        @test Dates.floorceil(lo, P(1)) === (lo, lo)
+        @test Dates.floorceil(hi, P(1)) === (hi, hi)
+        @test round(lo, P(1)) === lo
+        @test round(hi, P(1)) === hi
+        for Q in (Year, Quarter, Month, Week, Day)
+            @test_throws InexactError floor(lo, Q(typemax(Int64)))
+            @test_throws InexactError ceil(T(1970), Q(typemax(Int64)))
+        end
+        if P !== Nanosecond
+            for Q in (Year, Quarter, Month)
+                @test floor(T(1970), Q(typemax(Int64))) === T(0)
+                @test round(T(1970), Q(typemax(Int64))) === T(0)
+                @test ceil(lo, Q(typemax(Int64))) === T(0)
+            end
+        end
+        for Q in (Year, Quarter, Month, Week, Day, Hour, Minute, Second)
+            @test_throws DomainError floor(T(1970), Q(0))
+            @test_throws DomainError ceil(T(1970), Q(-1))
+        end
+    end
 end
 
 end

--- a/stdlib/Dates/test/types.jl
+++ b/stdlib/Dates/test/types.jl
@@ -180,7 +180,12 @@ end
     @test_throws ArgumentError Dates.Time(0, 0, 0, 0, -1)
     @test_throws ArgumentError Dates.Time(0, 0, 0, 0, 1000)
     @test_throws ArgumentError Dates.Time(0, 0, 0, 0, 0, -1)
-    @test_throws ArgumentError Dates.Time(0, 0, 0, 0, 0, 1000)
+    # the nanosecond part may carry a full fractional second (e.g. from parsing
+    # with the `n` code) as long as the sub-second parts stay below one second
+    @test Dates.Time(0, 0, 0, 0, 0, 1000) == Dates.Time(0, 0, 0, 0, 1)
+    @test Dates.Time(0, 0, 0, 0, 0, 999999999) == Dates.Time(0, 0, 0, 999, 999, 999)
+    @test_throws ArgumentError Dates.Time(0, 0, 0, 0, 0, 1000000000)
+    @test_throws ArgumentError Dates.Time(0, 0, 0, 1, 0, 999999999)
 end
 a = Dates.DateTime(2000)
 b = Dates.Date(2000)


### PR DESCRIPTION
This adds `Timestamp{P}` with second, millisecond, microsecond, or nanosecond resolution. One type family covers the four common timestamp units, so callers can choose precision and range explicitly. `Timestamp(...)` defaults to nanoseconds, and `Timestamp(ts::Timestamp)` preserves the input's resolution. `DateTime` keeps its current representation and API.

## Representation and behavior

Each concrete `Timestamp{P}` wraps `UTInstant{P}` and stores an `Int64` count since `1970-01-01T00:00:00`. Nanoseconds cover 1677–2262; microseconds cover approximately ±292 thousand years, milliseconds ±292 million years, and seconds ±292 billion years. Use concrete element and field types, such as `Vector{Timestamp{Microsecond}}` and `::Timestamp{Microsecond}`, for compact storage. The bare `Timestamp` family is not concrete.

The type supports construction by parts, calendar accessors and queries, period arithmetic, rounding, adjusters, ranges, parsing, formatting, and system-clock reads. The physical counts match Arrow/NumPy timestamp buffers at the corresponding resolution; validity, sentinel, and timezone metadata still need separate handling.

- Constructors and conversions between resolutions require exact representation. Period arithmetic preserves `P` and rejects finer durations that cannot be represented, rather than silently rounding them as `DateTime` does.
- Mixed arithmetic promotes to the finer resolution, and both operands must fit that type. Equality, ordering, and hashing compare instants directly across resolutions, `Date`, and `DateTime`, including values outside their shared range.
- Ordinary arithmetic wraps at storage boundaries: `typemax(Timestamp{P}) + P(1) == typemin(Timestamp{P})`. Rounding checks the mathematical result and throws when it cannot be represented. A valid ceiling still works when the corresponding floor is below the storage limit. Oversized timestamp range lengths throw instead of becoming negative.
- `Dates.value(ts)` and raw period conversions count from the Unix epoch. The enclosing `TimeType` supplies the epoch; `DateTime` continues to use Rata Die milliseconds.

## Parameter choices

Following the parameterization suggestion, this uses resolution alone. Epoch and integer-storage parameters have real uses, but they are deferred rather than exposed as unused placeholders.

A configurable epoch could support PostgreSQL's 2000-based microsecond counts or move the nanosecond window to a different historical period. It would also add epoch rules to conversion, comparison, promotion, hashing, and range limits. It would not by itself define a time scale, timezone, or leap-second policy. The fixed Unix epoch serves this PR's interchange use cases with a smaller API.

Wider storage could preserve nanoseconds outside the current range; microseconds do not replace that requirement. However, the proposed arbitrary `I <: Integer` also needs a coherent duration and calendar contract: built-in `Period` values contain `Int64`, full `Int128` timestamp ranges exceed the current calendar machinery, and `BigInt` has no finite `typemin`/`typemax`. Smaller integers offer compact counts but are outside this PR's `Int64` interchange target. A generic backing type or spare parameters would publish those contracts before implementing them. This does not promise that adding type parameters later would be nonbreaking.

## Other changes in this PR

The new `n` format code handles fractional seconds up to nanosecond precision. The default `Time` format uses it, so printed sub-millisecond values parse back correctly. `Time` also accepts a full fractional second in its nanosecond argument. Parsing `DateTime` with `n` requires exact millisecond representation. A formerly literal `n` in a format string must now be escaped; NEWS explicitly identifies this breaking change.

Hashes for `Date` and `DateTime` change to make equal instants hash equally across the three types. The relevant adjusters and `Time(dt)` constructor are generalized to `AbstractDateTime`. `now(Timestamp)` and `now(Timestamp, UTC)` use libuv's `uv_clock_gettime` and support explicit resolution.

## Validation

- Full Dates suite: 8,082,505 checks passed on the local Julia 1.14 development binary.
- Repository Revise runner with two workers: 8,082,503 checks passed. The direct suite includes two additional global checks.
- Independent stress and BigInt-oracle checks: 225,090 passed, including the full signed storage range, precision changes, very large periods, and rounding limits.
- All 17 Timestamp documentation entries resolve. No method ambiguities or unbound type arguments were detected.
- Local A/B measurements recover the original accessor, month-floor, and formatting performance; month ceiling is faster. Checked day flooring adds approximately 4 ns per element in the vector microbenchmark.

The full manual reaches cross-reference checks without a Dates error, but local rendering is blocked by `Base.deepcopy_impl` and `Base.unsplat` missing from the older binary. Windows and 32-bit execution require CI. The existing `needs pkgeval` gate remains relevant to the format-code and existing-type changes.

## AI disclosure

The original implementation was prepared with Claude Code and reviewed with Codex. Codex prepared this parameterization and cleanup. Claude Desktop, using Fable 5.1 with Max effort, reviewed the design and implementation through follow-up discussion. Human review of this update remains necessary.

Co-authored by Codex
