### PR TITLE
codegen: Correct native ABI lowering on RISC-V, x86-64, and AArch64

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -558,6 +558,13 @@ Julia type is a homogeneous tuple of `VecElement` that naturally maps to the SIM
 >     primitive type with a power-of-two number of bytes (e.g. 1, 2, 4, 8, 16, etc) such as
 >     Int8 or Float64.
 
+The ABI for vectors smaller than a SIMD register is not portable between C compilers.
+On x86-64, Julia follows gcc when classifying vectors of a single floating-point
+element; clang differs for some arguments and return values. On AArch64, Julia passes
+vectors smaller than the 8-byte minimum for a short vector as composites in
+general-purpose registers. This matches gcc and clang for structures containing such a
+vector, although they disagree on bare vectors of these sizes.
+
 For instance, consider this C routine that uses AVX intrinsics:
 
 ```c

--- a/src/abi_aarch64.cpp
+++ b/src/abi_aarch64.cpp
@@ -17,14 +17,13 @@ Type *get_llvm_vectype(jl_datatype_t *dt, LLVMContext &ctx) const JL_CANSAFEPOIN
 {
     // Assume jl_is_datatype(dt) && !jl_is_abstracttype(dt)
     // `!dt->name->mutabl && dt->pointerfree && !dt->haspadding && dt->isbitsegal && dt->nfields > 0`
-    if (dt->layout == NULL || jl_is_layout_opaque(dt->layout))
+    // Only tuples of VecElement are lowered as LLVM vectors.
+    if (!jl_is_tuple_type(dt) || dt->layout == NULL || jl_is_layout_opaque(dt->layout))
         return nullptr;
     size_t nfields = dt->layout->nfields;
     assert(nfields > 0);
-    if (nfields < 2)
-        return nullptr;
     Type *lltype;
-    // Short vector should be either 8 bytes or 16 bytes.
+    // Short vectors are defined by size, not element count.
     // Note that there are only two distinct fundamental types for
     // short vectors so we normalize them to <2 x i32> and <4 x i32>
     switch (jl_datatype_size(dt)) {
@@ -119,6 +118,18 @@ bool isHFAorHVA(jl_datatype_t *dt, size_t dsz, size_t &nele, ElementType &ele, L
     // handles this slightly differently.
     // Ref https://llvm.org/bugs/show_bug.cgi?id=26162
     while (size_t nfields = jl_datatype_nfields(dt)) {
+        // A short vector is fundamental, not a single-field aggregate.
+        if (Type *vectype = get_llvm_vectype(dt, ctx)) {
+            if ((ele.sz && dsz != ele.sz) || (ele.type && ele.type != vectype))
+                return false;
+            ele.type = vectype;
+            ele.sz = dsz;
+            nele++;
+            return true;
+        }
+        // Other vectors are not HFAs or HVAs.
+        if (is_vector_type(dt))
+            return false;
         // For composite types, find the first non zero sized member
         size_t i;
         size_t fieldsz;
@@ -135,21 +146,13 @@ bool isHFAorHVA(jl_datatype_t *dt, size_t dsz, size_t &nele, ElementType &ele, L
                 return false;
             continue;
         }
-        if (Type *vectype = get_llvm_vectype(dt, ctx)) {
-            if ((ele.sz && dsz != ele.sz) || (ele.type && ele.type != vectype))
-                return false;
-            ele.type = vectype;
-            ele.sz = dsz;
-            nele++;
-            return true;
-        }
         // Otherwise, process each members
         for (; i < nfields; i++) {
             size_t fieldsz = jl_field_size(dt, i);
             if (fieldsz == 0)
                 continue;
             jl_datatype_t *fieldtype = (jl_datatype_t*)jl_field_type(dt, i);
-            if (!jl_is_datatype(dt))
+            if (!jl_is_datatype(fieldtype))
                 return false;
             // Check element count.
             // This needs to be done after the zero size member check
@@ -306,7 +309,12 @@ Type *classify_arg(jl_datatype_t *dt, bool *fpreg, bool *onstack,
     //   and x[NGRN+1]. x[NGRN] shall contain the lower addressed double-word
     //   of the memory representation of the argument. The NGRN is incremented
     //   by two. The argument has now been allocated.
-    // <merged into C.7 above>
+    // <merged into C.7 above for integral types>
+    // Preserve alignment for LLVM's register and stack allocation.
+    if (jl_datatype_size(dt) == 16 && jl_datatype_align(dt) == 16) {
+        *rewrite_len = 1;
+        return Type::getInt128Ty(ctx);
+    }
     // C.10
     //   If the argument is a Composite Type and the size in double-words of
     //   the argument is not more than 8 minus NGRN, then the argument is
@@ -375,8 +383,11 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret, LLVMContext &ctx) const
     bool fpreg = false;
     bool onstack = false;
     size_t rewrite_len = 0;
-    if (Type *rewrite_ty = classify_arg(dt, &fpreg, &onstack, &rewrite_len, ctx))
+    if (Type *rewrite_ty = classify_arg(dt, &fpreg, &onstack, &rewrite_len, ctx)) {
+        if (rewrite_ty->isIntegerTy(128))
+            return rewrite_ty;
         return ArrayType::get(rewrite_ty, rewrite_len);
+    }
     return NULL;
 }
 

--- a/src/abi_riscv.cpp
+++ b/src/abi_riscv.cpp
@@ -20,15 +20,24 @@
 
 struct ABI_RiscvLayout : AbiLayout {
 
+// This layout is only selected on riscv64.
 static const size_t XLen = 8;
+// ABI_FLEN follows the compiler ABI used to build the runtime.
+#if defined(__riscv_float_abi_double)
 static const size_t FLen = 8;
+#elif defined(__riscv_float_abi_single)
+static const size_t FLen = 4;
+#elif defined(_CPU_RISCV64_)
+static const size_t FLen = 0;
+#else
+static const size_t FLen = 8; // non-host fallback
+#endif
 static const int NumArgGPRs = 8;
 static const int NumArgFPRs = 8;
 
-// available register num is needed to determine if fp pair or int-fp pair in a struct should be unpacked
-// WARN: with this, use_sret must only be called once before the next
-// needPassByRef call, otherwise avail_gprs is wrong
+// Classify the return first because an sret pointer consumes a GPR.
 int avail_gprs, avail_fprs;
+bool ret_classified = false;
 
 // preferred type is determined at the same time as use_sret & needPassByRef
 // cache it here to avoid computing it again in preferred_llvm_type
@@ -46,12 +55,21 @@ struct ElementType {
 
 bool is_floattype(jl_datatype_t *dt) const
 {
-    return dt == jl_float16_type || dt == jl_float32_type || dt == jl_float64_type;
+    return dt == jl_float16_type || dt == jl_bfloat16_type ||
+           dt == jl_float32_type || dt == jl_float64_type;
+}
+
+// Pointers do not satisfy the float-plus-integer aggregate rule.
+bool is_pointertype(jl_datatype_t *dt) const
+{
+    return jl_is_cpointer_type((jl_value_t*)dt) || jl_is_llvmpointer_type((jl_value_t*)dt);
 }
 
 Type *get_llvm_fptype(jl_datatype_t *dt, LLVMContext &ctx) const
 {
     assert(is_floattype(dt));
+    if (dt == jl_bfloat16_type)
+        return Type::getBFloatTy(ctx);
     switch (jl_datatype_size(dt)) {
     case 2: return Type::getHalfTy(ctx);
     case 4: return Type::getFloatTy(ctx);
@@ -66,9 +84,6 @@ Type *get_llvm_fptype(jl_datatype_t *dt, LLVMContext &ctx) const
 Type *get_llvm_inttype(jl_datatype_t *dt, LLVMContext &ctx) const
 {
     assert(jl_is_primitivetype(dt));
-    // XXX: without Zfh, Float16 is passed in integer registers
-    if (dt == jl_float16_type)
-        return Type::getInt32Ty(ctx);
     assert(!is_floattype(dt));
     if (dt == jl_bool_type)
         return getInt8Ty(ctx);
@@ -80,14 +95,14 @@ Type *get_llvm_inttype(jl_datatype_t *dt, LLVMContext &ctx) const
     return Type::getIntNTy(ctx, nb * 8);
 }
 
+// Flatten at most two fields for the hardware floating-point convention.
 bool should_use_fp_conv(jl_datatype_t *dt, ElementType &ele1, ElementType &ele2) const JL_CANSAFEPOINT
 {
     if (jl_is_primitivetype(dt)) {
         size_t dsz = jl_datatype_size(dt);
-        if (dsz > FLen) {
-            return false;
-        }
         if (is_floattype(dt)) {
+            if (dsz > FLen)
+                return false;
             if (ele1.type == RegPassKind::UNKNOWN) {
                 ele1.type = RegPassKind::FLOAT;
                 ele1.dt = dt;
@@ -97,12 +112,13 @@ bool should_use_fp_conv(jl_datatype_t *dt, ElementType &ele1, ElementType &ele2)
                 ele2.dt = dt;
             }
             else {
-                // 3 elements not eligible, must be a pair
+                // More than two fields use the integer convention.
                 return false;
             }
         }
-        // integer or pointer type or bitstypes
         else {
+            if (dsz > XLen || is_pointertype(dt))
+                return false;
             if (ele1.type == RegPassKind::UNKNOWN) {
                 ele1.type = RegPassKind::INTEGER;
                 ele1.dt = dt;
@@ -112,55 +128,33 @@ bool should_use_fp_conv(jl_datatype_t *dt, ElementType &ele1, ElementType &ele2)
                 return false;
             }
             // ele1.type == RegPassKind::FLOAT
+            else if (ele2.type == RegPassKind::UNKNOWN) {
+                ele2.type = RegPassKind::INTEGER;
+                ele2.dt = dt;
+            }
             else {
-                if (ele2.type == RegPassKind::UNKNOWN) {
-                    ele2.type = RegPassKind::INTEGER;
-                    ele2.dt = dt;
-                }
-                else {
-                    // 3 elements not eligible, must be a pair
-                    return false;
-                }
+                // More than two fields use the integer convention.
+                return false;
             }
         }
+        return true;
     }
-    else { // aggregates
-        while (size_t nfields = jl_datatype_nfields(dt)) {
-            size_t i;
-            size_t fieldsz;
-            for (i = 0; i < nfields; i++) {
-                if ((fieldsz = jl_field_size(dt, i))) {
-                    break;
-                }
-            }
-            assert(i < nfields);
-            // If there's only one non zero sized member, try again on this member
-            if (fieldsz == jl_datatype_size(dt)) {
-                dt = (jl_datatype_t *)jl_field_type(dt, i);
-                if (!jl_is_datatype(dt)) // could be inline union #46787
-                    return false;
-                continue;
-            }
-            for (; i < nfields; i++) {
-                size_t fieldsz = jl_field_size(dt, i);
-                if (fieldsz == 0)
-                    continue;
-                jl_datatype_t *fieldtype = (jl_datatype_t *)jl_field_type(dt, i);
-                if (!jl_is_datatype(dt)) // could be inline union
-                    return false;
-                // This needs to be done after the zero size member check
-                if (ele2.type != RegPassKind::UNKNOWN) {
-                    // we already have a pair and can't accept more elements
-                    return false;
-                }
-                if (!should_use_fp_conv(fieldtype, ele1, ele2)) {
-                    return false;
-                }
-            }
-            break;
-        }
+    // Vectors use the integer convention; a bare `VecElement` still flattens.
+    if (is_vector_type(dt))
+        return false;
+    size_t nfields = jl_datatype_nfields(dt);
+    for (size_t i = 0; i < nfields; i++) {
+        if (jl_field_size(dt, i) == 0)
+            continue;
+        if (jl_field_isptr(dt, i))
+            return false;
+        jl_value_t *ft = jl_field_type(dt, i);
+        // Inline unions are not flattened (#46787).
+        if (!jl_is_datatype(ft))
+            return false;
+        if (!should_use_fp_conv((jl_datatype_t*)ft, ele1, ele2))
+            return false;
     }
-    // Tuple{Int,} can reach here as well, but doesn't really hurt
     return true;
 }
 
@@ -245,12 +239,10 @@ Type *classify_arg(jl_datatype_t *ty, int &avail_gprs, int &avail_fprs, bool &on
         if (avail_gprs >= 2) {
             avail_gprs -= 2;
         }
-        // should we handle variadic as well?
-        // Variadic arguments with 2×XLEN-bit alignment and size at most 2×XLEN
-        // bits are passed in an aligned register pair
         else {
             avail_gprs = 0;
         }
+        // LLVM handles the aligned register pair for `i128` varargs.
 
         if (!jl_is_primitivetype(ty)) {
             // Aggregates or scalars passed on the stack are aligned to the
@@ -279,11 +271,18 @@ Type *classify_arg(jl_datatype_t *ty, int &avail_gprs, int &avail_fprs, bool &on
     if (!jl_is_primitivetype(ty)) {
         return get_llvm_inttype_byxlen(XLen, ctx);
     }
+    // Keep the FP type so LLVM can apply the integer convention.
+    if (is_floattype(ty)) {
+        return get_llvm_fptype(ty, ctx);
+    }
     return get_llvm_inttype(ty, ctx);
 }
 
 bool use_sret(jl_datatype_t *ty, LLVMContext &ctx) override JL_CANSAFEPOINT
 {
+    assert(!ret_classified && avail_gprs == NumArgGPRs && avail_fprs == NumArgFPRs &&
+           "use_sret must be called exactly once, before any argument is classified");
+    ret_classified = true;
     bool onstack = false;
     int gprs = 2;
     int fprs = FLen ? 2 : 0;
@@ -300,9 +299,13 @@ bool use_sret(jl_datatype_t *ty, LLVMContext &ctx) override JL_CANSAFEPOINT
 bool needPassByRef(jl_datatype_t *ty, AttrBuilder &ab, LLVMContext &ctx,
                    Type *Ty) override JL_CANSAFEPOINT
 {
+    assert(ret_classified && "the return value must be classified before the arguments");
     bool onstack = false;
+    // Variadic arguments never use the hardware floating-point convention.
+    int no_fprs = 0;
     this->cached_llvmtype =
-        classify_arg(ty, this->avail_gprs, this->avail_fprs, onstack, ctx);
+        classify_arg(ty, this->avail_gprs, this->varargs ? no_fprs : this->avail_fprs,
+                     onstack, ctx);
     return onstack;
 }
 

--- a/src/abi_x86_64.cpp
+++ b/src/abi_x86_64.cpp
@@ -38,6 +38,12 @@
 
 enum ArgClass { Integer, Sse, SseUp, X87, X87Up, ComplexX87, NoClass, Memory };
 
+static bool is_fp_scalar_type(jl_value_t *t)
+{
+    return t == (jl_value_t*)jl_float64_type || t == (jl_value_t*)jl_float32_type ||
+           t == (jl_value_t*)jl_float16_type || t == (jl_value_t*)jl_bfloat16_type;
+}
+
 struct ABI_x86_64Layout : AbiLayout {
 
 // used to track the state of the ABI generator during
@@ -118,8 +124,7 @@ struct Classification {
 void classifyType(Classification& accum, jl_datatype_t *dt, uint64_t offset) const JL_CANSAFEPOINT
 {
     // Floating point types
-    if (dt == jl_float64_type || dt == jl_float32_type || dt == jl_float16_type ||
-        dt == jl_bfloat16_type) {
+    if (is_fp_scalar_type((jl_value_t*)dt)) {
         accum.addField(offset, Sse);
     }
     // Misc types
@@ -147,7 +152,16 @@ void classifyType(Classification& accum, jl_datatype_t *dt, uint64_t offset) con
     else if (is_native_simd_type(dt)) {
         accum.addField(offset, Sse);
     }
-    // Other struct types
+    // GCC passes one-element floating-point vectors in memory.
+    else if (is_vector_type(dt) && jl_datatype_nfields(dt) == 1 &&
+             is_fp_scalar_type(jl_tparam0(jl_field_type(dt, 0)))) {
+        accum.addField(offset, Memory);
+    }
+    // Other 64-bit vectors use class SSE.
+    else if (is_vector_type(dt) && jl_datatype_size(dt) == 8) {
+        accum.addField(offset, Sse);
+    }
+    // Other aggregates, including GCC's smaller multi-element vectors.
     else if (jl_datatype_size(dt) <= 16 && dt->layout && !jl_is_layout_opaque(dt->layout)) {
         size_t i;
         for (i = 0; i < jl_datatype_nfields(dt); ++i) {
@@ -255,6 +269,9 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret, LLVMContext &ctx) const
             return types[0];
         case Integer:
             assert(size > 8);
+            // Keep i128 intact so register exhaustion spills the whole argument.
+            if (size == 16 && jl_is_primitivetype(dt))
+                return Type::getInt128Ty(ctx);
             types[1] = Type::getIntNTy(ctx, (nbits-64));
             return StructType::get(ctx,ArrayRef<Type*>(&types[0],2));
         case Sse:

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -376,6 +376,8 @@ static Value *emit_plt(
 
 class AbiLayout {
 public:
+    // True while classifying variadic arguments.
+    bool varargs = false;
     virtual ~AbiLayout() {}
     virtual bool use_sret(jl_datatype_t *ty, LLVMContext &ctx) JL_CANSAFEPOINT = 0;
     virtual bool needPassByRef(jl_datatype_t *ty, AttrBuilder&, LLVMContext &ctx, Type* llvm_t) JL_CANSAFEPOINT = 0;
@@ -398,6 +400,21 @@ static bool is_native_simd_type(jl_datatype_t *dt) JL_CANSAFEPOINT {
             // Not homogeneous
             return false;
     // Type is homogeneous.  Check if it maps to LLVM vector.
+    return jl_special_vector_alignment(n, ft0) != 0;
+}
+
+// Match the `VecElement` tuples lowered as LLVM vectors.
+static bool is_vector_type(jl_datatype_t *dt) JL_CANSAFEPOINT
+{
+    if (!jl_is_tuple_type(dt))
+        return false;
+    uint32_t n = jl_datatype_nfields(dt);
+    if (n == 0)
+        return false;
+    jl_value_t *ft0 = jl_field_type(dt, 0);
+    for (uint32_t i = 1; i < n; ++i)
+        if (jl_field_type(dt, i) != ft0)
+            return false;
     return jl_special_vector_alignment(n, ft0) != 0;
 }
 
@@ -1307,11 +1324,16 @@ std::string generate_func_sig(const char *fname) JL_CANSAFEPOINT
                 // see pull req #978. need to annotate signext/zeroext for
                 // small integer arguments.
                 jl_datatype_t *bt = (jl_datatype_t*)tti;
-                if (jl_datatype_size(bt) < 4) {
+                size_t sz = jl_datatype_size(bt);
+                if (sz < 4) {
                     if (jl_signed_type && jl_subtype(tti, (jl_value_t*)jl_signed_type))
                         ab.addAttribute(Attribute::SExt);
                     else
                         ab.addAttribute(Attribute::ZExt);
+                }
+                else if (sz == 4 && ctx->TargetTriple.isRISCV64()) {
+                    // RISC-V sign-extends all 32-bit arguments to XLEN.
+                    ab.addAttribute(Attribute::SExt);
                 }
             }
         }
@@ -1324,6 +1346,8 @@ std::string generate_func_sig(const char *fname) JL_CANSAFEPOINT
 
         // Whether or not LLVM wants us to emit a pointer to the data
         assert(t && "LLVM type should not be null");
+        if (nreqargs > 0 && i == nreqargs)
+            abi->varargs = true;
         bool byRef = abi->needPassByRef((jl_datatype_t*)tti, ab, LLVMCtx, t);
 
         if (jl_is_cpointer_type(tti)) {
@@ -1345,10 +1369,16 @@ std::string generate_func_sig(const char *fname) JL_CANSAFEPOINT
             if (!llvmcall && cc == CallingConv::C) {
                 if (pat->isIntegerTy() && pat->getPrimitiveSizeInBits() < sizeof(int) * 8)
                     pat = getInt32Ty(lrt->getContext());
-                if (pat->isFloatingPointTy() && pat->getPrimitiveSizeInBits() < sizeof(double) * 8)
+                // Default argument promotion does not widen `_Float16` or `__bf16`.
+                if (pat->isFloatTy())
                     pat = getDoubleTy(lrt->getContext());
                 ab.removeAttribute(Attribute::SExt);
                 ab.removeAttribute(Attribute::ZExt);
+                if (ctx->TargetTriple.isRISCV64() && pat->isIntegerTy() &&
+                        pat->getPrimitiveSizeInBits() <= 32) {
+                    // RISC-V applies the same XLEN extension to variadic integers.
+                    ab.addAttribute(Attribute::SExt);
+                }
             }
         }
 
@@ -1364,6 +1394,18 @@ std::string generate_func_sig(const char *fname) JL_CANSAFEPOINT
     // If return value is boxed it must be non-null.
     if (retboxed)
         RetAttrs = RetAttrs.addAttribute(LLVMCtx, Attribute::NonNull);
+    else if (ctx->TargetTriple.isRISCV64() && rt != jl_bottom_type &&
+             jl_is_primitivetype(rt) && lrt->isIntegerTy()) {
+        // RISC-V returns integers as if passed as the first named argument.
+        size_t sz = jl_datatype_size(rt);
+        if (sz < 4) {
+            bool issigned = jl_signed_type && jl_subtype(rt, (jl_value_t*)jl_signed_type);
+            RetAttrs = RetAttrs.addAttribute(LLVMCtx, issigned ? Attribute::SExt : Attribute::ZExt);
+        }
+        else if (sz == 4) {
+            RetAttrs = RetAttrs.addAttribute(LLVMCtx, Attribute::SExt);
+        }
+    }
     if (rt == jl_bottom_type)
         FnAttrs = FnAttrs.addAttribute(LLVMCtx, Attribute::NoReturn);
 

--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -980,5 +980,183 @@ DLLEXPORT void cancelspin_handler(void *state, uint8_t sev) {
     cell[0] = 1;
 }
 
+// Use a wider prototype to observe the caller's XLEN extension.
+DLLEXPORT int64_t test_reg_32(int64_t x) {
+    return x;
+}
+
+DLLEXPORT int64_t test_reg_32_va(int n, ...) {
+    va_list ap;
+    va_start(ap, n);
+    int64_t x = va_arg(ap, int64_t);
+    va_end(ap);
+    return x;
+}
+
+// Exercise ABI classification at register boundaries; sentinels detect miscounts.
+typedef struct {
+    int64_t i[8];
+    double d[8];
+    int64_t s1;
+    double s2;
+    char buf[32];
+} abi_probe_t;
+DLLEXPORT abi_probe_t abi_probe;
+// GCC and Clang disagree on one-element floating-point vectors on x86-64.
+#ifdef __clang__
+DLLEXPORT int abi_probe_clang = 1;
+#else
+DLLEXPORT int abi_probe_clang = 0;
+#endif
+// GCC before 8.4 and 9.3 loads a variadic `__int128` from the register save
+// area with an aligned 16-byte load, which faults when the value starts at an
+// odd register slot (e.g. `rsi:rdx`).
+#if defined(_CPU_X86_64_) && !defined(_OS_WINDOWS_) && defined(__GNUC__) && !defined(__clang__) && \
+    (__GNUC__ < 8 || (__GNUC__ == 8 && __GNUC_MINOR__ < 4) || \
+     (__GNUC__ == 9 && __GNUC_MINOR__ < 3))
+DLLEXPORT int abi_probe_va_i128_regs = 0;
+#else
+DLLEXPORT int abi_probe_va_i128_regs = 1;
+#endif
+
+#define ABI_P0I
+#define ABI_P0D
+#define ABI_A0I
+#define ABI_A0D
+#define ABI_S0I
+#define ABI_S0D
+#define ABI_P5I int64_t i0, int64_t i1, int64_t i2, int64_t i3, int64_t i4,
+#define ABI_P7I ABI_P5I int64_t i5, int64_t i6,
+#define ABI_P8I ABI_P7I int64_t i7,
+#define ABI_P7D double d0, double d1, double d2, double d3, double d4, double d5, double d6,
+#define ABI_P8D ABI_P7D double d7,
+// Values used by the C caller.
+#define ABI_A5I 1000, 1001, 1002, 1003, 1004,
+#define ABI_A7I ABI_A5I 1005, 1006,
+#define ABI_A8I ABI_A7I 1007,
+#define ABI_A7D 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5,
+#define ABI_A8D ABI_A7D 7.5,
+#define ABI_S5I abi_probe.i[0] = i0; abi_probe.i[1] = i1; abi_probe.i[2] = i2; abi_probe.i[3] = i3; \
+                abi_probe.i[4] = i4;
+#define ABI_S7I ABI_S5I abi_probe.i[5] = i5; abi_probe.i[6] = i6;
+#define ABI_S8I ABI_S7I abi_probe.i[7] = i7;
+#define ABI_S7D abi_probe.d[0] = d0; abi_probe.d[1] = d1; abi_probe.d[2] = d2; abi_probe.d[3] = d3; \
+                abi_probe.d[4] = d4; abi_probe.d[5] = d5; abi_probe.d[6] = d6;
+#define ABI_S8D ABI_S7D abi_probe.d[7] = d7;
+
+#define ABI_PROBE(name, T, G, F) \
+    DLLEXPORT void test_abi_arg_##name##_##G##_##F(ABI_P##G##I ABI_P##F##D T x, int64_t s1, double s2) { \
+        ABI_S##G##I ABI_S##F##D \
+        memcpy(abi_probe.buf, &x, sizeof(x)); abi_probe.s1 = s1; abi_probe.s2 = s2; } \
+    DLLEXPORT T test_abi_ret_##name##_##G##_##F(ABI_P##G##I ABI_P##F##D int64_t s1) { \
+        ABI_S##G##I ABI_S##F##D abi_probe.s1 = s1; \
+        T r; memcpy(&r, abi_probe.buf, sizeof(r)); return r; } \
+    DLLEXPORT void test_abi_cbarg_##name##_##G##_##F(void (*cb)(ABI_P##G##I ABI_P##F##D T, int64_t, double)) { \
+        T x; memcpy(&x, abi_probe.buf, sizeof(x)); cb(ABI_A##G##I ABI_A##F##D x, -77, 3.25); } \
+    DLLEXPORT void test_abi_cbret_##name##_##G##_##F(T (*cb)(ABI_P##G##I ABI_P##F##D int64_t)) { \
+        T r = cb(ABI_A##G##I ABI_A##F##D -77); memcpy(abi_probe.buf, &r, sizeof(r)); }
+// Vary the leading arguments to exercise register-pair alignment and spills.
+#define ABI_VA(name, T, G) \
+    DLLEXPORT void test_abi_va_##name##_##G(int n, ...) { \
+        va_list ap; va_start(ap, n); \
+        for (int k = 0; k < G; k++) abi_probe.i[k] = va_arg(ap, int64_t); \
+        T x = va_arg(ap, T); memcpy(abi_probe.buf, &x, sizeof(x)); \
+        abi_probe.s1 = va_arg(ap, int64_t); abi_probe.s2 = va_arg(ap, double); va_end(ap); }
+#define ABI_BASIC(name, T) ABI_PROBE(name, T, 0, 0)
+#define ABI_FP1(name, T) ABI_BASIC(name, T) ABI_PROBE(name, T, 0, 8)
+#define ABI_FP2(name, T) \
+    ABI_BASIC(name, T) ABI_PROBE(name, T, 0, 7) ABI_PROBE(name, T, 0, 8)
+#define ABI_MIXED(name, T) \
+    ABI_BASIC(name, T) ABI_PROBE(name, T, 7, 7) \
+    ABI_PROBE(name, T, 8, 7) ABI_PROBE(name, T, 7, 8)
+#define ABI_I128(name, T) \
+    ABI_BASIC(name, T) ABI_PROBE(name, T, 5, 0) \
+    ABI_PROBE(name, T, 7, 0) ABI_PROBE(name, T, 8, 0)
+#define ABI_VA_BASIC(name, T) ABI_VA(name, T, 0)
+#define ABI_VA_I128(name, T) \
+    ABI_VA_BASIC(name, T) ABI_VA(name, T, 4) ABI_VA(name, T, 5) ABI_VA(name, T, 7)
+
+#ifdef _P64
+typedef struct { float x; } abi_S_f;
+typedef struct { double x; } abi_S_d;
+typedef struct { abi_S_d s; } abi_N_d;
+typedef struct { double v[1]; } abi_T1d;
+typedef struct { float a; float b; } abi_S_ff;
+typedef struct { float a; double b; } abi_S_fd;
+typedef struct { float v[2]; } abi_T2f;
+typedef struct { float a; int32_t b; } abi_S_fi;
+typedef struct { int32_t a; float b; } abi_S_if;
+typedef struct { double a; int64_t b; } abi_S_di;
+typedef struct { abi_S_f s; int32_t i; } abi_M_fi;
+typedef struct { int64_t x; } abi_S_l;
+typedef struct { double d; abi_S_l s; } abi_M_dl;
+typedef struct { float a; void *b; } abi_S_fp;
+typedef double abi_V1d __attribute__((vector_size(8)));
+typedef float abi_V2f __attribute__((vector_size(8)));
+typedef int32_t abi_V2i __attribute__((vector_size(8)));
+typedef int64_t abi_V1l __attribute__((vector_size(8)));
+typedef float abi_V1f __attribute__((vector_size(4)));
+typedef double abi_V2d __attribute__((vector_size(16)));
+typedef struct { double d; abi_V1d v; } abi_S_dV1;
+typedef struct { double d; abi_V2i v; } abi_S_dV2i;
+typedef struct { abi_V1f v; } abi_S_V1f;
+typedef struct { __int128 x; } abi_A16;
+ABI_FP1(Float32, float)
+ABI_FP1(Float64, double)
+ABI_I128(Int128, __int128)
+ABI_BASIC(Ptr, void*)
+ABI_FP1(S_f, abi_S_f)
+ABI_BASIC(S_d, abi_S_d)
+ABI_BASIC(N_d, abi_N_d)
+ABI_BASIC(T1d, abi_T1d)
+ABI_FP2(S_ff, abi_S_ff)
+ABI_FP2(S_fd, abi_S_fd)
+ABI_BASIC(T2f, abi_T2f)
+ABI_MIXED(S_fi, abi_S_fi)
+ABI_BASIC(S_if, abi_S_if)
+ABI_BASIC(S_di, abi_S_di)
+ABI_BASIC(M_fi, abi_M_fi)
+ABI_BASIC(S_l, abi_S_l)
+ABI_BASIC(M_dl, abi_M_dl)
+ABI_BASIC(S_fp, abi_S_fp)
+ABI_BASIC(V1d, abi_V1d)
+ABI_BASIC(V2f, abi_V2f)
+ABI_BASIC(V2i, abi_V2i)
+ABI_BASIC(V1l, abi_V1l)
+ABI_BASIC(V1f, abi_V1f)
+ABI_BASIC(V2d, abi_V2d)
+ABI_BASIC(S_dV1, abi_S_dV1)
+ABI_BASIC(S_dV2i, abi_S_dV2i)
+ABI_BASIC(S_V1f, abi_S_V1f)
+ABI_I128(A16, abi_A16)
+ABI_VA_I128(Int128, __int128)
+ABI_VA_BASIC(S_f, abi_S_f)
+ABI_VA_BASIC(S_ff, abi_S_ff)
+ABI_VA_BASIC(S_fi, abi_S_fi)
+ABI_VA_I128(A16, abi_A16)
+// Unions and pointer fields use the integer convention.
+typedef struct { double x; int32_t y; uint8_t sel; } abi_SU;
+typedef struct { double x; void *y; } abi_SA;
+DLLEXPORT double test_abi_union(abi_SU s) { memcpy(abi_probe.buf, &s, sizeof(s)); return s.x; }
+DLLEXPORT double test_abi_boxed(abi_SA s) { abi_probe.s1 = (int64_t)(uintptr_t)s.y; return s.x; }
+#endif
+// These bit-copying probes are also used for `BFloat16`.
+#if defined(__FLT16_MANT_DIG__)
+DLLEXPORT int abi_probe_float16 = 1;
+typedef struct { _Float16 x; } abi_S_h;
+typedef struct { _Float16 a; _Float16 b; } abi_S_hh;
+typedef struct { _Float16 a; double b; } abi_S_hd;
+typedef struct { _Float16 a; int32_t b; } abi_S_hi;
+ABI_FP1(Float16, _Float16)
+ABI_BASIC(S_h, abi_S_h)
+ABI_FP2(S_hh, abi_S_hh)
+ABI_FP2(S_hd, abi_S_hd)
+ABI_MIXED(S_hi, abi_S_hi)
+// `_Float16` is not promoted through `...`.
+ABI_VA_BASIC(Float16, _Float16)
+#else
+DLLEXPORT int abi_probe_float16 = 0;
+#endif
+
 // global variable for cglobal testing
 DLLEXPORT const int global_var = 1;

--- a/src/ccalltest_common.h
+++ b/src/ccalltest_common.h
@@ -4,6 +4,7 @@
 #include <complex.h>
 #include <stdint.h>
 #include <inttypes.h>
+#include <stdarg.h>
 
 #include "../src/support/platform.h"
 #include "../src/support/dtypes.h"

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1349,6 +1349,220 @@ elseif Sys.ARCH !== :i686 && Sys.ARCH !== :arm # TODO
 
 end
 
+# The wider C prototype exposes RISC-V's XLEN extension. Keep these calls out of
+# line so constant materialization cannot hide incorrect lowering.
+@noinline reg_probe32(x::UInt32) = ccall((:test_reg_32, libccalltest), Int64, (UInt32,), x)
+@noinline reg_probe32(x::Char) = ccall((:test_reg_32, libccalltest), Int64, (Char,), x)
+@noinline function reg_probe32_va(x::UInt32)
+    ccall((:test_reg_32_va, libccalltest), Int64, (Cint, UInt32...), Cint(0), x)
+end
+@noinline cfun_ret_u32(x::Int64) = 0xdeadbeef % UInt32
+if Sys.ARCH === :riscv64
+    @test reg_probe32(0x80000000) === Int64(-2147483648)
+    @test reg_probe32(0xdeadbeef) === Int64(reinterpret(Int32, 0xdeadbeef))
+    @test reg_probe32(0x7fffffff) === Int64(2147483647)
+    @test reg_probe32('\U10000') === Int64(reinterpret(Int32, reinterpret(UInt32, '\U10000')))
+    @test reg_probe32_va(0x80000000) === Int64(-2147483648)
+    @test ccall(@cfunction(cfun_ret_u32, UInt32, (Int64,)), Int64, (Int64,), 0) ===
+          Int64(reinterpret(Int32, 0xdeadbeef))
+end
+
+# Exercise caller and callee classification at affected register boundaries.
+# Trailing sentinels also check register accounting.
+struct ABI_S_f; x::Float32; end
+struct ABI_S_d; x::Float64; end
+struct ABI_N_d; s::ABI_S_d; end
+struct ABI_T1d; v::NTuple{1,Float64}; end
+struct ABI_S_ff; a::Float32; b::Float32; end
+struct ABI_S_fd; a::Float32; b::Float64; end
+struct ABI_T2f; v::NTuple{2,Float32}; end
+struct ABI_S_fi; a::Float32; b::Int32; end
+struct ABI_S_if; a::Int32; b::Float32; end
+struct ABI_S_di; a::Float64; b::Int64; end
+struct ABI_M_fi; s::ABI_S_f; i::Int32; end
+struct ABI_S_l; x::Int64; end
+struct ABI_S_ve; x::VecElement{Int64}; end
+struct ABI_M_dl; d::Float64; s::ABI_S_l; end
+struct ABI_S_fp; a::Float32; b::Ptr{Cvoid}; end
+struct ABI_S_dV1; d::Float64; v::VecReg{1,Float64}; end
+struct ABI_S_dV2i; d::Float64; v::V2xI32; end
+struct ABI_S_V1f; v::VecReg{1,Float32}; end
+struct ABI_A16; x::Int128; end
+struct ABI_S_h; x::Float16; end
+struct ABI_S_hh; a::Float16; b::Float16; end
+struct ABI_S_hd; a::Float16; b::Float64; end
+struct ABI_S_hi; a::Float16; b::Int32; end
+struct ABI_S_bf; x::Core.BFloat16; end
+struct ABI_S_bfbf; a::Core.BFloat16; b::Core.BFloat16; end
+struct ABI_S_bfd; a::Core.BFloat16; b::Float64; end
+struct ABI_S_bfi; a::Core.BFloat16; b::Int32; end
+struct ABI_SU; x::Float64; y::Union{Int32,Float32}; end
+struct ABI_SA; x::Float64; y::Any; end
+# Must match `abi_probe_t`.
+struct ABIProbe
+    i::NTuple{8,Int64}
+    d::NTuple{8,Float64}
+    s1::Int64
+    s2::Float64
+    buf::NTuple{32,UInt8}
+end
+if Sys.ARCH === :riscv64 || (Sys.ARCH === :x86_64 && Sys.islinux()) || Sys.ARCH === :aarch64
+    abi_probe_ptr() = cglobal((:abi_probe, libccalltest), ABIProbe)
+    abi_probe() = unsafe_load(abi_probe_ptr())
+    abi_buf_ptr(::Type{T}) where {T} = Ptr{T}(abi_probe_ptr() + fieldoffset(ABIProbe, 5))
+    abi_val(::Type{T}, s) where {T<:Base.BitInteger} = hash(s) % T
+    abi_val(::Type{T}, s) where {T<:Union{Int128,UInt128}} =
+        (T(hash(s) % UInt64) << 64) | T(hash(s + 1) % UInt64)
+    abi_val(::Type{T}, s) where {T<:Union{Float16,Float32,Float64}} = T(s) + T(0.25) - T(50)
+    abi_val(::Type{Core.BFloat16}, s) = Core.Intrinsics.bitcast(Core.BFloat16, UInt16(0x4000 + s))
+    abi_val(::Type{Ptr{Cvoid}}, s) = Ptr{Cvoid}(hash(s) % UInt)
+    function abi_val(::Type{T}, s) where {T}
+        vals = ntuple(i -> abi_val(fieldtype(T, i), 7s + i), fieldcount(T))
+        return T <: Tuple ? convert(T, vals) : T(vals...)
+    end
+
+    # Julia type, C suffix, named positions, variadic type, variadic GPR counts.
+    abi_types = Any[
+        (Float32, :Float32, ((0, 0), (0, 8)), nothing, ()),
+        (Float64, :Float64, ((0, 0), (0, 8)), nothing, ()),
+        (Ptr{Cvoid}, :Ptr, ((0, 0),), nothing, ()),
+        (ABI_S_f, :S_f, ((0, 0), (0, 8)), ABI_S_f, (0,)),
+        (ABI_S_d, :S_d, ((0, 0),), nothing, ()),
+        (ABI_N_d, :N_d, ((0, 0),), nothing, ()),
+        (ABI_T1d, :T1d, ((0, 0),), nothing, ()),
+        (ABI_S_ff, :S_ff, ((0, 0), (0, 7), (0, 8)), ABI_S_ff, (0,)),
+        (ABI_S_fd, :S_fd, ((0, 0), (0, 7), (0, 8)), nothing, ()),
+        (ABI_T2f, :T2f, ((0, 0),), nothing, ()),
+        (ABI_S_fi, :S_fi, ((0, 0), (7, 7), (8, 7), (7, 8)), ABI_S_fi, (0,)),
+        (ABI_S_if, :S_if, ((0, 0),), nothing, ()),
+        (ABI_S_di, :S_di, ((0, 0),), nothing, ()),
+        (ABI_M_fi, :M_fi, ((0, 0),), nothing, ()),
+        # A non-tuple VecElement wrapper is a scalar aggregate, not a vector.
+        (ABI_S_ve, :S_l, ((0, 0),), nothing, ()),
+        (ABI_M_dl, :M_dl, ((0, 0),), nothing, ()),
+        (ABI_S_fp, :S_fp, ((0, 0),), nothing, ()),
+        (V2xF64, :V2d, ((0, 0),), nothing, ()),
+        (V2xF32, :V2f, ((0, 0),), nothing, ()),
+        (V2xI32, :V2i, ((0, 0),), nothing, ()),
+        # A one-element 8-byte vector is an AArch64 short vector.
+        (VecReg{1,Int64}, :V1l, ((0, 0),), nothing, ()),
+        (ABI_S_dV2i, :S_dV2i, ((0, 0),), nothing, ()),
+        # GCC and Clang disagree on one-element floating-point vectors.
+        (VecReg{1,Float64}, :V1d, ((0, 0),), nothing, ()),
+        (VecReg{1,Float32}, :V1f, ((0, 0),), nothing, ()),
+        (ABI_S_dV1, :S_dV1, ((0, 0),), nothing, ()),
+        # Sub-8-byte vectors are not AArch64 short vectors.
+        (ABI_S_V1f, :S_V1f, ((0, 0),), nothing, ()),
+        # Exercise register exhaustion and aligned variadic pairs.
+        (Int128, :Int128, ((0, 0), (5, 0), (7, 0), (8, 0)), Int128, (0, 4, 5, 7)),
+        (ABI_A16, :A16, ((0, 0), (5, 0), (7, 0), (8, 0)), ABI_A16, (0, 4, 5, 7)),
+    ]
+    if unsafe_load(cglobal((:abi_probe_float16, libccalltest), Cint)) != 0
+        # Reuse the bit-copying `_Float16` probes for `BFloat16`.
+        push!(abi_types,
+              (Float16, :Float16, ((0, 0), (0, 8)), Float16, (0,)),
+              (ABI_S_h, :S_h, ((0, 0),), nothing, ()),
+              (ABI_S_hh, :S_hh, ((0, 0), (0, 7), (0, 8)), nothing, ()),
+              (ABI_S_hd, :S_hd, ((0, 0), (0, 7), (0, 8)), nothing, ()),
+              (ABI_S_hi, :S_hi, ((0, 0), (7, 7), (8, 7), (7, 8)), nothing, ()),
+              (Core.BFloat16, :Float16, ((0, 0), (0, 8)), Core.BFloat16, (0,)),
+              (ABI_S_bf, :S_h, ((0, 0),), nothing, ()),
+              (ABI_S_bfbf, :S_hh, ((0, 0), (0, 7), (0, 8)), nothing, ()),
+              (ABI_S_bfd, :S_hd, ((0, 0), (0, 7), (0, 8)), nothing, ()),
+              (ABI_S_bfi, :S_hi, ((0, 0), (7, 7), (8, 7), (7, 8)), nothing, ()))
+    end
+
+    const abi_cb_got = Ref{Any}(nothing)
+    const abi_cb_ret = Ref{Any}(nothing)
+    abi_clang = unsafe_load(cglobal((:abi_probe_clang, libccalltest), Cint)) != 0
+    # Compiler-specific vector conventions that Julia cannot match simultaneously.
+    abi_skip = Any[]
+    if Sys.ARCH === :x86_64 && abi_clang
+        # Julia follows GCC for these vectors.
+        push!(abi_skip, VecReg{1,Float64}, VecReg{1,Float32}, ABI_S_V1f)
+    elseif Sys.ARCH === :aarch64
+        # Bare sub-8-byte vectors differ; test the shared wrapper ABI instead.
+        push!(abi_skip, VecReg{1,Float32})
+    end
+    for (T, cname, positions, vaT, va_leads) in abi_types, (g, f) in positions
+        leadtypes = (fill(Int64, g)..., fill(Float64, f)...)
+        leads = (Int64[abi_val(Int64, 100 + k) for k in 0:g-1]..., Float64[abi_val(Float64, 200 + k) for k in 0:f-1]...)
+        cleads = (Int64[1000 + k for k in 0:g-1]..., Float64[0.5 + k for k in 0:f-1]...)
+        leadparams = [:($(Symbol(:l, k))::$(leadtypes[k])) for k in 1:g+f]
+        leadsyms = [Symbol(:l, k) for k in 1:g+f]
+        local x, s1, s2 = abi_val(T, 1), abi_val(Int64, 2), abi_val(Float64, 3)
+        T in abi_skip && continue
+        suffix = "$(cname)_$(g)_$(f)"
+        probe_arg = Symbol("abi_probe_arg_", suffix)
+        probe_ret = Symbol("abi_probe_ret_", suffix)
+        cbarg = Symbol("abi_probe_cbarg_", suffix)
+        cbret = Symbol("abi_probe_cbret_", suffix)
+
+        # Julia caller: argument.
+        @eval @noinline $probe_arg(x::$T, s1::Int64, s2::Float64) =
+            ccall(($(QuoteNode(Symbol("test_abi_arg_", suffix))), libccalltest), Cvoid,
+                  ($(leadtypes...), $T, Int64, Float64), $(leads...), x, s1, s2)
+        @eval $probe_arg($x, $s1, $s2)
+        got = abi_probe()
+        @test unsafe_load(abi_buf_ptr(T)) === x
+        @test (got.s1, got.s2) === (s1, s2)
+        @test got.i[1:g] == leads[1:g] && got.d[1:f] == leads[g+1:end]
+
+        # Julia caller: return.
+        unsafe_store!(abi_buf_ptr(T), x)
+        @eval @noinline $probe_ret(s1::Int64) =
+            ccall(($(QuoteNode(Symbol("test_abi_ret_", suffix))), libccalltest), $T,
+                  ($(leadtypes...), Int64), $(leads...), s1)
+        @test (@eval $probe_ret($s1)) === x
+        got = abi_probe()
+        @test got.s1 === s1
+        @test got.i[1:g] == leads[1:g] && got.d[1:f] == leads[g+1:end]
+
+        # Julia callee: argument.
+        unsafe_store!(abi_buf_ptr(T), x)
+        @eval $cbarg($(leadparams...), x::$T, s1::Int64, s2::Float64) =
+            (abi_cb_got[] = (($(leadsyms...),), x, s1, s2); nothing)
+        @eval ccall(($(QuoteNode(Symbol("test_abi_cbarg_", suffix))), libccalltest), Cvoid, (Ptr{Cvoid},),
+                    @cfunction($cbarg, Cvoid, ($(leadtypes...), $T, Int64, Float64)))
+        @test abi_cb_got[] === (cleads, x, Int64(-77), 3.25)
+
+        # Julia callee: return.
+        abi_cb_ret[] = x
+        @eval $cbret($(leadparams...), s1::Int64) = (abi_cb_got[] = (($(leadsyms...),), s1); abi_cb_ret[]::$T)
+        @eval ccall(($(QuoteNode(Symbol("test_abi_cbret_", suffix))), libccalltest), Cvoid, (Ptr{Cvoid},),
+                    @cfunction($cbret, $T, ($(leadtypes...), Int64)))
+        @test unsafe_load(abi_buf_ptr(T)) === x
+        @test abi_cb_got[] === (cleads, Int64(-77))
+    end
+
+    # Inline unions and boxed fields are not flattened.
+    let su = ABI_SU(abi_val(Float64, 7), Int32(-123456)), sa = ABI_SA(abi_val(Float64, 8), abi_cb_got)
+        @test ccall((:test_abi_union, libccalltest), Float64, (ABI_SU,), su) === su.x
+        @test unsafe_load(abi_buf_ptr(Float64)) === su.x
+        @test ccall((:test_abi_boxed, libccalltest), Float64, (ABI_SA,), sa) === sa.x
+        @test abi_probe().s1 === Int64(pointer_from_objref(sa.y))
+    end
+
+    # Exercise variadic classification and aligned register pairs.
+    # Old GCC miscompiles `va_arg(ap, __int128)` from the register save area.
+    abi_va_i128_regs = unsafe_load(cglobal((:abi_probe_va_i128_regs, libccalltest), Cint)) != 0
+    for (T, cname, positions, vaT, va_leads) in abi_types, g in va_leads
+        vaT === nothing && continue
+        vaT <: Union{Int128,ABI_A16} && g == 0 && !abi_va_i128_regs && continue
+        leads = Int64[abi_val(Int64, 100 + k) for k in 0:g-1]
+        local x, s1, s2 = abi_val(T, 4), abi_val(Int64, 5), abi_val(Float64, 6)
+        probe_va = Symbol("abi_probe_va_", cname, "_", g)
+        @eval @noinline $probe_va(x::$T, s1::Int64, s2::Float64) =
+            @ccall libccalltest.$(Symbol("test_abi_va_", cname, "_", g))(0::Cint; $([:($l::Int64) for l in leads]...),
+                                                                         x::$T, s1::Int64, s2::Float64)::Cvoid
+        @eval $probe_va($x, $s1, $s2)
+        got = abi_probe()
+        @test unsafe_load(abi_buf_ptr(vaT)) === (vaT === T ? x : vaT(x))
+        @test (got.s1, got.s2) === (s1, s2)
+        @test collect(got.i[1:g]) == leads
+    end
+end
+
 # Special calling convention for `Array`
 function f17204(a)
     b = similar(a)


### PR DESCRIPTION
Julia's native-call classifiers disagreed with C compilers for several scalar,
aggregate, and vector types. Failures at register boundaries could corrupt values
or shift subsequent arguments.

- RISC-V: apply the XLEN extension rule to 32-bit arguments and integer returns,
  classify variadic arguments with the integer convention, and flatten eligible
  floating-point aggregates using the runtime's ABI_FLEN.
- x86-64 SysV: preserve scalar `i128` so LLVM spills the entire argument when
  registers are insufficient, and classify 8-byte vectors as SSE.
- AArch64: recognize one-element short vector tuples while keeping ordinary
  `VecElement` wrappers as scalar aggregates, exclude smaller vectors from HFAs,
  preserve 16-byte aggregate alignment, and check the current field during HFA
  recursion.
- Preserve `_Float16` and `__bf16` through C varargs; only `float` receives the
  default floating-point promotion.