### PR TITLE
codegen: emit accurate DWARF types for unboxed values at -g2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -95,6 +95,11 @@ Compiler/Runtime improvements
   information. This prevents coverage from writing `.cov` files for Base sources into the Julia installation
   ([#62514]).
 
+* Debug information emitted for JIT-compiled code at `-g2` now describes unboxed values
+  accurately: primitive types carry their DWARF encoding (so `Float64` locals display as
+  floats in a debugger), struct locals list their fields by name with offsets, and type
+  names include their parameters (`Complex{Float64}` rather than `Complex`).
+
 Command-line option changes
 ---------------------------
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -249,6 +249,55 @@ static DICompileUnit *getOrCreateJuliaCU(Module &M,
     return CU;
 }
 
+// Render a Julia type the way `jl_static_show` does, e.g. "Complex{Float64}".
+// Debuggers show this string verbatim as the variable's type name.
+static std::string julia_type_di_name(jl_value_t *jt)
+{
+    ios_t buf;
+    ios_mem(&buf, 0);
+    jl_static_show((JL_STREAM*)&buf, jt);
+    std::string name(buf.buf, buf.size);
+    ios_close(&buf);
+    return name;
+}
+
+// Name of field `i` of `dt` for DW_TAG_member: the declared name for structs and
+// NamedTuples, and the 1-based index for Tuples.
+static std::string julia_field_di_name(jl_datatype_t *dt, size_t i)
+{
+    if (jl_is_namedtuple_type(dt)) {
+        jl_value_t *names = jl_tparam0(dt);
+        if (jl_is_tuple(names) && i < jl_nfields(names)) {
+            jl_value_t *s = jl_fieldref_noalloc(names, i);
+            if (jl_is_symbol(s))
+                return jl_symbol_name((jl_sym_t*)s);
+        }
+    }
+    else if (!jl_is_tuple_type(dt)) {
+        jl_svec_t *names = jl_field_names(dt);
+        if (names && i < jl_svec_len(names)) {
+            jl_value_t *s = jl_svecref(names, i);
+            if (jl_is_symbol(s))
+                return jl_symbol_name((jl_sym_t*)s);
+        }
+    }
+    return std::to_string(i + 1);
+}
+
+// DWARF base-type encoding for a Julia primitive type. Anything not listed
+// (Char, BFloat16, user-defined primitives, ...) is described by its raw bits.
+static unsigned julia_primitive_di_encoding(jl_value_t *jt)
+{
+    if (jt == (jl_value_t*)jl_bool_type)
+        return llvm::dwarf::DW_ATE_boolean;
+    if (jt == (jl_value_t*)jl_float16_type || jt == (jl_value_t*)jl_float32_type ||
+        jt == (jl_value_t*)jl_float64_type)
+        return llvm::dwarf::DW_ATE_float;
+    if (jl_subtype(jt, (jl_value_t*)jl_signed_type))
+        return llvm::dwarf::DW_ATE_signed;
+    return llvm::dwarf::DW_ATE_unsigned;
+}
+
 static DIType *_julia_type_to_di(jl_codegen_output_t *ctx, jl_debugcache_t &debuginfo, jl_value_t *jt, DIBuilder *dbuilder, bool isboxed)
 {
     jl_datatype_t *jdt = (jl_datatype_t*)jt;
@@ -259,41 +308,79 @@ static DIType *_julia_type_to_di(jl_codegen_output_t *ctx, jl_debugcache_t &debu
     DIType* &ditype = (ctx ? ctx->ditypes[jdt] : _ditype);
     if (ditype)
         return ditype;
-    const char *tname = jl_symbol_name(jdt->name->name);
-    if (jl_is_primitivetype(jt)) {
-        uint64_t SizeInBits = jl_datatype_nbits(jdt);
-        ditype = dbuilder->createBasicType(tname, SizeInBits, llvm::dwarf::DW_ATE_unsigned);
+    std::string tname = julia_type_di_name(jt);
+    uint64_t SizeInBits = jl_datatype_nbits(jdt);
+    uint32_t AlignInBits = 8 * jl_datatype_align(jdt);
+    if (jl_is_cpointer_type(jt)) {
+        // Ptr{T}: describe the pointee only for primitive T (Ptr{UInt8} and
+        // friends); following struct pointees could recurse through the type
+        // being defined, and Ptr{Cvoid}/abstract T have nothing to show.
+        jl_value_t *elt = jl_tparam0(jdt);
+        DIType *pointee = nullptr;
+        if (jl_is_primitivetype(elt) && !jl_is_cpointer_type(elt))
+            pointee = _julia_type_to_di(ctx, debuginfo, elt, dbuilder, false);
+        ditype = dbuilder->createPointerType(pointee, SizeInBits, AlignInBits, std::nullopt, tname);
+    }
+    else if (jl_is_primitivetype(jt)) {
+        ditype = dbuilder->createBasicType(tname, SizeInBits, julia_primitive_di_encoding(jt));
     }
     else if (jl_is_structtype(jt) && !jl_is_layout_opaque(jdt->layout) && !jl_is_array_type(jdt)) {
-        size_t ntypes = jl_datatype_nfields(jdt);
-        SmallVector<llvm::Metadata*, 0> Elements(ntypes);
-        for (unsigned i = 0; i < ntypes; i++) {
-            jl_value_t *el = jl_field_type_concrete(jdt, i);
-            DIType *di;
-            if (jl_field_isptr(jdt, i))
-                di = debuginfo.jl_pvalue_dillvmt;
-            // TODO: elseif jl_islayout_inline
-            else
-                di = _julia_type_to_di(ctx, debuginfo, el, dbuilder, false);
-            Elements[i] = di;
-        }
-        DINodeArray ElemArray = dbuilder->getOrCreateArray(Elements);
         std::string unique_name;
         raw_string_ostream(unique_name) << (uintptr_t)jdt;
-        ditype = dbuilder->createStructType(
+        // Create the struct first so members can name it as their scope; the
+        // member list is filled in below.
+        DICompositeType *ditstruct = dbuilder->createStructType(
                 NULL,                       // Scope
                 tname,                      // Name
                 NULL,                       // File
                 0,                          // LineNumber
-                jl_datatype_nbits(jdt),     // SizeInBits
-                8 * jl_datatype_align(jdt), // AlignInBits
+                SizeInBits,                 // SizeInBits
+                AlignInBits,                // AlignInBits
                 DINode::FlagZero,           // Flags
                 NULL,                       // DerivedFrom
-                ElemArray,                  // Elements
+                nullptr,                    // Elements
                 dwarf::DW_LANG_Julia,       // RuntimeLanguage
                 nullptr,                    // VTableHolder
                 unique_name                 // UniqueIdentifier
                 );
+        ditype = ditstruct;
+        size_t ntypes = jl_datatype_nfields(jdt);
+        SmallVector<llvm::Metadata*, 0> Elements(ntypes);
+        for (unsigned i = 0; i < ntypes; i++) {
+            jl_value_t *el = jl_field_type_concrete(jdt, i);
+            uint64_t fsz = 8 * (uint64_t)jl_field_size(jdt, i);
+            uint64_t foff = 8 * (uint64_t)jl_field_offset(jdt, i);
+            uint32_t falign;
+            DIType *di;
+            if (jl_field_isptr(jdt, i)) {
+                di = debuginfo.jl_pvalue_dillvmt;
+                falign = 8 * sizeof(void*);
+            }
+            else if (jl_is_datatype(el) && ((jl_datatype_t*)el)->isconcretetype) {
+                di = _julia_type_to_di(ctx, debuginfo, el, dbuilder, false);
+                falign = 8 * jl_datatype_align(el);
+            }
+            else {
+                // Inline-allocated Union: the payload bytes followed by the
+                // selector byte. Expose the raw storage as a byte array.
+                DIType *u8 = _julia_type_to_di(ctx, debuginfo, (jl_value_t*)jl_uint8_type, dbuilder, false);
+                di = dbuilder->createArrayType(fsz, 8, u8,
+                        dbuilder->getOrCreateArray({dbuilder->getOrCreateSubrange(0, fsz / 8)}));
+                falign = 8;
+            }
+            Elements[i] = dbuilder->createMemberType(
+                    ditstruct,                            // Scope
+                    julia_field_di_name(jdt, i),          // Name
+                    NULL,                                 // File
+                    0,                                    // LineNo
+                    fsz,                                  // SizeInBits
+                    falign,                               // AlignInBits
+                    foff,                                 // OffsetInBits
+                    DINode::FlagZero,                     // Flags
+                    di                                    // Ty
+                    );
+        }
+        dbuilder->replaceArrays(ditstruct, dbuilder->getOrCreateArray(Elements));
     }
     else {
         // return a typealias for types with hidden content

--- a/test/llvmpasses/debuginfo-types.jl
+++ b/test/llvmpasses/debuginfo-types.jl
@@ -1,0 +1,81 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no %s %t && cat %t/f.ll | FileCheck %s
+
+# Checks the DWARF type descriptions emitted for unboxed values at -g2:
+# primitive types carry a real encoding, structs list their fields as named
+# members with offsets, and type names include the type parameters.
+
+using InteractiveUtils
+
+dir = ARGS[1]
+rm(dir, force=true, recursive=true)
+mkdir(dir)
+
+struct Pose
+    x::Float64
+    n::Int32
+    tag::String
+end
+
+struct MaybeInt
+    u::Union{Int64, Nothing}
+end
+
+@noinline function f(p::Pose, c::Complex{Float64}, b::Bool, ptr::Ptr{UInt8},
+                     t::Tuple{Int64, Float32},
+                     nt::NamedTuple{(:a, :b), Tuple{Int8, UInt16}}, m::MaybeInt)
+    return p.x + c.re + t[2]
+end
+
+open(joinpath(dir, "f.ll"), "w") do io
+    params = Base.CodegenParams(debug_info_level=Cint(2))
+    code_llvm(io, f, (Pose, Complex{Float64}, Bool, Ptr{UInt8}, Tuple{Int64, Float32},
+                      NamedTuple{(:a, :b), Tuple{Int8, UInt16}}, MaybeInt);
+              raw=true, dump_module=true, debuginfo=:source, optimize=false, params=params)
+end
+
+# Primitive types get a DWARF encoding matching their Julia semantics.
+# CHECK-DAG: [[F64:![0-9]+]] = !DIBasicType(name: "Float64", size: 64, encoding: DW_ATE_float)
+# CHECK-DAG: [[F32:![0-9]+]] = !DIBasicType(name: "Float32", size: 32, encoding: DW_ATE_float)
+# CHECK-DAG: [[I64:![0-9]+]] = !DIBasicType(name: "Int64", size: 64, encoding: DW_ATE_signed)
+# CHECK-DAG: [[I32:![0-9]+]] = !DIBasicType(name: "Int32", size: 32, encoding: DW_ATE_signed)
+# CHECK-DAG: [[I8:![0-9]+]] = !DIBasicType(name: "Int8", size: 8, encoding: DW_ATE_signed)
+# CHECK-DAG: [[U16:![0-9]+]] = !DIBasicType(name: "UInt16", size: 16, encoding: DW_ATE_unsigned)
+# CHECK-DAG: [[U8:![0-9]+]] = !DIBasicType(name: "UInt8", size: 8, encoding: DW_ATE_unsigned)
+# CHECK-DAG: !DIBasicType(name: "Bool", size: 8, encoding: DW_ATE_boolean)
+
+# Boxed fields are jl_value_t*; Ptr{T} is a named pointer type.
+# CHECK-DAG: [[JLV:![0-9]+]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: {{![0-9]+}}, size: 64, align: 64)
+# CHECK-DAG: !DIDerivedType(tag: DW_TAG_pointer_type, name: "Ptr{UInt8}", baseType: [[U8]], size: 64, align: 64)
+
+# Structs: full name, and one DW_TAG_member per field with name and offset.
+# CHECK-DAG: [[POSE:![0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Main.Pose", size: 192, align: 64, elements: [[POSE_ELTS:![0-9]+]], runtimeLang: DW_LANG_Julia
+# CHECK-DAG: [[POSE_ELTS]] = !{[[POSE_X:![0-9]+]], [[POSE_N:![0-9]+]], [[POSE_TAG:![0-9]+]]}
+# CHECK-DAG: [[POSE_X]] = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: [[POSE]], baseType: [[F64]], size: 64, align: 64)
+# CHECK-DAG: [[POSE_N]] = !DIDerivedType(tag: DW_TAG_member, name: "n", scope: [[POSE]], baseType: [[I32]], size: 32, align: 32, offset: 64)
+# CHECK-DAG: [[POSE_TAG]] = !DIDerivedType(tag: DW_TAG_member, name: "tag", scope: [[POSE]], baseType: [[JLV]], size: 64, align: 64, offset: 128)
+
+# CHECK-DAG: [[CPLX:![0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Base.Complex{Float64}", size: 128, align: 64, elements: [[CPLX_ELTS:![0-9]+]], runtimeLang: DW_LANG_Julia
+# CHECK-DAG: [[CPLX_ELTS]] = !{[[CPLX_RE:![0-9]+]], [[CPLX_IM:![0-9]+]]}
+# CHECK-DAG: [[CPLX_RE]] = !DIDerivedType(tag: DW_TAG_member, name: "re", scope: [[CPLX]], baseType: [[F64]], size: 64, align: 64)
+# CHECK-DAG: [[CPLX_IM]] = !DIDerivedType(tag: DW_TAG_member, name: "im", scope: [[CPLX]], baseType: [[F64]], size: 64, align: 64, offset: 64)
+
+# Tuples number their fields from 1; NamedTuples use the declared names.
+# CHECK-DAG: [[TUP:![0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Tuple{Int64, Float32}", size: 128, align: 64, elements: [[TUP_ELTS:![0-9]+]], runtimeLang: DW_LANG_Julia
+# CHECK-DAG: [[TUP_ELTS]] = !{[[TUP_1:![0-9]+]], [[TUP_2:![0-9]+]]}
+# CHECK-DAG: [[TUP_1]] = !DIDerivedType(tag: DW_TAG_member, name: "1", scope: [[TUP]], baseType: [[I64]], size: 64, align: 64)
+# CHECK-DAG: [[TUP_2]] = !DIDerivedType(tag: DW_TAG_member, name: "2", scope: [[TUP]], baseType: [[F32]], size: 32, align: 32, offset: 64)
+
+# CHECK-DAG: [[NT:![0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "NamedTuple{(:a, :b), Tuple{Int8, UInt16}}", size: 32, align: 16, elements: [[NT_ELTS:![0-9]+]], runtimeLang: DW_LANG_Julia
+# CHECK-DAG: [[NT_ELTS]] = !{[[NT_A:![0-9]+]], [[NT_B:![0-9]+]]}
+# CHECK-DAG: [[NT_A]] = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: [[NT]], baseType: [[I8]], size: 8, align: 8)
+# CHECK-DAG: [[NT_B]] = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: [[NT]], baseType: [[U16]], size: 16, align: 16, offset: 16)
+
+# An inline-allocated Union field is exposed as its raw bytes (payload + selector).
+# CHECK-DAG: [[MI:![0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Main.MaybeInt", size: 128, align: 64, elements: [[MI_ELTS:![0-9]+]], runtimeLang: DW_LANG_Julia
+# CHECK-DAG: [[MI_ELTS]] = !{[[MI_U:![0-9]+]]}
+# CHECK-DAG: [[MI_U]] = !DIDerivedType(tag: DW_TAG_member, name: "u", scope: [[MI]], baseType: [[MI_BYTES:![0-9]+]], size: 72, align: 8)
+# CHECK-DAG: [[MI_BYTES]] = !DICompositeType(tag: DW_TAG_array_type, baseType: [[U8]], size: 72, align: 8, elements: [[MI_SUB:![0-9]+]])
+# CHECK-DAG: [[MI_SUB]] = !{[[MI_RANGE:![0-9]+]]}
+# CHECK-DAG: [[MI_RANGE]] = !DISubrange(count: 9, lowerBound: 0)


### PR DESCRIPTION
`_julia_type_to_di` described every Julia primitive as `DW_ATE_unsigned`, passed struct field types as bare elements instead of `DW_TAG_member` entries, and named types by their bare typename. In a debugger this made a `Float64` local print as an integer, a struct local print as `{}` with no fields, and `Complex{Float64}` show up as `Complex`.

This PR changes the `-g2` debug info so that:

- primitive types get a matching encoding: `Bool` → `DW_ATE_boolean`, `Float16/32/64` → `DW_ATE_float`, `Signed` subtypes → `DW_ATE_signed`, everything else stays `DW_ATE_unsigned` (raw bits; `Char` deliberately stays raw since it is not a code point);
- struct, `Tuple` and `NamedTuple` fields are emitted as named members with size, alignment and offset (Tuples number fields from 1); inline-allocated `Union` fields are exposed as their raw bytes (payload + selector);
- `Ptr{T}` is a named pointer type, with the pointee described for primitive `T` (following struct pointees could recurse through the type being defined);
- type names come from `jl_static_show`, so parameters are included.

A lit test (`test/llvmpasses/debuginfo-types.jl`) checks the emitted metadata.

### Requires an LLDB patch to be visible in lldb

Stock lldb refuses to parse variables in `DW_LANG_Julia` compile units at all ("This version of LLDB has no plugin for the language "julia"", `frame variable` prints nothing, and `expr` fails with "Could not find type system for language julia"). llvm/llvm-project#220895 routes `DW_LANG_Julia` to the Clang type system, the same escape hatch Rust, D and Dylan use. This PR is what makes the result of that patch correct; neither half is useful alone.

With both applied, stopped in a JIT frame of

```julia
struct P; x::Float64; y::Int64; end
@noinline function foo(a::Float64, b::Vector{Int}, p::P)
    s = a * 2.0
    n = length(b)
    ccall(:jl_breakpoint, Cvoid, (Any,), b)
    return s + n + p.x
end
foo(1.5, [1,2,3], P(0.25, 7))
```

lldb now shows

```
(lldb) frame variable -T
(typeof(Main.foo)) #self# = <no location, value may have been optimized out>
(double) a = <could not evaluate DW_OP_entry_value: no parent function>
(Array{Int64, 1}) b = <register rdi is not available>
(Main.P) p = {
  (double) x = 0.25
  (long) y = 7
}
(lldb) expr p.x * 4
(double) $0 = 1
```

whereas with the lldb patch but without this PR the same frame prints `(unsigned long) a` and `(P) p = {}`.

Not addressed here: SSA locals (`s`, `n` above) are still invisible, because codegen only emits `dbg.declare` for variables with stack slots and never `dbg.value`. That is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
