### PR TITLE
codegen: omit DWARF linkage names at -g2 so debuggers use Julia names

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9321,9 +9321,17 @@ static jl_llvm_functions_t
             subrty = debugcache.jl_di_func_sig;
         else
             subrty = get_specsig_di(ctx, debugcache, jlrettype, abi, dbuilder);
+        // At -g2, omit the mangled linkage name from DWARF so debuggers index
+        // and display the function by its Julia name: `break mycompute` in
+        // gdb then binds to every specialization, and frames show as
+        // `mycompute (a=1, b=2)` instead of `julia_mycompute_0 (...)`. The ELF
+        // symbol keeps the mangled name for profilers and `break julia_...`.
+        // gdb uses DW_AT_linkage_name as the symbol whenever it is present.
+        StringRef linkageName = ctx.emission_context.params->debug_info_level >= 2
+                                ? StringRef() : StringRef(f->getName());
         SP = dbuilder.createFunction(nullptr
                                      ,dbgFuncName      // Name
-                                     ,f->getName()     // LinkageName
+                                     ,linkageName      // LinkageName
                                      ,topfile          // File
                                      ,toplineno        // LineNo
                                      ,subrty           // Ty


### PR DESCRIPTION
gdb indexes a function by its `DW_AT_linkage_name` whenever one is present, so Julia functions could only be reached as `julia_<name>_<N>`: `break mycompute` reported the function as not defined (or worse, matched a dozen LLVM C++ methods of the same name), and frames displayed the mangled symbol. At debug level 2 and above the DWARF subprogram now carries only the Julia name. `break mycompute` binds to every specialization — also as a pending breakpoint before the code is compiled, resolving when the JIT registers the object — and frames display as `mycompute (a=1, b=2)`. The ELF symbol keeps the mangled name for profilers and `break julia_...`. Julia's own symbolizer already used the short name, so stack traces are unaffected.

Notes:
- lldb behavior is unchanged: it already matches functions by `DW_AT_name`.
- Plain names can collide with the runtime's own C/C++ symbols in gdb (e.g. `break compute` also matches several LLVM methods); `break file.jl:LINE` or `rbreak ^julia_name` disambiguates when that matters.
- Complementary to #62997 (accurate DWARF *types*); this changes only the subprogram name fields, so the two are independent.

Tested against gdb 15 and lldb 18 on x86-64 Linux with `ENABLE_GDBLISTENER=1 ./julia -g2`: pending `break mycompute` set before any code exists resolves at JIT registration and stops with `mycompute (a=1, b=2) at breakpoints.jl:3`; `-g1`/`-g0` output is unchanged.

This PR was drafted with Claude Code; the human author has not yet reviewed the text or the change in detail and will update this disclaimer once they have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
