### PR TITLE
codegen: emit dbg.value for boxed arguments, not dbg.declare

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9722,7 +9722,14 @@ static jl_llvm_functions_t
             // keep track of original (possibly boxed) value to avoid re-boxing or moving
             vi.value = theArg;
             if (debug_enabled && vi.dinfo && theArg.V) {
-                if (!theArg.inline_roots.empty() || theArg.ispointer()) {
+                if (theArg.isboxed) {
+                    // the variable's value IS the pointer in theArg.V (its
+                    // debug type is jl_value_t*); declare-at-address would
+                    // make debuggers dereference one level too many
+                    dbuilder.insertDbgValueIntrinsic(theArg.V, vi.dinfo, dbuilder.createExpression(),
+                                                        topdebugloc, ctx.builder.GetInsertBlock());
+                }
+                else if (!theArg.inline_roots.empty() || theArg.ispointer()) {
                     dbuilder.insertDeclare(theArg.V, vi.dinfo, dbuilder.createExpression(),
                                             topdebugloc, ctx.builder.GetInsertBlock());
                 }

--- a/test/llvmpasses/debuginfo-boxed-args.jl
+++ b/test/llvmpasses/debuginfo-boxed-args.jl
@@ -1,0 +1,20 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no %s %t && llvm-link -S %t/* | FileCheck %s
+
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+struct BoxedArgP
+    x::Float64
+    y::Int64
+end
+
+@noinline g(b::Vector{Int}, p::BoxedArgP, f::Float64) = length(b) + p.y + f
+
+# A boxed argument's debug variable is the jl_value_t* itself, so it takes
+# value semantics (#dbg_value); an unboxed argument passed by reference keeps
+# #dbg_declare, since its bytes do live at that address.
+# CHECK: #dbg_value(ptr addrspace(10) %"b::Array"
+# CHECK: #dbg_declare(ptr addrspace(11) %"p::BoxedArgP"
+# CHECK: #dbg_value(double %"f::Float64"
+emit(g, Vector{Int}, BoxedArgP, Float64; debuginfo=:source)

--- a/test/testhelpers/llvmpasses.jl
+++ b/test/testhelpers/llvmpasses.jl
@@ -16,7 +16,7 @@ end
 
 # Emit LLVM IR to dir
 counter = 0
-function emit(f, tt...)
+function emit(f, tt...; debuginfo=:none)
     global counter
     name = nameof(f)
     open(joinpath(dir, @sprintf("%05d-%s.ll", counter, name)), "w") do io
@@ -25,7 +25,7 @@ function emit(f, tt...)
             debug_info_kind=Cint(0), debug_info_level=Cint(2), safepoint_on_entry=true,
             gcstack_arg=true, unique_names=true,
         )
-        code_llvm(io, f, tt, raw=true, optimize=optimize, dump_module=true, debuginfo=:none, params=params)
+        code_llvm(io, f, tt, raw=true, optimize=optimize, dump_module=true, debuginfo=debuginfo, params=params)
     end
     counter+=1
 end


### PR DESCRIPTION
For a boxed argument, `theArg.V` is the `jl_value_t*` itself and its debug type is `jl_value_t*` (or a typedef of it), but `theArg.ispointer()` is true for boxed values, so the argument was emitted with declare-at-address semantics: the DWARF location said "the variable is stored *at* address = box pointer" (`DW_OP_breg` into memory), and debuggers computed the variable by loading memory at the box — showing the object's **first field** where the pointer should be. For an `Array` argument that means the debugger displays the data pointer as if it were the array, a wrong-but-plausible value:

```
(gdb) info address b
  Range ...: a complex DWARF expression: DW_OP_breg5 0 [$rdi]   # memory at rdi
(gdb) print/x b
$1 = 0x7fffe2b807d0        # ref.ptr_or_offset, not the box (0x7fffe2b86530)
```

Emitting `dbg.value` for boxed arguments makes the pointer itself the variable's value. The location lists become plain register locations, and the value is right:

```
(gdb) info address b
  Range ...: a variable in $rdi
  Range ...: a variable in $rbx
(gdb) print b
$1 = (jl_value_t *) 0x7fffe2b86530
```

(with the gdb pretty-printers from #62956: `$1 = 3-element Vector{Int64} = {1, 2, 3}`.)

Unboxed arguments passed by reference (e.g. a `struct P` passed as a pointer) keep `dbg.declare` — their bytes really do live at that address, which is what makes `frame variable p` show fields with #62997 — and plain bits arguments keep `dbg.value` as before. The jlcall (non-specsig) path already compensates for exactly this indirection by conditionally appending `DW_OP_deref`, so this brings the specsig path in line with it.

Found while reviewing #62997, which makes the wrong value *look* more trustworthy by giving it a proper type name; the two changes are independent and complementary. Verified with gdb 15 on a JIT frame (`ENABLE_GDBLISTENER=1`) before/after on top of both current master and #62997; `make -C src analyze-codegen` is clean, and a lit test checks that boxed args get `#dbg_value` while by-ref unboxed args keep `#dbg_declare`.

Disclosure: this PR was produced by Claude Code operating my account; I have not yet read the diff myself and will update this note once I have reviewed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)