### PR TITLE
Fix dead JuliaHub blog links in the inference devdocs

### DIFF
--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -6,8 +6,8 @@ In the Julia compiler, "type inference" refers to the process of deducing the ty
 values from the types of input values. Julia's approach to inference has been described in
 the blog posts below:
 1. [Shows a simplified implementation of the data-flow analysis algorithm, that Julia's type inference routine is based on.](https://aviatesk.github.io/posts/data-flow-problem/)
-2. [Gives a high level view of inference with a focus on its inter-procedural convergence guarantee.](https://info.juliahub.com/inference-convergence-algorithm-in-julia)
-3. [Explains a refinement on the algorithm introduced in 2.](https://info.juliahub.com/inference-convergence-algorithm-in-julia-revisited)
+2. [Gives a high level view of inference with a focus on its inter-procedural convergence guarantee.](https://juliahub.com/blog/inference-convergence-algorithm-in-julia)
+3. [Explains a refinement on the algorithm introduced in 2.](https://juliahub.com/blog/inference-convergence-algorithm-in-julia-revisited)
 
 ## Debugging compiler.jl
 


### PR DESCRIPTION
`doc/src/devdocs/inference.md` opens by pointing readers at three blog posts describing Julia's approach to inference. Items 2 and 3 both 404:

- `info.juliahub.com/inference-convergence-algorithm-in-julia`
- `info.juliahub.com/inference-convergence-algorithm-in-julia-revisited`

Both posts live at `juliahub.com/blog/` now under the same slugs, and both return 200 there. Item 1 (`aviatesk.github.io/posts/data-flow-problem/`) is fine and untouched. Only the two URLs change; the link text and list are unchanged.

I requested every URL under `doc/` while I was there. Nothing else needs fixing: the remaining apparent failures are a `$(file ...)` shell template in `index.md` and Wikipedia links whose trailing `)` a naive extractor clips.

Per `AGENTS.md`: the commit carries `Assisted-by: Claude Code (Opus 5)` and no `Co-authored-by:` trailer, and this is opened with the explicit permission of the human user directing the work.