### PR TITLE
jitlayers: index published CI symbol names instead of rebuilding the set per link

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2264,7 +2264,14 @@ void JuliaOJIT::registerCI(jl_code_instance_t *CI)
 void JuliaOJIT::unregisterCI(jl_code_instance_t *CI)
 {
     std::unique_lock Lock{LinkerMutex};
-    CISymbols.erase(CI);
+    auto It = CISymbols.find(CI);
+    if (It == CISymbols.end())
+        return;
+    if (It->second.invoke)
+        CISymbolNames.erase(It->second.invoke);
+    if (It->second.specptr)
+        CISymbolNames.erase(It->second.specptr);
+    CISymbols.erase(It);
 }
 
 #define addAbsoluteToMap(map,name) \
@@ -2377,6 +2384,10 @@ CISymbolPtr JuliaOJIT::makeUniqueCIName(jl_code_instance_t *CI, const CISymbolPt
         abort();
     }
     CISymbols[CI] = Ret;
+    if (wrapper)
+        CISymbolNames.insert(wrapper);
+    if (specialized)
+        CISymbolNames.insert(specialized);
     return Ret;
 }
 
@@ -2534,14 +2545,6 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
             makeAnonymousLinkGraphSymbol(G, *DestSym);
         It->second = renameLinkGraphSymbol(G, *It->second, Dest);
     }
-    SmallSet<SymbolStringPtr, 0> KnownCISyms;
-    for (auto &KV : CISymbols) {
-        auto &S = KV.second;
-        if (S.invoke)
-            KnownCISyms.insert(S.invoke);
-        if (S.specptr)
-            KnownCISyms.insert(S.specptr);
-    }
     SmallVector<jitlink::Symbol *, 0> DefinedSyms;
     for (auto *Sym : G.defined_symbols())
         DefinedSyms.push_back(Sym);
@@ -2549,7 +2552,7 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
     // before this materialization unit registered its interface. Any body that
     // remains in this graph for that CI must not be exported here.
     for (auto *Sym : DefinedSyms) {
-        if (Sym->hasName() && KnownCISyms.contains(Sym->getName()) &&
+        if (Sym->hasName() && CISymbolNames.contains(Sym->getName()) &&
             !OwnedSyms.contains(Sym->getName()))
             makeAnonymousLinkGraphSymbol(G, *Sym);
     }
@@ -2679,6 +2682,9 @@ CISymbolPtr *JuliaOJIT::linkCISymbol(jl_code_instance_t *CI)
     cantFail(JD.define(orc::absoluteSymbols(Symbols)));
 
     auto &CISym = CISymbols[CI] = {API, InvokeSym, SpecSym};
+    if (InvokeSym)
+        CISymbolNames.insert(InvokeSym);
+    CISymbolNames.insert(SpecSym);
     return &CISym;
 }
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -3,6 +3,7 @@
 #include "llvm-version.h"
 
 #include "llvm/ADT/SmallSet.h"
+#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/MapVector.h>
 #include <llvm/ADT/StringSet.h>
 #include <llvm/Support/AllocatorBase.h>
@@ -897,6 +898,10 @@ private:
     // CodeInstance is eligible for garbage collection, it must be removed from
     // this map first, with unregisterCI.
     CISymbolMap CISymbols;
+    // Every ORC symbol name owned by an entry in CISymbols, so that linkOutput
+    // can test a link graph's defined symbols without rebuilding the set from
+    // all of CISymbols on every materialization.
+    DenseSet<orc::SymbolStringPtr> CISymbolNames;
     jl_name_counter_t Names;
 
     std::unique_ptr<DLSymOptimizer> DLSymOpt;


### PR DESCRIPTION
Claude:

---

Since #62220, `JuliaOJIT::linkOutput` collects the ORC symbol names of every `CodeInstance` the JIT has ever published into a `SmallSet<SymbolStringPtr, 0>` (a `std::set`) on each materialization, only to test the link graph's defined symbols against it. That walk grows with the number of published `CodeInstance`s, so a long session pays O(n log n) per link and quadratic work overall. In a profile of the precompile worker for Makie, building and destroying that set was about 9% of the worker's wall time (3.8s of 40s), and every long-running JIT session, such as a test run, pays the same growth.

This keeps a `DenseSet` of those names alongside `CISymbols`, updated where entries are created and removed, and tests against it directly. The membership question is unchanged.

Precompile worker for Makie (`Base.compilecache`, macOS aarch64 M5 Pro, warm object cache, same base commit, two runs each):

| | worker total | include phase |
|---|---|---|
| master | 41.6s, 41.9s | 28.3s, 28.4s |
| this PR | 37.5s, 37.1s | 24.2s, 24.0s |

DataFrames, with far fewer published `CodeInstance`s, is unchanged at 8.9s.

Verified with `test/core.jl` and `test/compiler/codegen.jl`. The clang static analysis, GC-rooting and clang-tidy checks for `jitlayers.cpp` pass; the `clang-safety` thread-safety check reports the same 14 pre-existing diagnostics on master and on this branch, none in the changed code.
