### PR TITLE
precompilation: give workers GC mark threads

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3571,6 +3571,12 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
            $(have_color === nothing ? "--color=auto" : have_color ? "--color=yes" : "--color=no")
            -`
     cmd = addenv(cmd, "OPENBLAS_NUM_THREADS" => 1, "JULIA_NUM_THREADS" => 1)
+    # A single-threaded worker gets no GC mark threads by default. Its collections are
+    # infrequent but large (the heap holds every loaded dependency), so let them mark in
+    # parallel unless the caller has configured GC threads explicitly.
+    if !haskey(ENV, "JULIA_NUM_GC_THREADS")
+        cmd = `$cmd --gcthreads=$(precompile_gcthreads())`
+    end
     # Only request per-package timing reports when explicitly asked for (e.g. by
     # precompilepkgs), so that the marker lines don't leak into normal load logs.
     report_timing && (cmd = addenv(cmd, "JULIA_PRECOMP_REPORT_TIMING" => 1))
@@ -3588,6 +3594,10 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
     close(io.in)
     return io
 end
+
+# Mark threads for a precompile worker: a few per worker, scaled down on small machines so
+# that the driver's worker count times this stays well under the core count.
+precompile_gcthreads() = clamp(Sys.EFFECTIVE_CPU_THREADS::Int ÷ 4, 1, 4)
 
 const precompilation_stack = Vector{PkgId}()
 # Helpful for debugging when precompilation is unexpectedly nested.

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3558,6 +3558,12 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
         cpu_target = nothing
     end
     push!(opts, "--output-ji", output)
+    # A single-threaded worker gets no GC mark threads by default. Its collections are
+    # infrequent but large (the heap holds every loaded dependency), so let them mark in
+    # parallel unless the caller has configured GC threads explicitly.
+    if !haskey(ENV, "JULIA_NUM_GC_THREADS")
+        push!(opts, "--gcthreads=$(precompile_gcthreads())")
+    end
     if isassigned(PRECOMPILE_TRACE_COMPILE)
         push!(opts, "--trace-compile=$(PRECOMPILE_TRACE_COMPILE[])")
         push!(opts, "--trace-compile-timing")
@@ -3571,12 +3577,6 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
            $(have_color === nothing ? "--color=auto" : have_color ? "--color=yes" : "--color=no")
            -`
     cmd = addenv(cmd, "OPENBLAS_NUM_THREADS" => 1, "JULIA_NUM_THREADS" => 1)
-    # A single-threaded worker gets no GC mark threads by default. Its collections are
-    # infrequent but large (the heap holds every loaded dependency), so let them mark in
-    # parallel unless the caller has configured GC threads explicitly.
-    if !haskey(ENV, "JULIA_NUM_GC_THREADS")
-        cmd = `$cmd --gcthreads=$(precompile_gcthreads())`
-    end
     # Only request per-package timing reports when explicitly asked for (e.g. by
     # precompilepkgs), so that the marker lines don't leak into normal load logs.
     report_timing && (cmd = addenv(cmd, "JULIA_PRECOMP_REPORT_TIMING" => 1))


### PR DESCRIPTION
Claude:

---

Precompile workers run with `JULIA_NUM_THREADS=1`, and the runtime derives its mark-thread count from the compute-thread count, so a worker marks its heap on a single thread. That heap holds every loaded dependency plus everything inferred for the package, and the full collections before the image is written are among the largest single-threaded pauses in the worker: about 6% of a standalone Makie worker goes to GC.

This passes `--gcthreads` to the worker, scaled from `Sys.EFFECTIVE_CPU_THREADS ÷ 4` and clamped to 1 to 4, unless `JULIA_NUM_GC_THREADS` is already set in the environment. Collections in a worker are infrequent, so having a few mark threads per worker is fine even with the driver's full worker count running: the extra threads sleep between collections and only a handful of workers collect at the same time.

Measured on macOS aarch64 (M5 Pro, 15 threads, so 3 mark threads per worker), same build:

Standalone `Base.compilecache(Makie)`, two runs each:

| | worker total | include phase |
|---|---|---|
| no GC threads | 41.6s, 41.9s | 28.3s, 28.4s |
| `--gcthreads=3` | 38.9s, 39.7s | 26.5s, 27.2s |

Cold `precompilepkgs` of a CairoMakie environment (248 packages, 16 workers), two runs each:

| | wall | Makie worker | CairoMakie worker |
|---|---|---|---|
| no GC threads | 80.4s, 96.0s | 41.2s, 51.5s | 12.3s, 13.7s |
| `--gcthreads=3` | 77.0s, 79.2s | 39.1s, 40.5s | 11.2s, 11.4s |

The 96s run was the first cold precompile after a test-suite run and is a page-cache outlier; the other three runs are back to back.

Verified with `test/precompile.jl`.
