### PR TITLE
codegen: Lower `invoke_in_world` calls directly

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1043,6 +1043,23 @@ JL_CALLABLE(jl_f__apply_iterate)
     return result;
 }
 
+JL_DLLEXPORT size_t jl_enter_world(size_t world)
+{
+    jl_task_t *ct = jl_current_task;
+    size_t previous_world = ct->world_age;
+    if (!ct->ptls->in_pure_callback) {
+        ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
+        if (ct->world_age > world)
+            ct->world_age = world;
+    }
+    return previous_world;
+}
+
+JL_DLLEXPORT void jl_exit_world(size_t previous_world)
+{
+    jl_current_task->world_age = previous_world;
+}
+
 // this is like a regular call, but always runs in the newest world
 JL_CALLABLE(jl_f_invokelatest)
 {
@@ -1061,17 +1078,11 @@ JL_CALLABLE(jl_f_invokelatest)
 JL_CALLABLE(jl_f_invoke_in_world)
 {
     JL_NARGSV(invoke_in_world, 2);
-    jl_task_t *ct = jl_current_task;
-    size_t last_age = ct->world_age;
     JL_TYPECHK(invoke_in_world, ulong, args[0]);
     size_t world = jl_unbox_ulong(args[0]);
-    if (!ct->ptls->in_pure_callback) {
-        ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-        if (ct->world_age > world)
-            ct->world_age = world;
-    }
+    size_t previous_world = jl_enter_world(world);
     jl_value_t *ret = jl_apply(&args[1], nargs - 1);
-    ct->world_age = last_age;
+    jl_exit_world(previous_world);
     return ret;
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -969,6 +969,16 @@ static const auto jlapplygeneric_func = new JuliaFunction<>{
     get_func_sig,
     get_func_attrs,
 };
+static const auto jlenterworld_func = new JuliaFunction<TypeFnContextAndSizeT>{
+    XSTR(jl_enter_world),
+    [](LLVMContext &C, Type *T_size) { return FunctionType::get(T_size, {T_size}, false); },
+    nullptr,
+};
+static const auto jlexitworld_func = new JuliaFunction<TypeFnContextAndSizeT>{
+    XSTR(jl_exit_world),
+    [](LLVMContext &C, Type *T_size) { return FunctionType::get(getVoidTy(C), {T_size}, false); },
+    nullptr,
+};
 static const auto jlinvoke_func = new JuliaFunction<>{
     XSTR(jl_invoke),
     get_func2_sig,
@@ -4576,6 +4586,30 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
 // returns true if the call has been handled
 {
     ++EmittedBuiltinCalls;
+    if (f == BUILTIN(invoke_in_world) && nargs >= 2 && argv[1].typ == (jl_value_t*)jl_ulong_type) {
+        Value *world = emit_unbox(ctx, ctx.types().T_size, argv[1]);
+        Value *previous_world = ctx.builder.CreateCall(prepare_call(jlenterworld_func), {world});
+        setName(ctx.emission_context, previous_world, "previous_world");
+        CallInst *result = nullptr;
+        if (argv[2].constant && jl_isa(argv[2].constant, (jl_value_t*)jl_builtin_type)) {
+            auto it = builtin_func_map().find(argv[2].constant);
+            if (it != builtin_func_map().end()) {
+                result = emit_jlcall(ctx, it->second,
+                    Constant::getNullValue(ctx.types().T_prjlvalue),
+                    argv.drop_front(3), nargs - 2, julia_call);
+            }
+        }
+        if (result == nullptr)
+            result = emit_jlcall(ctx, jlapplygeneric_func, nullptr,
+                argv.drop_front(2), nargs - 1, julia_call);
+        // An exception skips this call, but the enclosing handler restores the
+        // task state, including the world age saved before `jl_enter_world`.
+        ctx.builder.CreateCall(prepare_call(jlexitworld_func), {previous_world});
+        setName(ctx.emission_context, result, "invoke_in_world_ret");
+        *ret = mark_julia_type(ctx, result, true, rt);
+        return true;
+    }
+
     if (f == BUILTIN(is) && nargs == 2) {
         // emit comparison test
         Value *ans = emit_f_is(ctx, argv[1], argv[2]);
@@ -10925,6 +10959,8 @@ static void init_jit_functions(void)
     for (int i = 0; i < jl_n_builtins; i++)
         add_named_global(jl_builtin_f_names[i], jl_builtin_f_addrs[i]);
     add_named_global(jlapplygeneric_func, &jl_apply_generic);
+    add_named_global(jlenterworld_func, &jl_enter_world);
+    add_named_global(jlexitworld_func, &jl_exit_world);
     add_named_global(jlinvoke_func, &jl_invoke);
     add_named_global(jltopeval_func, &jl_toplevel_eval);
     add_named_global(jlcopyast_func, &jl_copy_ast);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -116,6 +116,7 @@
     XX(jl_eh_restore_state_noexcept) \
     XX(jl_enter_handler) \
     XX(jl_enter_threaded_region) \
+    XX(jl_enter_world) \
     XX(jl_eqtable_get) \
     XX(jl_eqtable_pop) \
     XX(jl_eqtable_put) \
@@ -130,6 +131,7 @@
     XX(jl_exit) \
     XX(jl_exit_on_sigint) \
     XX(jl_exit_threaded_region) \
+    XX(jl_exit_world) \
     XX(jl_field_index) \
     XX(jl_field_isdefined) \
     XX(jl_gc_add_finalizer) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -844,6 +844,8 @@ JL_DLLEXPORT void jl_add_codeinsts_to_jit(jl_array_t *codeinsts, jl_array_t *src
 
 jl_value_t *jl_invoke_oneshot(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *meth) JL_CANSAFEPOINT;
 jl_value_t *jl_invoke_fromdispatch(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *mfunc) JL_CANSAFEPOINT;
+JL_DLLEXPORT size_t jl_enter_world(size_t world) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_exit_world(size_t previous_world) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst_uninit(jl_method_instance_t *mi, jl_value_t *owner) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -403,6 +403,21 @@ wc_aiw2 = get_world_counter()
 @test Base.invoke_in_world(wc_aiw1, g_inworld, 2, y=3) == "world one; x=2, y=3"
 @test Base.invoke_in_world(wc_aiw2, g_inworld, 2, y=3) == "world two; x=2, y=3"
 
+# Compiled world calls preserve builtin dispatch and the caller's task world.
+module CompiledBuiltinWorlds
+const value = 1
+lookup(world::UInt) = Core.invoke_in_world(world, Core.getglobal, @__MODULE__, :value)
+throwing_lookup(world::UInt) = Core.invoke_in_world(world, Core.getfield, (1,), 2)
+end
+wc_sbw1 = get_world_counter()
+Core.eval(CompiledBuiltinWorlds, :(const value = 2))
+wc_sbw2 = get_world_counter()
+@test CompiledBuiltinWorlds.lookup(wc_sbw1) == 1
+@test Core._call_in_world_total(wc_sbw2, CompiledBuiltinWorlds.lookup, wc_sbw1) == 2
+world_before_error = tls_world_age()
+@test_throws BoundsError CompiledBuiltinWorlds.throwing_lookup(wc_sbw1)
+@test tls_world_age() == world_before_error
+
 # logging
 mc48954(x, y) = false
 mc48954(x::Int, y::Int) = x == y


### PR DESCRIPTION
observed pretty reasonable speedups on a few `JuliaInterpreter.@interpret`-ed workloads, ranging from 2% to 18% faster depending on the case. I would not be surprised if it leads to downstream performance improvements to JET, Revise, etc. as well

Inspired by #59075

🤖: Carry the requested world age through codegen as an unboxed native value. Enter that world around an ordinary jlcall, preserving direct builtin dispatch while avoiding the generic builtin path and its boxed world-age argument.

If the callee throws, the enclosing exception handler restores the saved task state, including the caller's world age, matching the runtime builtin's behavior.

Assisted-by: Codex (GPT-5)