### PR TITLE
processor: Disable native x86 BFloat16 codegen

### DIFF
--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -625,10 +625,52 @@ jl_image_t jl_load_pkgimg(jl_image_buf_t image)
     return load_sysimg_target(image, match_pkgimg_target, NULL);
 }
 
+#if defined(_CPU_X86_64_) || defined(_CPU_X86_)
+// LLVM selects vcvtneps2bf16 for f32-to-bf16 conversions despite the
+// instruction unconditionally flushing subnormal inputs. Until LLVM provides
+// a narrower workaround (llvm/llvm-project#221052), disable the feature groups
+// that enable this instruction. This also disables other native x86 BF16
+// operations. Keep the feature bits intact because image matching uses them;
+// only these strings control code generation. Explicit negatives are needed
+// because the CPU name otherwise enables the features again.
+static void disable_native_bf16_codegen(std::string &features) JL_NOTSAFEPOINT
+{
+    static const char *const names[] = {"avx512bf16", "avxneconvert"};
+    std::string out;
+    size_t pos = 0;
+    do {
+        size_t end = features.find(',', pos);
+        if (end == std::string::npos)
+            end = features.size();
+        std::string tok = features.substr(pos, end - pos);
+        bool skip = tok.size() < 2;
+        for (auto name : names)
+            if (!skip && tok.compare(1, std::string::npos, name) == 0)
+                skip = true;
+        if (!skip) {
+            if (!out.empty())
+                out += ',';
+            out += tok;
+        }
+        pos = end + 1;
+    } while (pos <= features.size());
+    for (auto name : names) {
+        if (!out.empty())
+            out += ',';
+        out += '-';
+        out += name;
+    }
+    features = std::move(out);
+}
+#else
+static void disable_native_bf16_codegen(std::string &) JL_NOTSAFEPOINT {}
+#endif
+
 jl_llvm_target_t jl_get_llvm_target(const char *cpu_target, bool imaging)
 {
     init_jit_targets(cpu_target, imaging);
     auto &spec = jit_targets[0];
+    disable_native_bf16_codegen(spec.cpu_features);
     CF_DEBUG("[cpufeatures] jl_get_llvm_target: cpu='%s' features='%s'\n",
              spec.cpu_name.c_str(), spec.cpu_features.c_str());
     return {spec.cpu_name.c_str(), spec.cpu_features.c_str()};
@@ -676,6 +718,7 @@ extern "C" jl_clone_targets_t jl_get_llvm_clone_targets(const char *cpu_target)
         auto &s = specs[i];
         jl_target_spec_t &ele = result.specs[i];
         ele.cpu_name = strdup(s.cpu_name.c_str());
+        disable_native_bf16_codegen(s.cpu_features);
         ele.cpu_features = strdup(s.cpu_features.c_str());
         ele.base = s.base;
         ele.clone_all = (s.flags & tp::TF_CLONE_ALL) != 0;

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -287,6 +287,23 @@ end
 # In function: julia_compiled_fptrunc_3480
 # @test compiled_fptrunc(Core.BFloat16, 1.234) === reinterpret(Core.BFloat16, 0b0_01111111_0011110)
 @test compiled_fptrunc(Float32, 1.234) === 1.234f0
+# Float32 to BFloat16 conversion must preserve subnormals (JuliaMath/BFloat16s.jl#125).
+@noinline compiled_bfloat_fptrunc(x::Float32) = Core.Intrinsics.fptrunc(Core.BFloat16, x)
+let x = reinterpret(Float32, 0x00400000) # 2^-127, exactly the bf16 subnormal 0x0040
+    @test reinterpret(UInt16, compiled_bfloat_fptrunc(x)) === 0x0040
+    @test reinterpret(UInt16, compiled_bfloat_fptrunc(-x)) === 0x8040
+end
+@static if Sys.ARCH === :x86_64 || Sys.ARCH === :i686
+    script = """
+        using InteractiveUtils
+        @noinline f(x::Float32) = Core.Intrinsics.fptrunc(Core.BFloat16, x)
+        code_native(stdout, f, (Float32,); debuginfo=:none, dump_module=false)
+    """
+    for cpu_target in ("native,+avx512bf16,+avx512vl", "native,+avxneconvert")
+        asm = read(`$(Base.julia_cmd(; cpu_target)) --startup-file=no -e $script`, String)
+        @test !occursin("vcvtneps2bf16", asm)
+    end
+end
 @test_throws ErrorException compiled_fptrunc(Float64, 1.234f0)
 @test_throws ErrorException compiled_fptrunc(Int32, 1.234)
 @test_throws ErrorException compiled_fptrunc(Float32, 1234)


### PR DESCRIPTION
The x86 `vcvtneps2bf16` instruction unconditionally treats subnormal `Float32` inputs as signed zero, regardless of MXCSR. LLVM nevertheless uses it for an ordinary `fptrunc float to bfloat` when AVX512BF16 or AVXNECONVERT
is enabled.

This makes the result depend on the target CPU. For example, `2f0^-127` is exactly representable as the BFloat16 value with bits `0x0040`, but the native instruction produces zero. This is the cause of the `nextfloat` and `prevfloat` failures reported in JuliaMath/BFloat16s.jl#125. It is also inconsistent with LLVM's constant folding, which produces `0x0040` for the same conversion.

llvm/llvm-project#221052 proposed making the instruction respect LLVM's `denormal-fp-math` setting, as per LangRef. The LLVM reviewers do not currently want to change the default lowering: they consider BFloat16 denormal semantics unsettled and are concerned about losing native conversion performance for users who do not care about subnormals.

In order to avoid this miscompilation, we should for now remove AVX512BF16 and AVXNECONVERT from the feature strings used for JIT and multiversioning code generation. This is deliberately a correctness-over-performance workaround. Disabling these feature groups sadly also prevents LLVM from using other native x86 BFloat16 instructions, not only `vcvtneps2bf16`.

Fixes JuliaMath/BFloat16s.jl#125.

Assisted-by: Fable 5.1, Sol 5.6