### PR TITLE
codegen: Use at most three integer carriers for small copies

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1213,15 +1213,34 @@ static bool try_emit_typed_copy(jl_codectx_t &ctx, Value *dst, const jl_aliasinf
     jl_datatype_t *dt = (jl_datatype_t*)typ;
     if (dt->layout->flags.haspadding || sz != jl_datatype_size(dt))
         return false;
-    Type *T = julia_type_to_llvm(ctx, typ);
     const DataLayout &DL = ctx.builder.GetInsertBlock()->getModule()->getDataLayout();
-    if (DL.getTypeStoreSize(T) != sz)
+    unsigned copy_bits = sz * 8;
+    unsigned chunk_bits = std::min(copy_bits, DL.getLargestLegalIntTypeSizeInBits());
+    while (chunk_bits >= 8 && (copy_bits % chunk_bits || !isPowerOf2_32(chunk_bits)))
+        chunk_bits -= 8;
+    if (chunk_bits < 8)
         return false;
-    LoadInst *load = ctx.builder.CreateAlignedLoad(T, src, align_src);
-    setName(ctx.emission_context, load, src->getName() + ".copyload");
-    src_ai.decorateInst(load);
-    StoreInst *store = ctx.builder.CreateAlignedStore(load, dst, align_dst);
-    dst_ai.decorateInst(store);
+    unsigned nchunks = copy_bits / chunk_bits;
+    if (nchunks > 3)
+        return false;
+    Type *T = IntegerType::get(ctx.builder.getContext(), chunk_bits);
+    SmallVector<LoadInst*, 3> loads;
+    uint64_t chunk_size = chunk_bits / 8;
+    for (unsigned i = 0; i < nchunks; i++) {
+        uint64_t offset = i * chunk_size;
+        Value *src_chunk = emit_ptrgep(ctx, src, offset);
+        LoadInst *load = ctx.builder.CreateAlignedLoad(T, src_chunk, commonAlignment(align_src, offset));
+        setName(ctx.emission_context, load, src->getName() + ".copyload");
+        src_ai.decorateInst(load);
+        loads.push_back(load);
+    }
+    for (unsigned i = 0; i < nchunks; i++) {
+        uint64_t offset = i * chunk_size;
+        LoadInst *load = loads[i];
+        Value *dst_chunk = emit_ptrgep(ctx, dst, offset);
+        StoreInst *store = ctx.builder.CreateAlignedStore(load, dst_chunk, commonAlignment(align_dst, offset));
+        dst_ai.decorateInst(store);
+    }
     return true;
 }
 

--- a/test/llvmpasses/pipeline-o2.jl
+++ b/test/llvmpasses/pipeline-o2.jl
@@ -82,9 +82,52 @@ end
 # ALL-LABEL: @"julia_copy_complex!
 # ALL: vector.body
 # UNOPT-LABEL: @"julia_copy_complex!
-# UNOPT: [[COPY:%.*]] = load [2 x double]
-# UNOPT: store [2 x double] [[COPY]], ptr addrspace(13)
+# UNOPT: [[COMPLEX0:%.*copyload.*]] = load i64
+# UNOPT: [[COMPLEX1:%.*copyload.*]] = load i64
+# UNOPT: store i64 [[COMPLEX0]], ptr addrspace(13)
+# UNOPT: store i64 [[COMPLEX1]], ptr addrspace(13)
 function copy_complex!(dest, src)
+    @inbounds @simd for i in eachindex(dest, src)
+        dest[i] = src[i]
+    end
+end
+
+# ALL-LABEL: @"julia_copy_bytes!
+# ALL: vector.body
+# UNOPT-LABEL: @"julia_copy_bytes!
+# UNOPT: [[BYTES:%.*copyload.*]] = load i64
+# UNOPT: store i64 [[BYTES]], ptr addrspace(13)
+function copy_bytes!(dest, src)
+    @inbounds @simd for i in eachindex(dest, src)
+        dest[i] = src[i]
+    end
+end
+
+# ALL-LABEL: @"julia_copy_three_bytes!
+# ALL: vector.body
+# UNOPT-LABEL: @"julia_copy_three_bytes!
+# UNOPT: [[BYTES0:%.*copyload.*]] = load i8
+# UNOPT: [[BYTES1:%.*copyload.*]] = load i8
+# UNOPT: [[BYTES2:%.*copyload.*]] = load i8
+# UNOPT: store i8 [[BYTES0]], ptr addrspace(13)
+# UNOPT: store i8 [[BYTES1]], ptr addrspace(13)
+# UNOPT: store i8 [[BYTES2]], ptr addrspace(13)
+function copy_three_bytes!(dest, src)
+    @inbounds @simd for i in eachindex(dest, src)
+        dest[i] = src[i]
+    end
+end
+
+# ALL-LABEL: @"julia_copy_float3!
+# ALL: vector.body
+# UNOPT-LABEL: @"julia_copy_float3!
+# UNOPT: [[FLOAT0:%.*copyload.*]] = load i32
+# UNOPT: [[FLOAT1:%.*copyload.*]] = load i32
+# UNOPT: [[FLOAT2:%.*copyload.*]] = load i32
+# UNOPT: store i32 [[FLOAT0]], ptr addrspace(13)
+# UNOPT: store i32 [[FLOAT1]], ptr addrspace(13)
+# UNOPT: store i32 [[FLOAT2]], ptr addrspace(13)
+function copy_float3!(dest, src)
     @inbounds @simd for i in eachindex(dest, src)
         dest[i] = src[i]
     end
@@ -188,6 +231,9 @@ emit(multiiterate_read, Vector{Int64}, Vector{Int64})
 emit(multiiterate_write, Vector{Int64}, Vector{Int64}, Vector{Int64})
 emit(multiiterate_write!, Vector{Int64}, Vector{Int64})
 emit(copy_complex!, Vector{ComplexF64}, Vector{ComplexF64})
+emit(copy_bytes!, Vector{NTuple{8, UInt8}}, Vector{NTuple{8, UInt8}})
+emit(copy_three_bytes!, Vector{NTuple{3, UInt8}}, Vector{NTuple{3, UInt8}})
+emit(copy_float3!, Vector{NTuple{3, Float32}}, Vector{NTuple{3, Float32}})
 emit(copy_padded!, Vector{PaddedCopy}, Vector{PaddedCopy})
 emit(copy_large!, Vector{LargeCopy}, Vector{LargeCopy})
 


### PR DESCRIPTION
follow-up for a few regressions to https://github.com/JuliaLang/julia/pull/62905 which narrows the condition a bit further (so it is spiritually a partial revert) by requiring, in addition to the original conditions on the type (small, pointerfree, padding-free, non-volatile), that the type can be split into at most three of a single power-of-two-width integer type, no wider than the target’s largest native integer width (`DataLayout::isLegalInteger`)

"three" above is a little bit of a magic number arrived at via benchmarking, affecting primarily the 3, 6, and 12 byte cases.

I tried https://github.com/JuliaLang/julia/pull/62905#issuecomment-5532995202
> It might be better off using a vector uint8 of the right size instead of T

but that rule seemed to perform worse than the one here