### PR TITLE
precompilation: hand worker slots to packages by dependent-chain height

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -45,12 +45,22 @@ end
 # killed mid-imaging), degrading to bounded oversubscription instead of hanging.
 # `ntokens` tracks tokens actually held, so releases only post back while it is
 # positive and tokenless acquires can never over-post.
+#
+# Slots are handed out by priority rather than in request order: a package that a
+# long chain of other packages is waiting on starts before one nothing depends on,
+# so the environment's critical path is not delayed behind leaves that happened to
+# become ready first (see `schedule_priorities`).
 mutable struct WorkerLimiter
-    const sem::Base.Semaphore
+    const cond::Threads.Condition   # guards `active`, `seq` and `waiting`
+    const max::Int
     const jobserver::Bool
+    active::Int
+    seq::Int
+    const waiting::Vector{Tuple{Float64,Int}} # (priority, -request order) of tasks waiting for a slot
     @atomic ntokens::Int
 end
-WorkerLimiter(sem::Base.Semaphore, jobserver::Bool) = WorkerLimiter(sem, jobserver, 0)
+WorkerLimiter(max::Int, jobserver::Bool) =
+    WorkerLimiter(Threads.Condition(), max, jobserver, 0, 0, Tuple{Float64,Int}[], 0)
 
 # How long an acquire keeps polling for a baseline token before proceeding
 # without one. Generous enough that it is only ever hit when the pool has been
@@ -97,13 +107,35 @@ function _jobserver_release_baseline(w::WorkerLimiter)
     end
 end
 
-function Base.acquire(w::WorkerLimiter; cancel=Returns(false))
-    Base.acquire(w.sem)
+function _acquire_slot(w::WorkerLimiter, priority::Float64)
+    @lock w.cond begin
+        key = (priority, -(w.seq += 1))
+        push!(w.waiting, key)
+        # admitted when a slot is free and no waiter outranks us
+        while w.active >= w.max || maximum(w.waiting) != key
+            wait(w.cond)
+        end
+        deleteat!(w.waiting, findfirst(==(key), w.waiting)::Int)
+        w.active += 1
+    end
+    return nothing
+end
+
+function _release_slot(w::WorkerLimiter)
+    @lock w.cond begin
+        w.active -= 1
+        notify(w.cond)
+    end
+    return nothing
+end
+
+function Base.acquire(w::WorkerLimiter; priority::Float64=0.0, cancel=Returns(false))
+    _acquire_slot(w, priority)
     if w.jobserver
         try
             _jobserver_acquire_baseline(w; cancel)
         catch
-            Base.release(w.sem)
+            _release_slot(w)
             rethrow()
         end
     end
@@ -112,12 +144,12 @@ end
 
 function Base.release(w::WorkerLimiter)
     w.jobserver && _jobserver_release_baseline(w)
-    Base.release(w.sem)
+    _release_slot(w)
     return nothing
 end
 
-function Base.acquire(f, w::WorkerLimiter; cancel=Returns(false))
-    Base.acquire(w; cancel)
+function Base.acquire(f, w::WorkerLimiter; priority::Float64=0.0, cancel=Returns(false))
+    Base.acquire(w; priority, cancel)
     try
         return f()
     finally
@@ -2140,25 +2172,76 @@ function precompile_pkgs_maybe_cachefile_lock(f, s::PrecompileSession, pkg_confi
             # wait until the lock is available
             cachefile = @invokelatest Base.mkpidlock_hook(() -> begin
                     job.lock_holder = ""
-                    Base.acquire(f, s.parallel_limiter; cancel=() -> should_stop(s))
+                    # this worker already had a slot before it waited for the lock, so take the next one
+                    Base.acquire(f, s.parallel_limiter; priority=Inf, cancel=() -> should_stop(s))
                 end,
                 pidfile; stale_age)
         finally
-            Base.acquire(s.parallel_limiter; cancel=() -> should_stop(s)) # re-acquire so the outer release is balanced
+            Base.acquire(s.parallel_limiter; priority=Inf, cancel=() -> should_stop(s)) # re-acquire so the outer release is balanced
         end
     end
     return cachefile
+end
+
+# Rough proxy for how long a package takes to precompile, used only to order
+# scheduling: the bytes of Julia source next to its entry file.
+function precompile_cost_estimate(spec::Union{Nothing,Base.PkgLoadSpec})
+    spec === nothing && return 1.0
+    total = 0
+    try
+        for (root, _, files) in walkdir(dirname(spec.path))
+            for f in files
+                endswith(f, ".jl") && (total += filesize(joinpath(root, f)))
+            end
+        end
+    catch
+    end
+    return max(1.0, Float64(total))
+end
+
+# Scheduling priority of each package: its own estimated cost plus that of the
+# longest chain of packages that cannot start until it is done. Handing worker
+# slots out in this order starts the environment's critical path as early as
+# possible; in a cold precompile of a large environment the last package on that
+# path, not the total amount of work, sets the wall-clock time.
+function schedule_priorities(direct_deps::Dict{PkgId,Vector{PkgId}}, cost::Dict{PkgId,Float64})
+    dependents = Dict{PkgId,Vector{PkgId}}()
+    for (pkg, deps) in direct_deps, dep in deps
+        push!(get!(Vector{PkgId}, dependents, dep), pkg)
+    end
+    height = Dict{PkgId,Float64}()
+    visiting = Set{PkgId}()
+    for pkg in keys(direct_deps)
+        schedule_height!(height, visiting, dependents, cost, pkg)
+    end
+    return height
+end
+
+# A top-level function rather than a local one so the recursion does not box it.
+function schedule_height!(height::Dict{PkgId,Float64}, visiting::Set{PkgId},
+                          dependents::Dict{PkgId,Vector{PkgId}}, cost::Dict{PkgId,Float64}, pkg::PkgId)
+    haskey(height, pkg) && return height[pkg]
+    pkg in visiting && return 0.0 # circular dependency, reported elsewhere
+    push!(visiting, pkg)
+    best = 0.0
+    for d in get(dependents, pkg, PkgId[])
+        best = max(best, schedule_height!(height, visiting, dependents, cost, d))
+    end
+    delete!(visiting, pkg)
+    return height[pkg] = get(cost, pkg, 1.0) + best
 end
 
 function spawn_precompile_tasks!(s::PrecompileSession;
         direct_deps, was_processed, configs, circular_deps,
         requested_pkgids, pkg_names, requested_pkgs, from_loading)
     batch_tasks = Task[]
+    sourcespecs = Dict{PkgId,Union{Nothing,Base.PkgLoadSpec}}(pkg => Base.locate_package_load_spec(pkg) for pkg in keys(direct_deps))
+    priorities = schedule_priorities(direct_deps, Dict{PkgId,Float64}(pkg => precompile_cost_estimate(spec) for (pkg, spec) in sourcespecs))
     for (pkg, deps) in direct_deps
         cachepaths = Base.find_all_in_cache_path(pkg)
         freshpaths = String[]
         @lock s.cache_lock s.cachepath_cache[pkg] = freshpaths
-        sourcespec = Base.locate_package_load_spec(pkg)
+        sourcespec = sourcespecs[pkg]
         single_requested_pkg = length(requested_pkgs) == 1 &&
             (pkg in requested_pkgids || pkg.name in pkg_names)
         for config in configs
@@ -2215,7 +2298,7 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                     @lock s.cache_lock push!(freshpaths, freshpath)
                 end
                 if !circular && is_stale
-                    Base.acquire(s.parallel_limiter; cancel=() -> should_stop(s))
+                    Base.acquire(s.parallel_limiter; priority=get(priorities, pkg, 0.0), cancel=() -> should_stop(s))
                     is_serial_dep = pkg in s.serial_deps
                     is_project_dep = pkg in s.project_deps
 
@@ -2809,7 +2892,7 @@ function do_precompile(pkgs::Union{Vector{String}, Vector{PkgId}},
         configs, io, logio, logcalls, fancyprint, hascolor,
         warn_loaded, ignore_loaded, internal_call, strict, _from_loading,
         time_start, print_lock,
-        parallel_limiter=WorkerLimiter(Base.Semaphore(num_tasks), precompile_jobserver !== :none), num_tasks,
+        parallel_limiter=WorkerLimiter(num_tasks, precompile_jobserver !== :none), num_tasks,
         start_loaded_modules=Set{PkgId}(keys(Base.loaded_modules)), requested_pkgids, requested_all,
         direct_deps=graph.direct_deps,
         ext_to_parent=graph.ext_to_parent, parent_to_exts=graph.parent_to_exts,


### PR DESCRIPTION
The gains on this might be small, but I think it might make timing more reliably fast, avoiding bad orders in the current random ordering.

Claude:

---

`precompilepkgs` spawns one task per package, and once a package's dependencies are done that task races the others for a worker slot in request order. In a large environment the packages that the longest dependency chain is waiting on can therefore sit behind leaves nothing depends on, and in a cold precompile it is the last package on that chain, not the total amount of work, that sets the wall-clock time.

This replaces the semaphore in `WorkerLimiter` with a priority wait: each package's priority is an estimate of its own cost (bytes of Julia source next to its entry file) plus the longest chain of packages that cannot start until it is done, and the highest waiter is admitted first. A task that already held a slot before waiting on a cache-file pidlock re-acquires with `Inf` so it is not queued behind new work.

On a cold precompile of a CairoMakie environment (248 packages, 16 workers, macOS aarch64, M5 Pro) this is worth about 2%: 88.2s to 86.5s median wall time, ABBA x2. The gain is small because the tree there is bounded by Makie's own worker phases and, on macOS, by the serialised first-map validation of freshly linked images, neither of which ordering can change; 8 versus 16 slots made no difference either. Verified with `test/precompile.jl`.

