### PR TITLE
ccall: invoke `dlopen(...)` in latest world

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,10 @@ Language changes
   (e.g. `Type{Int} <: Union{DataType,UnionAll}` holds). `isa` and dispatch of type *values* are
   unaffected, and a method on `Type{Int}` remains more specific than one on `DataType`
   ([#33136], [#62141]).
+* The `Libdl.dlopen(lib)` call that the runtime makes on first use of a `ccall` or `cglobal`
+  whose library is a runtime value (e.g. a `LazyLibrary` or a custom type) now runs in the
+  latest world age, as if through `invokelatest`, rather than in the world of the calling
+  code. A `dlopen` method defined after the caller was compiled is now used at that site.
 
 Compiler/Runtime improvements
 -----------------------------

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -975,7 +975,8 @@ However, it is assumed that the library location and handle does not change
 once it is determined, so the result of the call may be cached and reused.
 Therefore, the number of times the `dlopen` expression executes is unspecified,
 and returning different values for multiple calls will result in unspecified
-(but valid) behavior.
+(but valid) behavior. The call runs in the latest world age, as if through
+[`invokelatest`](@ref Base.invokelatest).
 
 ### Computed Function Names
 

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -80,7 +80,13 @@ void *jl_lazy_load_and_lookup(jl_value_t *lib_val, jl_value_t *f_name)
         else if (jl_is_string(lib_val))
             lib_ptr = jl_get_library(jl_string_data(lib_val));
         else if (jl_libdl_dlopen_func != NULL) {
-            lib_ptr = jl_unbox_voidpointer(jl_apply_generic(jl_libdl_dlopen_func, &lib_val, 1));
+            jl_task_t *ct = jl_current_task;
+            size_t last_age = ct->world_age;
+            if (!ct->ptls->in_pure_callback)
+                ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
+            jl_value_t *ret = jl_apply_generic(jl_libdl_dlopen_func, &lib_val, 1);
+            ct->world_age = last_age;
+            lib_ptr = jl_unbox_voidpointer(ret);
         } else
             jl_type_error("cglobal/ccall", (jl_value_t*)jl_symbol_type, lib_val);
     }

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -2165,3 +2165,16 @@ const sym = :ZSTD_versionString
 get_zstd_version() = prefix * unsafe_string(ccall((sym, libzstd), Cstring, ()))
 @test startswith(get_zstd_version(), "Zstd")
 end
+
+# The `dlopen(lib)` that a `ccall` with a runtime library value performs on first use runs
+# in the latest world, like `invokelatest`, so a `dlopen` method defined after the calling
+# code was compiled is still used when the site first executes.
+struct LatestWorldLib end
+const latest_world_lib = LatestWorldLib()
+latest_world_lib_ccall(x) = ccall((:testUcharX, latest_world_lib), Int32, (UInt8,), x)
+function define_dlopen_then_ccall(x)
+    # this method lands in a newer world than the one the enclosing function runs in
+    Core.eval(@__MODULE__, :(Base.Libc.Libdl.dlopen(::LatestWorldLib) = Base.Libc.Libdl.dlopen(libccalltest)))
+    return latest_world_lib_ccall(x)
+end
+@test define_dlopen_then_ccall(3) == ccall((:testUcharX, libccalltest), Int32, (UInt8,), 3)


### PR DESCRIPTION
The world for this runtime invocation was never officially documented but has been the standard task world for a long time. We generally prefer `invokelatest` semantics wherever dispatches are purely dynamic to avoid unnecessary world age troubles, so this PR re-aligns the behavior to that standard.

This simplifies things for upcoming lazy `ccall` work:
  1. The temporary workaround in https://github.com/JuliaLang/julia/pull/62912 and the TypedCallable that we'd like to permanently replace it with both introduce `invokelatest` semantics for part of the `LazyLibrary` interface. That can be special-cased world behavior for that specific callback, but it is still a minor breaking change to `LazyLibrary`. It seems simpler to change the `dlopen(...)` behavior uniformly and take the minor breakage all at once.
  2. This removes the only case where we want to enqueue a call in the target compilation world, but not for the JIT. This was causing some awkwardness in https://github.com/JuliaLang/julia/pull/62910 - This runtime callback is quite unlikely to fire in this particular world if we are JIT'ing, since there is a good chance it (will have) fired in another world already. The `invokelatest` queue handles this more naturally, since the JIT is already aware it should not speculate over what the latest world will be so it is not over-eager when collecting invokes.

This should be truly a "minor" change. I doubt that packages are depending on the existing world age semantics in practice.

To be careful we should run a PkgEval on this before merging though.

Tests provided by Claude Fable 5.1 🤖 .