### PR TITLE
Exact integer calculation in `isapprox`

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -235,7 +235,7 @@ function isapprox(x::Integer, y::Integer;
         return x == y
     else
         # We need to take the difference `max` - `min` when comparing unsigned integers.
-        _x, _y = x < y ? (x, y) : (y, x)
+        _x, _y = minmax(x, y)
         # note: check x == y to avoid NaN comparisons for e.g. rtol=Inf and x==y==0
         return x == y || norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
     end

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -228,17 +228,87 @@ function isapprox(x::Number, y::Number;
          (nans && isnan(x) && isnan(y))
 end
 
+"""
+    _uabsdiff(x::Integer, y::Integer)
+
+The exact `|x - y|`, in a type wide enough to hold it, as [`uabs`](@ref Base.uabs) is for
+`|x|`: `x - y` overflows (`typemax(Int8) - typemin(Int8)`) and `promote(x, y)` throws for a
+mixed signed/unsigned pair with a negative operand (`promote(-1, 0x1)`). Distinct from
+`absdiff`, which returns the raw difference as well and does overflow.
+"""
+_uabsdiff(x::Integer, y::Integer) = x < y ? y - x : x - y
+
+# `Bool` is an `Integer` but not a `BitInteger`, and it promotes to the type of the other
+# operand, so the generic method would overflow for e.g. `_uabsdiff(true, typemin(Int8))`.
+# `false`/`true` convert losslessly to every integer type, which also keeps the pair to one
+# signedness rather than sending it down the mixed path.
+_uabsdiff(x::Bool, y::BitInteger) = _uabsdiff(oftype(y, x), y)
+_uabsdiff(x::BitInteger, y::Bool) = _uabsdiff(x, oftype(x, y))
+
+# Equal signedness: promotion is lossless. `max - min` is at most
+# `typemax(T) - typemin(T)`, so it fits in the unsigned type of the same width.
+function _uabsdiff(x::BitUnsigned, y::BitUnsigned)
+    lo, hi = minmax(x, y)
+    return hi - lo
+end
+function _uabsdiff(x::BitSigned, y::BitSigned)
+    lo, hi = minmax(x, y)
+    # wraps when the signs differ, i.e. mod 2^n which is `hi - lo`
+    return unsigned(hi) - unsigned(lo)
+end
+
+# Mixed signedness, in the common unsigned type: returns `(m, u, d, carried)`, where `u` is
+# `y`, `d` is `|x - y|` reduced mod `2^n`, and `carried` says it wrapped. The exact `|x - y|`
+# is `d` if it did not, and `m + u` in a wider type if it did, `m` then holding `|x|`.
+function _mixed_uabsdiff(x::BitSigned, y::BitUnsigned)
+    U = promote_type(unsigned(typeof(x)), typeof(y))
+    v, u = x % U, y % U # `x % U` is `x` reduced mod `2^nbits(U)`
+    # `ifelse` keeps the sign test a `select`, since the sign of `x` is not predictable.
+    d = ifelse(x < y, u - v, v - u)
+    return -v, u, d, (x < 0) & (d < u) # a carry needs `x < 0` and leaves `d` below `u`
+end
+
+function _uabsdiff(x::BitSigned, y::BitUnsigned)
+    m, u, d, carried = _mixed_uabsdiff(x, y)
+    return carried ? widen(m) + widen(u) : d
+end
+_uabsdiff(x::BitUnsigned, y::BitSigned) = _uabsdiff(y, x)
+
+# Returns `|x - y| <= b`. Only a mixed signed/unsigned pair can exceed the common unsigned
+# type, and only by carrying out of it. No bound in that type reaches a difference that
+# carried. So a wider type is built only for an out-of-range tolerance, and
+# `Int128`/`UInt128` never reaches `BigInt`.
+_uabsdiff_le(x::Integer, y::Integer, b::Real) = _uabsdiff(x, y) <= b
+# The carried case, kept out of the hot path: below 128 bits `widen` is cheap enough to be
+# inlined, which would enlarge the caller. Returning a `Bool` keeps the call from boxing. Its
+# guard stays at the call site, folding away for a bound the unsigned type can hold.
+@noinline _widesum_le(m::T, u::T, b::Real) where {T<:BitUnsigned} = widen(m) + widen(u) <= b
+function _uabsdiff_le(x::BitSigned, y::BitUnsigned, b::Real)
+    m, u, d, carried = _mixed_uabsdiff(x, y)
+    carried & (b > typemax(d)) && return _widesum_le(m, u, b)
+    return (d <= b) & !carried # a carry puts the difference out of range for `b`
+end
+_uabsdiff_le(x::BitUnsigned, y::BitSigned, b::Real) = _uabsdiff_le(y, x, b)
+
+# The `rtol` scale, and whether it overflowed. Overflow means the bound outgrew the type
+# holding it, so it exceeds every representable difference and the comparison is `true`.
+_scaled_rtol(rtol::Real, scale::Integer) = (rtol * scale, false)
+_scaled_rtol(rtol::BitInteger, scale::BitInteger) = mul_with_overflow(promote(rtol, scale)...)
+
 function isapprox(x::Integer, y::Integer;
                   atol::Real=0, rtol::Real=rtoldefault(x,y,atol),
                   nans::Bool=false, norm::Function=abs)
-    if norm === abs && atol < 1 && rtol == 0
-        return x == y
-    else
-        # We need to take the difference `max` - `min` when comparing unsigned integers.
-        _x, _y = minmax(x, y)
-        # note: check x == y to avoid NaN comparisons for e.g. rtol=Inf and x==y==0
-        return x == y || norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
+    # note: check x == y to avoid NaN comparisons for e.g. rtol=Inf and x==y==0
+    if norm === abs
+        atol < 1 && rtol == 0 && return x == y
+        x == y && return true # before the bound, which a negative `rtol` cannot even form
+        # `uabs` rather than `abs` so that `typemin` is exact and `max` cannot promote across
+        # signedness; `abs` is then the identity on it and on the result of `_uabsdiff`
+        b, overflowed = _scaled_rtol(rtol, max(uabs(x), uabs(y)))
+        return overflowed || _uabsdiff_le(x, y, max(atol, b))
     end
+    return x == y ||
+        norm(_uabsdiff(x, y)) <= max(atol, rtol*max(norm(uabs(x)), norm(uabs(y))))
 end
 
 """

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -236,8 +236,7 @@ function isapprox(x::Integer, y::Integer;
     else
         # We need to take the difference `max` - `min` when comparing unsigned integers.
         _x, _y = x < y ? (x, y) : (y, x)
-        # Equal arguments cannot overflow, so keep the `Number` method's guard: without it a
-        # `NaN` tolerance (e.g. `rtol*0 == Inf*0`) would reject them.
+        # note: check x == y to avoid NaN comparisons for e.g. rtol=Inf and x==y==0
         return x == y || norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
     end
 end

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -236,7 +236,9 @@ function isapprox(x::Integer, y::Integer;
     else
         # We need to take the difference `max` - `min` when comparing unsigned integers.
         _x, _y = x < y ? (x, y) : (y, x)
-        return norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
+        # Equal arguments cannot overflow, so keep the `Number` method's guard: without it a
+        # `NaN` tolerance (e.g. `rtol*0 == Inf*0`) would reject them.
+        return x == y || norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
     end
 end
 

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -222,8 +222,8 @@ end
         @test !isapprox(typemin(T), T(0), atol=0.99)
         @test !isapprox(typemin(T), unsigned(T)(0), atol=0.99)
         @test !isapprox(typemin(T), 0, atol=0.99)
-        @test_broken !isapprox(typemin(T), T(0), atol=1)
-        @test_broken !isapprox(typemin(T), unsigned(T)(0), atol=1)
+        @test !isapprox(typemin(T), T(0), atol=1)
+        @test !isapprox(typemin(T), unsigned(T)(0), atol=1)
         @test !isapprox(typemin(T), 0, atol=1)
 
         @test !isapprox(typemin(T)+T(10), T(10))
@@ -232,7 +232,7 @@ end
         @test !isapprox(typemin(T)+T(10), T(10), atol=0.99)
         @test !isapprox(typemin(T)+T(10), unsigned(T)(10), atol=0.99)
         @test !isapprox(typemin(T)+T(10), 10, atol=0.99)
-        @test_broken !isapprox(typemin(T)+T(10), T(10), atol=1)
+        @test !isapprox(typemin(T)+T(10), T(10), atol=1)
         @test !isapprox(typemin(T)+T(10), unsigned(T)(10), atol=1)
         @test !isapprox(typemin(T)+T(10), 10, atol=1)
 
@@ -243,14 +243,14 @@ end
         @test !isapprox(typemin(T), unsigned(T)(0))
         @test !isapprox(typemin(T), T(0), atol=0.99)
         @test !isapprox(typemin(T), unsigned(T)(0), atol=0.99)
-        @test_broken !isapprox(typemin(T), T(0), atol=1)
-        @test_broken !isapprox(typemin(T), unsigned(T)(0), atol=1)
+        @test !isapprox(typemin(T), T(0), atol=1)
+        @test !isapprox(typemin(T), unsigned(T)(0), atol=1)
 
         @test !isapprox(typemin(T)+T(10), T(10))
         @test !isapprox(typemin(T)+T(10), unsigned(T)(10))
         @test !isapprox(typemin(T)+T(10), T(10), atol=0.99)
         @test !isapprox(typemin(T)+T(10), unsigned(T)(10), atol=0.99)
-        @test_broken !isapprox(typemin(T)+T(10), T(10), atol=1)
+        @test !isapprox(typemin(T)+T(10), T(10), atol=1)
         @test !isapprox(typemin(T)+T(10), unsigned(T)(10), atol=1)
 
         @test isapprox(typemin(T), 0.0, rtol=1)
@@ -300,6 +300,70 @@ end
     end
     @test isapprox(0, 0; rtol=Inf)
     @test isapprox(5, 5; atol=NaN)
+end
+
+@testset "isapprox for integers is exact" begin
+    # every value that makes `x - y`, `abs(x)` or `promote(x, y)` misbehave
+    testvals(::Type{Bool}) = (false, true)
+    testvals(::Type{BigInt}) = (-(big(1) << 200), big(-1), big(0), big(1), big(1) << 200)
+    testvals(T) = unique(T[typemin(T), typemin(T)+one(T), zero(T), one(T), T(10),
+                           typemax(T)-one(T), typemax(T)])
+    # `Any` keeps each value in its own type; `vcat` would promote them to a common one
+    values = Any[v for T in (Bool, Base.BitInteger_types..., BigInt) for v in testvals(T)]
+
+    @test all(x -> Base.uabs(x) == abs(big(x)), values)
+
+    wrongdiff, wrongatol, wrongrtol = [], [], []
+    for x in values, y in values
+        bx, by = big(x), big(y)
+        d = abs(bx - by)
+        d == Base._uabsdiff(x, y) || push!(wrongdiff, (x, y))
+        # `atol` alone is the bound, and an integer `rtol` scales an exactly representable
+        # `max(|x|, |y|)`, so both comparisons can be checked against exact arithmetic
+        for atol in (0, 1, 1000)
+            isapprox(x, y; atol) == (d <= atol) || push!(wrongatol, (x, y, atol))
+        end
+        for rtol in (1, 2, 3) # 2 and 3 overflow the scale at the extremes
+            isapprox(x, y; rtol) == (d <= rtol * max(abs(bx), abs(by))) ||
+                push!(wrongrtol, (x, y, rtol))
+        end
+    end
+    @test isempty(wrongdiff)
+    @test isempty(wrongatol)
+    @test isempty(wrongrtol)
+
+    # a mixed signed/unsigned pair used to throw, because `max` and `minmax` promote
+    for T in (Int8, Int16, Int32, Int64, Int128)
+        U = unsigned(T)
+        @test isapprox(typemin(T), U(0); atol=big(2)^(8*sizeof(T)-1))
+        @test !isapprox(typemin(T), U(0); atol=big(2)^(8*sizeof(T)-1) - 1)
+        @test isapprox(typemin(T), typemax(U); atol=big(2)^(8*sizeof(T)-1) + typemax(U))
+        @test !isapprox(typemin(T), typemax(U); atol=big(2)^(8*sizeof(T)-1) + typemax(U) - 1)
+        @test isapprox(typemin(T), T(0); rtol=1)
+    end
+
+    # a difference that carries out of the common unsigned type is decided without one,
+    # so only a tolerance that is itself out of range reaches a wider type
+    for T in (Int8, Int16, Int32, Int64, Int128)
+        U = unsigned(T)
+        @test !isapprox(typemin(T), typemax(U); atol=typemax(U))
+        @test !isapprox(typemax(U), typemin(T); atol=typemax(U))
+        @test !isapprox(typemin(T), typemax(U); atol=NaN)
+        @test isapprox(typemin(T), typemax(U); atol=Inf)
+        @test isapprox(typemin(T), typemax(U); atol=big(typemax(U)) + big(2)^(8*sizeof(T)-1))
+    end
+    # an `rtol` scale that overflows its type still bounds every possible difference
+    for T in Base.BitInteger_types
+        @test isapprox(zero(T), typemax(T); rtol=3)
+        @test isapprox(typemax(T), zero(T); rtol=typemax(T))
+        T <: Signed && @test isapprox(typemin(T), zero(T); rtol=2)
+    end
+
+    let x = Ref{Int128}(typemin(Int128)), y = Ref{UInt128}(typemax(UInt128))
+        carried() = isapprox(x[], y[]; atol=1.0)
+        carried()
+        @test @allocated(carried()) == 0
+    end
 end
 
 @testset "Conversion from floating point to unsigned integer near extremes (#51063)" begin

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -286,6 +286,22 @@ end
     end
 end
 
+@testset "isapprox(x, x) for integers agrees with the `Number` method" begin
+    tolerances = (0, 1, 0.5, 1e-8, Inf, NaN, -1)
+    for T in (Base.BitInteger_types..., BigInt)
+        for x in (T(0), T(5), T === BigInt ? BigInt(1) << 200 : typemax(T))
+            for atol in tolerances, rtol in tolerances
+                # equal arguments cannot overflow, so the `Integer` method has no reason to
+                # deviate from the `Number` method it specializes
+                @test isapprox(x, x; atol, rtol) ==
+                      invoke(isapprox, Tuple{Number,Number}, x, x; atol, rtol) == true
+            end
+        end
+    end
+    @test isapprox(0, 0; rtol=Inf)
+    @test isapprox(5, 5; atol=NaN)
+end
+
 @testset "Conversion from floating point to unsigned integer near extremes (#51063)" begin
     @test_throws InexactError UInt32(4.2949673f9)
     @test_throws InexactError UInt64(1.8446744f19)


### PR DESCRIPTION
This is a follow-up on #62975. While #62975 fixes a single problem with a minimum of changes, the current PR is basically a rewrite of the integer methods of `isapprox`. It fixes all known test errors, adds a lot of easy-to-get-wrong cases as tests and gets these cases correct, too, except the one which would let the specialized method diverge from the general method (the tolerance bounds round when the integers are too large to be stored exactly in the floats).

The resulting performance drop by the fixes might not be acceptable, that's why the relevant part is rewritten. The core idea is to handle the cases without promoting to a type which is wider than the widest of the two input types. Instead a few small, but tricky, helper functions are used to get it right within the limited precision, by e.g. wrapping a lot. This, unfortunately, adds quite some code, although it's mostly comments and documentation, but following through the code is not too easy. I used multiple iterations and this is the optimum I achieved, but suggestions are welcome. However, quite some things are, unfortunately, not without a negative performance impact.

However, the code complexity pays off. The regressions can be limited to a performance drop of ~20% and some of the cases actually got faster. And for all I know this is the first time that the cases are actually correct (within the limits of the generalized method, so this needs a brave soul in the future to fix these, too, if these ever should be fixed). 

:robot: from here on:

Ratios are new/master, min-of-N over 3 interleaved passes (lower is better).

**Floating-point tolerance** (`atol=0.0, rtol=1e-8`)

| pair | ratio |
| --- | --- |
| `Int128`/`Int128` | 0.77x |
| `UInt128`/`UInt128` | 0.93x |
| `Bool`/`Int64` | 1.00x |
| `UInt64`/`UInt64` | 1.00x |
| `Int64`/`Int64` | 1.01x |
| `Int8`/`Int64` | 1.04x |
| `Int128`/`UInt128` | 1.06x |
| `UInt64`/`Int64` | 1.11x |
| `Int64`/`UInt64` | 1.18x |
| `Int8`/`UInt64` | 1.18x |

**Integer tolerance** (`atol=2`, `rtol=0`)

| pair | ratio |
| --- | --- |
| `Int64`/`UInt64` | 0.54x |
| `Int64`/`Int64` | 0.80x |
| `Bool`/`Int64` | 0.83x |
| `Int128`/`UInt128` | 1.04x |

The default fast path (`atol < 1`, `rtol == 0`) is unchanged.

I used Claude Opus 5 with a lot of iterations when creating this PR.