### PR TITLE
MMTk: increment allocation counter in fast path

### DIFF
--- a/src/gc-mmtk/llvm-final-gc-lowering-mmtk.cpp
+++ b/src/gc-mmtk/llvm-final-gc-lowering-mmtk.cpp
@@ -98,12 +98,19 @@ Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
                 builder.SetInsertPoint(fastpath);
                 builder.CreateStore(new_cursor, cursor_ptr);
 
-                // ptls->gc_tls.gc_num.allocd += osize;
+                // ptls->gc_tls_common.gc_num.allocd += osize;
                 auto pool_alloc_pos = ConstantInt::get(Type::getInt64Ty(target->getContext()), offsetof(jl_tls_states_t, gc_tls_common) + offsetof(jl_gc_tls_states_common_t, gc_num));
                 auto pool_alloc_tls = builder.CreateInBoundsGEP(Type::getInt8Ty(target->getContext()), ptls, pool_alloc_pos);
                 auto pool_allocd = builder.CreateAlignedLoad(Type::getInt64Ty(target->getContext()), pool_alloc_tls, Align(sizeof(void *)));
                 auto pool_allocd_total = builder.CreateAdd(pool_allocd, pool_osize);
                 builder.CreateStore(pool_allocd_total, pool_alloc_tls);
+
+                // ptls->gc_tls_common.gc_num.poolalloc++;
+                auto pool_count_pos = ConstantInt::get(Type::getInt64Ty(target->getContext()), offsetof(jl_tls_states_t, gc_tls_common) + offsetof(jl_gc_tls_states_common_t, gc_num) + offsetof(jl_thread_gc_num_common_t, poolalloc));
+                auto pool_count_tls = builder.CreateInBoundsGEP(Type::getInt8Ty(target->getContext()), ptls, pool_count_pos);
+                auto pool_count = builder.CreateAlignedLoad(Type::getInt64Ty(target->getContext()), pool_count_tls, Align(sizeof(void *)));
+                auto pool_count_total = builder.CreateAdd(pool_count, ConstantInt::get(Type::getInt64Ty(target->getContext()), 1));
+                builder.CreateStore(pool_count_total, pool_count_tls);
 
                 auto v_raw = builder.CreateNSWAdd(result, ConstantInt::get(Type::getInt64Ty(target->getContext()), sizeof(jl_taggedvalue_t)));
                 auto v_as_ptr = builder.CreateIntToPtr(v_raw, smallAllocFunc->getReturnType());

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1552,6 +1552,15 @@ end
 # a function that allocates iff no constprop
 @inline maybealloc59278(n, _) = ntuple(i->rand(), n)
 
+# allocates once per iteration; the result escapes so it cannot be optimized away
+const alloc_sink_fastpath = Ref{Any}(nothing)
+@noinline function allocs_inlined_fastpath(n)
+    for i in 1:n
+        alloc_sink_fastpath[] = Ref{Int}(i)
+    end
+    nothing
+end
+
 @testset "Base/timing.jl" begin
     @test Base.jit_total_bytes() >= 0
 
@@ -1575,6 +1584,9 @@ end
     @test ((@allocated treshape59278(X, n, m))==0) == ((@allocations treshape59278(X, n, m))==0)
     # TODO: would be nice to have but not yet reliable
     #@test ((@allocated begin treshape59278(X, n, m) end)==0) == ((@allocations begin treshape59278(X, n, m) end)==0)
+
+    # test that `@allocations` counts the expected number of allocations (even on fastpaths)
+    @test (@allocations allocs_inlined_fastpath(1000)) >= 1000
 
     # test that all wrapped allocations are counted and constprop is not done
     @test (@allocated @noinline maybealloc59278(10, [])) > (@allocated maybealloc59278(10, 0)) > 0


### PR DESCRIPTION
We were maintaining the allocated bytes in `gc_num.allocd` but not the allocation count in `gc_num.poolalloc`. This should fix allocation counts reported by `@allocations` and `@time` / `@timed`

These counts were always broken, but https://github.com/JuliaLang/julia/pull/62905 introduced some codegen changes that affected allocation elision that made the `misc.jl` tests hit this by accident.

Found after investigation of https://buildkite.com/julialang/julia-pr/builds/2070#01a06c76-9fbf-46a0-82cb-61c875d1e955/L1604 by Claude Opus 5 🤖 