### PR TITLE
[`versioninfo`] Use `format_bytes` to display a reasonable number of digits

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -171,7 +171,7 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
     end
 
     if verbose
-        println(io, "  Memory: $(Sys.total_memory()/2^30) GiB ($(Sys.free_memory()/2^20) MiB free)")
+        println(io, "  Memory: $(Base.format_bytes(Sys.total_memory())) ($(Base.format_bytes(Sys.free_memory())) free)")
         try println(io, "  Uptime: $(Sys.uptime()) sec"); catch; end
         print(io, "  Load Avg: ")
         Base.print_matrix(io, Sys.loadavg()')


### PR DESCRIPTION
When I opened https://github.com/JuliaLang/julia/pull/61390, I wanted it to be the least controversial as possible to make it easier to merge. 

I didn't use `format_bytes` for the memory reporting since it's not public, but it's already used and imported in the same file, and it makes the memory info line go from this on nightly:
```
  Memory: 30.839019775390625 GiB (17268.78125 MiB free)
```
to a more reasonable number of digits:
```
  Memory: 30.839 GiB (16.872 GiB free)
```

My other `versioninfo` improvement PRs: #62960, #63029