### PR TITLE
precompilation: sample precompile workers with the runtime profiler

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3419,9 +3419,91 @@ end
 const newly_inferred = []
 
 # this is called in the external process that generates precompiled package files
+# Sampling profiler for a precompile worker, enabled by pointing
+# `JULIA_PRECOMPILE_PROFILE` at a directory. Every worker then writes
+# `<pkg>-<pid>.profdata`, the raw sample buffer, and `<pkg>-<pid>.profsyms`, its
+# instruction pointers resolved to stack frames. The dump is deliberately split
+# that way because an instruction pointer can only be resolved by the process
+# that recorded it, while everything else is better done afterwards in a session
+# that can load Profile. See the "Profiling package precompilation" devdocs.
+#
+# This runs inside the worker, so it only uses `ccall` and `Base.StackTraces`:
+# loading a package here would place it in the output image's dependency list.
+const _precompile_profile_nmeta = 4 # threadid, taskid, cpu_cycle_clock, sleepstate
+
+function _precompile_profile_start(pkg::PkgId)
+    dir = get(ENV, "JULIA_PRECOMPILE_PROFILE", "")
+    isempty(dir) && return nothing
+    delay = something(tryparse(Float64, get(ENV, "JULIA_PRECOMPILE_PROFILE_DELAY", "")), 0.001)
+    nsamples = something(tryparse(Int, get(ENV, "JULIA_PRECOMPILE_PROFILE_NSAMPLES", "")), 10_000_000)
+    status = ccall(:jl_profile_init, Cint, (Csize_t, UInt64), nsamples, round(UInt64, 1e9 * delay))
+    if status != 0
+        @warn "Could not allocate the precompile profile buffer" pkg status
+        return nothing
+    end
+    status = ccall(:jl_profile_start_timer, Cint, (Bool,), false)
+    if status != 0
+        @warn "Could not start the precompile profiler" pkg status
+        return nothing
+    end
+    prefix = joinpath(abspath(dir), string(pkg.name, "-", getpid()))
+    # `_postoutput` runs after the package image has been written, so dumping
+    # there covers image generation as well as `include`. It only runs when
+    # native code is emitted; without it, fall back to `atexit`, which runs
+    # before the `.ji` is written and so covers `include` alone.
+    if JLOptions().outputo != C_NULL
+        postoutput(() -> _precompile_profile_dump(prefix))
+    else
+        atexit(() -> _precompile_profile_dump(prefix))
+    end
+    return nothing
+end
+
+function _precompile_profile_dump(prefix::String)
+    ccall(:jl_profile_stop_timer, Cvoid, ())
+    len = Int(ccall(:jl_profile_len_data, Csize_t, ()))
+    ptr = convert(Ptr{UInt}, ccall(:jl_profile_get_data, Ptr{UInt8}, ()))
+    data = Vector{UInt}(undef, len)
+    unsafe_copyto!(pointer(data), ptr, len)
+    try
+        mkpath(dirname(prefix))
+        open(prefix * ".profdata", "w") do io
+            write(io, data)
+        end
+        # Mark the metadata trailer of each block so it is not mistaken for an
+        # instruction pointer: a block ends with the four metadata fields
+        # followed by two null entries.
+        meta = falses(len)
+        for i in (_precompile_profile_nmeta + 2):len
+            if data[i] == 0 && data[i-1] == 0 && data[i-2] != 0
+                meta[(i-_precompile_profile_nmeta-1):i] .= true
+            end
+        end
+        ips = Set{UInt}()
+        for i in 1:len
+            (meta[i] || data[i] == 0) && continue
+            push!(ips, data[i])
+        end
+        open(prefix * ".profsyms", "w") do io
+            println(io, "# ip\tinlined\tline\tfrom_c\tfunc\tfile")
+            for ip in ips, sf in StackTraces.lookup(convert(Ptr{Cvoid}, ip))
+                println(io, ip, '\t', sf.inlined ? 1 : 0, '\t', sf.line, '\t',
+                        sf.from_c ? 1 : 0, '\t', sf.func, '\t', sf.file)
+            end
+        end
+        if ccall(:jl_profile_is_buffer_full, Cint, ()) != 0
+            @warn "The precompile profile buffer filled up; raise JULIA_PRECOMPILE_PROFILE_NSAMPLES or JULIA_PRECOMPILE_PROFILE_DELAY" prefix
+        end
+    catch ex
+        @warn "Could not write the precompile profile" prefix exception=(ex, catch_backtrace())
+    end
+    return nothing
+end
+
 function include_package_for_output(pkg::PkgId, input::String, syntax_version::VersionNumber, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String},
                                     concrete_deps::typeof(_concrete_dependencies), source::Union{Nothing,String},
                                     preresolved::Vector{Pair{PkgId,String}}=Pair{PkgId,String}[])
+    _precompile_profile_start(pkg)
 
     @lock require_lock begin
     m = start_loading(pkg, UInt128(0), false)
@@ -3517,7 +3599,7 @@ const PRECOMPILE_VERBOSE_TIMING_MARKER = "__JL_PRECOMP_VERBOSE_TIMING__"
 function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, output_o::Union{Nothing, String},
                            concrete_deps::typeof(_concrete_dependencies), flags::Cmd=``, cacheflags::CacheFlags=CacheFlags(),
                            internal_stderr::IO = stderr, internal_stdout::IO = stdout, loadable_exts::Union{Vector{PkgId},Nothing}=nothing;
-                           report_timing::Bool=false,
+                           report_timing::Bool=false, profile_dir::Union{Nothing,String}=nothing,
                            preresolved::Vector{Pair{PkgId,String}} = @lock(require_lock, collect(preresolved_cachefiles)))
     @nospecialize internal_stderr internal_stdout
     depot_path = String[abspath(x) for x in DEPOT_PATH]
@@ -3574,6 +3656,8 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
     # Only request per-package timing reports when explicitly asked for (e.g. by
     # precompilepkgs), so that the marker lines don't leak into normal load logs.
     report_timing && (cmd = addenv(cmd, "JULIA_PRECOMP_REPORT_TIMING" => 1))
+    # Ask this worker to profile itself; see `_precompile_profile_start`.
+    profile_dir === nothing || (cmd = addenv(cmd, "JULIA_PRECOMPILE_PROFILE" => profile_dir))
     io = open(pipeline(cmd, stderr = internal_stderr, stdout = internal_stdout),
               "w", stdout)
     # write data over stdin to avoid the (unlikely) case of exceeding max command line size
@@ -3637,11 +3721,11 @@ This can be used to reduce package load times. Cache files are stored in
 `DEPOT_PATH[1]/compiled`. See [Module initialization and precompilation](@ref)
 for important notes.
 """
-function compilecache(pkg::PkgId, internal_stderr::IO = stderr, internal_stdout::IO = stdout; flags::Cmd=``, cacheflags::CacheFlags=CacheFlags(), loadable_exts::Union{Vector{PkgId},Nothing}=nothing, signal_channel::Union{Channel{Int32},Nothing}=nothing, report_timing::Bool=false)
+function compilecache(pkg::PkgId, internal_stderr::IO = stderr, internal_stdout::IO = stdout; flags::Cmd=``, cacheflags::CacheFlags=CacheFlags(), loadable_exts::Union{Vector{PkgId},Nothing}=nothing, signal_channel::Union{Channel{Int32},Nothing}=nothing, report_timing::Bool=false, profile_dir::Union{Nothing,String}=nothing)
     @nospecialize internal_stderr internal_stdout
     spec = locate_package_load_spec(pkg)
     spec === nothing && throw(ArgumentError("$(repr("text/plain", pkg)) not found during precompilation"))
-    return compilecache(pkg, spec, internal_stderr, internal_stdout; flags, cacheflags, loadable_exts, signal_channel, report_timing)
+    return compilecache(pkg, spec, internal_stderr, internal_stdout; flags, cacheflags, loadable_exts, signal_channel, report_timing, profile_dir)
 end
 
 const MAX_NUM_PRECOMPILE_FILES = Ref(10)
@@ -3650,6 +3734,7 @@ function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stder
                       keep_loaded_modules::Bool = true; flags::Cmd=``, cacheflags::CacheFlags=CacheFlags(),
                       loadable_exts::Union{Vector{PkgId},Nothing}=nothing, signal_channel::Union{Channel{Int32},Nothing}=nothing,
                       pid_channel::Union{Channel{Int32},Nothing}=nothing, report_timing::Bool=false,
+                      profile_dir::Union{Nothing,String}=nothing,
                       preresolved::Vector{Pair{PkgId,String}} = @lock(require_lock, collect(preresolved_cachefiles)))
 
     @nospecialize internal_stderr internal_stdout
@@ -3688,7 +3773,7 @@ function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stder
             close(tmpio_o)
             close(tmpio_so)
         end
-        p = create_expr_cache(pkg, spec, tmppath, tmppath_o, concrete_deps, flags, cacheflags, internal_stderr, internal_stdout, loadable_exts; report_timing, preresolved)
+        p = create_expr_cache(pkg, spec, tmppath, tmppath_o, concrete_deps, flags, cacheflags, internal_stderr, internal_stdout, loadable_exts; report_timing, profile_dir, preresolved)
 
         # Report the PID of the compilation subprocess
         if pid_channel !== nothing

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -279,12 +279,14 @@ mutable struct BackgroundPrecompileState
     confirm_deadline::Float64  # time() deadline for confirmation
     info_requested::Bool  # whether SIGINFO/SIGUSR1 has been broadcast at least once
     key_listening::Bool  # whether a key listener task is currently consuming stdin
+    profile_dir::Union{Nothing, String}  # directory for worker profile dumps, or nothing to not profile
+    profile_pkgs::Union{Nothing, Set{String}}  # packages to profile, or nothing for all of them
 end
 Base.lock(f, bg::BackgroundPrecompileState) = lock(f, bg.lock)
 Base.lock(bg::BackgroundPrecompileState) = lock(bg.lock)
 Base.unlock(bg::BackgroundPrecompileState) = unlock(bg.lock)
 
-const BG = BackgroundPrecompileState(nothing, false, false, false, nothing, nothing, nothing, nothing, ReentrantLock(), Threads.Condition(), Channel{Int32}[], Dict{PkgId, Int}(), Set{PkgId}(), Threads.Condition(), Channel{PrecompileRequest}(Inf), false, false, :none, 0.0, false, false)
+const BG = BackgroundPrecompileState(nothing, false, false, false, nothing, nothing, nothing, nothing, ReentrantLock(), Threads.Condition(), Channel{Int32}[], Dict{PkgId, Int}(), Set{PkgId}(), Threads.Condition(), Channel{PrecompileRequest}(Inf), false, false, :none, 0.0, false, false, nothing, nothing)
 
 # Serializes the inject-vs-launch decision in `_precompilepkgs` with the launch
 # itself. Lock ordering: acquired before (outside) BG.lock, never while holding it.
@@ -1105,6 +1107,14 @@ precompiles only the given packages and their dependencies (unless
                   samples may be missed. Linux/macOS only, `-` elsewhere.
   Values under 5 ms and zero counts are dimmed for readability.
 
+- `profile::Union{Bool,AbstractString,AbstractVector{<:AbstractString}}`: When not `false`,
+  each selected package's worker samples itself and writes its profile to a file. Pass `true`
+  for every package, or a package name or list of names to profile only those. The dumps are
+  read back in a separate session; see the "Profiling package precompilation" devdocs.
+
+- `profile_dir::Union{Nothing,AbstractString}`: Where to write those dumps. Defaults to a
+  fresh temporary directory, whose path is printed when profiling starts.
+
 - `_from_loading::Bool`: Internal flag indicating the call originated from the
   package loading system. When `true` (not default): returns early instead of
   throwing when packages are not found; suppresses progress messages when not
@@ -1175,6 +1185,48 @@ function preresolved_snapshot(s::PrecompileSession)
     @lock s.cache_lock Pair{Base.PkgId,String}[k => first(v) for (k, v) in s.cachepath_cache if !isempty(v)]
 end
 
+# Turn the `profile` / `profile_dir` keywords of `precompilepkgs` into the
+# settings that `spawn_precompile_tasks!` hands to each worker. Kept on `BG`
+# rather than on the session so a request merged into a running background run
+# picks it up, the same way `verbose` does.
+function setup_worker_profiling!(profile, profile_dir, io)
+    if profile === false
+        if profile_dir !== nothing
+            throw(ArgumentError("`profile_dir` was given but `profile` is false; pass `profile=true` to enable profiling"))
+        end
+        # clear any setting left by an earlier profiling run
+        @lock BG begin
+            BG.profile_dir = nothing
+            BG.profile_pkgs = nothing
+        end
+        return nothing
+    end
+    pkgs = if profile === true
+        nothing
+    elseif profile isa AbstractString
+        Set{String}((profile,))
+    else
+        Set{String}(profile)
+    end
+    dir = profile_dir === nothing ? mktempdir(; prefix="jl_precompile_profile_", cleanup=false) : abspath(String(profile_dir))
+    mkpath(dir)
+    @lock BG begin
+        BG.profile_dir = dir
+        BG.profile_pkgs = pkgs
+    end
+    which = pkgs === nothing ? "all packages" : join(sort!(collect(pkgs)), ", ")
+    printpkgstyle(io, :Profiling, "$which into $dir", color = Base.info_color())
+    return nothing
+end
+
+# The directory this package's worker should dump its profile into, or `nothing`.
+function worker_profile_dir(pkg::PkgId)
+    dir, pkgs = @lock BG (BG.profile_dir, BG.profile_pkgs)
+    dir === nothing && return nothing
+    (pkgs === nothing || pkg.name in pkgs) || return nothing
+    return dir
+end
+
 function precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}}=String[];
                         internal_call::Bool=false,
                         strict::Bool = false,
@@ -1189,10 +1241,13 @@ function precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}}=String[];
                         fancyprint::Bool = can_fancyprint(io) && !timing && !verbose,
                         manifest::Bool=false,
                         ignore_loaded::Bool=true,
-                        detachable::Bool=false)
+                        detachable::Bool=false,
+                        profile::Union{Bool,AbstractString,AbstractVector{<:AbstractString}}=false,
+                        profile_dir::Union{Nothing,AbstractString}=nothing)
     # verbose timing mode requires timing to be enabled (per-package breakdown
     # is only shown alongside timing lines in non-fancy mode)
     verbose && (timing = true)
+    setup_worker_profiling!(profile, profile_dir, io)
     @debug "precompilepkgs called with" pkgs internal_call strict warn_loaded timing verbose _from_loading configs fancyprint manifest ignore_loaded detachable
     # monomorphize this to avoid latency problems
     _precompilepkgs(pkgs, internal_call, strict, warn_loaded, timing, verbose, _from_loading,
@@ -2255,6 +2310,7 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                                 Base.compilecache(pkg, sourcespec, std_pipe, std_pipe, !s.ignore_loaded;
                                                   flags=flags_, cacheflags, loadable_exts, signal_channel=make_signal_channel(),
                                                   pid_channel=pid_ch, report_timing=true,
+                                                  profile_dir=worker_profile_dir(pkg),
                                                   preresolved=preresolved_snapshot(s))
                             end
                         else
@@ -2281,6 +2337,7 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                                 Base.compilecache(pkg, sourcespec, std_pipe, std_pipe, !s.ignore_loaded;
                                                   flags=flags_, cacheflags, loadable_exts, signal_channel=make_signal_channel(),
                                                   pid_channel=pid_ch, report_timing=true,
+                                                  profile_dir=worker_profile_dir(pkg),
                                                   preresolved=preresolved_snapshot(s))
                             end
                         end

--- a/contrib/read_precompile_profile.jl
+++ b/contrib/read_precompile_profile.jl
@@ -1,0 +1,54 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Read a profile written by a precompilation worker, as enabled by
+# `precompilepkgs(profile=...)` or the `JULIA_PRECOMPILE_PROFILE` environment
+# variable, and hand it to `Profile` for analysis.
+#
+#     include("contrib/read_precompile_profile.jl")
+#     data, lidict = read_precompile_profile("/tmp/jl_precompile_profile_XXXX/Makie-12345")
+#     Profile.print(; C=true)  # see the docstring below for the exact call
+#
+# The worker writes two files because instruction pointers can only be resolved
+# in the process that recorded them: `<prefix>.profdata` holds the raw sample
+# buffer and `<prefix>.profsyms` the stack frames those pointers resolve to.
+
+using Profile
+using Base.StackTraces: StackFrame
+
+"""
+    read_precompile_profile(prefix) -> (data, lidict)
+
+Load the precompile-worker profile written to `\$prefix.profdata` and
+`\$prefix.profsyms`. `prefix` may also be either of those paths.
+
+The result is accepted directly by the `Profile` reporting functions:
+
+```julia
+data, lidict = read_precompile_profile(prefix)
+Profile.print(stdout, data, lidict; C=true, format=:tree)
+```
+"""
+function read_precompile_profile(prefix::AbstractString)
+    prefix = replace(String(prefix), r"\.(profdata|profsyms)$" => "")
+    data = collect(reinterpret(UInt, read(prefix * ".profdata")))
+    lidict = Dict{UInt64,Vector{StackFrame}}()
+    for line in eachline(prefix * ".profsyms")
+        (isempty(line) || startswith(line, '#')) && continue
+        ip_str, inlined, lineno, from_c, func, file = split(line, '\t'; limit=6)
+        ip = parse(UInt64, ip_str)
+        frame = StackFrame(Symbol(func), Symbol(file), parse(Int, lineno), nothing,
+                           from_c == "1", inlined == "1", ip)
+        push!(get!(Vector{StackFrame}, lidict, ip), frame)
+    end
+    return data, lidict
+end
+
+"""
+    print_precompile_profile(prefix; kwargs...)
+
+Read the profile at `prefix` and print it, passing `kwargs` on to `Profile.print`.
+"""
+function print_precompile_profile(prefix::AbstractString; io::IO=stdout, kwargs...)
+    data, lidict = read_precompile_profile(prefix)
+    Profile.print(io, data, lidict; kwargs...)
+end

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -361,6 +361,7 @@ DevDocs = [
         "devdocs/valgrind.md",
         "devdocs/gc-debug.md",
         "devdocs/external_profilers.md",
+        "devdocs/precompile_profiling.md",
         "devdocs/sanitizers.md",
         "devdocs/probes.md",
     ],

--- a/doc/src/devdocs/external_profilers.md
+++ b/doc/src/devdocs/external_profilers.md
@@ -89,6 +89,8 @@ end
 
 Here, we use a custom port for tracy which makes it easier to find the correct client in the Tracy UI to connect to.
 
+For sampled stack traces of the same worker processes, rather than the zones described here, see [Profiling package precompilation](@ref).
+
 ### Adding metadata to zones
 
 The various `jl_timing_show_*` and `jl_timing_printf` functions can be used to attach a string (or strings) to a zone. For example, the trace zone for inference shows the method instance that is being inferred.

--- a/doc/src/devdocs/precompile_profiling.md
+++ b/doc/src/devdocs/precompile_profiling.md
@@ -6,9 +6,12 @@ that session therefore shows you the driver waiting on its children and nothing 
 the time actually went. This page describes how to sample the workers themselves with the
 [`Profile`](@ref lib-profiling) stdlib.
 
-For zone-level timing of the same processes, such as how long inference or image generation
-took as labelled regions rather than as sampled stacks, see
-[Profiling package precompilation with Tracy](@ref).
+This complements Tracy rather than replacing it. Tracy can also sample call stacks in a
+worker, see [Enabling stack trace samples](@ref), and its sampler covers every thread in the
+process, including the image-generation threads this profiler cannot see, alongside the
+labelled zones and a timeline. What this page offers instead is a profile from any build,
+without `WITH_TRACY`, with the JIT-compiled Julia frames resolved, which Tracy's sampler does
+not yet do, in a form the `Profile` tooling already reads.
 
 ## Collecting a profile
 
@@ -86,7 +89,8 @@ instead, because the hook it dumps from only runs when native code is emitted.
     libuv threads that have no Julia thread state, so the profiler cannot see them: every
     sample comes from the worker's main thread. What that thread does while the shards run is
     wait, which shows up as `uv_thread_join` and was 12% of one measured worker. To see inside
-    image generation, use `JULIA_IMAGE_TIMINGS=1` for the per-shard timers, or Tracy.
+    image generation, use `JULIA_IMAGE_TIMINGS=1` for the per-shard timers, or Tracy's sampler,
+    which enumerates every thread in the process.
   * The effective sampling rate is lower than the requested one, because each sample has to
     unwind a deep stack. One worker running for about 10 s produced roughly 5,000 samples at a
     nominal 1 ms period. Read the profile as proportions, not as wall-clock time.

--- a/doc/src/devdocs/precompile_profiling.md
+++ b/doc/src/devdocs/precompile_profiling.md
@@ -82,6 +82,17 @@ instead, because the hook it dumps from only runs when native code is emitted.
 
 ## Caveats
 
+  * **Only Julia threads are sampled.** A worker's parallel image generation runs on raw
+    libuv threads that have no Julia thread state, so the profiler cannot see them: every
+    sample comes from the worker's main thread. What that thread does while the shards run is
+    wait, which shows up as `uv_thread_join` and was 12% of one measured worker. To see inside
+    image generation, use `JULIA_IMAGE_TIMINGS=1` for the per-shard timers, or Tracy.
+  * The effective sampling rate is lower than the requested one, because each sample has to
+    unwind a deep stack. One worker running for about 10 s produced roughly 5,000 samples at a
+    nominal 1 ms period. Read the profile as proportions, not as wall-clock time.
+  * Self time and inclusive time say very different things here. Type inference was 47% of one
+    worker inclusive but 9% by innermost frame, because its leaves are the runtime's own
+    subtyping and method lookup, which are attributed to those C functions instead.
   * Resolving symbols happens in the worker after sampling stops, and shows up in the worker's
     reported total time. Wall-clock numbers from a profiled run are not comparable with an
     unprofiled one; take timings separately.

--- a/doc/src/devdocs/precompile_profiling.md
+++ b/doc/src/devdocs/precompile_profiling.md
@@ -1,0 +1,91 @@
+# Profiling package precompilation
+
+Most of the work of precompiling a package happens in a short-lived worker process that the
+precompilation driver spawns, not in the session you typed `Pkg.precompile()` into. Profiling
+that session therefore shows you the driver waiting on its children and nothing about where
+the time actually went. This page describes how to sample the workers themselves with the
+[`Profile`](@ref lib-profiling) stdlib.
+
+For zone-level timing of the same processes, such as how long inference or image generation
+took as labelled regions rather than as sampled stacks, see
+[Profiling package precompilation with Tracy](@ref).
+
+## Collecting a profile
+
+The driver can turn on sampling for the workers it spawns:
+
+```julia
+using Base.Precompilation
+precompilepkgs(; profile = true)                       # every package
+precompilepkgs(; profile = "Makie")                    # just this one
+precompilepkgs(; profile = ["Makie", "CairoMakie"])    # or these
+precompilepkgs(; profile = true, profile_dir = "/tmp/profiles")
+```
+
+Each selected worker writes two files into the profile directory, named after the package and
+the worker's process id. The directory defaults to a fresh temporary one and is printed when
+the run starts.
+
+The same thing can be driven from the environment, which is useful when the precompilation is
+started by something other than a direct `precompilepkgs` call, such as `Pkg.precompile()`,
+`Pkg.add`, or a package being loaded for the first time:
+
+```
+JULIA_PRECOMPILE_PROFILE=/tmp/profiles julia --project -e 'using Pkg; Pkg.precompile()'
+```
+
+Every worker spawned under that variable profiles itself, so this is the blunt instrument;
+the `profile` keyword above is usually what you want.
+
+[`JULIA_PRECOMPILE_PROFILE_DELAY`](@ref JULIA_PRECOMPILE_PROFILE_DELAY) and
+[`JULIA_PRECOMPILE_PROFILE_NSAMPLES`](@ref JULIA_PRECOMPILE_PROFILE_NSAMPLES) set the sampling
+period in seconds and the buffer size in samples. They default to the same values as
+`Profile.init`, a 1 ms period and a 10 million entry buffer, which is about 80 MB per worker.
+A warning is printed if the buffer fills.
+
+## Reading a profile
+
+The worker writes `<pkg>-<pid>.profdata`, the raw sample buffer, and `<pkg>-<pid>.profsyms`,
+the stack frames its instruction pointers resolve to. The two are separate because an
+instruction pointer only means something in the process that recorded it, so the worker has to
+resolve its own symbols, while everything else is better done later in a session that can load
+`Profile`.
+
+`contrib/read_precompile_profile.jl` turns the pair back into the arguments the `Profile`
+reporting functions take:
+
+```julia
+include("contrib/read_precompile_profile.jl")
+data, lidict = read_precompile_profile("/tmp/profiles/Makie-64321")
+Profile.print(stdout, data, lidict; C = true, format = :flat, sortedby = :count)
+```
+
+Keep `C = true`. A precompile worker spends much of its time inside the runtime and LLVM, and
+those frames disappear from the report without it.
+
+The same `data` and `lidict` can be handed to any package that consumes `Profile` output, such
+as `ProfileView`, `PProf` or `FlameGraphs`, which is usually an easier way to read a worker's
+profile than the textual tree.
+
+## What the profile covers
+
+Sampling starts when the worker begins loading the package's dependencies and stops after the
+package image has been written, so it covers dependency loading, lowering, type inference,
+code generation, and image generation. Two things are outside it:
+
+  * The driver process, including the dependency resolution and the linker and `dsymutil`
+    invocations that run after the worker exits.
+  * Workers for packages that were already up to date, which are never spawned.
+
+If a package is precompiled with pkgimages disabled, the profile stops at the end of `include`
+instead, because the hook it dumps from only runs when native code is emitted.
+
+## Caveats
+
+  * Resolving symbols happens in the worker after sampling stops, and shows up in the worker's
+    reported total time. Wall-clock numbers from a profiled run are not comparable with an
+    unprofiled one; take timings separately.
+  * The buffer is allocated per worker, so profiling every package in a large environment with
+    many parallel workers costs memory. Prefer naming the packages you care about.
+  * Sampling perturbs what it measures. Treat the shape of the profile as the result, not the
+    absolute times.

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -577,6 +577,21 @@ This allows developers to get detailed debugging information from CI runs withou
 Enable collecting of a heap snapshot during execution via the profiling peek mechanism.
 See [Triggered During Execution](@ref).
 
+### [`JULIA_PRECOMPILE_PROFILE`](@id JULIA_PRECOMPILE_PROFILE)
+
+If set to a directory, every package precompilation worker samples itself and writes its
+profile there. See [Profiling package precompilation](@ref).
+
+### [`JULIA_PRECOMPILE_PROFILE_DELAY`](@id JULIA_PRECOMPILE_PROFILE_DELAY)
+
+The sampling period in seconds used when `JULIA_PRECOMPILE_PROFILE` is set. Defaults to
+`0.001`.
+
+### [`JULIA_PRECOMPILE_PROFILE_NSAMPLES`](@id JULIA_PRECOMPILE_PROFILE_NSAMPLES)
+
+The size of each worker's profile buffer, in samples, used when
+`JULIA_PRECOMPILE_PROFILE` is set. Defaults to `10000000`.
+
 ### [`JULIA_TIMING_SUBSYSTEMS`](@id JULIA_TIMING_SUBSYSTEMS)
 
 Allows you to enable or disable zones for a specific Julia run.

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3850,4 +3850,45 @@ if !Sys.iswindows() # child-on-fake-pty tests are skipped on Windows (see misc.j
     end
 end
 
+# Worker-side precompile profiling: `profile_dir` makes the worker sample itself and
+# write a raw buffer plus the symbols those samples resolve to.
+@testset "precompile profiling" begin
+    mkdepottempdir() do depot; mktempdir() do dir
+        pkgpath = joinpath(dir, "ProfMe")
+        mkpath(joinpath(pkgpath, "src"))
+        write(joinpath(pkgpath, "Project.toml"),
+              """
+              name = "ProfMe"
+              uuid = "b2b2b2b2-0000-0000-0000-000000000002"
+              version = "0.1.0"
+              """)
+        write(joinpath(pkgpath, "src", "ProfMe.jl"),
+              """
+              module ProfMe
+              f(x) = sum(abs2, x) + length(string(x))
+              precompile(f, (Vector{Int},))
+              end
+              """)
+        profdir = joinpath(dir, "profiles")
+        pushfirst!(LOAD_PATH, dir)
+        try
+            pkg = Base.identify_package("ProfMe")
+            @test pkg !== nothing
+            @test Base.compilecache(pkg; profile_dir=profdir) isa Tuple
+            dumps = filter(f -> startswith(f, "ProfMe-"), readdir(profdir))
+            @test count(endswith(".profdata"), dumps) == 1
+            @test count(endswith(".profsyms"), dumps) == 1
+            prefix = joinpath(profdir, chopsuffix(only(filter(endswith(".profdata"), dumps)), ".profdata"))
+            # the raw buffer is a `Vector{UInt}`, and every symbol line names a frame
+            @test filesize(prefix * ".profdata") % sizeof(UInt) == 0
+            syms = filter(l -> !startswith(l, "#"), readlines(prefix * ".profsyms"))
+            @test !isempty(syms)
+            @test all(l -> length(split(l, '\t')) == 6, syms)
+            @test all(l -> tryparse(UInt64, first(split(l, '\t'))) !== nothing, syms)
+        finally
+            popfirst!(LOAD_PATH)
+        end
+    end end
+end
+
 finish_precompile_test!()


### PR DESCRIPTION
Complimentary/alternative to the Tracy precompile worker profiler mechanism.

Claude:

---

Most of a package's precompilation happens in a worker process that the driver spawns, so profiling the session that called `Pkg.precompile()` shows the driver waiting on its children and nothing about where the time actually went. Tracy can see into those workers, through the zones in the external profiler devdocs and, built with `WITH_TRACY_CALLSTACKS`, sampled stacks as well. This adds a complementary route: a sampled profile of a worker from any build, with the JIT-compiled Julia frames resolved, which Tracy's sampler does not yet do, in the form the `Profile` tooling already reads.

The driver can turn it on for the workers it spawns:

```julia
precompilepkgs(; profile = true)                    # every package
precompilepkgs(; profile = "Makie")                 # just this one
precompilepkgs(; profile = ["Makie", "CairoMakie"]) # or these
precompilepkgs(; profile = true, profile_dir = "/tmp/profiles")
```

`JULIA_PRECOMPILE_PROFILE=<dir>` does the same for precompilation that starts some other way, such as a package being loaded for the first time. `JULIA_PRECOMPILE_PROFILE_DELAY` and `JULIA_PRECOMPILE_PROFILE_NSAMPLES` set the period and buffer size, defaulting to the same 1 ms and 10 million entries as `Profile.init`.

A selected worker starts the runtime's sampling profiler before it loads its dependencies, and dumps from a `Base.postoutput` hook, which runs after the package image has been written. The profile therefore covers dependency loading, lowering, inference, code generation and image generation. It does not cover the driver, or the link and `dsymutil` steps that run after the worker exits.

Each worker writes two files, `<pkg>-<pid>.profdata` with the raw sample buffer and `<pkg>-<pid>.profsyms` with the frames its instruction pointers resolve to. They are separate because a pointer only means something in the process that recorded it, so the worker has to resolve its own symbols while everything else is better done afterwards. `contrib/read_precompile_profile.jl` turns the pair back into the `(data, lidict)` that `Profile.print` and the viewer packages accept:

```julia
include("contrib/read_precompile_profile.jl")
data, lidict = read_precompile_profile("/tmp/profiles/DataFrames-8328")
Profile.print(stdout, data, lidict; C = true, format = :flat, sortedby = :count)
```

The worker side deliberately uses only `ccall` and `Base.StackTraces`. Loading Profile inside a worker would add it to the output image's dependency list, which would both invalidate the cache for normal sessions and change what is being measured. A profiled package still loads under `--compiled-modules=strict`, which is the check that the image is unaffected.

New devdoc page, `Profiling package precompilation`, with the mechanics, how to read a dump, what the profile does and does not cover, and the caveats: symbol resolution happens in the worker after sampling stops and lands in its reported total, the buffer is per worker so profiling a whole large environment costs memory, and sampling perturbs what it measures.


### What it showed on a real worker

Precompiling DataFrames and its 35 dependencies, profiling that one package, 5151 samples over a
worker of about 10s. Self time by innermost frame:

| bucket | self |
|---|---|
| runtime C (subtyping, method lookup, allocation) | 23.1% |
| waiting on the image-generation threads | 18.8% |
| codegen and LLVM | 14.7% |
| GC | 10.5% |
| lowering, femtolisp | 10.4% |
| inference and the optimizer | 8.7% |
| Julia code | 6.0% |
| serialization | 2.0% |

Inclusively the compile path is 47.5% and the output phase 29%, the latter splitting into
`jl_dump_native` at 16.9%, `jl_create_system_image` at 11.0%, and 1.0% in the collection pair at
`precompile.c:105`.

Two things about reading these are worth knowing, and are in the devdoc:

- **Only Julia threads are sampled.** A worker's image generation runs on raw libuv threads with no
  Julia thread state, so it is never sampled. What shows instead is the main thread waiting on it,
  `uv_thread_join` at 12.1%, the single largest leaf. `JULIA_IMAGE_TIMINGS=1`, or Tracy's sampler, which
  enumerates every thread in the process, are the way to see inside the shards.
- **Self and inclusive time diverge sharply.** Inference is 47% of this worker inclusive but 9% by
  innermost frame, because it bottoms out in the runtime's own subtyping and method lookup, which are
  charged to those C functions.

The effective sample rate also runs under the requested one, since each sample unwinds a deep stack:
about 5000 samples from a 10s worker at a nominal 1 ms period. Read the output as proportions.

### Stack quality depends on the unwinder

Worth noting for anyone using this on a build with the current unwinder. Measuring the same worker
both ways, libunwind returns a truncated stack of fewer than 10 frames for 25.3% of samples, with a
10th-percentile depth of a single frame, meaning a complete unwind failure that contributes a leaf and
no context. With #62395's framehop unwinder that falls to 19.5% and a 10th percentile of 7 frames,
mean depth 46.5 to 50.0. Both resolve 100% of instruction pointers, so symbolication is unaffected
either way. Nothing here depends on that PR; the profiles are just more complete with it.

