### PR TITLE
Reorder smalltags to speed up GC marking again

### DIFF
--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -2457,22 +2457,13 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
         }
         // Symbols are always marked
         assert(vtag != (uintptr_t)jl_symbol_type && vtag != jl_symbol_tag << 4);
-        if (vtag == (jl_datatype_tag << 4) ||
-            vtag == (jl_unionall_tag << 4) ||
-            vtag == (jl_uniontype_tag << 4) ||
-            vtag == (jl_typeeq_tag << 4) ||
-            vtag == (jl_typeegal_tag << 4) ||
-            vtag == (jl_tvar_tag << 4) ||
-            vtag == (jl_vararg_tag << 4) ||
-            vtag == (jl_globalref_tag << 4) ||
-            vtag == (jl_gotoifnot_tag << 4) ||
-            vtag == (jl_returnnode_tag << 4) ||
-            vtag == (jl_enternode_tag << 4) ||
-            vtag == (jl_pinode_tag << 4) ||
-            vtag == (jl_phinode_tag << 4) ||
-            vtag == (jl_phicnode_tag << 4) ||
-            vtag == (jl_upsilonnode_tag << 4) ||
-            vtag == (jl_quotenode_tag << 4)) {
+        if (vtag >= jl_max_tags << 4) {
+            jl_datatype_t *vt = (jl_datatype_t *)vtag;
+            if (__unlikely(!jl_is_datatype(vt) || vt->smalltag))
+                gc_dump_queue_and_abort(ptls, vt);
+        }
+        else if (vtag - (jl_gc_generic_tags_first << 4) <=
+                 (jl_gc_generic_tags_last - jl_gc_generic_tags_first) << 4) {
             // these objects have pointers in them, but no other special handling
             // so we want these to fall through to the end
             vtag = (uintptr_t)ijl_small_typeof[vtag / sizeof(*ijl_small_typeof)];
@@ -2631,11 +2622,6 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     gc_setmark(ptls, o, bits, dtsz);
             }
             return;
-        }
-        else {
-            jl_datatype_t *vt = (jl_datatype_t *)vtag;
-            if (__unlikely(!jl_is_datatype(vt) || vt->smalltag))
-                gc_dump_queue_and_abort(ptls, vt);
         }
         jl_datatype_t *vt = (jl_datatype_t *)vtag;
         if (vt->name == jl_genericmemory_typename) {

--- a/src/julia.h
+++ b/src/julia.h
@@ -1076,60 +1076,64 @@ typedef struct {
 
 // constants and type objects -------------------------------------------------
 
+/*
+ * Some very hot code is sensitive to the ordering of the smalltags
+ * here. Notably, the GC mark phase uses a range query
+ * (jl_gc_generic_tags_first/jl_gc_generic_tags_last) to quickly recognize
+ * smalltags that require no special handling.  The kinds (typeofbottom through
+ * datatype) are also important to keep contiguous.
+ */
 #define JL_SMALL_TYPEOF(XX) \
-    /* kinds */ \
     XX(typeofbottom) \
-    XX(datatype) \
-    XX(unionall) \
-    XX(uniontype) \
-    /* type parameter objects */ \
-    XX(vararg) \
-    XX(tvar) \
+    /* tags for objects with generic GC marking */ \
+      /* kinds (also includes typeofbottom) */ \
+        XX(unionall) \
+        XX(uniontype) \
+        XX(typeeq) \
+        XX(typeegal) \
+        XX(datatype) \
+      XX(tvar) \
+      XX(vararg) \
+      XX(gotoifnot) \
+      XX(returnnode) \
+      XX(enternode) \
+      XX(pinode) \
+      XX(phinode) \
+      XX(phicnode) \
+      XX(upsilonnode) \
+      XX(globalref) \
+      XX(quotenode) \
     XX(symbol) \
-    XX(module) \
     /* special GC objects */ \
-    XX(simplevector) \
-    XX(string) \
-    XX(task) \
+      XX(module) \
+      XX(simplevector) \
+      XX(string) \
+      XX(task) \
+      XX(cancel_source) \
+      XX(wait_entry) \
     /* bits types with special allocators */ \
-    XX(bool) \
-    XX(nothing) \
-    XX(char) \
-    /*XX(float16)*/ \
-    /*XX(float32)*/ \
-    /*XX(float64)*/ \
-    /*XX(bfloat16)*/ \
-    XX(int16) \
-    XX(int32) \
-    XX(int64) \
-    XX(int8) \
-    XX(uint16) \
-    XX(uint32) \
-    XX(uint64) \
-    XX(uint8) \
-    XX(addrspacecore) \
-    XX(intrinsic) \
-    /* AST objects */ \
+      XX(bool) \
+      XX(nothing) \
+      XX(char) \
+      /*XX(float16)*/ \
+      /*XX(float32)*/ \
+      /*XX(float64)*/ \
+      /*XX(bfloat16)*/ \
+      XX(int16) \
+      XX(int32) \
+      XX(int64) \
+      XX(int8) \
+      XX(uint16) \
+      XX(uint32) \
+      XX(uint64) \
+      XX(uint8) \
+      XX(addrspacecore) \
+      XX(intrinsic) \
     XX(argument) \
     /* XX(newvarnode) */ \
     XX(slotnumber) \
     XX(ssavalue) \
-    XX(gotoifnot) \
-    XX(returnnode) \
-    XX(enternode) \
-    XX(pinode) \
-    XX(phinode) \
-    XX(phicnode) \
-    XX(upsilonnode) \
-    XX(globalref) \
     XX(gotonode) \
-    XX(quotenode) \
-    XX(typeeq) \
-    XX(typeegal) \
-    XX(cancel_source) \
-    XX(wait_entry) \
-    /* Add new tags here to keep existing builds ABI stable - we don't guarantee ABI \
-       stability, but it'll help PkgEval to not break it unnecessarily */ \
     /* end of JL_SMALL_TYPEOF */
 enum jl_small_typeof_tags {
     jl_null_tag = 0,
@@ -1137,6 +1141,8 @@ enum jl_small_typeof_tags {
     JL_SMALL_TYPEOF(XX)
 #undef XX
     jl_tags_count,
+    jl_gc_generic_tags_first = jl_unionall_tag,
+    jl_gc_generic_tags_last = jl_quotenode_tag,
     jl_bitstags_first = jl_char_tag, // n.b. bool is not considered a bitstype, since it can be compared by pointer
     jl_max_tags = 64
 };
@@ -1820,10 +1826,7 @@ STATIC_INLINE int jl_is_kind(jl_value_t *v) JL_NOTSAFEPOINT
 STATIC_INLINE int jl_is_kindtag(uintptr_t t) JL_NOTSAFEPOINT
 {
     t >>= 4;
-    return (t==(uintptr_t)jl_uniontype_tag || t==(uintptr_t)jl_datatype_tag ||
-            t==(uintptr_t)jl_unionall_tag || t==(uintptr_t)jl_typeeq_tag ||
-            t==(uintptr_t)jl_typeegal_tag ||
-            t==(uintptr_t)jl_typeofbottom_tag);
+    return t - jl_typeofbottom_tag <= jl_datatype_tag - jl_typeofbottom_tag;
 }
 
 STATIC_INLINE int jl_is_type(jl_value_t *v) JL_NOTSAFEPOINT


### PR DESCRIPTION
When smalltags were first added in e26b63cf41, kinds were made to occoupy a contiguous range, as well as tags for types that take the generic marking path in the GC.  Since then, new tags have been added that must also go through the generic GC path, which caused the code generated for GC marking to regress.

The important case was the big condition at the beginning of `gc_mark_outrefs`, checking for all of the smalltags that must be scanned by the GC but which have no special handling:

```c
if (vtag == (jl_datatype_tag << 4) ||
    vtag == (jl_unionall_tag << 4) ||
    vtag == (jl_uniontype_tag << 4) ||
    vtag == (jl_typeeq_tag << 4) ||
    vtag == (jl_typeegal_tag << 4) ||
    vtag == (jl_tvar_tag << 4) ||
    vtag == (jl_vararg_tag << 4) ||
    vtag == (jl_globalref_tag << 4) ||
    vtag == (jl_gotoifnot_tag << 4) ||
    vtag == (jl_returnnode_tag << 4) ||
    vtag == (jl_enternode_tag << 4) ||
    vtag == (jl_pinode_tag << 4) ||
    vtag == (jl_phinode_tag << 4) ||
    vtag == (jl_phicnode_tag << 4) ||
    vtag == (jl_upsilonnode_tag << 4) ||
    vtag == (jl_quotenode_tag << 4)) {
    // these objects have pointers in them, but no other special handling
    // so we want these to fall through to the end
    vtag = (uintptr_t)ijl_small_typeof[vtag / sizeof(*ijl_small_typeof)];
}
```

The code generated for this was quite bad.  If the objects being scanned are close enough to be cache hits, this made GC marking instruction bound.  This commit puts the smalltags back into a sensible order, and changes the check to a range check:

```c
if (vtag - (jl_gc_generic_tags_first << 4) <=
    (jl_gc_generic_tags_last - jl_gc_generic_tags_first) << 4)
```

On this microbenchmark, minimum GC times are improved by about 10% on aarch64 macOS with Apple clang 17 (TBD if x86 gcc on Linux was producing the same bad code):
```julia
mutable struct Node
    next::Union{Nothing,Node}
    value::Int
end

function makeheap(n)
    nodes = [Node(nothing, i) for i in 1:n]
    order = collect(1:n)
    for i in 1:n-1
        nodes[i].next = nodes[i+1]
    end
    nodes[1]
end

GC.gc()
heap = makeheap(10_000_000)
times = Float64[]
for i=1:50
    push!(times, (@timed GC.gc()).gctime)
end

println(minimum(times))
```

Assisted-by: Codex (GPT-6)