### PR TITLE
tasks: Fix lost wakeups in `waitall`/`waitany`

### DIFF
--- a/base/park.jl
+++ b/base/park.jl
@@ -182,11 +182,11 @@ end
 """
     repark!(ws, w::WaitEntry) -> Bool
 
-Re-park on the still-enqueued registration `w`: arm and recheck, with
-the same `Bool` contract as [`park!`](@ref). For the multi-wait loop -
-the caller's bookkeeping between wakes runs unarmed (a completion
-landing there pops-and-drops the unarmed entry; the recheck here catches
-the fired predicate before suspending, so nothing is lost).
+Re-arm and recheck `w`, with the same `Bool` contract as [`park!`](@ref).
+The caller must ensure every pending waitable is still registered and its
+recheck observes notifications delivered while `w` was unarmed. `DoneWait`
+does not satisfy this contract: notification removes the slot required by
+its recheck. Multi-task waits must enqueue pending tasks with [`park!`](@ref).
 """
 function repark!(ws, w::WaitEntry)
     ct = current_task()

--- a/base/task.jl
+++ b/base/task.jl
@@ -646,14 +646,10 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
         end
     end
 
-    # Park on all remaining tasks at once through a single multi-slot wait
-    # entry - one flat waitable per pending task (duplicates share a slot)
-    # plus the governing cancellation source. Each completion notify claims
-    # the entry through the standard wake-claim protocol; the registrations
-    # stay in place across re-parks, so the loop re-arms (`repark!`)
-    # instead of re-registering after every completion, and the driver's
-    # membership-qualified rechecks make the arm-then-suspend sound while
-    # this bookkeeping runs unarmed.
+    # Re-run `park!` for pending tasks after each wake: the previous park
+    # may have stopped at a completed task, and notifications while unarmed
+    # can consume registrations. Keep registrations for pending tasks, but
+    # synchronize with completed tasks' notifiers before reusing their slots.
     ct = current_task()
     src = cancel_source(tok)
     src === nothing || checkcancel(src)
@@ -663,12 +659,10 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
     end
     src === nothing || push!(ws, SourceWait(src, 0x00))
     w = acquire_wait_entry!(ct, ws)
-    parked = park!(ws, w, false)
     while true
-        # suspend only when the park armed (a `false` park/re-park means a
-        # waitable fired - a completion, or the source - and the driver
-        # already dequeued the fired slot)
-        parked && wait_safe_interrupt(ws, w)
+        # suspend only when the park armed (a `false` park means a waitable
+        # fired - a completion, or the source - and the self-claim won)
+        park!(ws, w, false) && wait_safe_interrupt(ws, w)
         # the fired-source outcome (and, level-triggered, any cancelled
         # state) delivers here: withdraw and throw
         if src !== nothing && iscancelled(src)
@@ -681,6 +675,7 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
             done && continue
             t = tasks[i]
             if istaskdone(t)
+                wait_dequeue!(DoneWait(t), w, WAKE_WITHDRAWN)
                 done_mask[i] = true
                 exception |= istaskfailed(t)
                 nremaining -= 1
@@ -689,7 +684,11 @@ function _wait_multiple(tasks::Vector{Task}, throwexc::Bool=false, all::Bool=fal
         if nremaining == 0 || (!all && any(done_mask)) || (exception && failfast)
             break
         end
-        parked = repark!(ws, w)
+        empty!(ws)
+        for (i, done) in enumerate(done_mask)
+            done || push!(ws, DoneWait(tasks[i]))
+        end
+        src === nothing || push!(ws, SourceWait(src, 0x00))
     end
     withdraw!(ws, w)
 

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -951,19 +951,30 @@ end
     end
     foreach(wait, ts2)
 
-    # waitall re-arms the same registered entry across completions
+    # waitall reuses its entry and source registration across completions
+    src3 = CancellationTokenSource()
     c3 = Channel{Int}(0)
     ts3 = [@async take!(c3) for _ in 1:3]
-    wa3 = @async waitall(ts3)
+    wa3 = @async waitall(ts3; cancel=CancellationToken(src3))
     @test timedwait(() -> (x = @atomic wa3.waiting_on; x isa Base.WaitEntryN), 10.0) == :ok
     w3 = (@atomic wa3.waiting_on)::Base.WaitEntryN
-    for _ in 1:3
+    for n in 1:2
         put!(c3, 0)
+        @test timedwait(10.0) do
+            (@atomic wa3.waiting_on) === w3 &&
+                count(i -> Base._slot_owner(w3, i) isa Base.ThreadSynchronizer,
+                      1:Base._nslots(w3)) == 3 - n
+        end == :ok
+        @test registry_entries(src3) == [w3]
     end
+    put!(c3, 0)
     done3, remaining3 = fetch(wa3)
     @test length(done3) == 3 && isempty(remaining3)
     @test (@atomic wa3.waiting_on) === nothing
     @test count(i -> Base._slot_owner(w3, i) isa Base.ThreadSynchronizer, 1:Base._nslots(w3)) == 0
+    @test (@atomic :monotonic w3.task) === nothing
+    cancel!(src3)
+    @test isempty(registry_entries(src3))
 end
 
 @testset "level-triggered delivery and shielding" begin

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1463,6 +1463,29 @@ end
             end
         end
     end
+
+    # Tasks completing on other threads while the waiter registers with them
+    # or runs its bookkeeping between two wakes: the multi-wait used to keep
+    # a partially registered entry across wakes and deadlock within a few
+    # iterations of this loop.
+    if threadpoolsize() > 1
+        @testset "concurrent completions" begin
+            for _ in 1:20_000
+                tasks = [Threads.@spawn nothing for _ in 1:3]
+                done, pending = waitall(tasks)
+                @test length(done) == 3 && isempty(pending)
+            end
+            for _ in 1:2_000
+                event = Threads.Event()
+                tasks = [Threads.@spawn(wait(event)), Threads.@spawn(nothing), Threads.@spawn(wait(event))]
+                done, pending = waitany(tasks)
+                @test tasks[2] in done
+                notify(event)
+                done, pending = waitall(tasks)
+                @test length(done) == 3 && isempty(pending)
+            end
+        end
+    end
 end
 
 @testset "Base.Experimental.task_metrics" begin

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -101,20 +101,27 @@ end
 @test threadpool() in (:interactive, :default) # thread 1 could be in the interactive pool
 @test 1 <= threadpoolsize(:default) <= Threads.maxthreadid()
 
-# basic lock check
+# basic lock check: `t1` blocks in `lock` on a spin lock held by the root
+# task, which parks meanwhile. A spinning task never yields, so it must not
+# run on the thread the root task is bound to - pin it to another thread of
+# the default pool.
+function spawn_pinned(f, tid)
+    t = Task(f)
+    t.sticky = true
+    ccall(:jl_set_task_tid, Cint, (Any, Cint), t, tid - 1) == 1 || error("failed to pin task to thread $tid")
+    return schedule(t)
+end
+other_default_tid() = first(tid for tid in Threads.threadpooltids(:default) if tid != Threads.threadid())
 if threadpoolsize(:default) > 1
     let lk = SpinLock()
         c1 = Base.Event()
-        c2 = Base.Event()
         @test trylock(lk)
         @test !trylock(lk)
-        t1 = Threads.@spawn (notify(c1); lock(lk); unlock(lk); trylock(lk))
-        t2 = Threads.@spawn (notify(c2); trylock(lk))
-        Libc.systemsleep(0.1) # block our thread from scheduling for a bit
-        wait(c1)
-        wait(c2)
+        t2 = Threads.@spawn trylock(lk)
         @test !fetch(t2)
         @test istaskdone(t2)
+        t1 = spawn_pinned(() -> (notify(c1); lock(lk); unlock(lk); trylock(lk)), other_default_tid())
+        wait(c1)
         @test !istaskdone(t1)
         unlock(lk)
         @test fetch(t1)
@@ -125,16 +132,13 @@ end
 if threadpoolsize() > 1
     let lk = Base.Threads.PaddedSpinLock()
         c1 = Base.Event()
-        c2 = Base.Event()
         @test trylock(lk)
         @test !trylock(lk)
-        t1 = Threads.@spawn (notify(c1); lock(lk); unlock(lk); trylock(lk))
-        t2 = Threads.@spawn (notify(c2); trylock(lk))
-        Libc.systemsleep(0.1) # block our thread from scheduling for a bit
-        wait(c1)
-        wait(c2)
+        t2 = Threads.@spawn trylock(lk)
         @test !fetch(t2)
         @test istaskdone(t2)
+        t1 = spawn_pinned(() -> (notify(c1); lock(lk); unlock(lk); trylock(lk)), other_default_tid())
+        wait(c1)
         @test !istaskdone(t1)
         unlock(lk)
         @test fetch(t1)


### PR DESCRIPTION
`waitall` and `waitany` can hang even after all the tasks they are waiting for
have finished. The waiting code assumes that every unfinished task is still
registered to wake it. That assumption can fail when a task finishes during
setup, leaving later tasks unregistered, or between wakeups, when a completion
notification can remove a registration without waking the waiter.

This change retries registration for the remaining tasks after each wake,
keeping registrations that are still in place. Before removing a completed
task from the wait set, it takes that task's notification lock to ensure its
notifier has finished using the registration. The wait entry and buffer are
reused across wakes. `waitall(...; failfast=false)` uses a separate sequential
path and is unaffected.

The second commit fixes another deadlock in the spin-lock tests. A task
spinning on a lock held by the main task could run on the same thread,
preventing the main task from resuming to release the lock. Pin the spinning
task to another default-pool thread instead of relying on a fixed delay to
influence scheduling.

Both problems were reproduced while investigating the [FreeBSD threads CI
timeout](https://buildkite.com/julialang/julia-buildkite-ci/builds/146#01a07342-b3f0-4703-bb14-e3ff28ce9138).
The CI log lost the hung child's output, so we cannot tell which deadlock
occurred in that job. The multi-task wait bug also reproduces on Linux.

Tested on Linux after rebuilding the sysimage from the final source:

- `make test-threads` passes, including all six child thread configurations.
- `make test-cancellation` passes all 1,644 checks.
- Three runs of 300,000 concurrent `waitall` calls pass; the unfixed method
  hangs in comparison runs.
- Targeted checks cover early return, cancellation, duplicate tasks,
  `failfast`, and tasks finishing in stages, including cleanup of wait queues.

An earlier version passed 60 runs on a FreeBSD VM under load, compared with
four hangs in 98 unfixed runs. The final version has not been rerun on FreeBSD.

Fixes https://github.com/JuliaLang/julia/issues/63108

Assisted by: Fable 5.1, GPT 6 Astra