### PR TITLE
pkgimages: relocation-lean image format and replay-driven package loading (#62254 rebased)

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -874,7 +874,7 @@ function is_edge_recursed(edge::MethodInstance, caller::AbsIntState)
     end
 end
 is_edge_recursed(edge::CodeInstance, caller::AbsIntState) =
-    is_edge_recursed(edge.def, caller)
+    is_edge_recursed(ci_def(edge), caller)
 
 function is_method_recursed(method::Method, caller::AbsIntState)
     return any(AbsIntStackUnwind(caller)) do sv::AbsIntState

--- a/Compiler/src/bindinginvalidations.jl
+++ b/Compiler/src/bindinginvalidations.jl
@@ -44,6 +44,18 @@ end
 function scan_edge_list(ci::Core.CodeInstance, binding::Core.Binding)
     isdefined(ci, :edges) || return false
     edges = ci.edges
+    if edges isa Core.InternedCodeInstance
+        # image CodeInstances carry their edges as relocation-free words
+        i = 1
+        while i <= getfield(edges, :nedges)
+            if ccall(:jl_ici_ref, Any, (Any, Csize_t), edges, i - 1) === binding
+                return true
+            end
+            i += 1
+        end
+        return false
+    end
+    edges = edges::Core.SimpleVector
     i = 1
     while i <= length(edges)
         if isassigned(edges, i) && edges[i] === binding
@@ -197,7 +209,7 @@ function scan_new_methods!(internal_methods::Vector{Any}, image_backedges_only::
     end
     for method in internal_methods
         if isa(method, Method)
-           scan_new_method!(method, image_backedges_only)
+            scan_new_method!(method, image_backedges_only)
         end
     end
 end

--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -316,6 +316,7 @@ function enqueue_specialization!(all::Bool, worklist, mi::MethodInstance)
     codeinst = isdefined(mi, :cache) ? mi.cache : nothing
     while codeinst !== nothing
         do_compile = false
+        ci_materialize!(codeinst)
         if codeinst.owner !== nothing
             # This code instance is from a foreign interpreter, so we skip it
         elseif use_const_api(codeinst) # Check if invoke is jl_fptr_const_return

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -135,6 +135,21 @@ end
     return ccall(:jl_edge_sig_replayable, Int32, (Any,), sig)
 end
 
+# min world of a replayed call edge: its match set is the recorded one (targets
+# i:i+n-1 of the edge list), whose methods became available in this session at
+# their activation worlds, so the edge is valid from the latest of those, as
+# verify_call would report for an unchanged match set
+function replayed_minworld(expecteds::Union{Core.SimpleVector, Core.InternedCodeInstance}, i::Int, n::Int)
+    minworld = get_require_world()
+    for k = i:i+n-1
+        pw = get_method_from_edge(edges_ref(expecteds, k)).primary_world
+        if minworld < pw
+            minworld = pw
+        end
+    end
+    return minworld
+end
+
 function verify_method_graph(codeinst::CodeInstance, validation_world::UInt, workspace::VerifyMethodWorkspace)
     @assert isempty(workspace.stack) "workspace corrupted"
     @assert isempty(workspace.visiting) "workspace corrupted"
@@ -276,7 +291,7 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                         sig = edge.specTypes
                         r = edge_replay_mode(sig)
                         if r == 1
-                            min_valid2, max_valid2 = get_require_world(), validation_world
+                            min_valid2, max_valid2 = replayed_minworld(initial.callees, j, 1), validation_world
                         else
                             min_valid2, max_valid2 = verify_call(sig, initial.callees, j, 1, world, true, matches, workspace)
                         end
@@ -287,7 +302,7 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                         fully_covers = edge > 0
                         r = edge_replay_mode(sig)
                         if r == 1
-                            min_valid2, max_valid2 = get_require_world(), validation_world
+                            min_valid2, max_valid2 = replayed_minworld(initial.callees, j+2, nmatches), validation_world
                         else
                             min_valid2, max_valid2 = verify_call(sig, initial.callees, j+2, nmatches, world, fully_covers, matches, workspace)
                         end
@@ -322,7 +337,7 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                         end
                         r = edge_replay_mode(edge)
                         if r == 1
-                            min_valid2, max_valid2 = get_require_world(), validation_world
+                            min_valid2, max_valid2 = max(get_require_world(), meth.primary_world), validation_world
                         else
                             min_valid2, max_valid2 = verify_invokesig(edge, meth, world, matches)
                         end

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using ..Compiler.Base
-using ..Compiler: _findsup, store_backedges, JLOptions, get_world_counter,
+using ..Compiler: Compiler, _findsup, store_backedges, JLOptions, get_world_counter,
     _methods_by_ftype, get_methodtable, get_ci_mi, should_instrument,
     morespecific, RefValue, get_require_world, Vector, IdDict
 using .Core: CodeInstance, MethodInstance
@@ -72,9 +72,9 @@ function insert_backedges(internal_methods::Vector{Any})
     # determine which CodeInstance objects are still valid in our image
     # to enable any applicable new codes
     backedges_only = unsafe_load(cglobal(:jl_first_image_replacement_world, UInt)) == typemax(UInt)
-    scan_new_methods!(internal_methods, backedges_only)
+    Compiler.@zone "LOAD_ScanNewMethods" scan_new_methods!(internal_methods, backedges_only)
     workspace = VerifyMethodWorkspace()
-    scan_new_code!(internal_methods, workspace)
+    Compiler.@zone "LOAD_ScanNewCode" scan_new_code!(internal_methods, workspace)
     nothing
 end
 
@@ -92,13 +92,20 @@ function scan_new_code!(internal_methods::Vector{Any}, workspace::VerifyMethodWo
     end
 end
 
+# 0: verify this edge normally; 1: its match world is provably unchanged since
+# the precompile worker (skip); 2: skip would be legal, but verify and compare
+@inline function edge_replay_mode(@nospecialize(sig))
+    _jl_debug_method_invalidation[] === nothing || return Int32(0)
+    return ccall(:jl_edge_sig_replayable, Int32, (Any,), sig)
+end
+
 function verify_method_graph(codeinst::CodeInstance, validation_world::UInt, workspace::VerifyMethodWorkspace)
     @assert isempty(workspace.stack) "workspace corrupted"
     @assert isempty(workspace.visiting) "workspace corrupted"
     @assert isempty(workspace.initial_states) "workspace corrupted"
     @assert isempty(workspace.work_states) "workspace corrupted"
     @assert isempty(workspace.result_states) "workspace corrupted"
-    child_cycle, minworld, maxworld = verify_method(codeinst, validation_world, workspace)
+    child_cycle, minworld, maxworld = Compiler.@zone "VERIFY_MethodGraph" verify_method(codeinst, validation_world, workspace)
     @assert child_cycle == 0
     @assert isempty(workspace.stack) "workspace corrupted"
     @assert isempty(workspace.visiting) "workspace corrupted"
@@ -230,13 +237,29 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
 
                     if edge isa MethodInstance
                         sig = edge.specTypes
-                        min_valid2, max_valid2 = verify_call(sig, initial.callees, j, 1, world, true, matches)
+                        r = edge_replay_mode(sig)
+                        if r == 1
+                            min_valid2, max_valid2 = get_require_world(), validation_world
+                        else
+                            min_valid2, max_valid2 = verify_call(sig, initial.callees, j, 1, world, true, matches)
+                            if r == 2 && max_valid2 < validation_world
+                                ccall(:jl_safe_printf, Cvoid, (Ptr{UInt8},), "EDGE VERIFY MISMATCH (call)\n")
+                            end
+                        end
                         j += 1
                     elseif edge isa Int
                         sig = initial.callees[j+1]
                         nmatches = abs(edge)
                         fully_covers = edge > 0
-                        min_valid2, max_valid2 = verify_call(sig, initial.callees, j+2, nmatches, world, fully_covers, matches)
+                        r = edge_replay_mode(sig)
+                        if r == 1
+                            min_valid2, max_valid2 = get_require_world(), validation_world
+                        else
+                            min_valid2, max_valid2 = verify_call(sig, initial.callees, j+2, nmatches, world, fully_covers, matches)
+                            if r == 2 && max_valid2 < validation_world
+                                ccall(:jl_safe_printf, Cvoid, (Ptr{UInt8},), "EDGE VERIFY MISMATCH (call)\n")
+                            end
+                        end
                         j += 2 + nmatches
                         edge = sig
                     elseif edge isa Core.Binding
@@ -266,7 +289,15 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                         else
                             meth = callee::Method
                         end
-                        min_valid2, max_valid2 = verify_invokesig(edge, meth, world, matches)
+                        r = edge_replay_mode(edge)
+                        if r == 1
+                            min_valid2, max_valid2 = get_require_world(), validation_world
+                        else
+                            min_valid2, max_valid2 = verify_invokesig(edge, meth, world, matches)
+                            if r == 2 && max_valid2 < validation_world
+                                ccall(:jl_safe_printf, Cvoid, (Ptr{UInt8},), "EDGE VERIFY MISMATCH (invoke)\n")
+                            end
+                        end
                         j += 2
                     end
 

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -3,7 +3,7 @@
 using ..Compiler.Base
 using ..Compiler: Compiler, _findsup, store_backedges, JLOptions, get_world_counter,
     _methods_by_ftype, get_methodtable, get_ci_mi, should_instrument,
-    morespecific, RefValue, get_require_world, Vector, IdDict
+    morespecific, RefValue, get_require_world, Vector, IdDict, ci_materialize!
 using .Core: CodeInstance, MethodInstance
 
 const CI_FLAGS_NATIVE_CACHE_VALID = 0b1000
@@ -17,7 +17,7 @@ struct VerifyMethodInitialState
     codeinst::CodeInstance
     mi::MethodInstance
     def::Method
-    callees::Core.SimpleVector
+    callees::Union{Core.SimpleVector, Core.InternedCodeInstance}
 end
 
 struct VerifyMethodWorkState
@@ -44,11 +44,27 @@ struct VerifyMethodWorkspace
     stack::Vector{CodeInstance}
     visiting::IdDict{CodeInstance,Int}
 
-    function VerifyMethodWorkspace()
+    # whether the image carries a backedge log that is bulk-applied after
+    # verification, making per-CodeInstance store_backedges unnecessary
+    prelinked::Bool
+
+    # scratch for the per-edge match details; only live within one
+    # init_and_process_callees stage (the debug log snapshots via copy)
+    matches::Vector{Any}
+
+    function VerifyMethodWorkspace(prelinked::Bool=false)
         new(VerifyMethodInitialState[], VerifyMethodWorkState[], VerifyMethodResultState[],
-            CodeInstance[], IdDict{CodeInstance,Int}())
+            CodeInstance[], IdDict{CodeInstance,Int}(), prelinked, Any[])
     end
 end
+
+# Image CodeInstances may carry their forward edges as an
+# InternedCodeInstance — a relocation-free word list decoded lazily in C —
+# instead of a SimpleVector; these helpers make the walk agnostic.
+edges_length(e::Core.SimpleVector) = length(e)
+edges_length(e::Core.InternedCodeInstance) = getfield(e, :nedges)
+edges_ref(e::Core.SimpleVector, j::Int) = e[j]
+edges_ref(e::Core.InternedCodeInstance, j::Int) = ccall(:jl_ici_ref, Any, (Any, Csize_t), e, j - 1)
 
 # Helper functions to create default states
 function VerifyMethodInitialState(codeinst::CodeInstance)
@@ -68,32 +84,50 @@ end
 
 # Restore backedges to external targets
 # `internal_methods` = [caller1, ...], the list of worklist-owned code instances internally
-function insert_backedges(internal_methods::Vector{Any})
+function insert_backedges(internal_methods::Vector{Any}, backedge_log)
     # determine which CodeInstance objects are still valid in our image
     # to enable any applicable new codes
     backedges_only = unsafe_load(cglobal(:jl_first_image_replacement_world, UInt)) == typemax(UInt)
     Compiler.@zone "LOAD_ScanNewMethods" scan_new_methods!(internal_methods, backedges_only)
-    workspace = VerifyMethodWorkspace()
-    Compiler.@zone "LOAD_ScanNewCode" scan_new_code!(internal_methods, workspace)
+    workspace = VerifyMethodWorkspace(backedge_log !== nothing)
+    # verify every root, then register the image's backedges, then promote: a
+    # method definition landing after registration invalidates the registered
+    # callers and makes the promotion a no-op, one landing before it leaves
+    # them unregistered and unpromoted (valid only up to their validation
+    # world), as with per-CodeInstance store_backedges
+    worlds = Compiler.@zone "LOAD_ScanNewCode" scan_new_code!(internal_methods, workspace)
+    if backedge_log !== nothing
+        # bulk-register the image's recorded backedges for the callers that
+        # verified at the current world, in place of per-CodeInstance store_backedges
+        Compiler.@zone "VERIFY_Store" ccall(:jl_apply_backedge_log, Cvoid, (Any,), backedge_log)
+    end
+    for i = 1:length(internal_methods)
+        codeinst = internal_methods[i]
+        codeinst isa CodeInstance || continue
+        # under the world_counter_lock, set max_world to typemax(UInt) for the root and its
+        # dependencies (recursively) if the world has not moved since validation; from then on
+        # the ordinary backedge mechanism is responsible for maintaining validity
+        @ccall jl_promote_ci_to_current(codeinst::Any, worlds[i]::UInt)::Cvoid
+    end
     nothing
 end
 
 function scan_new_code!(internal_methods::Vector{Any}, workspace::VerifyMethodWorkspace)
+    worlds = Vector{UInt}(undef, length(internal_methods))
     for i = 1:length(internal_methods)
         codeinst = internal_methods[i]
-        codeinst isa CodeInstance || continue
-        # codeinst.owner === nothing || continue
         validation_world = get_world_counter()
-        verify_method_graph(codeinst, validation_world, workspace)
-        # After validation, under the world_counter_lock, set max_world to typemax(UInt) for all dependencies
-        # (recursively). From that point onward the ordinary backedge mechanism is responsible for maintaining
-        # validity.
-        @ccall jl_promote_ci_to_current(codeinst::Any, validation_world::UInt)::Cvoid
+        worlds[i] = validation_world
+        codeinst isa CodeInstance || continue
+        if (@atomic :monotonic codeinst.max_world) == WORLD_AGE_REVALIDATION_SENTINEL
+            verify_method_graph(codeinst, validation_world, workspace)
+        end
     end
+    return worlds
 end
 
 # 0: verify this edge normally; 1: its match world is provably unchanged since
-# the precompile worker (skip); 2: skip would be legal, but verify and compare
+# the precompile worker (skip)
 @inline function edge_replay_mode(@nospecialize(sig))
     _jl_debug_method_invalidation[] === nothing || return Int32(0)
     return ccall(:jl_edge_sig_replayable, Int32, (Any,), sig)
@@ -131,9 +165,9 @@ function gen_staged_sig(def::Method, mi::MethodInstance)
 end
 
 function needs_instrumentation(codeinst::CodeInstance, mi::MethodInstance, def::Method, validation_world::UInt)
-    # foreign CIs (owner !== nothing) aren't run as native code here, so instrumenting them is moot
-    codeinst.owner === nothing || return false
     if JLOptions().code_coverage != 0 || JLOptions().malloc_log != 0
+        # foreign CIs (owner !== nothing) aren't run as native code here, so instrumenting them is moot
+        ci_materialize!(codeinst).owner === nothing || return false
         # test if the code needs to run with instrumentation, in which case we cannot use existing generated code
         if isdefined(def, :debuginfo) ? # generated_only functions do not have debuginfo, so fall back to considering their codeinst debuginfo though this may be slower and less reliable
             should_instrument(def.module, def.debuginfo) :
@@ -222,12 +256,13 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
             end
 
             # Process all non-CodeInstance edges
-            if !isempty(initial.callees) && maxworld != get_require_world()
-                matches = []
+            if edges_length(initial.callees) != 0 && maxworld != get_require_world()
+                matches = workspace.matches
+                empty!(matches)
                 j = 1
-                while j <= length(initial.callees)
+                while j <= edges_length(initial.callees)
                     local min_valid2::UInt, max_valid2::UInt
-                    edge = initial.callees[j]
+                    edge = edges_ref(initial.callees, j)
                     @assert !(edge isa Method) "unexpected Method edge indicates corrupt edges list creation"
 
                     if edge isa CodeInstance
@@ -241,24 +276,18 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                         if r == 1
                             min_valid2, max_valid2 = get_require_world(), validation_world
                         else
-                            min_valid2, max_valid2 = verify_call(sig, initial.callees, j, 1, world, true, matches)
-                            if r == 2 && max_valid2 < validation_world
-                                ccall(:jl_safe_printf, Cvoid, (Ptr{UInt8},), "EDGE VERIFY MISMATCH (call)\n")
-                            end
+                            min_valid2, max_valid2 = verify_call(sig, initial.callees, j, 1, world, true, matches, workspace)
                         end
                         j += 1
                     elseif edge isa Int
-                        sig = initial.callees[j+1]
+                        sig = edges_ref(initial.callees, j+1)
                         nmatches = abs(edge)
                         fully_covers = edge > 0
                         r = edge_replay_mode(sig)
                         if r == 1
                             min_valid2, max_valid2 = get_require_world(), validation_world
                         else
-                            min_valid2, max_valid2 = verify_call(sig, initial.callees, j+2, nmatches, world, fully_covers, matches)
-                            if r == 2 && max_valid2 < validation_world
-                                ccall(:jl_safe_printf, Cvoid, (Ptr{UInt8},), "EDGE VERIFY MISMATCH (call)\n")
-                            end
+                            min_valid2, max_valid2 = verify_call(sig, initial.callees, j+2, nmatches, world, fully_covers, matches, workspace)
                         end
                         j += 2 + nmatches
                         edge = sig
@@ -276,7 +305,7 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                             max_valid2 = 0
                         end
                     else
-                        callee = initial.callees[j+1]
+                        callee = edges_ref(initial.callees, j+1)
                         if callee isa Core.MethodTable
                             j += 2
                             continue
@@ -294,9 +323,6 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                             min_valid2, max_valid2 = get_require_world(), validation_world
                         else
                             min_valid2, max_valid2 = verify_invokesig(edge, meth, world, matches)
-                            if r == 2 && max_valid2 < validation_world
-                                ccall(:jl_safe_printf, Cvoid, (Ptr{UInt8},), "EDGE VERIFY MISMATCH (invoke)\n")
-                            end
                         end
                         j += 2
                     end
@@ -325,8 +351,8 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
             # Find next CodeInstance edge that needs processing
             recursive_index = work.recursive_index
             found_child = false
-            while recursive_index ≤ length(initial.callees)
-                edge = initial.callees[recursive_index]
+            while recursive_index ≤ edges_length(initial.callees)
+                edge = edges_ref(initial.callees, recursive_index)
                 recursive_index += 1
 
                 if edge isa CodeInstance
@@ -362,8 +388,8 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                         end
                     end
                     @atomic :monotonic child.max_world = result.result_maxworld
-                    if result.result_maxworld == validation_world && validation_world == get_world_counter() && isdefined(child, :edges)
-                        store_backedges(child, child.edges)
+                    if !workspace.prelinked && result.result_maxworld == validation_world && validation_world == get_world_counter() && isdefined(child, :edges) && child.edges isa Core.SimpleVector
+                        Compiler.@zone "VERIFY_Store" store_backedges(child, child.edges)
                     end
                     @assert workspace.visiting[child] == length(workspace.stack) + 1 "internal error maintaining workspace"
                     delete!(workspace.visiting, child)
@@ -502,12 +528,16 @@ end
 # pruned `ml_matches` lookup is cheaper (~8 is the empirical crossover).
 const VERIFY_INTERF_CAP = 8
 
-function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n::Int, world::UInt, fully_covers::Bool, matches::Vector{Any})
+function verify_call(@nospecialize(sig), expecteds::Union{Core.SimpleVector, Core.InternedCodeInstance}, i::Int, n::Int, world::UInt, fully_covers::Bool, matches::Vector{Any}, workspace::VerifyMethodWorkspace)
+    Compiler.@zone "VERIFY_Call" _verify_call(sig, expecteds, i, n, world, fully_covers, matches)
+end
+
+function _verify_call(@nospecialize(sig), expecteds::Union{Core.SimpleVector, Core.InternedCodeInstance}, i::Int, n::Int, world::UInt, fully_covers::Bool, matches::Vector{Any})
     # verify that these edges intersect with the same methods as before
     mi = nothing
     expected_deleted = false
     for j = 1:n
-        t = expecteds[i+j-1]
+        t = edges_ref(expecteds, i+j-1)
         meth = get_method_from_edge(t)
         if iszero(meth.dispatch_status & METHOD_SIG_LATEST_WHICH)
             expected_deleted = true
@@ -522,7 +552,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         if n == 1
             # first, fast-path a check if the expected method simply dominates its sig anyways
             # so the result of ml_matches is already simply known
-            let t = expecteds[i], meth, minworld, maxworld
+            let t = edges_ref(expecteds, i), meth, minworld, maxworld
                 meth = get_method_from_edge(t)
                 if !(t isa Method)
                     if t isa CodeInstance
@@ -554,7 +584,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         if interference_fast_path_success && n == 1
             # Skip to ml_matches for large interference sets (see VERIFY_INTERF_CAP). The set
             # is packed, so isassigned(., cap+1) tests "size > cap" without any typeintersect.
-            let interf = get_method_from_edge(expecteds[i]).interferences, cap = VERIFY_INTERF_CAP
+            let interf = get_method_from_edge(edges_ref(expecteds, i)).interferences, cap = VERIFY_INTERF_CAP
                 if length(interf) > cap && isassigned(interf, cap + 1)
                     interference_fast_path_success = false
                 end
@@ -564,7 +594,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         if interference_fast_path_success
             local interference_minworld::UInt = 1
             for j = 1:n
-                meth = get_method_from_edge(expecteds[i+j-1])
+                meth = get_method_from_edge(edges_ref(expecteds, i+j-1))
                 if interference_minworld < meth.primary_world
                     interference_minworld = meth.primary_world
                 end
@@ -580,7 +610,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                     world < interference_method.primary_world && break # this and later entries are for a future world
                     local found_in_expecteds = false
                     for j = 1:n
-                        if interference_method === get_method_from_edge(expecteds[i+j-1])
+                        if interference_method === get_method_from_edge(edges_ref(expecteds, i+j-1))
                             found_in_expecteds = true
                             break
                         end
@@ -590,14 +620,14 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                         if !(ti === Union{})
                             # try looking for a different expected method that fully covers this interference_method anyways over their intersection
                             for j = 1:n
-                                meth2 = get_method_from_edge(expecteds[i+j-1])
+                                meth2 = get_method_from_edge(edges_ref(expecteds, i+j-1))
                                 if method_morespecific_via_interferences(meth2, interference_method) && ti <: meth2.sig
                                     found_in_expecteds = true
                                     break
                                 end
                             end
                             if !found_in_expecteds
-                                meth2 = get_method_from_edge(expecteds[i])
+                                meth2 = get_method_from_edge(edges_ref(expecteds, i))
                                 interference_fast_path_success = false
                                 break
                             end
@@ -635,7 +665,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
             match = result[k]::Core.MethodMatch
             local found = false
             for j = 1:n
-                t = expecteds[i+j-1]
+                t = edges_ref(expecteds, i+j-1)
                 if match.method == get_method_from_edge(t)
                     found = true
                     break
@@ -702,7 +732,7 @@ function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UIn
 end
 
 # Wrapper to call insert_backedges in typeinf_world for external calls
-function insert_backedges_typeinf(internal_methods::Vector{Any})
-    args = Any[insert_backedges, internal_methods]
+function insert_backedges_typeinf(internal_methods::Vector{Any}, backedge_log)
+    args = Any[insert_backedges, internal_methods, backedge_log]
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
 end

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -3,10 +3,11 @@
 using ..Compiler.Base
 using ..Compiler: Compiler, _findsup, store_backedges, JLOptions, get_world_counter,
     _methods_by_ftype, get_methodtable, get_ci_mi, should_instrument,
-    morespecific, RefValue, get_require_world, Vector, IdDict, ci_materialize!
+    morespecific, RefValue, get_require_world, Vector, IdDict, ci_materialize!, ci_edges_svec
 using .Core: CodeInstance, MethodInstance
 
 const CI_FLAGS_NATIVE_CACHE_VALID = 0b1000
+const CI_FLAGS_BACKEDGES_LOGGED = 0b10000 # the image's backedge log carries this CodeInstance's backedges
 const WORLD_AGE_REVALIDATION_SENTINEL::UInt = 1
 const _jl_debug_method_invalidation = RefValue{Union{Nothing,Vector{Any}}}(nothing)
 debug_method_invalidation(onoff::Bool) =
@@ -45,7 +46,8 @@ struct VerifyMethodWorkspace
     visiting::IdDict{CodeInstance,Int}
 
     # whether the image carries a backedge log that is bulk-applied after
-    # verification, making per-CodeInstance store_backedges unnecessary
+    # verification; CodeInstances it covers are flagged BACKEDGES_LOGGED and
+    # skip per-CodeInstance store_backedges, the rest still register here
     prelinked::Bool
 
     # scratch for the per-edge match details; only live within one
@@ -388,8 +390,14 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                         end
                     end
                     @atomic :monotonic child.max_world = result.result_maxworld
-                    if !workspace.prelinked && result.result_maxworld == validation_world && validation_world == get_world_counter() && isdefined(child, :edges) && child.edges isa Core.SimpleVector
-                        Compiler.@zone "VERIFY_Store" store_backedges(child, child.edges)
+                    if result.result_maxworld == validation_world && validation_world == get_world_counter() &&
+                       (!workspace.prelinked || child.flags & CI_FLAGS_BACKEDGES_LOGGED == 0) && isdefined(child, :edges)
+                        # the image's backedge log covers the CodeInstances the worker
+                        # registered backedges for (flagged at save); register the rest here
+                        edges = child.edges
+                        if edges isa Union{Core.SimpleVector, Core.InternedCodeInstance}
+                            Compiler.@zone "VERIFY_Store" store_backedges(child, ci_edges_svec(edges))
+                        end
                     end
                     @assert workspace.visiting[child] == length(workspace.stack) + 1 "internal error maintaining workspace"
                     delete!(workspace.visiting, child)

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -86,7 +86,7 @@ end
 
 # Restore backedges to external targets
 # `internal_methods` = [caller1, ...], the list of worklist-owned code instances internally
-function insert_backedges(internal_methods::Vector{Any}, backedge_log)
+function insert_backedges(internal_methods::Vector{Any}, backedge_log::Union{Vector{Any}, Nothing})
     # determine which CodeInstance objects are still valid in our image
     # to enable any applicable new codes
     backedges_only = unsafe_load(cglobal(:jl_first_image_replacement_world, UInt)) == typemax(UInt)
@@ -755,7 +755,7 @@ function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UIn
 end
 
 # Wrapper to call insert_backedges in typeinf_world for external calls
-function insert_backedges_typeinf(internal_methods::Vector{Any}, backedge_log)
+function insert_backedges_typeinf(internal_methods::Vector{Any}, backedge_log::Union{Vector{Any}, Nothing})
     args = Any[insert_backedges, internal_methods, backedge_log]
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
 end

--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -243,7 +243,12 @@ function edge_debuginfo(di, pc::Int)
     _, eid::Int, epc::Int = getdebugidx(di, pc)
     # XXX: eid > 0 should imply epc > 0
     (eid > 0 && epc > 0) || return (nothing, 0)
-    (di.edges[eid]::DebugInfo, epc)
+    es = di.edges
+    # image DebugInfos carry their inlinee list in the interned word form
+    # (a DebugInfoStream holds a Vector, a runtime DebugInfo a SimpleVector)
+    e = es isa Core.InternedCodeInstance ?
+        ccall(:jl_ici_ref, Any, (Any, Csize_t), es, eid - 1) : es[eid]
+    (e::DebugInfo, epc)
 end
 
 # All 1-based.  0 if unavailable.

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -259,7 +259,7 @@ function _add_edges_impl(edges::Vector{Any}, info::MethodMatchInfo, mi_edge::Boo
             mi = specialize_method(m) # don't allow `Method`-edge for this optimized format
             edge = mi
         else
-            mi = edge.def::MethodInstance
+            mi = ci_def(edge)::MethodInstance
         end
         if mi.specTypes === m.spec_types
             add_one_edge!(edges, edge)
@@ -275,7 +275,7 @@ function _add_edges_impl(edges::Vector{Any}, info::MethodMatchInfo, mi_edge::Boo
         for i = 1:nmatches
             edge = method_match_edge(info, i, mi_edge)
             if edge isa CodeInstance
-                @assert edge.def.def === info.results[i].method
+                @assert get_ci_mi(edge).def === info.results[i].method
             end
             push!(edges, edge)
         end
@@ -305,7 +305,7 @@ function add_one_edge!(edges::Vector{Any}, edge::CodeInstance)
         edgeᵢ isa Int && (i += 2 + abs(edgeᵢ); continue)
         edgeᵢ isa CodeInstance && (edgeᵢ = get_ci_mi(edgeᵢ))
         edgeᵢ isa MethodInstance || (i += 1; continue)
-        if edgeᵢ === edge.def && !(i > 1 && edges[i-1] isa Type)
+        if edgeᵢ === ci_def(edge) && !(i > 1 && edges[i-1] isa Type)
             if edgeᵢ_orig isa MethodInstance
                 # found edge we can upgrade
                 edges[i] = edge
@@ -482,7 +482,7 @@ function add_invoke_edge!(edges::Vector{Any}, @nospecialize(atype), edge::Union{
             i += 2 + abs(edgeᵢ)
             continue
         end
-        edgeᵢ isa CodeInstance && (edgeᵢ = edgeᵢ.def)
+        edgeᵢ isa CodeInstance && (edgeᵢ = ci_def(edgeᵢ))
         if !(edgeᵢ isa MethodInstance || edgeᵢ isa Method)
             i += 1
             continue
@@ -508,9 +508,10 @@ function add_invoke_edge!(edges::Vector{Any}, @nospecialize(atype), edge::CodeIn
             i += 2 + abs(edgeᵢ)
             continue
         end
-        edgeᵢ isa CodeInstance && (edgeᵢ = edgeᵢ.def)
-        if ((edgeᵢ isa MethodInstance && edgeᵢ === edge.def) ||
-            (edgeᵢ isa Method && edgeᵢ === edge.def.def))
+        edgeᵢ isa CodeInstance && (edgeᵢ = ci_def(edgeᵢ))
+        edgedef = ci_def(edge)
+        if ((edgeᵢ isa MethodInstance && edgeᵢ === edgedef) ||
+            (edgeᵢ isa Method && edgedef isa MethodInstance && edgeᵢ === edgedef.def))
             i == 1 && (i += 1; continue)
             edge_minus_1 = edges[i - 1]
             if edge_minus_1 isa Type && edge_minus_1 == atype
@@ -546,7 +547,7 @@ function add_inlining_edge!(edges::Vector{Any}, edge::MethodInstance)
             edges[i] = edge
             return
         end
-        edgeᵢ isa CodeInstance && (edgeᵢ = edgeᵢ.def)
+        edgeᵢ isa CodeInstance && (edgeᵢ = ci_def(edgeᵢ))
         if edgeᵢ isa MethodInstance && edgeᵢ === edge
             return # found existing covered edge
         end
@@ -566,12 +567,13 @@ function add_inlining_edge!(edges::Vector{Any}, edge::CodeInstance)
             i += 2 + abs(edgeᵢ)
             continue
         end
-        if edgeᵢ isa Method && edgeᵢ === edge.def.def
+        edgedef = ci_def(edge)
+        if edgeᵢ isa Method && edgedef isa MethodInstance && edgeᵢ === edgedef.def
             # found edge we can upgrade
             edges[i] = edge
             return
         end
-        if edgeᵢ isa MethodInstance && edgeᵢ === edge.def
+        if edgeᵢ isa MethodInstance && edgeᵢ === edgedef
             # found edge we can upgrade
             edges[i] = edge
             return

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -690,7 +690,15 @@ end
     typebound_nothrow(𝕃, ub) || return false
     return true
 end
-add_tfunc(Core._typevar, 3, 3, typevar_tfunc, 100)
+@nospecs function typevar_tfunc(𝕃::AbstractLattice, n, lb_arg, ub_arg, strict)
+    strict isa Const || return TypeVar
+    strictval = strict.val
+    strictval isa Bool || return Union{}
+    # strict vars carry a flag that PartialTypeVar cannot represent; stay imprecise
+    strictval && return TypeVar
+    return typevar_tfunc(𝕃, n, lb_arg, ub_arg)
+end
+add_tfunc(Core._typevar, 3, 4, typevar_tfunc, 100)
 
 struct MemoryOrder x::Cint end
 const MEMORY_ORDER_UNSPECIFIED = MemoryOrder(-2)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1150,7 +1150,7 @@ function lookup_cached_edge(interp::AbstractInterpreter, method::Method,
         return return_cached_result(interp, method, local_result, nothing, caller,
             edgecycle, edgelimited), nothing
     end
-    @assert codeinst.def === mi "MethodInstance for cached edge does not match"
+    @assert ci_def(codeinst) === mi "MethodInstance for cached edge does not match"
 
     if local_result !== nothing
         return return_cached_result(interp, method, local_result, codeinst, caller,
@@ -1227,6 +1227,19 @@ function completed_inference_result(interp::AbstractInterpreter, frame::Inferenc
             Core.svec(internal_result_edges(frame)...))
     end
     return LocalInferenceResult(result, proof, get_inference_world(interp))
+end
+
+function codeinst_edges_sub(existing_edge::CodeInstance, min_world::UInt, max_world::UInt,
+                            edges::Union{SimpleVector, Core.InternedCodeInstance})
+    # return if the existing edge has more restrictions than the other arguments (more edges and narrower worlds)
+    # (interned edge lists of image CodeInstances compare by identity, which
+    # can only miss a chance to reuse `existing_edge`)
+    if existing_edge.min_world >= min_world &&
+       existing_edge.max_world <= max_world &&
+       existing_edge.edges == edges
+        return true
+    end
+    return false
 end
 
 function _schedule_edge_infer_task!(caller::AbsIntState, frame::InferenceState, result::InferenceResult,
@@ -1414,6 +1427,12 @@ for the code of a function that inference has found to just return a constant. F
 stored - the constant is used directly. However, because this is an ABI implementation detail, it is nice to maintain
 consistency and just synthesize a CodeInfo when the reflection APIs ask for them - this function does that.
 """
+# image CodeInstances may carry their edges as a Core.InternedCodeInstance;
+# materialize before handing the list onward
+ci_edges_svec(edges::SimpleVector) = edges
+ci_edges_svec(edges::Core.InternedCodeInstance) =
+    ccall(:jl_ici_to_svec, Core.SimpleVector, (Any,), edges)
+
 function codeinfo_for_const(::AbstractInterpreter, mi::MethodInstance, worlds::WorldRange, edges::SimpleVector, @nospecialize(val))
     method = mi.def::Method
     tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
@@ -1578,7 +1597,7 @@ function ci_get_source(interp::AbstractInterpreter, code::CodeInstance, @nospeci
         inf === nothing || return inf
     end
     if use_const_api(code)
-        return codeinfo_for_const(interp, get_ci_mi(code), WorldRange(code.min_world, code.max_world), code.edges, code.rettype_const)
+        return codeinfo_for_const(interp, get_ci_mi(code), WorldRange(code.min_world, code.max_world), ci_edges_svec(code.edges), code.rettype_const)
     end
     if isa(src, String)
         src = _uncompressed_ir(code, src)
@@ -1622,12 +1641,12 @@ end
 
 function ci_cache_head(mi::MethodInstance)
     isdefined(mi, :cache, :acquire) || return nothing
-    return @atomic :acquire mi.cache
+    return ci_materialize!(@atomic :acquire mi.cache)
 end
 
 function ci_cache_next(code::CodeInstance)
     isdefined(code, :next, :acquire) || return nothing
-    return @atomic :acquire code.next
+    return ci_materialize!(@atomic :acquire code.next)
 end
 
 function find_cached_ci(interp::AbstractInterpreter, mi::MethodInstance,
@@ -1682,7 +1701,7 @@ function ci_is_equivalent_winner(candidate::CodeInstance, ci::CodeInstance,
                                  valid_worlds::WorldRange)
     return (candidate !== ci &&
         ci_worlds_cover(candidate, valid_worlds) &&
-        candidate.def === ci.def &&
+        ci_def(candidate) === ci_def(ci) &&
         candidate.owner === ci.owner &&
         isdefined(candidate, :inferred, :acquire) &&
         isdefined(candidate, :rettype) &&
@@ -2127,7 +2146,7 @@ function compile!(codeinfos::Vector{Any}, workqueue::CompilationQueue;
             end
             # now make sure everything has source code, if desired
             if use_const_api(callee)
-                src = codeinfo_for_const(interp, mi, WorldRange(callee.min_world, callee.max_world), callee.edges, callee.rettype_const)
+                src = codeinfo_for_const(interp, mi, WorldRange(callee.min_world, callee.max_world), ci_edges_svec(callee.edges), callee.rettype_const)
             else
                 src = get(interp.codegen, callee, nothing)
                 if src === nothing
@@ -2244,7 +2263,7 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim_m
         while i <= length(cis)
             ci = cis[i]::CodeInstance
             if isdefined(ci, :edges)
-                edges = ci.edges
+                edges = ci_edges_svec(ci.edges) # image CodeInstances may carry an interned edge list
                 for j = 1:length(edges)
                     isassigned(edges, j) || continue
                     edge = edges[j]

--- a/Compiler/src/utilities.jl
+++ b/Compiler/src/utilities.jl
@@ -174,6 +174,16 @@ isa_compileable_sig(@nospecialize(atype), sparams::SimpleVector, method::Method)
 isa_compileable_sig(m::MethodInstance) = (def = m.def; !isa(def, Method) || isa_compileable_sig(m.specTypes, m.sparam_vals, def))
 isa_compileable_sig(::ABIOverride) = false
 
+# image CodeInstances may carry their `def` in the interned edge container;
+# always go through the C accessor: the field reads as undefined until
+# rematerialized, and `isdefined` const-folds to true for CodeInstance
+ci_def(ci::CodeInstance) = ccall(:jl_ci_def, Any, (Any,), ci)
+# decode the remaining interned fields in place (a no-op for runtime
+# CodeInstances); C chain walks do this as they go (see `jl_ci_next`), so call
+# it before reading such fields of a CodeInstance taken straight from an image
+# or from a cache chain walked here
+ci_materialize!(ci::CodeInstance) = (ccall(:jl_ci_materialize_all, Cvoid, (Any,), ci); ci)
+
 
 """
     is_declared_inline(method::Method)::Bool

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -303,7 +303,7 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
                 haskey(parents, edge) || (parents[edge] = (codeinst, i))
                 edge in inspected && continue
                 edge_mi = get_ci_mi(edge)
-                if edge_mi === edge.def
+                if edge_mi === ci_def(edge)
                     ci = get(caches, edge_mi, nothing)
                     ci isa CodeInstance && continue # assume that only this_world matters for trim
                 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1165,7 +1165,7 @@ function explicit_manifest_deps_get(project_file::String, where::PkgId, name::St
     manifest_file === nothing && return nothing # manifest not found--keep searching LOAD_PATH
     d = get_deps(parsed_toml(manifest_file))
     for (dep_name, entries) in d
-        entries::Vector{Any}
+        entries = entries::Vector{Any}
         for entry in entries
             entry = entry::Dict{String, Any}
             uuid = get(entry, "uuid", nothing)::Union{String, Nothing}
@@ -1493,10 +1493,11 @@ function _include_from_serialized(pkg::PkgId, path::String, ocachepath::Union{No
 
         sv = sv::SimpleVector
         internal_methods = sv[3]::Vector{Any}
+        backedge_log = sv[4]
         Compiler.@zone "CC: INSERT_BACKEDGES" begin
             ccall(:jl_set_loading_closure_from_depmods, Cvoid, (Any, Any), depmods, internal_methods)
             try
-                ReinferUtils.insert_backedges_typeinf(internal_methods)
+                ReinferUtils.insert_backedges_typeinf(internal_methods, backedge_log)
             finally
                 ccall(:jl_clear_loading_closure, Cvoid, ())
             end
@@ -1761,7 +1762,7 @@ function insert_extension_triggers(env::String, pkg::PkgId)::Union{Nothing,Missi
         manifest_file === nothing && return
         d = get_deps(parsed_toml(manifest_file))
         for (dep_name, entries) in d
-            entries::Vector{Any}
+            entries = entries::Vector{Any}
             for entry in entries
                 entry = entry::Dict{String, Any}
                 uuid = get(entry, "uuid", nothing)::Union{String, Nothing}
@@ -1776,7 +1777,7 @@ function insert_extension_triggers(env::String, pkg::PkgId)::Union{Nothing,Missi
                         deps′_expanded = Dict{String, Any}()
                         for (dep_name, entries) in d
                             dep_name in deps′ || continue
-                            entries::Vector{Any}
+                            entries = entries::Vector{Any}
                             if length(entries) != 1
                                 error("expected a single entry for $(repr(dep_name)) in $(repr(project_file))")
                             end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1494,7 +1494,12 @@ function _include_from_serialized(pkg::PkgId, path::String, ocachepath::Union{No
         sv = sv::SimpleVector
         internal_methods = sv[3]::Vector{Any}
         Compiler.@zone "CC: INSERT_BACKEDGES" begin
-            ReinferUtils.insert_backedges_typeinf(internal_methods)
+            ccall(:jl_set_loading_closure_from_depmods, Cvoid, (Any, Any), depmods, internal_methods)
+            try
+                ReinferUtils.insert_backedges_typeinf(internal_methods)
+            finally
+                ccall(:jl_clear_loading_closure, Cvoid, ())
+            end
         end
         restored = register_restored_modules(sv, pkg, path)
 
@@ -4605,7 +4610,10 @@ end
 @constprop :none function stale_cachefile(modspec::PkgLoadSpec, cachefile::String; ignore_loaded::Bool = false, requested_flags::CacheFlags=CacheFlags(), reasons=nothing, verify_checksums::Bool=true)
     return stale_cachefile(PkgId(""), UInt128(0), modspec, cachefile; ignore_loaded, requested_flags, reasons, verify_checksums)
 end
-@constprop :none function stale_cachefile(modkey::PkgId, build_id::UInt128, modspec::PkgLoadSpec, cachefile::String;
+@constprop :none function stale_cachefile(modkey::PkgId, build_id::UInt128, modspec::PkgLoadSpec, cachefile::String; kwargs...)
+    Compiler.@zone "STALECHECK" _stale_cachefile(modkey, build_id, modspec, cachefile; kwargs...)
+end
+@constprop :none function _stale_cachefile(modkey::PkgId, build_id::UInt128, modspec::PkgLoadSpec, cachefile::String;
                                           ignore_loaded::Bool=false, requested_flags::CacheFlags=CacheFlags(),
                                           reasons::Union{Dict{Symbol,Int},Nothing}=nothing, stalecheck::Bool=true,
                                           verify_checksums::Bool=true)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1493,7 +1493,7 @@ function _include_from_serialized(pkg::PkgId, path::String, ocachepath::Union{No
 
         sv = sv::SimpleVector
         internal_methods = sv[3]::Vector{Any}
-        backedge_log = sv[4]
+        backedge_log = sv[4]::Union{Vector{Any}, Nothing}
         Compiler.@zone "CC: INSERT_BACKEDGES" begin
             ccall(:jl_set_loading_closure_from_depmods, Cvoid, (Any, Any), depmods, internal_methods)
             try

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1789,10 +1789,38 @@ function _uncompressed_ir(m::Method)
 end
 
 _uncompressed_ir(codeinst::CodeInstance, s::String) =
-    ccall(:jl_uncompress_ir, Ref{CodeInfo}, (Any, Any, Any), codeinst.def.def::Method, codeinst, s)
+    ccall(:jl_uncompress_ir, Ref{CodeInfo}, (Any, Any, Any), (get_ci_mi(codeinst).def)::Method, codeinst, s)
+
+# image CodeInstances and DebugInfos may carry pointer fields in the interned
+# edge container; always go through the C accessors: the fields read as
+# undefined until rematerialized, and `isdefined` const-folds to true.
+ci_def(codeinst::CodeInstance) = ccall(:jl_ci_def, Any, (Any,), codeinst)
+
+# (`next` is never interned: it is runtime-mutable cache-chain state)
+const _ci_interned_fields = (:def, :owner, :rettype, :exctype,
+                             :rettype_const, :inferred, :debuginfo, :analysis_results)
+
+# NOTE: `isdefined` const-folds to true for these always-constructed fields,
+# so the probe must be the unconditional C call (whose fast path is a single
+# branch when nothing is interned)
+function getproperty(ci::CodeInstance, name::Symbol)
+    name in _ci_interned_fields && ccall(:jl_ci_materialize_all, Cvoid, (Any,), ci)
+    return getfield(ci, name)
+end
+function getproperty(ci::CodeInstance, name::Symbol, order::Symbol)
+    name in _ci_interned_fields && ccall(:jl_ci_materialize_all, Cvoid, (Any,), ci)
+    return getfield(ci, name, order)
+end
+
+function getproperty(di::Core.DebugInfo, name::Symbol)
+    if name === :def || name === :linetable || name === :codelocs || name === :edges
+        ccall(:jl_di_materialize_all, Cvoid, (Any,), di)
+    end
+    return getfield(di, name)
+end
 
 function get_ci_mi(codeinst::CodeInstance)
-    def = codeinst.def
+    def = ci_def(codeinst)
     if def isa Core.ABIOverride
         return def.def
     else

--- a/base/show.jl
+++ b/base/show.jl
@@ -1496,7 +1496,7 @@ end
 show(io::IO, mi::Core.MethodInstance) = show_mi(io, mi)
 function show(io::IO, codeinst::Core.CodeInstance)
     print(io, "CodeInstance for ")
-    def = codeinst.def
+    def = ci_def(codeinst)
     if isa(def, Core.ABIOverride)
         show_mi(io, def.def)
         print(io, " (ABI Overridden)")

--- a/doc/src/devdocs/agents/skills/load-profiling/SKILL.md
+++ b/doc/src/devdocs/agents/skills/load-profiling/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: load-profiling
+description: How to profile Julia load/precompile time reliably — which instruments to trust for locating vs sizing vs deciding, the known tracy distortions (wandering GC, inclusive totals, attach overhead), and the A/B doctrine for wall-time claims.
+---
+
+# Reliable profiling of Julia load time
+
+Hard-won methodology from the 2026 load-time optimization campaign. Three
+multi-day "opportunities" (ScanNewMethods, ACTIVATE_Tag sig-walk, GC-defer)
+were phantoms of instrumentation; each survived zone profiling and in-process
+timers, and died only under same-binary same-depot A/B walls. Use the right
+instrument for each question.
+
+## The three questions and their instruments
+
+| Question | Instrument | Never use |
+|---|---|---|
+| *Where* does time go? | tracy timeline (attached), zone names | — |
+| *How big* is a phase? | **counts backend self-time, n≥5 plain runs** | single tracy capture totals |
+| *Is it worth removing?* | **same-depot A/B walls (n≥8–10/arm)** | any zone number |
+
+A zone number is a search hint, not a size. A size is an upper bound, not a
+win. Only the A/B is a win.
+
+## Instrument 1: the timing-counts backend (primary sizing tool)
+
+Build with both backends (`Make.user`):
+
+```
+WITH_TRACY := 1
+WITH_TIMING_COUNTS := 1
+```
+
+`WITH_TIMING_COUNTS` changes only C flags — **make does not track flag
+changes**, so force it: `make -C src clean && make -j`. Set `JULIA_TIMINGS=1`
+in the environment to get the `JULIA TIMINGS` table on stderr at exit (it is
+opt-in because an unconditional dump breaks tests that assert on subprocess
+stderr, e.g. test/precompile.jl's Iterators check), with per-event **Self**
+and **Total** cycles (TSC ≈ 3.0 GHz on the current box; calibrate per machine via
+ROOT-total / process lifetime; here 1 Mcyc ≈ 0.33 ms).
+
+- **Self excludes children** — a GC pause that fires inside a zone lands in
+  the GC/GC_Mark events, not the enclosing zone's self. Self is the
+  GC-normalized number.
+- Runs standalone: no profiler attach, no `JULIA_WAIT_FOR_TRACY`, ~zero
+  distortion. The self column closes: Σ(self) ≈ LOAD_Require total ≈ wall.
+- Always aggregate **n≥5 runs** with `scratch-tools/timings-parse.py
+  run1.err run2.err ...` (mean ± sd per event). A number without an sd is a
+  single sample of a lottery (see below).
+
+## Instrument 2: tracy (timeline/locating only)
+
+- `tracy-csvexport <trace>` reports **inclusive** totals: parents
+  double-count children (GC, SUBTYPE, INTERSECT). Do not diff inclusive
+  totals across traces — different zone-set configurations change parent
+  totals with no change in work.
+- `tracy-csvexport -e` gives self-times, but on the **attached** process,
+  which runs ~13% slower overall and non-uniformly: per-zone-event cost
+  scales with instance count (measured: SUBTYPE self +28%, INTERSECT_EnvS
+  +41% at 314–811k instances; LOAD_Relocs only +10%).
+- Even `-e` self is polluted by **unzoned safepoint waits**: when a GC pause
+  is executed by another thread, the waiting thread has no nested zone, so
+  the pause lands in whatever zone that thread had open. The counts backend
+  largely escapes this because the main thread (sole allocator) wins the GC
+  race and nests its own GC event.
+- Capture recipe: start julia with `JULIA_WAIT_FOR_TRACY=1` in background,
+  then `tracy-capture -f -o out.tracy` (attaching late truncates the trace —
+  a partial capture looks like a mysteriously cheap load).
+
+## The wandering-GC lottery (why single captures lie)
+
+~330–350 ms of GC runs during a full CairoMakie load, in a handful of
+pauses. Each pause is billed inside whichever zone allocated the triggering
+byte — a different zone on every run. Measured signature across 5 plain
+runs: ADD_METHOD, ACTIVATE_TmapIns, LOAD_ScanNewMethods, LOAD_Pkgimg all
+showed **total-sd ≈ 235 Mcyc (±78 ms) while their self-sd stayed ≤ 2%** —
+the same pause rotating between them. Historical example: the
+"ScanNewMethods 48 ms → 114 ms regression" that motivated a full
+investigation was GC placement, not work growth (its true self is a stable
+52 ms). If a zone's total moves between runs but its self doesn't, it's the
+lottery, not a regression.
+
+## The migration trap (why even true self-time ≠ removable wall)
+
+Deleting a phase with X ms of *stable, real* self-time can move walls by ~0:
+its cycles may substitute for stalls other phases would otherwise pay
+(first-touch page faults, cache/TLB warming, lazy materialization — whoever
+touches first gets billed). Measured example (scan on/off via a
+temporary gate that skipped it, interleaved n=3/arm): the scan's
+52 ms of stable self-time gave Δwall = 0.000 s (2.444 vs 2.444 mean),
+Δinstructions = +156 M (≈ the scan's real work — it does execute), Δcycles
+statistically zero — ~200 M extra instructions absorbed into existing
+stalls. Hardware-counter check for this trap: measure Δinstructions vs
+Δcycles with `scratch-tools/miniperf` (groups: `a` =
+cycles/instructions/faults/task-clock, `b` = cache/dTLB/frontend-stall) —
+if instructions rise by the phase's work but cycles barely move, the time
+migrated; note counter multiplexing adds ~±1% jitter, so size expected
+deltas against that. Perf context for this workload: IPC ≈ 1.4 (not memory-bound in
+the classic sense), ~236k page faults, 27% frontend stalls, 10M dTLB misses;
+`perf` binary is absent in the sandbox but `perf_event_paranoid=0`, so
+perf_event_open works — miniperf wraps it.
+
+## The A/B doctrine (the only decider)
+
+Wall-time claims require: same binary, same depot, only an env gate
+differing; n≥8–10 alternating runs per arm; compare means against the
+measured noise floor (±8–15 ms here; `taskset` to fixed cores, e.g. 8–15).
+Wire temporary gates in C (`getenv` + static memo) — Compiler-side gates
+force a 15-minute sysimage rebuild and a full depot regen. Never trust an
+A/B where the depot regenerated between arms: cache-layout luck alone is
+worth ±50 ms.
+
+## Calibration anchors (this box, 255-image CairoMakie workload, walls ≈2.5 s)
+
+Stable self-times (plain counts runs): LOAD_Relocs ≈ 450 ms,
+VERIFY_Prepass ≈ 300 ms, GC_Mark ≈ 325 ms, SUBTYPE ≈ 280 ms,
+LOAD_Uniquing ≈ 253 ms, JIT_Compile ≈ 100 ms, VERIFY_Store ≈ 100 ms,
+STALECHECK ≈ 84 ms, LOAD_ScanNewMethods ≈ 52 ms, ADD_METHOD ≈ 9 ms.
+History says byte/record-volume cuts move walls; pure CPU-work removal
+usually doesn't survive the A/B. Sharpest formulation (four A/Bs deep): a
+phase's wall cost is its **cache/memory footprint**, not its instruction
+count. Swapping expensive compute for cheap compute over the same data
+measures ~0 (fdisj fast path: −73 ms of verdict compute, −6 ± 16 ms wall);
+eliminating the phase's data-touching wholesale materializes (SC oracle:
+−172 ms wall). Optimize by not touching data, not by touching it faster.
+
+## Tooling paths
+
+- `/workspace/scratch-tools/miniperf.c` (+ built binary) — perf_event_open
+  wrapper; usage: `miniperf a|b <cmd...>`, counters print to stderr as `MP`.
+- `/workspace/scratch-tools/timings-parse.py` — aggregates JULIA TIMINGS
+  tables across runs.
+- Keep tools and measurement logs in `/workspace/scratch-tools/`
+  (git-excluded): `/tmp` scratchpads AND `/root/.claude/jobs/*/tmp` are
+  pruned mid-session by the sandbox.

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -543,8 +543,8 @@ static void generate_cfunc_thunks(jl_codegen_output_t &out) JL_CANSAFEPOINT
     DenseMap<jl_method_instance_t*, jl_code_instance_t*> compiled_mi;
     for (auto &[ci, _] : out.ci_funcs) {
         jl_method_instance_t *mi = jl_get_ci_mi(ci);
-        if ((ci->owner == jl_nothing || ci->owner == (jl_value_t*)jl_trim_sym) &&
-            jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0 && ci->def == (jl_value_t*)mi)
+        if ((jl_ci_owner(ci) == jl_nothing || jl_ci_owner(ci) == (jl_value_t*)jl_trim_sym) &&
+            jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0 && jl_ci_defobj(ci) == (jl_value_t*)mi)
             compiled_mi[mi] = ci;
     }
     size_t latestworld = jl_atomic_load_acquire(&jl_world_counter);
@@ -580,7 +580,7 @@ static void generate_cfunc_thunks(jl_codegen_output_t &out) JL_CANSAFEPOINT
                 codeinst = it->second;
                 JL_GC_PROMISE_ROOTED(codeinst);
                 const auto &decls = out.ci_funcs.find(codeinst)->second;
-                jl_value_t *astrt = codeinst->rettype;
+                jl_value_t *astrt = jl_ci_rettype(codeinst);
                 if (astrt != (jl_value_t*)jl_bottom_type &&
                     jl_type_intersection(astrt, declrt) == jl_bottom_type) {
                     // Do not warn if the function never returns since it is
@@ -589,7 +589,7 @@ static void generate_cfunc_thunks(jl_codegen_output_t &out) JL_CANSAFEPOINT
                     jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name_from_method_instance(mi));
                 }
                 if (decls.invoke_api == JL_INVOKE_CONST) {
-                    std::string gf_thunk_name = emit_abi_constreturn(out, cfunc.abi, codeinst->rettype_const);
+                    std::string gf_thunk_name = emit_abi_constreturn(out, cfunc.abi, jl_ci_rettype_const(codeinst));
                     auto F = out.get_module().getFunction(gf_thunk_name);
                     assert(F);
                     assign_fptr(F);
@@ -833,22 +833,22 @@ static jl_code_instance_t *jl_get_ci_equiv_range(jl_code_instance_t *ci JL_PROPA
 {
     size_t target_min = jl_atomic_load_relaxed(&ci->min_world);
     size_t target_max = jl_atomic_load_relaxed(&ci->max_world);
-    jl_value_t *def = ci->def;
+    jl_value_t *def = jl_ci_defobj(ci);
     jl_method_instance_t *mi = jl_get_ci_mi(ci);
-    jl_value_t *owner = ci->owner;
-    jl_value_t *rettype = ci->rettype;
+    jl_value_t *owner = jl_ci_owner(ci);
+    jl_value_t *rettype = jl_ci_rettype(ci);
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     while (codeinst) {
         if (codeinst != ci &&
-            jl_atomic_load_relaxed(&codeinst->inferred) != NULL &&
+            jl_ci_inferred(codeinst) != NULL &&
             jl_atomic_load_relaxed(&codeinst->min_world) <= target_min &&
             jl_atomic_load_relaxed(&codeinst->max_world) >= target_max &&
-            jl_egal(codeinst->def, def) &&
-            jl_egal(codeinst->owner, owner) &&
-            jl_egal(codeinst->rettype, rettype)) {
+            jl_egal(jl_ci_defobj(codeinst), def) &&
+            jl_egal(jl_ci_owner(codeinst), owner) &&
+            jl_egal(jl_ci_rettype(codeinst), rettype)) {
             return codeinst;
         }
-        codeinst = jl_atomic_load_relaxed(&codeinst->next);
+        codeinst = jl_ci_next(codeinst);
     }
     return ci;
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1922,8 +1922,9 @@ JL_CALLABLE(jl_f_invoke)
         jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
         jl_callptr_t invoke = jl_atomic_load_acquire(&codeinst->invoke);
         // N.B.: specTypes need not be a subtype of the method signature. We need to check both.
-        if (jl_is_abioverride(codeinst->def)) {
-            jl_datatype_t *abi = (jl_datatype_t*)((jl_abi_override_t*)(codeinst->def))->abi;
+        jl_value_t *cidef = jl_ci_defobj(codeinst);
+        if (jl_is_abioverride(cidef)) {
+            jl_datatype_t *abi = (jl_datatype_t*)((jl_abi_override_t*)cidef)->abi;
             if (!jl_tuple1_isa(args[0], &args[2], nargs - 1, abi)) {
                 jl_type_error("invoke: argument type error (ABI overwrite)", (jl_value_t*)abi, arg_tuple(args[0], &args[2], nargs - 1));
             }
@@ -2822,6 +2823,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("MethodCache", (jl_value_t*)jl_methcache_type);
     add_builtin("Method", (jl_value_t*)jl_method_type);
     add_builtin("CodeInstance", (jl_value_t*)jl_code_instance_type);
+    add_builtin("InternedCodeInstance", (jl_value_t*)jl_interned_code_instance_type);
     add_builtin("TypeMapEntry", (jl_value_t*)jl_typemap_entry_type);
     add_builtin("TypeMapLevel", (jl_value_t*)jl_typemap_level_type);
     add_builtin("Symbol", (jl_value_t*)jl_symbol_type);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5970,7 +5970,7 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, jl_code_instance_t 
 {
     jl_method_instance_t *mi = jl_get_ci_mi(ci);
     bool is_opaque_closure = jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
-    return emit_call_specfun_other(ctx, is_opaque_closure, get_ci_abi(ci), ci->rettype, NULL,
+    return emit_call_specfun_other(ctx, is_opaque_closure, get_ci_abi(ci), jl_ci_rettype(ci), NULL,
         specFunctionObject, argv, nargs, cc, return_roots, inferred_retty,
         jl_atomic_load_relaxed(&ci->ipo_purity_bits));
 }
@@ -6047,11 +6047,11 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
                 auto invoke = jl_atomic_load_acquire(&codeinst->invoke);
                  // check if we know how to handle this specptr
                 if (invoke == jl_fptr_const_return_addr) {
-                    result = mark_julia_const(ctx, codeinst->rettype_const);
+                    result = mark_julia_const(ctx, jl_ci_rettype_const(codeinst));
                 }
                 else {
                     bool specsig, needsparams;
-                    std::tie(specsig, needsparams) = uses_specsig(get_ci_abi(codeinst), mi, codeinst->rettype, ctx.params->prefer_specsig);
+                    std::tie(specsig, needsparams) = uses_specsig(get_ci_abi(codeinst), mi, jl_ci_rettype(codeinst), ctx.params->prefer_specsig);
                     if (needsparams) {
                         Value *r = emit_jlcall(ctx, jlinvoke_func, track_pjlvalue(ctx, literal_pointer_val(ctx, (jl_value_t*)mi)), argv, nargs, julia_call2);
                         result = mark_julia_type(ctx, r, true, rt);
@@ -6064,7 +6064,7 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
                         if (specsig)
                             result = emit_call_specfun_other(ctx, codeinst, protoname, argv, nargs, &cc, &return_roots, rt);
                         else
-                            result = emit_call_specfun_boxed(ctx, codeinst->rettype, protoname, argv, nargs, rt);
+                            result = emit_call_specfun_boxed(ctx, jl_ci_rettype(codeinst), protoname, argv, nargs, rt);
                     }
                 }
                 handled = true;
@@ -7884,9 +7884,9 @@ Function *emit_specsig_to_fptr1(jl_codegen_output_t &out, jl_code_instance_t *ci
     jl_value_t *specTypes = get_ci_abi(ci);
     jl_returninfo_t info =
         get_specsig_function(out, &out.get_module(), nullptr, gf_thunk_name, specTypes,
-                             ci->rettype, is_opaque_closure);
+                             jl_ci_rettype(ci), is_opaque_closure);
     Function *spec_func = cast<Function>(info.decl.getCallee());
-    emit_specsig_to_fptr1(spec_func, info.cc, info.return_roots, specTypes, ci->rettype,
+    emit_specsig_to_fptr1(spec_func, info.cc, info.return_roots, specTypes, jl_ci_rettype(ci),
                           is_opaque_closure, out, func);
     return spec_func;
 }
@@ -7957,19 +7957,19 @@ std::string emit_abi_converter(jl_codegen_output_t &out, jl_abi_t from_abi, jl_c
     gf_thunk_name += "_gfthunk";
     if (target_specsig) {
         jl_value_t *abi = get_ci_abi(codeinst);
-        jl_returninfo_t targetspec = get_specsig_function(out, M, target, "", abi, codeinst->rettype, target_is_opaque_closure);
+        jl_returninfo_t targetspec = get_specsig_function(out, M, target, "", abi, jl_ci_rettype(codeinst), target_is_opaque_closure);
         if (from_abi.specsig)
             emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, from_abi.is_opaque_closure, out,
-                    target, mi->specTypes, codeinst->rettype, &targetspec, nullptr);
+                    target, mi->specTypes, jl_ci_rettype(codeinst), &targetspec, nullptr);
         else
-            gen_invoke_wrapper(mi, abi, codeinst->rettype, from_abi.rt, targetspec, -1, from_abi.is_opaque_closure, gf_thunk_name, M, out);
+            gen_invoke_wrapper(mi, abi, jl_ci_rettype(codeinst), from_abi.rt, targetspec, -1, from_abi.is_opaque_closure, gf_thunk_name, M, out);
     }
     else {
         if (from_abi.specsig)
             emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, from_abi.is_opaque_closure, out,
-                    target, mi->specTypes, codeinst->rettype, nullptr, nullptr);
+                    target, mi->specTypes, jl_ci_rettype(codeinst), nullptr, nullptr);
         else
-            emit_fptr1_wrapper(M, gf_thunk_name, target, nullptr, from_abi.rt, codeinst->rettype, out);
+            emit_fptr1_wrapper(M, gf_thunk_name, target, nullptr, from_abi.rt, jl_ci_rettype(codeinst), out);
     }
     return gf_thunk_name;
 }
@@ -7995,9 +7995,9 @@ std::string emit_abi_dispatcher(jl_codegen_output_t &out, jl_abi_t from_abi, jl_
     raw_string_ostream(gf_thunk_name) << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1) << "_gfthunk";
     if (from_abi.specsig)
         emit_specsig_to_specsig(M, gf_thunk_name, from_abi.sigt, from_abi.rt, from_abi.is_opaque_closure, out,
-                target, from_abi.sigt, codeinst ? codeinst->rettype : (jl_value_t*)jl_any_type, nullptr, nullptr);
+                target, from_abi.sigt, codeinst ? jl_ci_rettype(codeinst) : (jl_value_t*)jl_any_type, nullptr, nullptr);
     else
-        emit_fptr1_wrapper(M, gf_thunk_name, target, nullptr, from_abi.rt, codeinst ? codeinst->rettype : (jl_value_t*)jl_any_type, out);
+        emit_fptr1_wrapper(M, gf_thunk_name, target, nullptr, from_abi.rt, codeinst ? jl_ci_rettype(codeinst) : (jl_value_t*)jl_any_type, out);
     return gf_thunk_name;
 }
 
@@ -8019,14 +8019,14 @@ std::string emit_abi_constreturn(jl_codegen_output_t &out, jl_abi_t from_abi, jl
 std::string emit_abi_constreturn(jl_codegen_output_t &out, bool specsig, jl_code_instance_t *codeinst)
 {
     jl_value_t *sigt = get_ci_abi(codeinst);
-    jl_value_t *rt = codeinst->rettype;
+    jl_value_t *rt = jl_ci_rettype(codeinst);
 
     jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
     bool is_opaque_closure = jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
 
     jl_abi_t abi = {sigt, rt, specsig, is_opaque_closure};
 
-    return emit_abi_constreturn(out, abi, codeinst->rettype_const);
+    return emit_abi_constreturn(out, abi, jl_ci_rettype_const(codeinst));
 }
 
 // (get_abi_converter / method table mutating thread)
@@ -9891,17 +9891,18 @@ static jl_llvm_functions_t
             append_lineinfo = [&](jl_debuginfo_t *debuginfo, jl_value_t *func, size_t to,
                                   size_t pc, bool innermost) -> bool {
             while (1) {
-                if (!jl_is_symbol(debuginfo->def)) // this is a path
-                    func = debuginfo->def; // this is inlined
+                jl_value_t *didef = jl_di_def(debuginfo);
+                if (!jl_is_symbol(didef)) // this is a path
+                    func = didef; // this is inlined
                 struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, pc);
                 size_t i = lineidx.loc;
                 if (i < 0) // pc out of range: broken debuginfo?
                     return false;
                 if (i == 0 && lineidx.to == 0) // no update
                     return false;
-                if (pc > 0 && jl_is_debuginfo(debuginfo->linetable)) {
+                if (pc > 0 && jl_is_debuginfo(jl_di_linetable(debuginfo))) {
                     // indirection node
-                    if (!append_lineinfo((jl_debuginfo_t *)debuginfo->linetable,
+                    if (!append_lineinfo((jl_debuginfo_t *)jl_di_linetable(debuginfo),
                                          func, to, i, lineidx.to == 0))
                         return false; // no update
                 }
@@ -9971,7 +9972,7 @@ static jl_llvm_functions_t
                 if (to == 0)
                     return true;
                 pc = lineidx.pc;
-                debuginfo = (jl_debuginfo_t*)jl_svecref(debuginfo->edges, to - 1);
+                debuginfo = (jl_debuginfo_t*)jl_edgelist_ref((jl_value_t*)debuginfo->edges, to - 1);
                 func = NULL;
             }
         };
@@ -10107,14 +10108,15 @@ static jl_llvm_functions_t
     if (coverage_mode != JL_LOG_NONE) {
         // record all lines that could be covered
         std::function<void(jl_debuginfo_t *debuginfo, jl_value_t *func)> record_line_exists = [&](jl_debuginfo_t *debuginfo, jl_value_t *func) {
-            if (!jl_is_symbol(debuginfo->def)) // this is a path
-                func = debuginfo->def; // this is inlined
-            for (size_t i = 0; i < jl_svec_len(debuginfo->edges); i++) {
-                jl_debuginfo_t *edge = (jl_debuginfo_t*)jl_svecref(debuginfo->edges, i);
+            jl_value_t *didef2 = jl_di_def(debuginfo);
+            if (!jl_is_symbol(didef2)) // this is a path
+                func = didef2; // this is inlined
+            for (size_t i = 0; i < jl_edgelist_len((jl_value_t*)debuginfo->edges); i++) {
+                jl_debuginfo_t *edge = (jl_debuginfo_t*)jl_edgelist_ref((jl_value_t*)debuginfo->edges, i);
                 record_line_exists(edge, NULL);
             }
-            while (jl_is_debuginfo(debuginfo->linetable))
-                debuginfo = (jl_debuginfo_t*)debuginfo->linetable;
+            while (jl_is_debuginfo(jl_di_linetable(debuginfo)))
+                debuginfo = (jl_debuginfo_t*)jl_di_linetable(debuginfo);
             jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
             StringRef file = jl_cdi_file(debuginfo);
             if (file.empty())
@@ -10723,7 +10725,7 @@ jl_llvm_functions_t jl_emit_codedecls(jl_codegen_output_t &out,
     jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
     bool specsig, needsparams;
     std::tie(specsig, needsparams) = uses_specsig(
-        get_ci_abi(codeinst), mi, codeinst->rettype, out.params->prefer_specsig);
+        get_ci_abi(codeinst), mi, jl_ci_rettype(codeinst), out.params->prefer_specsig);
     if (jl_atomic_load_relaxed(&codeinst->invoke) == jl_fptr_const_return_addr) {
         decls.invoke_api = JL_INVOKE_CONST;
     }
@@ -10811,10 +10813,10 @@ std::optional<jl_llvm_functions_t> jl_emit_codeinst(
         // to satisfy the dispatching implementation requirements of jl_f_opaque_closure_call
         if (mi->def.method != jl_opaque_closure_method)
             return {}; // user error
-        decls = jl_emit_oc_wrapper(out, mi, codeinst->rettype);
+        decls = jl_emit_oc_wrapper(out, mi, jl_ci_rettype(codeinst));
     } else {
         //assert(jl_egal((jl_value_t*)jl_atomic_load_relaxed(&codeinst->debuginfo), (jl_value_t*)src->debuginfo) && "trying to generate code for a codeinst for an incompatible src");
-        decls = jl_emit_code(out, mi, src, get_ci_abi(codeinst), codeinst->rettype, codeinst);
+        decls = jl_emit_code(out, mi, src, get_ci_abi(codeinst), jl_ci_rettype(codeinst), codeinst);
     }
     if (!decls)
         return {};

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9891,7 +9891,7 @@ static jl_llvm_functions_t
             append_lineinfo = [&](jl_debuginfo_t *debuginfo, jl_value_t *func, size_t to,
                                   size_t pc, bool innermost) -> bool {
             while (1) {
-                jl_value_t *didef = jl_di_def(debuginfo);
+                jl_value_t *didef = jl_di_def_ro(debuginfo);
                 if (!jl_is_symbol(didef)) // this is a path
                     func = didef; // this is inlined
                 struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, pc);
@@ -9900,9 +9900,9 @@ static jl_llvm_functions_t
                     return false;
                 if (i == 0 && lineidx.to == 0) // no update
                     return false;
-                if (pc > 0 && jl_is_debuginfo(jl_di_linetable(debuginfo))) {
+                if (pc > 0 && jl_is_debuginfo(jl_di_linetable_ro(debuginfo))) {
                     // indirection node
-                    if (!append_lineinfo((jl_debuginfo_t *)jl_di_linetable(debuginfo),
+                    if (!append_lineinfo((jl_debuginfo_t *)jl_di_linetable_ro(debuginfo),
                                          func, to, i, lineidx.to == 0))
                         return false; // no update
                 }
@@ -9972,7 +9972,7 @@ static jl_llvm_functions_t
                 if (to == 0)
                     return true;
                 pc = lineidx.pc;
-                debuginfo = (jl_debuginfo_t*)jl_edgelist_ref((jl_value_t*)debuginfo->edges, to - 1);
+                debuginfo = (jl_debuginfo_t*)jl_edgelist_ref_nobox((jl_value_t*)debuginfo->edges, to - 1);
                 func = NULL;
             }
         };
@@ -10108,15 +10108,15 @@ static jl_llvm_functions_t
     if (coverage_mode != JL_LOG_NONE) {
         // record all lines that could be covered
         std::function<void(jl_debuginfo_t *debuginfo, jl_value_t *func)> record_line_exists = [&](jl_debuginfo_t *debuginfo, jl_value_t *func) {
-            jl_value_t *didef2 = jl_di_def(debuginfo);
+            jl_value_t *didef2 = jl_di_def_ro(debuginfo);
             if (!jl_is_symbol(didef2)) // this is a path
                 func = didef2; // this is inlined
             for (size_t i = 0; i < jl_edgelist_len((jl_value_t*)debuginfo->edges); i++) {
-                jl_debuginfo_t *edge = (jl_debuginfo_t*)jl_edgelist_ref((jl_value_t*)debuginfo->edges, i);
+                jl_debuginfo_t *edge = (jl_debuginfo_t*)jl_edgelist_ref_nobox((jl_value_t*)debuginfo->edges, i);
                 record_line_exists(edge, NULL);
             }
-            while (jl_is_debuginfo(jl_di_linetable(debuginfo)))
-                debuginfo = (jl_debuginfo_t*)jl_di_linetable(debuginfo);
+            while (jl_is_debuginfo(jl_di_linetable_ro(debuginfo)))
+                debuginfo = (jl_debuginfo_t*)jl_di_linetable_ro(debuginfo);
             jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
             StringRef file = jl_cdi_file(debuginfo);
             if (file.empty())

--- a/src/engine.c
+++ b/src/engine.c
@@ -185,14 +185,14 @@ void jl_engine_fulfill(jl_code_instance_t *ci, jl_code_info_t *src)
     jl_task_t *ct = jl_current_task;
     uv_mutex_lock(&engine_lock);
     jl_method_instance_t *mi = jl_get_ci_mi(ci);
-    reservation_info_t *info = get_reservation(mi, ci->owner);
+    reservation_info_t *info = get_reservation(mi, jl_ci_owner(ci));
     if (info == HT_NOTFOUND || info->ci != ci) {
         uv_mutex_unlock(&engine_lock);
         return;
     }
     assert(jl_atomic_load_relaxed(&ct->tid) == info->tid);
     ct->ptls->engine_nqueued--; // re-enables finalizers, but doesn't immediately try to run them
-    remove_reservation(mi, ci->owner);
+    remove_reservation(mi, jl_ci_owner(ci));
     free(info);
     uv_cond_broadcast(&engine_wait);
     uv_mutex_unlock(&engine_lock);

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -728,8 +728,14 @@ JL_DLLEXPORT void jl_gc_scan_vm_specific_roots(RootsWorkClosure* closure)
     add_node_to_roots_buffer(closure, &buf, &len, jl_method_table);
     if (jl_method_contributors)
         add_node_to_roots_buffer(closure, &buf, &len, jl_method_contributors);
+    if (jl_method_contributor_methods)
+        add_node_to_roots_buffer(closure, &buf, &len, jl_method_contributor_methods);
     if (jl_activation_certs)
         add_node_to_roots_buffer(closure, &buf, &len, jl_activation_certs);
+    if (jl_sig_tn_table)
+        add_node_to_roots_buffer(closure, &buf, &len, jl_sig_tn_table);
+    if (jl_backedge_log)
+        add_node_to_roots_buffer(closure, &buf, &len, jl_backedge_log);
 
     // builtin values
     add_node_to_roots_buffer(closure, &buf, &len, jl_an_empty_vec_any);

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -726,6 +726,8 @@ JL_DLLEXPORT void jl_gc_scan_vm_specific_roots(RootsWorkClosure* closure)
 
     // add global_method_table
     add_node_to_roots_buffer(closure, &buf, &len, jl_method_table);
+    if (jl_method_contributors)
+        add_node_to_roots_buffer(closure, &buf, &len, jl_method_contributors);
 
     // builtin values
     add_node_to_roots_buffer(closure, &buf, &len, jl_an_empty_vec_any);

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -728,6 +728,8 @@ JL_DLLEXPORT void jl_gc_scan_vm_specific_roots(RootsWorkClosure* closure)
     add_node_to_roots_buffer(closure, &buf, &len, jl_method_table);
     if (jl_method_contributors)
         add_node_to_roots_buffer(closure, &buf, &len, jl_method_contributors);
+    if (jl_activation_certs)
+        add_node_to_roots_buffer(closure, &buf, &len, jl_activation_certs);
 
     // builtin values
     add_node_to_roots_buffer(closure, &buf, &len, jl_an_empty_vec_any);

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3148,6 +3148,10 @@ static void gc_mark_roots(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
     gc_try_claim_and_push(mq, jl_backedge_log, NULL);
     gc_try_claim_and_push(mq, jl_sig_tn_table, NULL);
     gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_method_contributors, "method_contributors");
+    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_method_contributor_methods, "method_contributor_methods");
+    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_activation_certs, "activation_certs");
+    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_backedge_log, "backedge_log");
+    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_sig_tn_table, "sig_tn_table");
     gc_heap_snapshot_record_gc_roots((jl_value_t*)_jl_debug_method_invalidation, "debug_method_invalidation");
     // constants
     gc_try_claim_and_push(mq, jl_emptytuple_type, NULL);

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3142,6 +3142,8 @@ static void gc_mark_roots(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
         gc_heap_snapshot_record_array_edge_index((jl_value_t*)jl_anytuple_type_type, (jl_value_t*)v, i);
     }
     gc_try_claim_and_push(mq, _jl_debug_method_invalidation, NULL);
+    gc_try_claim_and_push(mq, jl_method_contributors, NULL);
+    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_method_contributors, "method_contributors");
     gc_heap_snapshot_record_gc_roots((jl_value_t*)_jl_debug_method_invalidation, "debug_method_invalidation");
     // constants
     gc_try_claim_and_push(mq, jl_emptytuple_type, NULL);

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3143,6 +3143,7 @@ static void gc_mark_roots(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
     }
     gc_try_claim_and_push(mq, _jl_debug_method_invalidation, NULL);
     gc_try_claim_and_push(mq, jl_method_contributors, NULL);
+    gc_try_claim_and_push(mq, jl_activation_certs, NULL);
     gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_method_contributors, "method_contributors");
     gc_heap_snapshot_record_gc_roots((jl_value_t*)_jl_debug_method_invalidation, "debug_method_invalidation");
     // constants

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3143,7 +3143,10 @@ static void gc_mark_roots(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
     }
     gc_try_claim_and_push(mq, _jl_debug_method_invalidation, NULL);
     gc_try_claim_and_push(mq, jl_method_contributors, NULL);
+    gc_try_claim_and_push(mq, jl_method_contributor_methods, NULL);
     gc_try_claim_and_push(mq, jl_activation_certs, NULL);
+    gc_try_claim_and_push(mq, jl_backedge_log, NULL);
+    gc_try_claim_and_push(mq, jl_sig_tn_table, NULL);
     gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_method_contributors, "method_contributors");
     gc_heap_snapshot_record_gc_roots((jl_value_t*)_jl_debug_method_invalidation, "debug_method_invalidation");
     // constants

--- a/src/gf.c
+++ b/src/gf.c
@@ -2331,7 +2331,14 @@ static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_in
     return 1;
 }
 
-static jl_value_t *get_intersect_matches(jl_typemap_t *defs, jl_typemap_entry_t *newentry, jl_typemap_entry_t **replaced, size_t world) JL_CANSAFEPOINT
+static int intersect_entry_foreign(jl_typemap_entry_t *ml, struct typemap_intersection_env *closure)
+{
+    // hybrid certificate scan: only look at methods the precompile worker
+    // could not have seen (outside the loading image's dependency closure)
+    return !method_in_loading_closure(ml->func.method);
+}
+
+static jl_value_t *get_intersect_matches(jl_typemap_t *defs, jl_typemap_entry_t *newentry, jl_typemap_entry_t **replaced, size_t world, int foreign_only) JL_CANSAFEPOINT
 {
     jl_tupletype_t *type = newentry->sig;
     jl_tupletype_t *ttypes = (jl_tupletype_t*)jl_unwrap_unionall((jl_value_t*)type);
@@ -2348,7 +2355,8 @@ static jl_value_t *get_intersect_matches(jl_typemap_t *defs, jl_typemap_entry_t 
     struct matches_env env = {{get_intersect_visitor, (jl_value_t*)type, va, /* .search_slurp = */ 0,
             /* .min_valid = */ world, /* .max_valid = */ world,
             /* .ti = */ NULL, /* .env = */ NULL, /* .issubty = */ 0,
-            /* .emptiness_only = */ 1},
+            /* .emptiness_only = */ 1,
+            /* .entry_filter = */ foreign_only ? intersect_entry_foreign : NULL},
         /* .newentry = */ newentry, /* .shadowed */ NULL, /* .replaced */ NULL};
     JL_GC_PUSH3(&env.match.env, &env.match.ti, &env.shadowed);
     jl_typemap_intersection_visitor(defs, 0, &env.match);
@@ -2733,7 +2741,38 @@ static void _typename_add_backedge(jl_typename_t *tn, int explct, void *env0) JL
 // contributors all lie within the image's dependency closure faces exactly the
 // prior world its precompile worker analyzed.
 JL_DLLEXPORT jl_genericmemory_t *jl_method_contributors = NULL;
+JL_DLLEXPORT jl_genericmemory_t *jl_activation_certs = NULL; // method -> certificate (precompile worker)
 JL_DLLEXPORT uint64_t jl_contrib_stats[8];
+
+static int activate_replay_mode(void)
+{
+    static int mode = -1;
+    if (mode == -1) {
+        const char *e = getenv("JULIA_ACTIVATE_REPLAY");
+        mode = e == NULL ? 0 : (e[0] == '2' ? 2 : (e[0] == '1' ? 1 : 0));
+    }
+    return mode;
+}
+
+static void record_activation_cert(jl_method_t *method, jl_svec_t *cert)
+{
+    if (jl_activation_certs == NULL) {
+        if (jl_an_empty_memory_any == NULL)
+            return;
+        jl_activation_certs = (jl_genericmemory_t*)jl_an_empty_memory_any;
+    }
+    jl_genericmemory_t *newtable = jl_eqtable_put(jl_activation_certs, (jl_value_t*)method, (jl_value_t*)cert, NULL);
+    if (newtable != jl_activation_certs)
+        jl_activation_certs = newtable;
+}
+
+JL_DLLEXPORT jl_value_t *jl_get_activation_cert(jl_method_t *method)
+{
+    if (jl_activation_certs == NULL)
+        return jl_nothing;
+    jl_value_t *cert = jl_eqtable_get(jl_activation_certs, (jl_value_t*)method, NULL);
+    return cert == NULL ? jl_nothing : cert;
+}
 
 static size_t *jl_loading_closure_bits = NULL; // bitset over linkage blobs
 static size_t jl_loading_closure_nblobs = 0;
@@ -3311,6 +3350,11 @@ cleanup:
 
 void jl_method_table_activate(jl_typemap_entry_t *newentry)
 {
+    jl_method_table_activate_with_cert(newentry, NULL);
+}
+
+void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t *cert)
+{
     JL_TIMING(ADD_METHOD, ADD_METHOD);
     jl_method_t *method = newentry->func.method;
     jl_methtable_t *mt = jl_method_get_table(method);
@@ -3333,7 +3377,9 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     jl_value_t *isect = NULL;
     jl_value_t *isect2 = NULL;
     jl_genericmemory_t *interferences = NULL;
-    JL_GC_PUSH6(&oldvalue, &oldmi, &loctag, &isect, &isect2, &interferences);
+    jl_svec_t *newcert = NULL;
+    JL_GC_PUSH7(&oldvalue, &oldmi, &loctag, &isect, &isect2, &interferences, &newcert);
+    int record_cert = jl_generating_output() && jl_options.incremental && mt == jl_method_table;
     int closure_clean = 0;
     if (jl_loading_closure_bits != NULL && mt == jl_method_table) {
         int clean = 1;
@@ -3347,10 +3393,23 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         jl_contrib_stats[closure_clean ? 0 : 1]++;
     }
     jl_typemap_entry_t *replaced = NULL;
-    // Check what entries this intersects with in the prior world.
+    int replaying = cert != NULL && jl_svec_len(cert) == 4 && activate_replay_mode() >= 1;
+    // With a certificate, the dependency-closure part of the prior world is
+    // replayed below and the scan is restricted to foreign entries (methods
+    // the precompile worker could not have seen). The two passes each use
+    // their partial view of the intersecting set: is_replacing and the
+    // missing-backedge checks are monotone in that set, so a partial view
+    // can only over-invalidate, never under-invalidate.
     current_activation_clean = closure_clean;
-    oldvalue = get_intersect_matches(jl_atomic_load_relaxed(&mt->defs), newentry, &replaced, max_world);
+    oldvalue = get_intersect_matches(jl_atomic_load_relaxed(&mt->defs), newentry, &replaced, max_world, replaying);
     current_activation_clean = 0;
+    record_cert = record_cert && !replaying;
+    if (replaying && replaced != NULL) {
+        // a foreign method replaces this one exactly: certificate context is
+        // unusable, redo the full scan
+        replaying = 0;
+        oldvalue = get_intersect_matches(jl_atomic_load_relaxed(&mt->defs), newentry, &replaced, max_world, 0);
+    }
     jl_method_t *const *d;
     size_t j, n;
     if (oldvalue == NULL) {
@@ -3377,7 +3436,166 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     // is covered by another method that is morespecific than both, causing them
     // to have no relevant type intersection for sorting).
     interferences = (jl_genericmemory_t*)jl_atomic_load_relaxed(&method->interferences);
+    if (replaying) {
+        jl_value_t *foreign_oldvalue = oldvalue;
+        // Replay the precompile worker's scan results: same prior world for
+        // this method's typenames (contributor check), so the intersecting
+        // set, specificity flags, and image-mi invalidations are as recorded.
+        jl_value_t *cd = jl_svecref(cert, 0);
+        jl_array_t *cflags = (jl_array_t*)jl_svecref(cert, 1);
+        jl_value_t *cmis = jl_svecref(cert, 2);
+        dispatch_bits = jl_unbox_int32(jl_svecref(cert, 3)) | METHOD_SIG_LATEST_WHICH;
+        if (cd != jl_nothing) {
+            oldvalue = cd;
+            d = (jl_method_t**)jl_array_ptr_data(oldvalue);
+            n = jl_array_nrows(oldvalue);
+            oldmi = jl_alloc_vec_any(0);
+            int32_t *fl = jl_array_data(cflags, int32_t);
+            char *morespec = (char*)alloca(n);
+            for (j = 0; j < n; j++)
+                morespec[j] = (char)(fl[j] & 1);
+            for (j = 0; j < n; j++) {
+                jl_method_t *m = d[j];
+                char ambig = (char)((fl[j] >> 1) & 1);
+                int m_dispatch = jl_atomic_load_relaxed(&m->dispatch_status);
+                if (morespec[j] || ambig) {
+                    ssize_t idx;
+                    if (!has_key(interferences, (jl_value_t*)m))
+                        interferences = jl_idset_put_key(interferences, (jl_value_t*)m, &idx);
+                }
+                if (!morespec[j]) {
+                    m_dispatch &= ~METHOD_SIG_LATEST_ONLY;
+                    jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
+                    ssize_t idx;
+                    m_interferences = jl_idset_put_key(m_interferences, (jl_value_t*)method, &idx);
+                    jl_gc_write_atomic(m, m->interferences, m_interferences, release);
+                }
+                jl_atomic_store_relaxed(&m->dispatch_status, m_dispatch);
+                if (morespec[j])
+                    continue;
+                jl_method_instance_t *unspec = jl_atomic_load_relaxed(&m->unspecialized);
+                if (unspec)
+                    jl_array_ptr_1d_push(oldmi, (jl_value_t*)unspec);
+                // live-scan only the specializations the worker could not have
+                // seen (not owned by the dependency closure)
+                loctag = jl_atomic_load_relaxed(&m->specializations);
+                _Atomic(jl_method_instance_t*) *data;
+                size_t l;
+                if (jl_is_svec(loctag)) {
+                    data = (_Atomic(jl_method_instance_t*)*)jl_svec_data(loctag);
+                    l = jl_svec_len(loctag);
+                }
+                else {
+                    data = (_Atomic(jl_method_instance_t*)*)&loctag;
+                    l = 1;
+                }
+                for (size_t i = 0; i < l; i++) {
+                    jl_method_instance_t *mi = jl_atomic_load_relaxed(&data[i]);
+                    if ((jl_value_t*)mi == jl_nothing)
+                        continue;
+                    if (method_in_loading_closure((jl_method_t*)mi))
+                        continue; // covered by the certificate's mi list
+                    if (jl_type_intersection2(type, mi->specTypes, &isect, &isect2)) {
+                        int replaced_dispatch = is_replacing(ambig, type, m, d, n, isect, isect2, morespec);
+                        int invalidatedmi = _invalidate_dispatch_backedges(mi, type, m, d, n, replaced_dispatch, ambig, max_world, morespec);
+                        if (replaced_dispatch) {
+                            jl_atomic_store_relaxed(&mi->dispatch_status, 0);
+                            jl_array_ptr_1d_push(oldmi, (jl_value_t*)mi);
+                        }
+                        invalidated |= invalidatedmi;
+                    }
+                    isect = NULL;
+                    isect2 = NULL;
+                }
+            }
+            // recorded image-mi invalidations
+            if (cmis != jl_nothing) {
+                jl_array_t *cma = (jl_array_t*)cmis;
+                for (size_t i = 0, lc = jl_array_nrows(cma); i < lc; i += 2) {
+                    jl_method_instance_t *mi = (jl_method_instance_t*)jl_array_ptr_ref(cma, i);
+                    int replaced_dispatch = jl_unbox_int32(jl_array_ptr_ref(cma, i + 1));
+                    jl_method_t *m = mi->def.method;
+                    char ambig = 0;
+                    for (j = 0; j < n; j++) {
+                        if (d[j] == m) {
+                            ambig = (char)((fl[j] >> 1) & 1);
+                            break;
+                        }
+                    }
+                    int invalidatedmi = _invalidate_dispatch_backedges(mi, type, m, d, n, replaced_dispatch, ambig, max_world, morespec);
+                    if (replaced_dispatch) {
+                        jl_atomic_store_relaxed(&mi->dispatch_status, 0);
+                        jl_array_ptr_1d_push(oldmi, (jl_value_t*)mi);
+                    }
+                    invalidated |= invalidatedmi;
+                }
+            }
+        }
+        jl_contrib_stats[7]++; // replayed activations
+        if (activate_replay_mode() == 2) {
+            // verify: recompute the full intersecting set and check that it is
+            // exactly certificate ∪ foreign scan, with matching flags
+            jl_typemap_entry_t *vrepl = NULL;
+            loctag = get_intersect_matches(jl_atomic_load_relaxed(&mt->defs), newentry, &vrepl, max_world, 0);
+            size_t vn = loctag == NULL ? 0 : jl_array_nrows(loctag);
+            jl_method_t **vdd = loctag == NULL ? NULL : (jl_method_t**)jl_array_ptr_data(loctag);
+            int mism = 0;
+            for (size_t i = 0; i < vn; i++) {
+                jl_method_t *m = vdd[i];
+                int found = 0;
+                for (j = 0; j < n && !found; j++)
+                    found = d[j] == m;
+                if (!found && foreign_oldvalue) {
+                    jl_method_t **fdd = (jl_method_t**)jl_array_ptr_data(foreign_oldvalue);
+                    for (size_t k = 0, fn = jl_array_nrows(foreign_oldvalue); k < fn && !found; k++)
+                        found = fdd[k] == m;
+                }
+                if (!found && !method_in_loading_closure(m)) {
+                    // a closure-owned extra only reflects the worker's legal
+                    // domination truncation (interference sets are documented
+                    // under-approximations); a foreign extra is a real hole
+                    mism++;
+                    jl_safe_printf("  vd-extra (foreign!): %s.%s\n",
+                                   jl_symbol_name(m->module->name), jl_symbol_name(m->name));
+                }
+            }
+            if (cd != jl_nothing) {
+                int32_t *vfl = jl_array_data(cflags, int32_t);
+                for (j = 0; j < n; j++) {
+                    jl_method_t *m = d[j];
+                    int ms = jl_type_morespecific(m->sig, type);
+                    int am = !ms && !jl_type_morespecific(type, m->sig);
+                    if (((vfl[j] & 1) != (ms ? 1 : 0)) || (((vfl[j] >> 1) & 1) != (am ? 1 : 0))) {
+                        mism++;
+                        if (jl_contrib_stats[4] < 20)
+                            jl_safe_printf("  flag-mismatch: %s.%s cert=%d live=(%d,%d)\n",
+                                           jl_symbol_name(m->module->name), jl_symbol_name(m->name),
+                                           (int)vfl[j], ms, am);
+                    }
+                }
+            }
+            if (mism) {
+                jl_contrib_stats[4] += mism;
+                jl_safe_printf("CERT VERIFY MISMATCH (%d) for %s.%s\n", mism,
+                               jl_symbol_name(method->module->name), jl_symbol_name(method->name));
+            }
+            loctag = NULL;
+        }
+        // dispatch bits from the certificate; the foreign pass below may
+        // clear LATEST_ONLY further
+        oldvalue = foreign_oldvalue;
+        if (oldvalue)
+            oldmi = oldmi == NULL ? jl_alloc_vec_any(0) : oldmi;
+    }
     if (oldvalue) {
+        // when replaying, this is the live pass over the foreign-only
+        // intersecting set (replaced was handled above)
+        if (replaying) {
+            d = (jl_method_t**)jl_array_ptr_data(oldvalue);
+            n = jl_array_nrows(oldvalue);
+            if (oldmi == NULL)
+                oldmi = jl_alloc_vec_any(0);
+        }
         assert(n > 0);
         if (replaced) {
             oldvalue = (jl_value_t*)replaced;
@@ -3445,10 +3663,20 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
             // Compute all morespec values upfront
             for (j = 0; j < n; j++)
                 morespec[j] = (char)jl_type_morespecific(d[j]->sig, type);
+            if (record_cert) {
+                newcert = jl_alloc_svec(4);
+                jl_svecset(newcert, 0, oldvalue);
+                jl_value_t *cf = (jl_value_t*)jl_alloc_array_1d(jl_array_int32_type, n);
+                jl_svecset(newcert, 1, cf);
+                jl_svecset(newcert, 2, jl_alloc_vec_any(0));
+            }
             for (j = 0; j < n; j++) {
                 jl_method_t *m = d[j];
                 // Compute ambig state: is there an ambiguity between new method and old m?
                 char ambig = !morespec[j] && !jl_type_morespecific(type, m->sig);
+                if (newcert)
+                    jl_array_data((jl_array_t*)jl_svecref(newcert, 1), int32_t)[j] =
+                        (int32_t)((morespec[j] ? 1 : 0) | (ambig ? 2 : 0));
                 // Compute updates to the dispatch state bits
                 int m_dispatch = jl_atomic_load_relaxed(&m->dispatch_status);
                 if (morespec[j] || ambig) {
@@ -3501,6 +3729,12 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                         // such that everything in `morespecific` dominates everything in `ambiguous`, and everything in `ambiguous` dominates everything in `lessspecific`
                         // And then compute where each isect falls, and whether it changed group--necessitating invalidation--or not.
                         int replaced_dispatch = is_replacing(ambig, type, m, d, n, isect, isect2, morespec);
+                        if (newcert) {
+                            jl_array_t *cmis = (jl_array_t*)jl_svecref(newcert, 2);
+                            jl_array_ptr_1d_push(cmis, (jl_value_t*)mi);
+                            loctag = jl_box_int32(replaced_dispatch);
+                            jl_array_ptr_1d_push(cmis, loctag);
+                        }
                         // found that this specialization dispatch got replaced by m
                         // call invalidate_backedges(mi, max_world, "jl_method_table_insert");
                         // but ignore invoke-type edges
@@ -3582,6 +3816,17 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     jl_atomic_store_relaxed(&newentry->max_world, ~(size_t)0);
     jl_atomic_store_relaxed(&method->dispatch_status, dispatch_bits); // TODO: this should be sequenced fully after the world counter store
     jl_gc_write_atomic(method, method->interferences, jl_genericmemory_t, interferences, release);
+    if (record_cert && !replaced) {
+        if (newcert == NULL) { // n == 0: record just the dispatch bits
+            newcert = jl_alloc_svec(4);
+            jl_svecset(newcert, 0, jl_nothing);
+            jl_svecset(newcert, 1, jl_nothing);
+            jl_svecset(newcert, 2, jl_nothing);
+        }
+        loctag = jl_box_int32(dispatch_bits);
+        jl_svecset(newcert, 3, loctag);
+        record_activation_cert(method, newcert);
+    }
     JL_GC_POP();
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -3242,21 +3242,11 @@ JL_DLLEXPORT uint64_t jl_isect_memo_hits = 0, jl_isect_memo_misses = 0;
 //     C <: ∃W.M (concrete types have no proper subtypes besides ⊥), and one
 //     empty slot empties the whole covariant tuple. Per-slot ∃-rewrapping of
 //     the method's unionall vars over-approximates, which only retains.
-static int fdisj_fast(void) JL_NOTSAFEPOINT
-{
-    static int on = -1;
-    if (on == -1) {
-        char *e = getenv("JULIA_FDISJ_FAST");
-        on = e == NULL || strcmp(e, "0") != 0;
-    }
-    return on;
-}
-
 static int fdisj_isect_empty(jl_value_t *msig0, jl_value_t *qsig) JL_CANSAFEPOINT
 {
     jl_value_t *msig = jl_unwrap_unionall(msig0);
     jl_value_t *uq = jl_unwrap_unionall(qsig);
-    if (fdisj_fast() && jl_is_datatype(msig) && jl_is_datatype(uq) && !jl_is_unionall(qsig)) {
+    if (jl_is_datatype(msig) && jl_is_datatype(uq) && !jl_is_unionall(qsig)) {
         size_t np = jl_nparams(msig);
         size_t nq = jl_nparams(uq);
         int mva = np > 0 && jl_is_vararg(jl_tparam(msig, np - 1));
@@ -3294,16 +3284,6 @@ static int fdisj_isect_empty(jl_value_t *msig0, jl_value_t *qsig) JL_CANSAFEPOIN
     }
     jl_isect_memo_misses++; // full-intersection fallback
     return jl_has_empty_intersection(msig0, qsig);
-}
-
-static int fdisj_v2(void) JL_NOTSAFEPOINT
-{
-    static int on = -1;
-    if (on == -1) {
-        char *e = getenv("JULIA_FDISJ_V2");
-        on = e == NULL || strcmp(e, "0") != 0;
-    }
-    return on;
 }
 
 // does `target` appear on the nominal supertype chain of `n`'s wrapper?
@@ -3439,7 +3419,7 @@ static void _typename_check_foreign_disjoint(jl_typename_t *tn, int explct, void
                 // object, type-side = the wrapper type (chain-walkable at
                 // scan time; legacy name-symbol form is still decoded)
                 jl_value_t *pfv = pf == NULL ? jl_nothing :
-                    typeside ? (fdisj_v2() ? pf->wrapper : (jl_value_t*)pf->name)
+                    typeside ? pf->wrapper
                              : (jl_value_t*)pf;
                 // rooted: typenames by their types (reachable from m->sig,
                 // held by `ms`), symbols permanently
@@ -3485,12 +3465,7 @@ static void _typename_check_foreign_disjoint(jl_typename_t *tn, int explct, void
     }
     // fail fast when the number of candidate intersections is too large for
     // this to beat ordinary verification
-    // TODO: temporary tuning knob for evaluation
-    static size_t cap = (size_t)-1;
-    if (cap == (size_t)-1) {
-        char *ev = getenv("JULIA_EDGE_FDISJ_CAP");
-        cap = ev ? (size_t)atol(ev) : 64;
-    }
+    const size_t cap = 64;
     JL_GC_PROMISE_ROOTED(memo); // held by `ms`
     jl_array_t *residue = (jl_array_t*)jl_svecref(memo, 0);
     JL_GC_PROMISE_ROOTED(residue);
@@ -3513,7 +3488,7 @@ static void _typename_check_foreign_disjoint(jl_typename_t *tn, int explct, void
     // bound's name lies on N's supertype chain
     jl_typename_t *qub = NULL;
     int qubts = 0;
-    if (fdisj_v2() && q1 == NULL)
+    if (q1 == NULL)
         qub = fdisj_slot1_nominal_ub(env->sig, &qubts);
     JL_GC_PROMISE_ROOTED(qub);
     if (q1 != NULL) {
@@ -3532,7 +3507,7 @@ static void _typename_check_foreign_disjoint(jl_typename_t *tn, int explct, void
         nisect++; \
         if (!fdisj_isect_empty((jl_value_t*)m_->sig, env->sig)) { \
             /* move-to-front: repeated dirty patterns hit on the first test */ \
-            if (fdisj_v2() && (size_t)(idx0_) >= (size_t)(stride_)) { \
+            if ((size_t)(idx0_) >= (size_t)(stride_)) { \
                 for (int s_ = 0; s_ < (stride_); s_++) { \
                     jl_value_t *tmp_ = jl_array_ptr_ref((arr_), s_); \
                     jl_array_ptr_set((arr_), s_, jl_array_ptr_ref((arr_), (idx0_) + s_)); \
@@ -3760,50 +3735,29 @@ JL_DLLEXPORT int jl_edge_sig_replayable(jl_value_t *sig) JL_CANSAFEPOINT
     }
     int clean = 1;
     int decomposed;
-    static int sc_fuse = -1;
-    if (sc_fuse == -1) {
-        char *e = getenv("JULIA_SC_FUSE");
-        sc_fuse = e == NULL || strcmp(e, "0") != 0;
-    }
-    if (sc_fuse) {
-        // single decomposition: collect the typenames once, then run the
-        // contributor check and (only if needed) the foreign-disjoint second
-        // chance over the collected list instead of re-walking the signature
-        struct _tn_collect coll = { 0 };
-        decomposed = sig_tns_foreach(_typename_collect_for_verdict, sig, &coll);
-        if (decomposed < 0)
-            decomposed = jl_foreach_top_typename_for(_typename_collect_for_verdict, sig, 1, &coll);
-        if (coll.n > TN_COLLECT_MAX)
-            decomposed = 0; // overflow: treat as undecomposable (dirty)
-        if (decomposed) {
-            for (size_t i = 0; i < coll.n && clean; i++)
-                _typename_check_contributor(coll.tns[i], 1, &clean);
-            if (!clean) {
-                // second chance: the closure does not cover all contributors
-                // to these typenames, but if no foreign contributor method
-                // intersects this signature, its match set is still provably
-                // unchanged relative to the precompile worker (deletions
-                // poison; an exact replacement's new method carries the
-                // replaced signature, so it covers the removal too)
-                struct _foreign_disjoint fenv = { sig, 1 };
-                for (size_t i = 0; i < coll.n && fenv.ok; i++)
-                    _typename_check_foreign_disjoint(coll.tns[i], 1, &fenv);
-                if (fenv.ok) {
-                    clean = 1;
-                }
-            }
-        }
-    }
-    else {
-        decomposed = sig_tns_foreach(_typename_check_contributor, sig, &clean);
-        if (decomposed < 0)
-            decomposed = jl_foreach_top_typename_for(_typename_check_contributor, sig, 1, &clean);
-        if (decomposed && !clean) {
+    // single decomposition: collect the typenames once, then run the
+    // contributor check and (only if needed) the foreign-disjoint second
+    // chance over the collected list instead of re-walking the signature
+    struct _tn_collect coll = { 0 };
+    decomposed = sig_tns_foreach(_typename_collect_for_verdict, sig, &coll);
+    if (decomposed < 0)
+        decomposed = jl_foreach_top_typename_for(_typename_collect_for_verdict, sig, 1, &coll);
+    if (coll.n > TN_COLLECT_MAX)
+        decomposed = 0; // overflow: treat as undecomposable (dirty)
+    if (decomposed) {
+        for (size_t i = 0; i < coll.n && clean; i++)
+            _typename_check_contributor(coll.tns[i], 1, &clean);
+        if (!clean) {
+            // second chance: the closure does not cover all contributors
+            // to these typenames, but if no foreign contributor method
+            // intersects this signature, its match set is still provably
+            // unchanged relative to the precompile worker (deletions
+            // poison; an exact replacement's new method carries the
+            // replaced signature, so it covers the removal too)
             struct _foreign_disjoint fenv = { sig, 1 };
-            int fdec = sig_tns_foreach(_typename_check_foreign_disjoint, sig, &fenv);
-            if (fdec < 0)
-                fdec = jl_foreach_top_typename_for(_typename_check_foreign_disjoint, sig, 1, &fenv);
-            if (fdec && fenv.ok) {
+            for (size_t i = 0; i < coll.n && fenv.ok; i++)
+                _typename_check_foreign_disjoint(coll.tns[i], 1, &fenv);
+            if (fenv.ok) {
                 clean = 1;
             }
         }

--- a/src/gf.c
+++ b/src/gf.c
@@ -3108,6 +3108,20 @@ static void _typename_check_contributor(jl_typename_t *tn, int explct, void *env
 // Is `sig`'s method-matching world provably unchanged relative to the loading
 // image's precompile worker? (all contributors to its typenames lie within the
 // dependency closure). Returns the replay mode when so, 0 otherwise.
+// Can a nominal slot type hold type objects? True for the kinds and everything
+// else under AnyType (and Any itself): such slots intersect Type-shaped slots,
+// so they can neither be keyed nor serve as a plain nominal bound.
+static int fdisj_typeside_nominal(jl_datatype_t *dt) JL_NOTSAFEPOINT
+{
+    if (dt == jl_any_type)
+        return 1;
+    for (jl_datatype_t *w = dt; w != jl_any_type && w != NULL; w = w->super) {
+        if (w == jl_anytype_type)
+            return 1;
+    }
+    return 0;
+}
+
 // Bucket key for a tuple slot type: a typename such that two slots with
 // different (non-NULL) keys are provably value-disjoint. Non-abstract,
 // non-kind datatypes key by their typename (instances carry exactly that
@@ -3130,19 +3144,9 @@ static jl_typename_t *fdisj_slot_key(jl_value_t *t)
     if (!jl_is_datatype(t))
         return NULL;
     jl_datatype_t *dt = (jl_datatype_t*)t;
-    if (dt->name == jl_type_typename) {
-        // Type{X} is invariant: Type{X} ∩ Type{Y} needs X == Y, so X's base
-        // typename partitions soundly even for abstract or UnionAll-valued X.
-        // Typevar-valued X stays unkeyed; kind-typed slots (which do intersect
-        // Type{X}) never take this branch and stay in the residue.
-        jl_value_t *x = jl_tparam0(dt);
-        while (jl_is_unionall(x))
-            x = ((jl_unionall_t*)x)->body;
-        if (!jl_is_datatype(x))
-            return NULL;
-        return ((jl_datatype_t*)x)->name;
-    }
-    if (dt->name->abstract || jl_is_kind((jl_value_t*)dt))
+    // n.b. the bare `TypeEq` kind is the only DataType carrying the `Type`
+    // typename; like every kind it is unfilterable
+    if (dt->name->abstract || fdisj_typeside_nominal(dt))
         return NULL;
     return dt->name;
 }
@@ -3183,15 +3187,7 @@ static jl_typename_t *fdisj_slot0_key(jl_value_t *sig)
     if (!jl_is_datatype(t))
         return NULL;
     jl_datatype_t *dt = (jl_datatype_t*)t;
-    if (dt->name == jl_type_typename) {
-        jl_value_t *x = jl_tparam0(dt);
-        while (jl_is_unionall(x))
-            x = ((jl_unionall_t*)x)->body;
-        if (!jl_is_datatype(x))
-            return NULL;
-        return ((jl_datatype_t*)x)->name; // constructor family (abstract X fine: invariant)
-    }
-    if (dt->name->abstract || jl_is_kind((jl_value_t*)dt))
+    if (dt->name->abstract || fdisj_typeside_nominal(dt))
         return NULL;
     return dt->name;
 }
@@ -3217,29 +3213,7 @@ static jl_typename_t *fdisj_slot1_nominal_ub(jl_value_t *sig, int *typeside)
     if (!jl_is_datatype(t))
         return NULL;
     jl_datatype_t *dt = (jl_datatype_t*)t;
-    if (jl_is_typeeq((jl_value_t*)dt))
-        return NULL;
-    if (dt->name == jl_type_typename) {
-        // Type{X} with non-concrete X (concrete X would have been bucketed):
-        // the nominal bound of X still prefilters typelike queries, whose
-        // slot values are types on X's nominal chain
-        jl_value_t *x = jl_tparam0(dt);
-        if (jl_is_typevar(x))
-            x = ((jl_tvar_t*)x)->ub;
-        while (jl_is_unionall(x))
-            x = ((jl_unionall_t*)x)->body;
-        if (jl_is_typevar(x))
-            x = ((jl_tvar_t*)x)->ub;
-        if (!jl_is_datatype(x))
-            return NULL;
-        jl_datatype_t *xdt = (jl_datatype_t*)x;
-        if ((jl_value_t*)xdt == (jl_value_t*)jl_any_type || jl_is_kind((jl_value_t*)xdt) ||
-            xdt->name == jl_type_typename || jl_is_typeeq((jl_value_t*)xdt))
-            return NULL;
-        *typeside = 1;
-        return xdt->name;
-    }
-    if ((jl_value_t*)dt == (jl_value_t*)jl_any_type || jl_is_kind((jl_value_t*)dt))
+    if (fdisj_typeside_nominal(dt))
         return NULL;
     return dt->name;
 }
@@ -3257,8 +3231,7 @@ static int fdisj_slot1_is_typelike(jl_value_t *sig)
     if (!jl_is_datatype(t))
         return 1;
     jl_datatype_t *dt = (jl_datatype_t*)t;
-    return jl_is_typeeq((jl_value_t*)dt) || dt->name == jl_type_typename ||
-           jl_is_kind((jl_value_t*)dt);
+    return fdisj_typeside_nominal(dt);
 }
 
 JL_DLLEXPORT uint64_t jl_isect_memo_hits = 0, jl_isect_memo_misses = 0;

--- a/src/gf.c
+++ b/src/gf.c
@@ -268,12 +268,33 @@ static jl_method_instance_t *jl_specializations_get_linfo_(jl_method_t *m JL_PRO
         }
         if (hv) {
             _Atomic(jl_method_instance_t*) *data = (_Atomic(jl_method_instance_t*)*)jl_svec_data(specializations);
-            for (i = 0; i < cl; i++) {
+            // Hashed entries fill a contiguous prefix (inserts always land at
+            // its boundary), but the array also holds an unhashed suffix, so
+            // the boundary cannot be binary-searched. Image loads insert many
+            // specializations into the same hot methods back to back, and the
+            // linear boundary scan is O(prefix) per insert: remember recent
+            // boundaries per method and verify a hint with two loads
+            // (data[h-1] filled and data[h] empty is exact, by contiguity).
+            // Stale or torn hints fail verification and fall back to the scan.
+            static _Atomic(jl_method_t*) bnd_m[4096];
+            static _Atomic(size_t) bnd_i[4096];
+            size_t slot = ((((uintptr_t)m) >> 4) * 0x9E3779B97F4A7C15ULL >> 52) & 4095;
+            i = 0;
+            if (jl_atomic_load_relaxed(&bnd_m[slot]) == m) {
+                size_t h = jl_atomic_load_relaxed(&bnd_i[slot]);
+                if (h > 0 && h <= cl &&
+                    (jl_value_t*)jl_atomic_load_relaxed(&data[h - 1]) != jl_nothing &&
+                    (h == cl || (jl_value_t*)jl_atomic_load_relaxed(&data[h]) == jl_nothing))
+                    i = h;
+            }
+            for (; i < cl; i++) {
                 jl_method_instance_t *mi = jl_atomic_load_relaxed(&data[i]);
                 if ((jl_value_t*)mi == jl_nothing)
                     break;
                 assert(!jl_types_equal(mi->specTypes, type));
             }
+            jl_atomic_store_relaxed(&bnd_m[slot], m);
+            jl_atomic_store_relaxed(&bnd_i[slot], i + 1); // next boundary after this insert
             // i points at the place to insert
         }
         if (hv ? (i + 1 >= cl || jl_svecref(specializations, i + 1) != jl_nothing) : (i <= 1 || jl_svecref(specializations, i - 2) != jl_nothing)) {
@@ -383,7 +404,7 @@ jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *sname, jl_fptr_args
 // only relevant for bootstrapping. otherwise fairly broken.
 static int emit_codeinst_and_edges(jl_code_instance_t *codeinst) JL_CANSAFEPOINT
 {
-    jl_value_t *code = jl_atomic_load_relaxed(&codeinst->inferred);
+    jl_value_t *code = jl_ci_inferred(codeinst);
     if (code) {
         if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL)
             return 1;
@@ -408,8 +429,8 @@ static int emit_codeinst_and_edges(jl_code_instance_t *codeinst) JL_CANSAFEPOINT
 static jl_code_instance_t *jl_method_inferred_with_abi(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t world) JL_CANSAFEPOINT
 {
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
-    for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
-        if (codeinst->owner != jl_nothing)
+    for (; codeinst; codeinst = jl_ci_next(codeinst)) {
+        if (jl_ci_owner(codeinst) != jl_nothing)
             continue;
         if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
             if (emit_codeinst_and_edges(codeinst) && jl_atomic_load_relaxed(&codeinst->invoke) != NULL)
@@ -588,14 +609,14 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_uninferred(
 {
     jl_value_t *owner = jl_nothing; // TODO: owner should be arg
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
-    for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
+    for (; codeinst; codeinst = jl_ci_next(codeinst)) {
         if (jl_atomic_load_relaxed(&codeinst->min_world) <= min_world &&
             jl_atomic_load_relaxed(&codeinst->max_world) >= max_world &&
-            jl_egal(codeinst->owner, owner) &&
-            jl_egal(codeinst->rettype, rettype)) {
+            jl_egal(jl_ci_owner(codeinst), owner) &&
+            jl_egal(jl_ci_rettype(codeinst), rettype)) {
             if (di == NULL)
                 return codeinst;
-            jl_debuginfo_t *debuginfo = jl_atomic_load_relaxed(&codeinst->debuginfo);
+            jl_debuginfo_t *debuginfo = jl_ci_debuginfo(codeinst);
             if (di != debuginfo) {
                 jl_gc_wb(codeinst, di);
                 if (!(debuginfo == NULL && jl_atomic_cmpswap_relaxed(&codeinst->debuginfo, &debuginfo, di)))
@@ -622,7 +643,7 @@ JL_DLLEXPORT int jl_mi_cache_has_ci(jl_method_instance_t *mi,
     while (codeinst) {
         if (codeinst == ci)
             return 1;
-        codeinst = jl_atomic_load_relaxed(&codeinst->next);
+        codeinst = jl_ci_next(codeinst);
     }
     return 0;
 }
@@ -640,13 +661,13 @@ static int jl_codeinst_edges_sub(jl_code_instance_t *ci, size_t min_world2, size
 // return whether the codeinst can be substituted in place of ci for an invoke target in target_world
 JL_DLLEXPORT int jl_is_ci_equiv(jl_code_instance_t *ci JL_PROPAGATES_ROOT, jl_code_instance_t *codeinst, size_t target_world) JL_NOTSAFEPOINT
 {
-    jl_value_t *def = ci->def;
-    jl_value_t *owner = ci->owner;
-    jl_value_t *rettype = ci->rettype;
-    if ((!jl_atomic_load_relaxed(&codeinst->inferred)) == (!jl_atomic_load_relaxed(&ci->inferred)) &&
-        jl_egal(codeinst->def, def) &&
-        jl_egal(codeinst->owner, owner) &&
-        jl_egal(codeinst->rettype, rettype)) {
+    jl_value_t *def = jl_ci_defobj(ci);
+    jl_value_t *owner = jl_ci_owner(ci);
+    jl_value_t *rettype = jl_ci_rettype(ci);
+    if ((!jl_ci_inferred(codeinst)) == (!jl_ci_inferred(ci)) &&
+        jl_egal(jl_ci_defobj(codeinst), def) &&
+        jl_egal(jl_ci_owner(codeinst), owner) &&
+        jl_egal(jl_ci_rettype(codeinst), rettype)) {
         if (!target_world || jl_atomic_load_relaxed(&codeinst->invoke) != NULL) {
             size_t min_world = jl_atomic_load_relaxed(&ci->min_world);
             size_t max_world = jl_atomic_load_relaxed(&ci->max_world);
@@ -671,7 +692,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_ci_equiv(jl_code_instance_t *ci JL_PROPA
     while (codeinst) {
         if (codeinst != ci && jl_is_ci_equiv(ci, codeinst, target_world))
             return codeinst;
-        codeinst = jl_atomic_load_relaxed(&codeinst->next);
+        codeinst = jl_ci_next(codeinst);
     }
     return ci;
 }
@@ -781,14 +802,14 @@ JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi,
     jl_value_t *parent = (jl_value_t*)mi;
     _Atomic(jl_code_instance_t*) *slot = &mi->cache;
     jl_code_instance_t *oldci = jl_atomic_load_relaxed(slot);
-    int hasinferred = jl_atomic_load_relaxed(&ci->inferred) != NULL;
+    int hasinferred = jl_ci_inferred(ci) != NULL;
     int hasinvoke = hasinferred && jl_atomic_load_relaxed(&ci->invoke) != NULL;
     size_t max_world = jl_atomic_load_relaxed(&ci->max_world);
-    jl_code_instance_t *next = jl_atomic_load_relaxed(&ci->next);
+    jl_code_instance_t *next = jl_ci_next(ci);
     while (oldci) {
         if (oldci == ci)
             break;
-        int old_hasinferred = jl_atomic_load_relaxed(&oldci->inferred) != NULL;
+        int old_hasinferred = jl_ci_inferred(oldci) != NULL;
         int old_hasinvoke = old_hasinferred && jl_atomic_load_relaxed(&oldci->invoke) != NULL;
         size_t old_max_world = jl_atomic_load_relaxed(&oldci->max_world);
         if (hasinvoke && !old_hasinvoke)
@@ -948,7 +969,7 @@ static void foreach_top_nth_typename(void (*f)(jl_typename_t*, int, void*) JL_CA
 // This is not capable of walking to all top-typenames for an explicitly encountered
 // Function or Any, so the caller has a fallback that can scan the entire table in that case.
 // We do not de-duplicate calls when encountering a Union.
-static int jl_foreach_top_typename_for(void (*f)(jl_typename_t*, int, void*) JL_CANSAFEPOINT, jl_value_t *argtypes JL_PROPAGATES_ROOT, int all_subtypes, void *env) JL_CANSAFEPOINT
+int jl_foreach_top_typename_for(void (*f)(jl_typename_t*, int, void*) JL_CANSAFEPOINT, jl_value_t *argtypes JL_PROPAGATES_ROOT, int all_subtypes, void *env) JL_CANSAFEPOINT
 {
     unsigned facts = 0;
     foreach_top_nth_typename(f, argtypes, 1, &facts, env);
@@ -2198,10 +2219,14 @@ JL_DLLEXPORT void jl_promote_cis_to_current(jl_code_instance_t **cis, size_t n, 
             if (jl_atomic_load_relaxed(&current_ci->max_world) != validated_world)
                 continue;
             jl_atomic_store_relaxed(&current_ci->max_world, ~(size_t)0);
-            jl_svec_t *edges = jl_atomic_load_relaxed(&current_ci->edges);
-            for (size_t i = 0; i < jl_svec_len(edges); i++) {
-                jl_value_t *edge = jl_svecref(edges, i);
-                if (!jl_is_code_instance(edge))
+            jl_value_t *edges = (jl_value_t*)jl_atomic_load_relaxed(&current_ci->edges);
+            jl_interned_code_instance_t *iedges =
+                edges != NULL && jl_typetagis(edges, jl_interned_code_instance_type) ?
+                (jl_interned_code_instance_t*)edges : NULL;
+            size_t nedges = edges == NULL ? 0 : iedges ? iedges->nedges : jl_svec_len(edges);
+            for (size_t i = 0; i < nedges; i++) {
+                jl_value_t *edge = iedges ? jl_ici_ref_nobox(iedges, i) : jl_svecref(edges, i);
+                if (edge == NULL || !jl_is_code_instance(edge))
                     continue;
                 arraylist_push(&workqueue, edge);
             }
@@ -2288,19 +2313,15 @@ struct matches_env {
 
 // nonzero while scanning for an activation whose typename contributors were
 // all within the loading image's dependency closure (measurement)
-static int current_activation_clean = 0;
 static int method_in_loading_closure(jl_method_t *m);
-extern JL_DLLEXPORT uint64_t jl_contrib_stats[12];
+static void record_backedge_log(jl_value_t *target, jl_value_t *invokesig, jl_value_t *caller) JL_CANSAFEPOINT;
+static void jl_method_table_add_backedge_batch(jl_value_t *typ, jl_value_t **callers, size_t n) JL_CANSAFEPOINT;
+static int sig_tns_enabled(void);
 
 static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_intersection_env *closure0) JL_CANSAFEPOINT
 {
     struct matches_env *closure = container_of(closure0, struct matches_env, match);
     jl_method_t *oldmethod = oldentry->func.method;
-    if (current_activation_clean) {
-        jl_contrib_stats[4]++;
-        if (!method_in_loading_closure(oldmethod))
-            jl_contrib_stats[3]++; // invariant violation: clean typename, foreign method
-    }
     assert(oldentry != closure->newentry && "entry already added");
     assert(jl_atomic_load_relaxed(&oldentry->min_world) <= jl_atomic_load_relaxed(&closure->newentry->min_world) && "old method cannot be newer than new method");
     //assert(jl_atomic_load_relaxed(&oldentry->max_world) != jl_atomic_load_relaxed(&closure->newentry->min_world) && "method cannot be added at the same time as method deleted");
@@ -2340,6 +2361,7 @@ static int intersect_entry_foreign(jl_typemap_entry_t *ml, struct typemap_inters
 
 static jl_value_t *get_intersect_matches(jl_typemap_t *defs, jl_typemap_entry_t *newentry, jl_typemap_entry_t **replaced, size_t world, int foreign_only) JL_CANSAFEPOINT
 {
+    JL_TIMING(ADD_METHOD, ACTIVATE_IsectScan);
     jl_tupletype_t *type = newentry->sig;
     jl_tupletype_t *ttypes = (jl_tupletype_t*)jl_unwrap_unionall((jl_value_t*)type);
     size_t l = jl_nparams(ttypes);
@@ -2518,9 +2540,13 @@ static void _invalidate_backedges(jl_method_instance_t *replaced_mi, jl_code_ins
         if (replaced_ci) {
             // If we're invalidating a particular codeinstance, only invalidate
             // this backedge it actually has an edge for our codeinstance.
-            jl_svec_t *edges = jl_atomic_load_relaxed(&replaced->edges);
-            for (size_t j = 0; j < jl_svec_len(edges); ++j) {
-                jl_value_t *edge = jl_svecref(edges, j);
+            jl_value_t *edges = (jl_value_t*)jl_atomic_load_relaxed(&replaced->edges);
+            jl_interned_code_instance_t *iedges =
+                edges != NULL && jl_typetagis(edges, jl_interned_code_instance_type) ?
+                (jl_interned_code_instance_t*)edges : NULL;
+            size_t nedges = edges == NULL ? 0 : iedges ? iedges->nedges : jl_svec_len(edges);
+            for (size_t j = 0; j < nedges; ++j) {
+                jl_value_t *edge = iedges ? jl_ici_ref_nobox(iedges, j) : jl_svecref(edges, j);
                 if (edge == (jl_value_t*)replaced_mi || edge == (jl_value_t*)replaced_ci)
                     goto found;
             }
@@ -2679,12 +2705,13 @@ JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, 
             jl_gc_write(callee, callee->backedges, jl_array_t, backedges);
         }
         push_edge(backedges, invokesig, caller);
+        record_backedge_log((jl_value_t*)callee, invokesig, (jl_value_t*)caller);
     }
     JL_UNLOCK(&callee->def.method->writelock);
 }
 
 
-static int jl_foreach_top_typename_for(void (*f)(jl_typename_t*, int, void*) JL_CANSAFEPOINT, jl_value_t *argtypes JL_PROPAGATES_ROOT, int all_subtypes, void *env) JL_CANSAFEPOINT;
+int jl_foreach_top_typename_for(void (*f)(jl_typename_t*, int, void*) JL_CANSAFEPOINT, jl_value_t *argtypes JL_PROPAGATES_ROOT, int all_subtypes, void *env) JL_CANSAFEPOINT;
 
 struct _typename_add_backedge {
     jl_value_t *typ;
@@ -2742,19 +2769,18 @@ static void _typename_add_backedge(jl_typename_t *tn, int explct, void *env0) JL
 // prior world its precompile worker analyzed.
 JL_DLLEXPORT jl_genericmemory_t *jl_method_contributors = NULL;
 JL_DLLEXPORT jl_genericmemory_t *jl_activation_certs = NULL; // method -> certificate (precompile worker)
-JL_DLLEXPORT uint64_t jl_contrib_stats[12];
 
 static int activate_replay_mode(void)
 {
     static int mode = -1;
     if (mode == -1) {
         const char *e = getenv("JULIA_ACTIVATE_REPLAY");
-        mode = e == NULL ? 0 : (e[0] == '2' ? 2 : (e[0] == '1' ? 1 : 0));
+        mode = e != NULL && e[0] == '1';
     }
     return mode;
 }
 
-static void record_activation_cert(jl_method_t *method, jl_svec_t *cert)
+static void record_activation_cert(jl_method_t *method, jl_svec_t *cert) JL_CANSAFEPOINT
 {
     if (jl_activation_certs == NULL) {
         if (jl_an_empty_memory_any == NULL)
@@ -2774,13 +2800,176 @@ JL_DLLEXPORT jl_value_t *jl_get_activation_cert(jl_method_t *method)
     return cert == NULL ? jl_nothing : cert;
 }
 
+// Log of backedge registrations performed by this session's own
+// CodeInstances, recorded during incremental precompile as flat
+// (target, invokesig, caller) triples: target is a MethodInstance, a Binding,
+// or `nothing` (a method-table edge, with the signature in the second slot).
+// Serialized with the image and bulk-replayed at load for the callers that
+// re-validate, replacing the per-CodeInstance edge-list decoding walk.
+JL_DLLEXPORT jl_array_t *jl_backedge_log JL_GLOBALLY_ROOTED;
+static jl_mutex_t backedge_log_lock;
+
+static void record_backedge_log(jl_value_t *target, jl_value_t *invokesig, jl_value_t *caller) JL_CANSAFEPOINT
+{
+    if (!jl_generating_output() || !jl_options.incremental)
+        return;
+    if (jl_object_in_image(caller))
+        return; // image-owned caller: replayed by its own image's log
+    JL_LOCK(&backedge_log_lock);
+    if (jl_backedge_log == NULL)
+        jl_backedge_log = jl_alloc_vec_any(0);
+    jl_array_ptr_1d_push(jl_backedge_log, target);
+    jl_array_ptr_1d_push(jl_backedge_log, invokesig == NULL ? jl_nothing : invokesig);
+    jl_array_ptr_1d_push(jl_backedge_log, caller);
+    JL_UNLOCK(&backedge_log_lock);
+}
+
+void jl_record_binding_backedge(jl_binding_t *b, jl_value_t *edge) JL_CANSAFEPOINT
+{
+    // Method-edge binding backedges arise from source scanning, which loads
+    // re-run themselves; only CodeInstance callers replay from the log.
+    if (jl_is_code_instance(edge))
+        record_backedge_log((jl_value_t*)b, NULL, edge);
+}
+
+// Re-apply a loaded image's backedge log for the callers that survived
+// re-validation (see store_backedges, whose per-CodeInstance work this
+// replaces when a log is present). The serialized form is compact:
+// log = [unique_objects::Vector{Any}, idxstream::Vector{UInt8}], where the
+// stream holds varint-encoded (target, invokesig, caller) index triples —
+// this keeps the log's relocation footprint at one entry per unique object.
+// The counting pass pre-sizes the backedge arrays: appending edge-by-edge
+// re-grows them repeatedly and dominates load-time allocation churn.
+JL_DLLEXPORT void jl_apply_backedge_log(jl_array_t *log) JL_CANSAFEPOINT
+{
+    assert(jl_array_nrows(log) == 2);
+    jl_array_t *uobjs = (jl_array_t*)jl_array_ptr_ref(log, 0);
+    jl_array_t *idxb = (jl_array_t*)jl_array_ptr_ref(log, 1);
+    jl_value_t **uo = jl_array_ptr_data(uobjs);
+    size_t nuniq = jl_array_nrows(uobjs);
+    (void)nuniq; // asserted against below
+    uint8_t *bytes = jl_array_data(idxb, uint8_t);
+    size_t nbytes = jl_array_nrows(idxb);
+    // callers verified at the current world are registered; anything else was
+    // invalidated, or verified at an older world and will not be promoted
+    size_t world = jl_atomic_load_acquire(&jl_world_counter);
+#define BELOG_NEXT(out) do { \
+        size_t v_ = 0; \
+        int shift_ = 0; \
+        uint8_t c_; \
+        do { \
+            assert(bp < nbytes); \
+            c_ = bytes[bp++]; \
+            v_ |= (size_t)(c_ & 0x7f) << shift_; \
+            shift_ += 7; \
+        } while (c_ & 0x80); \
+        assert(v_ < nuniq); \
+        (out) = uo[v_]; \
+    } while (0)
+    // stream = groups of (target, count, count x (invokesig, caller)), sorted
+    // by target then invokesig at save; decode each group's live pairs into a
+    // scratch, then register with one lock/pre-size per callee and one
+    // signature decomposition per method-table run
+    size_t scratchcap = 256;
+    jl_value_t **scratch = (jl_value_t**)malloc_s(scratchcap * sizeof(jl_value_t*));
+    size_t bp = 0;
+    while (bp < nbytes) {
+        jl_value_t *target;
+        size_t n;
+        BELOG_NEXT(target);
+        {
+            size_t v_ = 0;
+            int shift_ = 0;
+            uint8_t c_;
+            do {
+                assert(bp < nbytes);
+                c_ = bytes[bp++];
+                v_ |= (size_t)(c_ & 0x7f) << shift_;
+                shift_ += 7;
+            } while (c_ & 0x80);
+            n = v_;
+        }
+        if (2 * n > scratchcap) {
+            while (2 * n > scratchcap)
+                scratchcap *= 2;
+            scratch = (jl_value_t**)realloc_s(scratch, scratchcap * sizeof(jl_value_t*));
+        }
+        // decode the group, keeping only callers that survived re-validation
+        size_t nlive = 0;
+        for (size_t k = 0; k < n; k++) {
+            jl_value_t *invokesig, *caller;
+            BELOG_NEXT(invokesig);
+            BELOG_NEXT(caller);
+            if (jl_atomic_load_relaxed(&((jl_code_instance_t*)caller)->max_world) != world)
+                continue;
+            scratch[2 * nlive] = invokesig;
+            scratch[2 * nlive + 1] = caller;
+            nlive++;
+        }
+        if (nlive == 0)
+            continue;
+        if (target == jl_nothing) {
+            // runs of identical invokesig are contiguous: one decomposition per run
+            for (size_t k = 0; k < nlive; ) {
+                jl_value_t *invokesig = scratch[2 * k];
+                size_t e = k;
+                while (e < nlive && scratch[2 * e] == invokesig)
+                    e++;
+                // compact the run's callers in place (pairs -> pointer list)
+                for (size_t i = k; i < e; i++)
+                    scratch[2 * k + (i - k)] = scratch[2 * i + 1];
+                jl_method_table_add_backedge_batch(invokesig, &scratch[2 * k], e - k);
+                k = e;
+            }
+        }
+        else if (jl_is_method_instance(target)) {
+            jl_method_instance_t *callee = (jl_method_instance_t*)target;
+            JL_LOCK(&callee->def.method->writelock);
+            if (jl_atomic_load_relaxed(&allow_new_worlds)) {
+                jl_array_t *backedges = jl_mi_get_backedges(callee);
+                if (!backedges) {
+                    backedges = jl_alloc_vec_any(0);
+                    jl_gc_write(callee, callee->backedges, jl_array_t, backedges);
+                }
+                // pre-size for the group (grow-then-shrink keeps the buffer)
+                jl_array_grow_end(backedges, 2 * nlive);
+                jl_array_del_end(backedges, 2 * nlive);
+                for (size_t k = 0; k < nlive; k++) {
+                    jl_value_t *invokesig = scratch[2 * k];
+                    jl_value_t *caller = scratch[2 * k + 1];
+                    push_edge(backedges, invokesig == jl_nothing ? NULL : invokesig,
+                              (jl_code_instance_t*)caller);
+                    record_backedge_log((jl_value_t*)callee,
+                                        invokesig == jl_nothing ? NULL : invokesig, caller);
+                }
+            }
+            JL_UNLOCK(&callee->def.method->writelock);
+        }
+        else {
+            for (size_t k = 0; k < nlive; k++) {
+                jl_value_t *caller = scratch[2 * k + 1];
+                jl_maybe_add_binding_backedge((jl_binding_t*)target, caller,
+                                              jl_get_ci_mi((jl_code_instance_t*)caller)->def.method);
+            }
+        }
+    }
+#undef BELOG_NEXT
+    free(scratch);
+}
+
 static size_t *jl_loading_closure_bits = NULL; // bitset over linkage blobs
 static size_t jl_loading_closure_nblobs = 0;
+// Generation counter for the per-typename cleanliness memo stored in the
+// contributor tag arrays; bumped whenever the closure changes so stale
+// verdicts are recomputed. 0 never matches (arrays start at generation 0).
+static int32_t jl_loading_closure_gen = 0;
 
 JL_DLLEXPORT void jl_set_loading_closure_blobs(size_t *bits, size_t nblobs)
 {
     jl_loading_closure_bits = bits;
     jl_loading_closure_nblobs = nblobs;
+    if (++jl_loading_closure_gen <= 0)
+        jl_loading_closure_gen = 1;
 }
 
 static int blob_in_loading_closure(size_t idx)
@@ -2791,14 +2980,19 @@ static int blob_in_loading_closure(size_t idx)
             (idx % (8 * sizeof(size_t)))) & 1;
 }
 
-static int method_in_loading_closure(jl_method_t *m)
+static int object_in_loading_closure(jl_value_t *v)
 {
-    if (!jl_object_in_image((jl_value_t*)m))
+    if (!jl_object_in_image(v))
         return 0;
-    return blob_in_loading_closure(jl_external_blob_index((jl_value_t*)m));
+    return blob_in_loading_closure(jl_external_blob_index(v));
 }
 
-static void contributor_add_tag(jl_typename_t *tn, int32_t tag)
+static int method_in_loading_closure(jl_method_t *m)
+{
+    return object_in_loading_closure((jl_value_t*)m);
+}
+
+static void contributor_add_tag(jl_typename_t *tn, int32_t tag) JL_CANSAFEPOINT
 {
     if (jl_method_contributors == NULL) {
         if (jl_an_empty_memory_any == NULL)
@@ -2807,7 +3001,10 @@ static void contributor_add_tag(jl_typename_t *tn, int32_t tag)
     }
     jl_array_t *tags = (jl_array_t*)jl_eqtable_get(jl_method_contributors, (jl_value_t*)tn, NULL);
     if (tags == NULL) {
-        tags = jl_alloc_array_1d(jl_array_int32_type, 0);
+        // slots [0]=memo generation, [1]=memo verdict; tags start at [2]
+        tags = jl_alloc_array_1d(jl_array_int32_type, 2);
+        jl_array_data(tags, int32_t)[0] = 0;
+        jl_array_data(tags, int32_t)[1] = 0;
         JL_GC_PUSH1(&tags);
         jl_genericmemory_t *newtable = jl_eqtable_put(jl_method_contributors, (jl_value_t*)tn, (jl_value_t*)tags, NULL);
         JL_GC_POP();
@@ -2816,24 +3013,65 @@ static void contributor_add_tag(jl_typename_t *tn, int32_t tag)
     }
     size_t l = jl_array_nrows(tags);
     int32_t *d = jl_array_data(tags, int32_t);
-    for (size_t i = 0; i < l; i++)
+    for (size_t i = 2; i < l; i++)
         if (d[i] == tag)
             return;
     jl_array_grow_end(tags, 1);
-    jl_array_data(tags, int32_t)[l] = tag;
+    d = jl_array_data(tags, int32_t);
+    d[l] = tag;
+    d[0] = 0; // invalidate the cleanliness memo
 }
 
-static void _typename_tag_contributor(jl_typename_t *tn, int explct, void *env0)
+// Parallel to the tag table: per typename, the session-contributed methods
+// themselves (jl_nothing marks a deletion, which poisons the typename). Used
+// by the dirty-signature second chance in jl_edge_sig_replayable: when every
+// foreign contributor method on a signature's typenames is provably disjoint
+// from it, the signature's match set is still unchanged relative to the
+// precompile worker. Array layout: [0] boxed closure generation for the memo,
+// [1] memoized foreign-method subset (jl_nothing when poisoned or invalid),
+// methods from [2].
+JL_DLLEXPORT jl_genericmemory_t *jl_method_contributor_methods JL_GLOBALLY_ROOTED;
+
+static void contributor_add_method(jl_typename_t *tn, jl_value_t *m) JL_CANSAFEPOINT
+{
+    if (jl_method_contributor_methods == NULL) {
+        if (jl_an_empty_memory_any == NULL)
+            return;
+        jl_method_contributor_methods = (jl_genericmemory_t*)jl_an_empty_memory_any;
+    }
+    jl_array_t *ms = (jl_array_t*)jl_eqtable_get(jl_method_contributor_methods, (jl_value_t*)tn, NULL);
+    if (ms == NULL) {
+        ms = jl_alloc_vec_any(2);
+        JL_GC_PUSH1(&ms);
+        jl_array_ptr_set(ms, 0, jl_nothing);
+        jl_array_ptr_set(ms, 1, jl_nothing);
+        jl_genericmemory_t *newtable = jl_eqtable_put(jl_method_contributor_methods, (jl_value_t*)tn, (jl_value_t*)ms, NULL);
+        JL_GC_POP();
+        if (newtable != jl_method_contributor_methods)
+            jl_method_contributor_methods = newtable;
+    }
+    // methods insert here once per definition, so no dedup scan is needed
+    jl_array_ptr_1d_push(ms, m);
+    jl_array_ptr_set(ms, 0, jl_nothing); // invalidate the foreign-subset memo
+}
+
+struct _contrib_tag {
+    int32_t tag;
+    jl_value_t *method; // jl_nothing poisons (method deletion)
+};
+
+static void _typename_tag_contributor(jl_typename_t *tn, int explct, void *env0) JL_CANSAFEPOINT
 {
     // like the mt-backedge table: store only under explicitly encountered
-    // typenames; checks consult every callback. Exception: the shared Type
-    // typename is tagged unconditionally, because Type-signatures of
-    // unrelated families still intersect one another (every abstract-bounded
-    // constructor admits Type{Union{}}), so the per-family top typename is
-    // not a complete key for them.
-    if (!explct && tn != jl_type_typename)
+    // typenames; checks consult every callback. Constructor signatures get a
+    // strict lower bound on their Type var (see jl_strictify_ctor_var), so
+    // Type{Union{}} no longer makes unrelated constructor families intersect
+    // and the per-family top typename is a complete key.
+    if (!explct)
         return;
-    contributor_add_tag(tn, *(int32_t*)env0);
+    struct _contrib_tag *env = (struct _contrib_tag*)env0;
+    contributor_add_tag(tn, env->tag);
+    contributor_add_method(tn, env->method);
 }
 
 static void _typename_check_contributor(jl_typename_t *tn, int explct, void *env0)
@@ -2847,40 +3085,827 @@ static void _typename_check_contributor(jl_typename_t *tn, int explct, void *env
         return; // only (pre-session) sysimage contributions
     size_t l = jl_array_nrows(tags);
     int32_t *d = jl_array_data(tags, int32_t);
-    for (size_t i = 0; i < l; i++) {
-        if (d[i] < 0 || !blob_in_loading_closure((size_t)d[i])) {
-            jl_contrib_stats[d[i] < 0 ? 5 : 6]++; // dirty cause: session / foreign blob
+    if (d[0] == jl_loading_closure_gen) { // memoized for the current closure
+        if (!d[1])
             *clean = 0;
-            return;
+        return;
+    }
+    int tnclean = 1;
+    for (size_t i = 2; i < l; i++) {
+        if (d[i] < 0 || !blob_in_loading_closure((size_t)d[i])) {
+            tnclean = 0;
+            break;
         }
     }
+    d[0] = jl_loading_closure_gen;
+    d[1] = tnclean;
+    if (!tnclean)
+        *clean = 0;
 }
 
 // Is `sig`'s method-matching world provably unchanged relative to the loading
 // image's precompile worker? (all contributors to its typenames lie within the
 // dependency closure). Returns the replay mode when so, 0 otherwise.
-JL_DLLEXPORT int jl_edge_sig_replayable(jl_value_t *sig)
+// Bucket key for a tuple slot type: a typename such that two slots with
+// different (non-NULL) keys are provably value-disjoint. Non-abstract,
+// non-kind datatypes key by their typename (instances carry exactly that
+// typename); TypeEq{X} keys by X's typename (its instances are the types
+// X{...}, which only kind-typed slots can otherwise contain, and kinds are
+// unfilterable). Everything else — abstract, unions, typevars, varargs,
+// kinds — returns NULL (unfilterable).
+static jl_typename_t *fdisj_slot_key(jl_value_t *t)
+{
+    while (jl_is_unionall(t))
+        t = ((jl_unionall_t*)t)->body;
+    if (jl_is_typeeq(t)) {
+        jl_value_t *x = jl_typeeq_T(t);
+        while (jl_is_unionall(x))
+            x = ((jl_unionall_t*)x)->body;
+        if (!jl_is_datatype(x) || ((jl_datatype_t*)x)->name->abstract)
+            return NULL;
+        return ((jl_datatype_t*)x)->name;
+    }
+    if (!jl_is_datatype(t))
+        return NULL;
+    jl_datatype_t *dt = (jl_datatype_t*)t;
+    if (dt->name == jl_type_typename) {
+        // Type{X} is invariant: Type{X} ∩ Type{Y} needs X == Y, so X's base
+        // typename partitions soundly even for abstract or UnionAll-valued X.
+        // Typevar-valued X stays unkeyed; kind-typed slots (which do intersect
+        // Type{X}) never take this branch and stay in the residue.
+        jl_value_t *x = jl_tparam0(dt);
+        while (jl_is_unionall(x))
+            x = ((jl_unionall_t*)x)->body;
+        if (!jl_is_datatype(x))
+            return NULL;
+        return ((jl_datatype_t*)x)->name;
+    }
+    if (dt->name->abstract || jl_is_kind((jl_value_t*)dt))
+        return NULL;
+    return dt->name;
+}
+
+static jl_typename_t *fdisj_sig_key(jl_value_t *sig)
+{
+    jl_value_t *usig = jl_unwrap_unionall(sig);
+    if (!jl_is_datatype(usig) || jl_nparams(usig) < 2)
+        return NULL;
+    return fdisj_slot_key(jl_tparam(usig, 1));
+}
+
+struct _foreign_disjoint {
+    jl_value_t *sig;
+    int ok;
+};
+
+// key for the function slot: the function type's typename, or for a
+// constructor signature the constructed type's base typename (Type and
+// TypeEq parameters are invariant, so values under distinct names cannot
+// intersect); NULL when the slot is typevar/union/abstract-callable-shaped
+static jl_typename_t *fdisj_slot0_key(jl_value_t *sig)
+{
+    jl_value_t *usig = jl_unwrap_unionall(sig);
+    if (!jl_is_datatype(usig) || jl_nparams(usig) < 1)
+        return NULL;
+    jl_value_t *t = jl_tparam(usig, 0);
+    while (jl_is_unionall(t))
+        t = ((jl_unionall_t*)t)->body;
+    if (jl_is_typeeq(t)) {
+        jl_value_t *x = jl_typeeq_T(t);
+        while (jl_is_unionall(x))
+            x = ((jl_unionall_t*)x)->body;
+        if (!jl_is_datatype(x) || ((jl_datatype_t*)x)->name->abstract)
+            return NULL;
+        return ((jl_datatype_t*)x)->name;
+    }
+    if (!jl_is_datatype(t))
+        return NULL;
+    jl_datatype_t *dt = (jl_datatype_t*)t;
+    if (dt->name == jl_type_typename) {
+        jl_value_t *x = jl_tparam0(dt);
+        while (jl_is_unionall(x))
+            x = ((jl_unionall_t*)x)->body;
+        if (!jl_is_datatype(x))
+            return NULL;
+        return ((jl_datatype_t*)x)->name; // constructor family (abstract X fine: invariant)
+    }
+    if (dt->name->abstract || jl_is_kind((jl_value_t*)dt))
+        return NULL;
+    return dt->name;
+}
+
+// nominal upper-bound typename of a signature's second slot, for cheap
+// disjointness prefiltering: when a query's second slot has a concrete
+// typename Q, a method whose second slot is bounded by nominal abstract A can
+// only intersect it if A's name appears on Q's supertype chain. Returns NULL
+// when no sound nominal bound exists (union/kind/Type-shaped/Any slots).
+static jl_typename_t *fdisj_slot1_nominal_ub(jl_value_t *sig, int *typeside)
+{
+    *typeside = 0;
+    jl_value_t *usig = jl_unwrap_unionall(sig);
+    if (!jl_is_datatype(usig) || jl_nparams(usig) < 2)
+        return NULL;
+    jl_value_t *t = jl_tparam(usig, 1);
+    if (jl_is_typevar(t))
+        t = ((jl_tvar_t*)t)->ub;
+    while (jl_is_unionall(t))
+        t = ((jl_unionall_t*)t)->body;
+    if (jl_is_typevar(t))
+        t = ((jl_tvar_t*)t)->ub;
+    if (!jl_is_datatype(t))
+        return NULL;
+    jl_datatype_t *dt = (jl_datatype_t*)t;
+    if (jl_is_typeeq((jl_value_t*)dt))
+        return NULL;
+    if (dt->name == jl_type_typename) {
+        // Type{X} with non-concrete X (concrete X would have been bucketed):
+        // the nominal bound of X still prefilters typelike queries, whose
+        // slot values are types on X's nominal chain
+        jl_value_t *x = jl_tparam0(dt);
+        if (jl_is_typevar(x))
+            x = ((jl_tvar_t*)x)->ub;
+        while (jl_is_unionall(x))
+            x = ((jl_unionall_t*)x)->body;
+        if (jl_is_typevar(x))
+            x = ((jl_tvar_t*)x)->ub;
+        if (!jl_is_datatype(x))
+            return NULL;
+        jl_datatype_t *xdt = (jl_datatype_t*)x;
+        if ((jl_value_t*)xdt == (jl_value_t*)jl_any_type || jl_is_kind((jl_value_t*)xdt) ||
+            xdt->name == jl_type_typename || jl_is_typeeq((jl_value_t*)xdt))
+            return NULL;
+        *typeside = 1;
+        return xdt->name;
+    }
+    if ((jl_value_t*)dt == (jl_value_t*)jl_any_type || jl_is_kind((jl_value_t*)dt))
+        return NULL;
+    return dt->name;
+}
+
+// does the query's second slot have a Type/TypeEq shape (whose supertype
+// chain is kind-side, not the constructed type's chain)?
+static int fdisj_slot1_is_typelike(jl_value_t *sig)
+{
+    jl_value_t *usig = jl_unwrap_unionall(sig);
+    if (!jl_is_datatype(usig) || jl_nparams(usig) < 2)
+        return 1;
+    jl_value_t *t = jl_tparam(usig, 1);
+    while (jl_is_unionall(t))
+        t = ((jl_unionall_t*)t)->body;
+    if (!jl_is_datatype(t))
+        return 1;
+    jl_datatype_t *dt = (jl_datatype_t*)t;
+    return jl_is_typeeq((jl_value_t*)dt) || dt->name == jl_type_typename ||
+           jl_is_kind((jl_value_t*)dt);
+}
+
+JL_DLLEXPORT uint64_t jl_isect_memo_hits = 0, jl_isect_memo_misses = 0;
+
+// cheap sound disproofs before the full intersection lambda:
+// (1) plain non-vararg datatype-tuples of different arity never intersect;
+// (2) a concrete query slot C is disjoint from the method slot M unless
+//     C <: ∃W.M (concrete types have no proper subtypes besides ⊥), and one
+//     empty slot empties the whole covariant tuple. Per-slot ∃-rewrapping of
+//     the method's unionall vars over-approximates, which only retains.
+static int fdisj_fast(void) JL_NOTSAFEPOINT
+{
+    static int on = -1;
+    if (on == -1) {
+        char *e = getenv("JULIA_FDISJ_FAST");
+        on = e == NULL || strcmp(e, "0") != 0;
+    }
+    return on;
+}
+
+static int fdisj_isect_empty(jl_value_t *msig0, jl_value_t *qsig) JL_CANSAFEPOINT
+{
+    jl_value_t *msig = jl_unwrap_unionall(msig0);
+    jl_value_t *uq = jl_unwrap_unionall(qsig);
+    if (fdisj_fast() && jl_is_datatype(msig) && jl_is_datatype(uq) && !jl_is_unionall(qsig)) {
+        size_t np = jl_nparams(msig);
+        size_t nq = jl_nparams(uq);
+        int mva = np > 0 && jl_is_vararg(jl_tparam(msig, np - 1));
+        int qva = nq > 0 && jl_is_vararg(jl_tparam(uq, nq - 1));
+        if (!mva && !qva) {
+            if (np != nq) {
+                jl_isect_memo_hits++;
+                return 1; // arity mismatch: disjoint
+            }
+            for (size_t i = 0; i < np; i++) {
+                jl_value_t *qi = jl_tparam(uq, i);
+                jl_value_t *mi = jl_tparam(msig, i);
+                if (qi == mi)
+                    continue;
+                // only an atom (no proper nonempty subtypes) is disjoint from `mi` merely because it
+                // is not a subtype of it: concrete tuples of kinds, e.g. Tuple{DataType}, are not
+                if (!jl_is_atom_type(qi))
+                    continue;
+                int empty;
+                if (!jl_has_free_typevars(mi)) {
+                    empty = !jl_subtype(qi, mi);
+                }
+                else {
+                    jl_value_t *mre = jl_rewrap_unionall(mi, msig0);
+                    JL_GC_PUSH1(&mre);
+                    empty = !jl_subtype(qi, mre);
+                    JL_GC_POP();
+                }
+                if (empty) {
+                    jl_isect_memo_hits++;
+                    return 1;
+                }
+            }
+        }
+    }
+    jl_isect_memo_misses++; // full-intersection fallback
+    return jl_has_empty_intersection(msig0, qsig);
+}
+
+static int fdisj_v2(void) JL_NOTSAFEPOINT
+{
+    static int on = -1;
+    if (on == -1) {
+        char *e = getenv("JULIA_FDISJ_V2");
+        on = e == NULL || strcmp(e, "0") != 0;
+    }
+    return on;
+}
+
+// does `target` appear on the nominal supertype chain of `n`'s wrapper?
+static int tn_chain_contains(jl_typename_t *n, jl_typename_t *target) JL_NOTSAFEPOINT
+{
+    jl_datatype_t *w = (jl_datatype_t*)jl_unwrap_unionall(n->wrapper);
+    for (int d = 0; d < 24 && w != NULL; d++) {
+        if (w->name == target)
+            return 1;
+        if (w == jl_any_type)
+            return 0;
+        w = w->super;
+    }
+    return 1; // overflow: assume present (conservative)
+}
+
+static void _typename_check_foreign_disjoint(jl_typename_t *tn, int explct, void *env0) JL_CANSAFEPOINT
+{
+    struct _foreign_disjoint *env = (struct _foreign_disjoint*)env0;
+    (void)explct;
+    if (!env->ok || jl_method_contributor_methods == NULL)
+        return;
+    jl_array_t *ms = (jl_array_t*)jl_eqtable_get(jl_method_contributor_methods, (jl_value_t*)tn, NULL);
+    if (ms == NULL)
+        return; // only (pre-session) sysimage contributions
+    JL_GC_PROMISE_ROOTED(ms); // held by the rooted contributor table
+    jl_value_t **d = jl_array_ptr_data(ms);
+    // memo = (residue, famtab, nforeign): foreign methods grouped first by the
+    // function-slot key (function typename / constructed typename), then by
+    // the second-argument slot key; residue holds methods with no slot-0 key
+    jl_svec_t *memo = NULL;
+    if (d[0] != jl_nothing && jl_unbox_int32(d[0]) == jl_loading_closure_gen) {
+        if (d[1] == jl_nothing) { // memoized: poisoned
+            env->ok = 0;
+            return;
+        }
+        memo = (jl_svec_t*)d[1];
+    }
+    else if (d[0] != jl_nothing) {
+        // stale generation, but the contributor list itself is unchanged
+        // (adds and deletion tombstones clear d[0] in place): the memo is
+        // still valid if no contributor blob's closure membership changed
+        if (d[1] == jl_nothing) {
+            // poisoned by a deletion tombstone: closure-independent verdict
+            jl_array_ptr_set(ms, 0, jl_box_int32(jl_loading_closure_gen));
+            env->ok = 0;
+            return;
+        }
+        jl_svec_t *cand = (jl_svec_t*)d[1];
+        JL_GC_PROMISE_ROOTED(cand);
+        jl_value_t *snapv = jl_svecref(cand, 3);
+        if (snapv != jl_nothing) {
+            jl_array_t *snap = (jl_array_t*)snapv;
+            JL_GC_PROMISE_ROOTED(snap);
+            int32_t *sd = jl_array_data(snap, int32_t);
+            size_t ns = jl_array_nrows(snap);
+            int still = 1;
+            for (size_t i = 0; i < ns; i++) {
+                if (blob_in_loading_closure((size_t)(sd[i] >> 1)) != (sd[i] & 1)) {
+                    still = 0;
+                    break;
+                }
+            }
+            if (still) {
+                jl_array_ptr_set(ms, 0, jl_box_int32(jl_loading_closure_gen));
+                memo = cand;
+            }
+        }
+    }
+    if (memo == NULL) {
+        // (re)compute the foreign subset for the current closure
+        memo = jl_alloc_svec(4);
+        JL_GC_PUSH1(&memo);
+        jl_svecset(memo, 0, jl_alloc_vec_any(0));
+        jl_svecset(memo, 1, jl_an_empty_memory_any);
+        int poisoned = 0;
+        size_t nforeign = 0;
+        size_t l = jl_array_nrows(ms);
+        // closure-membership snapshot of the contributor blobs (session
+        // methods are always foreign, so they need no entry)
+        int32_t snapbuf[96];
+        size_t nsnap = 0;
+        int snapok = 1;
+        for (size_t i = 2; i < l; i++) {
+            jl_value_t *m = jl_array_ptr_data(ms)[i];
+            JL_GC_PROMISE_ROOTED(m); // held by `ms`
+            if (m == jl_nothing) { // deletion: poisoned
+                poisoned = 1;
+                break;
+            }
+            if (snapok && jl_object_in_image(m)) {
+                size_t blob = jl_external_blob_index(m);
+                int32_t ent = (int32_t)((blob << 1) | (blob_in_loading_closure(blob) ? 1 : 0));
+                size_t si = 0;
+                while (si < nsnap && snapbuf[si] != ent)
+                    si++;
+                if (si == nsnap) {
+                    if (nsnap == 96 || blob >= ((size_t)1 << 30))
+                        snapok = 0;
+                    else
+                        snapbuf[nsnap++] = ent;
+                }
+            }
+            if (object_in_loading_closure(m))
+                continue;
+            nforeign++;
+            jl_typename_t *k0 = fdisj_slot0_key(((jl_method_t*)m)->sig);
+            JL_GC_PROMISE_ROOTED(k0); // typenames are rooted by their types
+            if (k0 == NULL) {
+                jl_array_ptr_1d_push((jl_array_t*)jl_svecref(memo, 0), m);
+                continue;
+            }
+            jl_genericmemory_t *famtab = (jl_genericmemory_t*)jl_svecref(memo, 1);
+            JL_GC_PROMISE_ROOTED(famtab);
+            jl_svec_t *fam = (jl_svec_t*)jl_eqtable_get(famtab, (jl_value_t*)k0, NULL);
+            if (fam == NULL) {
+                fam = jl_alloc_svec(2);
+                JL_GC_PUSH1(&fam);
+                jl_svecset(fam, 0, jl_alloc_vec_any(0));
+                jl_svecset(fam, 1, jl_an_empty_memory_any);
+                jl_genericmemory_t *nt = jl_eqtable_put(famtab, (jl_value_t*)k0, (jl_value_t*)fam, NULL);
+                JL_GC_POP();
+                if (nt != famtab)
+                    jl_svecset(memo, 1, nt);
+            }
+            JL_GC_PROMISE_ROOTED(fam); // held by the family table
+            jl_typename_t *k1 = fdisj_sig_key(((jl_method_t*)m)->sig);
+            JL_GC_PROMISE_ROOTED(k1);
+            if (k1 == NULL) {
+                int typeside = 0;
+                jl_typename_t *pf = fdisj_slot1_nominal_ub(((jl_method_t*)m)->sig, &typeside);
+                // allocation-free side encoding: value-side = the typename
+                // object, type-side = the wrapper type (chain-walkable at
+                // scan time; legacy name-symbol form is still decoded)
+                jl_value_t *pfv = pf == NULL ? jl_nothing :
+                    typeside ? (fdisj_v2() ? pf->wrapper : (jl_value_t*)pf->name)
+                             : (jl_value_t*)pf;
+                // rooted: typenames by their types (reachable from m->sig,
+                // held by `ms`), symbols permanently
+                JL_GC_PROMISE_ROOTED(pfv);
+                jl_array_t *unk = (jl_array_t*)jl_svecref(fam, 0);
+                JL_GC_PROMISE_ROOTED(unk);
+                jl_array_ptr_1d_push(unk, m);
+                jl_array_ptr_1d_push(unk, pfv);
+            }
+            else {
+                jl_genericmemory_t *k1tab = (jl_genericmemory_t*)jl_svecref(fam, 1);
+                JL_GC_PROMISE_ROOTED(k1tab);
+                jl_array_t *bucket = (jl_array_t*)jl_eqtable_get(k1tab, (jl_value_t*)k1, NULL);
+                if (bucket == NULL) {
+                    bucket = jl_alloc_vec_any(0);
+                    JL_GC_PUSH1(&bucket);
+                    jl_genericmemory_t *nt = jl_eqtable_put(k1tab, (jl_value_t*)k1, (jl_value_t*)bucket, NULL);
+                    JL_GC_POP();
+                    if (nt != k1tab)
+                        jl_svecset(fam, 1, nt);
+                }
+                JL_GC_PROMISE_ROOTED(bucket);
+                jl_array_ptr_1d_push(bucket, m);
+            }
+        }
+        jl_svecset(memo, 2, jl_box_long((ssize_t)nforeign));
+        if (snapok && !poisoned) {
+            jl_array_t *snap = jl_alloc_array_1d(jl_array_int32_type, nsnap);
+            memcpy(jl_array_data(snap, int32_t), snapbuf, nsnap * sizeof(int32_t));
+            jl_svecset(memo, 3, snap);
+        }
+        else {
+            jl_svecset(memo, 3, jl_nothing);
+        }
+        jl_array_ptr_set(ms, 1, poisoned ? jl_nothing : (jl_value_t*)memo);
+        jl_value_t *boxedgen = jl_box_int32(jl_loading_closure_gen);
+        jl_array_ptr_set(ms, 0, boxedgen);
+        JL_GC_POP();
+        if (poisoned) {
+            env->ok = 0;
+            return;
+        }
+    }
+    // fail fast when the number of candidate intersections is too large for
+    // this to beat ordinary verification
+    // TODO: temporary tuning knob for evaluation
+    static size_t cap = (size_t)-1;
+    if (cap == (size_t)-1) {
+        char *ev = getenv("JULIA_EDGE_FDISJ_CAP");
+        cap = ev ? (size_t)atol(ev) : 64;
+    }
+    JL_GC_PROMISE_ROOTED(memo); // held by `ms`
+    jl_array_t *residue = (jl_array_t*)jl_svecref(memo, 0);
+    JL_GC_PROMISE_ROOTED(residue);
+    size_t nf = jl_array_nrows(residue);
+    jl_genericmemory_t *famtab0 = (jl_genericmemory_t*)jl_svecref(memo, 1);
+    JL_GC_PROMISE_ROOTED(famtab0);
+    jl_typename_t *q0 = fdisj_slot0_key(env->sig);
+    JL_GC_PROMISE_ROOTED(q0);
+    jl_typename_t *q1 = fdisj_sig_key(env->sig);
+    JL_GC_PROMISE_ROOTED(q1);
+    // supertype-chain names of the query's second slot: sound rejection set
+    // for nominally-bounded unkeyed methods (only when the slot is a plain
+    // concrete-named type, not Type/TypeEq-shaped)
+    jl_typename_t *qchain[24];
+    int nqchain = 0;
+    int qtypeside = 0;
+    // when the second slot has no concrete key, its nominal upper bound (if
+    // any) still soundly prunes concrete-marked entries: an entry with
+    // concrete-named marker N (same sidedness) can only intersect if the
+    // bound's name lies on N's supertype chain
+    jl_typename_t *qub = NULL;
+    int qubts = 0;
+    if (fdisj_v2() && q1 == NULL)
+        qub = fdisj_slot1_nominal_ub(env->sig, &qubts);
+    JL_GC_PROMISE_ROOTED(qub);
+    if (q1 != NULL) {
+        qtypeside = fdisj_slot1_is_typelike(env->sig);
+        jl_datatype_t *w = (jl_datatype_t*)jl_unwrap_unionall(q1->wrapper);
+        while (w != NULL && w != jl_any_type && nqchain < 24) {
+            qchain[nqchain++] = w->name;
+            w = w->super;
+        }
+        if (w != jl_any_type)
+            nqchain = 0; // overflow: disable the prefilter
+    }
+    uint64_t nisect = 0;
+#define FDISJ_TEST(arr_, idx0_, stride_) do { \
+        jl_method_t *m_ = (jl_method_t*)jl_array_ptr_ref((arr_), (idx0_)); \
+        nisect++; \
+        if (!fdisj_isect_empty((jl_value_t*)m_->sig, env->sig)) { \
+            /* move-to-front: repeated dirty patterns hit on the first test */ \
+            if (fdisj_v2() && (size_t)(idx0_) >= (size_t)(stride_)) { \
+                for (int s_ = 0; s_ < (stride_); s_++) { \
+                    jl_value_t *tmp_ = jl_array_ptr_ref((arr_), s_); \
+                    jl_array_ptr_set((arr_), s_, jl_array_ptr_ref((arr_), (idx0_) + s_)); \
+                    jl_array_ptr_set((arr_), (idx0_) + s_, tmp_); \
+                } \
+            } \
+            env->ok = 0; \
+            return; \
+        } \
+    } while (0)
+#define FDISJ_SCAN_FAM(famv) do { \
+        jl_svec_t *fam_ = (jl_svec_t*)(famv); \
+        JL_GC_PROMISE_ROOTED(fam_); \
+        jl_array_t *unk_ = (jl_array_t*)jl_svecref(fam_, 0); \
+        JL_GC_PROMISE_ROOTED(unk_); \
+        size_t nu_ = jl_array_nrows(unk_) / 2; \
+        if (nisect + nu_ > cap) { \
+            env->ok = 0; \
+            return; \
+        } \
+        for (size_t i_ = 0; i_ < nu_; i_++) { \
+            jl_value_t *pf_ = jl_array_ptr_ref(unk_, 2 * i_ + 1); \
+            if (pf_ != jl_nothing) { \
+                int pfts_; \
+                jl_typename_t *pftn_; \
+                if (jl_is_symbol(pf_)) { \
+                    pfts_ = 1; pftn_ = NULL; /* legacy: side known, chain not */ \
+                } \
+                else if (jl_typetagis(pf_, jl_typename_type)) { \
+                    pfts_ = 0; pftn_ = (jl_typename_t*)pf_; \
+                } \
+                else { \
+                    pfts_ = 1; pftn_ = ((jl_datatype_t*)jl_unwrap_unionall(pf_))->name; \
+                } \
+                if (nqchain > 0) { \
+                    if (pfts_ != qtypeside) \
+                        continue; /* Type-shaped and plain slots cannot intersect */ \
+                    int hit_ = 0; \
+                    for (int c_ = 0; c_ < nqchain; c_++) { \
+                        if (pftn_ ? qchain[c_] == pftn_ \
+                                  : (jl_value_t*)qchain[c_]->name == pf_) { hit_ = 1; break; } \
+                    } \
+                    if (!hit_) \
+                        continue; \
+                } \
+                else if (qub != NULL) { \
+                    if (pfts_ != qubts) \
+                        continue; /* sides cannot intersect */ \
+                    if (pftn_ != NULL && !pftn_->abstract && !tn_chain_contains(pftn_, qub)) \
+                        continue; /* concrete marker off the bound's chain */ \
+                } \
+            } \
+            FDISJ_TEST(unk_, 2 * i_, 2); \
+        } \
+        jl_genericmemory_t *k1tab_ = (jl_genericmemory_t*)jl_svecref(fam_, 1); \
+        JL_GC_PROMISE_ROOTED(k1tab_); \
+        if (q1 != NULL) { \
+            jl_array_t *bucket_ = (jl_array_t*)jl_eqtable_get(k1tab_, (jl_value_t*)q1, NULL); \
+            if (bucket_ != NULL) { \
+                JL_GC_PROMISE_ROOTED(bucket_); \
+                size_t nb_ = jl_array_nrows(bucket_); \
+                if (nisect + nb_ > cap) { \
+                    env->ok = 0; \
+                    return; \
+                } \
+                for (size_t i_ = 0; i_ < nb_; i_++) \
+                    FDISJ_TEST(bucket_, i_, 1); \
+            } \
+        } \
+        else { \
+            for (size_t j_ = 1; j_ < k1tab_->length; j_ += 2) { \
+                jl_array_t *bucket_ = (jl_array_t*)jl_genericmemory_ptr_ref(k1tab_, j_); \
+                if (bucket_ == NULL) \
+                    continue; \
+                if (qub != NULL) { \
+                    jl_typename_t *kb_ = (jl_typename_t*)jl_genericmemory_ptr_ref(k1tab_, j_ - 1); \
+                    if (kb_ != NULL && !kb_->abstract && !tn_chain_contains(kb_, qub)) \
+                        continue; /* concrete-keyed bucket off the bound's chain */ \
+                } \
+                JL_GC_PROMISE_ROOTED(bucket_); \
+                size_t nb_ = jl_array_nrows(bucket_); \
+                if (nisect + nb_ > cap) { \
+                    env->ok = 0; \
+                    return; \
+                } \
+                for (size_t i_ = 0; i_ < nb_; i_++) \
+                    FDISJ_TEST(bucket_, i_, 1); \
+            } \
+        } \
+    } while (0)
+    if (nf > cap) {
+        env->ok = 0;
+        return;
+    }
+    if (q0 == NULL) {
+        // unkeyed signature: candidate set is the whole foreign subset
+        size_t nforeign = (size_t)jl_unbox_long(jl_svecref(memo, 2));
+        if (nforeign + nf > cap) {
+            env->ok = 0;
+            return;
+        }
+    }
+    for (size_t i = 0; i < nf; i++)
+        FDISJ_TEST(residue, i, 1);
+    if (q0 != NULL) {
+        jl_svec_t *fam = (jl_svec_t*)jl_eqtable_get(famtab0, (jl_value_t*)q0, NULL);
+        if (fam != NULL)
+            FDISJ_SCAN_FAM(fam);
+    }
+    else {
+        // unkeyed signature: every family may intersect
+        for (size_t j = 1; j < famtab0->length; j += 2) {
+            jl_value_t *fam = jl_genericmemory_ptr_ref(famtab0, j);
+            if (fam == NULL)
+                continue;
+            FDISJ_SCAN_FAM(fam);
+        }
+    }
+#undef FDISJ_SCAN_FAM
+#undef FDISJ_TEST
+}
+
+// save-side typename decompositions of call/method signatures, registered per
+// image at load: sig -> svec(mask::Int, tn...), bit i of mask = explicitness
+JL_DLLEXPORT jl_genericmemory_t *jl_sig_tn_table JL_GLOBALLY_ROOTED;
+
+JL_DLLEXPORT void jl_register_sig_tns(jl_array_t *tab) JL_CANSAFEPOINT
+{
+    if (tab == NULL || jl_array_nrows(tab) == 0 || !sig_tns_enabled())
+        return;
+    if (jl_sig_tn_table == NULL)
+        jl_sig_tn_table = (jl_genericmemory_t*)jl_an_empty_memory_any;
+    size_t n = jl_array_nrows(tab);
+    for (size_t i = 0; i + 1 < n; i += 2) {
+        jl_value_t *sig = jl_array_ptr_ref(tab, i);
+        jl_value_t *tns = jl_array_ptr_ref(tab, i + 1);
+        if (sig == NULL || tns == NULL)
+            continue;
+        jl_genericmemory_t *nt = jl_eqtable_put(jl_sig_tn_table, sig, tns, NULL);
+        if (nt != jl_sig_tn_table)
+            jl_sig_tn_table = nt;
+    }
+}
+
+// iterate a stored decomposition exactly as jl_foreach_top_typename_for would;
+// returns -1 when the signature has no stored entry
+static int sig_tns_enabled(void)
+{
+    static int on = -1;
+    if (on == -1) {
+        // default off: one global eqtable across all images costs more in
+        // registration and probes than the decomposition it replaces; a
+        // per-image table design could revisit this
+        char *e = getenv("JULIA_SIG_TNS");
+        on = e != NULL && strcmp(e, "1") == 0 && sizeof(void*) == 8;
+    }
+    return on;
+}
+
+static int sig_tns_foreach(void (*f)(jl_typename_t*, int, void*) JL_CANSAFEPOINT, jl_value_t *sig, void *env)
+{
+    if (jl_sig_tn_table == NULL || !sig_tns_enabled())
+        return -1;
+    jl_svec_t *tns = (jl_svec_t*)jl_eqtable_get(jl_sig_tn_table, sig, NULL);
+    if (tns == NULL)
+        return -1;
+    JL_GC_PROMISE_ROOTED(tns); // held by the rooted table
+    size_t l = jl_svec_len(tns);
+    assert(l >= 1);
+    uint64_t mask = (uint64_t)jl_unbox_long(jl_svecref(tns, 0));
+    for (size_t i = 1; i < l; i++) {
+        jl_typename_t *tn = (jl_typename_t*)jl_svecref(tns, i);
+        JL_GC_PROMISE_ROOTED(tn);
+        f(tn, (mask >> (i - 1)) & 1, env);
+    }
+    return 1;
+}
+
+// Per-signature verdict memo: edge signatures repeat heavily both within and
+#define TN_COLLECT_MAX 15
+struct _tn_collect {
+    size_t n;
+    jl_typename_t *tns[TN_COLLECT_MAX + 1];
+};
+
+static void _typename_collect_for_verdict(jl_typename_t *tn, int explct, void *env0)
+{
+    struct _tn_collect *c = (struct _tn_collect*)env0;
+    (void)explct;
+    if (c->n <= TN_COLLECT_MAX)
+        c->tns[c->n] = tn;
+    c->n++;
+}
+
+// across CodeInstance edge lists. Pointer-keyed and direct-mapped (collisions
+// simply recompute); signatures are kept alive by the edge lists being
+// verified, and entries self-invalidate via the closure generation.
+// N.B.: assumes a non-moving GC.
+typedef struct {
+    jl_value_t *sig;
+    int32_t gen;
+    int32_t verdict;
+} edge_sig_memo_ent_t;
+static edge_sig_memo_ent_t *edge_sig_memo = NULL;
+#define EDGE_SIG_MEMO_SZ (1 << 19)
+
+JL_DLLEXPORT int jl_edge_sig_replayable(jl_value_t *sig) JL_CANSAFEPOINT
 {
     int mode = activate_replay_mode();
     if (mode < 1 || jl_loading_closure_bits == NULL)
         return 0;
-    int clean = 1;
-    jl_contrib_stats[8]++;
-    if (!jl_foreach_top_typename_for(_typename_check_contributor, sig, 1, &clean) || !clean) {
-        jl_value_t *usig = jl_unwrap_unionall(sig);
-        if (jl_is_datatype(usig) && jl_nparams(usig) > 0 && jl_is_typeeq(jl_tparam(usig, 0)))
-            jl_contrib_stats[10]++; // dirty with Type{...} first arg (constructor call)
-        return 0;
+    if (edge_sig_memo == NULL)
+        edge_sig_memo = (edge_sig_memo_ent_t*)calloc_s(EDGE_SIG_MEMO_SZ * sizeof(edge_sig_memo_ent_t));
+    size_t memoidx = (((uintptr_t)sig) * 0x9E3779B97F4A7C15ULL >> 32) & (EDGE_SIG_MEMO_SZ - 1);
+    edge_sig_memo_ent_t *ment = &edge_sig_memo[memoidx];
+    for (int probe = 0; probe < 8; probe++) {
+        edge_sig_memo_ent_t *e = &edge_sig_memo[(memoidx + probe) & (EDGE_SIG_MEMO_SZ - 1)];
+        if (e->sig == sig && e->gen == jl_loading_closure_gen)
+            return e->verdict ? mode : 0;
+        if (e->sig == NULL || e->gen != jl_loading_closure_gen) {
+            ment = e; // first free/stale slot in the window receives the store
+            break;
+        }
+        ment = e; // window full: overwrite the last probed slot
     }
-    jl_contrib_stats[9]++;
+    int clean = 1;
+    int decomposed;
+    static int sc_fuse = -1;
+    if (sc_fuse == -1) {
+        char *e = getenv("JULIA_SC_FUSE");
+        sc_fuse = e == NULL || strcmp(e, "0") != 0;
+    }
+    if (sc_fuse) {
+        // single decomposition: collect the typenames once, then run the
+        // contributor check and (only if needed) the foreign-disjoint second
+        // chance over the collected list instead of re-walking the signature
+        struct _tn_collect coll = { 0 };
+        decomposed = sig_tns_foreach(_typename_collect_for_verdict, sig, &coll);
+        if (decomposed < 0)
+            decomposed = jl_foreach_top_typename_for(_typename_collect_for_verdict, sig, 1, &coll);
+        if (coll.n > TN_COLLECT_MAX)
+            decomposed = 0; // overflow: treat as undecomposable (dirty)
+        if (decomposed) {
+            for (size_t i = 0; i < coll.n && clean; i++)
+                _typename_check_contributor(coll.tns[i], 1, &clean);
+            if (!clean) {
+                // second chance: the closure does not cover all contributors
+                // to these typenames, but if no foreign contributor method
+                // intersects this signature, its match set is still provably
+                // unchanged relative to the precompile worker (deletions
+                // poison; an exact replacement's new method carries the
+                // replaced signature, so it covers the removal too)
+                struct _foreign_disjoint fenv = { sig, 1 };
+                for (size_t i = 0; i < coll.n && fenv.ok; i++)
+                    _typename_check_foreign_disjoint(coll.tns[i], 1, &fenv);
+                if (fenv.ok) {
+                    clean = 1;
+                }
+            }
+        }
+    }
+    else {
+        decomposed = sig_tns_foreach(_typename_check_contributor, sig, &clean);
+        if (decomposed < 0)
+            decomposed = jl_foreach_top_typename_for(_typename_check_contributor, sig, 1, &clean);
+        if (decomposed && !clean) {
+            struct _foreign_disjoint fenv = { sig, 1 };
+            int fdec = sig_tns_foreach(_typename_check_foreign_disjoint, sig, &fenv);
+            if (fdec < 0)
+                fdec = jl_foreach_top_typename_for(_typename_check_foreign_disjoint, sig, 1, &fenv);
+            if (fdec && fenv.ok) {
+                clean = 1;
+            }
+        }
+    }
+    ment->sig = sig;
+    ment->gen = jl_loading_closure_gen;
+    ment->verdict = decomposed && clean;
+    if (!decomposed || !clean)
+        return 0;
     return mode;
 }
 
-static void contributor_tag_method(jl_method_t *method)
+static void contributor_tag_method(jl_method_t *method) JL_CANSAFEPOINT
 {
-    int32_t tag = jl_object_in_image((jl_value_t*)method) ?
+    struct _contrib_tag env;
+    env.tag = jl_object_in_image((jl_value_t*)method) ?
         (int32_t)jl_external_blob_index((jl_value_t*)method) : -1;
-    jl_foreach_top_typename_for(_typename_tag_contributor, (jl_value_t*)method->sig, 0, &tag);
+    env.method = (jl_value_t*)method;
+    jl_foreach_top_typename_for(_typename_tag_contributor, (jl_value_t*)method->sig, 0, &env);
+}
+
+struct _typename_add_backedge_batch {
+    jl_value_t *typ;
+    jl_value_t **callers;
+    size_t n;
+};
+
+static void _typename_add_backedge_batch(jl_typename_t *tn, int explct, void *env0) JL_CANSAFEPOINT
+{
+    struct _typename_add_backedge_batch *env = (struct _typename_add_backedge_batch*)env0;
+    JL_GC_PROMISE_ROOTED(env->typ);
+    if (!explct)
+        return;
+    // same two-level table as _typename_add_backedge: typename -> (signature -> callers)
+    jl_genericmemory_t *allbackedges = jl_method_table->backedges;
+    jl_genericmemory_t *table = (jl_genericmemory_t*)jl_eqtable_get(allbackedges, (jl_value_t*)tn, NULL);
+    jl_array_t *callers = table == NULL ? NULL : (jl_array_t*)jl_eqtable_get(table, env->typ, NULL);
+    if (callers == NULL) {
+        jl_array_t *newcallers = jl_alloc_vec_any(0);
+        jl_genericmemory_t *oldtable = table;
+        JL_GC_PUSH2(&newcallers, &table);
+        if (table == NULL)
+            table = (jl_genericmemory_t*)jl_an_empty_memory_any;
+        table = jl_eqtable_put(table, env->typ, (jl_value_t*)newcallers, NULL);
+        if (table != oldtable) {
+            jl_genericmemory_t *newtable = jl_eqtable_put(allbackedges, (jl_value_t*)tn, (jl_value_t*)table, NULL);
+            if (newtable != allbackedges)
+                jl_gc_write(jl_method_table, jl_method_table->backedges, jl_genericmemory_t, newtable);
+        }
+        JL_GC_POP();
+        callers = newcallers;
+    }
+    JL_GC_PROMISE_ROOTED(callers); // held by the per-typename table
+    // bulk append without the duplicate scan: replay callers are freshly loaded
+    // CodeInstances that cannot already be present
+    size_t base = jl_array_nrows(callers);
+    jl_array_grow_end(callers, env->n);
+    for (size_t i = 0; i < env->n; i++)
+        jl_array_ptr_set(callers, base + i, env->callers[i]);
+}
+
+// bulk variant of jl_method_table_add_backedge for backedge-log replay:
+// registers the same signature for n callers with one decomposition pass
+static void jl_method_table_add_backedge_batch(jl_value_t *typ, jl_value_t **callers, size_t n) JL_CANSAFEPOINT
+{
+    if (!jl_atomic_load_relaxed(&allow_new_worlds))
+        return;
+    jl_methtable_t *mt = jl_method_table;
+    jl_methcache_t *mc = mt->cache;
+    JL_LOCK(&mc->writelock);
+    if (jl_atomic_load_relaxed(&allow_new_worlds)) {
+        struct _typename_add_backedge_batch env = {typ, callers, n};
+        jl_foreach_top_typename_for(_typename_add_backedge_batch, typ, 0, &env);
+        for (size_t i = 0; i < n; i++)
+            record_backedge_log(jl_nothing, typ, callers[i]);
+    }
+    JL_UNLOCK(&mc->writelock);
 }
 
 // add a backedge from a non-existent signature to caller
@@ -2896,6 +3921,7 @@ JL_DLLEXPORT void jl_method_table_add_backedge(jl_value_t *typ, jl_code_instance
     if (jl_atomic_load_relaxed(&allow_new_worlds)) {
         struct _typename_add_backedge env = {typ, (jl_value_t*)caller};
         jl_foreach_top_typename_for(_typename_add_backedge, typ, 0, &env);
+        record_backedge_log(jl_nothing, typ, (jl_value_t*)caller);
     }
     JL_UNLOCK(&mc->writelock);
 }
@@ -2908,6 +3934,13 @@ struct _typename_invalidate_backedge {
     size_t n;
     size_t max_world;
     int invalidated;
+    // certificate support: when `record` is set (precompile worker),
+    // invalidated callers are appended to it; when `foreign_only` is set
+    // (certificate replay), entries whose caller lies in the loading closure
+    // are not re-derived — their invalidations were replayed from the
+    // certificate already, so dead ones are dropped and live ones kept.
+    jl_array_t *record;
+    int foreign_only;
 };
 
 static void _typename_invalidate_backedges(jl_typename_t *tn, int explct, void *env0) JL_CANSAFEPOINT
@@ -2919,6 +3952,7 @@ static void _typename_invalidate_backedges(jl_typename_t *tn, int explct, void *
     jl_genericmemory_t *table = (jl_genericmemory_t*)jl_eqtable_get(jl_method_table->backedges, (jl_value_t*)tn, NULL);
     if (table == NULL)
         return;
+    JL_TIMING(ADD_METHOD, ACTIVATE_TnScan);
     _Atomic(jl_value_t*) *tab = (_Atomic(jl_value_t*)*)table->ptr;
     size_t i, na = table->length;
     size_t alive = 0;
@@ -2929,6 +3963,40 @@ static void _typename_invalidate_backedges(jl_typename_t *tn, int explct, void *
             continue; // empty or deleted slot
         JL_GC_PROMISE_ROOTED(backedgetyp);
         JL_GC_PROMISE_ROOTED(callers);
+        size_t j, l = jl_array_nrows(callers);
+        if (env->foreign_only) {
+            // the precompile worker saw the callers owned by the loading image's
+            // dependency closure and their invalidation, if any, was replayed from
+            // the certificate: drop the dead ones, keep the live ones, and only
+            // re-derive the intersection when some caller is foreign to the closure
+            size_t keep = 0;
+            int foreign = 0;
+            for (j = 0; j < l; j++) {
+                jl_code_instance_t *backedge = (jl_code_instance_t*)jl_array_ptr_ref(callers, j);
+                JL_GC_PROMISE_ROOTED(backedge);
+                if (!object_in_loading_closure((jl_value_t*)backedge))
+                    foreign = 1;
+                else if (jl_atomic_load_relaxed(&backedge->max_world) != ~(size_t)0)
+                    continue;
+                jl_array_ptr_set(callers, keep++, (jl_value_t*)backedge);
+            }
+            if (keep != l) {
+                jl_array_del_end((jl_array_t*)callers, l - keep);
+                l = keep;
+            }
+            if (!foreign) {
+                if (l == 0) {
+                    // remove this entry (cf. `jl_eqtable_pop`)
+                    jl_gc_wb(table, NULL); // deletion barrier: snapshot the overwritten key/value for SATB collectors
+                    jl_atomic_store_relaxed(&tab[i], jl_nothing); // clear the key
+                    jl_atomic_store_relaxed(&tab[i + 1], NULL); // and the value
+                }
+                else {
+                    alive++;
+                }
+                continue;
+            }
+        }
         int missing = 0;
         if (jl_type_intersection2(backedgetyp, (jl_value_t*)env->type, env->isect, env->isect2)) {
             // See if the intersection was actually already fully
@@ -2958,14 +4026,28 @@ static void _typename_invalidate_backedges(jl_typename_t *tn, int explct, void *
         }
         *env->isect = *env->isect2 = NULL;
         if (missing) {
-            size_t j, l = jl_array_nrows(callers);
+            size_t keep = 0;
             for (j = 0; j < l; j++) {
                 jl_code_instance_t *backedge = (jl_code_instance_t*)jl_array_ptr_ref(callers, j);
                 JL_GC_PROMISE_ROOTED(backedge);
+                if (env->foreign_only && object_in_loading_closure((jl_value_t*)backedge)) {
+                    // replayed from the certificate already; still live, so keep it
+                    jl_array_ptr_set(callers, keep++, (jl_value_t*)backedge);
+                    continue;
+                }
                 invalidate_code_instance(backedge, env->max_world, 0);
                 env->invalidated = 1;
+                if (env->record)
+                    jl_array_ptr_1d_push(env->record, (jl_value_t*)backedge);
                 if (_jl_debug_method_invalidation)
                     jl_array_ptr_1d_push(_jl_debug_method_invalidation, (jl_value_t*)backedgetyp);
+            }
+            if (keep != 0) {
+                // closure-owned live callers stay; only the invalidated ones leave
+                if (keep != l)
+                    jl_array_del_end((jl_array_t*)callers, l - keep);
+                alive++;
+                continue;
             }
             // remove this entry (cf. `jl_eqtable_pop`)
             jl_gc_wb(table, NULL); // deletion barrier: snapshot the overwritten key/value for SATB collectors
@@ -3180,8 +4262,9 @@ JL_DLLEXPORT void jl_method_table_disable(jl_method_t *method) JL_CANSAFEPOINT
         jl_atomic_store_relaxed(&methodentry->max_world, world);
         jl_method_table_invalidate(method, world);
         if (jl_method_get_table(method) == jl_method_table) {
-            int32_t tag = -1; // deletions poison the typename for certificate replay
-            jl_foreach_top_typename_for(_typename_tag_contributor, (jl_value_t*)method->sig, 0, &tag);
+            // deletions poison the typename for certificate replay
+            struct _contrib_tag env = { -1, jl_nothing };
+            jl_foreach_top_typename_for(_typename_tag_contributor, (jl_value_t*)method->sig, 0, &env);
         }
         jl_atomic_store_release(&jl_world_counter, world + 1);
     }
@@ -3195,7 +4278,8 @@ jl_typemap_entry_t *jl_method_table_add(jl_methtable_t *mt, jl_method_t *method,
     JL_TIMING(ADD_METHOD, ADD_METHOD);
     assert(jl_is_method(method));
     assert(jl_is_mtable(mt));
-    jl_timing_show_method(method, JL_TIMING_DEFAULT_BLOCK);
+    // n.b. no jl_timing_show_method here: formatting the signature dominates
+    // the zone's self time under a connected profiler
     jl_typemap_entry_t *newentry = NULL;
     JL_GC_PUSH1(&newentry);
     // add our new entry
@@ -3204,9 +4288,13 @@ jl_typemap_entry_t *jl_method_table_add(jl_methtable_t *mt, jl_method_t *method,
     assert((jl_atomic_load_relaxed(&method->dispatch_status) & METHOD_SIG_LATEST_ONLY) == 0);
     JL_LOCK(&mt->cache->writelock);
     newentry = jl_typemap_alloc((jl_tupletype_t*)method->sig, simpletype, jl_emptysvec, (jl_value_t*)method, ~(size_t)0, 1);
-    jl_typemap_insert(&mt->defs, (jl_value_t*)mt, newentry, 0);
+    {
+        JL_TIMING(ADD_METHOD, ACTIVATE_TmapIns);
+        jl_typemap_insert(&mt->defs, (jl_value_t*)mt, newentry, 0);
+    }
 
     if (mt == jl_method_table) {
+        JL_TIMING(ADD_METHOD, ACTIVATE_Tag);
         update_max_args(method->sig);
         contributor_tag_method(method);
     }
@@ -3373,14 +4461,14 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     jl_method_table_activate_with_cert(newentry, NULL);
 }
 
-void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t *cert)
+void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t *cert) JL_CANSAFEPOINT
 {
-    JL_TIMING(ADD_METHOD, ADD_METHOD);
+    JL_TIMING(ADD_METHOD, ACTIVATE);
     jl_method_t *method = newentry->func.method;
     jl_methtable_t *mt = jl_method_get_table(method);
     assert(jl_is_mtable(mt));
     assert(jl_is_method(method));
-    jl_timing_show_method(method, JL_TIMING_DEFAULT_BLOCK);
+    // n.b. no jl_timing_show_method here (see jl_method_table_add)
     jl_value_t *type = (jl_value_t*)newentry->sig;
     jl_value_t *oldvalue = NULL;
     jl_array_t *oldmi = NULL;
@@ -3398,31 +4486,40 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
     jl_value_t *isect2 = NULL;
     jl_genericmemory_t *interferences = NULL;
     jl_svec_t *newcert = NULL;
-    JL_GC_PUSH7(&oldvalue, &oldmi, &loctag, &isect, &isect2, &interferences, &newcert);
+    jl_array_t *tnrecord = NULL; // missing-edge invalidations for the certificate
+    jl_value_t *foreign_oldvalue = NULL;
+    JL_GC_PUSH9(&oldvalue, &oldmi, &loctag, &isect, &isect2, &interferences, &newcert, &tnrecord, &foreign_oldvalue);
     int record_cert = jl_generating_output() && jl_options.incremental && mt == jl_method_table;
     int closure_clean = 0;
-    if (jl_loading_closure_bits != NULL && mt == jl_method_table) {
+    if (activate_replay_mode() >= 1 && jl_loading_closure_bits != NULL && mt == jl_method_table) {
         int clean = 1;
-        if (jl_foreach_top_typename_for(_typename_check_contributor, type, 1, &clean)) {
+        int cdec = sig_tns_foreach(_typename_check_contributor, type, &clean);
+        if (cdec < 0)
+            cdec = jl_foreach_top_typename_for(_typename_check_contributor, type, 1, &clean);
+        if (cdec) {
             closure_clean = clean;
         }
         else {
-            jl_contrib_stats[2]++; // cannot decompose: full-table semantics
             closure_clean = 0;
         }
-        jl_contrib_stats[closure_clean ? 0 : 1]++;
     }
     jl_typemap_entry_t *replaced = NULL;
-    int replaying = cert != NULL && jl_svec_len(cert) == 4 && activate_replay_mode() >= 1;
+    int replaying = cert != NULL && jl_svec_len(cert) == 5 && activate_replay_mode() >= 1;
     // With a certificate, the dependency-closure part of the prior world is
     // replayed below and the scan is restricted to foreign entries (methods
     // the precompile worker could not have seen). The two passes each use
     // their partial view of the intersecting set: is_replacing and the
     // missing-backedge checks are monotone in that set, so a partial view
     // can only over-invalidate, never under-invalidate.
-    current_activation_clean = closure_clean;
-    oldvalue = get_intersect_matches(jl_atomic_load_relaxed(&mt->defs), newentry, &replaced, max_world, replaying);
-    current_activation_clean = 0;
+    if (replaying && closure_clean) {
+        // contributor completeness (the invariant edge replay already relies
+        // on): a closure-clean signature has no foreign contributor to any
+        // typename it can reach, so the foreign-only scan is provably empty
+        oldvalue = NULL;
+    }
+    else {
+        oldvalue = get_intersect_matches(jl_atomic_load_relaxed(&mt->defs), newentry, &replaced, max_world, replaying);
+    }
     record_cert = record_cert && !replaying;
     if (replaying && replaced != NULL) {
         // a foreign method replaces this one exactly: certificate context is
@@ -3440,8 +4537,14 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
         assert(jl_is_array(oldvalue));
         d = (jl_method_t**)jl_array_ptr_data((jl_array_t*)oldvalue);
         n = jl_array_nrows(oldvalue);
-        oldmi = jl_alloc_vec_any(0);
     }
+    // oldmi collects invalidated instances for the dispatch-cache flush; it
+    // is usually empty, so it allocates lazily at the push sites
+#define OLDMI_PUSH(v) do { \
+        if (oldmi == NULL) \
+            oldmi = jl_alloc_vec_any(0); \
+        jl_array_ptr_1d_push(oldmi, (jl_value_t*)(v)); \
+    } while (0)
 
     // These get updated from their state stored in the caches files, since content in cache files gets added "all at once".
     int invalidated = 0;
@@ -3457,7 +4560,7 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
     // to have no relevant type intersection for sorting).
     interferences = (jl_genericmemory_t*)jl_atomic_load_relaxed(&method->interferences);
     if (replaying) {
-        jl_value_t *foreign_oldvalue = oldvalue;
+        foreign_oldvalue = oldvalue;
         // Replay the precompile worker's scan results: same prior world for
         // this method's typenames (contributor check), so the intersecting
         // set, specificity flags, and image-mi invalidations are as recorded.
@@ -3467,9 +4570,8 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
         dispatch_bits = jl_unbox_int32(jl_svecref(cert, 3)) | METHOD_SIG_LATEST_WHICH;
         if (cd != jl_nothing) {
             oldvalue = cd;
-            d = (jl_method_t**)jl_array_ptr_data(oldvalue);
-            n = jl_array_nrows(oldvalue);
-            oldmi = jl_alloc_vec_any(0);
+            d = (jl_method_t**)jl_array_ptr_data((jl_array_t*)oldvalue);
+            n = jl_array_nrows((jl_array_t*)oldvalue);
             int32_t *fl = jl_array_data(cflags, int32_t);
             char *morespec = (char*)alloca(n);
             for (j = 0; j < n; j++)
@@ -3488,16 +4590,17 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
                     jl_genericmemory_t *m_interferences = jl_atomic_load_relaxed(&m->interferences);
                     ssize_t idx;
                     m_interferences = jl_idset_put_key(m_interferences, (jl_value_t*)method, &idx);
-                    jl_gc_write_atomic(m, m->interferences, m_interferences, release);
+                    jl_gc_write_atomic(m, m->interferences, jl_genericmemory_t, m_interferences, release);
                 }
                 jl_atomic_store_relaxed(&m->dispatch_status, m_dispatch);
                 if (morespec[j])
                     continue;
                 jl_method_instance_t *unspec = jl_atomic_load_relaxed(&m->unspecialized);
                 if (unspec)
-                    jl_array_ptr_1d_push(oldmi, (jl_value_t*)unspec);
+                    OLDMI_PUSH(unspec);
                 // live-scan only the specializations the worker could not have
                 // seen (not owned by the dependency closure)
+                JL_TIMING(ADD_METHOD, ACTIVATE_SpecScan);
                 loctag = jl_atomic_load_relaxed(&m->specializations);
                 _Atomic(jl_method_instance_t*) *data;
                 size_t l;
@@ -3509,18 +4612,54 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
                     data = (_Atomic(jl_method_instance_t*)*)&loctag;
                     l = 1;
                 }
+                // slot-1 discriminators of the activating signature: a
+                // specialization whose (concrete) first-argument key differs,
+                // or whose key is off the nominal chain of an abstract bound,
+                // provably cannot intersect `type` (same partition rules as
+                // the foreign-disjoint bucketing)
+                jl_typename_t *tkey = fdisj_sig_key(type);
+                int tub_typeside = 0;
+                jl_typename_t *tub = tkey != NULL ? NULL :
+                    fdisj_slot1_nominal_ub(type, &tub_typeside);
                 for (size_t i = 0; i < l; i++) {
                     jl_method_instance_t *mi = jl_atomic_load_relaxed(&data[i]);
                     if ((jl_value_t*)mi == jl_nothing)
                         continue;
-                    if (method_in_loading_closure((jl_method_t*)mi))
+                    if (method_in_loading_closure((jl_method_t*)mi)) {
                         continue; // covered by the certificate's mi list
+                    }
+                    if (tkey != NULL || tub != NULL) {
+                        jl_typename_t *skey = fdisj_sig_key(mi->specTypes);
+                        if (skey != NULL) {
+                            if (tkey != NULL) {
+                                if (skey != tkey) {
+                                    continue; // distinct concrete/invariant keys
+                                }
+                            }
+                            else if (!tub_typeside) {
+                                // abstract nominal bound: reject when the spec's
+                                // concrete name is off its supertype chain
+                                jl_datatype_t *w = (jl_datatype_t*)jl_unwrap_unionall(skey->wrapper);
+                                int hit = 0, depth = 0;
+                                while (w != NULL && w != jl_any_type && depth++ < 24) {
+                                    if (w->name == tub) {
+                                        hit = 1;
+                                        break;
+                                    }
+                                    w = w->super;
+                                }
+                                if (!hit && depth < 24) {
+                                    continue;
+                                }
+                            }
+                        }
+                    }
                     if (jl_type_intersection2(type, mi->specTypes, &isect, &isect2)) {
                         int replaced_dispatch = is_replacing(ambig, type, m, d, n, isect, isect2, morespec);
                         int invalidatedmi = _invalidate_dispatch_backedges(mi, type, m, d, n, replaced_dispatch, ambig, max_world, morespec);
                         if (replaced_dispatch) {
                             jl_atomic_store_relaxed(&mi->dispatch_status, 0);
-                            jl_array_ptr_1d_push(oldmi, (jl_value_t*)mi);
+                            OLDMI_PUSH(mi);
                         }
                         invalidated |= invalidatedmi;
                     }
@@ -3545,76 +4684,34 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
                     int invalidatedmi = _invalidate_dispatch_backedges(mi, type, m, d, n, replaced_dispatch, ambig, max_world, morespec);
                     if (replaced_dispatch) {
                         jl_atomic_store_relaxed(&mi->dispatch_status, 0);
-                        jl_array_ptr_1d_push(oldmi, (jl_value_t*)mi);
+                        OLDMI_PUSH(mi);
                     }
                     invalidated |= invalidatedmi;
                 }
             }
         }
-        jl_contrib_stats[7]++; // replayed activations
-        if (activate_replay_mode() == 2) {
-            // verify: recompute the full intersecting set and check that it is
-            // exactly certificate ∪ foreign scan, with matching flags
-            jl_typemap_entry_t *vrepl = NULL;
-            loctag = get_intersect_matches(jl_atomic_load_relaxed(&mt->defs), newentry, &vrepl, max_world, 0);
-            size_t vn = loctag == NULL ? 0 : jl_array_nrows(loctag);
-            jl_method_t **vdd = loctag == NULL ? NULL : (jl_method_t**)jl_array_ptr_data(loctag);
-            int mism = 0;
-            for (size_t i = 0; i < vn; i++) {
-                jl_method_t *m = vdd[i];
-                int found = 0;
-                for (j = 0; j < n && !found; j++)
-                    found = d[j] == m;
-                if (!found && foreign_oldvalue) {
-                    jl_method_t **fdd = (jl_method_t**)jl_array_ptr_data(foreign_oldvalue);
-                    for (size_t k = 0, fn = jl_array_nrows(foreign_oldvalue); k < fn && !found; k++)
-                        found = fdd[k] == m;
-                }
-                if (!found && !method_in_loading_closure(m)) {
-                    // a closure-owned extra only reflects the worker's legal
-                    // domination truncation (interference sets are documented
-                    // under-approximations); a foreign extra is a real hole
-                    mism++;
-                    jl_safe_printf("  vd-extra (foreign!): %s.%s\n",
-                                   jl_symbol_name(m->module->name), jl_symbol_name(m->name));
-                }
+        // recorded missing-edge (mt-backedge) invalidations: closure-owned
+        // callers the worker's scan of these typenames' backedge buckets
+        // invalidated; the scan below then skips closure-owned entries
+        jl_value_t *ctn = jl_svecref(cert, 4);
+        if (ctn != jl_nothing) {
+            jl_array_t *cta = (jl_array_t*)ctn;
+            for (size_t i = 0, lc = jl_array_nrows(cta); i < lc; i++) {
+                jl_code_instance_t *ci = (jl_code_instance_t*)jl_array_ptr_ref(cta, i);
+                invalidate_code_instance(ci, max_world, 0);
+                invalidated = 1;
             }
-            if (cd != jl_nothing) {
-                int32_t *vfl = jl_array_data(cflags, int32_t);
-                for (j = 0; j < n; j++) {
-                    jl_method_t *m = d[j];
-                    int ms = jl_type_morespecific(m->sig, type);
-                    int am = !ms && !jl_type_morespecific(type, m->sig);
-                    if (((vfl[j] & 1) != (ms ? 1 : 0)) || (((vfl[j] >> 1) & 1) != (am ? 1 : 0))) {
-                        mism++;
-                        if (jl_contrib_stats[4] < 20)
-                            jl_safe_printf("  flag-mismatch: %s.%s cert=%d live=(%d,%d)\n",
-                                           jl_symbol_name(m->module->name), jl_symbol_name(m->name),
-                                           (int)vfl[j], ms, am);
-                    }
-                }
-            }
-            if (mism) {
-                jl_contrib_stats[4] += mism;
-                jl_safe_printf("CERT VERIFY MISMATCH (%d) for %s.%s\n", mism,
-                               jl_symbol_name(method->module->name), jl_symbol_name(method->name));
-            }
-            loctag = NULL;
         }
         // dispatch bits from the certificate; the foreign pass below may
         // clear LATEST_ONLY further
         oldvalue = foreign_oldvalue;
-        if (oldvalue)
-            oldmi = oldmi == NULL ? jl_alloc_vec_any(0) : oldmi;
     }
     if (oldvalue) {
         // when replaying, this is the live pass over the foreign-only
         // intersecting set (replaced was handled above)
         if (replaying) {
-            d = (jl_method_t**)jl_array_ptr_data(oldvalue);
-            n = jl_array_nrows(oldvalue);
-            if (oldmi == NULL)
-                oldmi = jl_alloc_vec_any(0);
+            d = (jl_method_t**)jl_array_ptr_data((jl_array_t*)oldvalue);
+            n = jl_array_nrows((jl_array_t*)oldvalue);
         }
         assert(n > 0);
         if (replaced) {
@@ -3670,11 +4767,11 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
                 jl_method_instance_t *mi = jl_atomic_load_relaxed(&data[i]);
                 if ((jl_value_t*)mi == jl_nothing)
                     continue;
-                jl_array_ptr_1d_push(oldmi, (jl_value_t*)mi);
+                OLDMI_PUSH(mi);
             }
             jl_method_instance_t *unspec = jl_atomic_load_relaxed(&m->unspecialized);
             if (unspec)
-                jl_array_ptr_1d_push(oldmi, (jl_value_t*)unspec);
+                OLDMI_PUSH(unspec);
             d = NULL;
             n = 0;
         }
@@ -3684,7 +4781,7 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
             for (j = 0; j < n; j++)
                 morespec[j] = (char)jl_type_morespecific(d[j]->sig, type);
             if (record_cert) {
-                newcert = jl_alloc_svec(4);
+                newcert = jl_alloc_svec(5);
                 jl_svecset(newcert, 0, oldvalue);
                 jl_value_t *cf = (jl_value_t*)jl_alloc_array_1d(jl_array_int32_type, n);
                 jl_svecset(newcert, 1, cf);
@@ -3724,7 +4821,7 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
                 // Now examine if this caused any invalidations.
                 jl_method_instance_t *unspec = jl_atomic_load_relaxed(&m->unspecialized);
                 if (unspec)
-                    jl_array_ptr_1d_push(oldmi, (jl_value_t*)unspec);
+                    OLDMI_PUSH(unspec);
                 loctag = jl_atomic_load_relaxed(&m->specializations); // use loctag for a gcroot
                 _Atomic(jl_method_instance_t*) *data;
                 size_t l;
@@ -3761,7 +4858,7 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
                         int invalidatedmi = _invalidate_dispatch_backedges(mi, type, m, d, n, replaced_dispatch, ambig, max_world, morespec);
                         if (replaced_dispatch) {
                             jl_atomic_store_relaxed(&mi->dispatch_status, 0);
-                            jl_array_ptr_1d_push(oldmi, (jl_value_t*)mi);
+                            OLDMI_PUSH(mi);
                         }
                         if (_jl_debug_method_invalidation && invalidatedmi) {
                             jl_array_ptr_1d_push(_jl_debug_method_invalidation, (jl_value_t*)mi);
@@ -3792,8 +4889,11 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
     }
 
     jl_methcache_t *mc = jl_method_table->cache;
+    if (record_cert && !replaced)
+        tnrecord = jl_alloc_vec_any(0);
     JL_LOCK(&mc->writelock);
-    struct _typename_invalidate_backedge typename_env = {type, &isect, &isect2, d, n, max_world, invalidated};
+    struct _typename_invalidate_backedge typename_env = {type, &isect, &isect2, d, n, max_world, invalidated,
+                                                         tnrecord, /* foreign_only */ replaying};
     if (!jl_foreach_top_typename_for(_typename_invalidate_backedges, type, 1, &typename_env)) {
         // if the new method cannot be split into exact backedges, scan the whole table for anything that might be affected
         jl_genericmemory_t *allbackedges = jl_method_table->backedges;
@@ -3808,6 +4908,7 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
     if (oldmi && jl_array_nrows(oldmi)) {
         // drop leafcache and search mc->cache and drop anything that might overlap with the new method
         // this is very cheap, so we don't mind being very conservative at over-approximating this
+        JL_TIMING(ADD_METHOD, ACTIVATE_MCache);
         struct invalidate_mt_env mt_cache_env;
         mt_cache_env.max_world = max_world;
         mt_cache_env.shadowed = oldmi;
@@ -3836,15 +4937,18 @@ void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t 
     jl_atomic_store_relaxed(&newentry->max_world, ~(size_t)0);
     jl_atomic_store_relaxed(&method->dispatch_status, dispatch_bits); // TODO: this should be sequenced fully after the world counter store
     jl_gc_write_atomic(method, method->interferences, jl_genericmemory_t, interferences, release);
+#undef OLDMI_PUSH
     if (record_cert && !replaced) {
         if (newcert == NULL) { // n == 0: record just the dispatch bits
-            newcert = jl_alloc_svec(4);
+            newcert = jl_alloc_svec(5);
             jl_svecset(newcert, 0, jl_nothing);
             jl_svecset(newcert, 1, jl_nothing);
             jl_svecset(newcert, 2, jl_nothing);
         }
         loctag = jl_box_int32(dispatch_bits);
         jl_svecset(newcert, 3, loctag);
+        jl_svecset(newcert, 4, tnrecord != NULL && jl_array_nrows(tnrecord) > 0 ?
+                               (jl_value_t*)tnrecord : jl_nothing);
         record_activation_cert(method, newcert);
     }
     JL_GC_POP();
@@ -3996,13 +5100,13 @@ STATIC_INLINE jl_value_t *_jl_rettype_inferred(jl_value_t *owner, jl_method_inst
     while (codeinst) {
         if (jl_atomic_load_relaxed(&codeinst->min_world) <= min_world &&
             max_world <= jl_atomic_load_relaxed(&codeinst->max_world) &&
-            jl_egal(codeinst->owner, owner)) {
+            jl_egal(jl_ci_owner(codeinst), owner)) {
 
-            jl_value_t *code = jl_atomic_load_relaxed(&codeinst->inferred);
+            jl_value_t *code = jl_ci_inferred(codeinst);
             if (code)
                 return (jl_value_t*)codeinst;
         }
-        codeinst = jl_atomic_load_relaxed(&codeinst->next);
+        codeinst = jl_ci_next(codeinst);
     }
     return (jl_value_t*)jl_nothing;
 }
@@ -4022,8 +5126,8 @@ JL_DLLEXPORT jl_value_t *(*const jl_rettype_inferred_addr)(jl_method_instance_t 
 STATIC_INLINE jl_callptr_t jl_method_compiled_callptr(jl_method_instance_t *mi, size_t world, jl_code_instance_t **codeinst_out) JL_NOTSAFEPOINT
 {
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
-    for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
-        if (codeinst->owner != jl_nothing)
+    for (; codeinst; codeinst = jl_ci_next(codeinst)) {
+        if (jl_ci_owner(codeinst) != jl_nothing)
             continue;
         if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
             jl_callptr_t invoke = jl_atomic_load_acquire(&codeinst->invoke);
@@ -4234,7 +5338,7 @@ JL_DLLEXPORT void jl_add_codeinsts_to_jit(jl_array_t *codeinsts, jl_array_t *src
     JL_LOCK(&mc->writelock);
     for (size_t i = 0; i < ncodeinsts; i++) {
         jl_code_instance_t *codeinst = (jl_code_instance_t*)jl_array_ptr_ref(codeinsts, i);
-        jl_method_instance_t *mi = (jl_method_instance_t*)codeinst->def;
+        jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
         if (!jl_is_method(mi->def.method))
             continue;
         jl_method_t *m = mi->def.method;
@@ -4289,7 +5393,7 @@ static jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi JL_PROPAGAT
     jl_svec_t *copy_edge = jl_is_method(m) ? jl_svec2(m->sig, codeinst2) : jl_emptysvec;
     JL_GC_PUSH1(&copy_edge);
     jl_code_instance_t *codeinst = jl_get_method_uninferred(
-            mi, codeinst2->rettype,
+            mi, jl_ci_rettype(codeinst2),
             jl_atomic_load_relaxed(&codeinst2->min_world),
             max_world2 < current_world ? max_world2 : current_world,
             jl_atomic_load_relaxed(&codeinst2->debuginfo),
@@ -4304,7 +5408,7 @@ static jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi JL_PROPAGAT
             }
             JL_UNLOCK(&world_counter_lock);
         }
-        jl_gc_write(codeinst, codeinst->rettype_const, jl_value_t, codeinst2->rettype_const);
+        jl_gc_write(codeinst, codeinst->rettype_const, jl_value_t, jl_ci_rettype_const(codeinst2));
         uint8_t specsigflags;
         jl_callptr_t invoke;
         void *fptr;
@@ -4467,7 +5571,7 @@ static jl_code_instance_t *jl_compile_method_very_internal(jl_method_instance_t 
             is_recompile = 1;
             break;
         }
-        codeinst_old = jl_atomic_load_relaxed(&codeinst_old->next);
+        codeinst_old = jl_ci_next(codeinst_old);
     }
 
     // jl_type_infer will internally do a cache lookup and jl_engine_reserve call
@@ -4572,7 +5676,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
 
 jl_value_t *jl_fptr_const_return(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
 {
-    return m->rettype_const;
+    return jl_ci_rettype_const(m);
 }
 
 jl_value_t *jl_fptr_args(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
@@ -6197,7 +7301,7 @@ static void invalidate_method_instance_caches(jl_method_instance_t *mi, size_t w
         if (jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0) {
             jl_atomic_store_release(&ci->max_world, world);
         }
-        ci = jl_atomic_load_relaxed(&ci->next);
+        ci = jl_ci_next(ci);
     }
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -2290,7 +2290,7 @@ struct matches_env {
 // all within the loading image's dependency closure (measurement)
 static int current_activation_clean = 0;
 static int method_in_loading_closure(jl_method_t *m);
-extern JL_DLLEXPORT uint64_t jl_contrib_stats[8];
+extern JL_DLLEXPORT uint64_t jl_contrib_stats[12];
 
 static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_intersection_env *closure0) JL_CANSAFEPOINT
 {
@@ -2742,7 +2742,7 @@ static void _typename_add_backedge(jl_typename_t *tn, int explct, void *env0) JL
 // prior world its precompile worker analyzed.
 JL_DLLEXPORT jl_genericmemory_t *jl_method_contributors = NULL;
 JL_DLLEXPORT jl_genericmemory_t *jl_activation_certs = NULL; // method -> certificate (precompile worker)
-JL_DLLEXPORT uint64_t jl_contrib_stats[8];
+JL_DLLEXPORT uint64_t jl_contrib_stats[12];
 
 static int activate_replay_mode(void)
 {
@@ -2854,6 +2854,26 @@ static void _typename_check_contributor(jl_typename_t *tn, int explct, void *env
             return;
         }
     }
+}
+
+// Is `sig`'s method-matching world provably unchanged relative to the loading
+// image's precompile worker? (all contributors to its typenames lie within the
+// dependency closure). Returns the replay mode when so, 0 otherwise.
+JL_DLLEXPORT int jl_edge_sig_replayable(jl_value_t *sig)
+{
+    int mode = activate_replay_mode();
+    if (mode < 1 || jl_loading_closure_bits == NULL)
+        return 0;
+    int clean = 1;
+    jl_contrib_stats[8]++;
+    if (!jl_foreach_top_typename_for(_typename_check_contributor, sig, 1, &clean) || !clean) {
+        jl_value_t *usig = jl_unwrap_unionall(sig);
+        if (jl_is_datatype(usig) && jl_nparams(usig) > 0 && jl_is_typeeq(jl_tparam(usig, 0)))
+            jl_contrib_stats[10]++; // dirty with Type{...} first arg (constructor call)
+        return 0;
+    }
+    jl_contrib_stats[9]++;
+    return mode;
 }
 
 static void contributor_tag_method(jl_method_t *method)

--- a/src/gf.c
+++ b/src/gf.c
@@ -2286,10 +2286,21 @@ struct matches_env {
     jl_typemap_entry_t *replaced;
 };
 
+// nonzero while scanning for an activation whose typename contributors were
+// all within the loading image's dependency closure (measurement)
+static int current_activation_clean = 0;
+static int method_in_loading_closure(jl_method_t *m);
+extern JL_DLLEXPORT uint64_t jl_contrib_stats[8];
+
 static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_intersection_env *closure0) JL_CANSAFEPOINT
 {
     struct matches_env *closure = container_of(closure0, struct matches_env, match);
     jl_method_t *oldmethod = oldentry->func.method;
+    if (current_activation_clean) {
+        jl_contrib_stats[4]++;
+        if (!method_in_loading_closure(oldmethod))
+            jl_contrib_stats[3]++; // invariant violation: clean typename, foreign method
+    }
     assert(oldentry != closure->newentry && "entry already added");
     assert(jl_atomic_load_relaxed(&oldentry->min_world) <= jl_atomic_load_relaxed(&closure->newentry->min_world) && "old method cannot be newer than new method");
     //assert(jl_atomic_load_relaxed(&oldentry->max_world) != jl_atomic_load_relaxed(&closure->newentry->min_world) && "method cannot be added at the same time as method deleted");
@@ -2625,6 +2636,7 @@ static int _invalidate_dispatch_backedges(jl_method_instance_t *mi, jl_value_t *
 // invalidate cached methods that overlap this definition
 static void invalidate_backedges(jl_method_instance_t *replaced_mi, size_t max_world, const char *why) JL_CANSAFEPOINT
 {
+    JL_TIMING(ADD_METHOD, INVALIDATE_Backedges);
     // Reset dispatch_status when method instance is replaced
     JL_LOCK(&replaced_mi->def.method->writelock);
     _invalidate_backedges(replaced_mi, NULL, max_world, 1);
@@ -2711,6 +2723,105 @@ static void _typename_add_backedge(jl_typename_t *tn, int explct, void *env0) JL
     if (n > 0 && jl_array_ptr_ref(callers, n - 1) == env->caller)
         return; // this edge already recorded
     jl_array_ptr_1d_push(callers, env->caller);
+}
+
+// ---- method-table contributor tracking ----
+// For every generic function (keyed by the same top-typename decomposition the
+// mt-backedge table uses), track which sources have contributed (or deleted)
+// methods under it: the linkage blob index for pkgimage-owned methods, -1 for
+// run-time sources (eval, deletion). A pkgimage activation whose typenames'
+// contributors all lie within the image's dependency closure faces exactly the
+// prior world its precompile worker analyzed.
+JL_DLLEXPORT jl_genericmemory_t *jl_method_contributors = NULL;
+JL_DLLEXPORT uint64_t jl_contrib_stats[8];
+
+static size_t *jl_loading_closure_bits = NULL; // bitset over linkage blobs
+static size_t jl_loading_closure_nblobs = 0;
+
+JL_DLLEXPORT void jl_set_loading_closure_blobs(size_t *bits, size_t nblobs)
+{
+    jl_loading_closure_bits = bits;
+    jl_loading_closure_nblobs = nblobs;
+}
+
+static int blob_in_loading_closure(size_t idx)
+{
+    if (idx >= jl_loading_closure_nblobs)
+        return 0;
+    return (jl_loading_closure_bits[idx / (8 * sizeof(size_t))] >>
+            (idx % (8 * sizeof(size_t)))) & 1;
+}
+
+static int method_in_loading_closure(jl_method_t *m)
+{
+    if (!jl_object_in_image((jl_value_t*)m))
+        return 0;
+    return blob_in_loading_closure(jl_external_blob_index((jl_value_t*)m));
+}
+
+static void contributor_add_tag(jl_typename_t *tn, int32_t tag)
+{
+    if (jl_method_contributors == NULL) {
+        if (jl_an_empty_memory_any == NULL)
+            return; // too early in bootstrap to track (table is per-session anyway)
+        jl_method_contributors = (jl_genericmemory_t*)jl_an_empty_memory_any;
+    }
+    jl_array_t *tags = (jl_array_t*)jl_eqtable_get(jl_method_contributors, (jl_value_t*)tn, NULL);
+    if (tags == NULL) {
+        tags = jl_alloc_array_1d(jl_array_int32_type, 0);
+        JL_GC_PUSH1(&tags);
+        jl_genericmemory_t *newtable = jl_eqtable_put(jl_method_contributors, (jl_value_t*)tn, (jl_value_t*)tags, NULL);
+        JL_GC_POP();
+        if (newtable != jl_method_contributors)
+            jl_method_contributors = newtable;
+    }
+    size_t l = jl_array_nrows(tags);
+    int32_t *d = jl_array_data(tags, int32_t);
+    for (size_t i = 0; i < l; i++)
+        if (d[i] == tag)
+            return;
+    jl_array_grow_end(tags, 1);
+    jl_array_data(tags, int32_t)[l] = tag;
+}
+
+static void _typename_tag_contributor(jl_typename_t *tn, int explct, void *env0)
+{
+    // like the mt-backedge table: store only under explicitly encountered
+    // typenames; checks consult every callback. Exception: the shared Type
+    // typename is tagged unconditionally, because Type-signatures of
+    // unrelated families still intersect one another (every abstract-bounded
+    // constructor admits Type{Union{}}), so the per-family top typename is
+    // not a complete key for them.
+    if (!explct && tn != jl_type_typename)
+        return;
+    contributor_add_tag(tn, *(int32_t*)env0);
+}
+
+static void _typename_check_contributor(jl_typename_t *tn, int explct, void *env0)
+{
+    int *clean = (int*)env0;
+    (void)explct;
+    if (!*clean || jl_method_contributors == NULL)
+        return;
+    jl_array_t *tags = (jl_array_t*)jl_eqtable_get(jl_method_contributors, (jl_value_t*)tn, NULL);
+    if (tags == NULL)
+        return; // only (pre-session) sysimage contributions
+    size_t l = jl_array_nrows(tags);
+    int32_t *d = jl_array_data(tags, int32_t);
+    for (size_t i = 0; i < l; i++) {
+        if (d[i] < 0 || !blob_in_loading_closure((size_t)d[i])) {
+            jl_contrib_stats[d[i] < 0 ? 5 : 6]++; // dirty cause: session / foreign blob
+            *clean = 0;
+            return;
+        }
+    }
+}
+
+static void contributor_tag_method(jl_method_t *method)
+{
+    int32_t tag = jl_object_in_image((jl_value_t*)method) ?
+        (int32_t)jl_external_blob_index((jl_value_t*)method) : -1;
+    jl_foreach_top_typename_for(_typename_tag_contributor, (jl_value_t*)method->sig, 0, &tag);
 }
 
 // add a backedge from a non-existent signature to caller
@@ -3009,6 +3120,10 @@ JL_DLLEXPORT void jl_method_table_disable(jl_method_t *method) JL_CANSAFEPOINT
         assert(jl_atomic_load_relaxed(&methodentry->max_world) == ~(size_t)0);
         jl_atomic_store_relaxed(&methodentry->max_world, world);
         jl_method_table_invalidate(method, world);
+        if (jl_method_get_table(method) == jl_method_table) {
+            int32_t tag = -1; // deletions poison the typename for certificate replay
+            jl_foreach_top_typename_for(_typename_tag_contributor, (jl_value_t*)method->sig, 0, &tag);
+        }
         jl_atomic_store_release(&jl_world_counter, world + 1);
     }
     JL_UNLOCK(&world_counter_lock);
@@ -3032,8 +3147,10 @@ jl_typemap_entry_t *jl_method_table_add(jl_methtable_t *mt, jl_method_t *method,
     newentry = jl_typemap_alloc((jl_tupletype_t*)method->sig, simpletype, jl_emptysvec, (jl_value_t*)method, ~(size_t)0, 1);
     jl_typemap_insert(&mt->defs, (jl_value_t*)mt, newentry, 0);
 
-    if (mt == jl_method_table)
+    if (mt == jl_method_table) {
         update_max_args(method->sig);
+        contributor_tag_method(method);
+    }
     JL_UNLOCK(&mt->cache->writelock);
     JL_GC_POP();
     return newentry;
@@ -3217,9 +3334,23 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     jl_value_t *isect2 = NULL;
     jl_genericmemory_t *interferences = NULL;
     JL_GC_PUSH6(&oldvalue, &oldmi, &loctag, &isect, &isect2, &interferences);
+    int closure_clean = 0;
+    if (jl_loading_closure_bits != NULL && mt == jl_method_table) {
+        int clean = 1;
+        if (jl_foreach_top_typename_for(_typename_check_contributor, type, 1, &clean)) {
+            closure_clean = clean;
+        }
+        else {
+            jl_contrib_stats[2]++; // cannot decompose: full-table semantics
+            closure_clean = 0;
+        }
+        jl_contrib_stats[closure_clean ? 0 : 1]++;
+    }
     jl_typemap_entry_t *replaced = NULL;
     // Check what entries this intersects with in the prior world.
+    current_activation_clean = closure_clean;
     oldvalue = get_intersect_matches(jl_atomic_load_relaxed(&mt->defs), newentry, &replaced, max_world);
+    current_activation_clean = 0;
     jl_method_t *const *d;
     size_t j, n;
     if (oldvalue == NULL) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -1306,7 +1306,8 @@ static void jl_compilation_sig(
             // and the result of matching the type signature
             // needs to be restricted to the concrete type 'kind'
             jl_value_t *kind = jl_typeof(jl_some_Type_T(elt));
-            if (!jl_has_free_typevars(decl_i) &&
+            if (!(jl_is_typeeq(elt) && jl_is_bottom_singleton_class(jl_typeeq_T(elt))) &&
+                    !jl_has_free_typevars(decl_i) &&
                     jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {
                 // if we can prove the match was against the kind (not a Type)
                 // it's simpler (and thus better) to put that cache instead
@@ -1627,9 +1628,10 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
             // and the result of matching the type signature
             // needs to be corrected to the concrete type 'kind' (and not to Type)
             jl_value_t *kind = jl_typeof(jl_some_Type_T(elt));
-            if (kind == jl_bottom_type) {
+            if (kind == jl_bottom_type ||
+                (jl_is_typeeq(elt) && jl_is_bottom_singleton_class(jl_typeeq_T(elt)))) {
                 JL_GC_POP();
-                return 0; // Type{Union{}} gets normalized to typeof(Union{})
+                return 0; // the bottom singleton class is under no single kind
             }
             if (!jl_has_free_typevars(decl_i) &&
                     jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -2774,8 +2774,10 @@ static int activate_replay_mode(void)
 {
     static int mode = -1;
     if (mode == -1) {
+        // replay of the precompile worker's activation and edge-validity results
+        // is on unless JULIA_ACTIVATE_REPLAY=0 opts out
         const char *e = getenv("JULIA_ACTIVATE_REPLAY");
-        mode = e != NULL && e[0] == '1';
+        mode = e == NULL || e[0] != '0';
     }
     return mode;
 }

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -35,7 +35,7 @@ extern "C" {
 #define TAG_EDGE               18
 #define TAG_STRING             19
 #define TAG_SHORT_INT64        20
-//#define TAG_UNUSED           21
+#define TAG_IMAGE_ROOT         21
 #define TAG_CNULL              22
 #define TAG_ARRAY1D            23
 #define TAG_SINGLETON          24
@@ -86,7 +86,7 @@ typedef struct {
     size_t ssaid;
     // method we're compressing for
     jl_method_t *method;
-    jl_svec_t *edges;
+    jl_value_t *edges; // SimpleVector, or InternedCodeInstance for image CodeInstances
     jl_ptls_t ptls;
     uint8_t relocatability;
 } jl_ircode_state;
@@ -146,7 +146,8 @@ static void literal_val_id(rle_reference *rr, jl_ircode_state *s, jl_value_t *v)
                 return tagged_root(rr, s, i);
         }
     }
-    for (size_t i = 0; i < jl_svec_len(s->edges); i++) {
+    size_t nedges = jl_is_svec(s->edges) ? jl_svec_len(s->edges) : 0; // never encode against interned edges
+    for (size_t i = 0; i < nedges; i++) {
         if (jl_svecref(s->edges, i) == v) {
             rr->index = i;
             return;
@@ -168,12 +169,47 @@ static void jl_encode_int32(jl_ircode_state *s, int32_t x)
     }
 }
 
+// identity-stable image objects can be referenced from compressed IR
+// directly as (image, offset). Uniquing-class objects (types, typenames,
+// MethodInstances, methods, modules, bindings, singletons, symbols) are
+// excluded: their canonical copy is load-order dependent, so a fixed offset
+// may name a superseded stub in another process.
+static int image_ref_eligible(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    if (jl_is_symbol(v) || jl_is_type(v) || jl_is_typevar(v) ||
+        jl_is_method_instance(v) || jl_is_method(v) || jl_is_module(v) ||
+        jl_is_binding(v) || jl_is_globalref(v) || jl_is_code_instance(v) ||
+        jl_typetagis(v, jl_typename_type))
+        return 0;
+    jl_datatype_t *t = (jl_datatype_t*)jl_typeof(v);
+    if (t->instance == v)
+        return 0; // singleton instance
+    return 1;
+}
+
 static void jl_encode_as_indexed_root(jl_ircode_state *s, jl_value_t *v) JL_CANSAFEPOINT
 {
     rle_reference rr = {.key = -1, .index = -1};
 
     if (jl_is_string(v))
         v = jl_as_global_root(v, 1);
+    // no direct image references while generating a non-incremental output:
+    // sysimage stages re-serialize this IR into a NEW image whose layout the
+    // recorded offsets would not match (package precompiles are safe: their
+    // dependency files stay byte-identical and build_id-verified)
+    if (jl_object_in_image(v) && image_ref_eligible(v) &&
+        !(jl_generating_output() && !jl_options.incremental)) {
+        uint64_t key, off;
+        int kind = jl_image_ref_of(v, &key, &off);
+        if (kind != 0 && (off & 7) == 0 && (off >> 3) <= UINT32_MAX) {
+            write_uint8(s->s, TAG_IMAGE_ROOT);
+            write_uint8(s->s, kind == 2 ? 1 : 0); // flags: bit0 = sysimage
+            if (kind != 2)
+                write_uint64(s->s, key);
+            write_uint32(s->s, (uint32_t)(off >> 3));
+            return;
+        }
+    }
     literal_val_id(&rr, s, v);
     int id = rr.index;
     assert(id >= 0);
@@ -799,14 +835,34 @@ static jl_value_t *jl_decode_value(jl_ircode_state *s)
         assert(index >= 0);
         return lookup_root(s->method, key, index);
     }
+    case TAG_IMAGE_ROOT: {
+        int flags = read_uint8(s->s);
+        uint64_t k = (flags & 1) ? 0 : read_uint64(s->s);
+        uint64_t off = ((uint64_t)read_uint32(s->s)) << 3;
+        jl_value_t *v = jl_image_ref_resolve(flags & 1, k, off);
+        if (v == NULL)
+            jl_errorf("compressed IR references image %llx which is not loaded",
+                      (unsigned long long)k);
+        return v;
+    }
     case TAG_METHODROOT:
         return lookup_root(s->method, 0, read_uint8(s->s));
     case TAG_LONG_METHODROOT:
         return lookup_root(s->method, 0, read_uint32(s->s));
     case TAG_EDGE:
-        return jl_svecref(s->edges, read_uint8(s->s));
+        {
+            size_t edge_i = read_uint8(s->s);
+            if (jl_is_svec(s->edges))
+                return jl_svecref(s->edges, edge_i);
+            return jl_ici_ref((jl_interned_code_instance_t*)s->edges, edge_i);
+        }
     case TAG_LONG_EDGE:
-        return jl_svecref(s->edges, read_uint32(s->s));
+        {
+            size_t edge_i = read_uint32(s->s);
+            if (jl_is_svec(s->edges))
+                return jl_svecref(s->edges, edge_i);
+            return jl_ici_ref((jl_interned_code_instance_t*)s->edges, edge_i);
+        }
     case TAG_SVEC: JL_FALLTHROUGH; case TAG_LONG_SVEC:
         return jl_decode_value_svec(s, tag);
     case TAG_COMMONSYM:
@@ -1013,7 +1069,7 @@ JL_DLLEXPORT jl_string_t *jl_compress_ir(jl_method_t *m, jl_code_info_t *code)
         code = (jl_code_info_t*)m->source;
     assert(jl_is_method(m));
     assert(jl_is_code_info(code));
-    assert(jl_array_nrows(code->code) == codelocs_nstmts(code->debuginfo->codelocs) || jl_string_len(code->debuginfo->codelocs) == 0);
+    assert(jl_array_nrows(code->code) == codelocs_nstmts(jl_di_codelocs_ro(code->debuginfo)) || jl_string_len(jl_di_codelocs_ro(code->debuginfo)) == 0);
     ios_t dest;
     ios_mem(&dest, 0);
 
@@ -1025,7 +1081,7 @@ JL_DLLEXPORT jl_string_t *jl_compress_ir(jl_method_t *m, jl_code_info_t *code)
         &dest,
         0,
         m,
-        (!isdef && jl_is_svec(edges)) ? (jl_svec_t*)edges : jl_emptysvec,
+        (!isdef && jl_is_svec(edges)) ? edges : (jl_value_t*)jl_emptysvec,
         jl_current_task->ptls,
         1
     };
@@ -1119,7 +1175,7 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ir(jl_method_t *m, jl_code_instance_t
         &src,
         0,
         m,
-        metadata == NULL ? NULL : jl_atomic_load_relaxed(&metadata->edges),
+        metadata == NULL ? NULL : (jl_value_t*)jl_atomic_load_relaxed(&metadata->edges),
         jl_current_task->ptls,
         1
     };
@@ -1174,13 +1230,15 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ir(jl_method_t *m, jl_code_instance_t
     jl_gc_write(code, code->slotnames, jl_array_t, jl_uncompress_argnames(slotnames));
 
     if (metadata) {
-        jl_debuginfo_t *new_debuginfo = jl_atomic_load_relaxed(&metadata->debuginfo);
+        jl_debuginfo_t *new_debuginfo = jl_ci_debuginfo(metadata);
+        if (new_debuginfo != NULL)
+            jl_di_materialize_all(new_debuginfo); // hand-out: raw readers walk this tree
         jl_gc_wb(code, new_debuginfo);
         code->debuginfo = new_debuginfo;
     } else
         jl_gc_write(code, code->debuginfo, jl_debuginfo_t, m->debuginfo);
     assert(code->debuginfo);
-    assert(jl_array_nrows(code->code) == codelocs_nstmts(code->debuginfo->codelocs) || jl_string_len(code->debuginfo->codelocs) == 0);
+    assert(jl_array_nrows(code->code) == codelocs_nstmts(jl_di_codelocs_ro(code->debuginfo)) || jl_string_len(jl_di_codelocs_ro(code->debuginfo)) == 0);
 
     (void) read_uint8(s.s);   // relocatability
     assert(!ios_eof(s.s));
@@ -1190,10 +1248,15 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ir(jl_method_t *m, jl_code_instance_t
     JL_UNLOCK(&m->writelock); // Might GC
     if (metadata) {
         jl_gc_write(code, code->parent, jl_method_instance_t, jl_get_ci_mi(metadata));
-        jl_gc_write(code, code->rettype, jl_value_t, metadata->rettype);
+        jl_gc_write(code, code->rettype, jl_value_t, jl_ci_rettype(metadata));
         code->min_world = jl_atomic_load_relaxed(&metadata->min_world);
         code->max_world = jl_atomic_load_relaxed(&metadata->max_world);
-        jl_gc_write(code, code->edges, jl_value_t, (jl_value_t*)s.edges);
+        {
+            jl_value_t *medges = s.edges;
+            if (medges != NULL && jl_typetagis(medges, jl_interned_code_instance_type))
+                medges = (jl_value_t*)jl_ici_to_svec((jl_interned_code_instance_t*)medges);
+            jl_gc_write(code, code->edges, jl_value_t, medges);
+        }
     }
     JL_GC_POP();
 
@@ -1423,7 +1486,7 @@ static const struct jl_codeloc_t badloc = {-1, 0, 0};
 
 JL_DLLEXPORT struct jl_codeloc_t jl_uncompress1_codeloc(jl_debuginfo_t *di, size_t pc) JL_NOTSAFEPOINT
 {
-    jl_string_t *cl = di->codelocs;
+    jl_string_t *cl = (jl_string_t*)jl_di_codelocs_ro(di);
     assert(jl_is_string(cl));
     int loc_offset, loc_bytes, to_bytes;
     size_t nstmts = codelocs_parseheader(cl, &loc_offset, &loc_bytes, &to_bytes);
@@ -1455,15 +1518,15 @@ static void cdi_deref(jl_debuginfo_t **p_di, int32_t *p_pc, int recursive) JL_NO
     int32_t pc = 0;
     if (!p_pc)
         p_pc = &pc;
-    if (jl_is_debuginfo(di->linetable)) {
+    if (jl_is_debuginfo(jl_di_linetable_ro(di))) {
         assert(*p_pc >= 0);
         *p_pc = jl_uncompress1_codeloc(di, *p_pc).loc;
-        *p_di = (jl_debuginfo_t *)di->linetable;
+        *p_di = (jl_debuginfo_t *)jl_di_linetable_ro(di);
         if (recursive) {
             cdi_deref(p_di, p_pc, recursive);
         }
     } else {
-        assert(jl_is_string(di->linetable) || jl_is_nothing(di->linetable));
+        assert(jl_is_string(jl_di_linetable_ro(di)) || jl_is_nothing(jl_di_linetable_ro(di)));
     }
 }
 
@@ -1472,7 +1535,7 @@ JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOT
     cdi_deref(&di, &pc, 1);
     pc = jl_uncompress1_codeloc(di, pc).loc;
     jl_sourcebytetable_header_t h;
-    const char *ptr = sbt_parseheader(di->linetable, &h);
+    const char *ptr = sbt_parseheader(jl_di_linetable_ro(di), &h);
     if (pc <= 0 || pc > h.nlocs) {
         return (jl_locspan_t){-1, -1};
     }
@@ -1488,11 +1551,11 @@ JL_DLLEXPORT jl_locspan_t jl_cdi_byte_to_xy(jl_debuginfo_t *di, int32_t b) JL_NO
 {
     cdi_deref(&di, NULL, 1);
     jl_sourcebytetable_header_t h;
-    sbt_parseheader(di->linetable, &h);
+    sbt_parseheader(jl_di_linetable_ro(di), &h);
     size_t off = SBT_HEADER_SIZE + h.nlocs * (h.byte_encl + h.span_encl);
-    size_t n_lines = (jl_string_len(di->linetable) - off) / h.byte_encl;
+    size_t n_lines = (jl_string_len(jl_di_linetable_ro(di)) - off) / h.byte_encl;
     jl_locspan_t out = {h.line_offset-1, -1};
-    const char *ptr = jl_string_data(di->linetable) + off;
+    const char *ptr = jl_string_data(jl_di_linetable_ro(di)) + off;
     for (int i = 0; i < n_lines; i++) {
         int32_t line_start = _take_u32(&ptr, h.byte_encl);
         if (line_start + h.byte_offset <= b) {
@@ -1513,9 +1576,9 @@ JL_DLLEXPORT jl_locspan_t jl_cdi_firstxy(jl_debuginfo_t *di, int32_t pc) JL_NOTS
     assert(pc > 0);
     cdi_deref(&di, &pc, 1);
     jl_locspan_t out = {-1, -1};
-    if (jl_is_nothing(di->linetable)) {
+    if (jl_is_nothing(jl_di_linetable_ro(di))) {
         out.first = jl_uncompress1_codeloc(di, pc).loc;
-    } else if (jl_is_string(di->linetable)) {
+    } else if (jl_is_string(jl_di_linetable_ro(di))) {
         out = jl_cdi_byte_to_xy(di, jl_cdi_bytespan(di, pc).first);
     }
     return out;
@@ -1530,10 +1593,10 @@ JL_DLLEXPORT int32_t jl_cdi_external_firstline(jl_debuginfo_t *di) JL_NOTSAFEPOI
 {
     int32_t pc = 0;
     cdi_deref(&di, &pc, 1);
-    if (jl_is_nothing(di->linetable)) {
+    if (jl_is_nothing(jl_di_linetable_ro(di))) {
         int32_t out = jl_uncompress1_codeloc(di, 0).loc;
         return out > 0 ? out : -1;
-    } else if (jl_is_string(di->linetable)) {
+    } else if (jl_is_string(jl_di_linetable_ro(di))) {
         return -1;
     }
     jl_unreachable();
@@ -1553,11 +1616,12 @@ JL_DLLEXPORT int32_t jl_cdi_firstline_all(jl_debuginfo_t *di) JL_NOTSAFEPOINT
 JL_DLLEXPORT const char *jl_cdi_file(jl_debuginfo_t *di) JL_NOTSAFEPOINT
 {
     cdi_deref(&di, NULL, 1);
-    if (jl_is_symbol(di->def)) {
-        return jl_symbol_name((jl_sym_t*)di->def);
-    } else if (jl_is_method_instance(di->def)) {
+    jl_value_t *didef = jl_di_def_ro(di);
+    if (jl_is_symbol(didef)) {
+        return jl_symbol_name((jl_sym_t*)didef);
+    } else if (jl_is_method_instance(didef)) {
         // reachable with hand-crafted CodeInstances in base tests
-        jl_value_t *m = ((jl_method_instance_t *)di->def)->def.value;
+        jl_value_t *m = ((jl_method_instance_t *)didef)->def.value;
         assert(jl_is_method(m) && "unimplemented");
         return jl_symbol_name(((jl_method_t*)m)->file);
     } else {
@@ -1702,7 +1766,7 @@ JL_DLLEXPORT jl_string_t *jl_compress_codelocs(int32_t firstloc, jl_value_t *cod
 
 JL_DLLEXPORT jl_value_t *jl_uncompress_codelocs(jl_debuginfo_t *di, size_t nstmts) // Memory{UInt8} => Vector{Int32}
 {
-    jl_string_t *cl = di->codelocs;
+    jl_string_t *cl = (jl_string_t*)jl_di_codelocs_ro(di);
     assert(jl_is_string(cl));
     int loc_offset, loc_bytes, to_bytes;
     size_t nlocs = codelocs_parseheader(cl, &loc_offset, &loc_bytes, &to_bytes);

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -280,7 +280,7 @@ StringRef jl_codegen_output_t::get_call_target(jl_code_instance_t *ci, bool spec
             jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
         jl_returninfo_t info =
             get_specsig_function(*this, &get_module(), nullptr, protoname, get_ci_abi(ci),
-                                 ci->rettype, is_opaque_closure);
+                                 jl_ci_rettype(ci), is_opaque_closure);
         target.decl = cast<Function>(info.decl.getCallee());
     }
     else {
@@ -339,7 +339,7 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
             }
             else if (invoke == jl_fptr_args_addr) {
                 assert(specptr != nullptr);
-                if (!from_abi.specsig && jl_subtype(codeinst->rettype, from_abi.rt))
+                if (!from_abi.specsig && jl_subtype(jl_ci_rettype(codeinst), from_abi.rt))
                     return specptr; // no adapter required
 
                 target = specptr;
@@ -347,7 +347,7 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
             }
             else if (specsigflags & JL_CI_FLAGS_SPECPTR_SPECIALIZED) {
                 assert(specptr != nullptr);
-                if (from_abi.specsig && jl_egal(mi->specTypes, from_abi.sigt) && jl_egal(codeinst->rettype, from_abi.rt))
+                if (from_abi.specsig && jl_egal(mi->specTypes, from_abi.sigt) && jl_egal(jl_ci_rettype(codeinst), from_abi.rt))
                     return specptr; // no adapter required
 
                 target = specptr;
@@ -375,7 +375,7 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
         }
         else if (invoke == jl_fptr_const_return_addr) {
             assert(codeinst);   // Convince the static analyzer
-            gf_thunk_name = emit_abi_constreturn(out, from_abi, codeinst->rettype_const);
+            gf_thunk_name = emit_abi_constreturn(out, from_abi, jl_ci_rettype_const(codeinst));
         }
         else {
             Value *llvminvoke = invoke ? literal_static_pointer_val((void*)invoke, PointerType::get(*ctx, 0)) : nullptr;
@@ -551,7 +551,7 @@ void jl_generate_fptr_for_unspecialized_impl(jl_code_instance_t *unspec)
         jl_method_instance_t *mi = jl_get_ci_mi(unspec);
         jl_code_instance_t *uninferred = jl_cached_uninferred(jl_atomic_load_relaxed(&mi->cache), 1);
         assert(uninferred);
-        src = (jl_code_info_t*)jl_atomic_load_relaxed(&uninferred->inferred);
+        src = (jl_code_info_t*)jl_ci_inferred(uninferred);
         assert(src);
     }
     if (src) {

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -34,6 +34,7 @@
     XX(char_type, jl_datatype_t*) \
     XX(code_info_type, jl_datatype_t*) \
     XX(code_instance_type, jl_datatype_t*) \
+    XX(interned_code_instance_type, jl_datatype_t*) \
     XX(const_type, jl_datatype_t*) \
     XX(core_module, jl_module_t*) \
     XX(datatype_type, jl_datatype_t*) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4155,7 +4155,7 @@ void jl_init_types(void) JL_GC_DISABLED
                         jl_svec(4,
                             jl_any_type, // union(jl_method_instance_type, jl_method_type, jl_symbol_type),
                             jl_any_type, // union(jl_nothing, jl_debuginfo_type)
-                            jl_simplevector_type, // memory{debuginfo}
+                            jl_any_type, // simplevector of debuginfo, or InternedCodeInstance in images
                             jl_string_type),
                         jl_emptysvec, 0, 0, 4);
     jl_debuginfo_type->name->mayinlinealloc = 0;
@@ -4359,7 +4359,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_any_type,
                             jl_any_type,
                             jl_debuginfo_type,
-                            jl_simplevector_type,
+                            jl_any_type, // edges: SimpleVector, or InternedCodeInstance in images
                             jl_any_type,
                             jl_uint32_type,
                             jl_uint16_type,
@@ -4379,6 +4379,17 @@ void jl_init_types(void) JL_GC_DISABLED
     // and there is no way to tell (during inference) if their value is finalized yet (to wait for them to be narrowed if applicable)
     jl_code_instance_type->name->constfields = code_instance_constfields;
     jl_code_instance_type->name->atomicfields = code_instance_atomicfields;
+
+    // Relocation-free serialized form of a CodeInstance's forward-edge list:
+    // one declared length field, then `nedges` opaque machine words appended
+    // to the same allocation (see staticdata.c; the words encode image
+    // objects as (image, offset) pairs and never require GC tracing since
+    // they only ever refer to immortal image memory).
+    jl_interned_code_instance_type = jl_new_datatype(jl_symbol("InternedCodeInstance"), core, jl_any_type, jl_emptysvec,
+                                                     jl_perm_symsvec(3, "nedges", "defword", "fieldmask"),
+                                                     jl_svec(3, jl_long_type, jl_ulong_type, jl_ulong_type),
+                                                     jl_emptysvec, 0, 1, 3);
+
 
     jl_method_match_type = jl_new_datatype(jl_symbol("MethodMatch"), core, jl_any_type, jl_emptysvec,
                                        jl_perm_symsvec(4, "spec_types", "sparams", "method", "fully_covers"),

--- a/src/julia.h
+++ b/src/julia.h
@@ -536,6 +536,7 @@ typedef struct _jl_opaque_closure_t {
 #define JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR   0b0010
 #define JL_CI_FLAGS_FROM_IMAGE               0b0100
 #define JL_CI_FLAGS_NATIVE_CACHE_VALID       0b1000
+#define JL_CI_FLAGS_BACKEDGES_LOGGED        0b10000 // the image's backedge log carries this CodeInstance's backedges
 
 typedef struct _jl_code_instance_t {
     JL_DATA_TYPE

--- a/src/julia.h
+++ b/src/julia.h
@@ -597,6 +597,23 @@ typedef struct _jl_code_instance_t {
     } specptr; // private data for `jlcall entry point
 } jl_code_instance_t;
 
+// Relocation-free serialized form of a CodeInstance's forward-edge list:
+// `nedges` opaque words follow the header in the same allocation. Words with
+// the high bit set are immediates (bit 62 set: zigzag-encoded literal Int;
+// clear: special-object ids, 0 = nothing); otherwise they are object
+// references encoded as (image-key << 40) | (offset in 8-byte units), where
+// image-key 0 is the containing image itself and k > 0 is its k-1'th
+// serialized dependency. Decoded lazily (jl_ici_ref); needs no GC tracing
+// since the referents are immortal image objects.
+typedef struct {
+    JL_DATA_TYPE
+    size_t nedges;
+    uintptr_t defword;   // interned ci->def reference, or 0 if the field is kept
+    uintptr_t fieldmask; // which owner fields have interned words appended after the edges
+    // uintptr_t words[nedges + popcount(fieldmask)];
+} jl_interned_code_instance_t;
+
+
 // May be used as the ->def field of a CodeInstance to override the ABI
 typedef struct _jl_abi_override_t {
     JL_DATA_TYPE

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -855,9 +855,198 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
         jl_debuginfo_t *di, jl_svec_t *edges /* , int absolute_max*/) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_code_instance_t *jl_get_ci_equiv(jl_code_instance_t *ci JL_PROPAGATES_ROOT, size_t target_world) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_is_ci_equiv(jl_code_instance_t *ci JL_PROPAGATES_ROOT, jl_code_instance_t *codeinst, size_t target_world) JL_NOTSAFEPOINT;
+
+JL_DLLEXPORT jl_value_t *jl_ici_materialize_def(jl_code_instance_t *ci) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_ci_def_ro(jl_code_instance_t *ci) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_ici_fieldref(jl_value_t *edges, int rank) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_ci_materialize_all(jl_code_instance_t *ci) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_di_materialize_all(jl_debuginfo_t *di) JL_CANSAFEPOINT; // allocates: converts the subtree
+int jl_foreach_top_typename_for(void (*f)(jl_typename_t*, int, void*) JL_CANSAFEPOINT, jl_value_t *argtypes JL_PROPAGATES_ROOT, int all_subtypes, void *env) JL_CANSAFEPOINT;
+JL_DLLEXPORT void jl_register_sig_tns(jl_array_t *tab) JL_CANSAFEPOINT;
+JL_DLLEXPORT int jl_image_ref_of(jl_value_t *v, uint64_t *key, uint64_t *offset) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_is_atom_type(jl_value_t *a) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_image_ref_resolve(int is_sysimg, uint64_t key, uint64_t offset) JL_NOTSAFEPOINT;
+
+// interned-field ranks (must match the hooks in staticdata.c)
+#define JL_ICI_CI_OWNER         0
+#define JL_ICI_CI_NEXT          1
+#define JL_ICI_CI_RETTYPE       2
+#define JL_ICI_CI_EXCTYPE       3
+#define JL_ICI_CI_RETTYPE_CONST 4
+#define JL_ICI_CI_INFERRED      5
+#define JL_ICI_CI_DEBUGINFO     6
+#define JL_ICI_CI_ANALYSIS      7
+#define JL_ICI_DI_DEF           0
+#define JL_ICI_DI_LINETABLE     1
+#define JL_ICI_DI_CODELOCS      2
+
+// materializing accessors: image CodeInstances/DebugInfos may carry these
+// fields in the interned container; decode on first read and write back
+STATIC_INLINE jl_value_t *jl_ci_owner(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->owner);
+    if (v == NULL) {
+        jl_ci_materialize_all(ci);
+        v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->owner);
+    }
+    return v;
+}
+
+STATIC_INLINE jl_code_instance_t *jl_ci_next(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    // `next` itself is never interned (runtime-mutable chain state; materialize_all
+    // does not touch it), but chain walks are the universal materialization trigger
+    // for the set-once interned fields: every CI a walk visits may be handed out as
+    // an edge/invoke target and read by raw getfield without further accessor checks
+    jl_ci_materialize_all(ci);
+    return jl_atomic_load_relaxed(&ci->next);
+}
+
+STATIC_INLINE jl_value_t *jl_ci_rettype(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->rettype);
+    if (v == NULL) {
+        jl_ci_materialize_all(ci);
+        v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->rettype);
+    }
+    return v;
+}
+
+STATIC_INLINE jl_value_t *jl_ci_exctype(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->exctype);
+    if (v == NULL) {
+        jl_ci_materialize_all(ci);
+        v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->exctype);
+    }
+    return v;
+}
+
+STATIC_INLINE jl_value_t *jl_ci_rettype_const(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->rettype_const);
+    if (v == NULL) {
+        jl_ci_materialize_all(ci);
+        v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->rettype_const);
+    }
+    return v;
+}
+
+STATIC_INLINE jl_value_t *jl_ci_inferred(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_value_t *v = jl_atomic_load_relaxed(&ci->inferred);
+    if (v == NULL) {
+        jl_ci_materialize_all(ci);
+        v = jl_atomic_load_relaxed(&ci->inferred);
+    }
+    return v;
+}
+
+STATIC_INLINE jl_debuginfo_t *jl_ci_debuginfo(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_debuginfo_t *v = jl_atomic_load_relaxed(&ci->debuginfo);
+    if (v == NULL) {
+        jl_ci_materialize_all(ci);
+        v = jl_atomic_load_relaxed(&ci->debuginfo);
+    }
+    return v;
+}
+
+STATIC_INLINE jl_value_t *jl_ci_analysis_results(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->analysis_results);
+    if (v == NULL) {
+        jl_ci_materialize_all(ci);
+        v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->analysis_results);
+    }
+    return v;
+}
+
+// read-only variants for signal/dump contexts
+STATIC_INLINE jl_debuginfo_t *jl_ci_debuginfo_ro(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_debuginfo_t *v = jl_atomic_load_relaxed(&ci->debuginfo);
+    if (v == NULL)
+        v = (jl_debuginfo_t*)jl_ici_fieldref((jl_value_t*)jl_atomic_load_relaxed(&ci->edges), JL_ICI_CI_DEBUGINFO);
+    return v;
+}
+
+STATIC_INLINE jl_value_t *jl_di_def(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_CANSAFEPOINT
+{
+    // convert the whole subtree while the interned container is still in
+    // place, so that raw reads below this node are safe once any materializing
+    // accessor has returned (a racing converter publishes `edges` last)
+    jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+    if (edges != NULL && jl_typetagis(edges, jl_interned_code_instance_type))
+        jl_di_materialize_all(di);
+    return jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->def);
+}
+
+STATIC_INLINE jl_value_t *jl_di_linetable(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_CANSAFEPOINT
+{
+    // convert the whole subtree while the interned container is still in
+    // place, so that raw reads below this node are safe once any materializing
+    // accessor has returned (a racing converter publishes `edges` last)
+    jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+    if (edges != NULL && jl_typetagis(edges, jl_interned_code_instance_type))
+        jl_di_materialize_all(di);
+    return jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->linetable);
+}
+
+STATIC_INLINE jl_value_t *jl_di_codelocs_(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_CANSAFEPOINT
+{
+    // convert the whole subtree while the interned container is still in
+    // place, so that raw reads below this node are safe once any materializing
+    // accessor has returned (a racing converter publishes `edges` last)
+    jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+    if (edges != NULL && jl_typetagis(edges, jl_interned_code_instance_type))
+        jl_di_materialize_all(di);
+    return jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->codelocs);
+}
+
+// read-only DebugInfo variants (stackwalk may run in a signal context)
+STATIC_INLINE jl_value_t *jl_di_def_ro(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&di->def);
+    if (v == NULL) {
+        jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+        v = jl_ici_fieldref(edges, JL_ICI_DI_DEF);
+        if (v == NULL) // converted meanwhile: the field was published before `edges`
+            v = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->def);
+    }
+    return v;
+}
+
+STATIC_INLINE jl_value_t *jl_di_linetable_ro(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&di->linetable);
+    if (v == NULL) {
+        jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+        v = jl_ici_fieldref(edges, JL_ICI_DI_LINETABLE);
+        if (v == NULL) // converted meanwhile: the field was published before `edges`
+            v = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->linetable);
+    }
+    return v;
+}
+
+STATIC_INLINE jl_value_t *jl_di_codelocs_ro(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&di->codelocs);
+    if (v == NULL) {
+        jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+        v = jl_ici_fieldref(edges, JL_ICI_DI_CODELOCS);
+        if (v == NULL) // converted meanwhile: the field was published before `edges`
+            v = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->codelocs);
+    }
+    return v;
+}
+JL_DLLEXPORT jl_value_t *jl_ci_def(jl_code_instance_t *ci);
+
 STATIC_INLINE jl_method_instance_t *jl_get_ci_mi(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *def = ci->def;
+    jl_value_t *def = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->def);
+    if (def == NULL) // interned in the image; decode and write back
+        def = jl_ici_materialize_def(ci);
     if (jl_is_abioverride(def))
         return ((jl_abi_override_t*)def)->def;
     assert(jl_is_method_instance(def));
@@ -887,6 +1076,15 @@ STATIC_INLINE jl_value_t *jl_sparam_defined_value(jl_value_t *sp JL_PROPAGATES_R
     return sp;
 }
 JL_DLLEXPORT jl_value_t *jl_sparam_slot_value(jl_value_t *sp JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
+
+// materializing variant returning the raw def object (MethodInstance or ABIOverride)
+STATIC_INLINE jl_value_t *jl_ci_defobj(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    jl_value_t *def = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->def);
+    if (def == NULL)
+        def = jl_ici_materialize_def(ci);
+    return def;
+}
 
 JL_DLLEXPORT jl_module_t *jl_debuginfo_module1(jl_value_t *debuginfo_def) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_debuginfo_name(jl_value_t *func) JL_NOTSAFEPOINT;
@@ -1444,13 +1642,15 @@ JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t* v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_gc_image_abi(void) JL_NOTSAFEPOINT;
 size_t jl_external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT;
 extern JL_DLLEXPORT jl_genericmemory_t *jl_method_contributors JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_genericmemory_t *jl_method_contributor_methods JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT void jl_set_loading_closure_blobs(size_t *bits, size_t nblobs);
-void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t *cert);
+void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t *cert) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_get_activation_cert(jl_method_t *method);
-JL_DLLEXPORT int jl_edge_sig_replayable(jl_value_t *sig);
+JL_DLLEXPORT int jl_edge_sig_replayable(jl_value_t *sig) JL_CANSAFEPOINT;
 JL_DLLEXPORT void jl_set_loading_closure_from_depmods(jl_array_t *depmods, jl_array_t *anchors);
 JL_DLLEXPORT void jl_clear_loading_closure(void);
 extern JL_DLLEXPORT jl_genericmemory_t *jl_activation_certs JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_genericmemory_t *jl_sig_tn_table JL_GLOBALLY_ROOTED;
 
 // the first argument to jl_idtable_rehash is used to return a value
 // make sure it is rooted if it is used after the function returns
@@ -1474,6 +1674,15 @@ JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(
 jl_method_instance_t *jl_specializations_get_or_insert(jl_method_instance_t *mi_ins JL_PROPAGATES_ROOT) JL_CANSAFEPOINT;
 JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, jl_value_t *invokesig, jl_code_instance_t *caller) JL_CANSAFEPOINT;
 JL_DLLEXPORT void jl_method_table_add_backedge(jl_value_t *typ, jl_code_instance_t *caller) JL_CANSAFEPOINT;
+extern JL_DLLEXPORT jl_array_t *jl_backedge_log JL_GLOBALLY_ROOTED;
+void jl_record_binding_backedge(jl_binding_t *b, jl_value_t *edge) JL_CANSAFEPOINT;
+JL_DLLEXPORT void jl_apply_backedge_log(jl_array_t *log) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_ici_ref(jl_interned_code_instance_t *ici, size_t i) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_ici_ref_nobox(jl_interned_code_instance_t *ici, size_t i) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_svec_t *jl_ici_to_svec(jl_interned_code_instance_t *ici) JL_CANSAFEPOINT;
+JL_DLLEXPORT int jl_ici_literal(jl_interned_code_instance_t *ici, size_t i, intptr_t *out) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_edgelist_len(jl_value_t *edges) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_edgelist_ref(jl_value_t *edges, size_t i) JL_CANSAFEPOINT;
 JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi,
                                      jl_code_instance_t *ci JL_ROOTED_BY_ARG(0) JL_MAYBE_UNROOTED) JL_CANSAFEPOINT;
 JL_DLLEXPORT int jl_mi_try_insert(jl_method_instance_t *mi,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -880,14 +880,26 @@ JL_DLLEXPORT jl_value_t *jl_image_ref_resolve(int is_sysimg, uint64_t key, uint6
 #define JL_ICI_DI_LINETABLE     1
 #define JL_ICI_DI_CODELOCS      2
 
+// Set-once object fields that a materializing compare-and-swap may publish
+// concurrently are read with atomic loads. The GC analyzer sees the plain
+// member read, which it tracks as rooted by the object (a cast through
+// `_Atomic` hides that from it).
+#ifdef __clang_gcanalyzer__
+#define jl_load_set_once(fieldp) (*(fieldp))
+#define jl_load_set_once_acquire(fieldp) (*(fieldp))
+#else
+#define jl_load_set_once(fieldp) jl_atomic_load_relaxed((_Atomic(__typeof__(*(fieldp)))*)(fieldp))
+#define jl_load_set_once_acquire(fieldp) jl_atomic_load_acquire((_Atomic(__typeof__(*(fieldp)))*)(fieldp))
+#endif
+
 // materializing accessors: image CodeInstances/DebugInfos may carry these
 // fields in the interned container; decode on first read and write back
 STATIC_INLINE jl_value_t *jl_ci_owner(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->owner);
+    jl_value_t *v = (jl_value_t*)jl_load_set_once(&ci->owner);
     if (v == NULL) {
         jl_ci_materialize_all(ci);
-        v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->owner);
+        v = (jl_value_t*)jl_load_set_once(&ci->owner);
     }
     return v;
 }
@@ -904,30 +916,30 @@ STATIC_INLINE jl_code_instance_t *jl_ci_next(jl_code_instance_t *ci JL_PROPAGATE
 
 STATIC_INLINE jl_value_t *jl_ci_rettype(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->rettype);
+    jl_value_t *v = (jl_value_t*)jl_load_set_once(&ci->rettype);
     if (v == NULL) {
         jl_ci_materialize_all(ci);
-        v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->rettype);
+        v = (jl_value_t*)jl_load_set_once(&ci->rettype);
     }
     return v;
 }
 
 STATIC_INLINE jl_value_t *jl_ci_exctype(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->exctype);
+    jl_value_t *v = (jl_value_t*)jl_load_set_once(&ci->exctype);
     if (v == NULL) {
         jl_ci_materialize_all(ci);
-        v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->exctype);
+        v = (jl_value_t*)jl_load_set_once(&ci->exctype);
     }
     return v;
 }
 
 STATIC_INLINE jl_value_t *jl_ci_rettype_const(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->rettype_const);
+    jl_value_t *v = (jl_value_t*)jl_load_set_once(&ci->rettype_const);
     if (v == NULL) {
         jl_ci_materialize_all(ci);
-        v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->rettype_const);
+        v = (jl_value_t*)jl_load_set_once(&ci->rettype_const);
     }
     return v;
 }
@@ -954,10 +966,10 @@ STATIC_INLINE jl_debuginfo_t *jl_ci_debuginfo(jl_code_instance_t *ci JL_PROPAGAT
 
 STATIC_INLINE jl_value_t *jl_ci_analysis_results(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->analysis_results);
+    jl_value_t *v = (jl_value_t*)jl_load_set_once(&ci->analysis_results);
     if (v == NULL) {
         jl_ci_materialize_all(ci);
-        v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->analysis_results);
+        v = (jl_value_t*)jl_load_set_once(&ci->analysis_results);
     }
     return v;
 }
@@ -976,10 +988,10 @@ STATIC_INLINE jl_value_t *jl_di_def(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_CA
     // convert the whole subtree while the interned container is still in
     // place, so that raw reads below this node are safe once any materializing
     // accessor has returned (a racing converter publishes `edges` last)
-    jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+    jl_value_t *edges = (jl_value_t*)jl_load_set_once_acquire(&di->edges);
     if (edges != NULL && jl_typetagis(edges, jl_interned_code_instance_type))
         jl_di_materialize_all(di);
-    return jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->def);
+    return (jl_value_t*)jl_load_set_once_acquire(&di->def);
 }
 
 STATIC_INLINE jl_value_t *jl_di_linetable(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_CANSAFEPOINT
@@ -987,10 +999,10 @@ STATIC_INLINE jl_value_t *jl_di_linetable(jl_debuginfo_t *di JL_PROPAGATES_ROOT)
     // convert the whole subtree while the interned container is still in
     // place, so that raw reads below this node are safe once any materializing
     // accessor has returned (a racing converter publishes `edges` last)
-    jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+    jl_value_t *edges = (jl_value_t*)jl_load_set_once_acquire(&di->edges);
     if (edges != NULL && jl_typetagis(edges, jl_interned_code_instance_type))
         jl_di_materialize_all(di);
-    return jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->linetable);
+    return (jl_value_t*)jl_load_set_once_acquire(&di->linetable);
 }
 
 STATIC_INLINE jl_value_t *jl_di_codelocs_(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_CANSAFEPOINT
@@ -998,45 +1010,45 @@ STATIC_INLINE jl_value_t *jl_di_codelocs_(jl_debuginfo_t *di JL_PROPAGATES_ROOT)
     // convert the whole subtree while the interned container is still in
     // place, so that raw reads below this node are safe once any materializing
     // accessor has returned (a racing converter publishes `edges` last)
-    jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+    jl_value_t *edges = (jl_value_t*)jl_load_set_once_acquire(&di->edges);
     if (edges != NULL && jl_typetagis(edges, jl_interned_code_instance_type))
         jl_di_materialize_all(di);
-    return jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->codelocs);
+    return (jl_value_t*)jl_load_set_once_acquire(&di->codelocs);
 }
 
 // read-only DebugInfo variants (stackwalk may run in a signal context)
 STATIC_INLINE jl_value_t *jl_di_def_ro(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&di->def);
+    jl_value_t *v = (jl_value_t*)jl_load_set_once(&di->def);
     if (v == NULL) {
-        jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+        jl_value_t *edges = (jl_value_t*)jl_load_set_once_acquire(&di->edges);
         v = jl_ici_fieldref(edges, JL_ICI_DI_DEF);
         if (v == NULL) // converted meanwhile: the field was published before `edges`
-            v = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->def);
+            v = (jl_value_t*)jl_load_set_once_acquire(&di->def);
     }
     return v;
 }
 
 STATIC_INLINE jl_value_t *jl_di_linetable_ro(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&di->linetable);
+    jl_value_t *v = (jl_value_t*)jl_load_set_once(&di->linetable);
     if (v == NULL) {
-        jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+        jl_value_t *edges = (jl_value_t*)jl_load_set_once_acquire(&di->edges);
         v = jl_ici_fieldref(edges, JL_ICI_DI_LINETABLE);
         if (v == NULL) // converted meanwhile: the field was published before `edges`
-            v = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->linetable);
+            v = (jl_value_t*)jl_load_set_once_acquire(&di->linetable);
     }
     return v;
 }
 
 STATIC_INLINE jl_value_t *jl_di_codelocs_ro(jl_debuginfo_t *di JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *v = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&di->codelocs);
+    jl_value_t *v = (jl_value_t*)jl_load_set_once(&di->codelocs);
     if (v == NULL) {
-        jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+        jl_value_t *edges = (jl_value_t*)jl_load_set_once_acquire(&di->edges);
         v = jl_ici_fieldref(edges, JL_ICI_DI_CODELOCS);
         if (v == NULL) // converted meanwhile: the field was published before `edges`
-            v = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->codelocs);
+            v = (jl_value_t*)jl_load_set_once_acquire(&di->codelocs);
     }
     return v;
 }
@@ -1044,7 +1056,7 @@ JL_DLLEXPORT jl_value_t *jl_ci_def(jl_code_instance_t *ci);
 
 STATIC_INLINE jl_method_instance_t *jl_get_ci_mi(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *def = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->def);
+    jl_value_t *def = (jl_value_t*)jl_load_set_once(&ci->def);
     if (def == NULL) // interned in the image; decode and write back
         def = jl_ici_materialize_def(ci);
     if (jl_is_abioverride(def))
@@ -1080,7 +1092,7 @@ JL_DLLEXPORT jl_value_t *jl_sparam_slot_value(jl_value_t *sp JL_PROPAGATES_ROOT)
 // materializing variant returning the raw def object (MethodInstance or ABIOverride)
 STATIC_INLINE jl_value_t *jl_ci_defobj(jl_code_instance_t *ci JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    jl_value_t *def = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->def);
+    jl_value_t *def = (jl_value_t*)jl_load_set_once(&ci->def);
     if (def == NULL)
         def = jl_ici_materialize_def(ci);
     return def;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1442,6 +1442,9 @@ void jl_gc_safe_enter_from_nonmutator(jl_ptls_t ptls) JL_CANSAFEPOINT_LEAVE;
 JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t* v) JL_NOTSAFEPOINT;
 // GC configuration baked into generated code; must match between an image and the runtime that loads it.
 JL_DLLEXPORT const char *jl_gc_image_abi(void) JL_NOTSAFEPOINT;
+size_t jl_external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT;
+extern JL_DLLEXPORT jl_genericmemory_t *jl_method_contributors JL_GLOBALLY_ROOTED;
+JL_DLLEXPORT void jl_set_loading_closure_blobs(size_t *bits, size_t nblobs);
 
 // the first argument to jl_idtable_rehash is used to return a value
 // make sure it is rooted if it is used after the function returns

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1447,6 +1447,9 @@ extern JL_DLLEXPORT jl_genericmemory_t *jl_method_contributors JL_GLOBALLY_ROOTE
 JL_DLLEXPORT void jl_set_loading_closure_blobs(size_t *bits, size_t nblobs);
 void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t *cert);
 JL_DLLEXPORT jl_value_t *jl_get_activation_cert(jl_method_t *method);
+JL_DLLEXPORT int jl_edge_sig_replayable(jl_value_t *sig);
+JL_DLLEXPORT void jl_set_loading_closure_from_depmods(jl_array_t *depmods, jl_array_t *anchors);
+JL_DLLEXPORT void jl_clear_loading_closure(void);
 extern JL_DLLEXPORT jl_genericmemory_t *jl_activation_certs JL_GLOBALLY_ROOTED;
 
 // the first argument to jl_idtable_rehash is used to return a value

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1308,6 +1308,18 @@ STATIC_INLINE jl_value_t *normalize_typeofbottom_layout_alias(jl_value_t *ty JL_
     return ty;
 }
 
+// `Type{Union{}}` and `typeof(Union{})` denote the same singleton set
+// {Union{}} but with different kinds (a `TypeEq` node vs the `TypeofBottom`
+// `DataType`), so the type-equality class of the bottom singleton type spans
+// more than one kind: `Type{typeof(Union{})}` contains both a `DataType`
+// instance and `TypeEq` instances, and `TypeEq(T) <: kind(typeof(T))`
+// reasoning (subtyping, method matching, cache guards) does not apply to it.
+STATIC_INLINE int jl_is_bottom_singleton_class(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    return t == (jl_value_t*)jl_typeofbottom_type ||
+           (jl_is_typeeq(t) && jl_typeeq_T(t) == jl_bottom_type);
+}
+
 STATIC_INLINE size_t jl_vararg_length(jl_value_t *v) JL_NOTSAFEPOINT
 {
     assert(jl_is_vararg(v));

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1683,6 +1683,14 @@ JL_DLLEXPORT jl_svec_t *jl_ici_to_svec(jl_interned_code_instance_t *ici) JL_CANS
 JL_DLLEXPORT int jl_ici_literal(jl_interned_code_instance_t *ici, size_t i, intptr_t *out) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_edgelist_len(jl_value_t *edges) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_edgelist_ref(jl_value_t *edges, size_t i) JL_CANSAFEPOINT;
+// element of an edge list without boxing literal words (NULL for a literal);
+// enough for DebugInfo edge lists, which hold only objects
+STATIC_INLINE jl_value_t *jl_edgelist_ref_nobox(jl_value_t *edges, size_t i) JL_NOTSAFEPOINT
+{
+    if (jl_typetagis(edges, jl_interned_code_instance_type))
+        return jl_ici_ref_nobox((jl_interned_code_instance_t*)edges, i);
+    return jl_svecref(edges, i);
+}
 JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi,
                                      jl_code_instance_t *ci JL_ROOTED_BY_ARG(0) JL_MAYBE_UNROOTED) JL_CANSAFEPOINT;
 JL_DLLEXPORT int jl_mi_try_insert(jl_method_instance_t *mi,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1445,6 +1445,9 @@ JL_DLLEXPORT const char *jl_gc_image_abi(void) JL_NOTSAFEPOINT;
 size_t jl_external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT;
 extern JL_DLLEXPORT jl_genericmemory_t *jl_method_contributors JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT void jl_set_loading_closure_blobs(size_t *bits, size_t nblobs);
+void jl_method_table_activate_with_cert(jl_typemap_entry_t *newentry, jl_svec_t *cert);
+JL_DLLEXPORT jl_value_t *jl_get_activation_cert(jl_method_t *method);
+extern JL_DLLEXPORT jl_genericmemory_t *jl_activation_certs JL_GLOBALLY_ROOTED;
 
 // the first argument to jl_idtable_rehash is used to return a value
 // make sure it is rooted if it is used after the function returns
@@ -1996,6 +1999,9 @@ struct typemap_intersection_env {
     int emptiness_only; // if set, `ti` and `env` are not materialized (`ti` is only a
                         // nonempty/bottom placeholder); the callback may consume just
                         // the match verdict and `issubty`
+    int (*entry_filter)(jl_typemap_entry_t *ml, struct typemap_intersection_env *closure);
+                        // if set, entries for which this returns 0 are skipped without
+                        // performing any intersection
 };
 int jl_typemap_intersection_visitor(jl_typemap_t *a, int offs, struct typemap_intersection_env *closure) JL_CANSAFEPOINT;
 void typemap_slurp_search(jl_typemap_entry_t *ml, struct typemap_intersection_env *closure);

--- a/src/method.c
+++ b/src/method.c
@@ -745,7 +745,7 @@ static jl_value_t *jl_call_staged(jl_method_t *def, jl_value_t *generator,
 JL_DLLEXPORT jl_code_instance_t *jl_cached_uninferred(jl_code_instance_t *codeinst, size_t world)
 {
     for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
-        if (codeinst->owner != (void*)jl_uninferred_sym)
+        if (jl_ci_owner(codeinst) != (void*)jl_uninferred_sym)
             continue;
         if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
             return codeinst;

--- a/src/module.c
+++ b/src/module.c
@@ -1915,6 +1915,7 @@ JL_DLLEXPORT int jl_maybe_add_binding_backedge(jl_binding_t *b, jl_value_t *edge
 {
     if (!edge)
         return 0;
+    jl_record_binding_backedge(b, edge);
     jl_module_t *defining_module = for_method->module;
     // N.B.: The logic for evaluating whether a backedge is required must
     // match the invalidation logic.

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -80,7 +80,7 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
         jl_read_codeinst_invoke(ci, &specsigflags, &invoke, &specptr, 1);
         callptr = (jl_fptr_args_t)invoke; // codegen puts the object (or a jl_fptr_interpret_call token )here for us, even though it was the wrong type to put here
 
-        selected_rt = ci->rettype;
+        selected_rt = jl_ci_rettype(ci);
         // If we're not allowed to generate a specsig with this, rt, fall
         // back to the invoke wrapper. We could instead generate a specsig->specsig
         // wrapper, but lets leave that for later.
@@ -89,10 +89,10 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
             // correct rt check here (or we could codegen a wrapper).
             specptr = NULL; // this will force codegen of the unspecialized version
             callptr = (jl_fptr_args_t)jl_interpret_opaque_closure;
-            jl_value_t *ts[2] = {rt_lb, (jl_value_t*)ci->rettype};
+            jl_value_t *ts[2] = {rt_lb, (jl_value_t*)jl_ci_rettype(ci)};
             selected_rt = jl_type_union(ts, 2);
         }
-        if (!jl_subtype(ci->rettype, rt_ub)) {
+        if (!jl_subtype(jl_ci_rettype(ci), rt_ub)) {
             // TODO: It would be better to try to get a specialization with the
             // correct rt check here (or we could codegen a wrapper).
             specptr = NULL; // this will force codegen of the unspecialized version
@@ -107,10 +107,10 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
             callptr = (jl_fptr_args_t)specptr;
         }
         else if (callptr == (jl_fptr_args_t)jl_fptr_const_return) {
-            callptr = jl_isa(ci->rettype_const, selected_rt) ?
+            callptr = jl_isa(jl_ci_rettype_const(ci), selected_rt) ?
                 (jl_fptr_args_t)jl_fptr_const_opaque_closure :
                 (jl_fptr_args_t)jl_fptr_const_opaque_closure_typeerror;
-            captures = ci->rettype_const;
+            captures = jl_ci_rettype_const(ci);
         }
     }
 

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1032,15 +1032,19 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
             out, "CodeInstance(min_world=0x%zx, max_world=0x%zx) for ",
             jl_atomic_load_relaxed(&ci->min_world),
             jl_atomic_load_relaxed(&ci->max_world));
-        if (jl_is_method_instance(ci->def)) {
-            n += jl_static_show_x(out, ci->def, depth, ctx);
+        jl_value_t *cidef = jl_ci_def_ro(ci);
+        if (cidef != NULL && jl_is_method_instance(cidef)) {
+            n += jl_static_show_x(out, cidef, depth, ctx);
         }
-        else if (jl_is_abioverride(ci->def)) {
-            jl_abi_override_t* def = (jl_abi_override_t*)ci->def;
+        else if (cidef != NULL && jl_is_abioverride(cidef)) {
+            jl_abi_override_t* def = (jl_abi_override_t*)cidef;
             n += jl_static_show_x(out, (jl_value_t*)def->def, depth, ctx);
             n += jl_printf(out, " (ABI overridden)");
         }
-        if (ci->owner != jl_nothing) {
+        jl_value_t *ciowner = ci->owner;
+        if (ciowner == NULL) // interned; decode without writing (dump context)
+            ciowner = jl_ici_fieldref((jl_value_t*)jl_atomic_load_relaxed(&ci->edges), JL_ICI_CI_OWNER);
+        if (ciowner != NULL && ciowner != jl_nothing) {
             n += jl_printf(out, " (foreign)");
         }
     }

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -433,7 +433,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
 
         f = cfuncdata->unspecialized;
     } else {
-        jl_value_t *astrt = codeinst->rettype;
+        jl_value_t *astrt = jl_ci_rettype(codeinst);
         if (astrt != (jl_value_t*)jl_bottom_type &&
             jl_type_intersection(astrt, declrt) == jl_bottom_type) {
             // Do not warn if the function never returns since it is

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -903,18 +903,25 @@ const char *jl_debuginfo_name(jl_value_t *func)
 // func == NULL : macro expansion
 static void jl_fprint_debugloc(ios_t *s, jl_debuginfo_t *debuginfo, jl_value_t *func, size_t ip, int inlined) JL_NOTSAFEPOINT
 {
-    if (!jl_is_symbol(debuginfo->def)) // this is a path or
-        func = debuginfo->def; // this is inlined code
+    jl_value_t *didef = jl_di_def_ro(debuginfo);
+    if (!jl_is_symbol(didef)) // this is a path or
+        func = didef; // this is inlined code
     struct jl_codeloc_t stmt = jl_uncompress1_codeloc(debuginfo, ip);
     intptr_t edges_idx = stmt.to;
     if (edges_idx) {
-        jl_debuginfo_t *edge = (jl_debuginfo_t*)jl_svecref(debuginfo->edges, edges_idx - 1);
+        jl_value_t *edges = (jl_value_t*)debuginfo->edges;
+        // inlinee lists never contain literal words, so the nobox accessor is
+        // total here and keeps this path allocation-free
+        jl_debuginfo_t *edge = (jl_debuginfo_t*)(jl_is_svec(edges) ?
+            jl_svecref(edges, edges_idx - 1) :
+            jl_ici_ref_nobox((jl_interned_code_instance_t*)edges, edges_idx - 1));
         assert(jl_typetagis(edge, jl_debuginfo_type));
         jl_fprint_debugloc(s, edge, NULL, stmt.pc, 1);
     }
     intptr_t ip2 = stmt.loc;
-    if (ip2 >= 0 && ip > 0 && jl_is_debuginfo(debuginfo->linetable)) {
-        jl_fprint_debugloc(s, (jl_debuginfo_t*)debuginfo->linetable, func, ip2, 0);
+    jl_value_t *dilt = jl_di_linetable_ro(debuginfo);
+    if (ip2 >= 0 && ip > 0 && jl_is_debuginfo(dilt)) {
+        jl_fprint_debugloc(s, (jl_debuginfo_t*)dilt, func, ip2, 0);
     }
     else {
         if (ip2 < 0) // set broken debug info to ignored
@@ -938,8 +945,8 @@ void jl_fprint_bt_entry_codeloc(ios_t *s, jl_bt_element_t *bt_entry) JL_NOTSAFEP
         jl_value_t *def = (jl_value_t*)jl_core_module; // just used as a token here that isa Module
         if (jl_is_code_instance(code)) {
             jl_code_instance_t *ci = (jl_code_instance_t*)code;
-            def = (jl_value_t*)ci->def;
-            code = jl_atomic_load_relaxed(&ci->inferred);
+            def = jl_ci_def_ro(ci); // no write-back: may run in a signal context
+            code = jl_ci_inferred(ci); // materializing is fine here: not the signal path
         } else if (jl_is_method_instance(code)) {
             jl_method_instance_t *mi = (jl_method_instance_t*)code;
             def = code;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1259,28 +1259,6 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
                 }
             }
         }
-        // Drop DebugInfo for CodeInstances that retain neither inferred IR
-        // nor native code in this image: with nothing to symbolize and
-        // nothing to splice during inlining, the debug tree (and its
-        // codelocs/linetable strings) is unreachable dead weight. Gated for
-        // measurement via JULIA_KEEP_ALL_DEBUGINFO=1.
-        if (s->incremental) {
-            static int keepdi = -1;
-            if (keepdi == -1) {
-                char *e = getenv("JULIA_KEEP_ALL_DEBUGINFO");
-                keepdi = e != NULL && strcmp(e, "1") == 0;
-            }
-            jl_value_t *inf_now = get_replaceable_field((jl_value_t**)&ci->inferred, 1);
-            if (!keepdi &&
-                (inf_now == NULL || inf_now == jl_nothing || jl_is_uint8(inf_now)) &&
-                jl_atomic_load_relaxed(&ci->debuginfo) != NULL) {
-                int32_t invokeptr_id = 0, specfptr_id = 0;
-                if (native_functions)
-                    jl_get_function_id(native_functions, ci, &invokeptr_id, &specfptr_id);
-                if (invokeptr_id == 0 && specfptr_id == 0)
-                    record_field_change((jl_value_t**)&ci->debuginfo, NULL);
-            }
-        }
         // Intern the edge list and (where encodable) the object fields into a
         // relocation-free container. Runs after every record_field_change
         // above so field reads see the values that will actually serialize.

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -523,6 +523,259 @@ static void record_field_change(jl_value_t **addr, jl_value_t *newval) JL_NOTSAF
         ptrhash_put(&field_replace, (void*)addr, newval);
 }
 
+// --- InternedCodeInstance: relocation-free edge lists (see julia.h) ---
+// Words are (imagekey << DEPS_IDX_OFFSET) | (offset in 8-byte units), where
+// imagekey 0 is the containing image's data section and k > 0 is the
+// serialized dependency with depsidx k-1; or, with the high bit set, a
+// zigzag-encoded literal Int (edge-group headers). Self-referential words
+// are patched after layout (ici_fixups); external ones resolve at build time.
+// The encoding needs the three tag bits above the 40-bit dependency index, so
+// it is 64-bit only: ici_try_build keeps the SimpleVector form elsewhere.
+#define ICI_WORD_BITS   (sizeof(uintptr_t) * 8)
+#define ICI_TAG_LITERAL (((uintptr_t)1) << (ICI_WORD_BITS - 1))
+#define ICI_TAG_REF     (((uintptr_t)1) << (ICI_WORD_BITS - 2))
+#define ICI_TAG_CONST   (((uintptr_t)1) << (ICI_WORD_BITS - 3)) // ref into the const-data stream (self image only)
+static void jl_queue_for_serialization_(jl_serializer_state *s, jl_value_t *v, int recursive, int immediate) JL_CANSAFEPOINT JL_GC_DISABLED;
+static jl_value_t *svec_dedup_canonical(jl_serializer_state *s, jl_value_t *v) JL_GC_DISABLED;
+
+static uintptr_t ici_field_gate(const char *envname, uintptr_t dflt) JL_NOTSAFEPOINT
+{
+    char *e = getenv(envname);
+    return e ? strtoull(e, NULL, 16) : dflt;
+}
+typedef struct { jl_value_t *target; jl_value_t *invokesig; uint32_t cls; uint32_t orig; } belog_trip_t;
+static int belog_trip_cmp(const void *a_, const void *b_) JL_NOTSAFEPOINT
+{
+    const belog_trip_t *a = (const belog_trip_t*)a_, *b = (const belog_trip_t*)b_;
+    if (a->cls != b->cls)
+        return a->cls < b->cls ? -1 : 1;
+    if (a->target != b->target)
+        return (uintptr_t)a->target < (uintptr_t)b->target ? -1 : 1;
+    if (a->invokesig != b->invokesig)
+        return (uintptr_t)a->invokesig < (uintptr_t)b->invokesig ? -1 : 1;
+    return a->orig < b->orig ? -1 : a->orig > b->orig ? 1 : 0;
+}
+
+// map from interned symbol to (depsidx+1)<<40 | index for symbols present in
+// a dependency image's symbol table; built once per incremental save so the
+// output references them as (dep, index) instead of re-serializing the names
+static htable_t depsym_map;
+#define DEPSYM_IDX_SHIFT ((sizeof(uintptr_t) >= 8) ? 40 : 0) // (depsidx+1) << 40 | index; 64-bit only
+static int depsym_map_init = 0;
+static void depsym_map_build(jl_serializer_state *s) JL_GC_DISABLED;
+
+// call/method signatures whose typename decompositions are serialized for the
+// loader (save-side shift of jl_foreach_top_typename_for)
+static htable_t edge_sig_set;
+static int edge_sig_set_init = 0;
+
+static int save_sig_tns_enabled(void) JL_NOTSAFEPOINT
+{
+    static int on = -1;
+    if (on == -1) {
+        char *e = getenv("JULIA_SIG_TNS");
+        on = e != NULL && strcmp(e, "1") == 0 && sizeof(void*) == 8; // packs explicitness bits into an Int
+    }
+    return on;
+}
+
+static void edge_sig_note(jl_value_t *sig) JL_GC_DISABLED
+{
+    if (sig == NULL || !jl_is_type(sig) || !save_sig_tns_enabled())
+        return;
+    if (!edge_sig_set_init) {
+        htable_new(&edge_sig_set, 1 << 12);
+        edge_sig_set_init = 1;
+    }
+    void **bp = ptrhash_bp(&edge_sig_set, (void*)sig);
+    if (*bp == HT_NOTFOUND)
+        *bp = (void*)sig;
+}
+
+// mirror of the load-side edge-group structure walk (reinfer.jl's verifier)
+static void collect_edge_group_sigs(jl_svec_t *edges) JL_GC_DISABLED
+{
+    size_t n = jl_svec_len(edges);
+    for (size_t j = 0; j < n; j++) {
+        jl_value_t *item = jl_svecref(edges, j);
+        if (item == NULL)
+            continue;
+        if (jl_is_long(item)) { // (n, sig, targets...) match group
+            ssize_t nt = jl_unbox_long(item);
+            if (nt < 0)
+                nt = -nt;
+            if (j + 1 < n)
+                edge_sig_note(jl_svecref(edges, j + 1));
+            j += 1 + (size_t)nt;
+        }
+        else if (jl_is_code_instance(item)) {
+            edge_sig_note(jl_get_ci_mi((jl_code_instance_t*)item)->specTypes);
+        }
+        else if (jl_is_method_instance(item)) {
+            edge_sig_note(((jl_method_instance_t*)item)->specTypes);
+        }
+        else if (jl_is_binding(item) || jl_is_method(item)) {
+        }
+        else { // (invokesig, target) pair
+            jl_value_t *target = j + 1 < n ? jl_svecref(edges, j + 1) : NULL;
+            if (target != NULL && !jl_is_mtable(target))
+                edge_sig_note(item);
+            j += 1;
+        }
+    }
+}
+
+static jl_typename_t *method_first_tn(jl_method_t *m) JL_NOTSAFEPOINT
+{
+    jl_value_t *sig = jl_unwrap_unionall(m->sig);
+    if (!jl_is_datatype(sig) || jl_nparams(sig) == 0)
+        return NULL;
+    jl_value_t *t = jl_tparam0(sig);
+    while (jl_is_unionall(t))
+        t = ((jl_unionall_t*)t)->body;
+    if (!jl_is_datatype(t))
+        return NULL;
+    return ((jl_datatype_t*)t)->name;
+}
+
+static int extext_method_cmp(const void *a_, const void *b_) JL_NOTSAFEPOINT
+{
+    // elements are (method, certificate) pairs; key on the method
+    jl_value_t *a = ((jl_value_t**)a_)[0], *b = ((jl_value_t**)b_)[0];
+    jl_typename_t *ta = jl_is_method(a) ? method_first_tn((jl_method_t*)a) : NULL;
+    jl_typename_t *tb = jl_is_method(b) ? method_first_tn((jl_method_t*)b) : NULL;
+    if (ta != tb)
+        return (uintptr_t)ta < (uintptr_t)tb ? -1 : 1;
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+
+struct _sig_tn_collect {
+    jl_value_t *tns[62];
+    uint64_t explbits;
+    int n;
+    int overflow;
+};
+
+static void _sig_tn_collect_cb(jl_typename_t *tn, int explct, void *env0) JL_NOTSAFEPOINT
+{
+    struct _sig_tn_collect *env = (struct _sig_tn_collect*)env0;
+    if (env->n >= 62) {
+        env->overflow = 1;
+        return;
+    }
+    if (explct)
+        env->explbits |= (uint64_t)1 << env->n;
+    env->tns[env->n++] = (jl_value_t*)tn;
+}
+
+static arraylist_t ici_fixups; // (ici, wordidx, target) triples
+static int ici_fixups_init = 0;
+
+static uintptr_t *ici_words(jl_interned_code_instance_t *ici) JL_NOTSAFEPOINT
+{
+    return (uintptr_t*)(ici + 1);
+}
+#define ICI_DEFWORD_IDX ((size_t)-1) // fixup-record sentinel for the defword slot
+
+// classify a field value for interning: 0 = keep the pointer field
+// (NULL, symbol, unmapped image, needs uniquing); 1 = immediate word in *w;
+// 2 = serialized with this image, patch after layout
+static int ici_classify_value(jl_serializer_state *s, jl_value_t *e, uintptr_t *w) JL_GC_DISABLED
+{
+    if (e == NULL || jl_is_symbol(e))
+        return 0;
+    if (jl_object_in_image(e)) {
+        uint32_t *blob_to_depsidx = jl_array_data(s->buildid_depmods_idxs, uint32_t);
+        size_t nblobmap = jl_array_len(s->buildid_depmods_idxs);
+        size_t blob = external_blob_index(e);
+        if (blob >= nblobmap || blob_to_depsidx[blob] == (uint32_t)-1)
+            return 0;
+        image_metadata_t *meta = (image_metadata_t*)image_tree.ranges[blob].data;
+        uintptr_t off = ((uintptr_t)e - (uintptr_t)meta->base) / SYS_EXTERNAL_LINK_UNIT;
+        assert(off < ((uintptr_t)1 << DEPS_IDX_OFFSET));
+        *w = ICI_TAG_REF | (((uintptr_t)blob_to_depsidx[blob] + 1) << DEPS_IDX_OFFSET) | off;
+        return 1;
+    }
+    if (!jl_needs_serialization(s, e))
+        return 0; // special relocation representation (boxed-int caches, root task, ...)
+    if (needs_uniquing(e, s->query_cache))
+        return 0;
+    return 2;
+}
+
+static jl_value_t *ici_try_build(jl_serializer_state *s, jl_svec_t *edges, size_t nfieldwords) JL_CANSAFEPOINT JL_GC_DISABLED
+{
+#ifndef _P64
+    return NULL;
+#endif
+    if (!s->incremental || s->buildid_depmods_idxs == NULL)
+        return NULL;
+    size_t n = jl_svec_len(edges);
+    if (n == 0 && nfieldwords == 0)
+        return NULL;
+    // at save time buildid_depmods_idxs maps linkage-blob index -> depsidx
+    uint32_t *blob_to_depsidx = jl_array_data(s->buildid_depmods_idxs, uint32_t);
+    size_t nblobmap = jl_array_len(s->buildid_depmods_idxs);
+    // validate every edge is encodable before allocating
+    for (size_t i = 0; i < n; i++) {
+        jl_value_t *e = jl_svecref(edges, i);
+        if (e == NULL)
+            return NULL; // unset entry: keep the svec form
+        if (jl_is_long(e))
+            continue; // literal
+        if (jl_object_in_image(e)) {
+            size_t blob = external_blob_index(e);
+            if (blob >= nblobmap || blob_to_depsidx[blob] == (uint32_t)-1)
+                return NULL; // not among our recorded dependencies
+        }
+    }
+    jl_task_t *ct = jl_current_task;
+    jl_interned_code_instance_t *ici = (jl_interned_code_instance_t*)jl_gc_alloc(
+        ct->ptls, sizeof(jl_interned_code_instance_t) + (n + nfieldwords) * sizeof(uintptr_t),
+        jl_interned_code_instance_type);
+    ici->nedges = n;
+    ici->defword = 0;
+    ici->fieldmask = 0;
+    uintptr_t *words = ici_words(ici);
+    memset(words + n, 0, nfieldwords * sizeof(uintptr_t));
+    for (size_t i = 0; i < n; i++) {
+        jl_value_t *e = jl_svecref(edges, i);
+        if (jl_is_long(e)) {
+            intptr_t v = jl_unbox_long(e);
+            words[i] = ICI_TAG_LITERAL | ((((uintptr_t)v << 1) ^ (uintptr_t)(v >> (ICI_WORD_BITS - 1))) & ~ICI_TAG_LITERAL);
+        }
+        else if (jl_object_in_image(e)) {
+            size_t blob = external_blob_index(e);
+            image_metadata_t *meta = (image_metadata_t*)image_tree.ranges[blob].data;
+            uintptr_t off = ((uintptr_t)e - (uintptr_t)meta->base) / SYS_EXTERNAL_LINK_UNIT;
+            assert(off < ((uintptr_t)1 << DEPS_IDX_OFFSET));
+            words[i] = ICI_TAG_REF | (((uintptr_t)blob_to_depsidx[blob] + 1) << DEPS_IDX_OFFSET) | off;
+        }
+        else {
+            jl_queue_for_serialization_(s, e, 1, 0);
+            if (needs_uniquing(e, s->query_cache)) {
+                // the image copy is a stub replaced by its canonical object at
+                // load: emit this word as an ordinary relocated pointer slot so
+                // the uniquing pass rewrites it (recognized at write time by
+                // its clear top two bits; heap pointers never set them)
+                words[i] = (uintptr_t)e;
+            }
+            else {
+                // serialized with this image: patch after layout
+                words[i] = 0;
+                if (!ici_fixups_init) {
+                    arraylist_new(&ici_fixups, 0);
+                    ici_fixups_init = 1;
+                }
+                arraylist_push(&ici_fixups, (void*)ici);
+                arraylist_push(&ici_fixups, (void*)i);
+                arraylist_push(&ici_fixups, (void*)e);
+            }
+        }
+    }
+    return (jl_value_t*)ici;
+}
+
 static jl_value_t *get_replaceable_field(jl_value_t **addr, int mutabl) JL_CANSAFEPOINT JL_GC_DISABLED
 {
     jl_value_t *fld = (jl_value_t*)ptrhash_get(&field_replace, addr);
@@ -678,6 +931,7 @@ static int codeinst_may_be_runnable(jl_code_instance_t *ci, int incremental) {
 // you want to handle uniquing of `Dict{String,Float64}` before you tackle `Vector{Dict{String,Float64}}`.
 // Uniquing is done in `serialization_order`, so the very first mention of such an object must
 // be the "source" rather than merely a cross-reference.
+
 static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_t *v, int recursive, int immediate) JL_CANSAFEPOINT JL_GC_DISABLED
 {
     jl_datatype_t *t = (jl_datatype_t*)jl_typeof(v);
@@ -841,6 +1095,73 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
             }
         }
     }
+    if (s->incremental && jl_is_method(v))
+        edge_sig_note(((jl_method_t*)v)->sig);
+    if (jl_typetagis(v, jl_debuginfo_type)) {
+        // intern the inlinee list and the def/linetable/codelocs fields
+        // (rank order must match JL_ICI_DI_* in julia_internal.h)
+        jl_debuginfo_t *di = (jl_debuginfo_t*)v;
+        jl_svec_t *diedges = (jl_svec_t*)get_replaceable_field((jl_value_t**)&di->edges, 1);
+        if (diedges != NULL && jl_is_svec(diedges) &&
+            ptrhash_get(&field_replace, (void*)&di->edges) == HT_NOTFOUND) {
+            jl_value_t **faddrs[3] = {
+                (jl_value_t**)&di->def,
+                (jl_value_t**)&di->linetable,
+                (jl_value_t**)&di->codelocs,
+            };
+            jl_value_t *fv[3];
+            uintptr_t fw[3];
+            int fc[3];
+            size_t nfw = 0;
+            uintptr_t gate = ici_field_gate("JULIA_ICI_DIMASK", ~(uintptr_t)0);
+            // method-source and toplevel DebugInfos (def is not a
+            // MethodInstance) are reachable via raw Method.debuginfo reads
+            // that no conversion chokepoint covers: keep their fields plain
+            jl_value_t *didef = get_replaceable_field(&di->def, 1);
+            if (didef == NULL || !jl_is_method_instance(didef))
+                gate = 0;
+            // only intern fields into containers the edge list needs anyway:
+            // minting ~300k new containers for empty-edge leaves shifts the
+            // whole data-stream layout for a marginal record win
+            if (jl_svec_len(diedges) == 0)
+                gate = 0;
+            for (int r = 0; r < 3; r++) {
+                fv[r] = get_replaceable_field(faddrs[r], 1);
+                fw[r] = 0;
+                fc[r] = (fv[r] == NULL || !(gate & ((uintptr_t)1 << r))) ? 0 : ici_classify_value(s, fv[r], &fw[r]);
+                if (fc[r])
+                    nfw++;
+            }
+            jl_value_t *ici = ici_try_build(s, diedges, nfw);
+            if (ici != NULL) {
+                jl_interned_code_instance_t *icid = (jl_interned_code_instance_t*)ici;
+                record_field_change((jl_value_t**)&di->edges, ici);
+                uintptr_t *words = ici_words(icid);
+                size_t wi = icid->nedges;
+                for (int r = 0; r < 3; r++) {
+                    if (!fc[r])
+                        continue;
+                    icid->fieldmask |= ((uintptr_t)1 << r);
+                    if (fc[r] == 1) {
+                        words[wi] = fw[r];
+                    }
+                    else {
+                        jl_queue_for_serialization_(s, fv[r], 1, 0);
+                        words[wi] = 0;
+                        if (!ici_fixups_init) {
+                            arraylist_new(&ici_fixups, 0);
+                            ici_fixups_init = 1;
+                        }
+                        arraylist_push(&ici_fixups, (void*)icid);
+                        arraylist_push(&ici_fixups, (void*)wi);
+                        arraylist_push(&ici_fixups, (void*)fv[r]);
+                    }
+                    record_field_change(faddrs[r], NULL);
+                    wi++;
+                }
+            }
+        }
+    }
     if (jl_is_code_instance(v)) {
         jl_code_instance_t *ci = (jl_code_instance_t*)v;
         jl_method_instance_t *mi = jl_get_ci_mi(ci);
@@ -935,6 +1256,113 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
                             }
                         }
                     }
+                }
+            }
+        }
+        // Drop DebugInfo for CodeInstances that retain neither inferred IR
+        // nor native code in this image: with nothing to symbolize and
+        // nothing to splice during inlining, the debug tree (and its
+        // codelocs/linetable strings) is unreachable dead weight. Gated for
+        // measurement via JULIA_KEEP_ALL_DEBUGINFO=1.
+        if (s->incremental) {
+            static int keepdi = -1;
+            if (keepdi == -1) {
+                char *e = getenv("JULIA_KEEP_ALL_DEBUGINFO");
+                keepdi = e != NULL && strcmp(e, "1") == 0;
+            }
+            jl_value_t *inf_now = get_replaceable_field((jl_value_t**)&ci->inferred, 1);
+            if (!keepdi &&
+                (inf_now == NULL || inf_now == jl_nothing || jl_is_uint8(inf_now)) &&
+                jl_atomic_load_relaxed(&ci->debuginfo) != NULL) {
+                int32_t invokeptr_id = 0, specfptr_id = 0;
+                if (native_functions)
+                    jl_get_function_id(native_functions, ci, &invokeptr_id, &specfptr_id);
+                if (invokeptr_id == 0 && specfptr_id == 0)
+                    record_field_change((jl_value_t**)&ci->debuginfo, NULL);
+            }
+        }
+        // Intern the edge list and (where encodable) the object fields into a
+        // relocation-free container. Runs after every record_field_change
+        // above so field reads see the values that will actually serialize.
+        jl_svec_t *ciedges = (jl_svec_t*)get_replaceable_field((jl_value_t**)&ci->edges, 1);
+        if (s->incremental && ciedges != NULL && (jl_value_t*)ciedges != jl_nothing && jl_is_svec(ciedges))
+            collect_edge_group_sigs(ciedges);
+        if (ciedges != NULL && (jl_value_t*)ciedges != jl_nothing && jl_is_svec(ciedges) &&
+            ptrhash_get(&field_replace, (void*)&ci->edges) == HT_NOTFOUND) {
+            // rank order must match JL_ICI_CI_* in julia_internal.h
+            jl_value_t **faddrs[8] = {
+                (jl_value_t**)&ci->owner,
+                (jl_value_t**)&ci->next,
+                (jl_value_t**)&ci->rettype,
+                (jl_value_t**)&ci->exctype,
+                (jl_value_t**)&ci->rettype_const,
+                (jl_value_t**)&ci->inferred,
+                (jl_value_t**)&ci->debuginfo,
+                (jl_value_t**)&ci->analysis_results,
+            };
+            jl_value_t *fv[8];
+            uintptr_t fw[8];
+            int fc[8];
+            size_t nfw = 0;
+            uintptr_t gate = ici_field_gate("JULIA_ICI_CIMASK", ~(uintptr_t)0);
+            for (int r = 0; r < 8; r++) {
+                fv[r] = get_replaceable_field(faddrs[r], 1);
+                fw[r] = 0;
+                // `next` is runtime-mutable chain state: cache insertion writes it
+                // blindly and NULL legitimately means end-of-chain, so a lazy image
+                // write-back can corrupt (even cycle) live mi->cache chains. It must
+                // always serialize as an ordinary pointer field.
+                fc[r] = (r == JL_ICI_CI_NEXT || fv[r] == NULL || !(gate & ((uintptr_t)1 << r))) ? 0 : ici_classify_value(s, fv[r], &fw[r]);
+                if (fc[r])
+                    nfw++;
+            }
+            jl_value_t *ici = ici_try_build(s, ciedges, nfw);
+            if (ici != NULL) {
+                jl_interned_code_instance_t *icid = (jl_interned_code_instance_t*)ici;
+                record_field_change((jl_value_t**)&ci->edges, ici);
+                // def rides in its dedicated slot (jl_get_ci_mi rematerializes)
+                jl_value_t *def = (gate & ((uintptr_t)1 << 8)) ? ci->def : NULL;
+                if (def != NULL) {
+                    uintptr_t dw = 0;
+                    int dc = ici_classify_value(s, def, &dw);
+                    if (dc == 1) {
+                        icid->defword = dw;
+                        record_field_change((jl_value_t**)&ci->def, NULL);
+                    }
+                    else if (dc == 2) {
+                        jl_queue_for_serialization_(s, def, 1, 0);
+                        if (!ici_fixups_init) {
+                            arraylist_new(&ici_fixups, 0);
+                            ici_fixups_init = 1;
+                        }
+                        arraylist_push(&ici_fixups, (void*)icid);
+                        arraylist_push(&ici_fixups, (void*)ICI_DEFWORD_IDX);
+                        arraylist_push(&ici_fixups, (void*)def);
+                        record_field_change((jl_value_t**)&ci->def, NULL);
+                    }
+                }
+                uintptr_t *words = ici_words(icid);
+                size_t wi = icid->nedges;
+                for (int r = 0; r < 8; r++) {
+                    if (!fc[r])
+                        continue;
+                    icid->fieldmask |= ((uintptr_t)1 << r);
+                    if (fc[r] == 1) {
+                        words[wi] = fw[r];
+                    }
+                    else {
+                        jl_queue_for_serialization_(s, fv[r], 1, 0); // field no longer references it
+                        words[wi] = 0;
+                        if (!ici_fixups_init) {
+                            arraylist_new(&ici_fixups, 0);
+                            ici_fixups_init = 1;
+                        }
+                        arraylist_push(&ici_fixups, (void*)icid);
+                        arraylist_push(&ici_fixups, (void*)wi);
+                        arraylist_push(&ici_fixups, (void*)fv[r]);
+                    }
+                    record_field_change(faddrs[r], NULL);
+                    wi++;
                 }
             }
         }
@@ -1086,6 +1514,10 @@ done_fields: ;
 
 static void jl_queue_for_serialization_(jl_serializer_state *s, jl_value_t *v, int recursive, int immediate) JL_GC_DISABLED
 {
+    if (v == NULL)
+        return;
+    if (jl_is_svec(v))
+        v = svec_dedup_canonical(s, v);
     if (!jl_needs_serialization(s, v))
         return;
 
@@ -1114,8 +1546,9 @@ static void jl_queue_for_serialization_(jl_serializer_state *s, jl_value_t *v, i
 
     void **bp = ptrhash_bp(&serialization_order, v);
     assert(!immediate || *bp != (void*)(uintptr_t)-2);
-    if (*bp == HT_NOTFOUND)
+    if (*bp == HT_NOTFOUND) {
         *bp = (void*)(uintptr_t)-1; // now enqueued
+    }
     else if (!s->incremental || !immediate || !recursive || *bp != (void*)(uintptr_t)-1)
         return;
 
@@ -1228,13 +1661,26 @@ static uintptr_t add_external_linkage(jl_serializer_state *s, jl_value_t *v, jl_
 static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v, jl_array_t *link_ids) JL_GC_DISABLED JL_CANSAFEPOINT
 {
     assert(v != NULL && "cannot get backref to NULL object");
+    if (jl_is_svec(v))
+        v = svec_dedup_canonical(s, v); // all references resolve to the interned representative
     if (jl_is_symbol(v)) {
         void **pidx = ptrhash_bp(&symbol_table, v);
         void *idx = *pidx;
         if (idx == HT_NOTFOUND) {
-            size_t l = strlen(jl_symbol_name((jl_sym_t*)v));
-            write_uint32(s->symbols, l);
-            ios_write(s->symbols, jl_symbol_name((jl_sym_t*)v), l + 1);
+            if (!depsym_map_init)
+                depsym_map_build(s);
+            void *shared = ptrhash_get(&depsym_map, v);
+            if (shared != HT_NOTFOUND) {
+                // present in a dependency image: reference it as (dep, index)
+                // (record flagged by the high bit of the length field)
+                write_uint32(s->symbols, 0x80000000u | (uint32_t)(((uintptr_t)shared >> DEPSYM_IDX_SHIFT) - 1));
+                write_uint32(s->symbols, (uint32_t)(uintptr_t)shared);
+            }
+            else {
+                size_t l = strlen(jl_symbol_name((jl_sym_t*)v));
+                write_uint32(s->symbols, l);
+                ios_write(s->symbols, jl_symbol_name((jl_sym_t*)v), l + 1);
+            }
             size_t offset = ++nsym_tag;
             assert(offset < ((uintptr_t)1 << RELOC_TAG_OFFSET) && "too many symbols");
             idx = to_seroder_entry(offset - 1);
@@ -1292,13 +1738,63 @@ static void record_uniquing(jl_serializer_state *s, jl_value_t *fld, uintptr_t o
     }
 }
 
+// --- SimpleVector de-duplication: egal svecs (type-parameter lists, field
+// type lists, ...) are interned to one representative during serialization,
+// so their element references are written once. Safe because svecs are
+// immutable after construction and egal-compared everywhere identity would
+// otherwise matter; typevar-containing lists never merge across distinct
+// vars since typevars are egal by identity.
+static htable_t svec_dedup_memo;   // svec -> canonical svec (identity-keyed)
+static htable_t svec_dedup_byhash; // content hash -> first svec with it
+static int svec_dedup_init = 0;
+static htable_t svec_dedup_skip;   // svecs mutated after queueing (detached certificates): never deduplicated
+static int svec_dedup_skip_init = 0;
+
+static jl_value_t *svec_dedup_canonical(jl_serializer_state *s, jl_value_t *v) JL_GC_DISABLED
+{
+    if (!s->incremental || !jl_is_svec(v))
+        return v;
+    size_t l = jl_svec_len(v);
+    if (l == 0)
+        return v;
+    if (svec_dedup_skip_init && ptrhash_has(&svec_dedup_skip, v))
+        return v;
+    if (!svec_dedup_init) {
+        htable_new(&svec_dedup_memo, 1 << 16);
+        htable_new(&svec_dedup_byhash, 1 << 16);
+        svec_dedup_init = 1;
+    }
+    void *memo = ptrhash_get(&svec_dedup_memo, v);
+    if (memo != HT_NOTFOUND)
+        return (jl_value_t*)memo;
+    jl_value_t *canon = v;
+    for (size_t i = 0; i < l; i++) {
+        if (jl_svecref(v, i) == NULL) { // unset slot: leave alone
+            ptrhash_put(&svec_dedup_memo, v, v);
+            return v;
+        }
+    }
+    uintptr_t hash = jl_object_id(v);
+    void **bp = ptrhash_bp(&svec_dedup_byhash, (void*)(hash | 1)); // |1: never a valid key collision with HT_NOTFOUND semantics on 0
+    if (*bp == HT_NOTFOUND)
+        *bp = v;
+    else if (jl_egal((jl_value_t*)*bp, v))
+        canon = (jl_value_t*)*bp;
+    // on hash collision without egality, keep v distinct (missed dedup only)
+    ptrhash_put(&svec_dedup_memo, v, canon);
+    return canon;
+}
+
 // Save blank space in stream `s` for a pointer `fld`, storing both location and target
 // in `relocs_list`.
 static void write_pointerfield(jl_serializer_state *s, jl_value_t *fld) JL_CANSAFEPOINT JL_GC_DISABLED
 {
+    if (fld != NULL && jl_is_svec(fld))
+        fld = svec_dedup_canonical(s, fld);
     if (fld != NULL) {
+        uintptr_t id = backref_id(s, fld, s->link_ids_relocs);
         arraylist_push(&s->relocs_list, (void*)(uintptr_t)ios_pos(s->s));
-        arraylist_push(&s->relocs_list, (void*)backref_id(s, fld, s->link_ids_relocs));
+        arraylist_push(&s->relocs_list, (void*)id);
         record_uniquing(s, fld, ios_pos(s->s));
     }
     write_pointer(s->s);
@@ -1309,8 +1805,9 @@ static void write_pointerfield(jl_serializer_state *s, jl_value_t *fld) JL_CANSA
 static void write_gctaggedfield(jl_serializer_state *s, jl_datatype_t *ref) JL_CANSAFEPOINT JL_GC_DISABLED
 {
     // jl_printf(JL_STDOUT, "gctaggedfield: position %p, value 0x%lx\n", (void*)(uintptr_t)ios_pos(s->s), ref);
+    uintptr_t id = backref_id(s, ref, s->link_ids_gctags);
     arraylist_push(&s->gctags_list, (void*)(uintptr_t)ios_pos(s->s));
-    arraylist_push(&s->gctags_list, (void*)backref_id(s, ref, s->link_ids_gctags));
+    arraylist_push(&s->gctags_list, (void*)id);
     write_pointer(s->s);
 }
 
@@ -1516,6 +2013,12 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
             arraylist_push(&s->uniquing_types, (void*)(uintptr_t)(ios_pos(f)|1));
         if (f == s->const_data)
             write_uint(s->const_data, ((uintptr_t)t->smalltag << 4) | GC_OLD_MARKED | GC_IN_IMAGE);
+        else if (t->smalltag) {
+            // small-tagged types (core, never uniqued) need no gctag
+            // relocation: the complete header is plain data
+            assert(!(s->incremental && jl_needs_serialization(s, (jl_value_t*)t) && needs_uniquing((jl_value_t*)t, s->query_cache)));
+            write_uint(f, ((uintptr_t)t->smalltag << 4) | GC_OLD_MARKED | GC_IN_IMAGE);
+        }
         else
             write_gctaggedfield(s, t);
         size_t reloc_offset = ios_pos(f);
@@ -1570,7 +2073,8 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
             newa->ref.mem = NULL; // relocation offset
             arraylist_push(&s->relocs_list, (void*)(reloc_offset + offsetof(jl_array_t, ref.mem))); // relocation location
             jl_value_t *mem = get_replaceable_field((jl_value_t**)&ar->ref.mem, 1);
-            arraylist_push(&s->relocs_list, (void*)backref_id(s, mem, s->link_ids_relocs)); // relocation target
+            uintptr_t memid = backref_id(s, mem, s->link_ids_relocs);
+            arraylist_push(&s->relocs_list, (void*)memid); // relocation target
             record_memoryref(s, reloc_offset + offsetof(jl_array_t, ref), ar->ref);
         }
         else if (jl_is_genericmemory(v)) {
@@ -1669,7 +2173,8 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                                 size_t fld_pos = reloc_offset + headersize + offset;
                                 if (fld != NULL) {
                                     arraylist_push(&s->relocs_list, (void*)(uintptr_t)fld_pos); // relocation location
-                                    arraylist_push(&s->relocs_list, (void*)backref_id(s, fld, s->link_ids_relocs)); // relocation target
+                                    uintptr_t fldid = backref_id(s, fld, s->link_ids_relocs);
+                                    arraylist_push(&s->relocs_list, (void*)fldid); // relocation target
                                     record_uniquing(s, fld, fld_pos);
                                 }
                                 memset(&f->buf[fld_pos], 0, sizeof(fld)); // relocation offset (none)
@@ -1815,8 +2320,9 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 jl_value_t *fld = get_replaceable_field((jl_value_t**)&data[offset], mutabl);
                 size_t fld_pos = offset + reloc_offset;
                 if (fld != NULL) {
+                    uintptr_t fld_id = backref_id(s, fld, s->link_ids_relocs);
                     arraylist_push(&s->relocs_list, (void*)(uintptr_t)(fld_pos)); // relocation location
-                    arraylist_push(&s->relocs_list, (void*)backref_id(s, fld, s->link_ids_relocs)); // relocation target
+                    arraylist_push(&s->relocs_list, (void*)fld_id); // relocation target
                     record_uniquing(s, fld, fld_pos);
                 }
                 memset(&f->buf[fld_pos], 0, sizeof(fld)); // relocation offset (none)
@@ -1860,12 +2366,33 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                     jl_atomic_store_relaxed(&newbpart->max_world, 0);
                 }
             }
+            else if (t == jl_interned_code_instance_type) {
+                assert(f == s->s);
+                jl_interned_code_instance_t *ici = (jl_interned_code_instance_t*)v;
+                // words are final except: raw heap pointers (uniqued targets)
+                // become ordinary relocated+uniqued pointer slots, and zero
+                // placeholders are patched after layout via ici_fixups
+                uintptr_t *words = ici_words(ici);
+                size_t nwords = ici->nedges + __builtin_popcountll(ici->fieldmask);
+                for (size_t i = 0; i < nwords; i++) {
+                    uintptr_t w = words[i];
+                    if (w != 0 && (w >> (ICI_WORD_BITS - 2)) == 0)
+                        write_pointerfield(s, (jl_value_t*)w);
+                    else
+                        write_uint(f, w);
+                }
+            }
             else if (jl_is_method(v)) {
                 assert(f == s->s);
                 write_padding(f, sizeof(jl_method_t) - tot); // hidden fields
                 jl_method_t *m = (jl_method_t*)v;
                 jl_method_t *newm = (jl_method_t*)&f->buf[reloc_offset];
                 if (s->incremental) {
+                    // scanned_methods lists are session state (cleared above);
+                    // 0x2 must clear with them or the load-time fetch_or path
+                    // never re-adds the method to its module's list
+                    jl_atomic_store_relaxed(&newm->did_scan_source,
+                        jl_atomic_load_relaxed(&newm->did_scan_source) & ~(uint8_t)0x2);
                     if (jl_atomic_load_relaxed(&newm->primary_world) > 1) {
                         jl_atomic_store_relaxed(&newm->primary_world, ~(size_t)0); // min-world
                         int dispatch_status = jl_atomic_load_relaxed(&newm->dispatch_status);
@@ -2048,6 +2575,106 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
     assert(s->uniquing_super.len == 0);
 }
 
+// --- lazy decode of InternedCodeInstance words (see julia.h) ---
+typedef struct {
+    uintptr_t data_base;
+    size_t data_size;
+    uintptr_t const_base;
+    uint32_t *depsmap; // depsidx -> image_tree range index
+    uintptr_t *depbase; // depsidx -> that image's mapped base (stable; image_tree.ranges may be reallocated)
+    uint32_t ndeps;
+    // identity for direct compressed-IR references (TAG_IMAGE_ROOT):
+    uint64_t key;      // jl_worklist_key of the image's worklist
+    _Atomic(uint8_t) has_key; // published with release once `key` is set
+    uint8_t is_sysimg;
+    // interned symbol table of the image, for cross-image symbol references
+    jl_sym_t **syms;
+    uint32_t nsyms;
+} ici_image_info_t;
+// registry of loaded images: appended by the loader (one writer at a time,
+// under the loading lock) and walked unlocked by readers on other threads
+// (compressed-IR encode, stack walks), so entries live in fixed chunks that
+// are never moved and the count is published with release semantics
+#define ICI_IMAGES_CHUNK 1024
+#define ICI_IMAGES_MAXCHUNKS 256
+static _Atomic(ici_image_info_t**) ici_image_chunks[ICI_IMAGES_MAXCHUNKS];
+static _Atomic(size_t) ici_images_len;
+static size_t ici_images_count(void) JL_NOTSAFEPOINT
+{
+    return jl_atomic_load_acquire(&ici_images_len);
+}
+static ici_image_info_t *ici_image_at(size_t k) JL_NOTSAFEPOINT
+{
+    ici_image_info_t **chunk = jl_atomic_load_relaxed(&ici_image_chunks[k / ICI_IMAGES_CHUNK]);
+    return chunk[k % ICI_IMAGES_CHUNK];
+}
+
+static void ici_register_image(uintptr_t base, size_t size, uintptr_t const_base, jl_array_t *depmods_idxs, int is_sysimg)
+{
+    ici_image_info_t *info = (ici_image_info_t*)malloc_s(sizeof(ici_image_info_t));
+    info->data_base = base;
+    info->data_size = size;
+    info->const_base = const_base;
+    info->key = 0;
+    jl_atomic_store_relaxed(&info->has_key, 0);
+    info->is_sysimg = (uint8_t)is_sysimg;
+    info->syms = NULL;
+    info->nsyms = 0;
+    info->ndeps = depmods_idxs ? jl_array_len(depmods_idxs) : 0;
+    info->depsmap = info->ndeps ? (uint32_t*)malloc_s(info->ndeps * sizeof(uint32_t)) : NULL;
+    info->depbase = info->ndeps ? (uintptr_t*)malloc_s(info->ndeps * sizeof(uintptr_t)) : NULL;
+    if (info->ndeps) {
+        uint32_t *idxs = jl_array_data(depmods_idxs, uint32_t);
+        for (uint32_t k = 0; k < info->ndeps; k++) {
+            // dependencies are registered before the images that use them
+            size_t ri = idxs[k];
+            assert(ri < image_tree.nranges);
+            info->depsmap[k] = (uint32_t)ri;
+            info->depbase[k] = (uintptr_t)((image_metadata_t*)image_tree.ranges[ri].data)->base;
+        }
+    }
+    size_t n = jl_atomic_load_relaxed(&ici_images_len);
+    if (n / ICI_IMAGES_CHUNK >= ICI_IMAGES_MAXCHUNKS)
+        jl_error("too many loaded images");
+    ici_image_info_t **chunk = jl_atomic_load_relaxed(&ici_image_chunks[n / ICI_IMAGES_CHUNK]);
+    if (chunk == NULL) {
+        chunk = (ici_image_info_t**)calloc_s(ICI_IMAGES_CHUNK * sizeof(ici_image_info_t*));
+        jl_atomic_store_release(&ici_image_chunks[n / ICI_IMAGES_CHUNK], chunk);
+    }
+    chunk[n % ICI_IMAGES_CHUNK] = info;
+    jl_atomic_store_release(&ici_images_len, n + 1);
+}
+
+static ici_image_info_t *ici_find_image(uintptr_t a) JL_NOTSAFEPOINT
+{
+    static _Atomic(ici_image_info_t*) last;
+    ici_image_info_t *hit = jl_atomic_load_acquire(&last);
+    if (hit && a - hit->data_base < hit->data_size)
+        return hit;
+    for (size_t k = 0, n = ici_images_count(); k < n; k++) {
+        hit = ici_image_at(k);
+        if (a - hit->data_base < hit->data_size) {
+            jl_atomic_store_release(&last, hit);
+            return hit;
+        }
+    }
+    return NULL;
+}
+
+// --- direct compressed-IR image references (TAG_IMAGE_ROOT) ---
+
+// stamp the worklist key on a restored image so this session's compressed IR
+// can reference its objects by (key, offset)
+static void ici_set_image_key(uintptr_t base, uint64_t key) JL_NOTSAFEPOINT
+{
+    ici_image_info_t *info = ici_find_image(base);
+    if (info != NULL && !info->is_sysimg) {
+        info->key = key;
+        jl_atomic_store_release(&info->has_key, 1);
+    }
+}
+
+
 // In deserialization, create Symbols and set up the
 // index for backreferencing
 static void jl_read_symbols(jl_serializer_state *s)
@@ -2055,14 +2682,59 @@ static void jl_read_symbols(jl_serializer_state *s)
     assert(deser_sym.len == 0);
     uintptr_t base = (uintptr_t)&s->symbols->buf[0];
     uintptr_t end = base + s->symbols->size;
+    // per-dependency symbol tables, resolved lazily once per image
+    size_t ndeps_tab = s->buildid_depmods_idxs ? jl_array_len(s->buildid_depmods_idxs) : 0;
+    jl_sym_t ***dep_syms = (jl_sym_t***)alloca((ndeps_tab ? ndeps_tab : 1) * sizeof(void*));
+    memset(dep_syms, 0, (ndeps_tab ? ndeps_tab : 1) * sizeof(void*));
     while (base < end) {
         uint32_t len = jl_load_unaligned_i32((void*)base);
         base += 4;
+        if (len & 0x80000000u) {
+            // shared with a dependency image: (depsidx, index) into its
+            // already-interned symbol table
+            uint32_t depsidx = len & 0x7fffffffu;
+            uint32_t symidx = jl_load_unaligned_i32((void*)base);
+            base += 4;
+            assert(depsidx < ndeps_tab);
+            jl_sym_t **tab = dep_syms[depsidx];
+            if (tab == NULL) {
+                ici_image_info_t *info = NULL;
+                if (depsidx == 0) {
+                    // dependency index 0 is the sysimage
+                    for (size_t k = 0, n = ici_images_count(); k < n; k++) {
+                        ici_image_info_t *e = ici_image_at(k);
+                        if (e->is_sysimg) {
+                            info = e;
+                            break;
+                        }
+                    }
+                }
+                else {
+                    size_t i = jl_array_data(s->buildid_depmods_idxs, uint32_t)[depsidx];
+                    assert(i < image_tree.nranges);
+                    image_metadata_t *meta = (image_metadata_t*)image_tree.ranges[i].data;
+                    info = ici_find_image(meta->base);
+                }
+                assert(info && info->syms && "dependency symbol table missing");
+                tab = dep_syms[depsidx] = info->syms;
+            }
+            arraylist_push(&deser_sym, (void*)tab[symidx]);
+            continue;
+        }
         const char *str = (const char*)base;
         base += len + 1;
         //printf("symbol %3d: %s\n", len, str);
         jl_sym_t *sym = _jl_symbol(str, len);
         arraylist_push(&deser_sym, (void*)sym);
+    }
+    // persist for cross-image references from images that depend on this one
+    // (s->s is not set during this pass; the symbols section lies within the
+    // same registered file span)
+    ici_image_info_t *self = ici_find_image((uintptr_t)s->symbols->buf);
+    if (self != NULL && self->syms == NULL && deser_sym.len > 0) {
+        self->syms = (jl_sym_t**)malloc_s(deser_sym.len * sizeof(jl_sym_t*));
+        memcpy(self->syms, deser_sym.items, deser_sym.len * sizeof(jl_sym_t*));
+        self->nsyms = (uint32_t)deser_sym.len;
     }
 }
 
@@ -2209,6 +2881,317 @@ static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t bas
     abort();
 }
 
+
+static void depsym_map_build(jl_serializer_state *s) JL_GC_DISABLED
+{
+    assert(!depsym_map_init);
+    htable_new(&depsym_map, 1 << 17);
+    depsym_map_init = 1;
+    if (sizeof(uintptr_t) < 8)
+        return; // the (depsidx+1)<<40 | index map values need a 64-bit pointer
+    if (!s->incremental || s->buildid_depmods_idxs == NULL || ici_images_count() == 0)
+        return;
+    uint32_t *blob_to_depsidx = jl_array_data(s->buildid_depmods_idxs, uint32_t);
+    size_t nblobmap = jl_array_len(s->buildid_depmods_idxs);
+    for (size_t k = 0, n = ici_images_count(); k < n; k++) {
+        ici_image_info_t *info = ici_image_at(k);
+        if (info->syms == NULL) {
+            continue;
+        }
+        uintptr_t depsidx;
+        if (info->is_sysimg) {
+            depsidx = 0; // by convention, dependency index 0 is the sysimage
+        }
+        else {
+            size_t blob = external_blob_index((jl_value_t*)info->data_base);
+            if (blob >= nblobmap || blob_to_depsidx[blob] == (uint32_t)-1) {
+                continue; // not a declared dependency of this output
+            }
+            depsidx = blob_to_depsidx[blob];
+        }
+        for (uint32_t i = 0; i < info->nsyms; i++) {
+            void **bp = ptrhash_bp(&depsym_map, (void*)info->syms[i]);
+            if (*bp == HT_NOTFOUND)
+                *bp = (void*)(((depsidx + 1) << DEPSYM_IDX_SHIFT) | i);
+        }
+    }
+}
+
+// probe: can `v` be referenced directly as (image key, offset)?
+// returns 0 = no, 1 = package image (*key set), 2 = sysimage; *offset is the
+// byte offset from the image's mapped base either way
+JL_DLLEXPORT int jl_image_ref_of(jl_value_t *v, uint64_t *key, uint64_t *offset) JL_NOTSAFEPOINT
+{
+    ici_image_info_t *info = ici_find_image((uintptr_t)v);
+    if (info == NULL)
+        return 0;
+    if (info->is_sysimg) {
+        *key = 0;
+        *offset = (uintptr_t)v - info->data_base;
+        return 2;
+    }
+    if (!jl_atomic_load_acquire(&info->has_key))
+        return 0;
+    *key = info->key;
+    *offset = (uintptr_t)v - info->data_base;
+    return 1;
+}
+
+// resolve a direct reference; NULL when the image is not loaded (the
+// dependency closure guarantee makes that unreachable for valid caches)
+JL_DLLEXPORT jl_value_t *jl_image_ref_resolve(int is_sysimg, uint64_t key, uint64_t offset) JL_NOTSAFEPOINT
+{
+    static _Atomic(ici_image_info_t*) last;
+    ici_image_info_t *hit = jl_atomic_load_acquire(&last);
+    if (hit == NULL || (is_sysimg ? !hit->is_sysimg : (!jl_atomic_load_acquire(&hit->has_key) || hit->key != key))) {
+        hit = NULL;
+        for (size_t k = 0, n = ici_images_count(); k < n; k++) {
+            ici_image_info_t *e = ici_image_at(k);
+            if (is_sysimg ? e->is_sysimg : (jl_atomic_load_acquire(&e->has_key) && e->key == key)) {
+                hit = e;
+                break;
+            }
+        }
+        if (hit == NULL)
+            return NULL;
+        jl_atomic_store_release(&last, hit);
+    }
+    assert(offset < hit->data_size);
+    return (jl_value_t*)(hit->data_base + offset);
+}
+
+static jl_value_t *ici_decode_ref(jl_interned_code_instance_t *ici, uintptr_t w) JL_NOTSAFEPOINT
+{
+    size_t key = (w & ~(ICI_TAG_REF | ICI_TAG_CONST)) >> DEPS_IDX_OFFSET;
+    uintptr_t off = (w & (((uintptr_t)1 << DEPS_IDX_OFFSET) - 1)) * SYS_EXTERNAL_LINK_UNIT;
+    ici_image_info_t *info = ici_find_image((uintptr_t)ici);
+    assert(info && "InternedCodeInstance outside any registered image");
+    if (w & ICI_TAG_CONST) {
+        assert(key == 0 && "const refs are self-image only");
+        return (jl_value_t*)(info->const_base + off);
+    }
+    if (key == 0)
+        return (jl_value_t*)(info->data_base + off);
+    assert(key - 1 < info->ndeps);
+    return (jl_value_t*)(info->depbase[key - 1] + off);
+}
+
+// decode an interned owner-field word; NULL if the field was not interned
+JL_DLLEXPORT jl_value_t *jl_ici_fieldref(jl_value_t *edges, int rank) JL_NOTSAFEPOINT
+{
+    if (edges == NULL || !jl_typetagis(edges, jl_interned_code_instance_type))
+        return NULL;
+    jl_interned_code_instance_t *ici = (jl_interned_code_instance_t*)edges;
+    uintptr_t bit = (uintptr_t)1 << rank;
+    if (!(ici->fieldmask & bit))
+        return NULL;
+    size_t idx = ici->nedges + __builtin_popcountll(ici->fieldmask & (bit - 1));
+    jl_value_t *v = ici_decode_ref(ici, ici_words(ici)[idx]);
+    return v;
+}
+
+JL_DLLEXPORT jl_value_t *jl_ici_ref(jl_interned_code_instance_t *ici, size_t i) JL_CANSAFEPOINT
+{
+    assert(i < ici->nedges);
+    uintptr_t w = ici_words(ici)[i];
+    if (w & ICI_TAG_LITERAL) {
+        uintptr_t z = w & ~ICI_TAG_LITERAL;
+        return jl_box_long((intptr_t)((z >> 1) ^ (0 - (z & 1))));
+    }
+    if (w & ICI_TAG_REF)
+        return ici_decode_ref(ici, w);
+    return (jl_value_t*)w; // relocated (and possibly uniqued) pointer
+}
+
+// like jl_ici_ref, but returns NULL for literal words instead of boxing
+JL_DLLEXPORT jl_value_t *jl_ici_ref_nobox(jl_interned_code_instance_t *ici, size_t i) JL_NOTSAFEPOINT
+{
+    assert(i < ici->nedges);
+    uintptr_t w = ici_words(ici)[i];
+    if (w & ICI_TAG_LITERAL)
+        return NULL;
+    if (w & ICI_TAG_REF)
+        return ici_decode_ref(ici, w);
+    return (jl_value_t*)w;
+}
+
+// if word `i` is an inline literal, store its value in `out` and return 1
+JL_DLLEXPORT int jl_ici_literal(jl_interned_code_instance_t *ici, size_t i, intptr_t *out) JL_NOTSAFEPOINT
+{
+    assert(i < ici->nedges);
+    uintptr_t w = ici_words(ici)[i];
+    if (!(w & ICI_TAG_LITERAL))
+        return 0;
+    uintptr_t z = w & ~ICI_TAG_LITERAL;
+    *out = (intptr_t)((z >> 1) ^ (0 - (z & 1)));
+    return 1;
+}
+
+JL_DLLEXPORT void jl_ci_materialize_all(jl_code_instance_t *ci) JL_NOTSAFEPOINT;
+
+// rematerialize an interned ci->def (and, as defense in depth, every other
+// interned field of this CodeInstance): decode the words and write the
+// objects back so subsequent reads take the plain-pointer paths
+JL_DLLEXPORT jl_value_t *jl_ici_materialize_def(jl_code_instance_t *ci) JL_NOTSAFEPOINT
+{
+    jl_value_t *edges = (jl_value_t*)jl_atomic_load_relaxed(&ci->edges);
+    assert(edges != NULL && jl_typetagis(edges, jl_interned_code_instance_type) &&
+           "NULL ci->def without an interned container");
+    jl_interned_code_instance_t *ici = (jl_interned_code_instance_t*)edges;
+    assert(ici->defword != 0);
+    jl_value_t *def = ici_decode_ref(ici, ici->defword);
+    jl_value_t *expected = NULL;
+    if (jl_atomic_cmpswap((_Atomic(jl_value_t*)*)&ci->def, &expected, def))
+        jl_gc_wb(ci, def);
+    jl_ci_materialize_all(ci); // fill the remaining interned fields too
+    return def;
+}
+
+// materialize every interned field of `ci` (invoked by the first accessor
+// that finds its field interned; also makes stray unrouted raw reads safe
+// once any accessor has touched the object)
+JL_DLLEXPORT void jl_ci_materialize_all(jl_code_instance_t *ci) JL_NOTSAFEPOINT
+{
+    jl_value_t *edges = (jl_value_t*)jl_atomic_load_relaxed(&ci->edges);
+    if (edges == NULL || !jl_typetagis(edges, jl_interned_code_instance_type))
+        return;
+    jl_interned_code_instance_t *ici = (jl_interned_code_instance_t*)edges;
+    if (ici->defword != 0 && jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->def) == NULL)
+        jl_ici_materialize_def(ci);
+    uintptr_t mask = ici->fieldmask;
+    if (mask == 0)
+        return;
+    // first readers on several threads may race here: each field is set once,
+    // from NULL, so every racer stores the same decoded object and a concurrent
+    // runtime store (e.g. dropping `inferred`) is never clobbered; runtime code
+    // never stores NULL into these fields, so NULL always means not yet decoded
+    jl_value_t *v;
+#define ICI_MAT(rank, fieldp) \
+    if (mask & ((uintptr_t)1 << (rank))) { \
+        _Atomic(jl_value_t*) *fp_ = (_Atomic(jl_value_t*)*)(fieldp); \
+        if (jl_atomic_load_relaxed(fp_) == NULL) { \
+            v = jl_ici_fieldref(edges, rank); \
+            jl_value_t *expected_ = NULL; \
+            if (v != NULL && jl_atomic_cmpswap(fp_, &expected_, v)) \
+                jl_gc_wb(ci, v); \
+        } \
+    }
+    ICI_MAT(JL_ICI_CI_OWNER, &ci->owner)
+    // JL_ICI_CI_NEXT is never interned nor materialized: `next` is runtime-mutable
+    // chain state and NULL is a valid runtime value (see the save-side comment)
+    ICI_MAT(JL_ICI_CI_RETTYPE, &ci->rettype)
+    ICI_MAT(JL_ICI_CI_EXCTYPE, &ci->exctype)
+    ICI_MAT(JL_ICI_CI_RETTYPE_CONST, &ci->rettype_const)
+    ICI_MAT(JL_ICI_CI_INFERRED, &ci->inferred)
+    ICI_MAT(JL_ICI_CI_DEBUGINFO, &ci->debuginfo)
+    ICI_MAT(JL_ICI_CI_ANALYSIS, &ci->analysis_results)
+#undef ICI_MAT
+}
+
+// materializing def accessor for Julia callers (the field itself reads as
+// undefined when interned, and isdefined const-folds for CodeInstance)
+JL_DLLEXPORT jl_value_t *jl_ci_def(jl_code_instance_t *ci)
+{
+    jl_value_t *def = ci->def;
+    if (def == NULL)
+        def = jl_ici_materialize_def(ci);
+    return def;
+}
+
+// read-only variant for signal/dump contexts (no heap write)
+JL_DLLEXPORT jl_value_t *jl_ci_def_ro(jl_code_instance_t *ci) JL_NOTSAFEPOINT
+{
+    jl_value_t *def = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->def);
+    if (def != NULL)
+        return def;
+    jl_value_t *edges = (jl_value_t*)jl_atomic_load_relaxed(&ci->edges);
+    if (edges == NULL || !jl_typetagis(edges, jl_interned_code_instance_type))
+        return NULL;
+    jl_interned_code_instance_t *ici = (jl_interned_code_instance_t*)edges;
+    if (ici->defword == 0)
+        return NULL;
+    return ici_decode_ref(ici, ici->defword);
+}
+
+// Convert an interned DebugInfo subtree back to its plain form: fill the
+// def/linetable/codelocs fields, restore `edges` to its SimpleVector form,
+// and recurse through edge children and the linetable chain. Raw compiled
+// field reads (`isdefined` const-folds for DebugInfo, and bootstrap-compiled
+// Compiler code bypasses getproperty overrides) are only safe against
+// converted nodes, so every path that hands a DebugInfo tree to Julia-visible
+// structures must convert it first; after conversion the object is
+// indistinguishable from a never-interned one. `edges` still holding the
+// interned container doubles as the not-yet-converted marker.
+JL_DLLEXPORT void jl_di_materialize_all(jl_debuginfo_t *di) JL_CANSAFEPOINT
+{
+    jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+    if (edges == NULL || !jl_typetagis(edges, jl_interned_code_instance_type))
+        return; // converted (or never interned)
+    jl_interned_code_instance_t *ici = (jl_interned_code_instance_t*)edges;
+    uintptr_t mask = ici->fieldmask;
+    jl_value_t *v;
+    // as for CodeInstances: each field is set once, from NULL
+#define ICI_MATD(rank, fieldp) \
+    if (mask & ((uintptr_t)1 << (rank))) { \
+        _Atomic(jl_value_t*) *fp_ = (_Atomic(jl_value_t*)*)(fieldp); \
+        if (jl_atomic_load_relaxed(fp_) == NULL) { \
+            v = jl_ici_fieldref(edges, rank); \
+            jl_value_t *expected_ = NULL; \
+            if (v != NULL && jl_atomic_cmpswap(fp_, &expected_, v)) \
+                jl_gc_wb(di, v); \
+        } \
+    }
+    ICI_MATD(JL_ICI_DI_DEF, &di->def)
+    ICI_MATD(JL_ICI_DI_LINETABLE, &di->linetable)
+    ICI_MATD(JL_ICI_DI_CODELOCS, &di->codelocs)
+#undef ICI_MATD
+    jl_value_t *lt = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&di->linetable);
+    if (lt != NULL && jl_is_debuginfo(lt))
+        jl_di_materialize_all((jl_debuginfo_t*)lt);
+    jl_svec_t *sv = jl_ici_to_svec(ici);
+    JL_GC_PUSH1(&sv);
+    for (size_t i = 0, n = jl_svec_len(sv); i < n; i++) {
+        jl_value_t *el = jl_svecref(sv, i);
+        if (el != NULL && jl_is_debuginfo(el))
+            jl_di_materialize_all((jl_debuginfo_t*)el);
+    }
+    // publish last: the interned container is the not-converted marker, and a
+    // concurrent converter's copy loses the exchange and is dropped, so readers
+    // only ever see one SimpleVector
+    jl_value_t *expected = edges;
+    if (jl_atomic_cmpswap((_Atomic(jl_value_t*)*)&di->edges, &expected, (jl_value_t*)sv))
+        jl_gc_wb(di, sv);
+    JL_GC_POP();
+}
+
+// dual-form edge list accessors: `edges` is a SimpleVector, or the interned
+// word form for image objects (CodeInstance and DebugInfo edge lists)
+JL_DLLEXPORT size_t jl_edgelist_len(jl_value_t *edges) JL_NOTSAFEPOINT
+{
+    if (jl_typetagis(edges, jl_interned_code_instance_type))
+        return ((jl_interned_code_instance_t*)edges)->nedges;
+    return jl_svec_len(edges);
+}
+
+JL_DLLEXPORT jl_value_t *jl_edgelist_ref(jl_value_t *edges, size_t i) JL_CANSAFEPOINT
+{
+    if (jl_typetagis(edges, jl_interned_code_instance_type))
+        return jl_ici_ref((jl_interned_code_instance_t*)edges, i);
+    return jl_svecref(edges, i);
+}
+
+// materialize the interned form back into a SimpleVector, for consumers
+// that hand the edge list onward (IR decompression, const CodeInfos)
+JL_DLLEXPORT jl_svec_t *jl_ici_to_svec(jl_interned_code_instance_t *ici) JL_CANSAFEPOINT
+{
+    size_t n = ici->nedges;
+    jl_svec_t *out = jl_alloc_svec(n);
+    JL_GC_PUSH1(&out);
+    for (size_t i = 0; i < n; i++)
+        jl_svecset(out, i, jl_ici_ref(ici, i));
+    JL_GC_POP();
+    return out;
+}
 
 static void jl_finish_relocs(char *base, size_t size, arraylist_t *list)
 {
@@ -3154,6 +4137,7 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
     ios_mem(&gvar_record, 0);
     ios_mem(&fptr_record, 0);
     jl_serializer_state s = {0};
+    jl_value_t *sig_tn_root = NULL;
     s.query_cache = query_cache;
     s.incremental = !(worklist == NULL);
     s.s = &sysimg;
@@ -3229,19 +4213,224 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             jl_queue_for_serialization(&s, module_init_order);
         }
         // step 1.1: as needed, serialize the data needed for insertion into the running system
+        arraylist_t cert_lists; // detached activation-certificate records: (cert, slot, list) triples
+        arraylist_new(&cert_lists, 0);
         if (extext_methods) {
+            // sort by first-argument typename so consecutive load-time
+            // insertions and activations share hot typemap paths; the array
+            // holds (method, activation certificate) pairs
+            size_t nex = jl_array_nrows(extext_methods);
+            if (nex > 3)
+                qsort(jl_array_ptr_data(extext_methods), nex / 2, 2 * sizeof(void*), extext_method_cmp);
+            // Detach the invalidation records of each activation certificate
+            // (slot 2: replaced-dispatch MethodInstances with their flag, slot 4:
+            // invalidated callers) before queueing: the worker's invalidated
+            // objects are dead weight the image otherwise drops, and rooting them
+            // here would serialize them. They are pruned against the reachable
+            // set below and requeued.
+            for (size_t i = 1; i < nex; i += 2) {
+                jl_value_t *cert = jl_array_ptr_ref(extext_methods, i);
+                if (cert == jl_nothing)
+                    continue;
+                // a detached certificate can transiently equal another one:
+                // keep it out of the svec deduplication so nothing aliases it
+                if (!svec_dedup_skip_init) {
+                    htable_new(&svec_dedup_skip, 256);
+                    svec_dedup_skip_init = 1;
+                }
+                ptrhash_put(&svec_dedup_skip, (void*)cert, (void*)cert);
+                for (int slot = 2; slot <= 4; slot += 2) {
+                    jl_value_t *lst = jl_svecref(cert, slot);
+                    if (lst == jl_nothing)
+                        continue;
+                    arraylist_push(&cert_lists, cert);
+                    arraylist_push(&cert_lists, (void*)(uintptr_t)slot);
+                    arraylist_push(&cert_lists, lst);
+                    jl_svecset(cert, slot, jl_nothing);
+                }
+            }
             // Queue method extensions
             jl_queue_for_serialization(&s, extext_methods);
             // Queue the new specializations
             jl_queue_for_serialization(&s, new_ext);
         }
         jl_serialize_reachable(&s);
+        if (worklist && edge_sig_set_init && edge_sig_set.count > 0) {
+            // serialize the typename decompositions of every collected call
+            // and method signature: the loader consumes them in place of
+            // jl_foreach_top_typename_for (contents ride as ordinary pointer
+            // arrays so relocation and uniquing canonicalize the typenames)
+            jl_array_t *sigtab = jl_alloc_vec_any(0);
+            jl_svec_t *tnsv = NULL;
+            JL_GC_PUSH2(&sigtab, &tnsv);
+            void **tab = edge_sig_set.table;
+            for (size_t i = 0; i < edge_sig_set.size; i += 2) {
+                if (tab[i + 1] == HT_NOTFOUND)
+                    continue;
+                jl_value_t *sig = (jl_value_t*)tab[i];
+                struct _sig_tn_collect env = { {NULL}, 0, 0, 0 };
+                if (!jl_foreach_top_typename_for(_sig_tn_collect_cb, sig, 1, &env))
+                    continue; // not decomposable: loader falls back
+                if (env.overflow)
+                    continue;
+                tnsv = jl_alloc_svec(1 + env.n);
+                jl_svecset(tnsv, 0, jl_box_long((int64_t)env.explbits));
+                for (int k = 0; k < env.n; k++)
+                    jl_svecset(tnsv, 1 + k, env.tns[k]);
+                jl_array_ptr_1d_push(sigtab, sig);
+                jl_array_ptr_1d_push(sigtab, (jl_value_t*)tnsv);
+            }
+            JL_GC_POP();
+            sig_tn_root = (jl_value_t*)sigtab;
+            jl_queue_for_serialization(&s, sig_tn_root);
+            jl_serialize_reachable(&s);
+        }
+        else if (worklist) {
+            jl_queue_for_serialization(&s, jl_nothing);
+        }
         // step 1.2: ensure all gvars are part of the sysimage too
         record_gvars(&s, &gvars);
         record_external_fns(&s, &external_fns);
         if (jl_options.trim)
             record_gvars(&s, &MIs);
         jl_serialize_reachable(&s);
+        // Prune the records that must not root otherwise-dead objects only now
+        // that every ordinary root (including those found in generated code) has
+        // been queued, so nothing reachable loses its record.
+        if (cert_lists.len > 0) {
+            // Keep a recorded object only if it exists at load: owned by a
+            // dependency image, or serialized with this image anyway. A
+            // worker-created MethodInstance or CodeInstance that is otherwise
+            // unreachable is not in the loaded image, and any live counterpart
+            // created outside the dependency closure is scanned live by replay.
+            for (size_t i = 0; i < cert_lists.len; i += 3) {
+                jl_svec_t *cert = (jl_svec_t*)cert_lists.items[i];
+                int slot = (int)(uintptr_t)cert_lists.items[i + 1];
+                jl_array_t *lst = (jl_array_t*)cert_lists.items[i + 2];
+                size_t stride = slot == 2 ? 2 : 1; // (mi, replaced_dispatch) pairs; callers
+                size_t n = jl_array_nrows(lst), ins = 0;
+                jl_value_t **d = jl_array_ptr_data(lst);
+                for (size_t k = 0; k + stride <= n; k += stride) {
+                    if (!jl_object_in_image(d[k]) && ptrhash_get(&serialization_order, d[k]) == HT_NOTFOUND)
+                        continue;
+                    for (size_t j = 0; j < stride; j++)
+                        d[ins + j] = d[k + j];
+                    ins += stride;
+                }
+                if (ins < n)
+                    jl_array_del_end(lst, n - ins);
+                if (ins == 0)
+                    continue; // the slot stays `nothing`
+                jl_svecset(cert, slot, (jl_value_t*)lst);
+                jl_queue_for_serialization(&s, (jl_value_t*)lst);
+            }
+            jl_serialize_reachable(&s);
+        }
+        arraylist_free(&cert_lists);
+        if (worklist && jl_backedge_log) {
+            // Prune the backedge registration log to callers that are being
+            // serialized anyway (still valid and reachable): the log must not
+            // root otherwise-dead or dropped CodeInstances into the image.
+            jl_array_t *belog = jl_backedge_log;
+            size_t bn = jl_array_nrows(belog), ins = 0;
+            jl_value_t **bd = jl_array_ptr_data(belog);
+            for (size_t i = 0; i + 2 < bn; i += 3) {
+                jl_code_instance_t *caller = (jl_code_instance_t*)bd[i + 2];
+                if (jl_atomic_load_relaxed(&caller->max_world) != ~(size_t)0)
+                    continue;
+                if (ptrhash_get(&serialization_order, caller) == HT_NOTFOUND)
+                    continue;
+                bd[ins] = bd[i];
+                bd[ins + 1] = bd[i + 1];
+                bd[ins + 2] = bd[i + 2];
+                ins += 3;
+            }
+            if (ins < bn)
+                jl_array_del_end(belog, bn - ins);
+            // Compact the serialized form: intern each referenced object once
+            // and store the triples as a varint index stream. The naive
+            // 3-pointers-per-entry form was ~22% of all image relocations.
+            {
+                htable_t uniq;
+                htable_new(&uniq, 1024);
+                jl_array_t *uobjs = jl_alloc_vec_any(0);
+                jl_array_t *idxbytes = NULL;
+                JL_GC_PUSH2(&uobjs, &idxbytes);
+                idxbytes = jl_alloc_array_1d(jl_array_uint8_type, 0);
+                size_t nlog = jl_array_nrows(belog);
+                size_t ntrip = nlog / 3;
+                // group triples by target (then invokesig) so the loader can
+                // lock and pre-size once per callee and decompose each
+                // method-table signature once per run; registration order is
+                // not semantically significant. Stream form: per group,
+                // varint(target) varint(count), then count x (varint invokesig,
+                // varint caller).
+                belog_trip_t *trips = (belog_trip_t*)malloc_s((ntrip ? ntrip : 1) * sizeof(belog_trip_t));
+                for (size_t i = 0; i < ntrip; i++) {
+                    jl_value_t *t = jl_array_ptr_ref(belog, 3 * i);
+                    trips[i].target = t;
+                    trips[i].invokesig = jl_array_ptr_ref(belog, 3 * i + 1);
+                    trips[i].cls = t == jl_nothing ? 1 : jl_is_method_instance(t) ? 0 : 2;
+                    trips[i].orig = (uint32_t)i;
+                }
+                qsort(trips, ntrip, sizeof(belog_trip_t), belog_trip_cmp);
+#define BELOG_UNIQ(o, out) do { \
+                    void **ubp_ = ptrhash_bp(&uniq, (void*)(o)); \
+                    if (*ubp_ == HT_NOTFOUND) { \
+                        (out) = jl_array_nrows(uobjs); \
+                        *ubp_ = (void*)((out) + 1); \
+                        jl_array_ptr_1d_push(uobjs, (o)); \
+                    } \
+                    else { \
+                        (out) = (size_t)(uintptr_t)*ubp_ - 1; \
+                    } \
+                } while (0)
+#define BELOG_EMIT(v) do { \
+                    size_t v_ = (v); \
+                    uint8_t vbuf_[10]; \
+                    int nb_ = 0; \
+                    do { \
+                        vbuf_[nb_] = v_ & 0x7f; \
+                        v_ >>= 7; \
+                        if (v_) \
+                            vbuf_[nb_] |= 0x80; \
+                        nb_++; \
+                    } while (v_); \
+                    size_t pos_ = jl_array_nrows(idxbytes); \
+                    jl_array_grow_end(idxbytes, nb_); \
+                    memcpy(jl_array_data(idxbytes, uint8_t) + pos_, vbuf_, nb_); \
+                } while (0)
+                for (size_t g = 0; g < ntrip; ) {
+                    size_t e = g + 1;
+                    while (e < ntrip && trips[e].target == trips[g].target)
+                        e++;
+                    size_t idx;
+                    BELOG_UNIQ(trips[g].target, idx);
+                    BELOG_EMIT(idx);
+                    BELOG_EMIT(e - g);
+                    for (size_t i = g; i < e; i++) {
+                        BELOG_UNIQ(trips[i].invokesig, idx);
+                        BELOG_EMIT(idx);
+                        jl_value_t *caller = jl_array_ptr_ref(belog, 3 * (size_t)trips[i].orig + 2);
+                        BELOG_UNIQ(caller, idx);
+                        BELOG_EMIT(idx);
+                    }
+                    g = e;
+                }
+#undef BELOG_EMIT
+#undef BELOG_UNIQ
+                free(trips);
+                htable_free(&uniq);
+                jl_array_t *compact = jl_alloc_vec_any(2);
+                jl_array_ptr_set(compact, 0, (jl_value_t*)uobjs);
+                jl_array_ptr_set(compact, 1, (jl_value_t*)idxbytes);
+                jl_backedge_log = compact; // rooted global; recording is done
+                belog = compact;
+                JL_GC_POP();
+            }
+            jl_queue_for_serialization(&s, (jl_value_t*)belog);
+            jl_serialize_reachable(&s);
+        }
         // Beyond this point, all content should already have been visited, so now we can prune
         // the rest and add some internal root arrays.
         // step 1.3: include some other special roots
@@ -3305,6 +4494,68 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
     { // step 2: build all the sysimg sections
         write_padding(&sysimg, sizeof(uintptr_t));
         jl_write_values(&s);
+        if (ici_fixups_init) {
+            // resolve self-referential InternedCodeInstance words now that the
+            // layout is final: offsets from the image data base, in units
+            for (size_t i = 0; i < ici_fixups.len; i += 3) {
+                jl_value_t *ici = (jl_value_t*)ici_fixups.items[i];
+                size_t wordidx = (size_t)ici_fixups.items[i + 1];
+                jl_value_t *target = (jl_value_t*)ici_fixups.items[i + 2];
+                uintptr_t ici_reloc = get_reloc_for_item(backref_id(&s, ici, NULL), 0);
+                uintptr_t tgt_reloc = get_reloc_for_item(backref_id(&s, target, NULL), 0);
+                assert((ici_reloc >> RELOC_TAG_OFFSET) == DataRef);
+                uintptr_t mask = (((uintptr_t)1 << RELOC_TAG_OFFSET) - 1);
+                uintptr_t word;
+                if ((ici_reloc >> RELOC_TAG_OFFSET) != DataRef)
+                    jl_safe_printf("ICI FIXUP: container reloc tag %d\n", (int)(ici_reloc >> RELOC_TAG_OFFSET));
+                if ((tgt_reloc >> RELOC_TAG_OFFSET) == DataRef) {
+                    word = ICI_TAG_REF | ((tgt_reloc & mask) / SYS_EXTERNAL_LINK_UNIT); // imagekey 0 == self
+                }
+                else if ((tgt_reloc >> RELOC_TAG_OFFSET) == ConstDataRef) {
+                    word = ICI_TAG_REF | ICI_TAG_CONST | (tgt_reloc & mask); // already in pointer units
+                }
+                else {
+                    void *ord = ptrhash_get(&serialization_order, target);
+                    void *canon = jl_is_svec(target) ? (void*)svec_dedup_canonical(&s, target) : (void*)target;
+                    void *ordc = ptrhash_get(&serialization_order, canon);
+                    jl_safe_printf("ICI FIXUP: tag %d type %s wordidx %zd ord=%p canon%s ordc=%p inimg=%d\n",
+                                   (int)(tgt_reloc >> RELOC_TAG_OFFSET),
+                                   jl_symbol_name(((jl_datatype_t*)jl_typeof(target))->name->name),
+                                   wordidx, ord, canon == (void*)target ? "=self" : "!=self", ordc,
+                                   jl_object_in_image(target));
+                    word = 0;
+                }
+                size_t wordpos = (ici_reloc & mask) +
+                    (wordidx == ICI_DEFWORD_IDX ? offsetof(jl_interned_code_instance_t, defword)
+                                                : sizeof(jl_interned_code_instance_t) + sizeof(uintptr_t) * wordidx);
+                if (wordpos + sizeof(word) > (size_t)s.s->size)
+                    jl_safe_printf("ICI FIXUP OOB: wordpos %zx size %zx wordidx %zd\n",
+                                   wordpos, (size_t)s.s->size, wordidx);
+                else
+                    memcpy(&s.s->buf[wordpos], &word, sizeof(word));
+            }
+            arraylist_free(&ici_fixups);
+            ici_fixups_init = 0;
+        }
+        if (svec_dedup_init) {
+            // freed only after the fixup pass: resolving fixup targets
+            // re-canonicalizes svecs and must see the same tables
+            htable_free(&svec_dedup_memo);
+            htable_free(&svec_dedup_byhash);
+            svec_dedup_init = 0;
+        }
+        if (svec_dedup_skip_init) {
+            htable_free(&svec_dedup_skip);
+            svec_dedup_skip_init = 0;
+        }
+        if (depsym_map_init) {
+            htable_free(&depsym_map);
+            depsym_map_init = 0;
+        }
+        if (edge_sig_set_init) {
+            htable_free(&edge_sig_set);
+            edge_sig_set_init = 0;
+        }
         external_fns_begin = write_gvars(&s, &gvars, &external_fns);
     }
 
@@ -3424,7 +4675,9 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             jl_write_value(&s, module_init_order);
             jl_write_value(&s, extext_methods);
             jl_write_value(&s, new_ext);
+            jl_write_value(&s, jl_backedge_log ? (jl_value_t*)jl_backedge_log : jl_nothing);
             jl_write_value(&s, s.method_roots_list);
+            jl_write_value(&s, sig_tn_root ? sig_tn_root : jl_nothing);
         }
         write_uint32(f, jl_array_len(s.link_ids_gctags));
         ios_write(f, (char*)jl_array_data(s.link_ids_gctags, uint32_t), jl_array_len(s.link_ids_gctags) * sizeof(uint32_t));
@@ -4048,12 +5301,13 @@ static int all_usings_unchanged_implicit(jl_module_t *mod)
 }
 
 static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
-                                                 jl_array_t *depmods, uint32_t checksum,
+                                                 jl_array_t *depmods, uint64_t checksum,
                                 /* outputs */    jl_array_t **restored JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **init_order JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **extext_methods JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **internal_methods JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **method_roots_list JL_REQUIRE_ROOTED_SLOT,
+                                                 jl_array_t **backedge_log JL_REQUIRE_ROOTED_SLOT,
                                                  pkgcachesizes *cachesizes) JL_CANSAFEPOINT JL_GC_DISABLED
 {
     jl_task_t *ct = jl_current_task;
@@ -4077,6 +5331,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     htable_t new_dt_objs;
     htable_new(&new_dt_objs, 0);
     arraylist_new(&deser_sym, 0);
+    jl_value_t *sig_tns_root = NULL;
 
     if (jl_options.use_sysimage_native_code != JL_OPTIONS_USE_SYSIMAGE_NATIVE_CODE_YES || IMAGE_NATIVE_CODE_TAINTED) {
         memset(&image->fptrs, 0, sizeof(image->fptrs));
@@ -4084,6 +5339,15 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         IMAGE_NATIVE_CODE_TAINTED = 1;
     }
 
+#ifdef ENABLE_TIMINGS
+    // Hand-rolled sub-region zone (no cleanup attribute: ends explicitly below)
+    static jl_timing_event_t *meta_timing_event = NULL;
+    if (!meta_timing_event)
+        meta_timing_event = jl_timing_event_create("LOAD_IMAGE", "LOAD_ImageMeta", __func__, __FILE__, __LINE__, 0);
+    jl_timing_block_t meta_timing_block = { 0 };
+    meta_timing_block.event = meta_timing_event;
+    jl_timing_block_start(&meta_timing_block);
+#endif
     // step 1: read section map
     assert(ios_pos(f) == 0 && f->bm == bm_mem);
     size_t sizeof_sysdata = read_uint(f);
@@ -4125,7 +5389,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     ios_seek(f, LLT_ALIGN(ios_pos(f), 8));
     assert(!ios_eof(f));
     s.s = f;
-    uintptr_t offset_restored = 0, offset_init_order = 0, offset_extext_methods = 0, offset_new_ext = 0, offset_method_roots_list = 0;
+    uintptr_t offset_restored = 0, offset_init_order = 0, offset_extext_methods = 0, offset_new_ext = 0, offset_backedge_log = 0, offset_method_roots_list = 0, offset_sig_tns = 0;
     if (!s.incremental) {
         size_t i;
         for (i = 0; tags[i] != NULL; i++) {
@@ -4161,9 +5425,13 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         offset_init_order = jl_read_offset(&s);
         offset_extext_methods = jl_read_offset(&s);
         offset_new_ext = jl_read_offset(&s);
+        offset_backedge_log = jl_read_offset(&s);
         offset_method_roots_list = jl_read_offset(&s);
+        offset_sig_tns = jl_read_offset(&s);
     }
     s.buildid_depmods_idxs = depmod_to_imageidx(depmods);
+    ici_register_image((uintptr_t)s.s->buf, (size_t)s.s->size, (uintptr_t)s.const_data->buf,
+                       s.incremental ? s.buildid_depmods_idxs : NULL, !s.incremental);
     size_t nlinks_gctags = read_uint32(f);
     if (nlinks_gctags > 0) {
         s.link_ids_gctags = jl_alloc_array_1d(jl_array_int32_type, nlinks_gctags);
@@ -4191,14 +5459,24 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         *init_order = (jl_array_t*)jl_delayed_reloc(&s, offset_init_order);
         *extext_methods = (jl_array_t*)jl_delayed_reloc(&s, offset_extext_methods);
         (void)(jl_array_t*)jl_delayed_reloc(&s, offset_new_ext);
+        jl_value_t *belog = jl_delayed_reloc(&s, offset_backedge_log);
+        if (backedge_log)
+            *backedge_log = belog == jl_nothing ? NULL : (jl_array_t*)belog;
         *method_roots_list = (jl_array_t*)jl_delayed_reloc(&s, offset_method_roots_list);
+        sig_tns_root = jl_delayed_reloc(&s, offset_sig_tns);
         *internal_methods = jl_alloc_vec_any(0);
     }
     s.s = NULL;
 
+#ifdef ENABLE_TIMINGS
+    jl_timing_block_end(&meta_timing_block);
+#endif
     // step 3: apply relocations
     assert(!ios_eof(f));
-    jl_read_symbols(&s);
+    {
+        JL_TIMING(LOAD_IMAGE, LOAD_Symbols);
+        jl_read_symbols(&s);
+    }
     ios_close(&symbols);
 
     char *image_base = (char*)&sysimg.buf[0];
@@ -4586,12 +5864,17 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     }
 
     s.s = &sysimg;
-    jl_update_all_fptrs(&s, image); // fptr relocs and registration
+    {
+        JL_TIMING(LOAD_IMAGE, LOAD_Fptrs);
+        jl_update_all_fptrs(&s, image); // fptr relocs and registration
+    }
     s.s = NULL;
 
     ios_close(&fptr_record);
     ios_close(&sysimg);
 
+    if (s.incremental && sig_tns_root != NULL && sig_tns_root != jl_nothing)
+        jl_register_sig_tns((jl_array_t*)sig_tns_root); // after uniquing: typenames are canonical
     if (!s.incremental)
         jl_gc_reset_alloc_count();
     arraylist_free(&deser_sym);
@@ -4697,9 +5980,9 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
     needs_permalloc = jl_options.permalloc_pkgimg || needs_permalloc;
 
     jl_value_t *restored = NULL;
-    jl_array_t *init_order = NULL, *extext_methods = NULL, *internal_methods = NULL, *method_roots_list = NULL;
+    jl_array_t *init_order = NULL, *extext_methods = NULL, *internal_methods = NULL, *method_roots_list = NULL, *backedge_log = NULL;
     jl_svec_t *cachesizes_sv = NULL;
-    JL_GC_PUSH6(&restored, &init_order, &extext_methods, &internal_methods, &method_roots_list, &cachesizes_sv);
+    JL_GC_PUSH7(&restored, &init_order, &extext_methods, &internal_methods, &method_roots_list, &cachesizes_sv, &backedge_log);
 
     { // make a permanent in-memory copy of f (excluding the header)
         ios_bufmode(f, bm_none);
@@ -4708,13 +5991,16 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
         char *sysimg;
         int success = !needs_permalloc;
         ios_seek(f, datastartpos);
-        if (needs_permalloc) {
-            sysimg = (char*)jl_gc_perm_alloc(len, 0, 64, 0);
-            jl_gc_notify_image_alloc(sysimg, len);
-        } else
-            sysimg = &f->buf[f->bpos];
-        if (needs_permalloc)
-            success = ios_readall(f, sysimg, len) == len;
+        {
+            JL_TIMING(LOAD_IMAGE, LOAD_ImageCopy);
+            if (needs_permalloc) {
+                sysimg = (char*)jl_gc_perm_alloc(len, 0, 64, 0);
+                jl_gc_notify_image_alloc(sysimg, len);
+            } else
+                sysimg = &f->buf[f->bpos];
+            if (needs_permalloc)
+                success = ios_readall(f, sysimg, len) == len;
+        }
         if (!success) {
             restored = jl_get_exceptionf(jl_errorexception_type, "Error reading package image file.");
             JL_SIGATOMIC_END();
@@ -4724,11 +6010,17 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
                 ios_close(f);
             ios_static_buffer(f, sysimg, len);
             pkgcachesizes cachesizes;
-            jl_restore_system_image_from_stream_(f, image, depmods, checksum, (jl_array_t**)&restored, &init_order, &extext_methods, &internal_methods, &method_roots_list, &cachesizes);
+            jl_restore_system_image_from_stream_(f, image, depmods, checksum, (jl_array_t**)&restored, &init_order, &extext_methods, &internal_methods, &method_roots_list, &backedge_log, &cachesizes);
             JL_SIGATOMIC_END();
 
+            // enable direct compressed-IR references to this image
+            ici_set_image_key((uintptr_t)sysimg, jl_worklist_key((jl_array_t*)restored));
             // Add roots to methods
-            int failed = jl_copy_roots(method_roots_list, jl_worklist_key((jl_array_t*)restored));
+            int failed;
+            {
+                JL_TIMING(LOAD_IMAGE, LOAD_CopyRoots);
+                failed = jl_copy_roots(method_roots_list, jl_worklist_key((jl_array_t*)restored));
+            }
             if (failed != 0) {
                 jl_printf(JL_STDERR, "Error copying roots to methods from Module: %s\n", pkgname);
                 abort();
@@ -4772,10 +6064,10 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
                 // `extext_methods` contains all worklist methods; `internal_methods`
                 // only partially overlaps it and exists only for per-object world-stamp
                 // updates during the fixup walk.
-                restored = (jl_value_t*)jl_svec(6, restored, init_order, internal_methods, extext_methods, method_roots_list, cachesizes_sv);
+                restored = (jl_value_t*)jl_svec(7, restored, init_order, internal_methods, extext_methods, method_roots_list, cachesizes_sv, backedge_log ? (jl_value_t*)backedge_log : jl_nothing);
             }
             else {
-                restored = (jl_value_t*)jl_svec(3, restored, init_order, internal_methods);
+                restored = (jl_value_t*)jl_svec(4, restored, init_order, internal_methods, backedge_log ? (jl_value_t*)backedge_log : jl_nothing);
             }
         }
     }
@@ -4796,8 +6088,8 @@ static void jl_restore_system_image_from_stream(ios_t *f, jl_image_t *image) JL_
         jl_throw(exc);
     ios_t f_payload;
     ios_static_buffer(&f_payload, f->buf + datastartpos, f->size - datastartpos);
-    jl_restore_system_image_from_stream_(&f_payload, image, NULL,
-                                         checksum, NULL, NULL, NULL, NULL, NULL, NULL);
+    jl_restore_system_image_from_stream_(&f_payload, image, NULL, checksum | ((uint64_t)0xfdfcfbfa << 32),
+                                         NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(jl_image_buf_t buf, jl_image_t *image, jl_array_t *depmods, int completeinfo, const char *pkgname, int needs_permalloc) JL_CANSAFEPOINT

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2958,7 +2958,7 @@ JL_DLLEXPORT jl_value_t *jl_image_ref_resolve(int is_sysimg, uint64_t key, uint6
         jl_atomic_store_release(&last, hit);
     }
     assert(offset < hit->data_size);
-    return (jl_value_t*)(hit->data_base + offset);
+    return (jl_value_t*)(hit->data_base + (uintptr_t)offset);
 }
 
 static jl_value_t *ici_decode_ref(jl_interned_code_instance_t *ici, uintptr_t w) JL_NOTSAFEPOINT

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2437,8 +2437,9 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
                 }
                 jl_atomic_store_relaxed(&newci->time_compile, 0.0);
                 jl_atomic_store_relaxed(&newci->invoke, NULL);
-                // preserve only JL_CI_FLAGS_NATIVE_CACHE_VALID bits
-                jl_atomic_store_relaxed(&newci->flags, jl_atomic_load_relaxed(&newci->flags) & JL_CI_FLAGS_NATIVE_CACHE_VALID);
+                // preserve only the NATIVE_CACHE_VALID and BACKEDGES_LOGGED bits
+                jl_atomic_store_relaxed(&newci->flags, jl_atomic_load_relaxed(&newci->flags) &
+                                        (JL_CI_FLAGS_NATIVE_CACHE_VALID | JL_CI_FLAGS_BACKEDGES_LOGGED));
                 jl_atomic_store_relaxed(&newci->specptr.fptr, NULL);
                 uintptr_t fptr_type = JL_INVOKE_SPECSIG;
                 int8_t builtin_id = 0;
@@ -4340,6 +4341,9 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
                     continue;
                 if (ptrhash_get(&serialization_order, caller) == HT_NOTFOUND)
                     continue;
+                // the loader skips store_backedges for flagged callers and
+                // registers everything else itself (see reinfer.jl)
+                jl_atomic_fetch_or_relaxed(&caller->flags, JL_CI_FLAGS_BACKEDGES_LOGGED);
                 bd[ins] = bd[i];
                 bd[ins + 1] = bd[i + 1];
                 bd[ins + 2] = bd[i + 2];

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -244,6 +244,46 @@ size_t jl_external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT
     return external_blob_index(v);
 }
 
+// Install the dependency-closure blob bitset (sysimage, each dependency image,
+// and the loading image itself, identified from the first image-owned anchor)
+// for the certificate-replay checks; used around pkgimage edge verification.
+static size_t *loading_closure_bits_owned = NULL;
+JL_DLLEXPORT void jl_set_loading_closure_from_depmods(jl_array_t *depmods, jl_array_t *anchors)
+{
+    size_t nblobs = n_linkage_blobs();
+    size_t nwords = (nblobs + 8 * sizeof(size_t) - 1) / (8 * sizeof(size_t));
+    size_t *bits = (size_t*)calloc_s(nwords ? nwords * sizeof(size_t) : sizeof(size_t));
+    bits[0] |= 1;
+    if (depmods) {
+        for (size_t i = 0, ld = jl_array_nrows(depmods); i < ld; i++) {
+            size_t idx = external_blob_index(jl_array_ptr_ref(depmods, i));
+            if (idx < nblobs)
+                bits[idx / (8 * sizeof(size_t))] |= (size_t)1 << (idx % (8 * sizeof(size_t)));
+        }
+    }
+    if (anchors) {
+        for (size_t i = 0, la = jl_array_nrows(anchors); i < la; i++) {
+            jl_value_t *a = jl_array_ptr_ref(anchors, i);
+            if (a && jl_object_in_image(a)) {
+                size_t idx = external_blob_index(a);
+                if (idx < nblobs)
+                    bits[idx / (8 * sizeof(size_t))] |= (size_t)1 << (idx % (8 * sizeof(size_t)));
+                break;
+            }
+        }
+    }
+    assert(loading_closure_bits_owned == NULL);
+    loading_closure_bits_owned = bits;
+    jl_set_loading_closure_blobs(bits, nblobs);
+}
+
+JL_DLLEXPORT void jl_clear_loading_closure(void)
+{
+    jl_set_loading_closure_blobs(NULL, 0);
+    free(loading_closure_bits_owned);
+    loading_closure_bits_owned = NULL;
+}
+
 JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t *obj) JL_NOTSAFEPOINT
 {
     if (obj == NULL)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -239,6 +239,11 @@ static size_t external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT
     return meta ? meta->idx : (size_t)-1;
 }
 
+size_t jl_external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    return external_blob_index(v);
+}
+
 JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t *obj) JL_NOTSAFEPOINT
 {
     if (obj == NULL)
@@ -2212,6 +2217,7 @@ static void jl_write_arraylist(ios_t *s, arraylist_t *list)
 
 static void jl_read_reloclist(jl_serializer_state *s, jl_array_t *link_ids, uint8_t bits) JL_CANSAFEPOINT
 {
+    JL_TIMING(LOAD_IMAGE, LOAD_Relocs);
     uintptr_t base = (uintptr_t)s->s->buf;
     uintptr_t last_pos = 0;
     uint8_t *current = (uint8_t *)(s->relocs->buf + s->relocs->bpos);
@@ -2425,6 +2431,7 @@ static uint32_t write_gvars(jl_serializer_state *s, arraylist_t *globals, arrayl
 // Pointer relocation for native-code referenced global variables
 static void jl_update_all_gvars(jl_serializer_state *s, jl_image_t *image, uint32_t external_fns_begin) JL_CANSAFEPOINT
 {
+    JL_TIMING(LOAD_IMAGE, LOAD_Gvars);
     if (image->gvars_base == NULL)
         return;
     uintptr_t base = (uintptr_t)s->s->buf;
@@ -4192,6 +4199,15 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     arraylist_new(&cleanup_list, 0);
     arraylist_t delay_list;
     arraylist_new(&delay_list, 0);
+#ifdef ENABLE_TIMINGS
+    // Hand-rolled sub-region zone (no cleanup attribute: ends explicitly below)
+    static jl_timing_event_t *uniquing_timing_event = NULL;
+    if (!uniquing_timing_event)
+        uniquing_timing_event = jl_timing_event_create("LOAD_IMAGE", "LOAD_Uniquing", __func__, __FILE__, __LINE__, 0);
+    jl_timing_block_t uniquing_timing_block = { 0 };
+    uniquing_timing_block.event = uniquing_timing_event;
+    jl_timing_block_start(&uniquing_timing_block);
+#endif
     JL_LOCK(&typecache_lock); // Might GC--prevent other threads from changing any type caches while we inspect them all
     for (size_t i = 0; i < s.uniquing_types.len; i++) {
         uintptr_t item = (uintptr_t)s.uniquing_types.items[i];
@@ -4404,6 +4420,15 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         o->bits.in_image = 1;
     }
     arraylist_free(&cleanup_list);
+#ifdef ENABLE_TIMINGS
+    jl_timing_block_end(&uniquing_timing_block);
+    static jl_timing_event_t *fixup_timing_event = NULL;
+    if (!fixup_timing_event)
+        fixup_timing_event = jl_timing_event_create("LOAD_IMAGE", "LOAD_Fixup", __func__, __FILE__, __LINE__, 0);
+    jl_timing_block_t fixup_timing_block = { 0 };
+    fixup_timing_block.event = fixup_timing_event;
+    jl_timing_block_start(&fixup_timing_block);
+#endif
     for (size_t i = 0; i < s.fixup_objs.len; i++) {
         uintptr_t item = (uintptr_t)s.fixup_objs.items[i];
         jl_value_t *obj = (jl_value_t*)(image_base + item);
@@ -4479,6 +4504,9 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     }
     arraylist_free(&s.fixup_types);
     arraylist_free(&s.fixup_objs);
+#ifdef ENABLE_TIMINGS
+    jl_timing_block_end(&fixup_timing_block);
+#endif
 
     if (s.incremental)
         jl_root_new_gvars(&s, image, external_fns_begin);
@@ -4682,7 +4710,7 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
             size_t world = jl_atomic_load_relaxed(&jl_world_counter);
             if (new_methods)
                 world += 1;
-            jl_activate_methods(extext_methods, internal_methods, world, pkgname);
+            jl_activate_methods(extext_methods, internal_methods, world, pkgname, depmods);
             // TODO: inject internal_methods into caches here, so the system can see them immediately as potential candidates (before validation)
             // allow users to start running in this updated world
             if (new_methods)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3035,7 +3035,7 @@ JL_DLLEXPORT void jl_ci_materialize_all(jl_code_instance_t *ci) JL_NOTSAFEPOINT
     if (edges == NULL || !jl_typetagis(edges, jl_interned_code_instance_type))
         return;
     jl_interned_code_instance_t *ici = (jl_interned_code_instance_t*)edges;
-    if (ici->defword != 0 && jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->def) == NULL)
+    if (ici->defword != 0 && (jl_value_t*)jl_load_set_once(&ci->def) == NULL)
         jl_ici_materialize_def(ci);
     uintptr_t mask = ici->fieldmask;
     if (mask == 0)
@@ -3080,7 +3080,7 @@ JL_DLLEXPORT jl_value_t *jl_ci_def(jl_code_instance_t *ci)
 // read-only variant for signal/dump contexts (no heap write)
 JL_DLLEXPORT jl_value_t *jl_ci_def_ro(jl_code_instance_t *ci) JL_NOTSAFEPOINT
 {
-    jl_value_t *def = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&ci->def);
+    jl_value_t *def = (jl_value_t*)jl_load_set_once(&ci->def);
     if (def != NULL)
         return def;
     jl_value_t *edges = (jl_value_t*)jl_atomic_load_relaxed(&ci->edges);
@@ -3103,7 +3103,7 @@ JL_DLLEXPORT jl_value_t *jl_ci_def_ro(jl_code_instance_t *ci) JL_NOTSAFEPOINT
 // interned container doubles as the not-yet-converted marker.
 JL_DLLEXPORT void jl_di_materialize_all(jl_debuginfo_t *di) JL_CANSAFEPOINT
 {
-    jl_value_t *edges = jl_atomic_load_acquire((_Atomic(jl_value_t*)*)&di->edges);
+    jl_value_t *edges = (jl_value_t*)jl_load_set_once_acquire(&di->edges);
     if (edges == NULL || !jl_typetagis(edges, jl_interned_code_instance_type))
         return; // converted (or never interned)
     jl_interned_code_instance_t *ici = (jl_interned_code_instance_t*)edges;
@@ -3124,7 +3124,7 @@ JL_DLLEXPORT void jl_di_materialize_all(jl_debuginfo_t *di) JL_CANSAFEPOINT
     ICI_MATD(JL_ICI_DI_LINETABLE, &di->linetable)
     ICI_MATD(JL_ICI_DI_CODELOCS, &di->codelocs)
 #undef ICI_MATD
-    jl_value_t *lt = jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)&di->linetable);
+    jl_value_t *lt = (jl_value_t*)jl_load_set_once(&di->linetable);
     if (lt != NULL && jl_is_debuginfo(lt))
         jl_di_materialize_all((jl_debuginfo_t*)lt);
     jl_svec_t *sv = jl_ici_to_svec(ici);

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -145,9 +145,9 @@ JL_DLLEXPORT void jl_finalize_precompile_inferred(int8_t cleanup_keep_ir)
         jl_code_instance_t *ci = (jl_code_instance_t*)jl_array_ptr_ref(newly_inferred, i);
         if (ci == NULL)
             continue;
-        if (ci->owner != jl_nothing)
+        if (jl_ci_owner(ci) != jl_nothing)
             continue; // foreign interpreters own their cached IR
-        jl_value_t *inferred = jl_atomic_load_relaxed(&ci->inferred);
+        jl_value_t *inferred = jl_ci_inferred(ci);
         if (inferred == NULL || !jl_is_code_info(inferred))
             continue;
         jl_method_instance_t *mi = jl_get_ci_mi(ci);
@@ -552,7 +552,7 @@ static jl_array_t *queue_used(jl_array_t *list, jl_query_cache *query_cache)
             int dispatch_status = jl_atomic_load_relaxed(&m->dispatch_status);
             if (!(dispatch_status & METHOD_SIG_LATEST_WHICH))
                 continue; // ignore replaced methods
-            if (jl_atomic_load_relaxed(&ci->inferred) && jl_is_method(m)) {
+            if (jl_ci_inferred(ci) && jl_is_method(m)) {
                 int found = jl_object_in_image((jl_value_t*)m->module) ? has_backedge_to_worklist(mi, &visited, &stack, query_cache) : 1;
                 assert(found == 0 || found == 1 || found == 2);
                 assert(stack.len == 0);
@@ -732,7 +732,7 @@ static const char *jl_git_commit(void) JL_CANSAFEPOINT
 
 
 // "magic" string and version header of .ji file
-static const int JI_FORMAT_VERSION = 16; // extext_methods carries (method, activation cert) pairs
+static const int JI_FORMAT_VERSION = 27; // did_scan_source 0x2 masked at save (scanned_methods lists are session state)
 static const char JI_MAGIC[] = "\373jli\r\n\032\n"; // based on PNG signature
 static const uint16_t BOM = 0xFEFF; // byte-order marker
 

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -918,8 +918,32 @@ static void jl_add_methods(jl_array_t *external) JL_CANSAFEPOINT
 }
 
 extern _Atomic(int) allow_new_worlds;
-static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size_t world, const char *pkgname) JL_CANSAFEPOINT
+static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size_t world, const char *pkgname, jl_array_t *depmods) JL_CANSAFEPOINT
 {
+    JL_TIMING(LOAD_IMAGE, LOAD_ActivateMethods);
+    // Install the dependency-closure blob bitset for contributor-cleanliness
+    // classification: sysimage (blob 0), every dependency image, and this
+    // image itself (its methods' blob).
+    size_t nblobs = n_linkage_blobs();
+    size_t nwords = (nblobs + 8 * sizeof(size_t) - 1) / (8 * sizeof(size_t));
+    size_t *closure_bits = (size_t*)calloc_s(nwords ? nwords * sizeof(size_t) : sizeof(size_t));
+    closure_bits[0] |= 1; // the sysimage
+    if (depmods) {
+        for (size_t i = 0, ld = jl_array_nrows(depmods); i < ld; i++) {
+            size_t idx = external_blob_index(jl_array_ptr_ref(depmods, i));
+            if (idx < nblobs)
+                closure_bits[idx / (8 * sizeof(size_t))] |= (size_t)1 << (idx % (8 * sizeof(size_t)));
+        }
+    }
+    for (size_t i = 0, le = jl_array_nrows(external); i < le; i++) {
+        jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_array_ptr_ref(external, i);
+        size_t idx = external_blob_index((jl_value_t*)entry->func.method);
+        if (idx < nblobs)
+            closure_bits[idx / (8 * sizeof(size_t))] |= (size_t)1 << (idx % (8 * sizeof(size_t)));
+    }
+    jl_set_loading_closure_blobs(closure_bits, nblobs);
+    if (pkgname)
+        jl_timing_puts(JL_TIMING_DEFAULT_BLOCK, pkgname);
     size_t i, l = jl_array_nrows(internal);
     for (i = 0; i < l; i++) {
         // allow_new_worlds doesn't matter here, since we aren't actually changing anything external
@@ -951,6 +975,8 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
     if (l) {
         if (!jl_atomic_load_relaxed(&allow_new_worlds)) {
             jl_printf(JL_STDERR, "WARNING: Method changes for %s have been disabled via a call to disable_new_worlds.\n", pkgname);
+            jl_set_loading_closure_blobs(NULL, 0);
+            free(closure_bits);
             return;
         }
         for (i = 0; i < l; i++) {
@@ -962,6 +988,8 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
             //jl_printf(JL_STDERR, "\n");
         }
     }
+    jl_set_loading_closure_blobs(NULL, 0);
+    free(closure_bits);
 }
 
 static int jl_copy_roots(jl_array_t *method_roots_list, uint64_t key) JL_CANSAFEPOINT

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -587,8 +587,22 @@ static int jl_collect_methcache_from_mod(jl_typemap_entry_t *ml, void *closure) 
 {
     jl_array_t *s = (jl_array_t*)closure;
     jl_method_t *m = ml->func.method;
-    if (!jl_object_in_image((jl_value_t*)m->module))
-        jl_array_ptr_1d_push(s, (jl_value_t*)m); // extext
+    if (!jl_object_in_image((jl_value_t*)m->module)) {
+        if (s) {
+            jl_array_ptr_1d_push(s, (jl_value_t*)m); // extext
+            jl_value_t *cert = jl_get_activation_cert(m);
+            if (cert != jl_nothing) {
+                // refresh the dispatch bits to the worker-final state: later
+                // activations may have cleared LATEST_ONLY after this method's
+                // own activation recorded its bits, and replay order does not
+                // preserve activation order
+                jl_value_t *bits = jl_box_int32(jl_atomic_load_relaxed(&m->dispatch_status) &
+                                                (METHOD_SIG_LATEST_WHICH | METHOD_SIG_LATEST_ONLY));
+                jl_svecset((jl_svec_t*)cert, 3, bits);
+            }
+            jl_array_ptr_1d_push(s, cert); // paired activation certificate
+        }
+    }
     return 1;
 }
 
@@ -718,7 +732,7 @@ static const char *jl_git_commit(void) JL_CANSAFEPOINT
 
 
 // "magic" string and version header of .ji file
-static const int JI_FORMAT_VERSION = 15;
+static const int JI_FORMAT_VERSION = 16; // extext_methods carries (method, activation cert) pairs
 static const char JI_MAGIC[] = "\373jli\r\n\032\n"; // based on PNG signature
 static const uint16_t BOM = 0xFEFF; // byte-order marker
 
@@ -906,7 +920,7 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
 static void jl_add_methods(jl_array_t *external) JL_CANSAFEPOINT
 {
     size_t i, l = jl_array_nrows(external);
-    for (i = 0; i < l; i++) {
+    for (i = 0; i < l; i += 2) { // (method, activation certificate) pairs
         jl_method_t *meth = (jl_method_t*)jl_array_ptr_ref(external, i);
         assert(jl_is_method(meth));
         assert(!meth->is_for_opaque_closure);
@@ -935,7 +949,7 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
                 closure_bits[idx / (8 * sizeof(size_t))] |= (size_t)1 << (idx % (8 * sizeof(size_t)));
         }
     }
-    for (size_t i = 0, le = jl_array_nrows(external); i < le; i++) {
+    for (size_t i = 0, le = jl_array_nrows(external); i < le; i += 2) {
         jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_array_ptr_ref(external, i);
         size_t idx = external_blob_index((jl_value_t*)entry->func.method);
         if (idx < nblobs)
@@ -979,10 +993,11 @@ static void jl_activate_methods(jl_array_t *external, jl_array_t *internal, size
             free(closure_bits);
             return;
         }
-        for (i = 0; i < l; i++) {
+        for (i = 0; i < l; i += 2) {
             jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_array_ptr_ref(external, i);
+            jl_value_t *cert = jl_array_ptr_ref(external, i + 1);
             //uint64_t t0 = uv_hrtime();
-            jl_method_table_activate(entry);
+            jl_method_table_activate_with_cert(entry, cert == jl_nothing ? NULL : (jl_svec_t*)cert);
             //jl_printf(JL_STDERR, "%f ", (double)(uv_hrtime() - t0) / 1e6);
             //jl_static_show(JL_STDERR, entry->func.value);
             //jl_printf(JL_STDERR, "\n");

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -611,8 +611,10 @@ static int jl_collect_methcache_from_mod(jl_typemap_entry_t *ml, void *closure) 
 static int jl_collect_methcache_internal(jl_typemap_entry_t *ml, void *closure) JL_CANSAFEPOINT
 {
     jl_array_t *s = (jl_array_t*)closure;
-    if (jl_atomic_load_relaxed(&ml->max_world) == ~(size_t)0)
+    if (jl_atomic_load_relaxed(&ml->max_world) == ~(size_t)0) {
         jl_array_ptr_1d_push(s, (jl_value_t*)ml->func.method); // extext
+        jl_array_ptr_1d_push(s, jl_nothing); // no activation certificate: keep the (method, cert) pairing
+    }
     return 1;
 }
 

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1748,6 +1748,30 @@ static jl_value_t *subtype_unionall_envout_value(jl_value_t *t, jl_unionall_t *u
     return wrap_tvar_env(*new_tvar, constrained);
 }
 
+// A type is an "atom" if it has no proper nonempty subtypes: any X <: A is
+// equal either to A or to Union{}. Values of a concrete non-kind datatype A
+// satisfy typeof(v) == A exactly. Kinds are excluded (Type{X} <: DataType is
+// proper and nonempty); TypeEq nodes are not datatypes. A concrete Tuple
+// additionally requires atom parameters: e.g. Tuple{DataType} has the proper
+// nonempty subtype Tuple{Type{Int}}. Used by the loader's foreign-method
+// disjointness check: an atom slot is disjoint from a method slot as soon as
+// it is not a subtype of it.
+JL_DLLEXPORT int jl_is_atom_type(jl_value_t *a) JL_NOTSAFEPOINT
+{
+    if (!jl_is_datatype(a))
+        return 0;
+    jl_datatype_t *d = (jl_datatype_t*)a;
+    if (!d->isconcretetype || jl_is_kind(a))
+        return 0;
+    if (d->name == jl_tuple_typename) {
+        for (size_t i = 0; i < jl_nparams(d); i++) {
+            if (!jl_is_atom_type(jl_tparam(d, i)))
+                return 0;
+        }
+    }
+    return 1;
+}
+
 static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8_t R, jl_param_pos_t param) JL_CANSAFEPOINT
 {
     u = unalias_unionall(u, e);

--- a/src/timing.c
+++ b/src/timing.c
@@ -71,6 +71,10 @@ static int cmp_counts_events(const void *a, const void *b) {
 void jl_print_timings(void)
 {
 #ifdef USE_TIMING_COUNTS
+    // opt-in: the exit dump breaks tests that assert on subprocess stderr
+    char *e = getenv("JULIA_TIMINGS");
+    if (e == NULL || strcmp(e, "1") != 0)
+        return;
     qsort(jl_timing_counts_events.items, jl_timing_counts_events.len,
           sizeof(jl_timing_counts_event_t *), cmp_counts_events);
 

--- a/src/timing.h
+++ b/src/timing.h
@@ -196,6 +196,8 @@ JL_DLLEXPORT void jl_timing_puts(jl_timing_block_t *cur_block, const char *str);
         X(DL_OPEN)               \
         X(JULIA_INIT)            \
         X(CORE_COMPILER)        \
+        X(SUBTYPE)               \
+        X(INTERSECT)             \
 
 
 #define JL_TIMING_COUNTERS \

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -123,8 +123,11 @@ static int sig_match_by_type_leaf(jl_value_t **types, jl_tupletype_t *sig, size_
     for (i = 0; i < n; i++) {
         jl_value_t *decl = jl_tparam(sig, i);
         jl_value_t *a = types[i];
-        if (jl_is_some_Type(a)) // decl is not Type, because it wouldn't be leafsig
+        if (jl_is_some_Type(a)) { // decl is not Type, because it would not be leafsig
+            if (jl_is_typeeq(a) && jl_is_bottom_singleton_class(jl_typeeq_T(a)))
+                return 0; // spans two kinds, so it matches no concrete kind decl
             a = jl_typeof(jl_some_Type_T(a));
+        }
         if (!jl_types_equal(a, decl))
             return 0;
     }
@@ -186,6 +189,8 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
         else {
             assert(jl_is_concrete_type(decl));
             if (jl_is_some_Type(a)) { // decl is not TypeEq/TypeEgal or AnyType, because it would be caught above, so it must be concrete
+                if (jl_is_typeeq(a) && jl_is_bottom_singleton_class(jl_typeeq_T(a)))
+                    return 0; // spans two kinds, so it matches no concrete kind decl
                 a = jl_typeof(jl_some_Type_T(a));
             }
             if (!jl_types_equal(a, decl))

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -621,6 +621,8 @@ static int jl_typemap_intersection_node_visitor(jl_typemap_entry_t *ml, struct t
             continue;
         if (closure->min_valid > jl_atomic_load_relaxed(&ml->max_world))
             continue;
+        if (closure->entry_filter && !closure->entry_filter(ml, closure))
+            continue;
         int nonempty;
         if (closure->emptiness_only) {
             // The callback consumes only the match verdict and `issubty`; skip

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -850,4 +850,15 @@ end
     a, b = deserialize(buf)
     @test a === b && Base._nslots(a) == 4
     GC.gc(true)
+# Type{Union{}} is a TypeEq node that used to dispatch (incorrectly) to the
+# DataType serialize method and crash on its layout
+@testset "Type{Union{}} round trip" begin
+    # n.b. Vector{Type{Union{}}} still crashes in array element layout, a
+    # separate pre-existing bug in the TypeofBottom layout aliasing
+    for t in (Type{Union{}}, Ref{Tuple{Type{Union{}}, Int}})
+        b = IOBuffer()
+        serialize(b, t)
+        seekstart(b)
+        @test deserialize(b) == t
+    end
 end

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -850,6 +850,8 @@ end
     a, b = deserialize(buf)
     @test a === b && Base._nslots(a) == 4
     GC.gc(true)
+end
+
 # Type{Union{}} is a TypeEq node that used to dispatch (incorrectly) to the
 # DataType serialize method and crash on its layout
 @testset "Type{Union{}} round trip" begin

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2206,6 +2206,171 @@ precompile_test_harness("Issue #48391") do load_path
     @test_throws ErrorException isless(x, x)
 end
 
+# Replay of the precompile worker's method-activation and edge-validity results
+# (JULIA_ACTIVATE_REPLAY): every scenario below loads in a fresh process so each
+# load order starts from the images alone.
+let exename = `$(Base.julia_cmd()) --startup-file=no`
+    global function replay_test_output(load_path, depot, body)
+        code = """
+            insert!(LOAD_PATH, 1, $(repr(load_path)))
+            insert!(DEPOT_PATH, 1, $(repr(depot)))
+            $body
+            """
+        return readchomp(`$exename -e $code`)
+    end
+end
+
+precompile_test_harness("replay: activation order") do load_path
+    write(joinpath(load_path, "ReplayDep.jl"),
+        """
+        module ReplayDep
+        f(x) = :dep
+        end
+        """)
+    # two extenders of ReplayDep.f, each precompiled without knowledge of the other;
+    # their callers are inferred against their own method only
+    write(joinpath(load_path, "ReplayExtA.jl"),
+        """
+        module ReplayExtA
+        using ReplayDep
+        ReplayDep.f(::Integer) = :a
+        callf() = ReplayDep.f(1)
+        precompile(callf, ())
+        end
+        """)
+    write(joinpath(load_path, "ReplayExtB.jl"),
+        """
+        module ReplayExtB
+        using ReplayDep
+        ReplayDep.f(::Signed) = :b
+        callf() = ReplayDep.f(1)
+        precompile(callf, ())
+        end
+        """)
+    Base.compilecache(Base.PkgId("ReplayDep"))
+    Base.compilecache(Base.PkgId("ReplayExtA"))
+    Base.compilecache(Base.PkgId("ReplayExtB"))
+    depot = DEPOT_PATH[1]
+    # whichever loads second, the more specific method wins everywhere: A's caller
+    # is invalidated by B's activation, or verified against B's method at A's load
+    for order in (("ReplayExtA", "ReplayExtB"), ("ReplayExtB", "ReplayExtA"))
+        out = replay_test_output(load_path, depot, """
+            using ReplayDep, $(order[1]), $(order[2])
+            print(Base.invokelatest(ReplayExtA.callf), " ", Base.invokelatest(ReplayExtB.callf), " ",
+                  Base.invokelatest(ReplayDep.f, 1))
+            """)
+        @test out == "b b b"
+    end
+    # a method defined in the session before loading is foreign to the image's
+    # dependency closure and must be scanned live
+    out = replay_test_output(load_path, depot, """
+        using ReplayDep
+        ReplayDep.f(::Int) = :session
+        using ReplayExtA
+        print(Base.invokelatest(ReplayExtA.callf), " ", Base.invokelatest(ReplayDep.f, 1))
+        """)
+    @test out == "session session"
+    # a deletion in the session leaves no method behind but marks the function's
+    # history, so the image's records for it cannot be replayed
+    out = replay_test_output(load_path, depot, """
+        using ReplayDep
+        ReplayDep.f(::Int) = :session
+        Base.delete_method(which(ReplayDep.f, (Int,)))
+        using ReplayExtA
+        print(Base.invokelatest(ReplayExtA.callf), " ", Base.invokelatest(ReplayDep.f, 1))
+        """)
+    @test out == "a a"
+end
+
+precompile_test_harness("replay: extension activation") do load_path
+    host_uuid = "0f0f2a5c-6c6d-4b1e-9d2a-2e7d5b7a1c01"
+    trig_uuid = "9b4b1d2e-7a3f-4c0e-8f6b-5a2c1d3e4f02"
+    mkpath(joinpath(load_path, "ReplayHost", "src")); mkpath(joinpath(load_path, "ReplayHost", "ext"))
+    mkpath(joinpath(load_path, "ReplayTrig", "src"))
+    write(joinpath(load_path, "Project.toml"),
+        """
+        [deps]
+        ReplayHost = "$host_uuid"
+        ReplayTrig = "$trig_uuid"
+        """)
+    write(joinpath(load_path, "Manifest.toml"),
+        """
+        julia_version = "$(VERSION)"
+        manifest_format = "2.0"
+
+        [[deps.ReplayHost]]
+        path = "ReplayHost"
+        uuid = "$host_uuid"
+        version = "0.1.0"
+        weakdeps = ["ReplayTrig"]
+
+            [deps.ReplayHost.extensions]
+            ReplayHostExt = "ReplayTrig"
+
+        [[deps.ReplayTrig]]
+        path = "ReplayTrig"
+        uuid = "$trig_uuid"
+        version = "0.1.0"
+        """)
+    write(joinpath(load_path, "ReplayHost", "Project.toml"),
+        """
+        name = "ReplayHost"
+        uuid = "$host_uuid"
+        version = "0.1.0"
+
+        [weakdeps]
+        ReplayTrig = "$trig_uuid"
+
+        [extensions]
+        ReplayHostExt = "ReplayTrig"
+        """)
+    write(joinpath(load_path, "ReplayHost", "src", "ReplayHost.jl"),
+        """
+        module ReplayHost
+        h(x) = :host
+        callh() = h(1)
+        precompile(callh, ())
+        end
+        """)
+    write(joinpath(load_path, "ReplayHost", "ext", "ReplayHostExt.jl"),
+        """
+        module ReplayHostExt
+        using ReplayHost, ReplayTrig
+        ReplayHost.h(::Int) = :ext
+        end
+        """)
+    write(joinpath(load_path, "ReplayTrig", "Project.toml"),
+        """
+        name = "ReplayTrig"
+        uuid = "$trig_uuid"
+        version = "0.1.0"
+        """)
+    write(joinpath(load_path, "ReplayTrig", "src", "ReplayTrig.jl"),
+        """
+        module ReplayTrig
+        end
+        """)
+    Base.compilecache(Base.PkgId(Base.UUID(host_uuid), "ReplayHost"))
+    Base.compilecache(Base.PkgId(Base.UUID(trig_uuid), "ReplayTrig"))
+    depot = DEPOT_PATH[1]
+    # the extension's worker sees the host's caller and records its invalidation;
+    # loading the trigger after the host must apply it
+    out = replay_test_output(load_path, depot, """
+        using ReplayHost
+        before = Base.invokelatest(ReplayHost.callh)
+        using ReplayTrig
+        print(before, " ", Base.invokelatest(ReplayHost.callh))
+        """)
+    @test out == "host ext"
+    # the other order: the extension activates as soon as the host arrives
+    out = replay_test_output(load_path, depot, """
+        using ReplayTrig
+        using ReplayHost
+        print(Base.invokelatest(ReplayHost.callh))
+        """)
+    @test out == "ext"
+end
+
 precompile_test_harness("Generator nospecialize") do load_path
     write(joinpath(load_path, "GenNoSpec.jl"),
         """

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2310,6 +2310,26 @@ precompile_test_harness("replay: worklist-owned method tables") do load_path
     @test out == "1 1 1"
 end
 
+precompile_test_harness("replay: bare TypeEq slot") do load_path
+    # `TypeEq`, the kind of every `Type{X}`, is the only DataType carrying the
+    # `Type` typename and it has no parameters; activating a method with that
+    # slot type must not index into them (the Compiler-as-a-package load did)
+    write(joinpath(load_path, "ReplayTypeEq.jl"),
+        """
+        module ReplayTypeEq
+        f(@nospecialize x) = 1
+        f(::Core.TypeEq) = 2
+        g() = f(Type{Int}) + f(1)
+        end
+        """)
+    Base.compilecache(Base.PkgId("ReplayTypeEq"))
+    out = replay_test_output(load_path, DEPOT_PATH[1], """
+        using ReplayTypeEq
+        print(ReplayTypeEq.g(), " ", ReplayTypeEq.f(Type{Vector}))
+        """)
+    @test out == "3 2"
+end
+
 precompile_test_harness("replay: extension activation") do load_path
     host_uuid = "0f0f2a5c-6c6d-4b1e-9d2a-2e7d5b7a1c01"
     trig_uuid = "9b4b1d2e-7a3f-4c0e-8f6b-5a2c1d3e4f02"

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2054,7 +2054,10 @@ precompile_test_harness("PkgCacheInspector") do load_path
     end
     @test any(internal_methods) do ci
         ci isa Core.CodeInstance || return false
-        mi = ci.def::Core.MethodInstance
+        # image CodeInstances carry `def` in the interned edge container;
+        # the raw field is not readable until rematerialized
+        mi = Base.ci_def(ci)
+        mi isa Core.MethodInstance || return false
         return mi.specTypes == Tuple{typeof(Base.repl_cmd), Int, String}
     end
 end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2282,6 +2282,34 @@ precompile_test_harness("replay: activation order") do load_path
     @test out == "a a"
 end
 
+precompile_test_harness("replay: worklist-owned method tables") do load_path
+    # methods of a method table the package itself defines carry no activation
+    # certificate; they must not break the (method, certificate) pairing of the
+    # image's method list (Revise's "External method tables" test found this)
+    write(joinpath(load_path, "ReplayOverlay.jl"),
+        """
+        module ReplayOverlay
+        Base.Experimental.@MethodTable(method_table)
+        Base.Experimental.@MethodTable(method_table_2)
+        foo() = 1
+        Base.Experimental.@overlay method_table print(x) = "print"
+        Base.Experimental.@overlay method_table show(x) = "show"
+        Base.Experimental.@overlay method_table cos(x) = "cos"
+        Base.Experimental.@overlay method_table_2 foo() = 2
+        bar() = foo()
+        baz() = bar()
+        end
+        """)
+    Base.compilecache(Base.PkgId("ReplayOverlay"))
+    out = replay_test_output(load_path, DEPOT_PATH[1], """
+        using ReplayOverlay
+        nm(sig, mt) = length(Base._methods_by_ftype(sig, mt, -1, Base.get_world_counter()))
+        print(Base.invokelatest(ReplayOverlay.baz), " ", nm(Tuple{typeof(cos), Any}, ReplayOverlay.method_table),
+              " ", nm(Tuple{typeof(ReplayOverlay.foo)}, ReplayOverlay.method_table_2))
+        """)
+    @test out == "1 1 1"
+end
+
 precompile_test_harness("replay: extension activation") do load_path
     host_uuid = "0f0f2a5c-6c6d-4b1e-9d2a-2e7d5b7a1c01"
     trig_uuid = "9b4b1d2e-7a3f-4c0e-8f6b-5a2c1d3e4f02"


### PR DESCRIPTION
This is #62254 (@keno's "make package loading faster") rebased onto current master, built, tested, benchmarked and cleaned up. Since that PR was opened, Claude Fable 5.1 and OpenAI gpt-6-astra have been released, so I pointed them at this, with a fair bit of hand holding. 

![image](https://github.com/user-attachments/assets/1a649d8d-23c3-487a-b72a-cfa2cc8ee06f)

Claude:

---

What the original PR's commits do, and what happened to each here:

- **Contributor tracking** (`gf.c`, kept): every method insertion records its source image under the top-typename decomposition the backedge table uses, so a loader can tell whether a signature's method-match set could have changed since the precompile worker saw it.
- **Activation certificates** (kept, now on by default): the worker records per new method the intersecting methods, their specificity flags, the specializations whose dispatch it invalidated and the dispatch bits; a closure-clean activation replays that record and scans only foreign methods. Keno had this behind `JULIA_ACTIVATE_REPLAY=1`; two new commits turn it on (`JULIA_ACTIVATE_REPLAY=0` opts out) and close the coverage gap below.
- **Edge-validity replay** (Compiler, kept, same switch): call edges whose signature has only closure-owned contributors skip live `verify_call` during revalidation.
- **Relocation-lean image format** (kept): `CodeInstance` edge lists and most fields become interned `(image, offset)` words decoded lazily on first access, backedges are re-registered from one compact log instead of per `CodeInstance`, compressed IR references image roots directly, symbols are shared across images. Keno's DebugInfo dropping for code without IR or native code is removed here: a `CodeInstance` whose code is shared can still execute, and an undefined `debuginfo` field broke every stack trace through it (Revise's and JuliaC's tests caught it). Its C pre-verification pass is removed here: it skipped `CodeInstance` targets inside counted match groups and invoke pairs, and measured within noise.
- **Bottom-singleton guard** (kept): `Type{typeof(Union{})}` spans more than one kind, so the kind-based fast paths in leaf-signature matching and compileable-signature normalization exclude it.
- **Timing zones and profiling notes** (kept): zones for the previously uninstrumented parts of loading, the counts report behind `JULIA_TIMINGS=1`, and a devdocs skill on measuring load time.
- **Subtype series** (five commits, split out): exhaustive enumeration of `∀` variables bounded by unions of atoms, `∃` witness caching, mixed atom/abstract bounds, closed-pair shortcuts, gate ordering. On master's own caches the enumeration commits alone add about 80 ms to `using CairoMakie` and 25 ms to the first plot, and they carry their own proof obligations; only the atom classifier stays, for the disjointness check.
- **Epsilon** (split out): strict lower bounds for constructor `Type` vars so `Type{Union{}}` never matches a constructor; a type-system change with a `TypeVar` layout change.

The full stack is kept on `ib/loading-62254-with-subtype`.

## Fixed on top of the original branch

- Bulk backedge registration predated #62733's two-level table and segfaulted every stdlib precompile worker.
- Backedges were registered after promotion, so a method defined in between missed the callers; the loader now verifies every root, registers the callers verified at the current world, then promotes, and a verified `CodeInstance` the log does not cover registers its backedges the ordinary way.
- Lazy materialization is thread-safe: interned fields are set once by compare-and-swap, DebugInfo conversion publishes `edges` last, the image registry is chunked with an atomic count and stable dependency bases.
- Activation certificates rooted worker-invalidated `MethodInstance`s and callers into the image; their record lists are kept out of SimpleVector deduplication and pruned against the reachable set after every root has been queued.
- Replayed call edges took the require world as their minimum where the live verifier uses the matching methods' activation worlds; they now take the latest activation world of their recorded targets (the "Issue #48391" test caught this once replay was on).
- Master-added raw reads of interned `CodeInstance` fields now materialize first; `edge_debuginfo` treated a `DebugInfoStream`'s `Vector` edges as interned words.
- Found by CI: the slot bucketing took any DataType named `Type` for `Type{X}` and read its first parameter, but on master that is only the parameterless `TypeEq` kind, so activating the Compiler package image's `_typename(::TypeEq)` read past an empty vector (a NULL read on i686, an assertion on the assert build, a wrong bucket key on 64-bit release); the loader entry point's untyped backedge-log argument kept the sysimage build from precompiling it, so REPL startup compiled it; the replay tables were GC roots but not heap-snapshot roots.
- Smaller: the foreign-method disjointness shortcut requires an atom; an unrooted `foreign_oldvalue`; two chain walks reading `owner` before materializing; a `uint32_t` checksum parameter and a misplaced Serialization testset from the rebase; every new function that allocates or locks carries `JL_CANSAFEPOINT`.

Removed: the `JULIA_SC_ORACLE` and `JULIA_LOAD_SCAN=0` gates (both unsound), the replay verification mode and its prints, `JULIA_ICI_DEBUG`, `JULIA_RELOC_STATS`, `JULIA_FDISJ_DUMP`, `jl_contrib_stats` and its timers, the GC bad-tag diagnostic, and the `JULIA_FDISJ_FAST`, `JULIA_FDISJ_V2`, `JULIA_SC_FUSE` and `JULIA_EDGE_FDISJ_CAP` evaluation switches. The native-image identity check is back to master's CRC. The interned encoding and the dependency symbol map are skipped on 32-bit targets.

## Benchmarks

The goal is to land without regressing precompile or first-run time, even at the cost of load time. The pipeline's TTFX job ([build 2143](https://buildkite.com/julialang/julia-pr/builds/2143#01a077f3-59d3-42f1-a1ad-0d4aa7badc82): macOS aarch64, 37 tasks, two ABBA blocks against the master build of the merge-base), geomean head/base per block:

| suite | per block | verdict at the job's threshold |
|---|---|---|
| precompile | 0.974, 0.977 | improvement (±2%) |
| load (cold) | 0.681, 0.687 | improvement (±2%) |
| run (cold) | 1.045, 1.051 | regression (±3%) |
| load+run (warm) | 0.687, 0.690 | improvement (±3%) |

Per task the cold-run shift is 5 to 40 ms (Flux +70 ms on a 7.1 s run); the geomean is carried by runs of 10 to 70 ms, and tasks whose run takes over half a second come out at +1.2 percent, while load plus run improves on every task. It is a GC shift, not compilation: the branch allocates less while loading and runs fewer collections during `using`, so the full sweep master does at the end of loading lands in the branch's first run instead. Fresh-session probes of the run snippet alone on the master and branch builds (ten each, interleaved) put the whole difference there: ExplicitImports 105 to 115 ms with GC 18 to 27 ms, Manifolds 73 to 74 ms with GC 9 to 11 ms; StaticArrays, which never collects, moves 8.8 to 9.1 ms. Forcing the collection at the end of loading would move it back at the cost of load time.

`using CairoMakie` then a first `scatter` save, fresh process per sample, 20 samples per arm in palindrome blocks on an idle M-series laptop, against a local build of the base commit a5e6c9942d:

| arm | load min | load median | first plot median |
|---|---|---|---|
| master | 2.572 s | 2.597 s | 0.222 s |
| this branch (replay on by default) | 1.726 s | 1.747 s | 0.263 s |
| this branch, `JULIA_ACTIVATE_REPLAY=0` | 2.450 s | 2.478 s | 0.255 s |

Precompiling the 297 dependencies fresh, two rounds each, mirrored order: master 121 and 121 s, replay on 119 and 121 s, replay off 121 and 119 s, so the worker's recording and its faster dependency loading are both in the noise. Compiled caches shrink from 1.4 GB to 750 MB.

The same tasks across releases (local sweep, fastest of three runs per task):

![TTFX sweep, 39 tasks: precompile, package load and script execution for 1.10 to 1.13, nightly and this branch](https://raw.githubusercontent.com/IanButterworth/julia/assets/pr62254/ttfx-2026-09-06-pr62254.png)

## Notes

Found and fixed on the split-out branch: the Epsilon commit's flags store landed on `vb.lb`, an arbitrary pinned type, zeroing the next pool cell's type tag (the sysimage build hit it deterministically); and the exhaustive enumeration changed the environment reported by `jl_type_intersection_with_env`, which `@isdefined(E)` inference relies on.

A new `precompile` testset covers the replay scenarios in fresh processes: two packages extending a dependency loaded in either order, a method defined (and one deleted) in the session before loading, and an extension invalidating a caller precompiled in its host, in both orders.



