### PR TITLE
llvm-julia-licm: Keep preserve tokens inside their defining loop

### DIFF
--- a/src/llvm-julia-licm.cpp
+++ b/src/llvm-julia-licm.cpp
@@ -165,19 +165,24 @@ struct JuliaLICM : public JuliaPassContext {
         auto SE = GetSE();
         MemorySSAUpdater MSSAU(MSSA);
 
-        // Lazy initialization of exit blocks insertion points.
-        bool exit_pts_init = false;
-        SmallVector<Instruction*, 8> _exit_pts;
-        auto get_exit_pts = [&] () -> MutableArrayRef<Instruction*> {
-            if (!exit_pts_init) {
-                exit_pts_init = true;
-                SmallVector<BasicBlock*, 8> exit_bbs;
+        // Lazily collect exit blocks; insertion points depend on the begin's loop.
+        bool exit_bbs_init = false;
+        SmallVector<BasicBlock*, 8> exit_bbs;
+        auto get_exit_pts = [&] (Loop *begin_loop) {
+            if (!exit_bbs_init) {
+                exit_bbs_init = true;
                 L->getUniqueExitBlocks(exit_bbs);
-                for (BasicBlock *bb: exit_bbs) {
-                    _exit_pts.push_back(&*bb->getFirstInsertionPt());
-                }
             }
-            return _exit_pts;
+            SmallVector<Instruction*, 8> exit_pts;
+            for (BasicBlock *bb: exit_bbs) {
+                // Keep the token inside its defining loop: LCSSA cannot insert
+                // token PHIs, so later loop cloning can otherwise break dominance.
+                // Omitting an end conservatively extends the preserve region.
+                if (begin_loop && !begin_loop->contains(bb))
+                    continue;
+                exit_pts.push_back(&*bb->getFirstInsertionPt());
+            }
+            return exit_pts;
         };
 
         bool changed = false;
@@ -226,7 +231,7 @@ struct JuliaLICM : public JuliaPassContext {
                     if (!DT->properlyDominates(begin->getParent(), header))
                         continue;
                     changed = true;
-                    auto exit_pts = get_exit_pts();
+                    auto exit_pts = get_exit_pts(LI->getLoopFor(begin->getParent()));
                     if (exit_pts.empty()) {
                         ++ErasedPreserveEnd;
                         eraseInstruction(*call, MSSAU);
@@ -234,7 +239,6 @@ struct JuliaLICM : public JuliaPassContext {
                     }
                     ++SunkPreserveEnd;
                     moveInstructionBefore(*call, *exit_pts[0], MSSAU, SE, MemorySSA::Beginning);
-                    exit_pts[0] = call;
                     LLVM_DEBUG(dbgs() << "Sunk gc_preserve_end: " << *call << "\n");
                     REMARK([&](){
                         return OptimizationRemark(DEBUG_TYPE, "Sunk", call)
@@ -247,7 +251,6 @@ struct JuliaLICM : public JuliaPassContext {
 #else
                         auto CI = CallInst::Create(call, {}, exit_pts[i]);
 #endif
-                        exit_pts[i] = CI;
                         createNewInstruction(CI, call, MSSAU);
                         LLVM_DEBUG(dbgs() << "Cloned and sunk gc_preserve_end: " << *CI << "\n");
                         REMARK([&](){

--- a/test/llvmpasses/julia-licm.ll
+++ b/test/llvmpasses/julia-licm.ll
@@ -1,6 +1,7 @@
 ; This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='JuliaLICM' -S %s | FileCheck %s --check-prefixes=CHECK,OPAQUE
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='function(loop-mssa(JuliaLICM)),verify' -verify-memoryssa -S %s | FileCheck %s --check-prefixes=CHECK,OPAQUE
 
 @tag = external addrspace(10) global {}, align 16
 
@@ -172,3 +173,51 @@ attributes #3 = { inaccessiblemem_or_argmemonly }
 !5 = !{!"jtbaa_data", !6, i64 0}
 !6 = !{!"jtbaa", !7, i64 0}
 !7 = !{!"jtbaa"}
+
+; COM: Keep loop-local preserve tokens inside their defining loop, while still
+; COM: sinking ends for tokens defined outside all loops to every exit.
+; CHECK-LABEL: @nested_loop_preserves
+define void @nested_loop_preserves({} addrspace(10)* %obj1, {} addrspace(10)* %obj2, i1 %inner_exit, i1 %outer_exit, i1 %err) {
+top:
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  %current_task = bitcast {}*** %pgcstack to {}**
+  %global_token = call token (...) @llvm.julia.gc_preserve_begin({} addrspace(10)* %obj1)
+  br label %outer
+; CHECK: outer:
+outer:
+  %obj = phi {} addrspace(10)* [ %obj1, %top ], [ %obj2, %outer.latch ]
+  br label %inner.preheader
+; CHECK: inner.preheader:
+; CHECK-NEXT: %preserve_token = call token (...) @llvm.julia.gc_preserve_begin
+; CHECK-NEXT: br label %inner
+inner.preheader:
+  br label %inner
+; CHECK: inner:
+inner:
+; CHECK-NOT: call token (...) @llvm.julia.gc_preserve_begin
+  %preserve_token = call token (...) @llvm.julia.gc_preserve_begin({} addrspace(10)* %obj)
+; CHECK-NOT: call void @llvm.julia.gc_preserve_end
+  call void @llvm.julia.gc_preserve_end(token %preserve_token)
+  call void @llvm.julia.gc_preserve_end(token %global_token)
+; CHECK-NEXT: br i1 %err
+  br i1 %err, label %fail, label %inner.latch
+; CHECK: inner.latch:
+inner.latch:
+  br i1 %inner_exit, label %outer.latch, label %inner
+; CHECK: outer.latch:
+; CHECK-NEXT: call void @llvm.julia.gc_preserve_end(token %preserve_token)
+; CHECK-NEXT: br i1 %outer_exit
+outer.latch:
+  br i1 %outer_exit, label %return, label %outer
+; CHECK: fail:
+; CHECK-NEXT: call void @llvm.julia.gc_preserve_end(token %global_token)
+; CHECK-NOT: @llvm.julia.gc_preserve_end(token %preserve_token)
+; CHECK: ret void
+fail:
+  ret void
+; CHECK: return:
+; CHECK-NEXT: call void @llvm.julia.gc_preserve_end(token %global_token)
+; CHECK-NEXT: ret void
+return:
+  ret void
+}

--- a/test/llvmpasses/julia-licm.ll
+++ b/test/llvmpasses/julia-licm.ll
@@ -13,6 +13,8 @@ declare token @llvm.julia.gc_preserve_begin(...)
 
 declare void @llvm.julia.gc_preserve_end(token)
 
+declare void @use({} addrspace(10)*)
+
 ; COM: check basic preserve hoist/sink functionality
 ; CHECK-LABEL: @hoist_sink_preserves
 define void @hoist_sink_preserves({} addrspace(10)* %obj, i1 %ret) {
@@ -196,6 +198,10 @@ inner.preheader:
 inner:
 ; CHECK-NOT: call token (...) @llvm.julia.gc_preserve_begin
   %preserve_token = call token (...) @llvm.julia.gc_preserve_begin({} addrspace(10)* %obj)
+; CHECK-NEXT: call void @use(ptr addrspace(10) %obj)
+; CHECK-NEXT: call void @use(ptr addrspace(10) %obj1)
+  call void @use({} addrspace(10)* %obj)
+  call void @use({} addrspace(10)* %obj1)
 ; CHECK-NOT: call void @llvm.julia.gc_preserve_end
   call void @llvm.julia.gc_preserve_end(token %preserve_token)
   call void @llvm.julia.gc_preserve_end(token %global_token)


### PR DESCRIPTION
JuliaLICM can sink an inner loop's `gc_preserve_end` past the enclosing
loop containing its `gc_preserve_begin`. The token then escapes its defining
loop, and LCSSA cannot insert token PHIs. Subsequent loop cloning can break
dominance, as seen while precompiling Parsers 3.0.0 on Julia 1.12 with LLVM
assertions in [JuliaGPU/GPUCompiler.jl#924's CI](https://github.com/JuliaGPU/GPUCompiler.jl/actions/runs/34050391805/job/101532856212).

Restrict sinking to exits inside the begin's loop. Begins outside all loops
remain unrestricted. Omitting an end conservatively extends preservation,
which GC lowering already supports.

Assisted-by: Claude Fable 5.1 and GPT 6 Astra