### PR TITLE
ranges: Interpolate LinRange in its own element type

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -56,6 +56,9 @@ widen(::Type{Complex{T}}) where {T} = Complex{widen(T)}
 float(::Type{Complex{T}}) where {T<:AbstractFloat} = Complex{T}
 float(::Type{Complex{T}}) where {T} = Complex{float(T)}
 
+# `Complex` does not exist yet where the other methods are defined, in range.jl.
+_lerp_fraction_type(::Type{Complex{T}}) where {T<:AbstractFloat} = _lerp_fraction_type(T)
+
 """
     real(z)
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -988,9 +988,12 @@ function unsafe_getindex(r::StepRangeLen{T}, i::Integer) where T
     convert(T, (r.ref + u*r.step))
 end
 unsafe_getindex(r::LinRange, i::Integer) = lerpi(i-oneunit(i), r.lendiv, r.start, r.stop)
+_lerp_fraction_type(::Type) = Float64
+_lerp_fraction_type(::Type{T}) where {T<:AbstractFloat} = promote_type(T, Float32)
 
 function lerpi(j::Integer, d::Integer, a::T, b::T) where T
-    t = j/d # ∈ [0,1]
+    F = _lerp_fraction_type(T)
+    t = F(j)/d # ∈ [0,1]
     # compute approximately fma(t, b, -fma(t, a, a))
     return T((1-t)*a + t*b)
 end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1815,6 +1815,21 @@ end
     end
 end
 
+@testset "Issue #37276" begin
+    # `lerpi` interpolates in the element type, so an element type wider than `Float64`
+    # keeps its own precision rather than being capped at `Float64`.
+    @test real(Base.lerpi(1, 10, Complex{BigFloat}(0), Complex{BigFloat}(1))) ==
+          Base.lerpi(1, 10, BigFloat(0), BigFloat(1))
+    @test real(LinRange(Complex{BigFloat}(0), Complex{BigFloat}(1), 11)[2]) ==
+          LinRange(BigFloat(0), BigFloat(1), 11)[2]
+    # A narrower element type interpolates in itself rather than widening to `Float64`.
+    for (j, d) in ((1, 3), (2, 3), (17, 97))
+        t = Float32(j)/d
+        @test Base.lerpi(j, d, 1f0, 2f0) === (1-t)*1f0 + t*2f0
+    end
+    @test Base.lerpi(1, 3, 1.0, 2.0) === (1-1/3)*1.0 + (1/3)*2.0
+end
+
 @testset "Issue #26532" begin
     x = range(3, stop=3, length=5)
     @test step(x) == 0.0


### PR DESCRIPTION
The generic `lerpi` computed its interpolation parameter as `j/d` on two
integers, which is always `Float64` regardless of the range's element type.

For an element type wider than `Float64` this caps accuracy: indexing a
`LinRange{Complex{BigFloat}}` was only as accurate as `Float64`, while
`LinRange{BigFloat}` reached full precision through its own `lerpi` method.

For a narrower element type it widens the arithmetic instead. Both endpoints
of a `LinRange{Float32}` were extended to `Float64`, the interpolation ran in
`Float64`, and a single truncation hid it at the end, which prevents the loop
from vectorizing.

Selecting the parameter's type by dispatch on the element type addresses both.
`Float64` remains the fallback, so element types that are not floating-point
numbers keep the arithmetic they had; `lerpi` accepts anything supporting
scalar multiplication, addition and construction, including vectors, rationals
and custom `Real` types that define no conversion to a float. `Float16` widens
to `Float32`, which it needs to index a range of more than a thousand points.

`Float64` results are bitwise unchanged. `Float32` results move by up to one
ulp, within the accuracy `LinRange` documents.

Fixes #37276

---

Verified against a `BigFloat` reference: the `Complex{BigFloat}` error at
`LinRange(0, 1, 11)[2]` drops from 5.55e-17 to 2.16e-78, matching the existing
`BigFloat` specialization exactly. `Float32` IR loses both `fpext`s and the
`fptrunc`. `Float64` output is bitwise identical over `d ∈ 0:97`, and
`LinRange{Int}` is unchanged.

The `Float32` change is a value change: 29,322 differing pairs over `d ∈ 3:200`,
each by about one ulp.

`make test-ranges` passes (12,439,274 assertions), though that run predates the
rebase onto current master; no intervening commit touched `base/range.jl`,
`base/complex.jl` or `test/ranges.jl`.

This was written by Claude Code (Opus 5). I have reviewed the diff and commit
message but have not independently checked the numerical claims above.
