### PR TITLE
GCLowering: Preserve alignment of GC frame slots

### DIFF
--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -19,7 +19,8 @@ void FinalLowerGC::lowerNewGCFrame(CallInst *target, Function &F)
     // Create the GC frame.
     IRBuilder<> builder(target);
     auto gcframe_alloca = builder.CreateAlloca(T_prjlvalue, ConstantInt::get(Type::getInt32Ty(F.getContext()), nRoots + 2));
-    gcframe_alloca->setAlignment(Align(16));
+    // LateLowerGCFrame records any stronger alignment needed by moved allocas.
+    gcframe_alloca->setAlignment(std::max(Align(16), target->getRetAlign().valueOrOne()));
     // addrspacecast as needed for non-0 alloca addrspace
     auto gcframe = cast<Instruction>(builder.CreateAddrSpaceCast(gcframe_alloca, PointerType::getUnqual(T_prjlvalue->getContext())));
     gcframe->takeName(target);

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2461,11 +2461,11 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
 
         // Replace Allocas
         unsigned AllocaSlot = 2; // first two words are metadata
-        auto replace_alloca = [this, gcframe, &AllocaSlot, T_int32](AllocaInst *&AI) {
-            // Pick a slot for the alloca.
-            AI->getAlign();
+        Align FrameAlign(16);
+        auto replace_alloca = [this, gcframe, &AllocaSlot, &FrameAlign, T_int32](AllocaInst *&AI) {
+            // Preserve both the alloca's alignment and its offset within the frame.
+            FrameAlign = std::max(FrameAlign, AI->getAlign());
             unsigned align = AI->getAlign().value() / sizeof(void*); // TODO: use DataLayout pointer size
-            assert(align <= 16 / sizeof(void*) && "Alignment exceeds llvm-final-gc-lowering abilities");
             if (align > 1)
                 AllocaSlot = LLT_ALIGN(AllocaSlot, align);
             Instruction *slotAddress = CallInst::Create(
@@ -2522,6 +2522,8 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
         }
         auto NRoots = ConstantInt::get(T_int32, MaxColor + 1 + AllocaSlot - 2);
         gcframe->setArgOperand(0, NRoots);
+        if (FrameAlign > Align(16))
+            gcframe->addRetAttr(Attribute::getWithAlignment(F->getContext(), FrameAlign));
         pushGcframe->setArgOperand(1, NRoots);
 
         // Insert GC frame stores

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -121,7 +121,7 @@ namespace jl_intrinsics {
     // passed as an argument.
     extern const IntrinsicDescription GCAllocBytes;
 
-    // `julia.new_gc_frame`: an intrinsic that creates a new GC frame.
+    // `julia.new_gc_frame`: creates a GC frame, honoring any return alignment attribute.
     extern const IntrinsicDescription newGCFrame;
 
     // `julia.push_gc_frame`: an intrinsic that pushes a GC frame.

--- a/test/llvmpasses/final-lower-gc.ll
+++ b/test/llvmpasses/final-lower-gc.ll
@@ -21,7 +21,7 @@ attributes #0 = { allocsize(1) }
 define void @gc_frame_lowering(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @gc_frame_lowering
-; OPAQUE: %gcframe = alloca ptr addrspace(10), i32 4
+; OPAQUE: %gcframe = alloca ptr addrspace(10), i32 4, align 16
   %gcframe = call {} addrspace(10)** @julia.new_gc_frame(i32 2)
 ; OPAQUE: [[GCFRAME_SLOT:%.*]] = call ptr @julia.get_pgcstack()
   %pgcstack = call {}*** @julia.get_pgcstack()

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -1,6 +1,7 @@
 ; This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='function(LateLowerGCFrame)' -S %s | FileCheck %s
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='function(LateLowerGCFrame,FinalLowerGC),verify' -S %s | FileCheck %s --check-prefix=FINAL
 
 @tag = external addrspace(10) global {}, align 16
 
@@ -212,6 +213,76 @@ define swiftcc ptr addrspace(10) @insert_element(ptr swiftself "gcstack" %0) {
   ret ptr addrspace(10) null
 }
 
+; Vectorization may give tracked-pointer allocas a larger alignment than the
+; usual 16-byte GC frame alignment. Preserve it through both lowering passes.
+define void @overaligned_gc_alloca(<8 x ptr addrspace(10)> %values) {
+; CHECK-LABEL: @overaligned_gc_alloca
+; CHECK: %gcframe = call align 64 ptr @julia.new_gc_frame(i32 15)
+; CHECK: %roots = call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 6)
+; FINAL-LABEL: @overaligned_gc_alloca
+; FINAL: %gcframe = alloca ptr addrspace(10), i32 17, align 64
+; FINAL: %roots = getelementptr inbounds ptr addrspace(10), ptr %gcframe, i32 8
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  %roots = alloca <8 x ptr addrspace(10)>, align 64
+; CHECK: store <8 x ptr addrspace(10)> %values, ptr %roots, align 64
+; FINAL: store <8 x ptr addrspace(10)> %values, ptr %roots, align 64
+  store <8 x ptr addrspace(10)> %values, ptr %roots, align 64
+  %root4addr = getelementptr ptr addrspace(10), ptr %roots, i64 4
+; CHECK: %root4 = load ptr addrspace(10), ptr %root4addr, align 32
+; FINAL: %root4 = load ptr addrspace(10), ptr %root4addr, align 32
+  %root4 = load ptr addrspace(10), ptr %root4addr, align 32
+  call void @boxed_simple(ptr addrspace(10) %root4, ptr addrspace(10) %root4)
+  ret void
+}
+
+
+; A callee's alignment requirement must remain true after moving the alloca.
+define void @overaligned_gc_call(<8 x ptr addrspace(10)> %values) {
+; CHECK-LABEL: @overaligned_gc_call
+; CHECK: %gcframe = call align 64 ptr @julia.new_gc_frame(i32 14)
+; CHECK: %roots = call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 6)
+; CHECK: call void @aligned_root_array(ptr align 64 %roots)
+; FINAL-LABEL: @overaligned_gc_call
+; FINAL: %gcframe = alloca ptr addrspace(10), i32 16, align 64
+; FINAL: %roots = getelementptr inbounds ptr addrspace(10), ptr %gcframe, i32 8
+; FINAL: call void @aligned_root_array(ptr align 64 %roots)
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  %roots = alloca <8 x ptr addrspace(10)>, align 64
+  store <8 x ptr addrspace(10)> %values, ptr %roots, align 64
+  call void @aligned_root_array(ptr align 64 %roots)
+  ret void
+}
+
+define void @aligned_root_array(ptr align 64 %roots) {
+  %values = load volatile <8 x ptr addrspace(10)>, ptr %roots, align 64
+  ret void
+}
+
+
+; Padding between moved allocas must be included in the frame's root count.
+define void @overaligned_gc_padding(<4 x ptr addrspace(10)> %values) {
+; CHECK-LABEL: @overaligned_gc_padding
+; CHECK: %gcframe = call align 64 ptr @julia.new_gc_frame(i32 18)
+; CHECK-DAG: call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 6)
+; CHECK-DAG: call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 14)
+; FINAL-LABEL: @overaligned_gc_padding
+; FINAL: %gcframe = alloca ptr addrspace(10), i32 20, align 64
+; FINAL-DAG: getelementptr inbounds ptr addrspace(10), ptr %gcframe, i32 8
+; FINAL-DAG: getelementptr inbounds ptr addrspace(10), ptr %gcframe, i32 16
+; FINAL: store <4 x ptr addrspace(10)> %values, ptr %a, align 64
+; FINAL: store <4 x ptr addrspace(10)> %values, ptr %b, align 64
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  %a = alloca <4 x ptr addrspace(10)>, align 64
+  %b = alloca <4 x ptr addrspace(10)>, align 64
+  store <4 x ptr addrspace(10)> %values, ptr %a, align 64
+  store <4 x ptr addrspace(10)> %values, ptr %b, align 64
+  call void @aligned_short_root_array(ptr align 64 %a)
+  call void @aligned_short_root_array(ptr align 64 %b)
+  ret void
+}
+
+
+declare void @aligned_short_root_array(ptr align 64)
 
 !0 = !{i64 0, i64 23}
 !1 = !{!1}


### PR DESCRIPTION
LLVM can turn an array of GC roots into a vector with stricter alignment than
Julia's usual 16-byte GC frame alignment. Moving that array into the frame
currently triggers an assertion. In release builds, the move leaves loads,
stores, and callees relying on alignment the frame does not guarantee.

Preserve the alignment of each moved alloca by aligning its slot within the
frame and raising the frame's alignment when necessary. Late GC lowering
records the requirement as a return alignment attribute on `julia.new_gc_frame`;
final lowering applies it to the stack allocation. The frame size includes
padding between slots. Functions without stricter requirements retain the
usual 16-byte frame alignment.

This preserves existing memory-access annotations and callee requirements.
The issue was encountered while building a coverage-enabled system image for
JuliaLang/julia#62724, but the fix is independent of coverage.

Assisted-by: Fable 5.1 and Sol 6