### PR TITLE
staticdata: Allow modules as immediate serialization targets

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -896,7 +896,8 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
     }
 
     if (immediate) // must be things that can be recursively handled, and valid as type parameters
-        assert(jl_is_immutable(t) || jl_is_typevar(v) || jl_is_symbol(v) || jl_is_svec(v));
+        assert(jl_is_immutable(t) || jl_is_typevar(v) || jl_is_symbol(v) || jl_is_svec(v) ||
+               jl_is_module(v));
 
     if (layout->npointers == 0) {
         // bitstypes do not require recursion

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1996,6 +1996,24 @@ precompile_test_harness("Module tparams") do load_path
     end
 end
 
+# A module reached only through a type parameter must support immediate serialization.
+precompile_test_harness("Module immediate serialization") do load_path
+    write(joinpath(load_path, "ModuleImmediateInline.jl"),
+        """
+        module ModuleImmediateInline
+            const value = Val{Module(:Anon)}()
+        end
+        """)
+    Base.compilecache(Base.PkgId("ModuleImmediateInline"))
+    (@eval (using ModuleImmediateInline))
+    invokelatest() do
+        m = typeof(ModuleImmediateInline.value).parameters[1]
+        @test m isa Module
+        @test nameof(m) === :Anon
+        @test ModuleImmediateInline.value === Val(m)
+    end
+end
+
 precompile_test_harness("PkgCacheInspector") do load_path
     # Test functionality needed by PkgCacheInspector.jl
     write(joinpath(load_path, "PCI.jl"),


### PR DESCRIPTION
Modules are valid type parameters, but the image serializer's assertion for
values that must be serialized immediately does not allow them. Precompiling
a package containing this definition fails in a Julia assertion build:

```julia
module ModuleImmediateInline
const value = Val{Module(:Anon)}()
end
```

The serializer visits the module before the type that uses it as a parameter,
so the type can be looked up in the type cache when the image is loaded. The
existing module handler already queues the module's contents separately;
only the assertion rejects it. This change adds modules to the accepted
values. Builds with assertions disabled are unaffected.

This surfaced while building instrumented stdlib package images for
JuliaLang/julia#62724, but the example above reproduces it without coverage.

Assisted-by: Fable 5.1 and Sol 6