### PR TITLE
REPL: fix face name in Monokai theme example

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -619,7 +619,7 @@ The default syntax highlighting theme is quite conservative but can be customize
     foreground = "#E6DB74"
     weight = "bold"
 
-    [julia_cmdstring]
+    [julia_cmd]
     inherit = "julia_string"
 
     [julia_char]


### PR DESCRIPTION
The example `faces.toml` in the REPL docs used `julia_cmdstring`, which is not a face defined by JuliaSyntaxHighlighting. Command strings use the `julia_cmd` face, so the entry silently had no effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)