### PR TITLE
codegen: Resolve callback ABI types before constructing wrappers

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1889,9 +1889,10 @@ function has_valid_abi_sparams(mi::MethodInstance)
         sp = mi.sparam_vals[i]
         isvarargtype(sp) && return false
         if isa(sp, SimpleVector)
-            # An unused binder is always undefined, not dependent on runtime type matching.
+            # Parameter binding cannot vary across calls if it is unused
+            # in the signature or if this is a dispatch tuple
             if length(sp) != 2 || sp[1] !== env.var || sp[2] !== false ||
-                    has_typevar(env.body, env.var)
+                    (has_typevar(env.body, env.var) && !isdispatchtuple(mi.specTypes))
                 return false
             end
         end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1884,11 +1884,18 @@ function has_valid_abi_sparams(mi::MethodInstance)
     def = mi.def
     isa(def, Method) || return true
     unionall_depth(def.sig) == length(mi.sparam_vals) || return false
+    env = def.sig
     for i = 1:length(mi.sparam_vals)
         sp = mi.sparam_vals[i]
-        if isa(sp, SimpleVector) || isvarargtype(sp)
-            return false
+        isvarargtype(sp) && return false
+        if isa(sp, SimpleVector)
+            # An unused binder is always undefined, not dependent on runtime type matching.
+            if length(sp) != 2 || sp[1] !== env.var || sp[2] !== false ||
+                    has_typevar(env.body, env.var)
+                return false
+            end
         end
+        env = env.body
     end
     return true
 end

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -2434,17 +2434,20 @@ let T1 = Array{Float64}, T2 = Array{_1,2} where _1
     @test rt >: Union{Type{Array{Float64}}, Type{Array{Float32}}}
 end
 
-# An unused static parameter does not invalidate the callable ABI (#27813).
-@testset "ABI eligibility of unused static parameters (#27813)" begin
+# An undefined static parameter does not invalidate the callable ABI (#27813).
+@testset "ABI eligibility of undefined static parameters (#27813)" begin
     @test_warn r"declares type variable S but does not use it" @eval begin
         abi_sparams27813(x::T) where {T,S} = x
         abi_sparams_first27813(x::T) where {S,T} = x
         abi_sparams_conditional27813(::Union{Nothing,Ref{S}}) where S = nothing
     end
+    abi_sparams_vararg27813(::S...) where S = nothing
     @test Compiler.has_valid_abi_sparams(Base.method_instance(abi_sparams27813, Tuple{Int}))
     @test Compiler.has_valid_abi_sparams(Base.method_instance(abi_sparams_first27813, Tuple{Int}))
     @test !Compiler.has_valid_abi_sparams(get_linfo(abi_sparams27813, Tuple{Any}))
-    @test !Compiler.has_valid_abi_sparams(Base.method_instance(abi_sparams_conditional27813, Tuple{Nothing}))
+    @test Compiler.has_valid_abi_sparams(Base.method_instance(abi_sparams_conditional27813, Tuple{Nothing}))
+    @test Compiler.has_valid_abi_sparams(Base.method_instance(abi_sparams_vararg27813, Tuple{}))
+    @test !Compiler.has_valid_abi_sparams(get_linfo(abi_sparams_conditional27813, Tuple{Union{Nothing,Ref{Float64}}}))
 end
 
 # Demonstrate IPO constant propagation (#24362)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -2434,6 +2434,19 @@ let T1 = Array{Float64}, T2 = Array{_1,2} where _1
     @test rt >: Union{Type{Array{Float64}}, Type{Array{Float32}}}
 end
 
+# An unused static parameter does not invalidate the callable ABI (#27813).
+@testset "ABI eligibility of unused static parameters (#27813)" begin
+    @test_warn r"declares type variable S but does not use it" @eval begin
+        abi_sparams27813(x::T) where {T,S} = x
+        abi_sparams_first27813(x::T) where {S,T} = x
+        abi_sparams_conditional27813(::Union{Nothing,Ref{S}}) where S = nothing
+    end
+    @test Compiler.has_valid_abi_sparams(Base.method_instance(abi_sparams27813, Tuple{Int}))
+    @test Compiler.has_valid_abi_sparams(Base.method_instance(abi_sparams_first27813, Tuple{Int}))
+    @test !Compiler.has_valid_abi_sparams(get_linfo(abi_sparams27813, Tuple{Any}))
+    @test !Compiler.has_valid_abi_sparams(Base.method_instance(abi_sparams_conditional27813, Tuple{Nothing}))
+end
+
 # Demonstrate IPO constant propagation (#24362)
 f_constant(x) = convert(Int, x)
 g_test_constant() = (f_constant(3) == 3 && f_constant(4) == 4 ? true : "BAD")

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3301,6 +3301,11 @@ static bool uses_specsig(jl_value_t *sig, bool needsparams, jl_value_t *rettype,
     return false; // jlcall sig won't require any box allocations
 }
 
+static bool sparam_is_closed_value(jl_value_t *sp) JL_NOTSAFEPOINT
+{
+    return !jl_is_svec(sp) && !jl_has_free_typevars(sp);
+}
+
 static std::pair<bool, bool> uses_specsig(jl_value_t *abi, jl_method_instance_t *lam, jl_value_t *rettype, bool prefer_specsig) JL_CANSAFEPOINT
 {
     bool needsparams = false;
@@ -3309,7 +3314,7 @@ static std::pair<bool, bool> uses_specsig(jl_value_t *abi, jl_method_instance_t 
             needsparams = true;
         for (size_t i = 0; i < jl_svec_len(lam->sparam_vals); ++i) {
             jl_value_t *sp = jl_svecref(lam->sparam_vals, i);
-            if (jl_is_svec(sp) || jl_has_free_typevars(sp))
+            if (!sparam_is_closed_value(sp))
                 needsparams = true;
         }
     }
@@ -8115,7 +8120,7 @@ static Function *gen_cfun_wrapper(
     Module *into, jl_codegen_output_t &out,
     const function_sig_t &sig, jl_value_t *ff, const char *aliasname,
     jl_value_t *declrt, jl_value_t *sigt,
-    jl_unionall_t *unionall_env, jl_svec_t *sparam_vals, jl_array_t **closure_types) JL_CANSAFEPOINT
+    jl_unionall_t *unionall_env, jl_array_t **closure_types) JL_CANSAFEPOINT
 {
     ++GeneratedCFuncWrappers;
     // Generate a c-callable wrapper
@@ -8230,21 +8235,10 @@ static Function *gen_cfun_wrapper(
         if (aref) // a pointer to a value
             jargty = jl_tparam0(jargty);
 
-        // if we know the outer function sparams, try to fill those in now
-        // so that the julia_to_native type checks are more likely to be doable (e.g. concrete types) at compile-time
         jl_value_t *jargty_proper = jargty;
         bool static_at = !(unionall_env && jl_has_typevar_from_unionall(jargty, unionall_env));
-        if (!static_at) {
-            if (sparam_vals) {
-                jargty_proper = rt1 = jl_instantiate_type_in_env(jargty, unionall_env, jl_svec_data(sparam_vals));
-                assert(jargty_proper != jargty);
-                jargty = jargty_proper;
-                static_at = true;
-            }
-            else {
-                jargty_proper = rt1 = jl_rewrap_unionall(jargty, (jl_value_t*)unionall_env);
-            }
-        }
+        if (!static_at)
+            jargty_proper = rt1 = jl_rewrap_unionall(jargty, (jl_value_t*)unionall_env);
 
         if (aref) {
             if (jargty == (jl_value_t*)jl_any_type) {
@@ -8447,6 +8441,25 @@ static const char *derive_sigt_name(jl_value_t *jargty)
     return jl_symbol_name(name);
 }
 
+static bool cfunction_type_has_static_env(jl_value_t *ty, jl_unionall_t *env,
+                                          jl_svec_t *sparam_vals) JL_NOTSAFEPOINT
+{
+    size_t nsparams = jl_svec_len(sparam_vals);
+    if ((size_t)jl_subtype_env_size((jl_value_t*)env) != nsparams)
+        return false;
+    jl_unionall_t *ua = env;
+    for (size_t i = 0; jl_is_unionall(ua); i++) {
+        jl_tvar_t *var = ua->var;
+        if (jl_has_typevar(ty, var)) {
+            jl_value_t *sp = jl_svecref(sparam_vals, i);
+            if (!sparam_is_closed_value(sp))
+                return false;
+        }
+        ua = (jl_unionall_t*)ua->body;
+    }
+    return true;
+}
+
 // Get the LLVM Function* for the C-callable entry point for a certain function
 // and argument types.
 // here argt does not include the leading function type argument
@@ -8455,55 +8468,57 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
     jl_unionall_t *unionall_env = (jl_is_method(ctx.linfo->def.method) && jl_is_unionall(ctx.linfo->def.method->sig))
         ? (jl_unionall_t*)ctx.linfo->def.method->sig
         : NULL;
-    jl_svec_t *sparam_vals = NULL;
-    if (ctx.spvals_ptr == NULL && jl_svec_len(ctx.linfo->sparam_vals) > 0)
-        sparam_vals = ctx.linfo->sparam_vals;
-
-    jl_value_t *rt = declrt;
-    if (jl_is_abstract_ref_type(declrt)) {
-        declrt = jl_tparam0(declrt);
-        if (!verify_ref_type(ctx, declrt, unionall_env, 0, "cfunction")) {
-            return jl_cgval_t();
-        }
-        if (unionall_env)
-            declrt = jl_rewrap_unionall(declrt, (jl_value_t*)unionall_env);
-        rt = (jl_value_t*)jl_any_type; // convert return type to jl_value_t*
-    }
-
-    // some sanity checking and check whether there's a vararg
-    size_t nargt = jl_svec_len(argt);
-    bool isVa = (nargt > 0 && jl_is_vararg(jl_svecref(argt, nargt - 1)));
-    assert(!isVa); (void)isVa;
 
     jl_array_t *closure_types = NULL;
     jl_value_t *sigt = NULL; // dispatch-sig = type signature with Ref{} annotations removed and applied to the env
+    jl_value_t *rt = NULL;
     jl_svec_t *argt_inst = NULL;
     JL_GC_PUSH5(&declrt, &sigt, &rt, &closure_types, &argt_inst);
-    // Substitute known static-parameter values into the declared argument
-    // types up front: the ABI and argument-unpacking decisions below must be
-    // made on the same types the call sites use, and `gen_cfun_wrapper` cannot
-    // substitute them itself when `unionall_env` is dropped for the
-    // non-closure case. (A raw `Ref{S}` element would be unpacked as a plain
-    // `jl_value_t*`, while a call site with `S = Any` passes a `jl_value_t**`.)
-    if (unionall_env && sparam_vals) {
+
+    jl_svec_t *sparam_vals = ctx.linfo->sparam_vals;
+    size_t nargt = jl_svec_len(argt);
+    if (unionall_env && jl_svec_len(sparam_vals) > 0) {
+        if (jl_has_typevar_from_unionall(declrt, unionall_env) &&
+                cfunction_type_has_static_env(declrt, unionall_env, sparam_vals)) {
+            declrt = jl_instantiate_type_in_env(declrt, unionall_env, jl_svec_data(sparam_vals));
+        }
         for (size_t i = 0; i < nargt; i++) {
             jl_value_t *jargty = jl_svecref(argt, i);
-            if (jl_has_typevar_from_unionall(jargty, unionall_env)) {
+            if (jl_has_typevar_from_unionall(jargty, unionall_env) &&
+                    cfunction_type_has_static_env(jargty, unionall_env, sparam_vals)) {
                 if (!argt_inst)
                     argt_inst = jl_svec_copy(argt);
-                jl_svecset(argt_inst, i, jl_instantiate_type_in_env(jargty, unionall_env, jl_svec_data(sparam_vals)));
+                jl_svecset(argt_inst, i,
+                    jl_instantiate_type_in_env(jargty, unionall_env, jl_svec_data(sparam_vals)));
             }
         }
         if (argt_inst)
             argt = argt_inst;
     }
+
+    rt = declrt;
+    if (jl_is_abstract_ref_type(declrt)) {
+        declrt = jl_tparam0(declrt);
+        if (!verify_ref_type(ctx, declrt, unionall_env, 0, "cfunction")) {
+            JL_GC_POP();
+            return jl_cgval_t();
+        }
+        if (unionall_env && jl_has_typevar_from_unionall(declrt, unionall_env))
+            declrt = jl_rewrap_unionall(declrt, (jl_value_t*)unionall_env);
+        rt = (jl_value_t*)jl_any_type; // convert return type to jl_value_t*
+    }
+
+    // some sanity checking and check whether there's a vararg
+    bool isVa = (nargt > 0 && jl_is_vararg(jl_svecref(argt, nargt - 1)));
+    assert(!isVa); (void)isVa;
+
     Type *lrt;
     bool retboxed;
     bool static_rt;
     const std::string err = verify_ccall_sig(
             /* inputs:  */
             rt, (jl_value_t*)argt, unionall_env,
-            sparam_vals,
+            NULL,
             &ctx.emission_context,
             /* outputs: */
             lrt, ctx.builder.getContext(),
@@ -8513,9 +8528,6 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
         JL_GC_POP();
         return jl_cgval_t();
     }
-    if (rt != declrt && rt != (jl_value_t*)jl_any_type)
-        jl_temporary_root(ctx, rt);
-
     function_sig_t sig("cfunction", lrt, rt, retboxed, false, argt, unionall_env, false, CallingConv::C, false, &ctx.emission_context);
     assert(sig.fargt.size() + sig.sret == sig.fargt_sig.size());
     if (!sig.err_msg.empty()) {
@@ -8540,10 +8552,7 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
             }
         }
         if (unionall_env && jl_has_typevar_from_unionall(jargty, unionall_env)) {
-            if (sparam_vals)
-                jargty = jl_instantiate_type_in_env(jargty, unionall_env, jl_svec_data(sparam_vals));
-            else
-                approx = true;
+            approx = true;
         }
         jl_svecset(sigt, i + 1, jargty);
     }
@@ -8570,7 +8579,7 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
             jl_Module, ctx.emission_context,
             sig, fexpr_val.constant, name,
             declrt, sigt,
-            unionall_env, sparam_vals, &closure_types);
+            unionall_env, &closure_types);
     bool outboxed;
     if (nest) {
         // F is actually an init_trampoline function that returns the real address
@@ -8659,7 +8668,7 @@ const char *jl_generate_ccallable(jl_codegen_output_t &out, jl_value_t *nameval,
                            argtypes, NULL, false, CallingConv::C, false, &out);
         if (sig.err_msg.empty()) {
             //Safe b/c out holds context lock
-            Function *cw = gen_cfun_wrapper(&out.get_module(), out, sig, ff, name, declrt, sigt, NULL, NULL, NULL);
+            Function *cw = gen_cfun_wrapper(&out.get_module(), out, sig, ff, name, declrt, sigt, NULL, NULL);
             auto alias =
                 GlobalAlias::create(cw->getValueType(), cw->getType()->getAddressSpace(),
                                     GlobalValue::ExternalLinkage, name, cw,

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1665,6 +1665,49 @@ callback27178(cb::CTF) where CTF<:CallThisFunc27178 = nothing
 get_c_func(fcn::FCN_TYPE) where {FCN_TYPE<:Function} = return make_cfunc27178(CallThisFunc27178(fcn))
 @test isa(get_c_func(sin), Ptr)
 
+# An unrelated unresolved static parameter must not make `@cfunction` dynamic (#27813).
+@testset "cfunction static parameters (#27813)" begin
+    @test_warn r"declares type variable S but does not use it" @eval begin
+        @noinline function cfunction27813(x::T) where {T,S}
+            cf = @cfunction identity Ref{T} (Ref{T},)
+            ccall(cf, Ref{T}, (Ref{T},), x)
+        end
+        @noinline cfunction_arg27813(::Ref{T}) where {T,S} =
+            @cfunction(identity, Any, (Ref{T},))
+        @noinline cfunction_ret27813(::Ref{T}) where {T,S} =
+            @cfunction(identity, Ref{T}, (Any,))
+        @noinline cfunction_undefined27813(x::T) where {T,S} =
+            @cfunction(identity, Ref{S}, (Any,))
+        @noinline cfunction_undefined_arg27813(x::T) where {T,S} =
+            @cfunction(identity, Any, (Ref{S},))
+    end
+    @test cfunction27813(1) === 1
+
+    r = Ref{Any}("callback")
+    cf = cfunction_arg27813(r)
+    @test ccall(cf, Any, (Ref{Any},), r) === r[]
+
+    cf = cfunction_ret27813(Ref(1))
+    @test ccall(cf, Any, (Any,), 1) === 1
+    @test_throws ErrorException("cfunction return type Ref{Any} is invalid. Use Any or Ptr{Any} instead.") cfunction_ret27813(Ref{Any}(1))
+    @test_throws UndefVarError cfunction_undefined27813(1)
+    @test_throws UndefVarError cfunction_undefined_arg27813(1)
+
+    if cfunction_closure
+        @eval begin
+            cfunction_pair27813(x, y) = (x, y)
+            @noinline function cfunction_mixed27813(x::T, y::S) where {T,S}
+                @nospecialize y
+                cf = @cfunction cfunction_pair27813 Any (Ref{T}, Ref{S})
+                GC.@preserve cf ccall(cf, Any, (Ref{T}, Ref{S}), x, y)
+            end
+        end
+        @test cfunction_mixed27813(1, 2) === (1, 2)
+        @test cfunction_mixed27813(1, "callback") === (1, "callback")
+        @test occursin("jl_get_cfunction_trampoline", sprint(code_llvm, cfunction_mixed27813, (Int, Any)))
+    end
+end
+
 # issue #27215
 function once_removed()
     function mycompare(a, b)::Cint

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1681,7 +1681,12 @@ get_c_func(fcn::FCN_TYPE) where {FCN_TYPE<:Function} = return make_cfunc27178(Ca
         @noinline cfunction_undefined_arg27813(x::T) where {T,S} =
             @cfunction(identity, Any, (Ref{S},))
     end
+    @noinline function cfunction_conditional27813(x::T, ::Union{Nothing,Ref{S}}) where {T,S}
+        cf = @cfunction identity Ref{T} (Ref{T},)
+        ccall(cf, Ref{T}, (Ref{T},), x)
+    end
     @test cfunction27813(1) === 1
+    @test cfunction_conditional27813(1, nothing) === 1
 
     r = Ref{Any}("callback")
     cf = cfunction_arg27813(r)


### PR DESCRIPTION
Fixes #27813

A collaboration between Astra and Fable, lightly steered. from git blame it seems some of this machinery hasn't changed in ages, so hopefully touching it doesn't kick up any dust, but AFAICT it makes sense?

-----
`@cfunction` currently treats the enclosing method’s static parameters as all known or all unknown. For example, in a method declared with `where {T,S}`, an unused, undefined `S` can force a callback using only `Ref{T}` onto the runtime-trampoline path—even when `T` is known.

After this PR, we resolve each callback argument and return type independently, using the parameters that type actually references. Do this before choosing the C ABI or generating the wrapper, so layout, argument unpacking, and dispatch all use consistently resolved types. Types that cannot be fully resolved retain their original environment and follow the existing dynamic path.

Non-inlined callback factories also need to reach codegen with their specialized types intact. Allow compilation of method instances with provably unused, undefined static parameters; previously these were rejected and could fall back to unspecialized codegen. Parameters whose values depend on runtime type matching remain subject to the existing restrictions. This does not remove the remaining generic-dispatch and boxed-call overhead.

Callback resolution and method calling-convention selection share the check for whether a parameter value is known. The invariant is that any callback type still depending on the method’s static parameters has a runtime environment available to resolve it (`needsparams` and `ctx.spvals_ptr`).