### PR TITLE
have log error backtrace participate in backtrace filtering

### DIFF
--- a/base/logging/ConsoleLogger.jl
+++ b/base/logging/ConsoleLogger.jl
@@ -57,6 +57,7 @@ min_enabled_level(logger::ConsoleLogger) = logger.min_level
 showvalue(io, msg) = show(io, "text/plain", msg)
 function showvalue(io, e::Tuple{Exception,Any})
     ex,bt = e
+    bt = Base.scrub_repl_backtrace(bt)
     showerror(io, ex, bt; backtrace = bt!==nothing)
 end
 showvalue(io, ex::Exception) = showerror(io, ex)

--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -506,7 +506,12 @@ end
           catch ex
               LazyString("Exception handling log message: ", ex)
           end
-    bt = real ? catch_backtrace() : backtrace()
+    bt = Base.scrub_repl_backtrace(real ? catch_backtrace() : stacktrace())
+    if !real
+        # drop the frames of the logging machinery itself
+        i = findfirst(fr -> fr.func === :logging_error, bt)
+        i === nothing || deleteat!(bt, 1:i)
+    end
     handle_message(
         logger, Error, msg, _module, :logevent_error, id, filepath, line;
         exception=(err,bt))

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -89,6 +89,8 @@ end
     @test kwargs[:b] === 2.0
 end
 
+__repl_entry_logtest(f) = f()
+
 @testset "Log message exception handling" begin
     # Exceptions in message creation are caught by default
     @test_logs (Error, Test.Ignored(), Test.Ignored(), :logevent_error) catch_exceptions=true @info "foo $(1÷0)"
@@ -112,6 +114,13 @@ end
         y = "the y"
         @test_logs (Info,"the msg") logmsg()
         @test only(collect_test_logs(logmsg)[1]).kwargs[:x] === "the y"
+    end
+    # backtraces of logging failures drop driver and logging machinery frames
+    for logmsg in (function() local msg; @info msg end, function() @info "foo $(1÷0)" end)
+        record = only(collect_test_logs(() -> __repl_entry_logtest(logmsg), catch_exceptions=true)[1])
+        bt = record.kwargs[:exception][2]::Vector{Base.StackTraces.StackFrame}
+        @test !isempty(bt)
+        @test !any(fr -> fr.func in (:logging_error, :backtrace, :__repl_entry_logtest, :collect_test_logs), bt)
     end
 end
 @testset "Log message handle_message exception handling" begin


### PR DESCRIPTION
Before:

```
julia> @info M
┌ Error: Exception while generating log record in module Main at REPL[1]:1
│   exception =
│    UndefVarError: `M` not defined in local scope
│    Suggestion: check for an assignment to a local variable that shadows a global of the same name.
│    Stacktrace:
│      [1] backtrace()
│        @ Base ./error.jl:124
│      [2] logging_error(logger::Any, level::Any, _module::Any, group::Any, id::Any, filepath::Any, line::Any, err::Any, real::Bool)
│        @ Base.CoreLogging ./logging/logging.jl:509
│      [3] top-level scope
│        @ REPL[1]:1
│      [4] macro expansion
│        @ logging/logging.jl:379 [inlined]
│      [5] __repl_entry_eval_expanded_with_loc(mod::Module, ast::Any, toplevel_file::Ref{Ptr{UInt8}}, toplevel_line::Ref{Int32})
│        @ REPL ~/.julia/juliaup/julia-1.12.7+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/REPL.jl:301
│      [6] toplevel_eval_with_hooks(mod::Module, ast::Any, toplevel_file::Any, toplevel_line::Any)
│        @ REPL ~/.julia/juliaup/julia-1.12.7+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/REPL.jl:308
│      [7] toplevel_eval_with_hooks(mod::Module, ast::Any, toplevel_file::Any, toplevel_line::Any)
│        @ REPL ~/.julia/juliaup/julia-1.12.7+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/REPL.jl:312
│      [8] toplevel_eval_with_hooks
│        @ ~/.julia/juliaup/julia-1.12.7+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/REPL.jl:305 [inlined]
│      [9] eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)
│        @ REPL ~/.julia/juliaup/julia-1.12.7+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/REPL.jl:330
│     [10] repl_backend_loop(backend::REPL.REPLBackend, get_module::Function)
│        @ REPL ~/.julia/juliaup/julia-1.12.7+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/REPL.jl:452
│     [11] start_repl_backend(backend::REPL.REPLBackend, consumer::Any; get_module::Function)
│        @ REPL ~/.julia/juliaup/julia-1.12.7+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/REPL.jl:427
│     [12] start_repl_backend
│        @ ~/.julia/juliaup/julia-1.12.7+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/REPL.jl:424 [inlined]
│     [13] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool, backend::Any)
│        @ REPL ~/.julia/juliaup/julia-1.12.7+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/REPL.jl:653
│     [14] run_repl(repl::REPL.AbstractREPL, consumer::Any)
│        @ REPL ~/.julia/juliaup/julia-1.12.7+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/REPL.jl:639
│     [15] run_std_repl(REPL::Module, quiet::Bool, banner::Symbol, history_file::Bool)
│        @ Base ./client.jl:478
│     [16] run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_file::Bool)
│        @ Base ./client.jl:499
│     [17] repl_main
│        @ ./client.jl:586 [inlined]
│     [18] _start()
│        @ Base ./client.jl:561
└ @ Main REPL[1]:1
```

After

```
julia> @info M
┌ Error: Exception while generating log record in module Main at REPL[2]:1
│   exception =
│    UndefVarError: `M` not defined in local scope
│    Suggestion: check for an assignment to a local variable that shadows a global of the same name.
│    Stacktrace:
│     [1] top-level scope
│       @ REPL[2]:1
│     [2] macro expansion
│       @ logging/logging.jl:379 [inlined]
└ @ Main REPL[2]:1
```

Assisted by Claude