### PR TITLE
test SecretBuffer pointer initialization

### DIFF
--- a/test/secretbuffer.jl
+++ b/test/secretbuffer.jl
@@ -60,6 +60,15 @@ using Test, Random
         @test Base.unsafe_string(ptr3) == ""
         @test s1 == s2 == s3
 
+        data3 = UInt8[0x73, 0x00, 0x65, 0xff]
+
+        GC.@preserve data3 begin
+            s6 = Base.unsafe_SecretBuffer!(pointer(data3), 3)
+            @test read(s6) == UInt8[0x73, 0x00, 0x65]
+            @test data3 == UInt8[0x00, 0x00, 0x00, 0xff]
+            shred!(s6)
+        end
+
         s4 = SecretBuffer(split("setec astronomy", " ")[1]) # initialize from SubString
         s5 = convert(SecretBuffer, split("setec astronomy", " ")[1]) # initialize from SubString
         @test s4 == s5


### PR DESCRIPTION
Add a test for "Base.unsafe_SecretBuffer!(::Ptr{UInt8}, len)"that verifies embedded NUL bytes are copied correctly and that only the specified bytes are securely zeroed.
The test also verifies that data outside the requested length remains unchanged.

Tested with `test/secretbuffer.jl` using Julia 1.12.7 (40/40 passing).