### PR TITLE
move CoreFoundation to libjulia-codgen for ~15% faster startup on minimal trimmed apps on MacOS

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1662,7 +1662,6 @@ endif
 
 ifeq ($(OS), Darwin)
 SHLIB_EXT := dylib
-OSLIBS += -framework CoreFoundation
 HAVE_SSP := 1
 JLIBLDFLAGS += -Wl,-compatibility_version,$(SOMAJOR) -Wl,-current_version,$(JULIA_MAJOR_VERSION).$(JULIA_MINOR_VERSION).$(JULIA_PATCH_VERSION)
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -239,6 +239,11 @@ RT_LIBS := $(call whole_archive,$(LIBUV)) $(call whole_archive,$(LIBUTF8PROC)) $
 CG_LIBS := $(LIBUNWIND) $(CG_LLVMLINK) $(OSLIBS) $(LIBTRACYCLIENT) $(LIBITTAPI) $(LIBLMDB)
 endif
 
+ifeq ($(OS),Darwin)
+# needed for codegen's dSYM lookup.
+CG_LIBS += -framework CoreFoundation
+endif
+
 ifeq ($(USEGCC),1)
 ifeq ($(USE_RT_STATIC_LIBGCC),1)
 RT_LIBS += -static-libgcc


### PR DESCRIPTION
measured via

```julia
# hello.jl
function @main(args::Vector{String})::Cint
    Core.println("Hello, world!")
    return 0
end
```
```
> julia +nightly --startup-file=no --project=. -m JuliaC --trim=safe --experimental --bundle bench_nightly --output-exe hello hello.jl
> ./julia --startup-file=no --project=. -m JuliaC --trim=safe --experimental --bundle bench_nightly --output-exe hello hello.jl

> hyperfine -N --warmup 10 --runs 200 ./bench_nightly/bin/hello
Benchmark 1: ./bench_nightly/bin/hello
  Time (mean ± σ):      16.9 ms ±   0.5 ms    [User: 13.2 ms, System: 3.0 ms]
  Range (min … max):    16.2 ms …  18.9 ms    200 runs
 
> hyperfine -N --warmup 10 --runs 200 ./bench_pr/bin/hello
Benchmark 1: ./bench_pr/bin/hello
  Time (mean ± σ):      14.5 ms ±   0.2 ms    [User: 11.6 ms, System: 2.4 ms]
  Range (min … max):    14.2 ms …  15.1 ms    200 runs
```