### PR TITLE
[1.12] Compiler: avoid specializing iteration continuations on user types (backport #61984)

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -1585,6 +1585,44 @@ function precise_container_type(interp::AbstractInterpreter, @nospecialize(itft)
     end
 end
 
+# State and captured context for the `iterate(arg)` / `iterate(arg, state)` continuations
+# (`InferIterate` / `InferIterate2Arg` below). User-derived data (`iteratef`, `itertype`) is
+# held here behind `@nospecialize` so that these continuations are not specialized on user
+# types (cf. `CallInferenceState`, `AbstractApplyState`, which exist for the same reason).
+mutable struct AbstractIterationState
+    stateordonet
+    stateordonet_widened
+    valtype
+    statetype
+    iteratef
+    itertype
+    may_have_terminated::Bool
+    nextstate::UInt8
+    const iterateresult::Future{AbstractIterationResult}
+    const call1future::Future{CallMeta}
+    const calls::Vector{CallMeta}
+    const ret::Vector{Any}
+    call2future::Future{CallMeta}
+    function AbstractIterationState(
+            @nospecialize(iteratef), @nospecialize(itertype),
+            iterateresult::Future{AbstractIterationResult}, call1future::Future{CallMeta}
+        )
+        return new(
+            #=stateordonet=#Bottom, #=stateordonet_widened=#Bottom, #=valtype=#Bottom, #=statetype=#Bottom,
+            iteratef, itertype, #=may_have_terminated=#false, #=nextstate=#0x00,
+            iterateresult, call1future, #=calls=#CallMeta[], #=ret=#Any[])
+    end
+end
+
+# continuation for `iterate(arg)`
+struct InferIterate
+    state::AbstractIterationState
+end
+# continuation for `iterate(arg, state)`
+struct InferIterate2Arg
+    state::AbstractIterationState
+end
+
 # simulate iteration protocol on container type up to fixpoint
 function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @nospecialize(itertype), sv::AbsIntState)
     if isa(itft, Const)
@@ -1593,27 +1631,146 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
         return Future(AbstractIterationResult(Any[Vararg{Any}], nothing, Effects()))
     end
     @assert !isvarargtype(itertype)
-
     iterateresult = Future{AbstractIterationResult}()
-    call1future = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[itft, itertype]), StmtInfo(true, false), sv)::Future
-    function inferiterate(interp, sv)
-        call1 = call1future[]
-        stateordonet = call1.rt
-        # Return Bottom if this is not an iterator.
-        # WARNING: Changes to the iteration protocol must be reflected here,
-        # this is not just an optimization.
-        # TODO: this doesn't realize that Array, GenericMemory, SimpleVector, Tuple, and NamedTuple do not use the iterate protocol
-        if stateordonet === Bottom
-            iterateresult[] = AbstractIterationResult(Any[Bottom], AbstractIterationInfo(CallMeta[CallMeta(Bottom, Any, call1.effects, call1.info)], true))
+    call1future = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[itft, itertype]), StmtInfo(true, false), sv)::Future{CallMeta}
+    state = AbstractIterationState(iteratef, itertype, iterateresult, call1future)
+    inferiterate = InferIterate(state)
+    # continue making progress as soon as possible, on iterate(arg)
+    if !(isready(call1future) && inferiterate(interp, sv))
+        push!(sv.tasks, inferiterate)
+    end
+    return iterateresult
+end
+
+function (inferiterate::InferIterate)(interp, sv)
+    state = inferiterate.state
+    call1 = state.call1future[]
+    # Return Bottom if this is not an iterator.
+    # WARNING: Changes to the iteration protocol must be reflected here,
+    # this is not just an optimization.
+    # TODO: this doesn't realize that Array, GenericMemory, SimpleVector, Tuple, and NamedTuple do not use the iterate protocol
+    if call1.rt === Bottom
+        state.iterateresult[] = AbstractIterationResult(Any[Bottom], AbstractIterationInfo(CallMeta[CallMeta(Bottom, Any, call1.effects, call1.info)], true))
+        return true
+    end
+    push!(state.calls, call1)
+    state.stateordonet = call1.rt
+    state.stateordonet_widened = widenconst(call1.rt)
+    # continue making progress as much as possible, on iterate(arg, state)
+    inferiterate_2arg = InferIterate2Arg(state)
+    inferiterate_2arg(interp, sv) || push!(sv.tasks, inferiterate_2arg)
+    return true
+end
+
+function (inferiterate_2arg::InferIterate2Arg)(interp, sv)
+    state = inferiterate_2arg.state
+    𝕃ᵢ = typeinf_lattice(interp)
+    iteratef = state.iteratef
+    itertype = state.itertype
+    calls = state.calls
+    ret = state.ret
+    iterateresult = state.iterateresult
+    if state.nextstate === 0x1
+        state.nextstate = 0xff
+        @goto state1
+    elseif state.nextstate === 0x2
+        state.nextstate = 0xff
+        @goto state2
+    else
+        @assert state.nextstate === 0x0
+        state.nextstate = 0xff
+    end
+
+    # Try to unroll the iteration up to max_tuple_splat, which covers any finite
+    # length iterators, or interesting prefix
+    while true
+        if state.stateordonet_widened === Nothing
+            iterateresult[] = AbstractIterationResult(ret, AbstractIterationInfo(calls, true))
             return true
         end
-        stateordonet_widened = widenconst(stateordonet)
-        calls = CallMeta[call1]
-        valtype = statetype = Bottom
-        ret = Any[]
-        𝕃ᵢ = typeinf_lattice(interp)
-        may_have_terminated = false
-        local call2future::Future{CallMeta}
+        if Nothing <: state.stateordonet_widened || length(ret) >= InferenceParams(interp).max_tuple_splat
+            break
+        end
+        if (!isa(state.stateordonet_widened, DataType) ||
+            !(state.stateordonet_widened <: Tuple) ||
+            isvatuple(state.stateordonet_widened) ||
+            length(state.stateordonet_widened.parameters) != 2)
+            break
+        end
+        nstatetype = getfield_tfunc(𝕃ᵢ, state.stateordonet, Const(2))
+        # If there's no new information in this statetype, don't bother continuing,
+        # the iterator won't be finite.
+        if ⊑(𝕃ᵢ, nstatetype, state.statetype)
+            iterateresult[] = AbstractIterationResult(Any[Bottom], AbstractIterationInfo(calls, false), EFFECTS_THROWS)
+            return true
+        end
+        state.valtype = getfield_tfunc(𝕃ᵢ, state.stateordonet, Const(1))
+        push!(ret, state.valtype)
+        state.statetype = nstatetype
+        state.call2future = abstract_call_known(
+            interp, iteratef, ArgInfo(nothing, Any[Const(iteratef), itertype, state.statetype]),
+            StmtInfo(true, false), sv)::Future{CallMeta}
+        if !isready(state.call2future)
+            state.nextstate = 0x1
+            return false
+            @label state1
+        end
+        let call = state.call2future[]
+            push!(calls, call)
+            state.stateordonet = call.rt
+            state.stateordonet_widened = widenconst(state.stateordonet)
+        end
+    end
+    # From here on, we start asking for results on the widened types, rather than
+    # the precise (potentially const) state type
+    # statetype and valtype are reinitialized in the first iteration below from the
+    # (widened) stateordonet, which has not yet been fully analyzed in the loop above
+    state.valtype = state.statetype = Bottom
+    state.may_have_terminated = Nothing <: state.stateordonet_widened
+    while state.valtype !== Any
+        nounion = typeintersect(state.stateordonet_widened, Tuple{Any,Any})
+        if nounion !== Union{} && !isa(nounion, DataType)
+            # nounion is of a type we cannot handle
+            state.valtype = Any
+            break
+        end
+        if nounion === Union{} || (nounion.parameters[1] <: state.valtype && nounion.parameters[2] <: state.statetype)
+            # reached a fixpoint or iterator failed/gave invalid answer
+            if !hasintersect(state.stateordonet_widened, Nothing)
+                # ... but cannot terminate
+                if state.may_have_terminated
+                    # ... and iterator may have terminated prior to this loop, but not during it
+                    state.valtype = Bottom
+                else
+                    #  ... or cannot have terminated prior to this loop
+                    iterateresult[] = AbstractIterationResult(Any[Bottom], AbstractIterationInfo(calls, false), Effects())
+                    return true
+                end
+            end
+            break
+        end
+        state.valtype = tmerge(state.valtype, nounion.parameters[1])
+        state.statetype = tmerge(state.statetype, nounion.parameters[2])
+        state.call2future = abstract_call_known(
+            interp, iteratef, ArgInfo(nothing, Any[Const(iteratef), itertype, state.statetype]),
+            StmtInfo(true, false), sv)::Future{CallMeta}
+        if !isready(state.call2future)
+            state.nextstate = 0x2
+            return false
+            @label state2
+        end
+        let call = state.call2future[]
+            push!(calls, call)
+            state.stateordonet = call.rt
+            state.stateordonet_widened = widenconst(state.stateordonet)
+        end
+    end
+    if state.valtype !== Union{}
+        push!(ret, Vararg{state.valtype})
+    end
+    iterateresult[] = AbstractIterationResult(ret, AbstractIterationInfo(calls, false))
+    return true
+end
 
         nextstate::UInt8 = 0x0
         function inferiterate_2arg(interp, sv)

--- a/doc/src/devdocs/sysimg.md
+++ b/doc/src/devdocs/sysimg.md
@@ -169,7 +169,7 @@ debug info, respectively, and so will make debugging more difficult.
 - Use tools like [JET.jl](https://github.com/aviatesk/JET.jl),
   [Cthulhu.jl](https://github.com/JuliaDebug/Cthulhu.jl), and/or
   [SnoopCompile](https://github.com/timholy/SnoopCompile.jl)
-  to identify failures of type-inference, and follow our [Performance Tips](@ref) to fix them.
+  to identify failures of type-inference, and follow our [Performance Tips](@ref man-performance-tips) to fix them.
 
 ### Compatibility concerns
 

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -64,7 +64,7 @@ and [Ruby](https://en.wikipedia.org/wiki/Ruby_(programming_language)).
 
 The most significant departures of Julia from typical dynamic languages are:
 
-  * The core language imposes very little; [Julia Base and the standard library](@ref man-core-base-and-stdlib) are written in Julia itself, including
+  * The core language imposes very little; [Julia Base and the standard library](@ref standard-modules) are written in Julia itself, including
     primitive operations like integer arithmetic
   * A rich language of types for constructing and describing objects, that can also optionally be
     used to make type declarations

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -1112,7 +1112,7 @@ loops cannot be merged because of the intervening `sort` function.
 
 Finally, the maximum efficiency is typically achieved when the output array of a vectorized operation
 is *pre-allocated*, so that repeated calls do not allocate new arrays over and over again for
-the results (see [Pre-allocating outputs](@ref)). A convenient syntax for this is `X .= ...`, which
+the results (see [Pre-allocate outputs](@ref)). A convenient syntax for this is `X .= ...`, which
 is equivalent to `broadcast!(identity, X, ...)` except that, as above, the `broadcast!` loop is
 fused with any nested "dot" calls. For example, `X .= sin.(Y)` is equivalent to `broadcast!(sin, X, Y)`,
 overwriting `X` with `sin.(Y)` in-place. If the left-hand side is an array-indexing expression,

--- a/doc/src/manual/memory-management.md
+++ b/doc/src/manual/memory-management.md
@@ -142,7 +142,7 @@ The best way to minimize GC impact is to reduce unnecessary allocations:
 
 ### Profiling Memory Usage
 
-For detailed guidance on profiling memory allocations and identifying performance bottlenecks, see the [Profiling](@ref man-profiling) section.
+For detailed guidance on profiling memory allocations and identifying performance bottlenecks, see the [Profiling](@ref lib-profiling) section.
 
 ## [Advanced Configuration](@id man-gc-advanced)
 

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -578,7 +578,7 @@ However, future calls to `tryeval` will continue to see the definition of `newfu
 
 You may want to try this for yourself to see how it works.
 
-The implementation of this behavior is a "world age counter", which is further described in the [Worldage](@ref man-worldage)
+The implementation of this behavior is a "world age counter", which is further described in the [Worldage](@ref "The World Age mechanism")
 manual chapter.
 
 ## Design Patterns with Parametric Methods

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -375,7 +375,7 @@ WARNING: import of M1.x into Main conflicts with an existing identifier; ignored
 ```
 
 The resolution of an implicit binding depends on the set of all `using`'d modules visible
-in the current world age. See [the manual chapter on world age](@ref man-worldage) for more
+in the current world age. See [the manual chapter on world age](@ref "The World Age mechanism") for more
 details.
 
 ### Default top-level definitions and bare modules

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -154,7 +154,7 @@ julia> time_sum(x)
 In some situations, your function may need to allocate memory as part of its operation, and this
 can complicate the simple picture above. In such cases, consider using one of the [tools](@ref tools)
 below to diagnose problems, or write a version of your function that separates allocation from
-its algorithmic aspects (see [Pre-allocating outputs](@ref)).
+its algorithmic aspects (see [Pre-allocate outputs](@ref)).
 
 !!! note
     For more serious benchmarking, consider the [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl)
@@ -1440,7 +1440,7 @@ may be the case during development of a package.
 Keeping the time taken to load the package down is usually helpful.
 General good practice for package developers includes:
 
-1. Reduce your dependencies to those you really need. Consider using [package extensions](@ref) to support interoperability with other packages without bloating your essential dependencies.
+1. Reduce your dependencies to those you really need. Consider using [package extensions](@ref man-extensions) to support interoperability with other packages without bloating your essential dependencies.
 3. Avoid use of [`__init__()`](@ref) functions unless there is no alternative, especially those which might trigger a lot
    of compilation, or just take a long time to execute.
 4. Where possible, fix [invalidations](https://julialang.org/blog/2020/08/invalidations/) among your dependencies and from your package code.


### PR DESCRIPTION
Manual backport of #61984 to 1.12.

`abstract_iteration`'s `inferiterate` / `inferiterate_2arg` continuations were closures capturing `itertype`, so every distinct iterated type produced a new closure type and a fresh specialization of the continuation. Under a custom `AbstractInterpreter` (Enzyme.jl's) this shows up as compile time: in a `--trace-compile-timing` trace of Enzyme.jl differentiating an Oceananigans ocean model on 1.12.7, `Compiler.var"#inferiterate_2arg#abstract_iteration##1"` was compiled 344 times (32 s) and `#inferiterate#...` 348 times (9 s) of a 725 s first call. #61984 moves the user-derived data into `AbstractIterationState` behind `@nospecialize` and makes the continuations callable structs, so they specialize once.

Conflict resolution: 1.12 does not have the `vtypes::Union{VarTable,Nothing}` argument that master threads through `abstract_iteration` / `abstract_call_known`, so the `vtypes` field, constructor argument and call arguments are dropped; everything else is as upstream.

Verified by loading `Compiler` from this branch as a package on 1.12.7: inferring `for v in x` over 8 distinct container types leaves 1 specialization each of `InferIterate2Arg` and `InferIterate`, and `Compiler/test/runtests.jl` passes (536889 pass, 49 broken, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxrYVEwRvZrx16j7ZYWyyG