### PR TITLE
Profile: keep the test's busy loop out of the vDSO

### DIFF
--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -29,13 +29,30 @@ let iobuf = IOBuffer()
     end
 end
 
+# Burn CPU time in Julia code rather than in `time_ns`. Most of a tight `time_ns` loop is
+# spent inside the kernel's vDSO `clock_gettime`, and on some kernels (e.g. Ubuntu's arm64
+# builds) libunwind cannot unwind out of that function. Samples taken there then carry no
+# Julia frames at all, and if every sample lands there the printing tests below see an
+# empty profile. The iteration count is hidden from inference so the call cannot be
+# constant-folded, and the result is kept alive with `donotdelete` so the loop cannot
+# be optimized away.
+@noinline function spin(n)
+    s = zero(UInt)
+    for i in 1:n
+        s = s ⊻ (UInt(i) + (s << 1))
+    end
+    return s
+end
+
 @noinline function busywait(t, n_tries)
     iter = 0
     init_data = Profile.len_data()
     while iter < n_tries && Profile.len_data() == init_data
         iter += 1
         tend = time_ns() + 1e9 * t
-        while time_ns() < tend end
+        while time_ns() < tend
+            Base.donotdelete(spin(Base.compilerbarrier(:const, 100_000)))
+        end
     end
 end
 


### PR DESCRIPTION
The Profile tests collect their samples by spinning on `time_ns()`, so nearly every sample is taken inside the kernel's vDSO `clock_gettime`. On some kernels (Ubuntu's arm64 builds, for instance) that function calls an out-of-line helper, and since the vDSO ships without unwind tables and has no backing file for symbol lookup, libunwind's frame record fallback cannot get past it: the backtrace ends after the two vDSO frames. When every sample ends up like that, the profile contains no Julia frames at all, and the printing tests that hide C frames fail on an empty report. Spin in Julia code between clock reads instead, so the samples land in JIT-compiled frames that unwind fine.

Assisted-by: Claude Code (Fable 5.1)