### PR TITLE
Add "foreign symbol usage" export + "foreign link policy" (for native linking)

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -81,9 +81,10 @@ import Base: ==, _topmod, append!, convert, copy, copy!, findall, first, get, ge
     getindex, haskey, in, isempty, isready, iterate, iterate, last, length, max_world,
     min_world, popfirst!, push!, resize!, setindex!, size, intersect
 
-# Needs to match UUID defined in Project.toml
+# Needs to match UUID defined in Project.toml, given as its (lo, hi) halves in
+# the layout of `jl_uuid_t` (a 128-bit literal cannot be parsed this early)
 ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), Compiler,
-    (0x807dbc54_b67e_4c79, 0x8afb_eafe4df6f2e1))
+    (0x8afb_eafe4df6f2e1, 0x807dbc54_b67e_4c79))
 
 const getproperty = Core.getfield
 const setproperty! = Core.setfield!

--- a/NEWS.md
+++ b/NEWS.md
@@ -191,6 +191,14 @@ Standard library changes
 
 #### JuliaSyntaxHighlighting
 
+#### Libdl
+
+* Library types used with `ccall` / `cglobal` can now subtype `Libdl.AbstractLibrary`
+  to opt-in to `Libdl.dlid` support. This allows libraries to identify themselves
+  at precompilation time by implementing `Libdl.dlid` and providing a `Libdl.LibraryID`.
+  The `LibraryID` is used by `JuliaC.jl` and the runtime to report required libraries
+  and symbols for `--trim` applications and configure linking on a per-library basis.
+
 #### LinearAlgebra
 
 #### Markdown

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -137,6 +137,7 @@ Core.eval(Sys, :(include("osinfo.jl")))
 module Filesystem end # Filesystem is populated in stages during bootstrap
 Core.eval(Filesystem, :(include("path.jl")))
 using .Filesystem
+import Core: UUID
 include("libc.jl") # Libdl (include in libc.jl) is required for regex.jl
 using .Libc: getpid, gethostname, time, memcpy, memset, memmove, memcmp
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -471,6 +471,14 @@ struct UUID
     UUID(value::UInt128) = new(value)
 end
 
+abstract type AbstractLibrary end
+
+struct LibraryID
+    pkg::UUID
+    name::String
+    LibraryID(pkg::UUID, name::String) = new(pkg, name)
+end
+
 abstract type Exception end
 struct ErrorException <: Exception
     msg::AbstractString

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -466,6 +466,11 @@ function apply_type_or_typeapp(@nospecialize(tc), @nospecialize params...)
     return apply_type(tc, params...)
 end
 
+struct UUID
+    value::UInt128
+    UUID(value::UInt128) = new(value)
+end
+
 abstract type Exception end
 struct ErrorException <: Exception
     msg::AbstractString

--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -9,7 +9,8 @@ import Base: DL_LOAD_PATH, isdebugbuild
 
 export DL_LOAD_PATH, RTLD_DEEPBIND, RTLD_FIRST, RTLD_GLOBAL, RTLD_LAZY, RTLD_LOCAL,
     RTLD_NODELETE, RTLD_NOLOAD, RTLD_NOW, dlclose, dlopen, dlopen_e, dlsym, dlsym_e,
-    dlpath, find_library, dlext, dllist, LazyLibrary, LazyLibraryPath, BundledLazyLibraryPath
+    dlpath, find_library, dlext, dllist, dlid, AbstractLibrary, LibraryID,
+    LazyLibrary, LazyLibraryPath, BundledLazyLibraryPath
 
 """
     DL_LOAD_PATH
@@ -345,6 +346,47 @@ See also [`LazyLibrary`](@ref), [`LazyLibraryPath`](@ref).
 """
 BundledLazyLibraryPath(subpath) = LazyLibraryPath(PrivateShlibdirGetter(), subpath)
 
+import Core: AbstractLibrary, LibraryID
+
+"""
+    LibraryID(pkg::Base.UUID, name::AbstractString)
+
+The stable identity of a library: the UUID of the package that provides it, together
+with the name of the library product within that package. This ID is used by the
+runtime to report `ccall` / `cglobal` usages within an AOT-compiled project and to
+opt-in to native linking.
+
+!!! compat "Julia 1.14"
+    `LibraryID` was added in Julia 1.14.
+"""
+LibraryID
+LibraryID(pkg::Base.UUID, name::AbstractString) = LibraryID(pkg, String(name))
+
+"""
+    AbstractLibrary
+
+Abstract supertype for library handles that carry a stable identity the compiler can
+rely on. Subtypes must implement [`dlid`](@ref).
+
+A subtype promises that the identity is invariant for the life of the handle. `ccall`
+and `cglobal` record it where the library is referenced.
+
+!!! compat "Julia 1.14"
+    `AbstractLibrary` was added in Julia 1.14.
+"""
+AbstractLibrary
+
+"""
+    dlid(lib::AbstractLibrary) -> Union{LibraryID, Nothing}
+
+Return the stable identity declared for `lib` as a [`LibraryID`](@ref), or `nothing`
+if `lib` has no declared identity. See also [`AbstractLibrary`](@ref).
+
+!!! compat "Julia 1.14"
+    `dlid` was added in Julia 1.14.
+"""
+function dlid end
+
 # Small helper struct to initialize a LazyLibrary with its initial set of dependencies
 struct InitialDependencies{T}
     dependencies::Vector{T}
@@ -353,7 +395,8 @@ end
 
 """
     LazyLibrary(name; flags = <default dlopen flags>,
-                dependencies = LazyLibrary[], on_load_callback = nothing)
+                dependencies = LazyLibrary[], on_load_callback = nothing,
+                id = nothing)
 
 Represents a lazily-loaded shared library that delays loading itself and its dependencies
 until first use in a `ccall()`, `@ccall`, `dlopen()`, `dlsym()`, `dlpath()`, or `cglobal()`.
@@ -370,6 +413,9 @@ This is a thread-safe mechanism for on-demand library initialization.
   You may call `ccall()` from within the `on_load_callback` but only for the current library
   and its dependencies, and user should not call `wait()` on any tasks within the on load
   callback as they may deadlock).
+- `id`: Optional stable identity for the library, reported by [`dlid`](@ref), given as a
+  [`LibraryID`](@ref) naming the owning package's UUID and the library's name. `nothing`
+  (the default) means the library declares no identity.
 
 The dlopen operation is thread-safe: only one thread loads the library, acquired after the
 release store of the reference to each dependency from loading of each dependency. Other
@@ -378,6 +424,9 @@ calls (there is no dlclose for lazy library and dlclose should not be called on 
 
 !!! compat "Julia 1.11"
     `LazyLibrary` was added in Julia 1.11.
+
+!!! compat "Julia 1.14"
+    The `id` keyword argument was added in Julia 1.14.
 
 See also [`LazyLibraryPath`](@ref), [`BundledLazyLibraryPath`](@ref), [`dlopen`](@ref),
 [`dlsym`](@ref), [`add_dependency!`](@ref).
@@ -398,10 +447,11 @@ For more examples including platform-specific libraries, lazy path construction,
 migration from `__init__()` patterns, see the manual section on
 [Using LazyLibrary for Lazy Loading](@ref man-lazylibrary).
 """
-mutable struct LazyLibrary
+mutable struct LazyLibrary <: AbstractLibrary
     # Name and flags to open with
     const path
     const flags::UInt32
+    const id::Union{LibraryID, Nothing}
 
     # Dependencies that must be loaded before we can load
     #
@@ -417,10 +467,11 @@ mutable struct LazyLibrary
     # Pointer that we eventually fill out upon first `dlopen()`
     @atomic handle::Ptr{Cvoid}
     function LazyLibrary(path; flags = default_rtld_flags, dependencies = LazyLibrary[],
-                         on_load_callback = nothing)
+                         on_load_callback = nothing, id::Union{LibraryID,Nothing} = nothing)
         return new(
             path,
             UInt32(flags),
+            id,
             Base.OncePerProcess{Vector{LazyLibrary}}(
                 InitialDependencies{LazyLibrary}(dependencies)
             ),
@@ -456,8 +507,9 @@ function add_dependency!(ll::LazyLibrary, dep::LazyLibrary)
     end
 end
 
-# Register `jl_libdl_dlopen_func` so that `ccall()` lowering knows
-# how to call `dlopen()`.
+dlid(ll::LazyLibrary) = ll.id
+
+# Register `jl_libdl_dlopen_func` so that `ccall()` lowering knows how to call `dlopen()`.
 Base.unsafe_store!(cglobal(:jl_libdl_dlopen_func, Any), dlopen)
 
 function dlopen(ll::LazyLibrary, flags::Integer = ll.flags; kwargs...)

--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -509,8 +509,9 @@ end
 
 dlid(ll::LazyLibrary) = ll.id
 
-# Register `jl_libdl_dlopen_func` so that `ccall()` lowering knows how to call `dlopen()`.
+# Register these so that `ccall()` lowering knows how to call `dlopen()` and `dlid()`.
 Base.unsafe_store!(cglobal(:jl_libdl_dlopen_func, Any), dlopen)
+Base.unsafe_store!(cglobal(:jl_libdl_dlid_func, Any), dlid)
 
 function dlopen(ll::LazyLibrary, flags::Integer = ll.flags; kwargs...)
     handle = @atomic :acquire ll.handle

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2881,7 +2881,7 @@ function maybe_loaded_precompile(key::PkgId, buildid::UInt128)
 end
 
 function module_build_id(m::Module)
-    hi, lo = ccall(:jl_module_build_id, NTuple{2,UInt64}, (Any,), m)
+    lo, hi = ccall(:jl_module_build_id, NTuple{2,UInt64}, (Any,), m)
     return (UInt128(hi) << 64) | lo
 end
 
@@ -3097,10 +3097,10 @@ function __require_prelocked(pkg::PkgId, env)
     # just load the file normally via include
     # for unknown dependencies
     uuid = pkg.uuid
-    uuid = (uuid === nothing ? (UInt64(0), UInt64(0)) : convert(NTuple{2, UInt64}, uuid))
-    old_uuid = ccall(:jl_module_uuid, NTuple{2, UInt64}, (Any,), __toplevel__)
+    uuid = (uuid === nothing ? UUID(0) : uuid)
+    old_uuid = ccall(:jl_module_uuid, UUID, (Any,), __toplevel__)
     if uuid !== old_uuid
-        ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), __toplevel__, uuid)
+        ccall(:jl_set_module_uuid, Cvoid, (Any, UUID), __toplevel__, uuid)
     end
     __toplevel__.var"#_internal_julia_parse" = VersionedParse(spec.julia_syntax_version)
     unlock(require_lock)
@@ -3111,7 +3111,7 @@ function __require_prelocked(pkg::PkgId, env)
         __toplevel__.var"#_internal_julia_parse" = Core._parse
         lock(require_lock)
         if uuid !== old_uuid
-            ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), __toplevel__, old_uuid)
+            ccall(:jl_set_module_uuid, Cvoid, (Any, UUID), __toplevel__, old_uuid)
         end
     end
     return loaded
@@ -3439,9 +3439,9 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
     end
     end
 
-    uuid_tuple = pkg.uuid === nothing ? (UInt64(0), UInt64(0)) : convert(NTuple{2, UInt64}, pkg.uuid)
+    uuid = pkg.uuid === nothing ? UUID(0) : pkg.uuid
 
-    ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), Base.__toplevel__, uuid_tuple)
+    ccall(:jl_set_module_uuid, Cvoid, (Any, UUID), Base.__toplevel__, uuid)
     if source !== nothing
         task_local_storage()[:SOURCE_PATH] = source
     end

--- a/base/pkgid.jl
+++ b/base/pkgid.jl
@@ -10,7 +10,7 @@ end
 PkgId(name::AbstractString) = PkgId(nothing, name)
 
 function PkgId(m::Module, name::String = String(nameof(moduleroot(m))))
-    uuid = UUID(ccall(:jl_module_uuid, NTuple{2, UInt64}, (Any,), m))
+    uuid = ccall(:jl_module_uuid, UUID, (Any,), m)
     UInt128(uuid) == 0 ? PkgId(name) : PkgId(uuid, name)
 end
 

--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -5,13 +5,15 @@ Represents a Universally Unique Identifier (UUID).
 Can be built from one `UInt128` (all byte values), two `UInt64`, or four `UInt32`.
 Conversion from a string will check the UUID validity.
 """
-struct UUID
-    value::UInt128
-end
+UUID
+
 UUID(u::UUID) = u
+UUID(value::Integer) = UUID(convert(UInt128, value))
 UUID(u::NTuple{2, UInt64}) = UUID((UInt128(u[1]) << 64) | UInt128(u[2]))
 UUID(u::NTuple{4, UInt32}) = UUID((UInt128(u[1]) << 96) | (UInt128(u[2]) << 64) |
                                   (UInt128(u[3]) << 32) | UInt128(u[4]))
+
+UInt128(u::UUID) = u.value
 
 function convert(::Type{NTuple{2, UInt64}}, uuid::UUID)
     bytes = uuid.value
@@ -28,8 +30,6 @@ function convert(::Type{NTuple{4, UInt32}}, uuid::UUID)
     ll = UInt32(bytes & 0xffffffff)
     return (hh, hl, lh, ll)
 end
-
-UInt128(u::UUID) = u.value
 
 let
     uuid_hash_seed = UInt === UInt64 ? 0xd06fa04f86f11b53 : 0x96a1f36d

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -3,6 +3,10 @@
 #include "llvm-version.h"
 #include "platform.h"
 
+#include <map>
+#include <set>
+#include <tuple>
+
 // target support
 #include <llvm/TargetParser/Triple.h>
 #include "llvm/Support/CodeGen.h"
@@ -902,6 +906,85 @@ static void aot_link_output(jl_codegen_output_t &out) JL_CANSAFEPOINT
     }
 }
 
+// The library a foreign site refers to, as (package UUID text, library name):
+// both set for a library identified at the call site, only the name for the
+// runtime's own libraries and static library strings, neither for a symbol
+// looked up across the process (RTLD_DEFAULT).
+static std::pair<std::string, std::string> used_foreign_library(const jl_used_foreign_symbol_t &dep)
+{
+    if (dep.lib_id != nullptr) {
+        const jl_libraryid_t *lid = (const jl_libraryid_t *)jl_data_ptr(dep.lib_id);
+        char uuid[JL_UUID_STRING_LEN + 1];
+        jl_uuid_to_string(&lid->pkg, uuid);
+        return {uuid, std::string(jl_string_data(lid->name), jl_string_len(lid->name))};
+    }
+    if (dep.lib == nullptr)
+        return {"", ""};
+    if ((intptr_t)dep.lib == (intptr_t)JL_LIBJULIA_DL_LIBNAME)
+        return {"", "libjulia"};
+    if ((intptr_t)dep.lib == (intptr_t)JL_LIBJULIA_INTERNAL_DL_LIBNAME)
+        return {"", "libjulia-internal"};
+    return {"", dep.lib};
+}
+
+// Write a JSON manifest of every ccall/cglobal usage site, grouped by library.
+// Each library record carries `package_uuid` if it is identified and `library`
+// if it has a name (`null` for symbols looked up across the process). Each
+// symbol entry records the kind of site and whether it was bound by a direct
+// external symbol reference (`native`) or left to runtime lookup (`lazy`).
+static void aot_export_used_foreign_symbols(jl_codegen_output_t &out, const char *path)
+{
+    std::map<std::pair<std::string, std::string>, SmallVector<const jl_used_foreign_symbol_t *, 0>> by_lib;
+    for (const auto &dep : out.used_foreign_symbols)
+        by_lib[used_foreign_library(dep)].push_back(&dep);
+
+    ios_t f;
+    if (ios_file(&f, path, 1, 1, 1, 1) == NULL) {
+        jl_safe_printf("WARNING: could not open used-foreign-symbols export path %s\n", path);
+        return;
+    }
+    auto json_string = [&f](const std::string &s) { jl_print_str_escape_json(&f, s.data(), s.size()); };
+    ios_printf(&f, "{\n  \"libraries\": [\n");
+    bool first_lib = true;
+    for (auto &[lib, sites] : by_lib) {
+        const auto &[package_uuid, library] = lib;
+        if (!first_lib)
+            ios_printf(&f, ",\n");
+        first_lib = false;
+        ios_printf(&f, "    {\n");
+        if (!package_uuid.empty())
+            ios_printf(&f, "      \"package_uuid\": \"%s\",\n", package_uuid.c_str());
+        ios_printf(&f, "      \"library\": ");
+        if (library.empty())
+            ios_printf(&f, "null");
+        else
+            json_string(library);
+        ios_printf(&f, ",\n");
+        ios_printf(&f, "      \"symbols\": [\n");
+        // One entry per distinct (symbol, kind, linkage); a symbol referenced
+        // from many call sites is a single dependency.
+        std::set<std::tuple<std::string, bool, bool>> seen;
+        bool first_sym = true;
+        for (auto *dep : sites) {
+            auto sym = std::make_tuple(std::string(dep->func ? dep->func : "<dynamic>"),
+                                       dep->is_cglobal, dep->native_linked);
+            if (!seen.insert(sym).second)
+                continue;
+            if (!first_sym)
+                ios_printf(&f, ",\n");
+            first_sym = false;
+            ios_printf(&f, "        {\"symbol\": ");
+            json_string(std::get<0>(sym));
+            ios_printf(&f, ", \"kind\": \"%s\", \"linkage\": \"%s\"}",
+                       dep->is_cglobal ? "cglobal" : "ccall",
+                       dep->native_linked ? "native" : "lazy");
+        }
+        ios_printf(&f, "\n      ]\n    }");
+    }
+    ios_printf(&f, "\n  ]\n}\n");
+    ios_close(&f);
+}
+
 static void jl_emit_native_to_output(jl_native_code_desc_t *data, jl_array_t *codeinfos,
                                       jl_array_t *ci_order, const jl_cgparams_t *cgparams,
                                       int external_linkage) JL_CANSAFEPOINT
@@ -974,6 +1057,8 @@ static void jl_emit_native_to_output(jl_native_code_desc_t *data, jl_array_t *co
     emit_always_inline(out,
                        [&ci_infos](jl_code_instance_t *ci) { return ci_infos.lookup(ci); });
     emit_llvmcall_modules(out);
+    if (const char *used_foreign_symbols_path = jl_get_export_foreign_symbol_usage())
+        aot_export_used_foreign_symbols(out, used_foreign_symbols_path);
     // finally, make sure all referenced methods get fixed up, particularly if the user declined to compile them
     aot_link_output(out);
     // including generating cfunction thunks

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -55,7 +55,7 @@ GlobalVariable *jl_emit_RTLD_DEFAULT_var(Module *M)
 }
 
 typedef struct {
-    jl_value_t *gcroot[2];     // GC roots for strings [f_name, f_lib]
+    jl_value_t *gcroot[3];     // GC roots [f_name, f_lib, lib_id]
 
     // Static name resolution (compile-time known)
     const char *f_name;        // static function name
@@ -64,6 +64,7 @@ typedef struct {
     // Dynamic name resolution (simple runtime expressions)
     jl_value_t *f_name_expr;   // expression for function name
     jl_value_t *f_lib_expr;    // expression for library name
+    jl_value_t *lib_id;        // value returned by dlid() at definition time
 
     // Runtime pointer
     Value *jl_ptr;             // callable pointer expression result
@@ -636,6 +637,8 @@ static void interpret_foreignsymbol(jl_codectx_t &ctx, native_sym_arg_t &out, jl
     out.jl_ptr = nullptr;
     out.gcroot[0] = nullptr;
     out.gcroot[1] = nullptr;
+    out.gcroot[2] = nullptr;
+    out.lib_id = nullptr;
 
     // Check if this is a tuple (normalized by julia-syntax.scm)
     if (jl_is_expr(arg) && ((jl_expr_t*)arg)->head == jl_tuple_sym) {
@@ -660,8 +663,8 @@ static void interpret_foreignsymbol(jl_codectx_t &ctx, native_sym_arg_t &out, jl
                 }
              }
         }
-        else if (nargs == 2) {
-            // Two element tuple: (func_name, lib_name)
+        else if (nargs == 2 || nargs == 3) {
+            // Three element tuple: (func_name, lib_ref, lib_id)
             jl_value_t *fname_arg = jl_array_ptr_ref(tuple_args, 0);
             jl_value_t *lib_arg = jl_array_ptr_ref(tuple_args, 1);
             out.f_name_expr = fname_arg;
@@ -688,6 +691,11 @@ static void interpret_foreignsymbol(jl_codectx_t &ctx, native_sym_arg_t &out, jl
                 else if (jl_is_string(lib_val)) {
                     out.f_lib = jl_string_data(lib_val);
                 }
+            }
+
+            if (nargs == 3) {
+                out.lib_id = jl_array_ptr_ref(tuple_args, 2);
+                out.gcroot[2] = out.lib_id;
             }
         }
     }
@@ -725,7 +733,7 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
     if (jl_is_expr(arg) && ((jl_expr_t*)arg)->head == jl_tuple_sym) {
         // Name lookup form
         native_sym_arg_t sym = {};
-        JL_GC_PUSH2(&sym.gcroot[0], &sym.gcroot[1]);
+        JL_GC_PUSH3(&sym.gcroot[0], &sym.gcroot[1], &sym.gcroot[2]);
         interpret_foreignsymbol(ctx, sym, arg);
         Value *res = runtime_sym_lookup(ctx, sym, ctx.f);
         JL_GC_POP();
@@ -1516,7 +1524,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
     }
     assert(jl_is_symbol(cc_sym));
     native_sym_arg_t symarg = {};
-    JL_GC_PUSH4(&rt, &at, &symarg.gcroot[0], &symarg.gcroot[1]);
+    JL_GC_PUSH5(&rt, &at, &symarg.gcroot[0], &symarg.gcroot[1], &symarg.gcroot[2]);
 
     CallingConv::ID cc = CallingConv::C;
     bool llvmcall = false;

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -733,6 +733,17 @@ static bool is_native_link_target(jl_codectx_t &ctx, const native_sym_arg_t &sym
     return jl_get_foreign_link_policy(symarg.lib_id) == 1;
 }
 
+// Record a ccall/cglobal usage site for the used-foreign-symbol manifest.
+static void record_used_foreign_symbol(jl_codectx_t &ctx, const native_sym_arg_t &symarg,
+                               bool is_cglobal, bool native_linked) JL_NOTSAFEPOINT
+{
+    if (jl_get_export_foreign_symbol_usage() == nullptr)
+        return;
+    ctx.emission_context.used_foreign_symbols.push_back(
+        jl_used_foreign_symbol_t{symarg.f_name, symarg.f_lib, symarg.lib_id,
+                         is_cglobal, native_linked});
+}
+
 // --- code generator for cglobal ---
 
 static jl_cgval_t emit_runtime_call(jl_codectx_t &ctx, JL_I::intrinsic f, ArrayRef<jl_cgval_t> argv, size_t nargs) JL_CANSAFEPOINT;
@@ -756,6 +767,7 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
         else {
             res = runtime_sym_lookup(ctx, sym, ctx.f);
         }
+        record_used_foreign_symbol(ctx, sym, /*is_cglobal=*/true, native_linked);
         JL_GC_POP();
         return mark_julia_type(ctx, res, false, (jl_value_t*)jl_voidpointer_type);
     } else {
@@ -2256,6 +2268,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         // Emit a plain external call and let the system linker bind it
         ++NativeLinkedCCalls;
         llvmf = jl_Module->getOrInsertFunction(symarg.f_name, functype).getCallee();
+        record_used_foreign_symbol(ctx, symarg, /*is_cglobal=*/false, /*native_linked=*/true);
     }
     else if (!ctx.params->use_jlplt) {
         if ((symarg.f_lib && !((symarg.f_lib == JL_EXE_LIBNAME) ||
@@ -2270,6 +2283,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
     }
     else {
         ++DeferredCCallLookups;
+        record_used_foreign_symbol(ctx, symarg, /*is_cglobal=*/false, /*native_linked=*/false);
         // vararg requires musttail,
         // but musttail is incompatible with noreturn.
         if (functype->isVarArg())

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -44,6 +44,7 @@ extern "C" JL_DLLEXPORT jl_value_t *ijl_genericmemory_owner(jl_genericmemory_t *
 
 STATISTIC(EmittedCCalls, "Number of ccalls emitted");
 STATISTIC(DeferredCCallLookups, "Number of ccalls looked up at runtime");
+STATISTIC(NativeLinkedCCalls, "Number of ccalls bound by direct external symbol reference");
 STATISTIC(LiteralCCalls, "Number of ccalls directly emitted through a pointer");
 STATISTIC(RetBoxedCCalls, "Number of ccalls that were retboxed");
 STATISTIC(SRetCCalls, "Number of ccalls that were marked sret");
@@ -721,6 +722,17 @@ static void interpret_foreignsymbol(jl_codectx_t &ctx, native_sym_arg_t &out, jl
     }
 }
 
+// Is this call site eligible for native linking, i.e. should it reference the
+// external symbol directly instead of resolving it lazily via a PLT at runtime?
+static bool is_native_link_target(jl_codectx_t &ctx, const native_sym_arg_t &symarg) JL_NOTSAFEPOINT
+{
+    if (!ctx.emission_context.imaging_mode)
+        return false;
+    if (symarg.f_name == nullptr || symarg.lib_id == nullptr)
+        return false;
+    return jl_get_foreign_link_policy(symarg.lib_id) == 1;
+}
+
 // --- code generator for cglobal ---
 
 static jl_cgval_t emit_runtime_call(jl_codectx_t &ctx, JL_I::intrinsic f, ArrayRef<jl_cgval_t> argv, size_t nargs) JL_CANSAFEPOINT;
@@ -735,7 +747,15 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
         native_sym_arg_t sym = {};
         JL_GC_PUSH3(&sym.gcroot[0], &sym.gcroot[1], &sym.gcroot[2]);
         interpret_foreignsymbol(ctx, sym, arg);
-        Value *res = runtime_sym_lookup(ctx, sym, ctx.f);
+        Value *res;
+        bool native_linked = is_native_link_target(ctx, sym);
+        if (native_linked) {
+            // Reference the data symbol directly; the system linker binds it.
+            res = jl_Module->getOrInsertGlobal(sym.f_name, getInt8Ty(ctx.builder.getContext()));
+        }
+        else {
+            res = runtime_sym_lookup(ctx, sym, ctx.f);
+        }
         JL_GC_POP();
         return mark_julia_type(ctx, res, false, (jl_value_t*)jl_voidpointer_type);
     } else {
@@ -2231,6 +2251,11 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         ++LiteralCCalls;
         null_pointer_check(ctx, symarg.jl_ptr, nullptr);
         llvmf = symarg.jl_ptr;
+    }
+    else if (is_native_link_target(ctx, symarg)) {
+        // Emit a plain external call and let the system linker bind it
+        ++NativeLinkedCCalls;
+        llvmf = jl_Module->getOrInsertFunction(symarg.f_name, functype).getCallee();
     }
     else if (!ctx.params->use_jlplt) {
         if ((symarg.f_lib && !((symarg.f_lib == JL_EXE_LIBNAME) ||

--- a/src/gc-heap-snapshot.c
+++ b/src/gc-heap-snapshot.c
@@ -13,7 +13,7 @@
 #include <string.h>
 
 // https://stackoverflow.com/a/33799784/751061
-static void print_str_escape_json(ios_t *stream, const char *s, size_t len) JL_NOTSAFEPOINT
+JL_DLLEXPORT void jl_print_str_escape_json(ios_t *stream, const char *s, size_t len) JL_NOTSAFEPOINT
 {
     ios_putc('"', stream);
     for (size_t i = 0; i < len; i++) {
@@ -126,7 +126,7 @@ static void st_print_json_array(string_table_t *t, ios_t *stream, int newlines) 
     for (size_t i = 0; i < t->count; i++) {
         if (i > 0)
             ios_printf(stream, newlines ? ",\n" : ",");
-        print_str_escape_json(stream, t->strings[i], t->lengths[i]);
+        jl_print_str_escape_json(stream, t->strings[i], t->lengths[i]);
     }
     ios_printf(stream, "]");
 }

--- a/src/gc-mmtk/gc-mmtk.c
+++ b/src/gc-mmtk/gc-mmtk.c
@@ -745,6 +745,7 @@ JL_DLLEXPORT void jl_gc_scan_vm_specific_roots(RootsWorkClosure* closure)
     // constants
     add_node_to_roots_buffer(closure, &buf, &len, jl_emptytuple_type);
     add_node_to_roots_buffer(closure, &buf, &len, cmpswap_names);
+    add_node_to_roots_buffer(closure, &buf, &len, jl_foreign_link_policy);
 
     // jl_global_roots_table must be transitively pinned
     RootsWorkBuffer tpinned_buf = (closure->report_tpinned_nodes_func)((void**)0, 0, 0, closure->data, true);

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3148,6 +3148,8 @@ static void gc_mark_roots(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
     gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_emptytuple_type, "emptytuple_type");
     gc_try_claim_and_push(mq, cmpswap_names, NULL);
     gc_heap_snapshot_record_gc_roots((jl_value_t*)cmpswap_names, "cmpswap_names");
+    gc_try_claim_and_push(mq, jl_foreign_link_policy, NULL);
+    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_foreign_link_policy, "foreign_link_policy");
     gc_try_claim_and_push(mq, jl_global_roots_list, NULL);
     gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_global_roots_list, "global_roots_list");
     gc_try_claim_and_push(mq, jl_global_roots_keyset, NULL);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -342,6 +342,19 @@ private:
     StringMap<unsigned> counter;
 };
 
+// One record per ccall/cglobal usage site, collected during codegen so the
+// AOT pipeline can emit a used-foreign-symbol manifest. Strings point into
+// interned/AST-owned storage that outlives codegen; `lib_id` is the
+// `AbstractLibrary` identity (a `LibraryID`) frozen at the call site (NULL when
+// the target is not an AbstractLibrary or declares none).
+struct jl_used_foreign_symbol_t {
+    const char *func;          // symbol name, NULL if dynamic
+    const char *lib;           // static library string or sentinel, NULL if dynamic
+    jl_value_t *lib_id;        // dlid() frozen at definition time, or NULL
+    bool is_cglobal;           // cglobal site rather than ccall
+    bool native_linked;        // bound via a direct external symbol reference
+};
+
 struct jl_linker_info_t {
     DenseMap<jl_code_instance_t *, jl_codeinst_funcs_t<orc::SymbolStringPtr>> ci_funcs;
     // Key on the enum's underlying integer type: LLVM's DenseMapInfo requires
@@ -400,6 +413,7 @@ public:
     DenseMap<jl_code_instance_t *, jl_llvm_functions_t> ci_funcs;
     SmallVector<std::pair<jl_code_instance_t *, GlobalVariable *>, 0> external_fns;
 
+    SmallVector<jl_used_foreign_symbol_t,0> used_foreign_symbols;
     SmallVector<cfunc_decl_t,0> cfuncs;
     std::map<void*, GlobalVariable*> global_targets;
     jl_array_t *temporary_roots = nullptr;

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -4,6 +4,7 @@
 #define JL_EXPORTED_DATA_POINTERS(XX) \
     XX(abioverride_type, jl_datatype_t*) \
     XX(abstractarray_type, jl_unionall_t*) \
+    XX(abstractlibrary_type, jl_datatype_t*) \
     XX(abstractstring_type, jl_datatype_t*) \
     XX(addrspace_type, jl_unionall_t*) \
     XX(addrspace_typename, jl_typename_t*) \

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -70,6 +70,7 @@
     XX(intrinsic_type, jl_datatype_t*) \
     XX(anytype_type, jl_datatype_t*) \
     XX(kwcall_type, jl_datatype_t*) \
+    XX(libraryid_type, jl_datatype_t*) \
     XX(lineinfonode_type, jl_datatype_t*) \
     XX(linenumbernode_type, jl_datatype_t*) \
     XX(llvmpointer_type, jl_unionall_t*) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4690,7 +4690,6 @@ void post_boot_hooks(void)
     jl_undefvarerror_type    = (jl_datatype_t*)core("UndefVarError");
     jl_fielderror_type       = (jl_datatype_t*)core("FieldError");
     jl_atomicerror_type      = (jl_datatype_t*)core("ConcurrencyViolationError");
-    jl_abstractlibrary_type  = (jl_datatype_t*)core("AbstractLibrary");
     jl_boundserror_type      = (jl_datatype_t*)core("BoundsError");
     jl_typeerror_type        = (jl_datatype_t*)core("TypeError");
     jl_argumenterror_type    = (jl_datatype_t*)core("ArgumentError");
@@ -4710,6 +4709,11 @@ void post_boot_hooks(void)
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");
     jl_vecelement_typename = ((jl_datatype_t*)jl_unwrap_unionall(core("VecElement")))->name;
     jl_abioverride_type = (jl_datatype_t*)core("ABIOverride");
+
+    jl_abstractlibrary_type = (jl_datatype_t*)core("AbstractLibrary");
+    jl_libraryid_type = (jl_datatype_t*)core("LibraryID");
+    assert(jl_datatype_size(jl_libraryid_type) == sizeof(jl_libraryid_t));
+    assert(jl_field_offset(jl_libraryid_type, 1) == offsetof(jl_libraryid_t, name));
 
     jl_const_type = (jl_datatype_t*)core("Const");
     jl_partial_struct_type = (jl_datatype_t*)core("PartialStruct");

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4690,6 +4690,7 @@ void post_boot_hooks(void)
     jl_undefvarerror_type    = (jl_datatype_t*)core("UndefVarError");
     jl_fielderror_type       = (jl_datatype_t*)core("FieldError");
     jl_atomicerror_type      = (jl_datatype_t*)core("ConcurrencyViolationError");
+    jl_abstractlibrary_type  = (jl_datatype_t*)core("AbstractLibrary");
     jl_boundserror_type      = (jl_datatype_t*)core("BoundsError");
     jl_typeerror_type        = (jl_datatype_t*)core("TypeError");
     jl_argumenterror_type    = (jl_datatype_t*)core("ArgumentError");

--- a/src/julia.h
+++ b/src/julia.h
@@ -937,9 +937,10 @@ typedef struct _jl_binding_t {
     _Atomic(uint8_t) flags;
 } jl_binding_t;
 
-typedef struct {
-    uint64_t hi;
+// A 128-bit UUID with the layout of `Core.UUID`: a little-endian `UInt128`
+typedef struct JL_ALIGNED_ATTR(16) {
     uint64_t lo;
+    uint64_t hi;
 } jl_uuid_t;
 
 // Reading or writing requires `lock`:

--- a/src/julia.h
+++ b/src/julia.h
@@ -943,6 +943,11 @@ typedef struct JL_ALIGNED_ATTR(16) {
     uint64_t hi;
 } jl_uuid_t;
 
+typedef struct {
+    jl_uuid_t pkg;
+    jl_value_t *name;
+} jl_libraryid_t;
+
 // Reading or writing requires `lock`:
 //   scanned_methods, usings
 // Reading or writing requires `Base.require_lock`:

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -534,6 +534,7 @@ extern JL_DLLEXPORT jl_value_t *jl_typeinf_func JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_value_t *jl_compile_and_emit_func JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT size_t jl_typeinf_world;
 extern JL_DLLEXPORT size_t jl_lowering_world;
+extern JL_DLLEXPORT jl_value_t *jl_libdl_dlid_func JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_value_t *jl_libdl_dlopen_func JL_GLOBALLY_ROOTED;
 extern _Atomic(jl_typemap_entry_t*) call_cache[N_CALL_CACHE] JL_GLOBALLY_ROOTED;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -536,6 +536,10 @@ extern JL_DLLEXPORT size_t jl_typeinf_world;
 extern JL_DLLEXPORT size_t jl_lowering_world;
 extern JL_DLLEXPORT jl_value_t *jl_libdl_dlid_func JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_value_t *jl_libdl_dlopen_func JL_GLOBALLY_ROOTED;
+
+extern jl_genericmemory_t *jl_foreign_link_policy JL_GLOBALLY_ROOTED;
+JL_DLLEXPORT void jl_set_foreign_link_policy(jl_value_t *id, int native) JL_CANSAFEPOINT;
+JL_DLLEXPORT int jl_get_foreign_link_policy(jl_value_t *id) JL_NOTSAFEPOINT;
 extern _Atomic(jl_typemap_entry_t*) call_cache[N_CALL_CACHE] JL_GLOBALLY_ROOTED;
 
 void free_stack(void *stkbuf, size_t bufsz) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -540,6 +540,17 @@ extern JL_DLLEXPORT jl_value_t *jl_libdl_dlopen_func JL_GLOBALLY_ROOTED;
 extern jl_genericmemory_t *jl_foreign_link_policy JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT void jl_set_foreign_link_policy(jl_value_t *id, int native) JL_CANSAFEPOINT;
 JL_DLLEXPORT int jl_get_foreign_link_policy(jl_value_t *id) JL_NOTSAFEPOINT;
+
+// Canonical text of a UUID: lowercase hex, dashed 8-4-4-4-12
+#define JL_UUID_STRING_LEN 36
+JL_DLLEXPORT void jl_uuid_to_string(const jl_uuid_t *uuid, char *out) JL_NOTSAFEPOINT;
+// Write `s` as a quoted, escaped JSON string
+JL_DLLEXPORT void jl_print_str_escape_json(ios_t *stream, const char *s, size_t len) JL_NOTSAFEPOINT;
+
+// Used-foreign-symbol export: when set to a non-empty path, AOT codegen writes a JSON
+// manifest of every ccall/cglobal usage site there.
+JL_DLLEXPORT void jl_set_export_foreign_symbol_usage(const char *path) JL_NOTSAFEPOINT;
+JL_DLLEXPORT const char *jl_get_export_foreign_symbol_usage(void) JL_NOTSAFEPOINT;
 extern _Atomic(jl_typemap_entry_t*) call_cache[N_CALL_CACHE] JL_GLOBALLY_ROOTED;
 
 void free_stack(void *stkbuf, size_t bufsz) JL_NOTSAFEPOINT;

--- a/src/method.c
+++ b/src/method.c
@@ -73,6 +73,55 @@ JL_DLLEXPORT void jl_scan_method_source_now(jl_method_t *m, jl_value_t *src) JL_
     }
 }
 
+// Expand a foreign symbol 2-tuple `(fname, lib)` to a 3-tuple `(fname, lib, lib_id)` where
+// `lib_id` is computed by evaluating `dlid(lib_ref)` during method definition side effects.
+static void expand_library_id(jl_expr_t *e, jl_module_t *module,
+                              jl_svec_t *sparam_vals,
+                              const char *kind) JL_CANSAFEPOINT
+{
+    jl_value_t *fptr = jl_exprarg(e, 0);
+    if (!(jl_is_expr(fptr) && ((jl_expr_t*)fptr)->head == jl_tuple_sym))
+        return;
+    jl_expr_t *tuple_expr = (jl_expr_t*)fptr;
+    size_t nargs_tuple = jl_expr_nargs(tuple_expr);
+    if (nargs_tuple != 2 || jl_libdl_dlid_func == NULL)
+        return;
+    jl_task_t *ct = jl_current_task;
+    jl_value_t *lib_arg = jl_exprarg(tuple_expr, 1);
+    jl_value_t *lib_val = NULL;
+    jl_value_t *lib_id = NULL;
+    JL_GC_PUSH2(&lib_val, &lib_id);
+    if (jl_is_globalref(lib_arg)) {
+        JL_TRY {
+            lib_val = jl_interpret_toplevel_expr_in(module, lib_arg, NULL, sparam_vals);
+        }
+        JL_CATCH {
+            lib_val = NULL;
+        }
+    }
+    if (lib_val != NULL && jl_isa(lib_val, (jl_value_t*)jl_abstractlibrary_type)) {
+        JL_TRY {
+            lib_id = jl_apply_generic(jl_libdl_dlid_func, &lib_val, 1);
+        }
+        JL_CATCH {
+            if (jl_typetagis(jl_current_exception(ct), jl_errorexception_type))
+                jl_errorf("could not evaluate dlid() for %s library", kind);
+            else
+                jl_rethrow();
+        }
+        if (lib_id != NULL && lib_id != jl_nothing) {
+            if (!jl_typeis(lib_id, (jl_value_t*)jl_libraryid_type))
+                jl_errorf("dlid() for %s library must return a LibraryID or nothing", kind);
+            jl_expr_t *new_tuple = jl_exprn(jl_tuple_sym, 3);
+            jl_exprargset(new_tuple, 0, jl_exprarg(tuple_expr, 0));
+            jl_exprargset(new_tuple, 1, lib_arg);
+            jl_exprargset(new_tuple, 2, lib_id);
+            jl_exprargset(e, 0, (jl_value_t*)new_tuple);
+        }
+    }
+    JL_GC_POP();
+}
+
 static void normalize_foreignsymbol(jl_expr_t *e, jl_module_t *module, const char *kind) JL_CANSAFEPOINT
 {
     jl_task_t *ct = jl_current_task;
@@ -242,6 +291,7 @@ static jl_value_t *resolve_definition_effects(jl_value_t *expr, jl_module_t *mod
         JL_NARGSV(ccall method definition, 5); // (target, rt, at, nreq, (cc, effects, gc_safe))
         jl_task_t *ct = jl_current_task;
         normalize_foreignsymbol(e, module, "ccall");
+        expand_library_id(e, module, sparam_vals, "ccall");
         jl_value_t *rt = jl_exprarg(e, 1);
         jl_value_t *at = jl_exprarg(e, 2);
         if (!jl_is_type(rt)) {
@@ -287,6 +337,7 @@ static jl_value_t *resolve_definition_effects(jl_value_t *expr, jl_module_t *mod
     if (e->head == jl_foreignglobal_sym) {
         JL_NARGS(cglobal method definition, 1, 1); // (target)
         normalize_foreignsymbol(e, module, "cglobal");
+        expand_library_id(e, module, sparam_vals, "cglobal");
     }
     if (e->head == jl_call_sym && nargs > 0 &&
             jl_is_globalref(jl_exprarg(e, 0))) {

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -19,6 +19,7 @@
 #include "support/strhash.h"
 
 // --- library symbol lookup ---
+jl_value_t *jl_libdl_dlid_func JL_GLOBALLY_ROOTED;
 jl_value_t *jl_libdl_dlopen_func JL_GLOBALLY_ROOTED;
 
 // map from user-specified lib names to handles

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -52,6 +52,37 @@ JL_DLLEXPORT int jl_get_foreign_link_policy(jl_value_t *id) JL_NOTSAFEPOINT
     return policy == NULL ? -1 : policy == jl_true;
 }
 
+// Write the canonical text of a UUID (lowercase hex, dashed 8-4-4-4-12) into
+// `out`, which must hold JL_UUID_STRING_LEN + 1 bytes.
+JL_DLLEXPORT void jl_uuid_to_string(const jl_uuid_t *uuid, char *out) JL_NOTSAFEPOINT
+{
+    char hex[33];
+    snprintf(hex, sizeof(hex), "%016" PRIx64 "%016" PRIx64, uuid->hi, uuid->lo);
+    size_t pos = 0;
+    for (int i = 0; i < 32; i++) {
+        if (i == 8 || i == 12 || i == 16 || i == 20)
+            out[pos++] = '-';
+        out[pos++] = hex[i];
+    }
+    out[pos] = '\0';
+}
+
+// Used-foreign-symbols JSON export path, process-local. Read by the AOT codegen
+// pipeline (aot_export_used_foreign_symbols in aotcompile.cpp).
+static char *export_foreign_symbol_usage_path = NULL;
+
+JL_DLLEXPORT void jl_set_export_foreign_symbol_usage(const char *path) JL_NOTSAFEPOINT
+{
+    if (export_foreign_symbol_usage_path)
+        free(export_foreign_symbol_usage_path);
+    export_foreign_symbol_usage_path = (path && path[0]) ? strdup(path) : NULL;
+}
+
+JL_DLLEXPORT const char *jl_get_export_foreign_symbol_usage(void) JL_NOTSAFEPOINT
+{
+    return export_foreign_symbol_usage_path;
+}
+
 // map from user-specified lib names to handles
 static htable_t libMap;
 static jl_mutex_t libmap_lock;

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -22,6 +22,36 @@
 jl_value_t *jl_libdl_dlid_func JL_GLOBALLY_ROOTED;
 jl_value_t *jl_libdl_dlopen_func JL_GLOBALLY_ROOTED;
 
+// Foreign link policy: for each `LibraryID` registered here, whether AOT codegen
+// should bind that library's `ccall`/`cglobal` sites by direct external symbol
+// reference (`true`) or leave them to the run-time lookup (`false`).
+jl_genericmemory_t *jl_foreign_link_policy JL_GLOBALLY_ROOTED = NULL; // eqtable LibraryID => Bool; marked in gc_mark_roots
+static jl_mutex_t link_policy_map_lock;
+
+JL_DLLEXPORT void jl_set_foreign_link_policy(jl_value_t *id, int native)
+{
+    if (!jl_typeis(id, (jl_value_t*)jl_libraryid_type))
+        jl_type_error("jl_set_foreign_link_policy", (jl_value_t*)jl_libraryid_type, id);
+    JL_LOCK(&link_policy_map_lock);
+    jl_genericmemory_t *t = jl_foreign_link_policy;
+    if (t == NULL)
+        jl_foreign_link_policy = t = jl_alloc_memory_any(32);
+    int inserted;
+    jl_foreign_link_policy = jl_eqtable_put(t, id, native ? jl_true : jl_false, &inserted);
+    JL_UNLOCK(&link_policy_map_lock);
+}
+
+// 1 if `id` is to be bound natively, 0 if it is to be looked up at run time,
+// -1 if no policy was set for it
+JL_DLLEXPORT int jl_get_foreign_link_policy(jl_value_t *id) JL_NOTSAFEPOINT
+{
+    JL_LOCK_NOGC(&link_policy_map_lock);
+    jl_genericmemory_t *t = jl_foreign_link_policy;
+    jl_value_t *policy = t == NULL ? NULL : jl_eqtable_get(t, id, NULL);
+    JL_UNLOCK_NOGC(&link_policy_map_lock);
+    return policy == NULL ? -1 : policy == jl_true;
+}
+
 // map from user-specified lib names to handles
 static htable_t libMap;
 static jl_mutex_t libmap_lock;
@@ -456,6 +486,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
 void jl_init_runtime_ccall(void)
 {
     JL_MUTEX_INIT(&libmap_lock, "libmap_lock");
+    JL_MUTEX_INIT(&link_policy_map_lock, "link_policy_map_lock");
     strhash_new(&libMap, 16);
     uv_mutex_init(&trampoline_lock);
 }

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -659,7 +659,8 @@ jl_value_t *jl_lookup_foreignsymbol(jl_value_t *v)
             jl_error("cglobal function name cannot be empty tuple");
         } else if (nf == 1) {
             v = jl_fieldref(v, 0);
-        } else if (nf == 2) {
+        } else if (nf == 2 || (nf == 3 && jl_typeis(jl_fieldref(v, 2), (jl_value_t*)jl_libraryid_type))) {
+            // the third element is the identity recorded by method.c (see expand_library_id)
             f_lib = jl_fieldref(v, 1);
             v = jl_fieldref(v, 0);
         } else {

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -154,7 +154,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    6
+#define NUM_TAGS    7
 
 // An array of special references that need to be restored from the sysimg
 static void get_tags(jl_value_t **tags[NUM_TAGS])
@@ -166,6 +166,7 @@ static void get_tags(jl_value_t **tags[NUM_TAGS])
     INSERT_TAG(jl_module_init_order);
     INSERT_TAG(jl_typeinf_func);
     INSERT_TAG(jl_compile_and_emit_func);
+    INSERT_TAG(jl_libdl_dlid_func);
     INSERT_TAG(jl_libdl_dlopen_func);
     // n.b. must update NUM_TAGS when you add something here
 #undef INSERT_TAG

--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -7,6 +7,9 @@ using Base, Libdl, Base.BinaryPlatforms
 
 export libgfortran, libstdcxx, libgomp, libatomic, libgcc_s
 
+# This package's UUID, as in its Project.toml; names this JLL in each library's identity
+const _pkg_uuid = Base.UUID("e66e0078-7015-5450-92f7-15fbd957f2ae")
+
 # These get calculated in __init__()
 const PATH = Ref("")
 const PATH_list = String[]
@@ -26,7 +29,8 @@ const libatomic = LazyLibrary(
         BundledLazyLibraryPath("libatomic.so.1")
     else
         error("CompilerSupportLibraries_jll: Library 'libatomic' is not available for $(Sys.KERNEL)")
-    end
+    end;
+    id = LibraryID(_pkg_uuid, "libatomic")
 )
 
 if Sys.iswindows() || Sys.isapple() || arch(HostPlatform()) ∈ ("x86_64", "i686")
@@ -40,7 +44,8 @@ if Sys.iswindows() || Sys.isapple() || arch(HostPlatform()) ∈ ("x86_64", "i686
             BundledLazyLibraryPath("libquadmath.so.0")
         else
             error("CompilerSupportLibraries_jll: Library 'libquadmath' is not available for $(Sys.KERNEL)")
-        end
+        end;
+        id = LibraryID(_pkg_uuid, "libquadmath")
     )
 end
 
@@ -62,7 +67,8 @@ const libgcc_s = LazyLibrary(
         BundledLazyLibraryPath("libgcc_s.so.1")
     else
         error("CompilerSupportLibraries_jll: Library 'libgcc_s' is not available for $(Sys.KERNEL)")
-    end
+    end;
+    id = LibraryID(_pkg_uuid, "libgcc_s")
 )
 
 libgfortran_path::String = ""
@@ -76,6 +82,7 @@ const libgfortran = LazyLibrary(
     else
         error("CompilerSupportLibraries_jll: Library 'libgfortran' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libgfortran"),
     dependencies = @static if @isdefined(libquadmath)
         LazyLibrary[libgcc_s, libquadmath]
     else
@@ -94,6 +101,7 @@ const libstdcxx = LazyLibrary(
     else
         error("CompilerSupportLibraries_jll: Library 'libstdcxx' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libstdcxx"),
     dependencies = LazyLibrary[libgcc_s]
 )
 
@@ -108,6 +116,7 @@ const libgomp = LazyLibrary(
     else
         error("CompilerSupportLibraries_jll: Library 'libgomp' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libgomp"),
     dependencies = if Sys.iswindows()
         LazyLibrary[libgcc_s]
     else
@@ -127,7 +136,8 @@ let
         end
         if isfile(string(_libssp_path))
             global libssp_path::String = ""
-            @eval const libssp = LazyLibrary($(_libssp_path))
+            @eval const libssp = LazyLibrary($(_libssp_path);
+                                             id = LibraryID(_pkg_uuid, "libssp"))
         end
     end
 end

--- a/stdlib/GMP_jll/src/GMP_jll.jl
+++ b/stdlib/GMP_jll/src/GMP_jll.jl
@@ -9,6 +9,9 @@ end
 
 export libgmp, libgmpxx
 
+# This package's UUID, as in its Project.toml; names this JLL in each library's identity
+const _pkg_uuid = Base.UUID("781609d7-10c4-51f6-84f2-b8444358ff6d")
+
 # These get calculated in __init__()
 const PATH = Ref("")
 const PATH_list = String[]
@@ -24,7 +27,8 @@ const libgmp = LazyLibrary(
         BundledLazyLibraryPath("libgmp.10.dylib")
     else
         BundledLazyLibraryPath("libgmp.so.10")
-    end
+    end;
+    id = LibraryID(_pkg_uuid, "libgmp")
 )
 
 libgmpxx_path::String = ""
@@ -36,6 +40,7 @@ const libgmpxx = LazyLibrary(
     else
         BundledLazyLibraryPath("libgmpxx.so.4")
     end,
+    id = LibraryID(_pkg_uuid, "libgmpxx"),
     dependencies = if Sys.isfreebsd()
         LazyLibrary[libgmp, libgcc_s]
     elseif Sys.isapple()

--- a/stdlib/LLVMLibUnwind_jll/src/LLVMLibUnwind_jll.jl
+++ b/stdlib/LLVMLibUnwind_jll/src/LLVMLibUnwind_jll.jl
@@ -15,7 +15,10 @@ const LIBPATH_list = String[]
 artifact_dir::String = ""
 
 llvmlibunwind_path::String = ""
-const llvmlibunwind = LazyLibrary(BundledLazyLibraryPath("libunwind"))
+const llvmlibunwind = LazyLibrary(
+    BundledLazyLibraryPath("libunwind");
+    id = LibraryID(Base.UUID("47c5dbc3-30ba-59ef-96a6-123e260183d9"), "llvmlibunwind")
+)
 
 function eager_mode()
     dlopen(llvmlibunwind)

--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -31,6 +31,7 @@ const libcurl = LazyLibrary(
     else
         error("LibCURL_jll: Library 'libcurl' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(Base.UUID("deac9b47-8bc7-5906-a0fe-35ac56dc84c0"), "libcurl"),
     dependencies = if Sys.iswindows()
         if  Sys.WORD_SIZE == 32
             LazyLibrary[libz, libzstd, libnghttp2, libssh2, libgcc_s]

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -31,6 +31,7 @@ const libgit2 = LazyLibrary(
     else
         error("LibGit2_jll: Library 'libgit2' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(Base.UUID("e37daf67-58a4-590a-8e99-b0245dd2ffc5"), "libgit2"),
     dependencies = if Sys.iswindows()
         if Sys.WORD_SIZE == 32
             LazyLibrary[libssh2, libgcc_s, libpcre2_8, libz]

--- a/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
+++ b/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
@@ -34,6 +34,7 @@ const libssh2 = LazyLibrary(
     else
         error("LibSSH2_jll: Library 'libssh2' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(Base.UUID("29816b5a-b9ab-546f-933c-edad1886dfa8"), "libssh2"),
     dependencies = if Sys.iswindows()
         if Sys.WORD_SIZE == 32
             LazyLibrary[libgcc_s]

--- a/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
+++ b/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
@@ -21,6 +21,7 @@ artifact_dir::String = ""
 libunwind_path::String = ""
 const libunwind = LazyLibrary(
     BundledLazyLibraryPath("libunwind.so.8"),
+    id = LibraryID(Base.UUID("745a5e78-f969-53e9-954f-d19f2f74f4e3"), "libunwind"),
     dependencies = LazyLibrary[libz]
 )
 

--- a/stdlib/Libdl/docs/src/index.md
+++ b/stdlib/Libdl/docs/src/index.md
@@ -28,5 +28,8 @@ Libdl.DL_LOAD_PATH
 Libdl.LazyLibrary
 Libdl.LazyLibraryPath
 Libdl.BundledLazyLibraryPath
+Libdl.AbstractLibrary
+Libdl.LibraryID
+Libdl.dlid
 Libdl.add_dependency!
 ```

--- a/stdlib/Libdl/src/Libdl.jl
+++ b/stdlib/Libdl/src/Libdl.jl
@@ -9,13 +9,14 @@ module Libdl
 # Just re-export Base.Libc.Libdl:
 export DL_LOAD_PATH, RTLD_DEEPBIND, RTLD_FIRST, RTLD_GLOBAL, RTLD_LAZY, RTLD_LOCAL,
     RTLD_NODELETE, RTLD_NOLOAD, RTLD_NOW, dlclose, dlopen, dlopen_e, dlsym, dlsym_e,
-    dlpath, find_library, dlext, dllist, LazyLibrary, LazyLibraryPath, BundledLazyLibraryPath
+    dlpath, find_library, dlext, dllist, dlid, AbstractLibrary, LibraryID,
+    LazyLibrary, LazyLibraryPath, BundledLazyLibraryPath
 
 public add_dependency!
 
 import Base.Libc.Libdl: DL_LOAD_PATH, RTLD_DEEPBIND, RTLD_FIRST, RTLD_GLOBAL, RTLD_LAZY, RTLD_LOCAL,
                         RTLD_NODELETE, RTLD_NOLOAD, RTLD_NOW, dlclose, dlopen, dlopen_e, dlsym, dlsym_e,
-                        dlpath, find_library, dlext, dllist, LazyLibrary, LazyLibraryPath,
-                        BundledLazyLibraryPath, default_rtld_flags, add_dependency!
+                        dlpath, find_library, dlext, dllist, dlid, AbstractLibrary, LibraryID,
+                        LazyLibrary, LazyLibraryPath, BundledLazyLibraryPath, default_rtld_flags, add_dependency!
 
 end # module

--- a/stdlib/MPFR_jll/src/MPFR_jll.jl
+++ b/stdlib/MPFR_jll/src/MPFR_jll.jl
@@ -27,6 +27,7 @@ const libmpfr = LazyLibrary(
     else
         error("MPFR_jll: Library 'libmpfr' is not available for $(Sys.KERNEL)")
     end,
+    id = LibraryID(Base.UUID("3a97d323-0669-5f0c-9066-3539efd106a3"), "libmpfr"),
     dependencies = if Sys.iswindows()
         LazyLibrary[libgmp, libgcc_s]
     else

--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -30,6 +30,7 @@ const libopenblas = LazyLibrary(
     else
         BundledLazyLibraryPath(string("libopenblas", libsuffix, ".so"))
     end,
+    id = LibraryID(Base.UUID("4536629a-c528-5b80-bd46-f80d51c5b363"), "libopenblas"),
     dependencies = if Sys.iswindows()
         LazyLibrary[libgfortran, libgcc_s]
     elseif Sys.isapple()

--- a/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
+++ b/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
@@ -25,6 +25,7 @@ const libopenlibm = LazyLibrary(
     else
         BundledLazyLibraryPath("libopenlibm.so.4")
     end,
+    id = LibraryID(Base.UUID("05823500-19ac-5b8b-9628-191a04bc5112"), "libopenlibm"),
     dependencies = if Sys.iswindows()
         LazyLibrary[libgcc_s]
     else

--- a/stdlib/OpenSSL_jll/src/OpenSSL_jll.jl
+++ b/stdlib/OpenSSL_jll/src/OpenSSL_jll.jl
@@ -7,6 +7,9 @@ using Base, Libdl, Base.BinaryPlatforms
 
 export libcrypto, libssl
 
+# This package's UUID, as in its Project.toml; names this JLL in each library's identity
+const _pkg_uuid = Base.UUID("458c3c95-2e84-50aa-8efc-19380b2a3a95")
+
 # These get calculated in __init__()
 const PATH = Ref("")
 const PATH_list = String[]
@@ -28,7 +31,8 @@ const libcrypto = LazyLibrary(
         BundledLazyLibraryPath("libcrypto.so.3")
     else
         error("OpenSSL_jll: Library 'libcrypto' is not available for $(Sys.KERNEL)")
-    end
+    end;
+    id = LibraryID(_pkg_uuid, "libcrypto")
 )
 
 libssl_path::String = ""
@@ -46,6 +50,7 @@ const libssl = LazyLibrary(
     else
         error("OpenSSL_jll: Library 'libssl' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libssl"),
     dependencies = LazyLibrary[libcrypto]
 )
 

--- a/stdlib/PCRE2_jll/src/PCRE2_jll.jl
+++ b/stdlib/PCRE2_jll/src/PCRE2_jll.jl
@@ -23,7 +23,8 @@ const libpcre2_8 = LazyLibrary(
         BundledLazyLibraryPath("libpcre2-8.so.0")
     else
         error("PCRE2_jll: Library 'libpcre2_8' is not available for $(Sys.KERNEL)")
-    end
+    end;
+    id = LibraryID(Base.UUID("efcefdf7-47ab-520b-bdef-62a2eaa19f15"), "libpcre2_8")
 )
 
 function eager_mode()

--- a/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
+++ b/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
@@ -10,6 +10,9 @@ end
 
 export libamd, libbtf, libcamd, libccolamd, libcholmod, libcolamd, libklu, libldl, librbio, libspqr, libsuitesparseconfig, libumfpack
 
+# This package's UUID, as in its Project.toml; names this JLL in each library's identity
+const _pkg_uuid = Base.UUID("bea87d4a-7f5b-5778-9afe-8cc45184846c")
+
 # These get calculated in __init__()
 # Man I can't wait until these are automatically handled by an in-Base JLLWrappers clone.
 const PATH = Ref("")
@@ -28,7 +31,8 @@ const libsuitesparseconfig = LazyLibrary(
         BundledLazyLibraryPath("libsuitesparseconfig.so.7")
     else
         error("SuiteSparse_jll: Library 'libsuitesparseconfig' is not available for $(Sys.KERNEL)")
-    end
+    end;
+    id = LibraryID(_pkg_uuid, "libsuitesparseconfig")
 )
 
 libldl_path::String = ""
@@ -41,7 +45,8 @@ const libldl = LazyLibrary(
         BundledLazyLibraryPath("libldl.so.3")
     else
         error("SuiteSparse_jll: Library 'libldl' is not available for $(Sys.KERNEL)")
-    end
+    end;
+    id = LibraryID(_pkg_uuid, "libldl")
 )
 
 libbtf_path::String = ""
@@ -54,7 +59,8 @@ const libbtf = LazyLibrary(
         BundledLazyLibraryPath("libbtf.so.2")
     else
         error("SuiteSparse_jll: Library 'libbtf' is not available for $(Sys.KERNEL)")
-    end
+    end;
+    id = LibraryID(_pkg_uuid, "libbtf")
 )
 
 libcolamd_path::String = ""
@@ -68,6 +74,7 @@ const libcolamd = LazyLibrary(
     else
         error("SuiteSparse_jll: Library 'libcolamd' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libcolamd"),
     dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libsuitesparseconfig, libgcc_s]
     else
@@ -86,6 +93,7 @@ const libamd = LazyLibrary(
     else
         error("SuiteSparse_jll: Library 'libamd' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libamd"),
     dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libsuitesparseconfig, libgcc_s]
     else
@@ -104,6 +112,7 @@ const libcamd = LazyLibrary(
     else
         error("SuiteSparse_jll: Library 'libcamd' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libcamd"),
     dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libsuitesparseconfig, libgcc_s]
     else
@@ -122,6 +131,7 @@ const libccolamd = LazyLibrary(
     else
         error("SuiteSparse_jll: Library 'libccolamd' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libccolamd"),
     dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libsuitesparseconfig, libgcc_s]
     else
@@ -140,6 +150,7 @@ const librbio = LazyLibrary(
     else
         error("SuiteSparse_jll: Library 'librbio' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "librbio"),
     dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libsuitesparseconfig, libgcc_s]
     else
@@ -158,6 +169,7 @@ const libcholmod = LazyLibrary(
     else
         error("SuiteSparse_jll: Library 'libcholmod' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libcholmod"),
     dependencies = if Sys.iswindows()
         LazyLibrary[
             libsuitesparseconfig, libamd, libcamd, libccolamd, libcolamd, libblastrampoline, libgcc_s
@@ -180,6 +192,7 @@ const libklu = LazyLibrary(
     else
         error("SuiteSparse_jll: Library 'libklu' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libklu"),
     dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libsuitesparseconfig, libamd, libcolamd, libbtf, libgcc_s]
     else
@@ -198,6 +211,7 @@ const libspqr = LazyLibrary(
     else
         error("SuiteSparse_jll: Library 'libspqr' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libspqr"),
     dependencies = if Sys.iswindows()
         LazyLibrary[libsuitesparseconfig, libcholmod, libblastrampoline, libgcc_s]
     elseif Sys.isfreebsd() || Sys.isapple()
@@ -218,6 +232,7 @@ const libumfpack = LazyLibrary(
     else
         error("SuiteSparse_jll: Library 'libumfpack' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(_pkg_uuid, "libumfpack"),
     dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libsuitesparseconfig, libamd, libcholmod, libblastrampoline, libgcc_s]
     else

--- a/stdlib/Zlib_jll/src/Zlib_jll.jl
+++ b/stdlib/Zlib_jll/src/Zlib_jll.jl
@@ -23,7 +23,8 @@ const libz = LazyLibrary(
         BundledLazyLibraryPath("libz.so.1")
     else
         error("Zlib_jll: Library 'libz' is not available for $(Sys.KERNEL)")
-    end
+    end;
+    id = LibraryID(Base.UUID("83775a58-1f1d-513f-b197-d71354ab007a"), "libz")
 )
 
 function eager_mode()

--- a/stdlib/Zstd_jll/src/Zstd_jll.jl
+++ b/stdlib/Zstd_jll/src/Zstd_jll.jl
@@ -30,6 +30,7 @@ const libzstd = LazyLibrary(
     else
         error("Zstd_jll: Library 'libzstd' is not available for $(Sys.KERNEL)")
     end;
+    id = LibraryID(Base.UUID("3161d3a3-bdf6-5164-811a-617609db77b4"), "libzstd"),
     dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libgcc_s]
     else

--- a/stdlib/dSFMT_jll/src/dSFMT_jll.jl
+++ b/stdlib/dSFMT_jll/src/dSFMT_jll.jl
@@ -22,7 +22,8 @@ const libdSFMT = LazyLibrary(
         BundledLazyLibraryPath("libdSFMT.dylib")
     else
         BundledLazyLibraryPath("libdSFMT.so")
-    end
+    end;
+    id = LibraryID(Base.UUID("05ff407c-b0c1-5878-9df8-858cc2e60c36"), "libdSFMT")
 )
 
 function eager_mode()

--- a/stdlib/libLLVM_jll/src/libLLVM_jll.jl
+++ b/stdlib/libLLVM_jll/src/libLLVM_jll.jl
@@ -27,6 +27,7 @@ const libLLVM = LazyLibrary(
     else
         BundledLazyLibraryPath("$(Base.libllvm_name).so")
     end,
+    id = LibraryID(Base.UUID("8f36deef-c2a5-5394-99ed-8e07531fb29a"), "libLLVM"),
     dependencies = if Sys.isapple()
         LazyLibrary[libz, libzstd]
     elseif Sys.isfreebsd()

--- a/stdlib/libblastrampoline_jll/src/libblastrampoline_jll.jl
+++ b/stdlib/libblastrampoline_jll/src/libblastrampoline_jll.jl
@@ -41,6 +41,7 @@ const libblastrampoline = LazyLibrary(
     else
         BundledLazyLibraryPath("libblastrampoline.so.5")
     end,
+    id = LibraryID(Base.UUID("8e850b90-86db-534c-a0d3-1478176c7d93"), "libblastrampoline"),
     dependencies = LazyLibrary[],
     on_load_callback = libblastrampoline_on_load_callback
 )

--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
@@ -25,6 +25,7 @@ const libnghttp2 = LazyLibrary(
     else
         BundledLazyLibraryPath("libnghttp2.so.14")
     end,
+    id = LibraryID(Base.UUID("8e850ede-7688-5339-a07c-302acd2aaf8d"), "libnghttp2"),
     dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libgcc_s]
     else

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -2165,3 +2165,42 @@ const sym = :ZSTD_versionString
 get_zstd_version() = prefix * unsafe_string(ccall((sym, libzstd), Cstring, ()))
 @test startswith(get_zstd_version(), "Zstd")
 end
+
+# `Libdl.AbstractLibrary`, `LibraryID`, and `dlid`
+module TestAbstractLibraryAPI
+using Test, Libdl
+using Libdl: AbstractLibrary, LibraryID, LazyLibrary, LazyLibraryPath, dlid
+
+const test_pkg = Base.UUID(0x2fa1c7f0c93c48a0b4e2a5f0d6c60001)
+const test_id = LibraryID(test_pkg, "libfoo")
+
+struct IdentityDeclaringLib <: AbstractLibrary end
+Libdl.dlid(::IdentityDeclaringLib) = test_id
+struct NoIdentityLib <: AbstractLibrary end
+Libdl.dlid(::NoIdentityLib) = nothing
+
+@testset "AbstractLibrary API" begin
+    @test isabstracttype(AbstractLibrary)
+    @test LazyLibrary <: AbstractLibrary
+
+    # `LibraryID` compares by value (the runtime check uses `===`)
+    @test LibraryID(test_pkg, "lib" * "foo") === test_id
+    @test LibraryID(test_pkg, "libbar") !== test_id
+    @test LibraryID(Base.UUID(UInt128(test_pkg) + 1), "libfoo") !== test_id
+    @test test_id.pkg === test_pkg
+    @test test_id.name == "libfoo"
+
+    # no identity is derived from the path
+    @test dlid(LazyLibrary("libfoo")) === nothing
+    @test dlid(LazyLibrary(LazyLibraryPath("dir", "libfoo.so"))) === nothing
+
+    @test dlid(LazyLibrary("libfoo"; id=test_id)) === test_id
+    @test dlid(LazyLibrary(LazyLibraryPath("dir", "libfoo.so"); id=test_id)) === test_id
+
+    @test LazyLibrary("libfoo"; id=test_id).id === test_id
+    @test LazyLibrary("libfoo").id === nothing
+
+    @test dlid(IdentityDeclaringLib()) === test_id
+    @test dlid(NoIdentityLib()) === nothing
+end
+end

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -2204,3 +2204,62 @@ Libdl.dlid(::NoIdentityLib) = nothing
     @test dlid(NoIdentityLib()) === nothing
 end
 end
+
+# `ccall`/`cglobal` record `dlid(lib)` where the call is written
+module TestAbstractLibraryIdentity
+using Test, Libdl
+using Libdl: AbstractLibrary, LibraryID, LazyLibrary, LazyLibraryPath, dlid
+
+const libccalltest_path = Libdl.dlpath("libccalltest")
+
+const named_id = LibraryID(Base.UUID(0x2fa1c7f0c93c48a0b4e2a5f0d6c60001), "libccalltest")
+const named_lib = LazyLibrary(LazyLibraryPath(dirname(libccalltest_path),
+                                              basename(libccalltest_path)); id=named_id)
+
+echo_p_named(x) = ccall((:test_echo_p, named_lib), Ptr{Cvoid}, (Ptr{Cvoid},), x)
+
+module InterpretedCGlobal
+import ..named_lib
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
+address() = cglobal((:test_echo_p, named_lib))
+end
+
+@testset "identified library resolves" begin
+    p = Ptr{Cvoid}(UInt(0xdeadbeef))
+    @test echo_p_named(p) === p
+    # the interpreter sees the recorded identity too
+    @test InterpretedCGlobal.address() == cglobal((:test_echo_p, named_lib))
+end
+
+# the recorded identity is visible in lowered code as a third tuple element
+struct DeclaringLib <: AbstractLibrary end
+Libdl.dlid(::DeclaringLib) = LibraryID(Base.UUID(0x2fa1c7f0c93c48a0b4e2a5f0d6c60002), "libdeclaring")
+const declaring_lib = DeclaringLib()
+
+struct SilentLib <: AbstractLibrary end
+Libdl.dlid(::SilentLib) = nothing
+const silent_lib = SilentLib()
+
+struct MisdeclaredLib <: AbstractLibrary end
+Libdl.dlid(::MisdeclaredLib) = "not an identity"
+const misdeclared_lib = MisdeclaredLib()
+
+uses_declaring() = ccall((:my_symbol, declaring_lib), Cint, ())
+uses_silent() = ccall((:my_symbol, silent_lib), Cint, ())
+uses_string() = ccall((:my_symbol, "libbar"), Cint, ())
+cglobal_declaring() = cglobal((:my_global, declaring_lib))
+
+@testset "identity recorded at the call site" begin
+    let fptr = only(code_lowered(uses_declaring)).code[1].args[1]
+        @test fptr.head === :tuple
+        @test length(fptr.args) == 3
+        @test fptr.args[1] == QuoteNode(:my_symbol)
+        @test fptr.args[2] == GlobalRef(@__MODULE__, :declaring_lib)
+        @test fptr.args[3] === LibraryID(Base.UUID(0x2fa1c7f0c93c48a0b4e2a5f0d6c60002), "libdeclaring")
+    end
+    @test length(only(code_lowered(uses_silent)).code[1].args[1].args) == 2
+    @test length(only(code_lowered(uses_string)).code[1].args[1].args) == 2
+    @test length(only(code_lowered(cglobal_declaring)).code[1].args[1].args) == 3
+    @test_throws ErrorException @eval uses_misdeclared() = ccall((:my_symbol, misdeclared_lib), Cint, ())
+end
+end

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -2207,7 +2207,7 @@ end
 
 # `ccall`/`cglobal` record `dlid(lib)` where the call is written
 module TestAbstractLibraryIdentity
-using Test, Libdl
+using Test, Libdl, InteractiveUtils
 using Libdl: AbstractLibrary, LibraryID, LazyLibrary, LazyLibraryPath, dlid
 
 const libccalltest_path = Libdl.dlpath("libccalltest")
@@ -2262,4 +2262,33 @@ cglobal_declaring() = cglobal((:my_global, declaring_lib))
     @test length(only(code_lowered(cglobal_declaring)).code[1].args[1].args) == 3
     @test_throws ErrorException @eval uses_misdeclared() = ccall((:my_symbol, misdeclared_lib), Cint, ())
 end
+
+# foreign link policy; must not affect JIT codegen
+@testset "foreign link policy" begin
+    registered = LibraryID(Base.UUID(0xaabbccddeeff00112233445566778899), "libbar")
+    other = LibraryID(Base.UUID(0x11111111222233334444555555555555), "libfoo")
+    policy(id) = ccall(:jl_get_foreign_link_policy, Cint, (Any,), id)
+    setpolicy!(id, native) = ccall(:jl_set_foreign_link_policy, Cvoid, (Any, Cint), id, native)
+    @test policy(registered) == -1
+    setpolicy!(registered, true)
+    @test policy(registered) == 1
+    @test policy(other) == -1
+    # keyed by value; setting again replaces the entry
+    @test policy(LibraryID(registered.pkg, "lib" * "bar")) == 1
+    @test policy(LibraryID(registered.pkg, "LIBBAR")) == -1
+    setpolicy!(registered, false)
+    @test policy(registered) == 0
+    setpolicy!(registered, true)
+    @test policy(registered) == 1
+    @test_throws TypeError setpolicy!("not an identity", true)
+
+    # a policy must not change what the JIT emits
+    setpolicy!(dlid(named_lib), true)
+    ir = sprint(io -> code_llvm(io, echo_p_named, Tuple{Ptr{Cvoid}};
+                                raw=true, dump_module=false, optimize=true, debuginfo=:none))
+    @test occursin("jl_lazy_load_and_lookup", ir)
+    @test !occursin("@test_echo_p", ir)
+    p = Ptr{Cvoid}(UInt(0xfeedface))
+    @test echo_p_named(p) === p
 end
+end # module TestAbstractLibraryIdentity

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -2282,6 +2282,12 @@ end
     @test policy(registered) == 1
     @test_throws TypeError setpolicy!("not an identity", true)
 
+    @test ccall(:jl_get_export_foreign_symbol_usage, Ptr{Cchar}, ()) == C_NULL
+    ccall(:jl_set_export_foreign_symbol_usage, Cvoid, (Cstring,), "/tmp/deps.json")
+    @test unsafe_string(ccall(:jl_get_export_foreign_symbol_usage, Cstring, ())) == "/tmp/deps.json"
+    ccall(:jl_set_export_foreign_symbol_usage, Cvoid, (Cstring,), "")
+    @test ccall(:jl_get_export_foreign_symbol_usage, Ptr{Cchar}, ()) == C_NULL
+
     # a policy must not change what the JIT emits
     setpolicy!(dlid(named_lib), true)
     ir = sprint(io -> code_llvm(io, echo_p_named, Tuple{Ptr{Cvoid}};

--- a/test/trim/NativeLink/Project.toml
+++ b/test/trim/NativeLink/Project.toml
@@ -1,0 +1,1 @@
+# An anonymous project: the source is compiled as a script (see build.jl), not loaded as a package.

--- a/test/trim/NativeLink/build.jl
+++ b/test/trim/NativeLink/build.jl
@@ -1,0 +1,14 @@
+# Custom build: compile the source as a script, so its top-level registration of the
+# foreign link policy runs in the compiler process. Included in-process by
+# `test/trim.jl`, so `run_juliac` is in scope. `ARGS[1]` is the bundle directory.
+outdir = ARGS[1]
+projdir = @__DIR__
+
+run_juliac(String[
+    "--output-exe", "nativelink",
+    "--project", projdir,
+    "--trim=safe",
+    "--experimental",
+    joinpath(projdir, "src", "NativeLink.jl"),
+    "--bundle", outdir,
+])

--- a/test/trim/NativeLink/runtests.jl
+++ b/test/trim/NativeLink/runtests.jl
@@ -1,4 +1,5 @@
-# Verify the trimmed `NativeLink` executable binds an identified library natively
+# Verify the trimmed `NativeLink` executable binds an identified library natively and
+# that the build recorded the foreign symbols it uses
 using Test
 
 outdir = ARGS[1]
@@ -16,4 +17,14 @@ outdir = ARGS[1]
         syms = read(`$nmprog -u $exe`, String)
         @test occursin(r"\b_?jl_ver_patch\b", syms)
     end
+
+    manifest = joinpath(@__DIR__, "used-foreign-symbols.json")
+    @test isfile(manifest)
+    json = read(manifest, String)
+    @test occursin("\"package_uuid\": \"6a2ab6db-2a0d-40e1-8b5e-7a9e0d2f4c11\"", json)
+    @test occursin("\"library\": \"libjulia\"", json)
+    @test !occursin("<libjulia", json)
+    @test occursin("{\"symbol\": \"jl_ver_patch\", \"kind\": \"ccall\", \"linkage\": \"native\"}", json)
+    # everything else stays at run-time lookup
+    @test occursin("\"linkage\": \"lazy\"", json)
 end

--- a/test/trim/NativeLink/runtests.jl
+++ b/test/trim/NativeLink/runtests.jl
@@ -1,0 +1,19 @@
+# Verify the trimmed `NativeLink` executable binds an identified library natively
+using Test
+
+outdir = ARGS[1]
+
+@testset "NativeLink" begin
+    exe = joinpath(outdir, "bin", "nativelink" * splitext(Base.julia_exename())[2])
+    lines = readlines(addenv(`$exe`, "JULIA_LOAD_CODEGEN_LIB" => "0"))
+    @test lines[1] == "ver patch: $(VERSION.patch)"
+
+    # a natively bound symbol is an ordinary undefined symbol of the executable,
+    # rather than something looked up at run time
+    nmprog = Sys.which("llvm-nm")
+    nmprog === nothing && (nmprog = Sys.which("nm"))
+    if nmprog !== nothing
+        syms = read(`$nmprog -u $exe`, String)
+        @test occursin(r"\b_?jl_ver_patch\b", syms)
+    end
+end

--- a/test/trim/NativeLink/src/NativeLink.jl
+++ b/test/trim/NativeLink/src/NativeLink.jl
@@ -1,0 +1,17 @@
+# Built as a script (see build.jl) so that this top-level code runs in the compiler
+# process, ahead of codegen. Module initializers would not: while an image is being
+# generated they are deferred to image load.
+using Base.Libc.Libdl: LazyLibrary, LibraryID, dlid
+
+# libjulia is linked into every trimmed executable, so a natively bound call into it
+# resolves at link time
+const LIBJULIA = LazyLibrary("libjulia"; id = LibraryID(Base.UUID("6a2ab6db-2a0d-40e1-8b5e-7a9e0d2f4c11"), "libjulia"))
+
+native_ver_patch() = ccall((:jl_ver_patch, LIBJULIA), Cint, ())
+
+ccall(:jl_set_foreign_link_policy, Cvoid, (Any, Cint), dlid(LIBJULIA), true)
+
+function @main(args::Vector{String})::Cint
+    println(Core.stdout, "ver patch: ", native_ver_patch())
+    return 0
+end

--- a/test/trim/NativeLink/src/NativeLink.jl
+++ b/test/trim/NativeLink/src/NativeLink.jl
@@ -10,6 +10,8 @@ const LIBJULIA = LazyLibrary("libjulia"; id = LibraryID(Base.UUID("6a2ab6db-2a0d
 native_ver_patch() = ccall((:jl_ver_patch, LIBJULIA), Cint, ())
 
 ccall(:jl_set_foreign_link_policy, Cvoid, (Any, Cint), dlid(LIBJULIA), true)
+ccall(:jl_set_export_foreign_symbol_usage, Cvoid, (Cstring,),
+      joinpath(@__DIR__, "..", "used-foreign-symbols.json"))
 
 function @main(args::Vector{String})::Cint
     println(Core.stdout, "ver patch: ", native_ver_patch())


### PR DESCRIPTION
Dependent on https://github.com/JuliaLang/julia/pull/63026, this adds two runtime functions intended for use by JuliaC:
  1. `jl_set_foreign_link_policy` to configure whether AOT emits `ccall` / `cglobal` invocations for a given library via Julia's standard PLT mechanism or directly as an external C symbol
  2. `jl_set_export_foreign_symbol_usage` to configure a JSON logfile of all `ccall` / `cglobal` invocations encountered during AOT codegen
  
The first is used by JuliaC to support "native linking", which means linking libraries from JLLs via the standard C linker (loaded via `DT_NEEDED` if using a dynamic library, or otherwise linked statically to a `.a` variant of the JLL).

Static libraries themselves are generated via a new `StaticLibraryProduct` for BB2 (see https://github.com/JuliaPackaging/BinaryBuilder2.jl/pull/77). Once a recipe is configured in BB2 the intention is for the "swap" to be automatic - the `LibraryID` for a static and dynamic JLL product are shared, so it is enough to tell JuliaC `--link-native static:FFTW_jll.libfftw` and JuliaC will take care of the rest.

The second is used to prune dynamic libraries based on their usages in JuliaC applications.

Generated with help from Claude Fable 5 🤖 - draft because there are still some "AI-isms" to clean up. Otherwise this should be a straightforward addition to #63026