### PR TITLE
cli: rebuild loader_lib.c when the layout of jl_options changes

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -5,7 +5,7 @@ include $(JULIAHOME)/Make.inc
 include $(JULIAHOME)/deps/llvm-ver.make
 
 
-HEADERS := $(addprefix $(SRCDIR)/,jl_exports.h loader.h dl-cache.h) $(addprefix $(JULIAHOME)/src/,julia_fasttls.h support/platform.h support/dirpath.h jl_exported_data.inc jl_exported_funcs.inc)
+HEADERS := $(addprefix $(SRCDIR)/,jl_exports.h loader.h dl-cache.h) $(addprefix $(JULIAHOME)/src/,julia_fasttls.h jloptions.h support/platform.h support/dirpath.h jl_exported_data.inc jl_exported_funcs.inc)
 
 LOADER_CFLAGS = $(JCFLAGS) -I$(BUILDROOT)/src -I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(build_includedir) -ffreestanding
 LOADER_LIBPATHS = -L$(build_shlibdir) -L$(build_libdir)


### PR DESCRIPTION
`cli/loader_lib.c` defines `jl_options` for the public library, but its rule did not depend on `src/jloptions.h`. After a field is added to `jl_options_t`, an incremental build leaves the library with the old size while `libjulia-internal` reads the new layout: a read past the end of the object. Found while adding an option in #63069. The header goes into the rule's dependencies.

Disclosure: developed with Claude Code (Opus 5) under my direction. It wrote the code and this text; the measurements were run on my machine. I reviewed the changes. The commits carry an `Assisted-by` trailer.
