### PR TITLE
staticdata: the system image holds `nothing`, the boxed integers and its symbols

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -587,6 +587,7 @@ static NOINLINE void _finish_jl_init_(jl_image_buf_t sysimage, jl_ptls_t ptls, j
     if (sysimage.kind != JL_IMAGE_KIND_NONE) {
         // Load the .ji or .so sysimage
         jl_restore_system_image(&parsed_image, sysimage);
+        jl_init_common_symbols();
     }
     else {
         // No sysimage provided, init a minimal environment
@@ -792,7 +793,10 @@ JL_DLLEXPORT void jl_init_(jl_image_buf_t sysimage)
     // warning: this changes `jl_current_task`, so be careful not to call that from this function
     jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi);
     jl_init_box_caches();
-    jl_init_common_symbols();
+    // The image's symbols become the symbol table, so the symbols the runtime
+    // holds by name are read after the restore; without an image, make them here.
+    if (sysimage.kind == JL_IMAGE_KIND_NONE)
+        jl_init_common_symbols();
 #pragma GCC diagnostic pop
     JL_GC_PROMISE_ROOTED(ct);
     _finish_jl_init_(sysimage, ptls, ct);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1331,6 +1331,7 @@ STATIC_INLINE jl_vararg_kind_t jl_va_tuple_kind(jl_datatype_t *t) JL_NOTSAFEPOIN
 void jl_init_types(void) JL_CANSAFEPOINT JL_GC_DISABLED;
 void jl_init_flisp(void) JL_NOTSAFEPOINT;
 void jl_init_common_symbols(void) JL_NOTSAFEPOINT;
+void jl_set_root_symbol(jl_sym_t *root) JL_NOTSAFEPOINT;
 void jl_init_primitives(void) JL_CANSAFEPOINT JL_GC_DISABLED;
 void jl_init_llvm(void) JL_CANSAFEPOINT;
 void jl_init_runtime_ccall(void) JL_NOTSAFEPOINT;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -396,26 +396,41 @@ JL_DLLEXPORT int jl_running_on_valgrind(void)
 
 #define NBOX_C 1024
 
+// A package image references `nothing` and the small boxed integers by tag,
+// since they belong to the loading runtime; a trimmed image does too, to stay
+// small. A full system image holds them as objects.
+static int primordials_by_tag(jl_serializer_state *s) JL_NOTSAFEPOINT
+{
+    return s->incremental || jl_options.trim;
+}
+
 static int jl_needs_serialization(jl_serializer_state *s, jl_value_t *v) JL_NOTSAFEPOINT
 {
     // ignore items that are given a special relocation representation
     if (s->incremental && jl_object_in_image(v))
         return 0;
 
-    if (v == NULL || jl_is_symbol(v) || v == jl_nothing) {
+    if (v == NULL || jl_is_symbol(v)) {
         return 0;
     }
-    else if (jl_typetagis(v, jl_int64_tag << 4)) {
+    // A package image names `nothing` and the small boxed integers with a tag,
+    // because they belong to the runtime that loads it. The system image is
+    // that runtime, so it holds them itself and every field that points at one
+    // is a pointer the loader does not have to write.
+    else if (primordials_by_tag(s) && v == jl_nothing) {
+        return 0;
+    }
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_int64_tag << 4)) {
         int64_t i64 = *(int64_t*)v + NBOX_C / 2;
         if ((uint64_t)i64 < NBOX_C)
             return 0;
     }
-    else if (jl_typetagis(v, jl_int32_tag << 4)) {
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_int32_tag << 4)) {
         int32_t i32 = *(int32_t*)v + NBOX_C / 2;
         if ((uint32_t)i32 < NBOX_C)
             return 0;
     }
-    else if (jl_typetagis(v, jl_uint8_tag << 4)) {
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_uint8_tag << 4)) {
         return 0;
     }
     else if (v == (jl_value_t*)s->ptls->root_task) {
@@ -1200,20 +1215,20 @@ static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v, jl_array_t *
     else if (v == (jl_value_t*)s->ptls->root_task) {
         return (uintptr_t)TagRef << RELOC_TAG_OFFSET;
     }
-    else if (v == jl_nothing) {
+    else if (primordials_by_tag(s) && v == jl_nothing) {
         return ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + 1;
     }
-    else if (jl_typetagis(v, jl_int64_tag << 4)) {
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_int64_tag << 4)) {
         int64_t i64 = *(int64_t*)v + NBOX_C / 2;
         if ((uint64_t)i64 < NBOX_C)
             return ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + i64 + 2;
     }
-    else if (jl_typetagis(v, jl_int32_tag << 4)) {
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_int32_tag << 4)) {
         int32_t i32 = *(int32_t*)v + NBOX_C / 2;
         if ((uint32_t)i32 < NBOX_C)
             return ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + i32 + 2 + NBOX_C;
     }
-    else if (jl_typetagis(v, jl_uint8_tag << 4)) {
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_uint8_tag << 4)) {
         uint8_t u8 = *(uint8_t*)v;
         return ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + u8 + 2 + NBOX_C + NBOX_C;
     }
@@ -4079,6 +4094,8 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     assert(!ios_eof(f));
     s.s = f;
     uintptr_t offset_restored = 0, offset_init_order = 0, offset_extext_methods = 0, offset_new_ext = 0, offset_method_roots_list = 0;
+    // the `nothing` allocated by `julia_init`, replaced by the image's below
+    jl_value_t *init_nothing = jl_nothing;
     if (!s.incremental) {
         size_t i;
         for (i = 0; tags[i] != NULL; i++) {
@@ -4167,6 +4184,20 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     // s.link_ids_gvars will be processed in `jl_update_all_gvars`
     // s.link_ids_external_fns will be processed in `jl_update_all_gvars`
     jl_update_all_gvars(&s, image, external_fns_begin); // gvars relocs
+
+    // `julia_init` allocated a `nothing` before the root task existed, and the
+    // image's `nothing` replaced it above. Point the root task's fields at the
+    // image's one. The walk is over the layout so it does not depend on the field
+    // list; no other thread exists yet, so plain stores are fine.
+    if (!s.incremental && init_nothing != jl_nothing) {
+        jl_value_t *root = (jl_value_t*)s.ptls->root_task;
+        const jl_datatype_layout_t *task_layout = jl_task_type->layout;
+        for (size_t i = 0; i < task_layout->npointers; i++) {
+            jl_value_t **slot = &((jl_value_t**)root)[jl_ptr_offset(jl_task_type, i)];
+            if (*slot == init_nothing)
+                jl_gc_write(root, *slot, jl_value_t, jl_nothing);
+        }
+    }
     if (s.incremental) {
         jl_read_arraylist(s.relocs, &s.uniquing_types);
         jl_read_arraylist(s.relocs, &s.uniquing_objs);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -396,9 +396,9 @@ JL_DLLEXPORT int jl_running_on_valgrind(void)
 
 #define NBOX_C 1024
 
-// A package image references `nothing` and the small boxed integers by tag,
-// since they belong to the loading runtime; a trimmed image does too, to stay
-// small. A full system image holds them as objects.
+// A package image references `nothing`, the small boxed integers and the
+// symbols by tag, since they belong to the loading runtime; a trimmed image
+// does too, to stay small. A full system image holds them as objects.
 static int primordials_by_tag(jl_serializer_state *s) JL_NOTSAFEPOINT
 {
     return s->incremental || jl_options.trim;
@@ -410,13 +410,12 @@ static int jl_needs_serialization(jl_serializer_state *s, jl_value_t *v) JL_NOTS
     if (s->incremental && jl_object_in_image(v))
         return 0;
 
-    if (v == NULL || jl_is_symbol(v)) {
+    if (v == NULL) {
         return 0;
     }
-    // A package image names `nothing` and the small boxed integers with a tag,
-    // because they belong to the runtime that loads it. The system image is
-    // that runtime, so it holds them itself and every field that points at one
-    // is a pointer the loader does not have to write.
+    else if (primordials_by_tag(s) && jl_is_symbol(v)) {
+        return 0;
+    }
     else if (primordials_by_tag(s) && v == jl_nothing) {
         return 0;
     }
@@ -656,6 +655,14 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
 
     if (!recursive)
         goto done_fields;
+
+    // A symbol's two children are not fields of its type.
+    if (!primordials_by_tag(s) && jl_is_symbol(v)) {
+        jl_sym_t *sym = (jl_sym_t*)v;
+        jl_queue_for_serialization_(s, (jl_value_t*)jl_atomic_load_relaxed(&sym->left), 1, immediate);
+        jl_queue_for_serialization_(s, (jl_value_t*)jl_atomic_load_relaxed(&sym->right), 1, immediate);
+        goto done_fields;
+    }
 
     if (s->incremental && jl_is_datatype(v) && immediate) {
         jl_datatype_t *dt = (jl_datatype_t*)v;
@@ -1198,7 +1205,7 @@ static uintptr_t add_external_linkage(jl_serializer_state *s, jl_value_t *v, jl_
 static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v, jl_array_t *link_ids) JL_GC_DISABLED JL_CANSAFEPOINT
 {
     assert(v != NULL && "cannot get backref to NULL object");
-    if (jl_is_symbol(v)) {
+    if (primordials_by_tag(s) && jl_is_symbol(v)) {
         void **pidx = ptrhash_bp(&symbol_table, v);
         void *idx = *pidx;
         if (idx == HT_NOTFOUND) {
@@ -1459,7 +1466,8 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
         assert((!jl_is_datatype_singleton(t) || t->instance == v) && "detected singleton construction corruption");
         int mutabl = t->name->mutabl;
         ios_t *f = s->s;
-        if (t->smalltag) {
+        // A symbol has relocations (its children), so it stays in the data section.
+        if (t->smalltag && t != jl_symbol_type) {
             if (t->layout->npointers == 0 || t == jl_string_type) {
                 if (jl_datatype_nfields(t) == 0 || mutabl == 0 || t == jl_string_type) {
                     f = s->const_data;
@@ -1676,6 +1684,17 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
         else if (jl_is_string(v)) {
             ios_write(f, (char*)v, sizeof(void*) + jl_string_len(v));
             write_uint8(f, '\0'); // null-terminated strings for easier C-compatibility
+        }
+        else if (jl_is_symbol(v)) {
+            // left, right, hash, name; padded so the next object stays aligned
+            assert(f == s->s);
+            jl_sym_t *sym = (jl_sym_t*)v;
+            write_pointerfield(s, (jl_value_t*)jl_atomic_load_relaxed(&sym->left));
+            write_pointerfield(s, (jl_value_t*)jl_atomic_load_relaxed(&sym->right));
+            write_uint(f, sym->hash);
+            size_t len = strlen(jl_symbol_name(sym)) + 1;
+            ios_write(f, jl_symbol_name(sym), len);
+            write_padding(f, LLT_ALIGN(len, sizeof(void*)) - len);
         }
         else if (jl_is_cancel_source(v)) {
             // Variable-sized. Store parents, reset children (reconstructed on load).
@@ -3374,6 +3393,7 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
 #undef XX
             jl_write_value(&s, global_roots_list);
             jl_write_value(&s, global_roots_keyset);
+            jl_write_value(&s, primordials_by_tag(&s) ? NULL : (jl_value_t*)jl_get_root_symbol());
             jl_write_value(&s, s.ptls->root_task->tls);
             write_uint32(f, jl_get_gs_ctr());
             size_t world = jl_atomic_load_acquire(&jl_world_counter);
@@ -4096,6 +4116,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     uintptr_t offset_restored = 0, offset_init_order = 0, offset_extext_methods = 0, offset_new_ext = 0, offset_method_roots_list = 0;
     // the `nothing` allocated by `julia_init`, replaced by the image's below
     jl_value_t *init_nothing = jl_nothing;
+    jl_sym_t *image_symtab = NULL;
     if (!s.incremental) {
         size_t i;
         for (i = 0; tags[i] != NULL; i++) {
@@ -4118,6 +4139,8 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         export_jl_sysimg_globals();
         jl_global_roots_list = (jl_genericmemory_t*)jl_read_value(&s);
         jl_global_roots_keyset = (jl_genericmemory_t*)jl_read_value(&s);
+        // installed after the relocations, below
+        image_symtab = (jl_sym_t*)jl_read_value(&s);
         jl_gc_write(s.ptls->root_task, s.ptls->root_task->tls, jl_value_t, jl_read_value(&s));
 
         uint32_t gs_ctr = read_uint32(f);
@@ -4184,6 +4207,9 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     // s.link_ids_gvars will be processed in `jl_update_all_gvars`
     // s.link_ids_external_fns will be processed in `jl_update_all_gvars`
     jl_update_all_gvars(&s, image, external_fns_begin); // gvars relocs
+
+    if (image_symtab != NULL)
+        jl_set_root_symbol(image_symtab);
 
     // `julia_init` allocated a `nothing` before the root task existed, and the
     // image's `nothing` replaced it above. Point the root task's fields at the

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -123,6 +123,19 @@ JL_DLLEXPORT jl_sym_t *jl_get_root_symbol(void)
     return jl_atomic_load_relaxed(&symtab);
 }
 
+// Install the image's symbol tree as the symbol table. The table must be empty:
+// a symbol interned before the image is read would duplicate one of the image,
+// so `jl_init_common_symbols` runs after the restore.
+void jl_set_root_symbol(jl_sym_t *root) JL_NOTSAFEPOINT
+{
+    if (jl_atomic_load_relaxed(&symtab) != NULL) {
+        jl_safe_printf("ERROR: a symbol was made before the system image was read, "
+                       "so the image's symbol table cannot be installed.\n");
+        exit(1);
+    }
+    jl_atomic_store_release(&symtab, root);
+}
+
 static _Atomic(uint32_t) gs_ctr = 0;  // TODO: per-module?
 uint32_t jl_get_gs_ctr(void) { return jl_atomic_load_relaxed(&gs_ctr); }
 void jl_set_gs_ctr(uint32_t ctr) { jl_atomic_store_relaxed(&gs_ctr, ctr); }

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1675,6 +1675,37 @@ end
     end
 end
 
+@testset "the system image holds `nothing`, the booleans and the symbols" begin
+    exename = `$(Base.julia_cmd())`
+    # A system image holds these itself, so that every field which points at
+    # one is final in the file. The start adopts them: a symbol interned at run
+    # time finds the image's, and every field of the root task that holds
+    # `nothing` holds the image's `nothing`. A stale one there breaks `wait`.
+    script = """
+        in_image(x) = ccall(:jl_object_in_image, UInt8, (Any,), x) == 1
+        function failures()
+            bad = String[]
+            in_image(nothing) || push!(bad, "nothing")
+            (in_image(true) && in_image(false)) || push!(bad, "the booleans")
+            in_image(:sin) || push!(bad, "a symbol of the image")
+            in_image(Symbol("si" * "n")) || push!(bad, "a symbol interned at run time")
+            nameof(sin) === Symbol("si" * "n") || push!(bad, "the identity of a symbol")
+            # The other way round, so that the question is a real one.
+            in_image(Symbol("zz", rand(UInt))) && push!(bad, "a symbol of neither")
+            for f in fieldnames(Task)
+                isdefined(current_task(), f) || continue
+                v = getfield(current_task(), f)
+                if v === nothing && !in_image(v)
+                    push!(bad, "the field \$f of the root task")
+                end
+            end
+            return join(bad, ", ")
+        end
+        print(failures())
+        """
+    @test readchomp(`$exename -e $script`) == ""
+end
+
 # Build and use a system image, exercising both split (--output-o together with
 # --output-ji, heap goes into the .ji) and non-split (--output-o only, heap goes
 # into the .so) layouts, with --compress-sysimage on and off in each.


### PR DESCRIPTION
A package image references `nothing`, the small boxed integers and every symbol by tag, and the loader resolves the tag to an object of the loading runtime. The system image is that runtime, so paying the same way costs it 1.1 million relocations at every start, plus the interning of the whole symbol list. This serializes them as objects instead.

- `nothing`: the loader already reads `jl_nothing` from the image. `julia_init` allocates one earlier, so the fields of the root task that still point at that one are updated after the relocations, by a walk over the task layout.
- Boxed integers: two boxes of one value are equal by value, so nothing to adopt.
- Symbols: serialized with their two tree children. The image records the root, and the loader installs the image's tree as the process symbol table after the relocations. `jl_init_common_symbols` moves after the restore, and `jl_set_root_symbol` refuses a non-empty table.

A trimmed image (`--trim`) keeps the tag encoding: the symbol table is about 2.6 MB, more than a whole trimmed binary. `test/trim` and the JuliaC tests pass; the trimmed hello world is 1.66 MB and starts in 3.3 ms. Pruning the table to the referenced symbols would be the better answer; it is not in this PR.

`julia --startup-file=no -e ''`, minimum of 15 pinned runs, on top of #63067: 66.2 → 61.4 ms. `sys.so` grows 2.3 MB.

Test: `test/cmdlineargs.jl` checks with `jl_object_in_image` that a started process finds `nothing`, the booleans, an image symbol, a freshly interned symbol and the `nothing` fields of the root task in the image, and that a random new symbol is not. `core`, `channels`, `precompile`, `syntax` and `meta` pass.

Part of #63065. #63069 needs it to keep the residual list short.

Disclosure: developed with Claude Code (Opus 5) under my direction. It wrote the code and this text; the measurements were run on my machine. I reviewed the changes. The commits carry an `Assisted-by` trailer.
