### PR TITLE
staticdata: a pre-relocated system image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ all: debug release
 # sort is used to remove potential duplicates
 DIRS := $(sort $(build_bindir) $(build_depsbindir) $(build_libdir) $(build_private_libdir) $(build_private_libexecdir) $(build_libexecdir) $(build_includedir) $(build_includedir)/julia $(build_sysconfdir)/julia $(build_datarootdir)/julia $(build_datarootdir)/julia/stdlib $(build_man1dir))
 ifneq ($(BUILDROOT),$(JULIAHOME))
-BUILDDIRS := $(BUILDROOT) $(addprefix $(BUILDROOT)/,base src src/flisp src/support src/clangsa cli doc deps stdlib test test/clangsa test/embedding test/gcext test/llvmpasses)
+BUILDDIRS := $(BUILDROOT) $(addprefix $(BUILDROOT)/,base src src/flisp src/support src/clangsa cli doc deps stdlib test test/clangsa test/embedding test/gcext test/prelink test/llvmpasses)
 BUILDDIRMAKE := $(addsuffix /Makefile,$(BUILDDIRS)) $(BUILDROOT)/sysimage.mk $(BUILDROOT)/pkgimage.mk
 DIRS += $(BUILDDIRS)
 $(BUILDDIRMAKE): | $(BUILDDIRS)

--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,13 @@ Command-line option changes
   directory tree. For example, `@/src/Foo` tracks `/src/Foo/x.jl`, but not `/src/Foobar/x.jl`. Specifying the
   filesystem root as `@/` tracks every absolute path. `Base.is_file_tracked` now returns `false` when Julia was
   not started with either `@<path>` option ([#62514]).
+* `--sysimage-prelink={yes|no}` and `--output-prelinked <file>` build and write a pre-relocated system image.
+  A restore turns every relocation of the image into a pointer and writes almost every page of the image doing
+  so; when the image is linked into a program that does not move at every start, that work can be done once and
+  written into the program file. `--sysimage-prelink=yes` reserves room in the image being written for the
+  pointers a start must still write, and `--output-prelinked` restores the program's own image and writes the
+  program with the restored image to a file. A start of that file applies the short list and reads neither
+  relocation list. Writing the file is Linux only.
 
 Multi-threading changes
 -----------------------

--- a/base/options.jl
+++ b/base/options.jl
@@ -73,6 +73,8 @@ struct JLOptions
     target_sanitize_memory::Int8
     target_sanitize_thread::Int8
     target_sanitize_address::Int8
+    sysimage_prelink::Int8
+    output_prelinked::Ptr{UInt8}
 end
 
 # This runs early in the sysimage when `!=` is not defined yet

--- a/doc/src/devdocs/sysimg.md
+++ b/doc/src/devdocs/sysimg.md
@@ -124,6 +124,35 @@ Commit the updated headers and update Julia's cpufeatures dependency. A
 `static_assert` in `src/processor.cpp` checks `TARGET_TABLES_LLVM_VERSION_MAJOR`
 against Julia's LLVM version, so mismatches are caught at build time.
 
+## [A pre-relocated system image](@id sysimg-prelink)
+
+Loading a system image maps it and then applies its relocations, which writes
+almost every page of the image and is most of the cost of `jl_init`. When the
+image is linked into a program that is not position-independent, it is at the
+same address at every start, so the relocation can be done once, at build time,
+and its result written into the program file.
+
+* `--sysimage-prelink={yes|no}`, given to the process that writes an image,
+  reserves room for the residual list: the pointers a file cannot hold. Without
+  it the image is unchanged.
+* `--output-prelinked <file>`, given to a program that holds such an image,
+  restores it, writes the program with the restored image to `<file>`, and
+  exits. The program is copied through `/proc/self/exe`, so this is Linux only.
+
+A start of the written file applies the residual list, fills the global
+variable slots, registers the native code, and runs the fixup list. It reads
+neither relocation list and neither memory reference list; a change that adds
+work to those passes must add it to the residual list as well.
+
+The residual list holds every pointer whose target is outside the program: the
+objects the runtime creates before it reads the image, and the entry points of
+`libjulia-internal`, which a pre-relocated image reaches through thunks of its
+own.
+
+The runtime refuses, with a message and exit code 1: an image pre-relocated for
+another address, an image without native code, an image with several code
+variants, and a second pre-relocation.
+
 ## Trimming
 
 System images are typically quite large, since Base includes a lot of functionality, and by

--- a/src/init.c
+++ b/src/init.c
@@ -587,6 +587,7 @@ static NOINLINE void _finish_jl_init_(jl_image_buf_t sysimage, jl_ptls_t ptls, j
     if (sysimage.kind != JL_IMAGE_KIND_NONE) {
         // Load the .ji or .so sysimage
         jl_restore_system_image(&parsed_image, sysimage);
+        jl_init_common_symbols();
     }
     else {
         // No sysimage provided, init a minimal environment
@@ -792,7 +793,10 @@ JL_DLLEXPORT void jl_init_(jl_image_buf_t sysimage)
     // warning: this changes `jl_current_task`, so be careful not to call that from this function
     jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi);
     jl_init_box_caches();
-    jl_init_common_symbols();
+    // The image's symbols become the symbol table, so the symbols the runtime
+    // holds by name are read after the restore; without an image, make them here.
+    if (sysimage.kind == JL_IMAGE_KIND_NONE)
+        jl_init_common_symbols();
 #pragma GCC diagnostic pop
     JL_GC_PROMISE_ROOTED(ct);
     _finish_jl_init_(sysimage, ptls, ct);

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -166,6 +166,8 @@ JL_DLLEXPORT void jl_init_options(void) JL_NOTSAFEPOINT
                         0, // target_sanitize_memory
                         0, // target_sanitize_thread
                         0, // target_sanitize_address
+                        0, // sysimage_prelink
+                        NULL, // output-prelinked
     };
     jl_options_initialized = 1;
 }
@@ -327,6 +329,14 @@ static const char opts_hidden[] =
     "                                               functions\n"
     " --compress-sysimage={yes|no*}                 Compress the sys/pkgimage heap at the expense of\n"
     "                                               slightly increased load time.\n"
+    " --sysimage-prelink={yes|no*}                  Reserve room in the system image being written for\n"
+    "                                               the pointers a start of a pre-relocated image must\n"
+    "                                               write. Only an image written this way can be given\n"
+    "                                               to --output-prelinked.\n"
+    " --output-prelinked <file>                     Restore the system image of this program, write the\n"
+    "                                               program with the restored image to <file>, and stop.\n"
+    "                                               The image must be linked into a program that does not\n"
+    "                                               move at every start. Linux only.\n"
     "\n"
 
     // compiler debugging and experimental (see the devdocs for tips on using these options)
@@ -427,6 +437,8 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_rr_detach,
            opt_strip_metadata,
            opt_strip_ir,
+           opt_sysimage_prelink,
+           opt_output_prelinked,
            opt_heap_size_hint,
            opt_hard_heap_limit,
            opt_heap_target_increment,
@@ -503,6 +515,8 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "rr-detach",       no_argument,       0, opt_rr_detach },
         { "strip-metadata",  no_argument,       0, opt_strip_metadata },
         { "strip-ir",        no_argument,       0, opt_strip_ir },
+        { "sysimage-prelink",required_argument, 0, opt_sysimage_prelink },
+        { "output-prelinked",required_argument, 0, opt_output_prelinked },
         { "permalloc-pkgimg",required_argument, 0, opt_permalloc_pkgimg },
         { "heap-size-hint",  required_argument, 0, opt_heap_size_hint },
         { "hard-heap-limit", required_argument, 0, opt_hard_heap_limit },
@@ -1028,6 +1042,17 @@ restart_switch:
             break;
         case opt_strip_ir:
             jl_options.strip_ir = 1;
+            break;
+        case opt_sysimage_prelink:
+            if (!strcmp(optarg, "yes"))
+                jl_options.sysimage_prelink = 1;
+            else if (!strcmp(optarg, "no"))
+                jl_options.sysimage_prelink = 0;
+            else
+                jl_errorf("julia: invalid argument to --sysimage-prelink={yes|no} (%s)", optarg);
+            break;
+        case opt_output_prelinked:
+            jl_options.output_prelinked = optarg;
             break;
         case opt_heap_size_hint:
             if (optarg != NULL)

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -77,6 +77,8 @@ typedef struct {
     int8_t target_sanitize_memory;
     int8_t target_sanitize_thread;
     int8_t target_sanitize_address;
+    int8_t sysimage_prelink;
+    const char *output_prelinked;
 } jl_options_t;
 
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1331,6 +1331,7 @@ STATIC_INLINE jl_vararg_kind_t jl_va_tuple_kind(jl_datatype_t *t) JL_NOTSAFEPOIN
 void jl_init_types(void) JL_CANSAFEPOINT JL_GC_DISABLED;
 void jl_init_flisp(void) JL_NOTSAFEPOINT;
 void jl_init_common_symbols(void) JL_NOTSAFEPOINT;
+void jl_set_root_symbol(jl_sym_t *root) JL_NOTSAFEPOINT;
 void jl_init_primitives(void) JL_CANSAFEPOINT JL_GC_DISABLED;
 void jl_init_llvm(void) JL_CANSAFEPOINT;
 void jl_init_runtime_ccall(void) JL_NOTSAFEPOINT;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -396,26 +396,41 @@ JL_DLLEXPORT int jl_running_on_valgrind(void)
 
 #define NBOX_C 1024
 
+// A package image references `nothing` and the small boxed integers by tag,
+// since they belong to the loading runtime; a trimmed image does too, to stay
+// small. A full system image holds them as objects.
+static int primordials_by_tag(jl_serializer_state *s) JL_NOTSAFEPOINT
+{
+    return s->incremental || jl_options.trim;
+}
+
 static int jl_needs_serialization(jl_serializer_state *s, jl_value_t *v) JL_NOTSAFEPOINT
 {
     // ignore items that are given a special relocation representation
     if (s->incremental && jl_object_in_image(v))
         return 0;
 
-    if (v == NULL || jl_is_symbol(v) || v == jl_nothing) {
+    if (v == NULL || jl_is_symbol(v)) {
         return 0;
     }
-    else if (jl_typetagis(v, jl_int64_tag << 4)) {
+    // A package image names `nothing` and the small boxed integers with a tag,
+    // because they belong to the runtime that loads it. The system image is
+    // that runtime, so it holds them itself and every field that points at one
+    // is a pointer the loader does not have to write.
+    else if (primordials_by_tag(s) && v == jl_nothing) {
+        return 0;
+    }
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_int64_tag << 4)) {
         int64_t i64 = *(int64_t*)v + NBOX_C / 2;
         if ((uint64_t)i64 < NBOX_C)
             return 0;
     }
-    else if (jl_typetagis(v, jl_int32_tag << 4)) {
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_int32_tag << 4)) {
         int32_t i32 = *(int32_t*)v + NBOX_C / 2;
         if ((uint32_t)i32 < NBOX_C)
             return 0;
     }
-    else if (jl_typetagis(v, jl_uint8_tag << 4)) {
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_uint8_tag << 4)) {
         return 0;
     }
     else if (v == (jl_value_t*)s->ptls->root_task) {
@@ -1200,20 +1215,20 @@ static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v, jl_array_t *
     else if (v == (jl_value_t*)s->ptls->root_task) {
         return (uintptr_t)TagRef << RELOC_TAG_OFFSET;
     }
-    else if (v == jl_nothing) {
+    else if (primordials_by_tag(s) && v == jl_nothing) {
         return ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + 1;
     }
-    else if (jl_typetagis(v, jl_int64_tag << 4)) {
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_int64_tag << 4)) {
         int64_t i64 = *(int64_t*)v + NBOX_C / 2;
         if ((uint64_t)i64 < NBOX_C)
             return ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + i64 + 2;
     }
-    else if (jl_typetagis(v, jl_int32_tag << 4)) {
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_int32_tag << 4)) {
         int32_t i32 = *(int32_t*)v + NBOX_C / 2;
         if ((uint32_t)i32 < NBOX_C)
             return ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + i32 + 2 + NBOX_C;
     }
-    else if (jl_typetagis(v, jl_uint8_tag << 4)) {
+    else if (primordials_by_tag(s) && jl_typetagis(v, jl_uint8_tag << 4)) {
         uint8_t u8 = *(uint8_t*)v;
         return ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + u8 + 2 + NBOX_C + NBOX_C;
     }
@@ -4079,6 +4094,8 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     assert(!ios_eof(f));
     s.s = f;
     uintptr_t offset_restored = 0, offset_init_order = 0, offset_extext_methods = 0, offset_new_ext = 0, offset_method_roots_list = 0;
+    // the `nothing` allocated by `julia_init`, replaced by the image's below
+    jl_value_t *init_nothing = jl_nothing;
     if (!s.incremental) {
         size_t i;
         for (i = 0; tags[i] != NULL; i++) {
@@ -4167,6 +4184,20 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     // s.link_ids_gvars will be processed in `jl_update_all_gvars`
     // s.link_ids_external_fns will be processed in `jl_update_all_gvars`
     jl_update_all_gvars(&s, image, external_fns_begin); // gvars relocs
+
+    // `julia_init` allocated a `nothing` before the root task existed, and the
+    // image's `nothing` replaced it above. Point the root task's fields at the
+    // image's one. The walk is over the layout so it does not depend on the field
+    // list; no other thread exists yet, so plain stores are fine.
+    if (!s.incremental && init_nothing != jl_nothing) {
+        jl_value_t *root = (jl_value_t*)s.ptls->root_task;
+        const jl_datatype_layout_t *task_layout = jl_task_type->layout;
+        for (size_t i = 0; i < task_layout->npointers; i++) {
+            jl_value_t **slot = &((jl_value_t**)root)[jl_ptr_offset(jl_task_type, i)];
+            if (*slot == init_nothing)
+                jl_gc_write(root, *slot, jl_value_t, jl_nothing);
+        }
+    }
     if (s.incremental) {
         jl_read_arraylist(s.relocs, &s.uniquing_types);
         jl_read_arraylist(s.relocs, &s.uniquing_objs);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -396,9 +396,9 @@ JL_DLLEXPORT int jl_running_on_valgrind(void)
 
 #define NBOX_C 1024
 
-// A package image references `nothing` and the small boxed integers by tag,
-// since they belong to the loading runtime; a trimmed image does too, to stay
-// small. A full system image holds them as objects.
+// A package image references `nothing`, the small boxed integers and the
+// symbols by tag, since they belong to the loading runtime; a trimmed image
+// does too, to stay small. A full system image holds them as objects.
 static int primordials_by_tag(jl_serializer_state *s) JL_NOTSAFEPOINT
 {
     return s->incremental || jl_options.trim;
@@ -410,13 +410,12 @@ static int jl_needs_serialization(jl_serializer_state *s, jl_value_t *v) JL_NOTS
     if (s->incremental && jl_object_in_image(v))
         return 0;
 
-    if (v == NULL || jl_is_symbol(v)) {
+    if (v == NULL) {
         return 0;
     }
-    // A package image names `nothing` and the small boxed integers with a tag,
-    // because they belong to the runtime that loads it. The system image is
-    // that runtime, so it holds them itself and every field that points at one
-    // is a pointer the loader does not have to write.
+    else if (primordials_by_tag(s) && jl_is_symbol(v)) {
+        return 0;
+    }
     else if (primordials_by_tag(s) && v == jl_nothing) {
         return 0;
     }
@@ -656,6 +655,14 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
 
     if (!recursive)
         goto done_fields;
+
+    // A symbol's two children are not fields of its type.
+    if (!primordials_by_tag(s) && jl_is_symbol(v)) {
+        jl_sym_t *sym = (jl_sym_t*)v;
+        jl_queue_for_serialization_(s, (jl_value_t*)jl_atomic_load_relaxed(&sym->left), 1, immediate);
+        jl_queue_for_serialization_(s, (jl_value_t*)jl_atomic_load_relaxed(&sym->right), 1, immediate);
+        goto done_fields;
+    }
 
     if (s->incremental && jl_is_datatype(v) && immediate) {
         jl_datatype_t *dt = (jl_datatype_t*)v;
@@ -1198,7 +1205,7 @@ static uintptr_t add_external_linkage(jl_serializer_state *s, jl_value_t *v, jl_
 static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v, jl_array_t *link_ids) JL_GC_DISABLED JL_CANSAFEPOINT
 {
     assert(v != NULL && "cannot get backref to NULL object");
-    if (jl_is_symbol(v)) {
+    if (primordials_by_tag(s) && jl_is_symbol(v)) {
         void **pidx = ptrhash_bp(&symbol_table, v);
         void *idx = *pidx;
         if (idx == HT_NOTFOUND) {
@@ -1459,7 +1466,8 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
         assert((!jl_is_datatype_singleton(t) || t->instance == v) && "detected singleton construction corruption");
         int mutabl = t->name->mutabl;
         ios_t *f = s->s;
-        if (t->smalltag) {
+        // A symbol has relocations (its children), so it stays in the data section.
+        if (t->smalltag && t != jl_symbol_type) {
             if (t->layout->npointers == 0 || t == jl_string_type) {
                 if (jl_datatype_nfields(t) == 0 || mutabl == 0 || t == jl_string_type) {
                     f = s->const_data;
@@ -1676,6 +1684,17 @@ static void jl_write_values(jl_serializer_state *s) JL_CANSAFEPOINT JL_GC_DISABL
         else if (jl_is_string(v)) {
             ios_write(f, (char*)v, sizeof(void*) + jl_string_len(v));
             write_uint8(f, '\0'); // null-terminated strings for easier C-compatibility
+        }
+        else if (jl_is_symbol(v)) {
+            // left, right, hash, name; padded so the next object stays aligned
+            assert(f == s->s);
+            jl_sym_t *sym = (jl_sym_t*)v;
+            write_pointerfield(s, (jl_value_t*)jl_atomic_load_relaxed(&sym->left));
+            write_pointerfield(s, (jl_value_t*)jl_atomic_load_relaxed(&sym->right));
+            write_uint(f, sym->hash);
+            size_t len = strlen(jl_symbol_name(sym)) + 1;
+            ios_write(f, jl_symbol_name(sym), len);
+            write_padding(f, LLT_ALIGN(len, sizeof(void*)) - len);
         }
         else if (jl_is_cancel_source(v)) {
             // Variable-sized. Store parents, reset children (reconstructed on load).
@@ -3374,6 +3393,7 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
 #undef XX
             jl_write_value(&s, global_roots_list);
             jl_write_value(&s, global_roots_keyset);
+            jl_write_value(&s, primordials_by_tag(&s) ? NULL : (jl_value_t*)jl_get_root_symbol());
             jl_write_value(&s, s.ptls->root_task->tls);
             write_uint32(f, jl_get_gs_ctr());
             size_t world = jl_atomic_load_acquire(&jl_world_counter);
@@ -4096,6 +4116,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     uintptr_t offset_restored = 0, offset_init_order = 0, offset_extext_methods = 0, offset_new_ext = 0, offset_method_roots_list = 0;
     // the `nothing` allocated by `julia_init`, replaced by the image's below
     jl_value_t *init_nothing = jl_nothing;
+    jl_sym_t *image_symtab = NULL;
     if (!s.incremental) {
         size_t i;
         for (i = 0; tags[i] != NULL; i++) {
@@ -4118,6 +4139,8 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         export_jl_sysimg_globals();
         jl_global_roots_list = (jl_genericmemory_t*)jl_read_value(&s);
         jl_global_roots_keyset = (jl_genericmemory_t*)jl_read_value(&s);
+        // installed after the relocations, below
+        image_symtab = (jl_sym_t*)jl_read_value(&s);
         jl_gc_write(s.ptls->root_task, s.ptls->root_task->tls, jl_value_t, jl_read_value(&s));
 
         uint32_t gs_ctr = read_uint32(f);
@@ -4184,6 +4207,9 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     // s.link_ids_gvars will be processed in `jl_update_all_gvars`
     // s.link_ids_external_fns will be processed in `jl_update_all_gvars`
     jl_update_all_gvars(&s, image, external_fns_begin); // gvars relocs
+
+    if (image_symtab != NULL)
+        jl_set_root_symbol(image_symtab);
 
     // `julia_init` allocated a `nothing` before the root task existed, and the
     // image's `nothing` replaced it above. Point the root task's fields at the

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -119,6 +119,12 @@ Glossary
 #include <dlfcn.h>
 #include <sys/mman.h>
 #endif
+#if defined(_OS_LINUX_)
+#include <errno.h>
+#include <fcntl.h>
+#include <link.h>
+#include <unistd.h>
+#endif
 
 #include "valgrind.h"
 #include "julia_assert.h"
@@ -2244,7 +2250,196 @@ static void jl_write_arraylist(ios_t *s, arraylist_t *list)
     ios_write(s, (const char*)list->items, list->len * sizeof(void*));
 }
 
-static void jl_read_reloclist(jl_serializer_state *s, jl_array_t *link_ids, uint8_t bits) JL_CANSAFEPOINT
+// --- A pre-relocated system image ---
+//
+// When the image is linked into a non-PIE program it is at the same address at
+// every start, so the relocation passes can run once, at build time, and the
+// result be written back into the program file (`--output-prelinked`). A start
+// then applies only the residual list: pointers to objects the runtime creates
+// before reading the image, and entry points of libjulia-internal. The writer
+// reserves room for that list when asked (`--sysimage-prelink=yes`); an image
+// written without it is unchanged and carries no record.
+
+#define JL_PRELINK_MAGIC 0x50524c4e4b303031ull // "PRLNK001"
+
+static void prelink_failed(const char *what) JL_NOTSAFEPOINT
+{
+    // The restore is half way through: neither throwing nor the atexit hook works.
+    jl_safe_printf("ERROR: pre-relocated system image: %s\n", what);
+    exit(1);
+}
+
+typedef struct {
+    uintptr_t lo, hi;      // one loadable segment of the program that holds the image
+    uintptr_t file_offset; // where that segment starts in the program file
+    uintptr_t file_size;   // how much of it the file holds
+} prelink_segment_t;
+
+static struct {
+    uintptr_t blob;        // the image being located
+    int located;
+    int fixed;             // the program is at its link address
+    size_t n;
+    prelink_segment_t segments[32];
+} prelink_program;
+
+#if defined(_OS_LINUX_)
+static int prelink_visit_program(struct dl_phdr_info *info, size_t size, void *data) JL_NOTSAFEPOINT
+{
+    int holds = 0;
+    for (int i = 0; i < info->dlpi_phnum; i++) {
+        const ElfW(Phdr) *ph = &info->dlpi_phdr[i];
+        uintptr_t lo = info->dlpi_addr + ph->p_vaddr;
+        if (ph->p_type == PT_LOAD && lo <= prelink_program.blob && prelink_program.blob < lo + ph->p_memsz)
+            holds = 1;
+    }
+    if (!holds)
+        return 0;
+    prelink_program.fixed = info->dlpi_addr == 0;
+    for (int i = 0; i < info->dlpi_phnum; i++) {
+        const ElfW(Phdr) *ph = &info->dlpi_phdr[i];
+        if (ph->p_type != PT_LOAD || prelink_program.n == sizeof(prelink_program.segments) / sizeof(prelink_segment_t))
+            continue;
+        prelink_segment_t *seg = &prelink_program.segments[prelink_program.n++];
+        seg->lo = info->dlpi_addr + ph->p_vaddr;
+        seg->hi = seg->lo + ph->p_memsz;
+        seg->file_offset = ph->p_offset;
+        seg->file_size = ph->p_filesz;
+    }
+    return 1;
+}
+#endif
+
+// Find the segments of the program that holds the image.
+static void prelink_locate(const char *blob) JL_NOTSAFEPOINT
+{
+    memset(&prelink_program, 0, sizeof(prelink_program));
+    prelink_program.blob = (uintptr_t)blob;
+    prelink_program.located = 1;
+#if defined(_OS_LINUX_)
+    dl_iterate_phdr(prelink_visit_program, NULL);
+#endif
+}
+
+// A pointer is final when its target is inside the program: image data,
+// constants, or native code.
+static int prelink_is_final(uintptr_t v) JL_NOTSAFEPOINT
+{
+    if (v == 0)
+        return 1;
+    for (size_t i = 0; i < prelink_program.n; i++)
+        if (prelink_program.segments[i].lo <= v && v < prelink_program.segments[i].hi)
+            return 1;
+    return 0;
+}
+
+// Residual list: two counts (type-tag pass, general pass), then the
+// `(position, relocation id)` pairs, type-tag pass first.
+typedef struct {
+    uintptr_t *zone;
+    size_t capacity;       // pairs the zone holds
+    size_t n;              // pairs recorded
+    size_t total;          // pointers seen while recording
+} prelink_residual_t;
+
+static void prelink_record(prelink_residual_t *r, int pass, uintptr_t pos, uintptr_t id) JL_NOTSAFEPOINT
+{
+    if (r->n == r->capacity)
+        prelink_failed("the reserved room is full, which the writer's count should have prevented");
+    r->zone[2 + 2 * r->n] = pos;
+    r->zone[3 + 2 * r->n] = id;
+    r->n += 1;
+    r->zone[pass] += 1;
+}
+
+// Resolve one relocation to its target (before the type-tag substitution).
+static inline uintptr_t jl_apply_reloc(jl_serializer_state *s, uintptr_t base, uintptr_t *pv, uintptr_t id,
+                                       uint8_t bits, jl_array_t *link_ids, int *link_index) JL_CANSAFEPOINT
+{
+    uintptr_t v = get_item_for_reloc(s, base, id, link_ids, link_index);
+    uintptr_t stored = v;
+    if (bits && v && ((jl_datatype_t*)v)->smalltag)
+        stored = (uintptr_t)((jl_datatype_t*)v)->smalltag << 4; // TODO: should we have a representation that supports sweep without a relocation step?
+    *pv = stored | bits;
+    return v;
+}
+
+// Apply one pass of the residual list.
+static void prelink_apply_residual(jl_serializer_state *s, const prelink_residual_t *r, int pass,
+                                   jl_array_t *link_ids, uint8_t bits) JL_CANSAFEPOINT
+{
+    uintptr_t base = (uintptr_t)s->s->buf;
+    size_t first = pass == 0 ? 0 : r->zone[0];
+    size_t n = r->zone[pass];
+    const uintptr_t *pairs = r->zone + 2 + 2 * first;
+    int link_index = 0;
+    for (size_t i = 0; i < n; i++)
+        jl_apply_reloc(s, base, (uintptr_t*)(base + pairs[2 * i]), pairs[2 * i + 1], bits, link_ids, &link_index);
+    assert(!link_ids || link_index == jl_array_len(link_ids));
+}
+
+// Copy the running program to `output` with the restored image written over
+// its image bytes. Read through /proc/self/exe: Linux refuses to open a
+// running program for writing.
+static void prelink_write_back(const char *blob, size_t size, const char *output)
+{
+#if defined(_OS_LINUX_)
+    if (!prelink_program.located)
+        prelink_locate(blob);
+    if (prelink_program.n == 0)
+        prelink_failed("the image is not inside a loaded program");
+    if (!prelink_program.fixed)
+        prelink_failed("the program moves at every start; link it as an ET_EXEC (-no-pie)");
+    uintptr_t lo = (uintptr_t)blob, hi = lo + size;
+    const prelink_segment_t *seg = NULL;
+    for (size_t i = 0; i < prelink_program.n; i++) {
+        const prelink_segment_t *candidate = &prelink_program.segments[i];
+        if (candidate->lo <= lo && hi <= candidate->lo + candidate->file_size)
+            seg = candidate;
+    }
+    if (seg == NULL)
+        prelink_failed("the image is not inside one segment of the program that the file holds");
+    off_t file_offset = (off_t)(seg->file_offset + (lo - seg->lo));
+    int in = open("/proc/self/exe", O_RDONLY);
+    if (in < 0)
+        prelink_failed("cannot read the running program");
+    int out = open(output, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+    if (out < 0)
+        prelink_failed("cannot create the output file");
+    size_t chunk = 1 << 20;
+    char *buffer = (char*)malloc_s(chunk);
+    while (1) {
+        ssize_t got = read(in, buffer, chunk);
+        if (got < 0)
+            prelink_failed("cannot read the running program");
+        if (got == 0)
+            break;
+        for (ssize_t done = 0; done < got; ) {
+            ssize_t put = write(out, buffer + done, got - done);
+            if (put < 0)
+                prelink_failed("cannot write the output file");
+            done += put;
+        }
+    }
+    free(buffer);
+    for (size_t done = 0; done < size; ) {
+        ssize_t put = pwrite(out, blob + done, size - done, file_offset + done);
+        if (put < 0)
+            prelink_failed("cannot write the image into the output file");
+        done += put;
+    }
+    if (close(out) != 0)
+        prelink_failed("cannot close the output file");
+    close(in);
+#else
+    (void)blob; (void)size; (void)output;
+    prelink_failed("writing a pre-relocated program needs Linux");
+#endif
+}
+
+// `residual` records the pointers a pre-relocation cannot finalize, or NULL.
+static void jl_read_reloclist(jl_serializer_state *s, jl_array_t *link_ids, uint8_t bits,
+                              prelink_residual_t *residual, int pass) JL_CANSAFEPOINT
 {
     uintptr_t base = (uintptr_t)s->s->buf;
     uintptr_t last_pos = 0;
@@ -2270,16 +2465,20 @@ static void jl_read_reloclist(jl_serializer_state *s, jl_array_t *link_ids, uint
         uintptr_t pos = last_pos + pos_diff;
         last_pos = pos;
         uintptr_t *pv = (uintptr_t *)(base + pos);
-        uintptr_t v = *pv;
-        v = get_item_for_reloc(s, base, v, link_ids, &link_index);
-        if (bits && v && ((jl_datatype_t*)v)->smalltag)
-            v = (uintptr_t)((jl_datatype_t*)v)->smalltag << 4; // TODO: should we have a representation that supports sweep without a relocation step?
-        *pv = v | bits;
+        uintptr_t id = *pv;
+        uintptr_t v = jl_apply_reloc(s, base, pv, id, bits, link_ids, &link_index);
+        if (residual != NULL) {
+            residual->total += 1;
+            if (!prelink_is_final(v))
+                prelink_record(residual, pass, pos, id);
+        }
     }
     assert(!link_ids || link_index == jl_array_len(link_ids));
 }
 
-static void jl_read_memreflist(jl_serializer_state *s)
+// While recording, a memory reference outside the program cannot be written
+// to the file; none is expected.
+static void jl_read_memreflist(jl_serializer_state *s, int check_final)
 {
     uintptr_t base = (uintptr_t)s->s->buf;
     uintptr_t last_pos = 0;
@@ -2306,6 +2505,8 @@ static void jl_read_memreflist(jl_serializer_state *s)
         jl_genericmemoryref_t *pv = (jl_genericmemoryref_t*)(base + pos);
         size_t offset = (size_t)pv->ptr_or_offset;
         pv->ptr_or_offset = (void*)((char*)pv->mem->ptr + offset);
+        if (check_final && !prelink_is_final((uintptr_t)pv->ptr_or_offset))
+            prelink_failed("a memory reference points outside the program");
     }
 }
 
@@ -2376,6 +2577,22 @@ static jl_value_t *jl_delayed_reloc(jl_serializer_state *s, uintptr_t offset) JL
     return ret;
 }
 
+
+// Register the image's native code. The fptrs record already holds each
+// entry's method instance, written by `jl_update_all_fptrs` or by a pre-relocation.
+static void jl_register_image_fptrs(jl_serializer_state *s, jl_image_t *image)
+{
+    jl_image_fptrs_t fvars = image->fptrs;
+    // make these NULL now so we skip trying to restore GlobalVariable pointers later
+    image->gvars_base = NULL;
+    if (fvars.nptrs == 0)
+        return;
+    memcpy(image->jl_small_typeof, &jl_small_typeof, sizeof(jl_small_typeof));
+    int img_fvars_max = s->fptr_record->size / sizeof(void*);
+    jl_code_instance_t **linfos = (jl_code_instance_t**)&s->fptr_record->buf[0];
+    // Tell LLVM about the native code
+    jl_register_fptrs(image->base, &fvars, linfos, img_fvars_max);
+}
 
 static void jl_update_all_fptrs(jl_serializer_state *s, jl_image_t *image)
 {
@@ -3355,7 +3572,25 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
         jl_write_arraylist(s.relocs, &s.uniquing_objs);
         jl_write_arraylist(s.relocs, &s.fixup_types);
     }
+    size_t fixup_objs_pos = ios_pos(s.relocs);
     jl_write_arraylist(s.relocs, &s.fixup_objs);
+    // Room for the residual list: bounded by the relocations whose target is
+    // outside the image data and the constant data. Reserved only when asked.
+    write_padding(s.relocs, LLT_ALIGN(ios_pos(s.relocs), 8) - ios_pos(s.relocs));
+    size_t residual_pos = ios_pos(s.relocs);
+    size_t residual_capacity = 0;
+    if (!s.incremental && jl_options.sysimage_prelink) {
+        arraylist_t *lists[2] = {&s.gctags_list, &s.relocs_list};
+        for (int l = 0; l < 2; l++) {
+            for (size_t i = 0; i < lists[l]->len; i += 2) {
+                uintptr_t item = (uintptr_t)lists[l]->items[i + 1];
+                enum RefTags tag = (enum RefTags)(item >> RELOC_TAG_OFFSET);
+                if (tag != DataRef && tag != ConstDataRef)
+                    residual_capacity += 1;
+            }
+        }
+        write_padding(s.relocs, (2 + 2 * residual_capacity) * sizeof(uintptr_t));
+    }
     write_uint(f, relocs.size);
     write_padding(f, LLT_ALIGN(ios_pos(f), 8) - ios_pos(f));
     ios_seek(&relocs, 0);
@@ -3423,6 +3658,17 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
         write_uint32(f, jl_array_len(s.link_ids_external_fnvars));
         ios_write(f, (char*)jl_array_data(s.link_ids_external_fnvars, uint32_t), jl_array_len(s.link_ids_external_fnvars) * sizeof(uint32_t));
         write_uint32(f, external_fns_begin);
+        // Prelink record. The addresses stay zero until a pre-relocation writes the
+        // image back. The magic is last so a reader finds the record from the end.
+        if (residual_capacity != 0) {
+            write_padding(f, LLT_ALIGN(ios_pos(f), 8) - ios_pos(f));
+            write_uint(f, 0);                 // the address it was pre-relocated for
+            write_uint(f, 0);                 // reserved: the stub table it points at
+            write_uint(f, residual_pos);
+            write_uint(f, residual_capacity);
+            write_uint(f, fixup_objs_pos);
+            write_uint64(f, JL_PRELINK_MAGIC);
+        }
     }
 
     assert(object_worklist.len == 0);
@@ -4178,6 +4424,26 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         ios_read(f, (char*)jl_array_data(s.link_ids_external_fnvars, uint32_t), nlinks_external_fnvars * sizeof(uint32_t));
     }
     uint32_t external_fns_begin = read_uint32(f);
+    // The prelink record, if any, is at the end of the stream and ends with the
+    // magic; without `--sysimage-prelink=yes` there is none.
+    uintptr_t prelink_base = 0, prelink_stubs = 0;
+    size_t residual_pos = 0, residual_capacity = 0, fixup_objs_pos = 0;
+    size_t prelink_record_pos = 0;
+    if (!s.incremental && f->size >= 6 * sizeof(uintptr_t)) {
+        size_t magic_pos = f->size - sizeof(uint64_t);
+        if (jl_load_unaligned_i64(f->buf + magic_pos) == JL_PRELINK_MAGIC) {
+            prelink_record_pos = f->size - 6 * sizeof(uintptr_t);
+            size_t here = ios_pos(f);
+            ios_seek(f, prelink_record_pos);
+            prelink_base = read_uint(f);
+            prelink_stubs = read_uint(f);
+            residual_pos = read_uint(f);
+            residual_capacity = read_uint(f);
+            fixup_objs_pos = read_uint(f);
+            ios_seek(f, here);
+        }
+    }
+    (void)prelink_stubs;
     if (s.incremental) {
         assert(restored && init_order && extext_methods && internal_methods && method_roots_list);
         *restored = (jl_array_t*)jl_delayed_reloc(&s, offset_restored);
@@ -4189,6 +4455,29 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     }
     s.s = NULL;
 
+    // `prelink_output`: write a pre-relocated copy. `prelinked`: this image is one;
+    // take the fast path.
+    const char *prelink_output = s.incremental ? NULL : jl_options.output_prelinked;
+    int prelinked = prelink_base != 0;
+    if (prelinked && prelink_base != (uintptr_t)f->buf)
+        prelink_failed("the image was pre-relocated for another address than the one it is at");
+    if (prelinked && image->fptrs.nptrs == 0)
+        prelink_failed("a pre-relocated image needs its native code");
+    if (prelink_output != NULL && prelinked)
+        prelink_failed("the image is pre-relocated already");
+    if (prelink_output != NULL && residual_capacity == 0)
+        prelink_failed("the image reserved no room; write it with --sysimage-prelink=yes");
+    if (prelink_output != NULL && image->fptrs.nclones != 0)
+        prelink_failed("the image holds several code variants, and a pre-relocation would "
+                       "freeze the one this machine selected");
+    if (prelink_output != NULL)
+        prelink_locate(f->buf);
+    prelink_residual_t residual = {0};
+    if (residual_capacity != 0) {
+        residual.zone = (uintptr_t*)(relocs.buf + residual_pos);
+        residual.capacity = residual_capacity;
+    }
+
     // step 3: apply relocations
     assert(!ios_eof(f));
     jl_read_symbols(&s);
@@ -4198,12 +4487,24 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     reloc_t *relocs_base = (reloc_t*)&relocs.buf[0];
 
     s.s = &sysimg;
-    jl_read_reloclist(&s, s.link_ids_gctags, GC_OLD_MARKED | GC_IN_IMAGE); // gctags
-    size_t sizeof_tags = ios_pos(&relocs);
+    size_t sizeof_tags = 0;
+    if (prelinked) {
+        // Fast path: pointers into the program and memory references are final in the
+        // file; apply the residual list. The gvar slots live in .bss and are filled
+        // below either way.
+        prelink_apply_residual(&s, &residual, 0, s.link_ids_gctags, GC_OLD_MARKED | GC_IN_IMAGE);
+        prelink_apply_residual(&s, &residual, 1, s.link_ids_relocs, 0);
+        ios_seek(&relocs, fixup_objs_pos);
+    }
+    else {
+        prelink_residual_t *recording = prelink_output != NULL ? &residual : NULL;
+        jl_read_reloclist(&s, s.link_ids_gctags, GC_OLD_MARKED | GC_IN_IMAGE, recording, 0); // gctags
+        sizeof_tags = ios_pos(&relocs);
+        jl_read_reloclist(&s, s.link_ids_relocs, 0, recording, 1); // general relocs
+        jl_read_memreflist(&s, recording != NULL); // memowner_list relocs (must come before memref_list reads the pointers and after general relocs computes the pointers)
+        jl_read_memreflist(&s, recording != NULL); // memref_list relocs
+    }
     (void)sizeof_tags;
-    jl_read_reloclist(&s, s.link_ids_relocs, 0); // general relocs
-    jl_read_memreflist(&s); // memowner_list relocs (must come before memref_list reads the pointers and after general relocs computes the pointers)
-    jl_read_memreflist(&s); // memref_list relocs
     // s.link_ids_gvars will be processed in `jl_update_all_gvars`
     // s.link_ids_external_fns will be processed in `jl_update_all_gvars`
     jl_update_all_gvars(&s, image, external_fns_begin); // gvars relocs
@@ -4233,8 +4534,27 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         arraylist_new(&s.uniquing_types, 0);
         arraylist_new(&s.uniquing_objs, 0);
         arraylist_new(&s.fixup_types, 0);
+        assert(prelink_record_pos == 0 || ios_pos(&relocs) == fixup_objs_pos);
     }
     jl_read_arraylist(s.relocs, &s.fixup_objs);
+    if (!s.incremental) {
+        // Resolve the function pointers before the fixup list: the fixups write the
+        // first pointers a file cannot hold, and the image is written back before them.
+        if (prelinked)
+            jl_register_image_fptrs(&s, image);
+        else
+            jl_update_all_fptrs(&s, image); // fptr relocs and registration
+        if (prelink_output != NULL) {
+            uintptr_t base = (uintptr_t)f->buf;
+            memcpy(f->buf + prelink_record_pos, &base, sizeof(base));
+            jl_safe_printf("pre-relocated: %zu of %zu pointers on the list (%zu type tags, %zu other), room for %zu\n",
+                           residual.n, residual.total, (size_t)residual.zone[0],
+                           (size_t)residual.zone[1], residual.capacity);
+            prelink_write_back(f->buf, f->size, prelink_output);
+            // Written. The fixup list was not applied, so stop here.
+            exit(0);
+        }
+    }
     // Perform the uniquing of objects that we don't "own" and consequently can't promise
     // weren't created by some other package before this one got loaded:
     // - iterate through all objects that need to be uniqued. The first encounter has to be the
@@ -4574,9 +4894,11 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         cachesizes->fptrlist = sizeof_fptr_record;
     }
 
-    s.s = &sysimg;
-    jl_update_all_fptrs(&s, image); // fptr relocs and registration
-    s.s = NULL;
+    if (s.incremental) {
+        s.s = &sysimg;
+        jl_update_all_fptrs(&s, image); // fptr relocs and registration
+        s.s = NULL;
+    }
 
     ios_close(&fptr_record);
     ios_close(&sysimg);

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -123,6 +123,19 @@ JL_DLLEXPORT jl_sym_t *jl_get_root_symbol(void)
     return jl_atomic_load_relaxed(&symtab);
 }
 
+// Install the image's symbol tree as the symbol table. The table must be empty:
+// a symbol interned before the image is read would duplicate one of the image,
+// so `jl_init_common_symbols` runs after the restore.
+void jl_set_root_symbol(jl_sym_t *root) JL_NOTSAFEPOINT
+{
+    if (jl_atomic_load_relaxed(&symtab) != NULL) {
+        jl_safe_printf("ERROR: a symbol was made before the system image was read, "
+                       "so the image's symbol table cannot be installed.\n");
+        exit(1);
+    }
+    jl_atomic_store_release(&symtab, root);
+}
+
 static _Atomic(uint32_t) gs_ctr = 0;  // TODO: per-module?
 uint32_t jl_get_gs_ctr(void) { return jl_atomic_load_relaxed(&gs_ctr); }
 void jl_set_gs_ctr(uint32_t ctr) { jl_atomic_store_relaxed(&gs_ctr, ctr); }

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,6 +29,8 @@ EMBEDDING_ARGS := "JULIA=$(JULIA_EXECUTABLE)" "BIN=$(SRCDIR)/embedding" "CC=$(CC
 
 GCEXT_ARGS := "JULIA=$(JULIA_EXECUTABLE)" "BIN=$(SRCDIR)/gcext" "CC=$(CC)"
 
+PRELINK_ARGS := "JULIA=$(JULIA_EXECUTABLE)" "BIN=$(SRCDIR)/prelink" "CC=$(CC)"
+
 TEST_JULIA_OPTIONS := --check-bounds=yes --startup-file=no --depwarn=error
 TEST_SCRIPT_OPTIONS := --buildroot=$(call cygpath_w,$(BUILDROOT))
 
@@ -85,6 +87,10 @@ embedding:
 gcext:
 	@$(MAKE) -C $(SRCDIR)/$@ check $(GCEXT_ARGS)
 
+.PHONY: prelink
+prelink:
+	@$(MAKE) -C $(SRCDIR)/$@ check $(PRELINK_ARGS)
+
 .PHONY: clangsa
 clangsa:
 	@$(MAKE) -C $(SRCDIR)/$@
@@ -93,4 +99,5 @@ clangsa:
 clean:
 	@$(MAKE) -C embedding $@ $(EMBEDDING_ARGS)
 	@$(MAKE) -C gcext $@ $(GCEXT_ARGS)
+	@$(MAKE) -C prelink $@ $(PRELINK_ARGS)
 	@$(MAKE) -C llvmpasses $@

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1675,6 +1675,37 @@ end
     end
 end
 
+@testset "the system image holds `nothing`, the booleans and the symbols" begin
+    exename = `$(Base.julia_cmd())`
+    # A system image holds these itself, so that every field which points at
+    # one is final in the file. The start adopts them: a symbol interned at run
+    # time finds the image's, and every field of the root task that holds
+    # `nothing` holds the image's `nothing`. A stale one there breaks `wait`.
+    script = """
+        in_image(x) = ccall(:jl_object_in_image, UInt8, (Any,), x) == 1
+        function failures()
+            bad = String[]
+            in_image(nothing) || push!(bad, "nothing")
+            (in_image(true) && in_image(false)) || push!(bad, "the booleans")
+            in_image(:sin) || push!(bad, "a symbol of the image")
+            in_image(Symbol("si" * "n")) || push!(bad, "a symbol interned at run time")
+            nameof(sin) === Symbol("si" * "n") || push!(bad, "the identity of a symbol")
+            # The other way round, so that the question is a real one.
+            in_image(Symbol("zz", rand(UInt))) && push!(bad, "a symbol of neither")
+            for f in fieldnames(Task)
+                isdefined(current_task(), f) || continue
+                v = getfield(current_task(), f)
+                if v === nothing && !in_image(v)
+                    push!(bad, "the field \$f of the root task")
+                end
+            end
+            return join(bad, ", ")
+        end
+        print(failures())
+        """
+    @test readchomp(`$exename -e $script`) == ""
+end
+
 # Build and use a system image, exercising both split (--output-o together with
 # --output-ji, heap goes into the .ji) and non-split (--output-o only, heap goes
 # into the .so) layouts, with --compress-sysimage on and off in each.

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1675,6 +1675,58 @@ end
     end
 end
 
+@testset "--sysimage-prelink and --output-prelinked" begin
+    exename = `$(Base.julia_cmd())`
+    # The option takes yes or no and nothing else.
+    mktempdir() do dir
+        p = run(pipeline(ignorestatus(`$exename --sysimage-prelink=maybe -e 0`);
+                         stdout = devnull, stderr = "$(dir)/err"), wait = true)
+        @test p.exitcode != 0
+        @test occursin("invalid argument to --sysimage-prelink", read("$(dir)/err", String))
+    end
+    @test test_read_success(`$exename --sysimage-prelink=yes -E "Base.JLOptions().sysimage_prelink"`, Int) == 1
+    @test test_read_success(`$exename --sysimage-prelink=no -E "Base.JLOptions().sysimage_prelink"`, Int) == 0
+    # An image reserves the room only when it is asked to.
+    @test test_read_success(`$exename -E "Base.JLOptions().sysimage_prelink"`, Int) == 0
+    # An image written without the reservation cannot be pre-relocated, and the
+    # running image was written without it.
+    mktempdir() do dir
+        out = joinpath(dir, "prelinked")
+        p = run(pipeline(ignorestatus(`$exename --output-prelinked=$out -e 0`);
+                         stdout = devnull, stderr = "$(dir)/err"), wait = true)
+        @test p.exitcode == 1
+        @test occursin("reserved no room", read("$(dir)/err", String))
+        @test !isfile(out)
+    end
+    # An image asked to reserve the room is larger than the same image without,
+    # carries the record that says so, and both load.
+    magic = collect(reinterpret(UInt8, [0x50524c4e4b303031]))  # JL_PRELINK_MAGIC
+    carries_the_record(path) = open(path) do io
+        window = UInt8[]
+        while !eof(io)
+            append!(window, read(io, 1 << 20))
+            findfirst(magic, window) === nothing || return true
+            # Keep the last bytes, so that a record on a border is seen.
+            window = window[max(1, lastindex(window) - length(magic) + 2):end]
+        end
+        return false
+    end
+    mktempdir() do dir
+        for (name, prelink) in (("plain", "no"), ("room", "yes"))
+            @test "" == test_read_success(`$exename --sysimage-prelink=$prelink -t1,0 --output-o $(dir)/$(name).o.a -e 0`)
+        end
+        if isfile(joinpath(dir, "plain.o.a")) && isfile(joinpath(dir, "room.o.a"))
+            @test filesize(joinpath(dir, "room.o.a")) > filesize(joinpath(dir, "plain.o.a"))
+            @test !carries_the_record(joinpath(dir, "plain.o.a"))
+            @test carries_the_record(joinpath(dir, "room.o.a"))
+            for name in ("plain", "room")
+                Base.Linking.link_image(joinpath(dir, "$name.o.a"), joinpath(dir, "$name.so"))
+                @test readchomp(`$exename -t1,0 -J $(dir)/$(name).so -E "1 + 1"`) == "2"
+            end
+        end
+    end
+end
+
 @testset "the system image holds `nothing`, the booleans and the symbols" begin
     exename = `$(Base.julia_cmd())`
     # A system image holds these itself, so that every field which points at

--- a/test/prelink/.gitignore
+++ b/test/prelink/.gitignore
@@ -1,0 +1,4 @@
+/image.o.a
+/prelink
+/prelink-pie
+/prelinked

--- a/test/prelink/Makefile
+++ b/test/prelink/Makefile
@@ -1,0 +1,75 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# This Makefile template requires the following variables to be set
+# in the environment or on the command-line:
+#   JULIA: path to julia[.exe] executable
+#   BIN:   binary build directory
+
+ifndef JULIA
+  $(error "Please pass JULIA=[path of target julia binary], or set as environment variable!")
+endif
+ifndef BIN
+  $(error "Please pass BIN=[path of build directory], or set as environment variable!")
+endif
+
+#=============================================================================
+# this source directory, where prelink.c is located
+SRCDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+# get the executable suffix, if any
+EXE := $(suffix $(abspath $(JULIA)))
+
+# get compiler and linker flags. (see: `contrib/julia-config.jl`)
+JULIA_CONFIG := $(JULIA) -e 'include(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "julia-config.jl"))' --
+CFLAGS_ADD = $(shell $(JULIA_CONFIG) --cflags)
+LDFLAGS_ADD = -lm $(shell $(JULIA_CONFIG) --ldflags --ldlibs) -ljulia-internal
+
+# The image is at one address at every start only if the program does not move.
+FIXED_FLAGS := -no-pie
+
+# `--output-o` builds an image from source unless it is given one to start from.
+JULIA_SYSIMAGE := $(shell $(JULIA) --startup-file=no -e 'print(unsafe_string(Base.JLOptions().image_file))')
+IMAGE_FLAGS := --startup-file=no --sysimage='$(JULIA_SYSIMAGE)' --sysimage-prelink=yes \
+	--project=$(SRCDIR)/Prelinked -t1,0
+
+#=============================================================================
+
+release: $(BIN)/prelink$(EXE)
+debug:   $(BIN)/prelink$(EXE)
+
+$(BIN)/image.o.a: $(SRCDIR)/image.jl $(SRCDIR)/Prelinked/src/Prelinked.jl
+	$(JULIA) $(IMAGE_FLAGS) --output-o $@ $(SRCDIR)/image.jl $(SRCDIR)/Prelinked
+
+$(BIN)/prelink$(EXE): $(SRCDIR)/prelink.c $(BIN)/image.o.a
+	$(CC) $(SRCDIR)/prelink.c -o $@ $(FIXED_FLAGS) $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS) \
+		-Wl,--whole-archive $(BIN)/image.o.a -Wl,--no-whole-archive \
+		$(LDFLAGS_ADD) $(LDFLAGS)
+
+# The same image in a program that moves at every start.
+$(BIN)/prelink-pie$(EXE): $(SRCDIR)/prelink.c $(BIN)/image.o.a
+	$(CC) $(SRCDIR)/prelink.c -o $@ $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS) \
+		-Wl,--whole-archive $(BIN)/image.o.a -Wl,--no-whole-archive \
+		$(LDFLAGS_ADD) $(LDFLAGS)
+
+# Writing the file needs Linux.
+ifeq ($(shell uname),Linux)
+check: check-prelink
+else
+check:
+	@echo "a pre-relocated system image needs Linux; nothing to check here"
+endif
+
+check-prelink: $(BIN)/prelink$(EXE) $(BIN)/prelink-pie$(EXE)
+	$(JULIA) --depwarn=error $(SRCDIR)/prelink-test.jl $(BIN)
+	@echo SUCCESS
+
+clean:
+	-rm -f $(BIN)/prelink$(EXE) $(BIN)/prelink-pie$(EXE) \
+		$(BIN)/prelinked$(EXE) $(BIN)/image.o.a
+
+.PHONY: release debug clean check check-prelink
+
+# Makefile debugging trick:
+# call print-VARIABLE to see the runtime value of any variable
+print-%:
+	@echo '$*=$($*)'

--- a/test/prelink/Prelinked/Project.toml
+++ b/test/prelink/Prelinked/Project.toml
@@ -1,0 +1,3 @@
+name = "Prelinked"
+uuid = "b0f2e1a4-9d3c-4f6b-8a17-2c5d0e9b7431"
+version = "0.1.0"

--- a/test/prelink/Prelinked/src/Prelinked.jl
+++ b/test/prelink/Prelinked/src/Prelinked.jl
@@ -1,0 +1,12 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module Prelinked
+
+# The launcher calls this through `jl_call0`, so that nothing in the program
+# needs the parser.
+function julia_main()
+    println("prelinked ", 6 * 7)
+    return Int32(0)
+end
+
+end

--- a/test/prelink/image.jl
+++ b/test/prelink/image.jl
@@ -1,0 +1,14 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Build an application image: a system image that holds this program on top of
+# the one this Julia runs. The five lines before the `require` are what an
+# application needs of its environment.
+Base.reinit_stdio()
+@eval Sys BINDIR = ccall(:jl_get_julia_bindir, Any, ())::String
+@eval Sys STDLIB = $(abspath(Sys.BINDIR, "../share/julia/stdlib", string('v', VERSION.major, '.', VERSION.minor)))
+copy!(LOAD_PATH, [ARGS[1], "@stdlib"])
+Base.init_depot_path()
+let mod = Base.require(Base.PkgId(Base.UUID("b0f2e1a4-9d3c-4f6b-8a17-2c5d0e9b7431"), "Prelinked"))
+    # The launcher looks the program up in `Main`, so bind it there.
+    Core.eval(Main, Expr(:const, Expr(:(=), :Prelinked, mod)))
+end

--- a/test/prelink/prelink-test.jl
+++ b/test/prelink/prelink-test.jl
@@ -1,0 +1,72 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Drive the two programs that `Makefile` built: one that holds a system image
+# with the room for the list of a pre-relocation, and one that moves at every
+# start.
+
+using Test
+
+bin = ARGS[1]
+program = joinpath(bin, "prelink")
+prelinked = joinpath(bin, "prelinked")
+pie = joinpath(bin, "prelink-pie")
+answer = "prelinked 42"
+
+# Run `cmd` and give back its exit code, its output and its errors.
+function run_program(cmd)
+    out, err = IOBuffer(), IOBuffer()
+    p = run(pipeline(ignorestatus(cmd), stdout = out, stderr = err), wait = true)
+    return p.exitcode, String(take!(out)), String(take!(err))
+end
+
+@testset "a program that holds a system image" begin
+    code, out, err = run_program(`$program`)
+    @test code == 0
+    @test chomp(out) == answer
+end
+
+@testset "the program writes a pre-relocated copy of itself" begin
+    rm(prelinked, force = true)
+    code, out, err = run_program(`$program --julia-args --output-prelinked=$prelinked`)
+    @test code == 0
+    @test isfile(prelinked)
+    # The report says how much of the relocation the writer could not do. What
+    # is left is a pointer that the file cannot hold, and there are very few of
+    # them; if the count runs away, the image lost its own `nothing`, its
+    # symbols, or the thunks of the entry points of the runtime.
+    matched = match(r"pre-relocated: (\d+) of (\d+) pointers on the list", err)
+    @test matched !== nothing
+    if matched !== nothing
+        left, total = parse(Int, matched[1]), parse(Int, matched[2])
+        @test total > 100_000
+        @test left <= 64
+    end
+end
+
+@testset "the pre-relocated program does the same" begin
+    if isfile(prelinked)
+        @test Sys.isexecutable(prelinked)
+        code, out, err = run_program(`$prelinked`)
+        @test code == 0
+        @test chomp(out) == answer
+    end
+end
+
+@testset "what the runtime refuses" begin
+    # Each of these restores the image and stops before it writes anything.
+    # The runtime refuses two more that this harness cannot build: an image
+    # pre-relocated for another address, and an image with several code
+    # variants, which needs a base image that carries the same variants.
+    for (what, cmd, message) in (
+            ("an image that is pre-relocated already", `$prelinked`, "pre-relocated already"),
+            ("a program that moves at every start", `$pie`, "moves at every start"))
+        @testset "$what" begin
+            output = tempname()
+            code, out, err = run_program(`$cmd --julia-args --output-prelinked=$output`)
+            @test code == 1
+            @test occursin(message, err)
+            @test !isfile(output)
+            rm(output, force = true)
+        end
+    end
+end

--- a/test/prelink/prelink.c
+++ b/test/prelink/prelink.c
@@ -1,0 +1,68 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// The C entry of a program that holds its own system image. The image is
+// linked into this program, and the program is linked `-no-pie`, so the image
+// is at one address at every start and can be pre-relocated.
+//
+// Nothing here calls the parser: `jl_eval_string` would compile it to read one
+// line, which costs more than everything this program does.
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "julia.h"
+#include "uv.h"
+
+JULIA_DEFINE_FAST_TLS
+
+int main(int argc, char *argv[])
+{
+    argv = uv_setup_args(argc, argv);
+
+    // The arguments after `--julia-args` are the runtime's, not the program's.
+    int program_argc = argc;
+    for (int i = 0; i < argc; i++) {
+        if (strcmp(argv[i], "--julia-args") == 0) {
+            program_argc = i;
+            break;
+        }
+    }
+    int julia_argc = argc - program_argc;
+    if (julia_argc > 0) {
+        argv[program_argc] = argv[0];
+        char **julia_argv = &argv[program_argc];
+        jl_parse_opts(&julia_argc, &julia_argv);
+    }
+
+    // The image is this program: the loader finds it through the handle of the
+    // running program rather than through a file.
+    void *self = dlopen(NULL, RTLD_NOW | RTLD_NOLOAD | RTLD_LOCAL);
+    if (self == NULL) {
+        fprintf(stderr, "cannot open this program as a library: %s\n", dlerror());
+        return 1;
+    }
+    jl_init_with_image_handle(self);
+    jl_set_ARGS(program_argc, argv);
+
+    jl_module_t *module = (jl_module_t*)jl_get_global(jl_main_module, jl_symbol("Prelinked"));
+    if (module == NULL || !jl_is_module(module)) {
+        fprintf(stderr, "the image holds no module Prelinked\n");
+        return 1;
+    }
+    jl_value_t *entry = jl_get_function(module, "julia_main");
+    if (entry == NULL) {
+        fprintf(stderr, "the image holds no Prelinked.julia_main\n");
+        return 1;
+    }
+    jl_value_t *result = jl_call0(entry);
+    if (jl_exception_occurred()) {
+        jl_call2(jl_get_function(jl_base_module, "showerror"),
+                 jl_stderr_obj(), jl_exception_occurred());
+        jl_printf(jl_stderr_stream(), "\n");
+        return 1;
+    }
+    int code = (result != NULL && jl_typeis(result, jl_int32_type)) ? jl_unbox_int32(result) : 1;
+    jl_atexit_hook(code);
+    return code;
+}


### PR DESCRIPTION
Stacks on #63068; its two commits are under this one.

Applying the relocations of a system image writes almost every page of it: 47,566 page faults and 88 ms of a 105 ms `jl_init` on a 368 MB application image (#63065). When the image is linked into a non-PIE program it is at the same address at every start, so the relocation can be done once, at build time, and written into the program file.

- `--sysimage-prelink=yes`, when writing an image, reserves room for the residual list: the pointers a file cannot hold. Without it the image is unchanged, byte for byte.
- `--output-prelinked <file>`, on a program that holds such an image, restores it, writes the program with the restored image to `<file>`, and exits. Linux only, through `/proc/self/exe`; the fast path itself is portable.

A start of the written file applies the residual list, fills the gvar slots, registers the native code and runs the fixup list; it reads neither relocation list. The runtime refuses, with a message and exit code 1: an image pre-relocated for another address, an image without native code, an image with several code variants, and a second pre-relocation.

Measured on master, page cache evicted, minimum of 15 pinned runs, with #63070:

| program | start | minor faults | resident |
| --- | --- | --- | --- |
| hello world | 74.9 → 7.1 ms | 30,582 → 2,487 | 163 → 66 MB |
| a network simulator | 101.8 → 7.9 ms | 48,209 → 2,824 | 245 → 106 MB |

The remaining faults are the dynamic loader (about 1,150) and `jl_init` (about 1,200). The image pages stay clean file pages, so processes of the same program share them.

Tests: `test/prelink` (`make -C test prelink`, after `test/embedding`) builds a program with its own image, pre-relocates it, runs both, checks that at most 64 of 12 million pointers stay on the residual list, and checks the two refusals it can build; 1 min 36 s from clean. `test/cmdlineargs.jl` covers the options, the no-room refusal and the record. A devdoc section is added to `sysimg.md`. The full suite passes; `cmdlineargs` was run separately because `rr` does not support this CPU.

Reproduction: an 8-line image script and a 40-line C launcher; `julia --sysimage-prelink=yes --output-o app.o.a image.jl`, `cc -fPIC -no-pie ...`, `./app --julia-args --output-prelinked=app2`.

Disclosure: developed with Claude Code (Opus 5) under my direction. It wrote the code and this text; the measurements were run on my machine. I reviewed the changes. The commits carry an `Assisted-by` trailer.
