### PR TITLE
toml: a captured comment may end inside a multi-byte character

### DIFF
--- a/base/toml/parser.jl
+++ b/base/toml/parser.jl
@@ -532,7 +532,7 @@ function skip_comment(l::Parser)::Bool
         else
             start = l.prevpos
             accept_batch(l, !isnewline)
-            l.captured_comment = String(SubString(l.str, start:(l.prevpos-1)))
+            l.captured_comment = String(SubString(l.str, start:prevind(l.str, l.prevpos)))
         end
     end
     return found_comment

--- a/stdlib/TOML/test/comments.jl
+++ b/stdlib/TOML/test/comments.jl
@@ -348,3 +348,9 @@ end
     lines = split(out, '\n')
     @test lines[findfirst(==("b = 1"), lines) - 1] == "# above b"
 end
+
+@testset "a comment that ends in a multi-byte character" begin
+    data, comments = parse_with_comments("# ends in an em dash \u2014\nname = \"MyPkg\"\n")
+    @test data == Dict("name" => "MyPkg")
+    @test comments.items[["name"]].above == [" ends in an em dash \u2014"]
+end


### PR DESCRIPTION
**Where this comes from.** I found this while shortening the start of a compiled Julia program. This change has nothing to do with that work and needs none of it.

The comment capture of the parser slices `start:(prevpos-1)`, and `prevpos` is the index of the character AFTER the comment, so `prevpos - 1` lands inside that character when it is multi-byte. A TOML file whose comment ends in a non-ASCII character then throws `StringIndexError`, which `Pkg` reports as `Errored when reading Project.toml`.

`prevind` is the fix.

Found with a `Project.toml` whose comment ends with an em dash: `Pkg` could not read the project at all, on master.
