### PR TITLE
Make bootstrapping >2x faster by compiling inlineable code

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -238,7 +238,7 @@ function promotecache!(interp::AbstractInterpreter, caller::InferenceState)
             if isa(uncompressed, CodeInfo)
                 # record that the caller could use this result to generate code when required, if desired, to avoid repeating n^2 work
                 codegen[ci] = uncompressed
-                if bootstrapping_compiler && !(ci.inferred isa MaybeCompressed)
+                if bootstrapping_compiler
                     # This is necessary to get decent bootstrapping performance
                     # when compiling the compiler to inject everything eagerly
                     # where codegen can start finding and using it right away


### PR DESCRIPTION
On one machine, this made bootstrapping 2.4x faster.  Since 76a2a8f, we keep unspecialized code around even after an inferred one becomes available, which slows down bootstrapping considerably.  We more than win back the cost of eagerly compiling these functions in `promotecache!`.

Fixes #62198

Assisted-by: Codex:gpt-6-astra