### PR TITLE
REPL: stop history filtering at maxresults across batches

### DIFF
--- a/stdlib/REPL/src/History/resumablefiltering.jl
+++ b/stdlib/REPL/src/History/resumablefiltering.jl
@@ -278,6 +278,7 @@ are added to avoid showing duplicate history items.
 function filterchunkrev!(out::Vector{HistEntry}, candidates::DenseVector{HistEntry},
                          spec::FilterSpec, seen::Set{Tuple{Symbol,String}}, idx::Int = length(candidates);
                          maxtime::Float64 = Inf, maxresults::Int = length(candidates))
+    length(out) >= maxresults && return idx
     batchsize = clamp(length(candidates) ÷ 512, 10, 1000)
     for batch in Iterators.partition(idx:-1:1, batchsize)
         time() > maxtime && break
@@ -313,7 +314,7 @@ function filterchunkrev!(out::Vector{HistEntry}, candidates::DenseVector{HistEnt
             matchfail && continue
             push!(seen, (entry.mode, entry.content))
             pushfirst!(out, entry)
-            length(out) == maxresults && break
+            length(out) >= maxresults && return max(0, idx - 1)
         end
     end
     max(0, idx - 1)

--- a/stdlib/REPL/test/history.jl
+++ b/stdlib/REPL/test/history.jl
@@ -311,6 +311,23 @@ end
                 @test filterchunkrev!(results, entries, spec2, seen) == 0
                 @test results == [entries[3]]
             end
+            # Ensure maxresults stops filtering when matches span multiple batches.
+            @testset "Maximum results" begin
+                batch_entries = [
+                    HistEntry(:julia, now(UTC), "foo $i", UInt32(i))
+                    for i in 1:25
+                ]
+                spec = FilterSpec(ConditionSet("foo"))
+                empty!(results)
+                seen = Set{Tuple{Symbol,String}}()
+                idx = filterchunkrev!(results, batch_entries, spec, seen; maxresults = 2)
+                @test idx == 23
+                @test results == batch_entries[24:25]
+                empty!(results)
+                empty!(seen)
+                @test filterchunkrev!(results, batch_entries, spec, seen; maxresults = 0) == 25
+                @test isempty(results)
+            end
             @testset "Negative" begin
                 empty!(results)
                 cset = ConditionSet("!hello ; !test;! cos")


### PR DESCRIPTION
`filterchunkrev!` used `break` when `maxresults` was reached, but that only stopped the current batch. When matching entries spanned multiple batches, later batches continued adding results and the equality check could never succeed again.

Return immediately once the result limit is reached, preserving the resume index for subsequent filtering calls. Also handle an already satisfied limit, including `maxresults = 0`.

