### PR TITLE
[JuliaSyntax] use syntax versions in enable_in_core!/activate!

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -237,15 +237,16 @@ end
 # module bypasses package loading, so install the module parser binding
 # consulted by `Base.parser_for_module` directly; without it, `Meta.parse`-style
 # reparsing of Compiler sources (e.g. by Revise) uses unversioned syntax and
-# rejects `typegroup` blocks. `Base.JuliaSyntax` and `Base.VersionNumber` only
+# rejects `typegroup` blocks. `Base.VersionedParse` and `Base.VersionNumber` only
 # need to exist by the time this is called, not when it is defined, so this is
 # safe to define this early in bootstrap. When loaded as a package instead,
 # package loading has already declared an equivalent binding from the project's
 # `[syntax]` entry (and defining over it would error), so skip it then.
 if !isdefined(@__MODULE__, Symbol("#_internal_julia_parse"))
 function var"#_internal_julia_parse"(code, filename::String, lineno::Int, offset::Int, options::Symbol)
-    return Base.JuliaSyntax.core_parser_hook(code, filename, lineno, offset, options;
-                                             syntax_version=Base.VersionNumber(1, 14, 0))
+    # Route through `Base.VersionedParse` so that the parser installed as
+    # `Core._parse` is used, with the syntax version pinned to 1.14.
+    return Base.VersionedParse(Base.VersionNumber(1, 14, 0))(code, filename, lineno, offset, options)
 end
 end
 

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -851,11 +851,14 @@ function include_string(mapexpr::Function, mod::Module, code::AbstractString,
     # TODO: fix this hack.  The normal way of getting the parser for this module
     # only gives us Expr.  We probably want the parser to always create
     # SyntaxTree, then convert it to Expr if the version is too low.
+    #
+    # Modules without a declared syntax version are parsed by `Core._parse`,
+    # which defaults to the running Julia's syntax version; mirror that here.
     version = if isnothing(version) && isdefined(mod, Symbol("#_internal_julia_parse"))
         vp = getglobal(mod, Symbol("#_internal_julia_parse"))
-        vp isa Base.VersionedParse ? vp.ver : JuliaSyntax.JL_OLD_SYNTAX_VERSION
+        vp isa Base.VersionedParse ? vp.ver : JuliaSyntax.SYNTAX_VERSION
     else
-        version isa VersionNumber ? version : JuliaSyntax.JL_OLD_SYNTAX_VERSION
+        version isa VersionNumber ? version : JuliaSyntax.SYNTAX_VERSION
     end
     st = parseall(SyntaxTree, code; filename, version, ignore_warnings=true)
     @jl_assert kind(st) === K"toplevel" st

--- a/JuliaSyntax/docs/src/howto.md
+++ b/JuliaSyntax/docs/src/howto.md
@@ -13,6 +13,12 @@ using JuliaSyntax
 JuliaSyntax.enable_in_core!()
 ```
 
+Code which is not associated with a module that declares a syntax version (for
+example `Meta.parse(str)` without a `mod` argument) is parsed using the running
+Julia's syntax version. Use `JuliaSyntax.enable_in_core!(; syntax_version=...)`
+to choose a different default. Modules with a declared syntax version are always
+parsed at their declared version.
+
 This works well in Julia 1.9 but in Julia 1.8 will cause some startup latency.
 To reduce that you can create a custom system image by running the code in
 `./sysimage/compile.jl` as a Julia script (or directly using the shell, on

--- a/JuliaSyntax/src/integration/hooks.jl
+++ b/JuliaSyntax/src/integration/hooks.jl
@@ -163,7 +163,12 @@ end
 # Debug log file for dumping parsed code
 const _debug_log = Ref{Union{Nothing,IO}}(nothing)
 
-function core_parser_hook(code, filename::String, lineno::Int, offset::Int, options::Symbol; syntax_version = v"1.13")
+# Syntax version of the running Julia. The parser only distinguishes
+# (major, minor) - see `ParseStream`
+const SYNTAX_VERSION = VersionNumber(VERSION.major, VERSION.minor)
+
+function core_parser_hook(code, filename::String, lineno::Int, offset::Int, options::Symbol;
+                          syntax_version = SYNTAX_VERSION)
     try
         # TODO: Check that we do all this input wrangling without copying the
         # code buffer
@@ -306,6 +311,35 @@ function core_parser_hook(code, filename, offset, options)
     core_parser_hook(code, filename, 1, offset, options)
 end
 
+"""
+    CoreParserHook(default_syntax_version::VersionNumber)
+
+The callable which [`enable_in_core!`](@ref) installs as `Core._parse`
+(wrapped by `fix_world_age`). It forwards to [`core_parser_hook`](@ref), using
+`default_syntax_version` for callers which don't pass `syntax_version`
+explicitly. Such "unversioned" callers are those which reach the parser via
+`Core._parse` directly rather than via a module's `#_internal_julia_parse`
+binding - for example `Meta.parse(str)` without a `mod` argument.
+
+Versioned callers - `Base.VersionedParse`, installed for modules with a
+declared syntax version - pass `syntax_version=...` which takes precedence
+over the default.
+"""
+struct CoreParserHook
+    default_syntax_version::VersionNumber
+end
+
+function (hook::CoreParserHook)(code, filename::String, lineno::Int, offset::Int, options::Symbol;
+                                syntax_version = hook.default_syntax_version)
+    core_parser_hook(code, filename, lineno, offset, options; syntax_version=syntax_version)
+end
+
+# Signature used by the runtime prior to JuliaLang/julia#43876 (no `lineno`)
+function (hook::CoreParserHook)(code, filename, offset, options;
+                                syntax_version = hook.default_syntax_version)
+    core_parser_hook(code, filename, 1, offset, options; syntax_version=syntax_version)
+end
+
 if _has_v1_10_hooks
     Base.incomplete_tag(e::JuliaSyntax.ParseError) = e.incomplete_tag
 else
@@ -318,24 +352,32 @@ end
 _default_system_parser = _has_v1_6_hooks ? Core._parse : nothing
 
 # hook into InteractiveUtils.@activate
-activate!(enable=true) = enable_in_core!(enable)
+activate!(enable=true; kws...) = enable_in_core!(enable; kws...)
 
 """
-    enable_in_core!([enable=true; freeze_world_age=true, debug_filename=nothing])
+    enable_in_core!([enable=true; freeze_world_age=true, debug_filename=nothing,
+                     syntax_version=VersionNumber(VERSION.major, VERSION.minor)])
 
 Connect the JuliaSyntax parser to the Julia runtime so that it replaces the
-flisp parser for all parsing work. That is, JuliaSyntax will be used for
-`include()`, `Meta.parse()`, the REPL, etc. To reset to the reference parser,
-use `enable_in_core!(false)`.
+currently active parser for all parsing work. That is, JuliaSyntax will be
+used for `include()`, `Meta.parse()`, the REPL, etc. To reset to the
+reference parser, use `enable_in_core!(false)`.
 
 Keyword arguments:
 * `freeze_world_age` - Use a fixed world age for the parser to prevent
   recompilation of the parser due to any user-defined methods (default `true`).
 * `debug_filename` - File name of parser debug log (defaults to `nothing` or
   the value of `ENV["JULIA_SYNTAX_DEBUG_FILE"]`).
+* `syntax_version` - Julia syntax version used for code which is not
+  associated with a module that declares a syntax version. Defaults to the
+  major.minor version of the running Julia session. Modules with a declared
+  syntax version (via `syntax.julia_version` or `compat.julia` in Project.toml,
+  or `Base.Experimental.@set_syntax_version`) ask the parser for that version
+  explicitly and are not affected by this setting.
 """
 function enable_in_core!(enable=true; freeze_world_age = true,
-        debug_filename   = get(ENV, "JULIA_SYNTAX_DEBUG_FILE", nothing))
+        debug_filename   = get(ENV, "JULIA_SYNTAX_DEBUG_FILE", nothing),
+        syntax_version::VersionNumber = SYNTAX_VERSION)
     if !_has_v1_6_hooks
         error("Cannot use JuliaSyntax as the main Julia parser in Julia version $VERSION < 1.6")
     end
@@ -347,7 +389,7 @@ function enable_in_core!(enable=true; freeze_world_age = true,
     end
     if enable
         world_age = freeze_world_age ? Base.get_world_counter() : typemax(UInt)
-        _set_core_parse_hook(fix_world_age(core_parser_hook, world_age))
+        _set_core_parse_hook(fix_world_age(CoreParserHook(syntax_version), world_age))
     else
         @assert !isnothing(_default_system_parser)
         _set_core_parse_hook(_default_system_parser)

--- a/JuliaSyntax/src/precompile.jl
+++ b/JuliaSyntax/src/precompile.jl
@@ -7,6 +7,8 @@ let filename = joinpath(@__DIR__, "julia/literal_parsing.jl")
         enable_in_core!()
         Meta.parse("1 + 2")
         Meta.parse(SubString("1 + 2"))
+        # Versioned modules call the hook with an explicit syntax version
+        Core._parse("1 + 2", "none", 1, 0, :statement; syntax_version=SYNTAX_VERSION)
         enable_in_core!(false)
     end
 end

--- a/JuliaSyntax/test/hooks.jl
+++ b/JuliaSyntax/test/hooks.jl
@@ -132,6 +132,60 @@ end
         JuliaSyntax.enable_in_core!(false)
     end
 
+    @testset "enable_in_core! syntax_version" begin
+        wrapping_add = Expr(:call, Symbol("+%"), :a, :b)
+        ParseErrorT = JuliaSyntax._has_v1_10_hooks ? Meta.ParseError : JuliaSyntax.ParseError
+        # Restore whatever parser was installed before rather than relying on
+        # `enable_in_core!(false)`, which would leave flisp installed for the
+        # remainder of the test process when running against `Base.JuliaSyntax`.
+        saved_parser = Core._parse
+        try
+            # The default is the running Julia's major.minor version
+            JuliaSyntax.enable_in_core!()
+            if VERSION >= v"1.14.0-DEV"
+                @test Meta.parse("a +% b") == wrapping_add
+            else
+                @test_throws ParseErrorT Meta.parse("a +% b")
+            end
+
+            # Explicit default for unversioned parsing
+            JuliaSyntax.enable_in_core!(syntax_version=v"1.13")
+            @test_throws ParseErrorT Meta.parse("a +% b")
+            JuliaSyntax.enable_in_core!(syntax_version=v"1.14")
+            @test Meta.parse("a +% b") == wrapping_add
+            # Prerelease and patch information is ignored
+            JuliaSyntax.enable_in_core!(syntax_version=v"1.13.2-DEV.5")
+            @test_throws ParseErrorT Meta.parse("a +% b")
+            # activate! forwards the keyword
+            JuliaSyntax.activate!(syntax_version=v"1.14")
+            @test Meta.parse("a +% b") == wrapping_add
+
+            # A version passed by the caller wins over the hook's default
+            JuliaSyntax.enable_in_core!(syntax_version=v"1.13")
+            @test Core._parse("a +% b", "none", 1, 0, :statement; syntax_version=v"1.14") ==
+                Core.svec(wrapping_add, 6)
+            @test Meta.isexpr(Core._parse("a +% b", "none", 1, 0, :statement)[1], :error)
+
+            # A module's declared syntax version wins over the hook's default
+            if isdefined(Base, :set_syntax_version)
+                m13 = @eval(module SyntaxVersionHookTest13 end)
+                Base.set_syntax_version(m13, v"1.13")
+                m14 = @eval(module SyntaxVersionHookTest14 end)
+                Base.set_syntax_version(m14, v"1.14")
+                # `invokelatest`: the module parser bindings were declared in
+                # this world, so `Meta.parse` must look them up in a newer one.
+                JuliaSyntax.enable_in_core!(syntax_version=v"1.14")
+                @test_throws Meta.ParseError invokelatest(Meta.parse, "a +% b"; mod=m13)
+                @test_throws LoadError include_string(m13, "a +% b")
+                JuliaSyntax.enable_in_core!(syntax_version=v"1.13")
+                @test invokelatest(Meta.parse, "a +% b"; mod=m14) == wrapping_add
+                @test include_string(m14, "a = 1; b = 2; a +% b") == 3
+            end
+        finally
+            JuliaSyntax._set_core_parse_hook(saved_parser)
+        end
+    end
+
     @testset "Expr(:incomplete)" begin
         for (str, tag) in [
                 "\""           => :string

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ New language features
 * It is now possible to control which version of the Julia syntax will be used to parse a package by setting the
   `compat.julia` or `syntax.julia_version` key in Project.toml. This feature is similar to the notion of "editions"
   in other language ecosystems and will allow non-breaking evolution of Julia syntax in future versions.
+  Code parsed outside any module with a declared syntax version (e.g. `Meta.parse(str)`) uses the
+  running Julia's syntax version.
   See the "Syntax Versioning" section in the code loading documentation ([#60018]).
 * `ᵅ` (U+U+1D45), `ᵋ` (U+1D4B), `ᶲ` (U+1DB2), `˱` (U+02F1), `˲` (U+02F2), and `ₔ` (U+2094) can now also be used as
   operator suffixes, accessible as `\^alpha`, `\^epsilon`, `\^ltphi`, `\_<`, `\_>`, and `\_schwa` at the REPL

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -990,14 +990,32 @@ struct VersionedParse
     ver::VersionNumber
 end
 
+# Parse `code` with the parser currently installed as `Core._parse`, asking it
+# for syntax version `vp.ver`. The parser is looked up at call time so that a
+# parser activated after this module was created (e.g. a development copy of
+# JuliaSyntax loaded as a package and enabled with `enable_in_core!()`) is used
+# for versioned modules (`Main`, packages) as well as for unversioned parsing.
 function (vp::VersionedParse)(code, filename::String, lineno::Int, offset::Int, options::Symbol)
-    if !isdefined(Base, :JuliaSyntax)
-        if vp.ver === VERSION
-            return Core._parse
+    parser = Core._parse
+    if parser === nothing || parser === fl_parse
+        # The builtin flisp parser (in use during bootstrap, or when
+        # JULIA_USE_FLISP_PARSER is set) has no notion of syntax versions and
+        # accepts no keyword arguments. Prefer the vendored JuliaSyntax when it
+        # is available; otherwise flisp can only parse the running version's
+        # syntax.
+        if isdefined(Base, :JuliaSyntax)
+            return JuliaSyntax.core_parser_hook(code, filename, lineno, offset, options;
+                                                syntax_version=vp.ver)
+        elseif vp.ver.major == VERSION.major && vp.ver.minor == VERSION.minor
+            return fl_parse(code, filename, lineno, offset, options)
         end
         error("JuliaSyntax module is required for syntax version $(vp.ver), but it is not loaded.")
     end
-    Base.JuliaSyntax.core_parser_hook(code, filename, lineno, offset, options; syntax_version=vp.ver)
+    # `invokelatest`: the parser may have been installed in a newer world than
+    # the caller's (e.g. `Meta.parse` or `include_string` after activating a
+    # parser at runtime). The C entry point `jl_parse` already runs the parser
+    # in the latest world.
+    return invokelatest(parser, code, filename, lineno, offset, options; syntax_version=vp.ver)
 end
 
 function parser_for_active_project()

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -2159,6 +2159,61 @@ module M58272_to end
        @test_nowarn @test Core.include(m, joinpath(@__DIR__, "testhelpers", "return_syntax_version.jl")) == v"1.13"
     end
     include_world_age()
+
+    # `VersionedParse` must dispatch through whatever parser is installed as
+    # `Core._parse`, passing the module's syntax version along.
+    let saved_parser = Core._parse
+        m13 = @eval(module VersionedParseDispatch13 end)
+        Base.set_syntax_version(m13, v"1.13")
+        m14 = @eval(module VersionedParseDispatch14 end)
+        Base.set_syntax_version(m14, v"1.14")
+        # `invokelatest` below: the module parser bindings were declared in
+        # this world, so `Meta.parse` must look them up in a newer one.
+        seen = Ref{Any}(:unset)
+        function recording_parser(code, filename, lineno, offset, options; syntax_version=nothing)
+            seen[] = syntax_version
+            if syntax_version === nothing
+                return saved_parser(code, filename, lineno, offset, options)
+            else
+                return saved_parser(code, filename, lineno, offset, options; syntax_version)
+            end
+        end
+        # The recording parser forwards the keyword, so it needs a parser that
+        # accepts it (i.e. not flisp, as under JULIA_USE_FLISP_PARSER).
+        if parentmodule(saved_parser) === Base.JuliaSyntax
+            Core._setparser!(recording_parser)
+            try
+                @test include_string(m13, "1 + 1") == 2
+                @test seen[] == v"1.13"
+                seen[] = :unset
+                @test invokelatest(Meta.parse, "1 + 1"; mod=m14) == :(1 + 1)
+                @test seen[] == v"1.14"
+                seen[] = :unset
+                # C entry point (`jl_parse`), which passes the code as an svec
+                @test Core.include(m13, joinpath(@__DIR__, "testhelpers", "return_syntax_version.jl")) == v"1.13"
+                @test seen[] == v"1.13"
+                seen[] = :unset
+                # Unversioned parsing passes no version
+                @test Meta.parse("1 + 1") == :(1 + 1)
+                @test seen[] === nothing
+            finally
+                Core._setparser!(saved_parser)
+            end
+        end
+        # The flisp parser accepts no keyword arguments; versioned modules keep
+        # working (via the vendored JuliaSyntax) when it is installed as Core._parse.
+        Core._setparser!(Base.fl_parse)
+        try
+            @test invokelatest(Meta.parse, "a +% b"; mod=m14) == Expr(:call, Symbol("+%"), :a, :b)
+            @test_throws Meta.ParseError invokelatest(Meta.parse, "a +% b"; mod=m13)
+        finally
+            Core._setparser!(saved_parser)
+        end
+    end
+    # Unversioned parsing uses the running Julia's syntax version by default
+    if parentmodule(Core._parse) === Base.JuliaSyntax  # not under JULIA_USE_FLISP_PARSER
+        @test Meta.parse("a +% b") == Expr(:call, Symbol("+%"), :a, :b)
+    end
 end
 
 @testset "require_stdlib with isolated depot" begin

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3771,7 +3771,16 @@ end
 end
 
 @testset "public keyword" begin
-    p(str) = Base.remove_linenums!(Meta.parse(str))
+    function p(str)
+        ex = Base.remove_linenums!(Meta.parse(str))
+        # Unversioned parsing uses the running Julia's syntax version, which
+        # records that version as the first argument of `Expr(:module)`. These
+        # tests are about `public`, so drop it.
+        if Meta.isexpr(ex, :module) && ex.args[1] isa VersionNumber
+            popfirst!(ex.args)
+        end
+        ex
+    end
     # tests ported from JuliaSyntax.jl
     @test p("function f(public)\n    public + 3\nend") == Expr(:function, Expr(:call, :f, :public), Expr(:block, Expr(:call, :+, :public, 3)))
     @test p("public A, B") == Expr(:public, :A, :B)


### PR DESCRIPTION
Currently, if you load development version of JuliaSyntax, and use `JuliaSyntax.activate` or `JuliaSyntax.enable_in_core!`, it'll default to v1.13 syntax, which makes it annoying to test new features in the REPL when developing JuliaSyntax. 

This PR adds a `syntax_version` kwarg to those functions which defaults to `VersionNumber(VERSION.major, VERSION.minor)`. 

This also incidentally fixes things like `Meta.parse` which were not using the latest syntax:

#### Before: 
```julia-repl
julia> :(a +% b)
:(a +% b)

julia> Meta.parse("a +% b")
ERROR: ParseError:
# Error @ none:1:2
a +% b
#└ ── wrapping arithmetic operators `+%`, `-%`, and `*%` not supported in Julia version 1.13 < 1.14
Stacktrace:
 [1] parse(str::String, pos::Int64; filename::String, greedy::Bool, raise::Bool, depwarn::Bool, mod::Nothing, _parse::Function)
   @ Base.Meta meta.jl:365
 [2] parse(str::String; filename::String, raise::Bool, depwarn::Bool, mod::Nothing, _parse::Function)
   @ Base.Meta meta.jl:399
 [3] parse(str::String)
   @ Base.Meta meta.jl:397
 [4] top-level scope
   @ REPL[2]:1
```

#### After:
```julia-repl
julia> :(a +% b)
:(a +% b)

julia> Meta.parse("a +% b")
:(a +% b)
```



Assisted-by: Claude Code (Fable 5.1)