### PR TITLE
arrays: Fix nested views with IdentityUnitRange indices

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -433,6 +433,11 @@ function getindex(S::IdentityUnitRange, i::AbstractUnitRange{Bool})
     @boundscheck checkbounds(S, i)
     range(first(i) ? first(S) : last(S), length = last(i))
 end
+function getindex(S::IdentityUnitRange, i::Slice)
+    @inline
+    @boundscheck checkbounds(S, i)
+    return IdentityUnitRange(i.indices)
+end
 function getindex(S::IdentityUnitRange, i::StepRange{<:Integer})
     @inline
     @boundscheck checkbounds(S, i)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2500,6 +2500,11 @@ end
                     rs = r[s]
                     @test rs == s
                     @test axes(rs) == axes(s)
+                    # Preserve values and axes without retaining Slice's semantics
+                    # of representing a complete slice of a dimension
+                    if r isa Base.IdentityUnitRange && s isa Base.Slice
+                        @test rs isa Base.IdentityUnitRange
+                    end
                 end
                 @test_throws BoundsError r[Base.IdentityUnitRange(first(r):last(r) + 1)]
             end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -923,6 +923,43 @@ end
     end
 end
 
+@testset "issue #62906: views of views with slices" begin
+    @testset "reading" begin
+        M = reshape(1.0:25.0, 5, 5)
+        r = Base.IdentityUnitRange(2:4)
+        A = view(M, r, :)
+        B = view(A, :, 3)
+
+        @test axes(B) == (r,)
+        @test [B[2], B[3], B[4]] == [12.0, 13.0, 14.0]
+
+        for rows in (1:3, 2:4)
+            M = reshape(collect(1:16), 4, 4)
+            A = view(M, Base.IdentityUnitRange(rows), :)
+            W = view(A, :, :)
+
+            @test axes(W) == axes(A)
+            @test W[4] == W[first(rows), 2] == M[first(rows), 2]
+        end
+    end
+
+    @testset "writing" begin
+        for rows in (1:3, 2:4)
+            M = reshape(collect(1:16), 4, 4)
+            expected = copy(M)
+            for j in 1:4, i in rows
+                expected[i, j] = -1
+            end
+
+            A = view(M, Base.IdentityUnitRange(rows), :)
+            W = view(A, :, :)
+
+            W .= -1
+            @test M == expected
+        end
+    end
+end
+
 @testset "issue #29608; contiguousness" begin
     @test Base.iscontiguous(view(ones(1), 1))
     @test Base.iscontiguous(view(ones(10), 1:10))


### PR DESCRIPTION
This PR fixes #62906, where nested views involving `IdentityUnitRange` and `Slice` can read from and write to the wrong elements of their parent array.

Indexing an `IdentityUnitRange` with a `Slice` can return the `Slice` itself. During reindexing, this can cause a selection covering only part of the parent's axis to be treated as a full-axis selection.

I implemented [the fix posted by nhz2](https://github.com/JuliaLang/julia/issues/62906#issuecomment-5454701418) and added tests for the returned index type, preservation of axes, and reading and writing through nested views.

## Why the issue happens

Before the fix, `r[s]` in the example below has the expected values and axis. However, the call dispatches to `getindex(::IdentityUnitRange, ::AbstractUnitRange{<:Integer})`, which returns the `Slice` unchanged via `convert(AbstractUnitRange{eltype(S)}, i)`.

When this result is used as an index into `M`, it incorrectly indicates that `2:4` spans the whole first axis of `M`. The actual first axis is `1:5`.

For this example, the `Slice` method of `compute_offset1` uses `1`, the first index of the parent's first axis, instead of 2, the first index of the view's axis. This gives an offset of `11` instead of `10` and shifts reads by one element.

This fix returns an `IdentityUnitRange` instead of a `Slice`. This preserves the values and axes without carrying over the `Slice`'s full-axis assumption.

## Example of the issue and the fix

Before the fix: `r[s]` returns a `Slice`, and `B = view(M, rows, 3)` reads from the wrong elements of `M`.

```julia
julia> using Base: IdentityUnitRange, Slice

julia> r = IdentityUnitRange(2:4)
Base.IdentityUnitRange(2:4)

julia> s = Slice(axes(r, 1))
Base.Slice(Base.IdentityUnitRange(2:4))

julia> rows = r[s]
Base.Slice(Base.IdentityUnitRange(2:4))

julia> M = reshape(1.0:25.0, 5, 5)
5×5 reshape(::StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}, 5, 5) with eltype Float64:
 1.0   6.0  11.0  16.0  21.0
 2.0   7.0  12.0  17.0  22.0
 3.0   8.0  13.0  18.0  23.0
 4.0   9.0  14.0  19.0  24.0
 5.0  10.0  15.0  20.0  25.0

julia> B = view(M, rows, 3)
3-element view(reshape(::StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}, 5, 5), :, 3) with eltype Float64 with indices 2:4:
 13.0
 14.0
 15.0
```
After the fix: `r[s]` returns an `IdentityUnitRange`, and `B` reads the expected elements while retaining its `2:4` axis.

```julia
julia> rows = r[s]
Base.IdentityUnitRange(2:4)

julia> B = view(M, rows, 3)
3-element view(reshape(::StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}, 5, 5), Base.IdentityUnitRange(2:4), 3) with eltype Float64 with indices 2:4:
 12.0
 13.0
 14.0
```


Assisted-by: Codex (GPT-6)