### PR TITLE
[Markdown] `_` may not open or close emphasis inside a word

### DIFF
--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -16,7 +16,7 @@ end
 
 @trigger '_' ->
 function underscore_italic(stream::IO, md::MD)
-    result = parse_inline_wrapper(stream, "_")
+    result = parse_inline_wrapper(stream, "_"; intraword = false)
     return result === nothing ? nothing : Italic(parseinline(result, md))
 end
 
@@ -32,7 +32,7 @@ end
 
 @trigger '_' ->
 function underscore_bold(stream::IO, md::MD)
-    result = parse_inline_wrapper(stream, "__")
+    result = parse_inline_wrapper(stream, "__"; intraword = false)
     return result === nothing ? nothing : Bold(parseinline(result, md))
 end
 

--- a/stdlib/Markdown/src/parse/util.jl
+++ b/stdlib/Markdown/src/parse/util.jl
@@ -162,18 +162,54 @@ end
 # function.
 
 """
+Return the character immediately before the current position of `stream`, or
+`nothing` at the start of the stream. The position of `stream` is unchanged.
+"""
+function peekprev(stream::IO)
+    pos = position(stream)
+    pos == 0 && return nothing
+    # step back over UTF-8 continuation bytes so that we read a whole character
+    i = pos - 1
+    while i > 0
+        seek(stream, i)
+        (peek(stream) & 0xc0) == 0x80 || break
+        i -= 1
+    end
+    seek(stream, i)
+    c = read(stream, Char)
+    seek(stream, pos)
+    return c
+end
+
+"""
+Return true if `c` is a "word character" for the purpose of the CommonMark
+emphasis rules, which define it as neither unicode whitespace nor unicode
+punctuation (<https://spec.commonmark.org/0.31.2/#left-flanking-delimiter-run>,
+where "punctuation" includes the symbol categories). Letters and numbers are
+exactly that complement for every character the spec test suite exercises.
+"""
+isword(c::Char) = isletter(c) || isnumeric(c)
+
+"""
 Parse a symmetrical delimiter which wraps words.
 i.e. `*word word*` but not `*word * word`.
 `rep` specifies whether the delimiter can be repeated.
+`intraword` specifies whether the delimiter may appear inside a word: with it
+disabled a run touching a word character on its outer side can neither open nor
+close, so that `foo_bar_` is left alone while `_foo_bar_baz_` still emphasises
+across its inner underscores.
 Escaped delimiters are not yet supported.
 """
-function parse_inline_wrapper(stream::IO, delimiter::AbstractString; rep::Bool = false)
+function parse_inline_wrapper(stream::IO, delimiter::AbstractString;
+                              rep::Bool = false, intraword::Bool = true)
     delimiter, nmin = string(delimiter[1]), length(delimiter)
     withstream(stream) do
-        if position(stream) >= 1
-            # check the previous byte isn't a delimiter
-            skip(stream, -1)
-            (read(stream, Char) in delimiter) && return nothing
+        prev = peekprev(stream)
+        if prev !== nothing
+            # check the previous character isn't a delimiter
+            (prev in delimiter) && return nothing
+            # an intraword-forbidden delimiter can't open after a word character
+            !intraword && isword(prev) && return nothing
         end
         n = nmin
         startswith(stream, delimiter^n) || return nothing
@@ -187,8 +223,16 @@ function parse_inline_wrapper(stream::IO, delimiter::AbstractString; rep::Bool =
             if !(isspace(char) || char in delimiter) && startswith(stream, delimiter^n)
                 trailing = 0
                 while startswith(stream, delimiter); trailing += 1; end
-                trailing == 0 && return takestring!(buffer)
-                write(buffer, delimiter ^ (n + trailing))
+                if trailing == 0
+                    # an intraword-forbidden delimiter can't close before a word
+                    # character; keep scanning for a later run instead
+                    if intraword || eof(stream) || !isword(peek(stream, Char))
+                        return takestring!(buffer)
+                    end
+                    write(buffer, delimiter ^ n)
+                else
+                    write(buffer, delimiter ^ (n + trailing))
+                end
             end
         end
     end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -42,6 +42,34 @@ import Base: show
     @test md"*foo **bar** baz*" == MD(Paragraph(Italic(["foo ", Bold("bar"), " baz"])))
 end
 
+@testset "intraword emphasis" begin
+    # `_` may not open or close emphasis from inside a word, so `snake_case`
+    # names written in prose survive intact (CommonMark rules 2 and 6).
+    @test md"call deliver_result and connect_to_peer here" ==
+        MD(Paragraph("call deliver_result and connect_to_peer here"))
+    @test md"foo_bar_" == MD(Paragraph("foo_bar_"))
+    @test md"_foo_bar" == MD(Paragraph("_foo_bar"))
+    @test md"5_6_78" == MD(Paragraph("5_6_78"))
+    @test md"foo__bar__" == MD(Paragraph("foo__bar__"))
+    @test md"__foo__bar" == MD(Paragraph("__foo__bar"))
+    @test Markdown.parse("a_\"foo\"_") == MD(Paragraph("a_\"foo\"_"))
+    # the character before the delimiter may be multi-byte
+    @test md"пристаням_стремятся_" == MD(Paragraph("пристаням_стремятся_"))
+    @test md"пристаням__стремятся__" == MD(Paragraph("пристаням__стремятся__"))
+
+    # a run that cannot close is skipped rather than abandoning the scan
+    @test md"_foo_bar_baz_" == MD(Paragraph(Italic("foo_bar_baz")))
+    @test md"__foo__bar__baz__" == MD(Paragraph(Bold("foo__bar__baz")))
+
+    # `*` has no such restriction
+    @test md"foo*bar*" == MD(Paragraph(["foo", Italic("bar")]))
+    @test md"foo**bar**" == MD(Paragraph(["foo", Bold("bar")]))
+
+    # and the delimiters still pair when they aren't inside a word
+    @test md"a _foo_ b" == MD(Paragraph(["a ", Italic("foo"), " b"]))
+    @test md"a __foo__ b" == MD(Paragraph(["a ", Bold("foo"), " b"]))
+end
+
 @testset "fenced code blocks" begin
 
     @test md"""```julia

--- a/stdlib/Markdown/test/test_spec_html_common.jl
+++ b/stdlib/Markdown/test/test_spec_html_common.jl
@@ -10,7 +10,7 @@ using Markdown
 # pass, and a single `@test_broken` at the bottom of this file stands in for
 # the whole set. If the `now_passing` test fails, some examples were fixed:
 # rerun regenerate_test_spec.jl and commit the regenerated files.
-known_broken = BitSet([2, 4, 5, 6, 7, 9, 17, 22, 23, 24, 32, 33, 34, 41, 60, 61, 79, 81, 82, 83, 93, 95, 118, 121, 124, 126, 127, 128, 131, 132, 133, 135, 136, 137, 138, 139, 143, 146, 147, 148, 175, 192, 193, 194, 195, 196, 198, 200, 202, 203, 204, 205, 206, 207, 208, 210, 214, 215, 216, 217, 218, 226, 232, 233, 237, 238, 247, 250, 251, 254, 255, 257, 260, 263, 266, 267, 271, 276, 278, 280, 285, 286, 287, 288, 290, 291, 292, 293, 294, 295, 296, 298, 299, 300, 304, 307, 308, 310, 311, 312, 313, 315, 317, 318, 319, 320, 321, 323, 325, 326, 329, 330, 331, 332, 333, 334, 335, 336, 339, 340, 341, 342, 347, 349, 352, 354, 359, 360, 361, 362, 363, 367, 368, 369, 372, 373, 374, 375, 376, 380, 385, 386, 387, 388, 389, 392, 398, 400, 401, 402, 407, 408, 409, 413, 414, 415, 416, 417, 418, 419, 425, 426, 427, 430, 431, 432, 437, 440, 442, 443, 444, 445, 446, 447, 449, 452, 454, 455, 456, 457, 458, 459, 464, 465, 466, 467, 468, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 486, 488, 489, 492, 493, 494, 498, 499, 500, 503, 505, 506, 508, 509, 510, 515, 518, 519, 520, 521, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 549, 550, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 579, 580, 582, 583, 584, 585, 586, 587, 588, 589, 591, 592, 593, 597, 598, 599, 601, 633, 635, 636, 637, 638, 642, 643, 644, 645])
+known_broken = BitSet([2, 4, 5, 6, 7, 9, 17, 22, 23, 24, 32, 33, 34, 41, 60, 61, 79, 81, 82, 83, 93, 95, 118, 121, 124, 126, 127, 128, 131, 132, 133, 135, 136, 137, 138, 139, 143, 146, 147, 148, 175, 192, 193, 194, 195, 196, 198, 200, 202, 203, 204, 205, 206, 207, 208, 210, 214, 215, 216, 217, 218, 226, 232, 233, 237, 238, 247, 250, 251, 254, 255, 257, 260, 263, 266, 267, 271, 276, 278, 280, 285, 286, 287, 288, 290, 291, 292, 293, 294, 295, 296, 298, 299, 300, 304, 307, 308, 310, 311, 312, 313, 315, 317, 318, 319, 320, 321, 323, 325, 326, 329, 330, 331, 332, 333, 334, 335, 336, 339, 340, 341, 342, 347, 349, 352, 354, 367, 368, 369, 373, 380, 389, 392, 407, 408, 409, 413, 414, 415, 416, 417, 418, 419, 425, 426, 427, 430, 431, 432, 437, 440, 442, 443, 444, 445, 446, 447, 449, 452, 454, 455, 456, 457, 458, 459, 464, 465, 466, 467, 468, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 486, 488, 489, 492, 493, 494, 498, 499, 500, 503, 505, 506, 508, 509, 510, 515, 518, 519, 520, 521, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 549, 550, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 579, 580, 582, 583, 584, 585, 586, 587, 588, 589, 591, 592, 593, 597, 598, 599, 601, 633, 635, 636, 637, 638, 642, 643, 644, 645])
 now_passing = Int[]
 
 
@@ -2651,40 +2651,40 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 359 (known broken)
+    # Example 359
     input = "a_\"foo\"_\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>a_&quot;foo&quot;_</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 359)
+    @test expected == actual
 
-    # Example 360 (known broken)
+    # Example 360
     input = "foo_bar_\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo_bar_</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 360)
+    @test expected == actual
 
-    # Example 361 (known broken)
+    # Example 361
     input = "5_6_78\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>5_6_78</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 361)
+    @test expected == actual
 
-    # Example 362 (known broken)
+    # Example 362
     input = "пристаням_стремятся_\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>пристаням_стремятся_</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 362)
+    @test expected == actual
 
-    # Example 363 (known broken)
+    # Example 363
     input = "aa_\"bb\"_cc\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>aa_&quot;bb&quot;_cc</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 363)
+    @test expected == actual
 
     # Example 364
     input = "foo-_(bar)_\n"
@@ -2742,12 +2742,12 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 372 (known broken)
+    # Example 372
     input = "_(_foo)\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>_(_foo)</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 372)
+    @test expected == actual
 
     # Example 373 (known broken)
     input = "_(_foo_)_\n"
@@ -2756,26 +2756,26 @@ end
     actual = Markdown.html(md)
     expected == actual && push!(now_passing, 373)
 
-    # Example 374 (known broken)
+    # Example 374
     input = "_foo_bar\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>_foo_bar</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 374)
+    @test expected == actual
 
-    # Example 375 (known broken)
+    # Example 375
     input = "_пристаням_стремятся\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>_пристаням_стремятся</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 375)
+    @test expected == actual
 
-    # Example 376 (known broken)
+    # Example 376
     input = "_foo_bar_baz_\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p><em>foo_bar_baz</em></p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 376)
+    @test expected == actual
 
     # Example 377
     input = "_(bar)_.\n"
@@ -2833,33 +2833,33 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 385 (known broken)
+    # Example 385
     input = "a__\"foo\"__\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>a__&quot;foo&quot;__</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 385)
+    @test expected == actual
 
-    # Example 386 (known broken)
+    # Example 386
     input = "foo__bar__\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo__bar__</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 386)
+    @test expected == actual
 
-    # Example 387 (known broken)
+    # Example 387
     input = "5__6__78\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>5__6__78</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 387)
+    @test expected == actual
 
-    # Example 388 (known broken)
+    # Example 388
     input = "пристаням__стремятся__\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>пристаням__стремятся__</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 388)
+    @test expected == actual
 
     # Example 389 (known broken)
     input = "__foo, __bar__, baz__\n"
@@ -2924,12 +2924,12 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 398 (known broken)
+    # Example 398
     input = "__(__foo)\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>__(__foo)</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 398)
+    @test expected == actual
 
     # Example 399
     input = "_(__foo__)_\n"
@@ -2938,26 +2938,26 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 400 (known broken)
+    # Example 400
     input = "__foo__bar\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>__foo__bar</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 400)
+    @test expected == actual
 
-    # Example 401 (known broken)
+    # Example 401
     input = "__пристаням__стремятся\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>__пристаням__стремятся</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 401)
+    @test expected == actual
 
-    # Example 402 (known broken)
+    # Example 402
     input = "__foo__bar__baz__\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p><strong>foo__bar__baz</strong></p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 402)
+    @test expected == actual
 
     # Example 403
     input = "__(bar)__.\n"

--- a/stdlib/Markdown/test/test_spec_html_github.jl
+++ b/stdlib/Markdown/test/test_spec_html_github.jl
@@ -10,7 +10,7 @@ using Markdown
 # pass, and a single `@test_broken` at the bottom of this file stands in for
 # the whole set. If the `now_passing` test fails, some examples were fixed:
 # rerun regenerate_test_spec.jl and commit the regenerated files.
-known_broken = BitSet([2, 4, 5, 6, 7, 9, 17, 22, 23, 24, 32, 33, 34, 41, 46, 55, 59, 60, 61, 79, 80, 81, 82, 83, 84, 86, 87, 89, 90, 91, 93, 95, 96, 102, 103, 106, 115, 118, 121, 124, 126, 127, 128, 131, 132, 133, 135, 136, 137, 138, 139, 141, 143, 146, 147, 148, 175, 192, 193, 194, 195, 196, 198, 200, 202, 203, 204, 205, 206, 207, 208, 210, 214, 215, 216, 217, 218, 226, 232, 233, 237, 238, 247, 250, 251, 254, 255, 257, 260, 263, 266, 267, 271, 276, 278, 280, 285, 286, 287, 288, 290, 291, 292, 293, 294, 295, 296, 298, 299, 300, 304, 307, 308, 310, 311, 312, 313, 315, 317, 318, 319, 320, 321, 323, 325, 326, 329, 330, 331, 332, 333, 334, 335, 336, 339, 340, 341, 342, 347, 349, 352, 354, 359, 360, 361, 362, 363, 367, 368, 369, 372, 373, 374, 375, 376, 380, 385, 386, 387, 388, 389, 392, 398, 400, 401, 402, 407, 408, 409, 413, 414, 415, 416, 417, 418, 419, 425, 426, 427, 430, 431, 432, 437, 440, 442, 443, 444, 445, 446, 447, 449, 452, 454, 455, 456, 457, 458, 459, 464, 465, 466, 467, 468, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 486, 488, 489, 492, 493, 494, 498, 499, 500, 503, 505, 506, 508, 509, 510, 515, 518, 519, 520, 521, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 549, 550, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 579, 580, 582, 583, 584, 585, 586, 587, 588, 589, 591, 592, 593, 597, 598, 599, 601, 626, 633, 635, 636, 637, 638, 642, 643, 645])
+known_broken = BitSet([2, 4, 5, 6, 7, 9, 17, 22, 23, 24, 32, 33, 34, 41, 46, 55, 59, 60, 61, 79, 80, 81, 82, 83, 84, 86, 87, 89, 90, 91, 93, 95, 96, 102, 103, 106, 115, 118, 121, 124, 126, 127, 128, 131, 132, 133, 135, 136, 137, 138, 139, 141, 143, 146, 147, 148, 175, 192, 193, 194, 195, 196, 198, 200, 202, 203, 204, 205, 206, 207, 208, 210, 214, 215, 216, 217, 218, 226, 232, 233, 237, 238, 247, 250, 251, 254, 255, 257, 260, 263, 266, 267, 271, 276, 278, 280, 285, 286, 287, 288, 290, 291, 292, 293, 294, 295, 296, 298, 299, 300, 304, 307, 308, 310, 311, 312, 313, 315, 317, 318, 319, 320, 321, 323, 325, 326, 329, 330, 331, 332, 333, 334, 335, 336, 339, 340, 341, 342, 347, 349, 352, 354, 367, 368, 369, 373, 380, 389, 392, 407, 408, 409, 413, 414, 415, 416, 417, 418, 419, 425, 426, 427, 430, 431, 432, 437, 440, 442, 443, 444, 445, 446, 447, 449, 452, 454, 455, 456, 457, 458, 459, 464, 465, 466, 467, 468, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 486, 488, 489, 492, 493, 494, 498, 499, 500, 503, 505, 506, 508, 509, 510, 515, 518, 519, 520, 521, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 549, 550, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 579, 580, 582, 583, 584, 585, 586, 587, 588, 589, 591, 592, 593, 597, 598, 599, 601, 626, 633, 635, 636, 637, 638, 642, 643, 645])
 now_passing = Int[]
 
 
@@ -2651,40 +2651,40 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 359 (known broken)
+    # Example 359
     input = "a_\"foo\"_\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>a_&quot;foo&quot;_</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 359)
+    @test expected == actual
 
-    # Example 360 (known broken)
+    # Example 360
     input = "foo_bar_\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>foo_bar_</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 360)
+    @test expected == actual
 
-    # Example 361 (known broken)
+    # Example 361
     input = "5_6_78\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>5_6_78</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 361)
+    @test expected == actual
 
-    # Example 362 (known broken)
+    # Example 362
     input = "пристаням_стремятся_\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>пристаням_стремятся_</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 362)
+    @test expected == actual
 
-    # Example 363 (known broken)
+    # Example 363
     input = "aa_\"bb\"_cc\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>aa_&quot;bb&quot;_cc</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 363)
+    @test expected == actual
 
     # Example 364
     input = "foo-_(bar)_\n"
@@ -2742,12 +2742,12 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 372 (known broken)
+    # Example 372
     input = "_(_foo)\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>_(_foo)</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 372)
+    @test expected == actual
 
     # Example 373 (known broken)
     input = "_(_foo_)_\n"
@@ -2756,26 +2756,26 @@ end
     actual = Markdown.html(md)
     expected == actual && push!(now_passing, 373)
 
-    # Example 374 (known broken)
+    # Example 374
     input = "_foo_bar\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>_foo_bar</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 374)
+    @test expected == actual
 
-    # Example 375 (known broken)
+    # Example 375
     input = "_пристаням_стремятся\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>_пристаням_стремятся</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 375)
+    @test expected == actual
 
-    # Example 376 (known broken)
+    # Example 376
     input = "_foo_bar_baz_\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p><em>foo_bar_baz</em></p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 376)
+    @test expected == actual
 
     # Example 377
     input = "_(bar)_.\n"
@@ -2833,33 +2833,33 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 385 (known broken)
+    # Example 385
     input = "a__\"foo\"__\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>a__&quot;foo&quot;__</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 385)
+    @test expected == actual
 
-    # Example 386 (known broken)
+    # Example 386
     input = "foo__bar__\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>foo__bar__</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 386)
+    @test expected == actual
 
-    # Example 387 (known broken)
+    # Example 387
     input = "5__6__78\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>5__6__78</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 387)
+    @test expected == actual
 
-    # Example 388 (known broken)
+    # Example 388
     input = "пристаням__стремятся__\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>пристаням__стремятся__</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 388)
+    @test expected == actual
 
     # Example 389 (known broken)
     input = "__foo, __bar__, baz__\n"
@@ -2924,12 +2924,12 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 398 (known broken)
+    # Example 398
     input = "__(__foo)\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>__(__foo)</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 398)
+    @test expected == actual
 
     # Example 399
     input = "_(__foo__)_\n"
@@ -2938,26 +2938,26 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 400 (known broken)
+    # Example 400
     input = "__foo__bar\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>__foo__bar</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 400)
+    @test expected == actual
 
-    # Example 401 (known broken)
+    # Example 401
     input = "__пристаням__стремятся\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>__пристаням__стремятся</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 401)
+    @test expected == actual
 
-    # Example 402 (known broken)
+    # Example 402
     input = "__foo__bar__baz__\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p><strong>foo__bar__baz</strong></p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 402)
+    @test expected == actual
 
     # Example 403
     input = "__(bar)__.\n"

--- a/stdlib/Markdown/test/test_spec_html_julia.jl
+++ b/stdlib/Markdown/test/test_spec_html_julia.jl
@@ -10,7 +10,7 @@ using Markdown
 # pass, and a single `@test_broken` at the bottom of this file stands in for
 # the whole set. If the `now_passing` test fails, some examples were fixed:
 # rerun regenerate_test_spec.jl and commit the regenerated files.
-known_broken = BitSet([2, 4, 5, 6, 7, 9, 17, 22, 23, 24, 32, 33, 34, 41, 46, 55, 60, 61, 79, 81, 82, 83, 87, 93, 95, 106, 118, 121, 124, 126, 127, 128, 131, 132, 133, 135, 136, 137, 138, 139, 143, 146, 147, 148, 175, 192, 193, 194, 195, 196, 198, 200, 202, 203, 204, 205, 206, 207, 208, 210, 214, 215, 216, 217, 218, 226, 232, 233, 237, 238, 247, 250, 251, 254, 255, 257, 260, 263, 266, 267, 271, 276, 278, 280, 285, 286, 287, 288, 290, 291, 292, 293, 294, 295, 296, 298, 299, 300, 304, 307, 308, 310, 311, 312, 313, 315, 317, 318, 319, 320, 321, 323, 325, 326, 329, 330, 331, 332, 333, 334, 335, 336, 339, 340, 341, 342, 347, 349, 352, 354, 359, 360, 361, 362, 363, 367, 368, 369, 372, 373, 374, 375, 376, 380, 385, 386, 387, 388, 389, 392, 398, 400, 401, 402, 407, 408, 409, 413, 414, 415, 416, 417, 418, 419, 425, 426, 427, 430, 431, 432, 437, 440, 442, 443, 444, 445, 446, 447, 449, 452, 454, 455, 456, 457, 458, 459, 464, 465, 466, 467, 468, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 486, 488, 489, 492, 493, 494, 498, 499, 500, 503, 505, 506, 508, 509, 510, 515, 518, 519, 520, 521, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 549, 550, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 579, 580, 582, 583, 584, 585, 586, 587, 588, 589, 591, 592, 593, 597, 598, 599, 601, 626, 633, 635, 636, 637, 638, 642, 643, 644, 645])
+known_broken = BitSet([2, 4, 5, 6, 7, 9, 17, 22, 23, 24, 32, 33, 34, 41, 46, 55, 60, 61, 79, 81, 82, 83, 87, 93, 95, 106, 118, 121, 124, 126, 127, 128, 131, 132, 133, 135, 136, 137, 138, 139, 143, 146, 147, 148, 175, 192, 193, 194, 195, 196, 198, 200, 202, 203, 204, 205, 206, 207, 208, 210, 214, 215, 216, 217, 218, 226, 232, 233, 237, 238, 247, 250, 251, 254, 255, 257, 260, 263, 266, 267, 271, 276, 278, 280, 285, 286, 287, 288, 290, 291, 292, 293, 294, 295, 296, 298, 299, 300, 304, 307, 308, 310, 311, 312, 313, 315, 317, 318, 319, 320, 321, 323, 325, 326, 329, 330, 331, 332, 333, 334, 335, 336, 339, 340, 341, 342, 347, 349, 352, 354, 367, 368, 369, 373, 380, 389, 392, 407, 408, 409, 413, 414, 415, 416, 417, 418, 419, 425, 426, 427, 430, 431, 432, 437, 440, 442, 443, 444, 445, 446, 447, 449, 452, 454, 455, 456, 457, 458, 459, 464, 465, 466, 467, 468, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 486, 488, 489, 492, 493, 494, 498, 499, 500, 503, 505, 506, 508, 509, 510, 515, 518, 519, 520, 521, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 549, 550, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 579, 580, 582, 583, 584, 585, 586, 587, 588, 589, 591, 592, 593, 597, 598, 599, 601, 626, 633, 635, 636, 637, 638, 642, 643, 644, 645])
 now_passing = Int[]
 
 
@@ -2651,40 +2651,40 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 359 (known broken)
+    # Example 359
     input = "a_\"foo\"_\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>a_&quot;foo&quot;_</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 359)
+    @test expected == actual
 
-    # Example 360 (known broken)
+    # Example 360
     input = "foo_bar_\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>foo_bar_</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 360)
+    @test expected == actual
 
-    # Example 361 (known broken)
+    # Example 361
     input = "5_6_78\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>5_6_78</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 361)
+    @test expected == actual
 
-    # Example 362 (known broken)
+    # Example 362
     input = "пристаням_стремятся_\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>пристаням_стремятся_</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 362)
+    @test expected == actual
 
-    # Example 363 (known broken)
+    # Example 363
     input = "aa_\"bb\"_cc\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>aa_&quot;bb&quot;_cc</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 363)
+    @test expected == actual
 
     # Example 364
     input = "foo-_(bar)_\n"
@@ -2742,12 +2742,12 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 372 (known broken)
+    # Example 372
     input = "_(_foo)\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>_(_foo)</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 372)
+    @test expected == actual
 
     # Example 373 (known broken)
     input = "_(_foo_)_\n"
@@ -2756,26 +2756,26 @@ end
     actual = Markdown.html(md)
     expected == actual && push!(now_passing, 373)
 
-    # Example 374 (known broken)
+    # Example 374
     input = "_foo_bar\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>_foo_bar</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 374)
+    @test expected == actual
 
-    # Example 375 (known broken)
+    # Example 375
     input = "_пристаням_стремятся\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>_пристаням_стремятся</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 375)
+    @test expected == actual
 
-    # Example 376 (known broken)
+    # Example 376
     input = "_foo_bar_baz_\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p><em>foo_bar_baz</em></p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 376)
+    @test expected == actual
 
     # Example 377
     input = "_(bar)_.\n"
@@ -2833,33 +2833,33 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 385 (known broken)
+    # Example 385
     input = "a__\"foo\"__\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>a__&quot;foo&quot;__</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 385)
+    @test expected == actual
 
-    # Example 386 (known broken)
+    # Example 386
     input = "foo__bar__\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>foo__bar__</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 386)
+    @test expected == actual
 
-    # Example 387 (known broken)
+    # Example 387
     input = "5__6__78\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>5__6__78</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 387)
+    @test expected == actual
 
-    # Example 388 (known broken)
+    # Example 388
     input = "пристаням__стремятся__\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>пристаням__стремятся__</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 388)
+    @test expected == actual
 
     # Example 389 (known broken)
     input = "__foo, __bar__, baz__\n"
@@ -2924,12 +2924,12 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 398 (known broken)
+    # Example 398
     input = "__(__foo)\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>__(__foo)</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 398)
+    @test expected == actual
 
     # Example 399
     input = "_(__foo__)_\n"
@@ -2938,26 +2938,26 @@ end
     actual = Markdown.html(md)
     @test expected == actual
 
-    # Example 400 (known broken)
+    # Example 400
     input = "__foo__bar\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>__foo__bar</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 400)
+    @test expected == actual
 
-    # Example 401 (known broken)
+    # Example 401
     input = "__пристаням__стремятся\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>__пристаням__стремятся</p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 401)
+    @test expected == actual
 
-    # Example 402 (known broken)
+    # Example 402
     input = "__foo__bar__baz__\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p><strong>foo__bar__baz</strong></p>\n"
     actual = Markdown.html(md)
-    expected == actual && push!(now_passing, 402)
+    @test expected == actual
 
     # Example 403
     input = "__(bar)__.\n"


### PR DESCRIPTION
`Markdown.parse("call deliver_result and connect_to_peer here")` paired
the underscore in `deliver_result` with the one in `connect_to_peer`,
eating both and italicising the words between. Any `snake_case` name
written in prose rather than in backticks loses characters this way.

CommonMark forbids that: an underscore with a letter on each side can
neither open nor close emphasis. Conversely, `*` has no such restriction
— `foo*bar*` is emphasis — so the rule belongs to the delimiter, not to
`parse_inline_wrapper`, which is shared by `*`, `_`, `~` and `$`. It
gains an `intraword` keyword, default `true`, that the two underscore
triggers pass as `false`. With it off, a run touching a word character
on its outer side cannot open, and cannot close either; in the closing
case the scan continues instead of giving up, so `_foo_bar_baz_` still
emphasises across its inner underscores.

Reading the character before a run now steps back over UTF-8
continuation bytes, which the pre-existing "previous character isn't a
delimiter" check also needed.

17 more CommonMark spec examples now pass in each flavor and none newly
fail, so the generated spec test files are regenerated with
`regenerate_test_spec.jl`. This also fixes the docstring in #42068,
where a stray trailing underscore swallowed the rest of a sentence and
an inline code span with it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
