### PR TITLE
signals-win: recover from profiler unwind faults

### DIFF
--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -583,6 +583,12 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
             break;
         }
     }
+    else if (ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION &&
+             jl_get_safe_restore()) {
+        // Also honor unwind recovery on unmanaged threads, such as the profiler.
+        jl_throw_in_ctx(NULL, NULL, ExceptionInfo->ContextRecord);
+        return EXCEPTION_CONTINUE_EXECUTION;
+    }
     ios_t full_error, summary;
     ios_mem(&full_error, 0);
     if (ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ILLEGAL_INSTRUCTION) {
@@ -684,6 +690,10 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
     static int recursion = 0;
     if (recursion++)
         exit(1);
+    else if (ct == NULL)
+        // Avoid Julia teardown on an unmanaged thread: the profiler may have
+        // faulted with a thread suspended that the atexit hooks need to run.
+        jl_raise(SIGSEGV);
     else
         jl_exit(1);
 }

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -88,7 +88,9 @@ static int jl_unw_stepn(bt_cursor_t *cursor, jl_bt_element_t *bt_data, size_t *b
     if (!jl_trylock_profile())
         return 0;
 #endif
-#if !defined(_OS_WINDOWS_) // no point on windows, since RtlVirtualUnwind won't give us a second chance if the segfault happens in ntdll
+// Windows guards RtlVirtualUnwind in jl_unw_step so recovery cannot bypass
+// cleanup of locks acquired during function-table lookup.
+#if !defined(_OS_WINDOWS_)
     jl_jmp_buf *old_buf = jl_get_safe_restore();
     jl_jmp_buf buf;
     jl_set_safe_restore(&buf);
@@ -733,6 +735,18 @@ static int jl_unw_step(bt_cursor_t *cursor, int from_signal_handler, uintptr_t *
     else {
         PVOID HandlerData;
         DWORD64 EstablisherFrame;
+        // An asynchronous sample can have registers inconsistent with the unwind
+        // info (e.g. during a task switch), causing RtlVirtualUnwind to fault.
+        // Recover here to truncate the backtrace and let the profiler resume
+        // the sampled thread. Keep function-table lookup outside this guard:
+        // it can hold locks that recovery would leave locked.
+        jl_jmp_buf *old_buf = jl_get_safe_restore();
+        jl_jmp_buf buf;
+        jl_set_safe_restore(&buf);
+        if (jl_setjmp(buf, 0)) {
+            jl_set_safe_restore(old_buf);
+            return 0;
+        }
         (void)RtlVirtualUnwind(
                 0 /*UNW_FLAG_NHANDLER*/,
                 ImageBase,
@@ -742,6 +756,7 @@ static int jl_unw_step(bt_cursor_t *cursor, int from_signal_handler, uintptr_t *
                 &HandlerData,
                 &EstablisherFrame,
                 NULL);
+        jl_set_safe_restore(old_buf);
     }
     return cursor->Rip != 0;
 #endif


### PR DESCRIPTION
The Windows profiler can hit an access violation in RtlVirtualUnwind while
walking a suspended thread's stack. Previously this entered Julia's fatal
error path on the profiler thread, which has no Julia task. Teardown could
then hang waiting for the suspended thread, until the test watchdog killed
the process.

Guard RtlVirtualUnwind with the existing safe_restore mechanism and honor
that recovery on unmanaged threads. A fault now ends the backtrace, allowing
the profiler to resume the sampled thread and continue. Keep function-table
lookup outside the guard so recovery cannot skip its lock cleanup. For
unguarded fatal faults on unmanaged threads, use jl_raise to avoid running
Julia's atexit hooks.

Sampling during a task switch is one possible trigger: the captured
registers can be inconsistent with the unwind information. The exact CI
trigger is unknown, but a native reproducer with an invalid frame register
reproduces the access violation and hang. With the fix, it continues with a
truncated backtrace. Windows Server 2022 validation using a replacement
runtime DLL also passed 20 runs of profile_spawnmany_exec.jl and the Profile
stdlib tests (15459 passed, 2 broken). A separate native-thread fault with
the calling thread suspended exited promptly without running Julia atexit
hooks.

Observed in JuliaLang/julia#62951:
https://buildkite.com/julialang/julia-pr/builds/2237#01a08662-2185-442d-80a2-550d7887b90a

Assisted by: Fable 5.1, Sol 6.