### PR TITLE
[release-1.13] build: don't install glibc-only `libc_nonshared.a` on musl targets (#63084)

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1440,6 +1440,17 @@ BB_TRIPLET := $(subst $(SPACE),-,$(filter-out cxx%,$(filter-out libgfortran%,$(s
 
 LIBGFORTRAN_VERSION := $(subst libgfortran,,$(filter libgfortran%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN))))
 
+# The C library of the target. This only matters on Linux, where it is either glibc
+# (`*-linux-gnu*`) or musl (`*-linux-musl*`) as recorded in the normalized triplet;
+# it is left empty elsewhere.
+ifeq ($(OS),Linux)
+ifneq (,$(findstring musl,$(BB_TRIPLET)))
+LIBC := musl
+else
+LIBC := glibc
+endif
+endif
+
 # CSL_NEXT_GLIBCXX_VERSION is a triple of the symbols representing support for whatever
 # the next libstdc++ version would be. This is used for two things.
 # 1. Whether the system libraries are new enough, if we need to use the libs bundled with CSL

--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ ifneq ($(OS),Darwin)
 	$(INSTALL_M) $(build_libdir)/crtn.o $(DESTDIR)$(private_libdir)/
 	$(INSTALL_M) $(build_libdir)/crtbeginS.o $(DESTDIR)$(private_libdir)/
 	$(INSTALL_M) $(build_libdir)/crtendS.o $(DESTDIR)$(private_libdir)/
-ifeq ($(OS),Linux)
+ifeq ($(LIBC),glibc)
 	$(INSTALL_M) $(build_libdir)/libc_nonshared.a $(DESTDIR)$(private_libdir)/
 endif
 endif

--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -146,7 +146,7 @@ $(eval $(call copy_csl_static,crti.o))
 $(eval $(call copy_csl_static,crtn.o))
 $(eval $(call copy_csl_static,crtbeginS.o))
 $(eval $(call copy_csl_static,crtendS.o))
-ifeq ($(OS),Linux) # glibc-specific
+ifeq ($(LIBC),glibc)
 $(eval $(call copy_csl_static,libc_nonshared.a))
 endif
 endif
@@ -216,7 +216,7 @@ install-csl:
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/$(GCC_VERSION)/crtbeginS.o $(build_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/$(GCC_VERSION)/crtendS.o $(build_libdir)/
 	ln -sf $(call versioned_libname,libgcc_s,1) $(build_shlibdir)/libgcc_s.$(SHLIB_EXT)
-ifeq ($(OS),Linux)
+ifeq ($(LIBC),glibc)
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/$(GCC_VERSION)/libc_nonshared.a $(build_libdir)/
 endif
 endif


### PR DESCRIPTION
Backport of #63084 to release-1.13, which has the same problem via the backport of #61652 (72981a369b): the 1.13.0-rc4 musl cross builds fail in JuliaPackaging/Yggdrasil#14705, e.g. https://buildkite.com/julialang/yggdrasil/builds/32579#01a07c3a-2e15-48d8-8c10-3101bad0c306
