### PR TITLE
tests: Pick the UDP cancellation test port via the OS, not listenany

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -211,6 +211,10 @@ Standard library changes
 
 #### REPL
 
+#### Sockets
+
+* `getsockname` now also accepts a `UDPSocket`, returning the address and port it is bound to ([#63091]).
+
 #### SharedArrays
 
 * `close(::SharedArray)` eagerly releases the shared-memory mappings referenced through the

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -894,51 +894,55 @@ JL_DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, void *host,
     return uv_tcp_bind(handle, (struct sockaddr*)&addr, flags);
 }
 
-JL_DLLEXPORT int jl_tcp_getsockname(uv_tcp_t *handle, uint16_t *port,
-                                    void *host, uint32_t *family)
+static void jl_sockaddr_unpack(struct sockaddr_storage *addr, uint16_t *port,
+                               void *host, uint32_t *family)
 {
-    int namelen;
-    struct sockaddr_storage addr;
-    memset(&addr, 0, sizeof(struct sockaddr_storage));
-    namelen = sizeof addr;
-    int res = uv_tcp_getsockname(handle, (struct sockaddr*)&addr, &namelen);
-    if (res)
-        return res;
-    *family = addr.ss_family;
-    if (addr.ss_family == AF_INET) {
-        struct sockaddr_in *addr4 = (struct sockaddr_in*)&addr;
+    *family = addr->ss_family;
+    if (addr->ss_family == AF_INET) {
+        struct sockaddr_in *addr4 = (struct sockaddr_in*)addr;
         *port = addr4->sin_port;
         memcpy(host, &(addr4->sin_addr), 4);
     }
-    else if (addr.ss_family == AF_INET6) {
-        struct sockaddr_in6 *addr6 = (struct sockaddr_in6*)&addr;
+    else if (addr->ss_family == AF_INET6) {
+        struct sockaddr_in6 *addr6 = (struct sockaddr_in6*)addr;
         *port = addr6->sin6_port;
         memcpy(host, &(addr6->sin6_addr), 16);
     }
+}
+
+JL_DLLEXPORT int jl_tcp_getsockname(uv_tcp_t *handle, uint16_t *port,
+                                    void *host, uint32_t *family)
+{
+    struct sockaddr_storage addr;
+    memset(&addr, 0, sizeof(struct sockaddr_storage));
+    int namelen = sizeof addr;
+    int res = uv_tcp_getsockname(handle, (struct sockaddr*)&addr, &namelen);
+    if (res == 0)
+        jl_sockaddr_unpack(&addr, port, host, family);
     return res;
 }
 
 JL_DLLEXPORT int jl_tcp_getpeername(uv_tcp_t *handle, uint16_t *port,
                                     void *host, uint32_t *family)
 {
-    int namelen;
     struct sockaddr_storage addr;
     memset(&addr, 0, sizeof(struct sockaddr_storage));
-    namelen = sizeof addr;
+    int namelen = sizeof addr;
     int res = uv_tcp_getpeername(handle, (struct sockaddr*)&addr, &namelen);
-    if (res)
-        return res;
-    *family = addr.ss_family;
-    if (addr.ss_family == AF_INET) {
-        struct sockaddr_in *addr4 = (struct sockaddr_in*)&addr;
-        *port = addr4->sin_port;
-        memcpy(host, &(addr4->sin_addr), 4);
-    }
-    else if (addr.ss_family == AF_INET6) {
-        struct sockaddr_in6 *addr6 = (struct sockaddr_in6*)&addr;
-        *port = addr6->sin6_port;
-        memcpy(host, &(addr6->sin6_addr), 16);
-    }
+    if (res == 0)
+        jl_sockaddr_unpack(&addr, port, host, family);
+    return res;
+}
+
+JL_DLLEXPORT int jl_udp_getsockname(uv_udp_t *handle, uint16_t *port,
+                                    void *host, uint32_t *family)
+{
+    struct sockaddr_storage addr;
+    memset(&addr, 0, sizeof(struct sockaddr_storage));
+    int namelen = sizeof addr;
+    int res = uv_udp_getsockname(handle, (struct sockaddr*)&addr, &namelen);
+    if (res == 0)
+        jl_sockaddr_unpack(&addr, port, host, family);
     return res;
 }
 

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -851,11 +851,14 @@ function leave_multicast_group(sock::UDPSocket, group_addr::IPAddr,
 end
 
 """
-    getsockname(sock::Union{TCPServer, TCPSocket}) -> (IPAddr, UInt16)
+    getsockname(sock::Union{TCPServer, TCPSocket, UDPSocket}) -> (IPAddr, UInt16)
 
 Get the IP address and port that the given socket is bound to.
+
+!!! compat "Julia 1.14"
+    `UDPSocket` support requires Julia 1.14.
 """
-getsockname(sock::Union{TCPSocket, TCPServer}) = _sockname(sock, true)
+getsockname(sock::Union{TCPSocket, TCPServer, UDPSocket}) = _sockname(sock, true)
 
 
 """
@@ -873,7 +876,11 @@ function _sockname(sock, self=true)
     rfamily = Ref{Cuint}(0)
 
     iolock_begin()
-    if self
+    if sock isa UDPSocket
+        r = ccall(:jl_udp_getsockname, Int32,
+                (Ptr{Cvoid}, Ref{Cushort}, Ptr{Cvoid}, Ref{Cuint}),
+                sock.handle, rport, raddress, rfamily)
+    elseif self
         r = ccall(:jl_tcp_getsockname, Int32,
                 (Ptr{Cvoid}, Ref{Cushort}, Ptr{Cvoid}, Ref{Cuint}),
                 sock.handle, rport, raddress, rfamily)

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -338,12 +338,16 @@ end
 @testset "getsockname errors" begin
     sock = TCPSocket()
     serv = Sockets.TCPServer()
+    udp = UDPSocket()
     @test_throws MethodError getpeername(serv)
+    @test_throws MethodError getpeername(udp)
     @test_throws Base._UVError("cannot obtain socket name", Base.UV_EBADF) getpeername(sock)
     @test_throws Base._UVError("cannot obtain socket name", Base.UV_EBADF) getsockname(serv)
     @test_throws Base._UVError("cannot obtain socket name", Base.UV_EBADF) getsockname(sock)
+    @test_throws Base._UVError("cannot obtain socket name", Base.UV_EBADF) getsockname(udp)
     close(sock)
     close(serv)
+    close(udp)
 end
 
 
@@ -459,6 +463,7 @@ end
         set_sockets_watchdog_state("UDP IPv4 bind";
             details=(host=ip"127.0.0.1",))
         a, aport = bind_udp_any(ip"127.0.0.1")
+        @test getsockname(a) == (ip"127.0.0.1", aport)
         b = UDPSocket()
         set_sockets_watchdog_state("UDP IPv4 bind";
             details=(host=ip"127.0.0.1", receiver_port=aport),
@@ -564,6 +569,7 @@ end
         set_sockets_watchdog_state("UDP IPv6 bind";
             details=(host=ip"::1",))
         a, aport = bind_udp_any(ip"::1")
+        @test getsockname(a) == (ip"::1", aport)
         b = UDPSocket()
         set_sockets_watchdog_state("UDP IPv6 bind";
             details=(host=ip"::1", receiver_port=aport),

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -1792,17 +1792,18 @@ end
 end
 
 @testset "cancelled recvfrom stops reception (no dropped datagram)" begin
-    # bind the receiver to a known free port (found via listenany, like the
-    # Sockets tests; retried in case another process grabs it in between)
-    local udp, port
-    for attempt in 1:10
-        port, tcpserver = Sockets.listenany(Sockets.localhost, 0)
-        close(tcpserver)
-        udp = Sockets.UDPSocket()
-        Sockets.bind(udp, Sockets.localhost, port) && break
-        close(udp)
-        attempt == 10 && error("could not bind a UDP test port")
-    end
+    # bind the receiver to an OS-assigned port: deriving a UDP port from a
+    # free TCP port (as `listenany` would) fails on Windows CI, where whole
+    # blocks of UDP ports are reserved (excluded port ranges) and sequential
+    # ephemeral TCP port assignment keeps landing inside them (#38711)
+    udp = Sockets.UDPSocket()
+    Sockets.bind(udp, Sockets.localhost, 0) || error("could not bind a UDP test port")
+    # recover the assigned port; the Sockets getsockname only covers TCP
+    sockaddr = zeros(UInt8, 128) # aliases sockaddr_storage
+    len = Ref{Cint}(length(sockaddr))
+    Base.uv_error("getsockname", ccall(:uv_udp_getsockname, Cint,
+        (Ptr{Cvoid}, Ptr{UInt8}, Ptr{Cint}), udp.handle, sockaddr, len))
+    port = (UInt16(sockaddr[3]) << 8) | UInt16(sockaddr[4]) # sin_port, network order
     src = CancellationTokenSource()
     t = @async Sockets.recvfrom(udp; cancel=CancellationToken(src))
     @test timedwait(() -> is_parked(t), 10.0) == :ok

--- a/test/cancellation.jl
+++ b/test/cancellation.jl
@@ -1798,12 +1798,7 @@ end
     # ephemeral TCP port assignment keeps landing inside them (#38711)
     udp = Sockets.UDPSocket()
     Sockets.bind(udp, Sockets.localhost, 0) || error("could not bind a UDP test port")
-    # recover the assigned port; the Sockets getsockname only covers TCP
-    sockaddr = zeros(UInt8, 128) # aliases sockaddr_storage
-    len = Ref{Cint}(length(sockaddr))
-    Base.uv_error("getsockname", ccall(:uv_udp_getsockname, Cint,
-        (Ptr{Cvoid}, Ptr{UInt8}, Ptr{Cint}), udp.handle, sockaddr, len))
-    port = (UInt16(sockaddr[3]) << 8) | UInt16(sockaddr[4]) # sin_port, network order
+    port = Sockets.getsockname(udp)[2]
     src = CancellationTokenSource()
     t = @async Sockets.recvfrom(udp; cancel=CancellationToken(src))
     @test timedwait(() -> is_parked(t), 10.0) == :ok


### PR DESCRIPTION
The "cancelled recvfrom" test derived its UDP port from a free TCP port (listenany, close, rebind as UDP), but a port that is free for TCP need not be bindable for UDP (#38711). On Windows Server CI machines, Hyper-V excluded port ranges reserve whole blocks of UDP ports, and ephemeral TCP ports are assigned sequentially, so all ten retries landed in the same reserved block and the test errored with "could not bind a UDP test port":

https://buildkite.com/julialang/julia-ci/builds/507#01a08186-2a11-489d-be7b-aa4603a9688b

Bind the receiver to port 0 instead, so the OS picks a bindable UDP port, and recover the assigned port via uv_udp_getsockname (the Sockets getsockname only covers TCP).

Assisted by Claude