### PR TITLE
intfuncs: Fix hex digit count for odd-width primitives

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1017,7 +1017,9 @@ function dec(x::Unsigned, pad::Int, neg::Bool)
 end
 
 function hex(x::Unsigned, pad::Int, neg::Bool)
-    m = 2 * sizeof(x) - (leading_zeros(x) >> 2)
+    # count nibbles from the logical width, which for a primitive type whose
+    # bit size is not a multiple of 8 is narrower than its byte size
+    m = (top_set_bit(x) + 3) >> 2
     n = neg + max(pad, m)
     str = _string_n(n)
     GC.@preserve str begin

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -525,6 +525,40 @@ primitive type BitString128 128 end
     @test bitstring(bit63(0x4000_0000_0000_0001)) == "1" * repeat("0", 61) * "1"
 end
 
+# A primitive type whose logical width is not a multiple of 8 occupies more
+# bytes than it uses, so the digit counts must come from the width, not from
+# `sizeof`. These types carry just the methods `bin`, `oct` and `hex` call.
+for nbits in (4, 6, 12, 21, 24, 63)
+    T = Symbol(:OddUInt, nbits)
+    # `% UInt8` widens the types narrower than a byte and truncates the rest
+    to_u8 = nbits < 8 ? :(Core.Intrinsics.zext_int(UInt8, x)) :
+                        :(Core.Intrinsics.trunc_int(UInt8, x))
+    @eval begin
+        primitive type $T <: Unsigned $nbits end
+        $T(x::UInt64) = Core.Intrinsics.trunc_int($T, x)
+        Base.UInt64(x::$T) = Core.Intrinsics.zext_int(UInt64, x)
+        Base.rem(x::$T, ::Type{UInt8}) = $to_u8
+        Base.leading_zeros(x::$T) =
+            Int(Core.Intrinsics.zext_int(UInt64, Core.Intrinsics.ctlz_int(x)))
+        Base.top_set_bit(x::$T) = $nbits - leading_zeros(x)
+        Base.:(>>)(x::$T, k::UInt) = Core.Intrinsics.lshr_int(x, k)
+    end
+end
+
+@testset "bin/oct/hex for primitive types of $nbits bits" for nbits in (4, 6, 12, 21, 24, 63)
+    T = getfield(@__MODULE__, Symbol(:OddUInt, nbits))
+    for v in UInt64[0, 1, 7, 8, 1000, 0x1234, UInt64(1) << (nbits - 1), (UInt64(1) << nbits) - 1]
+        v < UInt64(1) << nbits || continue
+        x = T(v)
+        @test UInt64(x) === v
+        # the same value in a wider type prints the same, without padding
+        for base in (2, 8, 16)
+            @test string(x, base = base) == string(v, base = base)
+            @test string(x, base = base, pad = 20) == string(v, base = base, pad = 20)
+        end
+    end
+end
+
 @testset "digits/base" begin
     @test digits(5, base = 3) == [2, 1]
     @test digits(5, pad = 3) == [5, 0, 0]


### PR DESCRIPTION
`hex` derived the number of nibbles from `sizeof(x)`, the byte-rounded storage size, so a primitive type whose logical width is not a multiple of eight printed with spurious leading zeros. Count from the logical width instead, which agrees with `bin` and `oct`.

Assisted-by: Claude Code (Opus 5)