### PR TITLE
types: Allow primitive type size as a parameter

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -527,6 +527,15 @@ function sizeof_nothrow(@nospecialize(x))
     return true
 end
 
+# `Core.bitsizeof` throws for a primitive type that has no layout yet, such as
+# `BitInt{N}` when the bit size `N` is still a free type parameter
+@nospecs function primitive_bitsize(ty)
+    isprimitivetype(ty) || return nothing
+    ty = unwrap_unionall(ty) # `isprimitivetype` looks through `UnionAll` too
+    ty.layout == C_NULL && return nothing
+    return Core.bitsizeof(ty)::Int
+end
+
 # f shall be Core.sizeof or Core.bitsizeof
 function _const_sizeof(@nospecialize(f), @nospecialize(x))
     # Constant GenericMemory does not have constant size
@@ -3286,7 +3295,8 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
         if !isconcrete
             return Union{ErrorException, TypeError}
         end
-        if !(isprimitivetype(ty) && isprimitivetype(xty) && Core.bitsizeof(ty) === Core.bitsizeof(xty))
+        nb = primitive_bitsize(ty)
+        if nb === nothing || nb !== primitive_bitsize(xty)
             return ErrorException
         end
         return Union{}
@@ -3302,7 +3312,8 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
             return Union{ErrorException, TypeError}
         end
         xty = widenconst(argtypes[2])
-        if !(isprimitivetype(ty) && isprimitivetype(xty))
+        nbty, nbxty = primitive_bitsize(ty), primitive_bitsize(xty)
+        if nbty === nothing || nbxty === nothing
             return ErrorException
         end
 
@@ -3312,14 +3323,14 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
             !(ty <: CORE_FLOAT_TYPES && xty <: CORE_FLOAT_TYPES && Core.sizeof(ty) > Core.sizeof(xty))
             return ErrorException
         end
-        if (f === Intrinsics.sext_int || f === Intrinsics.zext_int) && !(Core.bitsizeof(ty) > Core.bitsizeof(xty))
+        if (f === Intrinsics.sext_int || f === Intrinsics.zext_int) && !(nbty > nbxty)
             return ErrorException
         end
         if f === Intrinsics.fptrunc &&
             !(ty <: CORE_FLOAT_TYPES && xty <: CORE_FLOAT_TYPES && Core.sizeof(ty) < Core.sizeof(xty))
             return ErrorException
         end
-        if f === Intrinsics.trunc_int && !(Core.bitsizeof(ty) < Core.bitsizeof(xty))
+        if f === Intrinsics.trunc_int && !(nbty < nbxty)
             return ErrorException
         end
         if (f === Intrinsics.fptoui || f === Intrinsics.fptosi) && !(xty <: CORE_FLOAT_TYPES)
@@ -3352,7 +3363,10 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
     isshift = f === shl_int || f === lshr_int || f === ashr_int
     argtype1 = widenconst(argtypes[1])
     isprimitivetype(argtype1) || return ErrorException
-    f === bswap_int && Core.bitsizeof(argtype1) % 16 != 0 && return ErrorException
+    if f === bswap_int
+        nb1 = primitive_bitsize(argtype1)
+        (nb1 === nothing || nb1 % 16 != 0) && return ErrorException
+    end
     if contains_is(_FLOAT_INTRINSICS, f)
         argtype1 <: CORE_FLOAT_TYPES || return ErrorException
     end

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@ New language features
   call can be placed on its own line without switching to the comma separated
   call syntax ([#60181]).
 * Primitive types with non-byte-multiple logical widths can now be defined ([#61359]).
+* The width of a primitive type may be given by one of its type parameters, as in
+  `primitive type BitInt{N} <: Signed N end`, so that each instantiation has its own size ([#63074]).
 * Introduced explicitly wrapping arithmetic operators `+%`, `-%`, `*%` to annotate arithmetic operations
   that are semantically safe to wrap/overflow. Their behavior is currently identical to the default `+`, `-`, `*`
   operators. However, in a future version, there may be opt-in support to detect unannotated wrapping

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -221,6 +221,12 @@ The number after the name indicates how many bits of storage the type requires. 
 only sizes that are multiples of 8 bits are supported.
 The [`Bool`](@ref) declaration shows how a primitive type can be optionally
 declared to be a subtype of some supertype.
+
+The size may instead name one of the type parameters, giving each instantiation its own width:
+
+```julia
+primitive type BitInt{N} <: Signed N end
+```
 """
 kw"primitive type"
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -305,6 +305,22 @@ byte-rounded storage, so `sizeof(T)` rounds their storage size up to a whole num
 when their logical width is not a multiple of 8 bits. Use `Core.bitsizeof(T)` to query the declared
 logical width.
 
+A primitive type may take type parameters, and its bit width may be given by one of them:
+
+```jldoctest
+julia> primitive type BitInt{N} <: Signed N end
+
+julia> Core.bitsizeof(BitInt{21})
+21
+
+julia> sizeof(BitInt{21})
+3
+```
+
+Each instantiation then has its own layout, so `BitInt{21}` and `BitInt{64}` are distinct concrete
+types of different size, while `BitInt` itself has no layout. The width parameter must be a positive
+`Int`, and must be written as a bare parameter name -- an expression such as `8N` is not accepted.
+
 Non-byte primitive widths are accepted, but remain an expert-only feature. They are more likely to
 expose compiler, runtime, or ABI bugs than the standard built-in primitive widths, and arrays still
 use byte-rounded element storage rather than packed bit layouts. Therefore, boolean values, although

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -674,7 +674,7 @@ JL_CALLABLE(jl_f_bitsizeof)
         return jl_box_long(jl_unbox_long(jl_f_sizeof(F, args, 1)) * 8);
     if (jl_is_datatype(x)) {
         jl_datatype_t *dx = (jl_datatype_t*)x;
-        if (jl_is_primitivetype(dx))
+        if (jl_is_primitivetype(dx) && dx->layout)
             return jl_box_long(jl_datatype_nbits(dx));
         return jl_box_long(jl_unbox_long(jl_f_sizeof(F, args, 1)) * 8);
     }
@@ -2357,15 +2357,33 @@ JL_CALLABLE(jl_f__primitivetype)
     JL_TYPECHK(_primitivetype, symbol, args[1]);
     JL_TYPECHK(_primitivetype, simplevector, args[2]);
     jl_sym_t *name = (jl_sym_t*)args[1];
+    jl_svec_t *params = (jl_svec_t*)args[2];
     jl_value_t *vnb = args[3];
-    if (!jl_is_long(vnb))
-        jl_errorf("invalid declaration of primitive type %s",
-                  jl_symbol_name((jl_sym_t*)name));
-    ssize_t nb = jl_unbox_long(vnb);
-    if (nb < 1 || nb >= (1 << 23))
-        jl_errorf("invalid number of bits in primitive type %s",
-                  jl_symbol_name((jl_sym_t*)name));
-    jl_datatype_t *dt = jl_new_primitivetype(args[1], (jl_module_t*)args[0], NULL, (jl_svec_t*)args[2], nb);
+    jl_datatype_t *dt;
+    if (jl_is_typevar(vnb)) {
+        // the size is one of the type parameters, e.g.
+        // `primitive type BitInt{N} <: Signed N end`
+        size_t i, np = jl_svec_len(params);
+        for (i = 0; i < np && jl_svecref(params, i) != vnb; i++) ;
+        if (i == np)
+            jl_errorf("invalid declaration of primitive type %s: the number of bits must be "
+                      "a constant or one of the type parameters",
+                      jl_symbol_name(name));
+        if (i >= JL_MAX_NBITS_PARAM)
+            jl_errorf("invalid declaration of primitive type %s: the number of bits must be "
+                      "one of the first %d type parameters",
+                      jl_symbol_name(name), JL_MAX_NBITS_PARAM);
+        dt = jl_new_primitivetype_paramsize(args[1], (jl_module_t*)args[0], NULL, params, i + 1);
+    }
+    else {
+        if (!jl_is_long(vnb))
+            jl_errorf("invalid declaration of primitive type %s",
+                      jl_symbol_name(name));
+        if (!valid_primitive_nbits(vnb))
+            jl_errorf("invalid number of bits in primitive type %s",
+                      jl_symbol_name(name));
+        dt = jl_new_primitivetype(args[1], (jl_module_t*)args[0], NULL, params, jl_unbox_long(vnb));
+    }
     return dt->name->wrapper;
 }
 
@@ -2610,7 +2628,9 @@ int equiv_type(jl_value_t *ta, jl_value_t *tb) JL_CANSAFEPOINT
           dta->name->mutabl == dtb->name->mutabl &&
           dta->name->n_uninitialized == dtb->name->n_uninitialized &&
           dta->isprimitivetype == dtb->isprimitivetype &&
-          (!dta->isprimitivetype || dta->layout->size == dtb->layout->size) &&
+          dta->name->nbits_param == dtb->name->nbits_param &&
+          (!dta->isprimitivetype || dta->name->nbits_param ||
+           dta->layout->size == dtb->layout->size) &&
           (dta->name->atomicfields == NULL
            ? dtb->name->atomicfields == NULL
            : (dtb->name->atomicfields != NULL &&

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -83,6 +83,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     tn->names = NULL;
     tn->hash = bitmix(bitmix(module ? module->build_id.lo : 0, name->hash), 0xa1ada1da);
     tn->_unused = 0;
+    tn->nbits_param = 0;
     tn->abstract = abstract;
     tn->mutabl = mutabl;
     tn->mayinlinealloc = 0;
@@ -641,6 +642,8 @@ static void jl_get_genericmemory_layout(jl_datatype_t *st) JL_CANSAFEPOINT
     }
 }
 
+static const jl_datatype_layout_t *primitive_layout(size_t nbits) JL_NOTSAFEPOINT;
+
 void jl_compute_field_offsets(jl_datatype_t *st)
 {
     const uint64_t max_offset = (((uint64_t)1) << 32) - 1;
@@ -657,6 +660,16 @@ void jl_compute_field_offsets(jl_datatype_t *st)
     }
     if (st->name == jl_genericmemory_typename) {
         jl_get_genericmemory_layout(st);
+        return;
+    }
+    if (st->name->nbits_param) {
+        // primitive type sized by a type parameter: the layout exists only once
+        // that parameter is a concrete bit count
+        jl_value_t *nbits = jl_tparam(st, st->name->nbits_param - 1);
+        if (jl_is_long(nbits)) {
+            st->layout = primitive_layout(jl_unbox_long(nbits));
+            st->isbitstype = st->isconcretetype;
+        }
         return;
     }
     int isbitstype = st->isconcretetype && st->name->mayinlinealloc;
@@ -1012,12 +1025,9 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(
     return t;
 }
 
-JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name, jl_module_t *module,
-                                                 jl_datatype_t *super,
-                                                 jl_svec_t *parameters, size_t nbits)
+// layout of a primitive type holding `nbits` bits, padded up to whole bytes
+static const jl_datatype_layout_t *primitive_layout(size_t nbits) JL_NOTSAFEPOINT
 {
-    jl_datatype_t *bt = jl_new_datatype((jl_sym_t*)name, module, super, parameters,
-                                        jl_emptysvec, jl_emptysvec, jl_emptysvec, 0, 0, 0);
     uint32_t nbytes = (nbits + 7) / 8;
     uint8_t unused_bits = (uint8_t)(nbytes * 8 - nbits);
     uint32_t alignm = next_power_of_two(nbytes);
@@ -1035,15 +1045,49 @@ JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name, jl_module_t *
 # endif
     if (alignm > MAX_ALIGN)
         alignm = MAX_ALIGN;
+    return jl_get_layout(nbytes, 0, 0, alignm, unused_bits != 0, 1, 0, unused_bits, NULL, NULL);
+}
+
+static jl_datatype_t *new_primitivetype(jl_value_t *name, jl_module_t *module,
+                                        jl_datatype_t *super, jl_svec_t *parameters) JL_CANSAFEPOINT
+{
+    jl_datatype_t *bt = jl_new_datatype((jl_sym_t*)name, module, super, parameters,
+                                        jl_emptysvec, jl_emptysvec, jl_emptysvec, 0, 0, 0);
     // memoize isprimitivetype, since it is much easier than checking
     // (dta->name->names == svec() && dta->layout && dta->layout->size != 0)
     // and we easily have a free bit for it in the DataType flags
     bt->isprimitivetype = 1;
     bt->ismutationfree = 1;
     bt->isidentityfree = 1;
-    bt->isbitstype = (parameters == jl_emptysvec);
-    bt->layout = jl_get_layout(nbytes, 0, 0, alignm, unused_bits != 0, 1, 0, unused_bits, NULL, NULL);
+    // jl_new_datatype saw a fieldless type and gave it a singleton layout
+    bt->layout = NULL;
     bt->instance = NULL;
+    return bt;
+}
+
+JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name, jl_module_t *module,
+                                                 jl_datatype_t *super,
+                                                 jl_svec_t *parameters, size_t nbits)
+{
+    jl_datatype_t *bt = new_primitivetype(name, module, super, parameters);
+    bt->isbitstype = (parameters == jl_emptysvec);
+    bt->layout = primitive_layout(nbits);
+    return bt;
+}
+
+// primitive type whose bit size is the `nbits_param`-th (1-based) type
+// parameter: the wrapper has no layout, each instantiation computes its own
+// from the parameter (see `jl_compute_field_offsets`)
+JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype_paramsize(jl_value_t *name, jl_module_t *module,
+                                                           jl_datatype_t *super,
+                                                           jl_svec_t *parameters,
+                                                           uint32_t nbits_param)
+{
+    assert(nbits_param >= 1 && nbits_param <= jl_svec_len(parameters) &&
+           nbits_param <= JL_MAX_NBITS_PARAM);
+    jl_datatype_t *bt = new_primitivetype(name, module, super, parameters);
+    bt->name->nbits_param = nbits_param;
+    bt->isbitstype = 0;
     return bt;
 }
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -78,6 +78,9 @@ static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_CANSAF
                 return 0;
             if (dt->layout || !dt->name->mayinlinealloc)
                 return 0;
+            if (dt->name->nbits_param)
+                // primitive type whose size is a type parameter
+                return layout_uses_free_typevars(jl_tparam(dt, dt->name->nbits_param - 1), env);
             if (dt->name == jl_namedtuple_typename) {
                 jl_value_t *names = jl_tparam0(dt);
                 jl_value_t *types = jl_tparam1(dt);
@@ -357,6 +360,10 @@ JL_DLLEXPORT int jl_has_typevar_from_unionall(jl_value_t *t, jl_unionall_t *ua)
 
 int jl_has_fixed_layout(jl_datatype_t *dt)
 {
+    if (dt->name->nbits_param)
+        // a primitive type sized by a type parameter has a layout exactly when
+        // that parameter is a concrete bit count
+        return jl_is_long(jl_tparam(dt, dt->name->nbits_param - 1));
     // A type with isconcretetype=1 but types=NULL is currently being instantiated
     // and doesn't have a fixed layout yet. This prevents infinite recursion when
     // computing layouts for mutually recursive parametric types.
@@ -399,7 +406,9 @@ int jl_type_mappable_to_c(jl_value_t *ty)
     if (jl_is_structtype(ty))
         return jl_has_fixed_layout((jl_datatype_t*)ty) && ((jl_datatype_t*)ty)->name->atomicfields == NULL;
     if (jl_is_primitivetype(ty))
-        return 1; // as isbits
+        // a primitive type sized by a type parameter has no layout until that
+        // parameter is known
+        return ((jl_datatype_t*)ty)->layout != NULL; // as isbits
     if (ty == (jl_value_t*)jl_any_type || ty == (jl_value_t*)jl_bottom_type || jl_is_abstract_ref_type(ty))
         return 1; // as boxed
     return 0; // refuse to map Union and UnionAll to C
@@ -2804,6 +2813,22 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
         if (!jl_is_typevar(addrspace) && !jl_is_addrspace(addrspace)) {
             if (!nothrow)
                 jl_type_error_rt("GenericMemory", "addrspace parameter", (jl_value_t*)jl_addrspace_type, addrspace);
+            invalid = 1;
+        }
+    }
+    else if (tn->nbits_param) {
+        // the bit size of a parametric primitive type must be a positive Int
+        jl_value_t *nbits = jl_svecref(p, tn->nbits_param - 1);
+        if (!jl_is_typevar(nbits) && !valid_primitive_nbits(nbits)) {
+            if (!nothrow) {
+                jl_datatype_t *w = (jl_datatype_t*)jl_unwrap_unionall(tn->wrapper);
+                jl_tvar_t *tv = (jl_tvar_t*)jl_svecref(w->parameters, tn->nbits_param - 1);
+                if (!jl_is_long(nbits))
+                    jl_type_error_rt(jl_symbol_name(tn->name), jl_symbol_name(tv->name),
+                                     (jl_value_t*)jl_long_type, nbits);
+                jl_errorf("invalid number of bits in primitive type %s",
+                          jl_symbol_name(tn->name));
+            }
             invalid = 1;
         }
     }

--- a/src/julia.h
+++ b/src/julia.h
@@ -644,7 +644,12 @@ typedef struct {
     uint8_t abstract:1;
     uint8_t mutabl:1;
     uint8_t mayinlinealloc:1;
-    uint8_t _unused:5;
+    // for a primitive type whose bit size is given by one of its type
+    // parameters, the 1-based index of that parameter; 0 if the size is fixed.
+    // e.g. `primitive type BitInt{N} <: Signed N end` records 1 here, so that
+    // `BitInt{21}` gets a 21-bit layout while `BitInt{N}` has none.
+    uint8_t nbits_param:4;
+    uint8_t _unused:1;
     _Atomic(uint8_t) cache_entry_count; // (approximate counter of TypeMapEntry for heuristics)
     uint8_t max_methods; // override for inference's max_methods setting (0 = no additional limit or relaxation)
     uint8_t constprop_heustic; // override for inference's constprop heuristic
@@ -2076,6 +2081,11 @@ JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name,
                                                  jl_module_t *module,
                                                  jl_datatype_t *super,
                                                  jl_svec_t *parameters, size_t nbits) JL_CANSAFEPOINT;
+JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype_paramsize(jl_value_t *name,
+                                                 jl_module_t *module,
+                                                 jl_datatype_t *super,
+                                                 jl_svec_t *parameters,
+                                                 uint32_t nbits_param) JL_CANSAFEPOINT;
 
 // constructors
 JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *bt, const void *src) JL_CANSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -993,6 +993,22 @@ int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_array_t *jl_find_free_typevars(jl_value_t *v) JL_CANSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_rewrap_free_typevars(jl_value_t *t, jl_array_t *pre);
 int jl_has_fixed_layout(jl_datatype_t *t) JL_CANSAFEPOINT;
+
+// upper bound on the bit size of a primitive type, keeping its byte size well
+// within the 32 bits the layout reserves for it
+#define JL_MAX_PRIMITIVE_NBITS (1 << 23)
+
+// how many leading type parameters `jl_typename_t.nbits_param` can address
+#define JL_MAX_NBITS_PARAM 15
+
+STATIC_INLINE int valid_primitive_nbits(jl_value_t *nbits) JL_NOTSAFEPOINT
+{
+    if (!jl_is_long(nbits))
+        return 0;
+    ssize_t nb = jl_unbox_long(nbits);
+    return nb >= 1 && nb < JL_MAX_PRIMITIVE_NBITS;
+}
+
 JL_DLLEXPORT int jl_struct_try_layout(jl_datatype_t *dt) JL_CANSAFEPOINT;
 JL_DLLEXPORT int jl_type_mappable_to_c(jl_value_t *ty) JL_CANSAFEPOINT;
 jl_svec_t *jl_outer_unionall_vars(jl_value_t *u) JL_CANSAFEPOINT;

--- a/test/bitint.jl
+++ b/test/bitint.jl
@@ -1,0 +1,430 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# `BitInt{N}` and `BitUInt{N}`: two's-complement integers of arbitrary width,
+# built on primitive types whose bit size is a type parameter. Besides being a
+# worked example of that feature, this exercises conversion, promotion and the
+# integer intrinsics at widths that are not multiples of eight.
+
+using Test
+
+using Core.Intrinsics:
+    bitcast, trunc_int, sext_int, zext_int,
+    add_int, sub_int, mul_int, neg_int,
+    checked_sdiv_int, checked_srem_int, checked_udiv_int, checked_urem_int,
+    and_int, or_int, xor_int, not_int,
+    shl_int, lshr_int, ashr_int, flipsign_int,
+    eq_int, slt_int, sle_int, ult_int, ule_int,
+    ctpop_int, ctlz_int, cttz_int
+
+primitive type BitInt{N}  <: Signed   N end
+primitive type BitUInt{N} <: Unsigned N end
+
+const NBitInteger = Union{BitInt, BitUInt}
+
+## width and signedness, both statically known ##
+
+nbits(::Type{BitInt{N}})  where {N} = N
+nbits(::Type{BitUInt{N}}) where {N} = N
+nbits(::Type{T}) where {T<:Base.BitInteger} = 8 * sizeof(T)
+nbits(x::Integer) = nbits(typeof(x))
+
+issigned(::Type{<:Signed})   = true
+issigned(::Type{<:Unsigned}) = false
+
+## conversion ##
+
+# Reinterpret `x` at the width of `To`: truncate when narrowing, and when
+# widening replicate the sign bit or zero-fill according to `From`. This is the
+# raw bit-level move; `_convert` adds the range check on top of it.
+@inline function _extend(::Type{To}, x::From) where {To,From}
+    n, m = nbits(To), nbits(From)
+    n == m ? bitcast(To, x) :
+    n <  m ? trunc_int(To, x) :
+    issigned(From) ? sext_int(To, x) : zext_int(To, x)
+end
+
+@inline _isneg(x::T) where {T} = issigned(T) && slt_int(x, _extend(T, 0x00))
+
+# every value of `From` fits in `To`, so no check is needed
+@inline _always_exact(::Type{To}, ::Type{From}) where {To,From} =
+    issigned(To) == issigned(From) ? nbits(To) >= nbits(From) :
+    issigned(To) ? nbits(To) > nbits(From) : false
+
+# `x` is representable in `To` exactly when the bits survive the round trip and
+# the sign does not change. The sign test is what rules out e.g. `Int8(0xff)`,
+# where the round trip alone would be lossless.
+@inline function _convert(::Type{To}, x::From) where {To,From}
+    y = _extend(To, x)
+    _always_exact(To, From) && return y
+    (_isneg(x) === _isneg(y) && eq_int(_extend(From, y), x)) ||
+        throw(InexactError(:convert, To, x))
+    y
+end
+
+BitInt{N}(x::BitInt{N})   where {N} = x
+BitUInt{N}(x::BitUInt{N}) where {N} = x
+
+(::Type{T})(x::NBitInteger)      where {T<:NBitInteger}     = _convert(T, x)
+(::Type{T})(x::Base.BitInteger)  where {T<:NBitInteger}     = _convert(T, x)
+(::Type{T})(x::NBitInteger)      where {T<:Base.BitInteger} = _convert(T, x)
+(::Type{T})(x::Bool)             where {T<:NBitInteger}     = ifelse(x, one(T), zero(T))
+
+# `%`: truncating conversion, never throws
+Base.rem(x::BitInt{N},  ::Type{BitInt{N}})  where {N} = x
+Base.rem(x::BitUInt{N}, ::Type{BitUInt{N}}) where {N} = x
+Base.rem(x::NBitInteger,     ::Type{T}) where {T<:NBitInteger}     = _extend(T, x)
+Base.rem(x::Base.BitInteger, ::Type{T}) where {T<:NBitInteger}     = _extend(T, x)
+Base.rem(x::NBitInteger,     ::Type{T}) where {T<:Base.BitInteger} = _extend(T, x)
+
+Base.signed(::Type{BitInt{N}})    where {N} = BitInt{N}
+Base.signed(::Type{BitUInt{N}})   where {N} = BitInt{N}
+Base.unsigned(::Type{BitInt{N}})  where {N} = BitUInt{N}
+Base.unsigned(::Type{BitUInt{N}}) where {N} = BitUInt{N}
+
+Base.signed(x::BitUInt{N})   where {N} = bitcast(BitInt{N}, x)
+Base.unsigned(x::BitInt{N})  where {N} = bitcast(BitUInt{N}, x)
+
+Base.Signed(x::BitUInt{N})  where {N} = BitInt{N}(x)
+Base.Unsigned(x::BitInt{N}) where {N} = BitUInt{N}(x)
+
+## constants and limits ##
+
+Base.zero(::Type{T}) where {T<:NBitInteger} = _extend(T, 0x00)
+Base.one(::Type{T})  where {T<:NBitInteger} = _extend(T, 0x01)
+
+Base.typemin(::Type{BitUInt{N}}) where {N} = zero(BitUInt{N})
+Base.typemax(::Type{BitUInt{N}}) where {N} = not_int(zero(BitUInt{N}))
+Base.typemin(::Type{BitInt{N}})  where {N} = shl_int(one(BitInt{N}), N - 1)
+Base.typemax(::Type{BitInt{N}})  where {N} = not_int(typemin(BitInt{N}))
+
+# a doubled width always holds a product, which is what `widemul` needs
+Base.widen(::Type{BitInt{N}})  where {N} = BitInt{2N}
+Base.widen(::Type{BitUInt{N}}) where {N} = BitUInt{2N}
+
+## arithmetic ##
+
+Base.:(-)(x::NBitInteger)                    = neg_int(x)
+Base.:(+)(x::T, y::T) where {T<:NBitInteger} = add_int(x, y)
+Base.:(-)(x::T, y::T) where {T<:NBitInteger} = sub_int(x, y)
+Base.:(*)(x::T, y::T) where {T<:NBitInteger} = mul_int(x, y)
+
+Base.:(-%)(x::NBitInteger)                    = neg_int(x)
+Base.:(+%)(x::T, y::T) where {T<:NBitInteger} = add_int(x, y)
+Base.:(-%)(x::T, y::T) where {T<:NBitInteger} = sub_int(x, y)
+Base.:(*%)(x::T, y::T) where {T<:NBitInteger} = mul_int(x, y)
+
+Base.div(x::T, y::T) where {T<:BitInt}  = checked_sdiv_int(x, y)
+Base.rem(x::T, y::T) where {T<:BitInt}  = checked_srem_int(x, y)
+Base.div(x::T, y::T) where {T<:BitUInt} = checked_udiv_int(x, y)
+Base.rem(x::T, y::T) where {T<:BitUInt} = checked_urem_int(x, y)
+
+# `fld`, `mod` and friends reach the two-argument form through this
+Base.div(x::T, y::T, ::typeof(RoundToZero)) where {T<:NBitInteger} = div(x, y)
+
+Base.flipsign(x::T, y::T) where {T<:BitInt} = flipsign_int(x, y)
+
+## bitwise ##
+
+Base.:(~)(x::NBitInteger)                      = not_int(x)
+Base.:(&)(x::T, y::T)   where {T<:NBitInteger} = and_int(x, y)
+Base.:(|)(x::T, y::T)   where {T<:NBitInteger} = or_int(x, y)
+Base.xor(x::T, y::T)    where {T<:NBitInteger} = xor_int(x, y)
+
+# the generic operators in Base reduce every shift count to a `UInt`
+Base.:(>>)(x::BitInt,       y::UInt) = ashr_int(x, y)
+Base.:(>>)(x::BitUInt,      y::UInt) = lshr_int(x, y)
+Base.:(<<)(x::NBitInteger,  y::UInt) = shl_int(x, y)
+Base.:(>>>)(x::NBitInteger, y::UInt) = lshr_int(x, y)
+
+# a count of up to `N` need not fit in `BitInt{N}` (e.g. `N == 2`), so read the
+# result back through the unsigned companion, where it always does
+@inline _count(x::T) where {T<:NBitInteger} = Int(bitcast(unsigned(T), x) % UInt)
+
+Base.count_ones(x::NBitInteger)     = _count(ctpop_int(x))
+Base.leading_zeros(x::NBitInteger)  = _count(ctlz_int(x))
+Base.trailing_zeros(x::NBitInteger) = _count(cttz_int(x))
+Base.top_set_bit(x::NBitInteger)    = nbits(x) - leading_zeros(x)
+
+## comparison ##
+
+Base.:(==)(x::T, y::T) where {T<:NBitInteger} = eq_int(x, y)
+Base.:(<)(x::T, y::T)  where {T<:BitInt}      = slt_int(x, y)
+Base.:(<)(x::T, y::T)  where {T<:BitUInt}     = ult_int(x, y)
+Base.:(<=)(x::T, y::T) where {T<:BitInt}      = sle_int(x, y)
+Base.:(<=)(x::T, y::T) where {T<:BitUInt}     = ule_int(x, y)
+
+## promotion ##
+
+# The result must hold every value of both operands: a signed type wins only
+# when it is strictly wider than the unsigned one, matching `Int32`/`UInt32`.
+_promote_nbits(N, M) = N > M ? N : M
+
+Base.promote_rule(::Type{BitInt{N}},  ::Type{BitInt{M}})  where {N,M} = BitInt{_promote_nbits(N, M)}
+Base.promote_rule(::Type{BitUInt{N}}, ::Type{BitUInt{M}}) where {N,M} = BitUInt{_promote_nbits(N, M)}
+Base.promote_rule(::Type{BitInt{N}},  ::Type{BitUInt{M}}) where {N,M} = N > M ? BitInt{N} : BitUInt{M}
+
+Base.promote_rule(::Type{BitInt{N}},  ::Type{T}) where {N,T<:Base.BitSigned}   = BitInt{_promote_nbits(N, 8sizeof(T))}
+Base.promote_rule(::Type{BitUInt{N}}, ::Type{T}) where {N,T<:Base.BitUnsigned} = BitUInt{_promote_nbits(N, 8sizeof(T))}
+Base.promote_rule(::Type{BitInt{N}},  ::Type{T}) where {N,T<:Base.BitUnsigned} = N > 8sizeof(T) ? BitInt{N} : BitUInt{8sizeof(T)}
+Base.promote_rule(::Type{BitUInt{N}}, ::Type{T}) where {N,T<:Base.BitSigned}   = 8sizeof(T) > N ? BitInt{8sizeof(T)} : BitUInt{N}
+
+## exact value, for arbitrary width ##
+
+_wide(x::BitInt{N})  where {N} = Int64(x)
+_wide(x::BitUInt{N}) where {N} = UInt64(x)
+
+function _bigint(x::T) where {T<:NBitInteger}
+    n, u, r = nbits(T), unsigned(x), big(0)
+    for k in 0:32:n-1
+        r |= big(u >>> UInt(k) % BitUInt{32} % UInt32) << k
+    end
+    _isneg(x) ? r - (big(1) << n) : r
+end
+
+Base.BigInt(x::T) where {T<:NBitInteger} = nbits(T) <= 64 ? big(_wide(x)) : _bigint(x)
+
+(::Type{T})(x::NBitInteger) where {T<:AbstractFloat} = T(BigInt(x))
+Base.AbstractFloat(x::NBitInteger) = Float64(x)
+Base.:(/)(x::T, y::T) where {T<:NBitInteger} = float(x) / float(y)
+
+## tests ##
+
+using Random
+
+# reference semantics: an N-bit two's-complement window onto the integers
+_wrap(::Type{BitUInt{N}}, v) where {N} = mod(big(v), big(1) << N)
+_wrap(::Type{BitInt{N}},  v) where {N} = mod(big(v) + (big(1) << (N-1)), big(1) << N) - (big(1) << (N-1))
+
+function _make(::Type{T}, v::Integer) where {T<:NBitInteger}
+    n = nbits(T)
+    u = mod(big(v), big(1) << n)
+    r = zero(T)
+    for k in 0:32:n-1
+        r |= (UInt32((u >> k) & 0xffffffff) % T) << UInt(k)
+    end
+    r
+end
+
+function _randval(rng, n)
+    v = big(0)
+    for k in 0:64:n-1
+        v |= big(rand(rng, UInt64)) << k
+    end
+    v & ((big(1) << n) - 1)
+end
+
+const WIDTHS = (2, 3, 8, 13, 16, 21, 32, 47, 64, 100)
+
+@testset "parametric primitive integers" begin
+
+@testset "layout" begin
+    @test Core.bitsizeof(BitInt{21}) == 21
+    @test Core.bitsizeof(BitUInt{21}) == 21
+    @test isbitstype(BitInt{21}) && isbitstype(BitUInt{21})
+    @test BitInt{21} <: Signed && BitUInt{21} <: Unsigned
+    @test !isconcretetype(BitInt) && !isconcretetype(BitUInt)
+end
+
+@testset "values round-trip through BigInt" begin
+    rng = Xoshiro(0x51ce)
+    for n in WIDTHS, T in (BitInt{n}, BitUInt{n}), _ in 1:20
+        v = _randval(rng, n)
+        @test BigInt(_make(T, v)) == _wrap(T, v)
+    end
+    @test BigInt(zero(BitInt{100})) == 0
+    @test BigInt(one(BitUInt{100})) == 1
+end
+
+@testset "arithmetic matches arbitrary precision" begin
+    rng = Xoshiro(0xa11e)
+    for n in WIDTHS, T in (BitInt{n}, BitUInt{n}), _ in 1:20
+        x, y = _make(T, _randval(rng, n)), _make(T, _randval(rng, n))
+        a, b = BigInt(x), BigInt(y)
+
+        @test BigInt(x + y) == _wrap(T, a + b)
+        @test BigInt(x - y) == _wrap(T, a - b)
+        @test BigInt(x * y) == _wrap(T, a * b)
+        @test BigInt(-x)    == _wrap(T, -a)
+        @test BigInt(x +% y) == BigInt(x + y)
+        @test BigInt(x -% y) == BigInt(x - y)
+        @test BigInt(x *% y) == BigInt(x * y)
+
+        @test BigInt(~x)     == _wrap(T, ~a)
+        @test BigInt(x & y)  == _wrap(T, a & b)
+        @test BigInt(x | y)  == _wrap(T, a | b)
+        @test BigInt(xor(x, y)) == _wrap(T, xor(a, b))
+
+        @test (x <  y) == (a <  b)
+        @test (x <= y) == (a <= b)
+        @test (x == y) == (a == b)
+        @test isequal(x, y) == (a == b)
+
+        # `typemin ÷ -1` is the one signed quotient that does not exist
+        if !iszero(y) && !(x === typemin(T) && b == -1)
+            @test BigInt(div(x, y)) == _wrap(T, div(a, b))
+            @test BigInt(rem(x, y)) == _wrap(T, rem(a, b))
+            @test BigInt(fld(x, y)) == _wrap(T, fld(a, b))
+            @test BigInt(mod(x, y)) == _wrap(T, mod(a, b))
+        end
+
+        for k in (0, 1, n ÷ 2, n - 1, n, n + 7)
+            @test BigInt(x << k)  == _wrap(T, a * big(2)^k)
+            @test BigInt(x >> k)  == _wrap(T, fld(a, big(2)^k))
+            @test BigInt(x >>> k) == _wrap(T, BigInt(unsigned(x)) >> k)
+        end
+
+        u = BigInt(unsigned(x))
+        @test count_ones(x)     == count_ones(u)
+        @test Base.top_set_bit(x) == (iszero(u) ? 0 : ndigits(u, base=2))
+        @test leading_zeros(x)  == n - Base.top_set_bit(x)
+        @test trailing_zeros(x) == (iszero(u) ? n : trailing_zeros(u))
+    end
+end
+
+@testset "matches Base at matching widths" begin
+    rng = Xoshiro(0xba5e)
+    for B in (Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64)
+        T = B <: Signed ? BitInt{8sizeof(B)} : BitUInt{8sizeof(B)}
+        for _ in 1:50
+            a, b = rand(rng, B), rand(rng, B)
+            x, y = T(a), T(b)
+            @test T(a +% b) === x + y
+            @test T(a -% b) === x - y
+            @test T(a *% b) === x * y
+            @test T(~a)     === ~x
+            @test T(a & b)  === x & y
+            @test T(a | b)  === x | y
+            @test T(xor(a, b)) === xor(x, y)
+            @test (a < b)   === (x < y)
+            @test (a <= b)  === (x <= y)
+            @test count_ones(a) === count_ones(x)
+            @test leading_zeros(a) === leading_zeros(x)
+            @test trailing_zeros(a) === trailing_zeros(x)
+            for k in (0, 3, 8sizeof(B) - 1, 8sizeof(B) + 1)
+                @test T(a << k)  === x << k
+                @test T(a >> k)  === x >> k
+                @test T(a >>> k) === x >>> k
+            end
+            iszero(b) || (a === typemin(B) && b == -1) || begin
+                @test T(div(a, b)) === div(x, y)
+                @test T(rem(a, b)) === rem(x, y)
+            end
+        end
+        @test T(typemin(B)) === typemin(T)
+        @test T(typemax(B)) === typemax(T)
+    end
+    @test_throws DivideError div(typemin(BitInt{21}), BitInt{21}(-1))
+    @test_throws DivideError div(BitInt{21}(1), zero(BitInt{21}))
+end
+
+@testset "conversion" begin
+    @test BitInt{47}(BitInt{21}(-5)) === BitInt{47}(-5)
+    @test BitInt{5}(BitInt{21}(-5))  === BitInt{5}(-5)
+    @test BitUInt{47}(BitUInt{21}(5)) === BitUInt{47}(5)
+    @test BitInt{22}(typemax(BitUInt{21})) === BitInt{22}(2^21 - 1)
+    @test BitUInt{21}(BitInt{21}(5)) === BitUInt{21}(5)
+    @test Int64(BitInt{21}(-1)) === -1
+    @test Int64(typemax(BitUInt{21})) === Int64(2^21 - 1)
+    @test BitInt{21}(Int64(-1)) === BitInt{21}(-1)
+    @test BitInt{100}(typemin(Int64)) === _make(BitInt{100}, typemin(Int64))
+    @test BitInt{21}(true) === one(BitInt{21})
+    @test BitInt{21}(false) === zero(BitInt{21})
+    @test convert(BitInt{47}, BitInt{21}(-5)) === BitInt{47}(-5)
+
+    @test_throws InexactError BitInt{5}(BitInt{21}(100))
+    @test_throws InexactError BitUInt{21}(BitInt{21}(-1))
+    @test_throws InexactError BitInt{21}(typemax(BitUInt{21}))
+    @test_throws InexactError BitUInt{21}(Int64(-1))
+    @test_throws InexactError BitInt{21}(Int64(1) << 21)
+    @test_throws InexactError Int8(BitInt{21}(1000))
+    @test_throws InexactError UInt64(BitInt{21}(-1))
+
+    # `%` truncates instead of throwing
+    rng = Xoshiro(0xc0de)
+    for n in WIDTHS, m in WIDTHS, S in (BitInt{n}, BitUInt{n}), T in (BitInt{m}, BitUInt{m})
+        x = _make(S, _randval(rng, n))
+        @test BigInt(x % T) == _wrap(T, BigInt(x))
+    end
+    @test BitInt{21}(-1) % Int64 === -1
+    @test Int64(-1) % BitInt{21} === BitInt{21}(-1)
+    @test BitInt{21}(-1) % BitInt{21} === BitInt{21}(-1)
+end
+
+@testset "signedness" begin
+    @test signed(BitUInt{21}) === BitInt{21}
+    @test signed(BitInt{21}) === BitInt{21}
+    @test unsigned(BitInt{21}) === BitUInt{21}
+    @test unsigned(BitUInt{21}) === BitUInt{21}
+    @test signed(typemax(BitUInt{21})) === BitInt{21}(-1)
+    @test unsigned(BitInt{21}(-1)) === typemax(BitUInt{21})
+    @test Signed(BitUInt{21}(5)) === BitInt{21}(5)
+    @test Unsigned(BitInt{21}(5)) === BitUInt{21}(5)
+    @test_throws InexactError Signed(typemax(BitUInt{21}))
+    @test_throws InexactError Unsigned(BitInt{21}(-1))
+end
+
+@testset "limits and widening" begin
+    for n in WIDTHS
+        @test BigInt(typemin(BitInt{n})) == -big(2)^(n-1)
+        @test BigInt(typemax(BitInt{n})) == big(2)^(n-1) - 1
+        @test typemin(BitUInt{n}) === zero(BitUInt{n})
+        @test BigInt(typemax(BitUInt{n})) == big(2)^n - 1
+        @test typemax(BitInt{n}) + one(BitInt{n}) === typemin(BitInt{n})
+        @test typemax(BitUInt{n}) + one(BitUInt{n}) === zero(BitUInt{n})
+        @test widen(BitInt{n}) === BitInt{2n}
+        @test widen(BitUInt{n}) === BitUInt{2n}
+        @test widen(typemin(BitInt{n})) === BitInt{2n}(typemin(BitInt{n}))
+    end
+    let x = typemin(BitInt{21})
+        @test BigInt(widemul(x, x)) == big(2)^40
+    end
+    @test BigInt(widemul(typemax(BitUInt{13}), typemax(BitUInt{13}))) == (big(2)^13 - 1)^2
+end
+
+@testset "promotion" begin
+    @test promote_type(BitInt{21}, BitInt{47}) === BitInt{47}
+    @test promote_type(BitUInt{21}, BitUInt{47}) === BitUInt{47}
+    @test promote_type(BitInt{21}, BitUInt{21}) === BitUInt{21}
+    @test promote_type(BitInt{47}, BitUInt{21}) === BitInt{47}
+    @test promote_type(BitInt{21}, Int32) === BitInt{32}
+    @test promote_type(BitInt{47}, Int32) === BitInt{47}
+    @test promote_type(BitUInt{21}, UInt64) === BitUInt{64}
+    @test promote_type(BitInt{21}, UInt64) === BitUInt{64}
+    @test promote_type(BitUInt{21}, Int64) === BitInt{64}
+    @test promote_type(BitUInt{64}, Int32) === BitUInt{64}
+
+    @test BitInt{21}(3) + Int32(4) === BitInt{32}(7)
+    @test BitInt{21}(3) < Int64(4)
+    @test BitInt{21}(3) == 3
+    @test BitUInt{21}(3) * BitInt{47}(-2) === BitInt{47}(-6)
+end
+
+@testset "printing" begin
+    @test string(BitInt{21}(-1000)) == "-1000"
+    @test string(BitInt{21}(-1000), base=16) == "-3e8"
+    @test string(BitUInt{21}(0x1234), base=16) == "1234"
+    @test repr(BitUInt{21}(1)) == "0x000001"
+    @test sprint(show, BitInt{21}(-1000)) == "-1000"
+    @test string(typemax(BitInt{100})) == string(big(2)^99 - 1)
+    @test string(typemin(BitInt{100})) == string(-big(2)^99)
+end
+
+@testset "inference and unboxing" begin
+    f(x, y) = (x + y) * x - div(x, y)
+    @test @inferred(f(BitInt{21}(7), BitInt{21}(3))) === BitInt{21}(68)
+    @test @inferred(BitInt{47}(BitInt{21}(-1))) === BitInt{47}(-1)
+    @test @inferred(typemax(BitInt{21})) === BitInt{21}(2^20 - 1)
+    @test @inferred(BitInt{21}(-1) % BitUInt{13}) === typemax(BitUInt{13})
+    @test @inferred(widen(BitInt{21}(-1))) === BitInt{42}(-1)
+    @test Base.return_types(+, (BitInt{21}, BitInt{21})) == [BitInt{21}]
+
+    # a concrete width is an ordinary isbits type: it stays unboxed
+    g(x, n) = (s = zero(x); for _ in 1:n; s += x; end; s)
+    g(BitInt{21}(3), 10)
+    @test @allocated(g(BitInt{21}(3), 1000)) == 0
+    a = fill(BitInt{21}(7), 4)
+    @test Base.elsize(a) == Base.aligned_sizeof(BitInt{21})
+    @test sum(a) === BitInt{21}(28)
+end
+
+end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -23,7 +23,7 @@ const TESTNAMES = [
         "errorshow", "sets", "goto", "llvmcall", "llvmcall2", "ryu",
         "some", "meta", "stacktraces", "docs", "gc",
         "misc", "threads", "stress", "binaryplatforms","stdlib_dependencies", "atexit",
-        "enums", "cmdlineargs", "int", "interpreter",
+        "enums", "cmdlineargs", "int", "bitint", "interpreter",
         "checked", "bitset", "floatfuncs", "precompile", "relocatedepot",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "cancellation", "iostream", "secretbuffer", "specificity",

--- a/test/core.jl
+++ b/test/core.jl
@@ -9407,3 +9407,70 @@ let A = Issue61347.A, S2 = Issue61347.S2
     @test isdefined(lazy, :super)
     @test getfield(lazy, :super) === supertype(lazy)
 end
+
+# primitive types whose bit size is given by a type parameter
+primitive type PrimN{N} <: Signed N end
+primitive type PrimTN{T,N} <: Signed N end
+primitive type Prim21 <: Signed 21 end
+struct WrapPrim21
+    v::Prim21
+end
+struct WrapPrimN{N}
+    v::PrimN{N}
+end
+prim_nbits(::PrimN{N}) where {N} = N
+@testset "parametric primitive type sizes" begin
+    @test Core.bitsizeof(PrimN{21}) == 21
+    @test sizeof(PrimN{21}) == 3
+    @test Core.bitsizeof(PrimN{64}) == 64
+    @test sizeof(PrimN{64}) == 8
+    @test isbitstype(PrimN{21})
+    @test isconcretetype(PrimN{21})
+    @test PrimN{21} <: Signed
+    @test isprimitivetype(PrimN{21})
+
+    # the size parameter need not come first
+    @test Core.bitsizeof(PrimTN{Int,24}) == 24
+    @test sizeof(PrimTN{Int,24}) == 3
+
+    # without a concrete size there is no layout
+    @test !isconcretetype(PrimN)
+    @test !isbitstype(PrimN)
+    @test_throws ErrorException sizeof(PrimN)
+    @test_throws ErrorException Core.bitsizeof(PrimN)
+
+    # the size parameter must be a positive Int within range
+    @test_throws TypeError PrimN{Float64}
+    @test_throws TypeError PrimN{:x}
+    @test_throws ErrorException PrimN{0}
+    @test_throws ErrorException PrimN{-1}
+    @test_throws ErrorException PrimN{1 << 23}
+
+    # ... and it must name one of the type parameters
+    @test_throws ErrorException @eval primitive type PrimBad{N} <: Signed $(TypeVar(:M)) end
+
+    # values round-trip through the intrinsics
+    x = Core.Intrinsics.trunc_int(PrimN{21}, 0x123456)
+    y = Core.Intrinsics.trunc_int(Prim21, 0x123456)
+    @test Core.Intrinsics.zext_int(UInt32, x) == 0x123456 & 0x1fffff
+    @test typeof(x) === PrimN{21}
+    @test x === Core.Intrinsics.trunc_int(PrimN{21}, 0x123456)
+
+    # inference and codegen see through the parameter
+    @test @inferred(prim_nbits(x)) === 21
+    @test Base.return_types(prim_nbits, (PrimN{21},)) == [Int]
+
+    # they can be stored, unboxed, in other containers, laid out exactly as the
+    # equivalent fixed-size primitive type
+    a = [x, x]
+    @test sizeof(a) == sizeof([y, y])
+    @test a[1] === x
+    @test sizeof(WrapPrimN{21}) == sizeof(WrapPrim21)
+    @test isbitstype(WrapPrimN{21})
+    @test !isconcretetype(WrapPrimN)
+
+    # redefinition with the same declaration reuses the type
+    old = PrimN
+    @eval primitive type PrimN{N} <: Signed N end
+    @test old === PrimN
+end


### PR DESCRIPTION
A primitive type declaration may now take its bit width from one of its type parameters:

```julia
primitive type BitInt{N} <: Signed N end
```

The width must be written as a bare parameter name, and must resolve to a positive `Int` below 2^23. The declaration itself gets no layout; each instantiation computes its own, so `BitInt{21}` and `BitInt{64}` are distinct concrete bits types of different size, while `BitInt{N}` with free `N` behaves like any other type whose layout is not yet determined. The parameter index is recorded in the typename's spare flag bits, which caps it at the first 15 type parameters.

A primitive type can therefore lack a size, and `Core.bitsizeof` throws for one. Inference asks for those sizes through a helper that reports "no size" instead of throwing, and reads that as "the intrinsic may throw".

`test/bitint.jl` builds arbitrary-width integers on the feature — conversion, promotion, limits, widening, the integer intrinsics — checked against arbitrary precision arithmetic and, at the built-in widths, against `Base`. We could promote this to an actual feature in `Base`, or in a package, or whatever; I mainly included it here to show why I want this feature, and to exercise it.

Stacked on #63093 (`mh/fix-hex-for-odd-sized-ints`), which the printing tests need (it fixes a bug we found while working on this PR).

Written by Claude Opus 5. I have not read any of it yet.

---

At this stage, I'd like to mainly solicit feedback on the general suggestion: is this something we want to have at all? If so, I'll work on polishing it, fixing comments etc., and incorporating feedback.