### PR TITLE
don't poll libuv on behalf of a finished task in `wait()`

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -1631,8 +1631,11 @@ function wait()
     record_running_time!(ct)
     # let GC run
     GC.safepoint()
-    # check for libuv events
-    process_events()
+    # check for libuv events, but not for a task that is already done: it never
+    # returns from this `wait()`, so the poll would only delay the switch to the
+    # next task. 1.12 got this for free by polling after the switch (#63048).
+    ct_done = istaskdone(ct)
+    ct_done || process_events()
 
     # get the next task to run
     W = workqueue_for(Threads.threadid())
@@ -1645,7 +1648,7 @@ function wait()
         # is delivered to a task that can observe it, rather than swallowed by
         # the internal scheduler task (#58689).
         sched_task = get_sched_task()
-        if ct !== sched_task && istaskdone(ct)
+        if ct !== sched_task && ct_done
             istaskdone(sched_task) && (sched_task = @task wait())
             return yieldto(sched_task)
         end

--- a/base/task.jl
+++ b/base/task.jl
@@ -1631,9 +1631,7 @@ function wait()
     record_running_time!(ct)
     # let GC run
     GC.safepoint()
-    # check for libuv events, but not for a task that is already done: it never
-    # returns from this `wait()`, so the poll would only delay the switch to the
-    # next task. 1.12 got this for free by polling after the switch (#63048).
+    # check for libuv events, but not on a completed task 
     ct_done = istaskdone(ct)
     ct_done || process_events()
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -1631,7 +1631,7 @@ function wait()
     record_running_time!(ct)
     # let GC run
     GC.safepoint()
-    # check for libuv events, but not on a completed task 
+    # check for libuv events, but not on a completed task (#63048)
     ct_done = istaskdone(ct)
     ct_done || process_events()
 


### PR DESCRIPTION
Fixes #63048.

#58595 moved `process_events()` from after `try_yieldto` to the top of `wait()`.
That PR was a style refactor ("simplify `wait()`"), so the reordering looks
unintentional. In 1.12 a done task never returned from `wait()` and so never
reached the call; now every finishing task pays a `uv_run(loop, UV_RUN_NOWAIT)`
on its way out.

Guarding on `istaskdone(ct)` restores the old behaviour. The result is reused
for the existing `sched_task` check below, so this doesn't add an atomic load
to the switch path.

`jl_finish_task` publishes `DONE`/`FAILED` (release) before invoking
`task_done_hook`, so the predicate is reliable where it matters.

Nothing should starve: if the workqueue is non-empty there's real work to run
and the next live task's `wait()` polls; once it drains, the done task yields
to the scheduler task (`wait_forever`), which is never done, so it polls before
parking in `jl_task_get_next`.

I haven't been able to build and benchmark this, so the `-t 1` numbers from the
issue still need confirming.

I also considered polling only when the local queue is empty, which would be
faster still, but libuv would then go unserviced while the run queue stays
busy — 1.12 polled on every resume, so that would trade one regression for
another. Happy to go that way instead if preferred.

Should get `backport 1.13`.

Disclosure: the analysis and the code   were done by claude code  ,under my review