### PR TITLE
Make `round`/`floor`/`ceil`/`trunc` with `digits` keyword more accurate.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -186,6 +186,12 @@ New library features
 Standard library changes
 ------------------------
 
+* `round`, `floor`, `ceil` and `trunc` with `digits` or `sigdigits` now apply the rounding mode to
+  the exact value of their argument whenever `base^digits` is representable. Previously the result
+  could land on the wrong side of the argument, e.g. `floor(2.0^53 - 4; digits=1)` returned
+  `2.0^53 - 3`, and the rounded intermediate product could break ties the wrong way:
+  `round(1.15, digits=1)` returned `1.2` although the `Float64` `1.15` is less than `115//100`;
+  it now returns `1.1`.
 * `codepoint(c)` now succeeds for overlong encodings.  `Base.ismalformed`, `Base.isoverlong`, and
   `Base.show_invalid` are now `public` and documented (but not exported) ([#55152]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -191,7 +191,7 @@ Standard library changes
   could land on the wrong side of the argument, e.g. `floor(2.0^53 - 4; digits=1)` returned
   `2.0^53 - 3`, and the rounded intermediate product could break ties the wrong way:
   `round(1.15, digits=1)` returned `1.2` although the `Float64` `1.15` is less than `115//100`;
-  it now returns `1.1`.
+  it now returns `1.1` ([#63105]).
 * `codepoint(c)` now succeeds for overlong encodings.  `Base.ismalformed`, `Base.isoverlong`, and
   `Base.show_invalid` are now `public` and documented (but not exported) ([#55152]).
 

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -74,13 +74,113 @@ function round(x::Real, r::RoundingMode=RoundNearest;
     end
 end
 
+# Rounding to digits scales x, rounds to an integer, and scales back. The scaling
+# step itself rounds, and if it lands exactly on a rounding boundary (an integer, or
+# a half-integer for the nearest modes) the mode can't tell which side the exact
+# value was on. floor(x) could end up above x. So `_mul_round` and `_div_round`
+# recover the scaling error with an fma and round the exact product or quotient.
+# The rounded integer may not be representable, hence the `TwicePrecision`.
+
+# round(s + δ, r) for an infinitesimal δ with the sign of σ (δ == 0 iff σ == 0).
+# Branch-free: the sign of σ is unpredictable. Needs eps(s) <= 1 so the step of
+# one is representable, and σ to have the sign of s when s is a signed zero;
+# callers pass |s| < maxintfloat/2 or |s| <= 4, and σ is the error of s itself.
+function _round_sticky(s, σ, ::RoundingMode{:Down})
+    f = floor(s)
+    return ifelse((f == s) & (σ < 0), f - one(f), f)
+end
+function _round_sticky(s, σ, ::RoundingMode{:Up})
+    c = ceil(s)
+    return ifelse((c == s) & (σ > 0), copysign(c + one(c), c), c)
+end
+function _round_sticky(s, σ, ::RoundingMode{:ToZero})
+    t = trunc(s)
+    return ifelse((t == s) & !iszero(σ) & (signbit(σ) != signbit(s)), copysign(t + copysign(one(t), σ), s), t)
+end
+function _round_sticky(s, σ, ::RoundingMode{:FromZero})
+    t = round(s, RoundFromZero)
+    return ifelse((t == s) & !iszero(σ) & (signbit(σ) == signbit(s)), t + copysign(one(t), σ), t)
+end
+function _round_sticky(s, σ, r::Union{RoundingMode{:Nearest}, RoundingMode{:NearestTiesAway}, RoundingMode{:NearestTiesUp}})
+    half = oftype(s, 0.5)
+    tie = (abs(s - trunc(s)) == half) & !iszero(σ)
+    return ifelse(tie, copysign(s + copysign(half, σ), s), round(s, r))
+end
+
+# parity of an integer-valued float, without converting to an Integer
+_iseven_integral(s) = s == 2 * trunc(s / 2)
+
+# round(s + err + δ, r) - s for an integer-valued s, |err| < |s|, and an infinitesimal
+# δ with the sign of σ. The result is an integer, but s plus it may not be representable.
+function _round_offset(s, err, σ, r::RoundingMode)
+    # Only the fractional part of err and the sign and parity of s + trunc(err) matter,
+    # so swap the big integer for a small one with the same sign and parity.
+    ei = trunc(err)
+    ef = err - ei                              # exact
+    b = copysign(oftype(s, _iseven_integral(s) == _iseven_integral(ei) ? 2 : 3), s)
+    t = b + ef
+    e = (b - t) + ef                           # exact: b + ef == t + e
+    return ei + (_round_sticky(t, iszero(e) ? σ : e, r) - b)
+end
+
+# round(x * y, r) applied to the exact product. Exact unless x * y underflows,
+# which loses the sign of err; here y is an integer, so it never does.
+@inline function _mul_round(x, y, r::RoundingMode)
+    xy, err = two_mul(x, y)          # x * y == xy + err
+    isfinite(xy) || return TwicePrecision(xy, zero(xy))
+    if abs(xy) < maxintfloat(xy) / 2
+        return TwicePrecision(_round_sticky(xy, err, r), zero(xy))
+    end
+    return TwicePrecision(xy, _round_offset(xy, err, zero(err), r))
+end
+
+# round(x / y, r) applied to the exact quotient. Exact for |x / y| < maxintfloat^2 / 4;
+# past that the rounded quotient generally doesn't fit in a TwicePrecision, and the
+# result is the closest one to x / y instead (within eps(lo) / 2 + 1 of the rounded quotient).
+@inline function _div_round(x, y, r::RoundingMode)
+    q = x / y
+    (isfinite(q) && isfinite(y)) || return TwicePrecision(round(q, r), zero(q))
+    rem = fma(-q, y, x)              # x == q * y + rem
+    if abs(q) < maxintfloat(q) / 2
+        return TwicePrecision(_round_sticky(q, flipsign(rem, y), r), zero(q))
+    end
+    # q is an integer and |rem / y| <= eps(q) / 2
+    δ = rem / y
+    if abs(δ) >= maxintfloat(q) / 2
+        return TwicePrecision(q, δ)  # δ is already an integer
+    end
+    ρ = fma(-δ, y, rem)              # rem == δ * y + ρ
+    return TwicePrecision(q, _round_offset(q, δ, flipsign(ρ, y), r))
+end
+
+# (v.hi + v.lo) / y as a float, for v from `_mul_round`. When v.lo != 0 this rounds
+# twice. With an integer numerator and y = 10^d the exact quotient is at least
+# ulp/(2*5^d) from any midpoint, which is beyond the error in c for d <= 21; for
+# d == 22 the margin is gone on paper but no counterexample has been found.
+@inline function _tp_div(v::TwicePrecision, y)
+    hi = v.hi / y
+    iszero(v.lo) && return hi
+    rq = fma(-hi, y, v.hi)           # exact: v.hi == hi * y + rq
+    c = (rq + v.lo) / y
+    return hi + c
+end
+
+# (v.hi + v.lo) * y as a float, for v from `_div_round`. Correctly rounded when
+# pe + v.lo * y is exact: both are multiples of 2^d for y = 10^d, and with |v.lo| <= 2
+# (the fast path in `_round_step` keeps |v.hi| < 2^55) the sum fits for d <= 21.
+@inline function _tp_mul(v::TwicePrecision, y)
+    iszero(v.lo) && return v.hi * y
+    p, pe = two_mul(v.hi, y)         # exact: v.hi * y == p + pe
+    return p + (pe + v.lo * y)
+end
+
 # round x to multiples of 1/invstep
 function _round_invstep(x, invstep, r::RoundingMode)
-    y = round(x * invstep, r) / invstep
-    if !isfinite(y)
-        return x
-    end
-    return y
+    # If 1/invstep is less than a quarter of the spacing of floats around x, the
+    # rounded value is within a quarter ulp of x and converts back to x, so skip the
+    # work. This also covers x * invstep overflowing.
+    eps(x) * abs(invstep) >= 4 && return x
+    return _tp_div(_mul_round(x, invstep, r), invstep)
 end
 
 # round x to multiples of 1/(invstepsqrt^2)
@@ -95,8 +195,13 @@ end
 
 # round x to multiples of step
 function _round_step(x, step, r::RoundingMode)
-    # TODO: use div with rounding mode
-    y = round(x / step, r) * step
+    if isfinite(step)
+        # step is less than a quarter of the spacing of floats around x: the result is x
+        eps(x) >= 4 * abs(step) && return x
+        y = _tp_mul(_div_round(x, step, r), step)
+    else
+        y = round(x / step, r) * step
+    end
     if !isfinite(y)
         if x > 0
             return (r == RoundUp ? oftype(x, Inf) : zero(x))

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -385,10 +385,10 @@ Float16(6.55e4)
 ```
 
 !!! note
-    Rounding to specified digits in bases other than 2 can be inexact when
-    operating on binary floating point numbers. For example, the [`Float64`](@ref)
-    value represented by `1.15` is actually *less* than 1.15, yet will be
-    rounded to 1.2. For example:
+    Rounding to specified digits in bases other than 2 acts on the exact value of the
+    binary floating point number, which may differ from the decimal literal used to
+    write it. For example, the [`Float64`](@ref) value represented by `1.15` is actually
+    *less* than 1.15, and so is rounded to 1.1:
 
     ```jldoctest
     julia> x = 1.15
@@ -401,8 +401,12 @@ Float16(6.55e4)
     true
 
     julia> round(x, digits=1)
-    1.2
+    1.1
     ```
+
+    When `base^digits` is representable, the result is the floating point number
+    closest to the exactly rounded value, which in bases other than 2 is itself
+    generally not representable.
 
 # Extensions
 

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -4,6 +4,7 @@
 using Base.MathConstants
 
 using Test
+using Random
 
 @testset "Float64 checks" begin
     # a + b returns a number exactly between prevfloat(1.) and 1., so its
@@ -297,6 +298,120 @@ end
     @test ceil(-123.456, digits=1) ≈ -123.4
     @test floor(123.456, digits=1) ≈ 123.4
     @test floor(-123.456, digits=1) ≈ -123.5
+end
+@testset "rounding to digits is exact w.r.t. the value of x" begin
+    modes = (RoundDown, RoundUp, RoundToZero, RoundFromZero,
+             RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp)
+    # `round(x * base^d, r) / base^d` on the exact value of `x`, rounded once at the end
+    function refround(x::T, r::RoundingMode, d::Integer, base::Integer=10) where {T<:AbstractFloat}
+        setprecision(BigFloat, 4 * max(precision(x), 53) + 4 * abs(d) + 64) do
+            s = big(base)^abs(d)
+            y = d >= 0 ? round(big(x) * s, r) / s : round(big(x) / s, r) * s
+            return T <: BigFloat ? BigFloat(y; precision=precision(x)) : T(y)
+        end
+    end
+
+    # the rounded product used to land exactly on a rounding boundary
+    let x = float(2^53 - 4)
+        for f in (floor, ceil, trunc, round)
+            @test f(x; digits=1) === x
+        end
+    end
+    @test floor(2.52379309758e8; digits=3) === 2.52379309757e8
+    @test ceil(4.312747009431438e17; digits=-2) === nextfloat(4.312747009431438e17)
+    @test floor(0.29; digits=2) === 0.28
+    @test round(1.15; digits=1) === 1.1
+    @test round(2.675; digits=2) === 2.67
+    @test round(0.5; digits=0) === 0.0
+    @test round(1.5; digits=0) === 2.0
+    @test round(Float32(1.15); digits=1) === 1.1f0            # also below 1.15
+    @test round(1.25; digits=1) === 1.2                        # exact ties are still ties
+    @test round(1.25, RoundNearestTiesAway; digits=1) === 1.3
+    @test round(-1.25, RoundNearestTiesUp; digits=1) === -1.2
+    # signed zeros
+    @test round(-0.0; digits=2) === -0.0
+    @test round(-0.1; digits=0) === -0.0
+    @test ceil(-0.4; digits=0) === -0.0
+    @test trunc(-1e-320; digits=-5) === -0.0
+    @test floor(-1e-320; digits=-5) === -1e5
+
+    # the primitives: `hi + lo == round(x * y, r)` exactly, even when not representable
+    hilo(t::Base.TwicePrecision) = (t.hi, t.lo)
+    let x = 2.0^53 - 4, y = 10.0
+        for r in modes
+            n, m = hilo(Base._mul_round(x, y, r))
+            @test isinteger(n) && isinteger(m)
+            @test big(n) + big(m) == round(big(x) * big(y), r)
+        end
+        @test hilo(Base._mul_round(1.15, 10.0, RoundNearest)) == (11.0, 0.0)
+        for r in modes, y in (100.0, -100.0)
+            n, m = hilo(Base._div_round(4.312747009431438e17, y, r))
+            @test big(n) + big(m) == round(big(4.312747009431438e17) / y, r)
+            n, m = hilo(Base._div_round(2.0^60 + 2.0^8, y / 10, r))
+            @test big(n) + big(m) == round((big(2)^60 + 2^8) / (y / 10), r)
+        end
+        # `_mul_round` is exact at any magnitude; `_div_round` up to |x/y| < maxintfloat^2/4,
+        # and within its documented bound beyond that
+        rng = Random.MersenneTwister(0xf00d)
+        for _ in 1:20, r in modes
+            x = ldexp(rand(rng) + 1, rand(rng, 100:900)) * rand(rng, (-1.0, 1.0)); y = (rand(rng) + 1) * rand(rng, (-1.0, 1.0))
+            n, m = hilo(Base._mul_round(x, y, r))
+            @test big(n) + big(m) == round(big(x) * big(y), r)
+            x = ldexp(rand(rng) + 1, rand(rng, 60:80)) * rand(rng, (-1.0, 1.0)); y = ldexp(rand(rng) + 1, -20) * rand(rng, (-1.0, 1.0))
+            @test abs(x / y) < 2.0^104
+            n, m = hilo(Base._div_round(x, y, r))
+            @test big(n) + big(m) == round(big(x) / big(y), r)
+            x = ldexp(rand(rng) + 1, rand(rng, 120:200)) * rand(rng, (-1.0, 1.0))
+            n, m = hilo(Base._div_round(x, y, r))
+            @test abs(big(n) + big(m) - round(big(x) / big(y), r)) <= big(eps(m)) / 2 + 1
+        end
+        for r in modes
+            @test Base._mul_round(1e200, 1e200, r) === Base.TwicePrecision(Inf, 0.0)
+            @test isnan(Base._mul_round(NaN, 1.0, r).hi)
+            @test Base._div_round(1.0, 0.0, r) === Base.TwicePrecision(Inf, 0.0)
+            @test Base._div_round(-1.0, Inf, r) === Base.TwicePrecision(-0.0, 0.0)
+        end
+    end
+
+    # sweep against the exact reference, including magnitudes where the scaled value is
+    # not representable, and where the result is x itself
+    rng = Random.MersenneTwister(0xc0ffee)
+    for (T, exps, ds) in ((Float64, -20:70, -4:4), (Float32, -20:40, -3:3), (Float16, -8:15, -2:2),
+                          (Float64, 1000:1023, 0:3), (Float64, -1074:-1040, -2:2),
+                          (Float64, -50:20, 15:22), (Float64, 40:120, -22:-15)),
+        _ in 1:150
+        x = T(ldexp(rand(rng) + 1, rand(rng, exps))) * rand(rng, (-one(T), one(T)))
+        for d in ds
+            @test floor(x; digits=d) <= x <= ceil(x; digits=d)
+            @test abs(trunc(x; digits=d)) <= abs(x)
+            for r in modes
+                @test round(x, r; digits=d) === refround(x, r, d)
+            end
+        end
+    end
+    for base in (2, 3, 16), _ in 1:50
+        x = ldexp(rand(rng) + 1, rand(rng, -10:60)) * rand(rng, (-1.0, 1.0))
+        for d in -3:6, r in modes
+            @test round(x, r; digits=d, base=base) === refround(x, r, d, base)
+        end
+    end
+
+    # BigFloat
+    setprecision(BigFloat, 256) do
+        x = big(2)^300 - big(2)^248
+        for f in (floor, ceil, trunc, round)
+            @test f(x; digits=1) == x
+        end
+        for _ in 1:30
+            x = ldexp(1 + big(rand(rng)) + big(rand(rng)) * big(2)^-53 + big(rand(rng)) * big(2)^-106 + big(rand(rng)) * big(2)^-159,
+                      rand(rng, -20:300)) * rand(rng, (-1, 1))
+            for d in (-3, -1, 0, 1, 3, 20, 60), r in modes
+                y = round(x, r; digits=d)
+                @test y == refround(x, r, d)
+                @test signbit(y) == signbit(refround(x, r, d))
+            end
+        end
+    end
 end
 @testset "rounding with too much (or too few) precision" begin
     for x in (12345.6789, 0, -12345.6789)


### PR DESCRIPTION
This fixes https://github.com/JuliaLang/julia/issues/63040, and also fixes a subtle case mentioned in the docstring of `round`:

```
  │ Note
  │
  │  Rounding to specified digits in bases other than 2 can be inexact when
  │  operating on binary floating point numbers. For example, the Float64 value
  │  represented by 1.15 is actually less than 1.15, yet will be rounded to 1.2.
  │  For example:
  │
  │  julia> x = 1.15
  │  1.15
  │  
  │  julia> big(1.15)
  │  1.149999999999999911182158029987476766109466552734375
  │  
  │  julia> x < 115//100
  │  true
  │  
  │  julia> round(x, digits=1)
  │  1.2
```

The idea is to basically use the TwicePrecision machinery and some other stuff to always faithfully round in the right direction (provided `base^digits` is a number we can represent). Following @adienes's suggestion, I added `_mul_round` and `_div_round` functions which implement "multiply and round" and "divide and round" more accurately. If people think there's a case for making these public, I can do so.  
 
__________

Measured on my machine, this change has a small but real impact on performance. For example:
```julia
using BenchmarkTools
@benchmark round(x; digits=1) setup=x=rand(Int)/rand(Int)
```
Before:
```
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  4.588 ns … 39.294 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.769 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.012 ns ±  0.961 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▄▆▅▆█▁                                            ▂ ▁▁▂  ▂ ▁
  ██████▄▄▃▄▃▂▂▂▂▄▃▂▂▃▄▄▄▂▅▄▄▃▅▅▄▅▃▄▅▅▄▅▆▅▆▆▆▇▆▆▆▅▅▅█▆███▅▅█ █
  4.59 ns      Histogram: log(frequency) by time      7.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
After:
```julia
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  6.402 ns … 15.078 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.613 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.630 ns ±  0.346 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▁ ▃ ▁         ▁  ▂     ▂     ▂▁ ▃   ▃ ▆ ▃   ▇▇ █ ▁   ▂     ▂
  █▁█▁█▁▃▁▁▁▁▁▁▁█▆▁█▁▆▁█▁█▁█▁▁▁██▁█▁▅▁█▁█▁█▁▆▆██▁█▁█▁█▁█▁█▁▃ █
  6.4 ns       Histogram: log(frequency) by time     6.67 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

and
```julia
using BenchmarkTools
@benchmark round(x; digits=1) setup=(x=rand(Int))
```
Before:
```
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  4.718 ns … 36.599 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.879 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.912 ns ±  0.593 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

       █▄                                                     
  ▃▃▂▃▃██▂▂▂▁▁▁▁▁▂▁▂▂▂▂▂▂▁▁▂▁▁▁▁▁▁▂▂▂▁▂▂▂▂▂▂▁▂▁▂▂▁▂▂▂▁▁▁▂▂▂▂ ▂
  4.72 ns        Histogram: frequency by time        6.33 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
After:
```
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  5.750 ns … 12.814 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.941 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.965 ns ±  0.369 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

       █                                                      
  ▃▂▂▃▅█▂▂▂▁▁▂▂▁▁▂▁▁▂▂▁▂▁▂▁▁▁▁▂▁▁▁▁▁▂▁▂▁▂▂▂▁▁▂▂▂▂▁▂▂▂▂▂▂▁▁▁▂ ▂
  5.75 ns        Histogram: frequency by time        7.92 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Assisted by Claude Code (Fable 5.1)