### PR TITLE
Compiler: Avoid `PartialStruct` constructor invalidations

### DIFF
--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -777,13 +777,13 @@ end
 # type.
 
 # Legacy constructor
-function Core.PartialStruct(𝕃::AbstractLattice, @nospecialize(typ), fields::Vector{Any})
+function Core.PartialStruct(𝕃::AbstractLattice, @nospecialize(typ::Type), fields::Vector{Any})
     undefs = partialstruct_init_undefs(typ, fields)
     undefs === nothing && error("This object never exists at runtime")
     return PartialStruct(𝕃, typ, undefs, fields)
 end
 
-function Core.PartialStruct(::AbstractLattice, @nospecialize(typ), undefs::Vector{Union{Nothing,Bool}}, fields::Vector{Any})
+function Core.PartialStruct(::AbstractLattice, @nospecialize(typ::Type), undefs::Vector{Union{Nothing,Bool}}, fields::Vector{Any})
     for i = 1:length(fields)
         assert_nested_slotwrapper(fields[i])
     end


### PR DESCRIPTION
The signature of the legacy lattice-aware wrapper

```julia
PartialStruct(𝕃::AbstractLattice, typ::Any, fields::Vector{Any})
```

overlaps the following inferred call signature for the core
constructor:

```julia
PartialStruct(
    typ::Any, undefs::Vector{Union{Nothing,Bool}}, fields::Vector{Any},
)
```

Loading a separate compiler implementation as the `Compiler` stdlib can therefore invalidate cached inference code in `Base.Compiler`.

This change constrains `typ` to `Type` in both lattice-aware wrappers, matching the core constructor's existing contract while retaining support for `UnionAll` types.