### PR TITLE
devdocs: document Backporter-era manual backport workflow

### DIFF
--- a/doc/src/devdocs/build/distributing.md
+++ b/doc/src/devdocs/build/distributing.md
@@ -160,55 +160,26 @@ Creating a point/patch release consists of several distinct steps.
 
 ## Backporting commits
 
-Some pull requests are labeled "backport pending x.y", e.g. "backport pending 0.6".
-This designates that the next subsequent release tagged from the release-x.y branch
+Some pull requests are labeled `backport x.y`, e.g. `backport 1.13`.
+This designates that the next release tagged from the release-x.y branch
 should include the commit(s) in that pull request.
-Once the pull request is merged into master, each of the commits should be [cherry
-picked](https://git-scm.com/docs/git-cherry-pick) to a dedicated branch that will
-ultimately be merged into release-x.y.
+Once the pull request is merged into master, its commits are cherry-picked onto the
+`backports-release-x.y` branch, which will ultimately be merged into release-x.y.
 
-### Creating a backports branch
-
-First, create a new branch based on release-x.y.
-The typical convention for Julia branches is to prefix the branch name with your
-initials if it's intended to be a personal branch.
-For the sake of example, we'll say that the author of the branch is Jane Smith.
+Most of this is done by [Backporter](https://github.com/KristofferC/Backporter), which
+also maintains a checklist of backported and still-pending pull requests in the pull
+request associated with `backports-release-x.y`.
+Commits that do not apply cleanly are backported by hand with
 
 ```
-git fetch origin
-git checkout release-x.y
-git rebase origin/release-x.y
-git checkout -b js/backport-x.y
+git cherry-pick -x <sha>
 ```
 
-This ensures that your local copy of release-x.y is up to date with origin before
-you create a new branch from it.
-
-### Cherry picking commits
-
-Now we do the actual backporting.
-Find all merged pull requests labeled "backport pending x.y" in the GitHub web UI.
-For each of these, scroll to the bottom where it says "someperson merged commit
-`123abc` into `master` XX minutes ago".
-Note that the commit name is a link; if you click it, you'll be shown the contents
-of the commit.
-If this page shows that `123abc` is a merge commit, go back to the PR page---we
-don't want merge commits, we want the actual commits.
-However, if this does not show a merge commit, it means that the PR was squash-merged.
-In that case, use the git SHA of the commit, listed next to commit on this page.
-
-Once you have the SHA of the commit, cherry-pick it onto the backporting branch:
-
-```
-git cherry-pick -x -e <sha>
-```
-
-There may be conflicts which need to be resolved manually.
-Once conflicts are resolved (if applicable), add a reference to the GitHub pull
-request that introduced the commit in the body of the commit message.
-
-After all of the relevant commits are on the backports branch, push the branch to
-GitHub.
+resolving conflicts as needed.
+The `-x` flag records the original commit in the message, which is how Backporter
+recognizes the commit as backported.
+See [Contributing to patch releases](@ref) for what to cherry-pick and how to contribute
+a manual backport.
 
 ## Checking for performance regressions
 
@@ -276,8 +247,10 @@ After you have ensured that
 * the backported commits do not break any registered packages,
 
 then the backport branch is ready to be merged into release-x.y.
-Once it's merged, go through and remove the "backport pending x.y" label from all pull
-requests containing the commits that have been backported.
+Once it's merged, remove the `backport x.y` label from all pull requests whose commits
+have been backported.
+Backporter's audit mode does this; it is available as the manually triggered
+`Backport Label Audit` GitHub Actions workflow.
 Do not remove the label from PRs that have not been backported.
 
 The release-x.y branch should now contain all of the new commits.

--- a/doc/src/devdocs/contributing/patch-releases.md
+++ b/doc/src/devdocs/contributing/patch-releases.md
@@ -27,18 +27,42 @@ The process of [creating a patch release](https://docs.julialang.org/en/v1/devdo
    next prerelease patch version, e.g. as in [this pull request](https://github.com/JuliaLang/julia/pull/37724).
 
 Step 2 above, i.e. backporting commits to the `backports-release-X.Y` branch, has largely
-been automated via [`Backporter`](https://github.com/KristofferC/Backporter): Backporter
-searches for merged pull requests with the relevant `backport-X.Y` tag, and attempts to
-cherry-pick the commits from those pull requests onto the `backports-release-X.Y` branch.
-Some commits apply successfully without intervention, others not so much. The latter
-commits require "manual" backporting, with which help is generally much appreciated.
-Backporter generates a report identifying those commits it managed to backport automatically
-and those that require manual backporting; this report is usually copied into the first
-post of the pull request associated with `backports-release-X.Y` and maintained as
-additional commits are automatically and/or manually backported.
+been automated via [`Backporter`](https://github.com/KristofferC/Backporter). A pull request
+is marked for backporting by adding the `backport X.Y` label. Backporter searches for merged
+pull requests carrying that label and cherry-picks their commits onto `backports-release-X.Y`.
+Some commits apply cleanly without intervention, others do not. The latter require "manual"
+backporting, with which help is generally much appreciated.
 
-When contributing a manual backport, if you have the necessary permissions, please push the
-backport directly to the `backports-release-X.Y` branch. If you lack the relevant
-permissions, please open a pull request against the `backports-release-X.Y` branch with the
-manual backport. Once the manual backport is live on the `backports-release-X.Y` branch,
-please remove the `backport-X.Y` tag from the originating pull request for the commits.
+Backporter maintains a checklist in the first post of the pull request associated with
+`backports-release-X.Y` (between `<!-- BACKPORTER:BEGIN -->` and `<!-- BACKPORTER:END -->`
+markers), listing the pull requests it backported, those that need a manual backport, and
+labeled pull requests that are not merged yet. The checklist is regenerated from the state
+of the branch on every run, so it does not need to be edited by hand.
+
+## Manual backports
+
+Backporter recognizes a pull request as already backported when a commit on
+`backports-release-X.Y`
+
+- has the pull request number in its subject line, e.g. `Fix foo (#12345)`, or
+- has a `(cherry picked from commit <sha>)` trailer naming the merge commit or one of the
+  pull request's commits, or
+- carries the same patch as one of the pull request's commits.
+
+A manual backport made with `git cherry-pick -x <sha>` that keeps the original subject
+line satisfies the first two, whether it reaches the branch by direct push or by merging a
+separate pull request.
+
+If you have the necessary permissions, push the manual backport directly to the
+`backports-release-X.Y` branch. Otherwise open a pull request against
+`backports-release-X.Y`, based on its current tip (the branch may be rebased or
+force-pushed while backports are collected), and mention the original pull request in
+the title, e.g. `[release-X.Y] Fix foo (#12345)`. Nothing else is required: no comment on
+the backports pull request, and no edit of its checklist; Backporter picks up the change
+the next time it runs.
+
+The `backport X.Y` label is removed once the backport has been released, i.e. once the
+commit is on `release-X.Y`. Backporter's audit mode (`--audit --apply`) does this, and is
+available to maintainers as the manually triggered `Backport Label Audit` GitHub Actions
+workflow. Removing the label by hand after the manual backport is on
+`backports-release-X.Y` is harmless but not necessary.


### PR DESCRIPTION
The contributor docs on patch releases predate the current Backporter tooling and disagreed with each other. `patch-releases.md` said the tracking-PR report is copied by hand and that contributors remove the `backport X.Y` label once a manual backport is on the backports branch; `distributing.md` still described collecting every labeled PR by hand on a personal branch, used the old "backport pending x.y" label name, and said labels are removed only after the merge into `release-x.y`.

Describe what happens today: Backporter regenerates the checklist in the backports PR from branch state, recognizes already-backported commits by the PR number in the subject, the `cherry picked from` trailer, or the patch itself, and removes labels in audit mode (the `Backport Label Audit` workflow). Spell out what a contributor of a manual backport has to do (cherry-pick with `-x`, push or open a PR against the backports branch) and what they do not (comment on the backports PR, edit its checklist, remove the label).

Assisted-by: Claude Code (Fable 5.1)