### PR TITLE
REPL: Add semantic prompt markers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -211,6 +211,8 @@ Standard library changes
 
 #### REPL
 
+* The Julia REPL now emits OSC 133 semantic prompt markers for terminal integration.
+
 #### Sockets
 
 * `getsockname` now also accepts a `UDPSocket`, returning the address and port it is bound to ([#63091]).

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -225,6 +225,8 @@ Use of this file can be disabled at startup by passing the `--history-file=no` f
 The interactive REPL emits OSC 133 semantic prompt markers. Terminals that support these markers
 can identify prompts, input, and output, enabling features such as navigating between prompts and
 selecting a command's output. Unsupported terminals ignore the markers.
+In the VS Code integrated terminal, the REPL also reports the exact command line so that commands
+can be copied together with their output.
 
 Semantic prompt markers can be disabled in `startup.jl`:
 

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -228,6 +228,9 @@ selecting a command's output. Unsupported terminals ignore the markers.
 In the VS Code integrated terminal, the REPL also reports the exact command line so that commands
 can be copied together with their output.
 
+Output from background tasks while the REPL is waiting for input is not bracketed by command
+markers, so terminals may associate it with the prompt rather than the command that started the task.
+
 Semantic prompt markers can be disabled in `startup.jl`:
 
 ```julia

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -220,6 +220,20 @@ and the current REPL mode you were in. The history searcher reads this log file 
 Multiple REPLs can write to this file at once, and every time you begin a search the newest history is fetched.
 Use of this file can be disabled at startup by passing the `--history-file=no` flag to Julia.
 
+## Terminal integration
+
+The interactive REPL emits OSC 133 semantic prompt markers. Terminals that support these markers
+can identify prompts, input, and output, enabling features such as navigating between prompts and
+selecting a command's output. Unsupported terminals ignore the markers.
+
+Semantic prompt markers can be disabled in `startup.jl`:
+
+```julia
+atreplinit() do repl
+    repl.options.semantic_prompts = false
+end
+```
+
 ## Key bindings
 
 The Julia REPL makes great use of key bindings. Several control-key bindings were already introduced

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -330,8 +330,8 @@ options(s::PromptState) =
         REPL.GlobalOptions::Options
     end
 
-semantic_prompts_enabled(p::Prompt) =
-    isdefined(p, :repl) && p.repl !== nothing && REPL.semantic_prompts_enabled(p.repl)
+semantic_prompt_markers(p::Prompt) =
+    isdefined(p, :repl) && p.repl !== nothing ? REPL.semantic_prompt_markers(p.repl) : nothing
 
 function setmark(s::MIState, guess_region_active::Bool=true)
     refresh = set_action!(s, :setmark)
@@ -1906,10 +1906,16 @@ default_completion_cb(::IOBuffer) = []
 default_enter_cb(_) = true
 
 function write_prompt(terminal::AbstractTerminal, s::PromptState, color::Bool)
-    semantic_prompts = semantic_prompts_enabled(s.p)
-    semantic_prompts && write(terminal, REPL.OSC_133_PROMPT_START)
+    markers = semantic_prompt_markers(s.p)
+    # Prompt rendering runs on every line refresh. Re-emitting these markers keeps
+    # the redrawn prompt bracketed and matches established shell integrations.
+    if markers !== nothing
+        write(terminal, markers.prompt_start)
+    end
     width = write_prompt(terminal, s.p, color)
-    semantic_prompts && write(terminal, REPL.OSC_133_PROMPT_END)
+    if markers !== nothing
+        write(terminal, markers.prompt_end)
+    end
     return width
 end
 function write_prompt(terminal::AbstractTerminal, p::Prompt, color::Bool)
@@ -3146,8 +3152,9 @@ function run_interface(terminal::TextTerminal, m::ModalInterface, s::MIState=ini
                 refresh_line(s)
                 print(terminal(s), "^C\n\n")
                 current_mode = mode(s)
-                if current_mode isa Prompt && semantic_prompts_enabled(current_mode)
-                    write(terminal(s), REPL.OSC_133_COMMAND_FINISH)
+                markers = current_mode isa Prompt ? semantic_prompt_markers(current_mode) : nothing
+                if markers !== nothing
+                    write(terminal(s), markers.command_finish)
                 end
                 transition(s, :reset)
                 refresh_line(s)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -330,6 +330,9 @@ options(s::PromptState) =
         REPL.GlobalOptions::Options
     end
 
+semantic_prompts_enabled(p::Prompt) =
+    isdefined(p, :repl) && p.repl !== nothing && REPL.semantic_prompts_enabled(p.repl)
+
 function setmark(s::MIState, guess_region_active::Bool=true)
     refresh = set_action!(s, :setmark)
     s.current_action === :setmark && s.key_repeats > 0 && activate_region(s, :mark)
@@ -1902,7 +1905,13 @@ refresh_line(s::BufferLike, termbuf::AbstractTerminal) = refresh_multi_line(term
 default_completion_cb(::IOBuffer) = []
 default_enter_cb(_) = true
 
-write_prompt(terminal::AbstractTerminal, s::PromptState, color::Bool) = write_prompt(terminal, s.p, color)
+function write_prompt(terminal::AbstractTerminal, s::PromptState, color::Bool)
+    semantic_prompts = semantic_prompts_enabled(s.p)
+    semantic_prompts && write(terminal, REPL.OSC_133_PROMPT_START)
+    width = write_prompt(terminal, s.p, color)
+    semantic_prompts && write(terminal, REPL.OSC_133_PROMPT_END)
+    return width
+end
 function write_prompt(terminal::AbstractTerminal, p::Prompt, color::Bool)
     prefix = prompt_string(p.prompt_prefix)
     suffix = prompt_string(p.prompt_suffix)
@@ -3136,6 +3145,10 @@ function run_interface(terminal::TextTerminal, m::ModalInterface, s::MIState=ini
                 move_input_end(s)
                 refresh_line(s)
                 print(terminal(s), "^C\n\n")
+                current_mode = mode(s)
+                if current_mode isa Prompt && semantic_prompts_enabled(current_mode)
+                    write(terminal(s), REPL.OSC_133_COMMAND_FINISH)
+                end
                 transition(s, :reset)
                 refresh_line(s)
             catch

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1905,20 +1905,14 @@ refresh_line(s::BufferLike, termbuf::AbstractTerminal) = refresh_multi_line(term
 default_completion_cb(::IOBuffer) = []
 default_enter_cb(_) = true
 
-function write_prompt(terminal::AbstractTerminal, s::PromptState, color::Bool)
-    markers = semantic_prompt_markers(s.p)
+write_prompt(terminal::AbstractTerminal, s::PromptState, color::Bool) = write_prompt(terminal, s.p, color)
+function write_prompt(terminal::AbstractTerminal, p::Prompt, color::Bool)
+    markers = semantic_prompt_markers(p)
     # Prompt rendering runs on every line refresh. Re-emitting these markers keeps
     # the redrawn prompt bracketed and matches established shell integrations.
     if markers !== nothing
         write(terminal, markers.prompt_start)
     end
-    width = write_prompt(terminal, s.p, color)
-    if markers !== nothing
-        write(terminal, markers.prompt_end)
-    end
-    return width
-end
-function write_prompt(terminal::AbstractTerminal, p::Prompt, color::Bool)
     prefix = prompt_string(p.prompt_prefix)
     suffix = prompt_string(p.prompt_suffix)
     write(terminal, prefix)
@@ -1926,6 +1920,9 @@ function write_prompt(terminal::AbstractTerminal, p::Prompt, color::Bool)
     width = write_prompt(terminal, p.prompt, color)
     color && write(terminal, Base.text_colors[:normal])
     write(terminal, suffix)
+    if markers !== nothing
+        write(terminal, markers.prompt_end)
+    end
     return width
 end
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -70,6 +70,15 @@ include("options.jl")
 include("StylingPasses.jl")
 using .StylingPasses
 
+const OSC_133_PROMPT_START = "\e]133;A\a"
+const OSC_133_PROMPT_END = "\e]133;B\a"
+const OSC_133_COMMAND_START = "\e]133;C\a"
+const OSC_133_COMMAND_FINISH = "\e]133;D\a"
+const OSC_133_COMMAND_FINISH_OK = "\e]133;D;0\a"
+const OSC_133_COMMAND_FINISH_ERROR = "\e]133;D;1\a"
+
+semantic_prompts_enabled(::AbstractREPL) = false
+
 function histsearch end # To work around circular dependency
 
 include("LineEdit.jl")
@@ -855,6 +864,7 @@ specialdisplay(r::LineEditREPL) = r.specialdisplay
 specialdisplay(r::AbstractREPL) = nothing
 terminal(r::LineEditREPL) = r.t
 hascolor(r::LineEditREPL) = r.hascolor
+semantic_prompts_enabled(r::LineEditREPL) = r.options.semantic_prompts
 
 LineEditREPL(t::TextTerminal, hascolor::Bool, envcolors::Bool=false) =
     LineEditREPL(t, hascolor,
@@ -1243,12 +1253,15 @@ end
 
 function respond(f, repl, main; pass_empty::Bool = false, suppress_on_semicolon::Bool = true)
     return function do_respond(s::MIState, buf, ok::Bool)
+        semantic_prompts = semantic_prompts_enabled(repl)
         if !ok
+            semantic_prompts && write(terminal(repl), OSC_133_COMMAND_FINISH)
             return transition(s, :abort)
         end
         line = String(take!(buf)::Vector{UInt8})
         if !isempty(line) || pass_empty
             reset(repl)
+            semantic_prompts && write(terminal(repl), OSC_133_COMMAND_START)
             local response
             try
                 ast = Base.invokelatest(f, line)
@@ -1257,7 +1270,16 @@ function respond(f, repl, main; pass_empty::Bool = false, suppress_on_semicolon:
                 response = Pair{Any, Bool}(current_exceptions(), true)
             end
             hide_output = suppress_on_semicolon && ends_with_semicolon(line)
-            print_response(repl, response, !hide_output, hascolor(repl))
+            try
+                print_response(repl, response, !hide_output, hascolor(repl))
+            finally
+                if semantic_prompts
+                    marker = response[2] ? OSC_133_COMMAND_FINISH_ERROR : OSC_133_COMMAND_FINISH_OK
+                    write(terminal(repl), marker)
+                end
+            end
+        elseif semantic_prompts
+            write(terminal(repl), OSC_133_COMMAND_FINISH)
         end
         prepare_next(repl)
         reset_state(s)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -70,6 +70,11 @@ include("options.jl")
 include("StylingPasses.jl")
 using .StylingPasses
 
+# OSC 133/633 lifecycle markers:
+# A: prompt starts; B: prompt ends and command input starts;
+# C: command execution/output starts; D: command finishes, optionally with an exit status
+# (0 for success, 1 for an error; no status for input cancelled or left empty).
+# VS Code's OSC 633 also supports E to report the explicit command line.
 struct SemanticPromptMarkers
     prompt_start::String
     prompt_end::String
@@ -1321,9 +1326,11 @@ function respond(f, repl, main; pass_empty::Bool = false, suppress_on_semicolon:
                 print_response(repl, response, !hide_output, hascolor(repl))
             finally
                 if markers !== nothing
-                    # Julia cannot access VS Code's nonce, so its command-line report is
-                    # untrusted and gets replaced when execution starts. Report it again
-                    # immediately before marking the command as finished.
+                    # VS Code documents E between B and C, but without its nonce an
+                    # untrusted command-line report gets replaced when execution starts.
+                    # Send E just before D instead, relying on VS Code's implementation:
+                    # setCommandLine updates the current command, which
+                    # handleCommandFinished then promotes to a completed command.
                     write_semantic_command_line(repl, markers, line)
                     marker = response[2] ? markers.command_finish_error : markers.command_finish_ok
                     write(terminal(repl), marker)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -70,14 +70,54 @@ include("options.jl")
 include("StylingPasses.jl")
 using .StylingPasses
 
-const OSC_133_PROMPT_START = "\e]133;A\a"
-const OSC_133_PROMPT_END = "\e]133;B\a"
-const OSC_133_COMMAND_START = "\e]133;C\a"
-const OSC_133_COMMAND_FINISH = "\e]133;D\a"
-const OSC_133_COMMAND_FINISH_OK = "\e]133;D;0\a"
-const OSC_133_COMMAND_FINISH_ERROR = "\e]133;D;1\a"
+struct SemanticPromptMarkers
+    prompt_start::String
+    prompt_end::String
+    command_start::String
+    command_finish::String
+    command_finish_ok::String
+    command_finish_error::String
+    command_line::Union{Nothing,String}
+end
 
-semantic_prompts_enabled(::AbstractREPL) = false
+# FinalTerm semantic prompt protocol:
+# https://iterm2.com/documentation-escape-codes.html
+const OSC_133_MARKERS = SemanticPromptMarkers(
+    "\e]133;A\a", "\e]133;B\a", "\e]133;C\a", "\e]133;D\a",
+    "\e]133;D;0\a", "\e]133;D;1\a", nothing,
+)
+# VS Code shell integration protocol:
+# https://code.visualstudio.com/docs/terminal/shell-integration#_supported-escape-sequences
+const OSC_633_MARKERS = SemanticPromptMarkers(
+    "\e]633;A\a", "\e]633;B\a", "\e]633;C\a", "\e]633;D\a",
+    "\e]633;D;0\a", "\e]633;D;1\a", "\e]633;E;",
+)
+
+semantic_prompt_markers(::AbstractREPL) = nothing
+default_semantic_prompt_markers() =
+    get(ENV, "TERM_PROGRAM", "") == "vscode" ? OSC_633_MARKERS : OSC_133_MARKERS
+
+function serialize_vscode_osc_message(message::AbstractString)
+    io = IOBuffer()
+    for byte in codeunits(message)
+        if byte == UInt8('\\')
+            write(io, "\\\\")
+        elseif byte == UInt8(';') || byte <= 0x20
+            write(io, "\\x", string(byte, base=16, pad=2))
+        else
+            write(io, byte)
+        end
+    end
+    return String(take!(io))
+end
+
+function write_semantic_command_line(
+    repl::AbstractREPL, markers::SemanticPromptMarkers, line::AbstractString,
+)
+    markers.command_line === nothing && return
+    write(terminal(repl), markers.command_line, serialize_vscode_osc_message(line), '\a')
+    return
+end
 
 function histsearch end # To work around circular dependency
 
@@ -842,6 +882,7 @@ mutable struct LineEditREPL <: AbstractREPL
     options::Options
     mistate::Union{MIState,Nothing}
     last_shown_line_infos::Vector{Tuple{String,Int}}
+    semantic_prompt_markers::SemanticPromptMarkers
     interface::ModalInterface
     backendref::REPLBackendRef
     frontend_task::Task
@@ -854,7 +895,7 @@ mutable struct LineEditREPL <: AbstractREPL
             opts.beep_colors = [""]
         end
         r = new(t,hascolor,prompt_color,input_color,answer_color,shell_color,help_color,pkg_color,history_file,in_shell,
-            in_help,envcolors,false,nothing, opts, nothing, Tuple{String,Int}[])
+            in_help,envcolors,false,nothing, opts, nothing, Tuple{String,Int}[], default_semantic_prompt_markers())
         r.prompt_ready_event = nothing
         r
     end
@@ -864,7 +905,8 @@ specialdisplay(r::LineEditREPL) = r.specialdisplay
 specialdisplay(r::AbstractREPL) = nothing
 terminal(r::LineEditREPL) = r.t
 hascolor(r::LineEditREPL) = r.hascolor
-semantic_prompts_enabled(r::LineEditREPL) = r.options.semantic_prompts
+semantic_prompt_markers(r::LineEditREPL) =
+    r.options.semantic_prompts ? r.semantic_prompt_markers : nothing
 
 LineEditREPL(t::TextTerminal, hascolor::Bool, envcolors::Bool=false) =
     LineEditREPL(t, hascolor,
@@ -1253,15 +1295,20 @@ end
 
 function respond(f, repl, main; pass_empty::Bool = false, suppress_on_semicolon::Bool = true)
     return function do_respond(s::MIState, buf, ok::Bool)
-        semantic_prompts = semantic_prompts_enabled(repl)
+        current_mode = LineEdit.mode(s)
+        markers = current_mode isa Prompt ? LineEdit.semantic_prompt_markers(current_mode) : nothing
         if !ok
-            semantic_prompts && write(terminal(repl), OSC_133_COMMAND_FINISH)
+            if markers !== nothing
+                write(terminal(repl), markers.command_finish)
+            end
             return transition(s, :abort)
         end
         line = String(take!(buf)::Vector{UInt8})
         if !isempty(line) || pass_empty
             reset(repl)
-            semantic_prompts && write(terminal(repl), OSC_133_COMMAND_START)
+            if markers !== nothing
+                write(terminal(repl), markers.command_start)
+            end
             local response
             try
                 ast = Base.invokelatest(f, line)
@@ -1273,13 +1320,17 @@ function respond(f, repl, main; pass_empty::Bool = false, suppress_on_semicolon:
             try
                 print_response(repl, response, !hide_output, hascolor(repl))
             finally
-                if semantic_prompts
-                    marker = response[2] ? OSC_133_COMMAND_FINISH_ERROR : OSC_133_COMMAND_FINISH_OK
+                if markers !== nothing
+                    # Julia cannot access VS Code's nonce, so its command-line report is
+                    # untrusted and gets replaced when execution starts. Report it again
+                    # immediately before marking the command as finished.
+                    write_semantic_command_line(repl, markers, line)
+                    marker = response[2] ? markers.command_finish_error : markers.command_finish_ok
                     write(terminal(repl), marker)
                 end
             end
-        elseif semantic_prompts
-            write(terminal(repl), OSC_133_COMMAND_FINISH)
+        elseif markers !== nothing
+            write(terminal(repl), markers.command_finish)
         end
         prepare_next(repl)
         reset_state(s)

--- a/stdlib/REPL/src/options.jl
+++ b/stdlib/REPL/src/options.jl
@@ -30,7 +30,7 @@ mutable struct Options
     hint_tab_completes::Bool
     auto_insert_closing_bracket::Bool # automatically insert closing brackets, quotes, etc.
     style_input::Bool # enable syntax highlighting for input
-    semantic_prompts::Bool # emit OSC 133 markers for terminal integration
+    semantic_prompts::Bool # emit semantic prompt markers for terminal integration
     # default IOContext settings at the REPL
     iocontext::Dict{Symbol,Any}
 end

--- a/stdlib/REPL/src/options.jl
+++ b/stdlib/REPL/src/options.jl
@@ -30,6 +30,7 @@ mutable struct Options
     hint_tab_completes::Bool
     auto_insert_closing_bracket::Bool # automatically insert closing brackets, quotes, etc.
     style_input::Bool # enable syntax highlighting for input
+    semantic_prompts::Bool # emit OSC 133 markers for terminal integration
     # default IOContext settings at the REPL
     iocontext::Dict{Symbol,Any}
 end
@@ -53,6 +54,7 @@ Options(;
         hint_tab_completes = true,
         auto_insert_closing_bracket = true,
         style_input = true,
+        semantic_prompts = true,
         iocontext = Dict{Symbol,Any}()) =
             Options(hascolor, extra_keymap, tabwidth,
                     kill_ring_max, region_animation_duration,
@@ -61,7 +63,7 @@ Options(;
                     backspace_align, backspace_adjust, confirm_exit,
                     auto_indent, auto_indent_tmp_off, auto_indent_bracketed_paste,
                     auto_indent_time_threshold, auto_refresh_time_delay,
-                    hint_tab_completes, auto_insert_closing_bracket, style_input,
+                    hint_tab_completes, auto_insert_closing_bracket, style_input, semantic_prompts,
                     iocontext)
 
 # for use by REPLs not having an options field

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -20,6 +20,29 @@ function new_state()
     LineEdit.init_state(term, LineEdit.ModalInterface([LineEdit.Prompt("test> ")]))
 end
 
+# Normal and prefix history search prompts emit one marker pair without changing their width.
+@testset "semantic prompt rendering" begin
+    for markers in (REPL.OSC_133_MARKERS, REPL.OSC_633_MARKERS),
+            enabled in (false, true), color in (false, true)
+        output = IOBuffer()
+        term = FakeTerminal(IOBuffer(), output, IOBuffer(), color)
+        repl = REPL.LineEditREPL(term, color)
+        repl.semantic_prompt_markers = markers
+        repl.options.semantic_prompts = enabled
+        prompt = LineEdit.Prompt("julia> "; repl)
+        prefix_prompt = LineEdit.PrefixHistoryPrompt(prompt.hist, prompt)
+        rendered = color ? Base.text_colors[:bold] * "julia> " * Base.text_colors[:normal] : "julia> "
+        expected = enabled ? markers.prompt_start * rendered * markers.prompt_end : rendered
+        for state in (prompt, LineEdit.init_state(term, prompt), LineEdit.init_state(term, prefix_prompt))
+            @test LineEdit.write_prompt(term, state, color) == 7
+            @test String(take!(output)) == expected
+        end
+        prompt.repl = nothing
+        @test LineEdit.write_prompt(term, prompt, color) == 7
+        @test String(take!(output)) == rendered
+    end
+end
+
 # History search initializes prompt modes added after MIState creation (#61584).
 module HistorySearchDynamicMode
 

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -66,7 +66,10 @@ end
 #end
 
 # REPL tests
-function fake_repl(@nospecialize(f); options::REPL.Options=REPL.Options(confirm_exit=false,style_input=false,auto_insert_closing_bracket=false))
+function fake_repl(@nospecialize(f);
+        options::REPL.Options=REPL.Options(confirm_exit=false, style_input=false,
+            auto_insert_closing_bracket=false),
+        semantic_prompts::Bool=false)
     # Use pipes so we can easily do blocking reads
     # In the future if we want we can add a test that the right object
     # gets displayed by intercepting the display
@@ -79,6 +82,7 @@ function fake_repl(@nospecialize(f); options::REPL.Options=REPL.Options(confirm_
 
     repl = REPL.LineEditREPL(FakeTerminal(input.out, output.in, err.in, options.hascolor), options.hascolor)
     repl.options = options
+    repl.options.semantic_prompts = semantic_prompts
 
     hard_kill = kill_timer(900) # Your debugging session starts now. You have 15 minutes. Go.
     f(input.in, output.out, repl)
@@ -92,6 +96,38 @@ function fake_repl(@nospecialize(f); options::REPL.Options=REPL.Options(confirm_
     Base.wait(t)
     close(hard_kill)
     nothing
+end
+
+# Semantic prompt markers delimit prompt input and output and report evaluation status.
+@test REPL.Options().semantic_prompts
+fake_repl(semantic_prompts=true) do stdin_write, stdout_read, repl
+    repl.specialdisplay = REPL.REPLDisplay(repl)
+    repl.history_file = false
+    repltask = @async REPL.run_repl(repl)
+
+    prompt = readuntil(stdout_read, REPL.OSC_133_PROMPT_END, keep=true)
+    @test occursin(REPL.OSC_133_PROMPT_START, prompt)
+
+    global semantic_prompt_output = repl.t
+    command = "print($(curmod_prefix)semantic_prompt_output, \"semantic output\"); nothing\n"
+    write(stdin_write, command)
+    response = readuntil(stdout_read, REPL.OSC_133_COMMAND_FINISH_OK, keep=true)
+    @test occursin(REPL.OSC_133_COMMAND_START * "semantic output", response)
+    readuntil(stdout_read, REPL.OSC_133_PROMPT_END)
+
+    write(stdin_write, "error(\"semantic failure\")\n")
+    response = readuntil(stdout_read, REPL.OSC_133_COMMAND_FINISH_ERROR, keep=true)
+    @test occursin(REPL.OSC_133_COMMAND_START, response)
+    @test occursin("semantic failure", response)
+    readuntil(stdout_read, REPL.OSC_133_PROMPT_END)
+
+    write(stdin_write, '\n')
+    readuntil(stdout_read, REPL.OSC_133_COMMAND_FINISH)
+    readuntil(stdout_read, REPL.OSC_133_PROMPT_END)
+
+    write(stdin_write, '\x04')
+    readuntil(stdout_read, REPL.OSC_133_COMMAND_FINISH)
+    Base.wait(repltask)
 end
 
 # Writing ^C to the repl will cause sigint, so let's not die on that

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -100,34 +100,72 @@ end
 
 # Semantic prompt markers delimit prompt input and output and report evaluation status.
 @test REPL.Options().semantic_prompts
-fake_repl(semantic_prompts=true) do stdin_write, stdout_read, repl
-    repl.specialdisplay = REPL.REPLDisplay(repl)
-    repl.history_file = false
-    repltask = @async REPL.run_repl(repl)
+@test REPL.serialize_vscode_osc_message("a b;c\\d\nα") ==
+    "a\\x20b\\x3bc\\\\d\\x0aα"
+withenv("TERM_PROGRAM" => "") do
+    fake_repl(semantic_prompts=true) do stdin_write, stdout_read, repl
+        markers = REPL.OSC_133_MARKERS
+        repl.specialdisplay = REPL.REPLDisplay(repl)
+        repl.history_file = false
+        repltask = @async REPL.run_repl(repl)
 
-    prompt = readuntil(stdout_read, REPL.OSC_133_PROMPT_END, keep=true)
-    @test occursin(REPL.OSC_133_PROMPT_START, prompt)
+        prompt = readuntil(stdout_read, markers.prompt_end, keep=true)
+        @test occursin(markers.prompt_start, prompt)
 
-    global semantic_prompt_output = repl.t
-    command = "print($(curmod_prefix)semantic_prompt_output, \"semantic output\"); nothing\n"
-    write(stdin_write, command)
-    response = readuntil(stdout_read, REPL.OSC_133_COMMAND_FINISH_OK, keep=true)
-    @test occursin(REPL.OSC_133_COMMAND_START * "semantic output", response)
-    readuntil(stdout_read, REPL.OSC_133_PROMPT_END)
+        write(stdin_write, "\"semantic output\"\n")
+        response = readuntil(stdout_read, markers.command_finish_ok, keep=true)
+        @test occursin(markers.command_start * "\"semantic output\"", response)
+        readuntil(stdout_read, markers.prompt_end)
 
-    write(stdin_write, "error(\"semantic failure\")\n")
-    response = readuntil(stdout_read, REPL.OSC_133_COMMAND_FINISH_ERROR, keep=true)
-    @test occursin(REPL.OSC_133_COMMAND_START, response)
-    @test occursin("semantic failure", response)
-    readuntil(stdout_read, REPL.OSC_133_PROMPT_END)
+        write(stdin_write, "error(\"semantic failure\")\n")
+        response = readuntil(stdout_read, markers.command_finish_error, keep=true)
+        @test occursin(markers.command_start, response)
+        @test occursin("semantic failure", response)
+        readuntil(stdout_read, markers.prompt_end)
 
-    write(stdin_write, '\n')
-    readuntil(stdout_read, REPL.OSC_133_COMMAND_FINISH)
-    readuntil(stdout_read, REPL.OSC_133_PROMPT_END)
+        write(stdin_write, '\n')
+        readuntil(stdout_read, markers.command_finish)
+        readuntil(stdout_read, markers.prompt_end)
 
-    write(stdin_write, '\x04')
-    readuntil(stdout_read, REPL.OSC_133_COMMAND_FINISH)
-    Base.wait(repltask)
+        # A prompt without an associated REPL emits neither prompt nor command markers.
+        julia_prompt = repl.interface.modes[1]::LineEdit.Prompt
+        julia_prompt.repl = nothing
+        write(stdin_write, "1 + 1\n")
+        response = readuntil(stdout_read, "julia> ", keep=true)
+        @test !occursin("\e]133;", response)
+        julia_prompt.repl = repl
+
+        write(stdin_write, '\x04')
+        readuntil(stdout_read, markers.command_finish)
+        Base.wait(repltask)
+    end
+end
+
+withenv("TERM_PROGRAM" => "vscode") do
+    fake_repl(semantic_prompts=true) do stdin_write, stdout_read, repl
+        markers = REPL.OSC_633_MARKERS
+        # The terminal protocol is selected once when the REPL is constructed.
+        withenv("TERM_PROGRAM" => "") do
+            repl.specialdisplay = REPL.REPLDisplay(repl)
+            repl.history_file = false
+            repltask = @async REPL.run_repl(repl)
+
+            prompt = readuntil(stdout_read, markers.prompt_end, keep=true)
+            @test occursin(markers.prompt_start, prompt)
+
+            write(stdin_write, "2 + 2\n")
+            response = readuntil(stdout_read, markers.command_finish_ok, keep=true)
+            command_line = markers.command_line * "2\\x20+\\x202\a"
+            @test occursin(markers.command_start * "4", response)
+            @test occursin(command_line * markers.command_finish_ok, response)
+            @test !occursin("\e]133;", response)
+            readuntil(stdout_read, markers.prompt_end)
+
+            write(stdin_write, '\x04')
+            readuntil(stdout_read, markers.command_finish)
+            Base.wait(repltask)
+        end
+    end
 end
 
 # Writing ^C to the repl will cause sigint, so let's not die on that


### PR DESCRIPTION
This allows the terminal to understand the REPL better, for example:

- what command ran
- what was the output of the command
- whether the command ran successfully

You can then do things like rerunning a previous command, copying the output, scrolling to previous prompts, etc.

<img width="217" height="278" alt="image" src="https://github.com/user-attachments/assets/0c0f886e-116d-40af-9d65-e19bb2dd4e7c" />

Reimplemented based on an OhMyREPL PR https://github.com/KristofferC/OhMyREPL.jl/pull/388.

Assisted-by: Codex (GPT-5)