### PR TITLE
Shortcut for `rationalize` when tolerance is zero

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -247,8 +247,22 @@ BigInt
 function rationalize(::Type{T}, x::AbstractFloat, tol::Real) where T<:Integer
     tol < 0 && throw(ArgumentError("Tolerance can not be negative. tol=$tol"))
     T<:Unsigned && x < 0 && __throw_negate_unsigned()
-    isnan(x) && return T(x)//one(T)
+    (isnan(x) || iszero(x)) && return T(x)//one(T)
     isinf(x) && return unsafe_rational(x < 0 ? -one(T) : one(T), zero(T))
+
+    if iszero(tol) && isbits(x)
+        try
+            isinteger(x) && return T(x)//one(T)
+            fpart = x - trunc(x)
+            sbits = significand_bits(typeof(x))
+            n = reinterpret(uinttype(typeof(x)), fpart)
+            e = max(exponent(fpart), exponent_min(typeof(x)))
+            s = sbits - e - min(trailing_zeros(n), sbits)
+            return T(ldexp(x, s)) // checked_pow(T(2), s)
+        catch err
+            isa(err,InexactError) || isa(err,OverflowError) || rethrow()
+        end
+    end
 
     p,  q  = (x < 0 ? -one(T) : one(T)), zero(T)
     pp, qq = zero(T), one(T)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -926,3 +926,23 @@ end
     @test rationalize(BigInt, r) == Rational{BigInt}(r) == r
     @test rationalize(Int64, big(r)) == r
 end
+
+@testset "rationalize float with zero tol" begin
+    @test rationalize(Int64, 0.1, tol=0) == 3602879701896397//36028797018963968
+    @test rationalize(Int64, -123.456, tol=0) == -8687443681197687//70368744177664
+    @test rationalize(Int64, 16.0, tol=0) == 16//1
+
+    for F in (Float16, Float32, Float64)
+        T = Base.inttype(F)
+        x = inv(maxintfloat(F))
+        @test rationalize(T, x, tol=0) == one(T)//T(maxintfloat(F))
+        @test rationalize(T, 17x, tol=0) == T(17)//T(maxintfloat(F))
+        @test rationalize(T, 256x, tol=0) == T(256)//T(maxintfloat(F))
+
+        for x in (floatmin(F), prevfloat(floatmin(F)), nextfloat(F(0.0)))
+            r = Rational{BigInt}(x)
+            @test rationalize(BigInt, x, tol=0) == r
+            @test (rationalize(T, x, tol=0) == r) == (r.den ≤ typemax(T))
+        end
+    end
+end


### PR DESCRIPTION
When `tol` is very small, the convergent algorithm may require more precision than the input type can handle and return an approximated result that doesn't satisfy `tol` even if a more accurate or exact result that fits in `T` exists. For example:

```julia
julia> rationalize(BigInt, nextfloat(Float16(0.0)), tol=0)
0//1

# expected: 1//16777216
```

When `tol` is zero and the input `x` is a IEEE 754 float, we can fix this issue by converting the binary representation of `x` into a rational, and only if the result doesn't fit in `T`, fall back to the best approximation algorithm.

Related: #61138, #49803, #49848, PR #61066.