### PR TITLE
libsupport: force `LC_COLLATE` to `"C"`

### DIFF
--- a/src/support/libsupportinit.c
+++ b/src/support/libsupportinit.c
@@ -53,6 +53,8 @@ void libsupport_init(void)
         setlocale(LC_ALL, "");
         // but use locale-independent numeric formats (for parsing)
         setlocale(LC_NUMERIC, "C");
+        // and locale-independent collation
+        setlocale(LC_COLLATE, "C");
         // and try to specify ASCII or UTF-8 (preferred) for our Libc and Cstring functions
         char *ctype = setlocale(LC_CTYPE, NULL);
         if (ctype) {


### PR DESCRIPTION
I am not sure if this should be considered a GCC issue (as described in https://github.com/JuliaLang/julia/issues/63117#issuecomment-5640155460) but this at least works around the issue in #63117. If this gets merged it should get backported

----------

🤖 

`libsupport_init` adopts the user's locale with `setlocale(LC_ALL, "")`, so every Julia process on Windows runs with a non-`"C"` `LC_COLLATE`. Under such a locale msvcrt's `strxfrm` reports a too-small output buffer by setting `errno = ERANGE`, and libstdc++ from GCC 15 (shipped since CompilerSupportLibraries_jll 1.5.5) now treats any `errno` after `strxfrm` as a failure and throws `std::system_error` from `std::collate::transform`. Code compiled with older GCC headers calls that from `std::regex` for every character when building a bracket matcher, so C++ libraries that dynamically link the bundled libstdc++ (e.g. gmsh_jll 4.15) fail as soon as they compile a regex.

Julia does not rely on locale-aware collation, so pin `LC_COLLATE` to `"C"` on all platforms, like `LC_NUMERIC` already is.

Fixes #63117

Assisted-by: Claude Code (Fable 5.1)