### PR TITLE
Test: accept block expressions in `@test_deprecated`

### DIFF
--- a/stdlib/Test/src/logging.jl
+++ b/stdlib/Test/src/logging.jl
@@ -374,50 +374,19 @@ macro test_deprecated(exs...)
     # Parse arguments: [pattern] expression [broken=...] [skip=...]
     length(exs) >= 1 || throw(ArgumentError("""`@test_deprecated` expects at least one argument.
                                Usage: `@test_deprecated [pattern] expr_to_run [broken=cond] [skip=cond]`"""))
-    pattern = r"deprecated"i
-    expression = nothing
-    kws = Any[]
+    # Only `broken=`/`skip=` are keywords; any other argument, whatever its
+    # syntax, is positional so that e.g. `begin ... end` or `x = f()` is the
+    # expression to run.
+    is_kw(e) = e isa Expr && e.head === :(=) && e.args[1] in (:broken, :skip)
+    kws = Any[e for e in exs if is_kw(e)]
+    positional = Any[e for e in exs if !is_kw(e)]
 
-    # Helper to check if an expression is a string macro (like r"..." or s"...")
-    is_string_macro(e) = e isa Expr && e.head === :macrocall &&
-                         length(e.args) >= 1 && e.args[1] isa Symbol &&
-                         endswith(String(e.args[1]), "_str")
-
-    for (i, e) in enumerate(exs)
-        if e isa Expr && e.head === :(=)
-            if e.args[1] in (:broken, :skip)
-                push!(kws, e)
-            else
-                # This is the expression (like `f(x=1)`)
-                expression !== nothing && throw(ArgumentError("""`@test_deprecated` expects at most one expression.
+    length(positional) >= 1 || throw(ArgumentError("""`@test_deprecated` needs an expression to run.
                                Usage: `@test_deprecated [pattern] expr_to_run [broken=cond] [skip=cond]`"""))
-                expression = e
-            end
-        elseif e isa Expr && e.head === :call
-            # This is the expression (function call)
-            expression !== nothing && throw(ArgumentError("""`@test_deprecated` expects at most one expression.
+    length(positional) <= 2 || throw(ArgumentError("""`@test_deprecated` expects at most one expression.
                                Usage: `@test_deprecated [pattern] expr_to_run [broken=cond] [skip=cond]`"""))
-            expression = e
-        elseif e isa Expr && e.head === :macrocall && !is_string_macro(e)
-            # This is the expression (macro call, but not a string macro like r"...")
-            expression !== nothing && throw(ArgumentError("""`@test_deprecated` expects at most one expression.
-                               Usage: `@test_deprecated [pattern] expr_to_run [broken=cond] [skip=cond]`"""))
-            expression = e
-        elseif i == 1 && (e isa Union{Regex, String, Symbol} || is_string_macro(e) ||
-                         (e isa Expr && e.head ∉ (:call, :macrocall)))
-            # First non-keyword argument that's a Regex, String, Symbol (variable), string macro,
-            # or non-call expression is the pattern
-            pattern = e
-        else
-            # Assume it's the expression
-            expression !== nothing && throw(ArgumentError("""`@test_deprecated` expects at most one expression.
-                               Usage: `@test_deprecated [pattern] expr_to_run [broken=cond] [skip=cond]`"""))
-            expression = e
-        end
-    end
-
-    expression === nothing && throw(ArgumentError("""`@test_deprecated` needs an expression to run.
-                               Usage: `@test_deprecated [pattern] expr_to_run [broken=cond] [skip=cond]`"""))
+    pattern = length(positional) == 1 ? r"deprecated"i : positional[1]
+    expression = positional[end]
 
     broken, skip, _ = extract_broken_skip_kws(kws, "@test_deprecated")
 

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1534,6 +1534,14 @@ let code = quote
 
             @test (@test_deprecated oldfunc()) == 42
 
+            # A block is the expression to run, not the pattern (issue #62197)
+            @test (@test_deprecated begin
+                oldfunc()
+            end) == 42
+            @test (@test_deprecated r"deprecated" begin
+                oldfunc()
+            end) == 42
+
             fails = @testset NoThrowTestSet "check that @test_deprecated detects bad input" begin
                 @test_deprecated newfunc()
                 @test_deprecated r"Not found in message" oldfunc()
@@ -1566,6 +1574,15 @@ let code = quote
             @test length(results) == 1
             @test results[1] isa Test.Broken
             @test results[1].test_type === :skipped
+
+            # keywords combine with a block expression
+            results = @testset NoThrowTestSet begin
+                @test_deprecated begin
+                    newfunc()
+                end broken=true
+            end
+            @test length(results) == 1
+            @test results[1] isa Test.Broken
         end
     end
     incl = "include($(repr(joinpath(@__DIR__, "nothrow_testset.jl"))))"


### PR DESCRIPTION
Fixes #62197.

`@test_deprecated begin ... end` fails on nightly with "needs an expression to run". #60543 added `broken=`/`skip=` keywords and, with them, a classifier that guessed the pattern from syntax: any first argument other than a call or macro call was taken as the pattern, so a `begin` block left no expression to run.

This restores the positional rule from 1.13, keeping the keywords: `broken=` and `skip=` are keywords, and of the remaining arguments one is the expression, two are pattern then expression. `@test_logs` already separates keywords this way.

Tests cover `begin ... end` alone, with a pattern, and with `broken=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
