### PR TITLE
codegen: only tag `Const` loads with the `@aliasscope` scope

### DIFF
--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -755,7 +755,7 @@ function iscall_with_boundscheck(@nospecialize(stmt), sv::PostOptAnalysisState)
         nargs = 4
     elseif f === memoryrefnew
         nargs= 3
-    elseif f === memoryrefget || f === memoryref_isassigned
+    elseif f === memoryrefget || f === Core.const_memoryrefget || f === memoryref_isassigned
         nargs = 4
     elseif f === memoryrefset!
         nargs = 5
@@ -1443,7 +1443,7 @@ function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptyp
                 # tuple iteration/destructuring makes that impossible
                 # return plus_saturate(argcost, isknowntype(extyp) ? 1 : params.inline_nonleaf_penalty)
                 return 0
-            elseif (f === Core.memoryrefget || f === Core.memoryref_isassigned) && length(ex.args) >= 3
+            elseif (f === Core.memoryrefget || f === Core.const_memoryrefget || f === Core.memoryref_isassigned) && length(ex.args) >= 3
                 atyp = argextype(ex.args[2], src, sptypes)
                 return isknowntype(atyp) ? 1 : params.inline_nonleaf_penalty
             elseif f === Core.memoryrefset! && length(ex.args) >= 3

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -2341,6 +2341,7 @@ end
 end
 
 add_tfunc(Core.memoryrefget, 3, 3, memoryrefget_tfunc, 20)
+add_tfunc(Core.const_memoryrefget, 3, 3, memoryrefget_tfunc, 20)
 add_tfunc(Core.memoryrefset!, 4, 4, memoryrefset!_tfunc, 20)
 add_tfunc(Core.memoryrefunset!, 3, 3, memoryrefunset!_tfunc, 20)
 add_tfunc(Core.memoryrefswap!, 4, 4, memoryrefswap!_tfunc, 20)
@@ -2511,7 +2512,7 @@ function memoryrefop_builtin_common_nothrow(𝕃::AbstractLattice, argtypes::Vec
     if ismemoryset
         # Additionally check element type compatibility
         memoryset_typecheck(𝕃, memtype, argtypes[2]) || return false
-    elseif f === memoryrefget
+    elseif f === memoryrefget || f === Core.const_memoryrefget
         # If we could potentially throw undef ref errors, bail out now.
         array_type_undefable(memtype) && return false
     end
@@ -2567,7 +2568,7 @@ function _builtin_nothrow(𝕃::AbstractLattice, @nospecialize(f::Builtin), argt
         return memoryrefop_builtin_common_nothrow(𝕃, argtypes, f)
     elseif f === memoryrefunset!
         return memoryrefop_builtin_common_nothrow(𝕃, argtypes, f)
-    elseif f === memoryrefget
+    elseif f === memoryrefget || f === Core.const_memoryrefget
         return memoryrefop_builtin_common_nothrow(𝕃, argtypes, f)
     elseif f === memoryref_isassigned
         return memoryrefop_builtin_common_nothrow(𝕃, argtypes, f)
@@ -2682,6 +2683,7 @@ const _EFFECT_FREE_BUILTINS = [
     memoryrefnew,
     memoryrefoffset,
     memoryrefget,
+    Core.const_memoryrefget,
     memoryref_isassigned,
     isdefined,
     Core.bitsizeof,
@@ -2727,6 +2729,7 @@ const _ARGMEM_BUILTINS = Any[
     memoryrefnew,
     memoryrefoffset,
     memoryrefget,
+    Core.const_memoryrefget,
     memoryref_isassigned,
     memoryrefset!,
     memoryrefunset!,
@@ -2912,6 +2915,7 @@ const _EFFECTS_KNOWN_BUILTINS = Any[
     Core.memorynew,
     memoryref_isassigned,
     memoryrefget,
+    Core.const_memoryrefget,
     # Core.memoryrefmodify!,
     memoryrefnew,
     memoryrefoffset,
@@ -3007,7 +3011,7 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argty
     else
         if contains_is(_CONSISTENT_BUILTINS, f)
             consistent = ALWAYS_TRUE
-        elseif f === memoryrefget || f === memoryrefset! || f === memoryrefunset! || f === memoryref_isassigned || f === Core._svec_len || f === Core._svec_ref
+        elseif f === memoryrefget || f === Core.const_memoryrefget || f === memoryrefset! || f === memoryrefunset! || f === memoryref_isassigned || f === Core._svec_len || f === Core._svec_ref
             consistent = CONSISTENT_IF_INACCESSIBLEMEMONLY
         elseif f === Core._typevar || f === Core.memorynew
             consistent = CONSISTENT_IF_NOTRETURNED
@@ -3029,7 +3033,7 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argty
         else
             inaccessiblememonly = ALWAYS_FALSE
         end
-        if f === memoryrefnew || f === memoryrefget || f === memoryrefset! || f === memoryrefunset! || f === memoryref_isassigned
+        if f === memoryrefnew || f === memoryrefget || f === Core.const_memoryrefget || f === memoryrefset! || f === memoryrefunset! || f === memoryref_isassigned
             noub = memoryop_noub(f, argtypes) ? ALWAYS_TRUE : ALWAYS_FALSE
         else
             noub = ALWAYS_TRUE
@@ -3050,7 +3054,7 @@ function memoryop_noub(@nospecialize(f), argtypes::Vector{Any})
             return true
         end
         expected_nargs = 3
-    elseif f === memoryrefget || f === memoryref_isassigned || f === memoryrefunset!
+    elseif f === memoryrefget || f === Core.const_memoryrefget || f === memoryref_isassigned || f === memoryrefunset!
         expected_nargs = 3
     else
         @assert f === memoryrefset! "unexpected memoryop is given"

--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -388,6 +388,40 @@ str = String(take!(io))
 @test occursin("aliasscope", str)
 @test occursin("noalias", str)
 
+# Issue #63129: inside `@aliasscope`, only loads of `Const` arrays may be assumed not to
+# alias the stores in the scope. A recurrence carried through a plain array must be exact.
+function fwd63129!(B, a, n)
+    for l in axes(B, 1)
+        @Base.Experimental.aliasscope begin
+            @inbounds for i in 2:n
+                B[l, i] -= a[i] * B[l, i-1]
+            end
+        end
+    end
+    return B
+end
+function acc63129!(output, input, n)
+    for I in CartesianIndices(output)
+        i, j = I.I
+        @Base.Experimental.aliasscope begin
+            for k in j:n
+                output[I] += input[i, k]
+            end
+        end
+    end
+    return output
+end
+let n = 16, B = rand(4, n), a = rand(n)
+    Bref = copy(B)
+    for l in axes(Bref, 1), i in 2:n
+        Bref[l, i] -= a[i] * Bref[l, i-1]
+    end
+    @test fwd63129!(copy(B), a, n) == Bref
+    input = rand(n, n)
+    ref = [sum(@view input[i, j:n]) for i in 1:n, j in 1:n]
+    @test acc63129!(zeros(n, n), input, n) ≈ ref
+end
+
 # Issue #10208 - Unnecessary boxing for calling objectid
 struct FooDictHash{T}
     x::T

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1248,6 +1248,10 @@ let (memoryrefnew, memoryrefget, memoryref_isassigned, memoryrefset!) =
     @test Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Int]))
     @test !Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Vararg{Bool}]))
     @test !Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Vararg{Any}]))
+    # `Core.const_memoryrefget` (loads of `Base.Experimental.Const`, #63129) has the same effects
+    @test Compiler.is_noub(builtin_effects(Core.const_memoryrefget, Any[MemoryRef,Symbol,Core.Const(true)]))
+    @test !Compiler.is_noub(builtin_effects(Core.const_memoryrefget, Any[MemoryRef,Symbol,Core.Const(false)]))
+    @test Compiler.is_effect_free(builtin_effects(Core.const_memoryrefget, Any[MemoryRef,Symbol,Bool]))
     @test Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Core.Const(true)]))
     @test !Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Core.Const(false)]))
     @test !Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Bool]))
@@ -1630,4 +1634,12 @@ let effects = Base.infer_effects(Core._task, (Function, Int))
     @test Compiler.is_terminates(effects)
     @test !Compiler.is_notaskstate(effects)
     @test Compiler.is_noub(effects)
+end
+
+# `Base.Experimental.Const` indexing goes through `Core.const_memoryrefget` (#63129) and must
+# keep the effects of the corresponding `Array` indexing
+let CT = Base.Experimental.Const{Float64,2}
+    @test Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex, (CT, Int)))
+    @test Compiler.is_effect_free(Base.infer_effects(getindex, (CT, Int)))
+    @test Compiler.is_effect_free(Base.infer_effects(getindex, (CT, Int, Int)))
 end

--- a/base/docs/intrinsicsdocs.jl
+++ b/base/docs/intrinsicsdocs.jl
@@ -64,6 +64,19 @@ The memory ordering specified must be compatible with the `isatomic` parameter.
 Core.memoryrefget
 
 """
+    Core.const_memoryrefget(::GenericMemoryRef, ordering::Symbol, boundscheck::Bool)
+
+Same as [`Core.memoryrefget`](@ref), but additionally promises that the memory being read is
+not modified by any store inside the enclosing `Base.Experimental.@aliasscope` region.
+Used to implement indexing of `Base.Experimental.Const`. Loads emitted by plain
+[`Core.memoryrefget`](@ref) make no such promise.
+
+!!! compat "Julia 1.14"
+    This function requires Julia 1.14 or later.
+"""
+Core.const_memoryrefget
+
+"""
     Core.memoryrefset!(::GenericMemoryRef, value, ordering::Symbol, boundscheck::Bool)
 
 Store the value to the `MemoryRef`, throwing a `BoundsError` if the `Memory` is empty. See `ref[] = value`.

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -9,7 +9,7 @@
 """
 module Experimental
 
-using Base: Threads, sync_varname, is_function_def, @propagate_inbounds
+using Base: Threads, sync_varname, is_function_def
 using Base: GenericCondition
 using Base.Meta
 
@@ -29,7 +29,16 @@ end
 Base.IndexStyle(::Type{<:Const}) = IndexLinear()
 Base.size(C::Const) = size(C.a)
 Base.axes(C::Const) = axes(C.a)
-@propagate_inbounds Base.getindex(A::Const, i1::Int, I::Int...) = A.a[i1, I...]
+Base.@assume_effects :noub_if_noinbounds function Base.getindex(A::Const, i::Int)
+    @inline
+    @boundscheck Base.checkbounds(A.a, i)
+    return Core.const_memoryrefget(Core.memoryrefnew(getfield(A.a, :ref), i, false), :not_atomic, false)
+end
+function Base.getindex(A::Const, i1::Int, i2::Int, I::Int...)
+    @inline
+    @boundscheck Base.checkbounds(A.a, i1, i2, I...) # generally _to_linear_index requires bounds checking
+    return @inbounds A[Base._to_linear_index(A.a, i1, i2, I...)]
+end
 
 """
     @aliasscope expr

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -23,6 +23,7 @@ Core.memorynew
 Core.memoryrefnew
 Core.memoryrefoffset
 Core.memoryrefget
+Core.const_memoryrefget
 Core.memoryrefset!
 Core.memoryref_isassigned
 Core.memoryrefswap!

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -30,6 +30,7 @@ extern "C" {
     XX(apply_type,"apply_type") \
     XX(cancellation_point,"cancellation_point!") \
     XX(compilerbarrier,"compilerbarrier") \
+    XX(const_memoryrefget,"const_memoryrefget") \
     XX(current_scope,"current_scope") \
     XX(donotdelete,"donotdelete") \
     XX(fieldtype,"fieldtype") \

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2123,6 +2123,14 @@ JL_CALLABLE(jl_f_memoryrefget)
     return jl_memoryrefget(m, kind == (jl_value_t*)jl_atomic_sym);
 }
 
+// Same as `memoryrefget` at runtime. Codegen additionally tags loads emitted from this
+// builtin with the active `Expr(:aliasscope)` scope, i.e. it asserts that the loaded memory
+// is not modified by any store inside that scope (see `Base.Experimental.Const`).
+JL_CALLABLE(jl_f_const_memoryrefget)
+{
+    return jl_f_memoryrefget(F, args, nargs);
+}
+
 JL_CALLABLE(jl_f_memoryrefset)
 {
     enum jl_memory_order order = jl_memory_order_notatomic;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4933,7 +4933,12 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         }
     }
 
-    else if (f == BUILTIN(memoryrefget) && nargs == 3) {
+    else if ((f == BUILTIN(memoryrefget) || f == BUILTIN(const_memoryrefget)) && nargs == 3) {
+        // `const_memoryrefget` is `memoryrefget` plus the promise that the loaded memory is
+        // not written to inside the enclosing `Expr(:aliasscope)` region, which is expressed by
+        // attaching the active alias scope to the load. Plain `memoryrefget` loads must not be
+        // tagged, since the stores inside the scope are tagged `noalias` with respect to it.
+        const bool isconstload = f == BUILTIN(const_memoryrefget);
         const jl_cgval_t &ref = argv[1];
         jl_value_t *mty_dt = jl_unwrap_unionall(ref.typ);
         if (jl_is_genericmemoryref_type(mty_dt) && jl_is_concrete_type(mty_dt)) {
@@ -5037,7 +5042,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                 }
                 *ret = typed_load(ctx, ptr, nullptr, ety,
                         isboxed ? ctx.alias().ptrarraybuf : ctx.alias().arraybuf,
-                        ctx.noalias().aliasscope.current,
+                        isconstload ? ctx.noalias().aliasscope.current : nullptr,
                         isboxed, Order, maybenull, al);
                 if (needlock) {
                     emit_lockstate_value(ctx, lock, false);

--- a/test/llvmpasses/aliasscopes.jl
+++ b/test/llvmpasses/aliasscopes.jl
@@ -51,15 +51,34 @@ function micro_ker!(AB, Ac, Bc, kc, offSetA, offSetB)
     return
 end
 
+# Loads of arrays that are not wrapped in `Const` must not be tagged with the scope
+# (issue #63129): the store to A[i] and the next iteration's load of A[i-1] alias.
+# CHECK-LABEL: @julia_recurrence
+function recurrence(A, B)
+    @aliasscope @inbounds for i in 2:length(A)
+        A[i] -= Const(B)[i] * A[i-1]
+# CHECK: load double, {{.*}} !alias.scope [[SCOPE4_PLAIN:![0-9]+]]
+# CHECK: load double, {{.*}} !alias.scope [[SCOPE4_LD:![0-9]+]]
+# CHECK: load double, {{.*}} !alias.scope [[SCOPE4_PLAIN]]
+# CHECK: store double {{.*}} !noalias [[SCOPE4_ST:![0-9]+]]
+    end
+    return 0
+end
+
 # CHECK-DAG: [[SCOPE_LD]] = !{[[ALIASSCOPE:![0-9]+]]
 # CHECK-DAG: [[SCOPE_ST]] = !{[[ALIASSCOPE]]
 # CHECK-DAG: [[SCOPE2_LD]] = !{[[ALIASSCOPE2:![0-9]+]]
 # CHECK-DAG: [[SCOPE2_ST]] = !{[[ALIASSCOPE2]]
 # CHECK-DAG: [[SCOPE3_LD]] = !{[[ALIASSCOPE3:![0-9]+]]
 # CHECK-DAG: [[SCOPE3_ST]] = !{[[ALIASSCOPE3]]
+# CHECK-DAG: [[SCOPE4_LD]] = !{[[ALIASSCOPE4:![0-9]+]]
+# CHECK-DAG: [[SCOPE4_ST]] = !{[[ALIASSCOPE4]]
+# CHECK-DAG: [[SCOPE4_PLAIN]] = !{[[JNOALIAS_DATA:![0-9]+]]}
+# CHECK-DAG: [[JNOALIAS_DATA]] = !{!"jnoalias_data"
 # CHECK-DAG: [[ALIASSCOPE]] = !{!"aliasscope", [[MDNODE:![0-9]+]]}
 # CHECK-DAG: [[MDNODE]] = !{!"simple"}
 
 emit(simple, Vector{Float64}, Vector{Float64})
 emit(constargs, Vector{Float64}, Const{Float64, 1})
 emit(micro_ker!, Matrix{Float64}, Vector{Float64}, Vector{Float64}, Int64, Int64, Int64)
+emit(recurrence, Vector{Float64}, Vector{Float64})


### PR DESCRIPTION
Fixes #63129, fixes #60029.

## Problem

Inside `Base.Experimental.@aliasscope`, codegen attaches the scope as `!noalias` to every store (intended) and as `!alias.scope` to **every** load (not intended: only loads of `Base.Experimental.Const` arrays are supposed to get it). That tells LLVM that no store inside the scope aliases any load inside the scope, for any array.

Before the `Memory{T}` rewrite (#51319), `Const` indexing went through the dedicated builtin `Core.const_arrayref`, and `emit_builtin_call` only tagged loads from that builtin:

```cpp
MDNode *aliasscope = (f == jl_builtin_const_arrayref) ? ctx.noalias().aliasscope.current : nullptr;
```

#51319 removed the builtin, made `Const.getindex` a plain `A.a[i...]`, and the new `memoryrefget` path passes `ctx.noalias().aliasscope.current` to `typed_load` unconditionally. Which loop shapes actually miscompile depends on the LLVM pipeline: LICM exploited it on 1.11/1.12 for the accumulation in #60029 (hidden, not fixed, by #52850), and `LoopUnrollPass` exploits it on LLVM 19+ for the loop-carried recurrence in #63129 (1.13.0 and master). The bisection and IR analysis are in https://github.com/JuliaLang/julia/issues/63129#issuecomment-5647424134.

## Fix

Restore a `Const`-specific load builtin, `Core.const_memoryrefget`, with the same runtime semantics, tfunc and effects as `Core.memoryrefget`. Codegen shares the `memoryrefget` emission path and attaches the active alias scope only when the builtin is `const_memoryrefget`; plain `memoryrefget` loads no longer get it. `Const.getindex` is implemented on top of the new builtin, mirroring `getindex(::Array, ::Int)` in `base/essentials.jl`.

Loads of `Const` arrays inside `@aliasscope` are tagged exactly as before, so the optimization the scope exists for is unchanged; `test/llvmpasses/aliasscopes.jl` still checks that.

## Tests

- `test/llvmpasses/aliasscopes.jl`: new `recurrence` case with a plain array that is stored to and loaded from inside the scope; checks that the `Const` load carries the scope and the plain loads do not (their `!alias.scope` is the single `jnoalias_data` entry), while the store carries `!noalias` with the scope.
- `Compiler/test/effects.jl`: `Core.const_memoryrefget` has the effects of `memoryrefget`, and `getindex(::Const, ::Int)` keeps `:noub_if_noinbounds` (set with `Base.@assume_effects`, since the internal `@_noub_if_noinbounds_meta` is inert outside `Base` proper) and effect-freeness, matching `Array`.
- `Compiler/test/codegen.jl`: runtime checks for the #63129 recurrence and the #60029 accumulation. Note these only exercise the miscompile when run without `--check-bounds=yes`; the IR test above is the one that guards the metadata directly.

With this branch, the reproducers from #63129 (including the `Const(a)` and bounds-checked variants and the 1-D form) and from #60029 all give exact results at `-O2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
