### PR TITLE
InteractiveUtils: run the compiler in the typeinf world for `code_llvm`, `code_native` and `code_warntype`

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -161,7 +161,7 @@ See also: [`@code_warntype`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref)
 """
 function code_warntype(io::IO, arginfo::ArgInfo;
                        world=Base.get_world_counter(),
-                       interp::Base.Compiler.AbstractInterpreter=Base.Compiler.NativeInterpreter(world),
+                       interp::Union{Nothing,Base.Compiler.AbstractInterpreter}=nothing,
                        debuginfo::Symbol=:default, optimize::Bool=false, kwargs...)
     (ccall(:jl_is_in_pure_context, Bool, ()) || world == typemax(UInt)) &&
         error("code reflection cannot be used from generated functions")
@@ -176,12 +176,14 @@ function code_warntype(io::IO, arginfo::ArgInfo;
         return nothing
     end
     tt = arginfo.tt
-    matches = findall(tt, Base.Compiler.method_table(interp))
+    passed_interp = interp
+    interp = passed_interp === nothing ? Base.invoke_default_compiler(:_default_interp, world) : interp
+    matches = Base.invoke_interp_compiler(passed_interp, :_findall_matches, interp, tt)
     matches === nothing && Base.raise_match_failure(:code_warntype, tt)
     for match in matches.matches
         match = match::Core.MethodMatch
-        src = Base.Compiler.typeinf_code(interp, match, optimize)
-        mi = Base.Compiler.specialize_method(match)
+        src = Base.invoke_interp_compiler(passed_interp, :typeinf_code, interp, match, optimize)
+        mi = Base.specialize_method(match)
         mi.def isa Method && (nargs = (mi.def::Method).nargs)
         print_warntype_mi(io, mi)
         if src isa Core.CodeInfo
@@ -255,7 +257,7 @@ function _dump_function(arginfo::ArgInfo, native::Bool, wrapper::Bool,
         if isempty(str)
             # if that failed (or we want metadata), use LLVM to generate more accurate assembly output
             if arginfo.oc === nothing
-                src = Base.Compiler.typeinf_code(Base.Compiler.NativeInterpreter(world), mi, true)
+                src = Base.invoke_interp_compiler(nothing, :typeinf_code, Base.invoke_default_compiler(:_default_interp, world), mi, true)
             else
                 src, rt = Base.get_oc_code_rt(nothing, arginfo.oc, arginfo.tt, true)
             end
@@ -264,7 +266,7 @@ function _dump_function(arginfo::ArgInfo, native::Bool, wrapper::Bool,
         end
     else
         if arginfo.oc === nothing
-            src = Base.Compiler.typeinf_code(Base.Compiler.NativeInterpreter(world), mi, true)
+            src = Base.invoke_interp_compiler(nothing, :typeinf_code, Base.invoke_default_compiler(:_default_interp, world), mi, true)
         else
             src, rt = Base.get_oc_code_rt(nothing, arginfo.oc, arginfo.tt, true)
         end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -1098,6 +1098,30 @@ const _interactiveutils_some_var_ = 0
 
 @test InteractiveUtils.varloc(@__MODULE__, :_interactiveutils_some_var_) == (@__FILE__, var_line)
 
+@testset "code_llvm and code_warntype run the compiler in the typeinf world" begin
+    # Methods with broad signatures invalidate compiler code that normal inference never
+    # notices, because it runs in the frozen typeinf world. `code_llvm`, `code_native` and
+    # `code_warntype` used to run `typeinf_code` in the current world instead, so the first
+    # call after such a definition recompiled the invalidated compiler.
+    script = """
+        using InteractiveUtils
+        struct Displacement <: Integer; val::Int; end
+        Base.convert(::Type{Int64}, x::Displacement) = x.val
+        Base.Int64(x::Displacement) = x.val
+        struct NotReal; val; end
+        Base.isless(x, y::NotReal) = isless(x, y.val)
+        code_llvm(devnull, sin, (Float64,))
+        code_native(devnull, sin, (Float64,))
+        code_warntype(devnull, sin, (Float64,))
+        """
+    trace = mktemp() do path, io
+        run(pipeline(`$(Base.julia_cmd()) --startup-file=no --trace-compile=$path -e $script`, stderr=devnull))
+        read(path, String)
+    end
+    recompiled = filter(l -> occursin("# recompile", l) && occursin("Base.Compiler.", l), split(trace, '\n'))
+    @test isempty(recompiled)
+end
+
 @testset "world argument for varinfo and subtypes" begin
     # varinfo: a non-const binding added after the recorded world should not
     # appear when querying that older world (its partition does not yet exist


### PR DESCRIPTION
I was looking at other things and both bots thought this was a bug.

Claude:

---

`code_llvm`, `code_native` and `code_warntype` ran type inference in the caller's world: `_dump_function` and `code_warntype` construct a `NativeInterpreter(world)` and call `Compiler.typeinf_code` on it directly. The interpreter's `world` is the world being analysed and is unaffected by this change; what the current world governed was the execution of the compiler's own methods.

Normal inference, and the Base reflection functions (`code_typed`, `infer_return_type`, `infer_effects`, `which`), run the compiler in the frozen typeinf world through `invoke_in_typeinf_world`. So user definitions can invalidate compiler code without any cost, until one of the InteractiveUtils entry points executes the compiler in the current world and has to recompile whatever was invalidated. Two ordinary definitions from `test/ranges.jl`, a `convert(::Type{Int64}, ::T)` and an `isless(x, y::T)`, invalidate over 600 Compiler methods, and the first `code_llvm` afterwards takes 3.2 s (the `typeinf_local` graph) where `code_typed` takes 5 ms. The whole ranges.jl test file paid 3.2 s of its 25 s of compile time this way. Interactive sessions pay it once per invalidation wave, and the sessions most likely to have such definitions are the ones where these macros get used.

This routes the three `typeinf_code` calls and `code_warntype`'s method lookup through `Base.invoke_interp_compiler` with the default interpreter obtained from `invoke_default_compiler`, the way `code_typed_by_type` already does. With no interpreter passed, the compiler now runs in the typeinf world and also honours `REFLECTION_COMPILER` (`Compiler.activate!`), which these functions previously ignored; an explicitly passed interpreter keeps running in the current world, as it must for interpreters defined after the typeinf world was frozen. REPL completions already do the equivalent with `COMPLETION_WORLD`.

After the change the same `code_llvm` call takes 80 ms. The test spawns a child, defines the two methods, runs the three macros under `--trace-compile` and checks that no `Base.Compiler` method is flagged as recompiled; on master it reports two.
